### PR TITLE
ROX-31612: Remove 2 pass search from deployment datastore

### DIFF
--- a/central/deployment/datastore/datastore_impl.go
+++ b/central/deployment/datastore/datastore_impl.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -173,27 +174,30 @@ func (ds *datastoreImpl) SearchListDeployments(ctx context.Context, q *v1.Query)
 // SearchDeployments
 func (ds *datastoreImpl) SearchDeployments(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error) {
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Deployment", "SearchDeployments")
-	results, err := ds.Search(ctx, q)
+	if q == nil {
+		q = pkgSearch.EmptyQuery()
+	}
+	// Clone the query and add select fields for SearchResult construction
+	clonedQuery := q.CloneVT()
+	selectSelects := []*v1.QuerySelect{
+		pkgSearch.NewQuerySelect(pkgSearch.DeploymentName).Proto(),
+		pkgSearch.NewQuerySelect(pkgSearch.Cluster).Proto(),
+		pkgSearch.NewQuerySelect(pkgSearch.Namespace).Proto(),
+	}
+	clonedQuery.Selects = append(clonedQuery.GetSelects(), selectSelects...)
+
+	results, err := ds.deploymentStore.Search(ctx, clonedQuery)
 	if err != nil {
 		return nil, err
 	}
-
-	ids := pkgSearch.ResultsToIDs(results)
-	deployments, missingIndices, err := ds.deploymentStore.GetMany(ctx, ids)
-	if err != nil {
-		return nil, err
+	for i := range results {
+		if results[i].FieldValues != nil {
+			if nameVal, ok := results[i].FieldValues[strings.ToLower(pkgSearch.DeploymentName.String())]; ok {
+				results[i].Name = nameVal
+			}
+		}
 	}
-	results = pkgSearch.RemoveMissingResults(results, missingIndices)
-
-	if len(deployments) != len(results) {
-		return nil, errors.Errorf("expected %d deployments but got %d", len(results), len(deployments))
-	}
-
-	protoResults := make([]*v1.SearchResult, 0, len(deployments))
-	for i, deployment := range deployments {
-		protoResults = append(protoResults, convertDeployment(deployment, results[i]))
-	}
-	return protoResults, nil
+	return pkgSearch.ResultsToSearchResultProtos(results, &DeploymentSearchResultConverter{}), nil
 }
 
 // SearchRawDeployments
@@ -468,14 +472,27 @@ func (ds *datastoreImpl) GetDeploymentIDs(ctx context.Context) ([]string, error)
 	return ds.deploymentStore.GetIDs(ctx)
 }
 
-// convertDeployment returns proto search result from a deployment object and the internal search result
-func convertDeployment(deployment *storage.Deployment, result pkgSearch.Result) *v1.SearchResult {
-	return &v1.SearchResult{
-		Category:       v1.SearchCategory_DEPLOYMENTS,
-		Id:             deployment.GetId(),
-		Name:           deployment.GetName(),
-		FieldToMatches: pkgSearch.GetProtoMatchesMap(result.Matches),
-		Score:          result.Score,
-		Location:       fmt.Sprintf("/%s/%s", deployment.GetClusterName(), deployment.GetNamespace()),
+type DeploymentSearchResultConverter struct{}
+
+func (c *DeploymentSearchResultConverter) BuildName(result *pkgSearch.Result) string {
+	return result.Name
+}
+
+func (c *DeploymentSearchResultConverter) BuildLocation(result *pkgSearch.Result) string {
+	fv := result.FieldValues
+	clusterName := fv[strings.ToLower(pkgSearch.Cluster.String())]
+	namespace := fv[strings.ToLower(pkgSearch.Namespace.String())]
+
+	if clusterName != "" && namespace != "" {
+		return fmt.Sprintf("/%s/%s", clusterName, namespace)
 	}
+	return ""
+}
+
+func (c *DeploymentSearchResultConverter) GetCategory() v1.SearchCategory {
+	return v1.SearchCategory_DEPLOYMENTS
+}
+
+func (c *DeploymentSearchResultConverter) GetScore(result *pkgSearch.Result) float64 {
+	return result.Score
 }


### PR DESCRIPTION
This PR removes 2 pass search from deployment datastore
## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
