### PR TITLE
ROX-32281: Fix file already closed error in memory benchmark

### DIFF
--- a/central/detection/lifecycle/indicator_filter_benchmark_test.go
+++ b/central/detection/lifecycle/indicator_filter_benchmark_test.go
@@ -210,7 +210,7 @@ func BenchmarkBuildIndicatorFilterMemory(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer func() { utils.Must(f.Close()) }()
+	b.Cleanup(func() { utils.Must(f.Close()) })
 
 	err = pprof.Lookup("heap").WriteTo(f, 0)
 	if err != nil {


### PR DESCRIPTION
## Description

Fixes 'file already closed' error in BenchmarkBuildIndicatorFilterMemory. The issue was caused by `defer utils.Must(f.Close())` which executed `f.Close()` immediately instead of deferring it. Uses `b.Cleanup()` to properly manage file cleanup with standard Go testing patterns.

**Root cause**: When passing `f.Close()` as an argument to `utils.Must()` in a defer statement, Go evaluates the argument immediately, closing the file before `pprof.WriteHeapProfile()` can write to it.

**Fix**: Changed to `b.Cleanup(func() { utils.Must(f.Close()) })` which ensures the file remains open during profile writing and aligns with Go testing best practices for lifecycle management.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Ran benchmark test locally and verified the memory profile file is generated with valid pprof data instead of being empty.