### PR TITLE
ROX-32145: Fix Image assertions in Permission Sets ui-e2e-tests

### DIFF
--- a/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
+++ b/ui/apps/platform/cypress/integration/accessControl/accessControlPermissionSets.test.js
@@ -165,7 +165,7 @@ describe('Access Control Permission sets', () => {
         });
     });
 
-    it('direct link to default Continuous Integration has limited read and write accesss', () => {
+    it('direct link to default Continuous Integration has limited read and write access', () => {
         const targetID = 'ffffffff-ffff-fff4-f5ff-fffffffffffd';
         visitAccessControlEntity(entitiesKey, targetID);
 
@@ -219,18 +219,20 @@ describe('Access Control Permission sets', () => {
         );
         cy.get(getAccessLevelSelectForResource('Detection')).should('contain', 'Read Access');
 
-        // Zero-based index for Image instead of ImageComponent, ImageIntegration, WatchedImage.
-        cy.get(getReadAccessIconForResource('Image', 0)).should(
+        // Zero-based index for Image because:
+        // preceded by BaseImage, BaseImageLayer
+        // followed by ImageComponent, ImageIntegration, WatchedImage.
+        cy.get(getReadAccessIconForResource('Image', 2)).should(
             'have.attr',
             'aria-label',
             'permitted'
         );
-        cy.get(getWriteAccessIconForResource('Image', 0)).should(
+        cy.get(getWriteAccessIconForResource('Image', 2)).should(
             'have.attr',
             'aria-label',
             'permitted'
         );
-        cy.get(getAccessLevelSelectForResource('Image', 0)).should(
+        cy.get(getAccessLevelSelectForResource('Image', 2)).should(
             'contain',
             'Read and Write Access'
         );


### PR DESCRIPTION
## Description

https://github.com/stackrox/stackrox/pull/17936/files#diff-dfc3df8184c6bf60222c2e904647bed823ea09d4e2c9befe5d388741d7d49352R55-R56

Added BaseImage and BaseImageLayer resources, but test assumed Image is the first occurrence of the word on the page

### Residue

Rewrite selector with `contains` method and RegExp for full match instead of `contains` pseudo-selector for partial match.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] fixed e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI