### PR TITLE
fix(sfa): makes the file access printer clearer

### DIFF
--- a/pkg/booleanpolicy/violationmessages/printer/file_access.go
+++ b/pkg/booleanpolicy/violationmessages/printer/file_access.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sliceutils"
 )
 
 const (
@@ -40,8 +41,8 @@ func UpdateFileAccessAlertViolationMessage(v *storage.Alert_FileAccessViolation)
 
 	parts := make([]string, 0, len(pathToOperation))
 	for _, path := range paths {
-		parts = append(parts, fmt.Sprintf("'%v' accessed (%s)", path, strings.Join(pathToOperation[path], ", ")))
+		parts = append(parts, fmt.Sprintf("'%v' accessed (%s)", path, strings.Join(sliceutils.Unique(pathToOperation[path]), ", ")))
 	}
 
-	v.Message = fmt.Sprintf("%s", strings.Join(parts, "; "))
+	v.Message = strings.Join(parts, "; ")
 }

--- a/pkg/booleanpolicy/violationmessages/printer/file_access_test.go
+++ b/pkg/booleanpolicy/violationmessages/printer/file_access_test.go
@@ -247,6 +247,24 @@ func TestUpdateFileAccessMessage(t *testing.T) {
 			},
 			expected: "'/test/file' accessed (OPEN)",
 		},
+		{
+			desc: "same file, many opens",
+			activity: []*storage.FileAccess{
+				{
+					File:      &storage.FileAccess_File{NodePath: "/test/file"},
+					Operation: storage.FileAccess_OPEN,
+				},
+				{
+					File:      &storage.FileAccess_File{NodePath: "/test/file"},
+					Operation: storage.FileAccess_OPEN,
+				},
+				{
+					File:      &storage.FileAccess_File{NodePath: "/test/file"},
+					Operation: storage.FileAccess_OPEN,
+				},
+			},
+			expected: "'/test/file' accessed (OPEN)",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Description

Previous to this change, we'd get something like `/etc/passwd accessed (OPEN) by cat` repeatedly if that file is accessed multiple times. This is not helpful, so this PR updates the printer so the message contains one entry for each file path, and accumulates all the kinds of access:

```
/etc/passwd accessed (OPEN, PERMISSION_CHANGE); /etc/shadow accessed (OPEN)
```

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Unit test changes are sufficient.
