### PR TITLE
ROX-31959: Add user-visible display values for file ops

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
@@ -130,13 +130,13 @@ const APIVerbs: DescriptorOption[] = ['CREATE', 'DELETE', 'GET', 'PATCH', 'UPDAT
 }));
 
 const fileOperationOptions: DescriptorOption[] = [
-    'OPEN',
-    'CREATE',
-    'UNLINK',
-    'RENAME',
-    'PERMISSION_CHANGE',
-    'OWNERSHIP_CHANGE',
-].map((operation) => ({ label: operation, value: operation }));
+    ['OPEN', 'Open'],
+    ['CREATE', 'Create'],
+    ['UNLINK', 'Delete'],
+    ['RENAME', 'Rename'],
+    ['PERMISSION_CHANGE', 'Permission change'],
+    ['OWNERSHIP_CHANGE', 'Ownership change'],
+].map(([value, label]) => ({ value, label }));
 
 const fileActivityPathOptions: DescriptorOption[] = [
     '/etc/passwd',


### PR DESCRIPTION
## Description

As discussed at the sync today, adds user-visible labels to the file operation values expected by the server. This is done primarily to handle the case of `UNLINK`, which is more intuitive as `Delete` as a user-selected option.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1280" height="892" alt="image" src="https://github.com/user-attachments/assets/1a954920-5244-4775-9190-95a7c0310fbf" />
