### PR TITLE
chore(lint): enable unconvert

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,7 @@ linters:
     - staticcheck
     - wrapcheck
   # - nakedret TODO: add in follow-up
-  # - unconvert TODO: add in follow-up
+    - unconvert
   # - unparam TODO: add in follow-up
   # - unused // enabled in Makefile as it fails with release tag
     - usestdlibvars

--- a/central/clusters/helmconfig/yaml.go
+++ b/central/clusters/helmconfig/yaml.go
@@ -62,7 +62,7 @@ func (h helmConfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		httputil.WriteGRPCStyleError(w, codes.Internal, errors.Wrap(err, "marshalling cluster configuration as YAML"))
 		return
 	}
-	configYamlBytes := []byte(configYaml)
+	configYamlBytes := configYaml
 
 	// Tell the browser this is a download.
 	w.Header().Add("Content-Disposition", fmt.Sprintf(`attachment; filename="values-%s.yaml"`, zip.GetSafeFilename(cluster.GetName())))

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -265,7 +265,7 @@ func CollectPostgresDatabaseSizes(postgresConfig *postgres.Config) []*stats.Data
 
 		dbDetails := &stats.DatabaseDetailsStats{
 			DatabaseName: database,
-			DatabaseSize: int64(dbSize),
+			DatabaseSize: dbSize,
 		}
 		detailsSlice = append(detailsSlice, dbDetails)
 	}

--- a/central/graphql/resolvers/loaders/policies.go
+++ b/central/graphql/resolvers/loaders/policies.go
@@ -93,10 +93,10 @@ func (idl *policyLoaderImpl) CountFromQuery(ctx context.Context, query *v1.Query
 	return int32(numResults), nil
 }
 
-// CountFromQuery returns the total number of policies.
+// CountAll returns the total number of policies.
 func (idl *policyLoaderImpl) CountAll(ctx context.Context) (int32, error) {
 	count, err := idl.CountFromQuery(ctx, search.EmptyQuery())
-	return int32(count), err
+	return count, err
 }
 
 func (idl *policyLoaderImpl) load(ctx context.Context, ids []string) ([]*storage.Policy, error) {

--- a/central/networkgraph/entity/datastore/datastore_impl.go
+++ b/central/networkgraph/entity/datastore/datastore_impl.go
@@ -570,7 +570,7 @@ func excludeEntityForGraphConfig(graphConfig *storage.NetworkGraphConfig, entity
 }
 
 func getScopeKey(id string) ([]sac.ScopeKey, error) {
-	decodedID, err := sac.ParseResourceID(string(id))
+	decodedID, err := sac.ParseResourceID(id)
 	if err != nil {
 		return nil, err
 	}

--- a/central/notifiers/syslog/syslog_test.go
+++ b/central/notifiers/syslog/syslog_test.go
@@ -122,7 +122,7 @@ func (s *SyslogNotifierTestSuite) TestCEFMakeTimestampExtensionPair() {
 	key := "key"
 	value := time.Now()
 
-	msTs := int64(value.Unix())*1000 + int64(value.Nanosecond())/1000000
+	msTs := value.Unix()*1000 + int64(value.Nanosecond())/1000000
 	expectedValue := []string{fmt.Sprintf("%s=%s", key, strconv.Itoa(int(msTs)))}
 
 	extensionPair := makeTimestampExtensionPair(key, &value)

--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -2862,8 +2862,8 @@ func (suite *PLOPDataStoreTestSuite) TestRemovePLOPsWithoutPodUIDScaleRaceCondit
 	// and pruned, then it will be pruned once. Therefore the number of rows pruned will
 	// be between the number of PLOPs that don't have poduids that were added and twice
 	// that number.
-	suite.GreaterOrEqual(int(plopsWithoutPodUids), totalPrunedCount/2)
-	suite.LessOrEqual(int(plopsWithoutPodUids), totalPrunedCount)
+	suite.GreaterOrEqual(plopsWithoutPodUids, totalPrunedCount/2)
+	suite.LessOrEqual(plopsWithoutPodUids, totalPrunedCount)
 }
 
 func (suite *PLOPDataStoreTestSuite) TestSortMany() {

--- a/central/sensor/service/pipeline/networkpolicies/pipeline.go
+++ b/central/sensor/service/pipeline/networkpolicies/pipeline.go
@@ -155,7 +155,7 @@ func (s *pipelineImpl) persistNetworkPolicy(ctx context.Context, action central.
 	case central.ResourceAction_CREATE_RESOURCE, central.ResourceAction_UPDATE_RESOURCE, central.ResourceAction_SYNC_RESOURCE:
 		return s.networkPolicies.UpsertNetworkPolicy(ctx, np)
 	case central.ResourceAction_REMOVE_RESOURCE:
-		return s.networkPolicies.RemoveNetworkPolicy(ctx, string(np.GetId()))
+		return s.networkPolicies.RemoveNetworkPolicy(ctx, np.GetId())
 	default:
 		return fmt.Errorf("Event action '%s' for network policy does not exist", action)
 	}

--- a/pkg/cloudproviders/gcp/utils/util.go
+++ b/pkg/cloudproviders/gcp/utils/util.go
@@ -51,7 +51,7 @@ func CreateSecurityCenterClientFromConfig(ctx context.Context,
 		return securitycenter.NewClient(ctx, option.WithGRPCDialOption(grpc.WithContextDialer(proxy.AwareDialContext)))
 	}
 	return securitycenter.NewClient(ctx,
-		option.WithCredentialsJSON([]byte(decCreds)),
+		option.WithCredentialsJSON(decCreds),
 		option.WithGRPCDialOption(grpc.WithContextDialer(proxy.AwareDialContext)),
 	)
 }
@@ -67,7 +67,7 @@ func CreateSecurityCenterClientFromConfigWithManager(ctx context.Context,
 		)
 	}
 	return securitycenter.NewClient(ctx,
-		option.WithCredentialsJSON([]byte(decCreds)),
+		option.WithCredentialsJSON(decCreds),
 		option.WithGRPCDialOption(grpc.WithContextDialer(proxy.AwareDialContext)),
 	)
 }

--- a/pkg/net/addr.go
+++ b/pkg/net/addr.go
@@ -306,7 +306,7 @@ func IPNetworkFromCIDR(cidr string) IPNetwork {
 
 	return IPNetwork{
 		ip:        IPFromBytes(ipNet.IP),
-		prefixLen: byte(uint8(ones)),
+		prefixLen: uint8(ones),
 	}
 }
 
@@ -320,7 +320,7 @@ func IPNetworkFromIPNet(ipNet net.IPNet) IPNetwork {
 
 	return IPNetwork{
 		ip:        addr,
-		prefixLen: byte(uint8(ones)),
+		prefixLen: uint8(ones),
 	}
 }
 

--- a/pkg/profiling/profiling_test.go
+++ b/pkg/profiling/profiling_test.go
@@ -15,7 +15,7 @@ func TestHeapDump(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	var limitBytes int64 = 2 // to be sure the test blows this limit
-	p := NewHeapProfiler(0.80, uint64(limitBytes), tmpDir, time.Duration(DefaultHeapProfilerBackoff)*time.Second)
+	p := NewHeapProfiler(0.80, uint64(limitBytes), tmpDir, DefaultHeapProfilerBackoff*time.Second)
 	runCheck := make(chan time.Time)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	now := time.Now()

--- a/pkg/protoconv/resources/volumes/gcepersistent.go
+++ b/pkg/protoconv/resources/volumes/gcepersistent.go
@@ -9,7 +9,7 @@ type gcePersistentDisk struct {
 }
 
 func (e *gcePersistentDisk) Source() string {
-	return string(e.PDName)
+	return e.PDName
 }
 
 func (e *gcePersistentDisk) Type() string {

--- a/pkg/sac/tests/test_scope_checker_core_test.go
+++ b/pkg/sac/tests/test_scope_checker_core_test.go
@@ -198,9 +198,9 @@ func (s *testScopeCheckerCoreTestSuite) TestFullMapTestScopeCheckerHierarchyTryA
 func createTestReadMultipleResourcesSomeWithNamespaceScope(t *testing.T) sac.ScopeCheckerCore {
 	testScope := map[storage.Access]map[permissions.Resource]*sac.TestResourceScope{
 		storage.Access_READ_ACCESS: {
-			permissions.Resource(resourceCluster): &sac.TestResourceScope{Included: true},
-			permissions.Resource(resourceNode):    &sac.TestResourceScope{Included: true},
-			permissions.Resource(resourceDeployment): &sac.TestResourceScope{
+			resourceCluster: &sac.TestResourceScope{Included: true},
+			resourceNode:    &sac.TestResourceScope{Included: true},
+			resourceDeployment: &sac.TestResourceScope{
 				Included: false,
 				Clusters: map[string]*sac.TestClusterScope{
 					clusterClusterID: {
@@ -217,7 +217,7 @@ func createTestReadMultipleResourcesSomeWithNamespaceScope(t *testing.T) sac.Sco
 func createTestReadMultipleResourcesWithDifferentNamespaceScope(t *testing.T) sac.ScopeCheckerCore {
 	testScope := map[storage.Access]map[permissions.Resource]*sac.TestResourceScope{
 		storage.Access_READ_ACCESS: {
-			permissions.Resource(resourceDeployment): &sac.TestResourceScope{
+			resourceDeployment: &sac.TestResourceScope{
 				Included: false,
 				Clusters: map[string]*sac.TestClusterScope{
 					clusterMyCluster: {
@@ -226,7 +226,7 @@ func createTestReadMultipleResourcesWithDifferentNamespaceScope(t *testing.T) sa
 					},
 				},
 			},
-			permissions.Resource(resourceNetworkGraph): &sac.TestResourceScope{
+			resourceNetworkGraph: &sac.TestResourceScope{
 				Included: false,
 				Clusters: map[string]*sac.TestClusterScope{
 					clusterMyCluster: {

--- a/roxctl/central/db/restore/v2_restorer.go
+++ b/roxctl/central/db/restore/v2_restorer.go
@@ -123,7 +123,7 @@ func (r *v2Restorer) updateTransferStatus(cancelCond concurrency.Waitable) {
 			}
 
 			remaining := r.headerSize + r.totalDataSize - currVal
-			remainingSecs := int64(remaining / avgSpeed)
+			remainingSecs := remaining / avgSpeed
 
 			newText := fmt.Sprintf(
 				"Transferring data at % 10.1f/s (ETA %02d:%02d:%02d)",

--- a/roxctl/common/k8s_port_forward_test.go
+++ b/roxctl/common/k8s_port_forward_test.go
@@ -41,7 +41,7 @@ func Test_getCentralAPIPort(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
-		assert.Equal(t, int32(tt.expectedPort), getCentralAPIPort(tt.pod), name)
+		assert.Equal(t, tt.expectedPort, getCentralAPIPort(tt.pod), name)
 	}
 }
 

--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -78,7 +78,7 @@ func main() {
 	defer cancel()
 
 	// Initialize logging and setup context.
-	err = initializeLogging(zerolog.Level(cfg.LogLevel))
+	err = initializeLogging(cfg.LogLevel)
 	if err != nil {
 		golog.Fatalf("failed to initialize logging: %v", err)
 	}

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -290,7 +290,7 @@ func NewIndexer(ctx context.Context, cfg config.IndexerConfig) (Indexer, error) 
 		vscnrs:          vscnrs,
 		pool:            pool,
 		root:            root,
-		getLayerTimeout: time.Duration(cfg.GetLayerTimeout),
+		getLayerTimeout: cfg.GetLayerTimeout,
 
 		metadataStore:          metadataStore,
 		externalIndexStore:     externalIndexStore,

--- a/sensor/admission-control/settingswatch/k8s.go
+++ b/sensor/admission-control/settingswatch/k8s.go
@@ -107,9 +107,9 @@ func parseSettings(cm *v1.ConfigMap) (*sensor.AdmissionControlSettings, error) {
 		return nil, errors.Wrap(err, "could not parse protobuf-encoded config data from configmap")
 	}
 
-	cacheVersion := string(cm.Data[admissioncontrol.CacheVersionDataKey])
-	centralEndpoint := string(cm.Data[admissioncontrol.CentralEndpointDataKey])
-	clusterID := string(cm.Data[admissioncontrol.ClusterIDDataKey])
+	cacheVersion := cm.Data[admissioncontrol.CacheVersionDataKey]
+	centralEndpoint := cm.Data[admissioncontrol.CentralEndpointDataKey]
+	clusterID := cm.Data[admissioncontrol.ClusterIDDataKey]
 
 	settings := &sensor.AdmissionControlSettings{
 		ClusterConfig:              &config,

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorsuites.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorsuites.go
@@ -48,7 +48,7 @@ func (c *SuitesDispatcher) ProcessEvent(obj, _ interface{}, action central.Resou
 					Status: &central.ComplianceOperatorStatus{
 						Phase:        string(complianceSuite.Status.Phase),
 						Result:       string(complianceSuite.Status.Result),
-						ErrorMessage: string(complianceSuite.Status.ErrorMessage),
+						ErrorMessage: complianceSuite.Status.ErrorMessage,
 						Conditions:   getStatusConditions(complianceSuite.Status.Conditions),
 					},
 				},


### PR DESCRIPTION
## Description

Enable the `unconvert` linter to detect unnecessary type conversions and fix all violations across the codebase.

Part of ongoing code quality improvements in #7729

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Ran `make golangci-lint` - 0 violations
- Code changes are purely removing unnecessary type conversions