### PR TITLE
fix: update layer FK type

### DIFF
--- a/central/baseimagelayer/store/postgres/store.go
+++ b/central/baseimagelayer/store/postgres/store.go
@@ -101,7 +101,7 @@ func insertIntoBaseImageLayers(batch *pgx.Batch, obj *storage.BaseImageLayer) er
 	values := []interface{}{
 		// parent primary keys start
 		pgutils.NilOrUUID(obj.GetId()),
-		obj.GetBaseImageId(),
+		pgutils.NilOrUUID(obj.GetBaseImageId()),
 		obj.GetLayerDigest(),
 		obj.GetIndex(),
 		serialized,
@@ -153,7 +153,7 @@ func copyFromBaseImageLayers(ctx context.Context, s pgSearch.Deleter, tx *postgr
 
 		return []interface{}{
 			pgutils.NilOrUUID(obj.GetId()),
-			obj.GetBaseImageId(),
+			pgutils.NilOrUUID(obj.GetBaseImageId()),
 			obj.GetLayerDigest(),
 			obj.GetIndex(),
 			serialized,

--- a/generated/storage/base_image.pb.go
+++ b/generated/storage/base_image.pb.go
@@ -125,7 +125,7 @@ func (x *BaseImage) GetFirstLayerDigest() string {
 type BaseImageLayer struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk,type(uuid)"`                                        // @gotags: sql:"pk,type(uuid)"
-	BaseImageId   string                 `protobuf:"bytes,2,opt,name=base_image_id,json=baseImageId,proto3" json:"base_image_id,omitempty" sql:"fk(BaseImage:id),index=category:unique;name:base_image_id_layer"` // @gotags: sql:"fk(BaseImage:id),index=category:unique;name:base_image_id_layer"
+	BaseImageId   string                 `protobuf:"bytes,2,opt,name=base_image_id,json=baseImageId,proto3" json:"base_image_id,omitempty" sql:"fk(BaseImage:id),type(uuid),index=category:unique;name:base_image_id_layer"` // @gotags: sql:"fk(BaseImage:id),type(uuid),index=category:unique;name:base_image_id_layer"
 	LayerDigest   string                 `protobuf:"bytes,3,opt,name=layer_digest,json=layerDigest,proto3" json:"layer_digest,omitempty" search:"Base Image Layer Digest,hidden" sql:"index=category:unique;name:base_image_id_layer"`   // @gotags: search:"Base Image Layer Digest,hidden" sql:"index=category:unique;name:base_image_id_layer"
 	Index         int32                  `protobuf:"varint,4,opt,name=index,proto3" json:"index,omitempty" search:"Base Image Index,hidden"`                                 // @gotags: search:"Base Image Index,hidden"
 	unknownFields protoimpl.UnknownFields

--- a/pkg/postgres/schema/base_image_layers.go
+++ b/pkg/postgres/schema/base_image_layers.go
@@ -56,7 +56,7 @@ const (
 // BaseImageLayers holds the Gorm model for Postgres table `base_image_layers`.
 type BaseImageLayers struct {
 	ID            string     `gorm:"column:id;type:uuid;primaryKey"`
-	BaseImageID   string     `gorm:"column:baseimageid;type:varchar;uniqueIndex:base_image_id_layer"`
+	BaseImageID   string     `gorm:"column:baseimageid;type:uuid;uniqueIndex:base_image_id_layer"`
 	LayerDigest   string     `gorm:"column:layerdigest;type:varchar;uniqueIndex:base_image_id_layer"`
 	Index         int32      `gorm:"column:index;type:integer"`
 	Serialized    []byte     `gorm:"column:serialized;type:bytea"`

--- a/proto/storage/base_image.proto
+++ b/proto/storage/base_image.proto
@@ -20,7 +20,7 @@ message BaseImage {
 
 message BaseImageLayer {
   string id = 1; // @gotags: sql:"pk,type(uuid)"
-  string base_image_id = 2; // @gotags: sql:"fk(BaseImage:id),index=category:unique;name:base_image_id_layer"
+  string base_image_id = 2; // @gotags: sql:"fk(BaseImage:id),type(uuid),index=category:unique;name:base_image_id_layer"
   string layer_digest = 3; // @gotags: search:"Base Image Layer Digest,hidden" sql:"index=category:unique;name:base_image_id_layer"
   int32 index = 4; // @gotags: search:"Base Image Index,hidden"
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Base Image Layer type should be fixed to avoid crash the DB

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->
```
cd central/baseimage/store/ && gogen .
[INFO] Generating for .
2025-12-11 00:16:26 Generating for storage.BaseImage
pkg/postgres/walker: 2025/12/10 18:16:26.004673 schema.go:370: Panic: Couldn't resolve reference in field &{Schema:0xc000996f00 Name:BaseImageId ProtoBufName:base_image_id ObjectGetter:{variable:false value:GetBaseImageId()} ColumnName:BaseImageId Type:string DataType:string SQLType:varchar ModelType:string Options:{ID:false Ignored:false Index:[0xc0009e8f40] PrimaryKey:false Unique:false IgnorePrimaryKey:false IgnoreUniqueConstraint:false IgnoreSearchLabels:map[] Reference:0xc00059f770 ColumnType: IgnoreChildFKs:false IgnoreChildIndexes:false} Search:{FieldName: Enabled:false Ignored:false} DerivedSearchFields:[] Derived:false} (ref: {BaseImage id false false false <nil>  false}): type not provided
panic: Couldn't resolve reference in field &{Schema:0xc000996f00 Name:BaseImageId ProtoBufName:base_image_id ObjectGetter:{variable:false value:GetBaseImageId()} ColumnName:BaseImageId Type:string DataType:string SQLType:varchar ModelType:string Options:{ID:false Ignored:false Index:[0xc0009e8f40] PrimaryKey:false Unique:false IgnorePrimaryKey:false IgnoreUniqueConstraint:false IgnoreSearchLabels:map[] Reference:0xc00059f770 ColumnType: IgnoreChildFKs:false IgnoreChildIndexes:false} Search:{FieldName: Enabled:false Ignored:false} DerivedSearchFields:[] Derived:false} (ref: {BaseImage id false false false <nil>  false}): type not provided

goroutine 1 [running]:
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc00020dec0, {0x0, 0x0, 0x0})
	/Users/yili/go/pkg/mod/github.com/stackrox/zap@v1.18.2-0.20240314134248-5f932edd0404/zapcore/entry.go:234 +0x2ca
go.uber.org/zap.(*SugaredLogger).log(0xc000096c48, 0x4, {0x107d59b28?, 0x48?}, {0xc00061b500?, 0x10834c301?, 0xc000672960?}, {0x0, 0x0, 0x0})
	/Users/yili/go/pkg/mod/github.com/stackrox/zap@v1.18.2-0.20240314134248-5f932edd0404/sugar.go:227 +0xec
go.uber.org/zap.(*SugaredLogger).Panicf(...)
	/Users/yili/go/pkg/mod/github.com/stackrox/zap@v1.18.2-0.20240314134248-5f932edd0404/sugar.go:159
github.com/stackrox/rox/pkg/logging.(*LoggerImpl).Panicf(0x108642fa0?, {0x107d59b28?, 0x107a49e8a?}, {0xc00061b500?, 0x0?, 0x1?})
	/Users/yili/yli3-RH-workingspace/stackrox/pkg/logging/logger.go:109 +0x45
...
main.main()
	/Users/yili/yli3-RH-workingspace/stackrox/tools/generate-helpers/pg-table-bindings/main.go:271 +0x71c
exit status 2
postgres/gen.go:3: running "pg-table-bindings-wrapper": exit status 1
```
Peviously `cd central/baseimage/store/ && gogen .`  gives me error (before this PR), but now it's happy

Testing [cluster](https://infra.rox.systems/cluster/yl-12-10-ahead-slipped-sheep): infractl artifacts --download-dir=<some dir> yl-12-10-ahead-slipped-sheep

address: https://136.116.172.20:8443/login
username: admin
pwd: UPsHaKdR14E9Ctr9JMuCaPyo7

