### PR TITLE
fix(scanner): Infinite retry on auth failure in ListTags

### DIFF
--- a/pkg/registries/docker/docker.go
+++ b/pkg/registries/docker/docker.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/docker/distribution/manifest/manifestlist"
 	manifestV1 "github.com/docker/distribution/manifest/schema1"
 	manifestV2 "github.com/docker/distribution/manifest/schema2"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/heroku/docker-registry-client/registry"
@@ -16,6 +18,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/registries/types"
@@ -259,11 +262,30 @@ func (r *Registry) HTTPClient() *http.Client {
 	return r.Client.Client
 }
 
+// buildTransport builds an http.RoundTripper with timeouts, TLS settings, and
+// metrics configured from the registry config. This transport is suitable for
+// use with go-containerregistry's remote.WithAuth() for authentication.
+func (r *Registry) buildTransport() http.RoundTripper {
+	transport := proxy.RoundTripper(
+		proxy.WithDialTimeout(env.RegistryDialerTimeout.DurationSetting()),
+		proxy.WithResponseHeaderTimeout(env.RegistryResponseTimeout.DurationSetting()),
+	)
+	if r.cfg.Insecure {
+		transport = proxy.RoundTripper(
+			proxy.WithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
+			proxy.WithDialTimeout(env.RegistryDialerTimeout.DurationSetting()),
+			proxy.WithResponseHeaderTimeout(env.RegistryResponseTimeout.DurationSetting()),
+		)
+	}
+	return r.cfg.MetricsHandler.RoundTripper(transport, r.cfg.RegistryType)
+}
+
 // ListTags lists all tags for a given repository, returning a list of tag names.
-// This uses google/go-containerregistry which properly handles pagination with
-// relative URLs, but uses the same transport used by the docker-registry-client
-// configuration. Reuse of the existing client's transport gives us,
-// authentication, transport timeouts, TLS settings, proxy config and metrics.
+// This uses google/go-containerregistry which properly handles pagination and
+// bearer token authentication. The transport is built from the same configuration
+// as the docker-registry-client (timeouts, TLS, metrics), but uses
+// go-containerregistry's native authentication instead of the docker-registry-client
+// auth wrappers.
 //
 // This function does not impose an overall timeout. The transport's per-request
 // timeouts (DialTimeout, ResponseHeaderTimeout) protect against hung requests.
@@ -277,9 +299,15 @@ func (r *Registry) ListTags(ctx context.Context, repository string) ([]string, e
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse repository %q", repoPath)
 	}
+
+	username, password := r.cfg.GetCredentials()
 	opts := []remote.Option{
 		remote.WithContext(ctx),
-		remote.WithTransport(r.Client.Client.Transport),
+		remote.WithTransport(r.buildTransport()),
+		remote.WithAuth(&authn.Basic{
+			Username: username,
+			Password: password,
+		}),
 	}
 	tags, err := remote.List(repo, opts...)
 	if err != nil {


### PR DESCRIPTION
## Description

The docker-registry-client's `TokenTransport.auth()` returns `nil` error on HTTP 401, causing infinite retry loops when pagination encounters authentication failures. This was discovered during base image watcher testing with repositories having >100 tags.

This PR replaces the buggy docker-registry-client transport with go-containerregistry's native authentication in `ListTags()`:
- Add `buildTransport()` helper to create transport with timeouts, TLS, metrics
- Use `remote.WithAuth()` for authentication instead of reusing wrapped transport
- Preserves all existing behavior (timeouts, TLS, metrics) without the bug

Other registry API methods (`ManifestDigest`, `Ping`, etc.) uses the docker-registry-client with the buggy `TokenTransport` wrapper. They could theoretically trigger the same infinite retry issue, but I'm guessing they either fail or succeeds on the single call, and the request completes.

Created https://issues.redhat.com/browse/ROX-32532 to investigate further.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed - bug fix, no user-facing changes
- [x] documentation PR is created and is linked above **OR** is not needed - no documentation changes needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

### Automated testing

- [x] modified existing tests - All existing ListTags unit tests pass

### How I validated my change

- Ran all existing ListTags unit tests: `go test -v ./pkg/registries/docker -run TestListTags`
- All tests pass (5 test cases covering basic functionality, pagination, errors, timeouts)
