### PR TITLE
fix(ui): Add client-side validators for policy name

### DIFF
--- a/ui/apps/platform/src/Containers/Policies/Wizard/policyValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/policyValidationSchemas.ts
@@ -18,6 +18,7 @@ import { policySectionValidators } from './Step3/policyCriteriaValidators';
 type PolicyStep1 = Pick<ClientPolicy, 'name' | 'severity' | 'categories'>;
 
 const policyNameLengthMessage = 'Policy name must be between 5 and 128 characters';
+// Backend policy validation reference at central/policy/service/validator.go
 const validationSchemaStep1: yup.ObjectSchema<PolicyStep1> = yup.object().shape({
     name: yup
         .string()


### PR DESCRIPTION
## Description

I have probably gone through the policy editor 100 times with an invalid policy name while doing other work, only to find out at the end of the wizard.

This adds simple validation of the policy name client side so users see an error sooner than later.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Empty:
<img width="1505" height="854" alt="image" src="https://github.com/user-attachments/assets/a780d1b6-109b-4d8c-95fc-ced2f0c90497" />

Too short:
<img width="1505" height="854" alt="image" src="https://github.com/user-attachments/assets/e0f79b78-ba1c-4175-ad0d-b1358446acda" />

Too long:
<img width="1505" height="854" alt="image" src="https://github.com/user-attachments/assets/c440e8d2-edbc-4b94-9dd1-359bf715520f" />


Valid characters according to BE validation:
<img width="1505" height="854" alt="image" src="https://github.com/user-attachments/assets/911a3234-96d2-482e-9e7e-67582ede29f2" />

Test with dollar signs in name:
<img width="1505" height="854" alt="image" src="https://github.com/user-attachments/assets/48634914-5022-482c-b00f-ec400ac80f60" />

