### PR TITLE
fix(ui): Removes the req for sectionName in the policy editor

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/policyValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/policyValidationSchemas.ts
@@ -62,7 +62,7 @@ const validationSchemaStep3: yup.ObjectSchema<PolicyStep3> = yup.object().shape(
                 yup
                     .object()
                     .shape({
-                        sectionName: yup.string().trim().required(),
+                        sectionName: yup.string().trim().optional(),
                         policyGroups: yup
                             .array()
                             .of(

--- a/ui/apps/platform/src/Containers/Policies/policies.utils.ts
+++ b/ui/apps/platform/src/Containers/Policies/policies.utils.ts
@@ -543,7 +543,7 @@ function trimClientWizardPolicy(policyUntrimmed: ClientPolicy): ClientPolicy {
         for (let iSection = 0; iSection !== policy.policySections.length; iSection += 1) {
             const policySection = policy.policySections[iSection];
 
-            policySection.sectionName = policySection.sectionName.trim();
+            policySection.sectionName = policySection.sectionName?.trim();
 
             // TODO value: make sure about empty string versus undefined.
             /*

--- a/ui/apps/platform/src/types/policy.proto.ts
+++ b/ui/apps/platform/src/types/policy.proto.ts
@@ -111,12 +111,12 @@ export type EnforcementAction =
     | 'FAIL_DEPLOYMENT_UPDATE_ENFORCEMENT';
 
 export type PolicySection = {
-    sectionName: string;
+    sectionName?: string;
     policyGroups: PolicyGroup[];
 };
 
 export type ClientPolicySection = {
-    sectionName: string;
+    sectionName?: string;
     policyGroups: ClientPolicyGroup[];
 };
 


### PR DESCRIPTION
## Description

A subtle bug was introduced here https://github.com/stackrox/stackrox/pull/17642/files#diff-c142cfab383c92b02f097aa14466ded304f85fa82637446170538f5343b9efe5L65-R65 when validation of the `sectionName` field was added that made it required.

When creating a policy via the Risk page - this field is left empty. Rather than add a section name in this case, I removed the validation. This is consistent with prior runtime behavior, and the API does not technically require that this field has a value or is even unique.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Visit the policy editor and edit the name of a section to make it empty (or create a policy from the risk page). The "Next" button should **not** be disabled.
<img width="1572" height="882" alt="image" src="https://github.com/user-attachments/assets/f150491b-45b1-4645-874c-73c49e7ced8e" />
