### PR TITLE
ROX-32257: Render CompoundSearchFilterLabels in Compliance

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterLabels.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterLabels.tsx
@@ -17,7 +17,7 @@ const iconGlobe = <Globe height="15px" />;
 export type CompoundSearchFilterLabelsProps = {
     attributesSeparateFromConfig: CompoundSearchFilterAttribute[];
     config: CompoundSearchFilterConfig;
-    isGlobalPredicate: IsGlobalPredicate; // for certain values in AdvancedFilterToolbar.tsx file
+    isGlobalPredicate?: IsGlobalPredicate; // for certain values in AdvancedFilterToolbar.tsx file
     onFilterChange?: (searchFilter: SearchFilter) => void; // omit for view-based report details
     searchFilter: SearchFilter;
 };

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx
@@ -15,10 +15,7 @@ import type { ClusterCheckStatus } from 'services/ComplianceResultsService';
 import type { TableUIState } from 'utils/getTableUIState';
 
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
-import SearchFilterChips, {
-    makeFilterChipDescriptorFromAttribute,
-    makeFilterChipDescriptors,
-} from 'Components/CompoundSearchFilter/components/SearchFilterChips';
+import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
 import SearchFilterSelectInclusive from 'Components/CompoundSearchFilter/components/SearchFilterSelectInclusive';
 import type {
     CompoundSearchFilterConfig,
@@ -67,8 +64,6 @@ function CheckDetailsTable({
     const { generatePathWithScanConfig } = useScanConfigRouter();
     const { page, perPage, setPage, setPerPage } = pagination;
 
-    const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig);
-
     return (
         <div id={tabContentIdForResults}>
             <Toolbar>
@@ -89,6 +84,16 @@ function CheckDetailsTable({
                                 searchFilter={searchFilter}
                             />
                         </ToolbarItem>
+                    </ToolbarGroup>
+                    <ToolbarGroup className="pf-v5-u-w-100">
+                        <CompoundSearchFilterLabels
+                            attributesSeparateFromConfig={[attributeForComplianceCheckStatus]}
+                            config={searchFilterConfig}
+                            onFilterChange={onFilterChange}
+                            searchFilter={searchFilter}
+                        />
+                    </ToolbarGroup>
+                    <ToolbarGroup className="pf-v5-u-w-100">
                         <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
                             <Pagination
                                 itemCount={checkResultsCount}
@@ -98,18 +103,6 @@ function CheckDetailsTable({
                                 onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
                             />
                         </ToolbarItem>
-                    </ToolbarGroup>
-                    <ToolbarGroup className="pf-v5-u-w-100">
-                        <SearchFilterChips
-                            searchFilter={searchFilter}
-                            onFilterChange={onFilterChange}
-                            filterChipGroupDescriptors={[
-                                ...filterChipGroupDescriptors,
-                                makeFilterChipDescriptorFromAttribute(
-                                    attributeForComplianceCheckStatus
-                                ),
-                            ]}
-                        />
                     </ToolbarGroup>
                 </ToolbarContent>
             </Toolbar>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ClusterDetailsTable.tsx
@@ -12,10 +12,7 @@ import {
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
-import SearchFilterChips, {
-    makeFilterChipDescriptorFromAttribute,
-    makeFilterChipDescriptors,
-} from 'Components/CompoundSearchFilter/components/SearchFilterChips';
+import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
 import SearchFilterSelectInclusive from 'Components/CompoundSearchFilter/components/SearchFilterSelectInclusive';
 import type {
     CompoundSearchFilterConfig,
@@ -77,8 +74,6 @@ function ClusterDetailsTable({
         setExpandedRows([]);
     }, [page, perPage, tableState]);
 
-    const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig);
-
     return (
         <>
             <Toolbar>
@@ -99,6 +94,16 @@ function ClusterDetailsTable({
                                 searchFilter={searchFilter}
                             />
                         </ToolbarItem>
+                    </ToolbarGroup>
+                    <ToolbarGroup className="pf-v5-u-w-100">
+                        <CompoundSearchFilterLabels
+                            attributesSeparateFromConfig={[attributeForComplianceCheckStatus]}
+                            config={searchFilterConfig}
+                            onFilterChange={onFilterChange}
+                            searchFilter={searchFilter}
+                        />
+                    </ToolbarGroup>
+                    <ToolbarGroup className="pf-v5-u-w-100">
                         <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
                             <Pagination
                                 itemCount={checkResultsCount}
@@ -108,18 +113,6 @@ function ClusterDetailsTable({
                                 onPerPageSelect={(_, newPerPage) => setPerPage(newPerPage)}
                             />
                         </ToolbarItem>
-                    </ToolbarGroup>
-                    <ToolbarGroup className="pf-v5-u-w-100">
-                        <SearchFilterChips
-                            searchFilter={searchFilter}
-                            onFilterChange={onFilterChange}
-                            filterChipGroupDescriptors={[
-                                ...filterChipGroupDescriptors,
-                                makeFilterChipDescriptorFromAttribute(
-                                    attributeForComplianceCheckStatus
-                                ),
-                            ]}
-                        />
                     </ToolbarGroup>
                 </ToolbarContent>
             </Toolbar>

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx
@@ -17,10 +17,7 @@ import ComplianceUsageDisclaimer, {
     COMPLIANCE_DISCLAIMER_KEY,
 } from 'Components/ComplianceUsageDisclaimer';
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
-import SearchFilterChips, {
-    makeFilterChipDescriptorFromAttribute,
-    makeFilterChipDescriptors,
-} from 'Components/CompoundSearchFilter/components/SearchFilterChips';
+import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
 import SearchFilterSelectInclusive from 'Components/CompoundSearchFilter/components/SearchFilterSelectInclusive';
 import type { OnSearchCallback } from 'Components/CompoundSearchFilter/types';
 import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
@@ -66,8 +63,6 @@ function CoveragesPage() {
     const [selectedProfileStats, setSelectedProfileStats] = useState<
         undefined | ComplianceProfileScanStats
     >(undefined);
-
-    const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig);
 
     const { searchFilter, setSearchFilter } = useURLSearch();
 
@@ -188,15 +183,13 @@ function CoveragesPage() {
                                         </ToolbarItem>
                                     </ToolbarGroup>
                                     <ToolbarGroup className="pf-v5-u-w-100">
-                                        <SearchFilterChips
-                                            searchFilter={searchFilter}
-                                            onFilterChange={setSearchFilter}
-                                            filterChipGroupDescriptors={[
-                                                ...filterChipGroupDescriptors,
-                                                makeFilterChipDescriptorFromAttribute(
-                                                    attributeForComplianceCheckStatus
-                                                ),
+                                        <CompoundSearchFilterLabels
+                                            attributesSeparateFromConfig={[
+                                                attributeForComplianceCheckStatus,
                                             ]}
+                                            config={searchFilterConfig}
+                                            onFilterChange={setSearchFilter}
+                                            searchFilter={searchFilter}
                                         />
                                     </ToolbarGroup>
                                 </ToolbarContent>


### PR DESCRIPTION
## Description

**Objective**: Use search filter config plus separate attributes as single source of truth.

**Bonus**: Render `Label` and `LabelGroup` instead of deprecated `Chip` and `ChipGroup` elements.

### Residue

1. Investigate whether I forgot about nowrap for select element that I might have mistakenly deleted or omitted in a previous contribution.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

Same steps as #18252

1. Visit /main/compliance/coverage/profiles/profile/checks

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CoveragesPage.tsx

    Select **Fail** and **Error** in **Compliance status**

    Search query in page address: `s[Compliance%20Check%20Status][1]=Error`
    Search query in data request: `Compliance Check Status:Fail,Error`
    Filter chips: **Compliance status Fail Error**

    Before change, with `Chip` and `ChipGroup` elements:
    <img width="1440" height="898" alt="CoveragesPage_Chip" src="https://github.com/user-attachments/assets/fddbacca-bf1f-4d25-939f-07221cfb3e92" />

    After change, with `Label` and `LabelGroup` elements:
    <img width="1440" height="898" alt="CoveragesPage_Label" src="https://github.com/user-attachments/assets/9097fb74-26db-4b20-9d71-0bb9b45d6076" />

2. Click a check link

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/CheckDetailsTable.tsx

    Select **Pass** in **Compliance status**

    Search query in page address: `s[Compliance%20Check%20Status][0]=Pass`
    Search query in data request: `Compliance Check Status:Pass`
    Filter chips: **Compliance status Pass**

    Before change, with `Chip` and `ChipGroup` elements and pagination in second row, plus wrap problem:
    <img width="1440" height="898" alt="CheckDetailsTable_Chip_wrap" src="https://github.com/user-attachments/assets/659b396f-a2d8-49c4-987a-31275f998900" />

    After change, with `Label` and `LabelGroup` elements and pagination in third row:
    <img width="1440" height="898" alt="CheckDetailsTable_Label_pagination" src="https://github.com/user-attachments/assets/614e8a1c-c28d-4bdb-b6cd-36273c03b3af" />

3. Go back, click **Clusters** toggle, and then click a cluster link

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/C  omplianceEnhanced/Coverage/ClusterDetailsTable.tsx

    Select **Manual** in **Compliance status**

    Search query in page address: `s[Compliance%20Check%20Status][0]=Manual`
    Search query in data request: `Compliance Check Status:Manual`
    Filter chips: **Compliance status Manual**

    After change, with `Label` and `LabelGroup` elements and pagination in third row:
    <img width="1440" height="898" alt="ClusterDetailsTable_Label_pagination" src="https://github.com/user-attachments/assets/4e1b0874-450d-49f0-bb0d-7c09323517c7" />