### PR TITLE
ROX-32144: retry registry test

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/ImageIntegrationService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ImageIntegrationService.groovy
@@ -5,6 +5,7 @@ import groovy.util.logging.Slf4j
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
 
+import io.stackrox.annotations.Retry
 import io.stackrox.proto.api.v1.ImageIntegrationServiceGrpc
 import io.stackrox.proto.api.v1.ImageIntegrationServiceOuterClass
 import io.stackrox.proto.storage.ImageIntegrationOuterClass
@@ -23,14 +24,9 @@ class ImageIntegrationService extends BaseService {
         return ImageIntegrationServiceGrpc.newBlockingStub(getChannel())
     }
 
+    @Retry
     static testImageIntegration(ImageIntegrationOuterClass.ImageIntegration integration) {
-        try {
-            getImageIntegrationClient().testImageIntegration(integration)
-            return true
-        } catch (Exception e) {
-            log.warn("could not get integration", e)
-            return false
-        }
+        return getImageIntegrationClient().testImageIntegration(integration)
     }
 
     static createImageIntegration(ImageIntegrationOuterClass.ImageIntegration integration,

--- a/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsTest.groovy
@@ -723,7 +723,7 @@ class IntegrationsTest extends BaseSpecification {
 
         when:
         "the integration is tested"
-        def outcome = ImageIntegrationService.getImageIntegrationClient().testImageIntegration(
+        def outcome = ImageIntegrationService.testImageIntegration(
                 imageIntegration.getCustomBuilder(customArgs).build()
         )
 
@@ -766,7 +766,7 @@ class IntegrationsTest extends BaseSpecification {
 
         when:
         "the integration is tested"
-        ImageIntegrationService.getImageIntegrationClient().testImageIntegration(
+        ImageIntegrationService.testImageIntegration(
                 imageIntegration.getCustomBuilder(getCustomArgs()).build()
         )
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Add the retry annotation to `testImageIntegration` and use in `IntegrationsTest`. Note that the previous `testImageIntegration` seemed to be unused.

This should address network flakes when trying to reach the registry:

```
18:07:06 | ERROR | IntegrationsTest          | Helpers                   | An exception occurred in test
io.grpc.StatusRuntimeException: INVALID_ARGUMENT: registry integration: Get "https://stackroxci.azurecr.io/v2/": net/http: TLS handshake timeout: invalid arguments: invalid arguments
 at io.stackrox.proto.api.v1.ImageIntegrationServiceGrpc$ImageIntegrationServiceBlockingStub.testImageIntegration(ImageIntegrationServiceGrpc.java:588) [3 skipped]
 at IntegrationsTest.$spock_feature_1_11(IntegrationsTest.groovy:727) [1 skipped]
 at util.OnFailureInterceptor.intercept(OnFailure.groovy:72) [9 skipped]
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151) [7 skipped]
 at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
 at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
 at util.OnFailureInterceptor.intercept(OnFailure.groovy:72) [6 skipped]
 at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61) [4 skipped]
```

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI