### PR TITLE
chore: Remove IBM NPGuard colleagues from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,11 +41,6 @@ sensor/**/*                       @stackrox/sensor-ecosystem
 tests/performance/**/*            @stackrox/sensor-ecosystem
 tests/roxctl/**/*                 @stackrox/sensor-ecosystem
 
-# Listing all users as "Outside collaborators cannot be added to a team"
-bats-tests/local/roxctl-netpol-*               @zivnevo @adisos @shireenf-ibm
-roxctl/netpol/**/*                             @zivnevo @adisos @shireenf-ibm
-tests/roxctl/bats-tests/test-data/np-guard/    @zivnevo @adisos @shireenf-ibm
-
 qa-tests-backend/**/*       @janisz
 
 /ui/**/* @stackrox/ui


### PR DESCRIPTION
## Description

See https://redhat-internal.slack.com/archives/CELUQKESC/p1764761175783269?thread_ts=1727709869.708299&cid=CELUQKESC

`CODEOWNERS` checks started showing errors after the colleagues were removed from the org. This should clean up the errors.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

Only relying on GitHub's verification and on PR reviews.
