### PR TITLE
ROX-31801: Add layer type filter for image components in VM

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageComponent.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageComponent.ts
@@ -29,4 +29,18 @@ export const Version: CompoundSearchFilterAttribute = {
     inputType: 'text',
 };
 
-export const imageComponentAttributes = [Name, Source, Version];
+export const LayerType: CompoundSearchFilterAttribute = {
+    displayName: 'Layer type',
+    filterChipLabel: 'Image component layer type',
+    searchTerm: 'Component Layer Type',
+    inputType: 'select',
+    featureFlagDependency: ['ROX_BASE_IMAGE_DETECTION'],
+    inputProps: {
+        options: [
+            { label: 'Application', value: 'APPLICATION' },
+            { label: 'Base image', value: 'BASE_IMAGE' },
+        ],
+    },
+};
+
+export const imageComponentAttributes = [Name, Source, Version, LayerType];


### PR DESCRIPTION
## Description

Add a new "Layer type" filter to the Vulnerability Management compound search filter for Image components. This filter allows users to distinguish between application-layer and base-image-layer components in image CVEs.

The filter:
- Displays options: `Application` and `Base image`
- Sends values: `APPLICATION` and `BASE_IMAGE` to backend
- Generates search queries: `Component Layer Type:APPLICATION` or `Component Layer Type:BASE_IMAGE`
- Is gated by the `ROX_BASE_IMAGE_DETECTION` feature flag

## User-facing documentation

- [x] Documentation PR is not needed (feature flag gated, backend integration required first)

## Testing and quality

- [x] the change is production ready: the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md) (`ROX_BASE_IMAGE_MANAGEMENT`)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests (UI filter attributes don't require unit tests; filter behavior tested through existing compound search filter infrastructure)
- [ ] added e2e tests (requires backend integration and feature flag to be enabled)
- [ ] added regression tests (not applicable)
- [ ] added compatibility tests (not applicable)
- [ ] modified existing tests (no existing tests modified)

### How I validated my change

- Manually enabled the feature flag in development to verify the filter displays correctly in the dropdown
- NOTE: Waiting for backend implementation of `inBaseImageLayer` field and `Component Layer Type` search query support to complete end-to-end testing

Without feature flag
<img width="1810" height="1521" alt="Screenshot 2025-12-05 at 12 51 15 PM" src="https://github.com/user-attachments/assets/84954742-dc1a-4176-9851-1cb83f8542ee" />

With feature flag

https://github.com/user-attachments/assets/896a2394-2567-4f34-96d6-d096a0e6d667

API request with proper query values

<img width="1552" height="981" alt="Screenshot 2025-12-05 at 12 43 23 PM" src="https://github.com/user-attachments/assets/7340d10f-41eb-481f-af05-72bed9c220f9" />


