### PR TITLE
ROX-32096: Add no-logical-or-preceding-array-or-object lint rule

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginLimited.js
+++ b/ui/apps/platform/eslint-plugins/pluginLimited.js
@@ -356,6 +356,40 @@ const rules = {
             };
         },
     },
+    'no-logical-or-preceding-array-or-object': {
+        // Consistently write more precise nullish coalescing operator.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Replace || with nullish coalescing ??',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                LogicalExpression(node) {
+                    if (node.operator === '||') {
+                        switch (node.right?.type) {
+                            case 'ArrayExpression':
+                                context.report({
+                                    node,
+                                    message: `Replace || with ?? preceding array expression`,
+                                });
+                                break;
+                            case 'ObjectExpression':
+                                context.report({
+                                    node,
+                                    message: `Replace || with ?? preceding object expression`,
+                                });
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                },
+            };
+        },
+    },
     'no-qualified-name-react': {
         // React.Whatever is possible with default import.
         // For consistency and as prerequisite to replace default import with JSX transform.

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -871,6 +871,48 @@ module.exports = [
         },
     },
     {
+        files: ['src/*/**/*.{js,jsx,ts,tsx}'],
+        ignores: [
+            'src/Components/CompoundSearchFilter/utils/utils.tsx', // prevent merge conflict
+            'src/Components/GroupedTabs.jsx', // deprecated
+            'src/Components/ReactSelect/ReactSelect.jsx', // deprecated
+            'src/Components/URLSearchInputWithAutocomplete.jsx', // deprecated
+            'src/Containers/AccessControl/**',
+            'src/Containers/Audit/**',
+            'src/Containers/Compliance/**', // deprecated
+            'src/Containers/ComplianceEnhanced/**',
+            'src/Containers/ConfigManagement/**',
+            'src/Containers/MitreAttackVectors/**',
+            'src/Containers/NetworkGraph/**',
+            'src/Containers/Policies/**',
+            'src/Containers/Risk/**',
+            'src/Containers/SystemConfig/**',
+            'src/Containers/SystemHealth/**',
+            'src/Containers/Violations/**',
+            'src/Containers/VulnMgmt/**', // deprecated
+            'src/Containers/Vulnerabilities/**',
+            'src/init/initializeAnalytics.js', // generated from segment api
+            'src/sagas/authSagas.js', // deprecated
+            'src/sagas/groupSagas.js', // deprecated
+            'src/sagas/roleSagas.js', // deprecated
+            'src/utils/URLParser.ts', // deprecated
+            'src/utils/WorkflowState.js', // deprecated
+            'src/utils/entityRelationships.ts', // deprecated
+            'src/utils/getSubListFromEntity.js', // deprecated
+            'src/utils/queryService.js', // deprecated
+        ],
+
+        // languageOptions from previous configuration object
+
+        // Key of plugin is namespace of its rules.
+        plugins: {
+            limited: pluginLimited,
+        },
+        rules: {
+            'limited/no-logical-or-preceding-array-or-object': 'error',
+        },
+    },
+    {
         files: ['src/**/*.{js,jsx,ts,tsx}'],
         ignores: [
             'src/Components/*.{js,jsx}', // deprecated

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
@@ -70,7 +70,7 @@ export function getEntityAttributes(
     entityName: string
 ): CompoundSearchFilterAttribute[] {
     const entity = getEntity(config, entityName);
-    return entity?.attributes || [];
+    return entity?.attributes ?? [];
 }
 
 export function getDefaultAttributeName(

--- a/ui/apps/platform/src/hooks/useFetchClustersForPermissions.ts
+++ b/ui/apps/platform/src/hooks/useFetchClustersForPermissions.ts
@@ -32,7 +32,7 @@ function useFetchClustersForPermissions(permissions: ResourceName[]): Result {
         getClustersForPermissions(requestedPermissions)
             .then((data) => {
                 setResult({
-                    clusters: data?.clusters || [],
+                    clusters: data?.clusters ?? [],
                     error: '',
                     isLoading: false,
                 });

--- a/ui/apps/platform/src/hooks/useURLParameter.ts
+++ b/ui/apps/platform/src/hooks/useURLParameter.ts
@@ -36,7 +36,7 @@ export function applyUpdatesToUrl(
         ? 'push'
         : 'replace';
 
-    const previousQuery = getQueryObject(search) || {};
+    const previousQuery = getQueryObject(search) ?? {};
     const newQuery = { ...previousQuery };
 
     updates.forEach(({ keyPrefix, newValue }) => {

--- a/ui/apps/platform/src/providers/UserPermissionProvider.tsx
+++ b/ui/apps/platform/src/providers/UserPermissionProvider.tsx
@@ -6,7 +6,7 @@ import useRestQuery from 'hooks/useRestQuery';
 
 export function UserPermissionProvider({ children }: { children: ReactNode }) {
     const { data, isLoading } = useRestQuery(fetchUserRolePermissions);
-    const userRolePermissions = data?.response || { resourceToAccess: {} };
+    const userRolePermissions = data?.response ?? { resourceToAccess: {} };
     const isLoadingPermissions = isLoading;
 
     return (

--- a/ui/apps/platform/src/services/ClustersService.ts
+++ b/ui/apps/platform/src/services/ClustersService.ts
@@ -233,7 +233,7 @@ export function fetchClusterInitBundles(): Promise<{ response: { items: ClusterI
         .get<{ items: ClusterInitBundle[] }>(`${clusterInitUrl}/init-bundles`)
         .then((response) => {
             return {
-                response: response.data || { items: [] },
+                response: response.data ?? { items: [] },
             };
         });
 }
@@ -242,7 +242,7 @@ export function fetchClusterRegistrationSecrets(): Promise<{ items: ClusterRegis
     return axios
         .get<{ items: ClusterRegistrationSecret[] }>(`${clusterInitUrl}/crs`)
         .then((response) => {
-            return response.data || { items: [] };
+            return response.data ?? { items: [] };
         });
 }
 
@@ -268,7 +268,7 @@ export function generateClusterInitBundle(data: { name: string }): Promise<{
         }>(`${clusterInitUrl}/init-bundles`, data)
         .then((response) => {
             return {
-                response: response.data || {},
+                response: response.data ?? {},
             };
         });
 }

--- a/ui/apps/platform/src/services/DelegatedRegistryConfigService.ts
+++ b/ui/apps/platform/src/services/DelegatedRegistryConfigService.ts
@@ -53,7 +53,7 @@ export function fetchDelegatedRegistryConfig(): Promise<DelegatedRegistryConfig>
 export function fetchDelegatedRegistryClusters(): Promise<DelegatedRegistryCluster[]> {
     return axios
         .get<{ clusters: DelegatedRegistryCluster[] }>(`${delegatedRegistryUrl}/clusters`)
-        .then((response) => response.data.clusters || []);
+        .then((response) => response.data.clusters ?? []);
 }
 
 /**

--- a/ui/apps/platform/src/services/MachineAccessService.ts
+++ b/ui/apps/platform/src/services/MachineAccessService.ts
@@ -28,7 +28,7 @@ export function fetchMachineAccessConfigs(): Promise<{
         .get<{ configs: AuthMachineToMachineConfig[] }>(machineAccessURL)
         .then((response) => {
             return {
-                response: response.data || { configs: [] },
+                response: response.data ?? { configs: [] },
             };
         });
 }
@@ -48,7 +48,7 @@ export function createMachineAccessConfig(data: AuthMachineToMachineConfig): Pro
         .post<AuthMachineToMachineConfig>(machineAccessURL, { config: data })
         .then((response) => {
             return {
-                response: response.data || {},
+                response: response.data ?? {},
             };
         });
 }

--- a/ui/apps/platform/src/services/SearchService.ts
+++ b/ui/apps/platform/src/services/SearchService.ts
@@ -157,5 +157,5 @@ export function fetchAutoCompleteResults(rawSearchRequest: RawSearchRequest): Pr
     const params = qs.stringify(rawSearchRequest, { arrayFormat: 'repeat' });
     return axios
         .get<AutocompleteResponse>(`${autoCompleteURL}?${params}`)
-        .then((response) => response?.data?.values || []);
+        .then((response) => response?.data?.values ?? []);
 }

--- a/ui/apps/platform/src/services/imageService.ts
+++ b/ui/apps/platform/src/services/imageService.ts
@@ -24,7 +24,7 @@ export function getImages(): Promise<ListImage[]> {
 export function getWatchedImages(): Promise<WatchedImage[]> {
     return axios
         .get<{ watchedImages: WatchedImage[] }>(watchedImagesUrl)
-        .then((response) => response.data.watchedImages || []);
+        .then((response) => response.data.watchedImages ?? []);
 }
 
 /*


### PR DESCRIPTION
## Description

Toward Q4 AI goal: help AI to help us.

Also for human finger memory of earlier idiom.

Prevent inconsistencies while writing code in editor instead via change requests by reviewers in contributions.

### Problem

Finger memory types `||` when `??` is more precise for `right` node:
* `ArrayExpression`
* `ObjectExpression`

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing

### Analysis

128 errors in 70 files:
* 21 files not in src/Containers folder
* 49 files in src/Containers folder
    * 8 files in 2 deprecated subfolders
    * 41 files in 12 non-deprecated subfolders

| files | subfolder |
| ---: | :--- |
| 1 | AccessControl |
| 1 | Audit |
| 3 | Compliance |
| 3 | ComplianceEnhanced |
| 10 | ConfigManagement |
| 1 | MitreAttackVectors |
| 6 | NetworkGraph |
| 5 | Policies |
| 2 | Risk |
| 2 | SystemConfig |
| 1 | SystemHealth |
| 2 | Violations |
| 6 | VulnMgmt |
| 6 | Vulnerabilities |

### Solution 

Use typescript-eslint playground to explore logical expression:

https://typescript-eslint.io/play/#ts=5.9.3&showAST=es&fileType=.tsx

1. Fix errors in non-deprected files that are not in src/Containers folder.
2. Add configuration object for lint rule with `ignores` array for table above.
    * Fix half of non-deprected subfolders in 2 contributions of about 20 files each.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
    See presence of errors before changes and absence of errors after.