### PR TITLE
ROX-31592: Use import type in WorkloadCves

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -795,7 +795,6 @@ module.exports = [
         ignores: [
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/VulnMgmt/**', // deprecated
-            'src/Containers/Vulnerabilities/WorkloadCves/**',
             'src/Containers/Workflow/**', // deprecated
         ],
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -23,10 +23,8 @@ import useURLSearch from 'hooks/useURLSearch';
 import usePermissions from 'hooks/usePermissions';
 import type { VulnerabilityState } from 'types/cve.proto';
 
-import DeploymentPageHeader, {
-    DeploymentMetadata,
-    deploymentMetadataFragment,
-} from './DeploymentPageHeader';
+import DeploymentPageHeader, { deploymentMetadataFragment } from './DeploymentPageHeader';
+import type { DeploymentMetadata } from './DeploymentPageHeader';
 import { detailsTabValues } from '../../types';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { getVulnStateScopedQueryString, parseQuerySearchFilter } from '../../utils/searchUtils';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties } from 'react';
+import React from 'react';
+import type { CSSProperties } from 'react';
 import {
     Bullseye,
     Divider,
@@ -9,15 +10,16 @@ import {
     Text,
 } from '@patternfly/react-core';
 import { gql, useQuery } from '@apollo/client';
-import { Pagination as PaginationParam } from 'services/types';
+import type { Pagination as PaginationParam } from 'services/types';
 
 import useURLSort from 'hooks/useURLSort';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
+import type { UseURLPaginationResult } from 'hooks/useURLPagination';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 
 import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
-import ImageResourceTable, { ImageResources, imageResourcesFragment } from './ImageResourceTable';
+import ImageResourceTable, { imageResourcesFragment } from './ImageResourceTable';
+import type { ImageResources } from './ImageResourceTable';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export type DeploymentPageResourcesProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { ReactNode } from 'react';
 import {
     Divider,
     Flex,
@@ -10,37 +11,29 @@ import {
     Title,
 } from '@patternfly/react-core';
 import { gql, useQuery } from '@apollo/client';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 
 import useFeatureFlags from 'hooks/useFeatureFlags';
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
+import type { UseURLPaginationResult } from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
-import { Pagination as PaginationParam } from 'services/types';
+import type { Pagination as PaginationParam } from 'services/types';
 import { getHasSearchApplied, getPaginationParams } from 'utils/searchUtils';
 import type { VulnerabilityState } from 'types/cve.proto';
 import NotFoundMessage from 'Components/NotFoundMessage';
 import { getSearchFilterConfigWithFeatureFlagDependency } from 'Components/CompoundSearchFilter/utils/utils';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
-import {
-    SummaryCardLayout,
-    SummaryCard,
-} from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import { getTableUIState } from 'utils/getTableUIState';
-import AdvancedFiltersToolbar from 'Containers/Vulnerabilities/components/AdvancedFiltersToolbar';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
 import useAnalytics, { WORKLOAD_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
-import {
-    imageComponentSearchFilterConfig,
-    imageCVESearchFilterConfig,
-    imageSearchFilterConfig,
-} from 'Containers/Vulnerabilities/searchFilterConfig';
 import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
+import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import CvesByStatusSummaryCard, {
     resourceCountByCveSeverityAndStatusFragment,
-    ResourceCountByCveSeverityAndStatus,
 } from '../../components/CvesByStatusSummaryCard';
+import type { ResourceCountByCveSeverityAndStatus } from '../../components/CvesByStatusSummaryCard';
+import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
 import {
     parseQuerySearchFilter,
     getHiddenSeverities,
@@ -49,10 +42,12 @@ import {
     getStatusesForExceptionCount,
 } from '../../utils/searchUtils';
 import {
-    DeploymentWithVulnerabilities,
-    formatVulnerabilityData,
-    imageMetadataContextFragment,
-} from '../Tables/table.utils';
+    imageComponentSearchFilterConfig,
+    imageCVESearchFilterConfig,
+    imageSearchFilterConfig,
+} from '../../searchFilterConfig';
+import { formatVulnerabilityData, imageMetadataContextFragment } from '../Tables/table.utils';
+import type { DeploymentWithVulnerabilities } from '../Tables/table.utils';
 import DeploymentVulnerabilitiesTable, {
     defaultColumns,
     deploymentWithVulnerabilitiesFragment,
@@ -98,7 +93,7 @@ export type DeploymentPageVulnerabilitiesProps = {
     pagination: UseURLPaginationResult;
     vulnerabilityState: VulnerabilityState;
     showVulnerabilityStateTabs: boolean;
-    additionalToolbarItems?: React.ReactNode;
+    additionalToolbarItems?: ReactNode;
     searchFilter: SearchFilter;
     setSearchFilter: (filter: SearchFilter) => void;
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
-import { UseURLSortResult } from 'hooks/useURLSort';
+import type { UseURLSortResult } from 'hooks/useURLSort';
 import DateDistance from 'Components/DateDistance';
 import EmptyTableResults from '../components/EmptyTableResults';
 import ImageNameLink from '../components/ImageNameLink';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
@@ -3,8 +3,9 @@ import { Link } from 'react-router-dom-v5-compat';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
-import { UseURLSortResult } from 'hooks/useURLSort';
-import { generateVisibilityForColumns, ManagedColumns } from 'hooks/useManagedColumns';
+import type { UseURLSortResult } from 'hooks/useURLSort';
+import { generateVisibilityForColumns } from 'hooks/useManagedColumns';
+import type { ManagedColumns } from 'hooks/useManagedColumns';
 import DateDistance from 'Components/DateDistance';
 import EmptyTableResults from '../components/EmptyTableResults';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, ReactNode, useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import {
     Alert,
     Breadcrumb,
@@ -43,16 +44,14 @@ import ImagePageVulnerabilities from './ImagePageVulnerabilities';
 import ImagePageResources from './ImagePageResources';
 import ImagePageSignatureVerification from './ImagePageSignatureVerification';
 import { detailsTabValues } from '../../types';
-import ImageDetailBadges, {
-    ImageDetails,
-    imageDetailsFragment,
-} from '../components/ImageDetailBadges';
+import ImageDetailBadges, { imageDetailsFragment } from '../components/ImageDetailBadges';
+import type { ImageDetails } from '../components/ImageDetailBadges';
 import getImageScanMessage from '../utils/getImageScanMessage';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { getImageBaseNameDisplay } from '../utils/images';
 import { parseQuerySearchFilter, getVulnStateScopedQueryString } from '../../utils/searchUtils';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
-import { defaultColumns as deploymentResourcesDefaultColumns } from './DeploymentResourceTable';
+import type { defaultColumns as deploymentResourcesDefaultColumns } from './DeploymentResourceTable';
 import CreateReportDropdown from '../components/CreateReportDropdown';
 import CreateViewBasedReportModal from '../components/CreateViewBasedReportModal';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties } from 'react';
+import React from 'react';
+import type { CSSProperties } from 'react';
 import {
     Bullseye,
     Divider,
@@ -9,22 +10,22 @@ import {
     Text,
 } from '@patternfly/react-core';
 import { gql, useQuery } from '@apollo/client';
-import { Pagination as PaginationParam } from 'services/types';
+import type { Pagination as PaginationParam } from 'services/types';
 
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import type { ColumnConfigOverrides } from 'hooks/useManagedColumns';
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
+import type { UseURLPaginationResult } from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
 import useSelectToggle from 'hooks/patternfly/useSelectToggle';
 
 import { getPaginationParams, getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import DeploymentResourceTable, {
-    DeploymentResources,
     deploymentResourcesFragment,
     deploymentResourcesTableId,
     defaultColumns as deploymentResourcesDefaultColumns,
 } from './DeploymentResourceTable';
+import type { DeploymentResources } from './DeploymentResourceTable';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export type ImagePageResourcesProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageSignatureVerification.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageSignatureVerification.tsx
@@ -4,7 +4,7 @@ import { Table, TableText, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-ta
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import DateDistance from 'Components/DateDistance';
-import { SignatureVerificationResult, VerifiedStatus } from '../../types';
+import type { SignatureVerificationResult, VerifiedStatus } from '../../types';
 
 export type ImagePageSignatureVerificationProps = {
     results?: SignatureVerificationResult[];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { ReactNode } from 'react';
 import {
     Divider,
     DropdownItem,
@@ -12,43 +13,36 @@ import {
     Title,
 } from '@patternfly/react-core';
 import { gql, useQuery } from '@apollo/client';
-import { SearchFilter } from 'types/search';
-import { UseURLPaginationResult } from 'hooks/useURLPagination';
+import type { SearchFilter } from 'types/search';
+import type { UseURLPaginationResult } from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
-import { Pagination as PaginationParam } from 'services/types';
+import type { Pagination as PaginationParam } from 'services/types';
 import { getHasSearchApplied, getPaginationParams } from 'utils/searchUtils';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useMap from 'hooks/useMap';
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import { getSearchFilterConfigWithFeatureFlagDependency } from 'Components/CompoundSearchFilter/utils/utils';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
-import {
-    SummaryCardLayout,
-    SummaryCard,
-} from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import { getTableUIState } from 'utils/getTableUIState';
-import AdvancedFiltersToolbar from 'Containers/Vulnerabilities/components/AdvancedFiltersToolbar';
+import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
 import useAnalytics, { WORKLOAD_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
-import useHasRequestExceptionsAbility from 'Containers/Vulnerabilities/hooks/useHasRequestExceptionsAbility';
-import {
-    imageComponentSearchFilterConfig,
-    imageCVESearchFilterConfig,
-} from 'Containers/Vulnerabilities/searchFilterConfig';
 import { hideColumnIf, overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import type { VulnerabilityState } from 'types/cve.proto';
 
 import CvesByStatusSummaryCard, {
-    ResourceCountByCveSeverityAndStatus,
     resourceCountByCveSeverityAndStatusFragment,
 } from '../../components/CvesByStatusSummaryCard';
+import type { ResourceCountByCveSeverityAndStatus } from '../../components/CvesByStatusSummaryCard';
+import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
+import useHasRequestExceptionsAbility from '../../hooks/useHasRequestExceptionsAbility';
 import ImageVulnerabilitiesTable, {
-    ImageVulnerability,
     defaultColumns,
     imageVulnerabilitiesFragment,
     tableId,
 } from '../Tables/ImageVulnerabilitiesTable';
+import type { ImageVulnerability } from '../Tables/ImageVulnerabilitiesTable';
 import {
     getHiddenSeverities,
     getHiddenStatuses,
@@ -57,16 +51,20 @@ import {
     parseQuerySearchFilter,
 } from '../../utils/searchUtils';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
-import { imageMetadataContextFragment, ImageMetadataContext } from '../Tables/table.utils';
+import { imageMetadataContextFragment } from '../Tables/table.utils';
+import type { ImageMetadataContext } from '../Tables/table.utils';
 import VulnerabilityStateTabs, {
     vulnStateTabContentId,
 } from '../components/VulnerabilityStateTabs';
-import ExceptionRequestModal, {
-    ExceptionRequestModalProps,
-} from '../../components/ExceptionRequestModal/ExceptionRequestModal';
+import ExceptionRequestModal from '../../components/ExceptionRequestModal/ExceptionRequestModal';
+import type { ExceptionRequestModalProps } from '../../components/ExceptionRequestModal/ExceptionRequestModal';
 import CompletedExceptionRequestModal from '../../components/ExceptionRequestModal/CompletedExceptionRequestModal';
 import useExceptionRequestModal from '../../hooks/useExceptionRequestModal';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
+import {
+    imageComponentSearchFilterConfig,
+    imageCVESearchFilterConfig,
+} from '../../searchFilterConfig';
 
 export const imageVulnerabilitiesQuery = gql`
     ${imageMetadataContextFragment}
@@ -104,7 +102,7 @@ export type ImagePageVulnerabilitiesProps = {
     pagination: UseURLPaginationResult;
     vulnerabilityState: VulnerabilityState;
     showVulnerabilityStateTabs: boolean;
-    additionalToolbarItems?: React.ReactNode;
+    additionalToolbarItems?: ReactNode;
     searchFilter: SearchFilter;
     setSearchFilter: (filter: SearchFilter) => void;
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -22,7 +22,7 @@ import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
 import { getHasSearchApplied, getPaginationParams } from 'utils/searchUtils';
-import { Pagination as PaginationParam } from 'services/types';
+import type { Pagination as PaginationParam } from 'services/types';
 
 import type { VulnerabilitySeverity, VulnerabilityState } from 'types/cve.proto';
 import useAnalytics, {
@@ -31,45 +31,42 @@ import useAnalytics, {
 } from 'hooks/useAnalytics';
 
 import { DynamicTableLabel } from 'Components/DynamicIcon';
-import {
-    SummaryCardLayout,
-    SummaryCard,
-} from 'Containers/Vulnerabilities/components/SummaryCardLayout';
 import { getTableUIState } from 'utils/getTableUIState';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
 import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import type { ColumnConfigOverrides } from 'hooks/useManagedColumns';
-import { HistoryAction } from 'hooks/useURLParameter';
+import type { HistoryAction } from 'hooks/useURLParameter';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import type { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
-import { WorkloadEntityTab, VulnerabilitySeverityLabel } from '../../types';
 import {
     getHiddenSeverities,
     getStatusesForExceptionCount,
     getVulnStateScopedQueryString,
     parseQuerySearchFilter,
 } from '../../utils/searchUtils';
-import CvePageHeader, { CveMetadata } from '../../components/CvePageHeader';
+import CvePageHeader from '../../components/CvePageHeader';
+import type { CveMetadata } from '../../components/CvePageHeader';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 
 import AffectedImagesTable, {
-    ImageForCve,
     imagesForCveFragment,
     tableId as affectedImagesTableId,
     defaultColumns as affectedImagesDefaultColumns,
 } from '../Tables/AffectedImagesTable';
+import type { ImageForCve } from '../Tables/AffectedImagesTable';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
+import type { WorkloadEntityTab, VulnerabilitySeverityLabel } from '../../types';
 import AffectedDeploymentsTable, {
-    DeploymentForCve,
     deploymentsForCveFragment,
     tableId as affectedDeploymentsTableId,
     defaultColumns as affectedDeploymentsDefaultColumns,
 } from '../Tables/AffectedDeploymentsTable';
+import type { DeploymentForCve } from '../Tables/AffectedDeploymentsTable';
 import AffectedImages from '../SummaryCards/AffectedImages';
-import BySeveritySummaryCard, {
-    ResourceCountsByCveSeverity,
-} from '../../components/BySeveritySummaryCard';
+import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
+import type { ResourceCountsByCveSeverity } from '../../components/BySeveritySummaryCard';
+import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
 import { resourceCountByCveSeverityAndStatusFragment } from '../../components/CvesByStatusSummaryCard';
 import VulnerabilityStateTabs, {
     vulnStateTabContentId,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -24,7 +24,7 @@ import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
 
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
-import { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
+import type { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
 import PageTitle from 'Components/PageTitle';
 import SearchFilterChips from 'Components/PatternFly/SearchFilterChips';
@@ -33,14 +33,11 @@ import { makeFilterChipDescriptors } from 'Components/CompoundSearchFilter/utils
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import useAnalytics, { WORKLOAD_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
-import {
-    clusterSearchFilterConfig,
-    namespaceSearchFilterConfig,
-} from 'Containers/Vulnerabilities/searchFilterConfig';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 import { getRegexScopedQueryString, parseQuerySearchFilter } from '../../utils/searchUtils';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
+import { clusterSearchFilterConfig, namespaceSearchFilterConfig } from '../../searchFilterConfig';
 import DeploymentFilterLink from './DeploymentFilterLink';
 
 type Namespace = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -3,13 +3,13 @@ import { useQuery } from '@apollo/client';
 import { Divider, DropdownItem, ToolbarItem } from '@patternfly/react-core';
 
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
-import useURLSort from 'hooks/useURLSort';
-import useURLPagination from 'hooks/useURLPagination';
+import type useURLSort from 'hooks/useURLSort';
+import type useURLPagination from 'hooks/useURLPagination';
 import useMap from 'hooks/useMap';
-import { VulnerabilityState } from 'types/cve.proto';
+import type { VulnerabilityState } from 'types/cve.proto';
 
 import { getTableUIState } from 'utils/getTableUIState';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import type { ColumnConfigOverrides } from 'hooks/useManagedColumns';
@@ -19,11 +19,11 @@ import WorkloadCVEOverviewTable, {
     tableId,
     unfilteredImageCountQuery,
 } from '../Tables/WorkloadCVEOverviewTable';
-import { VulnerabilitySeverityLabel } from '../../types';
-import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
-import ExceptionRequestModal, {
-    ExceptionRequestModalProps,
-} from '../../components/ExceptionRequestModal/ExceptionRequestModal';
+import type { VulnerabilitySeverityLabel } from '../../types';
+import TableEntityToolbar from '../../components/TableEntityToolbar';
+import type { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
+import ExceptionRequestModal from '../../components/ExceptionRequestModal/ExceptionRequestModal';
+import type { ExceptionRequestModalProps } from '../../components/ExceptionRequestModal/ExceptionRequestModal';
 import CompletedExceptionRequestModal from '../../components/ExceptionRequestModal/CompletedExceptionRequestModal';
 import useExceptionRequestModal from '../../hooks/useExceptionRequestModal';
 import { useImageCves } from './useImageCves';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { Divider, ToolbarItem } from '@patternfly/react-core';
 
-import useURLSort from 'hooks/useURLSort';
-import useURLPagination from 'hooks/useURLPagination';
+import type useURLSort from 'hooks/useURLSort';
+import type useURLPagination from 'hooks/useURLPagination';
 
 import { getTableUIState } from 'utils/getTableUIState';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import type { ColumnConfigOverrides } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
 import DeploymentsTable, { defaultColumns, tableId } from '../Tables/DeploymentOverviewTable';
-import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
-import { VulnerabilitySeverityLabel } from '../../types';
+import TableEntityToolbar from '../../components/TableEntityToolbar';
+import type { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
+import type { VulnerabilitySeverityLabel } from '../../types';
 import { useDeployments } from './useDeployments';
 
 type DeploymentsTableContainerProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -1,21 +1,19 @@
 import React from 'react';
 import { Divider, ToolbarItem } from '@patternfly/react-core';
 
-import useURLSort from 'hooks/useURLSort';
-import useURLPagination from 'hooks/useURLPagination';
+import type useURLSort from 'hooks/useURLSort';
+import type useURLPagination from 'hooks/useURLPagination';
 
 import { getTableUIState } from 'utils/getTableUIState';
-import { SearchFilter } from 'types/search';
+import type { SearchFilter } from 'types/search';
 import { overrideManagedColumns, useManagedColumns } from 'hooks/useManagedColumns';
 import type { ColumnConfigOverrides } from 'hooks/useManagedColumns';
 import ColumnManagementButton from 'Components/ColumnManagementButton';
-import ImageOverviewTable, {
-    ImageOverviewTableProps,
-    defaultColumns,
-    tableId,
-} from '../Tables/ImageOverviewTable';
-import { VulnerabilitySeverityLabel } from '../../types';
-import TableEntityToolbar, { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
+import ImageOverviewTable, { defaultColumns, tableId } from '../Tables/ImageOverviewTable';
+import type { ImageOverviewTableProps } from '../Tables/ImageOverviewTable';
+import type { VulnerabilitySeverityLabel } from '../../types';
+import TableEntityToolbar from '../../components/TableEntityToolbar';
+import type { TableEntityToolbarProps } from '../../components/TableEntityToolbar';
 import { useImages } from './useImages';
 
 type ImagesTableContainerProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/VulnerabilitiesOverview.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/VulnerabilitiesOverview.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
+import type { ReactNode } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import { Flex } from '@patternfly/react-core';
 
 import type { CompoundSearchFilterConfig } from 'Components/CompoundSearchFilter/types';
-import type {
-    DefaultFilters,
-    QuerySearchFilter,
-    WorkloadEntityTab,
-} from 'Containers/Vulnerabilities/types';
 import useAnalytics, { WORKLOAD_CVE_FILTER_APPLIED } from 'hooks/useAnalytics';
 import usePermissions from 'hooks/usePermissions';
 import type { UseURLPaginationResult } from 'hooks/useURLPagination';
@@ -18,15 +14,16 @@ import type { SearchFilter } from 'types/search';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
 import { getHasSearchApplied } from 'utils/searchUtils';
 
+import type { DefaultFilters, QuerySearchFilter, WorkloadEntityTab } from '../../types';
 import CVEsTableContainer from './CVEsTableContainer';
 import DeploymentsTableContainer from './DeploymentsTableContainer';
 import ImagesTableContainer from './ImagesTableContainer';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
-import { defaultColumns as cveDefaultColumns } from '../Tables/WorkloadCVEOverviewTable';
-import { defaultColumns as imageDefaultColumns } from '../Tables/ImageOverviewTable';
-import { defaultColumns as deploymentDefaultColumns } from '../Tables/DeploymentOverviewTable';
+import type { defaultColumns as cveDefaultColumns } from '../Tables/WorkloadCVEOverviewTable';
+import type { defaultColumns as imageDefaultColumns } from '../Tables/ImageOverviewTable';
+import type { defaultColumns as deploymentDefaultColumns } from '../Tables/DeploymentOverviewTable';
 
 function getSearchFilterEntityByTab(
     entityTab: WorkloadEntityTab
@@ -66,8 +63,8 @@ type VulnerabilitiesOverviewProps = {
     onUnwatchImage: (imageName: string) => void;
     activeEntityTabKey: WorkloadEntityTab;
     onEntityTabChange: (entityTab: WorkloadEntityTab) => void;
-    additionalToolbarItems: React.ReactNode;
-    additionalHeaderItems: React.ReactNode;
+    additionalToolbarItems: ReactNode;
+    additionalHeaderItems: ReactNode;
     showDeferralUI: boolean;
     cveTableColumnOverrides: ColumnConfigOverrides<keyof typeof cveDefaultColumns>;
     imageTableColumnOverrides: ColumnConfigOverrides<keyof typeof imageDefaultColumns>;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -31,17 +31,11 @@ import useAnalytics, {
     WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,
 } from 'hooks/useAnalytics';
 import useLocalStorage from 'hooks/useLocalStorage';
-import { SearchFilter } from 'types/search';
-import {
-    getWorkloadCveOverviewDefaultSortOption,
-    getDefaultZeroCveSortOption,
-    getWorkloadCveOverviewSortFields,
-    syncSeveritySortOption,
-} from 'Containers/Vulnerabilities/utils/sortUtils';
+import type { SearchFilter } from 'types/search';
 import { useIsFirstRender } from 'hooks/useIsFirstRender';
 import { hideColumnIf } from 'hooks/useManagedColumns';
 import useURLSort from 'hooks/useURLSort';
-import { VulnerabilityState } from 'types/cve.proto';
+import type { VulnerabilityState } from 'types/cve.proto';
 import LinkShim from 'Components/PatternFly/LinkShim';
 
 import {
@@ -51,20 +45,21 @@ import {
     imageComponentSearchFilterConfig,
     imageSearchFilterConfig,
     namespaceSearchFilterConfig,
-} from 'Containers/Vulnerabilities/searchFilterConfig';
-import {
-    DefaultFilters,
-    WorkloadEntityTab,
-    VulnMgmtLocalStorage,
-    workloadEntityTabValues,
-    isVulnMgmtLocalStorage,
-} from '../../types';
+} from '../../searchFilterConfig';
+import { isVulnMgmtLocalStorage, workloadEntityTabValues } from '../../types';
+import type { DefaultFilters, VulnMgmtLocalStorage, WorkloadEntityTab } from '../../types';
 import {
     parseQuerySearchFilter,
     getVulnStateScopedQueryString,
     getZeroCveScopedQueryString,
     getNamespaceViewPagePath,
 } from '../../utils/searchUtils';
+import {
+    getWorkloadCveOverviewDefaultSortOption,
+    getDefaultZeroCveSortOption,
+    getWorkloadCveOverviewSortFields,
+    syncSeveritySortOption,
+} from '../../utils/sortUtils';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 
 import WatchedImagesModal from '../WatchedImages/WatchedImagesModal';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/useImageCves.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/useImageCves.ts
@@ -2,13 +2,13 @@ import { useQuery } from '@apollo/client';
 import type { QueryHookOptions } from '@apollo/client';
 
 import { getPaginationParams } from 'utils/searchUtils';
-import { getStatusesForExceptionCount } from 'Containers/Vulnerabilities/utils/searchUtils';
 import type useURLPagination from 'hooks/useURLPagination';
 import type { ApiSortOption } from 'types/search';
 import type { VulnerabilityState } from 'types/cve.proto';
 
 import { cveListQuery } from '../Tables/WorkloadCVEOverviewTable';
 import type { ImageCVE } from '../Tables/WorkloadCVEOverviewTable';
+import { getStatusesForExceptionCount } from '../../utils/searchUtils';
 
 export function useImageCves({
     query,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -5,26 +5,25 @@ import { Table, Thead, Tr, Th, Tbody, Td, ExpandableRowContent } from '@patternf
 import { gql } from '@apollo/client';
 
 import useSet from 'hooks/useSet';
-import { UseURLSortResult } from 'hooks/useURLSort';
-import { VulnerabilityState } from 'types/cve.proto';
+import type { UseURLSortResult } from 'hooks/useURLSort';
+import type { VulnerabilityState } from 'types/cve.proto';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import { TableUIState } from 'utils/getTableUIState';
+import type { TableUIState } from 'utils/getTableUIState';
 import ExpandRowTh from 'Components/ExpandRowTh';
-import {
-    generateVisibilityForColumns,
-    getHiddenColumnCount,
-    ManagedColumns,
-} from 'hooks/useManagedColumns';
+import { generateVisibilityForColumns, getHiddenColumnCount } from 'hooks/useManagedColumns';
+import type { ManagedColumns } from 'hooks/useManagedColumns';
 import DeploymentComponentVulnerabilitiesTable, {
-    DeploymentComponentVulnerability,
-    ImageMetadataContext,
     deploymentComponentVulnerabilitiesFragment,
     imageMetadataContextFragment,
 } from './DeploymentComponentVulnerabilitiesTable';
+import type {
+    DeploymentComponentVulnerability,
+    ImageMetadataContext,
+} from './DeploymentComponentVulnerabilitiesTable';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
-import { VulnerabilitySeverityLabel } from '../../types';
+import type { VulnerabilitySeverityLabel } from '../../types';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 
 export const tableId = 'WorkloadCvesAffectedDeploymentsTable';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -5,22 +5,19 @@ import { LabelGroup } from '@patternfly/react-core';
 import { ExpandableRowContent, Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
 
 import useSet from 'hooks/useSet';
-import { UseURLSortResult } from 'hooks/useURLSort';
+import type { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
-import { VulnerabilityState } from 'types/cve.proto';
+import type { VulnerabilityState } from 'types/cve.proto';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import CvssFormatted from 'Components/CvssFormatted';
 import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import { TableUIState } from 'utils/getTableUIState';
+import type { TableUIState } from 'utils/getTableUIState';
 import ExpandRowTh from 'Components/ExpandRowTh';
 import { isNonEmptyArray } from 'utils/type.utils';
-import {
-    generateVisibilityForColumns,
-    getHiddenColumnCount,
-    ManagedColumns,
-} from 'hooks/useManagedColumns';
+import { generateVisibilityForColumns, getHiddenColumnCount } from 'hooks/useManagedColumns';
+import type { ManagedColumns } from 'hooks/useManagedColumns';
 import {
     getIsSomeVulnerabilityFixable,
     getHighestCvssScore,
@@ -32,11 +29,11 @@ import ImageNameLink from '../components/ImageNameLink';
 import PendingExceptionLabel from '../../components/PendingExceptionLabel';
 
 import ImageComponentVulnerabilitiesTable, {
-    ImageComponentVulnerability,
     imageComponentVulnerabilitiesFragment,
     imageMetadataContextFragment,
 } from './ImageComponentVulnerabilitiesTable';
-import { WatchStatus } from '../../types';
+import type { ImageComponentVulnerability } from './ImageComponentVulnerabilitiesTable';
+import type { WatchStatus } from '../../types';
 
 export const tableId = 'WorkloadCvesAffectedImagesTable';
 export const defaultColumns = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -7,7 +7,7 @@ import { gql } from '@apollo/client';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useTableSort from 'hooks/useTableSort';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
-import { VulnerabilityState } from 'types/cve.proto';
+import type { VulnerabilityState } from 'types/cve.proto';
 import CvssFormatted from 'Components/CvssFormatted';
 
 import AdvisoryLinkOrText from '../../components/AdvisoryLinkOrText';
@@ -15,11 +15,10 @@ import PendingExceptionLabel from '../../components/PendingExceptionLabel';
 import ImageNameLink from '../components/ImageNameLink';
 import {
     imageMetadataContextFragment,
-    ImageMetadataContext,
-    DeploymentComponentVulnerability,
     sortTableData,
     flattenDeploymentComponentVulns,
 } from './table.utils';
+import type { DeploymentComponentVulnerability, ImageMetadataContext } from './table.utils';
 import DockerfileLayer from '../components/DockerfileLayer';
 import ComponentLocation from '../components/ComponentLocation';
 import FixedByVersion from '../../components/FixedByVersion';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
@@ -5,19 +5,16 @@ import pluralize from 'pluralize';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Truncate } from '@patternfly/react-core';
 
-import { UseURLSortResult } from 'hooks/useURLSort';
+import type { UseURLSortResult } from 'hooks/useURLSort';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import TooltipTh from 'Components/TooltipTh';
 import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import { TableUIState } from 'utils/getTableUIState';
-import {
-    generateVisibilityForColumns,
-    getHiddenColumnCount,
-    ManagedColumns,
-} from 'hooks/useManagedColumns';
+import type { TableUIState } from 'utils/getTableUIState';
+import { generateVisibilityForColumns, getHiddenColumnCount } from 'hooks/useManagedColumns';
+import type { ManagedColumns } from 'hooks/useManagedColumns';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
-import { VulnerabilitySeverityLabel } from '../../types';
+import type { VulnerabilitySeverityLabel } from '../../types';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 import { getSeveritySortOptions } from '../../utils/sortUtils';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -7,20 +7,17 @@ import { gql } from '@apollo/client';
 
 // import useFeatureFlags from 'hooks/useFeatureFlags'; // Ross CISA KEV
 import useSet from 'hooks/useSet';
-import { UseURLSortResult } from 'hooks/useURLSort';
+import type { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
-import { VulnerabilityState } from 'types/cve.proto';
+import type { VulnerabilityState } from 'types/cve.proto';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import ExpandRowTh from 'Components/ExpandRowTh';
-import { TableUIState } from 'utils/getTableUIState';
-import {
-    generateVisibilityForColumns,
-    getHiddenColumnCount,
-    ManagedColumns,
-} from 'hooks/useManagedColumns';
+import type { TableUIState } from 'utils/getTableUIState';
+import { generateVisibilityForColumns, getHiddenColumnCount } from 'hooks/useManagedColumns';
+import type { ManagedColumns } from 'hooks/useManagedColumns';
 
 // import KnownExploitLabel from '../../components/KnownExploitLabel'; // Ross CISA KEV
 import PendingExceptionLabel from '../../components/PendingExceptionLabel';
@@ -31,7 +28,8 @@ import DeploymentComponentVulnerabilitiesTable, {
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 import { infoForEpssProbability } from './infoForTh';
-import { FormattedDeploymentVulnerability, formatEpssProbabilityAsPercent } from './table.utils';
+import { formatEpssProbabilityAsPercent } from './table.utils';
+import type { FormattedDeploymentVulnerability } from './table.utils';
 
 export const tableId = 'WorkloadCvesDeploymentVulnerabilitiesTable';
 export const defaultColumns = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -7,12 +7,11 @@ import useTableSort from 'hooks/useTableSort';
 
 import AdvisoryLinkOrText from '../../components/AdvisoryLinkOrText';
 import {
-    ImageComponentVulnerability,
-    ImageMetadataContext,
     flattenImageComponentVulns,
     imageMetadataContextFragment,
     sortTableData,
 } from './table.utils';
+import type { ImageComponentVulnerability, ImageMetadataContext } from './table.utils';
 import DockerfileLayer from '../components/DockerfileLayer';
 import ComponentLocation from '../components/ComponentLocation';
 import FixedByVersion from '../../components/FixedByVersion';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -2,23 +2,21 @@ import React, { useState } from 'react';
 import type { ReactNode } from 'react';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
-import { ActionsColumn, IAction, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import type { IAction } from '@patternfly/react-table';
 import { Flex, Label, LabelGroup } from '@patternfly/react-core';
 import { EyeIcon } from '@patternfly/react-icons';
 import isEmpty from 'lodash/isEmpty';
 
-import { UseURLSortResult } from 'hooks/useURLSort';
+import type { UseURLSortResult } from 'hooks/useURLSort';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import TooltipTh from 'Components/TooltipTh';
 import DateDistance from 'Components/DateDistance';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import { TableUIState } from 'utils/getTableUIState';
+import type { TableUIState } from 'utils/getTableUIState';
 import { ACTION_COLUMN_POPPER_PROPS } from 'constants/tables';
-import {
-    generateVisibilityForColumns,
-    getHiddenColumnCount,
-    ManagedColumns,
-} from 'hooks/useManagedColumns';
+import { generateVisibilityForColumns, getHiddenColumnCount } from 'hooks/useManagedColumns';
+import type { ManagedColumns } from 'hooks/useManagedColumns';
 import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';
 import usePermissions from 'hooks/usePermissions';
 import GenerateSbomModal, {
@@ -26,7 +24,11 @@ import GenerateSbomModal, {
 } from '../../components/GenerateSbomModal';
 import ImageNameLink from '../components/ImageNameLink';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
-import { SignatureVerificationResult, VulnerabilitySeverityLabel, WatchStatus } from '../../types';
+import type {
+    SignatureVerificationResult,
+    VulnerabilitySeverityLabel,
+    WatchStatus,
+} from '../../types';
 import ImageScanningIncompleteLabel from '../components/ImageScanningIncompleteLabel';
 import VerifiedSignatureLabel, {
     getVerifiedSignatureInResults,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -5,7 +5,6 @@ import { LabelGroup } from '@patternfly/react-core';
 import {
     ActionsColumn,
     ExpandableRowContent,
-    IAction,
     Table,
     Tbody,
     Td,
@@ -13,27 +12,26 @@ import {
     Thead,
     Tr,
 } from '@patternfly/react-table';
+import type { IAction } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
 // import useFeatureFlags from 'hooks/useFeatureFlags'; // Ross CISA KEV
 import useSet from 'hooks/useSet';
-import { UseURLSortResult } from 'hooks/useURLSort';
+import type { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
-import { CveBaseInfo, VulnerabilityState, isVulnerabilitySeverity } from 'types/cve.proto';
+import { isVulnerabilitySeverity } from 'types/cve.proto';
+import type { CveBaseInfo, VulnerabilityState } from 'types/cve.proto';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
-import useMap from 'hooks/useMap';
+import type useMap from 'hooks/useMap';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import CvssFormatted from 'Components/CvssFormatted';
 import TooltipTh from 'Components/TooltipTh';
 import DateDistance from 'Components/DateDistance';
 import ExpandRowTh from 'Components/ExpandRowTh';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
-import { TableUIState } from 'utils/getTableUIState';
-import {
-    generateVisibilityForColumns,
-    getHiddenColumnCount,
-    ManagedColumns,
-} from 'hooks/useManagedColumns';
+import type { TableUIState } from 'utils/getTableUIState';
+import { generateVisibilityForColumns, getHiddenColumnCount } from 'hooks/useManagedColumns';
+import type { ManagedColumns } from 'hooks/useManagedColumns';
 import { getIsSomeVulnerabilityFixable } from '../../utils/vulnerabilityUtils';
 /*
 // Ross CISA KEV
@@ -44,12 +42,14 @@ import {
 } from '../../utils/vulnerabilityUtils';
 */
 import ImageComponentVulnerabilitiesTable, {
-    ImageComponentVulnerability,
-    ImageMetadataContext,
     imageComponentVulnerabilitiesFragment,
 } from './ImageComponentVulnerabilitiesTable';
+import type {
+    ImageComponentVulnerability,
+    ImageMetadataContext,
+} from './ImageComponentVulnerabilitiesTable';
 
-import { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
+import type { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
 import CVESelectionTh from '../../components/CVESelectionTh';
 import CVESelectionTd from '../../components/CVESelectionTd';
 // import KnownExploitLabel from '../../components/KnownExploitLabel'; // Ross CISA KEV

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -5,7 +5,6 @@ import { gql } from '@apollo/client';
 import {
     ActionsColumn,
     ExpandableRowContent,
-    IAction,
     Table,
     Tbody,
     Td,
@@ -13,27 +12,25 @@ import {
     Thead,
     Tr,
 } from '@patternfly/react-table';
+import type { IAction } from '@patternfly/react-table';
 import { LabelGroup, Text } from '@patternfly/react-core';
 
 // import useFeatureFlags from 'hooks/useFeatureFlags'; // Ross CISA KEV
-import { UseURLSortResult } from 'hooks/useURLSort';
+import type { UseURLSortResult } from 'hooks/useURLSort';
 import useSet from 'hooks/useSet';
-import useMap from 'hooks/useMap';
-import { CveBaseInfo, VulnerabilityState } from 'types/cve.proto';
+import type useMap from 'hooks/useMap';
+import type { CveBaseInfo, VulnerabilityState } from 'types/cve.proto';
 import TooltipTh from 'Components/TooltipTh';
 import { DynamicColumnIcon } from 'Components/DynamicIcon';
 import CvssFormatted from 'Components/CvssFormatted';
 import DateDistance from 'Components/DateDistance';
-import { TableUIState } from 'utils/getTableUIState';
+import type { TableUIState } from 'utils/getTableUIState';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import ExpandRowTh from 'Components/ExpandRowTh';
 import { ACTION_COLUMN_POPPER_PROPS } from 'constants/tables';
-import {
-    generateVisibilityForColumns,
-    getHiddenColumnCount,
-    ManagedColumns,
-} from 'hooks/useManagedColumns';
-import { VulnerabilitySeverityLabel } from '../../types';
+import { generateVisibilityForColumns, getHiddenColumnCount } from 'hooks/useManagedColumns';
+import type { ManagedColumns } from 'hooks/useManagedColumns';
+import type { VulnerabilitySeverityLabel } from '../../types';
 // import { hasKnownExploit, hasKnownRansomwareCampaignUse } from '../../utils/vulnerabilityUtils'; // Ross CISA KEV
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import {
@@ -46,7 +43,7 @@ import {
     aggregateByDistinctCount,
     getSeveritySortOptions,
 } from '../../utils/sortUtils';
-import { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
+import type { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
 import CVESelectionTh from '../../components/CVESelectionTh';
 import CVESelectionTd from '../../components/CVESelectionTd';
 // import KnownExploitLabel from '../../components/KnownExploitLabel'; // Ross CISA KEV

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/infoForTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/infoForTh.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
-import { ThProps } from '@patternfly/react-table';
+import type { ThProps } from '@patternfly/react-table';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import PopoverBodyContent from 'Components/PopoverBodyContent';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -3,14 +3,10 @@ import { min, parse } from 'date-fns';
 import sortBy from 'lodash/sortBy';
 import uniq from 'lodash/uniq';
 
-import {
-    Advisory,
-    CveBaseInfo,
-    VulnerabilitySeverity,
-    isVulnerabilitySeverity,
-} from 'types/cve.proto';
-import { SourceType } from 'types/image.proto';
-import { ApiSortOptionSingle } from 'types/search';
+import { isVulnerabilitySeverity } from 'types/cve.proto';
+import type { Advisory, CveBaseInfo, VulnerabilitySeverity } from 'types/cve.proto';
+import type { SourceType } from 'types/image.proto';
+import type { ApiSortOptionSingle } from 'types/search';
 
 import {
     getHighestVulnerabilitySeverity,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
@@ -8,13 +8,14 @@ import {
     HelperTextItem,
     TextInput,
 } from '@patternfly/react-core';
-import { FormikHelpers, useFormik } from 'formik';
+import { useFormik } from 'formik';
+import type { FormikHelpers } from 'formik';
 import * as yup from 'yup';
 
-import { UseRestQueryReturn } from 'hooks/useRestQuery';
-import { UseRestMutationReturn } from 'hooks/useRestMutation';
+import type { UseRestQueryReturn } from 'hooks/useRestQuery';
+import type { UseRestMutationReturn } from 'hooks/useRestMutation';
 import useAnalytics, { WATCH_IMAGE_SUBMITTED } from 'hooks/useAnalytics';
-import { WatchedImage } from 'types/image.proto';
+import type { WatchedImage } from 'types/image.proto';
 
 const validationSchema = yup.object({
     imageName: yup.string().required('A valid image name is required'),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties, useCallback } from 'react';
+import React, { useCallback } from 'react';
+import type { CSSProperties } from 'react';
 import {
     Alert,
     Bullseye,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesTable.tsx
@@ -1,12 +1,13 @@
-import React, { CSSProperties } from 'react';
+import React from 'react';
+import type { CSSProperties } from 'react';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { Bullseye, Button, Icon } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 
-import { WatchedImage } from 'types/image.proto';
-import { UseRestMutationReturn } from 'hooks/useRestMutation';
+import type { WatchedImage } from 'types/image.proto';
+import type { UseRestMutationReturn } from 'hooks/useRestMutation';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
-import { Empty } from 'services/types';
+import type { Empty } from 'services/types';
 
 export type WatchedImagesTableProps = {
     className?: string;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext.ts
@@ -1,8 +1,8 @@
 import { createContext } from 'react';
-import { NonEmptyArray } from 'utils/type.utils';
+import type { NonEmptyArray } from 'utils/type.utils';
 
 import type { VulnerabilityState } from 'types/cve.proto';
-import { QuerySearchFilter, WorkloadEntityTab } from '../types';
+import type { QuerySearchFilter, WorkloadEntityTab } from '../types';
 
 export type WorkloadCveView = {
     urlBuilder: {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -14,10 +14,11 @@ import {
     vulnerabilitiesUserWorkloadsPath,
 } from 'routePaths';
 import ScannerV4IntegrationBanner from 'Components/ScannerV4IntegrationBanner';
-import useFeatureFlags, { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
+import useFeatureFlags from 'hooks/useFeatureFlags';
+import type { IsFeatureFlagEnabled } from 'hooks/useFeatureFlags';
 import usePermissions from 'hooks/usePermissions';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
-import { NonEmptyArray } from 'utils/type.utils';
+import type { NonEmptyArray } from 'utils/type.utils';
 import type { VulnerabilityState } from 'types/cve.proto';
 
 import DeploymentPageRoute from './Deployment/DeploymentPageRoute';
@@ -25,9 +26,10 @@ import ImagePageRoute from './Image/ImagePageRoute';
 import WorkloadCvesOverviewPage from './Overview/WorkloadCvesOverviewPage';
 import ImageCvePageRoute from './ImageCve/ImageCvePageRoute';
 import NamespaceViewPage from './NamespaceView/NamespaceViewPage';
-import { WorkloadCveView, WorkloadCveViewContext } from './WorkloadCveViewContext';
+import { WorkloadCveViewContext } from './WorkloadCveViewContext';
+import type { WorkloadCveView } from './WorkloadCveViewContext';
 
-import { QuerySearchFilter, WorkloadEntityTab } from '../types';
+import type { QuerySearchFilter, WorkloadEntityTab } from '../types';
 import { getOverviewPagePath, getWorkloadEntityPagePath } from '../utils/searchUtils';
 
 export const userWorkloadViewId = 'user-workloads';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocation.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocation.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Flex, Icon, Tooltip, Truncate } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 
-import { SourceType } from 'types/image.proto';
+import type { SourceType } from 'types/image.proto';
 
 export type ComponentLocationProps = {
     location: string;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CreateReportDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CreateReportDropdown.tsx
@@ -1,11 +1,7 @@
 import React, { useState } from 'react';
-import {
-    Dropdown,
-    DropdownItem,
-    DropdownList,
-    MenuToggle,
-    MenuToggleElement,
-} from '@patternfly/react-core';
+import type { MouseEvent as ReactMouseEvent, Ref } from 'react';
+import { Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';
+import type { MenuToggleElement } from '@patternfly/react-core';
 
 export type CreateReportDropdownProps = {
     onSelect: (value: string | number | undefined) => void;
@@ -19,7 +15,7 @@ function CreateReportDropdown({ onSelect }: CreateReportDropdownProps) {
     };
 
     const onSelectHandler = (
-        _event: React.MouseEvent<Element, MouseEvent> | undefined,
+        _event: ReactMouseEvent<Element, MouseEvent> | undefined,
         value: string | number | undefined
     ) => {
         onSelect(value);
@@ -32,7 +28,7 @@ function CreateReportDropdown({ onSelect }: CreateReportDropdownProps) {
                 isOpen={isOpen}
                 onSelect={onSelectHandler}
                 onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
-                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                toggle={(toggleRef: Ref<MenuToggleElement>) => (
                     <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
                         Create report
                     </MenuToggle>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
@@ -5,7 +5,7 @@ import { useFormik, FormikProvider } from 'formik';
 import { Globe } from 'react-feather';
 
 import useAnalytics, { WORKLOAD_CVE_DEFAULT_FILTERS_CHANGED } from 'hooks/useAnalytics';
-import { DefaultFilters, FixableStatus, VulnerabilitySeverityLabel } from '../../types';
+import type { DefaultFilters, FixableStatus, VulnerabilitySeverityLabel } from '../../types';
 
 function analyticsTrackDefaultFilters(
     analyticsTrack: ReturnType<typeof useAnalytics>['analyticsTrack'],

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DockerfileLayer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DockerfileLayer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CodeBlock, Flex, CodeBlockCode } from '@patternfly/react-core';
-import { TableDataRow } from '../Tables/table.utils';
+import type { TableDataRow } from '../Tables/table.utils';
 
 export type DockerfileLayerProps = {
     layer: TableDataRow['layer'];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionDetailsCell.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionDetailsCell.tsx
@@ -4,7 +4,7 @@ import { Td } from '@patternfly/react-table';
 
 import { exceptionManagementPath } from 'routePaths';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
-import { VulnerabilityState } from 'types/cve.proto';
+import type { VulnerabilityState } from 'types/cve.proto';
 import { ensureExhaustive } from 'utils/type.utils';
 
 function getExceptionManagementURL(

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
@@ -3,7 +3,7 @@ import { LabelGroup, Label } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
 
 import { getDistanceStrict, getDateTime } from 'utils/dateUtils';
-import { SignatureVerificationResult } from '../../types';
+import type { SignatureVerificationResult } from '../../types';
 import SignatureCountLabel from './SignatureCountLabel';
 import VerifiedSignatureLabel, { getVerifiedSignatureInResults } from './VerifiedSignatureLabel';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningIncompleteLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningIncompleteLabel.tsx
@@ -4,7 +4,7 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 import PopoverBodyContent from 'Components/PopoverBodyContent';
 
-import { ScanMessage } from 'messages/vulnMgmt.messages';
+import type { ScanMessage } from 'messages/vulnMgmt.messages';
 
 export type ImageScanningIncompleteLabelProps = {
     scanMessage: ScanMessage;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VerifiedSignatureLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VerifiedSignatureLabel.tsx
@@ -1,9 +1,10 @@
-import React, { CSSProperties } from 'react';
+import React from 'react';
+import type { CSSProperties } from 'react';
 import { Flex, FlexItem, Label, List, ListItem, Popover } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons';
 
 import PopoverBodyContent from 'Components/PopoverBodyContent';
-import { SignatureVerificationResult } from '../../types';
+import type { SignatureVerificationResult } from '../../types';
 
 export function getVerifiedSignatureInResults(
     results: SignatureVerificationResult[] | null | undefined

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Tabs, Tab, TabTitleText, TabsProps } from '@patternfly/react-core';
+import { Tabs, Tab, TabTitleText } from '@patternfly/react-core';
+import type { TabsProps } from '@patternfly/react-core';
 
-import { VulnerabilityState, isVulnerabilityState, vulnerabilityStates } from 'types/cve.proto';
+import { isVulnerabilityState, vulnerabilityStates } from 'types/cve.proto';
+import type { VulnerabilityState } from 'types/cve.proto';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 
 export const vulnStateTabContentId = 'vulnerability-state-tab-content';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useWorkloadCveViewContext.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/hooks/useWorkloadCveViewContext.ts
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
-import { WorkloadCveView, WorkloadCveViewContext } from '../WorkloadCveViewContext';
+import { WorkloadCveViewContext } from '../WorkloadCveViewContext';
+import type { WorkloadCveView } from '../WorkloadCveViewContext';
 
 export default function useWorkloadCveViewContext(): WorkloadCveView {
     const value = useContext(WorkloadCveViewContext);

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/getImageScanMessage.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/utils/getImageScanMessage.ts
@@ -1,7 +1,8 @@
 import isEmpty from 'lodash/isEmpty';
 import Raven from 'raven-js';
 
-import { imageScanMessages, ScanMessage } from 'messages/vulnMgmt.messages';
+import { imageScanMessages } from 'messages/vulnMgmt.messages';
+import type { ScanMessage } from 'messages/vulnMgmt.messages';
 
 export default function getImageScanMessage(
     imageNotes: string[],


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

Merge ahead of PatternFly 6 and also before I continue with CISA KEV.

### Procedure

Select a folder that will not cause merge conflicts with feature work in progress.

1. Edit eslint.config.js file to comment out folder in `ignores` array.
2. Edit files to fix errors.
3. Edit eslint.config.js file to delete out folder in `ignores` array.

Too many additional errors to delete folder from `ignores` for `'sort-imports'` rule in this contributions. Although it has auto fix, it complicates review.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
3. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.