### PR TITLE
ROX-32358: Add column management to vm4vm overview

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachinesCvesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/Overview/VirtualMachinesCvesTable.tsx
@@ -11,9 +11,15 @@ import {
 } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
+import ColumnManagementButton from 'Components/ColumnManagementButton';
 import DateDistance from 'Components/DateDistance';
 import { DynamicTableLabel } from 'Components/DynamicIcon';
 import TbodyUnified from 'Components/TableStateTemplates/TbodyUnified';
+import {
+    generateVisibilityForColumns,
+    getHiddenColumnCount,
+    useManagedColumns,
+} from 'hooks/useManagedColumns';
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
@@ -45,7 +51,36 @@ export const sortFields = [VIRTUAL_MACHINE_SORT_FIELD];
 
 export const defaultSortOption = { field: VIRTUAL_MACHINE_SORT_FIELD, direction: 'asc' } as const;
 
+export const defaultColumns = {
+    virtualMachine: {
+        title: 'Virtual machine',
+        isShownByDefault: true,
+        isUntoggleAble: true,
+    },
+    cvesBySeverity: {
+        title: 'CVEs by severity',
+        isShownByDefault: true,
+    },
+    cluster: {
+        title: 'Cluster',
+        isShownByDefault: true,
+    },
+    namespace: {
+        title: 'Namespace',
+        isShownByDefault: true,
+    },
+    scannedComponents: {
+        title: 'Scanned components',
+        isShownByDefault: true,
+    },
+    scanTime: {
+        title: 'Scan time',
+        isShownByDefault: true,
+    },
+} as const;
+
 function VirtualMachinesCvesTable() {
+    const managedColumnState = useManagedColumns('VirtualMachinesCvesTable', defaultColumns);
     const { page, perPage, setPage, setPerPage } = useURLPagination(DEFAULT_VM_PAGE_SIZE);
     const { searchFilter, setSearchFilter } = useURLSearch();
     const isFiltered = getHasSearchApplied(searchFilter);
@@ -54,6 +89,10 @@ function VirtualMachinesCvesTable() {
         defaultSortOption,
         onSort: () => setPage(1),
     });
+
+    const getVisibilityClass = generateVisibilityForColumns(managedColumnState.columns);
+    const hiddenColumnCount = getHiddenColumnCount(managedColumnState.columns);
+    const colSpan = Object.values(defaultColumns).length - hiddenColumnCount;
 
     const fetchVirtualMachines = useCallback(
         () => listVirtualMachines({ searchFilter, page, perPage, sortOption }),
@@ -95,6 +134,12 @@ function VirtualMachinesCvesTable() {
                         </Flex>
                     </SplitItem>
                     <SplitItem>
+                        <ColumnManagementButton
+                            columnConfig={managedColumnState.columns}
+                            onApplyColumns={managedColumnState.setVisibility}
+                        />
+                    </SplitItem>
+                    <SplitItem>
                         <Pagination
                             itemCount={data?.totalCount ?? 0}
                             perPage={perPage}
@@ -114,17 +159,26 @@ function VirtualMachinesCvesTable() {
                 >
                     <Thead>
                         <Tr>
-                            <Th sort={getSortParams('Virtual Machine Name')}>Virtual machine</Th>
-                            <Th>CVEs by severity</Th>
-                            <Th>Cluster</Th>
-                            <Th>Namespace</Th>
-                            <Th>Scanned components</Th>
-                            <Th>Scan time</Th>
+                            <Th
+                                className={getVisibilityClass('virtualMachine')}
+                                sort={getSortParams('Virtual Machine Name')}
+                            >
+                                Virtual machine
+                            </Th>
+                            <Th className={getVisibilityClass('cvesBySeverity')}>
+                                CVEs by severity
+                            </Th>
+                            <Th className={getVisibilityClass('cluster')}>Cluster</Th>
+                            <Th className={getVisibilityClass('namespace')}>Namespace</Th>
+                            <Th className={getVisibilityClass('scannedComponents')}>
+                                Scanned components
+                            </Th>
+                            <Th className={getVisibilityClass('scanTime')}>Scan time</Th>
                         </Tr>
                     </Thead>
                     <TbodyUnified
                         tableState={tableState}
-                        colSpan={7}
+                        colSpan={colSpan}
                         errorProps={{
                             title: 'There was an error loading results',
                         }}
@@ -140,7 +194,11 @@ function VirtualMachinesCvesTable() {
                                     const scanTime = virtualMachine?.scan?.scanTime;
                                     return (
                                         <Tr key={virtualMachine.id}>
-                                            <Td dataLabel="Virtual machine" modifier="nowrap">
+                                            <Td
+                                                className={getVisibilityClass('virtualMachine')}
+                                                dataLabel="Virtual machine"
+                                                modifier="nowrap"
+                                            >
                                                 <Link
                                                     to={getVirtualMachineEntityPagePath(
                                                         'VirtualMachine',
@@ -150,7 +208,10 @@ function VirtualMachinesCvesTable() {
                                                     {virtualMachine.name}
                                                 </Link>
                                             </Td>
-                                            <Td dataLabel="CVEs by severity">
+                                            <Td
+                                                className={getVisibilityClass('cvesBySeverity')}
+                                                dataLabel="CVEs by severity"
+                                            >
                                                 <SeverityCountLabels
                                                     criticalCount={
                                                         virtualMachineSeverityCounts.CRITICAL_VULNERABILITY_SEVERITY
@@ -170,18 +231,30 @@ function VirtualMachinesCvesTable() {
                                                     entity="virtual machine"
                                                 />
                                             </Td>
-                                            <Td dataLabel="Cluster">
+                                            <Td
+                                                className={getVisibilityClass('cluster')}
+                                                dataLabel="Cluster"
+                                            >
                                                 {virtualMachine.clusterName}
                                             </Td>
-                                            <Td dataLabel="Namespace">
+                                            <Td
+                                                className={getVisibilityClass('namespace')}
+                                                dataLabel="Namespace"
+                                            >
                                                 {virtualMachine.namespace}
                                             </Td>
-                                            <Td dataLabel="Scanned components">
+                                            <Td
+                                                className={getVisibilityClass('scannedComponents')}
+                                                dataLabel="Scanned components"
+                                            >
                                                 {getVirtualMachineScannedComponentsCount(
                                                     virtualMachine
                                                 )}
                                             </Td>
-                                            <Td dataLabel="Scan time">
+                                            <Td
+                                                className={getVisibilityClass('scanTime')}
+                                                dataLabel="Scan time"
+                                            >
                                                 {typeof scanTime === 'string' ? (
                                                     <DateDistance date={scanTime} />
                                                 ) : (


### PR DESCRIPTION
## Description

Added column management to the Virtual Machines overview table. Allows users to show/hide columns (CVEs by severity, Cluster, Namespace, Scanned packages, Scan time). This follows the same pattern used in other Workload CVE tables and stores column preferences in local storage.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
<img width="1683" height="695" alt="Screenshot 2026-01-12 at 2 38 01 PM" src="https://github.com/user-attachments/assets/11fe1f47-eaa6-4d5a-ac34-4b2747e83b57" />
<img width="1683" height="695" alt="Screenshot 2026-01-12 at 2 38 12 PM" src="https://github.com/user-attachments/assets/8a761535-7364-408e-94f6-d09ec1f749c2" />


