### PR TITLE
ROX-32037: Add no-TSTypeAssertion lint rule and fix errors

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginGeneric.js
+++ b/ui/apps/platform/eslint-plugins/pluginGeneric.js
@@ -506,6 +506,28 @@ const rules = {
     // If your rule only disallows something, prefix it with no.
     // However, we can write forbid instead of disallow as the verb in description and message.
 
+    'no-TSTypeAssertion': {
+        // Inconsistent with TSAsExpression which is project convention.
+        // TypeScript with erasableSyntaxOnly configuration option reports error for TSTypeAssertion.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Replace TSTypeAssertion with TSAsExpression',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                TSTypeAssertion(node) {
+                    const name = node.typeAnnotation?.typeName?.name ?? 'Whatever';
+                    context.report({
+                        node,
+                        message: `Replace TSTypeAssertion with TSAsExpression: as ${name}`,
+                    });
+                },
+            };
+        },
+    },
     'no-anchor-href-docs-string': {
         // Full path string lacks what getVersionedDocs function provides:
         // Include version number so doc page corresponds to product version.

--- a/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/tableColumnDescriptor.ts
@@ -105,7 +105,7 @@ const tableColumnDescriptor: Readonly<IntegrationTableColumnDescriptorMap> = {
             { accessor: 'role', Header: 'Role' },
             {
                 accessor: (config) => {
-                    const objectConfig = <ApiToken>config;
+                    const objectConfig = config as ApiToken;
                     return objectConfig.expiration
                         ? getDateTime(objectConfig.expiration)
                         : 'Unknown';
@@ -116,7 +116,7 @@ const tableColumnDescriptor: Readonly<IntegrationTableColumnDescriptorMap> = {
         machineAccess: [
             {
                 accessor: (config) => {
-                    const { type } = <AuthMachineToMachineConfig>config;
+                    const { type } = config as AuthMachineToMachineConfig;
                     if (type === 'GENERIC') {
                         return 'Generic';
                     }
@@ -135,7 +135,7 @@ const tableColumnDescriptor: Readonly<IntegrationTableColumnDescriptorMap> = {
             {
                 accessor: (config) => {
                     return transformDurationLongForm(
-                        (<AuthMachineToMachineConfig>config).tokenExpirationDuration
+                        (config as AuthMachineToMachineConfig).tokenExpirationDuration
                     );
                 },
                 Header: 'Token lifetime',


### PR DESCRIPTION
## Description

### Opportunity

https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly

> Node.js supports running TypeScript files directly as of v23.6; however, only TypeScript-specific syntax that does not have runtime semantics are supported under this mode. In other words, it must be possible to easily erase any TypeScript-specific syntax from a file, leaving behind a valid JavaScript file.

Although we do not run UI in Node.js we can form habits for professional development.

### Problem

3 out of 7 errors are for `<Type>value` angle bracket syntax for type assertion.

### Analysis

https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions

Maybe angle bracket syntax is not erasable because could be ambiguous with JSX.

Regardless, it is rare exception written by part time contributor instead of `as` which we write everywhere else.

### Solution 

Use typescript-eslint playground to explore type assertion:

Note: `.ts` instead of `.tsx`

https://typescript-eslint.io/play/#ts=5.9.3&showAST=es&fileType=.ts

### Residue

4 our of 7 errors are for `enum`
* 3 in Network Graph
* 1 in redux actions

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
    Temporarily add `"erasableSyntaxOnly": true,` property in tsconfig.json file.
    See presence of errors before changes and absence of errors after.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
    See presence of errors before changes and absence of errors after.