### PR TITLE
ROX-32281: update test image to 0.5.1

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image":"quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651",
+	"image":"quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1",
 	"containerEnv":{
 		"CI":"true"
 	},

--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -12,7 +12,7 @@ jobs:
     if:  ${{ github.repository_owner == 'stackrox' }}
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -114,7 +114,7 @@ jobs:
       UI_PKG_INSTALL_EXTRA_ARGS: --ignore-scripts
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -149,7 +149,7 @@ jobs:
   pre-build-cli:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -190,7 +190,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -260,7 +260,7 @@ jobs:
   pre-build-docs:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -320,7 +320,7 @@ jobs:
       GO_BINARIES_BUILD_ARTIFACT: ""
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -504,7 +504,7 @@ jobs:
     env:
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -599,7 +599,7 @@ jobs:
     needs:
       - define-job-matrix
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -739,7 +739,7 @@ jobs:
     env:
       ROX_PRODUCT_BRANDING: ""
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -796,7 +796,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
     needs:
     - pre-build-cli
     - pre-build-go-binaries

--- a/.github/workflows/check-crd-compatibility.yaml
+++ b/.github/workflows/check-crd-compatibility.yaml
@@ -20,7 +20,7 @@ jobs:
   check-crd-compatibility:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
     outputs:
       released_version: ${{ steps.get_previous_released_version.outputs.released_version }}
     steps:

--- a/.github/workflows/ci-failures-report.yml
+++ b/.github/workflows/ci-failures-report.yml
@@ -15,7 +15,7 @@ jobs:
     if:  ${{ github.repository_owner == 'stackrox' }}
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/fixxxer.yaml
+++ b/.github/workflows/fixxxer.yaml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '/fixxx' }}
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
     steps:
 
     - name: Fetch PR metadata

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -86,7 +86,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).pre_build_scanner_go_binary }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -146,7 +146,7 @@ jobs:
     needs: pre-build-scanner-go-binary
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.1
     if: contains(github.event.pull_request.labels.*.name, 'scan-go-binaries')
     env:
       ARTIFACT_DIR: junit-reports/
@@ -200,7 +200,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push_scanner }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -278,7 +278,7 @@ jobs:
       # race-condition-debug
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).push_scanner_manifests }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.1
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -17,7 +17,7 @@ jobs:
   db-integration-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.1
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -190,7 +190,7 @@ jobs:
     - prepare-environment
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.1
       volumes:
       # The updater makes heavy use of /tmp files.
       - /tmp:/tmp
@@ -282,7 +282,7 @@ jobs:
     - prepare-environment
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.1
       volumes:
       # The updater makes heavy use of /tmp files.
       - /tmp:/tmp

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -24,7 +24,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -50,7 +50,7 @@ jobs:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -91,7 +91,7 @@ jobs:
   style-check:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -236,7 +236,7 @@ jobs:
   openshift-ci-lint:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -97,7 +97,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -157,7 +157,7 @@ jobs:
   go-bench:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -207,7 +207,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -243,7 +243,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-0.5.1
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -286,7 +286,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -330,7 +330,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -364,7 +364,7 @@ jobs:
   openshift-ci-unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.openshift-ci/Dockerfile.build_root
+++ b/.openshift-ci/Dockerfile.build_root
@@ -27,4 +27,4 @@
 # For an example, see https://github.com/stackrox/stackrox/pull/2762 and its counterpart
 # https://github.com/openshift/release/pull/31561
 
-FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+FROM quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1

--- a/.openshift-ci/dev-requirements.txt
+++ b/.openshift-ci/dev-requirements.txt
@@ -1,4 +1,4 @@
-# These versions should match those used in the current CI test image (stackrox-test-0.5.0-1-g1d19ee8651).
+# These versions should match those used in the current CI test image (stackrox-test-0.5.1).
 # See .github/workflows/{lint,style}.yaml for that.
 # And the stackrox/rox-ci-image repo for the original source and pinned versions.
 pycodestyle==2.14.0

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-stackrox-build-0.5.0-1-g1d19ee8651
+stackrox-build-0.5.1

--- a/operator/bundle_helpers/requirements-gha.txt
+++ b/operator/bundle_helpers/requirements-gha.txt
@@ -1,5 +1,5 @@
 # TODO(ROX-26860): remove this file and use just requirements.txt once the GHA operator build runs with Python 3.9.
 # PyYAML > 6.0 requires Python > 3.6.
 PyYAML==6.0
-# pytest==7.0.1 is the latest available for the quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651 job container's Python.
+# pytest==7.0.1 is the latest available for the quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1 job container's Python.
 pytest==7.0.1

--- a/scale/signatures/deploy.yaml
+++ b/scale/signatures/deploy.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: update-signature
-            image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651
+            image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1
             imagePullPolicy: IfNotPresent
             command:
             - /bin/bash

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -148,7 +148,7 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
       --platform linux/amd64 \
       --rm -it \
       --entrypoint="$0" \
-      quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.0-1-g1d19ee8651 "$@"
+      quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.1 "$@"
     exit 0
 fi
 


### PR DESCRIPTION
## Description

Update CI test image references for Go 1.25:
- stackrox-test-0.4.9 -> stackrox-test-0.5.1
- stackrox-ui-test-0.4.9 -> stackrox-ui-test-0.5.1
- scanner-test-0.4.9 -> scanner-test-0.5.1
- stackrox-build-0.4.9 -> stackrox-build-0.5.1

Related PRs:
- https://github.com/stackrox/rox-ci-image/pull/239
- https://github.com/openshift/release/pull/72530
- https://github.com/openshift/release/pull/72531

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI runs with new image version validate the change.

---
Co-authored-by: AI Assistant