### PR TITLE
ROX-31821: Add tag listing to OCI registries interface

### DIFF
--- a/pkg/images/enricher/testing_test.go
+++ b/pkg/images/enricher/testing_test.go
@@ -160,6 +160,10 @@ func (*fakeRegistryScanner) HTTPClient() *http.Client {
 	return nil
 }
 
+func (*fakeRegistryScanner) ListTags(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
 func (f *fakeRegistryScanner) GetScanner() scannertypes.Scanner {
 	return f.scanner
 }

--- a/pkg/registries/docker/docker.go
+++ b/pkg/registries/docker/docker.go
@@ -9,6 +9,8 @@ import (
 	"github.com/docker/distribution/manifest/manifestlist"
 	manifestV1 "github.com/docker/distribution/manifest/schema1"
 	manifestV2 "github.com/docker/distribution/manifest/schema2"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/heroku/docker-registry-client/registry"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
@@ -67,6 +69,8 @@ type Registry struct {
 	repositoryListLock   sync.RWMutex
 
 	repoListOnce sync.Once
+
+	clientTimeout time.Duration
 }
 
 // NewDockerRegistryWithConfig creates a new instantiation of the docker registry
@@ -87,18 +91,18 @@ func NewDockerRegistryWithConfig(cfg *Config, integration *storage.ImageIntegrat
 		return nil, err
 	}
 
-	client.Client.Timeout = env.RegistryClientTimeout.DurationSetting()
-
 	repoListState := pkgUtils.IfThenElse(cfg.DisableRepoList, "disabled", "enabled")
 	log.Debugf("created integration %q with repo list %s", integration.GetName(), repoListState)
-
-	return &Registry{
+	r := &Registry{
 		url:                   url,
 		registry:              hostname,
 		Client:                client,
 		cfg:                   cfg,
 		protoImageIntegration: integration,
-	}, nil
+		clientTimeout:         env.RegistryClientTimeout.DurationSetting(),
+	}
+	r.Client.Client.Timeout = r.clientTimeout
+	return r, nil
 }
 
 // NewDockerRegistry creates a generic docker registry integration
@@ -253,4 +257,34 @@ func (r *Registry) Name() string {
 // HTTPClient returns the *http.Client used to contact the registry.
 func (r *Registry) HTTPClient() *http.Client {
 	return r.Client.Client
+}
+
+// ListTags lists all tags for a given repository, returning a list of tag names.
+// This uses google/go-containerregistry which properly handles pagination with
+// relative URLs, but uses the same transport used by the docker-registry-client
+// configuration. Reuse of the existing client's transport gives us,
+// authentication, transport timeouts,TLS settings, proxy config and metrics.
+func (r *Registry) ListTags(ctx context.Context, repository string) ([]string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if r.clientTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, r.clientTimeout)
+		defer cancel()
+	}
+	repoPath := fmt.Sprintf("%s/%s", r.registry, repository)
+	repo, err := name.NewRepository(repoPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse repository %q", repoPath)
+	}
+	opts := []remote.Option{
+		remote.WithContext(ctx),
+		remote.WithTransport(r.Client.Client.Transport),
+	}
+	tags, err := remote.List(repo, opts...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list tags for repository %q", repository)
+	}
+	return tags, nil
 }

--- a/pkg/registries/docker/docker_test.go
+++ b/pkg/registries/docker/docker_test.go
@@ -96,3 +96,206 @@ func TestLazyLoadRepoList(t *testing.T) {
 	assert.False(t, r.Match(imgName))
 	assert.Equal(t, 1, repoListCalls) // Lazy load should NOT have executed again.
 }
+
+func TestListTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		mockTags []string
+	}{
+		{
+			name: "mixed tags with artifacts",
+			mockTags: []string{
+				"8.10-1234",
+				"8.10-1234.sig",
+				"8.10-1234.sbom",
+				"8.10-1234.att",
+				"8.9-5678",
+				"sha256-abc123def456",
+				"latest",
+			},
+		},
+		{
+			name: "multiple tags",
+			mockTags: []string{
+				"1.0.0",
+				"1.1.0",
+				"latest",
+				"main",
+			},
+		},
+		{
+			name:     "empty tag list",
+			mockTags: []string{},
+		},
+		{
+			name: "realistic Red Hat UBI pattern",
+			mockTags: []string{
+				"8.10-1234",
+				"8.10-1234.sig",
+				"8.10-1234.sbom",
+				"8.10-1234.att",
+				"8.10-5678",
+				"8.10-5678.sig",
+				"8.10-5678.sbom",
+				"8.10-5678.att",
+				"sha256-aaaa",
+				"sha256-bbbb",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock HTTP server that returns our test tags
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					// Ping endpoint
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if r.URL.Path == "/v2/test/repo/tags/list" {
+					// Tags list endpoint
+					response := `{"name":"test/repo","tags":[`
+					for i, tag := range tt.mockTags {
+						if i > 0 {
+							response += ","
+						}
+						response += `"` + tag + `"`
+					}
+					response += `]}`
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(response))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer s.Close()
+
+			// Create registry with mock server
+			c := &Config{
+				Endpoint:        s.URL,
+				DisableRepoList: true,
+			}
+			r, err := NewDockerRegistryWithConfig(c, &storage.ImageIntegration{})
+			require.NoError(t, err)
+
+			// Call ListTags
+			tags, err := r.ListTags(t.Context(), "test/repo")
+			require.NoError(t, err)
+
+			// Verify all tags are returned
+			assert.ElementsMatch(t, tt.mockTags, tags,
+				"Expected all tags to be returned")
+		})
+	}
+}
+
+func TestListTagsPagination(t *testing.T) {
+	// Test that pagination works by simulating >100 tags
+	var allTags []string
+	for i := 1; i <= 150; i++ {
+		allTags = append(allTags, fmt.Sprintf("tag-%d", i))
+	}
+
+	pageSize := 100
+	callCount := 0
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/v2/test/repo/tags/list" {
+			callCount++
+
+			// Determine which page we're on based on the 'last' parameter
+			lastTag := r.URL.Query().Get("last")
+			startIdx := 0
+			if lastTag != "" {
+				// Find the index of the last tag
+				for i, tag := range allTags {
+					if tag == lastTag {
+						startIdx = i + 1
+						break
+					}
+				}
+			}
+
+			// Return up to pageSize tags
+			endIdx := startIdx + pageSize
+			if endIdx > len(allTags) {
+				endIdx = len(allTags)
+			}
+			pageTags := allTags[startIdx:endIdx]
+
+			// Build JSON response
+			response := `{"name":"test/repo","tags":[`
+			for i, tag := range pageTags {
+				if i > 0 {
+					response += ","
+				}
+				response += `"` + tag + `"`
+			}
+			response += `]}`
+
+			// Add Link header for pagination if there are more tags
+			if endIdx < len(allTags) {
+				linkHeader := fmt.Sprintf(`</v2/test/repo/tags/list?n=%d&last=%s>; rel="next"`,
+					pageSize, pageTags[len(pageTags)-1])
+				w.Header().Set("Link", linkHeader)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(response))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer s.Close()
+
+	c := &Config{
+		Endpoint:        s.URL,
+		DisableRepoList: true,
+	}
+	r, err := NewDockerRegistryWithConfig(c, &storage.ImageIntegration{})
+	require.NoError(t, err)
+
+	tags, err := r.ListTags(t.Context(), "test/repo")
+	require.NoError(t, err)
+
+	// Verify all 150 tags were retrieved (proving pagination works)
+	assert.Len(t, tags, 150, "Should retrieve all tags across multiple pages")
+	assert.ElementsMatch(t, allTags, tags, "All tags should match")
+
+	// Verify multiple API calls were made (proving pagination occurred)
+	assert.Greater(t, callCount, 1, "Should have made multiple paginated calls")
+}
+
+func TestListTagsError(t *testing.T) {
+	// Test error handling when registry returns an error
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/v2/test/repo/tags/list" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"errors":[{"code":"NAME_UNKNOWN","message":"repository not found"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer s.Close()
+
+	c := &Config{
+		Endpoint:        s.URL,
+		DisableRepoList: true,
+	}
+	r, err := NewDockerRegistryWithConfig(c, &storage.ImageIntegration{})
+	require.NoError(t, err)
+
+	tags, err := r.ListTags(t.Context(), "test/repo")
+	assert.Error(t, err, "Should return error when repository not found")
+	assert.Nil(t, tags, "Should return nil tags on error")
+	assert.Contains(t, err.Error(), "failed to list tags", "Error should mention tag listing failure")
+}

--- a/pkg/registries/factory_impl_test.go
+++ b/pkg/registries/factory_impl_test.go
@@ -87,6 +87,7 @@ var _ types.Registry = (*FakeReg)(nil)
 
 func (*FakeReg) Config(ctx context.Context) *types.Config                  { return nil }
 func (*FakeReg) HTTPClient() *http.Client                                  { return nil }
+func (*FakeReg) ListTags(_ context.Context, _ string) ([]string, error)    { return nil, nil }
 func (*FakeReg) Match(_ *storage.ImageName) bool                           { return false }
 func (*FakeReg) Metadata(_ *storage.Image) (*storage.ImageMetadata, error) { return nil, nil }
 func (f *FakeReg) Name() string                                            { return f.name }

--- a/pkg/registries/set_impl_test.go
+++ b/pkg/registries/set_impl_test.go
@@ -52,6 +52,10 @@ func (f *fakeRegistry) HTTPClient() *http.Client {
 	return nil
 }
 
+func (f *fakeRegistry) ListTags(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
 func (f *fakeRegistry) DataSource() *storage.DataSource {
 	return nil
 }

--- a/pkg/registries/types/mocks/types.go
+++ b/pkg/registries/types/mocks/types.go
@@ -71,6 +71,21 @@ func (mr *MockRegistryMockRecorder) HTTPClient() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HTTPClient", reflect.TypeOf((*MockRegistry)(nil).HTTPClient))
 }
 
+// ListTags mocks base method.
+func (m *MockRegistry) ListTags(ctx context.Context, repository string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTags", ctx, repository)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTags indicates an expected call of ListTags.
+func (mr *MockRegistryMockRecorder) ListTags(ctx, repository any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTags", reflect.TypeOf((*MockRegistry)(nil).ListTags), ctx, repository)
+}
+
 // Match mocks base method.
 func (m *MockRegistry) Match(image *storage.ImageName) bool {
 	m.ctrl.T.Helper()
@@ -192,6 +207,21 @@ func (m *MockImageRegistry) HTTPClient() *http.Client {
 func (mr *MockImageRegistryMockRecorder) HTTPClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HTTPClient", reflect.TypeOf((*MockImageRegistry)(nil).HTTPClient))
+}
+
+// ListTags mocks base method.
+func (m *MockImageRegistry) ListTags(ctx context.Context, repository string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTags", ctx, repository)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTags indicates an expected call of ListTags.
+func (mr *MockImageRegistryMockRecorder) ListTags(ctx, repository any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTags", reflect.TypeOf((*MockImageRegistry)(nil).ListTags), ctx, repository)
 }
 
 // Match mocks base method.

--- a/pkg/registries/types/types.go
+++ b/pkg/registries/types/types.go
@@ -84,6 +84,8 @@ type Registry interface {
 	Config(ctx context.Context) *Config
 	Name() string
 	HTTPClient() *http.Client
+	// ListTags lists all tags for a given repository in this registry.
+	ListTags(ctx context.Context, repository string) ([]string, error)
 }
 
 // ImageRegistry adds a DataSource function to Registry that describes which

--- a/pkg/scanners/clairv4/clairv4_test.go
+++ b/pkg/scanners/clairv4/clairv4_test.go
@@ -52,6 +52,10 @@ func (m *mockRegistry) HTTPClient() *http.Client {
 	return http.DefaultClient
 }
 
+func (m *mockRegistry) ListTags(_ context.Context, _ string) ([]string, error) {
+	panic("unsupported")
+}
+
 var (
 	_ http.Handler = (*noopHandler)(nil)
 	_ http.Handler = (*mockClair)(nil)


### PR DESCRIPTION
## Description

Implements `ListTags()` method for the Registry interface to support base image tag discovery (ROX-31821). Uses
 google/go-containerregistry for proper pagination handling with relative URLs (Red Hat registries). Reuses
existing transport configuration to avoid double auth wrapping and maintain consistency with `Metadata()`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed (internal API, not user-facing)
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed (internal API)

## Testing and quality

- [x] The change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests (TestListTags, TestListTagsPagination, TestListTagsError)
- [ ] added e2e tests (not needed - interface method only)
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Unit tests verify basic tag listing, pagination (150 tags), and error handling
- No artifact filtering by name (will be done later via manifest content-type)
- Reuses existing `r.Client.Client.Transport` to maintain auth, timeouts, TLS, metrics, and proxy config
- Reads `env.RegistryClientTimeout` directly for context timeout
- All tests passing locally
