### PR TITLE
ROX-31521: Disable policy enforcement for node event sources

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyActionsForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyActionsForm.tsx
@@ -1,4 +1,13 @@
-import { Divider, Flex, FlexItem, Form, FormGroup, Radio, Title } from '@patternfly/react-core';
+import {
+    Alert,
+    Divider,
+    Flex,
+    FlexItem,
+    Form,
+    FormGroup,
+    Radio,
+    Title,
+} from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import type { FormikContextType } from 'formik';
 
@@ -9,6 +18,8 @@ import NotifiersForm from './NotifiersForm';
 
 function PolicyActionsForm() {
     const { setFieldValue, values }: FormikContextType<ClientPolicy> = useFormikContext();
+    const isEnforcementDisabled =
+        values.eventSource === 'AUDIT_LOG_EVENT' || values.eventSource === 'NODE_EVENT';
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
             <FlexItem flex={{ default: 'flex_1' }} className="pf-v5-u-p-lg">
@@ -16,6 +27,15 @@ function PolicyActionsForm() {
                 <div className="pf-v5-u-mt-sm">
                     Configure activation state, enforcement, and notifiers of this policy.
                 </div>
+                {isEnforcementDisabled && (
+                    <Alert
+                        isInline
+                        variant="info"
+                        title="The selected event source does not support enforcement."
+                        component="p"
+                        className="pf-v5-u-mt-md"
+                    />
+                )}
             </FlexItem>
             <Divider component="div" />
             <Flex direction={{ default: 'column' }} className="pf-v5-u-p-lg">

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyEnforcementForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/PolicyEnforcementForm.tsx
@@ -54,12 +54,20 @@ function PolicyEnforcementForm() {
     const hasDeploy = values.lifecycleStages.includes('DEPLOY');
     const hasRuntime = values.lifecycleStages.includes('RUNTIME');
     const hasAuditLog = values.eventSource === 'AUDIT_LOG_EVENT';
+    const hasNodeEvent = values.eventSource === 'NODE_EVENT';
 
-    const responseMethodHelperText = showEnforcement
+    let responseMethodHelperText = showEnforcement
         ? 'Inform and enforce will execute enforcement behavior at the stages you select.'
-        : hasRuntime && hasAuditLog
-          ? 'Inform will always include violations for this policy in the violations list. Enforcement is not available for audit log event sources.'
-          : 'Inform will always include violations for this policy in the violations list.';
+        : 'Inform will always include violations for this policy in the violations list.';
+
+    if (hasAuditLog) {
+        responseMethodHelperText = 'Enforcement is not available for audit log event sources.';
+    }
+    if (hasNodeEvent) {
+        responseMethodHelperText = 'Enforcement is not available for node event sources.';
+    }
+
+    const isEnforcementDisabled = hasAuditLog || hasNodeEvent;
 
     return (
         <Form>
@@ -70,7 +78,7 @@ function PolicyEnforcementForm() {
                         isChecked={!showEnforcement}
                         id="policy-response-inform"
                         name="inform"
-                        isDisabled={hasRuntime && hasAuditLog}
+                        isDisabled={isEnforcementDisabled}
                         onChange={() => {
                             setShowEnforcement(false);
                             setFieldValue('enforcementActions', [], false); // do not validate, because code changes the value
@@ -81,7 +89,7 @@ function PolicyEnforcementForm() {
                         isChecked={showEnforcement}
                         id="policy-response-inform-enforce"
                         name="enforce"
-                        isDisabled={hasRuntime && hasAuditLog}
+                        isDisabled={isEnforcementDisabled}
                         onChange={() => setShowEnforcement(true)}
                     />
                 </Flex>
@@ -164,7 +172,7 @@ function PolicyEnforcementForm() {
                                             'RUNTIME',
                                             values.enforcementActions
                                         )}
-                                        isDisabled={!hasRuntime || hasAuditLog}
+                                        isDisabled={!hasRuntime || isEnforcementDisabled}
                                         onChange={(_event, isChecked) => {
                                             onChangeEnforcementActions('RUNTIME', isChecked);
                                         }}


### PR DESCRIPTION
## Description

Ensures policy enforcement is disabled for Node based event sources, in addition to audit log event sources.

Adds an informational alert at the top of the wizard step in both cases.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1282" height="904" alt="image" src="https://github.com/user-attachments/assets/79b4b302-801d-4c9d-834b-95ea328888e5" />