### PR TITLE
ROX-32529: remove file access fields from mapper

### DIFF
--- a/pkg/booleanpolicy/query_to_field_value_mappers.go
+++ b/pkg/booleanpolicy/query_to_field_value_mappers.go
@@ -50,8 +50,6 @@ var (
 		search.VolumeName:                    newMapper(fieldnames.VolumeName, directMap),
 		search.VolumeSource:                  newMapper(fieldnames.VolumeSource, directMap),
 		search.VolumeType:                    newMapper(fieldnames.VolumeType, directMap),
-		search.NodeFilePath:                  newMapper(fieldnames.NodeFilePath, directMap),
-		search.MountedFilePath:               newMapper(fieldnames.MountedFilePath, directMap),
 	}
 )
 

--- a/pkg/booleanpolicy/query_to_field_value_mappers_test.go
+++ b/pkg/booleanpolicy/query_to_field_value_mappers_test.go
@@ -406,11 +406,3 @@ func (s *SearchMapperTestSuite) TestConvertVolumeSource() {
 func (s *SearchMapperTestSuite) TestConvertVolumeType() {
 	s.testDirectMapSearchString(search.VolumeType, fieldnames.VolumeType)
 }
-
-func (s *SearchMapperTestSuite) TestConvertNodeFilePath() {
-	s.testDirectMapSearchString(search.NodeFilePath, fieldnames.NodeFilePath)
-}
-
-func (s *SearchMapperTestSuite) TestConvertMountedFilePath() {
-	s.testDirectMapSearchString(search.MountedFilePath, fieldnames.MountedFilePath)
-}


### PR DESCRIPTION
## Description

The file access fields do not currently need to exist in this mapper, which is used for constructing policies from the risk page. In the future we might need this, but for now I am removing them to make things a bit cleaner.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI should be enough, no tests added due to removing code.
