### PR TITLE
ROX-32166: Replace enum in NetworkGraph and enable erasableSyntaxOnly

### DIFF
--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleFakeGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleFakeGroup.tsx
@@ -16,10 +16,8 @@ import DefaultFakeGroup from './DefaultFakeGroup';
 
 const ICON_PADDING = 20;
 
-export enum DataTypes {
-    Default,
-    Alternate,
-}
+type DataTypes = 0 | 1;
+const DataTypesAlternate: DataTypes = 1;
 
 type StyleGroupProps = {
     element: Node;
@@ -42,7 +40,7 @@ const StyleFakeGroup: FunctionComponent<PropsWithChildren<StyleGroupProps>> = ({
 
     const getTypeIcon = (dataType?: DataTypes): ComponentClass<SVGIconProps> => {
         switch (dataType) {
-            case DataTypes.Alternate:
+            case DataTypesAlternate:
                 return AlternateIcon;
             default:
                 return DefaultIcon;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/StyleGroup.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/StyleGroup.tsx
@@ -15,10 +15,8 @@ import type { CustomGroupNodeData } from '../types/topology.type';
 
 const ICON_PADDING = 20;
 
-export enum DataTypes {
-    Default,
-    Alternate,
-}
+type DataTypes = 0 | 1;
+const DataTypesAlternate: DataTypes = 1;
 
 type StyleGroupProps = {
     element: Node;
@@ -42,7 +40,7 @@ const StyleGroup: FunctionComponent<PropsWithChildren<StyleGroupProps>> = ({
 
     const getTypeIcon = (dataType?: DataTypes): ComponentClass<SVGIconProps> => {
         switch (dataType) {
-            case DataTypes.Alternate:
+            case DataTypesAlternate:
                 return AlternateIcon;
             default:
                 return DefaultIcon;

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/defaultComponentFactory.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/defaultComponentFactory.tsx
@@ -2,14 +2,8 @@ import type { ComponentType, PropsWithChildren } from 'react';
 import { DefaultEdge, DefaultGroup, DefaultNode, GraphComponent } from '@patternfly/react-topology';
 import type { ComponentFactory, GraphElement } from '@patternfly/react-topology';
 
-enum CustomModelKind {
-    node = 'node',
-    graph = 'graph',
-    edge = 'edge',
-    fakeGroup = 'fakeGroup',
-}
+type CustomModelKind = 'node' | 'graph' | 'edge' | 'fakeGroup';
 
-// @ts-expect-error TODO: raise type error issue with patternfly/react-topology team
 const defaultComponentFactory: ComponentFactory = (
     kind: CustomModelKind,
     type: string
@@ -25,13 +19,13 @@ const defaultComponentFactory: ComponentFactory = (
             return DefaultGroup;
         default:
             switch (kind) {
-                case CustomModelKind.graph:
+                case 'graph':
                     return GraphComponent;
-                case CustomModelKind.node:
+                case 'node':
                     return DefaultNode;
-                case CustomModelKind.edge:
+                case 'edge':
                     return DefaultEdge;
-                case CustomModelKind.fakeGroup:
+                case 'fakeGroup':
                     return DefaultNode;
                 default:
                     return undefined;

--- a/ui/apps/platform/tsconfig.json
+++ b/ui/apps/platform/tsconfig.json
@@ -9,6 +9,7 @@
     "baseUrl": "src",
     "allowJs": true,
     "checkJs": false,
+    "erasableSyntaxOnly": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## Description

Follow up one replacement in #18024

### Opportunity

https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly

> Node.js supports running TypeScript files directly as of v23.6; however, only TypeScript-specific syntax that does not have runtime semantics are supported under this mode. In other words, it must be possible to easily erase any TypeScript-specific syntax from a file, leaving behind a valid JavaScript file.

Although we do not run UI in Node.js it seems possible that vite build might benefit from `erasableSyntaxOnly` property in tsconfig.json file.

### Analysis

Presumably imitation of code in react-topology package.

1. `enum CustomModelKind` used only within defaultComponentFactory.tsx file.

2. `enum DataTypes` export from files but used only within:
    * StyleFakeGroup.tsx
    * StyleGroup.tsx

### Solution

In the morning light of a new day, the change is easier than it had seemed yesterday.

1. Replace `enum` with string enumeration for type.
2. Replace property access with string literal for `case` in `switch` statement.

### Residue

1. During testing, I noticed screen tips for button bar have Title Case.

2. Find candidates for `ensureExhaustive` type utility.

    defaultComponentFactory.tsx file has an example:

    ```ts
    default:
        return undefined;
    ```

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated compile configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
    See presence of errors before changes and absence of errors after.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/network-graph

    * Click deployment, external entities, internal entities to open side panel

    * Click **Legend**

    * Click **Fit to Screen** or **Zoom Out** to see everthing disappear except for deployment icons at some sizes. With staging demo and local UI also with its UI.

        Both before and after changes, so independent rendering problem.

        Expected
        <img width="1440" height="898" alt="Network_Graph_Fit_to_Screen_staging_expected" src="https://github.com/user-attachments/assets/0d04f0d0-63ce-4bf9-89a0-d6f14b812c4d" />

        Unexpected
        <img width="1440" height="897" alt="Network_Graph_Fit_to_Screen_staging_unexpected" src="https://github.com/user-attachments/assets/514ec2f1-b3e2-4f70-a6e4-1f1fd45de031" />
