### PR TITLE
Fix gRPC connection drops on Azure LoadBalancer in qa-tests-backend

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -142,6 +142,8 @@ class BaseService {
                     .negotiationType(NegotiationType.TLS)
                     .sslContext(sslContext)
                     .keepAliveTime(1, TimeUnit.SECONDS)
+                    .keepAliveTimeout(10, TimeUnit.SECONDS)
+                    .keepAliveWithoutCalls(true)  // send keepalive even when idle to prevent load balancers from dropping idle connections
                     .idleTimeout(1, TimeUnit.MINUTES)
                     .build()
             effectiveChannel = null


### PR DESCRIPTION
## Description

The ARO qa-e2e-tests were failing with "Connection refused" errors when the test framework attempted its first gRPC call to Central, despite Central being healthy and the HTTP /v1/ping endpoint responding successfully.

Root cause: Azure LoadBalancers aggressively close idle TCP connections, even within their documented timeout window. The test framework opens a gRPC channel during setup but may not use it for 20-30 seconds. The existing `keepAliveTime(1 second)` configuration was not effective because keepalive pings were only sent during active RPCs, not during idle periods.

Fix: `Add keepAliveWithoutCalls(true)` to the `NettyChannelBuilder` configuration. This ensures keepalive pings are sent every second even when no RPCs are in flight, preventing Azure LoadBalancer from dropping the connection during the idle setup phase.

Also add `keepAliveTimeout(10 seconds)` to properly detect dead connections.

Failure details:
- Job: branch-ci-stackrox-stackrox-nightlies-aro-qa-e2e-tests
- Build: 1991302900814450688
- Test: VulnMgmtSACTest.setupSpec() at BaseSpecification.groovy:114
- Error: io.grpc.StatusRuntimeException: UNAVAILABLE: Network closed for unknown reason, followed by Connection refused

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

ARO tests are passing.


## AI disclaimer

I used Cursor to run the `/triage https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-nightlies-aro-qa-e2e-tests/1991302900814450688` command and propose a fix. 
I verified with [docs](https://grpc.github.io/grpc-java/javadoc/io/grpc/netty/class-use/NettyChannelBuilder.html) that the change makes sense.