### PR TITLE
ROX-30571: roxctl sbom scan

### DIFF
--- a/roxctl/maincommand/command.go
+++ b/roxctl/maincommand/command.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackrox/rox/roxctl/image"
 	"github.com/stackrox/rox/roxctl/logconvert"
 	"github.com/stackrox/rox/roxctl/netpol"
+	"github.com/stackrox/rox/roxctl/sbom"
 	"github.com/stackrox/rox/roxctl/scanner"
 	"github.com/stackrox/rox/roxctl/sensor"
 )
@@ -80,6 +81,7 @@ func Command() *cobra.Command {
 		deployment.Command(cliEnvironment),
 		logconvert.Command(cliEnvironment),
 		image.Command(cliEnvironment),
+		sbom.Command(cliEnvironment),
 		scanner.Command(cliEnvironment),
 		sensor.Command(cliEnvironment),
 		helm.Command(cliEnvironment),

--- a/roxctl/maincommand/command_tree_debug.yaml
+++ b/roxctl/maincommand/command_tree_debug.yaml
@@ -1940,6 +1940,53 @@ netpol:
       - server-name
       - token-file
       - use-current-k8s-context
+sbom:
+  PERSISTENT_FLAGS:
+    - timeout
+  INHERITED_FLAGS:
+    - ca
+    - direct-grpc
+    - endpoint
+    - force-http1
+    - help
+    - insecure
+    - insecure-skip-tls-verify
+    - no-color
+    - password
+    - plaintext
+    - server-name
+    - token-file
+    - use-current-k8s-context
+  scan:
+    LOCAL_FLAGS:
+      - content-type
+      - fail
+      - file
+      - severity
+    PERSISTENT_FLAGS:
+      - compact-output
+      - headers
+      - headers-as-comments
+      - merge-output
+      - no-header
+      - output
+      - required-headers
+      - row-jsonpath-expressions
+    INHERITED_FLAGS:
+      - ca
+      - direct-grpc
+      - endpoint
+      - force-http1
+      - help
+      - insecure
+      - insecure-skip-tls-verify
+      - no-color
+      - password
+      - plaintext
+      - server-name
+      - timeout
+      - token-file
+      - use-current-k8s-context
 scanner:
   INHERITED_FLAGS:
     - ca

--- a/roxctl/maincommand/command_tree_release.yaml
+++ b/roxctl/maincommand/command_tree_release.yaml
@@ -1901,6 +1901,53 @@ netpol:
       - server-name
       - token-file
       - use-current-k8s-context
+sbom:
+  PERSISTENT_FLAGS:
+    - timeout
+  INHERITED_FLAGS:
+    - ca
+    - direct-grpc
+    - endpoint
+    - force-http1
+    - help
+    - insecure
+    - insecure-skip-tls-verify
+    - no-color
+    - password
+    - plaintext
+    - server-name
+    - token-file
+    - use-current-k8s-context
+  scan:
+    LOCAL_FLAGS:
+      - content-type
+      - fail
+      - file
+      - severity
+    PERSISTENT_FLAGS:
+      - compact-output
+      - headers
+      - headers-as-comments
+      - merge-output
+      - no-header
+      - output
+      - required-headers
+      - row-jsonpath-expressions
+    INHERITED_FLAGS:
+      - ca
+      - direct-grpc
+      - endpoint
+      - force-http1
+      - help
+      - insecure
+      - insecure-skip-tls-verify
+      - no-color
+      - password
+      - plaintext
+      - server-name
+      - timeout
+      - token-file
+      - use-current-k8s-context
 scanner:
   INHERITED_FLAGS:
     - ca

--- a/roxctl/sbom/sbom.go
+++ b/roxctl/sbom/sbom.go
@@ -1,0 +1,23 @@
+package sbom
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
+	"github.com/stackrox/rox/roxctl/sbom/scan"
+)
+
+// Command defines the image command tree
+func Command(cliEnvironment environment.Environment) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "sbom",
+		Short: "Commands that you can run on SBOMs",
+	}
+
+	c.AddCommand(scan.Command(cliEnvironment))
+
+	flags.AddTimeoutWithDefault(c, 5*time.Minute)
+	return c
+}

--- a/roxctl/sbom/sbom.go
+++ b/roxctl/sbom/sbom.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stackrox/rox/roxctl/sbom/scan"
 )
 
-// Command defines the image command tree
+// Command defines the sbom command tree.
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "sbom",

--- a/roxctl/sbom/scan/scan.go
+++ b/roxctl/sbom/scan/scan.go
@@ -1,0 +1,271 @@
+package scan
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/printers"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/roxctl/common"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/flags"
+	"github.com/stackrox/rox/roxctl/common/printer"
+	"github.com/stackrox/rox/roxctl/common/scan"
+	"github.com/stackrox/rox/roxctl/common/util"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const (
+	sbomScanAPIPath = "/api/v1/sboms/scan"
+)
+
+// Command detects vulnerabilities from SBOM contents.
+func Command(cliEnvironment environment.Environment) *cobra.Command {
+	sbomScanCmd := &sbomScanCommand{env: cliEnvironment}
+
+	objectPrinterFactory, err := printer.NewObjectPrinterFactory("",
+		printer.NewTabularPrinterFactoryWithAutoMerge(),
+		printer.NewJSONPrinterFactory(false, false),
+		printer.NewSarifPrinterFactory(
+			printers.SarifVulnerabilityReport,
+			scan.SarifJSONPathExpressions,
+			&sbomScanCmd.sbomFilePath),
+	)
+	// should not happen when using default values, must be a programming error.
+	utils.Must(err)
+
+	// Set the Output Format to empty, by default raw unformatted json will be printed.
+	objectPrinterFactory.OutputFormat = ""
+
+	c := &cobra.Command{
+		Use:   "scan",
+		Short: "[DEV PREVIEW] Scan the specified SBOM and return scan results",
+		Long:  "[DEV PREVIEW] Scan the specified SBOM and return scan results. You must have write permissions to the `Image` resource. Currently supports SPDX 2.3 JSON documents with content types: [`application/spdx+json`, `text/spdx+json`].",
+		RunE: util.RunENoArgs(func(c *cobra.Command) error {
+			if err := sbomScanCmd.Construct(nil, c, objectPrinterFactory); err != nil {
+				return err
+			}
+
+			if err := sbomScanCmd.Validate(); err != nil {
+				return err
+			}
+
+			return sbomScanCmd.ScanSBOM()
+		}),
+	}
+
+	objectPrinterFactory.AddFlags(c)
+
+	c.Flags().StringVarP(&sbomScanCmd.sbomFilePath, "file", "", "", "SBOM file to scan. Must be SPDX 2.3 JSON.")
+	c.Flags().StringVarP(&sbomScanCmd.contentType, "content-type", "", "", "Set the content-type for the SBOM file, if unset will be auto-detected.")
+	c.Flags().StringSliceVar(&sbomScanCmd.severities, "severity", scan.AllSeverities, "List of severities to include in the output. Use this to filter for specific severities.")
+	c.Flags().BoolVarP(&sbomScanCmd.failOnFinding, "fail", "", false, "Fail if vulnerabilities have been found.")
+
+	utils.Must(c.MarkFlagRequired("file"))
+
+	return c
+}
+
+// sbomScanCommands holds all configurations and metadata to execute an SBOM scan.
+type sbomScanCommand struct {
+	sbomFilePath  string
+	contentType   string
+	severities    []string
+	failOnFinding bool
+
+	// injected or constructed values
+	env                environment.Environment
+	client             common.RoxctlHTTPClient
+	printer            printer.ObjectPrinter
+	standardizedFormat bool
+	noOutputFormat     bool
+}
+
+// Construct will enhance the struct with other values coming either from os.Args, other, global flags or environment variables.
+func (s *sbomScanCommand) Construct(_ []string, cmd *cobra.Command, f *printer.ObjectPrinterFactory) error {
+	var err error
+
+	if f.OutputFormat == "" {
+		s.noOutputFormat = true
+	} else {
+		p, err := f.CreatePrinter()
+		if err != nil {
+			return errors.Wrap(err, "could not create printer for displaying sbom scan result")
+		}
+		s.printer = p
+		s.standardizedFormat = f.IsStandardizedFormat()
+	}
+
+	s.client, err = s.env.HTTPClient(flags.Timeout(cmd))
+	if err != nil {
+		return errors.Wrap(err, "creating HTTP client")
+	}
+
+	return nil
+}
+
+// Validate will validate the injected values and check whether it's possible to execute the operation with the
+// provided values.
+func (s *sbomScanCommand) Validate() error {
+	// Check if the SBOM file exists.
+	if _, err := os.Stat(s.sbomFilePath); err != nil {
+		if os.IsNotExist(err) {
+			return errox.InvalidArgs.Newf("SBOM file does not exist: %q", s.sbomFilePath)
+		}
+		return errors.Wrapf(err, "checking SBOM file %q", s.sbomFilePath)
+	}
+
+	return nil
+}
+
+// Scan will execute the SBOM scan with retry functionality.
+func (s *sbomScanCommand) ScanSBOM() error {
+	// Open the SBOM file for reading.
+	sbomFile, err := os.Open(s.sbomFilePath)
+	if err != nil {
+		return fmt.Errorf("opening SBOM file: %w", err)
+	}
+	defer utils.IgnoreError(sbomFile.Close)
+
+	// Guess the media type.
+	if s.contentType == "" {
+		s.contentType, err = guessMediaType(sbomFile)
+		if err != nil {
+			return errors.Wrap(err, "auto detecting media type")
+		}
+	}
+
+	// Make the scan request.
+	req, err := s.client.NewReq(http.MethodPost, sbomScanAPIPath, sbomFile)
+	if err != nil {
+		return errors.Wrap(err, "creating SBOM scan request")
+	}
+	req.Header.Add("Content-Type", s.contentType)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("scanning SBOM: %w", err)
+	}
+	defer utils.IgnoreError(resp.Body.Close)
+
+	// Verify the scan was successful.
+	if resp.StatusCode != http.StatusOK {
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "received unexpected status code %d. Additionally, there was an error reading the response", resp.StatusCode)
+		}
+		return errox.InvariantViolation.Newf("received unexpected status code %d. Response Body: %s", resp.StatusCode, string(data))
+	}
+
+	// Central returns a 200 response with Content-Type text/html for any unimplemented '/api/*' endpoints,
+	// catch this and return an error.
+	contentType := resp.Header.Get("Content-Type")
+	if strings.Contains(contentType, "text/html") {
+		return errors.Errorf("received unexpected Content-Type %q from Central, confirm Central version supports SBOM scanning at: %q", contentType, sbomScanAPIPath)
+	}
+
+	// Print the results.
+	return s.printSBOMScanResults(resp.Body)
+}
+
+// guessMediaType will attempt to guess the media type of the SBOM file based on the first
+// 4KB bytes. If it is unable to guess will return an error.
+//
+// The backend currently requires SPDX 2.3 JSON, which when detected will return
+// media type `text/spdx+json`.
+func guessMediaType(sbomFile *os.File) (string, error) {
+	// Read 4KB of the file, should be enough to detect the SPDX metadata.
+	buf := make([]byte, 4096)
+	n, err := sbomFile.Read(buf)
+	if err != nil && err != io.EOF {
+		return "", errors.Wrap(err, "reading SBOM file")
+	}
+
+	// Reset file pointer to beginning so the file can be read again.
+	if _, err := sbomFile.Seek(0, 0); err != nil {
+		return "", errors.Wrap(err, "resetting file position")
+	}
+
+	content := string(buf[:n])
+
+	// Skip UTF-8 BOM if present (0xEF, 0xBB, 0xBF).
+	content = strings.TrimPrefix(content, "\xEF\xBB\xBF")
+
+	// Quick check if content looks like JSON by checking if it starts with { or [.
+	trimmed := strings.TrimLeft(content, " \t\n\r")
+	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") {
+		return "", errox.InvalidArgs.New("SBOM file does not appear to be valid JSON")
+	}
+
+	// Look for the spdxVersion field.
+	if idx := strings.Index(content, `"spdxVersion"`); idx != -1 {
+		remaining := content[idx+len(`"spdxVersion"`):]
+		// Find the colon after the field name.
+		colonIdx := strings.Index(remaining, ":")
+		if colonIdx != -1 {
+			// Get content after the colon.
+			afterColon := remaining[colonIdx+1:]
+			// Remove whitespace only.
+			afterColon = strings.TrimLeft(afterColon, " \t\n\r")
+			if strings.HasPrefix(afterColon, `"SPDX-2.3"`) {
+				return "text/spdx+json", nil
+			}
+		}
+	}
+
+	return "", errox.InvalidArgs.New("unsupported SBOM format")
+}
+
+// printSBOMScanResults prints the SBOM results using the appropriate format
+// specified via the command flags. The output format will resemble
+// that for the `image scan` command.
+func (s *sbomScanCommand) printSBOMScanResults(reader io.Reader) error {
+	if s.noOutputFormat {
+		// Write the raw contents by default.
+		_, err := io.Copy(s.env.InputOutput().Out(), reader)
+		if err != nil {
+			return errors.Wrap(err, "reading response body")
+		}
+		return nil
+	}
+
+	// To re-use formatting logic from elsewhere in roxctl, we marshal the contents into
+	// storage.Image which 'should have' overlapping field structure with v1.SBOMScanResponse.
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return errors.Wrap(err, "reading response body")
+	}
+
+	image := &storage.Image{}
+	err = protojson.Unmarshal(data, image)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling response")
+	}
+
+	cveSummary := scan.NewCVESummaryForPrinting(image.GetScan(), s.severities)
+	if !s.standardizedFormat {
+		scan.PrintCVESummary(s.sbomFilePath, cveSummary.Result.Summary, s.env.Logger())
+	}
+
+	if err := s.printer.Print(cveSummary, s.env.ColorWriter()); err != nil {
+		return errors.Wrap(err, "could not print scan results")
+	}
+
+	if !s.standardizedFormat {
+		scan.PrintCVEWarning(cveSummary.CountVulnerabilities(), cveSummary.CountComponents(), s.env.Logger())
+	}
+
+	if cveCount := cveSummary.CountVulnerabilities(); s.failOnFinding && cveCount > 0 {
+		//nolint:wrapcheck // Preserving error message from scan package for consistent CLI output.
+		return scan.NewErrVulnerabilityFound(cveCount)
+	}
+
+	return nil
+}

--- a/roxctl/sbom/scan/scan.go
+++ b/roxctl/sbom/scan/scan.go
@@ -104,7 +104,12 @@ func (s *sbomScanCommand) Construct(_ []string, cmd *cobra.Command, f *printer.O
 		s.standardizedFormat = f.IsStandardizedFormat()
 	}
 
-	s.client, err = s.env.HTTPClient(flags.Timeout(cmd))
+	s.client, err = s.env.HTTPClient(
+		flags.Timeout(cmd),
+		// Do not retry. Otherwise the http client's default retry count and delay make the scan
+		// appear hung when timeout expires.
+		common.WithRetryCount(0),
+	)
 	if err != nil {
 		return errors.Wrap(err, "creating HTTP client")
 	}

--- a/roxctl/sbom/scan/scan.go
+++ b/roxctl/sbom/scan/scan.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -120,6 +121,14 @@ func (s *sbomScanCommand) Validate() error {
 			return errox.InvalidArgs.Newf("SBOM file does not exist: %q", s.sbomFilePath)
 		}
 		return errors.Wrapf(err, "checking SBOM file %q", s.sbomFilePath)
+	}
+
+	for _, severity := range s.severities {
+		severity := strings.ToUpper(severity)
+		if !slices.Contains(scan.AllSeverities, severity) {
+			return errox.InvalidArgs.Newf("invalid severity %q used. Choose one of [%s]", severity,
+				strings.Join(scan.AllSeverities, ", "))
+		}
 	}
 
 	return nil

--- a/roxctl/sbom/scan/scan.go
+++ b/roxctl/sbom/scan/scan.go
@@ -27,6 +27,10 @@ const (
 	sbomScanAPIPath = "/api/v1/sboms/scan"
 )
 
+var (
+	validSeverities = scan.AllSeverities()
+)
+
 // Command detects vulnerabilities from SBOM contents.
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	sbomScanCmd := &sbomScanCommand{env: cliEnvironment}
@@ -66,7 +70,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	c.Flags().StringVarP(&sbomScanCmd.sbomFilePath, "file", "", "", "SBOM file to scan. Must be SPDX 2.3 JSON.")
 	c.Flags().StringVarP(&sbomScanCmd.contentType, "content-type", "", "", "Set the content-type for the SBOM file, if unset will be auto-detected.")
-	c.Flags().StringSliceVar(&sbomScanCmd.severities, "severity", scan.AllSeverities, "List of severities to include in the output. Use this to filter for specific severities.")
+	c.Flags().StringSliceVar(&sbomScanCmd.severities, "severity", validSeverities, "List of severities to include in the output. Use this to filter for specific severities.")
 	c.Flags().BoolVarP(&sbomScanCmd.failOnFinding, "fail", "", false, "Fail if vulnerabilities have been found.")
 
 	utils.Must(c.MarkFlagRequired("file"))
@@ -130,9 +134,9 @@ func (s *sbomScanCommand) Validate() error {
 
 	for _, severity := range s.severities {
 		severity := strings.ToUpper(severity)
-		if !slices.Contains(scan.AllSeverities, severity) {
+		if !slices.Contains(validSeverities, severity) {
 			return errox.InvalidArgs.Newf("invalid severity %q used. Choose one of [%s]", severity,
-				strings.Join(scan.AllSeverities, ", "))
+				strings.Join(validSeverities, ", "))
 		}
 	}
 

--- a/roxctl/sbom/scan/scan.go
+++ b/roxctl/sbom/scan/scan.go
@@ -260,7 +260,8 @@ func (s *sbomScanCommand) printSBOMScanResults(reader io.Reader) error {
 
 	cveSummary := scan.NewCVESummaryForPrinting(image.GetScan(), s.severities)
 	if !s.standardizedFormat {
-		scan.PrintCVESummary(s.sbomFilePath, cveSummary.Result.Summary, s.env.Logger())
+		s.env.Logger().PrintfLn("Scan results for SBOM: %s", s.sbomFilePath)
+		scan.PrintCVESummary(cveSummary.Result.Summary, s.env.Logger())
 	}
 
 	if err := s.printer.Print(cveSummary, s.env.ColorWriter()); err != nil {

--- a/roxctl/sbom/scan/scan.go
+++ b/roxctl/sbom/scan/scan.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -29,6 +30,8 @@ const (
 
 var (
 	validSeverities = scan.AllSeverities()
+
+	errInvalidSBOM = errox.InvalidArgs.New("invalid or unsupported SBOM")
 )
 
 // Command detects vulnerabilities from SBOM contents.
@@ -68,10 +71,10 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	objectPrinterFactory.AddFlags(c)
 
-	c.Flags().StringVarP(&sbomScanCmd.sbomFilePath, "file", "", "", "SBOM file to scan. Must be SPDX 2.3 JSON.")
-	c.Flags().StringVarP(&sbomScanCmd.contentType, "content-type", "", "", "Set the content-type for the SBOM file, if unset will be auto-detected.")
+	c.Flags().StringVar(&sbomScanCmd.sbomFilePath, "file", "", "SBOM file to scan. Must be SPDX 2.3 JSON.")
+	c.Flags().StringVar(&sbomScanCmd.contentType, "content-type", "", "Set the content-type for the SBOM file, if unset will be auto-detected.")
 	c.Flags().StringSliceVar(&sbomScanCmd.severities, "severity", validSeverities, "List of severities to include in the output. Use this to filter for specific severities.")
-	c.Flags().BoolVarP(&sbomScanCmd.failOnFinding, "fail", "", false, "Fail if vulnerabilities have been found.")
+	c.Flags().BoolVar(&sbomScanCmd.failOnFinding, "fail", false, "Fail if vulnerabilities have been found.")
 
 	utils.Must(c.MarkFlagRequired("file"))
 
@@ -193,52 +196,50 @@ func (s *sbomScanCommand) ScanSBOM() error {
 	return s.printSBOMScanResults(resp.Body)
 }
 
-// guessMediaType will attempt to guess the media type of the SBOM file based on the first
-// 4KB bytes. If it is unable to guess will return an error.
+// guessMediaType will attempt to guess the media type of the SBOM file.
+// If it is unable to guess will return an error.
 //
-// The backend currently requires SPDX 2.3 JSON, which when detected will return
-// media type `text/spdx+json`.
+// At this time only SPDX 2.3 JSON documents are supported.
 func guessMediaType(sbomFile *os.File) (string, error) {
-	// Read 4KB of the file, should be enough to detect the SPDX metadata.
-	buf := make([]byte, 4096)
-	n, err := sbomFile.Read(buf)
-	if err != nil && err != io.EOF {
-		return "", errors.Wrap(err, "reading SBOM file")
-	}
-
-	// Reset file pointer to beginning so the file can be read again.
-	if _, err := sbomFile.Seek(0, 0); err != nil {
-		return "", errors.Wrap(err, "resetting file position")
-	}
-
-	content := string(buf[:n])
-
-	// Skip UTF-8 BOM if present (0xEF, 0xBB, 0xBF).
-	content = strings.TrimPrefix(content, "\xEF\xBB\xBF")
-
-	// Quick check if content looks like JSON by checking if it starts with { or [.
-	trimmed := strings.TrimLeft(content, " \t\n\r")
-	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") {
-		return "", errox.InvalidArgs.New("SBOM file does not appear to be valid JSON")
-	}
-
-	// Look for the spdxVersion field.
-	if idx := strings.Index(content, `"spdxVersion"`); idx != -1 {
-		remaining := content[idx+len(`"spdxVersion"`):]
-		// Find the colon after the field name.
-		colonIdx := strings.Index(remaining, ":")
-		if colonIdx != -1 {
-			// Get content after the colon.
-			afterColon := remaining[colonIdx+1:]
-			// Remove whitespace only.
-			afterColon = strings.TrimLeft(afterColon, " \t\n\r")
-			if strings.HasPrefix(afterColon, `"SPDX-2.3"`) {
-				return "text/spdx+json", nil
+	decoder := json.NewDecoder(sbomFile)
+	for {
+		tok, err := decoder.Token()
+		if err != nil {
+			// io.EOF means the token stream is exhausted without having found
+			// a recognized spdxVersion. This covers both empty files and
+			// valid JSON documents that are not SPDX.
+			if err == io.EOF {
+				return "", errInvalidSBOM
 			}
+			// json.SyntaxError is returned when the decoder encounters bytes
+			// that are not valid JSON (e.g. XML, binary, plain text files).
+			if _, ok := err.(*json.SyntaxError); ok {
+				return "", errInvalidSBOM
+			}
+			return "", errors.Wrap(err, "reading SBOM file")
 		}
-	}
 
-	return "", errox.InvalidArgs.New("unsupported SBOM format")
+		// Skip if not the version field.
+		if val, ok := tok.(string); !ok || val != "spdxVersion" {
+			continue
+		}
+
+		// Read the version value.
+		tok, err = decoder.Token()
+		if err != nil {
+			return "", errors.Wrap(err, "reading SBOM file")
+		}
+
+		// If the version is supported, reset the file position and return the type.
+		if val, ok := tok.(string); ok && val == "SPDX-2.3" {
+			if _, err := sbomFile.Seek(0, 0); err != nil {
+				return "", errors.Wrap(err, "resetting file position")
+			}
+			return "text/spdx+json", nil
+		}
+
+		return "", errox.InvalidArgs.New("unsupported SBOM version")
+	}
 }
 
 // printSBOMScanResults prints the SBOM results using the appropriate format

--- a/roxctl/sbom/scan/scan_test.go
+++ b/roxctl/sbom/scan/scan_test.go
@@ -1,0 +1,657 @@
+package scan
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/environment/mocks"
+	cliIO "github.com/stackrox/rox/roxctl/common/io"
+	"github.com/stackrox/rox/roxctl/common/printer"
+	"github.com/stackrox/rox/roxctl/common/scan"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+var (
+	testSBOMScanResponse = &v1.SBOMScanResponse{
+		Scan: &v1.SBOMScanResponse_SBOMScan{
+			Components: []*storage.EmbeddedImageScanComponent{
+				{
+					Name:    "test-component",
+					Version: "1.0.0",
+					Vulns: []*storage.EmbeddedVulnerability{
+						{
+							Cve:      "CVE-2024-1234",
+							Severity: storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+							Cvss:     9.0,
+							Link:     "https://nvd.nist.gov/vuln/detail/CVE-2024-1234",
+							Advisory: &storage.Advisory{
+								Name: "ADVISORY-2024-1234",
+								Link: "https://example.com/advisory/2024-1234",
+							},
+							SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{
+								FixedBy: "1.0.1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestSBOMScanCommand(t *testing.T) {
+	suite.Run(t, new(sbomScanTestSuite))
+}
+
+type sbomScanTestSuite struct {
+	suite.Suite
+	tempDir string
+}
+
+func (s *sbomScanTestSuite) SetupTest() {
+	tempDir, err := os.MkdirTemp("", "sbom-scan-test-*")
+	s.Require().NoError(err)
+	s.tempDir = tempDir
+}
+
+func (s *sbomScanTestSuite) TearDownTest() {
+	if s.tempDir != "" {
+		_ = os.RemoveAll(s.tempDir)
+	}
+}
+
+func (s *sbomScanTestSuite) createTempFile(name string, content string) string {
+	filePath := filepath.Join(s.tempDir, name)
+	err := os.WriteFile(filePath, []byte(content), 0644)
+	s.Require().NoError(err)
+	return filePath
+}
+
+func (s *sbomScanTestSuite) TestConstruct() {
+	jsonFactory := printer.NewJSONPrinterFactory(false, false)
+	jsonPrinter, err := jsonFactory.CreatePrinter("json")
+	s.Require().NoError(err)
+
+	validObjPrinterFactory, err := printer.NewObjectPrinterFactory("json", jsonFactory)
+	s.Require().NoError(err)
+
+	emptyOutputFormatPrinterFactory, err := printer.NewObjectPrinterFactory("json", jsonFactory)
+	s.Require().NoError(err)
+	emptyOutputFormatPrinterFactory.OutputFormat = ""
+
+	cases := map[string]struct {
+		printerFactory     *printer.ObjectPrinterFactory
+		standardizedFormat bool
+		noOutputFormat     bool
+		expectedPrinter    printer.ObjectPrinter
+		httpClientErr      error
+		shouldFail         bool
+	}{
+		"valid printer factory with output format": {
+			printerFactory:     validObjPrinterFactory,
+			standardizedFormat: true,
+			expectedPrinter:    jsonPrinter,
+			noOutputFormat:     false,
+		},
+		"empty output format should set noOutputFormat flag": {
+			printerFactory: emptyOutputFormatPrinterFactory,
+			noOutputFormat: true,
+		},
+		"HTTP client error should propagate": {
+			printerFactory: validObjPrinterFactory,
+			httpClientErr:  errors.New("http client creation failed"),
+			shouldFail:     true,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			ctrl := gomock.NewController(s.T())
+			defer ctrl.Finish()
+
+			mockEnv := mocks.NewMockEnvironment(ctrl)
+			mockClient := &mockHTTPClient{}
+
+			// Mock the HTTPClient call.
+			if c.httpClientErr != nil {
+				mockEnv.EXPECT().HTTPClient(gomock.Any()).Return(nil, c.httpClientErr)
+			} else {
+				mockEnv.EXPECT().HTTPClient(gomock.Any()).Return(mockClient, nil)
+			}
+
+			// Create command with timeout flag to avoid panic.
+			cmd := &cobra.Command{Use: "test"}
+			cmd.Flags().Duration("timeout", 0, "")
+
+			sbomScanCmd := &sbomScanCommand{env: mockEnv}
+
+			err := sbomScanCmd.Construct(nil, cmd, c.printerFactory)
+
+			if c.shouldFail {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+				s.Assert().Equal(c.expectedPrinter, sbomScanCmd.printer)
+				s.Assert().Equal(c.standardizedFormat, sbomScanCmd.standardizedFormat)
+				s.Assert().Equal(c.noOutputFormat, sbomScanCmd.noOutputFormat)
+				s.Assert().NotNil(sbomScanCmd.client)
+			}
+		})
+	}
+}
+func (s *sbomScanTestSuite) TestValidate() {
+	cases := map[string]struct {
+		setupFunc  func() string
+		shouldFail bool
+		errorType  error
+	}{
+		"valid SBOM file exists": {
+			setupFunc: func() string {
+				return s.createTempFile("valid.json", `{"spdxVersion":"SPDX-2.3"}`)
+			},
+			shouldFail: false,
+		},
+		"SBOM file does not exist": {
+			setupFunc: func() string {
+				return filepath.Join(s.tempDir, "nonexistent.json")
+			},
+			shouldFail: true,
+			errorType:  errox.InvalidArgs,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			sbomPath := c.setupFunc()
+			cmd := &sbomScanCommand{
+				sbomFilePath: sbomPath,
+			}
+
+			err := cmd.Validate()
+			if c.shouldFail {
+				s.Require().Error(err)
+				s.Assert().ErrorIs(err, c.errorType)
+			} else {
+				s.Require().NoError(err)
+			}
+		})
+	}
+}
+
+func (s *sbomScanTestSuite) TestScanSBOM_Success() {
+	// Create a valid SBOM file.
+	sbomContent := `{"spdxVersion": "SPDX-2.3", "name": "test-sbom"}`
+	sbomPath := s.createTempFile("sbom.json", sbomContent)
+
+	responseData, err := protojson.Marshal(testSBOMScanResponse)
+	s.Require().NoError(err)
+
+	mockClient := &mockHTTPClient{
+		newReqFunc: func(method string, path string, body io.Reader) (*http.Request, error) {
+			s.Assert().Equal(http.MethodPost, method)
+			s.Assert().Equal(sbomScanAPIPath, path)
+			return http.NewRequest(method, "http://localhost"+path, body)
+		},
+		doFunc: func(req *http.Request) (*http.Response, error) {
+			// Verify the request has the correct content type.
+			s.Assert().Equal("text/spdx+json", req.Header.Get("Content-Type"))
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(responseData)),
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+			}, nil
+		},
+	}
+
+	// Create command with raw output (no formatting).
+	testIO, _, out, _ := cliIO.TestIO()
+	env := environment.NewTestCLIEnvironment(s.T(), testIO, printer.DefaultColorPrinter())
+
+	cmd := &sbomScanCommand{
+		sbomFilePath:   sbomPath,
+		env:            env,
+		client:         mockClient,
+		noOutputFormat: true,
+		severities:     scan.AllSeverities,
+	}
+
+	err = cmd.ScanSBOM()
+	s.Require().NoError(err)
+
+	// Verify raw output was written.
+	s.Assert().Contains(out.String(), "test-component")
+}
+
+func (s *sbomScanTestSuite) TestScanSBOM_FileNotFound() {
+	sbomPath := filepath.Join(s.tempDir, "nonexistent.json")
+
+	io, _, _, _ := cliIO.TestIO()
+	env := environment.NewTestCLIEnvironment(s.T(), io, printer.DefaultColorPrinter())
+
+	cmd := &sbomScanCommand{
+		sbomFilePath: sbomPath,
+		env:          env,
+	}
+
+	err := cmd.ScanSBOM()
+	s.Require().Error(err)
+	s.Assert().Contains(err.Error(), "opening SBOM file")
+}
+
+func (s *sbomScanTestSuite) TestScanSBOM_NonOKStatusCode() {
+	sbomContent := `{"spdxVersion": "SPDX-2.3", "name": "test"}`
+	sbomPath := s.createTempFile("sbom.json", sbomContent)
+
+	mockClient := &mockHTTPClient{
+		newReqFunc: func(method string, path string, body io.Reader) (*http.Request, error) {
+			return http.NewRequest(method, "http://localhost"+path, body)
+		},
+		doFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       io.NopCloser(strings.NewReader("Bad request")),
+			}, nil
+		},
+	}
+
+	io, _, _, _ := cliIO.TestIO()
+	env := environment.NewTestCLIEnvironment(s.T(), io, printer.DefaultColorPrinter())
+
+	cmd := &sbomScanCommand{
+		sbomFilePath: sbomPath,
+		env:          env,
+		client:       mockClient,
+	}
+
+	err := cmd.ScanSBOM()
+	s.Require().Error(err)
+	s.Assert().Contains(err.Error(), "400")
+	s.Assert().Contains(err.Error(), "Bad request")
+}
+
+func (s *sbomScanTestSuite) TestScanSBOM_HTMLContentType() {
+	sbomContent := `{"spdxVersion": "SPDX-2.3", "name": "test"}`
+	sbomPath := s.createTempFile("sbom.json", sbomContent)
+
+	mockClient := &mockHTTPClient{
+		newReqFunc: func(method string, path string, body io.Reader) (*http.Request, error) {
+			return http.NewRequest(method, "http://localhost"+path, body)
+		},
+		doFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("<html>Not Found</html>")),
+				Header: http.Header{
+					"Content-Type": []string{"text/html"},
+				},
+			}, nil
+		},
+	}
+
+	io, _, _, _ := cliIO.TestIO()
+	env := environment.NewTestCLIEnvironment(s.T(), io, printer.DefaultColorPrinter())
+
+	cmd := &sbomScanCommand{
+		sbomFilePath: sbomPath,
+		env:          env,
+		client:       mockClient,
+	}
+
+	err := cmd.ScanSBOM()
+	s.Require().Error(err)
+	s.Assert().Contains(err.Error(), "text/html")
+	s.Assert().Contains(err.Error(), "confirm Central version supports SBOM scanning")
+}
+
+func (s *sbomScanTestSuite) TestScanSBOM_WithContentTypeFlag() {
+	sbomContent := `{"spdxVersion": "SPDX-2.3", "name": "test"}`
+	sbomPath := s.createTempFile("sbom.json", sbomContent)
+
+	mockClient := &mockHTTPClient{
+		newReqFunc: func(method string, path string, body io.Reader) (*http.Request, error) {
+			return http.NewRequest(method, "http://localhost"+path, body)
+		},
+		doFunc: func(req *http.Request) (*http.Response, error) {
+			// Verify custom content type is used.
+			s.Assert().Equal("application/custom+json", req.Header.Get("Content-Type"))
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{}`)),
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+			}, nil
+		},
+	}
+
+	io, _, _, _ := cliIO.TestIO()
+	env := environment.NewTestCLIEnvironment(s.T(), io, printer.DefaultColorPrinter())
+
+	cmd := &sbomScanCommand{
+		sbomFilePath:   sbomPath,
+		contentType:    "application/custom+json",
+		env:            env,
+		client:         mockClient,
+		noOutputFormat: true,
+	}
+
+	err := cmd.ScanSBOM()
+	s.Require().NoError(err)
+}
+
+func (s *sbomScanTestSuite) TestScanSBOM_FailOnFinding() {
+	sbomContent := `{"spdxVersion": "SPDX-2.3", "name": "test"}`
+	sbomPath := s.createTempFile("sbom.json", sbomContent)
+
+	responseData, err := protojson.Marshal(testSBOMScanResponse)
+	s.Require().NoError(err)
+
+	mockClient := &mockHTTPClient{
+		newReqFunc: func(method string, path string, body io.Reader) (*http.Request, error) {
+			return http.NewRequest(method, "http://localhost"+path, body)
+		},
+		doFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(responseData)),
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+			}, nil
+		},
+	}
+
+	jsonFactory := printer.NewJSONPrinterFactory(false, false)
+	jsonPrinter, err := jsonFactory.CreatePrinter("json")
+	s.Require().NoError(err)
+
+	io, _, _, _ := cliIO.TestIO()
+	env := environment.NewTestCLIEnvironment(s.T(), io, printer.DefaultColorPrinter())
+
+	cmd := &sbomScanCommand{
+		sbomFilePath:       sbomPath,
+		env:                env,
+		client:             mockClient,
+		failOnFinding:      true,
+		printer:            jsonPrinter,
+		standardizedFormat: true,
+		severities:         scan.AllSeverities,
+	}
+
+	err = cmd.ScanSBOM()
+	s.Require().Error(err)
+	s.Assert().ErrorIs(err, scan.ErrVulnerabilityFound)
+}
+
+func (s *sbomScanTestSuite) TestGuessMediaType() {
+	cases := map[string]struct {
+		content       string
+		expectedType  string
+		shouldFail    bool
+		errorContains string
+	}{
+		"valid SPDX 2.3 JSON": {
+			content:      `{"spdxVersion": "SPDX-2.3", "name": "test"}`,
+			expectedType: "text/spdx+json",
+		},
+		"valid SPDX 2.3 JSON with whitespace": {
+			content:      `  {  "spdxVersion"  :  "SPDX-2.3"  }  `,
+			expectedType: "text/spdx+json",
+		},
+		"valid SPDX 2.3 JSON with newlines": {
+			content: `{
+				"spdxVersion": "SPDX-2.3",
+				"name": "test"
+			}`,
+			expectedType: "text/spdx+json",
+		},
+		"valid SPDX 2.3 JSON with UTF-8 BOM": {
+			content:      "\xEF\xBB\xBF{\"spdxVersion\": \"SPDX-2.3\"}",
+			expectedType: "text/spdx+json",
+		},
+		"SPDX 2.2 should fail": {
+			content:       `{"spdxVersion": "SPDX-2.2"}`,
+			shouldFail:    true,
+			errorContains: "unsupported SBOM format",
+		},
+		"not JSON format": {
+			content:       `not json content`,
+			shouldFail:    true,
+			errorContains: "does not appear to be valid JSON",
+		},
+		"JSON array instead of object": {
+			content:       `["item1", "item2"]`,
+			shouldFail:    true,
+			errorContains: "unsupported SBOM format",
+		},
+		"missing spdxVersion field": {
+			content:       `{"name": "test", "version": "1.0"}`,
+			shouldFail:    true,
+			errorContains: "unsupported SBOM format",
+		},
+		"empty file": {
+			content:       ``,
+			shouldFail:    true,
+			errorContains: "does not appear to be valid JSON",
+		},
+		"spdxVersion with tabs": {
+			content:      "{\t\"spdxVersion\"\t:\t\"SPDX-2.3\"\t}",
+			expectedType: "text/spdx+json",
+		},
+		"spdxVersion with mixed whitespace": {
+			content:      "{ \n\t\"spdxVersion\" \n\t: \n\t\"SPDX-2.3\" }",
+			expectedType: "text/spdx+json",
+		},
+		"just opening brace": {
+			content:       "{",
+			shouldFail:    true,
+			errorContains: "unsupported SBOM format",
+		},
+		"only whitespace": {
+			content:       "   \n\t  ",
+			shouldFail:    true,
+			errorContains: "does not appear to be valid JSON",
+		},
+		"spdxVersion inside string field": {
+			content:       `{"description": "this does NOT conform to \"spdxVersion\": \"SPDX-2.3\" spec"}`,
+			shouldFail:    true,
+			errorContains: "unsupported SBOM format",
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			filePath := s.createTempFile("sbom.json", c.content)
+			file, err := os.Open(filePath)
+			s.Require().NoError(err)
+			defer utils.IgnoreError(file.Close)
+
+			mediaType, err := guessMediaType(file)
+
+			if c.shouldFail {
+				s.Require().Error(err)
+				if c.errorContains != "" {
+					s.Assert().Contains(err.Error(), c.errorContains)
+				}
+			} else {
+				s.Require().NoError(err)
+				s.Assert().Equal(c.expectedType, mediaType)
+
+				// Verify file pointer is reset to beginning.
+				pos, err := file.Seek(0, io.SeekCurrent)
+				s.Require().NoError(err)
+				s.Assert().Equal(int64(0), pos, "file pointer should be reset to beginning")
+			}
+		})
+	}
+}
+
+func (s *sbomScanTestSuite) TestGuessMediaType_LargeFile() {
+	// Create content with spdxVersion field after 4KB but starting with valid JSON opening.
+	largeContent := `{` + strings.Repeat(" ", 5000) + `"spdxVersion": "SPDX-2.3"}`
+	filePath := s.createTempFile("large.json", largeContent)
+
+	file, err := os.Open(filePath)
+	s.Require().NoError(err)
+	defer utils.IgnoreError(file.Close)
+
+	// Should fail because spdxVersion is beyond the 4KB read buffer.
+	_, err = guessMediaType(file)
+	s.Assert().Error(err)
+	s.Assert().Contains(err.Error(), "unsupported SBOM format")
+}
+
+// TestSBOMScanResponseCompatibilityWithStorageImage verifies that v1.SBOMScanResponse
+// can be marshaled to JSON and then unmarshaled into storage.Image while preserving
+// all fields required by the printing/formatting logic (see roxctl/common/scan/cve.go).
+//
+// This contract verification is critical because printSBOMScanResults unmarshals the
+// API response into storage.Image to reuse existing formatting logic.
+//
+// The following vulnerability fields are used by the printer:
+//   - vulnerability.GetCve()                  → CveID
+//   - vulnerability.GetSeverity()             → CveSeverity
+//   - vulnerability.GetCvss()                 → CveCVSS
+//   - vulnerability.GetLink()                 → CveInfo
+//   - vulnerability.GetAdvisory().GetName()   → AdvisoryID
+//   - vulnerability.GetAdvisory().GetLink()   → AdvisoryInfo
+//   - comp.GetName()                          → ComponentName
+//   - comp.GetVersion()                       → ComponentVersion
+//   - vulnerability.GetFixedBy()              → ComponentFixedVersion
+//
+// If any of these fields fail to marshal/unmarshal correctly, that is a breaking change
+// which will trigger this test to fail.
+func (s *sbomScanTestSuite) TestSBOMScanResponseCompatibilityWithStorageImage() {
+	// Marshal the SBOMScanResponse to JSON
+	sbomJSON, err := protojson.Marshal(testSBOMScanResponse)
+	s.Require().NoError(err, "failed to marshal SBOMScanResponse to JSON")
+
+	// Unmarshal into storage.Image (this is what printSBOMScanResults does).
+	var image storage.Image
+	err = protojson.Unmarshal(sbomJSON, &image)
+	s.Require().NoError(err, "failed to unmarshal SBOMScanResponse JSON into storage.Image - this indicates a breaking compatibility issue")
+
+	// Verify the critical fields are preserved.
+	s.Require().NotNil(image.GetScan(), "Image.Scan should not be nil")
+	s.Require().NotNil(image.GetScan().GetComponents(), "Image.Scan.Components should not be nil")
+
+	// Verify component data is intact (used by printer).
+	s.Require().Len(image.GetScan().GetComponents(), 1, "should have 1 component")
+	component := image.GetScan().GetComponents()[0]
+	s.Assert().Equal("test-component", component.GetName(), "component name should be preserved (used by printer)")
+	s.Assert().Equal("1.0.0", component.GetVersion(), "component version should be preserved (used by printer)")
+
+	// Verify vulnerability data is intact (used by printer).
+	s.Require().Len(component.GetVulns(), 1, "should have 1 vulnerability")
+	vuln := component.GetVulns()[0]
+	s.Assert().Equal("CVE-2024-1234", vuln.GetCve(), "CVE ID should be preserved (used by printer)")
+	s.Assert().Equal(storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, vuln.GetSeverity(), "severity should be preserved (used by printer)")
+	s.Assert().Equal(float32(9.0), vuln.GetCvss(), "CVSS score should be preserved (used by printer)")
+	s.Assert().Equal("https://nvd.nist.gov/vuln/detail/CVE-2024-1234", vuln.GetLink(), "link should be preserved (used by printer)")
+
+	// Verify Advisory data is intact (used by printer).
+	s.Require().NotNil(vuln.GetAdvisory(), "Advisory should not be nil (used by printer)")
+	s.Assert().Equal("ADVISORY-2024-1234", vuln.GetAdvisory().GetName(), "Advisory name should be preserved (used by printer)")
+	s.Assert().Equal("https://example.com/advisory/2024-1234", vuln.GetAdvisory().GetLink(), "Advisory link should be preserved (used by printer)")
+
+	// Verify FixedBy data (used by printer).
+	s.Require().NotNil(vuln.GetSetFixedBy(), "SetFixedBy should not be nil (used by printer)")
+	fixedBy, ok := vuln.GetSetFixedBy().(*storage.EmbeddedVulnerability_FixedBy)
+	s.Require().True(ok, "SetFixedBy should be of type *storage.EmbeddedVulnerability_FixedBy")
+	s.Assert().Equal("1.0.1", fixedBy.FixedBy, "FixedBy version should be preserved (used by printer)")
+
+	// Test that the formatted output works correctly.
+	cveSummary := scan.NewCVESummaryForPrinting(image.GetScan(), scan.AllSeverities)
+	s.Assert().Equal(1, cveSummary.CountVulnerabilities(), "should count 1 vulnerability")
+	s.Assert().Equal(1, cveSummary.CountComponents(), "should count 1 component")
+}
+
+func (s *sbomScanTestSuite) TestPrintSBOMScanResults_FormattedOutput() {
+	responseData, err := protojson.Marshal(testSBOMScanResponse)
+	s.Require().NoError(err)
+
+	jsonFactory := printer.NewJSONPrinterFactory(false, false)
+	jsonPrinter, err := jsonFactory.CreatePrinter("json")
+	s.Require().NoError(err)
+
+	testIO, _, out, _ := cliIO.TestIO()
+	env := environment.NewTestCLIEnvironment(s.T(), testIO, printer.DefaultColorPrinter())
+
+	cmd := &sbomScanCommand{
+		env:                env,
+		printer:            jsonPrinter,
+		standardizedFormat: true,
+		severities:         scan.AllSeverities,
+		sbomFilePath:       "test.json",
+	}
+
+	err = cmd.printSBOMScanResults(bytes.NewReader(responseData))
+	s.Require().NoError(err)
+	s.Assert().Contains(out.String(), "CVE-2024-1234")
+	s.Assert().Contains(out.String(), "test-component")
+}
+
+func (s *sbomScanTestSuite) TestPrintSBOMScanResults_InvalidJSON() {
+	jsonFactory := printer.NewJSONPrinterFactory(false, false)
+	jsonPrinter, err := jsonFactory.CreatePrinter("json")
+	s.Require().NoError(err)
+
+	io, _, _, _ := cliIO.TestIO()
+	env := environment.NewTestCLIEnvironment(s.T(), io, printer.DefaultColorPrinter())
+
+	cmd := &sbomScanCommand{
+		env:                env,
+		printer:            jsonPrinter,
+		standardizedFormat: true,
+	}
+
+	err = cmd.printSBOMScanResults(strings.NewReader("invalid json"))
+	s.Require().Error(err)
+	s.Assert().Contains(err.Error(), "unmarshalling response")
+}
+
+// mockHTTPClient is a mock implementation of RoxctlHTTPClient interface.
+type mockHTTPClient struct {
+	doFunc             func(req *http.Request) (*http.Response, error)
+	newReqFunc         func(method string, path string, body io.Reader) (*http.Request, error)
+	doReqAndVerifyFunc func(path string, method string, code int, body io.Reader) (*http.Response, error)
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if m.doFunc != nil {
+		return m.doFunc(req)
+	}
+	return nil, errors.New("Do not implemented")
+}
+
+func (m *mockHTTPClient) NewReq(method string, path string, body io.Reader) (*http.Request, error) {
+	if m.newReqFunc != nil {
+		return m.newReqFunc(method, path, body)
+	}
+	return http.NewRequest(method, "http://localhost"+path, body)
+}
+
+func (m *mockHTTPClient) DoReqAndVerifyStatusCode(path string, method string, code int, body io.Reader) (*http.Response, error) {
+	if m.doReqAndVerifyFunc != nil {
+		return m.doReqAndVerifyFunc(path, method, code, body)
+	}
+	return nil, errors.New("DoReqAndVerifyStatusCode not implemented")
+}

--- a/roxctl/sbom/scan/scan_test.go
+++ b/roxctl/sbom/scan/scan_test.go
@@ -164,14 +164,14 @@ func (s *sbomScanTestSuite) TestValidate() {
 			setupFunc: func() string {
 				return s.createTempFile("valid.json", `{"spdxVersion":"SPDX-2.3"}`)
 			},
-			severities: scan.AllSeverities,
+			severities: scan.AllSeverities(),
 			shouldFail: false,
 		},
 		"SBOM file does not exist": {
 			setupFunc: func() string {
 				return filepath.Join(s.tempDir, "nonexistent.json")
 			},
-			severities: scan.AllSeverities,
+			severities: scan.AllSeverities(),
 			shouldFail: true,
 			errorType:  errox.InvalidArgs,
 		},
@@ -255,7 +255,7 @@ func (s *sbomScanTestSuite) TestScanSBOM_Success() {
 		env:            env,
 		client:         mockClient,
 		noOutputFormat: true,
-		severities:     scan.AllSeverities,
+		severities:     scan.AllSeverities(),
 	}
 
 	err = cmd.ScanSBOM()
@@ -419,7 +419,7 @@ func (s *sbomScanTestSuite) TestScanSBOM_FailOnFinding() {
 		failOnFinding:      true,
 		printer:            jsonPrinter,
 		standardizedFormat: true,
-		severities:         scan.AllSeverities,
+		severities:         scan.AllSeverities(),
 	}
 
 	err = cmd.ScanSBOM()
@@ -605,7 +605,7 @@ func (s *sbomScanTestSuite) TestSBOMScanResponseCompatibilityWithStorageImage() 
 	s.Assert().Equal("1.0.1", fixedBy.FixedBy, "FixedBy version should be preserved (used by printer)")
 
 	// Test that the formatted output works correctly.
-	cveSummary := scan.NewCVESummaryForPrinting(image.GetScan(), scan.AllSeverities)
+	cveSummary := scan.NewCVESummaryForPrinting(image.GetScan(), scan.AllSeverities())
 	s.Assert().Equal(1, cveSummary.CountVulnerabilities(), "should count 1 vulnerability")
 	s.Assert().Equal(1, cveSummary.CountComponents(), "should count 1 component")
 }
@@ -625,7 +625,7 @@ func (s *sbomScanTestSuite) TestPrintSBOMScanResults_FormattedOutput() {
 		env:                env,
 		printer:            jsonPrinter,
 		standardizedFormat: true,
-		severities:         scan.AllSeverities,
+		severities:         scan.AllSeverities(),
 		sbomFilePath:       "test.json",
 	}
 

--- a/roxctl/sbom/scan/scan_test.go
+++ b/roxctl/sbom/scan/scan_test.go
@@ -128,9 +128,9 @@ func (s *sbomScanTestSuite) TestConstruct() {
 
 			// Mock the HTTPClient call.
 			if c.httpClientErr != nil {
-				mockEnv.EXPECT().HTTPClient(gomock.Any()).Return(nil, c.httpClientErr)
+				mockEnv.EXPECT().HTTPClient(gomock.Any(), gomock.Any()).Return(nil, c.httpClientErr)
 			} else {
-				mockEnv.EXPECT().HTTPClient(gomock.Any()).Return(mockClient, nil)
+				mockEnv.EXPECT().HTTPClient(gomock.Any(), gomock.Any()).Return(mockClient, nil)
 			}
 
 			// Create command with timeout flag to avoid panic.

--- a/roxctl/sbom/scan/scan_test.go
+++ b/roxctl/sbom/scan/scan_test.go
@@ -449,34 +449,35 @@ func (s *sbomScanTestSuite) TestGuessMediaType() {
 			}`,
 			expectedType: "text/spdx+json",
 		},
-		"valid SPDX 2.3 JSON with UTF-8 BOM": {
-			content:      "\xEF\xBB\xBF{\"spdxVersion\": \"SPDX-2.3\"}",
-			expectedType: "text/spdx+json",
+		"SPDX 2.3 JSON with UTF-8 BOM": {
+			content:       "\xEF\xBB\xBF{\"spdxVersion\": \"SPDX-2.3\"}",
+			shouldFail:    true,
+			errorContains: "invalid or unsupported SBOM",
 		},
 		"SPDX 2.2 should fail": {
 			content:       `{"spdxVersion": "SPDX-2.2"}`,
 			shouldFail:    true,
-			errorContains: "unsupported SBOM format",
+			errorContains: "unsupported SBOM version",
 		},
 		"not JSON format": {
 			content:       `not json content`,
 			shouldFail:    true,
-			errorContains: "does not appear to be valid JSON",
+			errorContains: "invalid or unsupported SBOM",
 		},
 		"JSON array instead of object": {
 			content:       `["item1", "item2"]`,
 			shouldFail:    true,
-			errorContains: "unsupported SBOM format",
+			errorContains: "invalid or unsupported SBOM",
 		},
 		"missing spdxVersion field": {
 			content:       `{"name": "test", "version": "1.0"}`,
 			shouldFail:    true,
-			errorContains: "unsupported SBOM format",
+			errorContains: "invalid or unsupported SBOM",
 		},
 		"empty file": {
 			content:       ``,
 			shouldFail:    true,
-			errorContains: "does not appear to be valid JSON",
+			errorContains: "invalid or unsupported SBOM",
 		},
 		"spdxVersion with tabs": {
 			content:      "{\t\"spdxVersion\"\t:\t\"SPDX-2.3\"\t}",
@@ -489,17 +490,17 @@ func (s *sbomScanTestSuite) TestGuessMediaType() {
 		"just opening brace": {
 			content:       "{",
 			shouldFail:    true,
-			errorContains: "unsupported SBOM format",
+			errorContains: "invalid or unsupported SBOM",
 		},
 		"only whitespace": {
 			content:       "   \n\t  ",
 			shouldFail:    true,
-			errorContains: "does not appear to be valid JSON",
+			errorContains: "invalid or unsupported SBOM",
 		},
 		"spdxVersion inside string field": {
 			content:       `{"description": "this does NOT conform to \"spdxVersion\": \"SPDX-2.3\" spec"}`,
 			shouldFail:    true,
-			errorContains: "unsupported SBOM format",
+			errorContains: "invalid or unsupported SBOM",
 		},
 	}
 
@@ -528,21 +529,6 @@ func (s *sbomScanTestSuite) TestGuessMediaType() {
 			}
 		})
 	}
-}
-
-func (s *sbomScanTestSuite) TestGuessMediaType_LargeFile() {
-	// Create content with spdxVersion field after 4KB but starting with valid JSON opening.
-	largeContent := `{` + strings.Repeat(" ", 5000) + `"spdxVersion": "SPDX-2.3"}`
-	filePath := s.createTempFile("large.json", largeContent)
-
-	file, err := os.Open(filePath)
-	s.Require().NoError(err)
-	defer utils.IgnoreError(file.Close)
-
-	// Should fail because spdxVersion is beyond the 4KB read buffer.
-	_, err = guessMediaType(file)
-	s.Assert().Error(err)
-	s.Assert().Contains(err.Error(), "unsupported SBOM format")
 }
 
 // TestSBOMScanResponseCompatibilityWithStorageImage verifies that v1.SBOMScanResponse

--- a/tests/roxctl/bats-tests/local/expect/roxctl--help.txt
+++ b/tests/roxctl/bats-tests/local/expect/roxctl--help.txt
@@ -10,6 +10,7 @@ Available Commands:
   deployment           Commands related to deployments
   helm                 Commands related to StackRox Helm Charts
   image                Commands that you can run on a specific image
+  sbom                 Commands that you can run on SBOMs
   scanner              Commands related to the Scanner service
   sensor               Commands related to deploying StackRox services in 
                        secured clusters


### PR DESCRIPTION
## Description

Adds the `roxctl sbom scan` command.

**PR Stack:**                                                                                                                                                      
- #18503  ⬅️ **this PR**                                                                                                                 
- #18658                                                                                                     
- #18484 


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] modified existing tests

### How I validated my change

```
$ go run ./roxctl sbom scan --file dignore/rhacs-4.9.json
```
<details>
<summary>output</summary>

```json
{
  "id": "fake HashId",
  "scan": {
    "scannerVersion": "matcher=v7",
    "scanTime": "2026-01-16T00:48:23.865085543Z",
    "components": [
      {
        "name": "Fake Package #1",
        "version": "v1.0.0",
        "vulns": [
          {
            "cve": "Fake Vuln #1",
            "cvss": 3.3,
            "link": "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
            "scoreVersion": "V3",
            "cvssV3": {
              "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
              "exploitabilityScore": 0.8,
              "impactScore": 2.5,
              "attackComplexity": "COMPLEXITY_HIGH",
              "privilegesRequired": "PRIVILEGE_LOW",
              "userInteraction": "UI_REQUIRED",
              "confidentiality": "IMPACT_LOW",
              "integrity": "IMPACT_LOW",
              "score": 3.3,
              "severity": "LOW"
            },
            "severity": "CRITICAL_VULNERABILITY_SEVERITY",
            "cvssMetrics": [
              {
                "source": "SOURCE_NVD",
                "url": "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
                "cvssv3": {
                  "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
                  "exploitabilityScore": 0.8,
                  "impactScore": 2.5,
                  "attackComplexity": "COMPLEXITY_HIGH",
                  "privilegesRequired": "PRIVILEGE_LOW",
                  "userInteraction": "UI_REQUIRED",
                  "confidentiality": "IMPACT_LOW",
                  "integrity": "IMPACT_LOW",
                  "score": 3.3,
                  "severity": "LOW"
                }
              }
            ]
          },
          {
            "cve": "Fake Vuln #2",
            "cvss": 3.3,
            "link": "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
            "scoreVersion": "V3",
            "cvssV3": {
              "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
              "exploitabilityScore": 0.8,
              "impactScore": 2.5,
              "attackComplexity": "COMPLEXITY_HIGH",
              "privilegesRequired": "PRIVILEGE_LOW",
              "userInteraction": "UI_REQUIRED",
              "confidentiality": "IMPACT_LOW",
              "integrity": "IMPACT_LOW",
              "score": 3.3,
              "severity": "LOW"
            },
            "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
            "cvssMetrics": [
              {
                "source": "SOURCE_NVD",
                "url": "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
                "cvssv3": {
                  "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
                  "exploitabilityScore": 0.8,
                  "impactScore": 2.5,
                  "attackComplexity": "COMPLEXITY_HIGH",
                  "privilegesRequired": "PRIVILEGE_LOW",
                  "userInteraction": "UI_REQUIRED",
                  "confidentiality": "IMPACT_LOW",
                  "integrity": "IMPACT_LOW",
                  "score": 3.3,
                  "severity": "LOW"
                }
              }
            ]
          },
          {
            "cve": "Fake Vuln #3",
            "cvss": 8.2,
            "link": "https://access.redhat.com/security/cve/CVE-1234-567",
            "scoreVersion": "V3",
            "cvssV3": {
              "vector": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
              "exploitabilityScore": 2.8,
              "impactScore": 4.7,
              "attackVector": "ATTACK_ADJACENT",
              "scope": "CHANGED",
              "confidentiality": "IMPACT_LOW",
              "availability": "IMPACT_HIGH",
              "score": 8.2,
              "severity": "HIGH"
            },
            "severity": "MODERATE_VULNERABILITY_SEVERITY",
            "cvssMetrics": [
              {
                "source": "SOURCE_RED_HAT",
                "url": "https://access.redhat.com/security/cve/CVE-1234-567",
                "cvssv3": {
                  "vector": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
                  "exploitabilityScore": 2.8,
                  "impactScore": 4.7,
                  "attackVector": "ATTACK_ADJACENT",
                  "scope": "CHANGED",
                  "confidentiality": "IMPACT_LOW",
                  "availability": "IMPACT_HIGH",
                  "score": 8.2,
                  "severity": "HIGH"
                }
              },
              {
                "source": "SOURCE_NVD",
                "url": "https://nvd.nist.gov/vuln/detail/CVE-1234-567",
                "cvssv2": {
                  "vector": "AV:N/AC:M/Au:M/C:C/I:N/A:P",
                  "attackVector": "ATTACK_NETWORK",
                  "accessComplexity": "ACCESS_MEDIUM",
                  "confidentiality": "IMPACT_COMPLETE",
                  "availability": "IMPACT_PARTIAL",
                  "exploitabilityScore": 5.5,
                  "impactScore": 7.8,
                  "score": 6.4,
                  "severity": "MEDIUM"
                }
              }
            ]
          },
          {
            "cve": "Fake Vuln #4",
            "cvss": 3.3,
            "link": "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
            "scoreVersion": "V3",
            "cvssV3": {
              "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
              "exploitabilityScore": 0.8,
              "impactScore": 2.5,
              "attackComplexity": "COMPLEXITY_HIGH",
              "privilegesRequired": "PRIVILEGE_LOW",
              "userInteraction": "UI_REQUIRED",
              "confidentiality": "IMPACT_LOW",
              "integrity": "IMPACT_LOW",
              "score": 3.3,
              "severity": "LOW"
            },
            "severity": "LOW_VULNERABILITY_SEVERITY",
            "cvssMetrics": [
              {
                "source": "SOURCE_NVD",
                "url": "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
                "cvssv3": {
                  "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
                  "exploitabilityScore": 0.8,
                  "impactScore": 2.5,
                  "attackComplexity": "COMPLEXITY_HIGH",
                  "privilegesRequired": "PRIVILEGE_LOW",
                  "userInteraction": "UI_REQUIRED",
                  "confidentiality": "IMPACT_LOW",
                  "integrity": "IMPACT_LOW",
                  "score": 3.3,
                  "severity": "LOW"
                }
              }
            ]
          }
        ]
      },
      {
        "name": "Fake Package #2",
        "version": "v2.3.4",
        "vulns": [
          {
            "cve": "Fake Vuln #3",
            "cvss": 8.2,
            "link": "https://access.redhat.com/security/cve/CVE-1234-567",
            "scoreVersion": "V3",
            "cvssV3": {
              "vector": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
              "exploitabilityScore": 2.8,
              "impactScore": 4.7,
              "attackVector": "ATTACK_ADJACENT",
              "scope": "CHANGED",
              "confidentiality": "IMPACT_LOW",
              "availability": "IMPACT_HIGH",
              "score": 8.2,
              "severity": "HIGH"
            },
            "severity": "MODERATE_VULNERABILITY_SEVERITY",
            "cvssMetrics": [
              {
                "source": "SOURCE_RED_HAT",
                "url": "https://access.redhat.com/security/cve/CVE-1234-567",
                "cvssv3": {
                  "vector": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
                  "exploitabilityScore": 2.8,
                  "impactScore": 4.7,
                  "attackVector": "ATTACK_ADJACENT",
                  "scope": "CHANGED",
                  "confidentiality": "IMPACT_LOW",
                  "availability": "IMPACT_HIGH",
                  "score": 8.2,
                  "severity": "HIGH"
                }
              },
              {
                "source": "SOURCE_NVD",
                "url": "https://nvd.nist.gov/vuln/detail/CVE-1234-567",
                "cvssv2": {
                  "vector": "AV:N/AC:M/Au:M/C:C/I:N/A:P",
                  "attackVector": "ATTACK_NETWORK",
                  "accessComplexity": "ACCESS_MEDIUM",
                  "confidentiality": "IMPACT_COMPLETE",
                  "availability": "IMPACT_PARTIAL",
                  "exploitabilityScore": 5.5,
                  "impactScore": 7.8,
                  "score": 6.4,
                  "severity": "MEDIUM"
                }
              }
            ]
          },
          {
            "cve": "Fake Vuln #4",
            "cvss": 3.3,
            "link": "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
            "scoreVersion": "V3",
            "cvssV3": {
              "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
              "exploitabilityScore": 0.8,
              "impactScore": 2.5,
              "attackComplexity": "COMPLEXITY_HIGH",
              "privilegesRequired": "PRIVILEGE_LOW",
              "userInteraction": "UI_REQUIRED",
              "confidentiality": "IMPACT_LOW",
              "integrity": "IMPACT_LOW",
              "score": 3.3,
              "severity": "LOW"
            },
            "severity": "LOW_VULNERABILITY_SEVERITY",
            "cvssMetrics": [
              {
                "source": "SOURCE_NVD",
                "url": "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
                "cvssv3": {
                  "vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
                  "exploitabilityScore": 0.8,
                  "impactScore": 2.5,
                  "attackComplexity": "COMPLEXITY_HIGH",
                  "privilegesRequired": "PRIVILEGE_LOW",
                  "userInteraction": "UI_REQUIRED",
                  "confidentiality": "IMPACT_LOW",
                  "integrity": "IMPACT_LOW",
                  "score": 3.3,
                  "severity": "LOW"
                }
              }
            ]
          }
        ]
      }
    ],
    "operatingSystem": "unknown",
    "dataSource": {
      "id": "a87471e6-9678-4e66-8348-91e302b6de07",
      "name": "Scanner V4"
    }
  }
}
```

</details>

```sh
$ go run ./roxctl sbom scan --file=dignore/rhacs-4.9.json --output json
```

<details>
<summary>output</summary>

```json
{
  "result": {
    "summary": {
      "CRITICAL": 1,
      "IMPORTANT": 1,
      "LOW": 1,
      "MODERATE": 1,
      "TOTAL-COMPONENTS": 2,
      "TOTAL-VULNERABILITIES": 4
    },
    "vulnerabilities": [
      {
        "cveId": "Fake Vuln #1",
        "cveSeverity": "CRITICAL",
        "cveCVSS": 3.3,
        "cveInfo": "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
        "advisoryId": "",
        "advisoryInfo": "",
        "componentName": "Fake Package #1",
        "componentVersion": "v1.0.0",
        "componentFixedVersion": ""
      },
      {
        "cveId": "Fake Vuln #2",
        "cveSeverity": "IMPORTANT",
        "cveCVSS": 3.3,
        "cveInfo": "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
        "advisoryId": "",
        "advisoryInfo": "",
        "componentName": "Fake Package #1",
        "componentVersion": "v1.0.0",
        "componentFixedVersion": ""
      },
      {
        "cveId": "Fake Vuln #3",
        "cveSeverity": "MODERATE",
        "cveCVSS": 8.2,
        "cveInfo": "https://access.redhat.com/security/cve/CVE-1234-567",
        "advisoryId": "",
        "advisoryInfo": "",
        "componentName": "Fake Package #1",
        "componentVersion": "v1.0.0",
        "componentFixedVersion": ""
      },
      {
        "cveId": "Fake Vuln #4",
        "cveSeverity": "LOW",
        "cveCVSS": 3.3,
        "cveInfo": "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
        "advisoryId": "",
        "advisoryInfo": "",
        "componentName": "Fake Package #1",
        "componentVersion": "v1.0.0",
        "componentFixedVersion": ""
      },
      {
        "cveId": "Fake Vuln #3",
        "cveSeverity": "MODERATE",
        "cveCVSS": 8.2,
        "cveInfo": "https://access.redhat.com/security/cve/CVE-1234-567",
        "advisoryId": "",
        "advisoryInfo": "",
        "componentName": "Fake Package #2",
        "componentVersion": "v2.3.4",
        "componentFixedVersion": ""
      },
      {
        "cveId": "Fake Vuln #4",
        "cveSeverity": "LOW",
        "cveCVSS": 3.3,
        "cveInfo": "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
        "advisoryId": "",
        "advisoryInfo": "",
        "componentName": "Fake Package #2",
        "componentVersion": "v2.3.4",
        "componentFixedVersion": ""
      }
    ]
  }
}
```
</details>


```sh
go run ./roxctl sbom scan --file=dignore/rhacs-4.9.json --output table
```

<details>
<summary>output</summary>

```
Scan results for image: dignore/rhacs-4.9.json
(TOTAL-COMPONENTS: 2, TOTAL-VULNERABILITIES: 4, LOW: 1, MODERATE: 1, IMPORTANT: 1, CRITICAL: 1)

+-----------------+---------+--------------+-----------+------+-----------------------------------------------------+---------------+----------+---------------+
|    COMPONENT    | VERSION |     CVE      | SEVERITY  | CVSS |                        LINK                         | FIXED VERSION | ADVISORY | ADVISORY LINK |
+-----------------+---------+--------------+-----------+------+-----------------------------------------------------+---------------+----------+---------------+
| Fake Package #1 | v1.0.0  | Fake Vuln #1 | CRITICAL  | 3.3  |   https://nvd.nist.gov/vuln/detail/CVE-5678-1234    |       -       |    -     |       -       |
|                 |         +--------------+-----------+------+-----------------------------------------------------+---------------+----------+---------------+
|                 |         | Fake Vuln #2 | IMPORTANT | 3.3  |   https://nvd.nist.gov/vuln/detail/CVE-5678-1234    |       -       |    -     |       -       |
|                 |         +--------------+-----------+------+-----------------------------------------------------+---------------+----------+---------------+
|                 |         | Fake Vuln #3 | MODERATE  | 8.2  | https://access.redhat.com/security/cve/CVE-1234-567 |       -       |    -     |       -       |
|                 |         +--------------+-----------+------+-----------------------------------------------------+---------------+----------+---------------+
|                 |         | Fake Vuln #4 |    LOW    | 3.3  |   https://nvd.nist.gov/vuln/detail/CVE-5678-1234    |       -       |    -     |       -       |
+-----------------+---------+--------------+-----------+------+-----------------------------------------------------+---------------+----------+---------------+
| Fake Package #2 | v2.3.4  | Fake Vuln #3 | MODERATE  | 8.2  | https://access.redhat.com/security/cve/CVE-1234-567 |       -       |    -     |       -       |
|                 |         +--------------+-----------+------+-----------------------------------------------------+---------------+----------+---------------+
|                 |         | Fake Vuln #4 |    LOW    | 3.3  |   https://nvd.nist.gov/vuln/detail/CVE-5678-1234    |       -       |    -     |       -       |
+-----------------+---------+--------------+-----------+------+-----------------------------------------------------+---------------+----------+---------------+
WARN:	A total of 4 unique vulnerabilities were found in 2 components
```

</details>


```sh
$ go run ./roxctl sbom scan --file=rhacs-4.9.json --output csv
```

<details>
<summary>output</summary>

```csv
COMPONENT,VERSION,CVE,SEVERITY,CVSS,LINK,FIXED_VERSION,ADVISORY,ADVISORY_LINK
Fake Package #1,v1.0.0,Fake Vuln #1,CRITICAL,3.3,https://nvd.nist.gov/vuln/detail/CVE-5678-1234,-,-,-
Fake Package #1,v1.0.0,Fake Vuln #2,IMPORTANT,3.3,https://nvd.nist.gov/vuln/detail/CVE-5678-1234,-,-,-
Fake Package #1,v1.0.0,Fake Vuln #3,MODERATE,8.2,https://access.redhat.com/security/cve/CVE-1234-567,-,-,-
Fake Package #1,v1.0.0,Fake Vuln #4,LOW,3.3,https://nvd.nist.gov/vuln/detail/CVE-5678-1234,-,-,-
Fake Package #2,v2.3.4,Fake Vuln #3,MODERATE,8.2,https://access.redhat.com/security/cve/CVE-1234-567,-,-,-
Fake Package #2,v2.3.4,Fake Vuln #4,LOW,3.3,https://nvd.nist.gov/vuln/detail/CVE-5678-1234,-,-,-
```
</details>

```
$ go run ./roxctl sbom scan --file NOPE.json
ERROR:	SBOM file does not exist: "NOPE.json"
```

```
$ go run ./roxctl sbom scan --file dignore/rhacs-4.9.invalid.json 
ERROR:	auto detecting media type: SBOM file does not appear to be valid JSON
```

```
$ go run ./roxctl sbom scan --file dignore/rhacs-4.9.notspdx.json 
ERROR:	auto detecting media type: unsupported SBOM format
```

```
$ go run ./roxctl sbom scan --file dignore/rhacs-4.9.json --content-type WRONG
ERROR:	received unexpected status code 400. Response Body: {"code":3,"message":"validating media type: unsupported media type \"WRONG\", supported types [text/spdx+json application/spdx+json]"}
```