### PR TITLE
ROX-31694: adds fake file activity client to fake collector

### DIFF
--- a/scale/workloads/file-activity-scale.yaml
+++ b/scale/workloads/file-activity-scale.yaml
@@ -23,5 +23,5 @@ networkWorkload:
 
 fileActivityWorkload:
   activityInterval: 50ms
-  batchSize: 800
+  batchSize: 100
   numPaths: 500

--- a/scale/workloads/file-activity-scale.yaml
+++ b/scale/workloads/file-activity-scale.yaml
@@ -25,3 +25,4 @@ fileActivityWorkload:
   activityInterval: 50ms
   batchSize: 100
   numPaths: 500
+  nodeEventPercent: 50

--- a/scale/workloads/file-activity-scale.yaml
+++ b/scale/workloads/file-activity-scale.yaml
@@ -1,0 +1,27 @@
+nodeWorkload:
+  numNodes: 10
+
+numNamespaces: 3
+
+deploymentWorkload:
+- deploymentType: Deployment
+  numDeployments: 100
+  numLabels: 5
+  lifecycleDuration: 30m
+  updateInterval: 5m
+  podWorkload:
+    numContainers: 2
+    numPods: 3
+    lifecycleDuration: 10m
+    processWorkload:
+      processInterval: 30s
+      alertRate: 0
+
+networkWorkload:
+  flowInterval: 60s
+  batchSize: 50
+
+fileActivityWorkload:
+  activityInterval: 100ms
+  batchSize: 100
+  numPaths: 500

--- a/scale/workloads/file-activity-scale.yaml
+++ b/scale/workloads/file-activity-scale.yaml
@@ -22,6 +22,6 @@ networkWorkload:
   batchSize: 50
 
 fileActivityWorkload:
-  activityInterval: 100ms
-  batchSize: 100
+  activityInterval: 50ms
+  batchSize: 800
   numPaths: 500

--- a/scale/workloads/sample.yaml
+++ b/scale/workloads/sample.yaml
@@ -81,3 +81,12 @@ virtualMachineWorkload:
   # Delay before the first index report for each VM (±20% max deviation applied)
   initialReportDelay: 10s
 
+# File activity workload generates synthetic file access events (requires ROX_SENSITIVE_FILE_ACTIVITY=true)
+fileActivityWorkload:
+  # Every time the specified interval is reached...
+  activityInterval: 1s
+  # ...create this many random file access events
+  batchSize: 100
+  # Number of unique file paths to generate events for
+  numPaths: 200
+

--- a/scale/workloads/sample.yaml
+++ b/scale/workloads/sample.yaml
@@ -89,4 +89,6 @@ fileActivityWorkload:
   batchSize: 100
   # Number of unique file paths to generate events for
   numPaths: 200
+  # Percentage of events generated as node-level (0-100), remainder are deployment-level
+  nodeEventPercent: 50
 

--- a/sensor/common/filesystem/service/service_impl.go
+++ b/sensor/common/filesystem/service/service_impl.go
@@ -20,13 +20,26 @@ var (
 	log = logging.LoggerForModule()
 )
 
+// Option function for the file activity service.
+type Option func(*serviceImpl)
+
+// WithAuthFuncOverride sets a custom auth function override.
+func WithAuthFuncOverride(overrideFn func(context.Context, string) (context.Context, error)) Option {
+	return func(srv *serviceImpl) {
+		srv.authFuncOverride = overrideFn
+	}
+}
+
 // NewService creates a new streaming service with the fact agent. It should only be called once.
-func NewService(pipeline *pipeline.Pipeline, activityChan chan *sensorAPI.FileActivity) Service {
+func NewService(pipeline *pipeline.Pipeline, activityChan chan *sensorAPI.FileActivity, opts ...Option) Service {
 	srv := &serviceImpl{
 		pipeline:     pipeline,
 		activityChan: activityChan,
 		stoppers:     set.NewSet[concurrency.Stopper](),
 		stopping:     false,
+	}
+	for _, opt := range opts {
+		opt(srv)
 	}
 
 	return srv
@@ -34,11 +47,12 @@ func NewService(pipeline *pipeline.Pipeline, activityChan chan *sensorAPI.FileAc
 
 type serviceImpl struct {
 	sensor.UnimplementedFileActivityServiceServer
-	pipeline     *pipeline.Pipeline
-	activityChan chan *sensorAPI.FileActivity
-	stoppers     set.Set[concurrency.Stopper]
-	stopperLock  sync.Mutex
-	stopping     bool
+	pipeline         *pipeline.Pipeline
+	activityChan     chan *sensorAPI.FileActivity
+	stoppers         set.Set[concurrency.Stopper]
+	stopperLock      sync.Mutex
+	stopping         bool
+	authFuncOverride func(context.Context, string) (context.Context, error)
 }
 
 func (s *serviceImpl) Stop() {
@@ -76,6 +90,9 @@ func (s *serviceImpl) RegisterServiceHandler(_ context.Context, _ *runtime.Serve
 }
 
 func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	if s.authFuncOverride != nil {
+		return s.authFuncOverride(ctx, fullMethodName)
+	}
 	return ctx, errors.Wrapf(idcheck.CollectorOnly().Authorized(ctx, fullMethodName), "file activity authorization for  %q", fullMethodName)
 }
 

--- a/sensor/debugger/collector/fake_collector.go
+++ b/sensor/debugger/collector/fake_collector.go
@@ -28,6 +28,7 @@ func NewFakeCollector(cfg *FakeCollectorConfig) *FakeCollector {
 		stopper:            stopper,
 		networkFlowManager: newFakeNetworkFlowManager(stopper),
 		signalManager:      newSignalManager(stopper),
+		fileAccessManager:  newFakeFileAccessManager(stopper),
 	}
 }
 
@@ -57,6 +58,7 @@ type FakeCollector struct {
 	stopper            concurrency.Stopper
 	networkFlowManager *fakeNetworkFlowManager
 	signalManager      *fakeSignalManager
+	fileAccessManager  *fakeFileAccessManager
 }
 
 // Start FakeCollector.
@@ -70,6 +72,9 @@ func (c *FakeCollector) Start() error {
 		return err
 	}
 	if err := c.signalManager.start(c.config.sensorAddress); err != nil {
+		return err
+	}
+	if err := c.fileAccessManager.start(c.config.sensorAddress); err != nil {
 		return err
 	}
 	return nil
@@ -88,5 +93,9 @@ func (c *FakeCollector) SendFakeNetworkFlow(msg *sensor.NetworkConnectionInfoMes
 // SendFakeSignal sends a SignalStreamMessage to sensor.
 func (c *FakeCollector) SendFakeSignal(msg *sensor.SignalStreamMessage) {
 	c.signalManager.send(msg)
+}
 
+// SendFakeFileActivity sends a FileActivity to sensor.
+func (c *FakeCollector) SendFakeFileActivity(msg *sensor.FileActivity) {
+	c.fileAccessManager.send(msg)
 }

--- a/sensor/debugger/collector/file_access_client.go
+++ b/sensor/debugger/collector/file_access_client.go
@@ -1,0 +1,109 @@
+package collector
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/pkg/clientconn"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/mtls"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+type fakeFileAccessManager struct {
+	stopper        concurrency.Stopper
+	ctxCancel      context.CancelFunc
+	messageToSendC chan *sensor.FileActivity
+	sendErrC       chan error
+	conn           *grpc.ClientConn
+}
+
+func newFakeFileAccessManager(stopper concurrency.Stopper) *fakeFileAccessManager {
+	return &fakeFileAccessManager{
+		stopper:        stopper,
+		sendErrC:       make(chan error),
+		messageToSendC: make(chan *sensor.FileActivity),
+	}
+}
+
+func (m *fakeFileAccessManager) send(msg *sensor.FileActivity) {
+	select {
+	case <-m.stopper.Flow().StopRequested():
+		return
+	case m.messageToSendC <- msg:
+	}
+}
+
+func (m *fakeFileAccessManager) runSend(stream sensor.FileActivityService_CommunicateClient, msgC <-chan *sensor.FileActivity, errC chan<- error) {
+	defer close(errC)
+	for {
+		select {
+		case <-stream.Context().Done():
+			return
+		case msg, ok := <-msgC:
+			if !ok {
+				errC <- errors.New("channel closed")
+				return
+			}
+			if err := stream.Send(msg); err != nil {
+				errC <- err
+				return
+			}
+		}
+	}
+}
+
+func (m *fakeFileAccessManager) run(stream sensor.FileActivityService_CommunicateClient) {
+	defer func() {
+		m.ctxCancel()
+		m.stopper.Client().Stop()
+		close(m.messageToSendC)
+		if err := m.conn.Close(); err != nil {
+			log.Errorf("Error closing the grpc connection %v", err)
+		}
+	}()
+	for {
+		select {
+		case <-m.stopper.Flow().StopRequested():
+			// Close the stream and wait for response
+			if _, err := stream.CloseAndRecv(); err != nil {
+				log.Errorf("Error closing stream: %v", err)
+			}
+			return
+		case err := <-m.sendErrC:
+			log.Errorf("Error sending %v", err)
+			return
+		}
+	}
+}
+
+func (m *fakeFileAccessManager) start(address string) error {
+	clientconn.SetUserAgent("Rox Collector")
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = metadata.AppendToOutgoingContext(ctx, "rox-collector-hostname", "fake-collector")
+	m.ctxCancel = cancel
+	tlsOpts := clientconn.TLSConfigOptions{
+		UseClientCert:      clientconn.MustUseClientCert,
+		ServerName:         "localhost",
+		CustomCertVerifier: &insecureVerifier{},
+		RootCAs:            nil,
+	}
+	opts := clientconn.Options{
+		TLS: tlsOpts,
+	}
+	conn, err := clientconn.GRPCConnection(ctx, mtls.SensorSubject, address, opts)
+	if err != nil {
+		return errors.Wrapf(err, "creating gRPC connection to %s", address)
+	}
+	m.conn = conn
+	cli := sensor.NewFileActivityServiceClient(conn)
+	client, err := cli.Communicate(ctx)
+	if err != nil {
+		return errors.Wrap(err, "opening file activity stream")
+	}
+	go m.runSend(client, m.messageToSendC, m.sendErrC)
+	go m.run(client)
+	return nil
+}

--- a/sensor/debugger/collector/file_access_client.go
+++ b/sensor/debugger/collector/file_access_client.go
@@ -72,8 +72,13 @@ func (m *fakeFileAccessManager) run(stream sensor.FileActivityService_Communicat
 				log.Errorf("Error closing stream: %v", err)
 			}
 			return
-		case err := <-m.sendErrC:
-			log.Errorf("Error sending %v", err)
+		case err, ok := <-m.sendErrC:
+			if !ok {
+				return
+			}
+			if err != nil {
+				log.Errorf("Error sending %v", err)
+			}
 			return
 		}
 	}
@@ -101,6 +106,7 @@ func (m *fakeFileAccessManager) start(address string) error {
 	cli := sensor.NewFileActivityServiceClient(conn)
 	client, err := cli.Communicate(ctx)
 	if err != nil {
+		_ = conn.Close()
 		return errors.Wrap(err, "opening file activity stream")
 	}
 	go m.runSend(client, m.messageToSendC, m.sendErrC)

--- a/sensor/debugger/collector/file_activity_load_driver.go
+++ b/sensor/debugger/collector/file_activity_load_driver.go
@@ -1,0 +1,284 @@
+package collector
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// LoadDriverConfig configures the file activity load driver.
+type LoadDriverConfig struct {
+	// EventsPerSecond is the target event rate. 0 means unlimited (burst mode).
+	EventsPerSecond int
+	// NumUniquePaths is the number of distinct file paths to generate events for.
+	NumUniquePaths int
+	// Hostname is the hostname to set on generated events.
+	Hostname string
+	// ContainerID is the container ID to set on generated process signals.
+	// Empty means generate node-level events (no deployment enrichment).
+	ContainerID string
+	// OperationWeights controls the relative frequency of each operation type.
+	// Keys: "open", "create", "unlink", "rename", "chmod", "chown"
+	// Omitted keys default to 0. If all are 0, defaults to equal distribution.
+	OperationWeights map[string]int
+}
+
+// DefaultLoadDriverConfig returns a sensible default configuration.
+func DefaultLoadDriverConfig() LoadDriverConfig {
+	return LoadDriverConfig{
+		EventsPerSecond: 100,
+		NumUniquePaths:  50,
+		Hostname:        "fake-collector",
+		ContainerID:     "",
+		OperationWeights: map[string]int{
+			"open":   40,
+			"create": 20,
+			"unlink": 10,
+			"rename": 10,
+			"chmod":  10,
+			"chown":  10,
+		},
+	}
+}
+
+// LoadDriverStats tracks load driver execution statistics.
+type LoadDriverStats struct {
+	EventsSent int64
+	StartTime  time.Time
+	EndTime    time.Time
+	Errors     int64
+}
+
+// ActualRate returns the achieved events per second.
+func (s LoadDriverStats) ActualRate() float64 {
+	elapsed := s.EndTime.Sub(s.StartTime).Seconds()
+	if elapsed <= 0 {
+		return 0
+	}
+	return float64(s.EventsSent) / elapsed
+}
+
+// FileActivityLoadDriver generates synthetic file activity events and sends them
+// through a FakeCollector to stress-test the Sensor file activity pipeline.
+type FileActivityLoadDriver struct {
+	config    LoadDriverConfig
+	collector *FakeCollector
+	stopper   concurrency.Stopper
+	paths     []string
+	opPicker  weightedPicker
+}
+
+// NewFileActivityLoadDriver creates a load driver attached to the given fake collector.
+func NewFileActivityLoadDriver(collector *FakeCollector, config LoadDriverConfig) *FileActivityLoadDriver {
+	paths := generatePaths(config.NumUniquePaths)
+	picker := buildWeightedPicker(config.OperationWeights)
+
+	return &FileActivityLoadDriver{
+		config:    config,
+		collector: collector,
+		stopper:   concurrency.NewStopper(),
+		paths:     paths,
+		opPicker:  picker,
+	}
+}
+
+// Run starts generating events and blocks until the stopper is triggered.
+// Returns statistics about the run.
+func (d *FileActivityLoadDriver) Run() LoadDriverStats {
+	stats := LoadDriverStats{StartTime: time.Now()}
+	defer func() { stats.EndTime = time.Now() }()
+
+	if d.config.EventsPerSecond <= 0 {
+		d.runBurst(&stats)
+	} else {
+		d.runRateLimited(&stats)
+	}
+	return stats
+}
+
+// Stop signals the load driver to stop.
+func (d *FileActivityLoadDriver) Stop() {
+	d.stopper.Client().Stop()
+}
+
+func (d *FileActivityLoadDriver) runRateLimited(stats *LoadDriverStats) {
+	interval := time.Second / time.Duration(d.config.EventsPerSecond)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-d.stopper.Flow().StopRequested():
+			return
+		case <-ticker.C:
+			d.sendEvent(stats)
+		}
+	}
+}
+
+func (d *FileActivityLoadDriver) runBurst(stats *LoadDriverStats) {
+	for {
+		select {
+		case <-d.stopper.Flow().StopRequested():
+			return
+		default:
+			d.sendEvent(stats)
+		}
+	}
+}
+
+func (d *FileActivityLoadDriver) sendEvent(stats *LoadDriverStats) {
+	msg := d.generateEvent()
+	d.collector.SendFakeFileActivity(msg)
+	stats.EventsSent++
+
+	if stats.EventsSent%10000 == 0 {
+		elapsed := time.Since(stats.StartTime).Seconds()
+		log.Infof("Load driver: sent %d events (%.1f events/sec)", stats.EventsSent, float64(stats.EventsSent)/elapsed)
+	}
+}
+
+func (d *FileActivityLoadDriver) generateEvent() *sensor.FileActivity {
+	path := d.paths[rand.Intn(len(d.paths))]
+	op := d.opPicker.pick()
+	now := timestamppb.Now()
+
+	activity := &sensor.FileActivity{
+		Timestamp: now,
+		Process:   d.generateProcess(),
+		Hostname:  d.config.Hostname,
+	}
+
+	base := &sensor.FileActivityBase{
+		Path:     path,
+		HostPath: "/host" + path,
+	}
+
+	switch op {
+	case "open":
+		activity.File = &sensor.FileActivity_Open{
+			Open: &sensor.FileOpen{Activity: base},
+		}
+	case "create":
+		activity.File = &sensor.FileActivity_Creation{
+			Creation: &sensor.FileCreation{Activity: base},
+		}
+	case "unlink":
+		activity.File = &sensor.FileActivity_Unlink{
+			Unlink: &sensor.FileUnlink{Activity: base},
+		}
+	case "rename":
+		newPath := d.paths[rand.Intn(len(d.paths))]
+		activity.File = &sensor.FileActivity_Rename{
+			Rename: &sensor.FileRename{
+				Old: base,
+				New: &sensor.FileActivityBase{
+					Path:     newPath,
+					HostPath: "/host" + newPath,
+				},
+			},
+		}
+	case "chmod":
+		activity.File = &sensor.FileActivity_Permission{
+			Permission: &sensor.FilePermissionChange{
+				Activity: base,
+				Mode:     0644,
+			},
+		}
+	case "chown":
+		activity.File = &sensor.FileActivity_Ownership{
+			Ownership: &sensor.FileOwnershipChange{
+				Activity: base,
+				Uid:      1000,
+				Gid:      1000,
+				Username: "testuser",
+				Group:    "testgroup",
+			},
+		}
+	}
+
+	return activity
+}
+
+func (d *FileActivityLoadDriver) generateProcess() *sensor.ProcessSignal {
+	return &sensor.ProcessSignal{
+		Id:           uuid.NewV4().String(),
+		ContainerId:  d.config.ContainerID,
+		Name:         "test-process",
+		Args:         "--flag value",
+		ExecFilePath: "/usr/bin/test-process",
+		Pid:          uint32(rand.Intn(65535) + 1),
+		Uid:          1000,
+		Gid:          1000,
+	}
+}
+
+func generatePaths(n int) []string {
+	dirs := []string{
+		"/etc/security",
+		"/etc/pam.d",
+		"/etc/ssh",
+		"/var/log",
+		"/var/run",
+		"/tmp",
+		"/etc/kubernetes",
+		"/etc/cni",
+		"/etc/sysconfig",
+		"/etc/audit",
+	}
+
+	paths := make([]string, 0, n)
+	for i := range n {
+		dir := dirs[i%len(dirs)]
+		paths = append(paths, fmt.Sprintf("%s/file-%04d.conf", dir, i))
+	}
+	return paths
+}
+
+type weightedPicker struct {
+	ops     []string
+	weights []int
+	total   int
+}
+
+func buildWeightedPicker(weights map[string]int) weightedPicker {
+	allOps := []string{"open", "create", "unlink", "rename", "chmod", "chown"}
+
+	hasWeights := false
+	for _, w := range weights {
+		if w > 0 {
+			hasWeights = true
+			break
+		}
+	}
+
+	p := weightedPicker{}
+	for _, op := range allOps {
+		w := 1
+		if hasWeights {
+			w = weights[op]
+		}
+		if w > 0 {
+			p.ops = append(p.ops, op)
+			p.weights = append(p.weights, w)
+			p.total += w
+		}
+	}
+	return p
+}
+
+func (p *weightedPicker) pick() string {
+	r := rand.Intn(p.total)
+	for i, w := range p.weights {
+		r -= w
+		if r < 0 {
+			return p.ops[i]
+		}
+	}
+	return p.ops[len(p.ops)-1]
+}

--- a/sensor/debugger/k8s/k8sclient.go
+++ b/sensor/debugger/k8s/k8sclient.go
@@ -13,8 +13,12 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	fakeDynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -27,8 +31,14 @@ var (
 
 // MakeFakeClient creates a k8s client that is not connected to any cluster
 func MakeFakeClient() *ClientSet {
+	scheme := runtime.NewScheme()
+	_ = apiextensionsv1.AddToScheme(scheme)
+	listKinds := map[schema.GroupVersionResource]string{
+		{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}: "CustomResourceDefinitionList",
+	}
 	return &ClientSet{
-		k8s: fake.NewClientset(),
+		k8s:     fake.NewClientset(),
+		dynamic: fakeDynamic.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds),
 	}
 }
 

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -13,6 +13,7 @@ import (
 	configVersioned "github.com/openshift/client-go/config/clientset/versioned"
 	operatorVersioned "github.com/openshift/client-go/operator/clientset/versioned"
 	routeVersioned "github.com/openshift/client-go/route/clientset/versioned"
+	sensorInternal "github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fixtures/vmindexreport"
@@ -162,6 +163,7 @@ type WorkloadManager struct {
 	networkManager       manager.Manager
 	vmIndexReportHandler index.Handler
 	vmStore              *vmStore.VirtualMachineStore
+	fileActivityChan     chan *sensorInternal.FileActivity
 
 	// VM readiness coordinator
 	vmPrerequisitesReady *vmReadiness
@@ -329,6 +331,11 @@ func (w *WorkloadManager) SetSignalHandlers(processPipeline signal.Pipeline, net
 	w.processes = processPipeline
 	w.networkManager = networkManager
 	w.servicesInitialized.Signal()
+}
+
+// SetFileActivityChannel sets the channel for injecting file activity events into the pipeline
+func (w *WorkloadManager) SetFileActivityChannel(ch chan *sensorInternal.FileActivity) {
+	w.fileActivityChan = ch
 }
 
 // SetVMIndexReportHandler sets the handler that will accept VM index reports
@@ -534,6 +541,11 @@ func (w *WorkloadManager) initializePreexistingResources() {
 
 	w.wg.Add(1)
 	go w.manageFlows(w.shutdownCtx)
+
+	if w.workload.FileActivityWorkload.ActivityInterval > 0 {
+		w.wg.Add(1)
+		go w.manageFileActivity(w.shutdownCtx)
+	}
 
 	// Start VirtualMachine/VirtualMachineInstance workload if configured.
 	// This unified workload handles both informer events AND index reports.

--- a/sensor/kubernetes/fake/fileactivity.go
+++ b/sensor/kubernetes/fake/fileactivity.go
@@ -92,13 +92,21 @@ func (w *WorkloadManager) manageFileActivity(ctx context.Context) {
 }
 
 func (w *WorkloadManager) generateFileActivity(paths []string, hostname string) *sensorAPI.FileActivity {
-	containerID, ok := w.containerPool.randomElem()
-	if !ok {
-		return nil
-	}
-
 	path := paths[rand.Intn(len(paths))]
 	now := timestamppb.Now()
+
+	nodePercent := w.workload.FileActivityWorkload.NodeEventPercent
+	if nodePercent == 0 {
+		nodePercent = 50
+	}
+
+	var containerID string
+	if rand.Intn(100) >= nodePercent {
+		cid, ok := w.containerPool.randomElem()
+		if ok {
+			containerID = cid
+		}
+	}
 
 	process := &sensorAPI.ProcessSignal{
 		Id:           uuid.NewV4().String(),

--- a/sensor/kubernetes/fake/fileactivity.go
+++ b/sensor/kubernetes/fake/fileactivity.go
@@ -9,6 +9,7 @@ import (
 	sensorAPI "github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/pkg/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var fileActivityDirs = []string{
@@ -44,6 +45,8 @@ func (w *WorkloadManager) manageFileActivity(ctx context.Context) {
 		batchSize = 1
 	}
 
+	var nodeNames []string
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -59,8 +62,23 @@ func (w *WorkloadManager) manageFileActivity(ctx context.Context) {
 			continue
 		}
 
+		if len(nodeNames) == 0 {
+			nodeResp, err := w.fakeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+			if err != nil {
+				log.Errorf("error listing nodes for file activity: %v", err)
+				continue
+			}
+			for _, node := range nodeResp.Items {
+				nodeNames = append(nodeNames, node.Name)
+			}
+			if len(nodeNames) == 0 {
+				continue
+			}
+		}
+
 		for range batchSize {
-			activity := w.generateFileActivity(paths)
+			hostname := nodeNames[rand.Intn(len(nodeNames))]
+			activity := w.generateFileActivity(paths, hostname)
 			if activity == nil {
 				continue
 			}
@@ -73,7 +91,7 @@ func (w *WorkloadManager) manageFileActivity(ctx context.Context) {
 	}
 }
 
-func (w *WorkloadManager) generateFileActivity(paths []string) *sensorAPI.FileActivity {
+func (w *WorkloadManager) generateFileActivity(paths []string, hostname string) *sensorAPI.FileActivity {
 	containerID, ok := w.containerPool.randomElem()
 	if !ok {
 		return nil
@@ -101,7 +119,7 @@ func (w *WorkloadManager) generateFileActivity(paths []string) *sensorAPI.FileAc
 	activity := &sensorAPI.FileActivity{
 		Timestamp: now,
 		Process:   process,
-		Hostname:  "fake-workload",
+		Hostname:  hostname,
 	}
 
 	switch rand.Intn(6) {

--- a/sensor/kubernetes/fake/fileactivity.go
+++ b/sensor/kubernetes/fake/fileactivity.go
@@ -1,0 +1,160 @@
+package fake
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	sensorAPI "github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/pkg/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var fileActivityDirs = []string{
+	"/etc/security",
+	"/etc/pam.d",
+	"/etc/ssh",
+	"/var/log",
+	"/var/run",
+	"/tmp",
+	"/etc/kubernetes",
+	"/etc/cni",
+	"/etc/sysconfig",
+	"/etc/audit",
+}
+
+func (w *WorkloadManager) manageFileActivity(ctx context.Context) {
+	defer w.wg.Done()
+	if w.workload.FileActivityWorkload.ActivityInterval == 0 {
+		return
+	}
+
+	ticker := time.NewTicker(w.workload.FileActivityWorkload.ActivityInterval)
+	defer ticker.Stop()
+
+	numPaths := w.workload.FileActivityWorkload.NumPaths
+	if numPaths == 0 {
+		numPaths = 50
+	}
+	paths := generateFileActivityPaths(numPaths)
+
+	batchSize := w.workload.FileActivityWorkload.BatchSize
+	if batchSize == 0 {
+		batchSize = 1
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		if !w.servicesInitialized.IsDone() {
+			continue
+		}
+
+		if w.fileActivityChan == nil {
+			continue
+		}
+
+		for range batchSize {
+			activity := w.generateFileActivity(paths)
+			if activity == nil {
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case w.fileActivityChan <- activity:
+			}
+		}
+	}
+}
+
+func (w *WorkloadManager) generateFileActivity(paths []string) *sensorAPI.FileActivity {
+	containerID, ok := w.containerPool.randomElem()
+	if !ok {
+		return nil
+	}
+
+	path := paths[rand.Intn(len(paths))]
+	now := timestamppb.Now()
+
+	process := &sensorAPI.ProcessSignal{
+		Id:           uuid.NewV4().String(),
+		ContainerId:  containerID,
+		Name:         "test-process",
+		Args:         "--flag value",
+		ExecFilePath: "/usr/bin/test-process",
+		Pid:          uint32(rand.Intn(65535) + 1),
+		Uid:          1000,
+		Gid:          1000,
+	}
+
+	base := &sensorAPI.FileActivityBase{
+		Path:     path,
+		HostPath: "/host" + path,
+	}
+
+	activity := &sensorAPI.FileActivity{
+		Timestamp: now,
+		Process:   process,
+		Hostname:  "fake-workload",
+	}
+
+	switch rand.Intn(6) {
+	case 0:
+		activity.File = &sensorAPI.FileActivity_Open{
+			Open: &sensorAPI.FileOpen{Activity: base},
+		}
+	case 1:
+		activity.File = &sensorAPI.FileActivity_Creation{
+			Creation: &sensorAPI.FileCreation{Activity: base},
+		}
+	case 2:
+		activity.File = &sensorAPI.FileActivity_Unlink{
+			Unlink: &sensorAPI.FileUnlink{Activity: base},
+		}
+	case 3:
+		newPath := paths[rand.Intn(len(paths))]
+		activity.File = &sensorAPI.FileActivity_Rename{
+			Rename: &sensorAPI.FileRename{
+				Old: base,
+				New: &sensorAPI.FileActivityBase{
+					Path:     newPath,
+					HostPath: "/host" + newPath,
+				},
+			},
+		}
+	case 4:
+		activity.File = &sensorAPI.FileActivity_Permission{
+			Permission: &sensorAPI.FilePermissionChange{
+				Activity: base,
+				Mode:     0644,
+			},
+		}
+	case 5:
+		activity.File = &sensorAPI.FileActivity_Ownership{
+			Ownership: &sensorAPI.FileOwnershipChange{
+				Activity: base,
+				Uid:      1000,
+				Gid:      1000,
+				Username: "testuser",
+				Group:    "testgroup",
+			},
+		}
+	}
+
+	return activity
+}
+
+func generateFileActivityPaths(n int) []string {
+	paths := make([]string, 0, n)
+	for i := range n {
+		dir := fileActivityDirs[i%len(fileActivityDirs)]
+		paths = append(paths, fmt.Sprintf("%s/file-%04d.conf", dir, i))
+	}
+	return paths
+}

--- a/sensor/kubernetes/fake/workload.go
+++ b/sensor/kubernetes/fake/workload.go
@@ -121,6 +121,10 @@ type FileActivityWorkload struct {
 	ActivityInterval time.Duration `yaml:"activityInterval"`
 	BatchSize        int           `yaml:"batchSize"`
 	NumPaths         int           `yaml:"numPaths"`
+	// NodeEventPercent is the percentage of events generated as node-level (0-100).
+	// The remainder are deployment-level events with a container ID.
+	// Default: 50
+	NodeEventPercent int `yaml:"nodeEventPercent"`
 }
 
 // Workload is the definition of a scale workload

--- a/sensor/kubernetes/fake/workload.go
+++ b/sensor/kubernetes/fake/workload.go
@@ -116,6 +116,13 @@ type VirtualMachineWorkload struct {
 	NumPackages int `yaml:"numPackages"`
 }
 
+// FileActivityWorkload defines the rate and shape of file activity events
+type FileActivityWorkload struct {
+	ActivityInterval time.Duration `yaml:"activityInterval"`
+	BatchSize        int           `yaml:"batchSize"`
+	NumPaths         int           `yaml:"numPaths"`
+}
+
 // Workload is the definition of a scale workload
 type Workload struct {
 	DeploymentWorkload     []DeploymentWorkload    `yaml:"deploymentWorkload"`
@@ -126,6 +133,7 @@ type Workload struct {
 	ServiceWorkload        ServiceWorkload         `yaml:"serviceWorkload"`
 	SecretWorkload         SecretWorkload          `yaml:"secretWorkload"`
 	VirtualMachineWorkload VirtualMachineWorkload  `yaml:"virtualMachineWorkload"`
+	FileActivityWorkload   FileActivityWorkload    `yaml:"fileActivityWorkload"`
 	NumNamespaces          int                     `yaml:"numNamespaces"`
 	MatchLabels            bool                    `yaml:"matchLabels"`
 }

--- a/sensor/kubernetes/sensor/options.go
+++ b/sensor/kubernetes/sensor/options.go
@@ -16,22 +16,23 @@ import (
 // CreateOptions represents the custom configuration that can be provided when creating sensor
 // using CreateSensor.
 type CreateOptions struct {
-	clusterIDHandler                   clusterIDHandler
-	workloadManager                    *fake.WorkloadManager
-	centralConnFactory                 centralclient.CentralConnectionFactory
-	certLoader                         centralclient.CertLoader
-	localSensor                        bool
-	k8sClient                          client.Interface
-	introspectionK8sClient             client.Interface
-	traceWriter                        io.Writer
-	eventPipelineQueueSize             int
-	networkFlowServiceAuthFuncOverride func(context.Context, string) (context.Context, error)
-	signalServiceAuthFuncOverride      func(context.Context, string) (context.Context, error)
-	networkFlowWriter                  io.Writer
-	processIndicatorWriter             io.Writer
-	networkFlowTicker                  <-chan time.Time
-	deploymentIdentification           *storage.SensorDeploymentIdentification
-	processPipelineObserver            func(ProcessPipelineHandle)
+	clusterIDHandler                    clusterIDHandler
+	workloadManager                     *fake.WorkloadManager
+	centralConnFactory                  centralclient.CentralConnectionFactory
+	certLoader                          centralclient.CertLoader
+	localSensor                         bool
+	k8sClient                           client.Interface
+	introspectionK8sClient              client.Interface
+	traceWriter                         io.Writer
+	eventPipelineQueueSize              int
+	networkFlowServiceAuthFuncOverride  func(context.Context, string) (context.Context, error)
+	signalServiceAuthFuncOverride       func(context.Context, string) (context.Context, error)
+	fileActivityServiceAuthFuncOverride func(context.Context, string) (context.Context, error)
+	networkFlowWriter                   io.Writer
+	processIndicatorWriter              io.Writer
+	networkFlowTicker                   <-chan time.Time
+	deploymentIdentification            *storage.SensorDeploymentIdentification
+	processPipelineObserver             func(ProcessPipelineHandle)
 }
 
 // ProcessPipelineHandle exposes the subset of process pipeline functionality external callers need.
@@ -144,6 +145,13 @@ func (cfg *CreateOptions) WithNetworkFlowServiceAuthFuncOverride(fn func(context
 // Default: nil
 func (cfg *CreateOptions) WithSignalServiceAuthFuncOverride(fn func(context.Context, string) (context.Context, error)) *CreateOptions {
 	cfg.signalServiceAuthFuncOverride = fn
+	return cfg
+}
+
+// WithFileActivityServiceAuthFuncOverride sets the AuthFuncOverride for the FileActivity service.
+// Default: nil
+func (cfg *CreateOptions) WithFileActivityServiceAuthFuncOverride(fn func(context.Context, string) (context.Context, error)) *CreateOptions {
+	cfg.fileActivityServiceAuthFuncOverride = fn
 	return cfg
 }
 

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -289,8 +289,16 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	if features.SensitiveFileActivity.Enabled() {
 		activityChan := make(chan *sensorInternal.FileActivity)
 		fileSystemPipeline := filesystemPipeline.NewFileSystemPipeline(policyDetector, storeProvider.Entities(), activityChan)
-		fileSystemService := filesystemService.NewService(fileSystemPipeline, activityChan)
+		var fsOpts []filesystemService.Option
+		if cfg.fileActivityServiceAuthFuncOverride != nil && cfg.localSensor {
+			fsOpts = append(fsOpts, filesystemService.WithAuthFuncOverride(cfg.fileActivityServiceAuthFuncOverride))
+		}
+		fileSystemService := filesystemService.NewService(fileSystemPipeline, activityChan, fsOpts...)
 		apiServices = append(apiServices, fileSystemService)
+
+		if cfg.workloadManager != nil {
+			cfg.workloadManager.SetFileActivityChannel(activityChan)
+		}
 	}
 
 	if features.VirtualMachines.Enabled() {

--- a/sensor/tests/data/policies.json
+++ b/sensor/tests/data/policies.json
@@ -1,84 +1,6024 @@
-{"policies":[
-{"id":"014a03c6-9053-49b5-88ea-c1efcf19804f","name":"Required Annotation: Email","description":"Alert on deployments missing the 'email' annotation","rationale":"The 'email' annotation should always be specified so that issues with the deployment can quickly be routed to the proper party.","remediation":"Redeploy your service and set the 'email' annotation as your email or your team's email.","disabled":false,"categories":["DevOps Best Practices","Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.579174303Z","SORTName":"Required Annotation: Email","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Required Annotation","booleanOperator":"OR","negate":false,"values":[{"value":"email=[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"0501ac8b-5869-4e1e-b360-84dbf01f2c6c","name":"Shell Spawned by Java Application","description":"Detects execution of shell (bash/csh/sh/zsh) as a subprocess of a java application","rationale":"Java application launching a shell can be an indicator of remote code execution","remediation":"Determine whether this is intended behavior of the application or an indication of malicious activity","disabled":false,"categories":["System Modification"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Shell Spawned by Java Application","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"(/[s]*bin/){0,1}(ba|c|z){0,1}sh"}]},{"fieldName":"Process Ancestor","booleanOperator":"OR","negate":false,"values":[{"value":".*java"}]}]}],"mitreAttackVectors":[{"tactic":"TA0002","techniques":["T1059.004"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"08a06f5c-eed0-4fb8-a09e-16cc975e7beb","name":"Docker CIS 4.4: Ensure images are scanned and rebuilt to include security patches","description":"Images should be scanned frequently for any vulnerabilities. You should rebuild all images to include these patches and then instantiate new containers from them.","rationale":"Vulnerabilities are loopholes or bugs that can be exploited by hackers or malicious users, and security patches are updates to resolve these vulnerabilities. Image vulnerability scanning tools can be use to find vulnerabilities in images and then check for available patches to mitigate these. Patches update the system to a more recent code base which does not contain these problems, and being on a supported version of the code base is very important, as vendors do not tend to supply patches for older versions which have gone out of support. Security patches should be evaluated before applying and patching should be implemented in line with the organization's IT Security Policy. Care should be taken with the results returned by vulnerability assessment tools, as some will simply return results based on software banners, and these may not be entirely accurate.","remediation":"Images should be re-built ensuring that the latest version of the base images are used, to keep the operating system patch level at an appropriate level. Once the images have been re-built, containers should be re-started making use of the updated images.","disabled":false,"categories":["Docker CIS"],"lifecycleStages":["BUILD"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.580931106Z","SORTName":"Docker CIS 4.4: Ensure images are scanned and rebuilt to include security patches","SORTLifecycleStage":"BUILD","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Fixed By","booleanOperator":"OR","negate":false,"values":[{"value":".*"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"0a2ee697-cb88-4e13-8e62-c6a2a887e0cc","name":"chkconfig Execution","description":"Detected usage of the chkconfig service manager; typically this is not used within a container","rationale":"chkconfig can be used to activate and deactivate services, and should generally not be run within a container","remediation":"Consider removing the chkconfig utility, or using a base container image that doesn't have this utility in it","disabled":false,"categories":["System Modification"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"chkconfig Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"chkconfig"}]}]}],"mitreAttackVectors":[{"tactic":"TA0003","techniques":["T1543.002"]},{"tactic":"TA0004","techniques":["T1543.002"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"0ac267ae-9128-42c7-b15e-0e926844aa2f","name":"Kubernetes Dashboard Deployed","description":"Alert on the presence of the Kubernetes dashboard service","rationale":"The Kubernetes dashboard can be used to gain external access to a cluster, or to obtain additional access once inside.","remediation":"Modify your cluster configuration to disable the Kubernetes dashboard service if it is not in use. In Google Kubernetes Engine (GKE), you can execute: gcloud container clusters update --update-addons=KubernetesDashboard=DISABLED [cluster-name]","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Kubernetes Dashboard Deployed","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Image Remote","booleanOperator":"OR","negate":false,"values":[{"value":"r/.*kubernetesui/dashboard.*"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"101952d3-ec69-4ebe-bfa3-ff26b6e4c29d","name":"Compiler Tool Execution","description":"Alert when binaries used to compile software are executed at runtime","rationale":"Use of compilation tools during runtime indicates that new software may be being introduced into containers while they are running.","remediation":"Compile all necessary application code during the image build process. Avoid packaging software build tools in container images. Use your distribution's package manager to remove compilers and other build tools from images.","disabled":false,"categories":["Package Management"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Compiler Tool Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"make|gcc|llc|llvm-.*"}]}]}],"mitreAttackVectors":[{"tactic":"TA0008","techniques":["T1570"]},{"tactic":"TA0011","techniques":["T1105"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"1037940a-fc22-4f64-8784-b8f5bd1cc93f","name":"Shell Management","description":"Commands that are used to add/remove a shell","rationale":"Shell management is not usually done at runtime","remediation":"Ensure that the base image used to create the Dockerfile doesn't have shell binaries packaged with it.","disabled":false,"categories":["System Modification"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.579516883Z","SORTName":"Shell Management","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"add-shell|remove-shell"}]}]}],"mitreAttackVectors":[{"tactic":"TA0002","techniques":["T1059.004"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"13b4eddc-2619-4953-b1ee-4c762144ca1e","name":"Images with no scans","description":"Alert on deployments with images that have not been scanned","rationale":"Without a scan, there will be no vulnerability information for this image","remediation":"Configure the appropriate registry and scanner integrations so that StackRox can obtain scans for your images.","disabled":false,"categories":["Vulnerability Management"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.578512937Z","SORTName":"Images with no scans","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Unscanned Image","booleanOperator":"OR","negate":false,"values":[{"value":"true"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"18cbcb62-7d18-4a6c-b2ca-dd1242746943","name":"OpenShift: Kubeadmin Secret Accessed","description":"Alert when the kubeadmin secret is accessed","rationale":"Kubeadmin is the default administrative user for OpenShift and can be used to obtain full administrative access to the cluster. Investigating if this was accessed for valid business purposes can help organizations to control the use of administrative privileges","remediation":"Audit the access carefully to ensure that this secret is only accessed for valid business purposes.","disabled":false,"categories":["Anomalous Activity","Kubernetes Events"],"lifecycleStages":["RUNTIME"],"eventSource":"AUDIT_LOG_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"OpenShift: Kubeadmin Secret Accessed","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Kubernetes Resource","booleanOperator":"OR","negate":false,"values":[{"value":"SECRETS"}]},{"fieldName":"Kubernetes API Verb","booleanOperator":"OR","negate":false,"values":[{"value":"GET"}]},{"fieldName":"Kubernetes Resource Name","booleanOperator":"OR","negate":false,"values":[{"value":"kubeadmin"}]},{"fieldName":"Kubernetes User Name","booleanOperator":"OR","negate":true,"values":[{"value":"system:serviceaccount:openshift-authentication-operator:authentication-operator"},{"value":"system:apiserver"},{"value":"system:serviceaccount:openshift-authentication:oauth-openshift"},{"value":"system:serviceaccount:openshift-compliance:api-resource-collector"},{"value":"system:serviceaccount:openshift-oauth-apiserver:oauth-apiserver-sa"}]}]}],"mitreAttackVectors":[{"tactic":"TA0006","techniques":["T1552.007"]},{"tactic":"TA0007","techniques":["T1613"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"1913283f-ce3c-4134-84ef-195c4cd687ae","name":"Curl in Image","description":"Alert on deployments with curl present","rationale":"Leaving download tools like curl in an image makes it easier for attackers to use compromised containers, since they can easily download software.","remediation":"Use your package manager's \"remove\", \"purge\" or \"erase\" command to remove curl from the image build for production containers. Ensure that any configuration files are also removed.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on StackRox collector","deployment":{"name":"collector","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null},{"name":"Don't alert on StackRox central","deployment":{"name":"central","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null},{"name":"Don't alert on StackRox sensor","deployment":{"name":"sensor","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null},{"name":"Don't alert on StackRox admission controller","deployment":{"name":"admission-control","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.576094767Z","SORTName":"Curl in Image","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Image Component","booleanOperator":"OR","negate":false,"values":[{"value":"curl="}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"1a498d97-0cc2-45f5-b32e-1f3cca6a3113","name":"Required Annotation: Owner/Team","description":"Alert on deployments missing the 'owner' or 'team' annotation","rationale":"The 'owner' or 'team' annotation should always be specified so that the deployment can quickly be associated with a specific user or team.","remediation":"Redeploy your service and set the 'owner' or 'team' annotation to yourself or your team respectively per organizational standards.","disabled":false,"categories":["DevOps Best Practices","Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.579356199Z","SORTName":"Required Annotation: Owner/Team","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Required Annotation","booleanOperator":"OR","negate":false,"values":[{"value":"owner|team=.+"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"1b74ffdd-8e67-444c-9814-1c23863c8ccb","name":"Unauthorized Network Flow","description":"This policy generates a violation for the network flows that fall outside baselines for which 'alert on anomalous violations' is set.","rationale":"The network baseline is a list of flows that are allowed, and once it is frozen, any flow outside that is a concern.","remediation":"Evaluate this network flow. If deemed to be okay, add it to the baseline. If not, investigate further as required.","disabled":false,"categories":["Anomalous Activity"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Unauthorized Network Flow","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"Unauthorized Network Flow","policyGroups":[{"fieldName":"Unexpected Network Flow Detected","booleanOperator":"OR","negate":false,"values":[{"value":"true"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"1c224010-9e0b-41a8-be9a-a17c7040ce98","name":"Password Binaries","description":"Processes that indicate attempts to change passwd","rationale":"Attempts to change password during runtime in containers is unusual","remediation":"Ensure that the base image used to create the Dockerfile doesn't have passwd binaries packaged with it.","disabled":false,"categories":["System Modification"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.578640695Z","SORTName":"Password Binaries","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"shadowconfig|grpck|pwunconv|grpconv|pwck|groupmod|vipw|pwconv|useradd|newusers|cppw|chpasswd|usermod|groupadd|groupdel|grpunconv|chgpasswd|userdel|chage|chsh|gpasswd|chfn|expiry|passwd|vigr|cpgr"}]}]}],"mitreAttackVectors":[{"tactic":"TA0003","techniques":["T1098"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"1c4e2cab-ce24-4e2a-9a66-f61028e79931","name":"Login Binaries","description":"Processes that indicate login attempts","rationale":"Login processes at runtime are unusual in a container","remediation":"Ensure that the base image used to create the Dockerfile doesn't have login binaries packaged with it.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.577835960Z","SORTName":"Login Binaries","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"login|systemd|systemd|systemd-logind|gosu|su|nologin|faillog|lastlog|newgrp|sg"}]}]}],"mitreAttackVectors":[{"tactic":"TA0004","techniques":["T1548"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"22006cb7-f015-4a0e-b4cc-3ffe150bcbe9","name":"test-service","description":"","rationale":"","remediation":"","disabled":false,"categories":["DevOps Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T08:04:36.919637131Z","SORTName":"test-service","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"Policy Section 1","policyGroups":[{"fieldName":"Exposed Node Port","booleanOperator":"OR","negate":false,"values":[{"value":"30007"}]}]}],"mitreAttackVectors":[],"criteriaLocked":false,"mitreVectorsLocked":false,"isDefault":false},
-{"id":"2361bb4c-4cf6-4997-bae6-825da6cf932e","name":"Network Management Execution","description":"Detects execution of binaries that can be used to manipulate network configuration and management.","rationale":"Network management tools can be used for a variety of tasks, including mapping out your network, overwriting iptables rules, or ssh tunneling to name a few.","remediation":"Remove unncessary network managment tools from the container image.","disabled":false,"categories":["Network Tools"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift namespaces","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-.*","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Network Management Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"ip|ifrename|ethtool|ifconfig|arp|ipmaddr|iptunnel|route|nameif|mii-tool"}]}]}],"mitreAttackVectors":[{"tactic":"TA0007","techniques":["T1016"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"251136ca-c92c-4474-a2c7-4949c71b745f","name":"Process Targeting Kubernetes Service Endpoint","description":"Detects misuse of the Kubernetes Service API endpoint","rationale":"A pod communicating to a Kubernetes API from via command line is highly irregular","remediation":"Look for open ports that may allow remote execution. Remove network utilities like curl and wget that allow these connections. Consider a firewall deny ingress firewall rule to the node serving the API","disabled":false,"categories":["Kubernetes"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Process Targeting Kubernetes Service Endpoint","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Arguments","booleanOperator":"OR","negate":false,"values":[{"value":"https://(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|\\$.?KUBERNETES_(PORT_443_TCP_ADDR|SERVICE_HOST).?)(:443)?/apis?/(v1(beta.)?/)?(.*\\.k8s\\.io|clusterrole.*|role.*|networkpolicies|cronjobs|certificate.*|podsecurity.*|secrets.*)"}]}]}],"mitreAttackVectors":[{"tactic":"TA0007","techniques":["T1613"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"28f833df-eb14-4265-a4fe-4e5e8ce9d959","name":"crontab Execution","description":"Detects the usage of the crontab scheduled jobs editor","rationale":"Crontab running in a container with access to a shell makes it easier to 'clandestinely' schedule processes to run in order to better evade detection","remediation":"In Kubernetes, consider replacing your crontab with an orchestrator-native CronJob as part of Kube workload","disabled":false,"categories":["System Modification"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"crontab Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"anacron|cron|crond|crontab"}]}]}],"mitreAttackVectors":[{"tactic":"TA0003","techniques":["T1053.003"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"2db9a279-2aec-4618-a85d-7f1bdf4911b1","name":"90-Day Image Age","description":"Alert on deployments with images that haven't been updated in 90 days","rationale":"Base images are updated frequently with bug fixes and vulnerability patches. Image age exceeding 90 days may indicate a higher risk of vulnerabilities existing in the image.","remediation":"Rebuild your image, push a new minor version (with a new immutable tag), and update your service to use it.","disabled":false,"categories":["DevOps Best Practices","Security Best Practices"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"90-Day Image Age","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Image Age","booleanOperator":"OR","negate":false,"values":[{"value":"90"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"2e90874a-3521-44de-85c6-5720f519a701","name":"Latest tag","description":"Alert on deployments with images using tag 'latest'","rationale":"Using latest tag can result in running heterogeneous versions of code. Many Docker hosts cache the Docker images, which means newer versions of the latest tag will not be picked up. See https://docs.docker.com/develop/dev-best-practices for more best practices.","remediation":"Consider moving to semantic versioning based on code releases (semver.org) or using the first 12 characters of the source control SHA. This will allow you to tie the Docker image to the code.","disabled":false,"categories":["DevOps Best Practices"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Latest tag","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Image Tag","booleanOperator":"OR","negate":false,"values":[{"value":"latest"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"30e8cb50-d93f-42a1-b022-ec7de7ab7b65","name":"CAP_SYS_ADMIN capability added","description":"Alert on deployments with containers escalating with CAP_SYS_ADMIN","rationale":"CAP_SYS_ADMIN grants an elevated level of privilege to a container that may not be necessary. https://lwn.net/Articles/486306/ explains what CAP_SYS_ADMIN does and points to possible alternatives.","remediation":"Ensure that the container really needs the CAP_SYS_ADMIN capability or use a userspace derivative.","disabled":false,"categories":["Privileges"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"CAP_SYS_ADMIN capability added","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Add Capabilities","booleanOperator":"OR","negate":false,"values":[{"value":"SYS_ADMIN"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"32081d8e-84cd-4d67-b016-fe481c55b93a","name":"Linux User Add Execution","description":"Detects when the 'useradd' or 'adduser' binary is executed, which can be used to add a new linux user.","rationale":"Users or groups added in run time can be used to take ownership of files and processes.","remediation":"Consider using a base image that doesn't have a shell such as SCRATCH or gcr.io/distroless. If not, modify your Dockerfile to use the exec form of CMD/ENTRYPOINT ([\"using braces\"]) instead of the shell form (no braces)","disabled":false,"categories":["System Modification","Privileges"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Linux User Add Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"useradd|adduser|usermod"}]}]}],"mitreAttackVectors":[{"tactic":"TA0003","techniques":["T1098","T1136"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"32d770b9-c6ba-4398-b48a-0c3e807644ed","name":"Docker CIS 5.19: Ensure mount propagation mode is not enabled","description":"Mount propagation mode allows mounting container volumes in Bidirectional, Host to Container, and None modes. Do not use Bidirectional mount propagation mode unless explicitly needed.","rationale":"A Bidirectional mount is replicated at all mounts and changes made at any mount point are propagated to all other mount points. Mounting a volume in Bidirectional mode does not restrict any other container from mounting and making changes to that volume. As this is likely not a desirable option from a security standpoint, this feature should not be used unless explicitly required","remediation":"Do not mount volumes in Bidirectional propagation mode.","disabled":false,"categories":["Docker CIS"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on openshift-cluster-csi-drivers namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-csi-drivers","label":null}},"image":null,"expiration":null},{"name":"Don't alert on a pdcsi-node deployment","deployment":{"name":"pdcsi-node","scope":null},"image":null,"expiration":null}],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2021-01-19T22:26:36.455422100Z","SORTName":"Docker CIS 5.19: Ensure mount propagation mode is not enabled","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"Section 1","policyGroups":[{"fieldName":"Mount Propagation","booleanOperator":"OR","negate":false,"values":[{"value":"BIDIRECTIONAL"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"38bf79e7-48bf-4ab1-b72f-38e8ad8b4ec3","name":"Deployments should have at least one ingress Network Policy","description":"Alerts if deployments are missing an ingress Network Policy","rationale":"","remediation":"","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-apiserver namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-apiserver","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-scheduler namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-scheduler","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-controller-manager namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-controller-manager","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-sdn namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-sdn","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-network-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-network-operator","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-multus namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-multus","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-cluster-version namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-version","label":null}},"image":null,"expiration":null},{"name":"Don't alert on node-ca DaemonSet in the openshift-image-registry namespace","deployment":{"name":"node-ca","scope":{"cluster":"","namespace":"openshift-image-registry","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-etcd namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-etcd","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-machine-config-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-machine-config-operator","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-monitoring namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-monitoring","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-machine-api namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-machine-api","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-cluster-node-tuning-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-node-tuning-operator","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.578090548Z","SORTName":"Deployments should have at least one ingress Network Policy","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"Alert on missing ingres Network Policy","policyGroups":[{"fieldName":"Has Ingress Network Policy","booleanOperator":"OR","negate":false,"values":[{"value":"false"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"3a98be1e-d427-41ba-ad60-994e848a5554","name":"Emergency Deployment Annotation","description":"Alert on deployments that use the emergency annotation (e.g. \"admission.stackrox.io/break-glass\": \"ticket-1234\") to circumvent StackRox Admission Controller checks","rationale":"Ideally, all deployments should be validated before they are launched into the cluster; however, in case of emergency, annotations in the form of { \"admission.stackrox.io/break-glass\": \"ticket-1234\"} can be used to avoid those checks.","remediation":"Redeploy your service and unset the emergency annotation.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Emergency Deployment Annotation","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Disallowed Annotation","booleanOperator":"OR","negate":false,"values":[{"value":"admission.stackrox.io/break-glass="}]}]}],"mitreAttackVectors":[{"tactic":"TA0005","techniques":["T1610"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"3bf3cec3-d3e8-4512-86ca-b306697d4b75","name":"Secure Shell (ssh) Port Exposed","description":"Alert on deployments exposing port 22, commonly reserved for SSH access.","rationale":"Port 22 is reserved for SSH access. SSH should not typically be used within containers.","remediation":"Ensure that non-SSH services are not using port 22. Ensure that any actual SSH servers have been vetted.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Secure Shell (ssh) Port Exposed","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Exposed Port","booleanOperator":"OR","negate":false,"values":[{"value":"22"}]},{"fieldName":"Exposed Port Protocol","booleanOperator":"OR","negate":false,"values":[{"value":"tcp"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"3e546913-de60-445c-a6d5-e70ac4ed4e98","name":"Remote File Copy Binary Execution","description":"Alert on deployments that execute a remote file copy tool","rationale":"Remote copy tools can be used to exfiltrate data from a container","remediation":"Remove tools like scp, sshfs, ssh-copy-id, etc. from your image and redeploy it","disabled":false,"categories":["Network Tools"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Remote File Copy Binary Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"scp|sshfs|ssh-copy-id|rsync"}]}]}],"mitreAttackVectors":[{"tactic":"TA0008","techniques":["T1570"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"3ebdc07d-7c01-4508-9f81-3f3673fce536","name":"Process Targeting Cluster Kubernetes Docker Stats Endpoint","description":"Detects misuse of the Kubernetes docker stats endpoint","rationale":"A pod communicating to a Kubernetes API from via command line is highly irregular","remediation":"Look for open ports that may allow remote execution. Remove network utilities like curl and wget that allow these connections. Consider a firewall deny ingress firewall rule to the node serving the API","disabled":false,"categories":["Kubernetes"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Process Targeting Cluster Kubernetes Docker Stats Endpoint","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Arguments","booleanOperator":"OR","negate":false,"values":[{"value":"(http?://)?\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\:4194/*"}]}]}],"mitreAttackVectors":[{"tactic":"TA0007","techniques":["T1613"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"41e5153f-98d1-4830-9f80-983afcbe73c1","name":"Docker CIS 5.21: Ensure the default seccomp profile is not disabled","description":"Seccomp filtering provides a means to filter incoming system calls. The default seccomp profile uses an allow list to permit a large number of common system calls, and block all others.","rationale":"A large number of system calls are exposed to every userland process with many of them going unused for the entire lifetime of the process. Most of applications do not need all these system calls and would therefore benefit from having a reduced set of available system calls. Having a reduced set of system calls reduces the total kernel surface exposed to the application and thus improvises application security.","remediation":"By default, seccomp profiles are enabled. You do not need to do anything unless you want to modify and use a modified seccomp profile.","disabled":false,"categories":["Docker CIS"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.575159823Z","SORTName":"Docker CIS 5.21: Ensure the default seccomp profile is not disabled","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"Section 1","policyGroups":[{"fieldName":"Seccomp Profile Type","booleanOperator":"OR","negate":false,"values":[{"value":"UNCONFINED"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"436811e7-892f-4da6-a0f5-8cc459f1b954","name":"Docker CIS 5.15: Ensure that the host's process namespace is not shared","description":"The Process ID (PID) namespace isolates the process ID space, meaning that processes in different PID namespaces can have the same PID. This creates process level isolation between the containers and the host.","rationale":"PID namespace provides separation between processes. It prevents system processes from being visible, and allows process ids to be reused including PID 1. If the host's PID namespace is shared with containers, it would basically allow these to see all of the processes on the host system. This reduces the benefit of process level isolation between the host and the containers. Under these circumstances a malicious user who has access to a container could get access to processes on the host itself, manipulate them, and even be able to kill them. This could allow for the host itself being shut down, which could be extremely serious, particularly in a multi-tenanted environment. You should not share the host's process namespace with the containers running on it.","remediation":"You should not create a deployment with `hostPID: true`","disabled":false,"categories":["Docker CIS"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on the openshift-sdn namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-sdn","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Docker CIS 5.15: Ensure that the host's process namespace is not shared","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"Section 1","policyGroups":[{"fieldName":"Host PID","booleanOperator":"OR","negate":false,"values":[{"value":"true"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"47cb9e0a-879a-417b-9a8f-de644d7c8a77","name":"Docker CIS 5.16: Ensure that the host's IPC namespace is not shared","description":"IPC (POSIX/SysV IPC) namespace provides separation of named shared memory segments, semaphores and message queues. The IPC namespace on the host should therefore not be shared with containers and should remain isolated.","rationale":"The IPC namespace provides separation of IPC between the host and containers. If the host's IPC namespace is shared with the container, it would allow processes within the container to see all of IPC communications on the host system. This would remove the benefit of IPC level isolation between host and containers. An attacker with access to a container could get access to the host at this level with major consequences. The IPC namespace should therefore not be shared between the host and its containers.","remediation":"You should not create a deployment with `hostIPC: true`","disabled":false,"categories":["Docker CIS"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Docker CIS 5.16: Ensure that the host's IPC namespace is not shared","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"Section 1","policyGroups":[{"fieldName":"Host IPC","booleanOperator":"OR","negate":false,"values":[{"value":"true"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"550081a1-ad3a-4eab-a874-8eb68fab2bbd","name":"Required Label: Owner/Team","description":"Alert on deployments missing the 'owner' or 'team' label","rationale":"The 'owner' or 'team' label should always be specified so that the deployment can quickly be associated with a specific user or team.","remediation":"Redeploy your service and set the 'owner' or 'team' label to yourself or your team respectively per organizational standards.","disabled":false,"categories":["DevOps Best Practices","Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.580107859Z","SORTName":"Required Label: Owner/Team","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Required Label","booleanOperator":"OR","negate":false,"values":[{"value":"owner|team=.+"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"618e65ca-737b-4fec-bb42-57a04e7dfc28","name":"Secure Shell Server (sshd) Execution","description":"Detects container running the SSH daemon","rationale":"The secure shell server allows shell access to a container, which can be dangerous.","remediation":"If ssh is absolutely required, ensure that it is not using default authentication. Otherwise, consider removing it from the container altogether.","disabled":false,"categories":["Network Tools","Docker CIS"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Secure Shell Server (sshd) Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"sshd"}]}]}],"mitreAttackVectors":[{"tactic":"TA0001","techniques":["T1078"]},{"tactic":"TA0002","techniques":["T1059.004"]},{"tactic":"TA0008","techniques":["T1021.004"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"6226d4ad-7619-4a0b-a160-46373cfcee66","name":"Docker CIS 5.9 and 5.20: Ensure that the host's network namespace is not shared","description":"When HostNetwork is enabled the container is not placed inside a separate network stack. The container's networking is not containerized when this option is applied. The consequence of this is that the container has full access to the host's network interfaces. It also enables a shared UTS namespace. The UTS namespace provides isolation between two system identifiers: the hostname and the NIS domain name. It is used to set the hostname and the domain which are visible to running processes in that namespace. Processes running within containers do not typically require to know either the hostname or the domain name. The UTS namespace should therefore not be shared with the host.","rationale":"Selecting this option is potentially dangerous. It allows the container process to open reserved low numbered ports in the way that any other root process can. It also allows the container to access network services such as D-bus on a Docker host. A container process could potentially carry out undesired actions, such as shutting down the host. The container will also share the network namespace with the host, providing full permission for each container to change the hostname of the host. This is not in line with good security practice and should not be permitted.","remediation":"You should not create a deployment with `hostNetwork: true`","disabled":false,"categories":["Docker CIS"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-apiserver namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-apiserver","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-scheduler namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-scheduler","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-controller-manager namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-controller-manager","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-sdn namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-sdn","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-network-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-network-operator","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-multus namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-multus","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-cluster-version namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-version","label":null}},"image":null,"expiration":null},{"name":"Don't alert on node-ca DaemonSet in the openshift-image-registry namespace","deployment":{"name":"node-ca","scope":{"cluster":"","namespace":"openshift-image-registry","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-etcd namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-etcd","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-machine-config-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-machine-config-operator","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-monitoring namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-monitoring","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-machine-api namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-machine-api","label":null}},"image":null,"expiration":null},{"name":"Don't alert on host network usage within the openshift-cluster-node-tuning-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-node-tuning-operator","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Docker CIS 5.9 and 5.20: Ensure that the host's network namespace is not shared","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"Section 1","policyGroups":[{"fieldName":"Host Network","booleanOperator":"OR","negate":false,"values":[{"value":"true"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"629f847d-72b1-4009-8891-cbe479ab10ab","name":"Secure Shell (ssh) Port Exposed in Image","description":"Alert on deployments exposing port 22, commonly reserved for SSH access.","rationale":"Port 22 is reserved for SSH access. SSH should not typically be used within containers.","remediation":"Ensure that non-SSH services are not using port 22. Ensure that any actual SSH servers have been vetted.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Secure Shell (ssh) Port Exposed in Image","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Dockerfile Line","booleanOperator":"OR","negate":false,"values":[{"value":"EXPOSE=(22/tcp|\\s+22/tcp)"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"657f4d37-55ab-42f2-bdce-9a4b74a67328","name":"Insecure specified in CMD","description":"Alert on deployments using 'insecure' in the command","rationale":"Using insecure in a command implies accessing or providing data from a server on an unencrypted connection.","remediation":"Use a certificate manager and certificate rotation routinely to ensure secure service-to-service communication.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Insecure specified in CMD","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Dockerfile Line","booleanOperator":"OR","negate":false,"values":[{"value":"CMD=.*insecure.*"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"6abcaa13-9ed6-4109-a1a7-be2e8280e49e","name":"Docker CIS 5.7: Ensure privileged ports are not mapped within containers","description":"The TCP/IP port numbers below 1024 are considered privileged ports. Normal users and processes are not allowed to use them for various security reasons. Containers are, however, allowed to map their ports to privileged ports.","rationale":"By default, if the user does not specifically declare a container port to host port mapping, the containers ports will be mapped to available non-privileged host ports. Containers are, however, allow to map their ports to a privileged ports on the host if the user explicitly declares it. In Docker this is because containers are executed with NET_BIND_SERVICE Linux kernel capability which does not restrict privileged port mapping. The privileged ports receive and transmit various pieces of data which are security sensitive and allowing containers to use them is not in line with good security practice.","remediation":"You should not map container ports to privileged host ports when starting a container. You should also, ensure that there is no such container to host privileged port mapping declarations in the Dockerfile.","disabled":false,"categories":["Docker CIS"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Docker CIS 5.7: Ensure privileged ports are not mapped within containers","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Exposed Node Port","booleanOperator":"AND","negate":false,"values":[{"value":"\u003c= 1024"},{"value":"\u003e 0"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"6abf0df8-736b-4530-8849-6a1344cf17fe","name":"Netcat Execution Detected","description":"Detects execution of netcat in a container","rationale":"netcat is a known malicious process","remediation":"Consider removing package managers during the build process that could be used to download such software. Check that exposed ports don't allow for remote code execution","disabled":false,"categories":["Network Tools"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Netcat Execution Detected","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"nc"}]}]}],"mitreAttackVectors":[{"tactic":"TA0007","techniques":["T1046"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"6e0239e1-f4ca-43d0-ad3f-79ec683db811","name":"Shadow File Modification","description":"Processes that indicate attempts to modify shadow files","rationale":"Attempts to change shadow file during runtime in containers is unusual","remediation":"Ensure that the base image used to create the Dockerfile doesn't have shadow utils packaged with it.","disabled":false,"categories":["System Modification"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.582661559Z","SORTName":"Shadow File Modification","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"chage|gpasswd|lastlog|newgrp|sg|adduser|deluser|chpasswd|groupadd|groupdel|addgroup|delgroup|groupmems|groupmod|grpck|grpconv|grpunconv|newusers|pwck|pwconv|pwunconv|useradd|userdel|usermod|vigr|vipw|unix_chkpwd"}]}]}],"mitreAttackVectors":[{"tactic":"TA0003","techniques":["T1098"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"742e0361-bddd-4a2d-8758-f2af6197f61d","name":"Kubernetes Actions: Port Forward to Pod","description":"Alerts when Kubernetes API receives port forward request","rationale":"'pods/portforward' is non-standard way to access applications running on Kubernetes. Attackers with permissions could gain access to application and compromise it","remediation":"Restrict RBAC access to the 'pods/portforward' resource according to the Principle of Least Privilege. Limit exposing application through port forwarding only development, testing or debugging (non-production) activities. For external traffic, expose application through a LoadBalancer/NodePort service or Ingress Controller","disabled":false,"categories":["Kubernetes Events"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Kubernetes Actions: Port Forward to Pod","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Kubernetes Resource","booleanOperator":"OR","negate":false,"values":[{"value":"PODS_PORTFORWARD"}]}]}],"mitreAttackVectors":[{"tactic":"TA0002","techniques":["T1609"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"7448b475-8e80-4ece-bc9b-b9845c003a6f","name":"Docker CIS 5.1 Ensure that, if applicable, an AppArmor Profile is enabled","description":"AppArmor is an effective and easy-to-use Linux application security system. It is available on some Linux distributions by default, for example, on Debian and Ubuntu.","rationale":"AppArmor protects the Linux OS and applications from various threats by enforcing a security policy which is also known as an AppArmor profile. You can create your own AppArmor profile for containers or use Docker's default profile. Enabling this feature enforces security policies on containers as defined in the profile.","remediation":"If AppArmor is applicable for your Linux OS, you should enable it.  Verify AppArmor is installed, create or import an AppArmor profile for your containers, enable enforcement of the policy, and add the appropriate AppArmor annotations to your deployment.","disabled":false,"categories":["Docker CIS"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Docker CIS 5.1 Ensure that, if applicable, an AppArmor Profile is enabled","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"Section 1","policyGroups":[{"fieldName":"AppArmor Profile","booleanOperator":"OR","negate":false,"values":[{"value":"unconfined"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"74cfb824-2e65-46b7-b1b4-ba897e53af1f","name":"Ubuntu Package Manager in Image","description":"Alert on deployments with components of the Debian/Ubuntu package management system in the image.","rationale":"Package managers make it easier for attackers to use compromised containers, since they can easily add software.","remediation":"Run `dpkg -r --force-all apt apt-get \u0026\u0026 dpkg -r --force-all debconf dpkg` in the image build for production containers.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Ubuntu Package Manager in Image","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Image Component","booleanOperator":"OR","negate":false,"values":[{"value":"apt|dpkg="}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"7760a5f3-bca4-4ca8-94a7-ad89edbc0e2c","name":"Process with UID 0","description":"Alert on deployments that contain processes running with UID 0","rationale":"Processes that are running with UID 0 run as the root user. This can allow for unintended privilege escalation if a container mounts host directories that are owned by the host's root user","remediation":"Specify the USER instruction in the Docker image or the runAsUser field within the Pod Security Context","disabled":false,"categories":["DevOps Best Practices","Security Best Practices"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on StackRox Namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.579735755Z","SORTName":"Process with UID 0","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process UID","booleanOperator":"OR","negate":false,"values":[{"value":"0"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"7b71fba0-2afb-4e4e-abf3-0f461cd76acc","name":"OpenShift: Kubernetes Secret Accessed by an Impersonated User","description":"Alert when user impersonation is used to access a secret within the cluster.","rationale":"Users with impersonation access allows users to invoke any command as a different user, typically for troubleshooting purposes (i.e using the oc --as command). This may be used to bypass existing security controls such as RBAC.","remediation":"Audit usage of impersonation when accessing secrets to ensure this access is used for valid business purposes.","disabled":false,"categories":["Anomalous Activity","Kubernetes Events"],"lifecycleStages":["RUNTIME"],"eventSource":"AUDIT_LOG_EVENT","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"OpenShift: Kubernetes Secret Accessed by an Impersonated User","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Kubernetes Resource","booleanOperator":"OR","negate":false,"values":[{"value":"SECRETS"}]},{"fieldName":"Kubernetes API Verb","booleanOperator":"OR","negate":false,"values":[{"value":"GET"}]},{"fieldName":"Is Impersonated User","booleanOperator":"OR","negate":false,"values":[{"value":"true"}]}]}],"mitreAttackVectors":[{"tactic":"TA0004","techniques":["T1134.001"]},{"tactic":"TA0006","techniques":["T1552.007"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"80267b36-2182-4fb3-8b53-e80c031f4ad8","name":"ADD Command used instead of COPY","description":"Alert on deployments using an ADD command","rationale":"ADD incorporates a broader set of capabilities than COPY, including the ability to specify URLs as the source argument and automatic unpacking of compressed files onto the local filesystem. The effects of ADD can be unpredictable and can lead to larger images. Unless ADD's additional capabilities are required, COPY is recommended.","remediation":"Replace ADD with COPY when adding new files to the image. Per https://docs.docker.com/develop/develop-images/dockerfile_best-practices, it is better to use RUN curl instead of ADD if you need to access a URL.","disabled":false,"categories":["DevOps Best Practices","Docker CIS"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.577052631Z","SORTName":"ADD Command used instead of COPY","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Dockerfile Line","booleanOperator":"OR","negate":false,"values":[{"value":"ADD=.*"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"842feb9f-ecb1-4e3c-a4bf-8a1dcb63948a","name":"Wget in Image","description":"Alert on deployments with wget present","rationale":"Leaving download tools like wget in an image makes it easier for attackers to use compromised containers, since they can easily download software.","remediation":"Use your package manager's \"remove\" command to remove wget from the image build for production containers.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.580435853Z","SORTName":"Wget in Image","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Image Component","booleanOperator":"OR","negate":false,"values":[{"value":"wget="}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"86804b96-e87e-4eae-b56e-1718a8a55763","name":"Process Targeting Cluster Kubelet Endpoint","description":"Detects misuse of the healthz/kubelet API/heapster endpoint","rationale":"A pod communicating to a Kubernetes API from via command line is highly irregular","remediation":"Look for open ports that may allow remote execution. Remove network utilities like curl and wget that allow these connections. Consider a firewall deny ingress firewall rule to the node serving the API","disabled":false,"categories":["Kubernetes"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Process Targeting Cluster Kubelet Endpoint","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Arguments","booleanOperator":"OR","negate":false,"values":[{"value":"(https?://)?(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\:(10250|10248|10255)|heapster\\.kube\\-system/metrics|KUBERNETES_PORT_443_TCP_ADDR|KUBERNETES_SERVICE_HOST).*"}]}]}],"mitreAttackVectors":[{"tactic":"TA0007","techniques":["T1613"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"880fd131-46f0-43d2-82c9-547f5aa7e043","name":"iptables Execution","description":"Detects execution of iptables; iptables is a deprecated way of managing network state in containers","rationale":"iptables is a deprecated way of managing network state in containers","remediation":"Check for any processes that may be modifying iptables rules. Check for open ports that may be allowing code injection to modify iptables rules","disabled":false,"categories":["Network Tools"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-sdn namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-sdn","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"iptables Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"iptables"}]}]}],"mitreAttackVectors":[{"tactic":"TA0005","techniques":["T1562.004"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"886c3c94-3a6a-4f2b-82fc-d6bf5a310840","name":"No resource requests or limits specified","description":"Alert on deployments that have containers without resource requests and limits","rationale":"If a container does not have resource requests or limits specified then the host may become over-provisioned.","remediation":"Specify the requests and limits of CPU and Memory for your deployment.","disabled":false,"categories":["DevOps Best Practices","Docker CIS"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on system namespaces","deployment":{"name":"","scope":{"cluster":"","namespace":"^kube.*|^openshift.*|^redhat.*|^istio-system$","label":null}},"image":null,"expiration":null},{"name":"Don't alert on management-infra namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"management-infra","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"No resource requests or limits specified","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Container CPU Limit","booleanOperator":"OR","negate":false,"values":[{"value":"0.000000"}]}]},{"sectionName":"","policyGroups":[{"fieldName":"Container CPU Request","booleanOperator":"OR","negate":false,"values":[{"value":"0.000000"}]}]},{"sectionName":"","policyGroups":[{"fieldName":"Container Memory Limit","booleanOperator":"OR","negate":false,"values":[{"value":"0.000000"}]}]},{"sectionName":"","policyGroups":[{"fieldName":"Container Memory Request","booleanOperator":"OR","negate":false,"values":[{"value":"0.000000"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"89cae2e6-0cb7-4329-8692-c2c3717c1237","name":"Unauthorized Process Execution","description":"This policy generates a violation for any process execution that is not explicitly allowed by a locked process baseline for a given container specification within a Kubernetes deployment.","rationale":"A locked process baseline communicates high confidence that execution of a process not included in the baseline positively indicates malicious activity.","remediation":"Evaluate this process execution for malicious intent, examine other accessible resources for abnormal activity, then kill the pod in which this process executed.","disabled":false,"categories":["Anomalous Activity"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Unauthorized Process Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Unexpected Process Executed","booleanOperator":"OR","negate":false,"values":[{"value":"true"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"8ab0f199-4904-4808-9461-3501da1d1b77","name":"Kubernetes Actions: Exec into Pod","description":"Alerts when Kubernetes API receives request to execute command in container","rationale":"'pods/exec' is non-standard approach for interacting with containers. Attackers with permissions could execute malicious code and compromise resources within a cluster","remediation":"Restrict RBAC access to the 'pods/exec' resource according to the Principle of Least Privilege. Limit such usage only to development, testing or debugging (non-production) activities","disabled":false,"categories":["Kubernetes Events"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Kubernetes Actions: Exec into Pod","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Kubernetes Resource","booleanOperator":"OR","negate":false,"values":[{"value":"PODS_EXEC"}]}]}],"mitreAttackVectors":[{"tactic":"TA0002","techniques":["T1609"]},{"tactic":"TA0002","techniques":["T1059.004"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"8ac93556-4ad4-4220-a275-3f518db0ceb9","name":"Container using read-write root filesystem","description":"Alert on deployments with containers with read-write root filesystem","rationale":"Containers running with read-write root filesystem represent greater post-exploitation risk by allowing an attacker to modify important files in the container.","remediation":"Use a read-only root filesystem, and use volume mounts to allow writes to specific sub-directories depending on your application's needs.","disabled":false,"categories":["Privileges","Docker CIS"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-node namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-node","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-sdn namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-sdn","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.577324391Z","SORTName":"Container using read-write root filesystem","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Read-Only Root Filesystem","booleanOperator":"OR","negate":false,"values":[{"value":"false"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"900990b5-60ef-44e5-b7f6-4a1f22215d7f","name":"Apache Struts: CVE-2017-5638","description":"Alert on deployments with images containing Apache Struts vulnerability CVE-2017-5638","rationale":"CVE-2017-5638 is a serious and easily-exploitable vulnerability in Apache Struts.","remediation":"Rebuild your container with an updated version of Apache Struts.","disabled":false,"categories":["Vulnerability Management"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"CRITICAL_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Apache Struts: CVE-2017-5638","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"CVE","booleanOperator":"OR","negate":false,"values":[{"value":"CVE-2017-5638"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"93f4b2dd-ef5a-419e-8371-38aed480fb36","name":"Fixable CVSS \u003e= 6 and Privileged","description":"Alert on deployments running in privileged mode with fixable vulnerabilities with a CVSS of at least 6","rationale":"Known vulnerabilities make it easier for adversaries to exploit your application, and highly privileged containers pose greater risk. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).","remediation":"Use your package manager to update to a fixed version in future builds, run your container with lower privileges, or speak with your security team to mitigate the vulnerabilities.","disabled":false,"categories":["Vulnerability Management","Privileges"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Fixable CVSS \u003e= 6 and Privileged","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Privileged Container","booleanOperator":"OR","negate":false,"values":[{"value":"true"}]},{"fieldName":"Fixed By","booleanOperator":"OR","negate":false,"values":[{"value":".*"}]},{"fieldName":"CVSS","booleanOperator":"OR","negate":false,"values":[{"value":"\u003e= 6.000000"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"98c8396e-3541-48b9-a30a-371c86a8f0ef","name":"SetUID Processes","description":"Processes that are known to use setuid binaries","rationale":"setuid permits users to run certain programs with escalated privileges","remediation":"Ensure that the base image used to create the Dockerfile doesn't have setuid software packaged with it.","disabled":false,"categories":["System Modification"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.581424257Z","SORTName":"SetUID Processes","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"sshd|dbus-daemon-lau|ping|ping6|critical-stack-|pmmcli|filemng|PassengerAgent|bwrap|osdetect|nginxmng|sw-engine-fpm|start-stop-daem"}]}]}],"mitreAttackVectors":[{"tactic":"TA0004","techniques":["T1548.001"]},{"tactic":"TA0005","techniques":["T1548.001"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"9a91b4de-d52e-4d4d-a65e-1e785c3501b1","name":"Docker CIS 4.7: Alert on Update Instruction","description":"Ensure update instructions are not used alone in the Dockerfile","rationale":"Adding update instructions in a single line on the Dockerfile will cause the update layer to be cached. When you then build any image later using the same instruction, this will cause the previously cached update layer to be used, potentially preventing any fresh updates from being applied to later builds.","remediation":"Use update instructions together with install instructions and version pinning for packages while installing them. This prevents caching and forces the extraction of the required versions.","disabled":false,"categories":["Docker CIS"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on StackRox services","deployment":{"name":"","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Docker CIS 4.7: Alert on Update Instruction","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Dockerfile Line","booleanOperator":"OR","negate":false,"values":[{"value":"RUN=(/bin/sh -c)?\\s*apk update\\s*"},{"value":"RUN=(/bin/sh -c)?\\s*apt update\\s*"},{"value":"RUN=(/bin/sh -c)?\\s*apt-get update\\s*"},{"value":"RUN=(/bin/sh -c)?\\s*yum update\\s*"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"a05e063b-f37f-4d36-99f3-7ff0cb2b3ba8","name":"Linux Group Add Execution","description":"Detects when the 'addgroup' or 'groupadd' binary is executed, which can be used to add a new linux group.","rationale":"Groups added in run time can be used to take ownership of files and processes","remediation":"Consider using a base image that doesn't have a shell such as SCRATCH or gcr.io/distroless. If not, modify your Dockerfile to use the exec form of CMD/ENTRYPOINT ([\"using braces\"]) instead of the shell form (no braces)","disabled":false,"categories":["System Modification","Privileges"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Linux Group Add Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"addgroup|groupadd"}]}]}],"mitreAttackVectors":[{"tactic":"TA0003","techniques":["T1098","T1136"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"a3eb6dbe-e9ca-451a-919b-216cf7ee11f5","name":"30-Day Scan Age","description":"Alert on deployments with images that haven't been scanned in 30 days","rationale":"Out-of-date scans may not identify the most recent CVEs.","remediation":"Integrate a scanner with the StackRox Kubernetes Security Platform to trigger scans automatically.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"30-Day Scan Age","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Image Scan Age","booleanOperator":"OR","negate":false,"values":[{"value":"30"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"a5248b33-5027-4aaf-a6b6-896f73fc6d28","name":"Alpine Linux Package Manager (apk) in Image","description":"Alert on deployments with the Alpine Linux package manager (apk) present","rationale":"Package managers make it easier for attackers to use compromised containers, since they can easily add software.","remediation":"Run `apk --purge del apk-tools` in the image build for production containers.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on the master-etcd deployment","deployment":{"name":"master-etcd-openshift-master-.*","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Alpine Linux Package Manager (apk) in Image","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Image Component","booleanOperator":"OR","negate":false,"values":[{"value":"apk-tools="}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"a788556c-9268-4f30-a114-d456f2380818","name":"Secret Mounted as Environment Variable","description":"Alert on deployments with Kubernetes secret mounted as environment variable","rationale":"Using secrets in environment variables may allow inspection into your secrets from the host.","remediation":"Migrate your secrets from environment variables to your security team's secret management solution.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.580910702Z","SORTName":"Secret Mounted as Environment Variable","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Environment Variable","booleanOperator":"OR","negate":false,"values":[{"value":"SECRET_KEY=="}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"a919ccaf-6b43-4160-ac5d-a405e1440a41","name":"Fixable Severity at least Important","description":"Alert on deployments with fixable vulnerabilities with a Severity Rating at least Important","rationale":"Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).","remediation":"Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.","disabled":false,"categories":["Vulnerability Management"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":["FAIL_BUILD_ENFORCEMENT"],"notifiers":[],"lastUpdated":null,"SORTName":"Fixable Severity at least Important","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":true,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Fixed By","booleanOperator":"OR","negate":false,"values":[{"value":".*"}]},{"fieldName":"Severity","booleanOperator":"OR","negate":false,"values":[{"value":"\u003e= IMPORTANT"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"a9b9ecf7-9707-4e32-8b62-d03018ed454f","name":"Mounting Sensitive Host Directories","description":"Alert on deployments mounting sensitive host directories","rationale":"Mounting system directories from host implies container access to sensitive files on the host. This expands the attack surface of the container and gives an intruder an opportunity to break containment if the host is not properly secured.","remediation":"Ensure that deployments do not mount sensitive host directories, or exclude this deployment if host mount is required.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on StackRox collector","deployment":{"name":"collector","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null},{"name":"Don't alert on StackRox compliance","deployment":{"name":"","scope":{"cluster":"","namespace":"stackrox","label":{"key":"app","value":"stackrox-compliance"}}},"image":null,"expiration":null},{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-apiserver namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-apiserver","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-scheduler namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-scheduler","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-etcd namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-etcd","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-controller-manager namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-controller-manager","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-oauth-apiserver namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-oauth-apiserver","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-apiserver namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-apiserver","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-network-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-network-operator","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-machine-api namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-machine-api","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-dns namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-dns","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-cluster-csi-drivers namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-csi-drivers","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-cluster-node-tuning-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-node-tuning-operator","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-multus namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-multus","label":null}},"image":null,"expiration":null},{"name":"Don't alert on node-ca dameonset in the openshift-image-registry namespace","deployment":{"name":"node-ca","scope":{"cluster":"","namespace":"openshift-image-registry","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-sdn namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-sdn","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-machine-config-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-machine-config-operator","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Mounting Sensitive Host Directories","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Volume Source","booleanOperator":"OR","negate":false,"values":[{"value":"(/etc/.*|/sys/.*|/dev/.*|/proc/.*|/var/.*)"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"b3335ee3-6f1e-4c3a-a0ad-7c249c25c750","name":"systemd Execution","description":"Detected usage of the systemd service manager","rationale":"The systemd service manager is generally not used in containers, and its use could indicate suspicious activity","remediation":"Remove systemd from the image before deploying, or consider using a base image that doesn't bundle systemd","disabled":false,"categories":["System Modification"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"systemd Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"systemd"}]}]}],"mitreAttackVectors":[{"tactic":"TA0003","techniques":["T1543.002"]},{"tactic":"TA0004","techniques":["T1543.002"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"ccd66f67-0b69-4081-9d01-da692f7db3b4","name":"Mount Container Runtime Socket","description":"Alert on deployments with a volume mount on the container runtime socket","rationale":"Mounting the container runtime socket implies container access to the runtime daemon. With direct access to the runtime daemon, a user can schedule containers and collect information about the running containers. This can be used as a method of discovery or persistence in an attack. Depending on the container runtime configuration, this may also be used as a method of privilege escalation to the host operating system. Since this can be used as an attack, deployments that mount the container runtime socket should be minimized to those absolutely necessary.","remediation":"Investigate if this deployment is being deployed for legitimate business purposes, and if so, that mounting the container runtime socket is required. Perform one of the following actions based on this investigation: 1. Exclude the deployment in this policy because it is being deployed for legitimate use cases. 2. Do not mount the container runtime socket in the deployment and redeploy. 3. Launch an investigation into why a deployment with this insecure configuration useful to attackers was deployed.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on StackRox collector","deployment":{"name":"collector","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null},{"name":"Don't alert on ucp-agent","deployment":{"name":"ucp-agent","scope":null},"image":null,"expiration":null},{"name":"Don't alert on ucp-agent-s390x","deployment":{"name":"ucp-agent-s390x","scope":null},"image":null,"expiration":null},{"name":"Don't alert on StackRox compliance","deployment":{"name":"","scope":{"cluster":"","namespace":"stackrox","label":{"key":"app","value":"stackrox-compliance"}}},"image":null,"expiration":null}],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Mount Container Runtime Socket","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Volume Source","booleanOperator":"OR","negate":false,"values":[{"value":"/var/run/docker.sock"},{"value":"/var/run/crio/crio.sock"},{"value":"/run/crio/crio.sock"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"cf80fb33-c7d0-4490-b6f4-e56e1f27b4e4","name":"Log4Shell: log4j Remote Code Execution vulnerability","description":"Alert on deployments with images containing the Log4Shell vulnerabilities (CVE-2021-44228 and CVE-2021-45046). There are flaws in the Java logging library Apache Log4j in versions from 2.0-beta9 to 2.15.0, excluding 2.12.2.","rationale":"These vulnerabilities allows a remote attacker to execute code on the server if the system logs an attacker-controlled string value with the attacker's JNDI LDAP server lookup.","remediation":"Update the log4j libary to version 2.16.0 (for Java 8 or later), 2.12.2 (for Java 7) or later. If not possible to upgrade, then remove the JndiLookup class from the classpath: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class","disabled":false,"categories":["Vulnerability Management"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"CRITICAL_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Log4Shell: log4j Remote Code Execution vulnerability","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"CVE","booleanOperator":"OR","negate":false,"values":[{"value":"CVE-2021-44228"},{"value":"CVE-2021-45046"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"d03e0723-ef09-44da-bf29-fdd9e576fbf9","name":"Spring4Shell (Spring Framework Remote Code Execution) and Spring Cloud Function vulnerabilities","description":"Alert on deployments with images containing Spring4Shell vulnerability CVE-2022-22965 which affects the Spring MVC component and vulnerability CVE-2022-22963 which affects the Spring Cloud component. There are flaws in Spring Cloud Function (versions 3.1.6, 3.2.2 and older unsupported versions) and in Spring Framework (5.3.0 to 5.3.17, 5.2.0 to 5.2.19 and older unsupported versions).","rationale":"In Spring Cloud Function, when using routing functionality, a user can provide a specially crafted SpEL as a routing-expression that may result in remote code execution (RCE) and access to local resources. For Spring Framework, a Spring MVC or Spring WebFlux application running on JDK 9+ may be vulnerable to RCE via data binding.","remediation":"Upgrade Spring Cloud Function to version 3.1.7 or 3.2.3. Upgrade Spring Framework to version 5.3.18+ (if currently on 5.3.x) or 5.2.20+ (if currently on 5.2.x). If not possible to upgrade Spring Framework, then apply an appropriate workaround from the suggested workarounds on https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement","disabled":false,"categories":["Vulnerability Management"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"CRITICAL_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Spring4Shell (Spring Framework Remote Code Execution) and Spring Cloud Function vulnerabilities","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"CVE","booleanOperator":"OR","negate":false,"values":[{"value":"CVE-2022-22963"},{"value":"CVE-2022-22965"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"d3e480c1-c6de-4cd2-9006-9a3eb3ad36b6","name":"Required Image Label","description":"Alert on deployments with images missing the specified label.","rationale":"Only images with the specified label should be deployed to ensure all deployments contain approved images.","remediation":"Request that the maintainer add the required label to the image.","disabled":false,"categories":["DevOps Best Practices","Security Best Practices"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.578049102Z","SORTName":"Required Image Label","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Required Image Label","booleanOperator":"OR","negate":false,"values":[{"value":"required-label.*=required-value.*"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"d63564bd-c184-40bc-9f30-39711e010b82","name":"Alpine Linux Package Manager Execution","description":"Alert when the Alpine Linux package manager (apk) is executed at runtime","rationale":"Use of package managers at runtime indicates that new software may be being introduced into containers while they are running.","remediation":"Run `apk --purge del apk-tools` in the image build for production containers. Change applications to no longer use package managers at runtime, if applicable.","disabled":false,"categories":["Package Management"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Alpine Linux Package Manager Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"apk"}]}]}],"mitreAttackVectors":[{"tactic":"TA0011","techniques":["T1105"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"d7a275e1-1bba-47e7-92a1-42340c759883","name":"Ubuntu Package Manager Execution","description":"Alert when Debian/Ubuntu package manager programs are executed at runtime","rationale":"Use of package managers at runtime indicates that new software may be being introduced into containers while they are running.","remediation":"Run `dpkg -r --force-all apt \u0026\u0026 dpkg -r --force-all debconf dpkg` in the image build for production containers. Change applications to no longer use package managers at runtime, if applicable.","disabled":false,"categories":["Package Management"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Ubuntu Package Manager Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"apt-get|apt|dpkg"}]}]}],"mitreAttackVectors":[{"tactic":"TA0011","techniques":["T1105"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"da4e0776-159b-42a3-90a9-18cdd9b485ba","name":"OpenShift: Advanced Cluster Security Central Admin Secret Accessed","description":"Alert when the RHACS Central secret is accessed.","rationale":"The Central secret can be used to login to the Central user interface as the admin user. This secret is generally salted and hashed by default in the data.htpasswd field, but may contain a base64 encoded password in the field data.password (if deployed with an Operator). This field may be safely removed. This secret should only be accessed for break glass troubleshooting and initial configuration. An update or access of this secret may indicate that it will be used to administer and configure security controls.","remediation":"Ensure that the Central admin secret was accessed for valid buiness purposes.","disabled":false,"categories":["Anomalous Activity","Kubernetes Events"],"lifecycleStages":["RUNTIME"],"eventSource":"AUDIT_LOG_EVENT","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"OpenShift: Advanced Cluster Security Central Admin Secret Accessed","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Kubernetes Resource","booleanOperator":"OR","negate":false,"values":[{"value":"SECRETS"}]},{"fieldName":"Kubernetes API Verb","booleanOperator":"OR","negate":false,"values":[{"value":"GET"},{"value":"PATCH"},{"value":"UPDATE"}]},{"fieldName":"Kubernetes Resource Name","booleanOperator":"OR","negate":false,"values":[{"value":"central-htpasswd"}]},{"fieldName":"Kubernetes User Name","booleanOperator":"OR","negate":true,"values":[{"value":"system:serviceaccount:openshift-authentication-operator:rhacs-operator-controller-manager"}]}]}],"mitreAttackVectors":[{"tactic":"TA0006","techniques":["T1552.007"]},{"tactic":"TA0007","techniques":["T1613"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"dce17697-1b72-49d2-b18a-05d893cd9368","name":"Docker CIS 4.1: Ensure That a User for the Container Has Been Created","description":"Containers should run as a non-root user","rationale":"It is good practice to run the container as a non-root user, where possible. This can be done via the USER directive in the Dockerfile.","remediation":"Ensure that the Dockerfile for each container switches from the root user","disabled":false,"categories":["Docker CIS"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on StackRox namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null},{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-sdn namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-sdn","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-apiserver namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-apiserver","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-etcd namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-etcd","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-apiserver namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-apiserver","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-dns namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-dns","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-cluster-node-tuning-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-node-tuning-operator","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-cluster-csi-drivers namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-csi-drivers","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-machine-config-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-machine-config-operator","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Docker CIS 4.1: Ensure That a User for the Container Has Been Created","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Image User","booleanOperator":"OR","negate":false,"values":[{"value":"0"},{"value":"root"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"ddb7af9c-5ec1-45e1-a0cf-c36e3ef2b2ce","name":"Red Hat Package Manager Execution","description":"Alert when Red Hat/Fedora/CentOS package manager programs are executed at runtime.","rationale":"Use of package managers at runtime indicates that new software may be being introduced into containers while they are running.","remediation":"Run `rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')` in the image build for production containers. Change applications to no longer use package managers at runtime, if applicable.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[{"name":"Don't alert on StackRox scanner","deployment":{"name":"scanner","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-compliance namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-compliance","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Red Hat Package Manager Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"rpm|microdnf|dnf|yum"}]}]}],"mitreAttackVectors":[{"tactic":"TA0011","techniques":["T1105"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"e9635b83-4ec5-4e7a-9be1-1bcdd6d82bb7","name":"Cryptocurrency Mining Process Execution","description":"Cryptocurrency mining process spawned","rationale":"Cryptocurrency mining binaries are often evidence of malicious activity or a hijacked cluster.","remediation":"Ensure that the base image used to create the Dockerfile doesn't have cryptocurrency mining software packaged with it. Check for open ports that may allow for remote code execution","disabled":false,"categories":["Cryptocurrency Mining"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Cryptocurrency Mining Process Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":".*sgminer|.*cgminer|.*cpuminer|.*minerd|.*geth|.*ethminer|.*xmr-stak.*|.*xmrminer|.*cpuminer-multi|.*xmrig"}]}]}],"mitreAttackVectors":[{"tactic":"TA0040","techniques":["T1496"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"e971db42-e8d4-4a1d-a30c-41142ba54d71","name":"Improper Usage of Orchestrator Secrets Volume","description":"Alert on deployments that use a Dockerfile with 'VOLUME /run/secrets'","rationale":"/run/secrets is a path for secrets that gets populated by the orchestrator. Volumes should not be used for secrets, and data mounts should have a separate mount path.","remediation":"Mount the volume to a different path. If secrets are stored in the volume, utilize the orchestrator secrets or your security team's secret management solution instead.","disabled":false,"categories":["DevOps Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Improper Usage of Orchestrator Secrets Volume","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Dockerfile Line","booleanOperator":"OR","negate":false,"values":[{"value":"VOLUME=(?:(?:[,\\[\\s]?)|(?:.*[,\\s]+))/run/secrets(?:$|[,\\]\\s]).*"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"ed8c7957-14de-40bc-aeab-d27ceeecfa7b","name":"Iptables Executed in Privileged Container","description":"Alert on privileged pods that execute iptables","rationale":"Processes that are running with UID 0 run as the root user. iptables can be used in privileged containers to modify the node's network routing.","remediation":"Specify the USER instruction in the Docker image or the runAsUser field within the Pod Security Context","disabled":false,"categories":["Network Tools","Security Best Practices"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[{"name":"Don't alert on Kube System Namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-sdn namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-sdn","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"CRITICAL_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Iptables Executed in Privileged Container","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Privileged Container","booleanOperator":"OR","negate":false,"values":[{"value":"true"}]},{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"iptables"}]},{"fieldName":"Process UID","booleanOperator":"OR","negate":false,"values":[{"value":"0"}]}]}],"mitreAttackVectors":[{"tactic":"TA0004","techniques":["T1611"]},{"tactic":"TA0005","techniques":["T1562.004"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"f09f8da1-6111-4ca0-8f49-294a76c65115","name":"Fixable CVSS \u003e= 7","description":"Alert on deployments with fixable vulnerabilities with a CVSS of at least 7","rationale":"Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).","remediation":"Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.","disabled":false,"categories":["Vulnerability Management"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":["FAIL_BUILD_ENFORCEMENT"],"notifiers":[],"lastUpdated":"2022-07-20T07:29:24.579948545Z","SORTName":"Fixable CVSS \u003e= 7","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":true,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Fixed By","booleanOperator":"OR","negate":false,"values":[{"value":".*"}]},{"fieldName":"CVSS","booleanOperator":"OR","negate":false,"values":[{"value":"\u003e= 7.000000"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"f0bacecd-87be-4f51-89a5-8f86ad523620","name":"nmap Execution","description":"Alerts when the nmap process launches in a container during run time","rationale":"Nmap can be used to probe a running container's network to enumerate open ports and perform other actions such as OS version detection and launching over-the-network scripted attacks","remediation":"Consider removing package managers during the build process that could be used to download such software. Check that exposed ports don't allow for remote code execution","disabled":false,"categories":["Network Tools"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"nmap Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"nmap"}]}]}],"mitreAttackVectors":[{"tactic":"TA0007","techniques":["T1046"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"f0ccfb84-1a00-488b-943f-bd89e1b9ce13","name":"test-role","description":"","rationale":"","remediation":"","disabled":false,"categories":["DevOps Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":"2022-07-20T07:54:23.187332131Z","SORTName":"test-role","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"Policy Section 1","policyGroups":[{"fieldName":"Minimum RBAC Permissions","booleanOperator":"OR","negate":false,"values":[{"value":"ELEVATED_IN_NAMESPACE"}]}]}],"mitreAttackVectors":[],"criteriaLocked":false,"mitreVectorsLocked":false,"isDefault":false},
-{"id":"f2183906-4577-47de-9bf4-270d09e0a93c","name":"systemctl Execution","description":"Detected usage of the systemctl service manager","rationale":"The systemctl service manager is generally not used in containers, and its use could indicate suspicious activity","remediation":"Remove systemctl from the image before deploying, or consider using a base image that doesn't bundle systemctl","disabled":false,"categories":["System Modification"],"lifecycleStages":["RUNTIME"],"eventSource":"DEPLOYMENT_EVENT","exclusions":[{"name":"Don't alert on StackRox namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"systemctl Execution","SORTLifecycleStage":"RUNTIME","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Process Name","booleanOperator":"OR","negate":false,"values":[{"value":"systemctl"}]}]}],"mitreAttackVectors":[{"tactic":"TA0003","techniques":["T1543.002"]},{"tactic":"TA0004","techniques":["T1543.002"]}],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"f4996314-c3d7-4553-803b-b24ce7febe48","name":"Environment Variable Contains Secret","description":"Alert on deployments with environment variables that contain 'SECRET'","rationale":"Using secrets in environment variables may allow inspection into your secrets from the host or even through the orchestrator UI.","remediation":"Migrate your secrets from environment variables to orchestrator secrets or your security team's secret management solution.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"HIGH_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Environment Variable Contains Secret","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Environment Variable","booleanOperator":"OR","negate":false,"values":[{"value":"RAW=.*SECRET.*|.*PASSWORD.*="}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"f95ff08d-130a-465a-a27e-32ed1fb05555","name":"Red Hat Package Manager in Image","description":"Alert on deployments with components of the Red Hat/Fedora/CentOS package management system.","rationale":"Package managers make it easier for attackers to use compromised containers, since they can easily add software.","remediation":"Run `rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')` in the image build for production containers.","disabled":false,"categories":["Security Best Practices"],"lifecycleStages":["BUILD","DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on StackRox scanner","deployment":{"name":"scanner","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null},{"name":"Don't alert on system namespaces","deployment":{"name":"","scope":{"cluster":"","namespace":"^kube.*|^openshift.*|^redhat.*|^istio-system$","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"LOW_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Red Hat Package Manager in Image","SORTLifecycleStage":"BUILD,DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Image Component","booleanOperator":"OR","negate":false,"values":[{"value":"rpm|microdnf|dnf|yum="}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"fb8f8732-c31d-496b-8fb1-d5abe6056e27","name":"Pod Service Account Token Automatically Mounted","description":"Protect pod default service account tokens from compromise by minimizing the mounting of the default service account token to only those pods whose application requires interaction with the Kubernetes API.","rationale":"By default, Kubernetes automatically provisions a service account for each pod and mounts the secret at runtime. This service account is not typically used. If this pod is compromised and the compromised user has access to the service account, the service account could be used to escalate privileges within the cluster. To reduce the likelihood of privilege escalation this service account should not be mounted by default unless the pod requires direct access to the Kubernetes API as part of the pods functionality.","remediation":"Add `automountServiceAccountToken: false` or a value distinct from 'default' for the `serviceAccountName` key to the deployment's Pod configuration.","disabled":false,"categories":["Security Best Practices","Privileges"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Pod Service Account Token Automatically Mounted","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Automount Service Account Token","booleanOperator":"OR","negate":false,"values":[{"value":"true"}]},{"fieldName":"Service Account","booleanOperator":"OR","negate":false,"values":[{"value":"default"}]},{"fieldName":"Namespace","booleanOperator":"OR","negate":true,"values":[{"value":"kube-system"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true},
-{"id":"fe9de18b-86db-44d5-a7c4-74173ccffe2e","name":"Privileged Container","description":"Alert on deployments with containers running in privileged mode","rationale":"Containers running as privileged represent greater post-exploitation risk by allowing an attacker to access all host devices, run a daemon in the container, etc.","remediation":"Verify that privileged capabilities are required and cannot be provided with a subset of other controls.","disabled":false,"categories":["Privileges","Docker CIS"],"lifecycleStages":["DEPLOY"],"eventSource":"NOT_APPLICABLE","exclusions":[{"name":"Don't alert on the stackrox namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"stackrox","label":null}},"image":null,"expiration":null},{"name":"Don't alert on kube-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"kube-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on istio-system namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"istio-system","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-node namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-node","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-sdn namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-sdn","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-kube-apiserver namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-kube-apiserver","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-etcd namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-etcd","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-apiserver namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-apiserver","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-dns namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-dns","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-cluster-node-tuning-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-node-tuning-operator","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-cluster-csi-drivers namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-cluster-csi-drivers","label":null}},"image":null,"expiration":null},{"name":"Don't alert on openshift-machine-config-operator namespace","deployment":{"name":"","scope":{"cluster":"","namespace":"openshift-machine-config-operator","label":null}},"image":null,"expiration":null}],"scope":[],"severity":"MEDIUM_SEVERITY","enforcementActions":[],"notifiers":[],"lastUpdated":null,"SORTName":"Privileged Container","SORTLifecycleStage":"DEPLOY","SORTEnforcement":false,"policyVersion":"1.1","policySections":[{"sectionName":"","policyGroups":[{"fieldName":"Privileged Container","booleanOperator":"OR","negate":false,"values":[{"value":"true"}]}]}],"mitreAttackVectors":[],"criteriaLocked":true,"mitreVectorsLocked":true,"isDefault":true}]}
+{
+  "policies": [
+    {
+      "id": "014a03c6-9053-49b5-88ea-c1efcf19804f",
+      "name": "Required Annotation: Email",
+      "description": "Alert on deployments missing the 'email' annotation",
+      "rationale": "The 'email' annotation should always be specified so that issues with the deployment can quickly be routed to the proper party.",
+      "remediation": "Redeploy your service and set the 'email' annotation as your email or your team's email.",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices",
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.579174303Z",
+      "SORTName": "Required Annotation: Email",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Required Annotation",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "email=[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "0501ac8b-5869-4e1e-b360-84dbf01f2c6c",
+      "name": "Shell Spawned by Java Application",
+      "description": "Detects execution of shell (bash/csh/sh/zsh) as a subprocess of a java application",
+      "rationale": "Java application launching a shell can be an indicator of remote code execution",
+      "remediation": "Determine whether this is intended behavior of the application or an indication of malicious activity",
+      "disabled": false,
+      "categories": [
+        "System Modification"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Shell Spawned by Java Application",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "(/[s]*bin/){0,1}(ba|c|z){0,1}sh"
+                }
+              ]
+            },
+            {
+              "fieldName": "Process Ancestor",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": ".*java"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0002",
+          "techniques": [
+            "T1059.004"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "08a06f5c-eed0-4fb8-a09e-16cc975e7beb",
+      "name": "Docker CIS 4.4: Ensure images are scanned and rebuilt to include security patches",
+      "description": "Images should be scanned frequently for any vulnerabilities. You should rebuild all images to include these patches and then instantiate new containers from them.",
+      "rationale": "Vulnerabilities are loopholes or bugs that can be exploited by hackers or malicious users, and security patches are updates to resolve these vulnerabilities. Image vulnerability scanning tools can be use to find vulnerabilities in images and then check for available patches to mitigate these. Patches update the system to a more recent code base which does not contain these problems, and being on a supported version of the code base is very important, as vendors do not tend to supply patches for older versions which have gone out of support. Security patches should be evaluated before applying and patching should be implemented in line with the organization's IT Security Policy. Care should be taken with the results returned by vulnerability assessment tools, as some will simply return results based on software banners, and these may not be entirely accurate.",
+      "remediation": "Images should be re-built ensuring that the latest version of the base images are used, to keep the operating system patch level at an appropriate level. Once the images have been re-built, containers should be re-started making use of the updated images.",
+      "disabled": false,
+      "categories": [
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "BUILD"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.580931106Z",
+      "SORTName": "Docker CIS 4.4: Ensure images are scanned and rebuilt to include security patches",
+      "SORTLifecycleStage": "BUILD",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Fixed By",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": ".*"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "0a2ee697-cb88-4e13-8e62-c6a2a887e0cc",
+      "name": "chkconfig Execution",
+      "description": "Detected usage of the chkconfig service manager; typically this is not used within a container",
+      "rationale": "chkconfig can be used to activate and deactivate services, and should generally not be run within a container",
+      "remediation": "Consider removing the chkconfig utility, or using a base container image that doesn't have this utility in it",
+      "disabled": false,
+      "categories": [
+        "System Modification"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "chkconfig Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "chkconfig"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0003",
+          "techniques": [
+            "T1543.002"
+          ]
+        },
+        {
+          "tactic": "TA0004",
+          "techniques": [
+            "T1543.002"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "0ac267ae-9128-42c7-b15e-0e926844aa2f",
+      "name": "Kubernetes Dashboard Deployed",
+      "description": "Alert on the presence of the Kubernetes dashboard service",
+      "rationale": "The Kubernetes dashboard can be used to gain external access to a cluster, or to obtain additional access once inside.",
+      "remediation": "Modify your cluster configuration to disable the Kubernetes dashboard service if it is not in use. In Google Kubernetes Engine (GKE), you can execute: gcloud container clusters update --update-addons=KubernetesDashboard=DISABLED [cluster-name]",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Kubernetes Dashboard Deployed",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Image Remote",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "r/.*kubernetesui/dashboard.*"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "101952d3-ec69-4ebe-bfa3-ff26b6e4c29d",
+      "name": "Compiler Tool Execution",
+      "description": "Alert when binaries used to compile software are executed at runtime",
+      "rationale": "Use of compilation tools during runtime indicates that new software may be being introduced into containers while they are running.",
+      "remediation": "Compile all necessary application code during the image build process. Avoid packaging software build tools in container images. Use your distribution's package manager to remove compilers and other build tools from images.",
+      "disabled": false,
+      "categories": [
+        "Package Management"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Compiler Tool Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "make|gcc|llc|llvm-.*"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0008",
+          "techniques": [
+            "T1570"
+          ]
+        },
+        {
+          "tactic": "TA0011",
+          "techniques": [
+            "T1105"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "1037940a-fc22-4f64-8784-b8f5bd1cc93f",
+      "name": "Shell Management",
+      "description": "Commands that are used to add/remove a shell",
+      "rationale": "Shell management is not usually done at runtime",
+      "remediation": "Ensure that the base image used to create the Dockerfile doesn't have shell binaries packaged with it.",
+      "disabled": false,
+      "categories": [
+        "System Modification"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.579516883Z",
+      "SORTName": "Shell Management",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "add-shell|remove-shell"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0002",
+          "techniques": [
+            "T1059.004"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "13b4eddc-2619-4953-b1ee-4c762144ca1e",
+      "name": "Images with no scans",
+      "description": "Alert on deployments with images that have not been scanned",
+      "rationale": "Without a scan, there will be no vulnerability information for this image",
+      "remediation": "Configure the appropriate registry and scanner integrations so that StackRox can obtain scans for your images.",
+      "disabled": false,
+      "categories": [
+        "Vulnerability Management"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.578512937Z",
+      "SORTName": "Images with no scans",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Unscanned Image",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "true"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "18cbcb62-7d18-4a6c-b2ca-dd1242746943",
+      "name": "OpenShift: Kubeadmin Secret Accessed",
+      "description": "Alert when the kubeadmin secret is accessed",
+      "rationale": "Kubeadmin is the default administrative user for OpenShift and can be used to obtain full administrative access to the cluster. Investigating if this was accessed for valid business purposes can help organizations to control the use of administrative privileges",
+      "remediation": "Audit the access carefully to ensure that this secret is only accessed for valid business purposes.",
+      "disabled": false,
+      "categories": [
+        "Anomalous Activity",
+        "Kubernetes Events"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "AUDIT_LOG_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "OpenShift: Kubeadmin Secret Accessed",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Kubernetes Resource",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "SECRETS"
+                }
+              ]
+            },
+            {
+              "fieldName": "Kubernetes API Verb",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "GET"
+                }
+              ]
+            },
+            {
+              "fieldName": "Kubernetes Resource Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "kubeadmin"
+                }
+              ]
+            },
+            {
+              "fieldName": "Kubernetes User Name",
+              "booleanOperator": "OR",
+              "negate": true,
+              "values": [
+                {
+                  "value": "system:serviceaccount:openshift-authentication-operator:authentication-operator"
+                },
+                {
+                  "value": "system:apiserver"
+                },
+                {
+                  "value": "system:serviceaccount:openshift-authentication:oauth-openshift"
+                },
+                {
+                  "value": "system:serviceaccount:openshift-compliance:api-resource-collector"
+                },
+                {
+                  "value": "system:serviceaccount:openshift-oauth-apiserver:oauth-apiserver-sa"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0006",
+          "techniques": [
+            "T1552.007"
+          ]
+        },
+        {
+          "tactic": "TA0007",
+          "techniques": [
+            "T1613"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "1913283f-ce3c-4134-84ef-195c4cd687ae",
+      "name": "Curl in Image",
+      "description": "Alert on deployments with curl present",
+      "rationale": "Leaving download tools like curl in an image makes it easier for attackers to use compromised containers, since they can easily download software.",
+      "remediation": "Use your package manager's \"remove\", \"purge\" or \"erase\" command to remove curl from the image build for production containers. Ensure that any configuration files are also removed.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on StackRox collector",
+          "deployment": {
+            "name": "collector",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on StackRox central",
+          "deployment": {
+            "name": "central",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on StackRox sensor",
+          "deployment": {
+            "name": "sensor",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on StackRox admission controller",
+          "deployment": {
+            "name": "admission-control",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.576094767Z",
+      "SORTName": "Curl in Image",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Image Component",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "curl="
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "1a498d97-0cc2-45f5-b32e-1f3cca6a3113",
+      "name": "Required Annotation: Owner/Team",
+      "description": "Alert on deployments missing the 'owner' or 'team' annotation",
+      "rationale": "The 'owner' or 'team' annotation should always be specified so that the deployment can quickly be associated with a specific user or team.",
+      "remediation": "Redeploy your service and set the 'owner' or 'team' annotation to yourself or your team respectively per organizational standards.",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices",
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.579356199Z",
+      "SORTName": "Required Annotation: Owner/Team",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Required Annotation",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "owner|team=.+"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "1b74ffdd-8e67-444c-9814-1c23863c8ccb",
+      "name": "Unauthorized Network Flow",
+      "description": "This policy generates a violation for the network flows that fall outside baselines for which 'alert on anomalous violations' is set.",
+      "rationale": "The network baseline is a list of flows that are allowed, and once it is frozen, any flow outside that is a concern.",
+      "remediation": "Evaluate this network flow. If deemed to be okay, add it to the baseline. If not, investigate further as required.",
+      "disabled": false,
+      "categories": [
+        "Anomalous Activity"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Unauthorized Network Flow",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "Unauthorized Network Flow",
+          "policyGroups": [
+            {
+              "fieldName": "Unexpected Network Flow Detected",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "true"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "1c224010-9e0b-41a8-be9a-a17c7040ce98",
+      "name": "Password Binaries",
+      "description": "Processes that indicate attempts to change passwd",
+      "rationale": "Attempts to change password during runtime in containers is unusual",
+      "remediation": "Ensure that the base image used to create the Dockerfile doesn't have passwd binaries packaged with it.",
+      "disabled": false,
+      "categories": [
+        "System Modification"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.578640695Z",
+      "SORTName": "Password Binaries",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "shadowconfig|grpck|pwunconv|grpconv|pwck|groupmod|vipw|pwconv|useradd|newusers|cppw|chpasswd|usermod|groupadd|groupdel|grpunconv|chgpasswd|userdel|chage|chsh|gpasswd|chfn|expiry|passwd|vigr|cpgr"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0003",
+          "techniques": [
+            "T1098"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "1c4e2cab-ce24-4e2a-9a66-f61028e79931",
+      "name": "Login Binaries",
+      "description": "Processes that indicate login attempts",
+      "rationale": "Login processes at runtime are unusual in a container",
+      "remediation": "Ensure that the base image used to create the Dockerfile doesn't have login binaries packaged with it.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.577835960Z",
+      "SORTName": "Login Binaries",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "login|systemd|systemd|systemd-logind|gosu|su|nologin|faillog|lastlog|newgrp|sg"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0004",
+          "techniques": [
+            "T1548"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "22006cb7-f015-4a0e-b4cc-3ffe150bcbe9",
+      "name": "test-service",
+      "description": "",
+      "rationale": "",
+      "remediation": "",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T08:04:36.919637131Z",
+      "SORTName": "test-service",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "Policy Section 1",
+          "policyGroups": [
+            {
+              "fieldName": "Exposed Node Port",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "30007"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": false,
+      "mitreVectorsLocked": false,
+      "isDefault": false
+    },
+    {
+      "id": "2361bb4c-4cf6-4997-bae6-825da6cf932e",
+      "name": "Network Management Execution",
+      "description": "Detects execution of binaries that can be used to manipulate network configuration and management.",
+      "rationale": "Network management tools can be used for a variety of tasks, including mapping out your network, overwriting iptables rules, or ssh tunneling to name a few.",
+      "remediation": "Remove unncessary network managment tools from the container image.",
+      "disabled": false,
+      "categories": [
+        "Network Tools"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift namespaces",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-.*",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Network Management Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "ip|ifrename|ethtool|ifconfig|arp|ipmaddr|iptunnel|route|nameif|mii-tool"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0007",
+          "techniques": [
+            "T1016"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "251136ca-c92c-4474-a2c7-4949c71b745f",
+      "name": "Process Targeting Kubernetes Service Endpoint",
+      "description": "Detects misuse of the Kubernetes Service API endpoint",
+      "rationale": "A pod communicating to a Kubernetes API from via command line is highly irregular",
+      "remediation": "Look for open ports that may allow remote execution. Remove network utilities like curl and wget that allow these connections. Consider a firewall deny ingress firewall rule to the node serving the API",
+      "disabled": false,
+      "categories": [
+        "Kubernetes"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Process Targeting Kubernetes Service Endpoint",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Arguments",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "https://(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|\\$.?KUBERNETES_(PORT_443_TCP_ADDR|SERVICE_HOST).?)(:443)?/apis?/(v1(beta.)?/)?(.*\\.k8s\\.io|clusterrole.*|role.*|networkpolicies|cronjobs|certificate.*|podsecurity.*|secrets.*)"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0007",
+          "techniques": [
+            "T1613"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "28f833df-eb14-4265-a4fe-4e5e8ce9d959",
+      "name": "crontab Execution",
+      "description": "Detects the usage of the crontab scheduled jobs editor",
+      "rationale": "Crontab running in a container with access to a shell makes it easier to 'clandestinely' schedule processes to run in order to better evade detection",
+      "remediation": "In Kubernetes, consider replacing your crontab with an orchestrator-native CronJob as part of Kube workload",
+      "disabled": false,
+      "categories": [
+        "System Modification"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "crontab Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "anacron|cron|crond|crontab"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0003",
+          "techniques": [
+            "T1053.003"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "2db9a279-2aec-4618-a85d-7f1bdf4911b1",
+      "name": "90-Day Image Age",
+      "description": "Alert on deployments with images that haven't been updated in 90 days",
+      "rationale": "Base images are updated frequently with bug fixes and vulnerability patches. Image age exceeding 90 days may indicate a higher risk of vulnerabilities existing in the image.",
+      "remediation": "Rebuild your image, push a new minor version (with a new immutable tag), and update your service to use it.",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices",
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "90-Day Image Age",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Image Age",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "90"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "2e90874a-3521-44de-85c6-5720f519a701",
+      "name": "Latest tag",
+      "description": "Alert on deployments with images using tag 'latest'",
+      "rationale": "Using latest tag can result in running heterogeneous versions of code. Many Docker hosts cache the Docker images, which means newer versions of the latest tag will not be picked up. See https://docs.docker.com/develop/dev-best-practices for more best practices.",
+      "remediation": "Consider moving to semantic versioning based on code releases (semver.org) or using the first 12 characters of the source control SHA. This will allow you to tie the Docker image to the code.",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Latest tag",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Image Tag",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "latest"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "30e8cb50-d93f-42a1-b022-ec7de7ab7b65",
+      "name": "CAP_SYS_ADMIN capability added",
+      "description": "Alert on deployments with containers escalating with CAP_SYS_ADMIN",
+      "rationale": "CAP_SYS_ADMIN grants an elevated level of privilege to a container that may not be necessary. https://lwn.net/Articles/486306/ explains what CAP_SYS_ADMIN does and points to possible alternatives.",
+      "remediation": "Ensure that the container really needs the CAP_SYS_ADMIN capability or use a userspace derivative.",
+      "disabled": false,
+      "categories": [
+        "Privileges"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "CAP_SYS_ADMIN capability added",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Add Capabilities",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "SYS_ADMIN"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "32081d8e-84cd-4d67-b016-fe481c55b93a",
+      "name": "Linux User Add Execution",
+      "description": "Detects when the 'useradd' or 'adduser' binary is executed, which can be used to add a new linux user.",
+      "rationale": "Users or groups added in run time can be used to take ownership of files and processes.",
+      "remediation": "Consider using a base image that doesn't have a shell such as SCRATCH or gcr.io/distroless. If not, modify your Dockerfile to use the exec form of CMD/ENTRYPOINT ([\"using braces\"]) instead of the shell form (no braces)",
+      "disabled": false,
+      "categories": [
+        "System Modification",
+        "Privileges"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Linux User Add Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "useradd|adduser|usermod"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0003",
+          "techniques": [
+            "T1098",
+            "T1136"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "32d770b9-c6ba-4398-b48a-0c3e807644ed",
+      "name": "Docker CIS 5.19: Ensure mount propagation mode is not enabled",
+      "description": "Mount propagation mode allows mounting container volumes in Bidirectional, Host to Container, and None modes. Do not use Bidirectional mount propagation mode unless explicitly needed.",
+      "rationale": "A Bidirectional mount is replicated at all mounts and changes made at any mount point are propagated to all other mount points. Mounting a volume in Bidirectional mode does not restrict any other container from mounting and making changes to that volume. As this is likely not a desirable option from a security standpoint, this feature should not be used unless explicitly required",
+      "remediation": "Do not mount volumes in Bidirectional propagation mode.",
+      "disabled": false,
+      "categories": [
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on openshift-cluster-csi-drivers namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-cluster-csi-drivers",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on a pdcsi-node deployment",
+          "deployment": {
+            "name": "pdcsi-node",
+            "scope": null
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2021-01-19T22:26:36.455422100Z",
+      "SORTName": "Docker CIS 5.19: Ensure mount propagation mode is not enabled",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "Section 1",
+          "policyGroups": [
+            {
+              "fieldName": "Mount Propagation",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "BIDIRECTIONAL"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "38bf79e7-48bf-4ab1-b72f-38e8ad8b4ec3",
+      "name": "Deployments should have at least one ingress Network Policy",
+      "description": "Alerts if deployments are missing an ingress Network Policy",
+      "rationale": "",
+      "remediation": "",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-kube-apiserver namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-kube-apiserver",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-kube-scheduler namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-kube-scheduler",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-kube-controller-manager namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-kube-controller-manager",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-sdn namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-sdn",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-network-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-network-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-multus namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-multus",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-cluster-version namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-cluster-version",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on node-ca DaemonSet in the openshift-image-registry namespace",
+          "deployment": {
+            "name": "node-ca",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-image-registry",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on host network usage within the openshift-etcd namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-etcd",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on host network usage within the openshift-machine-config-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-machine-config-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on host network usage within the openshift-monitoring namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-monitoring",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on host network usage within the openshift-machine-api namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-machine-api",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on host network usage within the openshift-cluster-node-tuning-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-cluster-node-tuning-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.578090548Z",
+      "SORTName": "Deployments should have at least one ingress Network Policy",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "Alert on missing ingres Network Policy",
+          "policyGroups": [
+            {
+              "fieldName": "Has Ingress Network Policy",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "false"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "3a98be1e-d427-41ba-ad60-994e848a5554",
+      "name": "Emergency Deployment Annotation",
+      "description": "Alert on deployments that use the emergency annotation (e.g. \"admission.stackrox.io/break-glass\": \"ticket-1234\") to circumvent StackRox Admission Controller checks",
+      "rationale": "Ideally, all deployments should be validated before they are launched into the cluster; however, in case of emergency, annotations in the form of { \"admission.stackrox.io/break-glass\": \"ticket-1234\"} can be used to avoid those checks.",
+      "remediation": "Redeploy your service and unset the emergency annotation.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Emergency Deployment Annotation",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Disallowed Annotation",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "admission.stackrox.io/break-glass="
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0005",
+          "techniques": [
+            "T1610"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "3bf3cec3-d3e8-4512-86ca-b306697d4b75",
+      "name": "Secure Shell (ssh) Port Exposed",
+      "description": "Alert on deployments exposing port 22, commonly reserved for SSH access.",
+      "rationale": "Port 22 is reserved for SSH access. SSH should not typically be used within containers.",
+      "remediation": "Ensure that non-SSH services are not using port 22. Ensure that any actual SSH servers have been vetted.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Secure Shell (ssh) Port Exposed",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Exposed Port",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "22"
+                }
+              ]
+            },
+            {
+              "fieldName": "Exposed Port Protocol",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "tcp"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "3e546913-de60-445c-a6d5-e70ac4ed4e98",
+      "name": "Remote File Copy Binary Execution",
+      "description": "Alert on deployments that execute a remote file copy tool",
+      "rationale": "Remote copy tools can be used to exfiltrate data from a container",
+      "remediation": "Remove tools like scp, sshfs, ssh-copy-id, etc. from your image and redeploy it",
+      "disabled": false,
+      "categories": [
+        "Network Tools"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Remote File Copy Binary Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "scp|sshfs|ssh-copy-id|rsync"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0008",
+          "techniques": [
+            "T1570"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "3ebdc07d-7c01-4508-9f81-3f3673fce536",
+      "name": "Process Targeting Cluster Kubernetes Docker Stats Endpoint",
+      "description": "Detects misuse of the Kubernetes docker stats endpoint",
+      "rationale": "A pod communicating to a Kubernetes API from via command line is highly irregular",
+      "remediation": "Look for open ports that may allow remote execution. Remove network utilities like curl and wget that allow these connections. Consider a firewall deny ingress firewall rule to the node serving the API",
+      "disabled": false,
+      "categories": [
+        "Kubernetes"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Process Targeting Cluster Kubernetes Docker Stats Endpoint",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Arguments",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "(http?://)?\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\:4194/*"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0007",
+          "techniques": [
+            "T1613"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "41e5153f-98d1-4830-9f80-983afcbe73c1",
+      "name": "Docker CIS 5.21: Ensure the default seccomp profile is not disabled",
+      "description": "Seccomp filtering provides a means to filter incoming system calls. The default seccomp profile uses an allow list to permit a large number of common system calls, and block all others.",
+      "rationale": "A large number of system calls are exposed to every userland process with many of them going unused for the entire lifetime of the process. Most of applications do not need all these system calls and would therefore benefit from having a reduced set of available system calls. Having a reduced set of system calls reduces the total kernel surface exposed to the application and thus improvises application security.",
+      "remediation": "By default, seccomp profiles are enabled. You do not need to do anything unless you want to modify and use a modified seccomp profile.",
+      "disabled": false,
+      "categories": [
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.575159823Z",
+      "SORTName": "Docker CIS 5.21: Ensure the default seccomp profile is not disabled",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "Section 1",
+          "policyGroups": [
+            {
+              "fieldName": "Seccomp Profile Type",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "UNCONFINED"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "436811e7-892f-4da6-a0f5-8cc459f1b954",
+      "name": "Docker CIS 5.15: Ensure that the host's process namespace is not shared",
+      "description": "The Process ID (PID) namespace isolates the process ID space, meaning that processes in different PID namespaces can have the same PID. This creates process level isolation between the containers and the host.",
+      "rationale": "PID namespace provides separation between processes. It prevents system processes from being visible, and allows process ids to be reused including PID 1. If the host's PID namespace is shared with containers, it would basically allow these to see all of the processes on the host system. This reduces the benefit of process level isolation between the host and the containers. Under these circumstances a malicious user who has access to a container could get access to processes on the host itself, manipulate them, and even be able to kill them. This could allow for the host itself being shut down, which could be extremely serious, particularly in a multi-tenanted environment. You should not share the host's process namespace with the containers running on it.",
+      "remediation": "You should not create a deployment with `hostPID: true`",
+      "disabled": false,
+      "categories": [
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on the openshift-sdn namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-sdn",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Docker CIS 5.15: Ensure that the host's process namespace is not shared",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "Section 1",
+          "policyGroups": [
+            {
+              "fieldName": "Host PID",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "true"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "47cb9e0a-879a-417b-9a8f-de644d7c8a77",
+      "name": "Docker CIS 5.16: Ensure that the host's IPC namespace is not shared",
+      "description": "IPC (POSIX/SysV IPC) namespace provides separation of named shared memory segments, semaphores and message queues. The IPC namespace on the host should therefore not be shared with containers and should remain isolated.",
+      "rationale": "The IPC namespace provides separation of IPC between the host and containers. If the host's IPC namespace is shared with the container, it would allow processes within the container to see all of IPC communications on the host system. This would remove the benefit of IPC level isolation between host and containers. An attacker with access to a container could get access to the host at this level with major consequences. The IPC namespace should therefore not be shared between the host and its containers.",
+      "remediation": "You should not create a deployment with `hostIPC: true`",
+      "disabled": false,
+      "categories": [
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Docker CIS 5.16: Ensure that the host's IPC namespace is not shared",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "Section 1",
+          "policyGroups": [
+            {
+              "fieldName": "Host IPC",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "true"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "550081a1-ad3a-4eab-a874-8eb68fab2bbd",
+      "name": "Required Label: Owner/Team",
+      "description": "Alert on deployments missing the 'owner' or 'team' label",
+      "rationale": "The 'owner' or 'team' label should always be specified so that the deployment can quickly be associated with a specific user or team.",
+      "remediation": "Redeploy your service and set the 'owner' or 'team' label to yourself or your team respectively per organizational standards.",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices",
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.580107859Z",
+      "SORTName": "Required Label: Owner/Team",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Required Label",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "owner|team=.+"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "618e65ca-737b-4fec-bb42-57a04e7dfc28",
+      "name": "Secure Shell Server (sshd) Execution",
+      "description": "Detects container running the SSH daemon",
+      "rationale": "The secure shell server allows shell access to a container, which can be dangerous.",
+      "remediation": "If ssh is absolutely required, ensure that it is not using default authentication. Otherwise, consider removing it from the container altogether.",
+      "disabled": false,
+      "categories": [
+        "Network Tools",
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Secure Shell Server (sshd) Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "sshd"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0001",
+          "techniques": [
+            "T1078"
+          ]
+        },
+        {
+          "tactic": "TA0002",
+          "techniques": [
+            "T1059.004"
+          ]
+        },
+        {
+          "tactic": "TA0008",
+          "techniques": [
+            "T1021.004"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "6226d4ad-7619-4a0b-a160-46373cfcee66",
+      "name": "Docker CIS 5.9 and 5.20: Ensure that the host's network namespace is not shared",
+      "description": "When HostNetwork is enabled the container is not placed inside a separate network stack. The container's networking is not containerized when this option is applied. The consequence of this is that the container has full access to the host's network interfaces. It also enables a shared UTS namespace. The UTS namespace provides isolation between two system identifiers: the hostname and the NIS domain name. It is used to set the hostname and the domain which are visible to running processes in that namespace. Processes running within containers do not typically require to know either the hostname or the domain name. The UTS namespace should therefore not be shared with the host.",
+      "rationale": "Selecting this option is potentially dangerous. It allows the container process to open reserved low numbered ports in the way that any other root process can. It also allows the container to access network services such as D-bus on a Docker host. A container process could potentially carry out undesired actions, such as shutting down the host. The container will also share the network namespace with the host, providing full permission for each container to change the hostname of the host. This is not in line with good security practice and should not be permitted.",
+      "remediation": "You should not create a deployment with `hostNetwork: true`",
+      "disabled": false,
+      "categories": [
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-kube-apiserver namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-kube-apiserver",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-kube-scheduler namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-kube-scheduler",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-kube-controller-manager namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-kube-controller-manager",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-sdn namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-sdn",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-network-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-network-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-multus namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-multus",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-cluster-version namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-cluster-version",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on node-ca DaemonSet in the openshift-image-registry namespace",
+          "deployment": {
+            "name": "node-ca",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-image-registry",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on host network usage within the openshift-etcd namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-etcd",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on host network usage within the openshift-machine-config-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-machine-config-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on host network usage within the openshift-monitoring namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-monitoring",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on host network usage within the openshift-machine-api namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-machine-api",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on host network usage within the openshift-cluster-node-tuning-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-cluster-node-tuning-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Docker CIS 5.9 and 5.20: Ensure that the host's network namespace is not shared",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "Section 1",
+          "policyGroups": [
+            {
+              "fieldName": "Host Network",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "true"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "629f847d-72b1-4009-8891-cbe479ab10ab",
+      "name": "Secure Shell (ssh) Port Exposed in Image",
+      "description": "Alert on deployments exposing port 22, commonly reserved for SSH access.",
+      "rationale": "Port 22 is reserved for SSH access. SSH should not typically be used within containers.",
+      "remediation": "Ensure that non-SSH services are not using port 22. Ensure that any actual SSH servers have been vetted.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Secure Shell (ssh) Port Exposed in Image",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Dockerfile Line",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "EXPOSE=(22/tcp|\\s+22/tcp)"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "657f4d37-55ab-42f2-bdce-9a4b74a67328",
+      "name": "Insecure specified in CMD",
+      "description": "Alert on deployments using 'insecure' in the command",
+      "rationale": "Using insecure in a command implies accessing or providing data from a server on an unencrypted connection.",
+      "remediation": "Use a certificate manager and certificate rotation routinely to ensure secure service-to-service communication.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Insecure specified in CMD",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Dockerfile Line",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "CMD=.*insecure.*"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "6abcaa13-9ed6-4109-a1a7-be2e8280e49e",
+      "name": "Docker CIS 5.7: Ensure privileged ports are not mapped within containers",
+      "description": "The TCP/IP port numbers below 1024 are considered privileged ports. Normal users and processes are not allowed to use them for various security reasons. Containers are, however, allowed to map their ports to privileged ports.",
+      "rationale": "By default, if the user does not specifically declare a container port to host port mapping, the containers ports will be mapped to available non-privileged host ports. Containers are, however, allow to map their ports to a privileged ports on the host if the user explicitly declares it. In Docker this is because containers are executed with NET_BIND_SERVICE Linux kernel capability which does not restrict privileged port mapping. The privileged ports receive and transmit various pieces of data which are security sensitive and allowing containers to use them is not in line with good security practice.",
+      "remediation": "You should not map container ports to privileged host ports when starting a container. You should also, ensure that there is no such container to host privileged port mapping declarations in the Dockerfile.",
+      "disabled": false,
+      "categories": [
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Docker CIS 5.7: Ensure privileged ports are not mapped within containers",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Exposed Node Port",
+              "booleanOperator": "AND",
+              "negate": false,
+              "values": [
+                {
+                  "value": "<= 1024"
+                },
+                {
+                  "value": "> 0"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "6abf0df8-736b-4530-8849-6a1344cf17fe",
+      "name": "Netcat Execution Detected",
+      "description": "Detects execution of netcat in a container",
+      "rationale": "netcat is a known malicious process",
+      "remediation": "Consider removing package managers during the build process that could be used to download such software. Check that exposed ports don't allow for remote code execution",
+      "disabled": false,
+      "categories": [
+        "Network Tools"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Netcat Execution Detected",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "nc"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0007",
+          "techniques": [
+            "T1046"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "6e0239e1-f4ca-43d0-ad3f-79ec683db811",
+      "name": "Shadow File Modification",
+      "description": "Processes that indicate attempts to modify shadow files",
+      "rationale": "Attempts to change shadow file during runtime in containers is unusual",
+      "remediation": "Ensure that the base image used to create the Dockerfile doesn't have shadow utils packaged with it.",
+      "disabled": false,
+      "categories": [
+        "System Modification"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.582661559Z",
+      "SORTName": "Shadow File Modification",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "chage|gpasswd|lastlog|newgrp|sg|adduser|deluser|chpasswd|groupadd|groupdel|addgroup|delgroup|groupmems|groupmod|grpck|grpconv|grpunconv|newusers|pwck|pwconv|pwunconv|useradd|userdel|usermod|vigr|vipw|unix_chkpwd"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0003",
+          "techniques": [
+            "T1098"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "742e0361-bddd-4a2d-8758-f2af6197f61d",
+      "name": "Kubernetes Actions: Port Forward to Pod",
+      "description": "Alerts when Kubernetes API receives port forward request",
+      "rationale": "'pods/portforward' is non-standard way to access applications running on Kubernetes. Attackers with permissions could gain access to application and compromise it",
+      "remediation": "Restrict RBAC access to the 'pods/portforward' resource according to the Principle of Least Privilege. Limit exposing application through port forwarding only development, testing or debugging (non-production) activities. For external traffic, expose application through a LoadBalancer/NodePort service or Ingress Controller",
+      "disabled": false,
+      "categories": [
+        "Kubernetes Events"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Kubernetes Actions: Port Forward to Pod",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Kubernetes Resource",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "PODS_PORTFORWARD"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0002",
+          "techniques": [
+            "T1609"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "7448b475-8e80-4ece-bc9b-b9845c003a6f",
+      "name": "Docker CIS 5.1 Ensure that, if applicable, an AppArmor Profile is enabled",
+      "description": "AppArmor is an effective and easy-to-use Linux application security system. It is available on some Linux distributions by default, for example, on Debian and Ubuntu.",
+      "rationale": "AppArmor protects the Linux OS and applications from various threats by enforcing a security policy which is also known as an AppArmor profile. You can create your own AppArmor profile for containers or use Docker's default profile. Enabling this feature enforces security policies on containers as defined in the profile.",
+      "remediation": "If AppArmor is applicable for your Linux OS, you should enable it.  Verify AppArmor is installed, create or import an AppArmor profile for your containers, enable enforcement of the policy, and add the appropriate AppArmor annotations to your deployment.",
+      "disabled": false,
+      "categories": [
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Docker CIS 5.1 Ensure that, if applicable, an AppArmor Profile is enabled",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "Section 1",
+          "policyGroups": [
+            {
+              "fieldName": "AppArmor Profile",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "unconfined"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "74cfb824-2e65-46b7-b1b4-ba897e53af1f",
+      "name": "Ubuntu Package Manager in Image",
+      "description": "Alert on deployments with components of the Debian/Ubuntu package management system in the image.",
+      "rationale": "Package managers make it easier for attackers to use compromised containers, since they can easily add software.",
+      "remediation": "Run `dpkg -r --force-all apt apt-get && dpkg -r --force-all debconf dpkg` in the image build for production containers.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Ubuntu Package Manager in Image",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Image Component",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "apt|dpkg="
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "7760a5f3-bca4-4ca8-94a7-ad89edbc0e2c",
+      "name": "Process with UID 0",
+      "description": "Alert on deployments that contain processes running with UID 0",
+      "rationale": "Processes that are running with UID 0 run as the root user. This can allow for unintended privilege escalation if a container mounts host directories that are owned by the host's root user",
+      "remediation": "Specify the USER instruction in the Docker image or the runAsUser field within the Pod Security Context",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices",
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on StackRox Namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.579735755Z",
+      "SORTName": "Process with UID 0",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process UID",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "0"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "7b71fba0-2afb-4e4e-abf3-0f461cd76acc",
+      "name": "OpenShift: Kubernetes Secret Accessed by an Impersonated User",
+      "description": "Alert when user impersonation is used to access a secret within the cluster.",
+      "rationale": "Users with impersonation access allows users to invoke any command as a different user, typically for troubleshooting purposes (i.e using the oc --as command). This may be used to bypass existing security controls such as RBAC.",
+      "remediation": "Audit usage of impersonation when accessing secrets to ensure this access is used for valid business purposes.",
+      "disabled": false,
+      "categories": [
+        "Anomalous Activity",
+        "Kubernetes Events"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "AUDIT_LOG_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "OpenShift: Kubernetes Secret Accessed by an Impersonated User",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Kubernetes Resource",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "SECRETS"
+                }
+              ]
+            },
+            {
+              "fieldName": "Kubernetes API Verb",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "GET"
+                }
+              ]
+            },
+            {
+              "fieldName": "Is Impersonated User",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "true"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0004",
+          "techniques": [
+            "T1134.001"
+          ]
+        },
+        {
+          "tactic": "TA0006",
+          "techniques": [
+            "T1552.007"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "80267b36-2182-4fb3-8b53-e80c031f4ad8",
+      "name": "ADD Command used instead of COPY",
+      "description": "Alert on deployments using an ADD command",
+      "rationale": "ADD incorporates a broader set of capabilities than COPY, including the ability to specify URLs as the source argument and automatic unpacking of compressed files onto the local filesystem. The effects of ADD can be unpredictable and can lead to larger images. Unless ADD's additional capabilities are required, COPY is recommended.",
+      "remediation": "Replace ADD with COPY when adding new files to the image. Per https://docs.docker.com/develop/develop-images/dockerfile_best-practices, it is better to use RUN curl instead of ADD if you need to access a URL.",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices",
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.577052631Z",
+      "SORTName": "ADD Command used instead of COPY",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Dockerfile Line",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "ADD=.*"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "842feb9f-ecb1-4e3c-a4bf-8a1dcb63948a",
+      "name": "Wget in Image",
+      "description": "Alert on deployments with wget present",
+      "rationale": "Leaving download tools like wget in an image makes it easier for attackers to use compromised containers, since they can easily download software.",
+      "remediation": "Use your package manager's \"remove\" command to remove wget from the image build for production containers.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.580435853Z",
+      "SORTName": "Wget in Image",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Image Component",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "wget="
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "86804b96-e87e-4eae-b56e-1718a8a55763",
+      "name": "Process Targeting Cluster Kubelet Endpoint",
+      "description": "Detects misuse of the healthz/kubelet API/heapster endpoint",
+      "rationale": "A pod communicating to a Kubernetes API from via command line is highly irregular",
+      "remediation": "Look for open ports that may allow remote execution. Remove network utilities like curl and wget that allow these connections. Consider a firewall deny ingress firewall rule to the node serving the API",
+      "disabled": false,
+      "categories": [
+        "Kubernetes"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Process Targeting Cluster Kubelet Endpoint",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Arguments",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "(https?://)?(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\:(10250|10248|10255)|heapster\\.kube\\-system/metrics|KUBERNETES_PORT_443_TCP_ADDR|KUBERNETES_SERVICE_HOST).*"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0007",
+          "techniques": [
+            "T1613"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "880fd131-46f0-43d2-82c9-547f5aa7e043",
+      "name": "iptables Execution",
+      "description": "Detects execution of iptables; iptables is a deprecated way of managing network state in containers",
+      "rationale": "iptables is a deprecated way of managing network state in containers",
+      "remediation": "Check for any processes that may be modifying iptables rules. Check for open ports that may be allowing code injection to modify iptables rules",
+      "disabled": false,
+      "categories": [
+        "Network Tools"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-sdn namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-sdn",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "iptables Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "iptables"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0005",
+          "techniques": [
+            "T1562.004"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "886c3c94-3a6a-4f2b-82fc-d6bf5a310840",
+      "name": "No resource requests or limits specified",
+      "description": "Alert on deployments that have containers without resource requests and limits",
+      "rationale": "If a container does not have resource requests or limits specified then the host may become over-provisioned.",
+      "remediation": "Specify the requests and limits of CPU and Memory for your deployment.",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices",
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on system namespaces",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "^kube.*|^openshift.*|^redhat.*|^istio-system$",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on management-infra namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "management-infra",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "No resource requests or limits specified",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Container CPU Limit",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "0.000000"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Container CPU Request",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "0.000000"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Container Memory Limit",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "0.000000"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Container Memory Request",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "0.000000"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "89cae2e6-0cb7-4329-8692-c2c3717c1237",
+      "name": "Unauthorized Process Execution",
+      "description": "This policy generates a violation for any process execution that is not explicitly allowed by a locked process baseline for a given container specification within a Kubernetes deployment.",
+      "rationale": "A locked process baseline communicates high confidence that execution of a process not included in the baseline positively indicates malicious activity.",
+      "remediation": "Evaluate this process execution for malicious intent, examine other accessible resources for abnormal activity, then kill the pod in which this process executed.",
+      "disabled": false,
+      "categories": [
+        "Anomalous Activity"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Unauthorized Process Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Unexpected Process Executed",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "true"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "8ab0f199-4904-4808-9461-3501da1d1b77",
+      "name": "Kubernetes Actions: Exec into Pod",
+      "description": "Alerts when Kubernetes API receives request to execute command in container",
+      "rationale": "'pods/exec' is non-standard approach for interacting with containers. Attackers with permissions could execute malicious code and compromise resources within a cluster",
+      "remediation": "Restrict RBAC access to the 'pods/exec' resource according to the Principle of Least Privilege. Limit such usage only to development, testing or debugging (non-production) activities",
+      "disabled": false,
+      "categories": [
+        "Kubernetes Events"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Kubernetes Actions: Exec into Pod",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Kubernetes Resource",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "PODS_EXEC"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0002",
+          "techniques": [
+            "T1609"
+          ]
+        },
+        {
+          "tactic": "TA0002",
+          "techniques": [
+            "T1059.004"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "8ac93556-4ad4-4220-a275-3f518db0ceb9",
+      "name": "Container using read-write root filesystem",
+      "description": "Alert on deployments with containers with read-write root filesystem",
+      "rationale": "Containers running with read-write root filesystem represent greater post-exploitation risk by allowing an attacker to modify important files in the container.",
+      "remediation": "Use a read-only root filesystem, and use volume mounts to allow writes to specific sub-directories depending on your application's needs.",
+      "disabled": false,
+      "categories": [
+        "Privileges",
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-node namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-node",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-sdn namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-sdn",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.577324391Z",
+      "SORTName": "Container using read-write root filesystem",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Read-Only Root Filesystem",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "false"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "900990b5-60ef-44e5-b7f6-4a1f22215d7f",
+      "name": "Apache Struts: CVE-2017-5638",
+      "description": "Alert on deployments with images containing Apache Struts vulnerability CVE-2017-5638",
+      "rationale": "CVE-2017-5638 is a serious and easily-exploitable vulnerability in Apache Struts.",
+      "remediation": "Rebuild your container with an updated version of Apache Struts.",
+      "disabled": false,
+      "categories": [
+        "Vulnerability Management"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "CRITICAL_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Apache Struts: CVE-2017-5638",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "CVE",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "CVE-2017-5638"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "93f4b2dd-ef5a-419e-8371-38aed480fb36",
+      "name": "Fixable CVSS >= 6 and Privileged",
+      "description": "Alert on deployments running in privileged mode with fixable vulnerabilities with a CVSS of at least 6",
+      "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application, and highly privileged containers pose greater risk. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
+      "remediation": "Use your package manager to update to a fixed version in future builds, run your container with lower privileges, or speak with your security team to mitigate the vulnerabilities.",
+      "disabled": false,
+      "categories": [
+        "Vulnerability Management",
+        "Privileges"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Fixable CVSS >= 6 and Privileged",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Privileged Container",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "true"
+                }
+              ]
+            },
+            {
+              "fieldName": "Fixed By",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": ".*"
+                }
+              ]
+            },
+            {
+              "fieldName": "CVSS",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": ">= 6.000000"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "98c8396e-3541-48b9-a30a-371c86a8f0ef",
+      "name": "SetUID Processes",
+      "description": "Processes that are known to use setuid binaries",
+      "rationale": "setuid permits users to run certain programs with escalated privileges",
+      "remediation": "Ensure that the base image used to create the Dockerfile doesn't have setuid software packaged with it.",
+      "disabled": false,
+      "categories": [
+        "System Modification"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.581424257Z",
+      "SORTName": "SetUID Processes",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "sshd|dbus-daemon-lau|ping|ping6|critical-stack-|pmmcli|filemng|PassengerAgent|bwrap|osdetect|nginxmng|sw-engine-fpm|start-stop-daem"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0004",
+          "techniques": [
+            "T1548.001"
+          ]
+        },
+        {
+          "tactic": "TA0005",
+          "techniques": [
+            "T1548.001"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "9a91b4de-d52e-4d4d-a65e-1e785c3501b1",
+      "name": "Docker CIS 4.7: Alert on Update Instruction",
+      "description": "Ensure update instructions are not used alone in the Dockerfile",
+      "rationale": "Adding update instructions in a single line on the Dockerfile will cause the update layer to be cached. When you then build any image later using the same instruction, this will cause the previously cached update layer to be used, potentially preventing any fresh updates from being applied to later builds.",
+      "remediation": "Use update instructions together with install instructions and version pinning for packages while installing them. This prevents caching and forces the extraction of the required versions.",
+      "disabled": false,
+      "categories": [
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on StackRox services",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Docker CIS 4.7: Alert on Update Instruction",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Dockerfile Line",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "RUN=(/bin/sh -c)?\\s*apk update\\s*"
+                },
+                {
+                  "value": "RUN=(/bin/sh -c)?\\s*apt update\\s*"
+                },
+                {
+                  "value": "RUN=(/bin/sh -c)?\\s*apt-get update\\s*"
+                },
+                {
+                  "value": "RUN=(/bin/sh -c)?\\s*yum update\\s*"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "a05e063b-f37f-4d36-99f3-7ff0cb2b3ba8",
+      "name": "Linux Group Add Execution",
+      "description": "Detects when the 'addgroup' or 'groupadd' binary is executed, which can be used to add a new linux group.",
+      "rationale": "Groups added in run time can be used to take ownership of files and processes",
+      "remediation": "Consider using a base image that doesn't have a shell such as SCRATCH or gcr.io/distroless. If not, modify your Dockerfile to use the exec form of CMD/ENTRYPOINT ([\"using braces\"]) instead of the shell form (no braces)",
+      "disabled": false,
+      "categories": [
+        "System Modification",
+        "Privileges"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Linux Group Add Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "addgroup|groupadd"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0003",
+          "techniques": [
+            "T1098",
+            "T1136"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "a3eb6dbe-e9ca-451a-919b-216cf7ee11f5",
+      "name": "30-Day Scan Age",
+      "description": "Alert on deployments with images that haven't been scanned in 30 days",
+      "rationale": "Out-of-date scans may not identify the most recent CVEs.",
+      "remediation": "Integrate a scanner with the StackRox Kubernetes Security Platform to trigger scans automatically.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "30-Day Scan Age",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Image Scan Age",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "30"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "a5248b33-5027-4aaf-a6b6-896f73fc6d28",
+      "name": "Alpine Linux Package Manager (apk) in Image",
+      "description": "Alert on deployments with the Alpine Linux package manager (apk) present",
+      "rationale": "Package managers make it easier for attackers to use compromised containers, since they can easily add software.",
+      "remediation": "Run `apk --purge del apk-tools` in the image build for production containers.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on the master-etcd deployment",
+          "deployment": {
+            "name": "master-etcd-openshift-master-.*",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Alpine Linux Package Manager (apk) in Image",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Image Component",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "apk-tools="
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "a788556c-9268-4f30-a114-d456f2380818",
+      "name": "Secret Mounted as Environment Variable",
+      "description": "Alert on deployments with Kubernetes secret mounted as environment variable",
+      "rationale": "Using secrets in environment variables may allow inspection into your secrets from the host.",
+      "remediation": "Migrate your secrets from environment variables to your security team's secret management solution.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.580910702Z",
+      "SORTName": "Secret Mounted as Environment Variable",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Environment Variable",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "SECRET_KEY=="
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "a919ccaf-6b43-4160-ac5d-a405e1440a41",
+      "name": "Fixable Severity at least Important",
+      "description": "Alert on deployments with fixable vulnerabilities with a Severity Rating at least Important",
+      "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
+      "remediation": "Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.",
+      "disabled": false,
+      "categories": [
+        "Vulnerability Management"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [
+        "FAIL_BUILD_ENFORCEMENT"
+      ],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Fixable Severity at least Important",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": true,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Fixed By",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": ".*"
+                }
+              ]
+            },
+            {
+              "fieldName": "Severity",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": ">= IMPORTANT"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "a9b9ecf7-9707-4e32-8b62-d03018ed454f",
+      "name": "Mounting Sensitive Host Directories",
+      "description": "Alert on deployments mounting sensitive host directories",
+      "rationale": "Mounting system directories from host implies container access to sensitive files on the host. This expands the attack surface of the container and gives an intruder an opportunity to break containment if the host is not properly secured.",
+      "remediation": "Ensure that deployments do not mount sensitive host directories, or exclude this deployment if host mount is required.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on StackRox collector",
+          "deployment": {
+            "name": "collector",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on StackRox compliance",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": {
+                "key": "app",
+                "value": "stackrox-compliance"
+              }
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-kube-apiserver namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-kube-apiserver",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-kube-scheduler namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-kube-scheduler",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-etcd namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-etcd",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-kube-controller-manager namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-kube-controller-manager",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-oauth-apiserver namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-oauth-apiserver",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-apiserver namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-apiserver",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-network-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-network-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-machine-api namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-machine-api",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-dns namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-dns",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-cluster-csi-drivers namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-cluster-csi-drivers",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-cluster-node-tuning-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-cluster-node-tuning-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-multus namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-multus",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on node-ca dameonset in the openshift-image-registry namespace",
+          "deployment": {
+            "name": "node-ca",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-image-registry",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-sdn namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-sdn",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-machine-config-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-machine-config-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Mounting Sensitive Host Directories",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Volume Source",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "(/etc/.*|/sys/.*|/dev/.*|/proc/.*|/var/.*)"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "b3335ee3-6f1e-4c3a-a0ad-7c249c25c750",
+      "name": "systemd Execution",
+      "description": "Detected usage of the systemd service manager",
+      "rationale": "The systemd service manager is generally not used in containers, and its use could indicate suspicious activity",
+      "remediation": "Remove systemd from the image before deploying, or consider using a base image that doesn't bundle systemd",
+      "disabled": false,
+      "categories": [
+        "System Modification"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "systemd Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "systemd"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0003",
+          "techniques": [
+            "T1543.002"
+          ]
+        },
+        {
+          "tactic": "TA0004",
+          "techniques": [
+            "T1543.002"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "ccd66f67-0b69-4081-9d01-da692f7db3b4",
+      "name": "Mount Container Runtime Socket",
+      "description": "Alert on deployments with a volume mount on the container runtime socket",
+      "rationale": "Mounting the container runtime socket implies container access to the runtime daemon. With direct access to the runtime daemon, a user can schedule containers and collect information about the running containers. This can be used as a method of discovery or persistence in an attack. Depending on the container runtime configuration, this may also be used as a method of privilege escalation to the host operating system. Since this can be used as an attack, deployments that mount the container runtime socket should be minimized to those absolutely necessary.",
+      "remediation": "Investigate if this deployment is being deployed for legitimate business purposes, and if so, that mounting the container runtime socket is required. Perform one of the following actions based on this investigation: 1. Exclude the deployment in this policy because it is being deployed for legitimate use cases. 2. Do not mount the container runtime socket in the deployment and redeploy. 3. Launch an investigation into why a deployment with this insecure configuration useful to attackers was deployed.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on StackRox collector",
+          "deployment": {
+            "name": "collector",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on ucp-agent",
+          "deployment": {
+            "name": "ucp-agent",
+            "scope": null
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on ucp-agent-s390x",
+          "deployment": {
+            "name": "ucp-agent-s390x",
+            "scope": null
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on StackRox compliance",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": {
+                "key": "app",
+                "value": "stackrox-compliance"
+              }
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Mount Container Runtime Socket",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Volume Source",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "/var/run/docker.sock"
+                },
+                {
+                  "value": "/var/run/crio/crio.sock"
+                },
+                {
+                  "value": "/run/crio/crio.sock"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "cf80fb33-c7d0-4490-b6f4-e56e1f27b4e4",
+      "name": "Log4Shell: log4j Remote Code Execution vulnerability",
+      "description": "Alert on deployments with images containing the Log4Shell vulnerabilities (CVE-2021-44228 and CVE-2021-45046). There are flaws in the Java logging library Apache Log4j in versions from 2.0-beta9 to 2.15.0, excluding 2.12.2.",
+      "rationale": "These vulnerabilities allows a remote attacker to execute code on the server if the system logs an attacker-controlled string value with the attacker's JNDI LDAP server lookup.",
+      "remediation": "Update the log4j libary to version 2.16.0 (for Java 8 or later), 2.12.2 (for Java 7) or later. If not possible to upgrade, then remove the JndiLookup class from the classpath: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class",
+      "disabled": false,
+      "categories": [
+        "Vulnerability Management"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "CRITICAL_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Log4Shell: log4j Remote Code Execution vulnerability",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "CVE",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "CVE-2021-44228"
+                },
+                {
+                  "value": "CVE-2021-45046"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "d03e0723-ef09-44da-bf29-fdd9e576fbf9",
+      "name": "Spring4Shell (Spring Framework Remote Code Execution) and Spring Cloud Function vulnerabilities",
+      "description": "Alert on deployments with images containing Spring4Shell vulnerability CVE-2022-22965 which affects the Spring MVC component and vulnerability CVE-2022-22963 which affects the Spring Cloud component. There are flaws in Spring Cloud Function (versions 3.1.6, 3.2.2 and older unsupported versions) and in Spring Framework (5.3.0 to 5.3.17, 5.2.0 to 5.2.19 and older unsupported versions).",
+      "rationale": "In Spring Cloud Function, when using routing functionality, a user can provide a specially crafted SpEL as a routing-expression that may result in remote code execution (RCE) and access to local resources. For Spring Framework, a Spring MVC or Spring WebFlux application running on JDK 9+ may be vulnerable to RCE via data binding.",
+      "remediation": "Upgrade Spring Cloud Function to version 3.1.7 or 3.2.3. Upgrade Spring Framework to version 5.3.18+ (if currently on 5.3.x) or 5.2.20+ (if currently on 5.2.x). If not possible to upgrade Spring Framework, then apply an appropriate workaround from the suggested workarounds on https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement",
+      "disabled": false,
+      "categories": [
+        "Vulnerability Management"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "CRITICAL_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Spring4Shell (Spring Framework Remote Code Execution) and Spring Cloud Function vulnerabilities",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "CVE",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "CVE-2022-22963"
+                },
+                {
+                  "value": "CVE-2022-22965"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "d3e480c1-c6de-4cd2-9006-9a3eb3ad36b6",
+      "name": "Required Image Label",
+      "description": "Alert on deployments with images missing the specified label.",
+      "rationale": "Only images with the specified label should be deployed to ensure all deployments contain approved images.",
+      "remediation": "Request that the maintainer add the required label to the image.",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices",
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.578049102Z",
+      "SORTName": "Required Image Label",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Required Image Label",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "required-label.*=required-value.*"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "d63564bd-c184-40bc-9f30-39711e010b82",
+      "name": "Alpine Linux Package Manager Execution",
+      "description": "Alert when the Alpine Linux package manager (apk) is executed at runtime",
+      "rationale": "Use of package managers at runtime indicates that new software may be being introduced into containers while they are running.",
+      "remediation": "Run `apk --purge del apk-tools` in the image build for production containers. Change applications to no longer use package managers at runtime, if applicable.",
+      "disabled": false,
+      "categories": [
+        "Package Management"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Alpine Linux Package Manager Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "apk"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0011",
+          "techniques": [
+            "T1105"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "d7a275e1-1bba-47e7-92a1-42340c759883",
+      "name": "Ubuntu Package Manager Execution",
+      "description": "Alert when Debian/Ubuntu package manager programs are executed at runtime",
+      "rationale": "Use of package managers at runtime indicates that new software may be being introduced into containers while they are running.",
+      "remediation": "Run `dpkg -r --force-all apt && dpkg -r --force-all debconf dpkg` in the image build for production containers. Change applications to no longer use package managers at runtime, if applicable.",
+      "disabled": false,
+      "categories": [
+        "Package Management"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Ubuntu Package Manager Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "apt-get|apt|dpkg"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0011",
+          "techniques": [
+            "T1105"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "da4e0776-159b-42a3-90a9-18cdd9b485ba",
+      "name": "OpenShift: Advanced Cluster Security Central Admin Secret Accessed",
+      "description": "Alert when the RHACS Central secret is accessed.",
+      "rationale": "The Central secret can be used to login to the Central user interface as the admin user. This secret is generally salted and hashed by default in the data.htpasswd field, but may contain a base64 encoded password in the field data.password (if deployed with an Operator). This field may be safely removed. This secret should only be accessed for break glass troubleshooting and initial configuration. An update or access of this secret may indicate that it will be used to administer and configure security controls.",
+      "remediation": "Ensure that the Central admin secret was accessed for valid buiness purposes.",
+      "disabled": false,
+      "categories": [
+        "Anomalous Activity",
+        "Kubernetes Events"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "AUDIT_LOG_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "OpenShift: Advanced Cluster Security Central Admin Secret Accessed",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Kubernetes Resource",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "SECRETS"
+                }
+              ]
+            },
+            {
+              "fieldName": "Kubernetes API Verb",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "GET"
+                },
+                {
+                  "value": "PATCH"
+                },
+                {
+                  "value": "UPDATE"
+                }
+              ]
+            },
+            {
+              "fieldName": "Kubernetes Resource Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "central-htpasswd"
+                }
+              ]
+            },
+            {
+              "fieldName": "Kubernetes User Name",
+              "booleanOperator": "OR",
+              "negate": true,
+              "values": [
+                {
+                  "value": "system:serviceaccount:openshift-authentication-operator:rhacs-operator-controller-manager"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0006",
+          "techniques": [
+            "T1552.007"
+          ]
+        },
+        {
+          "tactic": "TA0007",
+          "techniques": [
+            "T1613"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "dce17697-1b72-49d2-b18a-05d893cd9368",
+      "name": "Docker CIS 4.1: Ensure That a User for the Container Has Been Created",
+      "description": "Containers should run as a non-root user",
+      "rationale": "It is good practice to run the container as a non-root user, where possible. This can be done via the USER directive in the Dockerfile.",
+      "remediation": "Ensure that the Dockerfile for each container switches from the root user",
+      "disabled": false,
+      "categories": [
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on StackRox namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-sdn namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-sdn",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-kube-apiserver namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-kube-apiserver",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-etcd namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-etcd",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-apiserver namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-apiserver",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-dns namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-dns",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-cluster-node-tuning-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-cluster-node-tuning-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-cluster-csi-drivers namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-cluster-csi-drivers",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-machine-config-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-machine-config-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Docker CIS 4.1: Ensure That a User for the Container Has Been Created",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Image User",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "0"
+                },
+                {
+                  "value": "root"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "ddb7af9c-5ec1-45e1-a0cf-c36e3ef2b2ce",
+      "name": "Red Hat Package Manager Execution",
+      "description": "Alert when Red Hat/Fedora/CentOS package manager programs are executed at runtime.",
+      "rationale": "Use of package managers at runtime indicates that new software may be being introduced into containers while they are running.",
+      "remediation": "Run `rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')` in the image build for production containers. Change applications to no longer use package managers at runtime, if applicable.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [
+        {
+          "name": "Don't alert on StackRox scanner",
+          "deployment": {
+            "name": "scanner",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-compliance namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-compliance",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Red Hat Package Manager Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "rpm|microdnf|dnf|yum"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0011",
+          "techniques": [
+            "T1105"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "e9635b83-4ec5-4e7a-9be1-1bcdd6d82bb7",
+      "name": "Cryptocurrency Mining Process Execution",
+      "description": "Cryptocurrency mining process spawned",
+      "rationale": "Cryptocurrency mining binaries are often evidence of malicious activity or a hijacked cluster.",
+      "remediation": "Ensure that the base image used to create the Dockerfile doesn't have cryptocurrency mining software packaged with it. Check for open ports that may allow for remote code execution",
+      "disabled": false,
+      "categories": [
+        "Cryptocurrency Mining"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Cryptocurrency Mining Process Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": ".*sgminer|.*cgminer|.*cpuminer|.*minerd|.*geth|.*ethminer|.*xmr-stak.*|.*xmrminer|.*cpuminer-multi|.*xmrig"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0040",
+          "techniques": [
+            "T1496"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "e971db42-e8d4-4a1d-a30c-41142ba54d71",
+      "name": "Improper Usage of Orchestrator Secrets Volume",
+      "description": "Alert on deployments that use a Dockerfile with 'VOLUME /run/secrets'",
+      "rationale": "/run/secrets is a path for secrets that gets populated by the orchestrator. Volumes should not be used for secrets, and data mounts should have a separate mount path.",
+      "remediation": "Mount the volume to a different path. If secrets are stored in the volume, utilize the orchestrator secrets or your security team's secret management solution instead.",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Improper Usage of Orchestrator Secrets Volume",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Dockerfile Line",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "VOLUME=(?:(?:[,\\[\\s]?)|(?:.*[,\\s]+))/run/secrets(?:$|[,\\]\\s]).*"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "ed8c7957-14de-40bc-aeab-d27ceeecfa7b",
+      "name": "Iptables Executed in Privileged Container",
+      "description": "Alert on privileged pods that execute iptables",
+      "rationale": "Processes that are running with UID 0 run as the root user. iptables can be used in privileged containers to modify the node's network routing.",
+      "remediation": "Specify the USER instruction in the Docker image or the runAsUser field within the Pod Security Context",
+      "disabled": false,
+      "categories": [
+        "Network Tools",
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [
+        {
+          "name": "Don't alert on Kube System Namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-sdn namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-sdn",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "CRITICAL_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Iptables Executed in Privileged Container",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Privileged Container",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "true"
+                }
+              ]
+            },
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "iptables"
+                }
+              ]
+            },
+            {
+              "fieldName": "Process UID",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "0"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0004",
+          "techniques": [
+            "T1611"
+          ]
+        },
+        {
+          "tactic": "TA0005",
+          "techniques": [
+            "T1562.004"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "f09f8da1-6111-4ca0-8f49-294a76c65115",
+      "name": "Fixable CVSS >= 7",
+      "description": "Alert on deployments with fixable vulnerabilities with a CVSS of at least 7",
+      "rationale": "Known vulnerabilities make it easier for adversaries to exploit your application. You can fix these high-severity vulnerabilities by updating to a newer version of the affected component(s).",
+      "remediation": "Use your package manager to update to a fixed version in future builds or speak with your security team to mitigate the vulnerabilities.",
+      "disabled": false,
+      "categories": [
+        "Vulnerability Management"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [
+        "FAIL_BUILD_ENFORCEMENT"
+      ],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:29:24.579948545Z",
+      "SORTName": "Fixable CVSS >= 7",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": true,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Fixed By",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": ".*"
+                }
+              ]
+            },
+            {
+              "fieldName": "CVSS",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": ">= 7.000000"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "f0bacecd-87be-4f51-89a5-8f86ad523620",
+      "name": "nmap Execution",
+      "description": "Alerts when the nmap process launches in a container during run time",
+      "rationale": "Nmap can be used to probe a running container's network to enumerate open ports and perform other actions such as OS version detection and launching over-the-network scripted attacks",
+      "remediation": "Consider removing package managers during the build process that could be used to download such software. Check that exposed ports don't allow for remote code execution",
+      "disabled": false,
+      "categories": [
+        "Network Tools"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "nmap Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "nmap"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0007",
+          "techniques": [
+            "T1046"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "f0ccfb84-1a00-488b-943f-bd89e1b9ce13",
+      "name": "test-role",
+      "description": "",
+      "rationale": "",
+      "remediation": "",
+      "disabled": false,
+      "categories": [
+        "DevOps Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": "2022-07-20T07:54:23.187332131Z",
+      "SORTName": "test-role",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "Policy Section 1",
+          "policyGroups": [
+            {
+              "fieldName": "Minimum RBAC Permissions",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "ELEVATED_IN_NAMESPACE"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": false,
+      "mitreVectorsLocked": false,
+      "isDefault": false
+    },
+    {
+      "id": "f2183906-4577-47de-9bf4-270d09e0a93c",
+      "name": "systemctl Execution",
+      "description": "Detected usage of the systemctl service manager",
+      "rationale": "The systemctl service manager is generally not used in containers, and its use could indicate suspicious activity",
+      "remediation": "Remove systemctl from the image before deploying, or consider using a base image that doesn't bundle systemctl",
+      "disabled": false,
+      "categories": [
+        "System Modification"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "DEPLOYMENT_EVENT",
+      "exclusions": [
+        {
+          "name": "Don't alert on StackRox namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "systemctl Execution",
+      "SORTLifecycleStage": "RUNTIME",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Process Name",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "systemctl"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [
+        {
+          "tactic": "TA0003",
+          "techniques": [
+            "T1543.002"
+          ]
+        },
+        {
+          "tactic": "TA0004",
+          "techniques": [
+            "T1543.002"
+          ]
+        }
+      ],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "f4996314-c3d7-4553-803b-b24ce7febe48",
+      "name": "Environment Variable Contains Secret",
+      "description": "Alert on deployments with environment variables that contain 'SECRET'",
+      "rationale": "Using secrets in environment variables may allow inspection into your secrets from the host or even through the orchestrator UI.",
+      "remediation": "Migrate your secrets from environment variables to orchestrator secrets or your security team's secret management solution.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "HIGH_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Environment Variable Contains Secret",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Environment Variable",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "RAW=.*SECRET.*|.*PASSWORD.*="
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "f95ff08d-130a-465a-a27e-32ed1fb05555",
+      "name": "Red Hat Package Manager in Image",
+      "description": "Alert on deployments with components of the Red Hat/Fedora/CentOS package management system.",
+      "rationale": "Package managers make it easier for attackers to use compromised containers, since they can easily add software.",
+      "remediation": "Run `rpm -e --nodeps $(rpm -qa '*rpm*' '*dnf*' '*libsolv*' '*hawkey*' 'yum*')` in the image build for production containers.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices"
+      ],
+      "lifecycleStages": [
+        "BUILD",
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on StackRox scanner",
+          "deployment": {
+            "name": "scanner",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on system namespaces",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "^kube.*|^openshift.*|^redhat.*|^istio-system$",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "LOW_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Red Hat Package Manager in Image",
+      "SORTLifecycleStage": "BUILD,DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Image Component",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "rpm|microdnf|dnf|yum="
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "fb8f8732-c31d-496b-8fb1-d5abe6056e27",
+      "name": "Pod Service Account Token Automatically Mounted",
+      "description": "Protect pod default service account tokens from compromise by minimizing the mounting of the default service account token to only those pods whose application requires interaction with the Kubernetes API.",
+      "rationale": "By default, Kubernetes automatically provisions a service account for each pod and mounts the secret at runtime. This service account is not typically used. If this pod is compromised and the compromised user has access to the service account, the service account could be used to escalate privileges within the cluster. To reduce the likelihood of privilege escalation this service account should not be mounted by default unless the pod requires direct access to the Kubernetes API as part of the pods functionality.",
+      "remediation": "Add `automountServiceAccountToken: false` or a value distinct from 'default' for the `serviceAccountName` key to the deployment's Pod configuration.",
+      "disabled": false,
+      "categories": [
+        "Security Best Practices",
+        "Privileges"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Pod Service Account Token Automatically Mounted",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Automount Service Account Token",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "true"
+                }
+              ]
+            },
+            {
+              "fieldName": "Service Account",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "default"
+                }
+              ]
+            },
+            {
+              "fieldName": "Namespace",
+              "booleanOperator": "OR",
+              "negate": true,
+              "values": [
+                {
+                  "value": "kube-system"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "fe9de18b-86db-44d5-a7c4-74173ccffe2e",
+      "name": "Privileged Container",
+      "description": "Alert on deployments with containers running in privileged mode",
+      "rationale": "Containers running as privileged represent greater post-exploitation risk by allowing an attacker to access all host devices, run a daemon in the container, etc.",
+      "remediation": "Verify that privileged capabilities are required and cannot be provided with a subset of other controls.",
+      "disabled": false,
+      "categories": [
+        "Privileges",
+        "Docker CIS"
+      ],
+      "lifecycleStages": [
+        "DEPLOY"
+      ],
+      "eventSource": "NOT_APPLICABLE",
+      "exclusions": [
+        {
+          "name": "Don't alert on the stackrox namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "stackrox",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on kube-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "kube-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on istio-system namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "istio-system",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-node namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-node",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-sdn namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-sdn",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-kube-apiserver namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-kube-apiserver",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-etcd namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-etcd",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-apiserver namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-apiserver",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-dns namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-dns",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-cluster-node-tuning-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-cluster-node-tuning-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-cluster-csi-drivers namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-cluster-csi-drivers",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        },
+        {
+          "name": "Don't alert on openshift-machine-config-operator namespace",
+          "deployment": {
+            "name": "",
+            "scope": {
+              "cluster": "",
+              "namespace": "openshift-machine-config-operator",
+              "label": null
+            }
+          },
+          "image": null,
+          "expiration": null
+        }
+      ],
+      "scope": [],
+      "severity": "MEDIUM_SEVERITY",
+      "enforcementActions": [],
+      "notifiers": [],
+      "lastUpdated": null,
+      "SORTName": "Privileged Container",
+      "SORTLifecycleStage": "DEPLOY",
+      "SORTEnforcement": false,
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "",
+          "policyGroups": [
+            {
+              "fieldName": "Privileged Container",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "true"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "mitreAttackVectors": [],
+      "criteriaLocked": true,
+      "mitreVectorsLocked": true,
+      "isDefault": true
+    },
+    {
+      "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      "name": "File Activity Load Test Policy",
+      "description": "Matches file access events for load testing",
+      "severity": "HIGH_SEVERITY",
+      "disabled": false,
+      "categories": [
+        "System Modification"
+      ],
+      "lifecycleStages": [
+        "RUNTIME"
+      ],
+      "eventSource": "NODE_EVENT",
+      "policyVersion": "1.1",
+      "policySections": [
+        {
+          "sectionName": "File access",
+          "policyGroups": [
+            {
+              "fieldName": "File Path",
+              "booleanOperator": "OR",
+              "negate": false,
+              "values": [
+                {
+                  "value": "/etc/**"
+                },
+                {
+                  "value": "/var/log/**"
+                },
+                {
+                  "value": "/tmp/**"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "enforcementActions": [],
+      "exclusions": [],
+      "scope": [],
+      "notifiers": [],
+      "isDefault": false,
+      "criteriaLocked": false,
+      "mitreVectorsLocked": false
+    }
+  ]
+}

--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -40,6 +40,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
@@ -99,6 +101,13 @@ type localSensorConfig struct {
 	FakeCollector      bool
 	Namespace          string
 	OperatorInstall    bool
+
+	// File activity load driver settings
+	FileActivityLoad      bool
+	FileActivityRate      int
+	FileActivityPaths     int
+	FileActivityHostname  string
+	FileActivityContainer string
 }
 
 func mustGetCommandLineArgs() localSensorConfig {
@@ -124,6 +133,12 @@ func mustGetCommandLineArgs() localSensorConfig {
 		FakeCollector:      false,
 		Namespace:          certs.DefaultNamespace,
 		OperatorInstall:    false,
+
+		FileActivityLoad:      false,
+		FileActivityRate:      100,
+		FileActivityPaths:     50,
+		FileActivityHostname:  "fake-collector",
+		FileActivityContainer: "",
 	}
 	flag.BoolVar(&sensorConfig.NoCPUProfile, "no-cpu-prof", sensorConfig.NoCPUProfile, "disables producing CPU profile for performance analysis")
 	flag.BoolVar(&sensorConfig.NoMemProfile, "no-mem-prof", sensorConfig.NoMemProfile, "disables producing memory profile for performance analysis")
@@ -146,6 +161,11 @@ func mustGetCommandLineArgs() localSensorConfig {
 	flag.StringVar(&sensorConfig.Namespace, "namespace", sensorConfig.Namespace, "namespace where sensor is deployed (used for certificate generation when connecting to real Central)")
 	flag.BoolVar(&sensorConfig.FakeCollector, "with-fake-collector", sensorConfig.FakeCollector, "enables sensor to allow connections from a fake collector")
 	flag.BoolVar(&sensorConfig.OperatorInstall, "operator-install", sensorConfig.OperatorInstall, "use together with connect-central, indicates that the remote ACS was installed with the Operator")
+	flag.BoolVar(&sensorConfig.FileActivityLoad, "file-activity-load", sensorConfig.FileActivityLoad, "generate synthetic file activity events at a configurable rate")
+	flag.IntVar(&sensorConfig.FileActivityRate, "file-activity-rate", sensorConfig.FileActivityRate, "target events/sec for file activity load (0 = unlimited burst)")
+	flag.IntVar(&sensorConfig.FileActivityPaths, "file-activity-paths", sensorConfig.FileActivityPaths, "number of unique file paths in generated events")
+	flag.StringVar(&sensorConfig.FileActivityHostname, "file-activity-hostname", sensorConfig.FileActivityHostname, "hostname for generated file activity events")
+	flag.StringVar(&sensorConfig.FileActivityContainer, "file-activity-container", sensorConfig.FileActivityContainer, "container ID for generated events (empty = node-level events)")
 	flag.Parse()
 
 	sensorConfig.CentralOutput = path.Clean(sensorConfig.CentralOutput)
@@ -230,9 +250,12 @@ func main() {
 		metrics.GatherThrottleMetricsForever(metrics.SensorSubsystem.String())
 	}
 	var k8sClient client.Interface
-	// when replying a trace, there is no need to connect to K8s cluster
-	if localConfig.ReplayK8sEnabled {
+	// when replying a trace or running a load test, there is no need to connect to K8s cluster
+	if localConfig.ReplayK8sEnabled || localConfig.FileActivityLoad {
 		k8sClient = k8s.MakeFakeClient()
+		if localConfig.FileActivityLoad {
+			seedFakeNode(k8sClient, localConfig.FileActivityHostname)
+		}
 	}
 	var (
 		workloadManager *fake.WorkloadManager
@@ -320,12 +343,13 @@ func main() {
 		sensorConfig = sensorConfig.WithDeploymentIdentification(deploymentID)
 	}
 
-	if localConfig.FakeCollector {
+	if localConfig.FakeCollector || localConfig.FileActivityLoad {
 		acceptAnyFn := func(ctx context.Context, _ string) (context.Context, error) {
 			return ctx, nil
 		}
 		sensorConfig.WithSignalServiceAuthFuncOverride(acceptAnyFn).
-			WithNetworkFlowServiceAuthFuncOverride(acceptAnyFn)
+			WithNetworkFlowServiceAuthFuncOverride(acceptAnyFn).
+			WithFileActivityServiceAuthFuncOverride(acceptAnyFn)
 	}
 
 	if localConfig.RecordK8sEnabled {
@@ -399,10 +423,33 @@ func main() {
 		spyCentral.ConnectionStarted.Wait()
 	}
 
-	if localConfig.FakeCollector {
-		fakeCollector := collector.NewFakeCollector(collector.WithDefaultConfig())
+	var loadDriver *collector.FileActivityLoadDriver
+	var fakeCollector *collector.FakeCollector
+	if localConfig.FakeCollector || localConfig.FileActivityLoad {
+		fakeCollector = collector.NewFakeCollector(collector.WithDefaultConfig())
 		if err := fakeCollector.Start(); err != nil {
 			log.Fatalln(err)
+		}
+
+		if localConfig.FileActivityLoad {
+			cfg := collector.LoadDriverConfig{
+				EventsPerSecond: localConfig.FileActivityRate,
+				NumUniquePaths:  localConfig.FileActivityPaths,
+				Hostname:        localConfig.FileActivityHostname,
+				ContainerID:     localConfig.FileActivityContainer,
+				OperationWeights: map[string]int{
+					"open": 40, "create": 20, "unlink": 10,
+					"rename": 10, "chmod": 10, "chown": 10,
+				},
+			}
+			loadDriver = collector.NewFileActivityLoadDriver(fakeCollector, cfg)
+			go func() {
+				log.Printf("Starting file activity load driver: rate=%d events/sec, paths=%d\n",
+					cfg.EventsPerSecond, cfg.NumUniquePaths)
+				stats := loadDriver.Run()
+				log.Printf("Load driver finished: sent=%d events, actual_rate=%.1f events/sec, errors=%d\n",
+					stats.EventsSent, stats.ActualRate(), stats.Errors)
+			}()
 		}
 	}
 
@@ -420,6 +467,14 @@ func main() {
 	}
 
 	cancelFunc()
+	if loadDriver != nil {
+		log.Printf("Stopping file activity load driver...")
+		loadDriver.Stop()
+	}
+	if fakeCollector != nil {
+		log.Printf("Stopping fake collector...")
+		fakeCollector.Stop()
+	}
 	if !localConfig.NoMemProfile {
 		writeMemoryProfile()
 	}
@@ -512,4 +567,15 @@ func setupCentralWithFakeConnection(localConfig localSensorConfig) (centralclien
 	fakeConnectionFactory := centralDebug.MakeFakeConnectionFactory(conn)
 
 	return fakeConnectionFactory, centralclient.EmptyCertLoader(), spyCentral
+}
+
+func seedFakeNode(k8sClient client.Interface, hostname string) {
+	_, err := k8sClient.Kubernetes().CoreV1().Nodes().Create(context.Background(), &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: hostname,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		log.Fatalf("Failed to seed fake node %q: %v", hostname, err)
+	}
 }

--- a/tools/local-sensor/scripts/README.md
+++ b/tools/local-sensor/scripts/README.md
@@ -106,3 +106,42 @@ These steps will generate five output files located in `tools/local-sensor/out`:
 - `local-sensor-cpu-<date>.prof`: Contains the CPU profile of the test run.
 - `local-sensor-mem-<date>.prof`: Contains the Memory profile of the test run.
 - `sensor_events_dump.json`: Contains information of all the events sent from sensor.
+
+## File activity load testing
+
+The script can generate synthetic file activity events to stress-test the Sensor file activity pipeline. This runs without a cluster -- it uses the fake collector and fake central.
+
+### Quick start
+
+```bash
+# Build and run a 60-second load test at 1000 events/sec
+./local-sensor.sh --build --file-activity-load --file-activity-rate 1000
+```
+
+### Full options
+
+```bash
+./local-sensor.sh --build --file-activity-load \
+  --file-activity-rate 5000 \
+  --file-activity-paths 200 \
+  --file-activity-duration 120 \
+  --with-policies path/to/policies.json
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--file-activity-load` | off | Enable the file activity load test |
+| `--file-activity-rate` | 100 | Target events/sec (0 = unlimited burst) |
+| `--file-activity-paths` | 50 | Number of unique file paths |
+| `--file-activity-duration` | 60 | Test duration in seconds |
+| `--file-activity-hostname` | fake-collector | Hostname on generated events |
+| `--file-activity-container` | (empty) | Container ID (empty = node-level events) |
+| `--with-policies` | sensor/tests/data/policies.json | Policies file for evaluation |
+
+### Output
+
+Results are printed to stdout and saved to `tools/local-sensor/out/`:
+
+- `file_activity_report.txt`: Human-readable summary with achieved rate, drop count, and queue metrics.
+- `file_activity_metrics.json`: Raw Prometheus metrics dump (requires `jq` for formatted report).
+- `file_activity_load.log`: Full local-sensor log output.

--- a/tools/local-sensor/scripts/local-sensor.sh
+++ b/tools/local-sensor/scripts/local-sensor.sh
@@ -23,6 +23,16 @@ RUN_TEST="no"
 TEST_TIMEOUT=600
 VERBOSE="false"
 
+# File activity load test settings
+RUN_FILE_ACTIVITY_LOAD="no"
+FILE_ACTIVITY_RATE=100
+FILE_ACTIVITY_PATHS=50
+FILE_ACTIVITY_DURATION=60
+FILE_ACTIVITY_HOSTNAME="fake-collector"
+FILE_ACTIVITY_CONTAINER=""
+FILE_ACTIVITY_METRICS_DUMP=$OUTPUT_DIR/file_activity_metrics.json
+FILE_ACTIVITY_REPORT=$OUTPUT_DIR/file_activity_report.txt
+
 function build_local_sensor() {
   [[ "$VERBOSE" == "false" ]] || echo "Building local-sensor: $LOCAL_SENSOR_BIN"
   mkdir -p "$OUTPUT_DIR"
@@ -54,10 +64,151 @@ function run_test() {
   [[ "$VERBOSE" == "false" ]] || echo "Test done"
 }
 
+function get_raw_metrics_url() {
+  echo "http://localhost${ROX_METRICS_PORT}/metrics"
+}
+
+function scrape_file_activity_metrics() {
+  local output_file=$1
+  local metrics_url
+  metrics_url=$(get_raw_metrics_url)
+  curl -s "$metrics_url" > "$output_file" 2>/dev/null || true
+}
+
+function extract_metric() {
+  local metrics_file=$1
+  local metric_name=$2
+  grep "^${metric_name}" "$metrics_file" 2>/dev/null | grep -v "^#" | head -1 | awk '{print $2}' || true
+}
+
+function extract_metric_with_label() {
+  local metrics_file=$1
+  local metric_name=$2
+  local label_match=$3
+  grep "^${metric_name}{.*${label_match}" "$metrics_file" 2>/dev/null | grep -v "^#" | awk '{print $2}' || true
+}
+
+function format_file_activity_report() {
+  local metrics_file=$1
+  local report_file=$2
+  local duration=$3
+  local rate=$4
+  local paths=$5
+
+  {
+    echo "============================================"
+    echo "  File Activity Load Test Report"
+    echo "============================================"
+    echo ""
+    echo "Configuration:"
+    echo "  Target rate:    $rate events/sec"
+    echo "  Unique paths:   $paths"
+    echo "  Duration:       ${duration}s"
+    echo "  Hostname:       $FILE_ACTIVITY_HOSTNAME"
+    echo "  Container ID:   ${FILE_ACTIVITY_CONTAINER:-<none (node-level)>}"
+    echo "  Policies file:  $POLICIES_FILE"
+    echo ""
+    echo "Pipeline metrics:"
+
+    local received dropped
+    received=$(extract_metric "$metrics_file" "rox_sensor_file_access_events_received_total")
+    dropped=$(extract_metric "$metrics_file" "rox_sensor_detector_file_access_queue_dropped_total")
+    # Convert scientific notation (e.g. 2.748109e+06) to integers
+    received=$(printf '%.0f' "${received:-0}" 2>/dev/null || echo "0")
+    dropped=$(printf '%.0f' "${dropped:-0}" 2>/dev/null || echo "0")
+
+    echo "  Events received:       ${received:-0}"
+    echo "  Events dropped:        ${dropped:-0}"
+
+    if [[ -n "$received" && "$received" != "0" ]]; then
+      local actual_rate
+      actual_rate=$(echo "scale=1; $received / $duration" | bc 2>/dev/null || echo "N/A")
+      echo "  Actual rate:           $actual_rate events/sec"
+    fi
+
+    if [[ -n "$dropped" && "$dropped" != "0" && -n "$received" ]]; then
+      local drop_pct
+      drop_pct=$(echo "scale=2; $dropped * 100 / ($received + $dropped)" | bc 2>/dev/null || echo "N/A")
+      echo "  Drop rate:             ${drop_pct}%"
+    else
+      echo "  Drop rate:             0%"
+    fi
+
+    echo ""
+    echo "Queue operations:"
+    local queue_add queue_remove
+    queue_add=$(extract_metric_with_label "$metrics_file" "rox_sensor_detector_file_access_queue_operations_total" 'Operation="Add"')
+    queue_remove=$(extract_metric_with_label "$metrics_file" "rox_sensor_detector_file_access_queue_operations_total" 'Operation="Remove"')
+    echo "  Added:                 ${queue_add:-0}"
+    echo "  Removed:               ${queue_remove:-0}"
+
+    echo ""
+    echo "Criteria match duration:"
+    local match_count match_sum
+    match_count=$(extract_metric "$metrics_file" "rox_sensor_file_access_criteria_match_duration_seconds_count")
+    match_sum=$(extract_metric "$metrics_file" "rox_sensor_file_access_criteria_match_duration_seconds_sum")
+    echo "  Total matches:         ${match_count:-0}"
+    echo "  Total time:            ${match_sum:-0}s"
+    if [[ -n "$match_count" && "$match_count" != "0" && -n "$match_sum" ]]; then
+      local avg_match
+      avg_match=$(echo "scale=6; $match_sum / $match_count" | bc 2>/dev/null || echo "N/A")
+      echo "  Avg per event:         ${avg_match}s"
+    fi
+
+    echo ""
+    echo "============================================"
+  } > "$report_file"
+}
+
+function run_file_activity_load() {
+  [[ "$VERBOSE" == "false" ]] || echo "Running file activity load test: rate=$FILE_ACTIVITY_RATE paths=$FILE_ACTIVITY_PATHS duration=${FILE_ACTIVITY_DURATION}s"
+  export ROX_METRICS_PORT=$ROX_METRICS_PORT
+
+  local sensor_args=(
+    -file-activity-load
+    -file-activity-rate="$FILE_ACTIVITY_RATE"
+    -file-activity-paths="$FILE_ACTIVITY_PATHS"
+    -file-activity-hostname="$FILE_ACTIVITY_HOSTNAME"
+    -with-metrics
+    -central-out=/dev/null
+    -skip-central-output
+    -no-cpu-prof
+    -no-mem-prof
+  )
+
+  if [[ -n "$FILE_ACTIVITY_CONTAINER" ]]; then
+    sensor_args+=(-file-activity-container="$FILE_ACTIVITY_CONTAINER")
+  fi
+
+  if [[ -n "$POLICIES_FILE" ]]; then
+    sensor_args+=(-with-policies="$POLICIES_FILE")
+  fi
+
+  $EXEC "${sensor_args[@]}" > "$OUTPUT_DIR"/file_activity_load.log 2>&1 &
+  PID=$!
+  [[ "$VERBOSE" == "false" ]] || echo "$LOCAL_SENSOR_BIN PID: $PID"
+
+  sleep "$FILE_ACTIVITY_DURATION"
+
+  local metrics_url
+  metrics_url=$(get_raw_metrics_url)
+  scrape_file_activity_metrics "$FILE_ACTIVITY_METRICS_DUMP"
+  [[ "$VERBOSE" == "false" ]] || echo "Metrics scraped to $FILE_ACTIVITY_METRICS_DUMP"
+
+  kill "$PID"
+
+  format_file_activity_report "$FILE_ACTIVITY_METRICS_DUMP" "$FILE_ACTIVITY_REPORT" \
+    "$FILE_ACTIVITY_DURATION" "$FILE_ACTIVITY_RATE" "$FILE_ACTIVITY_PATHS"
+
+  cat "$FILE_ACTIVITY_REPORT"
+  [[ "$VERBOSE" == "false" ]] || echo "File activity load test done"
+}
+
 function exec_option() {
   [[ "$RUN_BUILD" == "yes" ]] && build_local_sensor
   [[ "$RUN_GENERATE" == "yes" ]] && generate_k8s_events
   [[ "$RUN_TEST" == "yes" ]] && run_test
+  [[ "$RUN_FILE_ACTIVITY_LOAD" == "yes" ]] && run_file_activity_load
 }
 
 function print_header() {
@@ -76,6 +227,14 @@ function print_header() {
   echo "PROMETHEUS_QUERY    = $PROMETHEUS_QUERY"
   echo "PROMETHEUS_DUMP     = $PROMETHEUS_DUMP"
   echo "ROX_METRICS_PORT    = $ROX_METRICS_PORT"
+  if [[ "$RUN_FILE_ACTIVITY_LOAD" == "yes" ]]; then
+    echo "--- File Activity Load ---"
+    echo "FILE_ACTIVITY_RATE     = $FILE_ACTIVITY_RATE"
+    echo "FILE_ACTIVITY_PATHS    = $FILE_ACTIVITY_PATHS"
+    echo "FILE_ACTIVITY_DURATION = $FILE_ACTIVITY_DURATION"
+    echo "FILE_ACTIVITY_HOSTNAME = $FILE_ACTIVITY_HOSTNAME"
+    echo "FILE_ACTIVITY_CONTAINER= ${FILE_ACTIVITY_CONTAINER:-<none>}"
+  fi
   echo "=========================================="
 }
 
@@ -95,6 +254,15 @@ function print_help() {
       echo "--prometheus-query [query]                 query to be executed to retrieve the metrics dump"
       echo "--prometheus-dump-name [file name]         name of the file containing the metrics dump"
       echo "--metrics-endpoint [endpoint]              metrics endpoint"
+      echo ""
+      echo "File activity load testing:"
+      echo "--file-activity-load                       run file activity load test"
+      echo "--file-activity-rate [rate]                target events/sec (default: 100, 0 = burst)"
+      echo "--file-activity-paths [count]              number of unique file paths (default: 50)"
+      echo "--file-activity-duration [seconds]         duration of the load test (default: 60)"
+      echo "--file-activity-hostname [hostname]        hostname for generated events (default: fake-collector)"
+      echo "--file-activity-container [id]             container ID (default: empty = node-level events)"
+      echo ""
       echo "-h, --help                                 this help"
 }
 
@@ -197,6 +365,44 @@ function parse_args() {
         arg=$1
         [[ ${arg:0:1} == "-" ]] && echo "Invalid argument for --prometheus-dump-name $arg" && exit 1
         PROMETHEUS_DUMP=$OUTPUT_DIR/$arg
+        shift
+        ;;
+      --file-activity-load)
+        RUN_FILE_ACTIVITY_LOAD="yes"
+        shift
+        ;;
+      --file-activity-rate)
+        shift
+        arg=$1
+        [[ ${arg:0:1} == "-" ]] && echo "Invalid argument for --file-activity-rate $arg" && exit 1
+        FILE_ACTIVITY_RATE=$arg
+        shift
+        ;;
+      --file-activity-paths)
+        shift
+        arg=$1
+        [[ ${arg:0:1} == "-" ]] && echo "Invalid argument for --file-activity-paths $arg" && exit 1
+        FILE_ACTIVITY_PATHS=$arg
+        shift
+        ;;
+      --file-activity-duration)
+        shift
+        arg=$1
+        [[ ${arg:0:1} == "-" ]] && echo "Invalid argument for --file-activity-duration $arg" && exit 1
+        FILE_ACTIVITY_DURATION=$arg
+        shift
+        ;;
+      --file-activity-hostname)
+        shift
+        arg=$1
+        [[ ${arg:0:1} == "-" ]] && echo "Invalid argument for --file-activity-hostname $arg" && exit 1
+        FILE_ACTIVITY_HOSTNAME=$arg
+        shift
+        ;;
+      --file-activity-container)
+        shift
+        arg=$1
+        FILE_ACTIVITY_CONTAINER=$arg
         shift
         ;;
       -*)


### PR DESCRIPTION
## Description

Adds the ability to send generated FileActivity from the fake Collector to Sensor, to support e2e testing.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Nothing yet, but tests that use this functionality will be added in future PRs.