### PR TITLE
ROX-31126,ROX-31120: Policy criteria for cve fix timestamp

### DIFF
--- a/central/image/datastore/store/v2/postgres/store_test.go
+++ b/central/image/datastore/store/v2/postgres/store_test.go
@@ -80,6 +80,9 @@ func (s *ImagesStoreSuite) TestStore() {
 			vuln.SuppressActivation = nil
 			vuln.SuppressExpiry = nil
 			vuln.Advisory = nil
+			// TODO: Can be removed after the new CVE table and ImageCVE to EmbeddedVulnerability conversion to populate
+			// the two timestamps (FirstOccurenceInSystem and FixAvailable)
+			vuln.FixAvailableTimestamp = nil
 		}
 		comp.License = nil
 	}
@@ -135,6 +138,7 @@ func (s *ImagesStoreSuite) TestNVDCVSS() {
 	for _, component := range image.GetScan().GetComponents() {
 		for _, vuln := range component.GetVulns() {
 			vuln.CvssMetrics = []*storage.CVSSScore{nvdCvss}
+			vuln.FixAvailableTimestamp = nil
 		}
 
 	}

--- a/central/imagev2/datastore/store/postgres/store_test.go
+++ b/central/imagev2/datastore/store/postgres/store_test.go
@@ -92,6 +92,7 @@ func (s *ImagesV2StoreSuite) TestStore() {
 			vuln.SuppressActivation = nil
 			vuln.SuppressExpiry = nil
 			vuln.Advisory = nil
+			vuln.FixAvailableTimestamp = nil
 		}
 		comp.License = nil
 	}
@@ -147,6 +148,7 @@ func (s *ImagesV2StoreSuite) TestNVDCVSS() {
 	for _, component := range image.GetScan().GetComponents() {
 		for _, vuln := range component.GetVulns() {
 			vuln.CvssMetrics = []*storage.CVSSScore{nvdCvss}
+			vuln.FixAvailableTimestamp = nil
 		}
 
 	}

--- a/generated/api/v1/image_service.swagger.json
+++ b/generated/api/v1/image_service.swagger.json
@@ -1203,6 +1203,11 @@
           "format": "date-time",
           "description": "Time when the CVE was first seen in this image."
         },
+        "fixAvailableTimestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the fix for this CVE was made available according to the sources\nor the timestamp of the first scan after this field was introduced\nwhich discovered this CVE as fixable, if it is."
+        },
         "severity": {
           "$ref": "#/definitions/storageVulnerabilitySeverity"
         },
@@ -1225,7 +1230,7 @@
           "$ref": "#/definitions/storageEPSS"
         }
       },
-      "title": "Next Tag: 25"
+      "title": "Next Tag: 26"
     },
     "storageEmbeddedVulnerabilityScoreVersion": {
       "type": "string",

--- a/generated/api/v1/node_service.swagger.json
+++ b/generated/api/v1/node_service.swagger.json
@@ -629,6 +629,11 @@
           "format": "date-time",
           "description": "Time when the CVE was first seen in this image."
         },
+        "fixAvailableTimestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the fix for this CVE was made available according to the sources\nor the timestamp of the first scan after this field was introduced\nwhich discovered this CVE as fixable, if it is."
+        },
         "severity": {
           "$ref": "#/definitions/storageVulnerabilitySeverity"
         },
@@ -651,7 +656,7 @@
           "$ref": "#/definitions/storageEPSS"
         }
       },
-      "title": "Next Tag: 25"
+      "title": "Next Tag: 26"
     },
     "storageEmbeddedVulnerabilityScoreVersion": {
       "type": "string",

--- a/generated/api/v1/vuln_mgmt_service.swagger.json
+++ b/generated/api/v1/vuln_mgmt_service.swagger.json
@@ -910,6 +910,11 @@
           "format": "date-time",
           "description": "Time when the CVE was first seen in this image."
         },
+        "fixAvailableTimestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the fix for this CVE was made available according to the sources\nor the timestamp of the first scan after this field was introduced\nwhich discovered this CVE as fixable, if it is."
+        },
         "severity": {
           "$ref": "#/definitions/storageVulnerabilitySeverity"
         },
@@ -932,7 +937,7 @@
           "$ref": "#/definitions/storageEPSS"
         }
       },
-      "title": "Next Tag: 25"
+      "title": "Next Tag: 26"
     },
     "storageEmbeddedVulnerabilityScoreVersion": {
       "type": "string",

--- a/generated/storage/vulnerability.pb.go
+++ b/generated/storage/vulnerability.pb.go
@@ -127,7 +127,7 @@ func (EmbeddedVulnerability_VulnerabilityType) EnumDescriptor() ([]byte, []int) 
 	return file_storage_vulnerability_proto_rawDescGZIP(), []int{0, 1}
 }
 
-// Next Tag: 25
+// Next Tag: 26
 type EmbeddedVulnerability struct {
 	state    protoimpl.MessageState `protogen:"open.v1"`
 	Cve      string                 `protobuf:"bytes,1,opt,name=cve,proto3" json:"cve,omitempty" search:"CVE"` // @gotags: search:"CVE"
@@ -155,8 +155,12 @@ type EmbeddedVulnerability struct {
 	FirstSystemOccurrence *timestamppb.Timestamp `protobuf:"bytes,15,opt,name=first_system_occurrence,json=firstSystemOccurrence,proto3" json:"first_system_occurrence,omitempty" policy:"First System Occurrence Timestamp" hash:"ignore"` // @gotags: policy:"First System Occurrence Timestamp" hash:"ignore"
 	// Time when the CVE was first seen in this image.
 	FirstImageOccurrence *timestamppb.Timestamp `protobuf:"bytes,16,opt,name=first_image_occurrence,json=firstImageOccurrence,proto3" json:"first_image_occurrence,omitempty" policy:"First Image Occurrence Timestamp" hash:"ignore"` // @gotags: policy:"First Image Occurrence Timestamp" hash:"ignore"
-	Severity             VulnerabilitySeverity  `protobuf:"varint,19,opt,name=severity,proto3,enum=storage.VulnerabilitySeverity" json:"severity,omitempty" policy:"Severity"`                   // @gotags: policy:"Severity"
-	State                VulnerabilityState     `protobuf:"varint,20,opt,name=state,proto3,enum=storage.VulnerabilityState" json:"state,omitempty" search:"Vulnerability State"`                            // @gotags: search:"Vulnerability State"
+	// Timestamp when the fix for this CVE was made available according to the sources
+	// or the timestamp of the first scan after this field was introduced
+	// which discovered this CVE as fixable, if it is.
+	FixAvailableTimestamp *timestamppb.Timestamp `protobuf:"bytes,25,opt,name=fix_available_timestamp,json=fixAvailableTimestamp,proto3" json:"fix_available_timestamp,omitempty" policy:"CVE Fix Available Timestamp" hash:"ignore"` // @gotags: policy:"CVE Fix Available Timestamp" hash:"ignore"
+	Severity              VulnerabilitySeverity  `protobuf:"varint,19,opt,name=severity,proto3,enum=storage.VulnerabilitySeverity" json:"severity,omitempty" policy:"Severity"`                      // @gotags: policy:"Severity"
+	State                 VulnerabilityState     `protobuf:"varint,20,opt,name=state,proto3,enum=storage.VulnerabilityState" json:"state,omitempty" search:"Vulnerability State"`                               // @gotags: search:"Vulnerability State"
 	// cvss_metrics stores list of cvss scores from different sources like nvd, Redhat etc
 	CvssMetrics   []*CVSSScore `protobuf:"bytes,21,rep,name=cvss_metrics,json=cvssMetrics,proto3" json:"cvss_metrics,omitempty"`
 	NvdCvss       float32      `protobuf:"fixed32,22,opt,name=nvd_cvss,json=nvdCvss,proto3" json:"nvd_cvss,omitempty" search:"NVD CVSS"` // @gotags: search:"NVD CVSS"
@@ -330,6 +334,13 @@ func (x *EmbeddedVulnerability) GetFirstImageOccurrence() *timestamppb.Timestamp
 	return nil
 }
 
+func (x *EmbeddedVulnerability) GetFixAvailableTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.FixAvailableTimestamp
+	}
+	return nil
+}
+
 func (x *EmbeddedVulnerability) GetSeverity() VulnerabilitySeverity {
 	if x != nil {
 		return x.Severity
@@ -493,7 +504,7 @@ var File_storage_vulnerability_proto protoreflect.FileDescriptor
 
 const file_storage_vulnerability_proto_rawDesc = "" +
 	"\n" +
-	"\x1bstorage/vulnerability.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x11storage/cve.proto\"\xc2\v\n" +
+	"\x1bstorage/vulnerability.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x11storage/cve.proto\"\x96\f\n" +
 	"\x15EmbeddedVulnerability\x12\x10\n" +
 	"\x03cve\x18\x01 \x01(\tR\x03cve\x12-\n" +
 	"\badvisory\x18\x18 \x01(\v2\x11.storage.AdvisoryR\badvisory\x12\x12\n" +
@@ -515,7 +526,8 @@ const file_storage_vulnerability_proto_rawDesc = "" +
 	"\x13suppress_activation\x18\r \x01(\v2\x1a.google.protobuf.TimestampR\x12suppressActivation\x12C\n" +
 	"\x0fsuppress_expiry\x18\x0e \x01(\v2\x1a.google.protobuf.TimestampR\x0esuppressExpiry\x12R\n" +
 	"\x17first_system_occurrence\x18\x0f \x01(\v2\x1a.google.protobuf.TimestampR\x15firstSystemOccurrence\x12P\n" +
-	"\x16first_image_occurrence\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\x14firstImageOccurrence\x12:\n" +
+	"\x16first_image_occurrence\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampR\x14firstImageOccurrence\x12R\n" +
+	"\x17fix_available_timestamp\x18\x19 \x01(\v2\x1a.google.protobuf.TimestampR\x15fixAvailableTimestamp\x12:\n" +
 	"\bseverity\x18\x13 \x01(\x0e2\x1e.storage.VulnerabilitySeverityR\bseverity\x121\n" +
 	"\x05state\x18\x14 \x01(\x0e2\x1b.storage.VulnerabilityStateR\x05state\x125\n" +
 	"\fcvss_metrics\x18\x15 \x03(\v2\x12.storage.CVSSScoreR\vcvssMetrics\x12\x19\n" +
@@ -585,19 +597,20 @@ var file_storage_vulnerability_proto_depIdxs = []int32{
 	7,  // 9: storage.EmbeddedVulnerability.suppress_expiry:type_name -> google.protobuf.Timestamp
 	7,  // 10: storage.EmbeddedVulnerability.first_system_occurrence:type_name -> google.protobuf.Timestamp
 	7,  // 11: storage.EmbeddedVulnerability.first_image_occurrence:type_name -> google.protobuf.Timestamp
-	8,  // 12: storage.EmbeddedVulnerability.severity:type_name -> storage.VulnerabilitySeverity
-	9,  // 13: storage.EmbeddedVulnerability.state:type_name -> storage.VulnerabilityState
-	10, // 14: storage.EmbeddedVulnerability.cvss_metrics:type_name -> storage.CVSSScore
-	11, // 15: storage.EmbeddedVulnerability.epss:type_name -> storage.EPSS
-	12, // 16: storage.NodeVulnerability.cve_base_info:type_name -> storage.CVEInfo
-	8,  // 17: storage.NodeVulnerability.severity:type_name -> storage.VulnerabilitySeverity
-	7,  // 18: storage.NodeVulnerability.snooze_start:type_name -> google.protobuf.Timestamp
-	7,  // 19: storage.NodeVulnerability.snooze_expiry:type_name -> google.protobuf.Timestamp
-	20, // [20:20] is the sub-list for method output_type
-	20, // [20:20] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	7,  // 12: storage.EmbeddedVulnerability.fix_available_timestamp:type_name -> google.protobuf.Timestamp
+	8,  // 13: storage.EmbeddedVulnerability.severity:type_name -> storage.VulnerabilitySeverity
+	9,  // 14: storage.EmbeddedVulnerability.state:type_name -> storage.VulnerabilityState
+	10, // 15: storage.EmbeddedVulnerability.cvss_metrics:type_name -> storage.CVSSScore
+	11, // 16: storage.EmbeddedVulnerability.epss:type_name -> storage.EPSS
+	12, // 17: storage.NodeVulnerability.cve_base_info:type_name -> storage.CVEInfo
+	8,  // 18: storage.NodeVulnerability.severity:type_name -> storage.VulnerabilitySeverity
+	7,  // 19: storage.NodeVulnerability.snooze_start:type_name -> google.protobuf.Timestamp
+	7,  // 20: storage.NodeVulnerability.snooze_expiry:type_name -> google.protobuf.Timestamp
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_storage_vulnerability_proto_init() }

--- a/generated/storage/vulnerability_vtproto.pb.go
+++ b/generated/storage/vulnerability_vtproto.pb.go
@@ -45,6 +45,7 @@ func (m *EmbeddedVulnerability) CloneVT() *EmbeddedVulnerability {
 	r.SuppressExpiry = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.SuppressExpiry).CloneVT())
 	r.FirstSystemOccurrence = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.FirstSystemOccurrence).CloneVT())
 	r.FirstImageOccurrence = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.FirstImageOccurrence).CloneVT())
+	r.FixAvailableTimestamp = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.FixAvailableTimestamp).CloneVT())
 	r.Severity = m.Severity
 	r.State = m.State
 	r.NvdCvss = m.NvdCvss
@@ -226,6 +227,9 @@ func (this *EmbeddedVulnerability) EqualVT(that *EmbeddedVulnerability) bool {
 	if !this.Advisory.EqualVT(that.Advisory) {
 		return false
 	}
+	if !(*timestamppb1.Timestamp)(this.FixAvailableTimestamp).EqualVT((*timestamppb1.Timestamp)(that.FixAvailableTimestamp)) {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -354,6 +358,18 @@ func (m *EmbeddedVulnerability) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 			return 0, err
 		}
 		i -= size
+	}
+	if m.FixAvailableTimestamp != nil {
+		size, err := (*timestamppb1.Timestamp)(m.FixAvailableTimestamp).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xca
 	}
 	if m.Advisory != nil {
 		size, err := m.Advisory.MarshalToSizedBufferVT(dAtA[:i])
@@ -784,6 +800,10 @@ func (m *EmbeddedVulnerability) SizeVT() (n int) {
 	}
 	if m.Advisory != nil {
 		l = m.Advisory.SizeVT()
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.FixAvailableTimestamp != nil {
+		l = (*timestamppb1.Timestamp)(m.FixAvailableTimestamp).SizeVT()
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -1579,6 +1599,42 @@ func (m *EmbeddedVulnerability) UnmarshalVT(dAtA []byte) error {
 				m.Advisory = &Advisory{}
 			}
 			if err := m.Advisory.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 25:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FixAvailableTimestamp", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.FixAvailableTimestamp == nil {
+				m.FixAvailableTimestamp = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.FixAvailableTimestamp).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -2596,6 +2652,42 @@ func (m *EmbeddedVulnerability) UnmarshalVTUnsafe(dAtA []byte) error {
 				m.Advisory = &Advisory{}
 			}
 			if err := m.Advisory.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 25:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FixAvailableTimestamp", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.FixAvailableTimestamp == nil {
+				m.FixAvailableTimestamp = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.FixAvailableTimestamp).UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/pkg/booleanpolicy/default_policies_test.go
+++ b/pkg/booleanpolicy/default_policies_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
 	"github.com/stackrox/rox/pkg/booleanpolicy/violationmessages/printer"
 	"github.com/stackrox/rox/pkg/defaults/policies"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/images/types"
 	imgUtils "github.com/stackrox/rox/pkg/images/utils"
@@ -63,6 +64,7 @@ func enhancedDeploymentWithNetworkPolicies(dep *storage.Deployment, images []*st
 }
 
 func TestDefaultPolicies(t *testing.T) {
+	t.Setenv(features.CVEFixTimestampCriteria.EnvVar(), "true")
 	suite.Run(t, new(DefaultPoliciesTestSuite))
 }
 
@@ -201,6 +203,55 @@ func (suite *DefaultPoliciesTestSuite) TestFixableAndImageFirstOccurenceCriteria
 	}
 
 	policy := policyWithGroups(storage.EventSource_NOT_APPLICABLE, fixablePolicyGroup, firstImageOccurrenceGroup)
+
+	deployment := suite.deployments["HEARTBLEEDDEPID"]
+	depMatcher, err := BuildDeploymentMatcher(policy)
+	require.NoError(suite.T(), err)
+	violations, err := depMatcher.MatchDeployment(nil, enhancedDeployment(deployment, suite.getImagesForDeployment(deployment)))
+	require.Len(suite.T(), violations.AlertViolations, 1)
+	require.NoError(suite.T(), err)
+
+}
+
+func (suite *DefaultPoliciesTestSuite) TestFixableAndFixTimestampAvailableCriteria() {
+	heartbleedDep := &storage.Deployment{
+		Id: "HEARTBLEEDDEPID",
+		Containers: []*storage.Container{
+			{
+				Name:            "nginx",
+				SecurityContext: &storage.SecurityContext{Privileged: true},
+				Image:           &storage.ContainerImage{Id: "HEARTBLEEDDEPSHA"},
+			},
+		},
+	}
+
+	ts := time.Now().AddDate(0, 0, -5)
+	protoTs, err := protocompat.ConvertTimeToTimestampOrError(ts)
+	require.NoError(suite.T(), err)
+
+	suite.addDepAndImages(heartbleedDep, &storage.Image{
+		Id:   "HEARTBLEEDDEPSHA",
+		Name: &storage.ImageName{FullName: "heartbleed"},
+		Scan: &storage.ImageScan{
+			Components: []*storage.EmbeddedImageScanComponent{
+				{Name: "heartbleed", Version: "1.2", Vulns: []*storage.EmbeddedVulnerability{
+					{Cve: "CVE-2014-0160", Link: "https://heartbleed", Cvss: 6, SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{FixedBy: "v1.2"},
+						FixAvailableTimestamp: protoTs},
+				}},
+			},
+		},
+	})
+
+	fixablePolicyGroup := &storage.PolicyGroup{
+		FieldName: fieldnames.Fixable,
+		Values:    []*storage.PolicyValue{{Value: "true"}},
+	}
+	fixTimestampAvailableGroup := &storage.PolicyGroup{
+		FieldName: fieldnames.DaysSinceFixAvailable,
+		Values:    []*storage.PolicyValue{{Value: "2"}},
+	}
+
+	policy := policyWithGroups(storage.EventSource_NOT_APPLICABLE, fixablePolicyGroup, fixTimestampAvailableGroup)
 
 	deployment := suite.deployments["HEARTBLEEDDEPID"]
 	depMatcher, err := BuildDeploymentMatcher(policy)

--- a/pkg/booleanpolicy/field_metadata.go
+++ b/pkg/booleanpolicy/field_metadata.go
@@ -305,6 +305,17 @@ func initializeFieldMetadata() FieldMetadata {
 		[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
 		[]RuntimeFieldType{}, negationForbidden, operatorsForbidden)
 
+	if features.CVEFixTimestampCriteria.Enabled() {
+		f.registerFieldMetadata(fieldnames.DaysSinceFixAvailable,
+			querybuilders.ForDays(search.CVEFixAvailable),
+			violationmessages.VulnContextFields,
+			func(*validateConfiguration) *regexp.Regexp {
+				return integerValueRegex
+			},
+			[]storage.EventSource{storage.EventSource_NOT_APPLICABLE},
+			[]RuntimeFieldType{}, negationForbidden, operatorsForbidden)
+	}
+
 	f.registerFieldMetadata(fieldnames.DisallowedAnnotation,
 		querybuilders.ForFieldLabelMap(search.DeploymentAnnotation, query.MapShouldContain),
 		nil,

--- a/pkg/booleanpolicy/field_metadata_test.go
+++ b/pkg/booleanpolicy/field_metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/pkg/booleanpolicy/fieldnames"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -13,9 +14,12 @@ type FieldMetadataValidationSuite struct {
 }
 
 func TestAllFieldsMetadata(t *testing.T) {
+	t.Setenv(features.CVEFixTimestampCriteria.EnvVar(), "true")
+	t.Setenv(features.SensitiveFileActivity.EnvVar(), "true")
+	ResetFieldMetadataSingleton(t)
 	suite.Run(t, new(FieldMetadataValidationSuite))
 }
 
-func (s *FieldMetadataValidationSuite) ValidateAllFieldMetadata() {
+func (s *FieldMetadataValidationSuite) TestValidateAllFieldMetadata() {
 	assert.Equal(s.T(), fieldnames.Count(), len(FieldMetadataSingleton().fieldsToQB))
 }

--- a/pkg/booleanpolicy/fieldnames/list.go
+++ b/pkg/booleanpolicy/fieldnames/list.go
@@ -18,6 +18,7 @@ var (
 	ContainerMemRequest            = newFieldName("Container Memory Request")
 	ContainerName                  = newFieldName("Container Name")
 	DaysSincePublished             = newFieldName("Days Since CVE Was Published")
+	DaysSinceFixAvailable          = newFieldName("Days Since CVE Fix Was Available")
 	DaysSinceImageFirstDiscovered  = newFieldName("Days Since CVE Was First Discovered In Image")
 	DaysSinceSystemFirstDiscovered = newFieldName("Days Since CVE Was First Discovered In System")
 	DisallowedAnnotation           = newFieldName("Disallowed Annotation")

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -54,6 +54,7 @@ var (
 	CVE                = newFieldLabel("CVE")
 	CVEType            = newFieldLabel("CVE Type")
 	CVEPublishedOn     = newFieldLabel("CVE Published On")
+	CVEFixAvailable    = newFieldLabel("CVE Fix Available Timestamp")
 	CVECreatedTime     = newFieldLabel("CVE Created Time")
 	CVESuppressed      = newFieldLabel("CVE Snoozed")
 	CVESuppressExpiry  = newFieldLabel("CVE Snooze Expiry")

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -19375,6 +19375,11 @@
                 "type": "google.protobuf.Timestamp"
               },
               {
+                "id": 25,
+                "name": "fix_available_timestamp",
+                "type": "google.protobuf.Timestamp"
+              },
+              {
                 "id": 19,
                 "name": "severity",
                 "type": "VulnerabilitySeverity"

--- a/proto/storage/vulnerability.proto
+++ b/proto/storage/vulnerability.proto
@@ -8,7 +8,7 @@ import "storage/cve.proto";
 option go_package = "./storage;storage";
 option java_package = "io.stackrox.proto.storage";
 
-// Next Tag: 25
+// Next Tag: 26
 message EmbeddedVulnerability {
   // ScoreVersion can be deprecated ROX-26066
   enum ScoreVersion {
@@ -51,6 +51,10 @@ message EmbeddedVulnerability {
   google.protobuf.Timestamp first_image_occurrence = 16; // @gotags: policy:"First Image Occurrence Timestamp" hash:"ignore"
   // This was first_node_occurrence
   reserved 17;
+  // Timestamp when the fix for this CVE was made available according to the sources
+  // or the timestamp of the first scan after this field was introduced
+  // which discovered this CVE as fixable, if it is.
+  google.protobuf.Timestamp fix_available_timestamp = 25; // @gotags: policy:"CVE Fix Available Timestamp" hash:"ignore"
 
   VulnerabilitySeverity severity = 19; // @gotags: policy:"Severity"
   VulnerabilityState state = 20; // @gotags: search:"Vulnerability State"

--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -69,5 +69,6 @@ tests/performance/scale/config/metrics-acs.yml
 tests/performance/scale/config/metrics-full.yml
 ui/apps/platform/package-lock.json
 ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SignatureIntegrationForm.tsx
+ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
 ui/apps/platform/src/fonts/Open_Sans_Regular.json
 ui/apps/platform/src/images/globalSearchEmptyState.svg

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -609,6 +609,17 @@ export const policyCriteriaDescriptors: Descriptor[] = [
         lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
     },
     {
+        label: 'Days Since CVE Fix Available',
+        name: 'Days Since CVE Fix Available',
+        shortName: 'Days since CVE fix available',
+        category: policyCriteriaCategories.IMAGE_SCANNING,
+        type: 'number',
+        placeholder: '0',
+        canBooleanLogic: false,
+        lifecycleStages: ['BUILD', 'DEPLOY', 'RUNTIME'],
+        featureFlagDependency: ['ROX_CVE_FIX_TIMESTAMP'],
+    },
+    {
         label: 'Days Since CVE Was First Discovered In Image',
         name: 'Days Since CVE Was First Discovered In Image',
         shortName: 'Days since CVE was first discovered in image',


### PR DESCRIPTION
## Description

1. Proto changes to add cve fix timestamp to the embedded vulnerability proto
2. Adding the BE + UI for the new criterion: CVE fix available timestamp
3. Unit tests - new ones, and fixing existing ones

Please expect follow on PRs for the work to update the new proto field in the scan data and conversion to embedded vuln paths.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change
Unit tests, CI