### PR TITLE
fix(sfa): copy timestamp to file access

### DIFF
--- a/sensor/common/filesystem/pipeline/pipeline.go
+++ b/sensor/common/filesystem/pipeline/pipeline.go
@@ -48,8 +48,9 @@ func NewFileSystemPipeline(detector detector.Detector, clusterEntities *clustere
 func (p *Pipeline) translate(fs *sensorAPI.FileActivity) *storage.FileAccess {
 
 	access := &storage.FileAccess{
-		Process:  p.getIndicator(fs.GetProcess()),
-		Hostname: fs.GetHostname(),
+		Process:   p.getIndicator(fs.GetProcess()),
+		Hostname:  fs.GetHostname(),
+		Timestamp: fs.GetTimestamp(),
 	}
 
 	switch fs.GetFile().(type) {


### PR DESCRIPTION
## Description

Ensures that the timestamp is correctly translated over to the `storage.FileAccess`.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Trivial change, CI should be enough. Will be exercised more in #17853 and #17801 
