### PR TITLE
ROX-31852: Abstract Risk service calls into custom hooks

### DIFF
--- a/ui/apps/platform/src/Containers/Risk/useDeploymentsCount.ts
+++ b/ui/apps/platform/src/Containers/Risk/useDeploymentsCount.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react';
+
+import useRestQuery from 'hooks/useRestQuery';
+import type { UseRestQueryReturn } from 'hooks/useRestQuery';
+import { fetchDeploymentsCount } from 'services/DeploymentsService';
+import type { SearchFilter } from 'types/search';
+import { ORCHESTRATOR_COMPONENTS_KEY } from 'utils/orchestratorComponents';
+
+type UseDeploymentsCountParams = {
+    searchFilter: SearchFilter;
+};
+
+export default function useDeploymentsCount({
+    searchFilter,
+}: UseDeploymentsCountParams): UseRestQueryReturn<number> {
+    const shouldHideOrchestratorComponents =
+        localStorage.getItem(ORCHESTRATOR_COMPONENTS_KEY) !== 'true';
+
+    const requestFn = useCallback(() => {
+        const effectiveSearchFilter = {
+            ...searchFilter,
+            ...(shouldHideOrchestratorComponents ? { 'Orchestrator Component': 'false' } : {}),
+        };
+
+        return fetchDeploymentsCount(effectiveSearchFilter);
+    }, [searchFilter, shouldHideOrchestratorComponents]);
+
+    return useRestQuery(requestFn);
+}

--- a/ui/apps/platform/src/Containers/Risk/useDeploymentsWithProcessInfo.ts
+++ b/ui/apps/platform/src/Containers/Risk/useDeploymentsWithProcessInfo.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+
+import useRestQuery from 'hooks/useRestQuery';
+import type { UseRestQueryReturn } from 'hooks/useRestQuery';
+import { fetchDeploymentsWithProcessInfo } from 'services/DeploymentsService';
+import type { ListDeploymentWithProcessInfo } from 'services/DeploymentsService';
+import type { ApiSortOption, SearchFilter } from 'types/search';
+import { ORCHESTRATOR_COMPONENTS_KEY } from 'utils/orchestratorComponents';
+
+type UseDeploymentsWithProcessInfoParams = {
+    searchFilter: SearchFilter;
+    sortOption: ApiSortOption;
+    page: number;
+    perPage: number;
+};
+
+export default function useDeploymentsWithProcessInfo({
+    searchFilter,
+    sortOption,
+    page,
+    perPage,
+}: UseDeploymentsWithProcessInfoParams): UseRestQueryReturn<ListDeploymentWithProcessInfo[]> {
+    const shouldHideOrchestratorComponents =
+        localStorage.getItem(ORCHESTRATOR_COMPONENTS_KEY) !== 'true';
+
+    const requestFn = useCallback(() => {
+        const effectiveSearchFilter = {
+            ...searchFilter,
+            ...(shouldHideOrchestratorComponents ? { 'Orchestrator Component': 'false' } : {}),
+        };
+
+        return fetchDeploymentsWithProcessInfo(effectiveSearchFilter, sortOption, page, perPage);
+    }, [searchFilter, sortOption, page, perPage, shouldHideOrchestratorComponents]);
+
+    return useRestQuery(requestFn);
+}


### PR DESCRIPTION
## Description

Cleanup/refactor in preparation of migrating table to PatternFly. 

Removes use of `useDeepCompareEffect` and abstract's Risk page service calls into custom hooks.


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Existing e2e tests.

Manual testing of search/sort/pagination of table UI.
