### PR TITLE
ROX-31907: Delete MainPage from ignores of no-Tailwind

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -887,7 +887,6 @@ module.exports = [
             'src/Components/FixableCVECount/**', // deprecated
             'src/Components/HeaderWithSubText/**', // deprecated
             'src/Components/Labeled/**', // deprecated
-            'src/Components/KeyValue/**', // fix errors, and then delete
             'src/Components/Menu/**', // deprecated
             'src/Components/Metadata/**', // deprecated
             'src/Components/MetadataStatsList/**', // deprecated
@@ -923,9 +922,8 @@ module.exports = [
             'src/Containers/ConfigManagement/**',
             'src/Containers/Images/**', // deprecated
             'src/Containers/Login/**', // rewrite in PatternFly, and then delete; also in tailwind.config.js file
-            'src/Containers/MainPage/**', // fix errors, and then delete; also in tailwind.config.js file
+            'src/Containers/MainPage/Header/Header.tsx', // investigate ignore-react-onclickoutside
             'src/Containers/Risk/**', // rewrite in PatternFly, and then delete; also in tailwind.config.js file
-            'src/Containers/Violations/Details/ProcessCardContent.jsx', // fix error and then delete; also in tailwind.config.js file
             'src/Containers/VulnMgmt/**', // deprecated
             'src/Containers/Workflow/**', // deprecated
         ],

--- a/ui/apps/platform/src/Containers/MainPage/Banners/CredentialExpiryBanner.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Banners/CredentialExpiryBanner.tsx
@@ -51,20 +51,15 @@ function CredentialExpiryBanner({
         </Button>
     );
     const name = nameOfComponent[component];
-    const message = (
-        <span className="flex-1 text-center">
+
+    return (
+        <Banner className="pf-v5-u-text-align-center" variant={getBannerVariant(type)}>
             {`${name} certificate ${getCredentialExpiryPhrase(expirationDate, now)}. `}
             {showCertGenerateAction ? (
                 <>To use renewed certificates, {downloadLink} and apply it to your cluster.</>
             ) : (
                 'Contact your administrator.'
             )}
-        </span>
-    );
-
-    return (
-        <Banner className="pf-v5-u-text-align-center" variant={getBannerVariant(type)}>
-            {message}
         </Banner>
     );
 }

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -329,7 +329,7 @@ function Body({ hasReadAccess, isFeatureFlagEnabled }: BodyProps): ReactElement 
     const routePredicates = { hasReadAccess, isFeatureFlagEnabled };
 
     return (
-        <div className="flex flex-col h-full w-full relative overflow-auto bg-base-100">
+        <div id="BodyRoutes">
             <ErrorBoundary>
                 <Routes>
                     <Route path="/" element={<Navigate to={dashboardPath} replace />} />

--- a/ui/apps/platform/src/Containers/MainPage/Header/ClusterStatusButton.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/ClusterStatusButton.tsx
@@ -1,7 +1,12 @@
 import type { CSSProperties, ReactElement } from 'react';
-import { Activity } from 'react-feather';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { Tooltip } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Tooltip } from '@patternfly/react-core';
+import {
+    CheckCircleIcon,
+    ExclamationCircleIcon,
+    ExclamationTriangleIcon,
+    PortIcon,
+} from '@patternfly/react-icons';
 
 import { clustersBasePath } from 'routePaths';
 
@@ -26,7 +31,6 @@ const ClusterStatusButton = ({
     const navigate = useNavigate();
     const hasDegradedClusters = degraded > 0;
     const hasUnhealthyClusters = unhealthy > 0;
-    const hasProblems = hasDegradedClusters || hasUnhealthyClusters;
 
     const contentElement = (
         <div>
@@ -50,31 +54,10 @@ const ClusterStatusButton = ({
         </div>
     );
 
-    // Border radius for background circle to emphasize icon color.
-    const classNameProblems = hasProblems ? 'rounded-lg' : '';
-
-    let styleProblems: CSSProperties | undefined;
-    /*
-     * Explicit white background because the following did not work:
-     * `backgroundColor: var(--pf-v5-global--BackgroundColor--100)`
-     */
-    if (hasUnhealthyClusters) {
-        styleProblems = {
-            backgroundColor: '#ffffff',
-            color: 'var(--pf-v5-global--danger-color--100)',
-        };
-    } else if (hasDegradedClusters) {
-        styleProblems = {
-            backgroundColor: '#ffffff',
-            color: 'var(--pf-v5-global--warning-color--100)',
-        };
-    }
-
     const onClick = () => {
-        navigate(`${clustersBasePath}`);
-        // TODO after ClustersPage sets search filter according to search query string in URL:
-        // If any clusters have problems, then Clusters list has search filter.
-        // search: hasUnhealthyClusters || hasDegradedClusters ? '?s[Cluster Health][0]=UNHEALTHY&s[Cluster Health][1]=DEGRADED' : '',
+        navigate(
+            `${clustersBasePath}?s[Cluster status][0]=UNHEALTHY&s[Cluster status][1]=DEGRADED`
+        );
     };
 
     // On masthead, black text on white background like a dropdown menu.
@@ -91,16 +74,26 @@ const ClusterStatusButton = ({
             position="bottom"
             style={styleTooltip}
         >
-            <button
-                aria-label="Cluster status problems"
-                type="button"
-                onClick={onClick}
-                className="flex h-full items-center pt-2 pb-2 px-4"
-            >
-                <div className={classNameProblems} style={styleProblems}>
-                    <Activity className="h-4 w-4" />
-                </div>
-            </button>
+            <Button variant="plain" aria-label="Cluster status problems" onClick={onClick}>
+                <Flex
+                    direction={{ default: 'row' }}
+                    flexWrap={{ default: 'nowrap' }}
+                    spaceItems={{ default: 'spaceItemsSm' }}
+                >
+                    <FlexItem>
+                        <PortIcon />
+                    </FlexItem>
+                    <FlexItem>
+                        {hasUnhealthyClusters ? (
+                            <ExclamationCircleIcon />
+                        ) : hasDegradedClusters ? (
+                            <ExclamationTriangleIcon />
+                        ) : (
+                            <CheckCircleIcon />
+                        )}
+                    </FlexItem>
+                </Flex>
+            </Button>
         </Tooltip>
     );
 };

--- a/ui/apps/platform/src/Containers/MainPage/Header/Header.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/Header.tsx
@@ -22,10 +22,7 @@ function Header(): ReactElement {
     // PageToggleButton assumes isManagedSidebar prop of Page element.
     // aria-label="primary" prop makes header element a unique landmark.
     return (
-        <Masthead
-            className="ignore-react-onclickoutside theme-dark"
-            inset={{ default: 'insetNone' }}
-        >
+        <Masthead className="ignore-react-onclickoutside" inset={{ default: 'insetNone' }}>
             <Notifications />
             <PublicConfigHeader />
             <Banners />

--- a/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
@@ -34,7 +34,7 @@ function MastheadToolbar(): ReactElement {
     return (
         <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             {showOrchestratorComponentsToggle && (
-                <FlexItem>
+                <FlexItem spacer={{ default: 'spacerLg' }}>
                     <OrchestratorComponentsToggle />
                 </FlexItem>
             )}

--- a/ui/apps/platform/src/Containers/MainPage/Header/OrchestratorComponentsToggle.css
+++ b/ui/apps/platform/src/Containers/MainPage/Header/OrchestratorComponentsToggle.css
@@ -1,0 +1,4 @@
+.pf-v5-c-masthead__content .pf-v5-c-switch__label {
+    --pf-v5-c-switch__input--checked__label--Color: var(--pf-v5-global--Color--100);
+    --pf-v5-c-switch__input--not-checked__label--Color: var(--pf-v5-global--Color--100);
+}

--- a/ui/apps/platform/src/Containers/MainPage/Header/OrchestratorComponentsToggle.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/OrchestratorComponentsToggle.tsx
@@ -4,6 +4,8 @@ import { Switch } from '@patternfly/react-core';
 
 import { ORCHESTRATOR_COMPONENTS_KEY } from 'utils/orchestratorComponents';
 
+import './OrchestratorComponentsToggle.css';
+
 const OrchestratorComponentsToggle = (): ReactElement => {
     const [showOrchestratorComponents, setShowOrchestratorComponents] = useState('false');
 
@@ -20,19 +22,15 @@ const OrchestratorComponentsToggle = (): ReactElement => {
         location.reload(); // TODO instead pages could re-render on change to Redux store.
     }
 
-    // TODO: update wrapper classes to PatternFly, like  `pf-v5-u-background-color-100
     return (
-        <div className="flex justify-center items-center pr-3 relative" style={{ top: '2px' }}>
-            <Switch
-                id="orchestrator-components-toggle"
-                aria-label="Toggle Showing Orchestrator Components"
-                isChecked={showOrchestratorComponents === 'true'}
-                onChange={(_event, value) => handleToggle(value)}
-            />
-            <span className="p-2 text-base-600" aria-hidden="true">
-                Show Orchestrator Components
-            </span>
-        </div>
+        <Switch
+            id="orchestrator-components-toggle"
+            aria-label="Toggle Showing Orchestrator Components"
+            hasCheckIcon
+            isChecked={showOrchestratorComponents === 'true'}
+            label="Show orchestrator components"
+            onChange={(_event, value) => handleToggle(value)}
+        />
     );
 };
 

--- a/ui/apps/platform/src/css/style.css
+++ b/ui/apps/platform/src/css/style.css
@@ -36,3 +36,12 @@ body {
   overflow: hidden;
   position: relative;
 }
+
+#BodyRoutes {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: auto;
+  position: relative;
+  width: 100%;
+}

--- a/ui/apps/platform/tailwind.config.js
+++ b/ui/apps/platform/tailwind.config.js
@@ -663,9 +663,8 @@ module.exports = {
     //     './src/Containers/ConfigManagement/**/*.{js,jsx,ts,tsx}',
     //     './src/Containers/Images/**/*.{js,jsx,ts,tsx}', // deprecated
     //     './src/Containers/Login/**/*.{js,jsx,ts,tsx}', // fix errors, and then delete
-    //     './src/Containers/MainPage/**/*.{js,jsx,ts,tsx}', // fix errors, and then delete
+    //     './src/Containers/MainPage/Header/Header.tsx', // investigate ignore-react-onclickoutside
     //     './src/Containers/Risk/**/*.{js,jsx,ts,tsx}', // rewrite in PatternFly, and then delete
-    //     './src/Containers/Violations/Details/ProcessCardContent.jsx', // fix error and then delete
     //     './src/Containers/VulnMgmt/**/*.{js,jsx,ts,tsx}', // deprecated
     //     './src/Containers/Workflow/**/*.{js,jsx,ts,tsx}', // deprecated
     // ],


### PR DESCRIPTION
## Description

Delete leftover Tailwind classes from PatternFly routes.
* Prevent coupling or conflicts between PatternFly and Tailwind styles.
* Minimize file paths for `purge` in tailwind.config.js file.
    Wait until after Brad merges improvements in #17858
* Enable option to load and unload Tailwind styles only for classic routes.

### Errors

1. src/Containers/MainPage/Banners/CredentialExpiryBanner.tsx

    * `span` has `className="flex-1 text-center"`

2. src/Containers/MainPage/Body.tsx

    * `div` has `className="flex flex-col h-full w-full relative overflow-auto bg-base-100`
 
3. src/Containers/MainPage/Header/ClusterStatusButton.tsx

    * `button` has `className="flex h-full items-center pt-2 pb-2 px-4"`
    * `div` has `className={classNameProblems}` which can have `'rounded-lg'` but lint rule did not find, because not inline string or template literal.
    * `Activity` has `className="h-4 w-4"`

4. src/Containers/MainPage/Header/Header.tsx

    * `Masthead` has `className="ignore-react-onclickoutside theme-dark"`

5. src/Containers/MainPage/Header/OrchestratorComponentsToggle.tsx

    * `div` has `className="flex justify-center items-center pr-3 relative"` and `style={{ top: '2px' }}`
    * `span` has `className="p-2 text-base-600" aria-hidden="true"`

### Analysis and Solution

1. src/Containers/MainPage/Banners/CredentialExpiryBanner.tsx

    * Move content from redundant `span` element into `Banner` element.

2. src/Containers/MainPage/Body.tsx

    * Replace `className` with `id` prop in `div` element.
    * Replace Tailwind classes with style rule in style.css file.
        This file contains minimal style rules for foundation of page structure.

3. src/Containers/MainPage/Header/ClusterStatusButton.tsx

    * Fix and add search query for UNHEALTHY or DEGRADED to clusters link.
    * Replace HTML `button` with PatternFly `Button` element.
        https://www.patternfly.org/components/button#variant-examples
    * Replace React Feature `Activity` with PatternFly `PortIcon` icon.
        Although not semantic, has same heartbeat appearance.
        https://www.patternfly.org/design-foundations/icons#all-icons
    * Replace color with PatternFly icons used elsewhere for cluster status.
        Color for icons makes them disappear in black background of masthead.

4. src/Containers/MainPage/Header/Header.tsx

    * Delete obsolete theme class.
    * Keep other class for now. See **Residue** item 1.

5. src/Containers/MainPage/Header/OrchestratorComponentsToggle.tsx

    * Replace padding right with `spacer={{ default: 'spacerLg' }}` prop in MastheadToolbar.tsx file.
    * Replace text with `label` and `hasCheckIcon` props of `Switch` element.
        https://www.patternfly.org/components/switch
    * Replace Tailwind class that depended on `theme-dark` class (see previous item) with PatternFly variables. See **Residue** item 2.

### Bonus

Thank you **David** for removing need for folder or file from `ignores` array in #17835
* src/Components/KeyValue
* src/Containers/Violations/Details/ProcessCardContent.jsx

### Residue

1. Investigate `ignore-react-onclickoutside` class.
2. Replace **orchestrator components** with application/platform search filter, as discussed with **David**.
    If I understood correctly, clearer for Risk than for Search.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run lint:fast-dev` in ui/apps/platform folder.
2. `npm run tsc` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/dashboard

    Before changes, see cluster status with Tailwind icon and link to unfiltered clusters.
    <img width="1920" height="968" alt="ClusterStatusButton_with_Tailwind" src="https://github.com/user-attachments/assets/23443b06-7ac2-460f-b8f7-e5b2b21f6419" />

2. Click cluster status button.

    After changes, see cluster status with PatternFly icons and link to filtered clusters.
    <img width="1920" height="968" alt="ClusterStatusButton_ExclamationCircleIcon" src="https://github.com/user-attachments/assets/e5b3ecc9-8c82-4399-b7dc-50c8e3f9ed19" />

    Temporarily edit component to render warning icon.
    <img width="1439" height="70" alt="ClusterStatusButton_ExclamationTriangleIcon" src="https://github.com/user-attachments/assets/28e774dc-ef38-4469-aaaf-e0671cc08c6c" />

    Temporarily edit component to render healthy icon.
    <img width="1440" height="70" alt="ClusterStatusButton_CheckCircleIcon" src="https://github.com/user-attachments/assets/a48051ad-a460-4690-81bd-c2a20de2f52f" />

3. Click **Search**

    Before changes, see orchestrator components switch (off) with Tailwind.
    <img width="1440" height="134" alt="OrchestratorComponentsToggle_with_Tailwind" src="https://github.com/user-attachments/assets/8fc10723-6289-44c2-abb9-df9e15ac218b" />

    After changes, see orchestrator components switch (off) with PatternFly.
    <img width="1440" height="300" alt="OrchestratorComponentsToggle_without_Tailwind_off" src="https://github.com/user-attachments/assets/6c968115-5f17-42e8-a94d-e5e9bbd39996" />

    After changes, see orchestrator components switch (on) with PatternFly.
    <img width="1439" height="299" alt="OrchestratorComponentsToggle_without_Tailwind_on" src="https://github.com/user-attachments/assets/f957321a-0dac-4d7c-8218-72d093ba5fd4" />

4. Temporarily edit date and time for expiration banner.

    Before changes, see Tailwind.
    <img width="1439" height="186" alt="CredentialExpiryBanner_with_Tailwind" src="https://github.com/user-attachments/assets/f37be884-1108-4302-85ef-fef08427047a" />

    After changes, see PatternFly looks the same.
    <img width="1439" height="186" alt="CredentialExpiryBanner_without_Tailwind" src="https://github.com/user-attachments/assets/1cdad271-eee3-4ddf-819a-f2724d928a7b" />