### PR TITLE
ROX-32168: use retryable k8s client in tests

### DIFF
--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -67,7 +67,7 @@ func TestLogMatcher(t *testing.T) {
 }
 
 func TestCreateK8sClientWithConfig_RetriesOnFailure(t *testing.T) {
-	// This test verifies that the createK8sClientWithConfig function configures retries correctly
+	// This test verifies that the configureRetryableTransport function configures retries correctly
 	// by injecting a mock transport that fails initially, then succeeds
 
 	var callCount int
@@ -112,6 +112,7 @@ func TestCreateK8sClientWithConfig_RetriesOnFailure(t *testing.T) {
 			return mockTransport
 		},
 	}
+	configureRetryableTransport(t, restCfg)
 
 	// Create client with our mock config
 	client := createK8sClientWithConfig(t, restCfg)

--- a/tests/compliance_operator_test.go
+++ b/tests/compliance_operator_test.go
@@ -159,6 +159,8 @@ func getDynamicClientGenerator(t *testing.T) dynamic.Interface {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	require.NoError(t, err)
 
+	configureRetryableTransport(t, config)
+
 	dynamicClientGenerator, err := dynamic.NewForConfig(config)
 	require.NoError(t, err)
 	return dynamicClientGenerator
@@ -171,10 +173,10 @@ func TestDeleteAndAddRule(t *testing.T) {
 	// Remove a rule from the profile and verify it's gone from the results
 	ruleClient := dynamicClientGenerator.Resource(complianceoperator.Rule.GroupVersionResource()).Namespace(coNamespace)
 	rule, err := ruleClient.Get(context.Background(), envVarRule, metav1.GetOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err, "Failed to get rule %s before deletion", envVarRule)
 
 	err = ruleClient.Delete(context.Background(), envVarRule, metav1.DeleteOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err, "Failed to delete rule %s", envVarRule)
 
 	time.Sleep(defaultSleepTime)
 
@@ -199,7 +201,8 @@ func TestDeleteAndAddRule(t *testing.T) {
 
 	rule.SetResourceVersion("")
 	_, err = ruleClient.Create(context.Background(), rule, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err, "Failed to recreate rule %s", envVarRule)
+	t.Logf("Successfully recreated rule %s", envVarRule)
 
 	time.Sleep(defaultSleepTime)
 
@@ -214,10 +217,10 @@ func TestDeleteAndAddScanSettingBinding(t *testing.T) {
 	// Delete a scansettingbinding
 	ssbClient := dynamicClientGenerator.Resource(complianceoperator.ScanSettingBinding.GroupVersionResource()).Namespace(coNamespace)
 	ssb, err := ssbClient.Get(context.Background(), rhcosProfileName, metav1.GetOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err, "Failed to get ScanSettingBinding %s before deletion", rhcosProfileName)
 
 	err = ssbClient.Delete(context.Background(), rhcosProfileName, metav1.DeleteOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err, "Failed to delete ScanSettingBinding %s", rhcosProfileName)
 
 	time.Sleep(defaultSleepTime)
 
@@ -233,7 +236,8 @@ func TestDeleteAndAddScanSettingBinding(t *testing.T) {
 
 	ssb.SetResourceVersion("")
 	_, err = ssbClient.Create(context.Background(), ssb, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err, "Failed to recreate ScanSettingBinding %s", rhcosProfileName)
+	t.Logf("Successfully recreated ScanSettingBinding %s", rhcosProfileName)
 
 	time.Sleep(defaultSleepTime)
 
@@ -248,10 +252,10 @@ func TestDeleteAndAddProfile(t *testing.T) {
 	// Remove a profile and verify that the profile is gone
 	profileClient := dynamicClientGenerator.Resource(complianceoperator.Profile.GroupVersionResource()).Namespace(coNamespace)
 	profile, err := profileClient.Get(context.Background(), rhcosProfileName, metav1.GetOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err, "Failed to get Profile %s before deletion", rhcosProfileName)
 
 	err = profileClient.Delete(context.Background(), rhcosProfileName, metav1.DeleteOptions{})
-	require.NoError(t, err)
+	require.NoError(t, err, "Failed to delete Profile %s", rhcosProfileName)
 
 	time.Sleep(defaultSleepTime)
 
@@ -267,7 +271,8 @@ func TestDeleteAndAddProfile(t *testing.T) {
 
 	profile.SetResourceVersion("")
 	_, err = profileClient.Create(context.Background(), profile, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err, "Failed to recreate Profile %s", rhcosProfileName)
+	t.Logf("Successfully recreated Profile %s", rhcosProfileName)
 
 	time.Sleep(defaultSleepTime)
 
@@ -282,7 +287,7 @@ func TestUpdateProfile(t *testing.T) {
 	// Remove a profile and verify that the profile is gone
 	profileClient := dynamicClientGenerator.Resource(complianceoperator.Profile.GroupVersionResource()).Namespace(coNamespace)
 	profileObj, err := profileClient.Get(context.Background(), rhcosProfileName, metav1.GetOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err, "Failed to get Profile %s before update", rhcosProfileName)
 
 	originalRules := profileObj.Object["rules"]
 
@@ -291,7 +296,7 @@ func TestUpdateProfile(t *testing.T) {
 		chownRule,
 	}
 	profileObj, err = profileClient.Update(context.Background(), profileObj, metav1.UpdateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err, "Failed to update Profile %s", rhcosProfileName)
 
 	time.Sleep(defaultSleepTime)
 
@@ -314,7 +319,8 @@ func TestUpdateProfile(t *testing.T) {
 
 	profileObj.Object["rules"] = originalRules
 	_, err = profileClient.Update(context.Background(), profileObj, metav1.UpdateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err, "Failed to restore Profile %s to original rules", rhcosProfileName)
+	t.Logf("Successfully restored Profile %s to original rules", rhcosProfileName)
 
 	time.Sleep(defaultSleepTime)
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Use the retryable transport in the dynamic client generator, as well as any other test that uses `getConfig`. Also clarify some of the assertions for easier debugging.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI