### PR TITLE
ROX-31800: Add layer type support to image components table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -1,3 +1,4 @@
+import { Label } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { gql } from '@apollo/client';
 
@@ -25,6 +26,7 @@ export const imageComponentVulnerabilitiesFragment = gql`
         location
         source
         layerIndex
+        # TODO: Add inBaseImageLayer field once backend implements it
         imageVulnerabilities(query: $query) {
             severity
             fixedByVersion
@@ -52,8 +54,10 @@ function ImageComponentVulnerabilitiesTable({
 }: ImageComponentVulnerabilitiesTableProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isAdvisoryColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
+    const isLayerTypeColumnEnabled = isFeatureFlagEnabled('ROX_BASE_IMAGE_DETECTION');
 
-    const colSpanForDockerfileLayer = 5 + (isAdvisoryColumnEnabled ? 1 : 0);
+    const colSpanForDockerfileLayer =
+        5 + (isAdvisoryColumnEnabled ? 1 : 0) + (isLayerTypeColumnEnabled ? 1 : 0);
 
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
     const componentVulns = flattenImageComponentVulns(
@@ -76,12 +80,22 @@ function ImageComponentVulnerabilitiesTable({
                     <Th>CVE fixed in</Th>
                     {isAdvisoryColumnEnabled && <Th>Advisory</Th>}
                     <Th>Source</Th>
+                    {isLayerTypeColumnEnabled && <Th>Layer type</Th>}
                     <Th>Location</Th>
                 </Tr>
             </Thead>
             {sortedComponentVulns.map((componentVuln, index) => {
-                const { image, name, version, fixedByVersion, advisory, location, source, layer } =
-                    componentVuln;
+                const {
+                    image,
+                    name,
+                    version,
+                    fixedByVersion,
+                    advisory,
+                    location,
+                    source,
+                    layer,
+                    inBaseImageLayer = false,
+                } = componentVuln;
                 // No border on the last row
                 const style =
                     index !== componentVulns.length - 1
@@ -102,6 +116,13 @@ function ImageComponentVulnerabilitiesTable({
                                 </Td>
                             )}
                             <Td dataLabel="Source">{source}</Td>
+                            {isLayerTypeColumnEnabled && (
+                                <Td dataLabel="Layer type">
+                                    <Label color={inBaseImageLayer ? 'blue' : 'grey'} isCompact>
+                                        {inBaseImageLayer ? 'Base image' : 'Application'}
+                                    </Label>
+                                </Td>
+                            )}
                             <Td dataLabel="Location">
                                 <ComponentLocation location={location} source={source} />
                             </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -57,6 +57,7 @@ export type ComponentVulnerabilityBase = {
     location: string;
     source: SourceType;
     layerIndex: number | null;
+    inBaseImageLayer?: boolean;
     imageVulnerabilities: {
         severity: string;
         fixedByVersion: string;
@@ -105,6 +106,7 @@ export type TableDataRow = {
         value: string;
     } | null;
     pendingExceptionCount: number;
+    inBaseImageLayer?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Description

Added layer type support to the image components vulnerability table, displaying whether a component originates from the base image or application layers.

**Changes:**
- Added "Layer type" column to ImageComponentVulnerabilitiesTable (gated by `ROX_BASE_IMAGE_DETECTION` feature flag)
- Added `inBaseImageLayer` field to component vulnerability types
- Display layer type with color-coded labels: Blue for "Base image", Grey for "Application"
- TODO: Backend needs to implement `inBaseImageLayer` field in GraphQL schema

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Verified the new column appears when `ROX_BASE_IMAGE_DETECTION` feature flag is enabled
- Confirmed the column is hidden when the feature flag is disabled
- Checked that labels display with correct colors (blue for base image, grey for application)

Feature flag is off
<img width="1552" height="981" alt="Screenshot 2025-12-05 at 4 55 28 PM" src="https://github.com/user-attachments/assets/bdf328d6-4903-4323-979d-150055c07743" />

Feature flag is on and layer type is `Application` (Mocked for demo)
<img width="1552" height="981" alt="Screenshot 2025-12-05 at 4 55 48 PM" src="https://github.com/user-attachments/assets/0401c6dd-0d88-45b6-9ac1-3b52d1bd7623" />

Feature flag is on and layer type is `Base image` (Mocked for demo)
<img width="1552" height="981" alt="Screenshot 2025-12-05 at 4 56 03 PM" src="https://github.com/user-attachments/assets/76082f6f-ff34-4934-8537-b063dfff7664" />