### PR TITLE
ROX-14475: Rebase to UBI9 and leverage minimal images

### DIFF
--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -1,8 +1,8 @@
 ARG RPMS_REGISTRY=registry.access.redhat.com
-ARG RPMS_BASE_IMAGE=ubi8
+ARG RPMS_BASE_IMAGE=ubi9
 ARG RPMS_BASE_TAG=latest
 ARG BASE_REGISTRY=registry.access.redhat.com
-ARG BASE_IMAGE=ubi8-minimal
+ARG BASE_IMAGE=ubi9-minimal
 ARG BASE_TAG=latest
 
 FROM ${RPMS_REGISTRY}/${RPMS_BASE_IMAGE}:${RPMS_BASE_TAG} AS downloads
@@ -32,13 +32,13 @@ ARG ROX_PRODUCT_BRANDING
 ARG TARGET_ARCH=amd64
 
 LABEL name="main" \
-      vendor="StackRox" \
-      maintainer="https://stackrox.io/" \
-      summary="The StackRox Kubernetes Security Platform" \
-      description="This image contains components required to operate the StackRox Kubernetes Security Platform." \
-      version="${LABEL_VERSION}" \
-      release="${LABEL_RELEASE}" \
-      quay.expires-after="${QUAY_TAG_EXPIRATION}"
+    vendor="StackRox" \
+    maintainer="https://stackrox.io/" \
+    summary="The StackRox Kubernetes Security Platform" \
+    description="This image contains components required to operate the StackRox Kubernetes Security Platform." \
+    version="${LABEL_VERSION}" \
+    release="${LABEL_RELEASE}" \
+    quay.expires-after="${QUAY_TAG_EXPIRATION}"
 
 ENV PATH="/stackrox:$PATH" \
     ROX_ROXCTL_IN_MAIN_IMAGE="true" \

--- a/image/rhel/download.sh
+++ b/image/rhel/download.sh
@@ -40,7 +40,7 @@ if [[ "$arch" == "s390x" ]]; then
   mv /tmp/postgresql-*.rpm "${output_dir}/rpms/postgres.rpm"
 else
   postgres_major=15
-  pg_rhel_major=8
+  pg_rhel_major=9
   postgres_repo_url="https://download.postgresql.org/pub/repos/yum/reporpms/EL-${pg_rhel_major}-${arch}/pgdg-redhat-repo-latest.noarch.rpm"
   dnf install --disablerepo='*' -y "${postgres_repo_url}"
   postgres_minor=$(dnf list ${dnf_list_args[@]+"${dnf_list_args[@]}"} --disablerepo='*' ""--enablerepo=pgdg${postgres_major} -y postgresql${postgres_major}-server."$arch" | tail -n 1 | awk '{print $2}')

--- a/image/roxctl/Dockerfile
+++ b/image/roxctl/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:latest AS certs
+FROM registry.access.redhat.com/ubi9-minimal:latest AS certs
 
 FROM scratch
 COPY ./roxctl-linux /roxctl


### PR DESCRIPTION
## Description

This change rebases StackRox container/build images from UBI8 to UBI9 and adopts the minimal variants where applicable. It also updates the Konflux builder images to ubi9/go-toolset:1.24 and adjusts the PostgreSQL YUM repo to EL9 for the upstream build. Goal: align with RHEL9/UBI9 baselines, reduce CVE surface, and simplify supply-chain compliance going forward.

## User-facing documentation

not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md)(https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

reliant on your CI here :-)

### How I validated my change

- built locally with docker and podman, konflux builds not locally reproducible because they require entitled build nodes
