### PR TITLE
ROX-30599: Return NA when CVSS not available

### DIFF
--- a/central/cve/converter/utils/convert_utils.go
+++ b/central/cve/converter/utils/convert_utils.go
@@ -309,10 +309,15 @@ func EmbeddedVulnerabilityToImageCVE(os string, from *storage.EmbeddedVulnerabil
 		SnoozeExpiry:    from.GetSuppressExpiry(),
 		CvssMetrics:     from.GetCvssMetrics(),
 	}
-	if ret.GetCveBaseInfo().GetCvssV3() != nil {
+	// Determine the CVSS score version based on available CVSS data.
+	// Only set a specific version (V2 or V3) if the score is greater than 0.
+	// A score of 0 indicates that the CVSS score is not available for this CVE,
+	// in which case we should return UNKNOWN to avoid confusion.
+	ret.CveBaseInfo.ScoreVersion = storage.CVEInfo_UNKNOWN // Default to UNKNOWN
+	if ret.GetCveBaseInfo().GetCvssV3() != nil && ret.GetCveBaseInfo().GetCvssV3().GetScore() > 0 {
 		ret.CveBaseInfo.ScoreVersion = storage.CVEInfo_V3
 		ret.ImpactScore = from.GetCvssV3().GetImpactScore()
-	} else if ret.GetCveBaseInfo().GetCvssV2() != nil {
+	} else if ret.GetCveBaseInfo().GetCvssV2() != nil && ret.GetCveBaseInfo().GetCvssV2().GetScore() > 0 {
 		ret.CveBaseInfo.ScoreVersion = storage.CVEInfo_V2
 		ret.ImpactScore = from.GetCvssV2().GetImpactScore()
 	}
@@ -340,10 +345,15 @@ func EmbeddedVulnerabilityToClusterCVE(cveType storage.CVE_CVEType, from *storag
 		SnoozeExpiry: from.GetSuppressExpiry(),
 		Type:         cveType,
 	}
-	if ret.GetCveBaseInfo().GetCvssV3() != nil {
+	// Determine the CVSS score version based on available CVSS data.
+	// Only set a specific version (V2 or V3) if the score is greater than 0.
+	// A score of 0 indicates that the CVSS score is not available for this CVE,
+	// in which case we should return UNKNOWN to avoid confusion.
+	ret.CveBaseInfo.ScoreVersion = storage.CVEInfo_UNKNOWN // Default to UNKNOWN
+	if ret.GetCveBaseInfo().GetCvssV3() != nil && ret.GetCveBaseInfo().GetCvssV3().GetScore() > 0 {
 		ret.CveBaseInfo.ScoreVersion = storage.CVEInfo_V3
 		ret.ImpactScore = from.GetCvssV3().GetImpactScore()
-	} else if ret.GetCveBaseInfo().GetCvssV2() != nil {
+	} else if ret.GetCveBaseInfo().GetCvssV2() != nil && ret.GetCveBaseInfo().GetCvssV2().GetScore() > 0 {
 		ret.CveBaseInfo.ScoreVersion = storage.CVEInfo_V2
 		ret.ImpactScore = from.GetCvssV2().GetImpactScore()
 	}

--- a/central/cve/converter/utils/convert_utils_v2.go
+++ b/central/cve/converter/utils/convert_utils_v2.go
@@ -66,12 +66,17 @@ func EmbeddedVulnerabilityToImageCVEV2(imageID string, componentID string, index
 		}
 	}
 
+	// Determine the CVSS score version based on available CVSS data.
+	// Only set a specific version (V2 or V3) if the score is greater than 0.
+	// A score of 0 indicates that the CVSS score is not available for this CVE,
+	// in which case we should return UNKNOWN to avoid confusion.
 	var scoreVersion storage.CVEInfo_ScoreVersion
 	var impactScore float32
-	if from.GetCvssV3() != nil {
+	scoreVersion = storage.CVEInfo_UNKNOWN // Default to UNKNOWN
+	if from.GetCvssV3() != nil && from.GetCvssV3().GetScore() > 0 {
 		scoreVersion = storage.CVEInfo_V3
 		impactScore = from.GetCvssV3().GetImpactScore()
-	} else if from.GetCvssV2() != nil {
+	} else if from.GetCvssV2() != nil && from.GetCvssV2().GetScore() > 0 {
 		scoreVersion = storage.CVEInfo_V2
 		impactScore = from.GetCvssV2().GetImpactScore()
 	}

--- a/central/cve/converter/utils/convert_utils_v2_test.go
+++ b/central/cve/converter/utils/convert_utils_v2_test.go
@@ -130,6 +130,47 @@ var (
 			NvdCvss:               0,
 			Epss:                  nil,
 		},
+		// Test case 3: CVSS exists but score is 0 (unavailable).
+		// This should result in ScoreVersion being UNKNOWN, not V3.
+		{
+			Cve:          "cve3",
+			Cvss:         5.0,
+			Summary:      "Test vulnerability with zero CVSS score",
+			Link:         "http://example.com/cve3",
+			SetFixedBy:   nil,
+			ScoreVersion: 1,
+			CvssV2:       nil,
+			// CvssV3 exists but with score = 0
+			CvssV3: &storage.CVSSV3{
+				Vector:              "",
+				ExploitabilityScore: 0,
+				ImpactScore:         0,
+				AttackVector:        storage.CVSSV3_ATTACK_NETWORK,
+				AttackComplexity:    storage.CVSSV3_COMPLEXITY_LOW,
+				PrivilegesRequired:  storage.CVSSV3_PRIVILEGE_NONE,
+				UserInteraction:     storage.CVSSV3_UI_NONE,
+				Scope:               storage.CVSSV3_UNCHANGED,
+				Confidentiality:     storage.CVSSV3_IMPACT_NONE,
+				Integrity:           storage.CVSSV3_IMPACT_NONE,
+				Availability:        storage.CVSSV3_IMPACT_NONE,
+				Score:               0, // Score is 0 - not available
+				Severity:            storage.CVSSV3_NONE,
+			},
+			PublishedOn:           ts,
+			LastModified:          ts,
+			VulnerabilityType:     storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
+			VulnerabilityTypes:    []storage.EmbeddedVulnerability_VulnerabilityType{storage.EmbeddedVulnerability_IMAGE_VULNERABILITY},
+			Suppressed:            false,
+			SuppressActivation:    nil,
+			SuppressExpiry:        nil,
+			FirstSystemOccurrence: ts,
+			FirstImageOccurrence:  ts,
+			Severity:              storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+			State:                 0,
+			CvssMetrics:           nil,
+			NvdCvss:               0,
+			Epss:                  nil,
+		},
 	}
 )
 
@@ -268,6 +309,50 @@ func getTestCVEs(t *testing.T) []*storage.ImageCVEV2 {
 			},
 			ComponentId: getTestComponentID(1),
 		},
+		// Test case 3: Expected result when CVSS score is 0 (unavailable).
+		// ScoreVersion should be UNKNOWN, not V3.
+		{
+			Id:      getTestCVEID(testVulns[2], getTestComponentID(2), 2),
+			ImageId: "sha",
+			CveBaseInfo: &storage.CVEInfo{
+				Cve:          "cve3",
+				Summary:      "Test vulnerability with zero CVSS score",
+				Link:         "http://example.com/cve3",
+				PublishedOn:  ts,
+				CreatedAt:    ts,
+				LastModified: ts,
+				ScoreVersion: storage.CVEInfo_UNKNOWN, // Should be UNKNOWN
+				CvssV2:       nil,
+				CvssV3: &storage.CVSSV3{
+					Vector:              "",
+					ExploitabilityScore: 0,
+					ImpactScore:         0,
+					AttackVector:        storage.CVSSV3_ATTACK_NETWORK,
+					AttackComplexity:    storage.CVSSV3_COMPLEXITY_LOW,
+					PrivilegesRequired:  storage.CVSSV3_PRIVILEGE_NONE,
+					UserInteraction:     storage.CVSSV3_UI_NONE,
+					Scope:               storage.CVSSV3_UNCHANGED,
+					Confidentiality:     storage.CVSSV3_IMPACT_NONE,
+					Integrity:           storage.CVSSV3_IMPACT_NONE,
+					Availability:        storage.CVSSV3_IMPACT_NONE,
+					Score:               0,
+					Severity:            storage.CVSSV3_NONE,
+				},
+				References:  nil,
+				CvssMetrics: nil,
+				Epss:        nil,
+			},
+			Cvss:                 5.0,
+			Severity:             storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+			ImpactScore:          0, // Impact score is 0 because CVSS score is 0
+			Nvdcvss:              0,
+			NvdScoreVersion:      storage.CvssScoreVersion_UNKNOWN_VERSION,
+			FirstImageOccurrence: ts,
+			State:                0,
+			IsFixable:            false,
+			HasFixedBy:           nil,
+			ComponentId:          getTestComponentID(2),
+		},
 	}
 }
 
@@ -282,6 +367,11 @@ func getComponentInfo(t *testing.T) []*componentPieces {
 			imageID:     "sha",
 			componentID: getTestComponentID(1),
 			cveIndex:    1,
+		},
+		{
+			imageID:     "sha",
+			componentID: getTestComponentID(2),
+			cveIndex:    2,
 		},
 	}
 }


### PR DESCRIPTION
## Description

(compare the earlier PR which implemented this change when NVD CVSS score was unknown: https://github.com/stackrox/stackrox/pull/12770/files )

Assisted-by: Claude Code

Original prompt:
> Make code changes in the Go files so that the GraphQL API returns a CVSS Version of "UNKNOWN_VERSION" when the
CVSS score for a vulnerability is not available. Currently graphql returns 0 for cvss scores that are unavailable
for a CVE. This leads to confusion and wrong report data fro customers. We can use  EPSS and NVD CVSSS scores as
example which show NA currently when scores are not available. Be sure to add new test cases to the unit tests for
the files in which you change code, if those files already have unit test suites. Also, include high-level comments
to explain what your new or changed code is doing.

(incorrect changes to existing NVD CVSS handling suggested)

Follow-up prompt:
> You misunderstood the directions. The field that reflects NVD CVSS score already had this feature, but I am asking
 you to add something equivalent for the plain CVSS score. Undo all your changes so far and try to execute my
earlier request again.

Claude's response and later summary of revised changes:
> You're absolutely right - I apologize for the misunderstanding! Let me undo all my changes and focus on the plain
  CVSS score version field instead of the NVD score version.

(thinking omitted)

⏺ Summary

  I've successfully implemented the changes to make the GraphQL API return "UNKNOWN" for the CVSS score version when
   the CVSS score is not available (0). This matches the behavior already implemented for NVD CVSS scores and EPSS
  scores.

  Files Modified:

  1. central/cve/converter/utils/convert_utils_v2.go (lines 69-82)
    - Modified EmbeddedVulnerabilityToImageCVEV2 function to:
        - Default scoreVersion to storage.CVEInfo_UNKNOWN
      - Only set to V3 or V2 if the CVSS score is greater than 0
      - Added high-level comments explaining the logic
  2. central/cve/converter/utils/convert_utils.go (lines 312-324 and 348-360)
    - Modified EmbeddedVulnerabilityToImageCVE function (deprecated, but still in use)
    - Modified EmbeddedVulnerabilityToClusterCVE function
    - Both functions now use the same logic: check if CVSS score > 0 before setting version
  3. central/cve/converter/utils/convert_utils_v2_test.go
    - Added a new test case (test case 3) that specifically tests:
        - A CVE with CVSS V3 data but score = 0
      - Expected result: ScoreVersion should be UNKNOWN, not V3
    - Updated test helper functions to accommodate the new test case

  How It Works:

  Before the fix:
  - The code checked if CvssV3 or CvssV2 objects were not nil
  - If they existed, it would set the version to V3 or V2 regardless of the actual score value
  - When the score was 0 (not available), it would still report V3 or V2, causing confusion

  After the fix:
  - The code now defaults ScoreVersion to UNKNOWN
  - It checks both:
    a. That the CVSS object exists (!= nil)
    b. That the score is greater than 0 (GetScore() > 0)
  - Only when both conditions are true does it set the version to V3 or V2
  - When the GraphQL API returns this via the ScoreVersion() method in image_vulnerabilities.go:372, it calls
  .String() on the enum, which returns "UNKNOWN" instead of a misleading version number

  Test Results:

  All tests pass successfully:
  - ✅ TestImageCVEV2ToEmbeddedCVEs - Tests conversion from ImageCVEV2 to EmbeddedVulnerability
  - ✅ TestEmbeddedCVEToImageCVEV2 - Tests conversion from EmbeddedVulnerability to ImageCVEV2 (including the new
  test case with score = 0)
  - ✅ All other converter utils tests pass (NVD CVE tests, etc.)
  - ✅ All GraphQL resolver tests continue to pass

  The changes ensure that when customers query the GraphQL API for vulnerabilities with unavailable CVSS scores
  (score = 0), they will see "UNKNOWN" for the score version instead of a confusing "V2" or "V3", matching the
  behavior already in place for NVD CVSS scores and EPSS scores.


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

AI-written unit tests and code reviews
