### PR TITLE
ROX-32462: add retryablehttp k8s client to upgrader

### DIFF
--- a/pkg/retryablehttp/logger.go
+++ b/pkg/retryablehttp/logger.go
@@ -1,0 +1,19 @@
+package retryablehttp
+
+import (
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+// DebugLogger adapts logging.Logger to the retryablehttp.Logger interface.
+type DebugLogger struct {
+	logger logging.Logger
+}
+
+// Printf implements the retryablehttp.Logger interface by logging at Debug level.
+func (l *DebugLogger) Printf(format string, v ...interface{}) {
+	l.logger.Debugf(format, v...)
+}
+
+func NewDebugLogger(logger logging.Logger) *DebugLogger {
+	return &DebugLogger{logger: logger}
+}

--- a/pkg/retryablehttp/retryablehttp.go
+++ b/pkg/retryablehttp/retryablehttp.go
@@ -1,0 +1,105 @@
+package retryablehttp
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stackrox/rox/pkg/logging"
+	"k8s.io/client-go/rest"
+)
+
+var log = logging.ModuleForName("retryablehttp").Logger()
+
+const (
+	defaultRetryMax     = 3
+	defaultRetryWaitMin = 500 * time.Millisecond
+	defaultRetryWaitMax = 2 * time.Second
+)
+
+type config struct {
+	logger       retryablehttp.Logger
+	retryMax     int
+	retryWaitMax time.Duration
+	retryWaitMin time.Duration
+}
+
+// Option configures retry behavior for HTTP transports.
+type Option func(*config)
+
+// WithLogger sets a custom logger for retry operations.
+// Default is the module-specific logger for retryablehttp.
+func WithLogger(logger retryablehttp.Logger) Option {
+	return func(c *config) {
+		c.logger = logger
+	}
+}
+
+// WithRetryMax sets the maximum number of retry attempts.
+// Default is 3 retries.
+func WithRetryMax(max int) Option {
+	return func(c *config) {
+		c.retryMax = max
+	}
+}
+
+// WithRetryWaitMax sets the maximum wait time between retry attempts.
+// Default is 2 seconds.
+func WithRetryWaitMax(d time.Duration) Option {
+	return func(c *config) {
+		c.retryWaitMax = d
+	}
+}
+
+// WithRetryWaitMin sets the minimum wait time between retry attempts.
+// Default is 500 milliseconds.
+func WithRetryWaitMin(d time.Duration) Option {
+	return func(c *config) {
+		c.retryWaitMin = d
+	}
+}
+
+// ConfigureRESTConfig wraps a Kubernetes REST config's transport with retry logic.
+// This adds automatic retry for transient network errors, making Kubernetes clients more resilient.
+//
+// The function preserves any existing WrapTransport configuration by chaining the retryable
+// transport after existing transport wrappers.
+//
+// Example usage:
+//
+//	restCfg, _ := rest.InClusterConfig()
+//	retryablehttp.ConfigureRESTConfig(restCfg)
+//	client, _ := kubernetes.NewForConfig(restCfg)
+func ConfigureRESTConfig(restCfg *rest.Config, opts ...Option) {
+	cfg := &config{
+		logger:       NewDebugLogger(log),
+		retryMax:     defaultRetryMax,
+		retryWaitMax: defaultRetryWaitMax,
+		retryWaitMin: defaultRetryWaitMin,
+	}
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Set retryable client timeout to a fraction of REST config timeout.
+	// This ensures we have time for retries before the overall timeout expires.
+	clientTimeout := 9 * restCfg.Timeout / 10
+
+	// Preserve any existing WrapTransport configuration by chaining.
+	oldWrapTransport := restCfg.WrapTransport
+	restCfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		if oldWrapTransport != nil {
+			rt = oldWrapTransport(rt)
+		}
+
+		retryClient := retryablehttp.NewClient()
+		retryClient.RetryMax = cfg.retryMax
+		retryClient.RetryWaitMin = cfg.retryWaitMin
+		retryClient.RetryWaitMax = cfg.retryWaitMax
+		retryClient.Logger = cfg.logger
+		retryClient.HTTPClient.Timeout = clientTimeout
+		retryClient.HTTPClient.Transport = rt
+		return retryClient.StandardClient().Transport
+	}
+}

--- a/pkg/retryablehttp/retryablehttp_test.go
+++ b/pkg/retryablehttp/retryablehttp_test.go
@@ -1,0 +1,125 @@
+package retryablehttp
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
+)
+
+func TestConfigureRESTConfig_Defaults(t *testing.T) {
+	restCfg := &rest.Config{}
+
+	ConfigureRESTConfig(restCfg)
+
+	assert.NotNil(t, restCfg.WrapTransport)
+}
+
+func TestConfigureRESTConfig_CustomTimeout(t *testing.T) {
+	customTimeout := 60 * time.Second
+	restCfg := &rest.Config{
+		Timeout: customTimeout,
+	}
+
+	ConfigureRESTConfig(restCfg)
+
+	assert.Equal(t, customTimeout, restCfg.Timeout)
+}
+
+func TestConfigureRESTConfig_WithOptions(t *testing.T) {
+	testLogger := logging.ModuleForName("test").Logger()
+	restCfg := &rest.Config{}
+
+	ConfigureRESTConfig(restCfg,
+		WithLogger(NewDebugLogger(testLogger)),
+		WithRetryMax(5),
+		WithRetryWaitMax(5*time.Second),
+		WithRetryWaitMin(1*time.Second),
+	)
+
+	assert.NotNil(t, restCfg.WrapTransport)
+}
+
+func TestConfigureRESTConfig_PreservesExistingWrapTransport(t *testing.T) {
+	existingWrapperCalled := false
+
+	restCfg := &rest.Config{
+		Timeout: 30 * time.Second,
+	}
+
+	restCfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		existingWrapperCalled = true
+		return rt
+	}
+
+	ConfigureRESTConfig(restCfg)
+
+	// Call the configured WrapTransport to verify chaining.
+	mockTransport := &mockRoundTripper{}
+	wrappedTransport := restCfg.WrapTransport(mockTransport)
+
+	// Verify the existing wrapper was called.
+	assert.True(t, existingWrapperCalled, "existing WrapTransport should be preserved and called")
+	assert.NotNil(t, wrappedTransport)
+}
+
+func TestConfigureRESTConfig_NilExistingWrapTransport(t *testing.T) {
+	restCfg := &rest.Config{
+		Timeout: 30 * time.Second,
+	}
+
+	restCfg.WrapTransport = nil
+
+	ConfigureRESTConfig(restCfg)
+
+	// Verify WrapTransport was configured even when starting from nil.
+	assert.NotNil(t, restCfg.WrapTransport)
+
+	// Call the configured WrapTransport to verify it works.
+	mockTransport := &mockRoundTripper{}
+	wrappedTransport := restCfg.WrapTransport(mockTransport)
+	assert.NotNil(t, wrappedTransport)
+}
+
+func TestWithRetryMax(t *testing.T) {
+	cfg := &config{
+		retryMax: defaultRetryMax,
+	}
+
+	opt := WithRetryMax(10)
+	opt(cfg)
+
+	assert.Equal(t, 10, cfg.retryMax)
+}
+
+func TestWithRetryWaitMin(t *testing.T) {
+	cfg := &config{
+		retryWaitMin: defaultRetryWaitMin,
+	}
+
+	opt := WithRetryWaitMin(2 * time.Second)
+	opt(cfg)
+
+	assert.Equal(t, 2*time.Second, cfg.retryWaitMin)
+}
+
+func TestWithRetryWaitMax(t *testing.T) {
+	cfg := &config{
+		retryWaitMax: defaultRetryWaitMax,
+	}
+
+	opt := WithRetryWaitMax(10 * time.Second)
+	opt(cfg)
+
+	assert.Equal(t, 10*time.Second, cfg.retryWaitMax)
+}
+
+// mockRoundTripper is a simple mock implementation of http.RoundTripper for testing
+type mockRoundTripper struct{}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, nil
+}

--- a/tests/common.go
+++ b/tests/common.go
@@ -8,18 +8,17 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"net/http"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-retryablehttp"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/pkg/retry"
+	"github.com/stackrox/rox/pkg/retryablehttp"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
@@ -684,28 +683,12 @@ func getConfig(t testutils.T) *rest.Config {
 // configureRetryableTransport configures a rest.Config to use retryable HTTP client
 // for network resilience. This adds automatic retry logic for transient network errors.
 func configureRetryableTransport(t testutils.T, restCfg *rest.Config) {
-	// Configure retryable HTTP client for network resilience
-	retryClient := retryablehttp.NewClient()
-	retryClient.RetryMax = 3
-	retryClient.RetryWaitMin = 500 * time.Millisecond
-	retryClient.RetryWaitMax = 2 * time.Second
-	retryClient.Logger = testutilsLogger{t}
 	if restCfg.Timeout == 0 {
 		restCfg.Timeout = 30 * time.Second
 	}
-	// Set retryable timeout to 90% of rest config timeout to allow retries
-	retryClient.HTTPClient.Timeout = (9 * restCfg.Timeout) / 10
-
-	// Wrap the transport with retryable client
-	oldWrapTransport := restCfg.WrapTransport
-	restCfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
-		if oldWrapTransport != nil {
-			rt = oldWrapTransport(rt)
-		}
-
-		retryClient.HTTPClient.Transport = rt
-		return retryClient.StandardClient().Transport
-	}
+	retryablehttp.ConfigureRESTConfig(restCfg,
+		retryablehttp.WithLogger(&testutilsLogger{t}),
+	)
 }
 
 func createK8sClient(t testutils.T) kubernetes.Interface {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

In ROX-32462 a failed k8s client call failed the entire test. 

```
panic: rpc error: code = Internal desc = Internal error encountered.
	listing relevant objects of type admissionregistration.k8s.io/v1, Resource=validatingwebhookconfigurations in namespace stackrox
	github.com/stackrox/rox/sensor/upgrader/upgradectx.(*UpgradeContext).List
		github.com/stackrox/rox/sensor/upgrader/upgradectx/context.go:328
```

To make the upgrader more robust, this PR extracts `configureRetryableTransport` (previously used just for non groovy tests) into a common package. The new function is then used to configure a retryable k8s client for the upgrader.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI