### PR TITLE
ROX-32397: Fix NodeTest gRPC message size limit failures

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/BaseService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/BaseService.groovy
@@ -32,6 +32,10 @@ class BaseService {
     static final String BASIC_AUTH_USERNAME = Env.mustGetUsername()
     static final String BASIC_AUTH_PASSWORD = Env.mustGetPassword()
 
+    // Max gRPC message size for receiving responses from Central.
+    // This matches the server's defaultMaxResponseMsgSize in pkg/grpc/server.go.
+    static final int MAX_GRPC_MESSAGE_SIZE = 256 * 1024 * 1024 // 256MB
+
     static final EmptyOuterClass.Empty EMPTY = EmptyOuterClass.Empty.newBuilder().build()
 
     static ResourceByID getResourceByID(String id) {
@@ -143,6 +147,7 @@ class BaseService {
                     .sslContext(sslContext)
                     .keepAliveTime(1, TimeUnit.SECONDS)
                     .idleTimeout(1, TimeUnit.MINUTES)
+                    .maxInboundMessageSize(MAX_GRPC_MESSAGE_SIZE)
                     .build()
             effectiveChannel = null
 


### PR DESCRIPTION
## Description

Java test clients in qa-tests-backend were using gRPC's default 4MB max inbound message size, causing test failures when responses exceeded this limit. The `listNodes()` API returns ~4.2MB of data in CI environments, triggering `RESOURCE_EXHAUSTED` errors.

This PR configures the NettyChannelBuilder with a 256MB max inbound message size, matching the server's `defaultMaxResponseMsgSize` and Go client configuration.

Fixes ROX-32397, and should also resolve related issues ROX-29148, ROX-30756, ROX-31880.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Will validate via CI - the failing NodeTest should now pass with the increased message size limit. The fix aligns test client configuration with server capabilities (256MB response limit already supported).

This is a test infrastructure configuration fix with no production code changes.