### PR TITLE
ROX-32412: Enable compliance for metrics scraping

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -331,3 +331,26 @@ spec:
         configMap:
           name: collector-config
           optional: true
+
+{{- if ._rox.collector.exposeMonitoring }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: compliance-metrics
+  namespace: {{ ._rox._namespace }}
+  labels:
+    {{- include "srox.labels" (list . "service" "compliance-metrics") | nindent 4 }}
+    auto-upgrade.stackrox.io/component: "sensor"
+  annotations:
+    {{- include "srox.annotations" (list . "service" "compliance-metrics") | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+  - name: monitoring
+    port: 9091
+    targetPort: 9091
+    protocol: TCP
+  selector:
+    app: collector
+{{- end }}

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/monitoring.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/monitoring.test.yaml
@@ -14,6 +14,7 @@ tests:
     verifyMonitoringExposed(.services["scanner-v4-indexer"]) | assertThat(not)
     verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer")) | assertThat(not)
     .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. == null)
+    .services["compliance-metrics"] | assertThat(. == null)
 
 - name: monitoring should be exposed when enabled
   set:
@@ -29,6 +30,10 @@ tests:
     verifyMonitoringExposed(.services["scanner-v4-indexer"])
     verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer"))
     .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. != null)
+    .services["compliance-metrics"] | assertThat(. != null)
+    .services["compliance-metrics"].spec.clusterIP | assertThat(. == "None")
+    .services["compliance-metrics"].spec.ports[0].name | assertThat(. == "monitoring")
+    .services["compliance-metrics"].spec.ports[0].port | assertThat(. == 9091)
 
 - name: network policies should not be created when disabled
   set:
@@ -53,6 +58,7 @@ tests:
     .networkpolicys["admission-control-monitoring"] | assertThat(. != null)
     verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer"))
     .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. != null)
+    .services["compliance-metrics"] | assertThat(. != null)
 
 - name: monitoring should be overridable on a per-component basis (collector)
   set:
@@ -67,6 +73,7 @@ tests:
     .networkpolicys["admission-control-monitoring"] | assertThat(. != null)
     verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer"))
     .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. != null)
+    .services["compliance-metrics"] | assertThat(. == null)
 
 - name: monitoring should be overridable on a per-component basis (admission control)
   set:
@@ -81,6 +88,7 @@ tests:
     .networkpolicys["admission-control-monitoring"] | assertThat(. == null)
     verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer"))
     .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. != null)
+    .services["compliance-metrics"] | assertThat(. != null)
 
 - name: monitoring should be overridable on a per-component basis (scanner v4)
   set:
@@ -96,3 +104,4 @@ tests:
     .networkpolicys["admission-control-monitoring"] | assertThat(. != null)
     verifyMonitoringContainerPortExposed(container(.deployments["scanner-v4-indexer"]; "indexer")) | assertThat(not)
     .networkpolicys["scanner-v4-indexer-monitoring"] | assertThat(. == null)
+    .services["compliance-metrics"] | assertThat(. != null)


### PR DESCRIPTION
## Description

Add a headless Kubernetes Service (`compliance-metrics`) to expose the compliance container's Prometheus metrics endpoint for scraping.

**Problem**: The compliance container has a metrics endpoint on port 9091, but there was no Service to expose it. This meant Prometheus could not discover and scrape compliance metrics (e.g., VM relay metrics like `rox_compliance_virtual_machine_relay_*`).

**Solution**: Add a headless Service (`clusterIP: None`) that:
- Is conditionally created only when `collector.exposeMonitoring` is enabled (same flag that enables the NetworkPolicy allowing ingress)
- Uses port name `monitoring` for Prometheus auto-discovery
- Targets port 9091 on collector pods where the compliance container runs

This change is AI-assisted. The implementation and tests were generated by AI (Claude) and reviewed/validated by the user.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- [x] Deploying a cluster manually and checking if the metrics are visible in prometheus and grafana (requires changing the `ROX_METRICS_PORT` for compliance manually from `disabled` to `":9091"`)


