### PR TITLE
build: Add CONTAINER_RUNTIME variable to support podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 include $(CURDIR)/make/env.mk
 
 PLATFORM ?= linux/amd64
+CONTAINER_RUNTIME ?= docker
+export CONTAINER_RUNTIME
 ROX_PROJECT=apollo
 TESTFLAGS=-race -p 4
 BASE_DIR=$(CURDIR)
@@ -9,12 +11,14 @@ BENCHTIMEOUT ?= 20m
 BENCHCOUNT ?= 1
 
 podman =
+# If CONTAINER_RUNTIME is explicitly set to podman, detect it
+ifeq ($(CONTAINER_RUNTIME),podman)
+	podman = yes
 # docker --version might not contain any traces of podman in the latest
 # version, search for more output
-ifneq (,$(findstring podman,$(shell docker --version 2>/dev/null)))
+else ifneq (,$(findstring podman,$(shell $(CONTAINER_RUNTIME) --version 2>/dev/null)))
 	podman = yes
-endif
-ifneq (,$(findstring Podman,$(shell docker version 2>/dev/null)))
+else ifneq (,$(findstring Podman,$(shell $(CONTAINER_RUNTIME) version 2>/dev/null)))
 	podman = yes
 endif
 
@@ -225,7 +229,7 @@ config-controller-build-nodeps:
 .PHONY: fast-central
 fast-central: deps
 	@echo "+ $@"
-	docker run $(DOCKER_OPTS) -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make fast-central-build
+	$(CONTAINER_RUNTIME) run $(DOCKER_OPTS) -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make fast-central-build
 	$(SILENT)$(BASE_DIR)/scripts/k8s/kill-pod.sh central
 
 # fast is a dev mode options when using local dev
@@ -243,7 +247,7 @@ fast-sensor-kubernetes: sensor-kubernetes-build-dockerized
 .PHONY: fast-migrator
 fast-migrator:
 	@echo "+ $@"
-	docker run $(DOCKER_OPTS) -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make fast-migrator-build
+	$(CONTAINER_RUNTIME) run $(DOCKER_OPTS) -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make fast-migrator-build
 
 .PHONY: fast-migrator-build
 fast-migrator-build: migrator-build-nodeps
@@ -451,8 +455,8 @@ bin/$(HOST_OS)_$(GOARCH)/admission-control: build-prep
 .PHONY: build-volumes
 build-volumes:
 	$(SILENT)mkdir -p $(CURDIR)/linux-gocache
-	$(SILENT)docker volume inspect $(GOPATH_VOLUME_NAME) >/dev/null 2>&1 || docker volume create $(GOPATH_VOLUME_NAME)
-	$(SILENT)docker volume inspect $(GOCACHE_VOLUME_NAME) >/dev/null 2>&1 || docker volume create $(GOCACHE_VOLUME_NAME)
+	$(SILENT)$(CONTAINER_RUNTIME) volume inspect $(GOPATH_VOLUME_NAME) >/dev/null 2>&1 || $(CONTAINER_RUNTIME) volume create $(GOPATH_VOLUME_NAME)
+	$(SILENT)$(CONTAINER_RUNTIME) volume inspect $(GOCACHE_VOLUME_NAME) >/dev/null 2>&1 || $(CONTAINER_RUNTIME) volume create $(GOCACHE_VOLUME_NAME)
 
 .PHONY: main-build
 main-build: build-prep main-build-dockerized
@@ -461,12 +465,12 @@ main-build: build-prep main-build-dockerized
 .PHONY: sensor-build-dockerized
 sensor-build-dockerized: build-volumes
 	@echo "+ $@"
-	docker run $(DOCKER_OPTS) --rm -e CI -e BUILD_TAG -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make sensor-build
+	$(CONTAINER_RUNTIME) run $(DOCKER_OPTS) --rm -e CI -e BUILD_TAG -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make sensor-build
 
 .PHONY: sensor-kubernetes-build-dockerized
 sensor-kubernetes-build-dockerized: build-volumes
 	@echo "+ $@"
-	docker run $(DOCKER_OPTS) -e CI -e BUILD_TAG -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make sensor-kubernetes-build
+	$(CONTAINER_RUNTIME) run $(DOCKER_OPTS) -e CI -e BUILD_TAG -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make sensor-kubernetes-build
 
 .PHONY: sensor-build
 sensor-build:
@@ -480,7 +484,7 @@ sensor-kubernetes-build:
 .PHONY: main-build-dockerized
 main-build-dockerized: build-volumes
 	@echo "+ $@"
-	docker run $(DOCKER_OPTS) -i -e RACE -e CI -e BUILD_TAG -e SHORTCOMMIT -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make main-build-nodeps
+	$(CONTAINER_RUNTIME) run $(DOCKER_OPTS) -i -e RACE -e CI -e BUILD_TAG -e SHORTCOMMIT -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED --rm $(GOPATH_WD_OVERRIDES) $(LOCAL_VOLUME_ARGS) $(BUILD_IMAGE) make main-build-nodeps
 
 .PHONY: main-build-nodeps
 main-build-nodeps:
@@ -702,7 +706,7 @@ scale-image: scale-build clean-image
 	cp bin/linux_$(GOARCH)/profiler scale/image/rhel/bin/profiler
 	cp bin/linux_$(GOARCH)/chaos scale/image/rhel/bin/chaos
 	chmod +w scale/image/rhel/bin/*
-	docker build \
+	$(CONTAINER_RUNTIME) build \
 		-t stackrox/scale:$(TAG) \
 		-t quay.io/rhacs-eng/scale:$(TAG) \
 		-f scale/image/Dockerfile scale
@@ -711,7 +715,7 @@ webhookserver-image: webhookserver-build
 	-mkdir webhookserver/bin
 	cp bin/linux_$(GOARCH)/webhookserver webhookserver/bin/webhookserver
 	chmod +w webhookserver/bin/webhookserver
-	docker build \
+	$(CONTAINER_RUNTIME) build \
 		-t stackrox/webhookserver:1.2 \
 		-t quay.io/rhacs-eng/webhookserver:1.2 \
 		-f webhookserver/Dockerfile webhookserver
@@ -720,7 +724,7 @@ syslog-image: syslog-build
 	-mkdir qa-tests-backend/test-images/syslog/bin
 	cp bin/linux_$(GOARCH)/syslog qa-tests-backend/test-images/syslog/bin/syslog
 	chmod +w qa-tests-backend/test-images/syslog/bin/syslog
-	docker build \
+	$(CONTAINER_RUNTIME) build \
 		-t stackrox/qa:syslog_server_1_0 \
 		-t quay.io/rhacs-eng/qa:syslog_server_1_0 \
 		-f qa-tests-backend/test-images/syslog/Dockerfile qa-tests-backend/test-images/syslog

--- a/scripts/check-debugger.sh
+++ b/scripts/check-debugger.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+
 errecho() {
   echo >&2 -e "$@"
 }
@@ -17,9 +19,9 @@ if [[ -n "${BUILD_TAG}" && "${DEBUG_BUILD}" == "yes" ]]; then
 fi
 
 # This searches for a file in the image without running the container.
-container=$(docker create stackrox/main:"${TAG}")
-docker export "${container}" | tar t | grep 'bin/dlv$' && found_dlv="yes" || found_dlv="no"
-docker rm "${container}" &>/dev/null
+container=$(${CONTAINER_RUNTIME} create stackrox/main:"${TAG}")
+${CONTAINER_RUNTIME} export "${container}" | tar t | grep 'bin/dlv$' && found_dlv="yes" || found_dlv="no"
+${CONTAINER_RUNTIME} rm "${container}" &>/dev/null
 
 if [[ "${found_dlv}" != "${DEBUG_BUILD}" ]]; then
   if [[ "${DEBUG_BUILD}" == "yes" ]]; then

--- a/scripts/connect-ui.sh
+++ b/scripts/connect-ui.sh
@@ -2,8 +2,10 @@
 
 set -e
 
-# ensure logged in to docker
-docker login
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+
+# ensure logged in to container runtime
+${CONTAINER_RUNTIME} login
 
 # get clean cluster name
 CLUSTER_NAME="$(echo $1 | sed 's/-rg//')"

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -2,9 +2,14 @@
 
 set -e
 
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+
 echo "Building with platform linux/${GOARCH}"
-if docker info | grep buildx; then
-    docker buildx build --platform "linux/${GOARCH}" --load "$@"
+if ${CONTAINER_RUNTIME} info | grep buildx; then
+    # --load is only needed for docker buildx (podman loads images by default)
+    LOAD_FLAG=""
+    [[ "${CONTAINER_RUNTIME}" == "docker" ]] && LOAD_FLAG="--load"
+    ${CONTAINER_RUNTIME} buildx build --platform "linux/${GOARCH}" ${LOAD_FLAG} "$@"
 else
-    docker build --platform "linux/${GOARCH}" "$@"
+    ${CONTAINER_RUNTIME} build --platform "linux/${GOARCH}" "$@"
 fi

--- a/scripts/ensure_image.sh
+++ b/scripts/ensure_image.sh
@@ -4,6 +4,8 @@
 ## First, it tries to pull the image. If it succeeds, it exits.
 ## If not, it builds the image. If run in CI, it also pushes the image.
 
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+
 die() {
   echo >&2 "$@"
   exit 1
@@ -16,30 +18,30 @@ dir="$3"
 [[ -n "${image}" && -n "${dockerfile}" && -n "${dir}" ]] || die "Usage $0 <image> <dockerfile_path> <dir>"
 
 echo "Potentially pulling image ${image}"
-docker_pull_output="$(docker pull "${image}" 2>&1)"
+docker_pull_output="$(${CONTAINER_RUNTIME} pull "${image}" 2>&1)"
 if [[ "$?" -eq 0 ]]; then
   echo "Image exists. Exiting..."
   exit 0
 fi
 if [[ ! "${docker_pull_output}" =~ ^.*manifest\ for.*not\ found.*$ ]]; then
-  die "Unexpected docker pull error: ${docker_pull_output}"
+  die "Unexpected ${CONTAINER_RUNTIME} pull error: ${docker_pull_output}"
 fi
 
 set -e
 echo "Building the image since it doesn't exist"
-docker build -t "${image}" -f "${dockerfile}" "${dir}"
+${CONTAINER_RUNTIME} build -t "${image}" -f "${dockerfile}" "${dir}"
 if [[ -n "${CI}" ]]; then
     case "$image" in
         quay.io/rhacs-eng/*)
-            docker login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin <<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
+            ${CONTAINER_RUNTIME} login -u "$QUAY_RHACS_ENG_RW_USERNAME" --password-stdin <<<"$QUAY_RHACS_ENG_RW_PASSWORD" quay.io
             ;;
         quay.io/stackrox-io/*)
-            docker login -u "$QUAY_STACKROX_IO_RW_USERNAME" --password-stdin <<<"$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
+            ${CONTAINER_RUNTIME} login -u "$QUAY_STACKROX_IO_RW_USERNAME" --password-stdin <<<"$QUAY_STACKROX_IO_RW_PASSWORD" quay.io
             ;;
         *)
             die "Unsupported registry of image: $image"
     esac
-    docker push "${image}" | cat
+    ${CONTAINER_RUNTIME} push "${image}" | cat
 else
   echo "Not in CI, not pushing the new image..."
 fi


### PR DESCRIPTION
## Description

Adds `CONTAINER_RUNTIME` variable support throughout the build system to enable using podman as an alternative to docker.

**All scripts default to `docker` if `CONTAINER_RUNTIME` is not set, ensuring full backwards compatibility.**

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

```bash
$ CONTAINER_RUNTIME=podman make main-build
mkdir -p bin/{darwin_amd64,darwin_arm64,linux_amd64,linux_arm64,linux_ppc64le,linux_s390x,windows_amd64}
+ main-build-dockerized
podman run --security-opt label=disable -i -e RACE -e CI -e BUILD_TAG -e SHORTCOMMIT -e GOTAGS -e DEBUG_BUILD -e CGO_ENABLED --rm -w /src -e GOPATH=/go -e GOCACHE=/linux-gocache -e GIT_CONFIG_COUNT=1 -e GIT_CONFIG_KEY_0=safe.directory -e GIT_CONFIG_VALUE_0='/src' -v /Users/alexvulaj/Workspace/stackrox:/src:delegated -v /Users/alexvulaj/Workspace/stackrox/linux-gocache:/linux-gocache:delegated -v /Users/alexvulaj/Workspace/go:/go:delegated docker.io/library/golang:1.25 make main-build-nodeps
/src/scripts/go-build.sh \
        central \
        compliance/cmd/compliance \
        config-controller \
        migrator \
        sensor/admission-control \
        sensor/kubernetes \
        sensor/upgrader
CGO_ENABLED is not 0. Compiling with -linkmode=external
Compiling Go source in ./central ./compliance/cmd/compliance ./config-controller ./migrator ./sensor/admission-control ./sensor/kubernetes ./sensor/upgrader to bin/linux_arm64
CGO_ENABLED=0 /src/scripts/go-build.sh roxctl
Compiling Go source in ./roxctl to bin/linux_arm64
+ main-build
```
