### PR TITLE
ROX-32215: Remove React import statement in deprecated VulnMgmt

### DIFF
--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -26,12 +26,15 @@ const pluginGeneric = require('./eslint-plugins/pluginGeneric');
 const pluginLimited = require('./eslint-plugins/pluginLimited');
 const pluginPatternFly = require('./eslint-plugins/pluginPatternFly');
 
+const parser = parserTypeScriptESLint;
+const parserOptions = {
+    project: './tsconfig.eslint.json',
+    tsconfigRootDir: __dirname,
+};
+
 const parserAndOptions = {
-    parser: parserTypeScriptESLint,
-    parserOptions: {
-        project: './tsconfig.eslint.json',
-        tsconfigRootDir: __dirname,
-    },
+    parser,
+    parserOptions,
 };
 
 module.exports = [
@@ -588,7 +591,15 @@ module.exports = [
         files: ['src/*.{ts,tsx}', 'src/*/**/*.{js,jsx,ts,tsx}'], // product files, except for unit tests (including mockData and test-utils folders)
 
         languageOptions: {
-            ...parserAndOptions,
+            parser,
+            parserOptions: {
+                ...parserOptions,
+
+                // https://typescript-eslint.io/packages/parser/#jsxpragma
+                // If you are using the new JSX transform you can set this to null.
+                jsxPragma: null,
+            },
+
             globals: {
                 ...browserGlobals,
                 process: false, // for JavaScript files which have process.env.NODE_ENV and so on
@@ -600,6 +611,7 @@ module.exports = [
             accessibility: pluginAccessibility,
             generic: pluginGeneric,
             import: pluginImport,
+            limited: pluginLimited,
             patternfly: pluginPatternFly,
             react: pluginReact,
             'react-hooks': pluginReactHooks,
@@ -711,6 +723,12 @@ module.exports = [
             'react/style-prop-object': 'error',
             'react/void-dom-elements-no-children': 'error',
 
+            // Report as error: React.Whatever
+            'limited/no-qualified-name-react': 'error',
+            // Report as error: import React from 'react';
+            'react/jsx-uses-react': 'off',
+            'react/react-in-jsx-scope': 'off',
+
             // Explicit configuration because recommended includes React Compiler rules.
             // Core hooks rules
             'react-hooks/exhaustive-deps': 'error', // instead of 'warn'
@@ -800,37 +818,6 @@ module.exports = [
         // Separate from the following configuration to limit size of contributions.
         rules: {
             'limited/sort-named-imports': 'error',
-        },
-    },
-    {
-        files: ['src/**/*.{js,jsx,ts,tsx}'],
-        ignores: [
-            'src/Containers/VulnMgmt/**', // deprecated
-        ],
-
-        // After deprecated folders have been deleted:
-        // Move jsxPragma property to languageOptions at module scope.
-        // Move react rules into appropriate configuration objects.
-
-        // Set parserOptions and turn off rules explicitly,
-        // instead of implicitlu via jsx-runtime configuration of eslint-plugin-react package.
-
-        languageOptions: {
-            parserOptions: {
-                // https://typescript-eslint.io/packages/parser/#jsxpragma
-                // If you are using the new JSX transform you can set this to null.
-                jsxPragma: null,
-            },
-        },
-
-        plugins: {
-            limited: pluginLimited,
-            react: pluginReact,
-        },
-        rules: {
-            'limited/no-qualified-name-react': 'error',
-            'react/jsx-uses-react': 'off',
-            'react/react-in-jsx-scope': 'off',
         },
     },
     {

--- a/ui/apps/platform/src/Containers/VulnMgmt/Components/CustomDialogue.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Components/CustomDialogue.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Flex, FlexItem } from '@patternfly/react-core';
 import Modal from 'Components/Modal';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Components/ImagesCountTile.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Components/ImagesCountTile.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import entityTypes from 'constants/entityTypes';
 import { gql, useQuery } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Components/NodesCountTile.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Components/NodesCountTile.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import entityTypes from 'constants/entityTypes';
 import { gql, useQuery } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Components/ScanDataMessage.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Components/ScanDataMessage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Alert } from '@patternfly/react-core';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/CvesMenu.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/CvesMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql, useQuery } from '@apollo/client';
 
 import Loader from 'Components/Loader';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/VulnMgmtDashboardPage.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
 import usePermissions from 'hooks/usePermissions';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/WorkflowDashboardLayout.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Dashboard/WorkflowDashboardLayout.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import URLService from 'utils/URLService';
 import useCaseTypes from 'constants/useCaseTypes';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtClusterOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtClusterOverview.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 
 import CollapsibleSection from 'Components/CollapsibleSection';
 import DateTimeField from 'Components/DateTimeField';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtEntityCluster.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtEntityCluster.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import useCases from 'constants/useCaseTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 
 import CollapsibleSection from 'Components/CollapsibleSection';
 import entityTypes from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityImageComponent.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityImageComponent.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import useCases from 'constants/useCaseTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityNodeComponent.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtEntityNodeComponent.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import useCases from 'constants/useCaseTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import CollapsibleSection from 'Components/CollapsibleSection';
 import CveType from 'Components/CveType';
 import Metadata from 'Components/Metadata';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtEntityCve.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtEntityCve.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import { workflowEntityPropTypes, workflowEntityDefaultProps } from 'constants/entityPageProps';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
 import CollapsibleSection from 'Components/CollapsibleSection';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtEntityDeployment.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtEntityDeployment.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import useCases from 'constants/useCaseTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/EntityTabs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/EntityTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import type { ReactElement } from 'react';
 
 import GroupedTabs from 'Components/GroupedTabs';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtEntityImage.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtEntityImage.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import { workflowEntityPropTypes, workflowEntityDefaultProps } from 'constants/entityPageProps';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import pluralize from 'pluralize';
 import cloneDeep from 'lodash/cloneDeep';
 import { Alert, Button } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtEntityNamespace.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtEntityNamespace.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import useCases from 'constants/useCaseTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
 import CollapsibleSection from 'Components/CollapsibleSection';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtEntityNode.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtEntityNode.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { gql } from '@apollo/client';
 
 import useCases from 'constants/useCaseTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtNodeOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtNodeOverview.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
 import CollapsibleSection from 'Components/CollapsibleSection';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/RelatedEntitiesSideList.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import type { ReactNode } from 'react';
 
 import { defaultCountKeyMap as countKeyMap } from 'constants/workflowPages.constants';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidget.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidget.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import resolvePath from 'object-resolve-path';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TableWidgetFixableCves.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { gql, useQuery } from '@apollo/client';
 import { Alert } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/TileList.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/TileList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import TileLink from 'Components/TileLink';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/VulnMgmtEntity.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/VulnMgmtEntity.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import entityTypes from 'constants/entityTypes';
 import useCases from 'constants/useCaseTypes';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPage.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPage.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/prop-types */
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { Bullseye } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPageLayout.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPageLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';

--- a/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumb.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumb.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumbs.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/EntityBreadCrumbs.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { ChevronRight, ArrowLeft } from 'react-feather';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Clusters/ClusterTableCountLinks.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Clusters/ClusterTableCountLinks.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 
 import { resourceTypes } from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Clusters/VulnMgmtListClusters.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Clusters/VulnMgmtListClusters.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 
 import queryService from 'utils/queryService';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Components/VulnMgmtListComponents.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Components/VulnMgmtListComponents.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 
 import {

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveBulkActionDialogue.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { gql, useQuery } from '@apollo/client';
 import cloneDeep from 'lodash/cloneDeep';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveToPolicyShortForm.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/CveToPolicyShortForm.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import {
     Form,

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/VulnMgmtListCves.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';
 import { Archive, Bell, BellOff, Plus, Zap } from 'react-feather';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Deployments/VulnMgmtListDeployments.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Deployments/VulnMgmtListDeployments.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 
 import queryService from 'utils/queryService';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/EntityList.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/EntityList.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef, useLayoutEffect } from 'react';
+import { useContext, useRef, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import resolvePath from 'object-resolve-path';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/ImageComponents/VulnMgmtListImageComponents.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 
 import {

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/ImageTableCountLinks.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/ImageTableCountLinks.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import type { ReactElement } from 'react';
 
 import { resourceTypes } from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Images/VulnMgmtListImages.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Namespaces/VulnMgmtListNamespaces.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Namespaces/VulnMgmtListNamespaces.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 
 import queryService from 'utils/queryService';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/NodeComponents/VulnMgmtListNodeComponents.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 
 import { defaultHeaderClassName, defaultColumnClassName } from 'Components/Table';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Nodes/VulnMgmtListNodes.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Nodes/VulnMgmtListNodes.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 
 import queryService from 'utils/queryService';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/VulnMgmtList.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/VulnMgmtList.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Raven from 'raven-js';
 
 import entityTypes from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPage.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPage.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Bullseye } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPageLayout.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPageLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
 import { searchParams, sortParams, pagingParams } from 'constants/searchParams';

--- a/ui/apps/platform/src/Containers/VulnMgmt/TableCountLink.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/TableCountLink.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import type { ReactElement } from 'react';
 import pluralize from 'pluralize';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/TableCountLinks.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/TableCountLinks.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import type { ReactElement } from 'react';
 
 import entityTypes, { resourceTypes } from 'constants/entityTypes';

--- a/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.utils/vulnerabilityUtils.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/VulnMgmt.utils/vulnerabilityUtils.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import pluralize from 'pluralize';
 import reduce from 'lodash/reduce';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/WorkflowLayout.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/WorkflowLayout.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { memo } from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import isEqual from 'lodash/isEqual';
 
@@ -39,4 +39,4 @@ const Page = () => (
     </Routes>
 );
 
-export default React.memo(Page, isEqual);
+export default memo(Page, isEqual);

--- a/ui/apps/platform/src/Containers/VulnMgmt/WorkflowSidePanel.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/WorkflowSidePanel.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Link, useNavigate, useLocation } from 'react-router-dom-v5-compat';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/ClustersWithMostClusterVulnerabilities.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/ClustersWithMostClusterVulnerabilities.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { gql, useQuery } from '@apollo/client';
 import { ExclamationCircleIcon, InfoCircleIcon } from '@patternfly/react-icons';

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/CvesByCvssScore.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/CvesByCvssScore.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import entityTypes from 'constants/entityTypes';
 import { gql, useQuery } from '@apollo/client';

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/LabeledBarGraph.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/LabeledBarGraph.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import max from 'lodash/max';
 import { useNavigate } from 'react-router-dom-v5-compat';

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabilities.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabilities.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { gql, useQuery } from '@apollo/client';
 import sortBy from 'lodash/sortBy';

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabiltiesInDeployment.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabiltiesInDeployment.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { gql, useQuery } from '@apollo/client';
 import sortBy from 'lodash/sortBy';

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/NumberedGrid.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/NumberedGrid.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom-v5-compat';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/NumberedList.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/NumberedList.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom-v5-compat';
 import { Tooltip } from '@patternfly/react-core';

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/RecentlyDetectedImageVulnerabilities.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/RecentlyDetectedImageVulnerabilities.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { gql, useQuery } from '@apollo/client';
 import sortBy from 'lodash/sortBy';

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/Scatterplot.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/Scatterplot.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import {

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { gql, useQuery } from '@apollo/client';
 

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import pluralize from 'pluralize';
 import { gql, useQuery } from '@apollo/client';

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/ViewAllButton.tsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/ViewAllButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 


### PR DESCRIPTION
## Description

### Problem

When we move orphan components (that is only one remaining reference) into deprecated container folder:
* Components folder assume absence of jsxPragma import statement.
* Containers (deprecated) folder assumes presence of jsxPragma import statement.

### Analysis

Find in Files `React`

| folder | results |
| :--- | ---: |
| VulnMgmt | 94 | 67 |

### Solution

Follow up prerequisite changes in #18113

1. Move from limited configuration to generic configuration for product files.
2. Fix errors in deprecated folder.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
    See presence, and then absense, of errors.