### PR TITLE
ROX-31610: remove 2 pass searches from cve/image datastore

### DIFF
--- a/central/cve/image/v2/datastore/datastore_impl.go
+++ b/central/cve/image/v2/datastore/datastore_impl.go
@@ -34,9 +34,10 @@ func (ds *datastoreImpl) SearchImageCVEs(ctx context.Context, q *v1.Query) ([]*v
 	if err != nil {
 		return nil, err
 	}
+	searchTag := strings.ToLower(pkgSearch.CVE.String())
 	for i := range results {
 		if results[i].FieldValues != nil {
-			if nameVal, ok := results[i].FieldValues[strings.ToLower(pkgSearch.CVE.String())]; ok {
+			if nameVal, ok := results[i].FieldValues[searchTag]; ok {
 				results[i].Name = nameVal
 			}
 		}

--- a/central/cve/image/v2/datastore/datastore_sac_test.go
+++ b/central/cve/image/v2/datastore/datastore_sac_test.go
@@ -424,6 +424,11 @@ func (s *cveV2DataStoreSACTestSuite) TestSACImageCVESearchCVEs() {
 		fetchedCVEIDs := make([]string, 0, len(results))
 		for _, result := range results {
 			fetchedCVEIDs = append(fetchedCVEIDs, result.GetId())
+
+			// Verify that each result has proper fields populated
+			// CVE name should be the actual CVE string (e.g., "CVE-1234-0001")
+			// ID is a composite key that includes component and image context
+			s.Contains(result.GetId(), result.GetName(), "CVE ID should contain the CVE name")
 		}
 		s.ElementsMatch(expectedCVEIDs, fetchedCVEIDs)
 	})


### PR DESCRIPTION
This PR removes 2 pass search query from cve/image v2 datastore

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
