### PR TITLE
ROX-32087: Increase curl timeout when pulling vulns

### DIFF
--- a/.github/workflows/scripts/scanner-offline-bundle-generate.sh
+++ b/.github/workflows/scripts/scanner-offline-bundle-generate.sh
@@ -36,9 +36,10 @@ declare -A files_to_download=(
     ["$tmpdir/mapping.zip"]="https://definitions.stackrox.io/v4/redhat-repository-mappings/mapping.zip"
 )
 
-# Download the files
+# Download the files. The vulnerability bundle is ~317MB and may take longer than
+# 60 seconds on slower network conditions between GitHub runners and GCS.
 for f in "${!files_to_download[@]}"; do
-    curl --fail --silent --show-error --max-time 60 --retry 3 --create-dirs -o "$f" "${files_to_download[$f]}"
+    curl --fail --silent --show-error --max-time 300 --retry 3 --create-dirs -o "$f" "${files_to_download[$f]}"
 done
 unzip -j "$tmpdir/mapping.zip" "repomapping/*" -d "$tmpdir" && rm "$tmpdir/mapping.zip"
 


### PR DESCRIPTION
## Description

The `scanner-offline-bundle-generate.sh` script downloads a ~317MB file with a 60-second curl timeout. On slower network conditions (~4.7 MB/s vs typical ~12.7 MB/s), the download reaches 86-88% complete before timing out. All retries fail because the slow network persists.

This increasing timeout  to 300s.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
