### PR TITLE
ROX-31950: Update eslint-plugin-react-hooks 7 and replace recommended

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -711,10 +711,10 @@ module.exports = [
             'react/style-prop-object': 'error',
             'react/void-dom-elements-no-children': 'error',
 
-            // https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/index.js
-            ...pluginReactHooks.configs.recommended.rules,
-
+            // Explicit configuration because recommended includes React Compiler rules.
+            // Core hooks rules
             'react-hooks/exhaustive-deps': 'error', // instead of 'warn'
+            'react-hooks/rules-of-hooks': 'error',
         },
     },
     {

--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -127,7 +127,7 @@
                 "eslint-plugin-jest-dom": "^5.5.0",
                 "eslint-plugin-prettier": "^5.5.4",
                 "eslint-plugin-react": "^7.37.5",
-                "eslint-plugin-react-hooks": "^6.1.1",
+                "eslint-plugin-react-hooks": "^7.0.1",
                 "eslint-plugin-testing-library": "^7.13.4",
                 "globals": "^16.5.0",
                 "levenary": "^1.1.1",
@@ -8690,16 +8690,17 @@
             }
         },
         "node_modules/eslint-plugin-react-hooks": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-6.1.1.tgz",
-            "integrity": "sha512-St9EKZzOAQF704nt2oJvAKZHjhrpg25ClQoaAlHmPZuajFldVLqRDW4VBNAS01NzeiQF0m0qhG1ZA807K6aVaQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+            "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.24.4",
                 "@babel/parser": "^7.24.4",
-                "zod": "^3.22.4 || ^4.0.0",
-                "zod-validation-error": "^3.0.3 || ^4.0.0"
+                "hermes-parser": "^0.25.1",
+                "zod": "^3.25.0 || ^4.0.0",
+                "zod-validation-error": "^3.5.0 || ^4.0.0"
             },
             "engines": {
                 "node": ">=18"
@@ -10137,6 +10138,23 @@
             "peer": true,
             "bin": {
                 "he": "bin/he"
+            }
+        },
+        "node_modules/hermes-estree": {
+            "version": "0.25.1",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+            "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/hermes-parser": {
+            "version": "0.25.1",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+            "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hermes-estree": "0.25.1"
             }
         },
         "node_modules/highlight.js": {

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -155,7 +155,7 @@
         "eslint-plugin-jest-dom": "^5.5.0",
         "eslint-plugin-prettier": "^5.5.4",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^6.1.1",
+        "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-testing-library": "^7.13.4",
         "globals": "^16.5.0",
         "levenary": "^1.1.1",


### PR DESCRIPTION
## Description

Follow up suggestion by **Saif** in https://github.com/stackrox/stackrox/pull/17851#pullrequestreview-3484530933

Upgrade and solve problem now instead of surprise later.

### Problem

93 errors!

### Analysis

https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/CHANGELOG.md#700

> This release slims down presets to just 2 configurations (`recommended` and `recommended-latest`), and all compiler rules are enabled by default.

The decision to add 15 new rules to `recommended` whether or not a project uses React Compiler is hard to understand.

https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md#flat-config-eslintconfigjsts-1

### Solution

Replace `recommended` configuration with 2 classic rules that are relevant.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.