### PR TITLE
ROX-31858: Migrate sort to url hook from workflow state

### DIFF
--- a/ui/apps/platform/src/Containers/Risk/RiskTable.tsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskTable.tsx
@@ -1,12 +1,14 @@
 import NoResultsMessage from 'Components/NoResultsMessage';
 import Table from 'Components/TableV2';
 
-import riskTableColumnDescriptors from './riskTableColumnDescriptors';
 import type { ListDeploymentWithProcessInfo } from 'services/DeploymentsService';
-import type { ApiSortOptionSingle } from 'types/search';
+import type { UseURLSortResult } from 'hooks/useURLSort';
+import type { SortOption } from 'types/table';
 
-function sortOptionFromTableState(state) {
-    let sortOption: ApiSortOptionSingle | null = null;
+import riskTableColumnDescriptors from './riskTableColumnDescriptors';
+
+function convertTableSortToURLSetterSort(state): SortOption | null {
+    let sortOption: SortOption | null = null;
     if (state.sorted.length && state.sorted[0].id) {
         const column = riskTableColumnDescriptors.find(
             (col) => col.accessor === state.sorted[0].id
@@ -15,7 +17,7 @@ function sortOptionFromTableState(state) {
             // TODO we should be able to assert that column.searchField is not undefined after migrating away
             // from the legacy TableV2 and descriptor pattern
             field: column?.searchField ?? '',
-            reversed: state.sorted[0].desc,
+            direction: state.sorted[0].desc ? 'desc' : 'asc',
         };
     }
     return sortOption;
@@ -24,12 +26,12 @@ function sortOptionFromTableState(state) {
 type RiskTableProps = {
     currentDeployments: ListDeploymentWithProcessInfo[];
     selectedDeploymentId: string | undefined;
-    setSortOption: (sortOption: ApiSortOptionSingle) => void;
+    setSortOption: UseURLSortResult['setSortOption'];
 };
 
 function RiskTable({ currentDeployments, selectedDeploymentId, setSortOption }: RiskTableProps) {
     function onFetchData(state) {
-        const newSortOption = sortOptionFromTableState(state);
+        const newSortOption = convertTableSortToURLSetterSort(state);
         if (!newSortOption) {
             return;
         }

--- a/ui/apps/platform/src/Containers/Risk/RiskTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskTablePanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import { Bullseye } from '@patternfly/react-core';
@@ -9,20 +9,21 @@ import TableHeader from 'Components/TableHeader';
 import { PanelBody, PanelHead, PanelHeadEnd, PanelNew } from 'Components/Panel';
 import TablePagination from 'Components/TablePagination';
 import { DEFAULT_PAGE_SIZE } from 'Components/Table';
-import { pagingParams, sortParams } from 'constants/searchParams';
+import { pagingParams } from 'constants/searchParams';
 import workflowStateContext from 'Containers/workflowStateContext';
 import useURLSearch from 'hooks/useURLSearch';
+import useURLSort from 'hooks/useURLSort';
 import {
     fetchDeploymentsCount,
     fetchDeploymentsWithProcessInfo,
 } from 'services/DeploymentsService';
 import type { ListDeploymentWithProcessInfo } from 'services/DeploymentsService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { convertSortToGraphQLFormat, convertSortToRestFormat } from 'utils/searchUtils';
 import { ORCHESTRATOR_COMPONENTS_KEY } from 'utils/orchestratorComponents';
 import RiskTable from './RiskTable';
 
-const DEFAULT_RISK_SORT = [{ id: 'Deployment Risk Priority', desc: false }] as const;
+const sortFields = ['Deployment', 'Created', 'Cluster', 'Namespace', 'Deployment Risk Priority'];
+const defaultSortOption = { field: 'Deployment Risk Priority', direction: 'asc' } as const;
 
 type RiskTablePanelProps = {
     selectedDeploymentId: string | undefined;
@@ -37,10 +38,10 @@ function RiskTablePanel({
 }: RiskTablePanelProps) {
     const navigate = useNavigate();
     const workflowState = useContext(workflowStateContext);
-    const sortOption = workflowState.sort[sortParams.page] || DEFAULT_RISK_SORT;
     const currentPage = workflowState.paging[pagingParams.page];
 
     const { searchFilter } = useURLSearch();
+    const { sortOption, setSortOption } = useURLSort({ sortFields, defaultSortOption });
 
     const [currentDeployments, setCurrentDeployments] = useState<ListDeploymentWithProcessInfo[]>(
         []
@@ -51,20 +52,6 @@ function RiskTablePanel({
     function setPage(newPage) {
         navigate(workflowState.setPage(newPage).toUrl());
     }
-    const setSortOption = useCallback(
-        (newSortOption) => {
-            const convertedSortOption = convertSortToGraphQLFormat(newSortOption);
-
-            const newUrl = workflowState.setSort(convertedSortOption).setPage(0).toUrl();
-
-            navigate(newUrl);
-        },
-        [navigate, workflowState]
-    );
-
-    const restSort = convertSortToRestFormat(
-        sortOption.length > 0 ? sortOption : DEFAULT_RISK_SORT
-    );
 
     const shouldHideOrchestratorComponents =
         localStorage.getItem(ORCHESTRATOR_COMPONENTS_KEY) !== 'true';
@@ -76,7 +63,7 @@ function RiskTablePanel({
         };
         const { request } = fetchDeploymentsWithProcessInfo(
             effectiveSearchFilter,
-            restSort,
+            sortOption,
             currentPage + 1, // Convert 0-based to 1-based page
             DEFAULT_PAGE_SIZE
         );
@@ -98,7 +85,7 @@ function RiskTablePanel({
 
         const hasSearchFilters = Object.keys(searchFilter).length > 0;
         setIsViewFiltered(hasSearchFilters);
-    }, [searchFilter, restSort, currentPage, shouldHideOrchestratorComponents]);
+    }, [searchFilter, sortOption, currentPage, shouldHideOrchestratorComponents]);
 
     return (
         <PanelNew testid="panel">


### PR DESCRIPTION
## Description

Migrates Risk page `sort` handling from workflowState to useURLSort() hook.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Default:
<img width="1572" height="882" alt="image" src="https://github.com/user-attachments/assets/ddd774ea-e68a-4f98-b81b-783dfeca75ba" />

<img width="1572" height="882" alt="image" src="https://github.com/user-attachments/assets/76cfeda9-28b3-4673-9317-9763ab29347d" />
<img width="1572" height="882" alt="image" src="https://github.com/user-attachments/assets/38eb7686-2351-4ef7-a493-aad30472ab06" />
<img width="1572" height="882" alt="image" src="https://github.com/user-attachments/assets/39451ff7-2408-4cfe-8d42-2a0e4ff224e0" />
<img width="1572" height="882" alt="image" src="https://github.com/user-attachments/assets/71fee710-150b-44bb-8f7c-9a7674d0b9bf" />

<img width="1572" height="882" alt="image" src="https://github.com/user-attachments/assets/53ae78f4-418e-4832-977e-b99578b4be1f" />

