### PR TITLE
tests(sfa): unit tests for deployment policies with multiple sections

### DIFF
--- a/pkg/booleanpolicy/deployment_policies_test.go
+++ b/pkg/booleanpolicy/deployment_policies_test.go
@@ -622,6 +622,374 @@ func (s *DeploymentDetectionTestSuite) TestDeploymentMountedFileAccess() {
 	}
 }
 
+func (s *DeploymentDetectionTestSuite) TestDeploymentDualPathMatching() {
+	deployment := &storage.Deployment{
+		Name: "test-deployment",
+		Id:   "test-deployment-id",
+	}
+
+	type eventWrapper struct {
+		access      *storage.FileAccess
+		expectAlert bool
+	}
+
+	for _, tc := range []struct {
+		description string
+		policy      *storage.Policy
+		events      []eventWrapper
+	}{
+		// Valid test cases - expected behavior
+		{
+			description: "Event with both paths - policy matches node_path only",
+			policy: s.getDeploymentFileAccessPolicyWithOperations(
+				[]storage.FileAccess_Operation{storage.FileAccess_OPEN}, false,
+				"/etc/passwd",
+			),
+			events: []eventWrapper{
+				{
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: true,
+				},
+			},
+		},
+		{
+			description: "Event with both paths - policy matches mounted_path only",
+			policy: s.getMountedFileAccessPolicyWithOperations(
+				[]storage.FileAccess_Operation{storage.FileAccess_OPEN}, false,
+				"/etc/shadow",
+			),
+			events: []eventWrapper{
+				{
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: true,
+				},
+			},
+		},
+		{
+			description: "Event with both paths - policy requires BOTH paths (AND within section)",
+			policy:      s.getDualPathPolicy("/etc/passwd", "/etc/shadow", []storage.FileAccess_Operation{storage.FileAccess_OPEN}),
+			events: []eventWrapper{
+				{
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: true,
+				},
+			},
+		},
+		{
+			description: "Multi-section policy - first section matches (OR behavior)",
+			policy: s.getMultiSectionPolicy([]*storage.PolicySection{
+				{
+					SectionName: "section 1",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.NodeFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/passwd"}},
+						},
+						{
+							FieldName: fieldnames.FileOperation,
+							Values:    []*storage.PolicyValue{{Value: "OPEN"}},
+						},
+					},
+				},
+				{
+					SectionName: "section 2",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.NodeFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/shadow"}},
+						},
+						{
+							FieldName: fieldnames.FileOperation,
+							Values:    []*storage.PolicyValue{{Value: "OPEN"}},
+						},
+					},
+				},
+			}),
+			events: []eventWrapper{
+				{
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: true,
+				},
+			},
+		},
+		{
+			description: "Multi-section policy - second section matches (OR behavior)",
+			policy: s.getMultiSectionPolicy([]*storage.PolicySection{
+				{
+					SectionName: "section 1",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.NodeFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/shadow"}},
+						},
+						{
+							FieldName: fieldnames.FileOperation,
+							Values:    []*storage.PolicyValue{{Value: "OPEN"}},
+						},
+					},
+				},
+				{
+					SectionName: "section 2",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.NodeFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/passwd"}},
+						},
+						{
+							FieldName: fieldnames.FileOperation,
+							Values:    []*storage.PolicyValue{{Value: "OPEN"}},
+						},
+					},
+				},
+			}),
+			events: []eventWrapper{
+				{
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: true,
+				},
+			},
+		},
+		{
+			description: "Multi-section with mixed path types - node path section matches",
+			policy: s.getMultiSectionPolicy([]*storage.PolicySection{
+				{
+					SectionName: "section 1",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.NodeFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/passwd"}},
+						},
+					},
+				},
+				{
+					SectionName: "section 2",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.MountedFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/sudoers"}},
+						},
+					},
+				},
+			}),
+			events: []eventWrapper{
+				{
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: true,
+				},
+			},
+		},
+		{
+			description: "Multi-section with mixed path types - mounted path section matches",
+			policy: s.getMultiSectionPolicy([]*storage.PolicySection{
+				{
+					SectionName: "section 1",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.NodeFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/sudoers"}},
+						},
+					},
+				},
+				{
+					SectionName: "section 2",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.MountedFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/shadow"}},
+						},
+					},
+				},
+			}),
+			events: []eventWrapper{
+				{
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: true,
+				},
+			},
+		},
+		{
+			description: "Multi-section with dual paths in one section - complex AND/OR",
+			policy: s.getMultiSectionPolicy([]*storage.PolicySection{
+				{
+					SectionName: "section 1",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.NodeFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/passwd"}},
+						},
+						{
+							FieldName: fieldnames.MountedFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/shadow"}},
+						},
+					},
+				},
+				{
+					SectionName: "section 2",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.NodeFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/ssh/sshd_config"}},
+						},
+					},
+				},
+			}),
+			events: []eventWrapper{
+				{
+					// Matches section 1 (both node and mounted paths match)
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: true,
+				},
+			},
+		},
+
+		// Invalid/edge cases - unexpected behaviors
+		{
+			description: "Event with both paths - policy matches neither",
+			policy: s.getDeploymentFileAccessPolicyWithOperations(
+				[]storage.FileAccess_Operation{storage.FileAccess_OPEN}, false,
+				"/etc/sudoers",
+			),
+			events: []eventWrapper{
+				{
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: false,
+				},
+			},
+		},
+		{
+			description: "Event with both paths - policy requires BOTH but only node_path matches",
+			policy:      s.getDualPathPolicy("/etc/passwd", "/etc/sudoers", []storage.FileAccess_Operation{storage.FileAccess_OPEN}),
+			events: []eventWrapper{
+				{
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: false,
+				},
+			},
+		},
+		{
+			description: "Event with both paths - policy requires BOTH but only mounted_path matches",
+			policy:      s.getDualPathPolicy("/etc/sudoers", "/etc/shadow", []storage.FileAccess_Operation{storage.FileAccess_OPEN}),
+			events: []eventWrapper{
+				{
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: false,
+				},
+			},
+		},
+		{
+			description: "Event with both paths - policy requires BOTH but operation doesn't match",
+			policy:      s.getDualPathPolicy("/etc/passwd", "/etc/shadow", []storage.FileAccess_Operation{storage.FileAccess_CREATE}),
+			events: []eventWrapper{
+				{
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: false,
+				},
+			},
+		},
+		{
+			description: "Multi-section policy - no sections match",
+			policy: s.getMultiSectionPolicy([]*storage.PolicySection{
+				{
+					SectionName: "section 1",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.NodeFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/ssh/sshd_config"}},
+						},
+					},
+				},
+				{
+					SectionName: "section 2",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.MountedFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/sudoers"}},
+						},
+					},
+				},
+			}),
+			events: []eventWrapper{
+				{
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: false,
+				},
+			},
+		},
+		{
+			description: "Multi-section with dual paths - neither section matches completely",
+			policy: s.getMultiSectionPolicy([]*storage.PolicySection{
+				{
+					SectionName: "section 1",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.NodeFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/passwd"}},
+						},
+						{
+							FieldName: fieldnames.MountedFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/sudoers"}},
+						},
+					},
+				},
+				{
+					SectionName: "section 2",
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName: fieldnames.NodeFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/ssh/sshd_config"}},
+						},
+						{
+							FieldName: fieldnames.MountedFilePath,
+							Values:    []*storage.PolicyValue{{Value: "/etc/shadow"}},
+						},
+					},
+				},
+			}),
+			events: []eventWrapper{
+				{
+					// Section 1: node matches, mounted doesn't (AND fails)
+					// Section 2: node doesn't match, mounted does (AND fails)
+					// Overall: no section fully matches (OR fails)
+					access:      s.getDualPathFileAccessEvent("/etc/passwd", "/etc/shadow", storage.FileAccess_OPEN),
+					expectAlert: false,
+				},
+			},
+		},
+	} {
+		testutils.MustUpdateFeature(s.T(), features.SensitiveFileActivity, true)
+		defer testutils.MustUpdateFeature(s.T(), features.SensitiveFileActivity, false)
+		ResetFieldMetadataSingleton(s.T())
+		defer ResetFieldMetadataSingleton(s.T())
+
+		s.Run(tc.description, func() {
+			matcher, err := BuildDeploymentWithFileAccessMatcher(tc.policy)
+			s.Require().NoError(err)
+
+			for _, event := range tc.events {
+				var cache CacheReceptacle
+				enhancedDeployment := EnhancedDeployment{
+					Deployment:             deployment,
+					Images:                 nil,
+					NetworkPoliciesApplied: nil,
+				}
+				violations, err := matcher.MatchDeploymentWithFileAccess(&cache, enhancedDeployment, event.access)
+				s.Require().NoError(err)
+
+				if event.expectAlert {
+					s.Require().NotNil(violations.FileAccessViolation, "expected file access violation in alert")
+
+					fileAccessViolation := violations.FileAccessViolation
+					s.Require().Len(fileAccessViolation.GetAccesses(), 1, "expected one file access in alert")
+
+					protoassert.Equal(s.T(), event.access, fileAccessViolation.GetAccesses()[0])
+				} else {
+					s.Require().Nil(violations.FileAccessViolation, "expected no alerts")
+				}
+			}
+		})
+	}
+}
+
 // getFileAccessEvent is a generic helper for creating file access events.
 func (s *DeploymentDetectionTestSuite) getFileAccessEvent(path string, operation storage.FileAccess_Operation, isNodePath bool) *storage.FileAccess {
 	file := &storage.FileAccess_File{}
@@ -711,4 +1079,72 @@ func (s *DeploymentDetectionTestSuite) getMountedFileAccessPolicyWithOperations(
 
 func (s *DeploymentDetectionTestSuite) getMountedFileAccessPolicy(paths ...string) *storage.Policy {
 	return s.getFileAccessPolicy(false, nil, false, paths...)
+}
+
+// Helper to create file access events with BOTH node_path and mounted_path populated
+func (s *DeploymentDetectionTestSuite) getDualPathFileAccessEvent(nodePath, mountedPath string, operation storage.FileAccess_Operation) *storage.FileAccess {
+	return &storage.FileAccess{
+		File: &storage.FileAccess_File{
+			NodePath:    nodePath,
+			MountedPath: mountedPath,
+		},
+		Operation: operation,
+	}
+}
+
+// Helper to create a policy with both NodeFilePath AND MountedFilePath in the same section (AND behavior)
+func (s *DeploymentDetectionTestSuite) getDualPathPolicy(nodePath, mountedPath string, operations []storage.FileAccess_Operation) *storage.Policy {
+	policyGroups := []*storage.PolicyGroup{
+		{
+			FieldName: fieldnames.NodeFilePath,
+			Values:    []*storage.PolicyValue{{Value: nodePath}},
+		},
+		{
+			FieldName: fieldnames.MountedFilePath,
+			Values:    []*storage.PolicyValue{{Value: mountedPath}},
+		},
+	}
+
+	if len(operations) > 0 {
+		var operationValues []*storage.PolicyValue
+		for _, op := range operations {
+			operationValues = append(operationValues, &storage.PolicyValue{
+				Value: op.String(),
+			})
+		}
+		policyGroups = append(policyGroups, &storage.PolicyGroup{
+			FieldName: fieldnames.FileOperation,
+			Values:    operationValues,
+		})
+	}
+
+	return &storage.Policy{
+		Id:            uuid.NewV4().String(),
+		PolicyVersion: "1.1",
+		Name:          "Dual Path Policy",
+		Severity:      storage.Severity_HIGH_SEVERITY,
+		Categories:    []string{"File System"},
+		PolicySections: []*storage.PolicySection{
+			{
+				SectionName:  "section 1",
+				PolicyGroups: policyGroups,
+			},
+		},
+		LifecycleStages: []storage.LifecycleStage{storage.LifecycleStage_RUNTIME},
+		EventSource:     storage.EventSource_DEPLOYMENT_EVENT,
+	}
+}
+
+// Helper to create a multi-section policy (OR behavior across sections)
+func (s *DeploymentDetectionTestSuite) getMultiSectionPolicy(sections []*storage.PolicySection) *storage.Policy {
+	return &storage.Policy{
+		Id:              uuid.NewV4().String(),
+		PolicyVersion:   "1.1",
+		Name:            "Multi-Section Policy",
+		Severity:        storage.Severity_HIGH_SEVERITY,
+		Categories:      []string{"File System"},
+		PolicySections:  sections,
+		LifecycleStages: []storage.LifecycleStage{storage.LifecycleStage_RUNTIME},
+		EventSource:     storage.EventSource_DEPLOYMENT_EVENT,
+	}
 }


### PR DESCRIPTION
## Description

Fills a gap in the SFA unit tests for deployment policies. Handles cases where multiple path types (mounted/node) are provided in the policy and in the event. It also covers multiple policy sections with combinations of path types.

Test cases generated with the assistance of Claude.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Hopefully tests validate themselves. The Claude input, however, has been validated for correctness and usefulness.
