### PR TITLE
feat: active-passive HA PoC for Central using leader election

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -227,10 +228,16 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	pkgVersion "github.com/stackrox/rox/pkg/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
 
 var (
-	log = logging.CreateLogger(logging.CurrentModule(), 0)
+	log      = logging.CreateLogger(logging.CurrentModule(), 0)
+	isLeader atomic.Bool
 
 	authProviderBackendFactories = map[string]authproviders.BackendFactoryCreator{
 		oidc.TypeName:                oidc.NewFactory,
@@ -273,6 +280,75 @@ func runSafeMode() {
 	sig := <-signalsC
 	log.Infof("Caught %s signal", sig)
 	log.Info("Central terminated")
+}
+
+func runLeaderElection(ctx context.Context) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.Errorf("Failed to get in-cluster config: %v", err)
+		return
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Errorf("Failed to create kubernetes client: %v", err)
+		return
+	}
+
+	podName := os.Getenv("POD_NAME")
+	if podName == "" {
+		podName = "central-unknown"
+		log.Warn("POD_NAME not set, using default")
+	}
+
+	namespace := os.Getenv("POD_NAMESPACE")
+	if namespace == "" {
+		namespace = "stackrox"
+		log.Warn("POD_NAMESPACE not set, using default 'stackrox'")
+	}
+
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      "central-leader",
+			Namespace: namespace,
+		},
+		Client: client.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: podName,
+		},
+	}
+
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: 5 * time.Second,
+		RenewDeadline: 3 * time.Second,
+		RetryPeriod:   1 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				isLeader.Store(true)
+				pingService.IsLeader.Store(true)
+				log.Info("Became leader, starting all services")
+
+				// Start all services only when we become leader
+				go startGRPCServer()
+				go startTelemetryServer()
+
+				if env.ManagedCentral.BooleanSetting() {
+					clusterInternalServer := internal.NewHTTPServer(metrics.HTTPSingleton())
+					clusterInternalServer.AddRoutes(clusterInternalRoutes())
+					go clusterInternalServer.RunForever()
+				}
+			},
+			OnStoppedLeading: func() {
+				log.Fatal("Lost leadership, exiting for restart")
+			},
+			OnNewLeader: func(identity string) {
+				if identity != podName {
+					log.Infof("New leader elected: %s", identity)
+				}
+			},
+		},
+	})
 }
 
 func main() {
@@ -320,14 +396,8 @@ func main() {
 
 	features.LogFeatureFlags()
 
-	go startGRPCServer()
-	go startTelemetryServer()
-
-	if env.ManagedCentral.BooleanSetting() {
-		clusterInternalServer := internal.NewHTTPServer(metrics.HTTPSingleton())
-		clusterInternalServer.AddRoutes(clusterInternalRoutes())
-		clusterInternalServer.RunForever()
-	}
+	// Start leader election - services will start only when we become leader
+	go runLeaderElection(ctx)
 
 	waitForTerminationSignal()
 }

--- a/image/templates/helm/stackrox-central/templates/01-central-03-leader-election-rbac.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-03-leader-election-rbac.yaml
@@ -1,0 +1,33 @@
+{{- include "srox.init" . -}}
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: central-leader-election
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "srox.annotations" (list . "role" "central-leader-election") | nindent 4 }}
+  labels:
+    {{- include "srox.labels" (list . "role" "central-leader-election") | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: central-leader-election
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "srox.annotations" (list . "rolebinding" "central-leader-election") | nindent 4 }}
+  labels:
+    {{- include "srox.labels" (list . "rolebinding" "central-leader-election") | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: central
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: central-leader-election
+  apiGroup: rbac.authorization.k8s.io

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -11,7 +11,7 @@ metadata:
   annotations:
     {{- include "srox.annotations" (list . "deployment" "central") | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: 2
   minReadySeconds: 15
   selector:
     matchLabels:


### PR DESCRIPTION
## Description

Proof of concept for Central high availability using active-passive model with Kubernetes leader election.

## Changes
- Add leader election to Central using client-go
- Only leader pod passes readiness probe
- 2 replicas deployed

## Known Concerns
- Passive pod showing as "NotReady" for extended time periods may trigger customer alerts.
  - The correct "production ready" solution here would be to use separate liveness and readiness probes. Liveness passes on both pods (showing "healthy"), readiness only passes on leader (controlling traffic routing). Most k8s dashboards distinguish these clearly.

## Testing Summary

Deployed and tested on GKE cluster using CI-built image `4.10.x-788-g41b81b48a1`.

Deployment:
```bash
MAIN_IMAGE_TAG=4.10.x-788-g41b81b48a1 roxie deploy
...
# Verified leader election
$ oc get pods -n acs-central -l app=central
NAME                       READY   STATUS    RESTARTS   AGE
central-6646cfccd5-cgw7r   1/1     Running   0          3m21s <-- Leader (Ready)
central-6646cfccd5-j9pqh   0/1     Running   0          3m21s <-- Standby (Not Ready)

## Verified logs show correct behavior

## Testing Summary

Deployed and tested on GKE cluster using CI-built image `4.10.x-788-g41b81b48a1`.

**Deployment:**
```bash
MAIN_IMAGE_TAG=4.10.x-788-g41b81b48a1 roxie deploy

Verified leader election:
$ oc get pods -n acs-central -l app=central
NAME                       READY   STATUS    RESTARTS   AGE
central-6646cfccd5-cgw7r   1/1     Running   0          3m21s
central-6646cfccd5-j9pqh   0/1     Running   0          3m21s
- Only 1/2 pods Ready (leader pod)
- Standby pod running but NotReady

Verified logs show correct behavior:
$ oc logs -n acs-central central-6646cfccd5-cgw7r | grep -i "leader\|election"
I0114 20:18:45.903944       1 leaderelection.go:272] "Successfully acquired lease"
main: 2026/01/14 20:18:45.904209 main.go:330: Info: Became leader, starting all services

$ oc logs -n acs-central central-6646cfccd5-j9pqh | grep -i "leader\|election"
I0114 20:18:49.510579       1 leaderelection.go:258] "Attempting to acquire leader lease..."
main: 2026/01/14 20:18:49.528383 main.go:347: Info: New leader elected: central-6646cfccd5-cgw7r
- Leader: "Successfully acquired lease" → "Became leader, starting all services"
- Standby: "New leader elected: central-6646cfccd5-cgw7r"

Tested failover:
$ oc delete pod -n acs-central central-6646cfccd5-cgw7r
$ oc get pods -n acs-central -l app=central -w
central-6646cfccd5-j9pqh   0/1 → 1/1     (became leader ~15s after lease expired)
central-6646cfccd5-t4jll   0/1            (new standby pod created)

$ oc logs -n acs-central central-6646cfccd5-j9pqh | grep -i "leader\|election" | tail -20
I0114 20:23:05.591711       1 leaderelection.go:272] "Successfully acquired lease"
main: 2026/01/14 20:23:05.591915 main.go:330: Info: Became leader, starting all services
- Standby automatically became leader after ~15s
- Started all services and became Ready
- New standby pod created by deployment controller