### PR TITLE
ROX-31984: Fix commit/rollback with expired contexts

### DIFF
--- a/pkg/postgres/tests/tx_test.go
+++ b/pkg/postgres/tests/tx_test.go
@@ -1,0 +1,88 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pkgmocks "github.com/stackrox/rox/pkg/mocks/github.com/jackc/pgx/v5/mocks"
+	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+func TestTx(t *testing.T) {
+	suite.Run(t, new(postgresTxTestSuite))
+}
+
+type postgresTxTestSuite struct {
+	suite.Suite
+
+	mockCtrl *gomock.Controller
+	mockTx   *pkgmocks.MockTx
+	tx       *postgres.Tx
+}
+
+func (s *postgresTxTestSuite) SetupSuite() {
+	s.mockCtrl = gomock.NewController(s.T())
+}
+
+func (s *postgresTxTestSuite) TearDownSuite() {
+	s.mockCtrl.Finish()
+}
+
+func (s *postgresTxTestSuite) SetupTest() {
+	s.mockTx = pkgmocks.NewMockTx(s.mockCtrl)
+	s.tx = &postgres.Tx{}
+	s.tx.Tx = s.mockTx
+}
+
+// TestCommitWithExpiredContext verifies that Commit succeeds even when called with an expired context.
+func (s *postgresTxTestSuite) TestCommitWithExpiredContext() {
+	// Create an already-expired context
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(2 * time.Millisecond)
+
+	s.Error(ctx.Err(), "context should be expired")
+
+	s.mockTx.EXPECT().Commit(gomock.Any()).Times(1).Return(nil)
+
+	err := s.tx.Commit(ctx)
+	s.NoError(err)
+}
+
+// TestRollbackWithExpiredContext verifies that Rollback succeeds even when called with an expired context.
+func (s *postgresTxTestSuite) TestRollbackWithExpiredContext() {
+	// Create an already-expired context
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	defer cancel()
+	time.Sleep(2 * time.Millisecond)
+
+	s.Error(ctx.Err(), "context should be expired")
+
+	s.mockTx.EXPECT().Rollback(gomock.Any()).Times(1).Return(nil)
+
+	err := s.tx.Rollback(ctx)
+	s.NoError(err)
+}
+
+// TestCommitWithValidContext verifies normal Commit behavior works
+func (s *postgresTxTestSuite) TestCommitWithValidContext() {
+	ctx := context.Background()
+
+	s.mockTx.EXPECT().Commit(gomock.Any()).Times(1).Return(nil)
+
+	err := s.tx.Commit(ctx)
+	s.NoError(err)
+}
+
+// TestRollbackWithValidContext verifies normal Rollback behavior works
+func (s *postgresTxTestSuite) TestRollbackWithValidContext() {
+	ctx := context.Background()
+
+	s.mockTx.EXPECT().Rollback(gomock.Any()).Times(1).Return(nil)
+
+	err := s.tx.Rollback(ctx)
+	s.NoError(err)
+}


### PR DESCRIPTION
## Description

When a transaction's parent context expires (e.g., request timeout), calling `Commit()` or `Rollback()` would fail because they use the expired context for the database operation. This PR uses `context.WithoutCancel()` in both `Commit()` and `Rollback()` to detach from parent cancellation while preserving context values (trace IDs, SAC info, etc.). This ensures transaction cleanup always completes regardless of request timeout.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new tests added. The change is minimal (4 lines) and existing postgres package tests pass. This fix is defensive - it makes existing code more robust without changing behavior for non-expired contexts.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Ran all existing postgres package tests
- Reviewed code flow: inner transaction mode returns early (NOOP), so detaching only affects actual DB commits/rollbacks
