### PR TITLE
ROX-32112: Replace enum in fetchingReduxRoutines

### DIFF
--- a/ui/apps/platform/src/utils/fetchingReduxRoutines.ts
+++ b/ui/apps/platform/src/utils/fetchingReduxRoutines.ts
@@ -1,12 +1,12 @@
-export enum FetchingActionState {
-    REQUEST = 'REQUEST',
-    SUCCESS = 'SUCCESS',
-    FAILURE = 'FAILURE',
-}
+export const FetchingActionState = {
+    REQUEST: 'REQUEST',
+    SUCCESS: 'SUCCESS',
+    FAILURE: 'FAILURE',
+} as const;
 
-export type FetchingActionTypesMap = {
-    [prop in FetchingActionState]: string;
-};
+type FetchingActionStateKey = keyof typeof FetchingActionState;
+
+export type FetchingActionTypesMap = Record<FetchingActionStateKey, string>;
 
 /**
  * Creates a map of action types with values that use the given prefix.
@@ -16,15 +16,15 @@ export type FetchingActionTypesMap = {
  */
 export function createFetchingActionTypes<T extends string>(prefix: T): FetchingActionTypesMap {
     return {
-        REQUEST: `${prefix}_${FetchingActionState.REQUEST}`,
-        SUCCESS: `${prefix}_${FetchingActionState.SUCCESS}`,
-        FAILURE: `${prefix}_${FetchingActionState.FAILURE}`,
+        REQUEST: `${prefix}_REQUEST`,
+        SUCCESS: `${prefix}_SUCCESS`,
+        FAILURE: `${prefix}_FAILURE`,
     };
 }
 
 export type ActionTypeInfo = {
     prefix: string;
-    fetchingState: FetchingActionState;
+    fetchingState: FetchingActionStateKey;
 };
 
 /**


### PR DESCRIPTION
## Description

### Opportunity

https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly

> Node.js supports running TypeScript files directly as of v23.6; however, only TypeScript-specific syntax that does not have runtime semantics are supported under this mode. In other words, it must be possible to easily erase any TypeScript-specific syntax from a file, leaving behind a valid JavaScript file.

Although we do not run UI in Node.js it seems possible that vite build might benefit from `erasableSyntaxOnly` property in tsconfig.json file.

### Analysis

Find in Files `enum`
* 1 result in fetchingReduxRoutines.ts file
* 3 results in 3 files in NetworkGraph folder

### Solution

To apply saying about fast nickel versus slow dime:
* replace 1 `enum` first (pardon pun) that is ~self inflicted~ under our control
* as a starting point for 3 `enum` second in Network Graph which might or might not be coupled with assumptions by, or at least patterns from, topology graph package

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.