### PR TITLE
ROX-32160: Get process baselines by criteria

### DIFF
--- a/central/processbaseline/service/service.go
+++ b/central/processbaseline/service/service.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stackrox/rox/central/reprocessor"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/grpc"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+var (
+	log = logging.LoggerForModule()
 )
 
 // Service is the interface to the gRPC service for managing process baselines

--- a/central/processbaseline/service/service_impl.go
+++ b/central/processbaseline/service/service_impl.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"google.golang.org/grpc"
@@ -27,6 +28,7 @@ var (
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 		user.With(permissions.View(resources.DeploymentExtension)): {
 			v1.ProcessBaselineService_GetProcessBaseline_FullMethodName,
+			v1.ProcessBaselineService_GetProcessBaselineBulk_FullMethodName,
 		},
 		user.With(permissions.Modify(resources.DeploymentExtension)): {
 			v1.ProcessBaselineService_UpdateProcessBaselines_FullMethodName,
@@ -71,34 +73,39 @@ func validateKeyNotEmpty(key *storage.ProcessBaselineKey) error {
 	return nil
 }
 
-func (s *serviceImpl) GetProcessBaseline(ctx context.Context, request *v1.GetProcessBaselineRequest) (*storage.ProcessBaseline, error) {
-	if err := validateKeyNotEmpty(request.GetKey()); err != nil {
+func (s *serviceImpl) getProcessBaseline(ctx context.Context, key *storage.ProcessBaselineKey) (*storage.ProcessBaseline, error) {
+	if err := validateKeyNotEmpty(key); err != nil {
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
-	baseline, exists, err := s.dataStore.GetProcessBaseline(ctx, request.GetKey())
+	baseline, exists, err := s.dataStore.GetProcessBaseline(ctx, key)
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
 		// Make sure the deployment still exists before we try to build a baseline.
-		_, deploymentExists, err := s.deployments.GetDeployment(ctx, request.GetKey().GetDeploymentId())
+		_, deploymentExists, err := s.deployments.GetDeployment(ctx, key.GetDeploymentId())
 		if err != nil {
 			return nil, err
 		}
 		if !deploymentExists {
-			return nil, errors.Wrapf(errox.NotFound, "deployment with id '%q' does not exist", request.GetKey().GetDeploymentId())
+			return nil, errors.Wrapf(errox.NotFound, "deployment with id '%q' does not exist", key.GetDeploymentId())
 		}
 
 		// Build an unlocked baseline
-		baseline, err = s.dataStore.CreateUnlockedProcessBaseline(ctx, request.GetKey())
+		baseline, err = s.dataStore.CreateUnlockedProcessBaseline(ctx, key)
 		if err != nil {
 			return nil, err
 		}
 		if baseline == nil {
-			return nil, errors.Wrapf(errox.NotFound, "No process baseline with key %+v found", request.GetKey())
+			return nil, errors.Wrapf(errox.NotFound, "No process baseline with key %+v found", key)
 		}
 	}
+
 	return baseline, nil
+}
+
+func (s *serviceImpl) GetProcessBaseline(ctx context.Context, request *v1.GetProcessBaselineRequest) (*storage.ProcessBaseline, error) {
+	return s.getProcessBaseline(ctx, request.GetKey())
 }
 
 func bulkUpdate(keys []*storage.ProcessBaselineKey, parallelFunc func(*storage.ProcessBaselineKey) (*storage.ProcessBaseline, error)) *v1.UpdateProcessBaselinesResponse {
@@ -304,4 +311,83 @@ func (s *serviceImpl) reprocessUpdatedBaselines(resp **v1.UpdateProcessBaselines
 		keys = append(keys, pb.GetKey())
 	}
 	s.reprocessDeploymentRisks(keys)
+}
+
+func (s *serviceImpl) GetProcessBaselineBulk(ctx context.Context, request *v1.GetProcessBaselinesBulkRequest) (*v1.GetProcessBaselinesBulkResponse, error) {
+	query := request.GetQuery()
+	if query == nil {
+		return nil, errors.Wrap(errox.InvalidArgs, "query must not be nil")
+	}
+
+	// First we search for matching deployments and containers. Since process baselines are created lazily not process baselines
+	// that we are interested exist and we may need to create them. The information that we need is in the deployments datastore
+	// and might not be in the process baselines datastore. Also some fields that we are interested in such as image names are
+	// availabe in the deployments datastore and not in process baselines datastore.
+	deploymentQueryBuilder := search.NewQueryBuilder()
+
+	if len(query.GetClusterIds()) > 0 {
+		deploymentQueryBuilder = deploymentQueryBuilder.AddExactMatches(search.ClusterID, query.GetClusterIds()...)
+	}
+	if len(query.GetNamespaces()) > 0 {
+		deploymentQueryBuilder = deploymentQueryBuilder.AddExactMatches(search.Namespace, query.GetNamespaces()...)
+	}
+	if len(query.GetDeploymentNames()) > 0 {
+		deploymentQueryBuilder = deploymentQueryBuilder.AddExactMatches(search.DeploymentName, query.GetDeploymentNames()...)
+	}
+	if len(query.GetDeploymentIds()) > 0 {
+		deploymentQueryBuilder = deploymentQueryBuilder.AddExactMatches(search.DeploymentID, query.GetDeploymentIds()...)
+	}
+	if len(query.GetImages()) > 0 {
+		deploymentQueryBuilder = deploymentQueryBuilder.AddExactMatches(search.ImageName, query.GetImages()...)
+	}
+
+	deployments, err := s.deployments.SearchRawDeployments(ctx, deploymentQueryBuilder.ProtoQuery())
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the process baseline keys from the deployments and filter for container name
+	imageSet := set.NewStringSet(query.GetImages()...)
+	containerSet := set.NewStringSet(query.GetContainerNames()...)
+	baselineKeys := make([]*storage.ProcessBaselineKey, 0, len(deployments))
+	for _, deployment := range deployments {
+		for _, container := range deployment.GetContainers() {
+			imageName := container.GetImage().GetName().GetFullName()
+			containerName := container.GetName()
+			// We need to check that the container has the correct image and container name. Searching for an image
+			// will return all deployments that have that image, including containers that don't have that image.
+			// Containers need to be filtered for the container name, since that is not searchable.
+			if (imageSet.Contains(imageName) || len(imageSet) == 0) && (containerSet.Contains(containerName) || len(containerSet) == 0) {
+				baselineKey := &storage.ProcessBaselineKey{
+					DeploymentId:  deployment.GetId(),
+					ContainerName: containerName,
+					ClusterId:     deployment.GetClusterId(),
+					Namespace:     deployment.GetNamespace(),
+				}
+				baselineKeys = append(baselineKeys, baselineKey)
+			}
+		}
+	}
+
+	totalCount := int32(len(baselineKeys))
+
+	page := request.GetPagination()
+	if page != nil {
+		baselineKeys = paginated.PaginateSlice(int(page.GetOffset()), int(page.GetLimit()), baselineKeys)
+	}
+
+	baselines := make([]*storage.ProcessBaseline, 0, len(baselineKeys))
+	for _, baselineKey := range baselineKeys {
+		baseline, err := s.getProcessBaseline(ctx, baselineKey)
+		if err == nil {
+			baselines = append(baselines, baseline)
+		}
+	}
+
+	response := &v1.GetProcessBaselinesBulkResponse{
+		Baselines:  baselines,
+		TotalCount: totalCount,
+	}
+
+	return response, nil
 }

--- a/central/processbaseline/service/service_impl.go
+++ b/central/processbaseline/service/service_impl.go
@@ -316,7 +316,7 @@ func (s *serviceImpl) reprocessUpdatedBaselines(resp **v1.UpdateProcessBaselines
 func (s *serviceImpl) GetProcessBaselineBulk(ctx context.Context, request *v1.GetProcessBaselinesBulkRequest) (*v1.GetProcessBaselinesBulkResponse, error) {
 	query := request.GetQuery()
 	if query == nil {
-		return nil, errors.Wrap(errox.InvalidArgs, "query must not be nil")
+		return nil, errors.Wrap(errox.InvalidArgs, "Query must not be nil")
 	}
 
 	clusters := query.GetClusterIds()
@@ -344,6 +344,10 @@ func (s *serviceImpl) GetProcessBaselineBulk(ctx context.Context, request *v1.Ge
 	}
 	if len(query.GetImages()) > 0 {
 		deploymentQueryBuilder = deploymentQueryBuilder.AddExactMatches(search.ImageName, query.GetImages()...)
+	}
+
+	if deploymentQueryBuilder.Query() == "" {
+		return nil, errors.Wrap(errox.InvalidArgs, "At least one parameter must not be empty or a wild card, not counting container name")
 	}
 
 	deployments, err := s.deployments.SearchRawDeployments(ctx, deploymentQueryBuilder.ProtoQuery())

--- a/central/processbaseline/service/service_impl.go
+++ b/central/processbaseline/service/service_impl.go
@@ -391,7 +391,7 @@ func (s *serviceImpl) GetProcessBaselineBulk(ctx context.Context, request *v1.Ge
 		if err == nil {
 			baselines = append(baselines, baseline)
 		} else {
-			log.Errorf("Unable to get process baseline from process baseline key %+v: %+v", baseline, err)
+			log.Errorf("Unable to get process baseline from process baseline key %+v: %v", baselineKey, err)
 		}
 	}
 

--- a/central/processbaseline/service/service_impl_real_test.go
+++ b/central/processbaseline/service/service_impl_real_test.go
@@ -234,6 +234,7 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulk() {
 			name: "Filter by namespace",
 			query: &v1.ProcessBaselineQuery{
 				Namespaces: []string{namespace2},
+				ClusterIds: []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline2, baseline3, baseline4, baseline5},
 		},
@@ -241,6 +242,7 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulk() {
 			name: "Filter by deployment ID",
 			query: &v1.ProcessBaselineQuery{
 				DeploymentIds: []string{deployment1ID},
+				ClusterIds:    []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline1},
 		},
@@ -248,6 +250,7 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulk() {
 			name: "Filter by container name container1",
 			query: &v1.ProcessBaselineQuery{
 				ContainerNames: []string{"container1"},
+				ClusterIds:     []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline1, baseline3},
 		},
@@ -255,6 +258,7 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulk() {
 			name: "Filter by container name container2",
 			query: &v1.ProcessBaselineQuery{
 				ContainerNames: []string{"container2"},
+				ClusterIds:     []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline2},
 		},
@@ -262,6 +266,7 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulk() {
 			name: "Filter by container name container3",
 			query: &v1.ProcessBaselineQuery{
 				ContainerNames: []string{"container3"},
+				ClusterIds:     []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline4},
 		},
@@ -269,6 +274,7 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulk() {
 			name: "Filter by container name container4",
 			query: &v1.ProcessBaselineQuery{
 				ContainerNames: []string{"container4"},
+				ClusterIds:     []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline5},
 		},
@@ -276,6 +282,7 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulk() {
 			name: "Filter by deployment name",
 			query: &v1.ProcessBaselineQuery{
 				DeploymentNames: []string{"test-deployment-1"},
+				ClusterIds:      []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline1, baseline3, baseline4, baseline5},
 		},
@@ -283,20 +290,23 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulk() {
 			name: "Filter by deployment name test-deployment-2",
 			query: &v1.ProcessBaselineQuery{
 				DeploymentNames: []string{"test-deployment-2"},
+				ClusterIds:      []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline2},
 		},
 		{
 			name: "Filter by image nginx:1.19",
 			query: &v1.ProcessBaselineQuery{
-				Images: []string{"nginx:1.19"},
+				Images:     []string{"nginx:1.19"},
+				ClusterIds: []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline1},
 		},
 		{
 			name: "Filter by image redis:6.0",
 			query: &v1.ProcessBaselineQuery{
-				Images: []string{"redis:6.0"},
+				Images:     []string{"redis:6.0"},
+				ClusterIds: []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline2, baseline3, baseline4},
 		},
@@ -305,6 +315,7 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulk() {
 			query: &v1.ProcessBaselineQuery{
 				Images:         []string{"redis:6.0"},
 				ContainerNames: []string{"container1"},
+				ClusterIds:     []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline3},
 		},
@@ -321,6 +332,7 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulk() {
 			query: &v1.ProcessBaselineQuery{
 				DeploymentNames: []string{"test-deployment-1"},
 				Images:          []string{"nginx:1.19"},
+				ClusterIds:      []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline1},
 		},
@@ -329,25 +341,30 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulk() {
 			query: &v1.ProcessBaselineQuery{
 				Images:         []string{"nginx:1.19"},
 				ContainerNames: []string{"container1"},
+				ClusterIds:     []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{baseline1},
 		},
 		{
-			name:              "No filters returns all baselines",
-			query:             &v1.ProcessBaselineQuery{},
+			name: "No filters returns all baselines",
+			query: &v1.ProcessBaselineQuery{
+				ClusterIds: []string{"*"},
+			},
 			expectedBaselines: baselines,
 		},
 		{
 			name: "Filter by non-existent deployment name",
 			query: &v1.ProcessBaselineQuery{
 				DeploymentNames: []string{"non-existent"},
+				ClusterIds:      []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{},
 		},
 		{
 			name: "Filter by non-existent image",
 			query: &v1.ProcessBaselineQuery{
-				Images: []string{"non-existent:1.0"},
+				Images:     []string{"non-existent:1.0"},
+				ClusterIds: []string{"*"},
 			},
 			expectedBaselines: []*storage.ProcessBaseline{},
 		},
@@ -387,7 +404,9 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulkPagi
 
 	suite.T().Run("Pagination - offset 0, limit 2", func(t *testing.T) {
 		request := &v1.GetProcessBaselinesBulkRequest{
-			Query: &v1.ProcessBaselineQuery{},
+			Query: &v1.ProcessBaselineQuery{
+				ClusterIds: []string{"*"},
+			},
 			Pagination: &v1.Pagination{
 				Offset: 0,
 				Limit:  2,
@@ -403,7 +422,9 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulkPagi
 
 	suite.T().Run("Pagination - offset 1, limit 2", func(t *testing.T) {
 		request := &v1.GetProcessBaselinesBulkRequest{
-			Query: &v1.ProcessBaselineQuery{},
+			Query: &v1.ProcessBaselineQuery{
+				ClusterIds: []string{"*"},
+			},
 			Pagination: &v1.Pagination{
 				Offset: 1,
 				Limit:  2,
@@ -419,7 +440,9 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulkPagi
 
 	suite.T().Run("Pagination - offset 2, limit 2", func(t *testing.T) {
 		request := &v1.GetProcessBaselinesBulkRequest{
-			Query: &v1.ProcessBaselineQuery{},
+			Query: &v1.ProcessBaselineQuery{
+				ClusterIds: []string{"*"},
+			},
 			Pagination: &v1.Pagination{
 				Offset: 4,
 				Limit:  2,
@@ -435,7 +458,9 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulkPagi
 
 	suite.T().Run("Pagination - offset beyond available results", func(t *testing.T) {
 		request := &v1.GetProcessBaselinesBulkRequest{
-			Query: &v1.ProcessBaselineQuery{},
+			Query: &v1.ProcessBaselineQuery{
+				ClusterIds: []string{"*"},
+			},
 			Pagination: &v1.Pagination{
 				Offset: 10,
 				Limit:  2,
@@ -451,7 +476,9 @@ func (suite *ProcessBaselineServiceRealTestSuite) TestGetProcessBaselineBulkPagi
 
 	suite.T().Run("Pagination - limit only", func(t *testing.T) {
 		request := &v1.GetProcessBaselinesBulkRequest{
-			Query: &v1.ProcessBaselineQuery{},
+			Query: &v1.ProcessBaselineQuery{
+				ClusterIds: []string{"*"},
+			},
 			Pagination: &v1.Pagination{
 				Offset: 0,
 				Limit:  1,

--- a/generated/api/v1/process_baseline_service.pb.go
+++ b/generated/api/v1/process_baseline_service.pb.go
@@ -527,11 +527,199 @@ func (x *DeleteProcessBaselinesResponse) GetDryRun() bool {
 	return false
 }
 
+type ProcessBaselineQuery struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	ClusterIds      []string               `protobuf:"bytes,1,rep,name=cluster_ids,json=clusterIds,proto3" json:"cluster_ids,omitempty"`
+	Namespaces      []string               `protobuf:"bytes,2,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
+	DeploymentIds   []string               `protobuf:"bytes,3,rep,name=deployment_ids,json=deploymentIds,proto3" json:"deployment_ids,omitempty"`
+	DeploymentNames []string               `protobuf:"bytes,4,rep,name=deployment_names,json=deploymentNames,proto3" json:"deployment_names,omitempty"`
+	Images          []string               `protobuf:"bytes,5,rep,name=images,proto3" json:"images,omitempty"`
+	ContainerNames  []string               `protobuf:"bytes,6,rep,name=container_names,json=containerNames,proto3" json:"container_names,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ProcessBaselineQuery) Reset() {
+	*x = ProcessBaselineQuery{}
+	mi := &file_api_v1_process_baseline_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProcessBaselineQuery) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProcessBaselineQuery) ProtoMessage() {}
+
+func (x *ProcessBaselineQuery) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v1_process_baseline_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProcessBaselineQuery.ProtoReflect.Descriptor instead.
+func (*ProcessBaselineQuery) Descriptor() ([]byte, []int) {
+	return file_api_v1_process_baseline_service_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *ProcessBaselineQuery) GetClusterIds() []string {
+	if x != nil {
+		return x.ClusterIds
+	}
+	return nil
+}
+
+func (x *ProcessBaselineQuery) GetNamespaces() []string {
+	if x != nil {
+		return x.Namespaces
+	}
+	return nil
+}
+
+func (x *ProcessBaselineQuery) GetDeploymentIds() []string {
+	if x != nil {
+		return x.DeploymentIds
+	}
+	return nil
+}
+
+func (x *ProcessBaselineQuery) GetDeploymentNames() []string {
+	if x != nil {
+		return x.DeploymentNames
+	}
+	return nil
+}
+
+func (x *ProcessBaselineQuery) GetImages() []string {
+	if x != nil {
+		return x.Images
+	}
+	return nil
+}
+
+func (x *ProcessBaselineQuery) GetContainerNames() []string {
+	if x != nil {
+		return x.ContainerNames
+	}
+	return nil
+}
+
+type GetProcessBaselinesBulkRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Query         *ProcessBaselineQuery  `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
+	Pagination    *Pagination            `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetProcessBaselinesBulkRequest) Reset() {
+	*x = GetProcessBaselinesBulkRequest{}
+	mi := &file_api_v1_process_baseline_service_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetProcessBaselinesBulkRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetProcessBaselinesBulkRequest) ProtoMessage() {}
+
+func (x *GetProcessBaselinesBulkRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v1_process_baseline_service_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetProcessBaselinesBulkRequest.ProtoReflect.Descriptor instead.
+func (*GetProcessBaselinesBulkRequest) Descriptor() ([]byte, []int) {
+	return file_api_v1_process_baseline_service_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *GetProcessBaselinesBulkRequest) GetQuery() *ProcessBaselineQuery {
+	if x != nil {
+		return x.Query
+	}
+	return nil
+}
+
+func (x *GetProcessBaselinesBulkRequest) GetPagination() *Pagination {
+	if x != nil {
+		return x.Pagination
+	}
+	return nil
+}
+
+type GetProcessBaselinesBulkResponse struct {
+	state         protoimpl.MessageState     `protogen:"open.v1"`
+	Baselines     []*storage.ProcessBaseline `protobuf:"bytes,1,rep,name=baselines,proto3" json:"baselines,omitempty"`
+	TotalCount    int32                      `protobuf:"varint,2,opt,name=total_count,json=totalCount,proto3" json:"total_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetProcessBaselinesBulkResponse) Reset() {
+	*x = GetProcessBaselinesBulkResponse{}
+	mi := &file_api_v1_process_baseline_service_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetProcessBaselinesBulkResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetProcessBaselinesBulkResponse) ProtoMessage() {}
+
+func (x *GetProcessBaselinesBulkResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v1_process_baseline_service_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetProcessBaselinesBulkResponse.ProtoReflect.Descriptor instead.
+func (*GetProcessBaselinesBulkResponse) Descriptor() ([]byte, []int) {
+	return file_api_v1_process_baseline_service_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *GetProcessBaselinesBulkResponse) GetBaselines() []*storage.ProcessBaseline {
+	if x != nil {
+		return x.Baselines
+	}
+	return nil
+}
+
+func (x *GetProcessBaselinesBulkResponse) GetTotalCount() int32 {
+	if x != nil {
+		return x.TotalCount
+	}
+	return 0
+}
+
 var File_api_v1_process_baseline_service_proto protoreflect.FileDescriptor
 
 const file_api_v1_process_baseline_service_proto_rawDesc = "" +
 	"\n" +
-	"%api/v1/process_baseline_service.proto\x12\x02v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1estorage/process_baseline.proto\"J\n" +
+	"%api/v1/process_baseline_service.proto\x12\x02v1\x1a\x17api/v1/pagination.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1estorage/process_baseline.proto\"J\n" +
 	"\x19GetProcessBaselineRequest\x12-\n" +
 	"\x03key\x18\x01 \x01(\v2\x1b.storage.ProcessBaselineKeyR\x03key\"\xca\x01\n" +
 	"\x1dUpdateProcessBaselinesRequest\x12/\n" +
@@ -563,15 +751,35 @@ const file_api_v1_process_baseline_service_proto_rawDesc = "" +
 	"\x1eDeleteProcessBaselinesResponse\x12\x1f\n" +
 	"\vnum_deleted\x18\x01 \x01(\x05R\n" +
 	"numDeleted\x12\x17\n" +
-	"\adry_run\x18\x02 \x01(\bR\x06dryRun2\xb5\x06\n" +
+	"\adry_run\x18\x02 \x01(\bR\x06dryRun\"\xea\x01\n" +
+	"\x14ProcessBaselineQuery\x12\x1f\n" +
+	"\vcluster_ids\x18\x01 \x03(\tR\n" +
+	"clusterIds\x12\x1e\n" +
+	"\n" +
+	"namespaces\x18\x02 \x03(\tR\n" +
+	"namespaces\x12%\n" +
+	"\x0edeployment_ids\x18\x03 \x03(\tR\rdeploymentIds\x12)\n" +
+	"\x10deployment_names\x18\x04 \x03(\tR\x0fdeploymentNames\x12\x16\n" +
+	"\x06images\x18\x05 \x03(\tR\x06images\x12'\n" +
+	"\x0fcontainer_names\x18\x06 \x03(\tR\x0econtainerNames\"\x80\x01\n" +
+	"\x1eGetProcessBaselinesBulkRequest\x12.\n" +
+	"\x05query\x18\x01 \x01(\v2\x18.v1.ProcessBaselineQueryR\x05query\x12.\n" +
+	"\n" +
+	"pagination\x18\x02 \x01(\v2\x0e.v1.PaginationR\n" +
+	"pagination\"z\n" +
+	"\x1fGetProcessBaselinesBulkResponse\x126\n" +
+	"\tbaselines\x18\x01 \x03(\v2\x18.storage.ProcessBaselineR\tbaselines\x12\x1f\n" +
+	"\vtotal_count\x18\x02 \x01(\x05R\n" +
+	"totalCount2\xc3\a\n" +
 	"\x16ProcessBaselineService\x12o\n" +
 	"\x12GetProcessBaseline\x12\x1d.v1.GetProcessBaselineRequest\x1a\x18.storage.ProcessBaseline\" \x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/processbaselines/key\x12\x80\x01\n" +
 	"\x16UpdateProcessBaselines\x12!.v1.UpdateProcessBaselinesRequest\x1a\".v1.UpdateProcessBaselinesResponse\"\x1f\x82\xd3\xe4\x93\x02\x19:\x01*\x1a\x14/v1/processbaselines\x12\x81\x01\n" +
 	"\x14LockProcessBaselines\x12\x1f.v1.LockProcessBaselinesRequest\x1a\".v1.UpdateProcessBaselinesResponse\"$\x82\xd3\xe4\x93\x02\x1e:\x01*\x1a\x19/v1/processbaselines/lock\x12\x8e\x01\n" +
 	"\x18BulkLockProcessBaselines\x12\x1f.v1.BulkProcessBaselinesRequest\x1a&.v1.BulkUpdateProcessBaselinesResponse\")\x82\xd3\xe4\x93\x02#:\x01*\x1a\x1e/v1/processbaselines/bulk/lock\x12\x92\x01\n" +
 	"\x1aBulkUnlockProcessBaselines\x12\x1f.v1.BulkProcessBaselinesRequest\x1a&.v1.BulkUpdateProcessBaselinesResponse\"+\x82\xd3\xe4\x93\x02%:\x01*\x1a /v1/processbaselines/bulk/unlock\x12}\n" +
-	"\x16DeleteProcessBaselines\x12!.v1.DeleteProcessBaselinesRequest\x1a\".v1.DeleteProcessBaselinesResponse\"\x1c\x82\xd3\xe4\x93\x02\x16*\x14/v1/processbaselinesB'\n" +
-	"\x18io.stackrox.proto.api.v1Z\v./api/v1;v1X\x00b\x06proto3"
+	"\x16DeleteProcessBaselines\x12!.v1.DeleteProcessBaselinesRequest\x1a\".v1.DeleteProcessBaselinesResponse\"\x1c\x82\xd3\xe4\x93\x02\x16*\x14/v1/processbaselines\x12\x8b\x01\n" +
+	"\x16GetProcessBaselineBulk\x12\".v1.GetProcessBaselinesBulkRequest\x1a#.v1.GetProcessBaselinesBulkResponse\"(\x82\xd3\xe4\x93\x02\":\x01*\x1a\x1d/v1/processbaselines/bulk/getB'\n" +
+	"\x18io.stackrox.proto.api.v1Z\v./api/v1;v1X\x01b\x06proto3"
 
 var (
 	file_api_v1_process_baseline_service_proto_rawDescOnce sync.Once
@@ -585,7 +793,7 @@ func file_api_v1_process_baseline_service_proto_rawDescGZIP() []byte {
 	return file_api_v1_process_baseline_service_proto_rawDescData
 }
 
-var file_api_v1_process_baseline_service_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_api_v1_process_baseline_service_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_api_v1_process_baseline_service_proto_goTypes = []any{
 	(*GetProcessBaselineRequest)(nil),          // 0: v1.GetProcessBaselineRequest
 	(*UpdateProcessBaselinesRequest)(nil),      // 1: v1.UpdateProcessBaselinesRequest
@@ -597,37 +805,46 @@ var file_api_v1_process_baseline_service_proto_goTypes = []any{
 	(*BulkProcessBaselinesRequest)(nil),        // 7: v1.BulkProcessBaselinesRequest
 	(*DeleteProcessBaselinesRequest)(nil),      // 8: v1.DeleteProcessBaselinesRequest
 	(*DeleteProcessBaselinesResponse)(nil),     // 9: v1.DeleteProcessBaselinesResponse
-	(*storage.ProcessBaselineKey)(nil),         // 10: storage.ProcessBaselineKey
-	(*storage.BaselineItem)(nil),               // 11: storage.BaselineItem
-	(*storage.ProcessBaseline)(nil),            // 12: storage.ProcessBaseline
+	(*ProcessBaselineQuery)(nil),               // 10: v1.ProcessBaselineQuery
+	(*GetProcessBaselinesBulkRequest)(nil),     // 11: v1.GetProcessBaselinesBulkRequest
+	(*GetProcessBaselinesBulkResponse)(nil),    // 12: v1.GetProcessBaselinesBulkResponse
+	(*storage.ProcessBaselineKey)(nil),         // 13: storage.ProcessBaselineKey
+	(*storage.BaselineItem)(nil),               // 14: storage.BaselineItem
+	(*storage.ProcessBaseline)(nil),            // 15: storage.ProcessBaseline
+	(*Pagination)(nil),                         // 16: v1.Pagination
 }
 var file_api_v1_process_baseline_service_proto_depIdxs = []int32{
-	10, // 0: v1.GetProcessBaselineRequest.key:type_name -> storage.ProcessBaselineKey
-	10, // 1: v1.UpdateProcessBaselinesRequest.keys:type_name -> storage.ProcessBaselineKey
-	11, // 2: v1.UpdateProcessBaselinesRequest.add_elements:type_name -> storage.BaselineItem
-	11, // 3: v1.UpdateProcessBaselinesRequest.remove_elements:type_name -> storage.BaselineItem
-	12, // 4: v1.ProcessBaselinesResponse.baselines:type_name -> storage.ProcessBaseline
-	10, // 5: v1.ProcessBaselineUpdateError.key:type_name -> storage.ProcessBaselineKey
-	12, // 6: v1.UpdateProcessBaselinesResponse.baselines:type_name -> storage.ProcessBaseline
+	13, // 0: v1.GetProcessBaselineRequest.key:type_name -> storage.ProcessBaselineKey
+	13, // 1: v1.UpdateProcessBaselinesRequest.keys:type_name -> storage.ProcessBaselineKey
+	14, // 2: v1.UpdateProcessBaselinesRequest.add_elements:type_name -> storage.BaselineItem
+	14, // 3: v1.UpdateProcessBaselinesRequest.remove_elements:type_name -> storage.BaselineItem
+	15, // 4: v1.ProcessBaselinesResponse.baselines:type_name -> storage.ProcessBaseline
+	13, // 5: v1.ProcessBaselineUpdateError.key:type_name -> storage.ProcessBaselineKey
+	15, // 6: v1.UpdateProcessBaselinesResponse.baselines:type_name -> storage.ProcessBaseline
 	3,  // 7: v1.UpdateProcessBaselinesResponse.errors:type_name -> v1.ProcessBaselineUpdateError
-	10, // 8: v1.LockProcessBaselinesRequest.keys:type_name -> storage.ProcessBaselineKey
-	0,  // 9: v1.ProcessBaselineService.GetProcessBaseline:input_type -> v1.GetProcessBaselineRequest
-	1,  // 10: v1.ProcessBaselineService.UpdateProcessBaselines:input_type -> v1.UpdateProcessBaselinesRequest
-	6,  // 11: v1.ProcessBaselineService.LockProcessBaselines:input_type -> v1.LockProcessBaselinesRequest
-	7,  // 12: v1.ProcessBaselineService.BulkLockProcessBaselines:input_type -> v1.BulkProcessBaselinesRequest
-	7,  // 13: v1.ProcessBaselineService.BulkUnlockProcessBaselines:input_type -> v1.BulkProcessBaselinesRequest
-	8,  // 14: v1.ProcessBaselineService.DeleteProcessBaselines:input_type -> v1.DeleteProcessBaselinesRequest
-	12, // 15: v1.ProcessBaselineService.GetProcessBaseline:output_type -> storage.ProcessBaseline
-	5,  // 16: v1.ProcessBaselineService.UpdateProcessBaselines:output_type -> v1.UpdateProcessBaselinesResponse
-	5,  // 17: v1.ProcessBaselineService.LockProcessBaselines:output_type -> v1.UpdateProcessBaselinesResponse
-	4,  // 18: v1.ProcessBaselineService.BulkLockProcessBaselines:output_type -> v1.BulkUpdateProcessBaselinesResponse
-	4,  // 19: v1.ProcessBaselineService.BulkUnlockProcessBaselines:output_type -> v1.BulkUpdateProcessBaselinesResponse
-	9,  // 20: v1.ProcessBaselineService.DeleteProcessBaselines:output_type -> v1.DeleteProcessBaselinesResponse
-	15, // [15:21] is the sub-list for method output_type
-	9,  // [9:15] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	13, // 8: v1.LockProcessBaselinesRequest.keys:type_name -> storage.ProcessBaselineKey
+	10, // 9: v1.GetProcessBaselinesBulkRequest.query:type_name -> v1.ProcessBaselineQuery
+	16, // 10: v1.GetProcessBaselinesBulkRequest.pagination:type_name -> v1.Pagination
+	15, // 11: v1.GetProcessBaselinesBulkResponse.baselines:type_name -> storage.ProcessBaseline
+	0,  // 12: v1.ProcessBaselineService.GetProcessBaseline:input_type -> v1.GetProcessBaselineRequest
+	1,  // 13: v1.ProcessBaselineService.UpdateProcessBaselines:input_type -> v1.UpdateProcessBaselinesRequest
+	6,  // 14: v1.ProcessBaselineService.LockProcessBaselines:input_type -> v1.LockProcessBaselinesRequest
+	7,  // 15: v1.ProcessBaselineService.BulkLockProcessBaselines:input_type -> v1.BulkProcessBaselinesRequest
+	7,  // 16: v1.ProcessBaselineService.BulkUnlockProcessBaselines:input_type -> v1.BulkProcessBaselinesRequest
+	8,  // 17: v1.ProcessBaselineService.DeleteProcessBaselines:input_type -> v1.DeleteProcessBaselinesRequest
+	11, // 18: v1.ProcessBaselineService.GetProcessBaselineBulk:input_type -> v1.GetProcessBaselinesBulkRequest
+	15, // 19: v1.ProcessBaselineService.GetProcessBaseline:output_type -> storage.ProcessBaseline
+	5,  // 20: v1.ProcessBaselineService.UpdateProcessBaselines:output_type -> v1.UpdateProcessBaselinesResponse
+	5,  // 21: v1.ProcessBaselineService.LockProcessBaselines:output_type -> v1.UpdateProcessBaselinesResponse
+	4,  // 22: v1.ProcessBaselineService.BulkLockProcessBaselines:output_type -> v1.BulkUpdateProcessBaselinesResponse
+	4,  // 23: v1.ProcessBaselineService.BulkUnlockProcessBaselines:output_type -> v1.BulkUpdateProcessBaselinesResponse
+	9,  // 24: v1.ProcessBaselineService.DeleteProcessBaselines:output_type -> v1.DeleteProcessBaselinesResponse
+	12, // 25: v1.ProcessBaselineService.GetProcessBaselineBulk:output_type -> v1.GetProcessBaselinesBulkResponse
+	19, // [19:26] is the sub-list for method output_type
+	12, // [12:19] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_api_v1_process_baseline_service_proto_init() }
@@ -635,13 +852,14 @@ func file_api_v1_process_baseline_service_proto_init() {
 	if File_api_v1_process_baseline_service_proto != nil {
 		return
 	}
+	file_api_v1_pagination_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v1_process_baseline_service_proto_rawDesc), len(file_api_v1_process_baseline_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/generated/api/v1/process_baseline_service.pb.go
+++ b/generated/api/v1/process_baseline_service.pb.go
@@ -778,7 +778,7 @@ const file_api_v1_process_baseline_service_proto_rawDesc = "" +
 	"\x18BulkLockProcessBaselines\x12\x1f.v1.BulkProcessBaselinesRequest\x1a&.v1.BulkUpdateProcessBaselinesResponse\")\x82\xd3\xe4\x93\x02#:\x01*\x1a\x1e/v1/processbaselines/bulk/lock\x12\x92\x01\n" +
 	"\x1aBulkUnlockProcessBaselines\x12\x1f.v1.BulkProcessBaselinesRequest\x1a&.v1.BulkUpdateProcessBaselinesResponse\"+\x82\xd3\xe4\x93\x02%:\x01*\x1a /v1/processbaselines/bulk/unlock\x12}\n" +
 	"\x16DeleteProcessBaselines\x12!.v1.DeleteProcessBaselinesRequest\x1a\".v1.DeleteProcessBaselinesResponse\"\x1c\x82\xd3\xe4\x93\x02\x16*\x14/v1/processbaselines\x12\x8b\x01\n" +
-	"\x16GetProcessBaselineBulk\x12\".v1.GetProcessBaselinesBulkRequest\x1a#.v1.GetProcessBaselinesBulkResponse\"(\x82\xd3\xe4\x93\x02\":\x01*\x1a\x1d/v1/processbaselines/bulk/getB'\n" +
+	"\x16GetProcessBaselineBulk\x12\".v1.GetProcessBaselinesBulkRequest\x1a#.v1.GetProcessBaselinesBulkResponse\"(\x82\xd3\xe4\x93\x02\":\x01*\"\x1d/v1/processbaselines/bulk/getB'\n" +
 	"\x18io.stackrox.proto.api.v1Z\v./api/v1;v1X\x01b\x06proto3"
 
 var (

--- a/generated/api/v1/process_baseline_service.pb.gw.go
+++ b/generated/api/v1/process_baseline_service.pb.gw.go
@@ -213,6 +213,33 @@ func local_request_ProcessBaselineService_DeleteProcessBaselines_0(ctx context.C
 	return msg, metadata, err
 }
 
+func request_ProcessBaselineService_GetProcessBaselineBulk_0(ctx context.Context, marshaler runtime.Marshaler, client ProcessBaselineServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetProcessBaselinesBulkRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.GetProcessBaselineBulk(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ProcessBaselineService_GetProcessBaselineBulk_0(ctx context.Context, marshaler runtime.Marshaler, server ProcessBaselineServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetProcessBaselinesBulkRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetProcessBaselineBulk(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterProcessBaselineServiceHandlerServer registers the http handlers for service ProcessBaselineService to "mux".
 // UnaryRPC     :call ProcessBaselineServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -338,6 +365,26 @@ func RegisterProcessBaselineServiceHandlerServer(ctx context.Context, mux *runti
 			return
 		}
 		forward_ProcessBaselineService_DeleteProcessBaselines_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPut, pattern_ProcessBaselineService_GetProcessBaselineBulk_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/v1.ProcessBaselineService/GetProcessBaselineBulk", runtime.WithHTTPPathPattern("/v1/processbaselines/bulk/get"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ProcessBaselineService_GetProcessBaselineBulk_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ProcessBaselineService_GetProcessBaselineBulk_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -481,6 +528,23 @@ func RegisterProcessBaselineServiceHandlerClient(ctx context.Context, mux *runti
 		}
 		forward_ProcessBaselineService_DeleteProcessBaselines_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPut, pattern_ProcessBaselineService_GetProcessBaselineBulk_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/v1.ProcessBaselineService/GetProcessBaselineBulk", runtime.WithHTTPPathPattern("/v1/processbaselines/bulk/get"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ProcessBaselineService_GetProcessBaselineBulk_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ProcessBaselineService_GetProcessBaselineBulk_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -491,6 +555,7 @@ var (
 	pattern_ProcessBaselineService_BulkLockProcessBaselines_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "processbaselines", "bulk", "lock"}, ""))
 	pattern_ProcessBaselineService_BulkUnlockProcessBaselines_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "processbaselines", "bulk", "unlock"}, ""))
 	pattern_ProcessBaselineService_DeleteProcessBaselines_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "processbaselines"}, ""))
+	pattern_ProcessBaselineService_GetProcessBaselineBulk_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "processbaselines", "bulk", "get"}, ""))
 )
 
 var (
@@ -500,4 +565,5 @@ var (
 	forward_ProcessBaselineService_BulkLockProcessBaselines_0   = runtime.ForwardResponseMessage
 	forward_ProcessBaselineService_BulkUnlockProcessBaselines_0 = runtime.ForwardResponseMessage
 	forward_ProcessBaselineService_DeleteProcessBaselines_0     = runtime.ForwardResponseMessage
+	forward_ProcessBaselineService_GetProcessBaselineBulk_0     = runtime.ForwardResponseMessage
 )

--- a/generated/api/v1/process_baseline_service.pb.gw.go
+++ b/generated/api/v1/process_baseline_service.pb.gw.go
@@ -366,7 +366,7 @@ func RegisterProcessBaselineServiceHandlerServer(ctx context.Context, mux *runti
 		}
 		forward_ProcessBaselineService_DeleteProcessBaselines_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPut, pattern_ProcessBaselineService_GetProcessBaselineBulk_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_ProcessBaselineService_GetProcessBaselineBulk_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
@@ -528,7 +528,7 @@ func RegisterProcessBaselineServiceHandlerClient(ctx context.Context, mux *runti
 		}
 		forward_ProcessBaselineService_DeleteProcessBaselines_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
-	mux.Handle(http.MethodPut, pattern_ProcessBaselineService_GetProcessBaselineBulk_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle(http.MethodPost, pattern_ProcessBaselineService_GetProcessBaselineBulk_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)

--- a/generated/api/v1/process_baseline_service.swagger.json
+++ b/generated/api/v1/process_baseline_service.swagger.json
@@ -85,7 +85,7 @@
       }
     },
     "/v1/processbaselines/bulk/get": {
-      "put": {
+      "post": {
         "summary": "`GetProcessBaselineBulk` returns process baselines matching the provided query.",
         "operationId": "ProcessBaselineService_GetProcessBaselineBulk",
         "responses": {

--- a/generated/api/v1/process_baseline_service.swagger.json
+++ b/generated/api/v1/process_baseline_service.swagger.json
@@ -84,6 +84,39 @@
         ]
       }
     },
+    "/v1/processbaselines/bulk/get": {
+      "put": {
+        "summary": "`GetProcessBaselineBulk` returns process baselines matching the provided query.",
+        "operationId": "ProcessBaselineService_GetProcessBaselineBulk",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetProcessBaselinesBulkResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googlerpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetProcessBaselinesBulkRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ProcessBaselineService"
+        ]
+      }
+    },
     "/v1/processbaselines/bulk/lock": {
       "put": {
         "summary": "`BulkLockProcessBaselines` locks process baselines given a cluster and\nan optional set of namespaces. It returns success or an error.",
@@ -343,6 +376,27 @@
         }
       }
     },
+    "v1AggregateBy": {
+      "type": "object",
+      "properties": {
+        "aggrFunc": {
+          "$ref": "#/definitions/v1Aggregation"
+        },
+        "distinct": {
+          "type": "boolean"
+        }
+      }
+    },
+    "v1Aggregation": {
+      "type": "string",
+      "enum": [
+        "UNSET",
+        "COUNT",
+        "MIN",
+        "MAX"
+      ],
+      "default": "UNSET"
+    },
     "v1BulkProcessBaselinesRequest": {
       "type": "object",
       "properties": {
@@ -377,6 +431,33 @@
         }
       }
     },
+    "v1GetProcessBaselinesBulkRequest": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "$ref": "#/definitions/v1ProcessBaselineQuery"
+        },
+        "pagination": {
+          "$ref": "#/definitions/v1Pagination"
+        }
+      }
+    },
+    "v1GetProcessBaselinesBulkResponse": {
+      "type": "object",
+      "properties": {
+        "baselines": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/storageProcessBaseline"
+          }
+        },
+        "totalCount": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
     "v1LockProcessBaselinesRequest": {
       "type": "object",
       "properties": {
@@ -392,6 +473,71 @@
         }
       }
     },
+    "v1Pagination": {
+      "type": "object",
+      "properties": {
+        "limit": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "offset": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "sortOption": {
+          "$ref": "#/definitions/v1SortOption"
+        },
+        "sortOptions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1SortOption"
+          },
+          "description": "This field is under development. It is not supported on any REST APIs."
+        }
+      }
+    },
+    "v1ProcessBaselineQuery": {
+      "type": "object",
+      "properties": {
+        "clusterIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "namespaces": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deploymentIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deploymentNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "images": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "containerNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "v1ProcessBaselineUpdateError": {
       "type": "object",
       "properties": {
@@ -400,6 +546,21 @@
         },
         "key": {
           "$ref": "#/definitions/storageProcessBaselineKey"
+        }
+      }
+    },
+    "v1SortOption": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "reversed": {
+          "type": "boolean"
+        },
+        "aggregateBy": {
+          "$ref": "#/definitions/v1AggregateBy",
+          "description": "This field is under development. It is not supported on any REST APIs."
         }
       }
     },

--- a/generated/api/v1/process_baseline_service_grpc.pb.go
+++ b/generated/api/v1/process_baseline_service_grpc.pb.go
@@ -26,6 +26,7 @@ const (
 	ProcessBaselineService_BulkLockProcessBaselines_FullMethodName   = "/v1.ProcessBaselineService/BulkLockProcessBaselines"
 	ProcessBaselineService_BulkUnlockProcessBaselines_FullMethodName = "/v1.ProcessBaselineService/BulkUnlockProcessBaselines"
 	ProcessBaselineService_DeleteProcessBaselines_FullMethodName     = "/v1.ProcessBaselineService/DeleteProcessBaselines"
+	ProcessBaselineService_GetProcessBaselineBulk_FullMethodName     = "/v1.ProcessBaselineService/GetProcessBaselineBulk"
 )
 
 // ProcessBaselineServiceClient is the client API for ProcessBaselineService service.
@@ -51,6 +52,8 @@ type ProcessBaselineServiceClient interface {
 	BulkUnlockProcessBaselines(ctx context.Context, in *BulkProcessBaselinesRequest, opts ...grpc.CallOption) (*BulkUpdateProcessBaselinesResponse, error)
 	// `DeleteProcessBaselines` deletes baselines.
 	DeleteProcessBaselines(ctx context.Context, in *DeleteProcessBaselinesRequest, opts ...grpc.CallOption) (*DeleteProcessBaselinesResponse, error)
+	// `GetProcessBaselineBulk` returns process baselines matching the provided query.
+	GetProcessBaselineBulk(ctx context.Context, in *GetProcessBaselinesBulkRequest, opts ...grpc.CallOption) (*GetProcessBaselinesBulkResponse, error)
 }
 
 type processBaselineServiceClient struct {
@@ -121,6 +124,16 @@ func (c *processBaselineServiceClient) DeleteProcessBaselines(ctx context.Contex
 	return out, nil
 }
 
+func (c *processBaselineServiceClient) GetProcessBaselineBulk(ctx context.Context, in *GetProcessBaselinesBulkRequest, opts ...grpc.CallOption) (*GetProcessBaselinesBulkResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetProcessBaselinesBulkResponse)
+	err := c.cc.Invoke(ctx, ProcessBaselineService_GetProcessBaselineBulk_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ProcessBaselineServiceServer is the server API for ProcessBaselineService service.
 // All implementations should embed UnimplementedProcessBaselineServiceServer
 // for forward compatibility.
@@ -144,6 +157,8 @@ type ProcessBaselineServiceServer interface {
 	BulkUnlockProcessBaselines(context.Context, *BulkProcessBaselinesRequest) (*BulkUpdateProcessBaselinesResponse, error)
 	// `DeleteProcessBaselines` deletes baselines.
 	DeleteProcessBaselines(context.Context, *DeleteProcessBaselinesRequest) (*DeleteProcessBaselinesResponse, error)
+	// `GetProcessBaselineBulk` returns process baselines matching the provided query.
+	GetProcessBaselineBulk(context.Context, *GetProcessBaselinesBulkRequest) (*GetProcessBaselinesBulkResponse, error)
 }
 
 // UnimplementedProcessBaselineServiceServer should be embedded to have
@@ -170,6 +185,9 @@ func (UnimplementedProcessBaselineServiceServer) BulkUnlockProcessBaselines(cont
 }
 func (UnimplementedProcessBaselineServiceServer) DeleteProcessBaselines(context.Context, *DeleteProcessBaselinesRequest) (*DeleteProcessBaselinesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteProcessBaselines not implemented")
+}
+func (UnimplementedProcessBaselineServiceServer) GetProcessBaselineBulk(context.Context, *GetProcessBaselinesBulkRequest) (*GetProcessBaselinesBulkResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetProcessBaselineBulk not implemented")
 }
 func (UnimplementedProcessBaselineServiceServer) testEmbeddedByValue() {}
 
@@ -299,6 +317,24 @@ func _ProcessBaselineService_DeleteProcessBaselines_Handler(srv interface{}, ctx
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ProcessBaselineService_GetProcessBaselineBulk_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetProcessBaselinesBulkRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ProcessBaselineServiceServer).GetProcessBaselineBulk(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ProcessBaselineService_GetProcessBaselineBulk_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ProcessBaselineServiceServer).GetProcessBaselineBulk(ctx, req.(*GetProcessBaselinesBulkRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ProcessBaselineService_ServiceDesc is the grpc.ServiceDesc for ProcessBaselineService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -329,6 +365,10 @@ var ProcessBaselineService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteProcessBaselines",
 			Handler:    _ProcessBaselineService_DeleteProcessBaselines_Handler,
+		},
+		{
+			MethodName: "GetProcessBaselineBulk",
+			Handler:    _ProcessBaselineService_GetProcessBaselineBulk_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/generated/api/v1/process_baseline_service_vtproto.pb.go
+++ b/generated/api/v1/process_baseline_service_vtproto.pb.go
@@ -293,6 +293,100 @@ func (m *DeleteProcessBaselinesResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *ProcessBaselineQuery) CloneVT() *ProcessBaselineQuery {
+	if m == nil {
+		return (*ProcessBaselineQuery)(nil)
+	}
+	r := new(ProcessBaselineQuery)
+	if rhs := m.ClusterIds; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.ClusterIds = tmpContainer
+	}
+	if rhs := m.Namespaces; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.Namespaces = tmpContainer
+	}
+	if rhs := m.DeploymentIds; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.DeploymentIds = tmpContainer
+	}
+	if rhs := m.DeploymentNames; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.DeploymentNames = tmpContainer
+	}
+	if rhs := m.Images; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.Images = tmpContainer
+	}
+	if rhs := m.ContainerNames; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.ContainerNames = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ProcessBaselineQuery) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *GetProcessBaselinesBulkRequest) CloneVT() *GetProcessBaselinesBulkRequest {
+	if m == nil {
+		return (*GetProcessBaselinesBulkRequest)(nil)
+	}
+	r := new(GetProcessBaselinesBulkRequest)
+	r.Query = m.Query.CloneVT()
+	r.Pagination = m.Pagination.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetProcessBaselinesBulkRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *GetProcessBaselinesBulkResponse) CloneVT() *GetProcessBaselinesBulkResponse {
+	if m == nil {
+		return (*GetProcessBaselinesBulkResponse)(nil)
+	}
+	r := new(GetProcessBaselinesBulkResponse)
+	r.TotalCount = m.TotalCount
+	if rhs := m.Baselines; rhs != nil {
+		tmpContainer := make([]*storage.ProcessBaseline, len(rhs))
+		for k, v := range rhs {
+			if vtpb, ok := interface{}(v).(interface {
+				CloneVT() *storage.ProcessBaseline
+			}); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*storage.ProcessBaseline)
+			}
+		}
+		r.Baselines = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetProcessBaselinesBulkResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (this *GetProcessBaselineRequest) EqualVT(that *GetProcessBaselineRequest) bool {
 	if this == that {
 		return true
@@ -654,6 +748,140 @@ func (this *DeleteProcessBaselinesResponse) EqualVT(that *DeleteProcessBaselines
 
 func (this *DeleteProcessBaselinesResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*DeleteProcessBaselinesResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ProcessBaselineQuery) EqualVT(that *ProcessBaselineQuery) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if len(this.ClusterIds) != len(that.ClusterIds) {
+		return false
+	}
+	for i, vx := range this.ClusterIds {
+		vy := that.ClusterIds[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if len(this.Namespaces) != len(that.Namespaces) {
+		return false
+	}
+	for i, vx := range this.Namespaces {
+		vy := that.Namespaces[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if len(this.DeploymentIds) != len(that.DeploymentIds) {
+		return false
+	}
+	for i, vx := range this.DeploymentIds {
+		vy := that.DeploymentIds[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if len(this.DeploymentNames) != len(that.DeploymentNames) {
+		return false
+	}
+	for i, vx := range this.DeploymentNames {
+		vy := that.DeploymentNames[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if len(this.Images) != len(that.Images) {
+		return false
+	}
+	for i, vx := range this.Images {
+		vy := that.Images[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if len(this.ContainerNames) != len(that.ContainerNames) {
+		return false
+	}
+	for i, vx := range this.ContainerNames {
+		vy := that.ContainerNames[i]
+		if vx != vy {
+			return false
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ProcessBaselineQuery) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ProcessBaselineQuery)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *GetProcessBaselinesBulkRequest) EqualVT(that *GetProcessBaselinesBulkRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.Query.EqualVT(that.Query) {
+		return false
+	}
+	if !this.Pagination.EqualVT(that.Pagination) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *GetProcessBaselinesBulkRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*GetProcessBaselinesBulkRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *GetProcessBaselinesBulkResponse) EqualVT(that *GetProcessBaselinesBulkResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if len(this.Baselines) != len(that.Baselines) {
+		return false
+	}
+	for i, vx := range this.Baselines {
+		vy := that.Baselines[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &storage.ProcessBaseline{}
+			}
+			if q == nil {
+				q = &storage.ProcessBaseline{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*storage.ProcessBaseline) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
+				return false
+			}
+		}
+	}
+	if this.TotalCount != that.TotalCount {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *GetProcessBaselinesBulkResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*GetProcessBaselinesBulkResponse)
 	if !ok {
 		return false
 	}
@@ -1264,6 +1492,208 @@ func (m *DeleteProcessBaselinesResponse) MarshalToSizedBufferVT(dAtA []byte) (in
 	return len(dAtA) - i, nil
 }
 
+func (m *ProcessBaselineQuery) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ProcessBaselineQuery) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ProcessBaselineQuery) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.ContainerNames) > 0 {
+		for iNdEx := len(m.ContainerNames) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.ContainerNames[iNdEx])
+			copy(dAtA[i:], m.ContainerNames[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ContainerNames[iNdEx])))
+			i--
+			dAtA[i] = 0x32
+		}
+	}
+	if len(m.Images) > 0 {
+		for iNdEx := len(m.Images) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Images[iNdEx])
+			copy(dAtA[i:], m.Images[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Images[iNdEx])))
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
+	if len(m.DeploymentNames) > 0 {
+		for iNdEx := len(m.DeploymentNames) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.DeploymentNames[iNdEx])
+			copy(dAtA[i:], m.DeploymentNames[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DeploymentNames[iNdEx])))
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if len(m.DeploymentIds) > 0 {
+		for iNdEx := len(m.DeploymentIds) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.DeploymentIds[iNdEx])
+			copy(dAtA[i:], m.DeploymentIds[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DeploymentIds[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.Namespaces) > 0 {
+		for iNdEx := len(m.Namespaces) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Namespaces[iNdEx])
+			copy(dAtA[i:], m.Namespaces[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Namespaces[iNdEx])))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.ClusterIds) > 0 {
+		for iNdEx := len(m.ClusterIds) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.ClusterIds[iNdEx])
+			copy(dAtA[i:], m.ClusterIds[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ClusterIds[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetProcessBaselinesBulkRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetProcessBaselinesBulkRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetProcessBaselinesBulkRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Pagination != nil {
+		size, err := m.Pagination.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Query != nil {
+		size, err := m.Query.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetProcessBaselinesBulkResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetProcessBaselinesBulkResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetProcessBaselinesBulkResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.TotalCount != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.TotalCount))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Baselines) > 0 {
+		for iNdEx := len(m.Baselines) - 1; iNdEx >= 0; iNdEx-- {
+			if vtmsg, ok := interface{}(m.Baselines[iNdEx]).(interface {
+				MarshalToSizedBufferVT([]byte) (int, error)
+			}); ok {
+				size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			} else {
+				encoded, err := proto.Marshal(m.Baselines[iNdEx])
+				if err != nil {
+					return 0, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *GetProcessBaselineRequest) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -1490,6 +1920,95 @@ func (m *DeleteProcessBaselinesResponse) SizeVT() (n int) {
 	}
 	if m.DryRun {
 		n += 2
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ProcessBaselineQuery) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.ClusterIds) > 0 {
+		for _, s := range m.ClusterIds {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.Namespaces) > 0 {
+		for _, s := range m.Namespaces {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.DeploymentIds) > 0 {
+		for _, s := range m.DeploymentIds {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.DeploymentNames) > 0 {
+		for _, s := range m.DeploymentNames {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.Images) > 0 {
+		for _, s := range m.Images {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.ContainerNames) > 0 {
+		for _, s := range m.ContainerNames {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetProcessBaselinesBulkRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Query != nil {
+		l = m.Query.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Pagination != nil {
+		l = m.Pagination.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetProcessBaselinesBulkResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Baselines) > 0 {
+		for _, e := range m.Baselines {
+			if size, ok := interface{}(e).(interface {
+				SizeVT() int
+			}); ok {
+				l = size.SizeVT()
+			} else {
+				l = proto.Size(e)
+			}
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if m.TotalCount != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.TotalCount))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -2584,6 +3103,484 @@ func (m *DeleteProcessBaselinesResponse) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.DryRun = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ProcessBaselineQuery) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ProcessBaselineQuery: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ProcessBaselineQuery: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterIds", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ClusterIds = append(m.ClusterIds, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespaces", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Namespaces = append(m.Namespaces, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DeploymentIds", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DeploymentIds = append(m.DeploymentIds, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DeploymentNames", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DeploymentNames = append(m.DeploymentNames, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Images", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Images = append(m.Images, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContainerNames", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ContainerNames = append(m.ContainerNames, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetProcessBaselinesBulkRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetProcessBaselinesBulkRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetProcessBaselinesBulkRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Query == nil {
+				m.Query = &ProcessBaselineQuery{}
+			}
+			if err := m.Query.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &Pagination{}
+			}
+			if err := m.Pagination.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetProcessBaselinesBulkResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetProcessBaselinesBulkResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetProcessBaselinesBulkResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Baselines", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Baselines = append(m.Baselines, &storage.ProcessBaseline{})
+			if unmarshal, ok := interface{}(m.Baselines[len(m.Baselines)-1]).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Baselines[len(m.Baselines)-1]); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TotalCount", wireType)
+			}
+			m.TotalCount = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.TotalCount |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -3711,6 +4708,508 @@ func (m *DeleteProcessBaselinesResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 			}
 			m.DryRun = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ProcessBaselineQuery) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ProcessBaselineQuery: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ProcessBaselineQuery: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterIds", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ClusterIds = append(m.ClusterIds, stringValue)
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespaces", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Namespaces = append(m.Namespaces, stringValue)
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DeploymentIds", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.DeploymentIds = append(m.DeploymentIds, stringValue)
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DeploymentNames", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.DeploymentNames = append(m.DeploymentNames, stringValue)
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Images", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Images = append(m.Images, stringValue)
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContainerNames", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ContainerNames = append(m.ContainerNames, stringValue)
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetProcessBaselinesBulkRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetProcessBaselinesBulkRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetProcessBaselinesBulkRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Query == nil {
+				m.Query = &ProcessBaselineQuery{}
+			}
+			if err := m.Query.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pagination", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pagination == nil {
+				m.Pagination = &Pagination{}
+			}
+			if err := m.Pagination.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetProcessBaselinesBulkResponse) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetProcessBaselinesBulkResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetProcessBaselinesBulkResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Baselines", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Baselines = append(m.Baselines, &storage.ProcessBaseline{})
+			if unmarshal, ok := interface{}(m.Baselines[len(m.Baselines)-1]).(interface {
+				UnmarshalVTUnsafe([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Baselines[len(m.Baselines)-1]); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TotalCount", wireType)
+			}
+			m.TotalCount = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.TotalCount |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/proto/api/v1/process_baseline_service.proto
+++ b/proto/api/v1/process_baseline_service.proto
@@ -131,7 +131,7 @@ service ProcessBaselineService {
   // `GetProcessBaselineBulk` returns process baselines matching the provided query.
   rpc GetProcessBaselineBulk(GetProcessBaselinesBulkRequest) returns (GetProcessBaselinesBulkResponse) {
     option (google.api.http) = {
-      put: "/v1/processbaselines/bulk/get"
+      post: "/v1/processbaselines/bulk/get"
       body: "*"
     };
   }

--- a/proto/api/v1/process_baseline_service.proto
+++ b/proto/api/v1/process_baseline_service.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package v1;
 
+import "api/v1/pagination.proto";
 import weak "google/api/annotations.proto";
 import "storage/process_baseline.proto";
 
@@ -59,6 +60,25 @@ message DeleteProcessBaselinesResponse {
   bool dry_run = 2;
 }
 
+message ProcessBaselineQuery {
+  repeated string cluster_ids = 1;
+  repeated string namespaces = 2;
+  repeated string deployment_ids = 3;
+  repeated string deployment_names = 4;
+  repeated string images = 5;
+  repeated string container_names = 6;
+}
+
+message GetProcessBaselinesBulkRequest {
+  ProcessBaselineQuery query = 1;
+  Pagination pagination = 2;
+}
+
+message GetProcessBaselinesBulkResponse {
+  repeated storage.ProcessBaseline baselines = 1;
+  int32 total_count = 2;
+}
+
 // `ProcessBaselineService` APIs can be used to manage process baselines.
 service ProcessBaselineService {
   // `GetProcessBaselineById` returns the single
@@ -106,5 +126,13 @@ service ProcessBaselineService {
   // `DeleteProcessBaselines` deletes baselines.
   rpc DeleteProcessBaselines(DeleteProcessBaselinesRequest) returns (DeleteProcessBaselinesResponse) {
     option (google.api.http) = {delete: "/v1/processbaselines"};
+  }
+
+  // `GetProcessBaselineBulk` returns process baselines matching the provided query.
+  rpc GetProcessBaselineBulk(GetProcessBaselinesBulkRequest) returns (GetProcessBaselinesBulkResponse) {
+    option (google.api.http) = {
+      put: "/v1/processbaselines/bulk/get"
+      body: "*"
+    };
   }
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Currently it is only possible to get one process baseline at a time from the process baseline service. Users may want all process baselines in a particular cluster, or process baselines with a particular namespace in all clusters, or get process baselines by some other set of criteria. One example use case could be getting all process baselines for all collectors in all secured clusters. The process baselines for collectors in different secured clusters are independent of each other. If different processes run within the observation period in collectors of different secured clusters, they will have different process baselines. This may not be desired. It would be good to enable customers to easily see if process baselines involving the collector image are all the same. Once the customer has a list of process baseline keys, they could use that to make edits to the baselines using existing API endpoints.

This PR enables getting process baselines by the following criteria

Cluster id
Namespace
Deployment id
Deployment name
Images
Container name

Process baselines are added to the central db lazily. They are only added when the process baseline observation period ends, or when an API endpoint involving that process baseline is called. This means that if we want to return the process baselines matching a set of criteria, we should first look at the deployments and containers matching the criteria and then determine the process baselines from the deployments and containers. If we simply tried to match on process baselines, we would miss those that have not been created yet. Once the desired process baseline keys are obtained they are looped through one by one and are either obtained from the database or added to the database. This is not efficient. It could be improved by querying for all of the process baselines keys at once (taking batching into consideration), and then creating all of the missing process baselines at once (again using batching).

It is not possible to search deployments by container name. For this reason a query string is not used, but arrays of strings for each field is used instead. Since it is not possible to query by container name, the filtering by container name is done in memory. In a recent diagnostic bundle one user had ~165k deployments, about the same number of rows in the process_baselines table, and ~306k rows in the deployments_containers table. This many deployments could theoretically be brought into memory, but is not desirable. At least one criteria other than container name must be used. Pagination will also be used to reduce performance problems, but one difficulty is what stage this pagination will be done at. If it is done at the stage of getting deployments, than the number of process baselines might not correspond to what is specified in the pagination. Hence pagination will be done once the list of process baseline keys is obtained.

The list of cluster ids cannot be blank. However, it is possible to search for all cluster ids using a wild card. This is to ensure that if someone want to search for process baselines in all clusters they can, but only if they know what they are doing.

One issue is that container names cannot be used to query deployments. Hence, a filter will need to be used to get the deployments and containers with the correct container names. It is a requirement that at least one field other than container name be used.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

ACS was deployed with `ROX_BASELINE_GENERATION_DURATION` was set to 5m.

Three deployments were created with the same image, in three different namespaces. In each of deployments a process called `normal` was run. A process called `normal-delayed` was also run. However, that process is run at different times in the different deployments. In two of the deployments the `normal-delayed` process was run before the end of the process baseline generation period and in one of them it was after the process baseline generation period. In one of the deployments a process called `abnormal` is run during the process baseline generation period, via a `kubectl exec`. The process baselines with the image of interest were obtained with the new API endpoint. The output was then used to add `normal-delayed` to all of the process baselines and to remove `abnormal` from the process baselines.

This test was successful.

The expectation was that 

pb-demo-1 baseline would have normal, abnormal, and normal-delayed.
pb-demo-2 baseline would have only normal.
pb-demo-3 baseline would have normal and normal-delayed.

This is what was observed.

<details>
  <summary>The new API endpoint returned the following</summary>

```json

{
  "baselines": [
    {
      "id": "DC:daf61e51-9f52-46cf-b70a-17a99ac205fd:pb-demo-1:40a5265d-cafd-49de-a238-af37d2d840d7:demo-container",
      "key": {
        "deploymentId": "40a5265d-cafd-49de-a238-af37d2d840d7",
        "containerName": "demo-container",
        "clusterId": "daf61e51-9f52-46cf-b70a-17a99ac205fd",
        "namespace": "pb-demo-1"
      },
      "elements": [
        {
          "element": {
            "processName": "/bin/sleep"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/usr/bin/normal"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/entrypoint.sh"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/usr/bin/nohup"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/bin/sh"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/usr/bin/abnormal"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/usr/bin/normal-delayed"
          },
          "auto": true
        }
      ],
      "elementGraveyard": [],
      "created": "2025-12-17T05:23:03.571170391Z",
      "userLockedTimestamp": null,
      "stackRoxLockedTimestamp": "2025-12-17T05:23:03.571170391Z",
      "lastUpdate": "2025-12-17T05:23:03.571170391Z"
    },
    {
      "id": "DC:daf61e51-9f52-46cf-b70a-17a99ac205fd:pb-demo-2:5784a260-136d-4da2-8916-702b55a3eeeb:demo-container",
      "key": {
        "deploymentId": "5784a260-136d-4da2-8916-702b55a3eeeb",
        "containerName": "demo-container",
        "clusterId": "daf61e51-9f52-46cf-b70a-17a99ac205fd",
        "namespace": "pb-demo-2"
      },
      "elements": [
        {
          "element": {
            "processName": "/usr/bin/normal"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/bin/sleep"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/entrypoint.sh"
          },
          "auto": true
        }
      ],
      "elementGraveyard": [],
      "created": "2025-12-17T05:23:03.580889112Z",
      "userLockedTimestamp": null,
      "stackRoxLockedTimestamp": "2025-12-17T05:23:03.580889112Z",
      "lastUpdate": "2025-12-17T05:23:03.580889112Z"
    },
    {
      "id": "DC:daf61e51-9f52-46cf-b70a-17a99ac205fd:pb-demo-3:66449910-9fa2-4c84-bc17-39b0a2f1ea75:demo-container",
      "key": {
        "deploymentId": "66449910-9fa2-4c84-bc17-39b0a2f1ea75",
        "containerName": "demo-container",
        "clusterId": "daf61e51-9f52-46cf-b70a-17a99ac205fd",
        "namespace": "pb-demo-3"
      },
      "elements": [
        {
          "element": {
            "processName": "/bin/sleep"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/usr/bin/normal"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/entrypoint.sh"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/usr/bin/normal-delayed"
          },
          "auto": true
        }
      ],
      "elementGraveyard": [],
      "created": "2025-12-17T05:23:03.576744096Z",
      "userLockedTimestamp": null,
      "stackRoxLockedTimestamp": "2025-12-17T05:23:03.576744096Z",
      "lastUpdate": "2025-12-17T05:23:03.576744096Z"
    }
  ],
  "totalCount": 3
}
```
</details>

The following was the expectation for the process baselines after updating them.

The three baselines would all have normal, and normal-delayed. Abnormal is in the graveyard of all of the process baselines.

This is what is found.

<details>
  <summary>After updating the process baselines</summary>

```json

{
  "baselines": [
    {
      "id": "DC:daf61e51-9f52-46cf-b70a-17a99ac205fd:pb-demo-1:40a5265d-cafd-49de-a238-af37d2d840d7:demo-container",
      "key": {
        "deploymentId": "40a5265d-cafd-49de-a238-af37d2d840d7",
        "containerName": "demo-container",
        "clusterId": "daf61e51-9f52-46cf-b70a-17a99ac205fd",
        "namespace": "pb-demo-1"
      },
      "elements": [
        {
          "element": {
            "processName": "/bin/sh"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/usr/bin/normal-delayed"
          },
          "auto": false
        },
        {
          "element": {
            "processName": "/bin/sleep"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/usr/bin/normal"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/entrypoint.sh"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/usr/bin/nohup"
          },
          "auto": true
        }
      ],
      "elementGraveyard": [
        {
          "element": {
            "processName": "/usr/bin/abnormal"
          },
          "auto": false
        }
      ],
      "created": "2025-12-17T05:23:03.571170391Z",
      "userLockedTimestamp": null,
      "stackRoxLockedTimestamp": "2025-12-17T05:23:03.571170391Z",
      "lastUpdate": "2025-12-17T05:23:08.160179999Z"
    },
    {
      "id": "DC:daf61e51-9f52-46cf-b70a-17a99ac205fd:pb-demo-2:5784a260-136d-4da2-8916-702b55a3eeeb:demo-container",
      "key": {
        "deploymentId": "5784a260-136d-4da2-8916-702b55a3eeeb",
        "containerName": "demo-container",
        "clusterId": "daf61e51-9f52-46cf-b70a-17a99ac205fd",
        "namespace": "pb-demo-2"
      },
      "elements": [
        {
          "element": {
            "processName": "/usr/bin/normal"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/bin/sleep"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/entrypoint.sh"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/usr/bin/normal-delayed"
          },
          "auto": false
        }
      ],
      "elementGraveyard": [
        {
          "element": {
            "processName": "/usr/bin/abnormal"
          },
          "auto": false
        }
      ],
      "created": "2025-12-17T05:23:03.580889112Z",
      "userLockedTimestamp": null,
      "stackRoxLockedTimestamp": "2025-12-17T05:23:03.580889112Z",
      "lastUpdate": "2025-12-17T05:23:08.163836330Z"
    },
    {
      "id": "DC:daf61e51-9f52-46cf-b70a-17a99ac205fd:pb-demo-3:66449910-9fa2-4c84-bc17-39b0a2f1ea75:demo-container",
      "key": {
        "deploymentId": "66449910-9fa2-4c84-bc17-39b0a2f1ea75",
        "containerName": "demo-container",
        "clusterId": "daf61e51-9f52-46cf-b70a-17a99ac205fd",
        "namespace": "pb-demo-3"
      },
      "elements": [
        {
          "element": {
            "processName": "/bin/sleep"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/usr/bin/normal"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/entrypoint.sh"
          },
          "auto": true
        },
        {
          "element": {
            "processName": "/usr/bin/normal-delayed"
          },
          "auto": false
        }
      ],
      "elementGraveyard": [
        {
          "element": {
            "processName": "/usr/bin/abnormal"
          },
          "auto": false
        }
      ],
      "created": "2025-12-17T05:23:03.576744096Z",
      "userLockedTimestamp": null,
      "stackRoxLockedTimestamp": "2025-12-17T05:23:03.576744096Z",
      "lastUpdate": "2025-12-17T05:23:08.165926164Z"
    }
  ],
  "totalCount": 3
}

```

</details>
