### PR TITLE
ROX-31739: Move Version to second column in Vulnerabilities tables

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx
@@ -71,9 +71,9 @@ function NodeComponentsTable({ data }: NodeComponentsTableProps) {
             <Thead noWrap>
                 <Tr>
                     <Th sort={getSortParams('Component')}>Component</Th>
-                    <Th sort={getSortParams('Type')}>Type</Th>
                     <Th>Version</Th>
                     <Th>CVE fixed in</Th>
+                    <Th sort={getSortParams('Type')}>Type</Th>
                 </Tr>
             </Thead>
             <Tbody>
@@ -82,13 +82,13 @@ function NodeComponentsTable({ data }: NodeComponentsTableProps) {
                     return (
                         <Tr key={name}>
                             <Td dataLabel="Component">{name}</Td>
-                            <Td dataLabel="Type">{source}</Td>
                             <Td dataLabel="Version">{version}</Td>
                             <Td dataLabel="CVE fixed in">
                                 {fixedByVersion || (
                                     <VulnerabilityFixableIconText isFixable={false} />
                                 )}
                             </Td>
+                            <Td dataLabel="Type">{source}</Td>
                         </Tr>
                     );
                 })}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachineComponentsTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachineComponentsTable.tsx
@@ -14,10 +14,10 @@ function VirtualMachineComponentsTable({ components }: VirtualMachineComponentsT
             <Thead noWrap>
                 <Tr>
                     <Th>Component</Th>
-                    <Th>Type</Th>
                     <Th>Version</Th>
                     <Th>CVE fixed in</Th>
                     <Th>Advisory</Th>
+                    <Th>Type</Th>
                 </Tr>
             </Thead>
             <Tbody>
@@ -25,7 +25,6 @@ function VirtualMachineComponentsTable({ components }: VirtualMachineComponentsT
                     return (
                         <Tr key={name}>
                             <Td dataLabel="Component">{name}</Td>
-                            <Td dataLabel="Type">{sourceType}</Td>
                             <Td dataLabel="Version">{version}</Td>
                             <Td dataLabel="CVE fixed in">
                                 <FixedByVersion fixedByVersion={fixedBy ?? ''} />
@@ -33,6 +32,7 @@ function VirtualMachineComponentsTable({ components }: VirtualMachineComponentsT
                             <Td dataLabel="Advisory">
                                 <AdvisoryLinkOrText advisory={advisory} />
                             </Td>
+                            <Td dataLabel="Type">{sourceType}</Td>
                         </Tr>
                     );
                 })}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePackagesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePackagesTable.tsx
@@ -30,8 +30,8 @@ function VirtualMachinePackagesTable({
             <Thead>
                 <Tr>
                     <Th sort={getSortParams(COMPONENT_SORT_FIELD)}>Name</Th>
-                    <Th>Status</Th>
                     <Th>Version</Th>
+                    <Th>Status</Th>
                 </Tr>
             </Thead>
             <TbodyUnified
@@ -50,10 +50,10 @@ function VirtualMachinePackagesTable({
                             return (
                                 <Tr key={`${packageRow.name}-${packageRow.version}`}>
                                     <Td dataLabel="Name">{packageRow.name} </Td>
+                                    <Td dataLabel="Version">{packageRow.version}</Td>
                                     <Td dataLabel="Status">
                                         {packageRow.isScannable ? 'Scanned' : 'Not scanned'}
                                     </Td>
-                                    <Td dataLabel="Version">{packageRow.version}</Td>
                                 </Tr>
                             );
                         })}


### PR DESCRIPTION
## Description

### Problems

1. During sprint demo by **Brad** of virtual machine components table, I noticed **Version** column is not adjacent to **Component** as it is in image compoonents table.
2. Ditto for node components table. Thanks to **Mansur** for this observation.
3. Virtual machine packages table has similar problem.

### Analysis

1. Deployment components table has 3 image columns, followed by similar columns as image components table.
2. PlatformCves folder (also known as **Kubernetes components**) does not have components nor packages.

Why is it a problem?
1. Inconsistent with precedent of image and deployments.
2. Unexpected to separate **Name** and **Version** of component, package, or whatever.
3. Inconsistent with **Name** and **Version** in list of virtual machine components from exploratory document for virtual machine vulnerabilites.

### Solution

Discussed in UI/UX meeting on 2025-10-05 and then confirmed on 2025-10-12

Move columns.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central

### Manual testing

1. Visit /main/vulnerabilities click a vulnerability link, and then expand an image row

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx

    See **Component** first **Version** second **CVE fixed in** third **Advisory** fourth
    <img width="1440" height="898" alt="ImageComponentVulnerabilitiesTable" src="https://github.com/user-attachments/assets/a41f3411-757c-4ad4-a970-0b315660fe46" />

2. Click **Deployments** toggle

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentComponentVulnerabilitiesTable.tsx

    After 3 image columns, see the **Component** next **Version** next and so on
    <img width="1440" height="898" alt="DeploymentComponentVulnerabilitiesTable" src="https://github.com/user-attachments/assets/ff94f06c-a3f1-4aba-af23-0ce4cfc1510e" />

3. Visit /main/vulnerabilities/node-cves click a vulnerability link, and then expand an node row

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/components/NodeComponentsTable.tsx

    Before changes: **Component** first **Type** second **Version** third **CVE fixed in** fourth
    <img width="1440" height="898" alt="NodeComponentsTable_inconsistent" src="https://github.com/user-attachments/assets/17da6f56-4cf4-4090-8951-51eca4263949" />

    After changes: **Component** first **Version** second **CVE fixed in** third **Type** fourth
    <img width="1440" height="898" alt="NodeComponentsTable_consistent" src="https://github.com/user-attachments/assets/bd4ed30f-7f25-4aec-b107-93c214e39e7e" />

Not yet on staging demo, so these are steps as best as I understand:

1. Visit /main/vulnerabilities/virtual-machine-cves click a vulnerability link, and then expand a virtual machine row

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachineComponentsTable.tsx

    Before changes: **Component** first **Type** second **Version** third **CVE fixed in** fourth

    After changes: **Component** first **Version** second **CVE fixed in** third **Type** fourth

2. Click virtual machine link and then **Packages** tab.

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePackagesTable.tsx

    Before changes: **Name** first **Status** second **Version** third

    After changes: **Name** first **Version** second **Status** third
