### PR TITLE
ROX-31749: Paginate integrations health widget

### DIFF
--- a/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/Components/IntegrationHealthWidgetVisual.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import {
     Alert,
@@ -7,6 +8,7 @@ import {
     CardTitle,
     Flex,
     FlexItem,
+    Pagination,
 } from '@patternfly/react-core';
 
 import pluralize from 'pluralize';
@@ -27,9 +29,23 @@ const IntegrationHealthWidgetVisual = ({
     errorMessageFetching,
     isFetchingInitialRequest,
 }: IntegrationHealthWidgetVisualProps): ReactElement => {
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(10);
+
+    function onSetPage(_, newPage) {
+        setPage(newPage);
+    }
+
+    function onPerPageSelect(_, newPerPage) {
+        setPerPage(newPerPage);
+    }
+
     const integrations = integrationsMerged.filter((integrationMergedItem) => {
         return integrationMergedItem.status === 'UNHEALTHY';
     });
+
+    const startIndex = (page - 1) * perPage;
+    const paginatedIntegrations = integrations.slice(startIndex, startIndex + perPage);
 
     const icon = isFetchingInitialRequest
         ? SpinnerIcon
@@ -59,6 +75,17 @@ const IntegrationHealthWidgetVisual = ({
                                           )}`}
                                 </FlexItem>
                             )}
+                            {integrations.length > 0 && (
+                                <FlexItem align={{ default: 'alignRight' }}>
+                                    <Pagination
+                                        itemCount={integrations.length}
+                                        perPage={perPage}
+                                        page={page}
+                                        onSetPage={onSetPage}
+                                        onPerPageSelect={onPerPageSelect}
+                                    />
+                                </FlexItem>
+                            )}
                         </Flex>
                     </>
                 }
@@ -73,7 +100,7 @@ const IntegrationHealthWidgetVisual = ({
                             component="p"
                         />
                     ) : (
-                        <IntegrationsHealth integrations={integrations} />
+                        <IntegrationsHealth integrations={paginatedIntegrations} />
                     )}
                 </CardBody>
             )}


### PR DESCRIPTION
## Description

Add client side pagination to the integrations health widget.

This fixes a customer issue where 5000+ errors made the system health page basically unusable. Performance testing showed the slowdown was coming from trying to render too much on the page, not from the size of the API response. Adding client side pagination is a sufficient fix for now to keep the page functional when there’s an excessive amount of integration data to display.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="2243" height="1002" alt="Screenshot 2025-12-08 at 2 50 15 PM" src="https://github.com/user-attachments/assets/54365fcd-f791-49e6-9520-33fd01c0fbcb" />

