### PR TITLE
ROX-30290: Enable plugin telemetry and app source

### DIFF
--- a/ui/apps/platform/src/ConsolePlugin/AdministrationNamespaceSecurityTab/AdministrationNamespaceSecurityTab.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/AdministrationNamespaceSecurityTab/AdministrationNamespaceSecurityTab.tsx
@@ -2,8 +2,11 @@ import { WorkloadCveViewContext } from 'Containers/Vulnerabilities/WorkloadCves/
 
 import { VulnerabilitiesOverviewContainer } from '../Components/VulnerabilitiesOverviewContainer';
 import { useDefaultWorkloadCveViewContext } from '../hooks/useDefaultWorkloadCveViewContext';
+import { useAnalyticsPageView } from '../hooks/useAnalyticsPageView';
 
 export function AdministrationNamespaceSecurityTab() {
+    useAnalyticsPageView();
+
     const context = useDefaultWorkloadCveViewContext();
 
     return (

--- a/ui/apps/platform/src/ConsolePlugin/CveDetailPage/CveDetailPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/CveDetailPage/CveDetailPage.tsx
@@ -12,8 +12,11 @@ import {
     namespaceSearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
 import ImageCvePage from 'Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage';
+import { useAnalyticsPageView } from '../hooks/useAnalyticsPageView';
 
 export function CveDetailPage() {
+    useAnalyticsPageView();
+
     const [activeNamespace] = useActiveNamespace();
     const { searchFilter, setSearchFilter } = useURLSearch();
     const context = useDefaultWorkloadCveViewContext();

--- a/ui/apps/platform/src/ConsolePlugin/ImageDetailPage/ImageDetailPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/ImageDetailPage/ImageDetailPage.tsx
@@ -6,8 +6,11 @@ import ImagePage from 'Containers/Vulnerabilities/WorkloadCves/Image/ImagePage';
 import { useDefaultWorkloadCveViewContext } from 'ConsolePlugin/hooks/useDefaultWorkloadCveViewContext';
 import { WorkloadCveViewContext } from 'Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext';
 import { hideColumnIf } from 'hooks/useManagedColumns';
+import { useAnalyticsPageView } from '../hooks/useAnalyticsPageView';
 
 export function ImageDetailPage() {
+    useAnalyticsPageView();
+
     const { searchFilter, setSearchFilter } = useURLSearch();
     const context = useDefaultWorkloadCveViewContext();
     const [activeNamespace] = useActiveNamespace();

--- a/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/PluginProvider.tsx
@@ -4,10 +4,12 @@ import { ApolloProvider } from '@apollo/client';
 
 import axios from 'services/instance';
 import configureApolloClient from 'init/configureApolloClient';
+import { setAnalyticsSource } from 'init/initializeAnalytics';
 import { UserPermissionProvider } from 'providers/UserPermissionProvider';
 import { FeatureFlagsProvider } from 'providers/FeatureFlagProvider';
 import { MetadataProvider } from 'providers/MetadataProvider';
 import { PublicConfigProvider } from 'providers/PublicConfigProvider';
+import { TelemetryConfigProvider } from 'providers/TelemetryConfigProvider';
 
 import consoleFetchAxiosAdapter from './consoleFetchAxiosAdapter';
 import PluginContent from './PluginContent';
@@ -16,6 +18,16 @@ import { ScopeProvider, useScope } from './ScopeContext';
 const proxyBaseURL = '/api/proxy/plugin/advanced-cluster-security/api-service/proxy/central';
 const apolloClient = configureApolloClient();
 
+setAnalyticsSource('console-plugin');
+
+/*
+ *******************NOTE************************
+ * It is important to note that this component will render frequently as the user navigates through
+ * the console UI, even * when the pages being visited do not contain any widgets related to our plugin.
+ * Side effects must not be executed unnecessarily, and instead should be performed only
+ * when the plugin is actually rendered.
+ ***********************************************
+ */
 function PluginProviderContent({ children }: { children: ReactNode }) {
     const scopeRef = useScope();
 
@@ -33,7 +45,9 @@ function PluginProviderContent({ children }: { children: ReactNode }) {
                 <FeatureFlagsProvider>
                     <MetadataProvider>
                         <PublicConfigProvider>
-                            <PluginContent>{children}</PluginContent>
+                            <TelemetryConfigProvider>
+                                <PluginContent>{children}</PluginContent>
+                            </TelemetryConfigProvider>
                         </PublicConfigProvider>
                     </MetadataProvider>
                 </FeatureFlagsProvider>

--- a/ui/apps/platform/src/ConsolePlugin/ProjectSecurityTab/ProjectSecurityTab.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/ProjectSecurityTab/ProjectSecurityTab.tsx
@@ -2,8 +2,11 @@ import { WorkloadCveViewContext } from 'Containers/Vulnerabilities/WorkloadCves/
 
 import { VulnerabilitiesOverviewContainer } from '../Components/VulnerabilitiesOverviewContainer';
 import { useDefaultWorkloadCveViewContext } from '../hooks/useDefaultWorkloadCveViewContext';
+import { useAnalyticsPageView } from '../hooks/useAnalyticsPageView';
 
 export function ProjectSecurityTab() {
+    useAnalyticsPageView();
+
     const context = useDefaultWorkloadCveViewContext();
 
     return (

--- a/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/SecurityVulnerabilitiesPage/SecurityVulnerabilitiesPage.tsx
@@ -8,8 +8,11 @@ import { deleteKeysCaseInsensitive } from 'utils/searchUtils';
 
 import { VulnerabilitiesOverviewContainer } from '../Components/VulnerabilitiesOverviewContainer';
 import { useDefaultWorkloadCveViewContext } from '../hooks/useDefaultWorkloadCveViewContext';
+import { useAnalyticsPageView } from '../hooks/useAnalyticsPageView';
 
 export function SecurityVulnerabilitiesPage() {
+    useAnalyticsPageView();
+
     const { searchFilter, setSearchFilter } = useURLSearch();
     const context = useDefaultWorkloadCveViewContext();
 

--- a/ui/apps/platform/src/ConsolePlugin/WorkloadSecurityTab/WorkloadSecurityTab.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/WorkloadSecurityTab/WorkloadSecurityTab.tsx
@@ -12,9 +12,12 @@ import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import { useDefaultWorkloadCveViewContext } from '../hooks/useDefaultWorkloadCveViewContext';
 import { useWorkloadId } from '../hooks/useWorkloadId';
+import { useAnalyticsPageView } from '../hooks/useAnalyticsPageView';
 import { useNamespaceScope } from '../ScopeContext';
 
 export function WorkloadSecurityTab() {
+    useAnalyticsPageView();
+
     const context = useDefaultWorkloadCveViewContext();
     const pagination = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { searchFilter, setSearchFilter } = useURLSearch();

--- a/ui/apps/platform/src/ConsolePlugin/hooks/useAnalyticsPageView.ts
+++ b/ui/apps/platform/src/ConsolePlugin/hooks/useAnalyticsPageView.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import useAnalytics from 'hooks/useAnalytics';
+import { useLocation } from 'react-router-dom-v5-compat';
+
+/*
+ * This hook is used to track page views for the plugin.
+ */
+export function useAnalyticsPageView() {
+    const { analyticsPageVisit } = useAnalytics();
+    const location = useLocation();
+
+    useEffect(() => {
+        analyticsPageVisit('Page Viewed', '', { path: location.pathname });
+    }, [analyticsPageVisit, location.pathname]);
+}

--- a/ui/apps/platform/src/index.tsx
+++ b/ui/apps/platform/src/index.tsx
@@ -29,6 +29,7 @@ import AppPage from 'Containers/AppPage';
 import configureStore from 'init/configureStore';
 import installRaven from 'init/installRaven';
 import configureApollo from 'init/configureApolloClient';
+import { setAnalyticsSource } from 'init/initializeAnalytics';
 import { FeatureFlagsProvider } from 'providers/FeatureFlagProvider';
 import { PublicConfigProvider } from 'providers/PublicConfigProvider';
 import { TelemetryConfigProvider } from 'providers/TelemetryConfigProvider';
@@ -43,6 +44,7 @@ import { fetchCentralCapabilitiesThunk } from 'reducers/centralCapabilities';
 mobxConfigure({ isolateGlobalState: true });
 
 installRaven();
+setAnalyticsSource('standalone');
 
 const rootNode = document.getElementById('root');
 /* @ts-expect-error `createRoot` expects a non-null argument */

--- a/ui/apps/platform/src/init/initializeAnalytics.ts
+++ b/ui/apps/platform/src/init/initializeAnalytics.ts
@@ -1,10 +1,23 @@
 import { AnalyticsBrowser } from '@segment/analytics-next';
 import Raven from 'raven-js';
 
+export type AnalyticsSource = 'standalone' | 'console-plugin' | 'unknown';
+
 // Module-level isolated analytics instance
 // In Cypress tests, check for test mock instance first
 // @ts-expect-error - Cypress test mock is not typed
 let analyticsInstance: AnalyticsBrowser | null = window?.CYPRESS_ANALYTICS_INSTANCE ?? null;
+let analyticsSource: AnalyticsSource = 'unknown'; // Default to unknown, must be set prior to initialization
+
+/**
+ * Sets the module-level analytics source for the application
+ * Must be called once at the root of the application before initializing analytics
+ *
+ * @param source - The source of the analytics (standalone or console-plugin)
+ */
+export function setAnalyticsSource(source: Exclude<AnalyticsSource, 'unknown'>): void {
+    analyticsSource = source;
+}
 
 /**
  * Initializes Segment analytics once, encapsulate in module scope
@@ -21,6 +34,16 @@ export function initializeAnalytics(
     // Prevent duplicate initialization
     if (analyticsInstance) {
         return;
+    }
+
+    if (analyticsSource === 'unknown') {
+        Raven.captureMessage(
+            'Analytics source is unknown, events will still be collected but will not be segmented by source.'
+        );
+        // eslint-disable-next-line no-console
+        console.error(
+            'Analytics is being initialized with an unknown source, this is almost certainly a developer error.'
+        );
     }
 
     let cdnURL: string | undefined;
@@ -45,6 +68,24 @@ export function initializeAnalytics(
             },
         }
     );
+
+    analyticsInstance
+        .addSourceMiddleware(({ payload, next }) => {
+            const eventType = payload.type();
+
+            // Source is added as a property (not context) so it's available for segmentation in Amplitude
+            if (eventType === 'track' || eventType === 'page') {
+                // eslint-disable-next-line no-param-reassign
+                payload.obj.properties = {
+                    ...payload.obj.properties,
+                    acsApplicationSource: analyticsSource,
+                };
+            }
+            next(payload);
+        })
+        .catch((error) => {
+            Raven.captureException(error);
+        });
 
     if (userId) {
         analyticsInstance.identify(userId).catch((error) => {


### PR DESCRIPTION
## Description

Enables the TelemetryProvider in the OCP dynamic plugin, and modifies telemetry events to include the source of the analytics event, either the standalone UI or the plugin.

Depends on https://github.com/stackrox/stackrox/pull/18441

Edit: Not reflected in screenshots, but I was able to confirm that this approach along with the previous PR using `npm` for installing segment allows us to co-exist with the console analytics. The main console and our setup each issue independent events with their own separate `writeKey`.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Page view event in console-plugin:
<img width="1585" height="1184" alt="image" src="https://github.com/user-attachments/assets/b70b0f94-3196-4c59-845e-c31416941d9c" />

User action in console-plugin:
<img width="1585" height="1184" alt="image" src="https://github.com/user-attachments/assets/661a1240-c263-4dff-88d1-ee08b88d7d72" />

Page view event in standalone:
<img width="1585" height="1184" alt="image" src="https://github.com/user-attachments/assets/26a16511-92a0-4d08-b0ef-868fdd0feaed" />

User action in standalone:
<img width="1585" height="1184" alt="image" src="https://github.com/user-attachments/assets/da1c78e7-1db7-495e-99c8-5f23d1ab9410" />

