### PR TITLE
fix(central): cap sensor event queues

### DIFF
--- a/central/metrics/central.go
+++ b/central/metrics/central.go
@@ -91,6 +91,20 @@ var (
 		Help:      "Number of elements in removed from the queue",
 	}, []string{"Operation", "Type"})
 
+	sensorEventQueueDroppedCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "sensor_event_queue_dropped_total",
+		Help:      "Total number of sensor events dropped due to queue capacity limits",
+	}, []string{"Type"})
+
+	sensorEventQueueDepthGaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "sensor_event_queue_depth",
+		Help:      "Current depth of sensor event queues",
+	}, []string{"Type"})
+
 	resourceProcessedCounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
@@ -402,6 +416,16 @@ func IncrementSensorConnect(clusterID, state string) {
 // IncrementSensorEventQueueCounter increments the counter for the passed operation.
 func IncrementSensorEventQueueCounter(op metrics.Op, t string) {
 	sensorEventQueueCounterVec.With(prometheus.Labels{"Operation": op.String(), "Type": t}).Inc()
+}
+
+// GetSensorEventQueueDroppedCounter returns the dropped counter metric for a specific queue type.
+func GetSensorEventQueueDroppedCounter(queueType string) prometheus.Counter {
+	return sensorEventQueueDroppedCounterVec.With(prometheus.Labels{"Type": queueType})
+}
+
+// GetSensorEventQueueDepthGauge returns the depth gauge metric for a specific queue type.
+func GetSensorEventQueueDepthGauge(queueType string) prometheus.Gauge {
+	return sensorEventQueueDepthGaugeVec.With(prometheus.Labels{"Type": queueType})
 }
 
 // IncrementResourceProcessedCounter is a counter for how many times a resource has been processed in Central.

--- a/central/metrics/init.go
+++ b/central/metrics/init.go
@@ -13,6 +13,8 @@ func init() {
 		graphQLQueryHistogramVec,
 		indexOperationHistogramVec,
 		sensorEventQueueCounterVec,
+		sensorEventQueueDroppedCounterVec,
+		sensorEventQueueDepthGaugeVec,
 		resourceProcessedCounterVec,
 		totalNetworkFlowsReceivedCounter,
 		totalNetworkEndpointsReceivedCounter,

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -14,12 +14,13 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/deduperkey"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/reflectutils"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/version"
 )
 
-const workerQueueSize = 16
+var workerQueueSize = env.CentralSensorWorkerQueueSize.IntegerSetting()
 
 var (
 	deploymentEventType = reflectutils.Type((*central.SensorEvent_Deployment)(nil))

--- a/pkg/env/central_sensor_worker_queue.go
+++ b/pkg/env/central_sensor_worker_queue.go
@@ -1,0 +1,11 @@
+package env
+
+var (
+	// CentralSensorWorkerQueueSize controls the per-event-type worker queue parallelism in Central.
+	// It defaults to 16, matching historical behavior.
+	CentralSensorWorkerQueueSize = RegisterIntegerSetting("ROX_CENTRAL_SENSOR_WORKER_QUEUE_SIZE", 16).WithMinimum(1)
+
+	// CentralSensorWorkerQueueDepth caps the per-worker queue depth to avoid unbounded memory.
+	// Default 25 matches the previous hardcoded limit; must be >=1 to avoid disabling protection.
+	CentralSensorWorkerQueueDepth = RegisterIntegerSetting("ROX_CENTRAL_SENSOR_WORKER_QUEUE_DEPTH", 25).WithMinimum(1)
+)


### PR DESCRIPTION
## Description
- add env controls for sensor worker queue size and depth to prevent OOM from backlogged VM index reports
- expose queue depth/drop metrics and rate-limit drop logs for observability

## User-facing documentation
- [x] CHANGELOG.md is updated OR update is not needed
- [x] documentation PR is created and is linked above OR is not needed

## Testing and quality
- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

### Automated testing
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
- configuration/metrics change only; no automated tests added; gofmt applied.