### PR TITLE
ROX-31712: Auto-check 'All' option when all items selected

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterStatuses.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterStatuses.tsx
@@ -20,12 +20,14 @@ function SearchFilterStatuses({
     setStatusesSelected,
 }: SearchFilterStatusesProps) {
     function onSelect(selections: string[]) {
-        const hadAllOption = (statusesSelected ?? []).length === 0;
-        const isSelectAll = selections.includes(optionAll) && !hadAllOption;
+        const isAllCurrentlySelected = (statusesSelected ?? []).length === 0;
         const validStatuses = selections.filter((s) => s !== optionAll && isStatus(s));
-        const allOptionsSelected = validStatuses.length === statuses.length;
 
-        if (isSelectAll || validStatuses.length === 0 || allOptionsSelected) {
+        if (
+            (selections.includes(optionAll) && !isAllCurrentlySelected) ||
+            validStatuses.length === 0 ||
+            validStatuses.length === statuses.length
+        ) {
             setStatusesSelected(undefined);
             return;
         }

--- a/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterTypes.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DiscoveredClusters/SearchFilterTypes.tsx
@@ -20,12 +20,14 @@ function SearchFilterTypes({
     setTypesSelected,
 }: SearchFilterTypesProps) {
     function onSelect(selections: string[]) {
-        const hadAllOption = (typesSelected ?? []).length === 0;
-        const isSelectAll = selections.includes(optionAll) && !hadAllOption;
+        const isAllCurrentlySelected = (typesSelected ?? []).length === 0;
         const validTypes = selections.filter((s) => s !== optionAll && isType(s));
-        const allOptionsSelected = validTypes.length === types.length;
 
-        if (isSelectAll || validTypes.length === 0 || allOptionsSelected) {
+        if (
+            (selections.includes(optionAll) && !isAllCurrentlySelected) ||
+            validTypes.length === 0 ||
+            validTypes.length === types.length
+        ) {
             setTypesSelected(undefined);
             return;
         }


### PR DESCRIPTION
## Description

Fixes the checkbox select behavior in Discovered Clusters filters. When users manually select all individual status or type options, the "All" option now auto-checks and clears the selection (treating it as selecting all).

Also moves the "All" option to the top of the dropdown for better UX.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Manually tested the Discovered Clusters page filters
- Verified that selecting all individual options auto-checks "All"
- Verified that "All" option now appears at the top of the dropdown

### Screenshots

<img width="1553" height="981" alt="Screenshot 2026-01-08 at 9 28 36 AM" src="https://github.com/user-attachments/assets/1c34b942-0c60-4d3c-98d7-98e38cf7af21" />
<img width="1553" height="981" alt="Screenshot 2026-01-08 at 9 28 39 AM" src="https://github.com/user-attachments/assets/9c767426-0d29-4acd-b619-457786f4d550" />
