### PR TITLE
ROX-26952: Bump ready wait time for compliance-operator

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -528,7 +528,7 @@ install_the_compliance_operator() {
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/catalog-source.yaml"
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/operator-group.yaml"
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/subscription.yaml"
-        wait_for_object_to_appear openshift-compliance deploy/compliance-operator
+        wait_for_object_to_appear openshift-compliance deploy/compliance-operator 900
     else
         info "Reusing existing compliance operator deployment from $csv subscription"
     fi
@@ -1580,8 +1580,8 @@ wait_for_log_line() {
 }
 
 wait_for_profile_bundles_to_be_ready() {
-    wait_for_object_to_appear openshift-compliance profilebundle/ocp4
-    wait_for_object_to_appear openshift-compliance profilebundle/rhcos4
+    wait_for_object_to_appear openshift-compliance profilebundle/ocp4 900
+    wait_for_object_to_appear openshift-compliance profilebundle/rhcos4 900
     for pb in $(oc get pb -n openshift-compliance -o jsonpath="{.items[*].metadata.name}"); do
         local delay="300"
         local waitInterval=10


### PR DESCRIPTION
## Description

Based on several investigations, we have found out that compliance operator became ready just a minute or two after expired wait time.

This PR is bumping the wait time from 5 minutes to 15.

Similar to changes in: https://github.com/stackrox/stackrox/pull/14772

**Q&A**
**Q:** What is the reason for setting the new timeout to 15 min rather than a lower number?
**A:** Currently, all indicators suggest that the compliance operator just needs a little bit more time to get ready. If we bump it to 10 minutes, there may be cases (extreme edge cases) that require more time. But if we bump the wait time way above the currently observed required time, and we still face the issues, then probably something else is the problem, not the waiting time. Besides that, having a higher wait time does not hurt that much as failing because of a short wait time.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing test setup script

### How I validated my change

- [x] only based on investigations
- [x] checked that function supports 3rd argument
