### PR TITLE
ROX-29713: Fix race condition in SensorIntermediateRuntimeEvents

### DIFF
--- a/sensor/tests/helper/collector.go
+++ b/sensor/tests/helper/collector.go
@@ -40,6 +40,7 @@ func WaitToReceiveMessagesFromCollectorWithTimeout(ctx context.Context, signal *
 	expectedNetworkMessages []ExpectedNetworkConnectionMessageFn,
 	timeoutDuration time.Duration) {
 	timeout := time.NewTicker(timeoutDuration)
+	defer timeout.Stop()
 	for {
 		select {
 		case <-ctx.Done():
@@ -83,6 +84,7 @@ func WaitToReceiveMessagesFromCollectorWithTimeout(ctx context.Context, signal *
 		}
 		if len(expectedSignalMessages) == 0 && len(expectedNetworkMessages) == 0 {
 			signal.Signal()
+			return
 		}
 	}
 }


### PR DESCRIPTION
Problem: The test helper WaitToReceiveMessagesFromCollectorWithTimeout had a critical bug where it signaled completion but continued running the goroutine loop. This caused concurrent access to slice variables and channels while the main test was cleaning up, triggering race detector.

Solution:
1. Add return statement after signal.Signal() to exit goroutine on success
2. Add defer timeout.Stop() to prevent ticker goroutine leak

User request: Triage CI failure and find root cause and permanent solution for Test_SensorIntermediateRuntimeEvents race condition detected in sensor-integration-tests.

Note: Code partially generated with AI assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)