### PR TITLE
ROX-31984: Fix commit/rollback with expired contexts

### DIFF
--- a/pkg/postgres/tx.go
+++ b/pkg/postgres/tx.go
@@ -65,6 +65,8 @@ func (t *Tx) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.
 
 // Commit wraps pgx.Tx Commit but is a NOOP for inner transaction
 func (t *Tx) Commit(ctx context.Context) error {
+	// Ensure commit completes even if parent context is cancelled
+	ctx = context.WithoutCancel(ctx)
 	defer t.cancelFunc()
 	if t.mode == inner {
 		return nil
@@ -81,6 +83,8 @@ func (t *Tx) Commit(ctx context.Context) error {
 // In case Rollback or Commit might have the same effect (e.g. read only transaction)
 // prefer Commit.
 func (t *Tx) Rollback(ctx context.Context) error {
+	// Ensure rollback completes even if parent context is cancelled
+	ctx = context.WithoutCancel(ctx)
 	defer t.cancelFunc()
 
 	if err := t.Tx.Rollback(ctx); err != nil {


### PR DESCRIPTION
## Description

When a transaction's parent context expires (e.g., request timeout), calling `Commit()` or `Rollback()` would fail because they use the expired context for the database operation. This PR uses `context.WithoutCancel()` in both `Commit()` and `Rollback()` to detach from parent cancellation while preserving context values (trace IDs, SAC info, etc.). This ensures transaction cleanup always completes regardless of request timeout.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new tests added. The change is minimal (4 lines) and existing postgres package tests pass. This fix is defensive - it makes existing code more robust without changing behavior for non-expired contexts.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Ran all existing postgres package tests
- Reviewed code flow: inner transaction mode returns early (NOOP), so detaching only affects actual DB commits/rollbacks
