### PR TITLE
ROX-32217: File access printer shouldn't display empty paths

### DIFF
--- a/pkg/booleanpolicy/violationmessages/printer/file_access.go
+++ b/pkg/booleanpolicy/violationmessages/printer/file_access.go
@@ -27,7 +27,7 @@ func UpdateFileAccessAlertViolationMessage(v *storage.Alert_FileAccessViolation)
 	for _, fa := range v.GetAccesses() {
 		path := fa.GetFile().GetActualPath()
 		if path == "" {
-			path = fa.GetFile().GetMountedPath()
+			path = fa.GetFile().GetEffectivePath()
 			if path == "" {
 				path = UNKNOWN_FILE
 			}

--- a/pkg/booleanpolicy/violationmessages/printer/file_access_test.go
+++ b/pkg/booleanpolicy/violationmessages/printer/file_access_test.go
@@ -235,10 +235,10 @@ func TestUpdateFileAccessMessage(t *testing.T) {
 			expected: "'" + UNKNOWN_FILE + "' accessed (OPEN)",
 		},
 		{
-			desc: "Use MountedPath if NodePath is empty",
+			desc: "Use EffectivePath if ActualPath is empty",
 			activity: []*storage.FileAccess{
 				{
-					File:      &storage.FileAccess_File{NodePath: "", MountedPath: "/test/file"},
+					File:      &storage.FileAccess_File{ActualPath: "", EffectivePath: "/test/file"},
 					Operation: storage.FileAccess_OPEN,
 					Process: &storage.ProcessIndicator{
 						Signal: &storage.ProcessSignal{Name: "test"},


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Currently if there is a violation for a file event where the file path is blank, there will be a confusing message printed without a file. This makes it so that there is nothing printed in this case.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
