### PR TITLE
ROX-31953: Delete React and sort named imports in WorkloadCves

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -775,7 +775,6 @@ module.exports = [
         ignores: [
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/VulnMgmt/**', // deprecated
-            'src/Containers/Vulnerabilities/WorkloadCves/**',
         ],
 
         // languageOptions from previous configuration object
@@ -817,7 +816,6 @@ module.exports = [
         ignores: [
             'src/Containers/Compliance/**', // deprecated
             'src/Containers/VulnMgmt/**', // deprecated
-            'src/Containers/Vulnerabilities/WorkloadCves/**',
             'src/Containers/Workflow/**', // deprecated
         ],
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
-    PageSection,
     Breadcrumb,
-    Divider,
     BreadcrumbItem,
+    Divider,
+    PageSection,
     Skeleton,
     Tab,
     TabTitleText,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageDetails.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Bullseye,
     Card,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageHeader.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { gql } from '@apollo/client';
-import { Flex, Title, LabelGroup, Label } from '@patternfly/react-core';
+import { Flex, Label, LabelGroup, Title } from '@patternfly/react-core';
 import { getDateTime } from 'utils/dateUtils';
 
 import HeaderLoadingSkeleton from '../../components/HeaderLoadingSkeleton';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageResources.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { CSSProperties } from 'react';
 import {
     Bullseye,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageRoute.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageRoute.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import DeploymentPage from './DeploymentPage';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPageVulnerabilities.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import {
     Divider,
     Flex,
     PageSection,
     Pagination,
-    pluralize,
     Split,
     SplitItem,
     Title,
+    pluralize,
 } from '@patternfly/react-core';
 import { gql, useQuery } from '@apollo/client';
 import type { SearchFilter } from 'types/search';
@@ -33,17 +32,17 @@ import CvesByStatusSummaryCard, {
     resourceCountByCveSeverityAndStatusFragment,
 } from '../../components/CvesByStatusSummaryCard';
 import type { ResourceCountByCveSeverityAndStatus } from '../../components/CvesByStatusSummaryCard';
-import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
+import { SummaryCard, SummaryCardLayout } from '../../components/SummaryCardLayout';
 import {
-    parseQuerySearchFilter,
     getHiddenSeverities,
     getHiddenStatuses,
-    getVulnStateScopedQueryString,
     getStatusesForExceptionCount,
+    getVulnStateScopedQueryString,
+    parseQuerySearchFilter,
 } from '../../utils/searchUtils';
 import {
-    imageComponentSearchFilterConfig,
     imageCVESearchFilterConfig,
+    imageComponentSearchFilterConfig,
     imageSearchFilterConfig,
 } from '../../searchFilterConfig';
 import { formatVulnerabilityData, imageMetadataContextFragment } from '../Tables/table.utils';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
 import type { UseURLSortResult } from 'hooks/useURLSort';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/DeploymentResourceTable.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
-import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
 import type { UseURLSortResult } from 'hooks/useURLSort';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import {
     Alert,
@@ -13,8 +13,8 @@ import {
     PageSection,
     Skeleton,
     Tab,
-    Tabs,
     TabTitleText,
+    Tabs,
     Title,
     Tooltip,
 } from '@patternfly/react-core';
@@ -49,7 +49,7 @@ import type { ImageDetails } from '../components/ImageDetailBadges';
 import getImageScanMessage from '../utils/getImageScanMessage';
 import { DEFAULT_VM_PAGE_SIZE } from '../../constants';
 import { getImageBaseNameDisplay } from '../utils/images';
-import { parseQuerySearchFilter, getVulnStateScopedQueryString } from '../../utils/searchUtils';
+import { getVulnStateScopedQueryString, parseQuerySearchFilter } from '../../utils/searchUtils';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 import type { defaultColumns as deploymentResourcesDefaultColumns } from './DeploymentResourceTable';
 import CreateReportDropdown from '../components/CreateReportDropdown';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageResources.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { CSSProperties } from 'react';
 import {
     Bullseye,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageRoute.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageRoute.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import ImagePage from './ImagePage';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageSignatureVerification.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageSignatureVerification.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { Divider, Flex, FlexItem, Label, PageSection, Text } from '@patternfly/react-core';
-import { Table, TableText, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, TableText, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import DateDistance from 'Components/DateDistance';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import {
     Divider,
@@ -6,11 +5,11 @@ import {
     Flex,
     PageSection,
     Pagination,
-    pluralize,
     Split,
     SplitItem,
     Text,
     Title,
+    pluralize,
 } from '@patternfly/react-core';
 import { gql, useQuery } from '@apollo/client';
 import type { SearchFilter } from 'types/search';
@@ -35,7 +34,7 @@ import CvesByStatusSummaryCard, {
     resourceCountByCveSeverityAndStatusFragment,
 } from '../../components/CvesByStatusSummaryCard';
 import type { ResourceCountByCveSeverityAndStatus } from '../../components/CvesByStatusSummaryCard';
-import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
+import { SummaryCard, SummaryCardLayout } from '../../components/SummaryCardLayout';
 import useHasRequestExceptionsAbility from '../../hooks/useHasRequestExceptionsAbility';
 import ImageVulnerabilitiesTable, {
     defaultColumns,
@@ -62,8 +61,8 @@ import CompletedExceptionRequestModal from '../../components/ExceptionRequestMod
 import useExceptionRequestModal from '../../hooks/useExceptionRequestModal';
 import useWorkloadCveViewContext from '../hooks/useWorkloadCveViewContext';
 import {
-    imageComponentSearchFilterConfig,
     imageCVESearchFilterConfig,
+    imageComponentSearchFilterConfig,
 } from '../../searchFilterConfig';
 
 export const imageVulnerabilitiesQuery = gql`

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import {
     Breadcrumb,
@@ -56,7 +56,7 @@ import AffectedImagesTable, {
 import type { ImageForCve } from '../Tables/AffectedImagesTable';
 import AdvancedFiltersToolbar from '../../components/AdvancedFiltersToolbar';
 import EntityTypeToggleGroup from '../../components/EntityTypeToggleGroup';
-import type { WorkloadEntityTab, VulnerabilitySeverityLabel } from '../../types';
+import type { VulnerabilitySeverityLabel, WorkloadEntityTab } from '../../types';
 import AffectedDeploymentsTable, {
     deploymentsForCveFragment,
     tableId as affectedDeploymentsTableId,
@@ -66,7 +66,7 @@ import type { DeploymentForCve } from '../Tables/AffectedDeploymentsTable';
 import AffectedImages from '../SummaryCards/AffectedImages';
 import BySeveritySummaryCard from '../../components/BySeveritySummaryCard';
 import type { ResourceCountsByCveSeverity } from '../../components/BySeveritySummaryCard';
-import { SummaryCardLayout, SummaryCard } from '../../components/SummaryCardLayout';
+import { SummaryCard, SummaryCardLayout } from '../../components/SummaryCardLayout';
 import { resourceCountByCveSeverityAndStatusFragment } from '../../components/CvesByStatusSummaryCard';
 import VulnerabilityStateTabs, {
     vulnStateTabContentId,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageRoute.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageRoute.tsx
@@ -1,14 +1,12 @@
-import React from 'react';
-
 import { hideColumnIf } from 'hooks/useManagedColumns';
 import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';
 
 import {
-    imageSearchFilterConfig,
-    imageComponentSearchFilterConfig,
-    deploymentSearchFilterConfig,
-    namespaceSearchFilterConfig,
     clusterSearchFilterConfig,
+    deploymentSearchFilterConfig,
+    imageComponentSearchFilterConfig,
+    imageSearchFilterConfig,
+    namespaceSearchFilterConfig,
 } from '../../searchFilterConfig';
 import ImageCvePage from './ImageCvePage';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/DeploymentFilterLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/DeploymentFilterLink.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { pluralize } from '@patternfly/react-core';
 import { Link } from 'react-router-dom-v5-compat';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/NamespaceView/NamespaceViewPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Breadcrumb,
     BreadcrumbItem,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/CVEsTableContainer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQuery } from '@apollo/client';
 import { Divider, DropdownItem, ToolbarItem } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/DeploymentsTableContainer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Divider, ToolbarItem } from '@patternfly/react-core';
 
 import type useURLSort from 'hooks/useURLSort';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/ImagesTableContainer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Divider, ToolbarItem } from '@patternfly/react-core';
 
 import type useURLSort from 'hooks/useURLSort';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/VulnerabilitiesOverview.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/VulnerabilitiesOverview.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import { Flex } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
     Button,
     Card,
@@ -49,14 +49,14 @@ import {
 import { isVulnMgmtLocalStorage, workloadEntityTabValues } from '../../types';
 import type { DefaultFilters, VulnMgmtLocalStorage, WorkloadEntityTab } from '../../types';
 import {
-    parseQuerySearchFilter,
+    getNamespaceViewPagePath,
     getVulnStateScopedQueryString,
     getZeroCveScopedQueryString,
-    getNamespaceViewPagePath,
+    parseQuerySearchFilter,
 } from '../../utils/searchUtils';
 import {
-    getWorkloadCveOverviewDefaultSortOption,
     getDefaultZeroCveSortOption,
+    getWorkloadCveOverviewDefaultSortOption,
     getWorkloadCveOverviewSortFields,
     syncSeveritySortOption,
 } from '../../utils/sortUtils';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/AffectedImages.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/SummaryCards/AffectedImages.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Card, CardTitle, CardBody } from '@patternfly/react-core';
+import { Card, CardBody, CardTitle } from '@patternfly/react-core';
 
 export type AffectedImagesProps = {
     className?: string;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedDeploymentsTable.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
-import { Flex, pluralize, Truncate } from '@patternfly/react-core';
-import { Table, Thead, Tr, Th, Tbody, Td, ExpandableRowContent } from '@patternfly/react-table';
+import { Flex, Truncate, pluralize } from '@patternfly/react-core';
+import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
 import useSet from 'hooks/useSet';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/AffectedImagesTable.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import { gql } from '@apollo/client';
 import { LabelGroup } from '@patternfly/react-core';
-import { ExpandableRowContent, Table, Tbody, Td, Thead, Th, Tr } from '@patternfly/react-table';
+import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import useSet from 'hooks/useSet';
 import type { UseURLSortResult } from 'hooks/useURLSort';
@@ -19,11 +18,11 @@ import { isNonEmptyArray } from 'utils/type.utils';
 import { generateVisibilityForColumns, getHiddenColumnCount } from 'hooks/useManagedColumns';
 import type { ManagedColumns } from 'hooks/useManagedColumns';
 import {
-    getIsSomeVulnerabilityFixable,
+    getEarliestDiscoveredAtTime,
     getHighestCvssScore,
     getHighestNvdCvssScore,
     getHighestVulnerabilitySeverity,
-    getEarliestDiscoveredAtTime,
+    getIsSomeVulnerabilityFixable,
 } from '../../utils/vulnerabilityUtils';
 import ImageNameLink from '../components/ImageNameLink';
 import PendingExceptionLabel from '../../components/PendingExceptionLabel';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import { LabelGroup } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
@@ -14,9 +13,9 @@ import AdvisoryLinkOrText from '../../components/AdvisoryLinkOrText';
 import PendingExceptionLabel from '../../components/PendingExceptionLabel';
 import ImageNameLink from '../components/ImageNameLink';
 import {
+    flattenDeploymentComponentVulns,
     imageMetadataContextFragment,
     sortTableData,
-    flattenDeploymentComponentVulns,
 } from './table.utils';
 import type { DeploymentComponentVulnerability, ImageMetadataContext } from './table.utils';
 import DockerfileLayer from '../components/DockerfileLayer';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentOverviewTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { LabelGroup } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactNode } from 'react';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { LabelGroup } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
@@ -34,14 +33,14 @@ import type { VulnerabilitySeverityLabel } from '../../types';
 // import { hasKnownExploit, hasKnownRansomwareCampaignUse } from '../../utils/vulnerabilityUtils'; // Ross CISA KEV
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import {
-    getScoreVersionsForTopCVSS,
-    getScoreVersionsForTopNvdCVSS,
-    sortCveDistroList,
     aggregateByCVSS,
-    aggregateByEPSS,
     aggregateByCreatedTime,
     aggregateByDistinctCount,
+    aggregateByEPSS,
+    getScoreVersionsForTopCVSS,
+    getScoreVersionsForTopNvdCVSS,
     getSeveritySortOptions,
+    sortCveDistroList,
 } from '../../utils/sortUtils';
 import type { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
 import CVESelectionTh from '../../components/CVESelectionTh';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/infoForTh.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/infoForTh.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import type { ThProps } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/UnwatchImageModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/UnwatchImageModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Alert, Button, Flex, Modal, Text } from '@patternfly/react-core';
 
 import { unwatchImage } from 'services/imageService';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Button,
     Form,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import type { CSSProperties } from 'react';
 import {
     Alert,
@@ -7,10 +7,10 @@ import {
     Divider,
     Flex,
     Modal,
-    pluralize,
     Spinner,
     Text,
     Title,
+    pluralize,
 } from '@patternfly/react-core';
 import noop from 'lodash/noop';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WatchedImages/WatchedImagesTable.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import type { CSSProperties } from 'react';
-import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { Bullseye, Button, Icon } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { PageSection } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocation.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ComponentLocation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Flex, Icon, Tooltip, Truncate } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CreateReportDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CreateReportDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { MouseEvent as ReactMouseEvent, Ref } from 'react';
 import { Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';
 import type { MenuToggleElement } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CreateViewBasedReportModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CreateViewBasedReportModal.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Modal, Button, Alert, Flex, FlexItem } from '@patternfly/react-core';
+import { useState } from 'react';
+import { Alert, Button, Flex, FlexItem, Modal } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 
 import { runViewBasedReport } from 'services/ReportsService';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
-import { Button, Modal, Form, FormGroup, Checkbox } from '@patternfly/react-core';
+import { useState } from 'react';
+import { Button, Checkbox, Form, FormGroup, Modal } from '@patternfly/react-core';
 import cloneDeep from 'lodash/cloneDeep';
-import { useFormik, FormikProvider } from 'formik';
+import { FormikProvider, useFormik } from 'formik';
 import { Globe } from 'react-feather';
 
 import useAnalytics, { WORKLOAD_CVE_DEFAULT_FILTERS_CHANGED } from 'hooks/useAnalytics';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DockerfileLayer.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DockerfileLayer.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { CodeBlock, Flex, CodeBlockCode } from '@patternfly/react-core';
+import { CodeBlock, CodeBlockCode, Flex } from '@patternfly/react-core';
 import type { TableDataRow } from '../Tables/table.utils';
 
 export type DockerfileLayerProps = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/EmptyTableResults.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/EmptyTableResults.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { Bullseye, Button, Text } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-import { Tbody, Tr, Td } from '@patternfly/react-table';
+import { Tbody, Td, Tr } from '@patternfly/react-table';
 
 import EmptyStateTemplate from 'Components/EmptyStateTemplate';
 import useURLSearch from 'hooks/useURLSearch';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionDetailsCell.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ExceptionDetailsCell.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Td } from '@patternfly/react-table';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageDetailBadges.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { LabelGroup, Label } from '@patternfly/react-core';
+import { Label, LabelGroup } from '@patternfly/react-core';
 import { gql } from '@apollo/client';
 
-import { getDistanceStrict, getDateTime } from 'utils/dateUtils';
+import { getDateTime, getDistanceStrict } from 'utils/dateUtils';
 import type { SignatureVerificationResult } from '../../types';
 import SignatureCountLabel from './SignatureCountLabel';
 import VerifiedSignatureLabel, { getVerifiedSignatureInResults } from './VerifiedSignatureLabel';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageNameLink.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { Button, Flex, FlexItem, Tooltip, Truncate } from '@patternfly/react-core';
 import { OutlinedCopyIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningIncompleteLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/ImageScanningIncompleteLabel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Flex, FlexItem, Label, Popover } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SignatureCountLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/SignatureCountLabel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Flex, FlexItem, Label, Popover, Text } from '@patternfly/react-core';
 
 import useMetadata from 'hooks/useMetadata';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VerifiedSignatureLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VerifiedSignatureLabel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { CSSProperties } from 'react';
 import { Flex, FlexItem, Label, List, ListItem, Popover } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/VulnerabilityStateTabs.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Tabs, Tab, TabTitleText } from '@patternfly/react-core';
+import { Tab, TabTitleText, Tabs } from '@patternfly/react-core';
 import type { TabsProps } from '@patternfly/react-core';
 
 import { isVulnerabilityState, vulnerabilityStates } from 'types/cve.proto';


### PR DESCRIPTION
## Description

Double up to merge ahead of PatternFly 6.

Simplify configuration in eslint.config.js file as a follow up.

### Problem

Our convention includes `import React` as default import, even though React elements no longer need `React` in scope.

IDE let alone AI automatically inserts new named imports out of order.

The absence of a pattern becomes the pattern.

At least for me, unordered named imports become a speed bump when I need to add another:
* where to add?
* whether to reorder?

### Solution

Assume `import type` separate from `import` statements because that solves some problems with order of named imports.

1. Edit eslint.config.js file to delete line for folder in `ignores` array.
2. Run auto fix on command line to fix errors.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder: see presence of errors.
2. `npm run lint:fast-dev-fix` in ui/apps/platform folder: autofix like a codemod.
3. `npm run tsc` in ui/apps/platform folder: only the paranoid survive.
4. `npm run lint:fast-dev` in ui/apps/platform folder: see absence of errors.