### PR TITLE
chore: Bump Go to 1.25.3 to fix CVE-2025-58183

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/rox
 
-go 1.25.0
+go 1.25.3
 
 require (
 	cloud.google.com/go/artifactregistry v1.18.0

--- a/operator/tools/controller-gen/go.mod
+++ b/operator/tools/controller-gen/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/rox/operator/tools/controller-gen
 
-go 1.25
+go 1.25.3
 
 require sigs.k8s.io/controller-tools v0.19.0
 

--- a/operator/tools/envtest/go.mod
+++ b/operator/tools/envtest/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/rox/operator/tools/envtest
 
-go 1.25
+go 1.25.3
 
 require sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20240215124517-56159419231e
 

--- a/operator/tools/kustomize/go.mod
+++ b/operator/tools/kustomize/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/rox/operator/tools/kustomize
 
-go 1.25
+go 1.25.3
 
 require sigs.k8s.io/kustomize/kustomize/v5 v5.8.0
 

--- a/operator/tools/kuttl/go.mod
+++ b/operator/tools/kuttl/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/rox/operator/tools/kuttl
 
-go 1.25
+go 1.25.3
 
 require github.com/kudobuilder/kuttl v0.24.1-0.20251223085747-6c1c96eb4abd
 

--- a/operator/tools/operator-sdk/go.mod
+++ b/operator/tools/operator-sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/rox/operator/tools/operator-sdk
 
-go 1.25.0
+go 1.25.3
 
 require (
 	github.com/operator-framework/operator-lifecycle-manager v0.30.0

--- a/operator/tools/yq/go.mod
+++ b/operator/tools/yq/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/rox/operator/tools/yq
 
-go 1.25
+go 1.25.3
 
 require github.com/mikefarah/yq/v4 v4.50.1
 

--- a/tests/performance/scale/go.mod
+++ b/tests/performance/scale/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/stackrox/performance-scale-tests
 
-go 1.25
+go 1.25.3
 
 require (
 	github.com/cloud-bulldozer/go-commons v1.0.11

--- a/tools/check-workflow-run/go.mod
+++ b/tools/check-workflow-run/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/stackrox/tools/check-workflow-run
 
-go 1.25
+go 1.25.3
 
 require github.com/google/go-github/v61 v61.0.0
 

--- a/tools/linters/go.mod
+++ b/tools/linters/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/stackrox/tools/linters
 
-go 1.25
+go 1.25.3
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.7.2

--- a/tools/proto/go.mod
+++ b/tools/proto/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/stackrox/tools/proto
 
-go 1.25
+go 1.25.3
 
 require (
 	github.com/bufbuild/buf v1.63.0

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackrox/stackrox/tools/test
 
-go 1.25
+go 1.25.3
 
 require (
 	github.com/jstemmer/go-junit-report/v2 v2.1.0


### PR DESCRIPTION
## Description

Update all go.mod files to require Go 1.25.3, which includes the fix for CVE-2025-58183 (archive/tar unbounded allocation vulnerability).

**Problem:** The go.mod files declared go 1.25.0, which is vulnerable to CVE-2025-58183. While konflux builds already use Go 1.25.3, local development could use vulnerable versions.

**Solution:** Updated all 12 go.mod files to require go 1.25.3 to ensure developers are warned if using older Go versions and to document the actual Go version requirement.

**Why:** Konflux builder already uses Go 1.25.3, this change ensures consistency between production builds and local development environment requirements.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Verified all 12 go.mod files now declare go 1.25.3
- Confirmed konflux builder already uses Go 1.25.3 by running: `docker run --rm brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.25@sha256:527782f4a0270f786192281f68d0374f4a21b3ab759643eee4bfcafb6f539468 go version`
- CI will validate that the go.mod changes don't break any builds