### PR TITLE
ROX-31423: Standardize boolean toggle state updater pattern

### DIFF
--- a/ui/apps/platform/src/Components/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/CheckboxSelect.tsx
@@ -27,7 +27,7 @@ function CheckboxSelect({
     const [isOpen, setIsOpen] = useState(false);
 
     const onToggleClick = () => {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     };
 
     const onSelect = (

--- a/ui/apps/platform/src/Components/CollapsibleRow.jsx
+++ b/ui/apps/platform/src/Components/CollapsibleRow.jsx
@@ -11,7 +11,7 @@ const CollapsibleRow = ({ header, isCollapsible, children, isCollapsibleOpen, ha
         if (!isCollapsible) {
             return;
         }
-        setOpen(!open);
+        setOpen((prev) => !prev);
     }
 
     const icons = {

--- a/ui/apps/platform/src/Components/CollapsibleSection/CollapsibleSection.jsx
+++ b/ui/apps/platform/src/Components/CollapsibleSection/CollapsibleSection.jsx
@@ -20,7 +20,7 @@ const CollapsibleSection = ({
     const [isOpen, setIsOpen] = useState(defaultOpen);
 
     function toggleOpen() {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     }
 
     const Icon = isOpen ? (

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/AutocompleteSelect.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/AutocompleteSelect.tsx
@@ -157,7 +157,7 @@ function AutocompleteSelect({
     );
 
     const onToggleClick = () => {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     };
 
     const onSelect = (

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionText.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionText.tsx
@@ -95,7 +95,7 @@ function SearchFilterConditionText({ attribute, onSearch }: SearchFilterConditio
     const [isOpen, setIsOpen] = useState(false);
 
     const onToggleClick = () => {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     };
 
     const onSelect = (

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SimpleSelect.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SimpleSelect.tsx
@@ -25,7 +25,7 @@ function SimpleSelect({
     const [isOpen, setIsOpen] = useState(false);
 
     const onToggleClick = () => {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     };
 
     const onSelect = (

--- a/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/CheckboxSelect.tsx
@@ -100,7 +100,7 @@ function CheckboxSelect({
     const selectRef = useRef<HTMLDivElement>(null);
 
     function onToggle() {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     }
 
     function handleBlur(event: FocusEvent<HTMLDivElement>) {

--- a/ui/apps/platform/src/Components/PatternFly/MenuDropdown.tsx
+++ b/ui/apps/platform/src/Components/PatternFly/MenuDropdown.tsx
@@ -40,7 +40,7 @@ function MenuDropdown({
     const [isOpen, setIsOpen] = useState(false);
 
     function onToggleClick() {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     }
 
     function onSelectHandler(

--- a/ui/apps/platform/src/Components/ReportJob/PartialReportModal.tsx
+++ b/ui/apps/platform/src/Components/ReportJob/PartialReportModal.tsx
@@ -25,7 +25,7 @@ function PartialReportModal({ failedClusters = [], onDownload }: PartialReportMo
     const [perPage, setPerPage] = useState(20);
 
     const handleModalToggle = () => {
-        setIsModalOpen(!isModalOpen);
+        setIsModalOpen((prev) => !prev);
     };
 
     const startIndex = (page - 1) * perPage;

--- a/ui/apps/platform/src/Components/SelectSingle/useSelectToggleState.ts
+++ b/ui/apps/platform/src/Components/SelectSingle/useSelectToggleState.ts
@@ -15,7 +15,7 @@ function useSelectToggleState(onSelectionChange: (value: string) => void) {
     };
 
     const onToggle = () => {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     };
 
     return {

--- a/ui/apps/platform/src/Components/TypeaheadSelect/TypeaheadSelect.tsx
+++ b/ui/apps/platform/src/Components/TypeaheadSelect/TypeaheadSelect.tsx
@@ -76,7 +76,7 @@ function TypeaheadSelect({
     }
 
     function onToggle() {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     }
 
     function onInputChange(_event: FormEvent<HTMLInputElement>, text: string) {

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsPage.tsx
@@ -172,14 +172,14 @@ function ListeningEndpointsPage() {
         <MenuToggle
             ref={toggleRef}
             variant="typeahead"
-            onClick={() => setAutocompleteOpen(!autocompleteOpen)}
+            onClick={() => setAutocompleteOpen((prev) => !prev)}
             isExpanded={autocompleteOpen}
             isFullWidth
         >
             <TextInputGroup isPlain>
                 <TextInputGroupMain
                     value={autocompleteInputValue}
-                    onClick={() => setAutocompleteOpen(!autocompleteOpen)}
+                    onClick={() => setAutocompleteOpen((prev) => !prev)}
                     onChange={(_event, value) => {
                         setAutocompleteInputValue(value);
                         updateSearchValue(value);

--- a/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
+++ b/ui/apps/platform/src/Containers/Audit/ListeningEndpoints/ListeningEndpointsTable.tsx
@@ -73,7 +73,7 @@ function ListeningEndpointsTable({
                             // TODO Awkward type assertion here is fixed in PF 5 https://github.com/patternfly/patternfly-react/issues/8330
                             collapseAllAriaLabel: 'Expand or collapse all rows' as '',
                             onToggle: () => {
-                                setAllRowsExpanded(!areAllRowsExpanded);
+                                setAllRowsExpanded((prev) => !prev);
                                 invertedExpansionRowSet.clear();
                             },
                         }}

--- a/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
@@ -265,7 +265,7 @@ function ClusterPage({ clusterId }: ClusterPageProps): ReactElement {
     }
 
     function toggleSA() {
-        setCreateUpgraderSA(!createUpgraderSA);
+        setCreateUpgraderSA((prev) => !prev);
     }
 
     function onDownload() {

--- a/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/DelegateScanning/Components/DelegatedScanningSettings.tsx
@@ -63,7 +63,7 @@ function DelegatedScanningSettings({
                             <MenuToggle
                                 aria-label="Select default cluster"
                                 ref={toggleRef}
-                                onClick={() => setIsOpen(!isOpen)}
+                                onClick={() => setIsOpen((prev) => !prev)}
                                 isDisabled={!isEditing}
                                 isExpanded={isOpen}
                             >

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ScanConfigurationSelect.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/components/ScanConfigurationSelect.tsx
@@ -36,7 +36,7 @@ function ScanConfigurationSelect({
     const [isOpen, setIsOpen] = useState(false);
 
     const onToggleClick = () => {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     };
 
     const onSelect = (

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -281,7 +281,7 @@ function NetworkGraphPageContent() {
             });
         }
 
-        setIsCIDRBlockFormOpen(!isCIDRBlockFormOpen);
+        setIsCIDRBlockFormOpen((prev) => !prev);
     }
 
     return (

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultCIDRToggle.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/DefaultCIDRToggle.tsx
@@ -26,7 +26,7 @@ function DefaultCIDRToggle({ updateNetworkNodes = () => {} }): ReactElement {
     function toggleHandler(): void {
         setHideDefaultExternalSrcs(showDefaultExternalSrcs)
             .then(() => {
-                setShowDefaultExternalSrcs(!showDefaultExternalSrcs);
+                setShowDefaultExternalSrcs((prev) => !prev);
                 setErrorMessage('');
                 updateNetworkNodes();
             })

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NotifyYAMLModal.tsx
@@ -46,7 +46,7 @@ function NotifyYAMLModal({
     function onClose() {
         onClearAll();
         setErrorMessage(null);
-        setIsModalOpen(!isModalOpen);
+        setIsModalOpen((prev) => !prev);
     }
 
     let content: ReactElement = <div />;

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step1/PolicyCategoriesSelectField.tsx
@@ -34,7 +34,7 @@ function PolicyCategoriesSelectField(): ReactElement {
     const selectedCategories: string[] = (field.value as string[]) ?? [];
 
     const onToggle = () => {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     };
 
     const onSelect = (

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicyCriteriaModal.tsx
@@ -186,7 +186,7 @@ function PolicyCriteriaModal({
             <ModalBoxBody>
                 <Flex direction={{ default: 'column' }}>
                     <FlexItem>
-                        <Button variant="link" onClick={() => setAllExpanded(!allExpanded)}>
+                        <Button variant="link" onClick={() => setAllExpanded((prev) => !prev)}>
                             {allExpanded && 'Collapse all'}
                             {!allExpanded && 'Expand all'}
                         </Button>

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step3/PolicySection.tsx
@@ -68,7 +68,7 @@ function PolicySection({ sectionIndex, descriptors, readOnly = false }: PolicySe
                                     <Button
                                         variant="plain"
                                         className="pf-v5-u-px-sm"
-                                        onClick={() => setIsEditingName(!isEditingName)}
+                                        onClick={() => setIsEditingName((prev) => !prev)}
                                         title={
                                             isEditingName
                                                 ? 'Save name of policy section'

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step4/PolicyScopeForm.tsx
@@ -226,7 +226,7 @@ function PolicyScopeForm(): ReactElement {
                                 <MenuToggle
                                     variant="typeahead"
                                     aria-label="Typeahead menu toggle"
-                                    onClick={() => setIsExcludeImagesOpen(!isExcludeImagesOpen)}
+                                    onClick={() => setIsExcludeImagesOpen((prev) => !prev)}
                                     innerRef={toggleRef}
                                     isExpanded={isExcludeImagesOpen}
                                     isDisabled={
@@ -239,9 +239,7 @@ function PolicyScopeForm(): ReactElement {
                                     <TextInputGroup isPlain>
                                         <TextInputGroupMain
                                             value={filterValue}
-                                            onClick={() =>
-                                                setIsExcludeImagesOpen(!isExcludeImagesOpen)
-                                            }
+                                            onClick={() => setIsExcludeImagesOpen((prev) => !prev)}
                                             onChange={(_event, value) => setFilterValue(value)}
                                             autoComplete="off"
                                             placeholder="Select images to exclude"

--- a/ui/apps/platform/src/Containers/Policies/Wizard/Step6/ReviewPolicyForm.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/Step6/ReviewPolicyForm.tsx
@@ -120,7 +120,7 @@ function ReviewPolicyForm({
                         >
                             <Button
                                 variant="secondary"
-                                onClick={() => setShowPolicyResults(!showPolicyResults)}
+                                onClick={() => setShowPolicyResults((prev) => !prev)}
                             >
                                 Preview policy violations
                             </Button>

--- a/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/DiagnosticBundle/DiagnosticBundleForm.tsx
@@ -69,7 +69,7 @@ function DiagnosticBundleForm({
     }, [hasReadAccessForCluster]);
 
     function toggleClusterSelect() {
-        setClusterSelectOpen(!clusterSelectOpen);
+        setClusterSelectOpen((prev) => !prev);
     }
 
     function onSelect(_event: ReactMouseEvent | undefined, selection: string | number | undefined) {

--- a/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/K8sCard.tsx
@@ -28,7 +28,7 @@ function K8sCard({ message, keyValueAttrs = { attrs: [] }, time }: K8sCardProps)
     const [isExpanded, setIsExpanded] = useState(true);
 
     function onExpand() {
-        setIsExpanded(!isExpanded);
+        setIsExpanded((prev) => !prev);
     }
 
     return (

--- a/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/NetworkFlowCard.tsx
@@ -23,7 +23,7 @@ function NetworkFlowCard({ networkFlowInfo, message, time }: NetworkFlowCardProp
     const [isExpanded, setIsExpanded] = useState(true);
 
     function onExpand() {
-        setIsExpanded(!isExpanded);
+        setIsExpanded((prev) => !prev);
     }
 
     return (

--- a/ui/apps/platform/src/Containers/Violations/Details/TimestampedEventCard.tsx
+++ b/ui/apps/platform/src/Containers/Violations/Details/TimestampedEventCard.tsx
@@ -31,7 +31,7 @@ function TimestampedEventCard<T>({
     const [isExpanded, setIsExpanded] = useState(true);
 
     function onExpand() {
-        setIsExpanded(!isExpanded);
+        setIsExpanded((prev) => !prev);
     }
 
     const timestamps = events

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTablePanel.tsx
@@ -148,7 +148,7 @@ function ViolationsTablePanel({
     );
 
     function onToggleSelect() {
-        setIsSelectOpen(!isSelectOpen);
+        setIsSelectOpen((prev) => !prev);
     }
 
     // Handle setting confirmation modals for bulk actions

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/CollectionSelection.tsx
@@ -154,7 +154,7 @@ function CollectionSelection({
     }
 
     function onToggleClick() {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
         if (isOpen) {
             setSearch('');
         }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CreateReportDropdown.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/CreateReportDropdown.tsx
@@ -11,7 +11,7 @@ function CreateReportDropdown({ onSelect }: CreateReportDropdownProps) {
     const [isOpen, setIsOpen] = useState(false);
 
     const onToggleClick = () => {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     };
 
     const onSelectHandler = (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/components/DefaultFilterModal.tsx
@@ -52,7 +52,7 @@ function DefaultFilterModal({ defaultFilters, setLocalStorage }: DefaultFilterMo
         if (isOpen) {
             setValues(defaultFilters).catch(() => {});
         }
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     }
 
     function handleSeverityChange(severity: VulnerabilitySeverityLabel, isChecked: boolean) {

--- a/ui/apps/platform/src/hooks/patternfly/useSelectToggle.ts
+++ b/ui/apps/platform/src/hooks/patternfly/useSelectToggle.ts
@@ -35,7 +35,7 @@ interface SelectToggleReturn {
  */
 function useSelectToggle(defaultExpanded = false): SelectToggleReturn {
     const [isOpen, setIsOpen] = useState<boolean>(defaultExpanded);
-    const onToggle = useCallback(() => setIsOpen(!isOpen), [isOpen, setIsOpen]);
+    const onToggle = useCallback(() => setIsOpen((prev) => !prev), [setIsOpen]);
     const toggleSelect = useCallback(setIsOpen, [setIsOpen]);
     const openSelect = useCallback(() => toggleSelect(true), [toggleSelect]);
     const closeSelect = useCallback(() => toggleSelect(false), [toggleSelect]);

--- a/ui/apps/platform/src/hooks/useMultiSelect.tsx
+++ b/ui/apps/platform/src/hooks/useMultiSelect.tsx
@@ -16,7 +16,7 @@ function useMultiSelect(
     const [isOpen, setIsOpen] = useState(false);
 
     function onToggle() {
-        setIsOpen(!isOpen);
+        setIsOpen((prev) => !prev);
     }
 
     function onSelect(_event, selection) {


### PR DESCRIPTION
## Description

Standardized the boolean toggle state updater pattern across the UI codebase to use the functional updater form `setState((prev) => !prev)` instead of the direct value form `setState(!value)`.

This follows React's recommended pattern when new state depends on previous state, preventing stale closure bugs and correctly handling rapid state changes (e.g., multiple rapid clicks).

**Key Changes:**
- Updated 37 files (39 occurrences) to use `(prev) => !prev` pattern
- Includes hooks, components, and containers across the codebase

**TypeScript Constraint Exceptions:**
Two files retained the direct value pattern due to TypeScript prop constraints:
- `FlowBulkDropdown.tsx` - `setOpen` prop typed as `(o: boolean) => void`
- `CreateViewBasedReportModal.tsx` - `setIsOpen` prop typed as `(value: boolean) => void`

These props accept only boolean values, not functional updaters. Changing them would require updating parent component type contracts.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Verified TypeScript compilation passes with no errors
- Verified ESLint passes with no errors
- No behavioral changes - purely syntactic refactoring for consistency and safety