### PR TITLE
ROX-32169: Use ensureExhaustive type utility wherever possible

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/StatusCountIcon.tsx
@@ -3,6 +3,7 @@ import { BarsIcon, CheckCircleIcon, SecurityIcon, WrenchIcon } from '@patternfly
 import pluralize from 'pluralize';
 
 import IconText from 'Components/PatternFly/IconText/IconText';
+import { ensureExhaustive } from 'utils/type.utils';
 
 import {
     FAILING_VAR_COLOR,
@@ -37,6 +38,7 @@ function getStatusIcon(status: Status, count: number, disabled: boolean) {
                 color = OTHER_VAR_COLOR;
                 break;
             default:
+                ensureExhaustive(status);
                 break;
         }
     }
@@ -58,7 +60,7 @@ function getStatusIcon(status: Status, count: number, disabled: boolean) {
                 />
             );
         default:
-            return null;
+            return ensureExhaustive(status);
     }
 }
 

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/defaultComponentFactory.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/defaultComponentFactory.tsx
@@ -2,6 +2,8 @@ import type { ComponentType, PropsWithChildren } from 'react';
 import { DefaultEdge, DefaultGroup, DefaultNode, GraphComponent } from '@patternfly/react-topology';
 import type { ComponentFactory, GraphElement } from '@patternfly/react-topology';
 
+import { ensureExhaustive } from 'utils/type.utils';
+
 type CustomModelKind = 'node' | 'graph' | 'edge' | 'fakeGroup';
 
 const defaultComponentFactory: ComponentFactory = (
@@ -28,7 +30,7 @@ const defaultComponentFactory: ComponentFactory = (
                 case 'fakeGroup':
                     return DefaultNode;
                 default:
-                    return undefined;
+                    return ensureExhaustive(kind);
             }
     }
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/VulnerabilitiesOverview.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/VulnerabilitiesOverview.tsx
@@ -12,6 +12,7 @@ import type { VulnerabilityState } from 'types/cve.proto';
 import type { SearchFilter } from 'types/search';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
 import { getHasSearchApplied } from 'utils/searchUtils';
+import { ensureExhaustive } from 'utils/type.utils';
 
 import type { DefaultFilters, QuerySearchFilter, WorkloadEntityTab } from '../../types';
 import CVEsTableContainer from './CVEsTableContainer';
@@ -24,9 +25,7 @@ import type { defaultColumns as cveDefaultColumns } from '../Tables/WorkloadCVEO
 import type { defaultColumns as imageDefaultColumns } from '../Tables/ImageOverviewTable';
 import type { defaultColumns as deploymentDefaultColumns } from '../Tables/DeploymentOverviewTable';
 
-function getSearchFilterEntityByTab(
-    entityTab: WorkloadEntityTab
-): 'CVE' | 'Image' | 'Deployment' | undefined {
+function getSearchFilterEntityByTab(entityTab: WorkloadEntityTab): 'CVE' | 'Image' | 'Deployment' {
     switch (entityTab) {
         case 'CVE':
             return 'CVE';
@@ -35,7 +34,7 @@ function getSearchFilterEntityByTab(
         case 'Deployment':
             return 'Deployment';
         default:
-            return undefined;
+            return ensureExhaustive(entityTab);
     }
 }
 


### PR DESCRIPTION
## Description

Reduce chance that we follow leftover examples of less-type-safe pattern.

### Problem

Absence of `ensureExhaustive` type utility prevents TypeScript from reporting error in `switch` statement for lack of `case` when we add values to type of discriminant.

Follow up residue found in #18061

```ts
switch (whatever) {
    // cases
    default:
        return undefined;
}
```

### Analysis

Find in Files `ensureExhaustive(` has 28 results in 20 files.

Find candidates via temporary lint rules:
* `'no-switch-default-break'` has 8 candidates in 7 files
* `'no-switch-default-return-null'` has 2 candidates in 2 files
* `'no-switch-default-return-undefined'` has 3 candidates in 3 files

### Solution

Apparently my eyes fell on a needle in the haystack.

Because uses of`ensureExhaustive` outnumber candidates, just fix the problems instead of adding lint rules, to prevent false positives:
1. stylesComponentFactory.tsx file: switch discriminant has `enum` type `ModelKind` from react-topology package.
2. TooltipFieldValue.tsx file: switch discriminant is optional, therefore `default` case is reachable for `undefined` value.
3. ClusterPage.tsx file: default case is for multiple values of switch discriminant and string enumeration type changes rarely.
4. WorkloadCvesPage.tsx, aggregateUtils.ts, and other files: switch discriminant is untrusted string from page address, therefore `default` case is reachable for unexpected values.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.