### PR TITLE
ROX-32213: Enable consistent-type-imports for deprecated folders

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -749,6 +749,7 @@ module.exports = [
 
             '@typescript-eslint/array-type': 'error',
             '@typescript-eslint/consistent-type-exports': 'error',
+            '@typescript-eslint/consistent-type-imports': 'error',
 
             'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
         },
@@ -832,23 +833,6 @@ module.exports = [
             'limited/no-qualified-name-react': 'error',
             'react/jsx-uses-react': 'off',
             'react/react-in-jsx-scope': 'off',
-        },
-    },
-    {
-        files: ['src/**/*.{ts,tsx}'],
-        ignores: [
-            'src/Containers/Compliance/**', // deprecated
-            'src/Containers/VulnMgmt/**', // deprecated
-        ],
-
-        // languageOptions from previous configuration object
-
-        // Key of plugin is namespace of its rules.
-        plugins: {
-            '@typescript-eslint': pluginTypeScriptESLint,
-        },
-        rules: {
-            '@typescript-eslint/consistent-type-imports': 'error',
         },
     },
     {

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { useApolloClient } from '@apollo/client';
 import { Alert } from '@patternfly/react-core';
 
@@ -13,10 +14,8 @@ import { resourceTypes } from 'constants/entityTypes';
 import useCaseTypes from 'constants/useCaseTypes';
 import { useBooleanLocalStorage } from 'hooks/useLocalStorage';
 import usePermissions from 'hooks/usePermissions';
-import {
-    ComplianceStandardMetadata,
-    fetchComplianceStandardsSortedByName,
-} from 'services/ComplianceService';
+import { fetchComplianceStandardsSortedByName } from 'services/ComplianceService';
+import type { ComplianceStandardMetadata } from 'services/ComplianceService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import {

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardTile.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardTile.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
-import { DocumentNode, gql, useQuery } from '@apollo/client';
+import { gql, useQuery } from '@apollo/client';
+import type { DocumentNode } from '@apollo/client';
 
 import { complianceBasePath } from 'routePaths';
 

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceScanProgress.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceScanProgress.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Card, CardBody, CardProps, CardTitle, Progress } from '@patternfly/react-core';
+import { Card, CardBody, CardTitle, Progress } from '@patternfly/react-core';
+import type { CardProps } from '@patternfly/react-core';
 
-import { ComplianceRunStatusResponse } from './useComplianceRunStatuses';
+import type { ComplianceRunStatusResponse } from './useComplianceRunStatuses';
 
 export type ComplianceScanProgressProps = {
     runs: ComplianceRunStatusResponse['complianceRunStatuses']['runs'];

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsError.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsError.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Modal } from '@patternfly/react-core';
 
 export type ManageStandardsErrorProps = {

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
@@ -1,8 +1,10 @@
-import React, { ReactElement, useState } from 'react';
+import React, { useState } from 'react';
+import type { ReactElement } from 'react';
 import { Alert, Button, Checkbox, Form, Modal } from '@patternfly/react-core';
 import { useFormik } from 'formik';
 
-import { ComplianceStandardMetadata, patchComplianceStandard } from 'services/ComplianceService';
+import { patchComplianceStandard } from 'services/ComplianceService';
+import type { ComplianceStandardMetadata } from 'services/ComplianceService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 export type ManageStandardsModalProps = {

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/useComplianceRunStatuses.ts
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/useComplianceRunStatuses.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { DocumentNode, gql, useApolloClient, useQuery } from '@apollo/client';
+import { gql, useApolloClient, useQuery } from '@apollo/client';
+import type { DocumentNode } from '@apollo/client';
 
 export type ComplianceRunStatusResponse = {
     complianceRunStatuses: {

--- a/ui/apps/platform/src/Containers/Compliance/complianceRBAC.ts
+++ b/ui/apps/platform/src/Containers/Compliance/complianceRBAC.ts
@@ -1,5 +1,5 @@
-import { HasReadAccess } from 'hooks/usePermissions';
-import { ResourceName } from 'types/roleResources';
+import type { HasReadAccess } from 'hooks/usePermissions';
+import type { ResourceName } from 'types/roleResources';
 
 // Apply subset of patterns from routePaths.ts file.
 

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
@@ -1,9 +1,10 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { useQuery } from '@apollo/client';
 
 import Loader from 'Components/Loader';
 import { STANDARDS_QUERY } from 'queries/standard';
-import { ComplianceStandardScope } from 'services/ComplianceService';
+import type { ComplianceStandardScope } from 'services/ComplianceService';
 
 import ComplianceByStandard from './ComplianceByStandard';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Components/ScanDataMessage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Components/ScanDataMessage.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Alert } from '@patternfly/react-core';
 
-import { ScanMessage } from 'messages/vulnMgmt.messages';
+import type { ScanMessage } from 'messages/vulnMgmt.messages';
 
 // Component props have inconsistent name because ScanMessage is application-specific data structure.
 /* eslint-disable generic/react-props-name */

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/EntityTabs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/EntityTabs.tsx
@@ -1,12 +1,13 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { useContext } from 'react';
+import type { ReactElement } from 'react';
 
 import GroupedTabs from 'Components/GroupedTabs';
 import {
-    VulnerabilityManagementEntityType,
     getVulnerabilityManagementEntityTypesByRelationship,
     entityGroups,
     entityGroupMap,
 } from 'utils/entityRelationships';
+import type { VulnerabilityManagementEntityType } from 'utils/entityRelationships';
 import workflowStateContext from '../../workflowStateContext';
 import { entityNounSentenceCasePlural } from '../entitiesForVulnerabilityManagement';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.tsx
@@ -1,11 +1,10 @@
-import React, { ReactNode, useContext } from 'react';
+import React, { useContext } from 'react';
+import type { ReactNode } from 'react';
 
 import { defaultCountKeyMap as countKeyMap } from 'constants/workflowPages.constants';
 import workflowStateContext from 'Containers/workflowStateContext';
-import {
-    VulnerabilityManagementEntityType,
-    getVulnerabilityManagementEntityTypesByRelationship,
-} from 'utils/entityRelationships';
+import { getVulnerabilityManagementEntityTypesByRelationship } from 'utils/entityRelationships';
+import type { VulnerabilityManagementEntityType } from 'utils/entityRelationships';
 
 import TileList from './TileList';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TileList.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TileList.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import TileLink from 'Components/TileLink';
-import { VulnerabilityManagementEntityType } from 'utils/entityRelationships';
+import type { VulnerabilityManagementEntityType } from 'utils/entityRelationships';
 
 /*
  * OrdinaryCase for consistency with entityCountNounOrdinaryCase

--- a/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumb.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumb.tsx
@@ -1,8 +1,9 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
 import useEntityName from 'hooks/useEntityName';
-import { VulnerabilityManagementEntityType } from 'utils/entityRelationships';
+import type { VulnerabilityManagementEntityType } from 'utils/entityRelationships';
 
 import {
     entityNounSentenceCasePlural,

--- a/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumbs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumbs.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { useContext } from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { ChevronRight, ArrowLeft } from 'react-feather';
 
@@ -6,7 +7,8 @@ import entityTypes from 'constants/entityTypes';
 import EntityIcon from 'Components/EntityIcon';
 import workflowStateContext from 'Containers/workflowStateContext';
 
-import EntityBreadCrumb, { WorkflowEntity } from './EntityBreadCrumb';
+import EntityBreadCrumb from './EntityBreadCrumb';
+import type { WorkflowEntity } from './EntityBreadCrumb';
 
 const Icon = (
     <ChevronRight className="bg-base-200 border border-base-400 mx-4 rounded-full" size="14" />

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Clusters/ClusterTableCountLinks.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Clusters/ClusterTableCountLinks.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 
 import { resourceTypes } from 'constants/entityTypes';
 import TableCountLink from '../../TableCountLink';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/ImageTableCountLinks.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/ImageTableCountLinks.tsx
@@ -1,6 +1,8 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { useContext } from 'react';
+import type { ReactElement } from 'react';
 
-import { ResourceType, resourceTypes } from 'constants/entityTypes';
+import { resourceTypes } from 'constants/entityTypes';
+import type { ResourceType } from 'constants/entityTypes';
 import workflowStateContext from 'Containers/workflowStateContext';
 import TableCountLink from '../../TableCountLink';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/TableCountLink.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/TableCountLink.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { useContext } from 'react';
+import type { ReactElement } from 'react';
 import pluralize from 'pluralize';
 
 import TableCellLink from 'Components/TableCellLink';

--- a/ui/apps/platform/src/Containers/VulnMgmt/TableCountLinks.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/TableCountLinks.tsx
@@ -1,6 +1,8 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { useContext } from 'react';
+import type { ReactElement } from 'react';
 
-import entityTypes, { ResourceType, resourceTypes } from 'constants/entityTypes';
+import entityTypes, { resourceTypes } from 'constants/entityTypes';
+import type { ResourceType } from 'constants/entityTypes';
 import workflowStateContext from 'Containers/workflowStateContext';
 import TableCountLink from './TableCountLink';
 import fixableVulnTypeContext from './fixableVulnTypeContext';

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.utils/entities.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.utils/entities.ts
@@ -1,5 +1,5 @@
 import useCaseTypes from 'constants/useCaseTypes';
-import { VulnerabilityManagementEntityType } from 'utils/entityRelationships';
+import type { VulnerabilityManagementEntityType } from 'utils/entityRelationships';
 import { WorkflowState } from 'utils/WorkflowState';
 
 const useCase = useCaseTypes.VULN_MANAGEMENT;

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.utils/getImageScanMessage.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.utils/getImageScanMessage.ts
@@ -1,4 +1,5 @@
-import { imageScanMessages, ScanMessage } from 'messages/vulnMgmt.messages';
+import { imageScanMessages } from 'messages/vulnMgmt.messages';
+import type { ScanMessage } from 'messages/vulnMgmt.messages';
 
 export default function getImageScanMessage(
     imageNotes: string[],

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.utils/getNodeScanMessage.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.utils/getNodeScanMessage.ts
@@ -1,4 +1,5 @@
-import { nodeScanMessages, ScanMessage } from 'messages/vulnMgmt.messages';
+import { nodeScanMessages } from 'messages/vulnMgmt.messages';
+import type { ScanMessage } from 'messages/vulnMgmt.messages';
 
 export default function getNodeScanMessage(nodeNotes: string[], scanNotes: string[]): ScanMessage {
     const hasMissingScanData = nodeNotes?.includes('MISSING_SCAN_DATA');

--- a/ui/apps/platform/src/Containers/VulnMgmt/entitiesForVulnerabilityManagement.ts
+++ b/ui/apps/platform/src/Containers/VulnMgmt/entitiesForVulnerabilityManagement.ts
@@ -1,4 +1,4 @@
-import { VulnerabilityManagementEntityType as EntityType } from 'utils/entityRelationships';
+import type { VulnerabilityManagementEntityType as EntityType } from 'utils/entityRelationships';
 
 export const entityNounOrdinaryCaseSingular: Record<EntityType, string> = {
     CLUSTER: 'cluster',

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/ViewAllButton.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/ViewAllButton.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React from 'react';
+import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
 const ViewAllButton = ({ url }: { url: string }): ReactElement => {


### PR DESCRIPTION
## Description

**Objective**: Remove `import React as 'react';` in following contribution to remove obstacle to move orphan components into container folder.

* Deprecated folders have few enough TypeScript files that benefit to remove exception outweighs cost of changes.
* Based on previous experience, this change is better before than after the objective.

### Opportunity

In case `import type` helps performance of production compile and build in vite.

Not required by, but related to `erasableSyntaxOnly` configuration option in TypeScript:

https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly

### Analysis

```sh
find src/Containers/Compliance \( -name '*.ts' -o -name '*.tsx' \) -print >> …/deprecated_TypeScript_Compliance.txt
find src/Containers/VulnMgmt \( -name '*.ts' -o -name '*.tsx' \) -print >> …/deprecated_TypeScript_VulnMgmt.txt
```

| folder | changed | total |
| :--- | ---: | ---: |
| Compliance | 8 | 11 |
| VulnMgmt | 15 | 20 |

### Solution

1. Move `consistent-type-imports` to generic TypeScript configuration.
2. Fix errors in deprecated folders.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
    See presence, and then absense, of errors.