### PR TITLE
ROX-32260: Add vm scale test commands to scannerctl

### DIFF
--- a/pkg/fixtures/vmindexreport/generator_test.go
+++ b/pkg/fixtures/vmindexreport/generator_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewGeneratorWithSeed(t *testing.T) {
-	totalAvailable := len(packagesFixture)
+	totalAvailable := len(PackagesData)
 
 	tests := map[string]struct {
 		numPackages      int
@@ -35,7 +35,8 @@ func TestNewGeneratorWithSeed(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			gen := NewGeneratorWithSeed(tt.numPackages, 42)
+			gen, err := NewGeneratorWithSeed(tt.numPackages, 42)
+			require.NoError(t, err)
 
 			assert.Equal(t, tt.expectedPkgCount, gen.NumPackages(), "package count mismatch")
 			assert.Equal(t, 3, gen.NumRepositories(), "should always have 3 real repositories")
@@ -43,15 +44,16 @@ func TestNewGeneratorWithSeed(t *testing.T) {
 	}
 }
 
-func TestNewGeneratorWithSeed_PanicsOnNegativePackages(t *testing.T) {
-	assert.Panics(t, func() {
-		NewGeneratorWithSeed(-1, 42)
-	}, "should panic when numPackages is negative")
+func TestNewGeneratorWithSeed_ShouldReturnErrorOnNegativePackages(t *testing.T) {
+	_, err := NewGeneratorWithSeed(-1, 42)
+	assert.EqualError(t, err, "numPackages must be non-negative, got -1")
 }
 
 func TestNewGeneratorWithSeed_Reproducibility(t *testing.T) {
-	gen1 := NewGeneratorWithSeed(50, 123)
-	gen2 := NewGeneratorWithSeed(50, 123)
+	gen1, err := NewGeneratorWithSeed(50, 123)
+	require.NoError(t, err)
+	gen2, err := NewGeneratorWithSeed(50, 123)
+	require.NoError(t, err)
 
 	report1 := gen1.GenerateV4IndexReport()
 	report2 := gen2.GenerateV4IndexReport()
@@ -67,45 +69,51 @@ func TestNewGeneratorWithSeed_Reproducibility(t *testing.T) {
 	}
 }
 
-func TestNewGeneratorWithSeed_DifferentSeeds(t *testing.T) {
-	gen1 := NewGeneratorWithSeed(10, 111)
-	gen2 := NewGeneratorWithSeed(10, 222)
-
-	report1 := gen1.GenerateV4IndexReport()
-	report2 := gen2.GenerateV4IndexReport()
-
-	// Collect package names into sets
-	names1 := set.NewStringSet()
-	names2 := set.NewStringSet()
-	for _, pkg := range report1.GetContents().GetPackages() {
-		names1.Add(pkg.GetName())
-	}
-	for _, pkg := range report2.GetContents().GetPackages() {
-		names2.Add(pkg.GetName())
-	}
-
-	// Different seeds should produce different package selection (with high probability)
-	// The symmetric difference should be non-empty
-	diff := names1.Difference(names2).Union(names2.Difference(names1))
-	assert.NotEmpty(t, diff, "different seeds should produce different package selections")
-}
-
 func TestGenerateV4IndexReport(t *testing.T) {
-	gen := NewGeneratorWithSeed(10, 42)
+	gen, err := NewGeneratorWithSeed(10, 42)
+	require.NoError(t, err)
 	report := gen.GenerateV4IndexReport()
 
 	assert.Equal(t, MockDigest, report.GetHashId(), "HashId should match MockDigest")
 	assert.Equal(t, "IndexFinished", report.GetState(), "State should be IndexFinished")
 	assert.True(t, report.GetSuccess(), "Success should be true")
 
-	require.NotNil(t, report.GetContents(), "Contents should not be nil")
-	assert.Len(t, report.GetContents().GetPackages(), 10, "should have 10 packages")
-	assert.Len(t, report.GetContents().GetRepositories(), 3, "should have 3 repositories")
-	assert.Len(t, report.GetContents().GetEnvironments(), 10, "should have 10 environments")
+	contents := report.GetContents()
+	require.NotNil(t, contents, "Contents should not be nil")
+
+	// Basic cardinality checks.
+	assert.Len(t, contents.GetPackages(), 10, "should have 10 packages")
+	assert.Len(t, contents.GetRepositories(), 3, "should have 3 repositories")
+	assert.Len(t, contents.GetEnvironments(), 10, "should have 10 environments")
+
+	// Repositories in the report should exactly match the real RHEL repos defined in repoToCPEMapping.
+	expectedRepoIDs := set.NewStringSet()
+	for repoID := range repoToCPEMapping {
+		expectedRepoIDs.Add(repoID)
+	}
+
+	actualRepoIDs := set.NewStringSet()
+	for repoKey, repo := range contents.GetRepositories() {
+		actualRepoIDs.Add(repoKey)
+		assert.Equal(t, repoKey, repo.GetId(), "repository ID field should match its map key")
+	}
+
+	assert.True(t, expectedRepoIDs.Equal(actualRepoIDs), "repository IDs should match the keys in repoToCPEMapping")
+
+	// Each environment's RepositoryIds should be a subset of the real RHEL repos.
+	for envKey, envList := range contents.GetEnvironments() {
+		for _, env := range envList.GetEnvironments() {
+			for _, repoID := range env.GetRepositoryIds() {
+				assert.Truef(t, expectedRepoIDs.Contains(repoID),
+					"environment %q repository ID %q should be one of the real RHEL repos", envKey, repoID)
+			}
+		}
+	}
 }
 
 func TestGenerateV4IndexReport_ZeroPackages(t *testing.T) {
-	gen := NewGeneratorWithSeed(0, 42)
+	gen, err := NewGeneratorWithSeed(0, 42)
+	require.NoError(t, err)
 	report := gen.GenerateV4IndexReport()
 
 	// Report metadata should be unchanged
@@ -122,7 +130,8 @@ func TestGenerateV4IndexReport_ZeroPackages(t *testing.T) {
 }
 
 func TestGenerateV4IndexReport_PackagesHaveValidCPEs(t *testing.T) {
-	gen := NewGeneratorWithSeed(20, 42)
+	gen, err := NewGeneratorWithSeed(20, 42)
+	require.NoError(t, err)
 	report := gen.GenerateV4IndexReport()
 
 	for pkgID, pkg := range report.GetContents().GetPackages() {

--- a/pkg/fixtures/vmindexreport/packages_fixture.go
+++ b/pkg/fixtures/vmindexreport/packages_fixture.go
@@ -25,7 +25,7 @@ type PackageFixture struct {
 
 // packagesFixture contains real package data from a RHEL 9 system.
 // This data is used to generate realistic VM index reports.
-var packagesFixture = []PackageFixture{
+var PackagesData = []PackageFixture{
 	{"389-ds-base", "2.7.0-7.el9_7", "rhel-9-for-x86_64-appstream-rpms"},
 	{"389-ds-base-libs", "2.7.0-7.el9_7", "rhel-9-for-x86_64-appstream-rpms"},
 	{"389-ds-base-snmp", "2.7.0-7.el9_7", "rhel-9-for-x86_64-appstream-rpms"},

--- a/scanner/cmd/scannerctl/VM_SCALE_TEST.md
+++ b/scanner/cmd/scannerctl/VM_SCALE_TEST.md
@@ -1,0 +1,182 @@
+# Scanner V4 VM Scale Test Guide
+
+This guide documents how to run isolated load tests against Scanner V4 Matcher using `scannerctl vm-scale`.
+
+## Overview
+
+The `scannerctl vm-scale` command sends `GetVulnerabilities` requests with synthetic VM index reports directly to Scanner V4 Matcher, bypassing Central and Sensor. This allows isolated testing of Scanner V4 performance.
+
+## Prerequisites
+
+- Access to a Kubernetes cluster with StackRox deployed
+- `kubectl` configured to access the cluster
+- Go toolchain for building `scannerctl`
+
+## Step 1: Build scannerctl for Linux
+
+```bash
+cd /path/to/stackrox
+GOOS=linux GOARCH=amd64 go build -o bin/scannerctl-linux ./scanner/cmd/scannerctl
+```
+
+## Step 2: Create a Load Test Pod
+
+The pod must have `app=central` label to pass NetworkPolicy:
+
+```bash
+# Create pod with correct label
+kubectl run loadtest -n stackrox \
+  --image=alpine:latest \
+  --restart=Never \
+  --labels="app=central" \
+  -- sleep 3600
+
+# Wait for pod to be ready
+kubectl wait --for=condition=Ready pod/loadtest -n stackrox
+
+# Copy scannerctl binary
+kubectl cp bin/scannerctl-linux stackrox/loadtest:/scannerctl
+kubectl exec -n stackrox loadtest -- chmod +x /scannerctl
+```
+
+## Step 3: Run the Scale Test
+
+### Basic Test (verify connectivity)
+```bash
+kubectl exec -it -n stackrox loadtest -- /scannerctl vm-scale \
+  --matcher-address scanner-v4-matcher.stackrox.svc.cluster.local:8443 \
+  --insecure-skip-tls-verify \
+  --direct-pod-ips \
+  --requests 10 \
+  --workers 5 \
+  --packages 500 \
+  --verbose
+```
+
+### Sustained Load Test (rate-limited)
+```bash
+kubectl exec -it -n stackrox loadtest -- /scannerctl vm-scale \
+  --matcher-address scanner-v4-matcher.stackrox.svc.cluster.local:8443 \
+  --insecure-skip-tls-verify \
+  --direct-pod-ips \
+  --rate 3 \
+  --duration 2m \
+  --workers 20 \
+  --packages 500 \
+  --verbose
+```
+
+### High Load Test
+```bash
+kubectl exec -it -n stackrox loadtest -- /scannerctl vm-scale \
+  --matcher-address scanner-v4-matcher.stackrox.svc.cluster.local:8443 \
+  --insecure-skip-tls-verify \
+  --direct-pod-ips \
+  --rate 5 \
+  --duration 2m \
+  --workers 30 \
+  --packages 500 \
+  --verbose
+```
+
+## Step 4: Monitor During Test
+
+In separate terminals:
+
+```bash
+# Watch matcher pod CPU
+watch -n2 'kubectl top pods -n stackrox -l app=scanner-v4-matcher --use-protocol-buffers'
+
+# Watch DB CPU
+watch -n2 'kubectl top pods -n stackrox -l app=scanner-v4-db --use-protocol-buffers'
+
+# Watch matcher logs
+kubectl logs -f -n stackrox -l app=scanner-v4-matcher --prefix | grep -i "GetVulnerabilities"
+```
+
+## Step 5: Cleanup
+
+```bash
+kubectl delete pod loadtest -n stackrox
+```
+
+## Command Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--requests` | 100 | Total requests (ignored if `--duration` set) |
+| `--workers` | 15 | Number of parallel workers |
+| `--packages` | 2000 | Packages per VM index report |
+| `--repos` | 10 | Repositories per report |
+| `--rate` | 0 | Target req/s (0 = unlimited) |
+| `--duration` | 0 | Run duration (0 = use `--requests`) |
+| `--direct-pod-ips` | false | **Required for load distribution** - resolves DNS and connects directly to pod IPs |
+| `--verbose` | false | Print each request result |
+
+## Important Notes
+
+### Load Balancing Issue
+
+The `--direct-pod-ips` flag is **required** for proper load distribution across multiple matcher pods. Without it, gRPC's round-robin load balancing doesn't work correctly with headless services, and all requests go to a single pod.
+
+With `--direct-pod-ips`:
+1. DNS is resolved to get all pod IPs
+2. Workers are assigned to pods round-robin
+3. Each worker connects directly to its assigned pod
+
+### Worker Calculation
+
+Workers are needed to sustain the target rate when requests have latency:
+
+```
+Workers needed = rate × avg_latency
+```
+
+Example:
+- Target rate: 3 req/s
+- Average latency: 5 seconds
+- Workers needed: 3 × 5 = 15 workers
+
+### NetworkPolicy
+
+The loadtest pod must have `app=central` label because the Scanner V4 Matcher NetworkPolicy only allows ingress from pods with this label.
+
+## Example Output
+
+```
+2025/12/11 11:42:52 Resolved 5 pod IPs: [10.129.2.53:8443 10.128.2.57:8443 10.131.1.200:8443 10.131.1.201:8443 10.128.2.58:8443]
+2025/12/11 11:42:52 VM Scale Test Configuration:
+2025/12/11 11:42:52   Workers: 10
+2025/12/11 11:42:52   Packages per report: 500
+2025/12/11 11:42:52   Direct pod IPs: true
+2025/12/11 11:42:52   Total requests: 25
+2025/12/11 11:42:52 [worker-0] connecting to pod 10.129.2.53:8443
+2025/12/11 11:42:52 [worker-1] connecting to pod 10.128.2.57:8443
+...
+2025/12/11 11:42:55 [worker-7] [pod=10.131.1.200:8443] req=3 OK (3.01s)
+2025/12/11 11:42:55 [worker-3] [pod=10.131.1.201:8443] req=6 OK (3.14s)
+...
+=== VM Scale Test Results ===
+2025/12/11 11:43:01 Total time: 9.288152021s
+2025/12/11 11:43:01 Total requests: 25
+2025/12/11 11:43:01 Success: 25, Failure: 0
+2025/12/11 11:43:01 Throughput: 2.69 req/s
+```
+
+## Troubleshooting
+
+### Connection Timeout Errors
+
+If you see `dial tcp <ip>:8443: i/o timeout`:
+1. Check the loadtest pod has `app=central` label
+2. Verify NetworkPolicy allows traffic: `kubectl get networkpolicy -n stackrox scanner-v4-matcher -o yaml`
+
+### DNS Resolution Fails
+
+If DNS resolution fails:
+- Use full FQDN: `scanner-v4-matcher.stackrox.svc.cluster.local:8443`
+- Verify service exists: `kubectl get svc -n stackrox scanner-v4-matcher`
+
+### Only One Matcher Gets Load
+
+Make sure to use `--direct-pod-ips` flag. Without it, gRPC load balancing doesn't work correctly with headless services.

--- a/scanner/cmd/scannerctl/main.go
+++ b/scanner/cmd/scannerctl/main.go
@@ -110,6 +110,8 @@ func rootCmd(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(scaleCmd(ctx))
 	cmd.AddCommand(sbomCmd(ctx))
 	cmd.AddCommand(scanVM(ctx))
+	cmd.AddCommand(vmScaleCmd(ctx))
+	cmd.AddCommand(vmLearnCmd(ctx))
 	return &cmd
 }
 

--- a/scanner/cmd/scannerctl/vm_learn.go
+++ b/scanner/cmd/scannerctl/vm_learn.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/fixtures/vmindexreport"
+)
+
+// PackageVulnData stores vulnerability information for a single package.
+type PackageVulnData struct {
+	Index   int    `json:"index"`   // Index in the fixture array
+	Name    string `json:"name"`    // Package name
+	Version string `json:"version"` // Package version
+	Repo    string `json:"repo"`    // Repository
+	Vulns   int    `json:"vulns"`   // Number of vulnerabilities found
+}
+
+// LearnedVulnData is the top-level structure for the learned data file.
+type LearnedVulnData struct {
+	LearnedAt   time.Time         `json:"learned_at"`
+	MatcherAddr string            `json:"matcher_address"`
+	TotalPkgs   int               `json:"total_packages"`
+	Packages    []PackageVulnData `json:"packages"`
+}
+
+// LoadLearnedData loads vulnerability data from a JSON file.
+func LoadLearnedData(path string) (*LearnedVulnData, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+	var learned LearnedVulnData
+	if err := json.Unmarshal(data, &learned); err != nil {
+		return nil, fmt.Errorf("parsing JSON: %w", err)
+	}
+	return &learned, nil
+}
+
+// SaveLearnedData saves vulnerability data to a JSON file.
+func SaveLearnedData(path string, data *LearnedVulnData) error {
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling JSON: %w", err)
+	}
+	if err := os.WriteFile(path, jsonData, 0644); err != nil {
+		return fmt.Errorf("writing file: %w", err)
+	}
+	return nil
+}
+
+// vmLearnCmd creates the VM learn command to discover vulnerability counts per package.
+func vmLearnCmd(ctx context.Context) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "vm-learn",
+		Short: "Learn vulnerability counts for each package in the fixture",
+		Long: `Query Scanner V4 Matcher for each package individually to learn how many
+vulnerabilities each package has. This data is saved to a JSON file that can be
+used by vm-scale to craft specific test scenarios.
+
+Example:
+  # Learn vulnerability data and save to file
+  scannerctl vm-learn --output package_vulns.json
+
+  # Then use with vm-scale
+  scannerctl vm-scale --vuln-data package_vulns.json --target-vulns 100 --packages 50
+`,
+	}
+
+	flags := cmd.PersistentFlags()
+	outputFile := flags.String("output", "package_vulns.json", "Output file for learned vulnerability data")
+	verbose := flags.Bool("verbose", false, "Print progress for each package")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		matcherAddr, _ := cmd.Flags().GetString("matcher-address")
+
+		log.Printf("Learning vulnerability data for %d packages...", len(vmindexreport.PackagesData))
+		log.Printf("This may take a few minutes.")
+
+		// Create scanner client
+		scanner, err := factory.Create(ctx)
+		if err != nil {
+			return fmt.Errorf("creating scanner client: %w", err)
+		}
+
+		// Parse digest once
+		digest, err := name.NewDigest(vmindexreport.MockDigestWithRegistry)
+		if err != nil {
+			return fmt.Errorf("parsing digest: %w", err)
+		}
+
+		learned := &LearnedVulnData{
+			LearnedAt:   time.Now(),
+			MatcherAddr: matcherAddr,
+			TotalPkgs:   len(vmindexreport.PackagesData),
+			Packages:    make([]PackageVulnData, 0, len(vmindexreport.PackagesData)),
+		}
+
+		// Query each package individually
+		for i, pkg := range vmindexreport.PackagesData {
+			// Generate index report with just this one package
+			gen := vmindexreport.NewGeneratorWithPackageIndices([]int{i})
+			indexReport := gen.GenerateV4IndexReport()
+
+			// Query scanner
+			vulnReport, err := scanner.GetVulnerabilities(ctx, digest, indexReport.GetContents())
+			if err != nil {
+				log.Printf("[%d/%d] %s: ERROR - %v", i+1, len(vmindexreport.PackagesData), pkg.Name, err)
+				// Store with -1 vulns to indicate error
+				learned.Packages = append(learned.Packages, PackageVulnData{
+					Index:   i,
+					Name:    pkg.Name,
+					Version: pkg.Version,
+					Repo:    pkg.Repo,
+					Vulns:   -1,
+				})
+				continue
+			}
+
+			vulnCount := 0
+			if vulnReport != nil {
+				vulnCount = len(vulnReport.GetVulnerabilities())
+			}
+
+			learned.Packages = append(learned.Packages, PackageVulnData{
+				Index:   i,
+				Name:    pkg.Name,
+				Version: pkg.Version,
+				Repo:    pkg.Repo,
+				Vulns:   vulnCount,
+			})
+
+			if *verbose {
+				log.Printf("[%d/%d] %s (%s): %d vulns", i+1, len(vmindexreport.PackagesData), pkg.Name, pkg.Version, vulnCount)
+			} else if (i+1)%50 == 0 {
+				log.Printf("Progress: %d/%d packages scanned...", i+1, len(vmindexreport.PackagesData))
+			}
+		}
+
+		// Save results
+		if err := SaveLearnedData(*outputFile, learned); err != nil {
+			return fmt.Errorf("saving learned data: %w", err)
+		}
+
+		// Print summary
+		var withVulns, withoutVulns, totalVulns int
+		for _, pkg := range learned.Packages {
+			if pkg.Vulns > 0 {
+				withVulns++
+				totalVulns += pkg.Vulns
+			} else if pkg.Vulns == 0 {
+				withoutVulns++
+			}
+		}
+
+		log.Printf("\n=== Learning Complete ===")
+		log.Printf("Total packages: %d", len(learned.Packages))
+		log.Printf("Packages with vulnerabilities: %d", withVulns)
+		log.Printf("Packages without vulnerabilities: %d", withoutVulns)
+		log.Printf("Total vulnerabilities: %d", totalVulns)
+		log.Printf("Data saved to: %s", *outputFile)
+
+		return nil
+	}
+
+	return &cmd
+}

--- a/scanner/cmd/scannerctl/vm_scale.go
+++ b/scanner/cmd/scannerctl/vm_scale.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/spf13/cobra"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stackrox/rox/pkg/fixtures/vmindexreport"
+	"github.com/stackrox/rox/pkg/scannerv4/client"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+var (
+	vmScaleMatchDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "scannerctl_vm_scale_match_duration_seconds",
+		Help:    "Time to perform GetVulnerabilities per VM index report",
+		Buckets: prometheus.ExponentialBuckets(0.5, 2, 10), // 0.5s to 256s
+	}, []string{"worker_id", "error"})
+
+	vmScaleTotalRequests = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "scannerctl_vm_scale_total_requests",
+		Help: "Total number of GetVulnerabilities requests",
+	}, []string{"status"})
+)
+
+// vmScaleStats tracks stats for VM scale testing
+type vmScaleStats struct {
+	success atomic.Int64
+	failure atomic.Int64
+}
+
+func (s *vmScaleStats) String() string {
+	return fmt.Sprintf("success: %d, failure: %d", s.success.Load(), s.failure.Load())
+}
+
+// resolvePodIPs resolves a service address to individual pod IPs
+func resolvePodIPs(address string) ([]string, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address %q: %w", address, err)
+	}
+
+	ips, err := net.LookupHost(host)
+	if err != nil {
+		return nil, fmt.Errorf("DNS lookup failed for %q: %w", host, err)
+	}
+
+	// Append port to each IP
+	addresses := make([]string, len(ips))
+	for i, ip := range ips {
+		addresses[i] = net.JoinHostPort(ip, port)
+	}
+	return addresses, nil
+}
+
+// selectPackagesFromLearnedData selects package indices based on learned vulnerability data.
+// Returns the selected indices and expected vulnerability count.
+func selectPackagesFromLearnedData(learned *LearnedVulnData, numPackages int, targetVulns int, zeroVulnsOnly bool, vulnerableOnly bool) ([]int, int) {
+	// Separate packages by vulnerability status
+	var withVulns, withoutVulns []PackageVulnData
+	for _, pkg := range learned.Packages {
+		if pkg.Vulns < 0 {
+			continue // Skip errored packages
+		}
+		if pkg.Vulns > 0 {
+			withVulns = append(withVulns, pkg)
+		} else {
+			withoutVulns = append(withoutVulns, pkg)
+		}
+	}
+
+	// Sort vulnerable packages by vuln count (descending) for easier selection
+	sort.Slice(withVulns, func(i, j int) bool {
+		return withVulns[i].Vulns > withVulns[j].Vulns
+	})
+
+	var selected []int
+	expectedVulns := 0
+
+	switch {
+	case zeroVulnsOnly:
+		// Only use packages with 0 vulnerabilities
+		for i := 0; i < numPackages && i < len(withoutVulns); i++ {
+			selected = append(selected, withoutVulns[i].Index)
+		}
+
+	case vulnerableOnly:
+		// Only use packages with vulnerabilities
+		for i := 0; i < numPackages && i < len(withVulns); i++ {
+			selected = append(selected, withVulns[i].Index)
+			expectedVulns += withVulns[i].Vulns
+		}
+
+	case targetVulns > 0:
+		// Select packages to reach target vulnerability count
+		// Strategy: add vulnerable packages until we reach target, fill rest with non-vulnerable
+		for _, pkg := range withVulns {
+			if expectedVulns >= targetVulns {
+				break
+			}
+			selected = append(selected, pkg.Index)
+			expectedVulns += pkg.Vulns
+		}
+		// Fill remaining slots with non-vulnerable packages
+		for i := 0; len(selected) < numPackages && i < len(withoutVulns); i++ {
+			selected = append(selected, withoutVulns[i].Index)
+		}
+
+	default:
+		// Default: use first N packages (original behavior)
+		for i := 0; i < numPackages && i < len(learned.Packages); i++ {
+			if learned.Packages[i].Vulns >= 0 {
+				selected = append(selected, learned.Packages[i].Index)
+				expectedVulns += learned.Packages[i].Vulns
+			}
+		}
+	}
+
+	return selected, expectedVulns
+}
+
+// vmScaleCmd creates the VM scale test command
+func vmScaleCmd(ctx context.Context) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "vm-scale",
+		Short: "Perform scale tests by sending VM index reports directly to Scanner V4 Matcher",
+		Long: `Send GetVulnerabilities requests with synthetic VM index reports to Scanner V4 Matcher.
+
+This bypasses Central and Sensor, allowing isolated testing of Scanner V4 performance.
+
+Example:
+  # Send 100 requests with 15 workers, 2000 packages per report
+  scannerctl vm-scale --requests 100 --workers 15 --packages 2000
+
+  # Sustain 3 requests/second for 60 seconds
+  scannerctl vm-scale --rate 3 --duration 60s --packages 2000
+
+  # Use learned vulnerability data to control vulnerability count
+  scannerctl vm-learn --output vulns.json
+  scannerctl vm-scale --vuln-data vulns.json --target-vulns 100 --packages 50
+  scannerctl vm-scale --vuln-data vulns.json --zero-vulns --packages 500
+`,
+	}
+
+	flags := cmd.PersistentFlags()
+	numRequests := flags.Int("requests", 100, "Total number of requests to send (ignored if --duration is set)")
+	numWorkers := flags.Int("workers", 15, "Number of parallel workers")
+	numPackages := flags.Int("packages", 2000, "Number of packages per VM index report")
+	rateLimit := flags.Float64("rate", 0, "Target requests per second (0 = unlimited)")
+	duration := flags.Duration("duration", 0, "Run for this duration (0 = run until --requests completed)")
+	verbose := flags.Bool("verbose", false, "Print each request result")
+	directPodIPs := flags.Bool("direct-pod-ips", false, "Resolve service DNS and connect directly to pod IPs (distributes load)")
+
+	// Learned data options
+	vulnDataFile := flags.String("vuln-data", "", "Path to learned vulnerability data (from vm-learn command)")
+	targetVulns := flags.Int("target-vulns", 0, "Target number of vulnerabilities (requires --vuln-data)")
+	zeroVulnsOnly := flags.Bool("zero-vulns", false, "Use only packages with 0 vulnerabilities (requires --vuln-data)")
+	vulnerableOnly := flags.Bool("vulnerable-only", false, "Use only packages with vulnerabilities (requires --vuln-data)")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		matcherAddr, _ := cmd.Flags().GetString("matcher-address")
+
+		if *numPackages < 0 {
+			return fmt.Errorf("--packages must be non-negative, got %d", *numPackages)
+		}
+
+		// Resolve pod IPs if direct mode is enabled
+		var podAddresses []string
+		if *directPodIPs && matcherAddr != "" {
+			var err error
+			podAddresses, err = resolvePodIPs(matcherAddr)
+			if err != nil {
+				return fmt.Errorf("resolving pod IPs: %w", err)
+			}
+			log.Printf("Resolved %d pod IPs: %v", len(podAddresses), podAddresses)
+		}
+
+		log.Printf("VM Scale Test Configuration:")
+		log.Printf("  Workers: %d", *numWorkers)
+		log.Printf("  Packages per report: %d", *numPackages)
+		log.Printf("  Direct pod IPs: %v", *directPodIPs)
+		if *vulnDataFile != "" {
+			log.Printf("  Vuln data file: %s", *vulnDataFile)
+			if *zeroVulnsOnly {
+				log.Printf("  Mode: zero-vulns only")
+			} else if *vulnerableOnly {
+				log.Printf("  Mode: vulnerable-only")
+			} else if *targetVulns > 0 {
+				log.Printf("  Target vulns: %d", *targetVulns)
+			}
+		}
+		if *duration > 0 {
+			log.Printf("  Duration: %v", *duration)
+			log.Printf("  Rate limit: %.2f req/s", *rateLimit)
+		} else {
+			log.Printf("  Total requests: %d", *numRequests)
+		}
+
+		// Generate the index report template (reused for all requests)
+		var indexReport *v4.IndexReport
+		var expectedVulns int
+
+		if *vulnDataFile != "" {
+			// Load learned data and select packages
+			learned, err := LoadLearnedData(*vulnDataFile)
+			if err != nil {
+				return fmt.Errorf("loading vuln data: %w", err)
+			}
+			log.Printf("Loaded vulnerability data for %d packages (learned at %s)",
+				len(learned.Packages), learned.LearnedAt.Format(time.RFC3339))
+
+			indices, vulns := selectPackagesFromLearnedData(learned, *numPackages, *targetVulns, *zeroVulnsOnly, *vulnerableOnly)
+			expectedVulns = vulns
+
+			gen := vmindexreport.NewGeneratorWithPackageIndices(indices)
+			indexReport = gen.GenerateV4IndexReport()
+			log.Printf("Generated index report with %d packages, %d repos (expected ~%d vulns)",
+				gen.NumPackages(), gen.NumRepositories(), expectedVulns)
+		} else {
+			// Default behavior: use standard generator
+			gen, err := vmindexreport.NewGeneratorWithSeed(*numPackages, 42)
+			if err != nil {
+				return fmt.Errorf("creating VM index report generator: %w", err)
+			}
+			indexReport = gen.GenerateV4IndexReport()
+			log.Printf("Generated index report with %d packages, %d repos",
+				gen.NumPackages(), gen.NumRepositories())
+		}
+
+		digest, err := name.NewDigest(vmindexreport.MockDigestWithRegistry)
+		if err != nil {
+			return fmt.Errorf("parsing digest: %w", err)
+		}
+
+		var stats vmScaleStats
+		var wg sync.WaitGroup
+
+		// Channel for work distribution
+		workC := make(chan int, *numWorkers*2)
+
+		// Rate limiter (if enabled)
+		var rateLimiter <-chan time.Time
+		if *rateLimit > 0 {
+			interval := time.Duration(float64(time.Second) / *rateLimit)
+			rateLimiter = time.Tick(interval)
+		}
+
+		// Start workers - each with its OWN scanner client for load balancing
+		for i := 0; i < *numWorkers; i++ {
+			wg.Add(1)
+			workerID := i
+
+			// If direct pod IPs mode, assign each worker to a specific pod (round-robin)
+			var workerPodAddr string
+			if len(podAddresses) > 0 {
+				workerPodAddr = podAddresses[workerID%len(podAddresses)]
+			}
+
+			go func() {
+				defer wg.Done()
+
+				var scanner client.Scanner
+				var err error
+
+				if workerPodAddr != "" {
+					// Connect directly to assigned pod IP
+					log.Printf("[worker-%d] connecting to pod %s", workerID, workerPodAddr)
+					scanner, err = client.NewGRPCScanner(ctx,
+						client.WithMatcherAddress(workerPodAddr),
+						client.SkipTLSVerification,
+					)
+				} else {
+					// Use factory (connects to service address)
+					scanner, err = factory.Create(ctx)
+				}
+				if err != nil {
+					log.Printf("[worker-%d] failed to create scanner client: %v", workerID, err)
+					return
+				}
+
+				for reqID := range workC {
+					if rateLimiter != nil {
+						<-rateLimiter
+					}
+
+					start := time.Now()
+					vulnReport, err := scanner.GetVulnerabilities(ctx, digest, indexReport.GetContents())
+					elapsed := time.Since(start)
+
+					errStr := "false"
+					podInfo := ""
+					if workerPodAddr != "" {
+						podInfo = fmt.Sprintf(" [pod=%s]", workerPodAddr)
+					}
+					if err != nil {
+						errStr = "true"
+						stats.failure.Add(1)
+						vmScaleTotalRequests.WithLabelValues("error").Inc()
+						if *verbose {
+							log.Printf("[worker-%d]%s req=%d FAILED (%.2fs): %v", workerID, podInfo, reqID, elapsed.Seconds(), err)
+						}
+					} else {
+						stats.success.Add(1)
+						vmScaleTotalRequests.WithLabelValues("success").Inc()
+						vulnCount := 0
+						if vulnReport != nil {
+							vulnCount = len(vulnReport.GetVulnerabilities())
+						}
+						if *verbose {
+							log.Printf("[worker-%d]%s req=%d OK (%.2fs) vulns=%d", workerID, podInfo, reqID, elapsed.Seconds(), vulnCount)
+						}
+					}
+
+					vmScaleMatchDuration.WithLabelValues(
+						fmt.Sprintf("%d", workerID),
+						errStr,
+					).Observe(elapsed.Seconds())
+				}
+			}()
+		}
+
+		// Send work
+		startTime := time.Now()
+		if *duration > 0 {
+			// Duration-based mode
+			deadline := time.After(*duration)
+			reqID := 0
+		durationLoop:
+			for {
+				select {
+				case <-deadline:
+					break durationLoop
+				case workC <- reqID:
+					reqID++
+				}
+			}
+		} else {
+			// Request-count mode
+			for i := 0; i < *numRequests; i++ {
+				workC <- i
+			}
+		}
+		close(workC)
+
+		// Wait for all workers to finish
+		wg.Wait()
+		totalTime := time.Since(startTime)
+
+		totalReqs := stats.success.Load() + stats.failure.Load()
+		log.Printf("\n=== VM Scale Test Results ===")
+		log.Printf("Total time: %v", totalTime)
+		log.Printf("Total requests: %d", totalReqs)
+		log.Printf("Success: %d, Failure: %d", stats.success.Load(), stats.failure.Load())
+		log.Printf("Throughput: %.2f req/s", float64(totalReqs)/totalTime.Seconds())
+
+		return nil
+	}
+
+	return &cmd
+}

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -527,10 +527,15 @@ func (w *WorkloadManager) initializePreexistingResources() {
 		// Initialize report generator if index reports are enabled
 		var reportGen *vmindexreport.Generator
 		if w.workload.VirtualMachineWorkload.ReportInterval > 0 {
-			reportGen = vmindexreport.NewGeneratorWithSeed(
+			var err error
+			reportGen, err = vmindexreport.NewGeneratorWithSeed(
 				w.workload.VirtualMachineWorkload.NumPackages,
 				reportGeneratorSeed,
 			)
+			if err != nil {
+				log.Warnf("VM index reports disabled: failed to create generator: %v", err)
+				reportGen = nil
+			}
 			log.Infof("VM index reports enabled: interval=%s, packages=%d",
 				w.workload.VirtualMachineWorkload.ReportInterval,
 				w.workload.VirtualMachineWorkload.NumPackages)

--- a/sensor/kubernetes/fake/virtualmachines.go
+++ b/sensor/kubernetes/fake/virtualmachines.go
@@ -60,6 +60,10 @@ func validateVMWorkload(workload VirtualMachineWorkload) (VirtualMachineWorkload
 	if workload.PoolSize <= 0 {
 		return workload, nil
 	}
+	if workload.NumPackages < 0 {
+		defer func() { workload.NumPackages = 0 }()
+		return workload, fmt.Errorf("virtualMachineWorkload.numPackages is %d but must be non-negative; defaulting to 0", workload.NumPackages)
+	}
 	if workload.LifecycleDuration <= 0 {
 		workload.LifecycleDuration = defaultVMLifecycleDuration
 		return workload, fmt.Errorf("virtualMachineWorkload.lifecycleDuration not set or <= 0; defaulting to %s", defaultVMLifecycleDuration)

--- a/sensor/kubernetes/fake/virtualmachines_test.go
+++ b/sensor/kubernetes/fake/virtualmachines_test.go
@@ -152,7 +152,8 @@ func TestValidateVMWorkload(t *testing.T) {
 }
 
 func TestGenerateFakeIndexReport(t *testing.T) {
-	gen := vmindexreport.NewGeneratorWithSeed(10, 42) // 10 packages, seed=42 for reproducibility
+	gen, err := vmindexreport.NewGeneratorWithSeed(10, 42) // 10 packages, seed=42 for reproducibility
+	require.NoError(t, err)
 	tests := map[string]uint32{
 		"basic report": 1234,
 		"different VM": 9999,


### PR DESCRIPTION
## Description

Add `scannerctl vm-scale` and `vm-learn` commands for isolated load testing of Scanner V4 Matcher.

**Problem:** Investigating Scanner V4 performance bottlenecks requires sending controlled load directly to the Matcher without involving Sensor/Central. Existing tools don't support this workflow.

**Solution:**
- New `scannerctl vm-scale` command sends synthetic `GetVulnerabilities` requests with configurable packages, rate, and duration
- New `scannerctl vm-learn` command discovers which fixture packages have vulnerabilities, enabling controlled tests (e.g., "only vulnerable packages" or "zero-vuln packages")
- Documentation in `VM_SCALE_TEST.md` with reproduction steps

**Key features:**
- `--direct-pod-ips` flag to distribute load across multiple matcher pods (works around gRPC load balancing issues with headless services)
- `--vuln-data` with `--zero-vulns` / `--vulnerable-only` for controlled vulnerability counts
- `--rate` and `--duration` for sustained load testing

**AI Contribution:** ~80% of the code was AI-generated. The user directed the design, validated behavior on a live cluster, identified bugs (e.g., gRPC load balancing issue), and iteratively refined the implementation based on test results.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

This is internal tooling for performance analysis; no user-facing changes.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)

Internal tooling only, not shipped to customers.

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. **Build verification:**
   ```bash
   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/scannerctl-linux ./scanner/cmd/scannerctl
   ```

2. **Cluster testing:** Deployed `scannerctl` to an OpenShift cluster with 5 Scanner V4 Matcher replicas:
   ```bash
   kubectl run loadtest -n stackrox --image=alpine:latest --restart=Never --labels="app=central" -- sleep 86400
   kubectl cp bin/scannerctl-linux stackrox/loadtest:/scannerctl
   kubectl exec -n stackrox loadtest -- chmod +x /scannerctl
   ```

3. **Validated `vm-learn`:**
   ```bash
   kubectl exec -it -n stackrox loadtest -- /scannerctl vm-learn \
     --matcher-address scanner-v4-matcher.stackrox.svc.cluster.local:8443 \
     --insecure-skip-tls-verify \
     --output /tmp/package_vulns.json \
     --verbose
   ```
   Verified output JSON contains 508 packages with vulnerability counts.

4. **Validated `vm-scale` with various configurations:**
   - Zero-vuln packages: ~195 req/s throughput confirmed
   - Vulnerable packages: ~3.7 req/s throughput confirmed
   - Rate-limited tests: exact rate achieved (1 req/s, 3 req/s)
   - 60-second sustained tests with stable latencies

5. **Verified load distribution:** Monitored matcher pod CPU with `kubectl top pods` to confirm load is distributed across all 5 replicas when using `--direct-pod-ips`.

6. **CI:** Will rely on CI for build verification and existing test compatibility.

