### PR TITLE
ROX-32559: Render CompoundSearchFilterLabels in miscellaneous routes

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterLabels.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterLabels.tsx
@@ -17,7 +17,7 @@ const iconGlobe = <Globe height="15px" />;
 export type CompoundSearchFilterLabelsProps = {
     attributesSeparateFromConfig: CompoundSearchFilterAttribute[];
     config: CompoundSearchFilterConfig;
-    isGlobalPredicate: IsGlobalPredicate; // for certain values in AdvancedFilterToolbar.tsx file
+    isGlobalPredicate?: IsGlobalPredicate; // for certain values in AdvancedFilterToolbar.tsx file
     onFilterChange?: (searchFilter: SearchFilter) => void; // omit for view-based report details
     searchFilter: SearchFilter;
 };

--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -15,9 +15,7 @@ import {
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import CloseButton from 'Components/CloseButton';
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
-import SearchFilterChips, {
-    makeFilterChipDescriptors,
-} from 'Components/CompoundSearchFilter/components/SearchFilterChips';
+import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
 import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
 import Dialog from 'Components/Dialog';
 import LinkShim from 'Components/PatternFly/LinkShim';
@@ -58,8 +56,6 @@ import SecureClusterModal from './InitBundles/SecureClusterModal';
 import { clusterTablePollingInterval, getUpgradeableClusters } from './cluster.helpers';
 import NoClustersPage from './NoClustersPage';
 import { searchFilterConfig } from './searchFilterConfig';
-
-const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig);
 
 export type ClustersTablePanelProps = {
     selectedClusterId: string;
@@ -442,10 +438,11 @@ function ClustersTablePanel({ selectedClusterId }: ClustersTablePanelProps) {
                             )}
                         </ToolbarGroup>
                         <ToolbarGroup className="pf-v5-u-w-100">
-                            <SearchFilterChips
-                                searchFilter={searchFilter}
+                            <CompoundSearchFilterLabels
+                                attributesSeparateFromConfig={[]}
+                                config={searchFilterConfig}
                                 onFilterChange={setSearchFilter}
-                                filterChipGroupDescriptors={filterChipGroupDescriptors}
+                                searchFilter={searchFilter}
                             />
                         </ToolbarGroup>
                     </ToolbarContent>

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -29,9 +29,7 @@ import type { IAction } from '@patternfly/react-table';
 
 import type { ListPolicy } from 'types/policy.proto';
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
-import SearchFilterChips, {
-    makeFilterChipDescriptors,
-} from 'Components/CompoundSearchFilter/components/SearchFilterChips';
+import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
 import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import ConfirmationModal from 'Components/PatternFly/ConfirmationModal';
@@ -221,12 +219,11 @@ function PoliciesTable({
                             />
                         </ToolbarItem>
                         <ToolbarItem className="pf-v5-u-w-100">
-                            <SearchFilterChips
-                                searchFilter={searchFilter}
+                            <CompoundSearchFilterLabels
+                                attributesSeparateFromConfig={[]}
+                                config={searchFilterConfig}
                                 onFilterChange={handleChangeSearchFilter}
-                                filterChipGroupDescriptors={makeFilterChipDescriptors(
-                                    searchFilterConfig
-                                )}
+                                searchFilter={searchFilter}
                             />
                         </ToolbarItem>
                         <ToolbarGroup

--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx
@@ -8,9 +8,7 @@ import type {
     OnSearchCallback,
 } from 'Components/CompoundSearchFilter/types';
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
-import SearchFilterChips, {
-    makeFilterChipDescriptors,
-} from 'Components/CompoundSearchFilter/components/SearchFilterChips';
+import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
 import {
     Category as PolicyCategory,
     LifecycleStage as PolicyLifecycleStage,
@@ -96,8 +94,6 @@ function ViolationsTableSearchFilter({
     const { analyticsTrack } = useAnalytics();
     const trackAppliedFilter = createFilterTracker(analyticsTrack);
 
-    const filterChipGroupDescriptors = makeFilterChipDescriptors(searchFilterConfig);
-
     const onSearchHandler: OnSearchCallback = (payload) => {
         onSearch(payload);
         trackAppliedFilter('Policy Violations Filter Applied', payload);
@@ -117,10 +113,11 @@ function ViolationsTableSearchFilter({
                     </ToolbarItem>
                 </ToolbarGroup>
                 <ToolbarGroup className="pf-v5-u-w-100">
-                    <SearchFilterChips
-                        searchFilter={searchFilter}
+                    <CompoundSearchFilterLabels
+                        attributesSeparateFromConfig={[]}
+                        config={searchFilterConfig}
                         onFilterChange={onFilterChange}
-                        filterChipGroupDescriptors={filterChipGroupDescriptors}
+                        searchFilter={searchFilter}
                     />
                 </ToolbarGroup>
             </ToolbarContent>


### PR DESCRIPTION
## Description

**Objective**: Use search filter config plus separate attributes as single source of truth.

**Bonus**: Render `Label` and `LabelGroup` instead of deprecated `Chip` and `ChipGroup` elements.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/clusters

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx

    Select **Cluster Name** category with **staging-secured-cluster** value, and then **Cluster Status** category with **Healthy** and **Degraded** values.

    Search query in page address: `s[Cluster][0]=staging-secured-cluster&s[Cluster%20status][0]=HEALTHY&s[Cluster%20status][1]=DEGRADED`
    Search query in data request: `Cluster:staging-secured-cluster+Cluster status:HEALTHY,DEGRADED`
    Filter labels: **Cluster name staging-secured-cluster** and **Cluster status Healthy Degraded**

    Before change, with `Chip` and `ChipGroup` elements:
    <img width="1438" height="494" alt="ClustersTablePanel_Chip" src="https://github.com/user-attachments/assets/3b1e2ad2-c153-484a-97c3-f0e8cf51eeec" />

    After change, with `Label` and `LabelGroup` elements:
    <img width="1440" height="898" alt="ClustersTablePanel_Label" src="https://github.com/user-attachments/assets/a9da1822-6e3b-4bba-b2ed-a5a2bb83611c" />

2. Visit /main/policy-management/policies

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx

    Select **Policy Status** category with **Enabled** value.

    Search query in page address: `s[Disabled][0]=false`
    Search query in data request: `Disabled:false`
    Filter labels: **Status Enabled**

    Before change, with `Chip` and `ChipGroup` elements:
    <img width="1440" height="899" alt="PoliciesTable_Chip" src="https://github.com/user-attachments/assets/495d169d-339c-40fd-bd60-c440795b4d96" />

    After change, with `Label` and `LabelGroup` elements:
    <img width="1440" height="898" alt="PoliciesTable_Label" src="https://github.com/user-attachments/assets/14528818-28f3-4331-b758-dc4291dfa9b3" />

3. Visit /main/violations

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.tsx

    Select **Policy Severity** category with **Critical** and **High** values.

    Search query in page address: `s[Severity][0]=CRITICAL_SEVERITY&s[Severity][1]=HIGH_SEVERITY`
    Search query in data request: `Severity:CRITICAL_SEVERITY,HIGH_SEVERITY`
    Filter labels: **Policy severity Critical High**

    Before change, with `Chip` and `ChipGroup` elements:
    <img width="1440" height="898" alt="ViolationsTableSearchFilter_Chip" src="https://github.com/user-attachments/assets/1e0b92de-5f95-4381-9267-d2f1055fb076" />

    After change, with `Label` and `LabelGroup` elements:
    <img width="1440" height="898" alt="ViolationsTableSearchFilter_Label" src="https://github.com/user-attachments/assets/9c4efd2b-0722-4def-96c8-4b1be60a4ad4" />
