### PR TITLE
ROX-31296: replace deprecated fake.NewSimpleClientset with fake.NewClientset

### DIFF
--- a/operator/internal/central/values/translation/translation_test.go
+++ b/operator/internal/central/values/translation/translation_test.go
@@ -556,7 +556,7 @@ func TestTranslate(t *testing.T) {
 						},
 					},
 				},
-				clientSet: fake.NewSimpleClientset(
+				clientSet: fake.NewClientset(
 					makeSecret("central-tls-spec-secret",
 						map[string]string{
 							"key":  "central-tls-spec-secret-key-content",

--- a/pkg/cloudproviders/aws/metadata_test.go
+++ b/pkg/cloudproviders/aws/metadata_test.go
@@ -16,7 +16,7 @@ import (
 func TestGetClusterMetadataFromNodeLabels(t *testing.T) {
 
 	ctx := context.Background()
-	k8sClient := fake.NewSimpleClientset()
+	k8sClient := fake.NewClientset()
 	expectedClusterName := "my-cluster"
 	expectedClusterID := "arn:aws:eks:us-east-1:1234:cluster/my-cluster"
 

--- a/pkg/cloudproviders/azure/metadata_test.go
+++ b/pkg/cloudproviders/azure/metadata_test.go
@@ -22,7 +22,7 @@ func TestGetMetadata_NotOnAzure(t *testing.T) {
 func TestGetClusterMetadata(t *testing.T) {
 
 	ctx := context.Background()
-	k8sClient := fake.NewSimpleClientset()
+	k8sClient := fake.NewClientset()
 	expectedClusterName := "my-rg_my-cluster"
 	expectedClusterID := "1234_MC_my-rg_my-cluster_eastus"
 

--- a/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
@@ -122,7 +122,7 @@ func TestCredentialManager(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			k8sClient := fake.NewSimpleClientset()
+			k8sClient := fake.NewClientset()
 			var wg sync.WaitGroup
 			wg.Add(c.changes)
 			manager := newCredentialsManagerImpl(k8sClient, namespace, secretName, func() {

--- a/pkg/k8scfgwatch/cfg_watcher_test.go
+++ b/pkg/k8scfgwatch/cfg_watcher_test.go
@@ -43,7 +43,7 @@ func TestConfigMapTrigger(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			k8sClient := fake.NewSimpleClientset()
+			k8sClient := fake.NewClientset()
 			watcher := watch.NewFake()
 			watchReactor := NewTestWatchReactor(t, watcher)
 			k8sClient.WatchReactionChain = []k8sTest.WatchReactor{watchReactor}
@@ -94,7 +94,7 @@ func TestConfigMapContextCancelled(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			k8sClient := fake.NewSimpleClientset()
+			k8sClient := fake.NewClientset()
 			watcher := watch.NewFake()
 			watchReactor := NewTestWatchReactor(t, watcher)
 			k8sClient.WatchReactionChain = []k8sTest.WatchReactor{watchReactor}

--- a/pkg/metrics/tls_test.go
+++ b/pkg/metrics/tls_test.go
@@ -23,7 +23,7 @@ var (
 )
 
 func TestTLSConfigurerServerCertLoading(t *testing.T) {
-	cfgr := newTLSConfigurer("./testdata", fake.NewSimpleClientset(), "", "")
+	cfgr := newTLSConfigurer("./testdata", fake.NewClientset(), "", "")
 	cfgrTLSConfig, err := cfgr.TLSConfig()
 	require.NoError(t, err)
 	require.Empty(t, cfgrTLSConfig.Certificates)
@@ -36,7 +36,7 @@ func TestTLSConfigurerServerCertLoading(t *testing.T) {
 }
 
 func TestTLSConfigurerClientCALoading(t *testing.T) {
-	k8sClient := fake.NewSimpleClientset()
+	k8sClient := fake.NewClientset()
 	watcher := watch.NewFake()
 	watchReactor := k8scfgwatch.NewTestWatchReactor(t, watcher)
 	k8sClient.WatchReactionChain = []k8sTest.WatchReactor{watchReactor}
@@ -63,7 +63,7 @@ func TestTLSConfigurerClientCALoading(t *testing.T) {
 }
 
 func TestTLSConfigurerNoClientCAs(t *testing.T) {
-	k8sClient := fake.NewSimpleClientset()
+	k8sClient := fake.NewClientset()
 	watcher := watch.NewFake()
 	watchReactor := k8scfgwatch.NewTestWatchReactor(t, watcher)
 	k8sClient.WatchReactionChain = []k8sTest.WatchReactor{watchReactor}

--- a/pkg/secretinformer/informer_test.go
+++ b/pkg/secretinformer/informer_test.go
@@ -109,7 +109,7 @@ func TestSecretInformer(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			k8sClient := fake.NewSimpleClientset()
+			k8sClient := fake.NewClientset()
 
 			var wgAdd, wgUp, wgDel sync.WaitGroup
 			wgAdd.Add(c.expectedOnAddCnt)

--- a/roxctl/common/k8s_port_forward_test.go
+++ b/roxctl/common/k8s_port_forward_test.go
@@ -78,7 +78,7 @@ func Test_getCentralPod(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			core := fake.NewSimpleClientset(tt.objs...).CoreV1()
+			core := fake.NewClientset(tt.objs...).CoreV1()
 
 			got, err := getCentralPod(context.Background(), core, ns)
 			if (err != nil) != tt.wantErr {

--- a/roxctl/declarativeconfig/k8sobject/k8sobject_test.go
+++ b/roxctl/declarativeconfig/k8sobject/k8sobject_test.go
@@ -52,9 +52,9 @@ func TestReadFromK8sObject_ConfigMap(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			client := fake.NewSimpleClientset()
+			client := fake.NewClientset()
 			if c.cm != nil {
-				client = fake.NewSimpleClientset(c.cm)
+				client = fake.NewClientset(c.cm)
 			}
 			contents, err := readConfigMap(context.Background(), client, c.configMap, c.namespace)
 			if c.fail {
@@ -133,9 +133,9 @@ func TestWriteToK8sObject_ConfigMap(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			client := fake.NewSimpleClientset()
+			client := fake.NewClientset()
 			if c.cm != nil {
-				client = fake.NewSimpleClientset(c.cm)
+				client = fake.NewClientset(c.cm)
 			}
 			err := writeConfigMap(context.Background(), client, c.configMap, c.namespace, c.key, c.write)
 			if c.fail {
@@ -192,9 +192,9 @@ func TestReadFromK8sObject_Secret(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			client := fake.NewSimpleClientset()
+			client := fake.NewClientset()
 			if c.sec != nil {
-				client = fake.NewSimpleClientset(c.sec)
+				client = fake.NewClientset(c.sec)
 			}
 			contents, err := readSecret(context.Background(), client, c.secret, c.namespace)
 			if c.fail {
@@ -273,9 +273,9 @@ func TestWriteToK8sObject_Secret(t *testing.T) {
 
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			client := fake.NewSimpleClientset()
+			client := fake.NewClientset()
 			if c.sec != nil {
-				client = fake.NewSimpleClientset(c.sec)
+				client = fake.NewClientset(c.sec)
 			}
 			err := writeSecret(context.Background(), client, c.secret, c.namespace, c.key, c.write)
 			if c.fail {

--- a/sensor/debugger/certs/cert_fetcher_test.go
+++ b/sensor/debugger/certs/cert_fetcher_test.go
@@ -59,7 +59,7 @@ func (t *testClient) OpenshiftOperator() operatorVersioned.Interface {
 }
 
 func createTestClient(secrets ...*v1.Secret) client.Interface {
-	fakeClient := fake.NewSimpleClientset()
+	fakeClient := fake.NewClientset()
 	for _, secret := range secrets {
 		_, _ = fakeClient.CoreV1().Secrets(secret.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 	}

--- a/sensor/debugger/k8s/k8sclient.go
+++ b/sensor/debugger/k8s/k8sclient.go
@@ -28,7 +28,7 @@ var (
 // MakeFakeClient creates a k8s client that is not connected to any cluster
 func MakeFakeClient() *ClientSet {
 	return &ClientSet{
-		k8s: fake.NewSimpleClientset(),
+		k8s: fake.NewClientset(),
 	}
 }
 

--- a/sensor/kubernetes/certrefresh/ca_bundle_test.go
+++ b/sensor/kubernetes/certrefresh/ca_bundle_test.go
@@ -98,7 +98,7 @@ func TestCreateTLSCABundleConfigMap(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("POD_NAMESPACE", "test-namespace")
-			k8sClient := fake.NewSimpleClientset()
+			k8sClient := fake.NewClientset()
 
 			var certs []*x509.Certificate
 			switch tc.certCount {
@@ -173,7 +173,7 @@ func TestCreateTLSCABundleConfigMap(t *testing.T) {
 func TestCreateTLSCABundleConfigMapUpdate(t *testing.T) {
 	t.Setenv("POD_NAMESPACE", "test-namespace")
 
-	k8sClient := fake.NewSimpleClientset()
+	k8sClient := fake.NewClientset()
 
 	ctx := context.Background()
 	cert1 := createTestCertificate(t, "First CA")

--- a/sensor/kubernetes/certrefresh/certrepo/service_certificates_repository_test.go
+++ b/sensor/kubernetes/certrefresh/certrepo/service_certificates_repository_test.go
@@ -116,7 +116,7 @@ func (s *serviceCertificatesRepoSecretsImplSuite) TestGetDifferentCAsFailure() {
 				},
 			}
 			secrets := map[storage.ServiceType]*v1.Secret{scannerServiceType: secret1, unknownServiceType: secret2}
-			clientSet := fake.NewSimpleClientset(secret1, secret2)
+			clientSet := fake.NewClientset(secret1, secret2)
 			secretsClient := clientSet.CoreV1().Secrets(namespace)
 			repo := newTestRepo(secrets, secretsClient)
 
@@ -319,9 +319,9 @@ func (s *serviceCertificatesRepoSecretsImplSuite) newFixture(config certSecretsR
 	secrets := map[storage.ServiceType]*v1.Secret{scannerServiceType: secret}
 	var clientSet *fake.Clientset
 	if config.skipSecretCreation {
-		clientSet = fake.NewSimpleClientset(sensorDeployment)
+		clientSet = fake.NewClientset(sensorDeployment)
 	} else {
-		clientSet = fake.NewSimpleClientset(sensorDeployment, secret)
+		clientSet = fake.NewClientset(sensorDeployment, secret)
 	}
 	secretsClient := clientSet.CoreV1().Secrets(namespace)
 	clientSet.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor(config.k8sAPIVerbToError, "secrets", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {

--- a/sensor/kubernetes/certrefresh/securedcluster/cert_repo_init_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster/cert_repo_init_test.go
@@ -36,7 +36,7 @@ var (
 )
 
 func TestEnsureServiceCertificates(t *testing.T) {
-	clientSet := fake.NewSimpleClientset(sensorDeployment)
+	clientSet := fake.NewClientset(sensorDeployment)
 	secretsClient := clientSet.CoreV1().Secrets(namespace)
 	ctx := context.Background()
 

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer_test.go
@@ -666,7 +666,7 @@ func getFakeK8sClient(conf fakeK8sClientConfig) *fake.Clientset {
 		}
 	}
 
-	k8sClient := fake.NewSimpleClientset(objects...)
+	k8sClient := fake.NewClientset(objects...)
 
 	return k8sClient
 }

--- a/sensor/kubernetes/certrefresh/sensor_owner_ref_test.go
+++ b/sensor/kubernetes/certrefresh/sensor_owner_ref_test.go
@@ -73,7 +73,7 @@ func TestFetchSensorDeploymentOwnerRef(t *testing.T) {
 			name:      "Success",
 			podName:   sensorPodName,
 			namespace: sensorNamespace,
-			k8sClient: fake.NewSimpleClientset(
+			k8sClient: fake.NewClientset(
 				createTestPod(sensorPodName, sensorNamespace, replicaSetName),
 				createTestReplicaSet(replicaSetName, sensorNamespace, deploymentName),
 			),
@@ -84,7 +84,7 @@ func TestFetchSensorDeploymentOwnerRef(t *testing.T) {
 			name:          "EmptyPodName",
 			podName:       "",
 			namespace:     sensorNamespace,
-			k8sClient:     fake.NewSimpleClientset(),
+			k8sClient:     fake.NewClientset(),
 			expectedErr:   true,
 			expectedOwner: nil,
 		},
@@ -92,7 +92,7 @@ func TestFetchSensorDeploymentOwnerRef(t *testing.T) {
 			name:          "PodNotFound",
 			podName:       sensorPodName,
 			namespace:     sensorNamespace,
-			k8sClient:     fake.NewSimpleClientset(),
+			k8sClient:     fake.NewClientset(),
 			expectedErr:   true,
 			expectedOwner: nil,
 		},
@@ -100,7 +100,7 @@ func TestFetchSensorDeploymentOwnerRef(t *testing.T) {
 			name:      "ReplicaSetNotFound",
 			podName:   sensorPodName,
 			namespace: sensorNamespace,
-			k8sClient: fake.NewSimpleClientset(
+			k8sClient: fake.NewClientset(
 				createTestPod(sensorPodName, sensorNamespace, replicaSetName),
 			),
 			expectedErr:   true,
@@ -117,7 +117,7 @@ func TestFetchSensorDeploymentOwnerRef(t *testing.T) {
 					Kind:       "Kind",
 					Name:       "second-owner",
 				})
-				return fake.NewSimpleClientset(pod)
+				return fake.NewClientset(pod)
 			}(),
 			expectedErr:    true,
 			expectedErrMsg: "pod \"" + sensorPodName + "\" has unexpected owners",
@@ -135,7 +135,7 @@ func TestFetchSensorDeploymentOwnerRef(t *testing.T) {
 					Kind:       "Kind",
 					Name:       "second-owner",
 				})
-				return fake.NewSimpleClientset(pod, replicaSet)
+				return fake.NewClientset(pod, replicaSet)
 			}(),
 			expectedErr:    true,
 			expectedErrMsg: "replica set \"" + replicaSetName + "\" has unexpected owners",

--- a/sensor/kubernetes/certrefresh/tls_challenge_cert_loader_test.go
+++ b/sensor/kubernetes/certrefresh/tls_challenge_cert_loader_test.go
@@ -18,7 +18,7 @@ func TestHandleCABundleConfigMapUpdate(t *testing.T) {
 		t.Setenv("POD_NAMESPACE", "test-namespace")
 		t.Setenv("POD_NAME", "test-pod")
 
-		k8sClient := fake.NewSimpleClientset(createTestPod("test-pod", "test-namespace", "sensor-rs"),
+		k8sClient := fake.NewClientset(createTestPod("test-pod", "test-namespace", "sensor-rs"),
 			createTestReplicaSet("sensor-rs", "test-namespace", "sensor"))
 		centralCAs := []*x509.Certificate{testutils.IssueSelfSignedCert(t, "Primary CA").Leaf,
 			testutils.IssueSelfSignedCert(t, "Secondary CA").Leaf}

--- a/sensor/kubernetes/clusterhealth/updater_test.go
+++ b/sensor/kubernetes/clusterhealth/updater_test.go
@@ -45,7 +45,7 @@ type expectedHealthInfo struct {
 }
 
 func (s *UpdaterTestSuite) SetupTest() {
-	s.client = fake.NewSimpleClientset()
+	s.client = fake.NewClientset()
 	s.T().Setenv(namespaceVar, "stackrox-mock-ns")
 }
 

--- a/sensor/kubernetes/clustermetrics/cluster_metrics_test.go
+++ b/sensor/kubernetes/clustermetrics/cluster_metrics_test.go
@@ -32,7 +32,7 @@ type ClusterMetricsTestSuite struct {
 }
 
 func (s *ClusterMetricsTestSuite) SetupTest() {
-	s.client = fake.NewSimpleClientset()
+	s.client = fake.NewClientset()
 	defaultInterval = 10 * time.Millisecond
 }
 

--- a/sensor/kubernetes/clusterstatus/updater_test.go
+++ b/sensor/kubernetes/clusterstatus/updater_test.go
@@ -64,12 +64,12 @@ func (c *fakeClientSet) OpenshiftOperator() operatorVersioned.Interface {
 
 func (s *updaterSuite) createUpdater(getProviders func(context.Context) *storage.ProviderMetadata,
 	getMetadata providerMetadataFromOpenShift, configClient ...*configFake.Clientset) {
-	config := configFake.NewSimpleClientset()
+	config := configFake.NewClientset()
 	if len(configClient) != 0 {
 		config = configClient[0]
 	}
 	s.updater = NewUpdater(&fakeClientSet{
-		k8s:    fake.NewSimpleClientset(),
+		k8s:    fake.NewClientset(),
 		config: config,
 	})
 	s.updater.(*updaterImpl).getProviders = getProviders
@@ -478,9 +478,9 @@ func (s *updaterSuite) Test_GetCloudProviderMetadata() {
 	for name, tc := range cases {
 		s.Run(name, func() {
 			s.T().Setenv(env.OpenshiftAPI.EnvVar(), strconv.FormatBool(tc.openshift))
-			config := configFake.NewSimpleClientset()
+			config := configFake.NewClientset()
 			if tc.infra != nil {
-				config = configFake.NewSimpleClientset(tc.infra, tc.cv)
+				config = configFake.NewClientset(tc.infra, tc.cv)
 			}
 			s.createUpdater(tc.getProviders, getProviderMetadataFromOpenShiftConfig, config)
 			u := s.updater.(*updaterImpl)

--- a/sensor/kubernetes/complianceoperator/updater_test.go
+++ b/sensor/kubernetes/complianceoperator/updater_test.go
@@ -61,7 +61,7 @@ func (s *UpdaterTestSuite) SetupSuite() {
 
 func (s *UpdaterTestSuite) SetupTest() {
 	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.ComplianceV2Integrations})
-	s.client = fake.NewSimpleClientset()
+	s.client = fake.NewClientset()
 	_, err := s.client.CoreV1().Namespaces().Create(context.Background(), buildComplianceOperatorNamespace(defaultNS), metaV1.CreateOptions{})
 	s.Require().NoError(err)
 

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -343,7 +343,7 @@ func (w *WorkloadManager) initializePreexistingResources() {
 		}
 	}
 
-	w.fakeClient = fake.NewSimpleClientset(objects...)
+	w.fakeClient = fake.NewClientset(objects...)
 	w.fakeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
 		Major:        "1",
 		Minor:        "14",

--- a/sensor/kubernetes/fake/openshift.go
+++ b/sensor/kubernetes/fake/openshift.go
@@ -14,10 +14,10 @@ import (
 func initializeOpenshiftClients(clientSet *clientSetImpl) {
 	// Set up fake Openshift clients if we are in Openshift
 	if env.OpenshiftAPI.BooleanSetting() {
-		clientSet.openshiftApps = fakeAppVersioned.NewSimpleClientset()
-		clientSet.openshiftConfig = fakeConfigVersioned.NewSimpleClientset(getConfig()...)
-		clientSet.openshiftOperator = fakeOperatorVersioned.NewSimpleClientset()
-		clientSet.openshiftRoute = fakeRouteVersioned.NewSimpleClientset()
+		clientSet.openshiftApps = fakeAppVersioned.NewClientset()
+		clientSet.openshiftConfig = fakeConfigVersioned.NewClientset(getConfig()...)
+		clientSet.openshiftOperator = fakeOperatorVersioned.NewClientset()
+		clientSet.openshiftRoute = fakeRouteVersioned.NewClientset()
 	}
 }
 

--- a/sensor/kubernetes/listener/resources/rbac/binding_fetcher_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/binding_fetcher_test.go
@@ -65,7 +65,7 @@ var (
 )
 
 func Test_FetchBindingRemovesLastAppliedConfig(t *testing.T) {
-	fakeClient := fake.NewSimpleClientset()
+	fakeClient := fake.NewClientset()
 	fetcher := newBindingFetcher(fakeClient)
 
 	_, err := fakeClient.RbacV1().ClusterRoleBindings().Create(context.Background(), clusterRoleBinding, metav1.CreateOptions{})
@@ -92,7 +92,7 @@ func Test_FetchBindingRemovesLastAppliedConfig(t *testing.T) {
 }
 
 func Test_FetchBindingErrors(t *testing.T) {
-	fakeClient := fake.NewSimpleClientset()
+	fakeClient := fake.NewClientset()
 	fetcher := newBindingFetcher(fakeClient)
 	fetcher.numRetries = 2
 

--- a/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
+++ b/sensor/kubernetes/listener/resources/rbac/store_impl_test.go
@@ -121,7 +121,7 @@ func TestStore_DispatcherEvents(t *testing.T) {
 	}
 
 	tested := NewStore().(*storeImpl)
-	fakeClient := fake.NewSimpleClientset()
+	fakeClient := fake.NewClientset()
 	dispatcher := NewDispatcher(tested, fakeClient)
 
 	eventsInOrder := []struct {
@@ -517,7 +517,7 @@ func TestStore_DeploymentRelationship(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			tested := NewStore().(*storeImpl)
-			fakeClient := fake.NewSimpleClientset()
+			fakeClient := fake.NewClientset()
 			dispatcher := NewDispatcher(tested, fakeClient)
 			var ref []resolver.DeploymentResolution
 			for _, update := range testCase.orderedUpdates {

--- a/sensor/kubernetes/telemetry/gatherers/cluster_test.go
+++ b/sensor/kubernetes/telemetry/gatherers/cluster_test.go
@@ -33,7 +33,7 @@ func (s *ClusterGathererTestSuite) TestGatherCluster() {
 		},
 	}
 	gatherer := NewClusterGatherer(
-		fake.NewSimpleClientset(node, namespace),
+		fake.NewClientset(node, namespace),
 		resources.InitializeStore(nil).Deployments())
 	cluster := gatherer.Gather(context.Background())
 	s.NotNil(cluster)

--- a/sensor/kubernetes/telemetry/gatherers/namespace_test.go
+++ b/sensor/kubernetes/telemetry/gatherers/namespace_test.go
@@ -36,7 +36,7 @@ func (s *NamespaceGathererTestSuite) TestGatherNamespaces() {
 		},
 	}
 	gatherer := newNamespaceGatherer(
-		fake.NewSimpleClientset(knownNamespace, unknownNamespace),
+		fake.NewClientset(knownNamespace, unknownNamespace),
 		resources.InitializeStore(nil).Deployments())
 	namespaces, err := gatherer.Gather(context.Background())
 	s.Empty(err)

--- a/sensor/kubernetes/telemetry/gatherers/node_test.go
+++ b/sensor/kubernetes/telemetry/gatherers/node_test.go
@@ -53,7 +53,7 @@ func (s *NodeGathererTestSuite) TestGatherNodes() {
 			},
 		},
 	}
-	gatherer := newNodeGatherer(fake.NewSimpleClientset(noConditions, conditions))
+	gatherer := newNodeGatherer(fake.NewClientset(noConditions, conditions))
 	gathered, err := gatherer.Gather(context.Background())
 	s.NoError(err)
 	s.Len(gathered, 2)


### PR DESCRIPTION
## Description

Replace all occurrences of the deprecated fake.NewSimpleClientset() with fake.NewClientset() across test files and test utilities. The newer NewClientset() provides field management support for server-side apply testing, which NewSimpleClientset lacks.

This aligns with current Kubernetes client-go best practices and prepares the codebase for better field management testing capabilities.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI