### PR TITLE
chore(sensor): use Go 1.25 synctest for queue_test.go

### DIFF
--- a/sensor/common/detector/queue/queue_test.go
+++ b/sensor/common/detector/queue/queue_test.go
@@ -1,6 +1,8 @@
 package queue
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -8,108 +10,6 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stretchr/testify/assert"
 )
-
-func createAndStartQueue(t *testing.T, stopper concurrency.Stopper, size int) *Queue[*string] {
-	t.Helper()
-	q := NewQueue[*string](stopper, "queue", size, nil, nil)
-	q.Start()
-	return q
-}
-
-func push(t *testing.T, q *Queue[*string]) {
-	t.Helper()
-	old := q.queue.Len()
-	item := "item"
-	q.Push(&item)
-	assert.Equal(t, old+1, q.queue.Len())
-}
-
-func pause(_ *testing.T, q *Queue[*string]) {
-	q.Pause()
-}
-
-func resume(_ *testing.T, q *Queue[*string]) {
-	q.Resume()
-}
-
-// noPull verifies that Pull() blocks when the queue is paused.
-// With synctest's fake clock, time advances only when all goroutines are durably blocked.
-func noPull(t *testing.T, q *Queue[*string], stopper concurrency.Stopper) {
-	t.Helper()
-	ch := make(chan *string)
-	go func() {
-		defer close(ch)
-		select {
-		case item := <-q.Pull():
-			// Pull returned - either got an item or queue was stopped (nil).
-			// Use nested select to avoid blocking if nobody reads from ch.
-			if item != nil {
-				select {
-				case ch <- item:
-				case <-stopper.Flow().StopRequested():
-				}
-			}
-		case <-stopper.Flow().StopRequested():
-		}
-	}()
-	// With fake clock, this advances time instantly when goroutines are blocked
-	select {
-	case <-time.After(500 * time.Millisecond):
-		return // Expected: timeout means Pull() is blocked
-	case item := <-ch:
-		t.Fatalf("should not pull from the queue, but %s was pulled", *item)
-	}
-}
-
-// pull verifies that Pull() succeeds within a timeout.
-func pull(t *testing.T, q *Queue[*string], stopper concurrency.Stopper) {
-	t.Helper()
-	ch := make(chan *string)
-	go func() {
-		defer close(ch)
-		select {
-		case item := <-q.Pull():
-			// Use nested select to avoid blocking if nobody reads from ch.
-			select {
-			case ch <- item:
-			case <-stopper.Flow().StopRequested():
-			}
-		case <-stopper.Flow().StopRequested():
-		}
-	}()
-	select {
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timeout waiting to pull from the queue")
-	case item := <-ch:
-		assert.Equal(t, "item", *item)
-	}
-}
-
-// stopPull verifies that Pull() returns nil when the queue is stopped.
-func stopPull(t *testing.T, q *Queue[*string]) {
-	t.Helper()
-	// Schedule the stop after a delay - with fake clock this fires when goroutines block
-	time.AfterFunc(500*time.Millisecond, func() {
-		q.stopper.Client().Stop()
-	})
-	// Wait for the goroutine to be blocked, then time advances and AfterFunc fires
-	item := <-q.Pull()
-	assert.Nil(t, item, "Pull() should return nil after stop")
-}
-
-// pushPullBlocking verifies that Pull() blocks until an item is pushed.
-func pushPullBlocking(t *testing.T, q *Queue[*string]) {
-	t.Helper()
-	// Schedule a push after a delay - with fake clock this fires when goroutines block
-	time.AfterFunc(500*time.Millisecond, func() {
-		item := "item"
-		q.Push(&item)
-	})
-	// Pull will block, time advances, AfterFunc fires, then Pull returns
-	item := <-q.Pull()
-	assert.NotNil(t, item)
-	assert.Equal(t, "item", *item)
-}
 
 // TestPauseAndResume tests various queue pause/resume scenarios using synctest
 // for deterministic concurrent testing with a fake clock.
@@ -213,4 +113,115 @@ func TestPauseAndResume(t *testing.T) {
 			synctest.Test(t, testFn)
 		})
 	}
+}
+
+func createAndStartQueue(t *testing.T, stopper concurrency.Stopper, size int) *Queue[*string] {
+	t.Helper()
+	q := NewQueue[*string](stopper, "queue", size, nil, nil)
+	q.Start()
+	return q
+}
+
+func push(t *testing.T, q *Queue[*string]) {
+	t.Helper()
+	old := q.queue.Len()
+	item := "item"
+	q.Push(&item)
+	assert.Equal(t, old+1, q.queue.Len())
+}
+
+func pause(_ *testing.T, q *Queue[*string]) {
+	q.Pause()
+}
+
+func resume(_ *testing.T, q *Queue[*string]) {
+	q.Resume()
+}
+
+// noPull verifies that Pull() blocks when the queue is paused.
+// With synctest's fake clock, time advances only when all goroutines are durably blocked.
+func noPull(t *testing.T, q *Queue[*string], stopper concurrency.Stopper) {
+	t.Helper()
+	// errCh is used to signal errors from the goroutine as the goroutine should not call t.Fatal() directly.
+	errCh := make(chan error)
+	// Successful exit path - stop goroutine without writing to errCh.
+	done, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		defer close(errCh)
+		select {
+		case item, ok := <-q.Pull():
+			if !ok {
+				errCh <- fmt.Errorf("unexpected closed pull channel while paused")
+				return
+			}
+			if item == nil {
+				errCh <- fmt.Errorf("unexpected nil item pulled while paused")
+				return
+			}
+			errCh <- fmt.Errorf("should not pull from the queue, but %s was pulled", *item)
+		case <-done.Done():
+			return
+		case <-stopper.Flow().StopRequested():
+			errCh <- fmt.Errorf("unexpected stop request while asserting Pull() should block")
+		}
+	}()
+	// With fake clock, this advances time instantly when goroutines are blocked
+	select {
+	case <-time.After(50 * time.Millisecond):
+		return // Expected: timeout means Pull() is blocked
+	case err := <-errCh:
+		t.Fatal(err)
+	}
+}
+
+// pull verifies that Pull() succeeds within a timeout.
+func pull(t *testing.T, q *Queue[*string], stopper concurrency.Stopper) {
+	t.Helper()
+	ch := make(chan *string)
+	go func() {
+		defer close(ch)
+		select {
+		case item := <-q.Pull():
+			// Use nested select to avoid blocking if nobody reads from ch.
+			select {
+			case ch <- item:
+			case <-stopper.Flow().StopRequested():
+			}
+		case <-stopper.Flow().StopRequested():
+		}
+	}()
+	select {
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting to pull from the queue")
+	case item := <-ch:
+		assert.Equal(t, "item", *item)
+	}
+}
+
+// stopPull verifies that Pull() returns nil when the queue is stopped.
+func stopPull(t *testing.T, q *Queue[*string]) {
+	t.Helper()
+	// Schedule the stop after a delay - with fake clock this fires when goroutines block
+	time.AfterFunc(500*time.Millisecond, func() {
+		q.stopper.Client().Stop()
+	})
+	// Wait for the goroutine to be blocked, then time advances and AfterFunc fires
+	item := <-q.Pull()
+	assert.Nil(t, item, "Pull() should return nil after stop")
+}
+
+// pushPullBlocking verifies that Pull() blocks until an item is pushed.
+func pushPullBlocking(t *testing.T, q *Queue[*string]) {
+	t.Helper()
+	// Schedule a push after a delay - with fake clock this fires when goroutines block
+	time.AfterFunc(500*time.Millisecond, func() {
+		item := "item"
+		q.Push(&item)
+	})
+	// Pull will block, time advances, AfterFunc fires, then Pull returns
+	item := <-q.Pull()
+	assert.NotNil(t, item)
+	assert.Equal(t, "item", *item)
 }

--- a/sensor/common/detector/queue/queue_test.go
+++ b/sensor/common/detector/queue/queue_test.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"testing/synctest"
@@ -153,18 +154,18 @@ func noPull(t *testing.T, q *Queue[*string], stopper concurrency.Stopper) {
 		select {
 		case item, ok := <-q.Pull():
 			if !ok {
-				errCh <- fmt.Errorf("unexpected closed pull channel while paused")
+				errCh <- errors.New("unexpected closed pull channel while paused")
 				return
 			}
 			if item == nil {
-				errCh <- fmt.Errorf("unexpected nil item pulled while paused")
+				errCh <- errors.New("unexpected nil item pulled while paused")
 				return
 			}
 			errCh <- fmt.Errorf("should not pull from the queue, but %s was pulled", *item)
 		case <-done.Done():
 			return
 		case <-stopper.Flow().StopRequested():
-			errCh <- fmt.Errorf("unexpected stop request while asserting Pull() should block")
+			errCh <- errors.New("unexpected stop request while asserting Pull() should block")
 		}
 	}()
 	// With fake clock, this advances time instantly when goroutines are blocked


### PR DESCRIPTION
## Description

Apply Go 1.25's `testing/synctest` package (https://pkg.go.dev/testing/synctest) to `sensor/common/detector/queue/queue_test.go` to make concurrent tests deterministic and significantly faster.

### What changed
- Wrap test cases in `synctest.Test()` which provides a fake clock and goroutine tracking
- Replace `time.Sleep` with `synctest.Wait()` for goroutine synchronization
- `time.After` and `time.AfterFunc` now advance instantly when goroutines block
- Fix a pre-existing goroutine leak that `synctest` detected (orphaned goroutines after timeout)

### Why
- **Speed**: Test execution reduced from ~3.5s to ~0s (instant) - the fake clock eliminates real delays
- **Determinism**: Tests no longer depend on timing, eliminating potential flakiness
- **Correctness**: synctest's strict goroutine tracking exposed and helped fix a goroutine leak

### Performance comparison

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Test time | 3.51s | 0.00s | Instant |
| Package total | ~4.2s | ~0.6s | ~7x faster |

### AI disclosure
This change was developed with AI assistance. The user reviewed the code, identified issues with test coverage preservation and improper use of buffered channels, and directed corrections. The final implementation was validated by the user.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

1. Ran baseline measurements (5 runs) before changes:
   ```
   go test -v ./sensor/common/detector/queue/...
   # Result: TestPauseAndResume ~3.51s per run
   ```

2. Applied synctest changes and verified all 6 test scenarios pass:
   ```
   go test -v ./sensor/common/detector/queue/...
   # Result: All subtests pass with 0.00s execution time
   ```

3. Ran post-change measurements (5 runs) to confirm speedup:
   ```
   go test -count=1 ./sensor/common/detector/queue/...
   # Result: Package completes in ~0.6s (down from ~4.2s)
   ```

4. Verified test structure preserved: `TestPauseAndResume` with 6 subtests matching original names
