### PR TITLE
ROX-31859: Move Risk search out of workflowState

### DIFF
--- a/ui/apps/platform/src/services/DeploymentsService.ts
+++ b/ui/apps/platform/src/services/DeploymentsService.ts
@@ -131,27 +131,6 @@ export type ListDeploymentWithProcessInfo = {
     baselineStatuses: ContainerNameAndBaselineStatus[];
 };
 
-/**
- * Fetches count of registered deployments.
- */
-export function fetchDeploymentsCountLegacy(options: RestSearchOption[]): Promise<number> {
-    let searchOptions: RestSearchOption[] = options;
-    if (shouldHideOrchestratorComponents()) {
-        searchOptions = [...options, ...orchestratorComponentsOption];
-    }
-    const query = searchOptionsToQuery(searchOptions);
-    const queryObject =
-        searchOptions.length > 0
-            ? {
-                  query,
-              }
-            : {};
-    const params = queryString.stringify(queryObject, { arrayFormat: 'repeat' });
-    return axios
-        .get<{ count: number }>(`${deploymentsCountUrl}?${params}`)
-        .then((response) => response?.data?.count ?? 0);
-}
-
 export function fetchDeploymentsCount(searchFilter: SearchFilter): Promise<number> {
     const query = getRequestQueryStringForSearchFilter(searchFilter);
     const queryObject = query ? { query } : {};


### PR DESCRIPTION
## Description

Moves the Risk table search state out of `workflowState` and into the `useURLSearch` hook for consistency with the rest of the app. (And referential stability of the search state across renders!)

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Test filter:
<img width="1572" height="834" alt="image" src="https://github.com/user-attachments/assets/e2e78fdb-5312-42c0-b9e8-109bd113d275" />
<img width="1572" height="834" alt="image" src="https://github.com/user-attachments/assets/cd02236c-72a2-451e-a4ee-4e1e3ca66783" />

Test transition to policy workflow via "Create policy" and see that state is carried over. (The eagle-eyed reviewer will notice that the "next" button is disabled here. This is a bug that was introduced recently that will be fixed in a separate PR.)
<img width="1572" height="834" alt="image" src="https://github.com/user-attachments/assets/9b085bd6-fa4c-4e41-8ad5-b0b599d4fbd6" />

