### PR TITLE
ROX-31621, ROX-31622:  remove 2 pass seacrh query from policy category

### DIFF
--- a/central/policycategory/datastore/datastore_impl_postgres_test.go
+++ b/central/policycategory/datastore/datastore_impl_postgres_test.go
@@ -9,6 +9,7 @@ import (
 	pgStore "github.com/stackrox/rox/central/policycategory/store/postgres"
 	edgeDataStore "github.com/stackrox/rox/central/policycategoryedge/datastore"
 	policyCategoryEdgePostgres "github.com/stackrox/rox/central/policycategoryedge/store/postgres"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
@@ -97,4 +98,105 @@ func (s *PolicyCategoryPostgresDataStoreTestSuite) TestSearchWithPostgres() {
 	s.Len(categories, 1)
 	s.Equal("id-1", categories[0].GetId())
 
+}
+
+func (s *PolicyCategoryPostgresDataStoreTestSuite) TestSearchPolicyCategories() {
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
+		sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+		sac.ResourceScopeKeys(resources.WorkflowAdministration),
+	))
+
+	// Create test policy categories
+	category1 := &storage.PolicyCategory{
+		Id:        "test-cat-1",
+		Name:      "Security Best Practices",
+		IsDefault: true,
+	}
+
+	category2 := &storage.PolicyCategory{
+		Id:        "test-cat-2",
+		Name:      "Package Management",
+		IsDefault: true,
+	}
+
+	category3 := &storage.PolicyCategory{
+		Id:        "test-cat-3",
+		Name:      "Privileges",
+		IsDefault: false,
+	}
+
+	// Add categories
+	_, err := s.datastore.AddPolicyCategory(ctx, category1)
+	s.NoError(err)
+
+	_, err = s.datastore.AddPolicyCategory(ctx, category2)
+	s.NoError(err)
+
+	_, err = s.datastore.AddPolicyCategory(ctx, category3)
+	s.NoError(err)
+
+	// Define test cases
+	testCases := []struct {
+		name          string
+		query         *v1.Query
+		expectedCount int
+		expectedIDs   []string
+		expectedNames []string
+		validateFunc  func(results []*v1.SearchResult)
+	}{
+		{
+			name:          "empty query returns all categories with names populated",
+			query:         pkgSearch.EmptyQuery(),
+			expectedCount: 3,
+			expectedNames: []string{"Security Best Practices", "Package Management", "Privileges"},
+		},
+		{
+			name:          "nil query defaults to empty query",
+			query:         nil,
+			expectedCount: 3,
+			expectedNames: []string{"Security Best Practices", "Package Management", "Privileges"},
+		},
+		{
+			name:          "query by exact category name",
+			query:         pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.PolicyCategoryName, "Package Management").ProtoQuery(),
+			expectedCount: 1,
+			expectedIDs:   []string{"test-cat-2"},
+			expectedNames: []string{"Package Management"},
+		},
+	}
+
+	// Run test cases
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			results, err := s.datastore.SearchPolicyCategories(ctx, tc.query)
+			s.NoError(err)
+			s.Len(results, tc.expectedCount, "Expected %d results, got %d", tc.expectedCount, len(results))
+
+			actualIDs := make([]string, 0, len(results))
+			actualNames := make([]string, 0, len(results))
+			for _, result := range results {
+				actualIDs = append(actualIDs, result.GetId())
+				actualNames = append(actualNames, result.GetName())
+				s.Equal(result.GetCategory(), v1.SearchCategory_POLICY_CATEGORIES)
+			}
+
+			if len(tc.expectedNames) > 0 {
+				s.ElementsMatch(tc.expectedNames, actualNames)
+			}
+
+			if len(tc.expectedIDs) > 0 {
+				s.ElementsMatch(tc.expectedIDs, actualIDs)
+			}
+		})
+	}
+
+	// Clean up
+	s.NoError(s.datastore.DeletePolicyCategory(ctx, category1.GetId()))
+	s.NoError(s.datastore.DeletePolicyCategory(ctx, category2.GetId()))
+	s.NoError(s.datastore.DeletePolicyCategory(ctx, category3.GetId()))
+
+	// Verify cleanup
+	results, err := s.datastore.SearchPolicyCategories(ctx, pkgSearch.EmptyQuery())
+	s.NoError(err)
+	s.Empty(results)
 }

--- a/central/policycategoryedge/datastore/datastore_impl_postgres_test.go
+++ b/central/policycategoryedge/datastore/datastore_impl_postgres_test.go
@@ -1,0 +1,177 @@
+//go:build sql_integration
+
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	pgStore "github.com/stackrox/rox/central/policycategoryedge/store/postgres"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	pkgSearch "github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestPolicyCategoryEdgeDataStoreWithPostgres(t *testing.T) {
+	suite.Run(t, new(PolicyCategoryEdgePostgresDataStoreTestSuite))
+}
+
+type PolicyCategoryEdgePostgresDataStoreTestSuite struct {
+	suite.Suite
+
+	ctx       context.Context
+	db        postgres.DB
+	datastore DataStore
+}
+
+func (s *PolicyCategoryEdgePostgresDataStoreTestSuite) SetupSuite() {
+	s.ctx = context.Background()
+}
+
+func (s *PolicyCategoryEdgePostgresDataStoreTestSuite) SetupTest() {
+	s.db = pgtest.ForT(s.T())
+
+	policyCategoryEdgeStorage := pgStore.New(s.db)
+	s.datastore = New(policyCategoryEdgeStorage)
+}
+
+func (s *PolicyCategoryEdgePostgresDataStoreTestSuite) TearDownTest() {
+	s.db.Close()
+}
+
+func (s *PolicyCategoryEdgePostgresDataStoreTestSuite) TestSearchEdges() {
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(
+		sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+		sac.ResourceScopeKeys(resources.WorkflowAdministration),
+	))
+
+	// Insert test policies directly to database (needed for foreign key constraints)
+	_, err := s.db.Exec(ctx, `
+		INSERT INTO policies (id, name, disabled, lifecyclestages, categories)
+		VALUES
+			('policy-1', 'Test Policy 1', false, '{}', '{}'),
+			('policy-2', 'Test Policy 2',  false, '{}', '{}')
+	`)
+	s.NoError(err)
+
+	// Insert test categories directly to database
+	_, err = s.db.Exec(ctx, `
+		INSERT INTO policy_categories (id, name)
+		VALUES
+			('category-1', 'Test Category 1'),
+			('category-2', 'Test Category 2')
+	`)
+	s.NoError(err)
+
+	// Create test edges
+	edge1 := &storage.PolicyCategoryEdge{
+		Id:         uuid.NewV4().String(),
+		PolicyId:   "policy-1",
+		CategoryId: "category-1",
+	}
+
+	edge2 := &storage.PolicyCategoryEdge{
+		Id:         uuid.NewV4().String(),
+		PolicyId:   "policy-2",
+		CategoryId: "category-1",
+	}
+
+	edge3 := &storage.PolicyCategoryEdge{
+		Id:         uuid.NewV4().String(),
+		PolicyId:   "policy-1",
+		CategoryId: "category-2",
+	}
+
+	// Add edges
+	err = s.datastore.UpsertMany(ctx, []*storage.PolicyCategoryEdge{edge1, edge2, edge3})
+	s.NoError(err)
+
+	// Define test cases
+	testCases := []struct {
+		name          string
+		query         *v1.Query
+		expectedCount int
+		expectedIDs   []string
+		validateFunc  func(results []*v1.SearchResult)
+	}{
+		{
+			name:          "empty query returns all edges with names populated",
+			query:         pkgSearch.EmptyQuery(),
+			expectedCount: 3,
+			expectedIDs:   []string{edge1.GetId(), edge2.GetId(), edge3.GetId()},
+			validateFunc: func(results []*v1.SearchResult) {
+				for _, result := range results {
+					s.Equal(v1.SearchCategory_POLICY_CATEGORY_EDGE, result.GetCategory())
+					// Name should equal ID for edges
+					s.Equal(result.GetId(), result.GetName())
+				}
+			},
+		},
+		{
+			name:          "nil query defaults to empty query",
+			query:         nil,
+			expectedCount: 3,
+			validateFunc: func(results []*v1.SearchResult) {
+				for _, result := range results {
+					s.Equal(result.GetId(), result.GetName(), "Name should equal ID")
+				}
+			},
+		},
+		{
+			name:          "query by policy ID",
+			query:         pkgSearch.NewQueryBuilder().AddExactMatches(pkgSearch.PolicyID, "policy-1").ProtoQuery(),
+			expectedCount: 2,
+			expectedIDs:   []string{edge1.GetId(), edge3.GetId()},
+			validateFunc: func(results []*v1.SearchResult) {
+				for _, result := range results {
+					s.Equal(result.GetId(), result.GetName(), "Name should equal ID")
+				}
+			},
+		},
+	}
+
+	// Run test cases
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			results, err := s.datastore.SearchEdges(ctx, tc.query)
+			s.NoError(err)
+			s.Len(results, tc.expectedCount, "Expected %d results, got %d", tc.expectedCount, len(results))
+
+			// Validate expected IDs if provided
+			if len(tc.expectedIDs) > 0 {
+				actualIDs := make([]string, 0, len(results))
+				for _, result := range results {
+					actualIDs = append(actualIDs, result.GetId())
+				}
+				s.ElementsMatch(tc.expectedIDs, actualIDs)
+			}
+
+			// Run custom validation function if provided
+			if tc.validateFunc != nil {
+				tc.validateFunc(results)
+			}
+		})
+	}
+
+	// Clean up - delete in reverse order (edges first, then policies, then categories)
+	s.NoError(s.datastore.DeleteMany(ctx, edge1.GetId(), edge2.GetId(), edge3.GetId()))
+
+	// Delete test policies from database
+	_, err = s.db.Exec(ctx, `DELETE FROM policies WHERE id IN ('policy-1', 'policy-2')`)
+	s.NoError(err)
+
+	// Delete test categories from database
+	_, err = s.db.Exec(ctx, `DELETE FROM policy_categories WHERE id IN ('category-1', 'category-2')`)
+	s.NoError(err)
+
+	// Verify cleanup
+	results, err := s.datastore.SearchEdges(ctx, pkgSearch.EmptyQuery())
+	s.NoError(err)
+	s.Empty(results)
+}


### PR DESCRIPTION
This PR removes 2 pass search query from policy category datastore, policy category edge database

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
