### PR TITLE
ROX-32103: Add column management to vm details table

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePageVulnerabilities.tsx
@@ -11,9 +11,11 @@ import {
 } from '@patternfly/react-core';
 
 import { DynamicTableLabel } from 'Components/DynamicIcon';
+import ColumnManagementButton from 'Components/ColumnManagementButton';
 import type { UseURLPaginationResult } from 'hooks/useURLPagination';
 import type { UseUrlSearchReturn } from 'hooks/useURLSearch';
 import type { UseURLSortResult } from 'hooks/useURLSort';
+import { useManagedColumns } from 'hooks/useManagedColumns';
 import type { VirtualMachine } from 'services/VirtualMachineService';
 import { getTableUIState } from 'utils/getTableUIState';
 
@@ -38,7 +40,10 @@ import {
     getHiddenStatuses,
     parseQuerySearchFilter,
 } from '../../utils/searchUtils';
-import VirtualMachineVulnerabilitiesTable from './VirtualMachineVulnerabilitiesTable';
+import VirtualMachineVulnerabilitiesTable, {
+    defaultColumns,
+    tableId,
+} from './VirtualMachineVulnerabilitiesTable';
 
 // Currently we need all vm info to be fetched in the root component, hence this being passed in
 // there will likely be a call specific to this table in the future that should be made here
@@ -71,6 +76,8 @@ function VirtualMachinePageVulnerabilities({
     const hiddenStatuses = getHiddenStatuses(querySearchFilter);
     const hiddenSeverities = getHiddenSeverities(querySearchFilter);
     const isFiltered = getHasSearchApplied(searchFilter);
+
+    const managedColumnState = useManagedColumns(tableId, defaultColumns);
 
     const virtualMachineTableData = useMemo(
         () => getVirtualMachineCveTableData(virtualMachineData),
@@ -167,6 +174,12 @@ function VirtualMachinePageVulnerabilities({
                         </Flex>
                     </SplitItem>
                     <SplitItem>
+                        <ColumnManagementButton
+                            columnConfig={managedColumnState.columns}
+                            onApplyColumns={managedColumnState.setVisibility}
+                        />
+                    </SplitItem>
+                    <SplitItem>
                         <Pagination
                             itemCount={filteredVirtualMachineTableData.length}
                             perPage={perPage}
@@ -182,6 +195,7 @@ function VirtualMachinePageVulnerabilities({
                     onClearFilters={onClearFilters}
                     getSortParams={getSortParams}
                     tableState={tableState}
+                    tableConfig={managedColumnState.columns}
                 />
             </div>
         </PageSection>


### PR DESCRIPTION
## Description

Added column management to the Virtual Machine vulnerabilities table. Allows users to show/hide columns (CVE severity, CVE status, CVSS, EPSS probability, Affected components). This follows the same pattern used in other Workload CVE tables and stores column preferences in local storage.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Default view:
<img width="1689" height="352" alt="Screenshot 2025-12-15 at 3 02 40 PM" src="https://github.com/user-attachments/assets/764be25a-bfa7-4c67-829a-6e6ffd0f5afe" />


Changing displayed columns:
<img width="1689" height="352" alt="Screenshot 2025-12-15 at 3 02 58 PM" src="https://github.com/user-attachments/assets/6d1028e8-cf11-44a5-8f86-cdf1a5b7b58a" />

