### PR TITLE
ROX-32214: Remove React import statement in Compliance and Workflow

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -805,9 +805,7 @@ module.exports = [
     {
         files: ['src/**/*.{js,jsx,ts,tsx}'],
         ignores: [
-            'src/Containers/Compliance/**', // deprecated
             'src/Containers/VulnMgmt/**', // deprecated
-            'src/Containers/Workflow/**', // deprecated
         ],
 
         // After deprecated folders have been deleted:

--- a/ui/apps/platform/src/Containers/Compliance/ComplianceSearchInput.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/ComplianceSearchInput.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { CLIENT_SIDE_SEARCH_OPTIONS as SEARCH_OPTIONS } from 'constants/searchOptions';
 

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { useApolloClient } from '@apollo/client';
 import { Alert } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardTile.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardTile.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { gql, useQuery } from '@apollo/client';
 import type { DocumentNode } from '@apollo/client';

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceScanProgress.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceScanProgress.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Card, CardBody, CardTitle, Progress } from '@patternfly/react-core';
 import type { CardProps } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsError.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsError.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Modal } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ManageStandardsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { Alert, Button, Checkbox, Form, Modal } from '@patternfly/react-core';
 import { useFormik } from 'formik';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Cluster.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Cluster.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 
 import entityTypes from 'constants/entityTypes';
 import EntityCompliance from 'Containers/Compliance/widgets/EntityCompliance';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Control.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Control.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 
 import entityTypes from 'constants/entityTypes';
 import Widget from 'Components/Widget';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Header.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Header.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
 

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import pluralize from 'pluralize';
 import { gql } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Node.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Node.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import pluralize from 'pluralize';
 
 import entityTypes from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Page.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Page.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom-v5-compat';
 import URLService from 'utils/URLService';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/ResourceTabs.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/ResourceTabs.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom-v5-compat';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Standard.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Standard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import entityTypes from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/Compliance/List/Header.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/Header.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import lowerCase from 'lodash/lowerCase';
 import startCase from 'lodash/startCase';

--- a/ui/apps/platform/src/Containers/Compliance/List/List.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/List.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import lowerCase from 'lodash/lowerCase';

--- a/ui/apps/platform/src/Containers/Compliance/List/Page.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/Page.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom-v5-compat';
 import lowerCase from 'lodash/lowerCase';

--- a/ui/apps/platform/src/Containers/Compliance/List/SidePanel.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/SidePanel.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Link, useLocation, useNavigate } from 'react-router-dom-v5-compat';

--- a/ui/apps/platform/src/Containers/Compliance/List/SidePanelAdjacentArea.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/SidePanelAdjacentArea.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement, ReactNode } from 'react';
 
 type Width = '1/3' | '2/5' | '1/2' | '3/5';

--- a/ui/apps/platform/src/Containers/Compliance/List/Table.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/Table.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
 import orderBy from 'lodash/orderBy';

--- a/ui/apps/platform/src/Containers/Compliance/List/TableGroup.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/TableGroup.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import Table from 'Components/Table';
 import Collapsible from 'react-collapsible';

--- a/ui/apps/platform/src/Containers/Compliance/List/tableColumns.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/tableColumns.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import isEmpty from 'lodash/isEmpty';
 import qs from 'qs';
 

--- a/ui/apps/platform/src/Containers/Compliance/Page.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Page.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { memo } from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
 
@@ -34,4 +34,4 @@ const Page = () => (
     </searchContext.Provider>
 );
 
-export default React.memo(Page, isEqual);
+export default memo(Page, isEqual);

--- a/ui/apps/platform/src/Containers/Compliance/ScanButton.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/ScanButton.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Mutation } from '@apollo/client/react/components';
@@ -9,7 +9,7 @@ import { actions as notificationActions } from 'reducers/notifications';
 import { TRIGGER_SCAN } from 'queries/standard';
 import Button from 'Components/Button';
 
-class ScanButton extends React.Component {
+class ScanButton extends Component {
     static propTypes = {
         className: PropTypes.string,
         text: PropTypes.string.isRequired,

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ClusterVersion.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ClusterVersion.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { CLUSTER_VERSION_QUERY as QUERY } from 'queries/cluster';
 import { clusterVersionLabels } from 'messages/common';

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ClusterVersion.test.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ClusterVersion.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MockedProvider } from '@apollo/client/testing';
 import { screen } from '@testing-library/react';
 

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandard.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandard.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import capitalize from 'lodash/capitalize';
 import { Link, useLocation } from 'react-router-dom-v5-compat';

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { useQuery } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ControlRelatedResourceList.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ControlRelatedResourceList.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import URLService from 'utils/URLService';
 import entityTypes from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/EntityCompliance.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 

--- a/ui/apps/platform/src/Containers/Compliance/widgets/HorizontalBarChart.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/HorizontalBarChart.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     FlexibleWidthXYPlot,
     XAxis,

--- a/ui/apps/platform/src/Containers/Compliance/widgets/Labels.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/Labels.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/Compliance/widgets/LinkListWidget.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/LinkListWidget.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom-v5-compat';
 import { Alert } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ResourceCount.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ResourceCount.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import capitalize from 'lodash/capitalize';
 

--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsAcrossEntity.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { useQuery } from '@apollo/client';

--- a/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/StandardsByEntity.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { useQuery } from '@apollo/client';

--- a/ui/apps/platform/src/Containers/Compliance/widgets/VerticalBarChart.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/VerticalBarChart.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import {
     FlexibleWidthXYPlot,
     XAxis,

--- a/ui/apps/platform/src/Containers/Compliance/widgets/VerticalClusterBar.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/VerticalClusterBar.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     FlexibleXYPlot,
     XAxis,

--- a/ui/apps/platform/src/Containers/Workflow/widgets/ViolationFindings.jsx
+++ b/ui/apps/platform/src/Containers/Workflow/widgets/ViolationFindings.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
 import Widget from 'Components/Widget';

--- a/ui/apps/platform/src/Containers/Workflow/widgets/ViolationsAcrossThisDeployment.jsx
+++ b/ui/apps/platform/src/Containers/Workflow/widgets/ViolationsAcrossThisDeployment.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';
 import queryService from 'utils/queryService';


### PR DESCRIPTION
## Description

### Problem

When we move orphan components (that is only one remaining reference) into deprecated container folder:
* Components folder assume absence of jsxPragma import statement.
* Containers (deprecated) folder assumes presence of jsxPragma import statement.

### Analysis

Find in Files `React`

| folder | results |
| :--- | ---: |
| Compliance | 53 | 39 |
| VulnMgmt | 94 | 67 |
| Workflow | 2 | 2 |

### Solution

Follow up prerequisite changes in #18113

1. Delete folders from `ignores` array.
2. Fix errors in deprecated folder.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] updated lint configuration
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
    See presence, and then absense, of errors.