### PR TITLE
ROX-31973: Enable connections to operator installed centrals

### DIFF
--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -335,6 +335,14 @@ func main() {
 		WithLocalSensor(true).
 		WithWorkloadManager(workloadManager)
 
+	// When connecting to real Central, override deployment identification with explicit namespace
+	// to avoid panic during certificate generation (namespace is required but cannot be detected
+	// when running outside a Kubernetes pod without service account files)
+	if !isFakeCentral {
+		deploymentID := createDeploymentIdentificationWithNamespace(localConfig.Namespace)
+		sensorConfig = sensorConfig.WithDeploymentIdentification(deploymentID)
+	}
+
 	if localConfig.FakeCollector {
 		acceptAnyFn := func(ctx context.Context, _ string) (context.Context, error) {
 			return ctx, nil


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR aims to improve a couple of things in `local-sensor`:

- Operator installed centrals do not have the secret containing the cluster name `helm-effective-cluster-name`. This is not needed as the `helm-cluster-config` secret already contains the cluster name.
- The sensor namespace was not being passed to the `CertificateFetcher`. This would lead to failures fetching certs if sensor was installed in a different namespace.
- I suspect the following is not longer needed since the introduction of the `introspectionK8sClient` option:
```golang
	// When connecting to real Central, override deployment identification with explicit namespace
	// to avoid panic during certificate generation (namespace is required but cannot be detected
	// when running outside a Kubernetes pod without service account files)
	if !isFakeCentral && !localConfig.OperatorInstall {
		deploymentID := createDeploymentIdentificationWithNamespace(localConfig.Namespace)
		sensorConfig = sensorConfig.WithDeploymentIdentification(deploymentID)
	}
```
☝️ This last point needs to be investigated further. It seems to work sometimes. I'll leave as it was for this PR since it works with operator, helm, and deploy script installations.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Connecting local sensor with an operator installed Central works.
```bash
go run tools/local-sensor/main.go -no-cpu-prof -no-mem-prof -connect-central=<central-ip> -namespace=rhacs-operator -operator-install
```
- [x] Connecting local-sensor with a helm/deploy-script installed Central works.
```bash
go run tools/local-sensor/main.go -no-cpu-prof -no-mem-prof -connect-central=<central-ip>
```
