### PR TITLE
ROX-32270: Rewrite with switch in CompoundSearchFilterInputField

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -4,12 +4,7 @@ import { Flex } from '@patternfly/react-core';
 import type { SearchFilter } from 'types/search';
 import { ensureString } from 'utils/ensure';
 import { isOnSearchPayload } from '../types';
-import type {
-    CompoundSearchFilterAttribute,
-    CompoundSearchFilterConfig,
-    CompoundSearchFilterEntity,
-    OnSearchCallback,
-} from '../types';
+import type { CompoundSearchFilterConfig, OnSearchCallback } from '../types';
 import {
     getAttribute,
     getDefaultAttributeName,
@@ -23,15 +18,6 @@ import type { SelectedEntity } from './EntitySelector';
 import AttributeSelector from './AttributeSelector';
 import type { SelectedAttribute } from './AttributeSelector';
 import CompoundSearchFilterInputField from './CompoundSearchFilterInputField';
-
-// Change in key causes React to instantiate a new input element,
-// which has side effect to clear input state if same type as previous element.
-function getEntityAttributeKey(
-    entity: CompoundSearchFilterEntity,
-    attribute: CompoundSearchFilterAttribute
-) {
-    return `${entity.displayName} ${attribute.displayName}`;
-}
 
 export type CompoundSearchFilterProps = {
     config: CompoundSearchFilterConfig;
@@ -122,7 +108,9 @@ function CompoundSearchFilter({
             />
             {entity && attribute && (
                 <CompoundSearchFilterInputField
-                    key={getEntityAttributeKey(entity, attribute)}
+                    // Change in key causes React to instantiate a new input element,
+                    // which has side effect to clear input state if same type as previous element.
+                    key={`${entity.displayName} ${attribute.displayName}`}
                     entity={entity}
                     attribute={attribute}
                     searchFilter={searchFilter}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -1,4 +1,6 @@
 import type { SearchFilter } from 'types/search';
+import { ensureExhaustive } from 'utils/type.utils';
+
 import type {
     CompoundSearchFilterAttribute,
     CompoundSearchFilterEntity,
@@ -28,57 +30,53 @@ function CompoundSearchFilterInputField({
     searchFilter,
     additionalContextFilter,
 }: CompoundSearchFilterInputFieldProps) {
-    if (attribute.inputType === 'text') {
-        return <SearchFilterText attribute={attribute} onSearch={onSearch} />;
+    const { inputType } = attribute;
+    switch (inputType) {
+        case 'text':
+            return <SearchFilterText attribute={attribute} onSearch={onSearch} />;
+        case 'date-picker':
+            return <SearchFilterConditionDate attribute={attribute} onSearch={onSearch} />;
+        case 'condition-number':
+            return <SearchFilterConditionNumber attribute={attribute} onSearch={onSearch} />;
+        case 'condition-text':
+            return <SearchFilterConditionText attribute={attribute} onSearch={onSearch} />;
+        case 'autocomplete':
+            return (
+                <SearchFilterAutocompleteSelect
+                    additionalContextFilter={additionalContextFilter}
+                    attribute={attribute}
+                    onSearch={onSearch}
+                    searchCategory={entity.searchCategory}
+                    searchFilter={searchFilter}
+                />
+            );
+        case 'select-exclusive-double':
+            return (
+                <SearchFilterSelectExclusiveDouble
+                    attribute={attribute}
+                    onSearch={onSearch}
+                    searchFilter={searchFilter}
+                />
+            );
+        case 'select-exclusive-single':
+            return (
+                <SearchFilterSelectExclusiveSingle
+                    attribute={attribute}
+                    onSearch={onSearch}
+                    searchFilter={searchFilter}
+                />
+            );
+        case 'select':
+            return (
+                <SearchFilterSelectInclusive
+                    attribute={attribute}
+                    onSearch={onSearch}
+                    searchFilter={searchFilter}
+                />
+            );
+        default:
+            return ensureExhaustive(inputType);
     }
-    if (attribute.inputType === 'date-picker') {
-        return <SearchFilterConditionDate attribute={attribute} onSearch={onSearch} />;
-    }
-    if (attribute.inputType === 'condition-number') {
-        return <SearchFilterConditionNumber attribute={attribute} onSearch={onSearch} />;
-    }
-    if (attribute.inputType === 'condition-text') {
-        return <SearchFilterConditionText attribute={attribute} onSearch={onSearch} />;
-    }
-    if (attribute.inputType === 'autocomplete') {
-        return (
-            <SearchFilterAutocompleteSelect
-                additionalContextFilter={additionalContextFilter}
-                attribute={attribute}
-                onSearch={onSearch}
-                searchCategory={entity.searchCategory}
-                searchFilter={searchFilter}
-            />
-        );
-    }
-    if (attribute.inputType === 'select-exclusive-double') {
-        return (
-            <SearchFilterSelectExclusiveDouble
-                attribute={attribute}
-                onSearch={onSearch}
-                searchFilter={searchFilter}
-            />
-        );
-    }
-    if (attribute.inputType === 'select-exclusive-single') {
-        return (
-            <SearchFilterSelectExclusiveSingle
-                attribute={attribute}
-                onSearch={onSearch}
-                searchFilter={searchFilter}
-            />
-        );
-    }
-    if (attribute.inputType === 'select') {
-        return (
-            <SearchFilterSelectInclusive
-                attribute={attribute}
-                onSearch={onSearch}
-                searchFilter={searchFilter}
-            />
-        );
-    }
-    return <div />;
 }
 
 export default CompoundSearchFilterInputField;


### PR DESCRIPTION
## Description

**Review**: Hide space because of indentation changes

### Objectives

1. Easily compare props of search filter elements.

2. Minimize mental cost to add a new search filter element.

    And `default` case with `ensureExhaustive` prevents forgetting.

    Minimum changes:
    * types.ts
    * utils.ts often
    * new component file
    * CompoundSearchFilterInputField.tsx
    * attribute files

### Bonus

1. Simplify and comment about `key` prop of `CompoundSearchFilterInputField` element.

    https://github.com/stackrox/stackrox/pull/18254#discussion_r2628629842

### Residue

1. Investigate value conversions as prerequisite render filter chips in page and report via attribute as source of truth.

    See **Manual testing** step 7

    * Page address query string:
        `s[SEVERITY][0]=Critical&s[SEVERITY][1]=Important&s[SEVERITY][2]=Moderate`

    * Data request query string:
        `SEVERITY:CRITICAL_VULNERABILITY_SEVERITY,IMPORTANT_VULNERABILITY_SEVERITY,MODERATE_VULNERABILITY_SEVERITY`


## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/platform

2. Select **Namespace Name** and type **stack**

3. Select **Namespace ID** and see empty input

4. Select **Namespace Name** and enter **stackrox**

    Page address query string has `s[Namespace][0]=stackrox`
    Data request query string has `Namespace:r/stackrox`
    Search filter chip: **Namespace name stackrox**

5. Select **CVE CVSS** and enter condition **Is greater than** and value **9**

    Page address query string has `s[CVSS][0]=>9`
    Data request query string has `CVSS:>9`
    Search filter chip: **CVSS >9**

6. Select **CVE EPSS probablity** and enter condition **Is greater than or equal to** and value **90%**

    Page address query string has `s[EPSS%20Probability][0]=>=0.9`
    Data request query string has `EPSS Probability:>=0.9`
    Search filter chip: **CVSS >9**

7. Select **CVE Severity Moderate** (see **Residue** item 1)

    Page address query string has `s[SEVERITY][0]=Critical&s[SEVERITY][1]=Important&s[SEVERITY][2]=Moderate`
    Data request query string has `SEVERITY:CRITICAL_VULNERABILITY_SEVERITY,IMPORTANT_VULNERABILITY_SEVERITY,MODERATE_VULNERABILITY_SEVERITY`
    Search filter chip: **CVE severity Critical Important Moderate**
