### PR TITLE
ROX-29614: Delete cypress 'should sort Risk Priority column' test

### DIFF
--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -1,15 +1,8 @@
 import withAuth from '../../helpers/basicAuth';
-import {
-    assertSortedItems,
-    callbackForPairOfAscendingNumberValuesFromElements,
-    callbackForPairOfDescendingNumberValuesFromElements,
-} from '../../helpers/sort';
 import { getRegExpForTitleWithBranding } from '../../helpers/title';
 
 import {
     clickTab,
-    deploymentscountAlias,
-    deploymentswithprocessinfoAlias,
     viewRiskDeploymentByName,
     viewRiskDeploymentInNetworkGraph,
     visitRiskDeployments,
@@ -37,76 +30,6 @@ describe('Risk', () => {
             cy.get('.rt-th:contains("Cluster")');
             cy.get('.rt-th:contains("Namespace")');
             cy.get('.rt-th:contains("Priority")');
-        });
-
-        /*
-         * ROX-13468: assertSortedItems sometimes fails for sort descending (step 2) or resort ascending (step 3).
-         * This is the only sort test that fails and Risk is the only occurrence of TableV2 element.
-         * Skip test given the comment below (step 0) initial table state and other possible rendering problems.
-         */
-        it.skip('should sort the Priority column', () => {
-            visitRiskDeployments();
-
-            const thSelector = '.rt-th:contains("Priority")';
-            const tdSelector = '.rt-td:nth-child(5)';
-
-            // 0. Initial table state does not indicate that it is sorted ascending by the Priority column.
-            // TODO If possible, replace TableV2 with Table element in RiskTable component.
-            cy.get(thSelector)
-                .should('not.have.class', '-sort-asc')
-                .should('not.have.class', '-sort-desc');
-
-            // 1. Sort ascending by the Priority column.
-            cy.get(thSelector).click();
-            cy.location('search').should(
-                'eq',
-                '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
-            );
-
-            // There is no request because rows are already sorted ascending.
-
-            cy.get(thSelector).should('have.class', '-sort-asc');
-            cy.get(tdSelector).then((items) => {
-                assertSortedItems(items, callbackForPairOfAscendingNumberValuesFromElements);
-            });
-
-            // 2. Sort descending by the Priority column.
-            cy.get(thSelector).click();
-            cy.location('search').should(
-                'eq',
-                '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=true'
-            );
-
-            // There is a request because of change in sorting.
-            cy.wait(`@${deploymentswithprocessinfoAlias}`)
-                .its('request.url')
-                .should('include', 'sortOption.field=Deployment%20Risk%20Priority')
-                .should('include', 'sortOption.reversed=true');
-            cy.wait(`@${deploymentscountAlias}`);
-
-            cy.get(thSelector).should('have.class', '-sort-desc');
-            cy.get(tdSelector).then((items) => {
-                assertSortedItems(items, callbackForPairOfDescendingNumberValuesFromElements);
-            });
-
-            // 3. Sort ascending by the Priority column.
-            cy.get(thSelector).click();
-            cy.location('search').should(
-                'eq',
-                '?sort[id]=Deployment%20Risk%20Priority&sort[desc]=false'
-            );
-
-            // There is a request because of change in sorting.
-            cy.wait(`@${deploymentswithprocessinfoAlias}`)
-                .its('request.url')
-                .should('include', 'sortOption.field=Deployment%20Risk%20Priority')
-                .should('include', 'sortOption.reversed=false');
-            cy.wait(`@${deploymentscountAlias}`);
-
-            cy.get(thSelector).should('have.class', '-sort-asc');
-            cy.get(tdSelector).then((items) => {
-                assertSortedItems(items, callbackForPairOfAscendingNumberValuesFromElements);
-            });
         });
 
         it('should open side panel for deployment', () => {


### PR DESCRIPTION
## Description

Not worth the trouble, even if backend indeterminacy might have healed itself.

Especially in case Risk Score supersedes Risk Priority.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [x] deleted regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI