### PR TITLE
ROX-30570: Add ScanSBOM API to Scanner V4

### DIFF
--- a/generated/internalapi/scanner/v4/matcher_service.pb.go
+++ b/generated/internalapi/scanner/v4/matcher_service.pb.go
@@ -194,6 +194,104 @@ func (x *GetSBOMResponse) GetSbom() []byte {
 	return nil
 }
 
+type ScanSBOMRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// sbom is the raw SBOM content.
+	Sbom []byte `protobuf:"bytes,1,opt,name=sbom,proto3" json:"sbom,omitempty"`
+	// media_type identifies the SBOM format (e.g., application/spdx+json).
+	MediaType     string `protobuf:"bytes,2,opt,name=media_type,json=mediaType,proto3" json:"media_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScanSBOMRequest) Reset() {
+	*x = ScanSBOMRequest{}
+	mi := &file_internalapi_scanner_v4_matcher_service_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScanSBOMRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScanSBOMRequest) ProtoMessage() {}
+
+func (x *ScanSBOMRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internalapi_scanner_v4_matcher_service_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScanSBOMRequest.ProtoReflect.Descriptor instead.
+func (*ScanSBOMRequest) Descriptor() ([]byte, []int) {
+	return file_internalapi_scanner_v4_matcher_service_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ScanSBOMRequest) GetSbom() []byte {
+	if x != nil {
+		return x.Sbom
+	}
+	return nil
+}
+
+func (x *ScanSBOMRequest) GetMediaType() string {
+	if x != nil {
+		return x.MediaType
+	}
+	return ""
+}
+
+type ScanSBOMResponse struct {
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	VulnerabilityReport *VulnerabilityReport   `protobuf:"bytes,1,opt,name=vulnerability_report,json=vulnerabilityReport,proto3" json:"vulnerability_report,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *ScanSBOMResponse) Reset() {
+	*x = ScanSBOMResponse{}
+	mi := &file_internalapi_scanner_v4_matcher_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScanSBOMResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScanSBOMResponse) ProtoMessage() {}
+
+func (x *ScanSBOMResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_internalapi_scanner_v4_matcher_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScanSBOMResponse.ProtoReflect.Descriptor instead.
+func (*ScanSBOMResponse) Descriptor() ([]byte, []int) {
+	return file_internalapi_scanner_v4_matcher_service_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ScanSBOMResponse) GetVulnerabilityReport() *VulnerabilityReport {
+	if x != nil {
+		return x.VulnerabilityReport
+	}
+	return nil
+}
+
 type Metadata struct {
 	state                   protoimpl.MessageState `protogen:"open.v1"`
 	LastVulnerabilityUpdate *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=LastVulnerabilityUpdate,proto3" json:"LastVulnerabilityUpdate,omitempty"`
@@ -203,7 +301,7 @@ type Metadata struct {
 
 func (x *Metadata) Reset() {
 	*x = Metadata{}
-	mi := &file_internalapi_scanner_v4_matcher_service_proto_msgTypes[3]
+	mi := &file_internalapi_scanner_v4_matcher_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -215,7 +313,7 @@ func (x *Metadata) String() string {
 func (*Metadata) ProtoMessage() {}
 
 func (x *Metadata) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_scanner_v4_matcher_service_proto_msgTypes[3]
+	mi := &file_internalapi_scanner_v4_matcher_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -228,7 +326,7 @@ func (x *Metadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Metadata.ProtoReflect.Descriptor instead.
 func (*Metadata) Descriptor() ([]byte, []int) {
-	return file_internalapi_scanner_v4_matcher_service_proto_rawDescGZIP(), []int{3}
+	return file_internalapi_scanner_v4_matcher_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Metadata) GetLastVulnerabilityUpdate() *timestamppb.Timestamp {
@@ -253,13 +351,20 @@ const file_internalapi_scanner_v4_matcher_service_proto_rawDesc = "" +
 	"\x03uri\x18\x03 \x01(\tR\x03uri\x120\n" +
 	"\bcontents\x18\x04 \x01(\v2\x14.scanner.v4.ContentsR\bcontents\"%\n" +
 	"\x0fGetSBOMResponse\x12\x12\n" +
-	"\x04sbom\x18\x01 \x01(\fR\x04sbom\"`\n" +
+	"\x04sbom\x18\x01 \x01(\fR\x04sbom\"D\n" +
+	"\x0fScanSBOMRequest\x12\x12\n" +
+	"\x04sbom\x18\x01 \x01(\fR\x04sbom\x12\x1d\n" +
+	"\n" +
+	"media_type\x18\x02 \x01(\tR\tmediaType\"f\n" +
+	"\x10ScanSBOMResponse\x12R\n" +
+	"\x14vulnerability_report\x18\x01 \x01(\v2\x1f.scanner.v4.VulnerabilityReportR\x13vulnerabilityReport\"`\n" +
 	"\bMetadata\x12T\n" +
-	"\x17LastVulnerabilityUpdate\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x17LastVulnerabilityUpdate2\xe8\x01\n" +
+	"\x17LastVulnerabilityUpdate\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x17LastVulnerabilityUpdate2\xaf\x02\n" +
 	"\aMatcher\x12\\\n" +
 	"\x12GetVulnerabilities\x12%.scanner.v4.GetVulnerabilitiesRequest\x1a\x1f.scanner.v4.VulnerabilityReport\x12;\n" +
 	"\vGetMetadata\x12\x16.google.protobuf.Empty\x1a\x14.scanner.v4.Metadata\x12B\n" +
-	"\aGetSBOM\x12\x1a.scanner.v4.GetSBOMRequest\x1a\x1b.scanner.v4.GetSBOMResponseB\x1dZ\x1b./internalapi/scanner/v4;v4b\x06proto3"
+	"\aGetSBOM\x12\x1a.scanner.v4.GetSBOMRequest\x1a\x1b.scanner.v4.GetSBOMResponse\x12E\n" +
+	"\bScanSBOM\x12\x1b.scanner.v4.ScanSBOMRequest\x1a\x1c.scanner.v4.ScanSBOMResponseB\x1dZ\x1b./internalapi/scanner/v4;v4b\x06proto3"
 
 var (
 	file_internalapi_scanner_v4_matcher_service_proto_rawDescOnce sync.Once
@@ -273,32 +378,37 @@ func file_internalapi_scanner_v4_matcher_service_proto_rawDescGZIP() []byte {
 	return file_internalapi_scanner_v4_matcher_service_proto_rawDescData
 }
 
-var file_internalapi_scanner_v4_matcher_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_internalapi_scanner_v4_matcher_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_internalapi_scanner_v4_matcher_service_proto_goTypes = []any{
 	(*GetVulnerabilitiesRequest)(nil), // 0: scanner.v4.GetVulnerabilitiesRequest
 	(*GetSBOMRequest)(nil),            // 1: scanner.v4.GetSBOMRequest
 	(*GetSBOMResponse)(nil),           // 2: scanner.v4.GetSBOMResponse
-	(*Metadata)(nil),                  // 3: scanner.v4.Metadata
-	(*Contents)(nil),                  // 4: scanner.v4.Contents
-	(*timestamppb.Timestamp)(nil),     // 5: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),             // 6: google.protobuf.Empty
+	(*ScanSBOMRequest)(nil),           // 3: scanner.v4.ScanSBOMRequest
+	(*ScanSBOMResponse)(nil),          // 4: scanner.v4.ScanSBOMResponse
+	(*Metadata)(nil),                  // 5: scanner.v4.Metadata
+	(*Contents)(nil),                  // 6: scanner.v4.Contents
 	(*VulnerabilityReport)(nil),       // 7: scanner.v4.VulnerabilityReport
+	(*timestamppb.Timestamp)(nil),     // 8: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),             // 9: google.protobuf.Empty
 }
 var file_internalapi_scanner_v4_matcher_service_proto_depIdxs = []int32{
-	4, // 0: scanner.v4.GetVulnerabilitiesRequest.contents:type_name -> scanner.v4.Contents
-	4, // 1: scanner.v4.GetSBOMRequest.contents:type_name -> scanner.v4.Contents
-	5, // 2: scanner.v4.Metadata.LastVulnerabilityUpdate:type_name -> google.protobuf.Timestamp
-	0, // 3: scanner.v4.Matcher.GetVulnerabilities:input_type -> scanner.v4.GetVulnerabilitiesRequest
-	6, // 4: scanner.v4.Matcher.GetMetadata:input_type -> google.protobuf.Empty
-	1, // 5: scanner.v4.Matcher.GetSBOM:input_type -> scanner.v4.GetSBOMRequest
-	7, // 6: scanner.v4.Matcher.GetVulnerabilities:output_type -> scanner.v4.VulnerabilityReport
-	3, // 7: scanner.v4.Matcher.GetMetadata:output_type -> scanner.v4.Metadata
-	2, // 8: scanner.v4.Matcher.GetSBOM:output_type -> scanner.v4.GetSBOMResponse
-	6, // [6:9] is the sub-list for method output_type
-	3, // [3:6] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	6, // 0: scanner.v4.GetVulnerabilitiesRequest.contents:type_name -> scanner.v4.Contents
+	6, // 1: scanner.v4.GetSBOMRequest.contents:type_name -> scanner.v4.Contents
+	7, // 2: scanner.v4.ScanSBOMResponse.vulnerability_report:type_name -> scanner.v4.VulnerabilityReport
+	8, // 3: scanner.v4.Metadata.LastVulnerabilityUpdate:type_name -> google.protobuf.Timestamp
+	0, // 4: scanner.v4.Matcher.GetVulnerabilities:input_type -> scanner.v4.GetVulnerabilitiesRequest
+	9, // 5: scanner.v4.Matcher.GetMetadata:input_type -> google.protobuf.Empty
+	1, // 6: scanner.v4.Matcher.GetSBOM:input_type -> scanner.v4.GetSBOMRequest
+	3, // 7: scanner.v4.Matcher.ScanSBOM:input_type -> scanner.v4.ScanSBOMRequest
+	7, // 8: scanner.v4.Matcher.GetVulnerabilities:output_type -> scanner.v4.VulnerabilityReport
+	5, // 9: scanner.v4.Matcher.GetMetadata:output_type -> scanner.v4.Metadata
+	2, // 10: scanner.v4.Matcher.GetSBOM:output_type -> scanner.v4.GetSBOMResponse
+	4, // 11: scanner.v4.Matcher.ScanSBOM:output_type -> scanner.v4.ScanSBOMResponse
+	8, // [8:12] is the sub-list for method output_type
+	4, // [4:8] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_internalapi_scanner_v4_matcher_service_proto_init() }
@@ -314,7 +424,7 @@ func file_internalapi_scanner_v4_matcher_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internalapi_scanner_v4_matcher_service_proto_rawDesc), len(file_internalapi_scanner_v4_matcher_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/generated/internalapi/scanner/v4/matcher_service_grpc.pb.go
+++ b/generated/internalapi/scanner/v4/matcher_service_grpc.pb.go
@@ -23,6 +23,7 @@ const (
 	Matcher_GetVulnerabilities_FullMethodName = "/scanner.v4.Matcher/GetVulnerabilities"
 	Matcher_GetMetadata_FullMethodName        = "/scanner.v4.Matcher/GetMetadata"
 	Matcher_GetSBOM_FullMethodName            = "/scanner.v4.Matcher/GetSBOM"
+	Matcher_ScanSBOM_FullMethodName           = "/scanner.v4.Matcher/ScanSBOM"
 )
 
 // MatcherClient is the client API for Matcher service.
@@ -37,6 +38,8 @@ type MatcherClient interface {
 	GetMetadata(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*Metadata, error)
 	// GetSBOM returns an SBOM for a previously indexed manifest.
 	GetSBOM(ctx context.Context, in *GetSBOMRequest, opts ...grpc.CallOption) (*GetSBOMResponse, error)
+	// ScanSBOM decodes an SBOM and returns a vulnerability report.
+	ScanSBOM(ctx context.Context, in *ScanSBOMRequest, opts ...grpc.CallOption) (*ScanSBOMResponse, error)
 }
 
 type matcherClient struct {
@@ -77,6 +80,16 @@ func (c *matcherClient) GetSBOM(ctx context.Context, in *GetSBOMRequest, opts ..
 	return out, nil
 }
 
+func (c *matcherClient) ScanSBOM(ctx context.Context, in *ScanSBOMRequest, opts ...grpc.CallOption) (*ScanSBOMResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ScanSBOMResponse)
+	err := c.cc.Invoke(ctx, Matcher_ScanSBOM_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MatcherServer is the server API for Matcher service.
 // All implementations should embed UnimplementedMatcherServer
 // for forward compatibility.
@@ -89,6 +102,8 @@ type MatcherServer interface {
 	GetMetadata(context.Context, *emptypb.Empty) (*Metadata, error)
 	// GetSBOM returns an SBOM for a previously indexed manifest.
 	GetSBOM(context.Context, *GetSBOMRequest) (*GetSBOMResponse, error)
+	// ScanSBOM decodes an SBOM and returns a vulnerability report.
+	ScanSBOM(context.Context, *ScanSBOMRequest) (*ScanSBOMResponse, error)
 }
 
 // UnimplementedMatcherServer should be embedded to have
@@ -106,6 +121,9 @@ func (UnimplementedMatcherServer) GetMetadata(context.Context, *emptypb.Empty) (
 }
 func (UnimplementedMatcherServer) GetSBOM(context.Context, *GetSBOMRequest) (*GetSBOMResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetSBOM not implemented")
+}
+func (UnimplementedMatcherServer) ScanSBOM(context.Context, *ScanSBOMRequest) (*ScanSBOMResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ScanSBOM not implemented")
 }
 func (UnimplementedMatcherServer) testEmbeddedByValue() {}
 
@@ -181,6 +199,24 @@ func _Matcher_GetSBOM_Handler(srv interface{}, ctx context.Context, dec func(int
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Matcher_ScanSBOM_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ScanSBOMRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MatcherServer).ScanSBOM(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Matcher_ScanSBOM_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MatcherServer).ScanSBOM(ctx, req.(*ScanSBOMRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Matcher_ServiceDesc is the grpc.ServiceDesc for Matcher service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -199,6 +235,10 @@ var Matcher_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetSBOM",
 			Handler:    _Matcher_GetSBOM_Handler,
+		},
+		{
+			MethodName: "ScanSBOM",
+			Handler:    _Matcher_ScanSBOM_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/generated/internalapi/scanner/v4/matcher_service_vtproto.pb.go
+++ b/generated/internalapi/scanner/v4/matcher_service_vtproto.pb.go
@@ -81,6 +81,45 @@ func (m *GetSBOMResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *ScanSBOMRequest) CloneVT() *ScanSBOMRequest {
+	if m == nil {
+		return (*ScanSBOMRequest)(nil)
+	}
+	r := new(ScanSBOMRequest)
+	r.MediaType = m.MediaType
+	if rhs := m.Sbom; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.Sbom = tmpBytes
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ScanSBOMRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ScanSBOMResponse) CloneVT() *ScanSBOMResponse {
+	if m == nil {
+		return (*ScanSBOMResponse)(nil)
+	}
+	r := new(ScanSBOMResponse)
+	r.VulnerabilityReport = m.VulnerabilityReport.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ScanSBOMResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *Metadata) CloneVT() *Metadata {
 	if m == nil {
 		return (*Metadata)(nil)
@@ -162,6 +201,47 @@ func (this *GetSBOMResponse) EqualVT(that *GetSBOMResponse) bool {
 
 func (this *GetSBOMResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*GetSBOMResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ScanSBOMRequest) EqualVT(that *ScanSBOMRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if string(this.Sbom) != string(that.Sbom) {
+		return false
+	}
+	if this.MediaType != that.MediaType {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ScanSBOMRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ScanSBOMRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ScanSBOMResponse) EqualVT(that *ScanSBOMResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.VulnerabilityReport.EqualVT(that.VulnerabilityReport) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ScanSBOMResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ScanSBOMResponse)
 	if !ok {
 		return false
 	}
@@ -340,6 +420,96 @@ func (m *GetSBOMResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *ScanSBOMRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ScanSBOMRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ScanSBOMRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.MediaType) > 0 {
+		i -= len(m.MediaType)
+		copy(dAtA[i:], m.MediaType)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MediaType)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Sbom) > 0 {
+		i -= len(m.Sbom)
+		copy(dAtA[i:], m.Sbom)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Sbom)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ScanSBOMResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ScanSBOMResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ScanSBOMResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.VulnerabilityReport != nil {
+		size, err := m.VulnerabilityReport.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Metadata) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -435,6 +605,38 @@ func (m *GetSBOMResponse) SizeVT() (n int) {
 	_ = l
 	l = len(m.Sbom)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ScanSBOMRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Sbom)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.MediaType)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ScanSBOMResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.VulnerabilityReport != nil {
+		l = m.VulnerabilityReport.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -818,6 +1020,210 @@ func (m *GetSBOMResponse) UnmarshalVT(dAtA []byte) error {
 			m.Sbom = append(m.Sbom[:0], dAtA[iNdEx:postIndex]...)
 			if m.Sbom == nil {
 				m.Sbom = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ScanSBOMRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ScanSBOMRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ScanSBOMRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sbom", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Sbom = append(m.Sbom[:0], dAtA[iNdEx:postIndex]...)
+			if m.Sbom == nil {
+				m.Sbom = []byte{}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MediaType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MediaType = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ScanSBOMResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ScanSBOMResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ScanSBOMResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VulnerabilityReport", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.VulnerabilityReport == nil {
+				m.VulnerabilityReport = &VulnerabilityReport{}
+			}
+			if err := m.VulnerabilityReport.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
 			iNdEx = postIndex
 		default:
@@ -1306,6 +1712,211 @@ func (m *GetSBOMResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Sbom = dAtA[iNdEx:postIndex]
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ScanSBOMRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ScanSBOMRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ScanSBOMRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Sbom", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Sbom = dAtA[iNdEx:postIndex]
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MediaType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.MediaType = stringValue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ScanSBOMResponse) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ScanSBOMResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ScanSBOMResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VulnerabilityReport", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.VulnerabilityReport == nil {
+				m.VulnerabilityReport = &VulnerabilityReport{}
+			}
+			if err := m.VulnerabilityReport.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/go.mod
+++ b/go.mod
@@ -102,6 +102,7 @@ require (
 	github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b
 	github.com/operator-framework/helm-operator-plugins v0.0.0-00010101000000-000000000000
 	github.com/owenrumney/go-sarif/v2 v2.3.3
+	github.com/package-url/packageurl-go v0.1.5
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240409071808-615f978279ca
@@ -420,7 +421,6 @@ require (
 	github.com/openshift-online/ocm-api-model/model v0.0.454 // indirect
 	github.com/openshift/custom-resource-status v1.1.2 // indirect
 	github.com/operator-framework/operator-lib v0.17.0 // indirect
-	github.com/package-url/packageurl-go v0.1.5 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/pkg/scanners/scannerv4/scannerv4.go
+++ b/pkg/scanners/scannerv4/scannerv4.go
@@ -139,26 +139,17 @@ func (s *scannerv4) ScanSBOM(ctx context.Context, sbomReader io.Reader, contentT
 	ctx, cancel := context.WithTimeout(ctx, scanTimeout)
 	defer cancel()
 
-	var scannerVersion pkgscanner.Version
-	scannerVersion.Matcher = "v7"
-
-	// TODO(ROX-30570): START Remove
-	// Read all data from the SBOM reader and throw it away (testing purposes only)
-	_ = ctx
-	dataB, err := io.ReadAll(sbomReader)
+	sbomBytes, err := io.ReadAll(sbomReader)
 	if err != nil {
-		return nil, fmt.Errorf("reading sbom data: %w", err)
+		return nil, fmt.Errorf("reading sbom: %w", err)
 	}
-	log.Debugf("Scanned SBOM: %s", dataB)
-	// Create a fake vuln report for testing purposes
-	vr := fakeVulnReport()
-	// TODO(ROX-30570): END Remove
 
-	// TODO(ROX-30570): Replace with actual scanner client call
-	// vr, err := s.scannerClient.ScanSBOM(ctx, sbomReader, contentType, client.Version(&scannerVersion))
-	// if err != nil {
-	// 	return nil, fmt.Errorf("scanning sbom: %w", err)
-	// }
+	var scannerVersion pkgscanner.Version
+
+	vr, err := s.scannerClient.ScanSBOM(ctx, sbomBytes, contentType, client.Version(&scannerVersion))
+	if err != nil {
+		return nil, fmt.Errorf("scanning sbom: %w", err)
+	}
 
 	scannerVersionStr, err := scannerVersion.Encode()
 	if err != nil {
@@ -169,89 +160,6 @@ func (s *scannerv4) ScanSBOM(ctx context.Context, sbomReader io.Reader, contentT
 		Id:   vr.GetHashId(),
 		Scan: sbomScan(vr, scannerVersionStr),
 	}, nil
-}
-
-// fakeVulnReport generates a fake vuln report for testing purposes.
-//
-// TODO(ROX-30570): REMOVE
-func fakeVulnReport() *v4.VulnerabilityReport {
-	return &v4.VulnerabilityReport{
-		HashId: "fake HashId",
-		Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
-			"v1": {
-				Name:               "Fake Vuln #1",
-				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_CRITICAL,
-				CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
-					{
-						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
-							Vector: "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
-						},
-						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
-						Url:    "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
-					},
-				},
-			},
-			"v2": {
-				Name:               "Fake Vuln #2",
-				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
-				CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
-					{
-						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
-							Vector: "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
-						},
-						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
-						Url:    "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
-					},
-				},
-			},
-			"v3": {
-				Name:               "Fake Vuln #3",
-				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
-
-				CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
-					{
-						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
-							BaseScore: 8.2,
-							Vector:    "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:L/I:N/A:H",
-						},
-						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_RED_HAT,
-						Url:    "https://access.redhat.com/security/cve/CVE-1234-567",
-					},
-					{
-						V2: &v4.VulnerabilityReport_Vulnerability_CVSS_V2{
-							BaseScore: 6.4,
-							Vector:    "AV:N/AC:M/Au:M/C:C/I:N/A:P",
-						},
-						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
-						Url:    "https://nvd.nist.gov/vuln/detail/CVE-1234-567",
-					},
-				},
-			},
-			"v4": {
-				Name:               "Fake Vuln #4",
-				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_LOW,
-				CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
-					{
-						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
-							Vector: "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:N",
-						},
-						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
-						Url:    "https://nvd.nist.gov/vuln/detail/CVE-5678-1234",
-					},
-				},
-			},
-		},
-		PackageVulnerabilities: map[string]*v4.StringList{
-			"p1": {Values: []string{"v1", "v2", "v3", "v4"}},
-			"p2": {Values: []string{"v3", "v4"}},
-		},
-		Contents: &v4.Contents{
-			Packages: map[string]*v4.Package{
-				"p1": {Name: "Fake Package #1", Version: "v1.0.0"},
-				"p2": {Name: "Fake Package #2", Version: "v2.3.4"},
-			},
-		},
-	}
 }
 
 func sbomScan(vr *v4.VulnerabilityReport, scannerVersionStr string) *v1.SBOMScanResponse_SBOMScan {

--- a/pkg/scanners/scannerv4/scannerv4_test.go
+++ b/pkg/scanners/scannerv4/scannerv4_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -79,6 +81,86 @@ func TestGetVulnDefinitionsInfo(t *testing.T) {
 		})
 	}
 
+}
+
+func TestScanSBOM(t *testing.T) {
+	vulnReport := &v4.VulnerabilityReport{
+		HashId: "test-hash-id",
+		Contents: &v4.Contents{
+			Packages: map[string]*v4.Package{
+				"p1": {Name: "pkg-a", Version: "1.0.0"},
+			},
+		},
+		PackageVulnerabilities: map[string]*v4.StringList{
+			"p1": {Values: []string{"v1"}},
+		},
+		Vulnerabilities: map[string]*v4.VulnerabilityReport_Vulnerability{
+			"v1": {
+				Name:               "CVE-2024-0001",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		reader       func() *strings.Reader
+		readerErr    bool
+		clientRet    *v4.VulnerabilityReport
+		clientRetErr error
+		wantErr      string
+	}{
+		"success": {
+			reader:    func() *strings.Reader { return strings.NewReader(`{"fake":"sbom"}`) },
+			clientRet: vulnReport,
+		},
+		"client error": {
+			reader:       func() *strings.Reader { return strings.NewReader(`{"fake":"sbom"}`) },
+			clientRetErr: errors.New("matcher unavailable"),
+			wantErr:      "scanning sbom",
+		},
+		"reader error": {
+			readerErr: true,
+			wantErr:   "reading sbom",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			scannerClient := s4ClientMocks.NewMockScanner(ctrl)
+
+			if tc.readerErr {
+				s := scannerv4{scannerClient: scannerClient}
+				resp, err := s.ScanSBOM(context.Background(), iotest.ErrReader(errors.New("bad reader")), "application/json")
+				require.ErrorContains(t, err, tc.wantErr)
+				assert.Nil(t, resp)
+				return
+			}
+
+			scannerClient.EXPECT().
+				ScanSBOM(gomock.Any(), gomock.Any(), gomock.Eq("application/json"), gomock.Any()).
+				Return(tc.clientRet, tc.clientRetErr)
+
+			s := scannerv4{scannerClient: scannerClient}
+			resp, err := s.ScanSBOM(context.Background(), tc.reader(), "application/json")
+
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				assert.Nil(t, resp)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, "test-hash-id", resp.GetId())
+			require.NotNil(t, resp.GetScan())
+			assert.NotEmpty(t, resp.GetScan().GetComponents())
+			for _, c := range resp.GetScan().GetComponents() {
+				for _, v := range c.GetVulns() {
+					assert.Equal(t, storage.EmbeddedVulnerability_UNKNOWN_VULNERABILITY, v.GetVulnerabilityType())
+				}
+			}
+		})
+	}
 }
 
 // TestGetVirtualMachineScan_Success tests the successful enrichment flow.

--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -115,6 +115,9 @@ type Scanner interface {
 	// If ifModifiedSince is non-empty, returns Modified=false if data hasn't changed.
 	GetRepositoryToCPEMapping(ctx context.Context, ifModifiedSince string) (*Repo2CPEResult, error)
 
+	// ScanSBOM decodes an SBOM and returns a vulnerability report.
+	ScanSBOM(ctx context.Context, sbom []byte, mediaType string, callOpts ...CallOption) (*v4.VulnerabilityReport, error)
+
 	// Close cleans up any resources used by the implementation.
 	Close() error
 }
@@ -491,6 +494,34 @@ func (c *gRPCScanner) GetRepositoryToCPEMapping(ctx context.Context, ifModifiedS
 		LastModified: resp.GetLastModified(),
 		Data:         &repositorytocpe.MappingFile{Data: data},
 	}, nil
+}
+
+// ScanSBOM calls the Matcher's gRPC endpoint ScanSBOM to decode an SBOM and return vulnerabilities.
+func (c *gRPCScanner) ScanSBOM(ctx context.Context, sbom []byte, mediaType string, callOpts ...CallOption) (*v4.VulnerabilityReport, error) {
+	if c.matcher == nil {
+		return nil, errMatcherNotConfigured
+	}
+
+	options := makeCallOptions(callOpts...)
+
+	req := &v4.ScanSBOMRequest{
+		Sbom:      sbom,
+		MediaType: mediaType,
+	}
+	var resp *v4.ScanSBOMResponse
+	var responseMetadata metadata.MD
+	err := retryWithBackoff(ctx, defaultBackoff(), "matcher.ScanSBOM", func() error {
+		var err error
+		resp, err = c.matcher.ScanSBOM(ctx, req, grpc.Header(&responseMetadata))
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan SBOM: %w", err)
+	}
+
+	setMatcherVersion(options, responseMetadata)
+
+	return resp.GetVulnerabilityReport(), nil
 }
 
 func getImageManifestID(ref name.Digest) string {

--- a/pkg/scannerv4/client/mocks/client.go
+++ b/pkg/scannerv4/client/mocks/client.go
@@ -195,6 +195,26 @@ func (mr *MockScannerMockRecorder) IndexAndScanImage(arg0, arg1, arg2, arg3 any,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexAndScanImage", reflect.TypeOf((*MockScanner)(nil).IndexAndScanImage), varargs...)
 }
 
+// ScanSBOM mocks base method.
+func (m *MockScanner) ScanSBOM(ctx context.Context, sbom []byte, mediaType string, callOpts ...client.CallOption) (*v4.VulnerabilityReport, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, sbom, mediaType}
+	for _, a := range callOpts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ScanSBOM", varargs...)
+	ret0, _ := ret[0].(*v4.VulnerabilityReport)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ScanSBOM indicates an expected call of ScanSBOM.
+func (mr *MockScannerMockRecorder) ScanSBOM(ctx, sbom, mediaType any, callOpts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, sbom, mediaType}, callOpts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanSBOM", reflect.TypeOf((*MockScanner)(nil).ScanSBOM), varargs...)
+}
+
 // StoreImageIndex mocks base method.
 func (m *MockScanner) StoreImageIndex(ctx context.Context, ref name.Digest, indexerVersion string, contents *v4.Contents, callOpts ...client.CallOption) error {
 	m.ctrl.T.Helper()

--- a/proto/internalapi/central/sensor_events.proto
+++ b/proto/internalapi/central/sensor_events.proto
@@ -79,6 +79,7 @@ message SensorEvent {
     storage.Secret secret = 7;
     storage.Node node = 9;
     storage.NodeInventory node_inventory = 25;
+
     scanner.v4.IndexReport index_report = 34;
     storage.ServiceAccount service_account = 14;
     storage.K8sRole role = 15;

--- a/proto/internalapi/scanner/v4/matcher_service.proto
+++ b/proto/internalapi/scanner/v4/matcher_service.proto
@@ -32,6 +32,17 @@ message GetSBOMResponse {
   bytes sbom = 1;
 }
 
+message ScanSBOMRequest {
+  // sbom is the raw SBOM content.
+  bytes sbom = 1;
+  // media_type identifies the SBOM format (e.g., application/spdx+json).
+  string media_type = 2;
+}
+
+message ScanSBOMResponse {
+  VulnerabilityReport vulnerability_report = 1;
+}
+
 message Metadata {
   google.protobuf.Timestamp LastVulnerabilityUpdate = 1;
 }
@@ -46,4 +57,7 @@ service Matcher {
 
   // GetSBOM returns an SBOM for a previously indexed manifest.
   rpc GetSBOM(GetSBOMRequest) returns (GetSBOMResponse);
+
+  // ScanSBOM decodes an SBOM and returns a vulnerability report.
+  rpc ScanSBOM(ScanSBOMRequest) returns (ScanSBOMResponse);
 }

--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -254,7 +254,7 @@ func (b *Backends) APIServices() []grpc.APIService {
 	if b.Matcher != nil {
 		// Set the index report getter to the remote indexer if available, otherwise the
 		// local indexer. A nil getter is ok, see implementation.
-		var getter indexer.ReportGetter
+		var getter indexer.ReportProvider
 		getter = b.RemoteIndexer
 		if getter == nil {
 			getter = b.Indexer

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -133,9 +133,10 @@ func proxiedRemoteTransport(insecure bool) http.RoundTripper {
 	return tr
 }
 
-// ReportGetter can get index reports from an Indexer.
-type ReportGetter interface {
+// ReportProvider provides index reports and repository-to-CPE mappings from an Indexer.
+type ReportProvider interface {
 	GetIndexReport(context.Context, string, bool) (*claircore.IndexReport, bool, error)
+	GetRepositoryToCPEMapping(context.Context, string) (*FetchResult, error)
 }
 
 // ReportStorer stores a claircore.IndexReport.
@@ -147,10 +148,9 @@ type ReportStorer interface {
 //
 //go:generate mockgen-wrapper
 type Indexer interface {
-	ReportGetter
+	ReportProvider
 	ReportStorer
 	IndexContainerImage(context.Context, string, string, ...Option) (*claircore.IndexReport, error)
-	GetRepositoryToCPEMapping(context.Context, string) (*FetchResult, error)
 	Close(context.Context) error
 	Ready(context.Context) error
 }

--- a/scanner/indexer/mocks/indexer.go
+++ b/scanner/indexer/mocks/indexer.go
@@ -18,32 +18,32 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
-// MockReportGetter is a mock of ReportGetter interface.
-type MockReportGetter struct {
+// MockReportProvider is a mock of ReportProvider interface.
+type MockReportProvider struct {
 	ctrl     *gomock.Controller
-	recorder *MockReportGetterMockRecorder
+	recorder *MockReportProviderMockRecorder
 	isgomock struct{}
 }
 
-// MockReportGetterMockRecorder is the mock recorder for MockReportGetter.
-type MockReportGetterMockRecorder struct {
-	mock *MockReportGetter
+// MockReportProviderMockRecorder is the mock recorder for MockReportProvider.
+type MockReportProviderMockRecorder struct {
+	mock *MockReportProvider
 }
 
-// NewMockReportGetter creates a new mock instance.
-func NewMockReportGetter(ctrl *gomock.Controller) *MockReportGetter {
-	mock := &MockReportGetter{ctrl: ctrl}
-	mock.recorder = &MockReportGetterMockRecorder{mock}
+// NewMockReportProvider creates a new mock instance.
+func NewMockReportProvider(ctrl *gomock.Controller) *MockReportProvider {
+	mock := &MockReportProvider{ctrl: ctrl}
+	mock.recorder = &MockReportProviderMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockReportGetter) EXPECT() *MockReportGetterMockRecorder {
+func (m *MockReportProvider) EXPECT() *MockReportProviderMockRecorder {
 	return m.recorder
 }
 
 // GetIndexReport mocks base method.
-func (m *MockReportGetter) GetIndexReport(arg0 context.Context, arg1 string, arg2 bool) (*claircore.IndexReport, bool, error) {
+func (m *MockReportProvider) GetIndexReport(arg0 context.Context, arg1 string, arg2 bool) (*claircore.IndexReport, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIndexReport", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*claircore.IndexReport)
@@ -53,9 +53,24 @@ func (m *MockReportGetter) GetIndexReport(arg0 context.Context, arg1 string, arg
 }
 
 // GetIndexReport indicates an expected call of GetIndexReport.
-func (mr *MockReportGetterMockRecorder) GetIndexReport(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockReportProviderMockRecorder) GetIndexReport(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexReport", reflect.TypeOf((*MockReportGetter)(nil).GetIndexReport), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexReport", reflect.TypeOf((*MockReportProvider)(nil).GetIndexReport), arg0, arg1, arg2)
+}
+
+// GetRepositoryToCPEMapping mocks base method.
+func (m *MockReportProvider) GetRepositoryToCPEMapping(arg0 context.Context, arg1 string) (*indexer.FetchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRepositoryToCPEMapping", arg0, arg1)
+	ret0, _ := ret[0].(*indexer.FetchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRepositoryToCPEMapping indicates an expected call of GetRepositoryToCPEMapping.
+func (mr *MockReportProviderMockRecorder) GetRepositoryToCPEMapping(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepositoryToCPEMapping", reflect.TypeOf((*MockReportProvider)(nil).GetRepositoryToCPEMapping), arg0, arg1)
 }
 
 // MockReportStorer is a mock of ReportStorer interface.

--- a/scanner/indexer/remote.go
+++ b/scanner/indexer/remote.go
@@ -12,8 +12,7 @@ import (
 
 // RemoteIndexer represents the interface offered by remote indexers.
 type RemoteIndexer interface {
-	ReportGetter
-	GetRepositoryToCPEMapping(context.Context, string) (*FetchResult, error)
+	ReportProvider
 	Close(context.Context) error
 }
 

--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -23,10 +24,12 @@ import (
 	"github.com/quay/claircore/oracle"
 	"github.com/quay/claircore/photon"
 	"github.com/quay/claircore/pkg/ctxlock/v2"
+	"github.com/quay/claircore/purl"
 	"github.com/quay/claircore/python"
 	"github.com/quay/claircore/rhel"
 	"github.com/quay/claircore/rhel/rhcc"
 	"github.com/quay/claircore/ruby"
+	ccsbom "github.com/quay/claircore/sbom"
 	"github.com/quay/claircore/suse"
 	"github.com/quay/claircore/ubuntu"
 	"github.com/stackrox/rox/pkg/buildinfo"
@@ -36,6 +39,7 @@ import (
 	"github.com/stackrox/rox/scanner/enricher/csaf"
 	"github.com/stackrox/rox/scanner/enricher/fixedby"
 	"github.com/stackrox/rox/scanner/enricher/nvd"
+	"github.com/stackrox/rox/scanner/indexer"
 	"github.com/stackrox/rox/scanner/internal/httputil"
 	"github.com/stackrox/rox/scanner/matcher/repo2cpe"
 	"github.com/stackrox/rox/scanner/matcher/updater/vuln"
@@ -77,6 +81,7 @@ type Matcher interface {
 	GetLastVulnerabilityUpdate(ctx context.Context) (time.Time, error)
 	GetKnownDistributions(ctx context.Context) []claircore.Distribution
 	GetSBOM(ctx context.Context, ir *claircore.IndexReport, opts *sbom.Options) ([]byte, error)
+	DecodeSBOM(ctx context.Context, data io.Reader) (*claircore.IndexReport, error)
 	Ready(ctx context.Context) error
 	Initialized(ctx context.Context) error
 	Close(ctx context.Context) error
@@ -89,16 +94,14 @@ type matcherImpl struct {
 	pool          *pgxpool.Pool
 
 	vulnUpdater     *vuln.Updater
-	repo2cpeUpdater *repo2cpe.Updater
 	sbomer          *sbom.SBOMer
+	sbomDecoder     ccsbom.Decoder
+	repo2CPEUpdater *repo2cpe.Updater
 
 	readyWithVulns bool
 }
 
-// NewMatcher creates a new matcher. If repo2cpeGetter is non-nil and SBOM
-// scanning is enabled, a background updater is started for the
-// repository-to-CPE mapping.
-func NewMatcher(ctx context.Context, cfg config.MatcherConfig, repo2cpeGetter repo2cpe.Getter) (Matcher, error) {
+func NewMatcher(ctx context.Context, cfg config.MatcherConfig, reportProvider indexer.ReportProvider) (Matcher, error) {
 	var success bool
 
 	pool, err := postgres.Connect(ctx, cfg.Database.ConnString, "libvuln")
@@ -203,14 +206,17 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig, repo2cpeGetter re
 	// include vulnerabilities vs. not.
 	sbomer := sbom.NewSBOMer()
 
-	var repo2cpeUpdater *repo2cpe.Updater
+	var repo2CPEUpdater *repo2cpe.Updater
+	var rhelTransformFuncs []purl.TransformerFunc
 	if features.SBOMScanning.Enabled() {
-		if repo2cpeGetter != nil {
-			repo2cpeUpdater = repo2cpe.NewUpdater(repo2cpeGetter)
+		if reportProvider != nil {
+			repo2CPEUpdater = repo2cpe.NewUpdater(reportProvider)
+			rhelTransformFuncs = append(rhelTransformFuncs, sbom.NewRHELCPETransformFunc(repo2CPEUpdater))
 		} else {
-			slog.ErrorContext(ctx, "failed to create remote indexer for repo-to-CPE mapping; SBOM CPE data may be incomplete")
+			slog.ErrorContext(ctx, "unconfigured remote indexer may lead to inaccurate SBOM scanning results")
 		}
 	}
+	sbomDecoder := sbom.NewSPDXDecoder(sbom.NewPURLRegistry(rhelTransformFuncs...))
 
 	// Start the vulnerability updater.
 	go func() {
@@ -226,8 +232,9 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig, repo2cpeGetter re
 		pool:          pool,
 
 		vulnUpdater:     vulnUpdater,
-		repo2cpeUpdater: repo2cpeUpdater,
 		sbomer:          sbomer,
+		sbomDecoder:     sbomDecoder,
+		repo2CPEUpdater: repo2CPEUpdater,
 
 		readyWithVulns: cfg.Readiness == config.ReadinessVulnerability,
 	}, nil
@@ -249,10 +256,13 @@ func (m *matcherImpl) GetSBOM(ctx context.Context, ir *claircore.IndexReport, op
 	return m.sbomer.GetSBOM(ctx, ir, opts)
 }
 
-// Close closes the matcher.
+func (m *matcherImpl) DecodeSBOM(ctx context.Context, data io.Reader) (*claircore.IndexReport, error) {
+	return m.sbomDecoder.Decode(ctx, data)
+}
+
 func (m *matcherImpl) Close(ctx context.Context) error {
-	if m.repo2cpeUpdater != nil {
-		m.repo2cpeUpdater.Close()
+	if m.repo2CPEUpdater != nil {
+		m.repo2CPEUpdater.Close()
 	}
 	err := errors.Join(m.vulnUpdater.Stop(), m.libVuln.Close(ctx))
 	m.pool.Close()

--- a/scanner/matcher/mocks/matcher.go
+++ b/scanner/matcher/mocks/matcher.go
@@ -11,6 +11,7 @@ package mocks
 
 import (
 	context "context"
+	io "io"
 	reflect "reflect"
 	time "time"
 
@@ -55,6 +56,21 @@ func (m *MockMatcher) Close(ctx context.Context) error {
 func (mr *MockMatcherMockRecorder) Close(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockMatcher)(nil).Close), ctx)
+}
+
+// DecodeSBOM mocks base method.
+func (m *MockMatcher) DecodeSBOM(ctx context.Context, data io.Reader) (*claircore.IndexReport, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DecodeSBOM", ctx, data)
+	ret0, _ := ret[0].(*claircore.IndexReport)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DecodeSBOM indicates an expected call of DecodeSBOM.
+func (mr *MockMatcherMockRecorder) DecodeSBOM(ctx, data any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodeSBOM", reflect.TypeOf((*MockMatcher)(nil).DecodeSBOM), ctx, data)
 }
 
 // GetKnownDistributions mocks base method.

--- a/scanner/sbom/decoder.go
+++ b/scanner/sbom/decoder.go
@@ -4,6 +4,8 @@ import (
 	"github.com/quay/claircore/alpine"
 	"github.com/quay/claircore/aws"
 	"github.com/quay/claircore/debian"
+	"github.com/quay/claircore/gobin"
+	"github.com/quay/claircore/java"
 	"github.com/quay/claircore/nodejs"
 	"github.com/quay/claircore/oracle"
 	"github.com/quay/claircore/photon"
@@ -17,11 +19,11 @@ import (
 	"github.com/quay/claircore/ubuntu"
 )
 
-func NewPURLRegistry() *purl.Registry {
+func NewPURLRegistry(rhelTransformFuncs ...purl.TransformerFunc) *purl.Registry {
 	reg := purl.NewRegistry()
 
 	// Distro-based ecosystems with fixed namespaces.
-	reg.RegisterPurlType(rhel.PURLType, rhel.PURLNamespace, rhel.ParseRPMPURL)
+	reg.RegisterPurlType(rhel.PURLType, rhel.PURLNamespace, rhel.ParseRPMPURL, rhelTransformFuncs...)
 	reg.RegisterPurlType(suse.PURLType, suse.PURLNamespace, suse.ParsePURL)
 	reg.RegisterPurlType(oracle.PURLType, oracle.PURLNamespace, oracle.ParsePURL)
 	reg.RegisterPurlType(photon.PURLType, photon.PURLNamespace, photon.ParsePURL)
@@ -35,10 +37,10 @@ func NewPURLRegistry() *purl.Registry {
 	reg.RegisterPurlType(nodejs.PURLType, purl.NoneNamespace, nodejs.ParsePURL)
 	reg.RegisterPurlType(ruby.PURLType, purl.NoneNamespace, ruby.ParsePURL)
 	reg.RegisterPurlType(rhcc.PURLType, purl.NoneNamespace, rhcc.ParseOCIPURL)
-
-	// NOTE: golang and maven PURLs use variable namespaces (domain, groupId)
-	// that cannot be pre-registered with the current purl.Registry key scheme.
-	// These PURLs are gracefully skipped by the decoder.
+	// Language ecosystems with dynamic namespaces. Claricore purl.Registry's
+	// Parse function will use the purl.NoneNamespace as a fallback.
+	reg.RegisterPurlType(gobin.PURLType, purl.NoneNamespace, gobin.ParsePURL)
+	reg.RegisterPurlType(java.PURLType, purl.NoneNamespace, java.ParsePURL)
 
 	return reg
 }

--- a/scanner/sbom/decoder.go
+++ b/scanner/sbom/decoder.go
@@ -1,0 +1,48 @@
+package sbom
+
+import (
+	"github.com/quay/claircore/alpine"
+	"github.com/quay/claircore/aws"
+	"github.com/quay/claircore/debian"
+	"github.com/quay/claircore/nodejs"
+	"github.com/quay/claircore/oracle"
+	"github.com/quay/claircore/photon"
+	"github.com/quay/claircore/purl"
+	"github.com/quay/claircore/python"
+	"github.com/quay/claircore/rhel"
+	"github.com/quay/claircore/rhel/rhcc"
+	"github.com/quay/claircore/ruby"
+	"github.com/quay/claircore/sbom/spdx"
+	"github.com/quay/claircore/suse"
+	"github.com/quay/claircore/ubuntu"
+)
+
+func NewPURLRegistry() *purl.Registry {
+	reg := purl.NewRegistry()
+
+	// Distro-based ecosystems with fixed namespaces.
+	reg.RegisterPurlType(rhel.PURLType, rhel.PURLNamespace, rhel.ParseRPMPURL)
+	reg.RegisterPurlType(suse.PURLType, suse.PURLNamespace, suse.ParsePURL)
+	reg.RegisterPurlType(oracle.PURLType, oracle.PURLNamespace, oracle.ParsePURL)
+	reg.RegisterPurlType(photon.PURLType, photon.PURLNamespace, photon.ParsePURL)
+	reg.RegisterPurlType(aws.PURLType, aws.PURLNamespace, aws.ParsePURL)
+	reg.RegisterPurlType(alpine.PURLType, alpine.PURLNamespace, alpine.ParsePURL)
+	reg.RegisterPurlType(debian.PURLType, debian.PURLNamespace, debian.ParsePURL)
+	reg.RegisterPurlType(ubuntu.PURLType, ubuntu.PURLNamespace, ubuntu.ParsePURL)
+
+	// Language ecosystems without namespaces.
+	reg.RegisterPurlType(python.PURLType, purl.NoneNamespace, python.ParsePURL)
+	reg.RegisterPurlType(nodejs.PURLType, purl.NoneNamespace, nodejs.ParsePURL)
+	reg.RegisterPurlType(ruby.PURLType, purl.NoneNamespace, ruby.ParsePURL)
+	reg.RegisterPurlType(rhcc.PURLType, purl.NoneNamespace, rhcc.ParseOCIPURL)
+
+	// NOTE: golang and maven PURLs use variable namespaces (domain, groupId)
+	// that cannot be pre-registered with the current purl.Registry key scheme.
+	// These PURLs are gracefully skipped by the decoder.
+
+	return reg
+}
+
+func NewSPDXDecoder(registry purl.Converter) *spdx.Decoder {
+	return spdx.NewDefaultDecoder(spdx.WithDecoderPURLConverter(registry))
+}

--- a/scanner/sbom/decoder.go
+++ b/scanner/sbom/decoder.go
@@ -19,6 +19,12 @@ import (
 	"github.com/quay/claircore/ubuntu"
 )
 
+// NewPURLRegistry creates a PURL registry with all supported ecosystems. The registered
+// PURL types must be kept in sync with the indexer ecosystems and matcher factories used
+// by Claircore, otherwise the SBOM decoder may produce results that cannot match
+// vulnerabilities accurately.
+// - Indexer ecosystems can be found in scanner/indexer/indexer.go
+// - Matchers can be found in scanner/matcher/matcher.go
 func NewPURLRegistry(rhelTransformFuncs ...purl.TransformerFunc) *purl.Registry {
 	reg := purl.NewRegistry()
 

--- a/scanner/sbom/rhel.go
+++ b/scanner/sbom/rhel.go
@@ -1,0 +1,37 @@
+package sbom
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/package-url/packageurl-go"
+	"github.com/quay/claircore/rhel"
+	"github.com/stackrox/rox/scanner/matcher/repo2cpe"
+)
+
+func NewRHELCPETransformFunc(updater *repo2cpe.Updater) func(ctx context.Context, p *packageurl.PackageURL) error {
+	return func(ctx context.Context, p *packageurl.PackageURL) error {
+		qs := p.Qualifiers.Map()
+		if _, has := qs[rhel.PURLRepositoryCPEs]; has {
+			return nil
+		}
+		repoID, ok := qs[rhel.PURLRepositoryID]
+		if !ok || repoID == "" {
+			return nil
+		}
+		mapping, err := updater.Get(ctx)
+		if err != nil {
+			slog.WarnContext(ctx, "repo2cpe mapping unavailable; skipping CPE enrichment",
+				"repository_id", repoID, "reason", err)
+			return nil
+		}
+		cpes, found := mapping.GetCPEs(repoID)
+		if !found || len(cpes) == 0 {
+			return nil
+		}
+		qs[rhel.PURLRepositoryCPEs] = strings.Join(cpes, ",")
+		p.Qualifiers = packageurl.QualifiersFromMap(qs)
+		return nil
+	}
+}

--- a/scanner/sbom/rhel.go
+++ b/scanner/sbom/rhel.go
@@ -10,6 +10,13 @@ import (
 	"github.com/stackrox/rox/scanner/matcher/repo2cpe"
 )
 
+// NewRHELCPETransformFunc returns a PURL transformer that resolves
+// repository_id to repository_cpes. Clairore's RHEL matcher requires the
+// repository_cpes qualifier to produce IndexRecords for correct vulnerability
+// matching; without it, RHEL RPM PURLs are silently skipped. External SBOMs
+// typically only carry the repository_id query parameter, so this enrichment
+// step is necessary. Other PURL types (Alpine, Debian, etc.) do not use
+// CPE-based repository matching in Claircore.
 func NewRHELCPETransformFunc(updater *repo2cpe.Updater) func(ctx context.Context, p *packageurl.PackageURL) error {
 	return func(ctx context.Context, p *packageurl.PackageURL) error {
 		qs := p.Qualifiers.Map()

--- a/scanner/sbom/rhel_test.go
+++ b/scanner/sbom/rhel_test.go
@@ -1,0 +1,167 @@
+package sbom
+
+import (
+	"context"
+	"testing"
+
+	"github.com/package-url/packageurl-go"
+	"github.com/quay/claircore/rhel"
+	"github.com/stackrox/rox/pkg/scannerv4/repositorytocpe"
+	"github.com/stackrox/rox/scanner/indexer"
+	"github.com/stackrox/rox/scanner/matcher/repo2cpe"
+	"github.com/stackrox/rox/scanner/matcher/repo2cpe/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func newUpdaterWithMapping(t *testing.T, mapping map[string]repositorytocpe.Repo) *repo2cpe.Updater {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	g := mocks.NewMockGetter(ctrl)
+	g.EXPECT().
+		GetRepositoryToCPEMapping(gomock.Any(), gomock.Any()).
+		Return(&indexer.FetchResult{
+			Modified: true,
+			Data:     &repositorytocpe.MappingFile{Data: mapping},
+		}, nil).
+		AnyTimes()
+	u := repo2cpe.NewUpdater(g)
+	t.Cleanup(u.Close)
+	// Trigger lazy init.
+	_, err := u.Get(context.Background())
+	require.NoError(t, err)
+	return u
+}
+
+func TestNewRHELCPETransformFunc(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("enriches PURL with CPEs from mapping", func(t *testing.T) {
+		u := newUpdaterWithMapping(t, map[string]repositorytocpe.Repo{
+			"rhel-8-for-x86_64-baseos-rpms": {CPEs: []string{"cpe:/o:redhat:rhel:8", "cpe:/o:redhat:enterprise_linux:8"}},
+		})
+		tf := NewRHELCPETransformFunc(u)
+
+		p := packageurl.PackageURL{
+			Type:      rhel.PURLType,
+			Namespace: rhel.PURLNamespace,
+			Name:      "bash",
+			Version:   "5.1.8-6.el8",
+			Qualifiers: packageurl.QualifiersFromMap(map[string]string{
+				rhel.PURLRepositoryID: "rhel-8-for-x86_64-baseos-rpms",
+				"arch":                "x86_64",
+			}),
+		}
+
+		err := tf(ctx, &p)
+		require.NoError(t, err)
+
+		qs := p.Qualifiers.Map()
+		assert.Equal(t, "cpe:/o:redhat:rhel:8,cpe:/o:redhat:enterprise_linux:8", qs[rhel.PURLRepositoryCPEs])
+	})
+
+	t.Run("does not overwrite existing repository_cpes", func(t *testing.T) {
+		u := newUpdaterWithMapping(t, map[string]repositorytocpe.Repo{
+			"rhel-8-for-x86_64-baseos-rpms": {CPEs: []string{"cpe:/o:redhat:rhel:8"}},
+		})
+		tf := NewRHELCPETransformFunc(u)
+
+		p := packageurl.PackageURL{
+			Type:      rhel.PURLType,
+			Namespace: rhel.PURLNamespace,
+			Name:      "bash",
+			Version:   "5.1.8-6.el8",
+			Qualifiers: packageurl.QualifiersFromMap(map[string]string{
+				rhel.PURLRepositoryID:   "rhel-8-for-x86_64-baseos-rpms",
+				rhel.PURLRepositoryCPEs: "cpe:/o:redhat:original:8",
+			}),
+		}
+
+		err := tf(ctx, &p)
+		require.NoError(t, err)
+
+		qs := p.Qualifiers.Map()
+		assert.Equal(t, "cpe:/o:redhat:original:8", qs[rhel.PURLRepositoryCPEs])
+	})
+
+	t.Run("skips when no repository_id", func(t *testing.T) {
+		u := newUpdaterWithMapping(t, map[string]repositorytocpe.Repo{
+			"rhel-8-for-x86_64-baseos-rpms": {CPEs: []string{"cpe:/o:redhat:rhel:8"}},
+		})
+		tf := NewRHELCPETransformFunc(u)
+
+		p := packageurl.PackageURL{
+			Type:      rhel.PURLType,
+			Namespace: rhel.PURLNamespace,
+			Name:      "bash",
+			Version:   "5.1.8-6.el8",
+			Qualifiers: packageurl.QualifiersFromMap(map[string]string{
+				"arch": "x86_64",
+			}),
+		}
+
+		err := tf(ctx, &p)
+		require.NoError(t, err)
+
+		qs := p.Qualifiers.Map()
+		_, has := qs[rhel.PURLRepositoryCPEs]
+		assert.False(t, has)
+	})
+
+	t.Run("skips when repository_id not in mapping", func(t *testing.T) {
+		u := newUpdaterWithMapping(t, map[string]repositorytocpe.Repo{
+			"rhel-8-for-x86_64-baseos-rpms": {CPEs: []string{"cpe:/o:redhat:rhel:8"}},
+		})
+		tf := NewRHELCPETransformFunc(u)
+
+		p := packageurl.PackageURL{
+			Type:      rhel.PURLType,
+			Namespace: rhel.PURLNamespace,
+			Name:      "bash",
+			Version:   "5.1.8-6.el8",
+			Qualifiers: packageurl.QualifiersFromMap(map[string]string{
+				rhel.PURLRepositoryID: "unknown-repo",
+			}),
+		}
+
+		err := tf(ctx, &p)
+		require.NoError(t, err)
+
+		qs := p.Qualifiers.Map()
+		_, has := qs[rhel.PURLRepositoryCPEs]
+		assert.False(t, has)
+	})
+
+	t.Run("degrades gracefully when mapping unavailable", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		g := mocks.NewMockGetter(ctrl)
+		g.EXPECT().
+			GetRepositoryToCPEMapping(gomock.Any(), gomock.Any()).
+			Return(nil, assert.AnError).
+			AnyTimes()
+		u := repo2cpe.NewUpdater(g)
+		t.Cleanup(u.Close)
+		// Trigger lazy init (will fail).
+		_, _ = u.Get(context.Background())
+
+		tf := NewRHELCPETransformFunc(u)
+
+		p := packageurl.PackageURL{
+			Type:      rhel.PURLType,
+			Namespace: rhel.PURLNamespace,
+			Name:      "bash",
+			Version:   "5.1.8-6.el8",
+			Qualifiers: packageurl.QualifiersFromMap(map[string]string{
+				rhel.PURLRepositoryID: "rhel-8-for-x86_64-baseos-rpms",
+			}),
+		}
+
+		err := tf(ctx, &p)
+		require.NoError(t, err)
+
+		qs := p.Qualifiers.Map()
+		_, has := qs[rhel.PURLRepositoryCPEs]
+		assert.False(t, has)
+	})
+}

--- a/scanner/services/common.go
+++ b/scanner/services/common.go
@@ -13,7 +13,7 @@ import (
 
 // getClairIndexReport is a wrapper around indexer.GetIndexReport to return
 // errox.NotFound when the report does not exist or if it is not successful.
-func getClairIndexReport(ctx context.Context, indexer indexer.ReportGetter, hashID string, includeExternal bool) (*claircore.IndexReport, error) {
+func getClairIndexReport(ctx context.Context, indexer indexer.ReportProvider, hashID string, includeExternal bool) (*claircore.IndexReport, error) {
 	ir, found, err := indexer.GetIndexReport(ctx, hashID, includeExternal)
 	if err != nil {
 		return nil, err

--- a/scanner/services/matcher.go
+++ b/scanner/services/matcher.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/quay/claircore"
-	ccsbom "github.com/quay/claircore/sbom"
 	"github.com/quay/claircore/toolkit/log"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/env"
@@ -42,11 +41,9 @@ var matcherAuth = perrpc.FromMap(map[authz.Authorizer][]string{
 type matcherService struct {
 	v4.UnimplementedMatcherServer
 	// indexer is used to retrieve index reports.
-	indexer indexer.ReportGetter
+	indexer indexer.ReportProvider
 	// matcher is used to match vulnerabilities with index contents.
 	matcher matcher.Matcher
-	// sbomDecoder decodes SBOM documents into claircore index reports.
-	sbomDecoder ccsbom.Decoder
 	// disableEmptyContents allows the vulnerability matching API to reject requests with empty contents.
 	disableEmptyContents bool
 	// anonymousAuthEnabled specifies if the service should allow for traffic from anonymous users.
@@ -55,11 +52,10 @@ type matcherService struct {
 
 // NewMatcherService creates a new vulnerability matcher gRPC service, to enable
 // empty content in enrich requests, pass a non-nil indexer.
-func NewMatcherService(matcher matcher.Matcher, indexer indexer.ReportGetter) *matcherService {
+func NewMatcherService(matcher matcher.Matcher, indexer indexer.ReportProvider) *matcherService {
 	return &matcherService{
 		matcher:              matcher,
 		indexer:              indexer,
-		sbomDecoder:          scannersbom.NewSPDXDecoder(scannersbom.NewPURLRegistry()),
 		disableEmptyContents: indexer == nil,
 		anonymousAuthEnabled: env.ScannerV4AnonymousAuth.BooleanSetting(),
 	}
@@ -223,7 +219,7 @@ func (s *matcherService) ScanSBOM(ctx context.Context, req *v4.ScanSBOMRequest) 
 		return nil, status.Errorf(codes.FailedPrecondition, "the matcher is not initialized: %v", err)
 	}
 
-	ir, err := s.sbomDecoder.Decode(ctx, bytes.NewReader(req.GetSbom()))
+	ir, err := s.matcher.DecodeSBOM(ctx, bytes.NewReader(req.GetSbom()))
 	if err != nil {
 		slog.ErrorContext(ctx, "decoding SBOM", "reason", err)
 		return nil, errox.InvalidArgs.CausedBy(err)

--- a/scanner/services/matcher.go
+++ b/scanner/services/matcher.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/quay/claircore"
+	ccsbom "github.com/quay/claircore/sbom"
 	"github.com/quay/claircore/toolkit/log"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/env"
@@ -20,7 +22,7 @@ import (
 	"github.com/stackrox/rox/pkg/scannerv4/mappers"
 	"github.com/stackrox/rox/scanner/indexer"
 	"github.com/stackrox/rox/scanner/matcher"
-	"github.com/stackrox/rox/scanner/sbom"
+	scannersbom "github.com/stackrox/rox/scanner/sbom"
 	"github.com/stackrox/rox/scanner/services/validators"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -32,6 +34,7 @@ var matcherAuth = perrpc.FromMap(map[authz.Authorizer][]string{
 		v4.Matcher_GetVulnerabilities_FullMethodName,
 		v4.Matcher_GetMetadata_FullMethodName,
 		v4.Matcher_GetSBOM_FullMethodName,
+		v4.Matcher_ScanSBOM_FullMethodName,
 	},
 })
 
@@ -42,6 +45,8 @@ type matcherService struct {
 	indexer indexer.ReportGetter
 	// matcher is used to match vulnerabilities with index contents.
 	matcher matcher.Matcher
+	// sbomDecoder decodes SBOM documents into claircore index reports.
+	sbomDecoder ccsbom.Decoder
 	// disableEmptyContents allows the vulnerability matching API to reject requests with empty contents.
 	disableEmptyContents bool
 	// anonymousAuthEnabled specifies if the service should allow for traffic from anonymous users.
@@ -54,6 +59,7 @@ func NewMatcherService(matcher matcher.Matcher, indexer indexer.ReportGetter) *m
 	return &matcherService{
 		matcher:              matcher,
 		indexer:              indexer,
+		sbomDecoder:          scannersbom.NewSPDXDecoder(scannersbom.NewPURLRegistry()),
 		disableEmptyContents: indexer == nil,
 		anonymousAuthEnabled: env.ScannerV4AnonymousAuth.BooleanSetting(),
 	}
@@ -195,7 +201,7 @@ func (s *matcherService) GetSBOM(ctx context.Context, req *v4.GetSBOMRequest) (*
 		return nil, err
 	}
 
-	sbom, err := s.matcher.GetSBOM(ctx, ir, &sbom.Options{
+	sbom, err := s.matcher.GetSBOM(ctx, ir, &scannersbom.Options{
 		Name:      req.GetId(),
 		Namespace: req.GetUri(),
 		Comment:   fmt.Sprintf("Generated for '%s'", req.GetName()),
@@ -206,4 +212,36 @@ func (s *matcherService) GetSBOM(ctx context.Context, req *v4.GetSBOMRequest) (*
 	}
 
 	return &v4.GetSBOMResponse{Sbom: sbom}, nil
+}
+
+func (s *matcherService) ScanSBOM(ctx context.Context, req *v4.ScanSBOMRequest) (*v4.ScanSBOMResponse, error) {
+	if err := validators.ValidateScanSBOMRequest(req); err != nil {
+		return nil, errox.InvalidArgs.CausedBy(err)
+	}
+
+	if err := s.matcher.Initialized(ctx); err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "the matcher is not initialized: %v", err)
+	}
+
+	ir, err := s.sbomDecoder.Decode(ctx, bytes.NewReader(req.GetSbom()))
+	if err != nil {
+		slog.ErrorContext(ctx, "decoding SBOM", "reason", err)
+		return nil, errox.InvalidArgs.CausedBy(err)
+	}
+
+	ccReport, err := s.matcher.GetVulnerabilities(ctx, ir)
+	if err != nil {
+		slog.ErrorContext(ctx, "getting vulnerabilities", "reason", err)
+		return nil, err
+	}
+
+	report, err := mappers.ToProtoV4VulnerabilityReport(ctx, ccReport)
+	if err != nil {
+		slog.ErrorContext(ctx, "internal error: converting to v4.VulnerabilityReport", "reason", err)
+		return nil, err
+	}
+
+	report.Notes = s.notes(ctx, report)
+
+	return &v4.ScanSBOMResponse{VulnerabilityReport: report}, nil
 }

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -17,6 +17,8 @@ import (
 	matchermocks "github.com/stackrox/rox/scanner/matcher/mocks"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type matcherServiceTestSuite struct {
@@ -379,5 +381,77 @@ func (s *matcherServiceTestSuite) Test_matcherService_GetSBOM() {
 		})
 		s.Require().NoError(err)
 		s.Equal(res.GetSbom(), fakeSbomB)
+	})
+}
+
+func (s *matcherServiceTestSuite) Test_matcherService_ScanSBOM() {
+	// Minimal valid SPDX 2.3 JSON document.
+	validSPDX := []byte(`{
+		"spdxVersion": "SPDX-2.3",
+		"dataLicense": "CC0-1.0",
+		"SPDXID": "SPDXRef-DOCUMENT",
+		"name": "test",
+		"documentNamespace": "https://example.com/test",
+		"creationInfo": {
+			"created": "2024-01-01T00:00:00Z",
+			"creators": ["Tool: test"]
+		}
+	}`)
+
+	s.Run("error on nil request", func() {
+		srv := NewMatcherService(nil, nil)
+		_, err := srv.ScanSBOM(s.ctx, nil)
+		s.ErrorContains(err, "empty request")
+	})
+
+	s.Run("error on empty sbom", func() {
+		srv := NewMatcherService(nil, nil)
+		_, err := srv.ScanSBOM(s.ctx, &v4.ScanSBOMRequest{})
+		s.ErrorContains(err, "sbom is required")
+	})
+
+	s.Run("error on unsupported media type", func() {
+		srv := NewMatcherService(nil, nil)
+		_, err := srv.ScanSBOM(s.ctx, &v4.ScanSBOMRequest{
+			Sbom:      []byte("data"),
+			MediaType: "application/json",
+		})
+		s.ErrorContains(err, "unsupported media type")
+	})
+
+	s.Run("error when matcher not initialized", func() {
+		s.matcherMock.EXPECT().Initialized(gomock.Any()).Return(errors.New("not initialized"))
+		srv := NewMatcherService(s.matcherMock, nil)
+		_, err := srv.ScanSBOM(s.ctx, &v4.ScanSBOMRequest{
+			Sbom:      validSPDX,
+			MediaType: "application/spdx+json",
+		})
+		st, ok := status.FromError(err)
+		s.Require().True(ok)
+		s.Equal(codes.FailedPrecondition, st.Code())
+	})
+
+	s.Run("error on invalid sbom content", func() {
+		s.matcherMock.EXPECT().Initialized(gomock.Any()).Return(nil)
+		srv := NewMatcherService(s.matcherMock, nil)
+		_, err := srv.ScanSBOM(s.ctx, &v4.ScanSBOMRequest{
+			Sbom:      []byte("not valid json"),
+			MediaType: "application/spdx+json",
+		})
+		s.Error(err)
+	})
+
+	s.Run("success", func() {
+		s.matcherMock.EXPECT().Initialized(gomock.Any()).Return(nil)
+		s.matcherMock.EXPECT().
+			GetVulnerabilities(gomock.Any(), gomock.Any()).
+			Return(&claircore.VulnerabilityReport{}, nil)
+		srv := NewMatcherService(s.matcherMock, nil)
+		res, err := srv.ScanSBOM(s.ctx, &v4.ScanSBOMRequest{
+			Sbom:      validSPDX,
+			MediaType: "application/spdx+json",
+		})
+		s.Require().NoError(err)
+		s.NotNil(res.GetVulnerabilityReport())
 	})
 }

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -433,6 +433,9 @@ func (s *matcherServiceTestSuite) Test_matcherService_ScanSBOM() {
 
 	s.Run("error on invalid sbom content", func() {
 		s.matcherMock.EXPECT().Initialized(gomock.Any()).Return(nil)
+		s.matcherMock.EXPECT().
+			DecodeSBOM(gomock.Any(), gomock.Any()).
+			Return(nil, errors.New("decode error"))
 		srv := NewMatcherService(s.matcherMock, nil)
 		_, err := srv.ScanSBOM(s.ctx, &v4.ScanSBOMRequest{
 			Sbom:      []byte("not valid json"),
@@ -443,6 +446,9 @@ func (s *matcherServiceTestSuite) Test_matcherService_ScanSBOM() {
 
 	s.Run("success", func() {
 		s.matcherMock.EXPECT().Initialized(gomock.Any()).Return(nil)
+		s.matcherMock.EXPECT().
+			DecodeSBOM(gomock.Any(), gomock.Any()).
+			Return(&claircore.IndexReport{}, nil)
 		s.matcherMock.EXPECT().
 			GetVulnerabilities(gomock.Any(), gomock.Any()).
 			Return(&claircore.VulnerabilityReport{}, nil)

--- a/scanner/services/validators/validators.go
+++ b/scanner/services/validators/validators.go
@@ -94,6 +94,27 @@ func ValidateGetSBOMRequest(req *v4.GetSBOMRequest) error {
 	return nil
 }
 
+var supportedSBOMMediaTypes = map[string]bool{
+	"application/spdx+json": true,
+	"text/spdx+json":        true,
+}
+
+func ValidateScanSBOMRequest(req *v4.ScanSBOMRequest) error {
+	if req == nil {
+		return errox.InvalidArgs.New("empty request")
+	}
+	if len(req.GetSbom()) == 0 {
+		return errox.InvalidArgs.New("sbom is required")
+	}
+	if req.GetMediaType() == "" {
+		return errox.InvalidArgs.New("media type is required")
+	}
+	if !supportedSBOMMediaTypes[req.GetMediaType()] {
+		return errox.InvalidArgs.Newf("unsupported media type %q", req.GetMediaType())
+	}
+	return nil
+}
+
 func validateContents(contents *v4.Contents) error {
 	if contents == nil {
 		return nil

--- a/scanner/services/validators/validators_test.go
+++ b/scanner/services/validators/validators_test.go
@@ -260,6 +260,46 @@ func Test_validateGetVulnerabilitiesRequest(t *testing.T) {
 	}
 }
 
+func Test_validateScanSBOMRequest(t *testing.T) {
+	tests := map[string]struct {
+		req     *v4.ScanSBOMRequest
+		wantErr string
+	}{
+		"error on nil request": {
+			wantErr: "empty request",
+		},
+		"error on empty sbom": {
+			req:     &v4.ScanSBOMRequest{},
+			wantErr: "sbom is required",
+		},
+		"error on empty media type": {
+			req:     &v4.ScanSBOMRequest{Sbom: []byte("data")},
+			wantErr: "media type is required",
+		},
+		"error on unsupported media type": {
+			req:     &v4.ScanSBOMRequest{Sbom: []byte("data"), MediaType: "application/json"},
+			wantErr: "unsupported media type",
+		},
+		"no error with application/spdx+json": {
+			req: &v4.ScanSBOMRequest{Sbom: []byte("data"), MediaType: "application/spdx+json"},
+		},
+		"no error with text/spdx+json": {
+			req: &v4.ScanSBOMRequest{Sbom: []byte("data"), MediaType: "text/spdx+json"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateScanSBOMRequest(tt.req)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func Test_validateGetSBOMRequest(t *testing.T) {
 	tests := map[string]struct {
 		req     *v4.GetSBOMRequest


### PR DESCRIPTION
## Description

Wires up the remaining logic to get SBOM vulnerability reporting plumbed through stackrox.

- Add ScanSBOM RPC to the Matcher proto service with ScanSBOMRequest/ScanSBOMResponse messages
- Implement SBOM decoding in the matcher using claircore's SPDX decoder and PURL registry                                                                                                                                                                                      
- Enrich RHEL packages with CPE data from the repo-to-CPE mapping during SBOM decode (via a PURL transformer function)
- Add ScanSBOM to the scanner v4 gRPC client                                                                                                                                                                                                                                   
- Replace the fake vuln report stub in Central with the real client call
- The ReportGetter interface is renamed to ReportProvider and expanded to include GetRepositoryToCPEMapping, since the matcher now needs both index reports and the CPE mapping from the indexer. This also simplifies the NewMatcher constructor signature (one ReportProvider instead of a separate repo2cpe.Getter). 

PR stack:
- `master`
  - https://github.com/stackrox/stackrox/pull/18484
    - https://github.com/stackrox/stackrox/pull/18705
      - 👉 https://github.com/stackrox/stackrox/pull/18716

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

No automated testing. Will follow up in [ROX-27690](https://issues.redhat.com/browse/ROX-27690).

### How I validated my change

1. Deploy stackrox
2. Set the `ROX_SBOM_SCANNING` feature flag:
    ```
    ❯ kubectl set env deploy/central ROX_SBOM_SCANNING=true
    ❯ kubectl set env deploy/scanner-v4-indexer ROX_SBOM_SCANNING=true
    ```

#### Matcher API

1. Port forward Matcher
    ```
    ❯ kubectl port-forward svc/scanner-v4-indexer 8443
    ```
2. Hit the endpoint using a test file from https://github.com/quay/claircore/pull/1745
    ```
    ❯ jq -n --rawfile sbom /Users/blugo/dev/quay/claircore/work/sbom/spdx/testdata/decoder/konflux-syft+hermeto.spdx.json \
      '{sbom: ($sbom | @base64), media_type: "application/spdx+json"}' | \
        grpcurl -insecure \
          -import-path proto \
          -proto internalapi/scanner/v4/matcher_service.proto \
          -d @ \
          localhost:8443 scanner.v4.Matcher/ScanSBOM | head
    "vulnerabilityReport": {
      "vulnerabilities": {
        "554938": {
          "id": "554938",
          "name": "CVE-2025-66471",
          "description": "urllib3 streaming API improperly handles highly compressed data",
          "issued": "2025-12-05T18:15:54Z",
          "link": "https://github.com/urllib3/urllib3/security/advisories/GHSA-2xpw-w6gg-jr37 https://nvd.nist.gov/v
          "severity": "HIGH",
          "normalizedSeverity": "SEVERITY_IMPORTANT",
          "fixedInVersion": "2.6.0",
          "cvss": {
            "v3": {
              "baseScore": 7.5,
              "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
            },
            "source": "SOURCE_NVD",
            "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66471"
          },
          "cvssMetrics": [
            {
              "v3": {
                "baseScore": 7.5,
                "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"

    ```

#### scanner v4 client

Replicate the validation from https://github.com/stackrox/stackrox/pull/18484:
```
❯ curl -ski -X POST \
    -H "Content-Type: application/spdx+json" \
    -H "Authorization: Bearer $ROX_API_TOKEN" \
    --data-binary @/Users/blugo/dev/quay/claircore/work/sbom/spdx/testdata/decoder/konflux-syft+hermeto.spdx.json
    $ROX_ENDPOINT/api/v1/sboms/scan | head -n 30
content-type: application/json
vary: Accept-Encoding
date: Wed, 28 Jan 2026 06:32:41 GMT

{
  "scan": {
    "scannerVersion": "matcher=4.10.x-883-gf97aa6fc7a-dirty",
    "scanTime": "2026-01-28T06:32:41.166793266Z",
    "components": [
      {
        "name": "psmisc",
        "version": "23.4-3.el9",
        "architecture": "s390x"
      },
      {
        "name": "libsepol",
        "version": "3.6-3.el9",
        "architecture": "aarch64"
      },
      {
        "name": "gawk",
        "version": "5.1.0-6.el9",
        "architecture": "src"
      },
      {
        "name": "json-glib",
        "version": "1.6.6-1.el9",
        "architecture": "src"
      },
```

[ROX-27690]: https://uat-2-2-redhat.atlassian.net/browse/ROX-27690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ