### PR TITLE
chore(ui): Lift up Risk URL state and reset page

### DIFF
--- a/ui/apps/platform/src/Containers/Risk/RiskPageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskPageHeader.tsx
@@ -7,25 +7,30 @@ import {
 import SearchFilterInput from 'Components/SearchFilterInput';
 import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
 import usePermissions from 'hooks/usePermissions';
-import useURLSearch from 'hooks/useURLSearch';
 import searchOptionsToQuery from 'services/searchOptionsToQuery';
 
 import CreatePolicyFromSearch from './CreatePolicyFromSearch';
+import type { SearchFilter } from 'types/search';
 
 type RiskPageHeaderProps = {
     isViewFiltered: boolean;
     searchOptions: string[];
+    searchFilter: SearchFilter;
+    onSearch: (newSearchFilter: SearchFilter) => void;
 };
 
-function RiskPageHeader({ isViewFiltered, searchOptions }: RiskPageHeaderProps) {
+function RiskPageHeader({
+    isViewFiltered,
+    searchOptions,
+    searchFilter,
+    onSearch,
+}: RiskPageHeaderProps) {
     const isRouteEnabled = useIsRouteEnabled();
     const { hasReadWriteAccess } = usePermissions();
-
     // Require READ_WRITE_ACCESS to create plus READ_ACCESS to other resources for Policies route.
     const hasWriteAccessForCreatePolicy =
         hasReadWriteAccess('WorkflowAdministration') && isRouteEnabled('policy-management');
 
-    const { searchFilter, setSearchFilter } = useURLSearch();
     const subHeader = isViewFiltered ? 'Filtered view' : 'Default view';
     const autoCompleteCategory = searchCategories[entityTypes.DEPLOYMENT];
 
@@ -40,7 +45,7 @@ function RiskPageHeader({ isViewFiltered, searchOptions }: RiskPageHeaderProps) 
                 searchOptions={searchOptions}
                 searchCategory={autoCompleteCategory}
                 placeholder="Filter deployments"
-                handleChangeSearchFilter={(filter) => setSearchFilter(filter, 'push')}
+                handleChangeSearchFilter={onSearch}
                 autocompleteQueryPrefix={searchOptionsToQuery(prependAutocompleteQuery)}
             />
             {hasWriteAccessForCreatePolicy && <CreatePolicyFromSearch />}

--- a/ui/apps/platform/src/Containers/Risk/RiskTablePage.tsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskTablePage.tsx
@@ -1,19 +1,26 @@
-import { useState } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import { useQuery } from '@apollo/client';
 
 import { PageBody } from 'Components/Panel';
+import { DEFAULT_PAGE_SIZE } from 'Components/Table';
 import { searchCategories } from 'constants/entityTypes';
 import { SEARCH_OPTIONS_QUERY } from 'queries/search';
+import useURLPagination from 'hooks/useURLPagination';
+import useURLSort from 'hooks/useURLSort';
+import useURLSearch from 'hooks/useURLSearch';
+import { getHasSearchApplied } from 'utils/searchUtils';
+
 import RiskPageHeader from './RiskPageHeader';
-import RiskTablePanel from './RiskTablePanel';
+import RiskTablePanel, { sortFields, defaultSortOption } from './RiskTablePanel';
 
 function RiskTablePage() {
     const params = useParams();
     const { deploymentId } = params;
+    const urlSort = useURLSort({ sortFields, defaultSortOption });
+    const urlPagination = useURLPagination(DEFAULT_PAGE_SIZE);
+    const urlSearch = useURLSearch();
 
-    // Handle changes to applied search options.
-    const [isViewFiltered, setIsViewFiltered] = useState(false);
+    const isViewFiltered = getHasSearchApplied(urlSearch.searchFilter);
 
     const searchQueryOptions = {
         variables: {
@@ -27,13 +34,27 @@ function RiskTablePage() {
     );
     return (
         <>
-            <RiskPageHeader isViewFiltered={isViewFiltered} searchOptions={filteredSearchOptions} />
+            <RiskPageHeader
+                isViewFiltered={isViewFiltered}
+                searchOptions={filteredSearchOptions}
+                searchFilter={urlSearch.searchFilter}
+                onSearch={(newSearchFilter) => {
+                    urlPagination.setPage(1);
+                    urlSearch.setSearchFilter(newSearchFilter);
+                }}
+            />
             <PageBody>
                 <div className="flex-shrink-1 overflow-hidden w-full">
                     <RiskTablePanel
                         selectedDeploymentId={deploymentId}
                         isViewFiltered={isViewFiltered}
-                        setIsViewFiltered={setIsViewFiltered}
+                        sortOption={urlSort.sortOption}
+                        onSortOptionChange={(sortOption) => {
+                            urlSort.setSortOption(sortOption);
+                            urlPagination.setPage(1);
+                        }}
+                        searchFilter={urlSearch.searchFilter}
+                        pagination={urlPagination}
                     />
                 </div>
             </PageBody>


### PR DESCRIPTION
## Description

Lifts up the search/sort/pagination state on the Risk page to:

1. Have a single source of truth without multiple nested hook calls
2. Allow easy reset to `page=1` when the user searches or sorts

Note: Due to the usage of the legacy search bar, the page will be reset when the user applies a search _key_ in addition to applying a search _value_. This will not be fixed here, and will be resolved in a future change when we migrate to the new search component.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Repeat manual tests from all preceeding URL state change PRs.
