### PR TITLE
ROX-30730: Scan Konflux images with GHA

### DIFF
--- a/.github/workflows/check-image-vulnerabilities.yml
+++ b/.github/workflows/check-image-vulnerabilities.yml
@@ -131,8 +131,10 @@ jobs:
           set -euo pipefail
           tag="${{ needs.run-parameters.outputs.version }}"
           if [[ "${tag}" == *-nightly-* ]]; then
-            # Replace '.x' in patch version with '.0'. Example: 0.1.x-nightly-20260114 -> 0.1.0-nightly-20260114
-            tag="$(echo "${tag}" | sed -E 's@^(([[:digit:]]+\.)+)x(-)?@\10\3@g')"
+            # Replace '.x' in patch version with '.0' and append '-fast' suffix.
+            # Example: 0.1.x-nightly-20260114 -> 0.1.0-nightly-20260114-fast
+            suffix="fast"
+            tag="$(echo "${tag}" | sed -E 's@^(([[:digit:]]+\.)+)x(-)?@\10\3@g')-${suffix}"
           fi
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
## Description

Companion to https://github.com/stackrox/actions/pull/72.

* Workflow now scans Konflux and GHA-built images.
* Workflow now triggered by new tags (can be manually dispatched for other tags).
* Workflow uses composite action to stay DRY.
 
### TODO

* [x] update the action reference after that PR is merged.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

-->

Change to GHA, manual testing required, see below.

### How I validated my change

* Manual dispatch: 
  * "normal tag": https://github.com/stackrox/stackrox/actions/runs/20996200170
  * "nightly tag": https://github.com/stackrox/stackrox/actions/runs/20995456621
* Tagged build: 
  * https://github.com/stackrox/stackrox/actions/runs/20996766698 (tm-test-0 tag). Here I confirmed that 
    * the job is started by a new tag
    * upstream and Konflux jobs are looking for the correct images 