### PR TITLE
ROX-32221: Make vm index reports buffer size configurable

### DIFF
--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -20,4 +20,9 @@ var (
 	// connections carrying virtual machine index reports.
 	VirtualMachinesVsockPort = RegisterIntegerSetting("ROX_VIRTUAL_MACHINES_VSOCK_PORT", 818).
 					WithMaximum(65535).WithMinimum(0)
+
+	// VirtualMachinesIndexReportsBufferSize defines the buffer size for the channel receiving virtual machine
+	// index reports before they are sent to Central.
+	VirtualMachinesIndexReportsBufferSize = RegisterIntegerSetting("ROX_VIRTUAL_MACHINES_INDEX_REPORTS_BUFFER_SIZE", 100).
+						WithMinimum(0)
 )

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -10,6 +10,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
@@ -18,9 +19,6 @@ import (
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
 )
-
-// TODO: Buffer has been decreased for testing. Increase the buffer again.
-const indexReportsBufferedChannelSize = 1
 
 var (
 	errCapabilityNotSupported = errors.New("Central does not have virtual machine capability")
@@ -140,7 +138,7 @@ func (h *handlerImpl) Start() error {
 	if h.toCentral != nil || h.indexReports != nil {
 		return errStartMoreThanOnce
 	}
-	h.indexReports = make(chan *v1.IndexReport, indexReportsBufferedChannelSize)
+	h.indexReports = make(chan *v1.IndexReport, env.VirtualMachinesIndexReportsBufferSize.IntegerSetting())
 	h.toCentral = h.run(h.indexReports)
 	return nil
 }


### PR DESCRIPTION
## Description

Make the VM index reports channel buffer size configurable via `ROX_VIRTUAL_MACHINES_INDEX_REPORTS_BUFFER_SIZE` environment variable.

**Problem:** The buffer size was hardcoded to 1 (a testing workaround with a TODO to increase it), making it impossible to tune without code changes.

**Solution:** Extract to an env var with default of 100, following the existing `ROX_VIRTUAL_MACHINES_*` naming pattern.

**AI assistance:** Initial implementation generated by AI. User corrected `WithMinimum(1)` to `WithMinimum(0)` to allow unbuffered channels.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

No new tests added. The change uses the existing, well-tested `RegisterIntegerSetting` pattern. Existing VM handler tests cover the `Start()` path.

### How I validated my change

- [x] CI
- [ ] Manually on a cluster where I manipulated the size of the channel and looked at the performance dashboard in grafana


