### PR TITLE
feat(idea): api_counter metric

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -114,6 +114,7 @@ import (
 	logimbueHandler "github.com/stackrox/rox/central/logimbue/handler"
 	metadataService "github.com/stackrox/rox/central/metadata/service"
 	customMetrics "github.com/stackrox/rox/central/metrics/custom"
+	"github.com/stackrox/rox/central/metrics/custom/api_requests"
 	"github.com/stackrox/rox/central/metrics/telemetry"
 	mitreService "github.com/stackrox/rox/central/mitre/service"
 	namespaceService "github.com/stackrox/rox/central/namespace/service"
@@ -655,6 +656,7 @@ func startGRPCServer() {
 
 	c := phonehomeClient.Singleton()
 	c.SetInterceptor(ri)
+	api_requests.SetInterceptor(ri)
 
 	server := pkgGRPC.NewAPI(config)
 	server.Register(servicesToRegister()...)

--- a/central/metrics/custom/api_requests/interceptor.go
+++ b/central/metrics/custom/api_requests/interceptor.go
@@ -1,0 +1,68 @@
+package api_requests
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackrox/rox/pkg/clientprofile"
+	"github.com/stackrox/rox/pkg/eventual"
+	"github.com/stackrox/rox/pkg/grpc/common/requestinterceptor"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+var log = logging.LoggerForModule()
+
+const handlerName = "api_requests"
+
+var interceptor = eventual.New(
+	eventual.WithType[*requestinterceptor.RequestInterceptor]().
+		WithTimeout(5 * time.Minute).
+		WithContextCallback(func(ctx context.Context) {
+			log.Error("Request interceptor not provided within timeout; API request metrics will not be collected")
+		}),
+)
+
+// SetInterceptor provides the RequestInterceptor.
+func SetInterceptor(ri *requestinterceptor.RequestInterceptor) {
+	interceptor.Set(ri)
+}
+
+// RegisterHandler adds or removes the RecordRequest handler on the
+// RequestInterceptor based on whether any profile tracker is currently enabled.
+// Blocks until the interceptor is provided via SetInterceptor, or the timeout
+// expires. This is safe because runner.initialize runs in its own goroutine.
+// Call this after reconfiguring trackers.
+func RegisterHandler() {
+	ri := interceptor.Get()
+	if ri == nil {
+		return
+	}
+	for _, t := range profileTrackers {
+		if t.IsEnabled() {
+			ri.Add(handlerName, recordRequest)
+			log.Info("API request metrics handler registered")
+			return
+		}
+	}
+	ri.Remove(handlerName)
+	log.Info("API request metrics handler removed (no enabled profile trackers)")
+}
+
+// recordRequest matches the request against all profiles and increments every
+// matching tracker. If no profile matches, the unknown tracker is incremented.
+func recordRequest(rp *requestinterceptor.RequestParams) {
+	matched := false
+	for name, ruleset := range builtinProfiles {
+		if ruleset.CountMatched(rp, func(*clientprofile.Rule, clientprofile.Headers) {}) > 0 {
+			if t, ok := profileTrackers[name]; ok {
+				t.IncrementCounter(rp)
+				matched = true
+			}
+		}
+	}
+	if !matched {
+		if t, ok := profileTrackers[unknownProfile]; ok {
+			t.IncrementCounter(rp)
+		}
+	}
+}

--- a/central/metrics/custom/api_requests/labels.go
+++ b/central/metrics/custom/api_requests/labels.go
@@ -1,0 +1,64 @@
+package api_requests
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/stackrox/rox/central/metrics/custom/tracker"
+	"github.com/stackrox/rox/pkg/clientprofile"
+	"github.com/stackrox/rox/pkg/glob"
+	"github.com/stackrox/rox/pkg/grpc/common/requestinterceptor"
+)
+
+type finding = requestinterceptor.RequestParams
+
+// commonLabels are shared across all profile trackers.
+var commonLabels = tracker.LazyLabelGetters[*finding]{
+	"UserID": func(f *finding) string {
+		if f.UserID != nil {
+			return f.UserID.UID()
+		}
+		return ""
+	},
+	"Path":   func(f *finding) string { return f.Path },
+	"Method": func(f *finding) string { return f.Method },
+	"Status": func(f *finding) string { return strconv.Itoa(f.Code) },
+}
+
+// headerPatternToLabelPattern converts an HTTP header name pattern to a
+// Prometheus label pattern by removing hyphens.
+// E.g. "Rh-Servicenow-*" -> "RhServicenow*".
+func labelMatchesHeaderPattern(label tracker.Label, header glob.Pattern) bool {
+	p := glob.Pattern(strings.ReplaceAll(string(header), "-", ""))
+	return p.Match(string(label))
+}
+
+// makeHeaderGetter creates a getter that returns filtered values of the request
+// header matching the given label. headerPattern and valuePattern are the
+// profile header entry that matched the label at configuration time.
+func makeHeaderGetter(headerPattern, valuePattern glob.Pattern, label tracker.Label) tracker.Getter[*finding] {
+	return func(f *finding) string {
+		for h, values := range clientprofile.Headers(f.Headers).GetMatching(headerPattern, valuePattern) {
+			if compareIgnoringDash(h, label) {
+				return strings.Join(values, "; ")
+			}
+		}
+		return ""
+	}
+}
+
+// compareIgnoringDash reports whether header equals label when dashes in
+// header are skipped.
+func compareIgnoringDash(header string, label tracker.Label) bool {
+	li := 0
+	for i := range len(header) {
+		if header[i] == '-' {
+			continue
+		}
+		if li >= len(label) || header[i] != label[li] {
+			return false
+		}
+		li++
+	}
+	return li == len(label)
+}

--- a/central/metrics/custom/api_requests/labels_test.go
+++ b/central/metrics/custom/api_requests/labels_test.go
@@ -1,0 +1,124 @@
+package api_requests
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stackrox/rox/central/metrics/custom/tracker"
+	"github.com/stackrox/rox/pkg/glob"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_compareIgnoringDash(t *testing.T) {
+	cases := map[string]struct {
+		header string
+		label  tracker.Label
+		equal  bool
+	}{
+		"exact match":           {"Accept", "Accept", true},
+		"single dash":           {"User-Agent", "UserAgent", true},
+		"multiple dashes":       {"Rh-Servicenow-Instance", "RhServicenowInstance", true},
+		"leading dash":          {"-Leading", "Leading", true},
+		"trailing dash":         {"Trailing-", "Trailing", true},
+		"consecutive dashes":    {"A--B", "AB", true},
+		"all dashes":            {"---", "", true},
+		"both empty":            {"", "", true},
+		"header shorter":        {"Rh", "RhServicenow", false},
+		"label shorter":         {"Rh-Servicenow-Instance", "Rh", false},
+		"different characters":  {"X-Custom", "YCustom", false},
+		"dash only vs nonempty": {"-", "A", false},
+		"nonempty vs empty":     {"A", "", false},
+		"empty vs nonempty":     {"", "A", false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.equal, compareIgnoringDash(tc.header, tc.label))
+		})
+	}
+}
+
+func Test_makeHeaderGetter(t *testing.T) {
+	cases := map[string]struct {
+		headerPattern glob.Pattern
+		valuePattern  glob.Pattern
+		label         tracker.Label
+		finding       *finding
+		expected      string
+	}{
+		"exact header, any value": {
+			headerPattern: "Rh-Servicenow-Instance",
+			valuePattern:  "",
+			label:         "RhServicenowInstance",
+			finding:       &finding{Headers: http.Header{"Rh-Servicenow-Instance": {"prod.service-now.com"}}},
+			expected:      "prod.service-now.com",
+		},
+		"exact header, value filter matches": {
+			headerPattern: "User-Agent",
+			valuePattern:  "*ServiceNow*",
+			label:         "UserAgent",
+			finding:       &finding{Headers: http.Header{"User-Agent": {"Mozilla ServiceNow Bot"}}},
+			expected:      "Mozilla ServiceNow Bot",
+		},
+		"exact header, value filter rejects": {
+			headerPattern: "User-Agent",
+			valuePattern:  "*ServiceNow*",
+			label:         "UserAgent",
+			finding:       &finding{Headers: http.Header{"User-Agent": {"curl/8.0"}}},
+			expected:      "",
+		},
+		"exact header, multiple values partially filtered": {
+			headerPattern: "User-Agent",
+			valuePattern:  "roxctl/*",
+			label:         "UserAgent",
+			finding:       &finding{Headers: http.Header{"User-Agent": {"roxctl/4.5", "gateway"}}},
+			expected:      "roxctl/4.5",
+		},
+		"glob header pattern": {
+			headerPattern: "Rh-*",
+			valuePattern:  "*",
+			label:         "RhServicenowInstance",
+			finding:       &finding{Headers: http.Header{"Rh-Servicenow-Instance": {"prod"}}},
+			expected:      "prod",
+		},
+		"glob header, label selects correct header": {
+			headerPattern: "Rh-*",
+			valuePattern:  "*",
+			label:         "RhRoxctlCommand",
+			finding: &finding{Headers: http.Header{
+				"Rh-Servicenow-Instance": {"prod"},
+				"Rh-Roxctl-Command":      {"check image"},
+			}},
+			expected: "check image",
+		},
+		"header absent": {
+			headerPattern: "Rh-Servicenow-Instance",
+			valuePattern:  "",
+			label:         "RhServicenowInstance",
+			finding:       &finding{Headers: http.Header{"User-Agent": {"curl/8.0"}}},
+			expected:      "",
+		},
+		"no headers at all": {
+			headerPattern: "Rh-Servicenow-Instance",
+			valuePattern:  "",
+			label:         "RhServicenowInstance",
+			finding:       &finding{Headers: http.Header{}},
+			expected:      "",
+		},
+		"multiple values joined": {
+			headerPattern: "X-Custom",
+			valuePattern:  "",
+			label:         "XCustom",
+			finding:       &finding{Headers: http.Header{"X-Custom": {"a", "b", "c"}}},
+			expected:      "a; b; c",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, tc.headerPattern.Compile())
+			require.NoError(t, tc.valuePattern.Compile())
+			getter := makeHeaderGetter(tc.headerPattern, tc.valuePattern, tc.label)
+			assert.Equal(t, tc.expected, getter(tc.finding))
+		})
+	}
+}

--- a/central/metrics/custom/api_requests/profiles.go
+++ b/central/metrics/custom/api_requests/profiles.go
@@ -1,0 +1,41 @@
+package api_requests
+
+import (
+	"github.com/stackrox/rox/pkg/clientprofile"
+)
+
+const unknownProfile = "unknown"
+
+// builtinProfiles maps profile name to its matching criteria. A request can
+// match multiple profiles.
+var builtinProfiles = map[string]clientprofile.RuleSet{
+	"servicenow": {{
+		Headers: clientprofile.GlobMap{
+			"User-Agent": "*ServiceNow*",
+			"Rh-*":       clientprofile.NoHeaderOrAnyValue,
+		},
+	}},
+	"splunk_ta": {
+		clientprofile.PathPattern("/api/splunk/ta/*"),
+	},
+	"roxctl": {{
+		Headers: clientprofile.GlobMap{
+			"User-Agent": "roxctl/*",
+			"Rh-*":       clientprofile.NoHeaderOrAnyValue,
+		},
+	}},
+	"central": {
+		clientprofile.HeaderPattern("User-Agent", "Rox Central/*"),
+	},
+	"sensor": {
+		clientprofile.HeaderPattern("User-Agent", "Rox Sensor/*"),
+	},
+}
+
+func init() {
+	for _, criteria := range builtinProfiles {
+		if err := criteria.Compile(); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/central/metrics/custom/api_requests/tracker.go
+++ b/central/metrics/custom/api_requests/tracker.go
@@ -1,0 +1,130 @@
+package api_requests
+
+import (
+	"iter"
+	"maps"
+	"strings"
+
+	"github.com/stackrox/rox/central/metrics/custom/tracker"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/clientprofile"
+	"github.com/stackrox/rox/pkg/glob"
+)
+
+// profileTracker wraps a TrackerBase with api_requests-specific concerns:
+// metrics filtering by profile name and dynamic label resolution via glob
+// patterns.
+type profileTracker struct {
+	*tracker.TrackerBase[*finding]
+	profileName string
+	profile     clientprofile.RuleSet
+}
+
+func (pt *profileTracker) NewConfiguration(cfg *storage.PrometheusMetrics_Group) (*tracker.Configuration, error) {
+	return pt.TrackerBase.NewConfiguration(filterMetrics(cfg, pt.profileName))
+}
+
+func (pt *profileTracker) Reconfigure(cfg *tracker.Configuration) {
+	pt.TrackerBase.ResetGetters(resolveGetters(cfg.GetMetrics(), pt.profile))
+	pt.TrackerBase.Reconfigure(cfg)
+}
+
+// matchingProfileHeader returns the profile header entry whose label-form
+// matches the given metric label, or empty patterns if none matches.
+func matchingProfileHeader(label tracker.Label, profile clientprofile.RuleSet) (glob.Pattern, glob.Pattern) {
+	for _, rule := range profile {
+		for header, value := range rule.Headers {
+			if labelMatchesHeaderPattern(label, header) {
+				return header, value
+			}
+		}
+	}
+	return "", ""
+}
+
+// resolveGetters builds a getters map from common labels and resolved header
+// patterns for the given metric descriptors.
+func resolveGetters(metrics tracker.MetricDescriptors, profile clientprofile.RuleSet) tracker.LazyLabelGetters[*finding] {
+	getters := maps.Clone(commonLabels)
+	for _, labels := range metrics {
+		for _, label := range labels {
+			if _, isCommon := commonLabels[label]; isCommon {
+				continue
+			}
+			if hp, vp := matchingProfileHeader(label, profile); hp != "" {
+				getters[label] = makeHeaderGetter(hp, vp, label)
+			}
+		}
+	}
+	return getters
+}
+
+// filterMetrics returns a copy of the group config containing only
+// descriptors whose key starts with the given prefix.
+func filterMetrics(cfg *storage.PrometheusMetrics_Group, prefix string) *storage.PrometheusMetrics_Group {
+	if prefix == "" {
+		return cfg
+	}
+	filtered := &storage.PrometheusMetrics_Group{
+		Enabled:                cfg.GetEnabled(),
+		GatheringPeriodMinutes: cfg.GetGatheringPeriodMinutes(),
+		Descriptors:            make(map[string]*storage.PrometheusMetrics_Group_Labels),
+	}
+	for key, labels := range cfg.GetDescriptors() {
+		if strings.HasPrefix(key, prefix) {
+			filtered.Descriptors[key] = labels
+		}
+	}
+	return filtered
+}
+
+// profileTrackers maps profile name to its tracker.
+var profileTrackers = func() map[string]*profileTracker {
+	allProfiles := make(map[string]clientprofile.RuleSet, len(builtinProfiles)+1)
+	maps.Copy(allProfiles, builtinProfiles)
+	allProfiles[unknownProfile] = clientprofile.RuleSet{
+		clientprofile.HeaderPattern("User-Agent", clientprofile.NoHeaderOrAnyValue),
+	}
+
+	trackers := make(map[string]*profileTracker, len(allProfiles))
+	for name, profile := range allProfiles {
+		pt := &profileTracker{
+			TrackerBase: tracker.MakeGlobalTrackerBase(
+				"api_request",
+				"API requests from "+name,
+				maps.Clone(commonLabels),
+				nil,
+			),
+			profileName: name,
+			profile:     profile,
+		}
+		pt.KnownLabels = func(descriptors map[string]*storage.PrometheusMetrics_Group_Labels) []tracker.Label {
+			labels := commonLabels.Labels()
+			for _, desc := range descriptors {
+				for _, label := range desc.GetLabels() {
+					if hp, _ := matchingProfileHeader(tracker.Label(label), pt.profile); hp != "" {
+						labels = append(labels, tracker.Label(label))
+					}
+				}
+			}
+			return labels
+		}
+		trackers[name] = pt
+	}
+	return trackers
+}()
+
+// Trackers returns all profile trackers for registration with the runner.
+func Trackers() iter.Seq[*tracker.Registration] {
+	return func(yield func(*tracker.Registration) bool) {
+		for _, pt := range profileTrackers {
+			reg := &tracker.Registration{
+				Tracker:        pt,
+				GetGroupConfig: (*storage.PrometheusMetrics).GetApiRequests,
+			}
+			if !yield(reg) {
+				break
+			}
+		}
+	}
+}

--- a/central/metrics/custom/api_requests/tracker_test.go
+++ b/central/metrics/custom/api_requests/tracker_test.go
@@ -1,0 +1,272 @@
+package api_requests
+
+import (
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/stackrox/rox/central/metrics"
+	"github.com/stackrox/rox/central/metrics/custom/tracker"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/clientprofile"
+	"github.com/stackrox/rox/pkg/eventual"
+	"github.com/stackrox/rox/pkg/glob"
+	"github.com/stackrox/rox/pkg/grpc/common/requestinterceptor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchingProfileHeader(t *testing.T) {
+	cases := map[string]struct {
+		label          tracker.Label
+		profile        clientprofile.RuleSet
+		expectedHeader glob.Pattern
+		expectedValue  glob.Pattern
+	}{
+		"concrete header match": {
+			label: "XCustomHeader",
+			profile: clientprofile.RuleSet{
+				clientprofile.HeaderPattern("X-Custom-Header", "*"),
+			},
+			expectedHeader: "X-Custom-Header",
+			expectedValue:  "*",
+		},
+		"glob header match": {
+			label: "RhServicenowInstance",
+			profile: clientprofile.RuleSet{{
+				Headers: clientprofile.GlobMap{"Rh-*": "*"},
+			}},
+			expectedHeader: "Rh-*",
+			expectedValue:  "*",
+		},
+		"no match": {
+			label: "CompletelyUnknown",
+			profile: clientprofile.RuleSet{{
+				Headers: clientprofile.GlobMap{"Rh-*": "*"},
+			}},
+		},
+		"no headers in profile": {
+			label: "Anything",
+			profile: clientprofile.RuleSet{
+				clientprofile.PathPattern("/api/*"),
+			},
+		},
+		"matches across rules": {
+			label: "XExact",
+			profile: clientprofile.RuleSet{
+				{Headers: clientprofile.GlobMap{"Rh-*": "*"}},
+				{Headers: clientprofile.GlobMap{"X-Exact": "*"}},
+			},
+			expectedHeader: "X-Exact",
+			expectedValue:  "*",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			header, value := matchingProfileHeader(tc.label, tc.profile)
+			assert.Equal(t, tc.expectedHeader, header)
+			assert.Equal(t, tc.expectedValue, value)
+		})
+	}
+}
+
+func TestProfileTrackersAcceptExpectedLabels(t *testing.T) {
+	// Verify that each profile tracker accepts a configuration with all
+	// its derived labels. Descriptor keys must start with the profile name
+	// (the descriptor prefix).
+	expected := map[string][]string{
+		"servicenow": {"Method", "Path", "RhServicenowInstance", "Status", "UserAgent", "UserID"},
+		"splunk_ta":  {"Method", "Path", "Status", "UserID"},
+		"roxctl":     {"Method", "Path", "RhRoxctlCommand", "RhRoxctlCommandIndex", "Status", "UserAgent", "UserID"},
+		"sensor":     {"Method", "Path", "Status", "UserAgent", "UserID"},
+		"unknown":    {"Method", "Path", "Status", "UserAgent", "UserID"},
+	}
+
+	trackers := map[string]tracker.Tracker{}
+	for tr := range Trackers() {
+		trackers[tr.Tracker.(*profileTracker).profileName] = tr.Tracker
+	}
+	for name, labels := range expected {
+		t.Run(name, func(t *testing.T) {
+			tr, ok := trackers[name]
+			require.True(t, ok, "tracker %q not found", name)
+
+			cfg, err := tr.NewConfiguration(&storage.PrometheusMetrics_Group{
+				Enabled: true,
+				Descriptors: map[string]*storage.PrometheusMetrics_Group_Labels{
+					name + "_total": {Labels: labels},
+				},
+			})
+			require.NoError(t, err)
+			assert.NotNil(t, cfg)
+		})
+	}
+}
+
+func TestLabelPatternAcceptsDynamicLabels(t *testing.T) {
+	profile := clientprofile.RuleSet{{
+		Headers: clientprofile.GlobMap{
+			"Rh-*":       "*",
+			"User-Agent": "*",
+		},
+	}}
+
+	pt := &profileTracker{
+		TrackerBase: tracker.MakeGlobalTrackerBase("test", "test", maps.Clone(commonLabels), nil),
+		profileName: "profile",
+		profile:     profile,
+	}
+	pt.KnownLabels = func(descriptors map[string]*storage.PrometheusMetrics_Group_Labels) []tracker.Label {
+		labels := commonLabels.Labels()
+		for _, desc := range descriptors {
+			for _, label := range desc.GetLabels() {
+				if hp, _ := matchingProfileHeader(tracker.Label(label), pt.profile); hp != "" {
+					labels = append(labels, tracker.Label(label))
+				}
+			}
+		}
+		return labels
+	}
+
+	// Both concrete (UserAgent) and dynamic (RhServicenowInstance, RhCustomThing)
+	// labels should be accepted.
+	cfg, err := pt.NewConfiguration(&storage.PrometheusMetrics_Group{
+		Enabled: true,
+		Descriptors: map[string]*storage.PrometheusMetrics_Group_Labels{
+			"profile_total": {Labels: []string{"UserID", "UserAgent", "RhServicenowInstance", "RhCustomThing"}},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+
+	// A label that doesn't match any pattern should still be rejected.
+	_, err = pt.NewConfiguration(&storage.PrometheusMetrics_Group{
+		Enabled: true,
+		Descriptors: map[string]*storage.PrometheusMetrics_Group_Labels{
+			"profile_total": {Labels: []string{"CompletelyUnknown"}},
+		},
+	})
+	assert.Error(t, err)
+}
+
+func TestFilterDescriptors(t *testing.T) {
+	cfg := &storage.PrometheusMetrics_Group{
+		Enabled: true,
+		Descriptors: map[string]*storage.PrometheusMetrics_Group_Labels{
+			"alpha_total": {Labels: []string{"UserID"}},
+			"alpha_by_ns": {Labels: []string{"UserID"}},
+			"beta_total":  {Labels: []string{"UserID"}},
+			"unrelated":   {Labels: []string{"UserID"}},
+		},
+	}
+
+	filtered := filterMetrics(cfg, "alpha")
+	assert.Len(t, filtered.GetDescriptors(), 2)
+	assert.Contains(t, filtered.GetDescriptors(), "alpha_total")
+	assert.Contains(t, filtered.GetDescriptors(), "alpha_by_ns")
+
+	// No prefix returns original.
+	assert.Same(t, cfg, filterMetrics(cfg, ""))
+
+	// No matches returns empty descriptors.
+	filtered = filterMetrics(cfg, "gamma")
+	assert.Empty(t, filtered.GetDescriptors())
+}
+
+func TestAllProfilesEmitMetrics(t *testing.T) {
+	// Simulate the runner flow: collect Trackers(), validate and apply a
+	// shared configuration, fire requests matching different profiles, and
+	// verify that each profile produces its own counter metric.
+	metrics.DeleteGlobalRegistry()
+	interceptor = eventual.New[*requestinterceptor.RequestInterceptor]()
+	SetInterceptor(requestinterceptor.NewRequestInterceptor())
+
+	sharedGroup := &storage.PrometheusMetrics_Group{
+		Enabled: true,
+		Descriptors: map[string]*storage.PrometheusMetrics_Group_Labels{
+			"roxctl":     {Labels: []string{"Status"}},
+			"servicenow": {Labels: []string{"Status"}},
+			"unknown":    {Labels: []string{"Status"}},
+		},
+	}
+
+	// Collect trackers the same way runner.go does.
+	collected := slices.Collect(Trackers())
+	require.Len(t, collected, len(profileTrackers))
+
+	// Validate and apply configuration for each collected tracker.
+	for _, reg := range collected {
+		cfg, err := reg.Tracker.NewConfiguration(reg.GetGroupConfig(
+			&storage.PrometheusMetrics{ApiRequests: sharedGroup}))
+		require.NoError(t, err)
+		reg.Tracker.Reconfigure(cfg)
+	}
+	t.Cleanup(func() {
+		for _, reg := range collected {
+			reg.Tracker.Reconfigure(nil)
+		}
+		interceptor = eventual.New[*requestinterceptor.RequestInterceptor]()
+	})
+
+	RegisterHandler()
+
+	// Simulate requests matching each profile.
+	requests := map[string]*requestinterceptor.RequestParams{
+		"roxctl": {
+			Method:  "GET",
+			Path:    "/v1/metadata",
+			Code:    200,
+			Headers: http.Header{"User-Agent": {"roxctl/4.0"}},
+		},
+		"servicenow": {
+			Method:  "GET",
+			Path:    "/v1/alerts",
+			Code:    200,
+			Headers: http.Header{"User-Agent": {"Mozilla ServiceNow Bot"}},
+		},
+		"unknown": {
+			Method:  "GET",
+			Path:    "/v1/clusters",
+			Code:    200,
+			Headers: http.Header{"User-Agent": {"curl/8.0"}},
+		},
+	}
+	for _, rp := range requests {
+		recordRequest(rp)
+	}
+
+	globalRegistry, err := metrics.GetGlobalRegistry()
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	globalRegistry.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := rec.Body.String()
+
+	for profile := range requests {
+		assert.Contains(t, body, "rox_central_api_request_"+profile+"{",
+			"expected metric for profile %q", profile)
+	}
+}
+
+func TestSharedConfigAcceptedByAllTrackers(t *testing.T) {
+	// A single config group with descriptors for multiple profiles should be
+	// accepted by every tracker — each picks up only its own descriptors.
+	sharedConfig := &storage.PrometheusMetrics_Group{
+		Enabled: true,
+		Descriptors: map[string]*storage.PrometheusMetrics_Group_Labels{
+			"servicenow": {Labels: []string{"UserID", "Status", "RhServicenowInstance"}},
+			"roxctl":     {Labels: []string{"UserID", "Status", "UserAgent", "RhRoxctlCommand"}},
+			"unknown":    {Labels: []string{"UserID", "Status", "UserAgent"}},
+		},
+	}
+
+	for tr := range Trackers() {
+		t.Run(tr.Tracker.(*profileTracker).profileName, func(t *testing.T) {
+			cfg, err := tr.NewConfiguration(sharedConfig)
+			require.NoError(t, err)
+			assert.NotNil(t, cfg)
+		})
+	}
+}

--- a/central/metrics/custom/runner.go
+++ b/central/metrics/custom/runner.go
@@ -3,6 +3,7 @@ package custom
 import (
 	"context"
 	"net/http"
+	"slices"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -12,6 +13,7 @@ import (
 	expiryS "github.com/stackrox/rox/central/credentialexpiry/service"
 	deploymentDS "github.com/stackrox/rox/central/deployment/datastore"
 	"github.com/stackrox/rox/central/metrics"
+	"github.com/stackrox/rox/central/metrics/custom/api_requests"
 	"github.com/stackrox/rox/central/metrics/custom/clusters"
 	"github.com/stackrox/rox/central/metrics/custom/expiry"
 	"github.com/stackrox/rox/central/metrics/custom/image_vulnerabilities"
@@ -30,7 +32,7 @@ import (
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 )
 
-type trackerRunner []tracker.Registration
+type trackerRunner []*tracker.Registration
 
 // RunnerConfiguration is a composition of tracker configurations.
 // Returned by ValidateConfiguration() and accepted by Reconfigure(). This split
@@ -65,7 +67,7 @@ func withHardcodedConfiguration(period uint32, descriptors map[string][]string) 
 }
 
 func makeRunner(ds *runnerDatastores) trackerRunner {
-	return trackerRunner{{
+	runner := trackerRunner{{
 		image_vulnerabilities.New(ds.deployments),
 		(*storage.PrometheusMetrics).GetImageVulnerabilities,
 	}, {
@@ -92,8 +94,9 @@ func makeRunner(ds *runnerDatastores) trackerRunner {
 			// rox_central_cert_exp_hours
 			"hours": expiry.LazyLabels.GetLabels(),
 		}),
-	},
-	}
+	}}
+	runner = append(runner, slices.Collect(api_requests.Trackers())...)
+	return runner
 }
 
 func (tr trackerRunner) initialize(cds configDS.DataStore) {
@@ -142,6 +145,7 @@ func (tr trackerRunner) Reconfigure(cfg RunnerConfiguration) {
 			tracker.Reconfigure(cfg[i])
 		}
 	}
+	api_requests.RegisterHandler()
 }
 
 func (tr trackerRunner) ServeHTTP(w http.ResponseWriter, req *http.Request) {

--- a/central/metrics/custom/runner_test.go
+++ b/central/metrics/custom/runner_test.go
@@ -11,16 +11,22 @@ import (
 	alertDS "github.com/stackrox/rox/central/alert/datastore/mocks"
 	configDS "github.com/stackrox/rox/central/config/datastore/mocks"
 	deploymentDS "github.com/stackrox/rox/central/deployment/datastore/mocks"
+	"github.com/stackrox/rox/central/metrics/custom/api_requests"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
 	"github.com/stackrox/rox/pkg/grpc/authn/basic"
+	"github.com/stackrox/rox/pkg/grpc/common/requestinterceptor"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
 
 func TestRunner_makeRunner(t *testing.T) {
+	// Provide the interceptor so that RegisterHandler (called from
+	// runner.Reconfigure) does not block.
+	api_requests.SetInterceptor(requestinterceptor.NewRequestInterceptor())
+
 	ctrl := gomock.NewController(t)
 	t.Run("nil configuration", func(t *testing.T) {
 		cds := configDS.NewMockDataStore(ctrl)


### PR DESCRIPTION
## Description

Adds real-time counter metrics for API requests, broken down by client profile.

Each incoming API request is matched against built-in client profiles (`roxctl`, `servicenow`, `splunk_ta`, `sensor`) based on User-Agent headers and request paths. Unmatched requests fall into the `unknown` profile. A request can match multiple profiles.

Profile trackers are configured via the existing `apiRequests` metrics configuration group. Descriptor keys are filtered by profile name prefix, so each profile only picks up its own metrics (e.g., a `roxctl_total` descriptor is handled by the `roxctl` profile tracker). Labels can reference both common fields (`UserID`, `Status`, `Method`, `Path`) and profile-specific HTTP headers resolved dynamically via glob patterns (e.g., `Rh-Servicenow-Instance` → `RhServicenowInstance`).

The request interceptor handler is registered/unregistered dynamically based on whether any profile tracker is enabled, so there is zero overhead when the feature is disabled.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

#### Example output from manual testing

The built-in profiles are hardcoded in https://github.com/stackrox/stackrox/blob/michael/api_counter_metric/central/metrics/custom/api_requests/profiles.go

Configuration:

```json
    "metrics": {
      "apiRequests": {
        "descriptors": {
          "roxctl": {
            "labels": [
              "UserID",
              "Status",
              "UserAgent",
              "RhRoxctlCommand"
            ],
          },
          "servicenow": {
            "labels": [
              "UserID",
              "Status",
              "RhServicenowInstance"
            ],
          },
          "servicenow_2": {
            "labels": [
              "UserID",
              "Status",
              "UserAgent"
            ],
          },
          "unknown": {
            "labels": [
              "UserID",
              "Status",
              "UserAgent"
            ],
          }
        },
        "enabled": true
      }
    }
```

```
# HELP rox_central_api_request_roxctl The total number of API requests from roxctl aggregated by RhRoxctlCommand, Status, UserAgent, UserID
# TYPE rox_central_api_request_roxctl counter
rox_central_api_request_roxctl{RhRoxctlCommand="central whoami",Status="0",UserAgent="roxctl/4.11.x-172-gb61ea14666-dirty (linux; amd64) grpc-go/1.79.1",UserID="admin"} 2
# HELP rox_central_api_request_servicenow The total number of API requests from servicenow aggregated by RhServicenowInstance, Status, UserID
# TYPE rox_central_api_request_servicenow counter
rox_central_api_request_servicenow{RhServicenowInstance="test-instance",Status="200",UserID="admin"} 3
# HELP rox_central_api_request_servicenow_2 The total number of API requests from servicenow aggregated by Status, UserAgent, UserID
# TYPE rox_central_api_request_servicenow_2 counter
rox_central_api_request_servicenow_2{Status="200",UserAgent="ServiceNow/test-1",UserID="admin"} 3
# HELP rox_central_api_request_unknown The total number of API requests from unknown aggregated by Status, UserAgent, UserID
# TYPE rox_central_api_request_unknown counter
rox_central_api_request_unknown{Status="200",UserAgent="curl/8.15.0",UserID="admin"} 1
rox_central_api_request_unknown{Status="200",UserAgent="kube-probe/1.35; Rox Central/4.11.x-570-g6c0ad01b24 (linux; amd64) grpc-go/1.80.0",UserID=""} 30
rox_central_api_request_unknown{Status="304",UserAgent="Go-http-client/1.1",UserID="mtls:Scanner@7816343570999649157"} 2
```

<!-- GHIT dependencies begin -->
Current dependencies on/for this PR:

* [master](../tree/master)
  * **PR #21131**
    * **PR #21132**
      * **PR #21133**
        * **PR #21134**
          * **PR #21360**
            * **PR #21361**
              * **PR #18080** 👈
<!-- GHIT dependencies end -->