### PR TITLE
ROX-31609: Remove 2 pass search from cve/cluster datastore

### DIFF
--- a/central/cve/cluster/datastore/datastore_impl_postgres_test.go
+++ b/central/cve/cluster/datastore/datastore_impl_postgres_test.go
@@ -1,0 +1,145 @@
+//go:build sql_integration
+
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	pgStore "github.com/stackrox/rox/central/cve/cluster/datastore/store/postgres"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	pkgSearch "github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestClusterCVEDataStoreWithPostgres(t *testing.T) {
+	suite.Run(t, new(ClusterCVEPostgresDataStoreTestSuite))
+}
+
+type ClusterCVEPostgresDataStoreTestSuite struct {
+	suite.Suite
+
+	ctx       context.Context
+	db        postgres.DB
+	datastore DataStore
+}
+
+func (s *ClusterCVEPostgresDataStoreTestSuite) SetupSuite() {
+	s.ctx = context.Background()
+}
+
+func (s *ClusterCVEPostgresDataStoreTestSuite) SetupTest() {
+	s.db = pgtest.ForT(s.T())
+
+	store := pgStore.NewFullStore(s.db)
+	ds, err := New(store)
+	s.Require().NoError(err)
+	s.datastore = ds
+}
+
+func (s *ClusterCVEPostgresDataStoreTestSuite) TearDownTest() {
+	// Clean up test data
+	_, _ = s.db.Exec(context.Background(), "TRUNCATE TABLE cluster_cves CASCADE")
+}
+
+func (s *ClusterCVEPostgresDataStoreTestSuite) TearDownSuite() {
+	s.db.Close()
+}
+
+func (s *ClusterCVEPostgresDataStoreTestSuite) TestSearchClusterCVEs() {
+	ctx := sac.WithAllAccess(context.Background())
+
+	cve1 := &storage.ClusterCVE{
+		Id:   uuid.NewV4().String(),
+		Type: storage.CVE_K8S_CVE,
+		CveBaseInfo: &storage.CVEInfo{
+			Cve: "CVE-2021-1234",
+		},
+		Cvss:        8.5,
+		Severity:    storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+		ImpactScore: 5.9,
+	}
+
+	cve2 := &storage.ClusterCVE{
+		Id:   uuid.NewV4().String(),
+		Type: storage.CVE_K8S_CVE,
+		CveBaseInfo: &storage.CVEInfo{
+			Cve: "CVE-2021-5678",
+		},
+		Cvss:        7.2,
+		Severity:    storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+		ImpactScore: 4.5,
+	}
+
+	cve3 := &storage.ClusterCVE{
+		Id:   uuid.NewV4().String(),
+		Type: storage.CVE_OPENSHIFT_CVE,
+		CveBaseInfo: &storage.CVEInfo{
+			Cve: "CVE-2021-9999",
+		},
+		Cvss:        5.0,
+		Severity:    storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+		ImpactScore: 3.0,
+	}
+
+	// Upsert CVEs directly to database
+	store := pgStore.NewFullStore(s.db)
+	err := store.UpsertMany(ctx, []*storage.ClusterCVE{cve1, cve2, cve3})
+	s.NoError(err)
+
+	testCases := []struct {
+		name          string
+		query         *v1.Query
+		expectedCount int
+		expectedNames []string
+	}{
+		{
+			name:          "empty query returns all CVEs with names populated",
+			query:         pkgSearch.EmptyQuery(),
+			expectedCount: 3,
+			expectedNames: []string{"CVE-2021-1234", "CVE-2021-5678", "CVE-2021-9999"},
+		},
+		{
+			name:          "nil query defaults to empty query",
+			query:         nil,
+			expectedCount: 3,
+			expectedNames: []string{"CVE-2021-1234", "CVE-2021-5678", "CVE-2021-9999"},
+		},
+		{
+			name:          "query by CVE name",
+			query:         pkgSearch.NewQueryBuilder().AddStrings(pkgSearch.CVE, "CVE-2021-1234").ProtoQuery(),
+			expectedCount: 1,
+			expectedNames: []string{"CVE-2021-1234"},
+		},
+		{
+			name:          "query by severity",
+			query:         pkgSearch.NewQueryBuilder().AddStrings(pkgSearch.Severity, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY.String()).ProtoQuery(),
+			expectedCount: 1,
+			expectedNames: []string{"CVE-2021-1234"},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			results, err := s.datastore.SearchClusterCVEs(ctx, tc.query)
+			s.NoError(err)
+			s.Len(results, tc.expectedCount, "Expected %d results, got %d", tc.expectedCount, len(results))
+
+			actualNames := make([]string, 0, len(results))
+			for _, result := range results {
+				actualNames = append(actualNames, result.GetName())
+				s.Equal(v1.SearchCategory_CLUSTER_VULNERABILITIES, result.GetCategory())
+				s.NotEmpty(result.GetId())
+			}
+
+			if len(tc.expectedNames) > 0 {
+				s.ElementsMatch(tc.expectedNames, actualNames)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`SearchClusterCVEs` was performing two database queries:
1. First query returned only CVE IDs
2. Second query fetched full CVE objects just to extract the CVE name

This PR adds the `CVE` field to the query's select fields, allowing the CVE name to be retrieved in a single query. The name is then extracted directly from `FieldValues` instead of requiring a second database round trip.

This follows the pattern established in PR #17509 for image and namespace datastores.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Existing unit tests cover this change - the refactor maintains identical behavior and all tests pass.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Existing datastore unit tests pass
- Code compiles successfully
- Behavior is identical to previous implementation - same inputs produce same outputs, just with better performance