### PR TITLE
ROX-31903: Add ROX_CISA_KEV in WorkloadCves

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/DeploymentVulnerabilitiesTable.tsx
@@ -4,7 +4,7 @@ import { LabelGroup } from '@patternfly/react-core';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
-// import useFeatureFlags from 'hooks/useFeatureFlags'; // Ross CISA KEV
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useSet from 'hooks/useSet';
 import type { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilitySeverityIconText from 'Components/PatternFly/IconText/VulnerabilitySeverityIconText';
@@ -18,9 +18,10 @@ import type { TableUIState } from 'utils/getTableUIState';
 import { generateVisibilityForColumns, getHiddenColumnCount } from 'hooks/useManagedColumns';
 import type { ManagedColumns } from 'hooks/useManagedColumns';
 
-// import KnownExploitLabel from '../../components/KnownExploitLabel'; // Ross CISA KEV
+import KnownExploitLabel from '../../components/KnownExploitLabel';
+import KnownRansomwareCampaignLabel from '../../components/KnownRansomwareCampaignLabel';
 import PendingExceptionLabel from '../../components/PendingExceptionLabel';
-// import { hasKnownExploit, hasKnownRansomwareCampaignUse } from '../../utils/vulnerabilityUtils'; // Ross CISA KEV
+import { hasKnownExploit, hasKnownRansomwareCampaignUse } from '../../utils/vulnerabilityUtils';
 import DeploymentComponentVulnerabilitiesTable, {
     deploymentComponentVulnerabilitiesFragment,
 } from './DeploymentComponentVulnerabilitiesTable';
@@ -118,7 +119,7 @@ function DeploymentVulnerabilitiesTable({
     onClearFilters,
     tableConfig,
 }: DeploymentVulnerabilitiesTableProps) {
-    // const { isFeatureFlagEnabled } = useFeatureFlags(); // Ross CISA KEV
+    const { isFeatureFlagEnabled } = useFeatureFlags();
     const { urlBuilder } = useWorkloadCveViewContext();
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
@@ -183,26 +184,25 @@ function DeploymentVulnerabilitiesTable({
                         const epssProbability = cveBaseInfo?.epss?.epssProbability;
 
                         const labels: ReactNode[] = [];
-                        /*
-                        // Ross CISA KEV
                         if (
                             isFeatureFlagEnabled('ROX_SCANNER_V4') &&
-                            isFeatureFlagEnabled('ROX_KEV_EXPLOIT') &&
+                            isFeatureFlagEnabled('ROX_CISA_KEV') &&
                             hasKnownExploit(cveBaseInfo?.exploit)
                         ) {
-                            labels.push(<KnownExploitLabel key="exploit" isCompact />);
-                            // Future code if design decision is separate labels.
-                            // if (hasKnownRansomwareCampaignUse(cveBaseInfo?.exploit)) {
-                            //     labels.push(
-                            //         <KnownExploitLabel
-                            //             key="knownRansomwareCampaignUse"
-                            //             isCompact
-                            //             isKnownToBeUsedInRansomwareCampaigns
-                            //         />
-                            //     );
+                            // Add in deploymentWithVulnerabilitiesFragment following epss:
+                            // exploit {
+                            //     knownRansomwareCampaignUse
                             // }
+                            labels.push(<KnownExploitLabel key="exploit" isCompact />);
+                            if (hasKnownRansomwareCampaignUse(cveBaseInfo?.exploit)) {
+                                labels.push(
+                                    <KnownRansomwareCampaignLabel
+                                        key="knownRansomwareCampaignUse"
+                                        isCompact
+                                    />
+                                );
+                            }
                         }
-                        */
                         if (pendingExceptionCount > 0) {
                             labels.push(
                                 <PendingExceptionLabel

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -14,7 +14,7 @@ import {
 import type { IAction } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
-// import useFeatureFlags from 'hooks/useFeatureFlags'; // Ross CISA KEV
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useSet from 'hooks/useSet';
 import type { UseURLSortResult } from 'hooks/useURLSort';
 import VulnerabilityFixableIconText from 'Components/PatternFly/IconText/VulnerabilityFixableIconText';
@@ -31,15 +31,11 @@ import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
 import type { TableUIState } from 'utils/getTableUIState';
 import { generateVisibilityForColumns, getHiddenColumnCount } from 'hooks/useManagedColumns';
 import type { ManagedColumns } from 'hooks/useManagedColumns';
-import { getIsSomeVulnerabilityFixable } from '../../utils/vulnerabilityUtils';
-/*
-// Ross CISA KEV
 import {
     getIsSomeVulnerabilityFixable,
     hasKnownExploit,
     hasKnownRansomwareCampaignUse,
 } from '../../utils/vulnerabilityUtils';
-*/
 import ImageComponentVulnerabilitiesTable, {
     imageComponentVulnerabilitiesFragment,
 } from './ImageComponentVulnerabilitiesTable';
@@ -51,7 +47,8 @@ import type {
 import type { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
 import CVESelectionTh from '../../components/CVESelectionTh';
 import CVESelectionTd from '../../components/CVESelectionTd';
-// import KnownExploitLabel from '../../components/KnownExploitLabel'; // Ross CISA KEV
+import KnownExploitLabel from '../../components/KnownExploitLabel';
+import KnownRansomwareCampaignLabel from '../../components/KnownRansomwareCampaignLabel';
 import PendingExceptionLabel from '../../components/PendingExceptionLabel';
 import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
@@ -186,7 +183,7 @@ function ImageVulnerabilitiesTable({
     onClearFilters,
     tableConfig,
 }: ImageVulnerabilitiesTableProps) {
-    // const { isFeatureFlagEnabled } = useFeatureFlags(); // Ross CISA KEV
+    const { isFeatureFlagEnabled } = useFeatureFlags();
     const { urlBuilder } = useWorkloadCveViewContext();
     const getVisibilityClass = generateVisibilityForColumns(tableConfig);
     const hiddenColumnCount = getHiddenColumnCount(tableConfig);
@@ -277,26 +274,25 @@ function ImageVulnerabilitiesTable({
                         const epssProbability = cveBaseInfo?.epss?.epssProbability;
 
                         const labels: ReactNode[] = [];
-                        /*
-                        // Ross CISA KEV
                         if (
                             isFeatureFlagEnabled('ROX_SCANNER_V4') &&
-                            isFeatureFlagEnabled('ROX_KEV_EXPLOIT') &&
+                            isFeatureFlagEnabled('ROX_CISA_KEV') &&
                             hasKnownExploit(cveBaseInfo?.exploit)
                         ) {
-                            labels.push(<KnownExploitLabel key="exploit" isCompact />);
-                            // Future code if design decision is separate labels.
-                            // if (hasKnownRansomwareCampaignUse(cveBaseInfo?.exploit) {
-                            //     labels.push(
-                            //         <KnownExploitLabel
-                            //             key="knownRansomwareCampaignUse"
-                            //             isCompact
-                            //             isKnownToBeUsedInRansomwareCampaigns
-                            //         />
-                            //     );
+                            // Add in imageVulnerabilitiesFragment following epss:
+                            // exploit {
+                            //     knownRansomwareCampaignUse
                             // }
+                            labels.push(<KnownExploitLabel key="exploit" isCompact />);
+                            if (hasKnownRansomwareCampaignUse(cveBaseInfo?.exploit)) {
+                                labels.push(
+                                    <KnownRansomwareCampaignLabel
+                                        key="knownRansomwareCampaignUse"
+                                        isCompact
+                                    />
+                                );
+                            }
                         }
-                        */
                         if (pendingExceptionCount > 0) {
                             labels.push(
                                 <PendingExceptionLabel

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -14,7 +14,7 @@ import {
 import type { IAction } from '@patternfly/react-table';
 import { LabelGroup, Text } from '@patternfly/react-core';
 
-// import useFeatureFlags from 'hooks/useFeatureFlags'; // Ross CISA KEV
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import type { UseURLSortResult } from 'hooks/useURLSort';
 import useSet from 'hooks/useSet';
 import type useMap from 'hooks/useMap';
@@ -30,7 +30,7 @@ import { ACTION_COLUMN_POPPER_PROPS } from 'constants/tables';
 import { generateVisibilityForColumns, getHiddenColumnCount } from 'hooks/useManagedColumns';
 import type { ManagedColumns } from 'hooks/useManagedColumns';
 import type { VulnerabilitySeverityLabel } from '../../types';
-// import { hasKnownExploit, hasKnownRansomwareCampaignUse } from '../../utils/vulnerabilityUtils'; // Ross CISA KEV
+import { hasKnownExploit, hasKnownRansomwareCampaignUse } from '../../utils/vulnerabilityUtils';
 import SeverityCountLabels from '../../components/SeverityCountLabels';
 import {
     aggregateByCVSS,
@@ -45,7 +45,8 @@ import {
 import type { CveSelectionsProps } from '../../components/ExceptionRequestModal/CveSelections';
 import CVESelectionTh from '../../components/CVESelectionTh';
 import CVESelectionTd from '../../components/CVESelectionTd';
-// import KnownExploitLabel from '../../components/KnownExploitLabel'; // Ross CISA KEV
+import KnownExploitLabel from '../../components/KnownExploitLabel';
+import KnownRansomwareCampaignLabel from '../../components/KnownRansomwareCampaignLabel';
 import PendingExceptionLabel from '../../components/PendingExceptionLabel';
 import ExceptionDetailsCell from '../components/ExceptionDetailsCell';
 import PartialCVEDataAlert from '../../components/PartialCVEDataAlert';
@@ -223,7 +224,7 @@ function WorkloadCVEOverviewTable({
     onClearFilters,
     columnVisibilityState,
 }: WorkloadCVEOverviewTableProps) {
-    // const { isFeatureFlagEnabled } = useFeatureFlags(); // Ross CISA KEV
+    const { isFeatureFlagEnabled } = useFeatureFlags();
     const { urlBuilder } = useWorkloadCveViewContext();
     const expandedRowSet = useSet<string>();
     const getVisibilityClass = generateVisibilityForColumns(columnVisibilityState);
@@ -345,26 +346,25 @@ function WorkloadCVEOverviewTable({
                                 prioritizedDistros.length > 0 ? prioritizedDistros[0].summary : '';
 
                             const labels: ReactNode[] = [];
-                            /*
-                            // Ross CISA KEV
                             if (
                                 isFeatureFlagEnabled('ROX_SCANNER_V4') &&
-                                isFeatureFlagEnabled('ROX_KEV_EXPLOIT') &&
+                                isFeatureFlagEnabled('ROX_CISA_KEV') &&
                                 hasKnownExploit(cveBaseInfo?.exploit)
                             ) {
-                                labels.push(<KnownExploitLabel key="exploit" isCompact />);
-                                // Future code if design decision is separate labels.
-                                // if (hasKnownRansomwareCampaignUse(cveBaseInfo?.exploit) {
-                                //     labels.push(
-                                //         <KnownExploitLabel
-                                //             key="knownRansomwareCampaignUse"
-                                //             isCompact
-                                //             isKnownToBeUsedInRansomwareCampaigns
-                                //         />
-                                //     );
+                                // Add in cveListQuery following epss:
+                                // exploit {
+                                //     knownRansomwareCampaignUse
                                 // }
+                                labels.push(<KnownExploitLabel key="exploit" isCompact />);
+                                if (hasKnownRansomwareCampaignUse(cveBaseInfo?.exploit)) {
+                                    labels.push(
+                                        <KnownRansomwareCampaignLabel
+                                            key="knownRansomwareCampaignUse"
+                                            isCompact
+                                        />
+                                    );
+                                }
                             }
-                            */
                             if (pendingExceptionCount > 0) {
                                 labels.push(
                                     <PendingExceptionLabel

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
@@ -13,9 +13,10 @@ import {
 } from '../WorkloadCves/Tables/table.utils';
 import { getDistroLinkText } from '../utils/textUtils';
 import { sortCveDistroList } from '../utils/sortUtils';
-// import { hasKnownExploit, hasKnownRansomwareCampaignUse } from '../utils/vulnerabilityUtils'; // Ross CISA KEV
+import { hasKnownExploit, hasKnownRansomwareCampaignUse } from '../utils/vulnerabilityUtils';
 import HeaderLoadingSkeleton from './HeaderLoadingSkeleton';
-// import KnownExploitLabel from './KnownExploitLabel';
+import KnownExploitLabel from './KnownExploitLabel';
+import KnownRansomwareCampaignLabel from './KnownRansomwareCampaignLabel';
 
 export type CveMetadata = {
     cve: string;
@@ -51,26 +52,18 @@ function CvePageHeader({ data }: CvePageHeaderProps) {
     const hasEpssProbabilityLabel = isEpssProbabilityColumnEnabled && Boolean(cveBaseInfo); // not (yet) for Node CVE
 
     const labels: ReactNode[] = [];
-    /*
-    // Ross CISA KEV
     if (
         isFeatureFlagEnabled('ROX_SCANNER_V4') &&
-        isFeatureFlagEnabled('ROX_KEV_EXPLOIT') &&
+        isFeatureFlagEnabled('ROX_CISA_KEV') &&
         hasKnownExploit(cveBaseInfo?.exploit)
     ) {
         labels.push(<KnownExploitLabel key="exploit" isCompact={false} />);
-        // Future code if design decision is separate labels.
-        // if (hasKnownRansomwareCampaignUse(cveBaseInfo?.exploit) {
-        //     labels.push(
-        //         <KnownExploitLabel
-        //             key="knownRansomwareCampaignUse"
-        //             isCompact={false}
-        //             isKnownToBeUsedInRansomwareCampaigns
-        //         />
-        //     );
-        // }
+        if (hasKnownRansomwareCampaignUse(cveBaseInfo?.exploit)) {
+            labels.push(
+                <KnownRansomwareCampaignLabel key="knownRansomwareCampaignUse" isCompact={false} />
+            );
+        }
     }
-    */
     if (hasEpssProbabilityLabel) {
         labels.push(
             <Label key="epssProbability">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/KnownExploitLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/KnownExploitLabel.tsx
@@ -1,23 +1,17 @@
 import { Label, Tooltip } from '@patternfly/react-core';
 
 const tooltip =
-    'This CVE is identified with a “Known exploit” label because Red Hat has determined this CVE has a public exploit. This CVE is unpatched on your system. CVEs with this label should be addressed with high priority due to the risks posed by them. “Known exploit” does not mean we have taken steps to determine if the CVE has been exploited in your environment';
+    'This CVE has a public exploit, and this CVE is unpatched in your system. CVEs with this label should be addressed with high priority due to the risks posed by them. The existence of this label does not mean we have taken steps to determine if the CVE has been exploited in your environment.';
 
 export type KnownExploitLabelProps = {
     isCompact: boolean; // true for table and false for vulnerability page
-    isKnownToBeUsedInRansomwareCampaigns?: boolean;
 };
 
-function KnownExploitLabel({
-    isCompact,
-    isKnownToBeUsedInRansomwareCampaigns,
-}: KnownExploitLabelProps) {
+function KnownExploitLabel({ isCompact }: KnownExploitLabelProps) {
     return (
         <Tooltip content={tooltip} position="top-start" isContentLeftAligned>
             <Label color="red" isCompact={isCompact}>
-                {isKnownToBeUsedInRansomwareCampaigns
-                    ? 'Known to be used in ransomware campaigns'
-                    : 'Known exploit'}
+                Known exploit
             </Label>
         </Tooltip>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/KnownRansomwareCampaignLabel.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/KnownRansomwareCampaignLabel.tsx
@@ -1,0 +1,20 @@
+import { Label, Tooltip } from '@patternfly/react-core';
+
+const tooltip =
+    'This CVE has been exploited in a known ransomware campaign. CVEs with this label should be addressed with high priority due to the risks posed by them. The existence of this label does not mean we have taken steps to determine if the CVE has been exploited in your environment.';
+
+export type KnownRansomwareCampaignLabelProps = {
+    isCompact: boolean; // true for table and false for vulnerability page
+};
+
+function KnownRansomwareCampaignLabel({ isCompact }: KnownRansomwareCampaignLabelProps) {
+    return (
+        <Tooltip content={tooltip} position="top-start" isContentLeftAligned>
+            <Label color="red" isCompact={isCompact}>
+                Known ransomware campaign
+            </Label>
+        </Tooltip>
+    );
+}
+
+export default KnownRansomwareCampaignLabel;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/utils/vulnerabilityUtils.ts
@@ -83,7 +83,7 @@ export function hasKnownExploit(exploit: Exploit | null | undefined): exploit is
 }
 
 export function hasKnownRansomwareCampaignUse(exploit: Exploit | null | undefined) {
-    return exploit?.knownRansomwareCampaignUse === 'Known';
+    return Boolean(exploit?.knownRansomwareCampaignUse);
 }
 
 /**

--- a/ui/apps/platform/src/types/cve.proto.ts
+++ b/ui/apps/platform/src/types/cve.proto.ts
@@ -33,11 +33,8 @@ export type EPSS = {
 };
 
 export type Exploit = {
-    dateAdded: string; // ISO 8601 yyyy-mm-dd
-    shortDescription: string;
-    requiredAction: string;
-    dueDate: string; // ISO 8601 yyyy-mm-dd
-    knownRansomwareCampaignUse: string; // Known or Unknown
+    exists: boolean; // This will always be true.
+    knownRansomwareCampaignUse: boolean;
 };
 
 export type CveBaseInfo = {


### PR DESCRIPTION
## Description

**Goal**: Maximize supporting frontend work during 4.10 release.

Separate related contributions to divide and conquer:
* **optional column** in #17900
* **search filter**

Supersede frontend changes from draft by Ross in #16890

### Analysis

Find in Files `// Ross CISA KEV`. has 26 results in 9 files:
1. `includeKnownExploit` property:
    * 5 files in VulnerabilityReporting subfolder: optional column or columns
2. `exploit` and `knownRansomwareCampaignUse` properties:
    * 1 file in components subfolder: labels in vulnerability page
    * 3 files in WorkloadCves subfolder: labels in vulnerabilities tables

### Changes

1. Replace initial `ROX_KEV_EXPLOIT` with final `ROX_CISA_KEV` feature flag.
2. Replace commented code with conditional code for labels.
3. For GraphQL response in which property does not yet exist, assign `undefined` value to `exploit` property for labels.
4. Separate label components and update with wording from **Ross**.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/workload-cves

    Before and after changes, see **Pending exception** labels in some rows.
    Ditto for deployment and image vulneratilities, by the way.
    That is, uncommenting of conditional rendering did not break baseline with feature flag disabled.

    Temporarily simulate feature flag on with both labels for every vulnerability for sneek peek:
    <img width="1440" height="898" alt="WorkloadCVEOverviewTable" src="https://github.com/user-attachments/assets/167371ee-fc5f-4580-b284-b605b829a478" />

2. Click link to visit vulnerability page.

    Temporarily simulate feature flag on with both labels for every vulnerability for sneek peek:
    <img width="1440" height="898" alt="CvePageHeader" src="https://github.com/user-attachments/assets/fe332fe7-3a5f-465a-ab8e-710882848055" />
