### PR TITLE
fix(ui): Clear policy criteria when switch to Node event source

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step2/PolicyBehaviorForm.tsx
@@ -126,6 +126,7 @@ function PolicyBehaviorForm({ hasActiveViolations }: PolicyBehaviorFormProps) {
         setValues({
             ...values,
             eventSource: 'NODE_EVENT',
+            policySections: cloneDeep(initialPolicy.policySections),
             scope: [],
             excludedImageNames: [],
             excludedDeploymentScopes: [],


### PR DESCRIPTION
## Description

When changing from another Runtime event source to "Node", policy criteria are not cleared. This will cause validation errors when attempting to save the policy which cannot be cleared without a page refresh, as the invalid criteria are not visible in the UI.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Add criteria to a Runtime->Deploy policy, switch to Runtime->Node, and inspect the Network panel to ensure the criteria are cleared.
