### PR TITLE
feat(vm): Add test mode for VM load testing

### DIFF
--- a/compliance/virtualmachines/relay/relay.go
+++ b/compliance/virtualmachines/relay/relay.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/compliance/virtualmachines/relay/sender"
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 )
 
@@ -34,6 +35,10 @@ func New(reportStream IndexReportStream, reportSender sender.IndexReportSender) 
 
 func (r *Relay) Run(ctx context.Context) error {
 	log.Info("Starting virtual machine relay")
+
+	if env.IsVMTestModeEnabled() {
+		log.Warn("VM test mode is enabled; vsock CID validation is bypassed. Use only for load testing.")
+	}
 
 	reportChan, err := r.reportStream.Start(ctx)
 	if err != nil {

--- a/compliance/virtualmachines/relay/stream/vsock_index_report_stream.go
+++ b/compliance/virtualmachines/relay/stream/vsock_index_report_stream.go
@@ -207,7 +207,11 @@ func parseVMReport(data []byte) (*v1.VMReport, error) {
 }
 
 // validateReportedVsockCID ensures the message's vsock CID matches the connection.
+// In test mode, validation is bypassed to allow load testing with simulated VMs.
 func validateReportedVsockCID(vmReport *v1.VMReport, connVsockCID uint32) error {
+	if env.IsVMTestModeEnabled() {
+		return nil
+	}
 	reportedCID := vmReport.GetIndexReport().GetVsockCid()
 	if reportedCID != strconv.FormatUint(uint64(connVsockCID), 10) {
 		metrics.IndexReportsMismatchingVsockCID.Inc()

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -1,6 +1,10 @@
 package env
 
-import "time"
+import (
+	"time"
+
+	"github.com/stackrox/rox/pkg/buildinfo"
+)
 
 var (
 	// VirtualMachinesMaxConcurrentVsockConnections defines the maximum number of vsock connections handled in parallel.
@@ -45,4 +49,19 @@ var (
 	// then must wait for 5 seconds for tokens to refill at the rate limit.
 	// Default: 200 tokens
 	VMIndexReportBucketCapacity = RegisterIntegerSetting("ROX_VM_INDEX_REPORT_BUCKET_CAPACITY", 200).WithMinimum(1)
+
+	// VirtualMachinesTestMode enables test mode for VM load testing across all components.
+	// When enabled:
+	// - Relay: bypasses vsock CID validation for loopback testing
+	// - Sensor: auto-generates VMs on-the-fly, skips VM store cleanup
+	// - Central: auto-creates missing VMs when receiving index reports
+	// Use only for load testing scenarios.
+	VirtualMachinesTestMode = RegisterBooleanSetting("ROX_VM_TEST_MODE", false)
 )
+
+// IsVMTestModeEnabled returns true if VM test mode is enabled via environment variable
+// AND this is not a release build. This ensures test mode cannot be accidentally enabled
+// in production releases.
+func IsVMTestModeEnabled() bool {
+	return VirtualMachinesTestMode.BooleanSetting() && !buildinfo.ReleaseBuild
+}

--- a/sensor/common/virtualmachine/index/handler.go
+++ b/sensor/common/virtualmachine/index/handler.go
@@ -22,6 +22,7 @@ type Handler interface {
 //go:generate mockgen-wrapper
 type VirtualMachineStore interface {
 	GetFromCID(cid uint32) *virtualmachine.Info
+	AddOrUpdate(vm *virtualmachine.Info) *virtualmachine.Info
 }
 
 // NewHandler returns the virtual machine component for Sensor to use.

--- a/sensor/common/virtualmachine/index/mocks/handler.go
+++ b/sensor/common/virtualmachine/index/mocks/handler.go
@@ -192,6 +192,20 @@ func (m *MockVirtualMachineStore) EXPECT() *MockVirtualMachineStoreMockRecorder 
 	return m.recorder
 }
 
+// AddOrUpdate mocks base method.
+func (m *MockVirtualMachineStore) AddOrUpdate(vm *virtualmachine.Info) *virtualmachine.Info {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddOrUpdate", vm)
+	ret0, _ := ret[0].(*virtualmachine.Info)
+	return ret0
+}
+
+// AddOrUpdate indicates an expected call of AddOrUpdate.
+func (mr *MockVirtualMachineStoreMockRecorder) AddOrUpdate(vm any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOrUpdate", reflect.TypeOf((*MockVirtualMachineStore)(nil).AddOrUpdate), vm)
+}
+
 // GetFromCID mocks base method.
 func (m *MockVirtualMachineStore) GetFromCID(cid uint32) *virtualmachine.Info {
 	m.ctrl.T.Helper()

--- a/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/store/virtual_machine_store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
@@ -80,6 +81,13 @@ func (s *VirtualMachineStore) ClearState(id virtualmachine.VMID) {
 func (s *VirtualMachineStore) Cleanup() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+
+	// In test mode, preserve auto-generated test VMs in the vm-load-test namespace
+	if env.IsVMTestModeEnabled() {
+		log.Debug("Skipping VM store cleanup in test mode to preserve auto-generated VMs")
+		return
+	}
+
 	clear(s.virtualMachines)
 	clear(s.namespaceToID)
 	clear(s.cidToID)


### PR DESCRIPTION
## Description

Add `ROX_VM_TEST_MODE` environment variable to enable end-to-end load testing of the VM index report pipeline without requiring real VMs or vsock hardware.

When enabled (only works in non-release builds):
- **Relay**: Bypasses vsock CID validation, binds to `vsock.Local` for loopback testing
- **Sensor**: Auto-generates VMs on-the-fly when index reports arrive, skips VM store cleanup
- **Central**: Auto-creates missing VMs in database when receiving index reports

Uses deterministic UUID v5 generation based on vsock CID to ensure consistency between Sensor and Central when both auto-generate VM records.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Test mode is guarded by `!buildinfo.ReleaseBuild` check, cannot be enabled in production
- Builds successfully with `go build ./...`
- Companion PR #17970 (loadgen tool) uses this functionality for load testing