### PR TITLE
fix(ui): Resolve select dropdown width styling

### DIFF
--- a/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
+++ b/ui/apps/platform/src/Components/SelectSingle/SelectSingle.tsx
@@ -39,7 +39,7 @@ function SelectSingle({
     menuAppendTo = undefined,
     footer,
     maxHeight = '300px',
-    maxWidth = '30ch',
+    maxWidth = '100%',
     variant = 'default',
     className,
 }: SelectSingleProps): ReactElement {

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -176,7 +176,6 @@ function InitBundleForm(): ReactElement {
                                 isDisabled={values.platform !== 'OpenShift'}
                                 toggleAriaLabel="Installation method menu toggle"
                                 aria-label="Select an installation method"
-                                maxWidth="100%"
                             >
                                 {Object.entries(installationOptions)
                                     .filter(

--- a/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
+++ b/ui/apps/platform/src/Containers/Collections/RuleSelector/RuleSelector.tsx
@@ -80,7 +80,6 @@ function RuleSelector({
                 value={selection}
                 handleSelect={onRuleOptionSelect}
                 isDisabled={isDisabled}
-                maxWidth="100%"
             >
                 <SelectOption value="NoneSpecified">
                     No {pluralEntity.toLowerCase()} specified

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/EdgeStateSelect.tsx
@@ -29,6 +29,7 @@ function EdgeStateSelect({ edgeState, setEdgeState, isDisabled }: EdgeStateSelec
             value={edgeState}
             handleSelect={handleSelect}
             isDisabled={isDisabled}
+            maxWidth="30ch"
         >
             <SelectOption
                 value="active"

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
@@ -120,7 +120,6 @@ function PolicyCriteriaFieldInput({
                         handleSelect={handleChangeSelect}
                         isDisabled={readOnly}
                         placeholderText={descriptor.placeholder || 'Select an option'}
-                        maxWidth="100%"
                     >
                         {descriptor?.options?.map((option) => (
                             <SelectOption

--- a/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesFilterSelect.tsx
+++ b/ui/apps/platform/src/Containers/PolicyCategories/PolicyCategoriesFilterSelect.tsx
@@ -26,7 +26,6 @@ function PolicyCategoriesFilterSelect({
             isDisabled={isDisabled}
             placeholderText="Select category filter"
             toggleAriaLabel="Policy categories filter"
-            maxWidth="100%"
         >
             <SelectOption key={0} value="All categories">
                 All categories


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR fixes the width styling by making '100%' the default behavior in SelectSingle, while the EdgeStateSelect is a specific exception with a narrower '30ch' width.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] added e2e tests
- [x] added regression tests
- [x] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

<img width="1437" height="747" alt="Screenshot 2025-11-10 at 2 40 01 PM" src="https://github.com/user-attachments/assets/962e8d84-16b9-47a5-a03a-2e52c0d447e8" />
<img width="1433" height="745" alt="Screenshot 2025-11-10 at 2 43 36 PM" src="https://github.com/user-attachments/assets/0474e16d-239a-4d4f-a5f1-85b8838c9a68" />
<img width="1439" height="749" alt="Screenshot 2025-11-10 at 2 41 13 PM" src="https://github.com/user-attachments/assets/88facb4a-3333-42a7-8d5d-02b22625ee22" />
<img width="1436" height="742" alt="Screenshot 2025-11-10 at 2 41 21 PM" src="https://github.com/user-attachments/assets/b61ac3d9-61d8-4a03-a16f-543dee20bc37" />
<img width="1434" height="745" alt="Screenshot 2025-11-10 at 2 41 49 PM" src="https://github.com/user-attachments/assets/9b814fa9-5065-49e5-a9f1-b02a9e24b233" />
<img width="1439" height="746" alt="Screenshot 2025-11-10 at 2 42 05 PM" src="https://github.com/user-attachments/assets/9baea582-8240-46b3-a808-29f7f60343ca" />
<img width="1440" height="748" alt="Screenshot 2025-11-10 at 2 42 27 PM" src="https://github.com/user-attachments/assets/5b8fe4bf-bbf7-46bf-930b-7ed001b969b9" />
<img width="1438" height="748" alt="Screenshot 2025-11-10 at 2 50 39 PM" src="https://github.com/user-attachments/assets/c5c8e980-cd30-4e61-af2e-2b8ac91e0e62" />
<img width="1440" height="746" alt="Screenshot 2025-11-10 at 2 42 49 PM" src="https://github.com/user-attachments/assets/6b9ed6e3-ae33-459e-a7a2-9e109efc21cd" />
<img width="1440" height="749" alt="Screenshot 2025-11-10 at 2 43 05 PM" src="https://github.com/user-attachments/assets/dbc45a8b-4846-4982-ac04-38ccc640d1aa" />
<img width="1435" height="746" alt="Screenshot 2025-11-10 at 2 40 48 PM" src="https://github.com/user-attachments/assets/ec3a0058-6000-4981-9b8d-ac81a1442ad3" />
<img width="1440" height="747" alt="Screenshot 2025-11-10 at 2 40 54 PM" src="https://github.com/user-attachments/assets/c961d8cb-cb63-4470-9951-52e338ba44d8" />
