### PR TITLE
ROX-32110: Fix no-logical-or-preceding-array-or-object errors part 1

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -873,19 +873,11 @@ module.exports = [
     {
         files: ['src/*/**/*.{js,jsx,ts,tsx}'],
         ignores: [
-            'src/Components/CompoundSearchFilter/utils/utils.tsx', // prevent merge conflict
             'src/Components/GroupedTabs.jsx', // deprecated
             'src/Components/ReactSelect/ReactSelect.jsx', // deprecated
             'src/Components/URLSearchInputWithAutocomplete.jsx', // deprecated
-            'src/Containers/AccessControl/**',
-            'src/Containers/Audit/**',
             'src/Containers/Compliance/**', // deprecated
-            'src/Containers/ComplianceEnhanced/**',
             'src/Containers/ConfigManagement/**',
-            'src/Containers/MitreAttackVectors/**',
-            'src/Containers/NetworkGraph/**',
-            'src/Containers/Policies/**',
-            'src/Containers/Risk/**',
             'src/Containers/SystemConfig/**',
             'src/Containers/SystemHealth/**',
             'src/Containers/Violations/**',

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -82,7 +82,7 @@ function getNewAuthProviderTitle(type, availableProviderTypes) {
 
 function getRuleAttributes(type, availableProviderTypes) {
     return (
-        (availableProviderTypes.find(({ value }) => value === type)?.ruleAttributes as string[]) ||
+        (availableProviderTypes.find(({ value }) => value === type)?.ruleAttributes as string[]) ??
         []
     );
 }

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -160,7 +160,7 @@ function ListeningEndpointsPage() {
     }
 
     const selectedValues = searchValueAsArray(searchFilter[entity]);
-    const autocompleteOptions = autoCompleteData?.searchAutocomplete || [];
+    const autocompleteOptions = autoCompleteData?.searchAutocomplete ?? [];
 
     // Show create option if user has typed something that doesn't exist
     const shouldShowCreateOption =

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx
@@ -164,12 +164,11 @@ function ScanConfigOptions(): ReactElement {
                                                             : 'parameters.daysOfMonth'
                                                     }
                                                     value={
-                                                        formik.values.parameters.intervalType ===
+                                                        (formik.values.parameters.intervalType ===
                                                         'WEEKLY'
-                                                            ? formik.values.parameters.daysOfWeek ||
-                                                              []
+                                                            ? formik.values.parameters.daysOfWeek
                                                             : formik.values.parameters
-                                                                  .daysOfMonth || []
+                                                                  .daysOfMonth) ?? []
                                                     }
                                                     handleSelect={onScheduledDaysChange}
                                                     intervalType={

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
@@ -93,7 +93,7 @@ function CustomWizardFooter({
     }
 
     function handleNext() {
-        const hasNoErrors = Object.keys(formik.errors?.[stepId] || {}).length === 0;
+        const hasNoErrors = Object.keys(formik.errors?.[stepId] ?? {}).length === 0;
 
         if (!hasNoErrors) {
             setAllFieldsTouched(stepId);
@@ -198,19 +198,19 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
     }
 
     function canJumpToSelectClusters() {
-        return Object.keys(formik.errors?.parameters || {}).length === 0;
+        return Object.keys(formik.errors?.parameters ?? {}).length === 0;
     }
 
     function canJumpToSelectProfiles() {
-        return canJumpToSelectClusters() && Object.keys(formik.errors?.clusters || {}).length === 0;
+        return canJumpToSelectClusters() && Object.keys(formik.errors?.clusters ?? {}).length === 0;
     }
 
     function canJumpToConfigureReport() {
-        return canJumpToSelectProfiles() && Object.keys(formik.errors?.profiles || {}).length === 0;
+        return canJumpToSelectProfiles() && Object.keys(formik.errors?.profiles ?? {}).length === 0;
     }
 
     function canJumpToReviewConfig() {
-        return canJumpToConfigureReport() && Object.keys(formik.errors?.report || {}).length === 0;
+        return canJumpToConfigureReport() && Object.keys(formik.errors?.report ?? {}).length === 0;
     }
 
     function allClustersAreUnhealthy(): boolean {
@@ -259,7 +259,7 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
                     >
                         <ClusterSelection
                             alertRef={alertRef}
-                            clusters={clusters || []}
+                            clusters={clusters ?? []}
                             isFetchingClusters={isFetchingClusters}
                         />
                     </WizardStep>
@@ -280,7 +280,7 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
                     >
                         <ProfileSelection
                             alertRef={alertRef}
-                            profiles={profiles || []}
+                            profiles={profiles ?? []}
                             isFetchingProfiles={isFetchingProfiles}
                         />
                     </WizardStep>
@@ -314,7 +314,7 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
                         }}
                     >
                         <ReviewConfig
-                            clusters={clusters || []}
+                            clusters={clusters ?? []}
                             errorMessage={createScanConfigError}
                         />
                     </WizardStep>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/hooks/useWatchLastSnapshotForComplianceReports.ts
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/hooks/useWatchLastSnapshotForComplianceReports.ts
@@ -83,7 +83,7 @@ function useWatchLastSnapshotForComplianceReports(
     useInterval(refetch, 10000);
 
     const result: FetchLastComplianceReportSnapshotReturn = {
-        complianceReportSnapshots: data || {},
+        complianceReportSnapshots: data ?? {},
         isLoading,
         error: error ? getAxiosErrorMessage(error) : null,
         fetchSnapshots: refetch,

--- a/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsViewContainer.tsx
+++ b/ui/apps/platform/src/Containers/MitreAttackVectors/MitreAttackVectorsViewContainer.tsx
@@ -93,7 +93,7 @@ function MitreAttackVectorsViewContainer({
     );
 
     const policyMitreAttackVectors =
-        policyFormAttackVectors || data?.policy?.mitreAttackVectors || [];
+        policyFormAttackVectors ?? data?.policy?.mitreAttackVectors ?? [];
 
     return (
         <MitreAttackVectorsView

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphContainer.tsx
@@ -242,7 +242,7 @@ function fadeOutUnconnectedNodes(
             selectedNode.children.reduce((acc, currId) => {
                 const connectedNodeIds = getConnectedNodeIds(edges, currId);
                 return [...acc, ...connectedNodeIds];
-            }, [] as string[]) || [];
+            }, [] as string[]) ?? [];
         // we include the child nodes so that they aren't faded out
         emphasizedNodeIds = [...emphasizedNodeIds, ...selectedNode.children];
     } else {

--- a/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/TopologyComponent.tsx
@@ -277,8 +277,8 @@ const TopologyComponent = ({
                         <NamespaceSideBar
                             labelledById={labelledById}
                             namespaceId={selectedNode.id}
-                            nodes={model?.nodes || []}
-                            edges={model?.edges || []}
+                            nodes={model?.nodes ?? []}
+                            edges={model?.edges ?? []}
                             onNodeSelect={onNodeSelect}
                         />
                     )}
@@ -286,8 +286,8 @@ const TopologyComponent = ({
                         <DeploymentSideBar
                             labelledById={labelledById}
                             deploymentId={selectedNode.id}
-                            nodes={model?.nodes || []}
-                            edges={model?.edges || []}
+                            nodes={model?.nodes ?? []}
+                            edges={model?.edges ?? []}
                             edgeState={edgeState}
                             onNodeSelect={onNodeSelect}
                         />
@@ -296,8 +296,8 @@ const TopologyComponent = ({
                         <ExternalGroupSideBar
                             labelledById={labelledById}
                             id={selectedNode.id}
-                            nodes={model?.nodes || []}
-                            edges={model?.edges || []}
+                            nodes={model?.nodes ?? []}
+                            edges={model?.edges ?? []}
                             onNodeSelect={onNodeSelect}
                         />
                     )}
@@ -305,8 +305,8 @@ const TopologyComponent = ({
                         <GenericEntitiesSideBar
                             labelledById={labelledById}
                             id={selectedNode.id}
-                            nodes={model?.nodes || []}
-                            edges={model?.edges || []}
+                            nodes={model?.nodes ?? []}
+                            edges={model?.edges ?? []}
                             onNodeSelect={onNodeSelect}
                             EntityHeaderIcon={<CidrBlockIcon />}
                             sidebarTitle={selectedNode.data.externalSource.cidr ?? ''}
@@ -317,8 +317,8 @@ const TopologyComponent = ({
                         <ExternalEntitiesSideBar
                             labelledById={labelledById}
                             id={selectedNode.id}
-                            nodes={model?.nodes || []}
-                            edges={model?.edges || []}
+                            nodes={model?.nodes ?? []}
+                            edges={model?.edges ?? []}
                             scopeHierarchy={scopeHierarchy}
                             selectedExternalIP={selectedExternalIP}
                             onNodeSelect={onNodeSelect}
@@ -329,8 +329,8 @@ const TopologyComponent = ({
                         <GenericEntitiesSideBar
                             labelledById={labelledById}
                             id={selectedNode.id}
-                            nodes={model?.nodes || []}
-                            edges={model?.edges || []}
+                            nodes={model?.nodes ?? []}
+                            edges={model?.edges ?? []}
                             onNodeSelect={onNodeSelect}
                             EntityHeaderIcon={<InternalEntitiesIcon />}
                             sidebarTitle={'Unknown entity connections within your clusters'}

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormRow.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/CIDRFormRow.tsx
@@ -11,8 +11,8 @@ import {
 import { TrashIcon } from '@patternfly/react-icons';
 
 const CIDRFormRow = ({ idx, onRemoveRow, errors, touched }) => {
-    const { name: nameError, cidr: cidrError } = errors?.entity || {};
-    const { name: nameTouched, cidr: cidrTouched } = touched?.entity || {};
+    const { name: nameError, cidr: cidrError } = errors?.entity ?? {};
+    const { name: nameTouched, cidr: cidrTouched } = touched?.entity ?? {};
     const showNameError = nameError && nameTouched;
     const showCidrError = cidrError && cidrTouched;
     const hasError = showNameError || showCidrError;

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -66,7 +66,7 @@ function NamespaceSideBar({
         };
     });
     const namespacePolicyIds = deploymentNodes.reduce((acc, curr) => {
-        const policyIds: string[] = curr?.data?.policyIds || [];
+        const policyIds: string[] = curr?.data?.policyIds ?? [];
         return [...acc, ...policyIds];
     }, [] as string[]);
     const uniqueNamespacePolicyIds = uniq(namespacePolicyIds);

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/modelUtils.tsx
@@ -245,12 +245,12 @@ export function transformActiveData(
 
     nodes.forEach(({ entity, outEdges }) => {
         const { type, id } = entity;
-        const { networkPolicyState } = policyNodeMap[id]?.data || {};
+        const { networkPolicyState } = policyNodeMap[id]?.data ?? {};
         const isExternallyConnected = Object.keys(outEdges).some((nodeIdx) => {
             const { entity: targetEntity } = nodes[nodeIdx];
             return targetEntity.type === 'EXTERNAL_SOURCE' || targetEntity.type === 'INTERNET';
         });
-        const policyIds = policyNodeMap[id]?.data.policyIds || [];
+        const policyIds = policyNodeMap[id]?.data.policyIds ?? [];
 
         // to group deployments into namespaces
         if (type === 'DEPLOYMENT') {
@@ -340,7 +340,7 @@ export function transformActiveData(
     if (externalNodeIds.length > 0) {
         // adding external outEdges to nodes to indicate externally connected state
         Object.values(externalNodes).forEach((externalNode) => {
-            const { outEdges } = externalNode.data || {};
+            const { outEdges } = externalNode.data ?? {};
             Object.keys(outEdges).forEach((nodeIdx) => {
                 const { id: targetNodeId } = nodes[nodeIdx];
                 if (deploymentNodes[targetNodeId]) {

--- a/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
+++ b/ui/apps/platform/src/Containers/NetworkGraph/utils/simulatorUtils.ts
@@ -5,7 +5,7 @@ import type { NetworkScopeHierarchy } from '../types/networkScopeHierarchy';
 export function getDisplayYAMLFromNetworkPolicyModification(
     modification: NetworkPolicyModification | null
 ): string {
-    const { applyYaml, toDelete } = modification || {};
+    const { applyYaml, toDelete } = modification ?? {};
     const shouldDelete = toDelete && toDelete.length > 0;
     const showApplyYaml = applyYaml && applyYaml.length >= 2;
 

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
@@ -31,7 +31,7 @@ function PolicyCategoriesSelectField(): ReactElement {
     // Used to temporarily prevent dropdown from closing after selecting an item to maintain multi-select UX
     const [preventClose, setPreventClose] = useState(false);
 
-    const selectedCategories: string[] = (field.value as string[]) || [];
+    const selectedCategories: string[] = (field.value as string[]) ?? [];
 
     const onToggle = () => {
         setIsOpen(!isOpen);

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -103,7 +103,7 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
             }
         });
         values.excludedDeploymentScopes.forEach(({ scope }, idx) => {
-            const { ...rest } = omit(scope || {}, 'label');
+            const { ...rest } = omit(scope ?? {}, 'label');
 
             setFieldValue(
                 `excludedDeploymentScopes[${idx}]`,

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaFieldInput.tsx
@@ -148,7 +148,7 @@ function PolicyCriteriaFieldInput({
                     data-testid="policy-criteria-value-multiselect"
                 >
                     <CheckboxSelect
-                        selections={(value.value as string[]) || []}
+                        selections={(value.value as string[]) ?? []}
                         onChange={handleChangeSelectMultiple}
                         isDisabled={readOnly}
                         placeholderText={descriptor.placeholder || 'Select one or more options'}
@@ -162,7 +162,7 @@ function PolicyCriteriaFieldInput({
                             >
                                 {option.label}
                             </SelectOption>
-                        )) || []}
+                        )) ?? []}
                     </CheckboxSelect>
                 </FormGroup>
             );

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeCard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeCard.tsx
@@ -39,7 +39,7 @@ function PolicyScopeCard({
 }: PolicyScopeCardProps): ReactElement {
     const [field, , helper] = useField(name);
     const { value } = field;
-    const { scope } = value || {};
+    const { scope } = value ?? {};
     const { setValue } = helper;
 
     const clusterOptions: TypeaheadSelectOption[] = clusters.map((cluster) => ({
@@ -66,20 +66,20 @@ function PolicyScopeCard({
 
     function handleChangeLabelKey(key) {
         if (type === 'exclusion') {
-            const { label } = scope || {};
+            const { label } = scope ?? {};
             setValue({ ...value, scope: { ...scope, label: { ...label, key } } });
         } else {
-            const { label } = value || {};
+            const { label } = value ?? {};
             setValue({ ...value, label: { ...label, key } });
         }
     }
 
     function handleChangeLabelValue(val) {
         if (type === 'exclusion') {
-            const { label } = scope || {};
+            const { label } = scope ?? {};
             setValue({ ...value, scope: { ...scope, label: { ...label, value: val } } });
         } else {
-            const { label } = value || {};
+            const { label } = value ?? {};
             setValue({ ...value, label: { ...label, value: val } });
         }
     }

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step5/NotifiersForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step5/NotifiersForm.tsx
@@ -24,7 +24,7 @@ function NotifiersForm() {
     });
 
     function onSelectNotifier(e, isSelected, rowIndex) {
-        const selectedNotifiers = field.value || [];
+        const selectedNotifiers = field.value ?? [];
         if (isSelected) {
             helpers.setValue([...selectedNotifiers, notifiers[rowIndex].id]);
         } else {

--- a/ui/apps/platform/src/Containers/Risk/RiskPage.jsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskPage.jsx
@@ -43,7 +43,7 @@ const RiskPage = () => {
         },
     };
     const { data: searchData } = useQuery(SEARCH_OPTIONS_QUERY, searchQueryOptions);
-    const searchOptions = (searchData && searchData.searchOptions) || [];
+    const searchOptions = searchData?.searchOptions ?? [];
     const filteredSearchOptions = searchOptions.filter(
         (option) => option !== 'Orchestrator Component'
     );

--- a/ui/apps/platform/src/Containers/Risk/RiskTablePanel.jsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskTablePanel.jsx
@@ -59,7 +59,7 @@ function RiskTablePanel({
      * Compute outside hook to avoid double requests if no page search options
      * before and after response to request for searchOptions.
      */
-    const restSearch = convertToRestSearch(pageSearch || {});
+    const restSearch = convertToRestSearch(pageSearch ?? {});
     const restSort = convertSortToRestFormat(sortOption);
 
     useDeepCompareEffect(() => {


### PR DESCRIPTION
## Description

Follow up for lint rule added in #18021

Toward Q4 AI goal: help AI to help us.

Also for human finger memory of earlier idiom.

Prevent inconsistencies while writing code in editor instead via change requests in contributions.

* Include `Policies` and `Risk` in part 1, before work resumes.
    46 errors in 19 files.

* Exclude `SystemConfig` from part 1, just in case, because there is a contribution in progress.

### Learning

1. Factored out 2 `|| []` in consequent and alternate as 1 `?? []` for result of ternary expression, because **operator precedence** would require parentheses for both nullish coalescing **within** ternary expression:

    ```ts
    (formik.values.parameters.intervalType ===
        'WEEKLY'
            ? formik.values.parameters.daysOfWeek
            : formik.values.parameters
                    .daysOfMonth) ?? []
    ```

2. Concise alternative to optional chaining in assignment that had not occurred to me:

    ```ts
    const { label } = scope ?? {}
    ```

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
    See presence of errors before changes and absence of errors after.