### PR TITLE
ROX-32393: Increase reconnect wait time to central

### DIFF
--- a/sensor/tests/complianceoperator/sync_test.go
+++ b/sensor/tests/complianceoperator/sync_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	helloMessageTimeout = 20 * time.Second
+	helloMessageTimeout = time.Minute
 	coDeployment        = helper.K8sResourceInfo{Kind: "Deployment", YamlFile: "co-deployment.yaml", Name: "compliance-operator"}
 
 	testScanConfig = &central.ApplyComplianceScanConfigRequest{


### PR DESCRIPTION
## Description

Based on investigation, it looks like that sensor required a little bit longer to establish connection to central.

This PR is increasing wait time for reconnect.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] CI run
