### PR TITLE
fix(ui): align layer type filter with backend search term

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageComponent.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageComponent.ts
@@ -32,13 +32,13 @@ export const Version: CompoundSearchFilterAttribute = {
 export const LayerType: CompoundSearchFilterAttribute = {
     displayName: 'Layer type',
     filterChipLabel: 'Image component layer type',
-    searchTerm: 'Component Layer Type',
+    searchTerm: 'Component From Base Image',
     inputType: 'select',
     featureFlagDependency: ['ROX_BASE_IMAGE_DETECTION'],
     inputProps: {
         options: [
-            { label: 'Application', value: 'APPLICATION' },
-            { label: 'Base image', value: 'BASE_IMAGE' },
+            { label: 'Application', value: 'false' },
+            { label: 'Base image', value: 'true' },
         ],
     },
 };

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -109,7 +109,7 @@ type AnalyticsBoolean = 0 | 1;
  */
 export const searchCategoriesWithFilter = [
     'Component Source',
-    'Component Layer Type',
+    'Component From Base Image',
     'SEVERITY',
     'FIXABLE',
     'CLUSTER CVE FIXABLE',


### PR DESCRIPTION
## Description

Fixes [ROX-32569](https://issues.redhat.com/browse/ROX-32569)

The Layer type filter was silently failing because:
- UI sent: `Component Layer Type` with `APPLICATION`/`BASE_IMAGE`
- Backend expects: `Component From Base Image` with `true`/`false`

**Changes:**
- Updated `searchTerm` to match backend field
- Changed filter values from enums to booleans

## User-facing documentation

- [x] CHANGELOG.md update not needed (bug fix, no user-facing behavior change)
- [x] Documentation PR not needed

## Testing and quality

- [x] Production ready: gated by `ROX_BASE_IMAGE_DETECTION` feature flag

### Automated testing

- [ ] No automated tests added - filter attribute is a simple config object

### How I validated my change

- Verified search term matches backend proto definition (`from_base_image` field in `image_component.proto`)
- Confirmed no TypeScript or linting errors