### PR TITLE
ROX-31607: remove 2 pass queries from search result

### DIFF
--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -228,23 +228,26 @@ func (ds *datastoreImpl) Count(ctx context.Context, q *v1.Query) (int, error) {
 }
 
 func (ds *datastoreImpl) SearchResults(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
-	results, err := ds.Search(ctx, q)
+	if q == nil {
+		q = pkgSearch.EmptyQuery()
+	}
+	clonedQuery := q.CloneVT()
+	selectSelects := []*v1.QuerySelect{
+		pkgSearch.NewQuerySelect(pkgSearch.Cluster).Proto(),
+	}
+	clonedQuery.Selects = append(clonedQuery.GetSelects(), selectSelects...)
+	results, err := ds.Search(ctx, clonedQuery)
 	if err != nil {
 		return nil, err
 	}
-
-	clusters, missingIndices, err := ds.clusterStorage.GetMany(ctx, pkgSearch.ResultsToIDs(results))
-	if err != nil {
-		return nil, err
+	for i := range results {
+		if results[i].FieldValues != nil {
+			if nameVal, ok := results[i].FieldValues[strings.ToLower(pkgSearch.Cluster.String())]; ok {
+				results[i].Name = nameVal
+			}
+		}
 	}
-
-	results = pkgSearch.RemoveMissingResults(results, missingIndices)
-
-	protoResults := make([]*v1.SearchResult, 0, len(clusters))
-	for i, cluster := range clusters {
-		protoResults = append(protoResults, convertCluster(cluster, results[i]))
-	}
-	return protoResults, nil
+	return pkgSearch.ResultsToSearchResultProtos(results, &ClusterSearchResultConverter{}), nil
 }
 
 func (ds *datastoreImpl) searchRawClusters(ctx context.Context, q *v1.Query) ([]*storage.Cluster, error) {
@@ -1120,13 +1123,18 @@ func (ds *datastoreImpl) collectClusters(ctx context.Context) ([]*storage.Cluste
 	return clusters, nil
 }
 
-func convertCluster(cluster *storage.Cluster, result pkgSearch.Result) *v1.SearchResult {
-	return &v1.SearchResult{
-		Category:       v1.SearchCategory_CLUSTERS,
-		Id:             cluster.GetId(),
-		Name:           cluster.GetName(),
-		FieldToMatches: pkgSearch.GetProtoMatchesMap(result.Matches),
-		Score:          result.Score,
-		Location:       fmt.Sprintf("/%s", cluster.GetName()),
-	}
+// ClusterSearchResultConverter implements search.SearchResultConverter for cluster search results.
+// This enables single-pass query construction for SearchResult protos.
+type ClusterSearchResultConverter struct{}
+
+func (c *ClusterSearchResultConverter) BuildName(result *pkgSearch.Result) string {
+	return result.Name
+}
+
+func (c *ClusterSearchResultConverter) BuildLocation(result *pkgSearch.Result) string {
+	return fmt.Sprintf("/%s", result.Name)
+}
+
+func (c *ClusterSearchResultConverter) GetCategory() v1.SearchCategory {
+	return v1.SearchCategory_CLUSTERS
 }

--- a/central/cluster/datastore/datastore_impl_postgres_test.go
+++ b/central/cluster/datastore/datastore_impl_postgres_test.go
@@ -1341,12 +1341,23 @@ func (s *ClusterPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 				actual, err = s.nsDatastore.Search(tc.ctx, tc.query)
 			} else {
 				actual, err = s.clusterDatastore.Search(tc.ctx, tc.query)
+				// verify search results
+				searchRes, searchErr := s.clusterDatastore.SearchResults(tc.ctx, tc.query)
+				assert.Len(t, searchRes, len(tc.expectedIDs))
+				if tc.expectedError != "" {
+					assert.EqualError(t, searchErr, tc.expectedError)
+				} else {
+					assert.NoError(t, searchErr)
+				}
 			}
 			if tc.expectedError == "" {
 				assert.NoError(t, err)
+
 			} else {
 				assert.EqualError(t, err, tc.expectedError)
+
 			}
+
 			assert.Len(t, actual, len(tc.expectedIDs))
 			actualIDs := pkgSearch.ResultsToIDs(actual)
 			assert.ElementsMatch(t, tc.expectedIDs, actualIDs)


### PR DESCRIPTION
This PR removes 2 pass search from cluster datastore

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
