### PR TITLE
ROX-32849: Store VM agent facts and attach to VM events

### DIFF
--- a/sensor/common/virtualmachine/facts.go
+++ b/sensor/common/virtualmachine/facts.go
@@ -1,0 +1,89 @@
+package virtualmachine
+
+import (
+	"strings"
+
+	virtualMachineV1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+)
+
+// Keep the facts keys camelCase to match the style used elsewhere in the UI.
+const (
+	// FactsGuestOSKey records the guest OS name or "unknown".
+	FactsGuestOSKey = "guestOS"
+	// FactsDescriptionKey records the VM/VMI description from annotations.
+	FactsDescriptionKey = "description"
+	// FactsIPAddressesKey records IPs joined by ", ".
+	FactsIPAddressesKey = "ipAddresses"
+	// FactsActivePodsKey records active pod references joined by ", ".
+	FactsActivePodsKey = "activePods"
+	// FactsNodeNameKey records the node name where the VM is running.
+	FactsNodeNameKey = "nodeName"
+	// FactsBootOrderKey records disk boot order entries joined by ", ".
+	FactsBootOrderKey = "bootOrder"
+	// FactsCDRomDisksKey records CD-ROM disk names joined by ", ".
+	FactsCDRomDisksKey = "cdRomDisks"
+	// FactsDetectedOSKey records the detected OS string from discovered data.
+	FactsDetectedOSKey = "detectedOS"
+	// FactsOSVersionKey records the detected OS version string from discovered data.
+	FactsOSVersionKey = "osVersion"
+	// FactsActivationStatusKey records the activation status from discovered data.
+	FactsActivationStatusKey = "activationStatus"
+	// FactsDNFMetadataStatusKey records the DNF metadata status from discovered data.
+	FactsDNFMetadataStatusKey = "dnfMetadataStatus"
+	// FactsUnknownGuestOS is used when the guest OS is not known yet.
+	FactsUnknownGuestOS = "unknown"
+)
+
+// BuildFacts returns a map of VM facts, merged with discovered facts.
+func BuildFacts(vm *Info, discoveredFacts map[string]string) map[string]string {
+	facts := map[string]string{
+		FactsGuestOSKey: FactsUnknownGuestOS,
+	}
+	if vm == nil {
+		return facts
+	}
+	if vm.GuestOS != "" {
+		facts[FactsGuestOSKey] = vm.GuestOS
+	}
+	if vm.Description != "" {
+		facts[FactsDescriptionKey] = vm.Description
+	}
+	if vm.NodeName != "" {
+		facts[FactsNodeNameKey] = vm.NodeName
+	}
+	if len(vm.IPAddresses) > 0 {
+		facts[FactsIPAddressesKey] = strings.Join(vm.IPAddresses, ", ")
+	}
+	if len(vm.ActivePods) > 0 {
+		facts[FactsActivePodsKey] = strings.Join(vm.ActivePods, ", ")
+	}
+	if len(vm.BootOrder) > 0 {
+		facts[FactsBootOrderKey] = strings.Join(vm.BootOrder, ", ")
+	}
+	if len(vm.CDRomDisks) > 0 {
+		facts[FactsCDRomDisksKey] = strings.Join(vm.CDRomDisks, ", ")
+	}
+	for k, v := range discoveredFacts {
+		facts[k] = v
+	}
+	return facts
+}
+
+// StateFromInfo derives the VM state from Info.
+func StateFromInfo(vm *Info) virtualMachineV1.VirtualMachine_State {
+	if vm == nil {
+		return virtualMachineV1.VirtualMachine_UNKNOWN
+	}
+	if vm.Running {
+		return virtualMachineV1.VirtualMachine_RUNNING
+	}
+	return virtualMachineV1.VirtualMachine_STOPPED
+}
+
+// VSockCIDFromInfo returns the VSOCK CID and whether it is set.
+func VSockCIDFromInfo(vm *Info) (int32, bool) {
+	if vm == nil || vm.VSOCKCID == nil {
+		return 0, false
+	}
+	return int32(*vm.VSOCKCID), true
+}

--- a/sensor/common/virtualmachine/index/handler.go
+++ b/sensor/common/virtualmachine/index/handler.go
@@ -15,6 +15,11 @@ type Handler interface {
 	common.SensorComponent
 
 	Send(ctx context.Context, vm *v1.IndexReport) error
+	SendVirtualMachineUpdate(ctx context.Context, vmID virtualmachine.VMID) error
+}
+
+type clusterIDGetter interface {
+	Get() string
 }
 
 // VirtualMachineStore interface to the VirtualMachine store
@@ -22,12 +27,16 @@ type Handler interface {
 //go:generate mockgen-wrapper
 type VirtualMachineStore interface {
 	GetFromCID(cid uint32) *virtualmachine.Info
+	Get(id virtualmachine.VMID) *virtualmachine.Info
+	GetDiscoveredFacts(id virtualmachine.VMID) map[string]string
+	UpsertDiscoveredFacts(id virtualmachine.VMID, facts map[string]string)
 }
 
 // NewHandler returns the virtual machine component for Sensor to use.
-func NewHandler(store VirtualMachineStore) Handler {
+func NewHandler(clusterID clusterIDGetter, store VirtualMachineStore) Handler {
 	return &handlerImpl{
 		centralReady: concurrency.NewSignal(),
+		clusterID:    clusterID,
 		lock:         &sync.RWMutex{},
 		stopper:      concurrency.NewStopper(),
 		store:        store,

--- a/sensor/common/virtualmachine/index/handler.go
+++ b/sensor/common/virtualmachine/index/handler.go
@@ -14,8 +14,7 @@ import (
 type Handler interface {
 	common.SensorComponent
 
-	Send(ctx context.Context, vm *v1.IndexReport) error
-	SendVirtualMachineUpdate(ctx context.Context, vmID virtualmachine.VMID) error
+	Send(ctx context.Context, vm *v1.IndexReport, discoveredData *v1.DiscoveredData) error
 }
 
 type clusterIDGetter interface {

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"maps"
 	"strconv"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common"
@@ -35,17 +37,21 @@ type handlerImpl struct {
 	lock         *sync.RWMutex
 	stopper      concurrency.Stopper
 	toCentral    <-chan *message.ExpiringMessage
-	indexReports chan *v1.IndexReport
-	vmUpdates    chan *virtualmachine.Info
+	indexReports chan *indexReportWithData
 	clusterID    clusterIDGetter
 	store        VirtualMachineStore
+}
+
+type indexReportWithData struct {
+	report         *v1.IndexReport
+	discoveredData *v1.DiscoveredData
 }
 
 func (h *handlerImpl) Capabilities() []centralsensor.SensorCapability {
 	return nil
 }
 
-func (h *handlerImpl) Send(ctx context.Context, vm *v1.IndexReport) error {
+func (h *handlerImpl) Send(ctx context.Context, vm *v1.IndexReport, discoveredData *v1.DiscoveredData) error {
 	if h.stopper.Client().Stopped().IsDone() {
 		return errox.InvariantViolation.CausedBy(errInputChanClosed)
 	}
@@ -74,12 +80,30 @@ func (h *handlerImpl) Send(ctx context.Context, vm *v1.IndexReport) error {
 		}
 	}()
 
+	item := &indexReportWithData{
+		report:         vm,
+		discoveredData: discoveredData,
+	}
+
 	// Fast-path select to detect blocking on the channel for metrics
+	// Check context first to prioritize cancellation
 	select {
 	case <-ctx.Done():
-		// Handled in the next select statement
-	case h.indexReports <- vm:
-		return nil
+		// Context canceled, handle in next select statement
+	case h.indexReports <- item:
+		// Double-check context wasn't canceled during send
+		select {
+		case <-ctx.Done():
+			// Context was canceled, return error immediately
+			if err := ctx.Err(); errors.Is(err, context.DeadlineExceeded) {
+				outcome = metrics.IndexReportEnqueueOutcomeTimeout
+				return err //nolint:wrapcheck
+			}
+			outcome = metrics.IndexReportEnqueueOutcomeCanceled
+			return ctx.Err() //nolint:wrapcheck
+		default:
+			return nil
+		}
 	default:
 		blocked = true
 		blockingStart = time.Now()
@@ -94,43 +118,7 @@ func (h *handlerImpl) Send(ctx context.Context, vm *v1.IndexReport) error {
 		}
 		outcome = metrics.IndexReportEnqueueOutcomeCanceled
 		return ctx.Err() //nolint:wrapcheck
-	case h.indexReports <- vm:
-		return nil
-	}
-}
-
-func (h *handlerImpl) SendVirtualMachineUpdate(ctx context.Context, vmID virtualmachine.VMID) error {
-	if h.stopper.Client().Stopped().IsDone() {
-		return errox.InvariantViolation.CausedBy(errInputChanClosed)
-	}
-	if !centralcaps.Has(centralsensor.VirtualMachinesSupported) {
-		return errox.NotImplemented.CausedBy(errCapabilityNotSupported)
-	}
-	if !h.centralReady.IsDone() {
-		log.Warnf("Cannot send virtual machine update for vm_id=%q to Central because Central is not reachable", vmID)
-		return errox.ResourceExhausted.CausedBy(errCentralNotReachable)
-	}
-
-	vmInfo := h.store.Get(vmID)
-	if vmInfo == nil {
-		return errors.Wrapf(errVirtualMachineNotFound, "VirtualMachine with ID %q not found", vmID)
-	}
-
-	h.lock.RLock()
-	defer h.lock.RUnlock()
-	updatesCh := h.vmUpdates
-	if updatesCh == nil {
-		return errox.InvariantViolation.CausedBy(errInputChanClosed)
-	}
-	select {
-	case <-h.stopper.Flow().StopRequested():
-		return errox.InvariantViolation.CausedBy(errInputChanClosed)
-	case <-ctx.Done():
-		if err := ctx.Err(); errors.Is(err, context.DeadlineExceeded) {
-			return err //nolint:wrapcheck
-		}
-		return ctx.Err() //nolint:wrapcheck
-	case updatesCh <- vmInfo:
+	case h.indexReports <- item:
 		return nil
 	}
 }
@@ -198,12 +186,11 @@ func (h *handlerImpl) Start() error {
 	log.Debug("Starting virtual machine handler")
 	h.lock.Lock()
 	defer h.lock.Unlock()
-	if h.toCentral != nil || h.indexReports != nil || h.vmUpdates != nil {
+	if h.toCentral != nil || h.indexReports != nil {
 		return errStartMoreThanOnce
 	}
-	h.indexReports = make(chan *v1.IndexReport, env.VirtualMachinesIndexReportsBufferSize.IntegerSetting())
-	h.vmUpdates = make(chan *virtualmachine.Info, env.VirtualMachinesIndexReportsBufferSize.IntegerSetting())
-	h.toCentral = h.run(h.indexReports, h.vmUpdates)
+	h.indexReports = make(chan *indexReportWithData, env.VirtualMachinesIndexReportsBufferSize.IntegerSetting())
+	h.toCentral = h.run(h.indexReports)
 	return nil
 }
 
@@ -225,18 +212,13 @@ func (h *handlerImpl) Stop() {
 		close(h.indexReports)
 		h.indexReports = nil
 	}
-	if h.vmUpdates != nil {
-		close(h.vmUpdates)
-		h.vmUpdates = nil
-	}
 }
 
 // run handles the virtual machine data and forwards it to Central.
 // This is the only goroutine that writes into the toCentral channel, thus it is
 // responsible for creating and closing that chan.
 func (h *handlerImpl) run(
-	indexReports <-chan *v1.IndexReport,
-	vmUpdates <-chan *virtualmachine.Info,
+	indexReports <-chan *indexReportWithData,
 ) (toCentral <-chan *message.ExpiringMessage) {
 	ch2Central := make(chan *message.ExpiringMessage)
 	go func() {
@@ -249,18 +231,12 @@ func (h *handlerImpl) run(
 			select {
 			case <-h.stopper.Flow().StopRequested():
 				return
-			case indexReport, ok := <-indexReports:
+			case item, ok := <-indexReports:
 				if !ok {
 					h.stopper.Flow().StopWithError(errInputChanClosed)
 					return
 				}
-				h.handleIndexReport(ch2Central, indexReport)
-			case vmInfo, ok := <-vmUpdates:
-				if !ok {
-					h.stopper.Flow().StopWithError(errInputChanClosed)
-					return
-				}
-				h.handleVirtualMachineUpdate(ch2Central, vmInfo)
+				h.handleIndexReport(ch2Central, item)
 			}
 		}
 	}()
@@ -269,7 +245,7 @@ func (h *handlerImpl) run(
 
 func (h *handlerImpl) handleIndexReport(
 	toCentral chan *message.ExpiringMessage,
-	indexReport *v1.IndexReport,
+	item *indexReportWithData,
 ) {
 	startTime := time.Now()
 	outcome := metrics.IndexReportHandlingMessageToCentralSuccess
@@ -279,12 +255,18 @@ func (h *handlerImpl) handleIndexReport(
 			Observe(metrics.StartTimeToMS(startTime))
 	}()
 
-	if indexReport == nil {
+	if item == nil || item.report == nil {
 		outcome = metrics.IndexReportHandlingMessageToCentralNilReport
 		log.Warn("Received nil virtual machine index report: not sending to Central")
 		return
 	}
+	indexReport := item.report
 	log.Debugf("Handling virtual machine index report with vsock_cid=%q...", indexReport.GetVsockCid())
+
+	// Handle discovered facts if feature is enabled and we have discovered data
+	if features.VirtualMachines.Enabled() && item.discoveredData != nil {
+		h.handleDiscoveredFacts(toCentral, indexReport, item.discoveredData)
+	}
 
 	msg, outcome, err := h.newMessageToCentral(indexReport)
 	if err != nil {
@@ -296,16 +278,58 @@ func (h *handlerImpl) handleIndexReport(
 	metrics.IndexReportsSent.With(metrics.StatusSuccessLabels).Inc()
 }
 
-func (h *handlerImpl) handleVirtualMachineUpdate(
+func (h *handlerImpl) handleDiscoveredFacts(
 	toCentral chan *message.ExpiringMessage,
-	vmInfo *virtualmachine.Info,
+	indexReport *v1.IndexReport,
+	data *v1.DiscoveredData,
 ) {
-	if vmInfo == nil {
-		log.Warn("Received nil virtual machine update request: not sending to Central")
+	if data == nil {
 		return
 	}
-	msg := h.newVirtualMachineUpdateMessage(vmInfo)
-	h.sendToCentral(toCentral, msg)
+
+	cid, err := strconv.ParseUint(indexReport.GetVsockCid(), 10, 32)
+	if err != nil {
+		log.Warnf("Invalid vsock CID %q in index report: %v", indexReport.GetVsockCid(), err)
+		return
+	}
+
+	vmInfo := h.store.GetFromCID(uint32(cid))
+	if vmInfo == nil {
+		log.Debugf("VM with vsock_cid=%q not found, skipping discovered facts storage", indexReport.GetVsockCid())
+		metrics.IndexReportsForUnknownVMCID.Inc()
+		return
+	}
+
+	facts := factsFromDiscoveredData(data)
+	if len(facts) == 0 {
+		return
+	}
+
+	previousFacts := h.store.GetDiscoveredFacts(vmInfo.ID)
+	h.store.UpsertDiscoveredFacts(vmInfo.ID, facts)
+
+	if !maps.Equal(previousFacts, facts) {
+		// Emit VM update message when facts change
+		msg := h.newVirtualMachineUpdateMessage(vmInfo)
+		h.sendToCentral(toCentral, msg)
+	}
+}
+
+func factsFromDiscoveredData(data *v1.DiscoveredData) map[string]string {
+	facts := make(map[string]string)
+	if data.GetDetectedOs() != v1.DetectedOS_UNKNOWN {
+		facts[virtualmachine.FactsDetectedOSKey] = data.GetDetectedOs().String()
+	}
+	if data.GetOsVersion() != "" {
+		facts[virtualmachine.FactsOSVersionKey] = data.GetOsVersion()
+	}
+	if data.GetActivationStatus() != v1.ActivationStatus_ACTIVATION_UNSPECIFIED {
+		facts[virtualmachine.FactsActivationStatusKey] = data.GetActivationStatus().String()
+	}
+	if data.GetDnfMetadataStatus() != v1.DnfMetadataStatus_DNF_METADATA_UNSPECIFIED {
+		facts[virtualmachine.FactsDNFMetadataStatusKey] = data.GetDnfMetadataStatus().String()
+	}
+	return facts
 }
 
 func (h *handlerImpl) newMessageToCentral(indexReport *v1.IndexReport) (*message.ExpiringMessage, string, error) {

--- a/sensor/common/virtualmachine/index/mocks/handler.go
+++ b/sensor/common/virtualmachine/index/mocks/handler.go
@@ -142,6 +142,20 @@ func (mr *MockHandlerMockRecorder) Send(ctx, vm any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockHandler)(nil).Send), ctx, vm)
 }
 
+// SendVirtualMachineUpdate mocks base method.
+func (m *MockHandler) SendVirtualMachineUpdate(ctx context.Context, vmID virtualmachine.VMID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendVirtualMachineUpdate", ctx, vmID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendVirtualMachineUpdate indicates an expected call of SendVirtualMachineUpdate.
+func (mr *MockHandlerMockRecorder) SendVirtualMachineUpdate(ctx, vmID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendVirtualMachineUpdate", reflect.TypeOf((*MockHandler)(nil).SendVirtualMachineUpdate), ctx, vmID)
+}
+
 // Start mocks base method.
 func (m *MockHandler) Start() error {
 	m.ctrl.T.Helper()
@@ -168,6 +182,44 @@ func (mr *MockHandlerMockRecorder) Stop() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockHandler)(nil).Stop))
 }
 
+// MockclusterIDGetter is a mock of clusterIDGetter interface.
+type MockclusterIDGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockclusterIDGetterMockRecorder
+	isgomock struct{}
+}
+
+// MockclusterIDGetterMockRecorder is the mock recorder for MockclusterIDGetter.
+type MockclusterIDGetterMockRecorder struct {
+	mock *MockclusterIDGetter
+}
+
+// NewMockclusterIDGetter creates a new mock instance.
+func NewMockclusterIDGetter(ctrl *gomock.Controller) *MockclusterIDGetter {
+	mock := &MockclusterIDGetter{ctrl: ctrl}
+	mock.recorder = &MockclusterIDGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockclusterIDGetter) EXPECT() *MockclusterIDGetterMockRecorder {
+	return m.recorder
+}
+
+// Get mocks base method.
+func (m *MockclusterIDGetter) Get() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockclusterIDGetterMockRecorder) Get() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockclusterIDGetter)(nil).Get))
+}
+
 // MockVirtualMachineStore is a mock of VirtualMachineStore interface.
 type MockVirtualMachineStore struct {
 	ctrl     *gomock.Controller
@@ -192,6 +244,34 @@ func (m *MockVirtualMachineStore) EXPECT() *MockVirtualMachineStoreMockRecorder 
 	return m.recorder
 }
 
+// Get mocks base method.
+func (m *MockVirtualMachineStore) Get(id virtualmachine.VMID) *virtualmachine.Info {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", id)
+	ret0, _ := ret[0].(*virtualmachine.Info)
+	return ret0
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockVirtualMachineStoreMockRecorder) Get(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockVirtualMachineStore)(nil).Get), id)
+}
+
+// GetDiscoveredFacts mocks base method.
+func (m *MockVirtualMachineStore) GetDiscoveredFacts(id virtualmachine.VMID) map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDiscoveredFacts", id)
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// GetDiscoveredFacts indicates an expected call of GetDiscoveredFacts.
+func (mr *MockVirtualMachineStoreMockRecorder) GetDiscoveredFacts(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiscoveredFacts", reflect.TypeOf((*MockVirtualMachineStore)(nil).GetDiscoveredFacts), id)
+}
+
 // GetFromCID mocks base method.
 func (m *MockVirtualMachineStore) GetFromCID(cid uint32) *virtualmachine.Info {
 	m.ctrl.T.Helper()
@@ -204,4 +284,16 @@ func (m *MockVirtualMachineStore) GetFromCID(cid uint32) *virtualmachine.Info {
 func (mr *MockVirtualMachineStoreMockRecorder) GetFromCID(cid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFromCID", reflect.TypeOf((*MockVirtualMachineStore)(nil).GetFromCID), cid)
+}
+
+// UpsertDiscoveredFacts mocks base method.
+func (m *MockVirtualMachineStore) UpsertDiscoveredFacts(id virtualmachine.VMID, facts map[string]string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpsertDiscoveredFacts", id, facts)
+}
+
+// UpsertDiscoveredFacts indicates an expected call of UpsertDiscoveredFacts.
+func (mr *MockVirtualMachineStoreMockRecorder) UpsertDiscoveredFacts(id, facts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertDiscoveredFacts", reflect.TypeOf((*MockVirtualMachineStore)(nil).UpsertDiscoveredFacts), id, facts)
 }

--- a/sensor/common/virtualmachine/index/mocks/handler.go
+++ b/sensor/common/virtualmachine/index/mocks/handler.go
@@ -129,31 +129,17 @@ func (mr *MockHandlerMockRecorder) ResponsesC() *gomock.Call {
 }
 
 // Send mocks base method.
-func (m *MockHandler) Send(ctx context.Context, vm *v1.IndexReport) error {
+func (m *MockHandler) Send(ctx context.Context, vm *v1.IndexReport, discoveredData *v1.DiscoveredData) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Send", ctx, vm)
+	ret := m.ctrl.Call(m, "Send", ctx, vm, discoveredData)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockHandlerMockRecorder) Send(ctx, vm any) *gomock.Call {
+func (mr *MockHandlerMockRecorder) Send(ctx, vm, discoveredData any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockHandler)(nil).Send), ctx, vm)
-}
-
-// SendVirtualMachineUpdate mocks base method.
-func (m *MockHandler) SendVirtualMachineUpdate(ctx context.Context, vmID virtualmachine.VMID) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendVirtualMachineUpdate", ctx, vmID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SendVirtualMachineUpdate indicates an expected call of SendVirtualMachineUpdate.
-func (mr *MockHandlerMockRecorder) SendVirtualMachineUpdate(ctx, vmID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendVirtualMachineUpdate", reflect.TypeOf((*MockHandler)(nil).SendVirtualMachineUpdate), ctx, vmID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockHandler)(nil).Send), ctx, vm, discoveredData)
 }
 
 // Start mocks base method.

--- a/sensor/common/virtualmachine/index/service.go
+++ b/sensor/common/virtualmachine/index/service.go
@@ -15,6 +15,6 @@ type Service interface {
 }
 
 // NewService returns the VirtualMachineIndexReportServiceServer API for Sensor to use.
-func NewService(handler Handler) Service {
-	return &serviceImpl{handler: handler}
+func NewService(handler Handler, store VirtualMachineStore) Service {
+	return &serviceImpl{handler: handler, store: store}
 }

--- a/sensor/common/virtualmachine/index/service_impl_test.go
+++ b/sensor/common/virtualmachine/index/service_impl_test.go
@@ -32,6 +32,7 @@ type virtualMachineServiceSuite struct {
 }
 
 func (s *virtualMachineServiceSuite) SetupTest() {
+	s.T().Setenv(features.VirtualMachines.EnvVar(), "true")
 	s.ctrl = gomock.NewController(s.T())
 	s.store = mocks.NewMockVirtualMachineStore(s.ctrl)
 	s.service = &serviceImpl{

--- a/sensor/common/virtualmachine/metrics/metrics.go
+++ b/sensor/common/virtualmachine/metrics/metrics.go
@@ -104,6 +104,16 @@ var IndexReportEnqueueBlockedTotal = prometheus.NewCounter(
 	},
 )
 
+// IndexReportsForUnknownVMCID counts index reports that did not resolve to a VM in the store.
+var IndexReportsForUnknownVMCID = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "virtual_machine_index_reports_unknown_vm_vsock_cid_total",
+		Help:      "Total number of virtual machine index reports referencing an vsock ID of a VM that is unknown to Sensor",
+	},
+)
+
 // VMDiscoveredData is a counter for VM discovered data grouped by detected OS and status values.
 var VMDiscoveredData = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
@@ -134,6 +144,7 @@ func init() {
 		IndexReportProcessingDurationMilliseconds,
 		IndexReportBlockingEnqueueDurationMilliseconds,
 		IndexReportEnqueueBlockedTotal,
+		IndexReportsForUnknownVMCID,
 		VMDiscoveredData,
 		IndexReportAcksReceived,
 	)

--- a/sensor/kubernetes/fake/virtualmachines.go
+++ b/sensor/kubernetes/fake/virtualmachines.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/fixtures/vmindexreport"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -385,7 +386,13 @@ func (w *WorkloadManager) sendOneIndexReport(
 		return
 	}
 
-	if err := w.vmIndexReportHandler.Send(ctx, report); err != nil {
+	fakeDiscoveredData := &v1.DiscoveredData{
+		DetectedOs:        v1.DetectedOS_RHEL,
+		OsVersion:         fmt.Sprintf("9.%d", vsockCID%5),
+		ActivationStatus:  v1.ActivationStatus(vsockCID%2 + 1),
+		DnfMetadataStatus: v1.DnfMetadataStatus(vsockCID%2 + 1),
+	}
+	if err := w.vmIndexReportHandler.Send(ctx, report, fakeDiscoveredData); err != nil {
 		// Don't log errors during shutdown
 		if ctx.Err() == nil {
 			log.Debugf("Failed to send index report for VM %d: %v", vsockCID, err)

--- a/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/mocks/virtualmachineinstances.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/mocks/virtualmachineinstances.go
@@ -80,6 +80,20 @@ func (mr *MockvirtualMachineStoreMockRecorder) Get(id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockvirtualMachineStore)(nil).Get), id)
 }
 
+// GetDiscoveredFacts mocks base method.
+func (m *MockvirtualMachineStore) GetDiscoveredFacts(id virtualmachine.VMID) map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDiscoveredFacts", id)
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// GetDiscoveredFacts indicates an expected call of GetDiscoveredFacts.
+func (mr *MockvirtualMachineStoreMockRecorder) GetDiscoveredFacts(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiscoveredFacts", reflect.TypeOf((*MockvirtualMachineStore)(nil).GetDiscoveredFacts), id)
+}
+
 // Has mocks base method.
 func (m *MockvirtualMachineStore) Has(id virtualmachine.VMID) bool {
 	m.ctrl.T.Helper()

--- a/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachineinstances.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachineinstances.go
@@ -24,6 +24,7 @@ type virtualMachineStore interface {
 	Remove(id virtualmachine.VMID)
 	UpdateStateOrCreate(vm *virtualmachine.Info)
 	ClearState(id virtualmachine.VMID)
+	GetDiscoveredFacts(id virtualmachine.VMID) map[string]string
 }
 
 type VirtualMachineInstanceDispatcher struct {
@@ -111,5 +112,5 @@ func (d *VirtualMachineInstanceDispatcher) ProcessEvent(
 	}
 
 	// Send an Update event for the VirtualMachine that handles this instance
-	return component.NewEvent(createEvent(central.ResourceAction_UPDATE_RESOURCE, d.clusterID, vm))
+	return component.NewEvent(createEvent(central.ResourceAction_UPDATE_RESOURCE, d.clusterID, vm, d.store))
 }

--- a/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachineinstances_test.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachineinstances_test.go
@@ -51,6 +51,7 @@ func (s *virtualMachineInstanceSuite) SetupSubTest() {
 
 	s.mockCtrl = gomock.NewController(s.T())
 	s.store = mocks.NewMockvirtualMachineStore(s.mockCtrl)
+	s.store.EXPECT().GetDiscoveredFacts(gomock.Any()).AnyTimes().Return(map[string]string{})
 	s.dispatcher = NewVirtualMachineInstanceDispatcher(clusterID, s.store)
 }
 
@@ -113,7 +114,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 						Namespace: vmiNamespace,
 						ClusterId: clusterID,
 						State:     virtualMachineV1.VirtualMachine_STOPPED,
-						Facts:     getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:     getFactsForTest(s.T(), vmInfo.FactsUnknownGuestOS),
 					},
 				},
 			}),
@@ -145,7 +146,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 						Namespace: vmiNamespace,
 						ClusterId: clusterID,
 						State:     virtualMachineV1.VirtualMachine_STOPPED,
-						Facts:     getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:     getFactsForTest(s.T(), vmInfo.FactsUnknownGuestOS),
 					},
 				},
 			}),
@@ -169,7 +170,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 						Namespace: vmiNamespace,
 						ClusterId: clusterID,
 						State:     virtualMachineV1.VirtualMachine_STOPPED,
-						Facts:     getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:     getFactsForTest(s.T(), vmInfo.FactsUnknownGuestOS),
 					},
 				},
 			}),
@@ -217,7 +218,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 						Namespace: vmiNamespace,
 						ClusterId: clusterID,
 						State:     virtualMachineV1.VirtualMachine_STOPPED,
-						Facts:     getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:     getFactsForTest(s.T(), vmInfo.FactsUnknownGuestOS),
 					},
 				},
 			}),
@@ -253,7 +254,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 						Namespace: vmiNamespace,
 						ClusterId: clusterID,
 						State:     virtualMachineV1.VirtualMachine_STOPPED,
-						Facts:     getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:     getFactsForTest(s.T(), vmInfo.FactsUnknownGuestOS),
 					},
 				},
 			}),
@@ -274,7 +275,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 						Namespace: vmiNamespace,
 						ClusterId: clusterID,
 						State:     virtualMachineV1.VirtualMachine_STOPPED,
-						Facts:     getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:     getFactsForTest(s.T(), vmInfo.FactsUnknownGuestOS),
 					},
 				},
 			}),
@@ -310,7 +311,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 						Namespace: vmiNamespace,
 						ClusterId: clusterID,
 						State:     virtualMachineV1.VirtualMachine_STOPPED,
-						Facts:     getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:     getFactsForTest(s.T(), vmInfo.FactsUnknownGuestOS),
 					},
 				},
 			}),
@@ -363,7 +364,7 @@ func (s *virtualMachineInstanceSuite) Test_VirtualMachineInstanceEvents() {
 						VsockCid:    int32(vsockVal),
 						VsockCidSet: true,
 						State:       virtualMachineV1.VirtualMachine_RUNNING,
-						Facts:       getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:       getFactsForTest(s.T(), vmInfo.FactsUnknownGuestOS),
 					},
 				},
 			}),

--- a/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachines.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachines.go
@@ -11,18 +11,6 @@ import (
 	kubeVirtV1 "kubevirt.io/api/core/v1"
 )
 
-// Keep the facts keys camelCase to match the style used elsewhere in the UI.
-const (
-	GuestOSKey     = "guestOS"
-	DescriptionKey = "description"
-	IPAddressesKey = "ipAddresses"
-	ActivePodsKey  = "activePods"
-	NodeNameKey    = "nodeName"
-	BootOrderKey   = "bootOrder"
-	CDRomDisksKey  = "cdRomDisks"
-	UnknownGuestOS = "unknown"
-)
-
 type VirtualMachineDispatcher struct {
 	clusterID string
 	store     virtualMachineStore
@@ -72,5 +60,5 @@ func processVirtualMachine(vm *virtualmachine.Info, action central.ResourceActio
 	} else {
 		vm = store.AddOrUpdate(vm)
 	}
-	return component.NewEvent(createEvent(action, clusterID, vm))
+	return component.NewEvent(createEvent(action, clusterID, vm, store))
 }

--- a/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachines_test.go
+++ b/sensor/kubernetes/listener/resources/virtualmachine/dispatcher/virtualmachines_test.go
@@ -45,6 +45,7 @@ func (s *virtualMachineSuite) SetupSubTest() {
 
 	s.mockCtrl = gomock.NewController(s.T())
 	s.store = mocks.NewMockvirtualMachineStore(s.mockCtrl)
+	s.store.EXPECT().GetDiscoveredFacts(gomock.Any()).AnyTimes().Return(map[string]string{})
 	s.dispatcher = NewVirtualMachineDispatcher(clusterID, s.store)
 }
 
@@ -89,7 +90,7 @@ func (s *virtualMachineSuite) Test_VirtualMachineEvents() {
 						Namespace: vmNamespace,
 						ClusterId: clusterID,
 						State:     virtualMachineV1.VirtualMachine_STOPPED,
-						Facts:     getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:     getFactsForTest(s.T(), virtualmachine.FactsUnknownGuestOS),
 					},
 				},
 			}),
@@ -122,7 +123,7 @@ func (s *virtualMachineSuite) Test_VirtualMachineEvents() {
 						Namespace: vmNamespace,
 						ClusterId: clusterID,
 						State:     virtualMachineV1.VirtualMachine_STOPPED,
-						Facts:     getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:     getFactsForTest(s.T(), virtualmachine.FactsUnknownGuestOS),
 					},
 				},
 			}),
@@ -155,7 +156,7 @@ func (s *virtualMachineSuite) Test_VirtualMachineEvents() {
 						Namespace: vmNamespace,
 						ClusterId: clusterID,
 						State:     virtualMachineV1.VirtualMachine_STOPPED,
-						Facts:     getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:     getFactsForTest(s.T(), virtualmachine.FactsUnknownGuestOS),
 					},
 				},
 			}),
@@ -176,7 +177,7 @@ func (s *virtualMachineSuite) Test_VirtualMachineEvents() {
 						Namespace: vmNamespace,
 						ClusterId: clusterID,
 						State:     virtualMachineV1.VirtualMachine_STOPPED,
-						Facts:     getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:     getFactsForTest(s.T(), virtualmachine.FactsUnknownGuestOS),
 					},
 				},
 			}),
@@ -224,7 +225,7 @@ func (s *virtualMachineSuite) Test_VirtualMachineEvents() {
 						State:       virtualMachineV1.VirtualMachine_RUNNING,
 						VsockCid:    int32(runningVSockCID),
 						VsockCidSet: true,
-						Facts:       getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:       getFactsForTest(s.T(), virtualmachine.FactsUnknownGuestOS),
 					},
 				},
 			}),
@@ -260,7 +261,7 @@ func (s *virtualMachineSuite) Test_VirtualMachineEvents() {
 						State:       virtualMachineV1.VirtualMachine_RUNNING,
 						VsockCid:    int32(runningVSockCID),
 						VsockCidSet: true,
-						Facts:       getFactsForTest(s.T(), UnknownGuestOS),
+						Facts:       getFactsForTest(s.T(), virtualmachine.FactsUnknownGuestOS),
 					},
 				},
 			}),

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -192,7 +192,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 
 	var virtualMachineHandler vmIndex.Handler
 	if features.VirtualMachines.Enabled() {
-		virtualMachineHandler = vmIndex.NewHandler(storeProvider.VirtualMachines())
+		virtualMachineHandler = vmIndex.NewHandler(clusterID, storeProvider.VirtualMachines())
 		components = append(components, virtualMachineHandler)
 	}
 
@@ -276,7 +276,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	}
 
 	if features.VirtualMachines.Enabled() {
-		apiServices = append(apiServices, vmIndex.NewService(virtualMachineHandler))
+		apiServices = append(apiServices, vmIndex.NewService(virtualMachineHandler, storeProvider.VirtualMachines()))
 	}
 
 	if admCtrlSettingsMgr != nil {


### PR DESCRIPTION
## Description

Wire roxagent discovered VM facts into Sensor so they are cached by VM ID and merged into `VirtualMachine` events sent to Central under the ROX_VIRTUAL_MACHINES feature flag. This keeps the existing VM store lifecycle semantics while allowing Central to receive agent facts without synchronizing event streams.

As the informer events about VirtualMachines and VirtualMachineInstances happen relatively rarely, in this PR an update message is being sent to Central whenever new facts arrive from the Relay.

AI assistance: initial store/mapping/dispatcher/test changes were generated by AI; user corrected log/metrics placement and race commentary and adjusted formatting and test structure.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- [x] Manually on a cluster

<img width="1186" height="1047" alt="Screenshot 2026-01-27 at 18 07 06" src="https://github.com/user-attachments/assets/eca4e95c-ff5a-4f8e-92a0-fe5a14dc4a1b" />
