### PR TITLE
refactor(operator): remove deprecated admission controller defaults

### DIFF
--- a/operator/internal/securedcluster/values/translation/translation.go
+++ b/operator/internal/securedcluster/values/translation/translation.go
@@ -97,7 +97,7 @@ func (t Translator) translate(ctx context.Context, sc platform.SecuredCluster) (
 	if err := platform.MergeSecuredClusterDefaultsIntoSpec(&sc); err != nil {
 		return nil, err
 	}
-	t.setDefaults(&sc)
+	scanner.SetScannerDefaults(&sc.Spec)
 
 	v := translation.NewValuesBuilder()
 
@@ -486,12 +486,6 @@ func (t Translator) getLocalScannerV4ComponentValues(ctx context.Context, secure
 	}
 
 	return &sv
-}
-
-// Sets defaults that might not be applied on the resource due to ROX-8046.
-// Only defaults that result in behaviour different from the Helm chart defaults should be included here.
-func (t Translator) setDefaults(sc *platform.SecuredCluster) {
-	scanner.SetScannerDefaults(&sc.Spec)
 }
 
 func getMetaValues(sc platform.SecuredCluster) *translation.ValuesBuilder {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR removes the setting of deprecated admission controller fields in the translation logic of the Operator.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI should be sufficient.