### PR TITLE
chore: contrib guide: relax history restrictions

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -43,8 +43,9 @@
 
 - Between review cycles, you may create commits at will and freely rewrite,
   squash, or rebase your branch.
-- Requesting a PR review locks your commits. Once you request (or re-request) a
-  PR review, those commits become immutable -- only add new commits on top.
+- Requesting a PR review locks your commits. A review cycle ends when all
+  requested reviewers have responded. Once you request (or re-request) a PR
+  review, those commits become immutable -- only add new commits on top.
 - For locked commits, only use `git rebase` (or the `smart-rebase` script) for
   rebasing on top of latest `master` changes. **Do not use merge commits**
   because they complicate reviewing and confuse Jira linkage.


### PR DESCRIPTION
## Description

The contribution guide's rules for commit history management were too strict and did not account for the fact developers need flexibility to rewrite commit history to their development branches for various reasons (simplification, clarity, testing, change of approach, etc). This relax it, but keep reviewers history intact.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
