### PR TITLE
ROX-32968: Remove Close function in safe Channel

### DIFF
--- a/pkg/safe/channel.go
+++ b/pkg/safe/channel.go
@@ -5,10 +5,11 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 )
 
-// Channel provides a thread-safe channel with race-free shutdown semantics.
-// It encapsulates a channel along with synchronization primitives to ensure
-// safe writes and closure even during concurrent shutdown scenarios.
+// Channel provides a thread-safe channel with panic-free shutdown semantics.
+// It encapsulates a channel along with synchronization primitives to prevent
+// panics from sending on a closed channel during concurrent shutdown scenarios.
 // The channel is automatically closed when the waitable is triggered.
+// Write rejection after shutdown is best-effort - writes in progress may succeed.
 type Channel[T any] struct {
 	mu       sync.RWMutex
 	ch       chan T
@@ -16,8 +17,9 @@ type Channel[T any] struct {
 }
 
 // NewChannel creates a new Channel with the specified buffer size.
-// The waitable parameter is used to coordinate shutdown - writes will fail
-// when the waitable is triggered, and the channel will be automatically closed.
+// The waitable parameter is used to coordinate shutdown - writes will make
+// best-effort to fail when the waitable is triggered, and the channel will be
+// automatically closed. Writes already in progress may complete successfully.
 // Panics if waitable is nil or size is negative.
 func NewChannel[T any](size int, waitable concurrency.Waitable) *Channel[T] {
 	if waitable == nil {
@@ -44,23 +46,25 @@ func NewChannel[T any](size int, waitable concurrency.Waitable) *Channel[T] {
 }
 
 // Write pushes an item to the channel, blocking if the channel is full.
-// This operation is safe to call concurrently with Close.
+// This operation is safe to call concurrently with channel closure (no panics).
 //
-// Returns ErrWaitableTriggered if the waitable is triggered before or during the write.
+// Returns ErrWaitableTriggered if the waitable is triggered before the write starts
+// or while blocked waiting for channel space. Writes already holding the lock when
+// the waitable triggers may complete successfully (best-effort rejection).
 //
 // Thread-safety and double-select pattern:
 //
 // The RLock is required because Write/TryWrite calls may occur in different goroutines
-// from the Close call, and not all Write/TryWrite calls are in the same goroutine either.
+// from the auto-close goroutine, and not all Write/TryWrite calls are in the same goroutine either.
 // RLock is sufficient (rather than full Lock) because writing to a channel is already
-// thread-safe in Go; the lock only coordinates shutdown with Close.
+// thread-safe in Go; the lock only coordinates shutdown with the auto-close goroutine.
 //
 // The double-select pattern prevents panics when writing to a closed channel:
 //
 //  1. Caller A: Write() -> acquires RLock
-//  2. Caller B: Close() -> waits for lock (blocked by A's RLock)
+//  2. Auto-close goroutine: waitable triggers -> waits for lock (blocked by A's RLock)
 //  3. Caller A: Write() ends -> releases RLock
-//  4. Caller B: Close() acquires lock -> closes channel -> releases lock
+//  4. Auto-close goroutine: acquires lock -> closes channel -> releases lock
 //  5. Caller C: Write() -> acquires RLock -> first select detects triggered waitable -> exits early
 //
 // Without the first select (fast-path check), we would proceed to the second select where
@@ -68,7 +72,7 @@ func NewChannel[T any](size int, waitable concurrency.Waitable) *Channel[T] {
 // channel, potentially causing a panic.
 //
 // The second select is needed because if we're blocked waiting to write to a full channel
-// and another caller triggers the waitable, we should immediately stop trying to write and exit.
+// and the waitable is triggered, we should immediately stop trying to write and exit.
 func (s *Channel[T]) Write(item T) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -91,18 +95,18 @@ func (s *Channel[T]) Write(item T) error {
 
 // TryWrite attempts to push an item to the channel without blocking.
 // If the channel is full, it returns ErrChannelFull immediately.
-// This operation is safe to call concurrently with Close.
+// This operation is safe to call concurrently with channel closure (no panics).
 //
 // Returns:
-//   - ErrWaitableTriggered if the waitable is triggered before or during the write
+//   - ErrWaitableTriggered if the waitable is triggered before the write starts (best-effort)
 //   - ErrChannelFull if the channel is full and cannot accept the item
 //
 // Thread-safety and double-select pattern:
 //
 // The RLock is required because Write/TryWrite calls may occur in different goroutines
-// from the Close call, and not all Write/TryWrite calls are in the same goroutine either.
+// from the auto-close goroutine, and not all Write/TryWrite calls are in the same goroutine either.
 // RLock is sufficient (rather than full Lock) because writing to a channel is already
-// thread-safe in Go; the lock only coordinates shutdown with Close.
+// thread-safe in Go; the lock only coordinates shutdown with the auto-close goroutine.
 //
 // The double-select pattern prevents panics when writing to a closed channel:
 // See the Write function documentation for a detailed explanation of the race condition

--- a/pkg/safe/channel.go
+++ b/pkg/safe/channel.go
@@ -25,6 +25,9 @@ func NewChannel[T any](size int, waitable concurrency.Waitable) *Channel[T] {
 	if waitable == nil {
 		panic("waitable must not be nil")
 	}
+	if waitable.Done() == nil {
+		panic("waitable.Done() must not be nil")
+	}
 	if size < 0 {
 		panic("size must not be negative")
 	}

--- a/pkg/safe/channel_test.go
+++ b/pkg/safe/channel_test.go
@@ -210,22 +210,7 @@ func TestSafeChannel_NegativeSize(t *testing.T) {
 	}, "NewChannel should panic when size is negative")
 }
 
-func TestSafeChannel_Close_MultipleTimes(t *testing.T) {
-	defer goleak.AssertNoGoroutineLeaks(t)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	ch := NewChannel[int](5, ctx)
-
-	cancel()
-	<-ctx.Done()
-
-	// Close multiple times should not panic
-	ch.Close()
-	ch.Close()
-	ch.Close()
-}
-
-func TestSafeChannel_Close_ProperShutdownSequence(t *testing.T) {
+func TestSafeChannel_AutoClose_WhenWaitableTriggered(t *testing.T) {
 	defer goleak.AssertNoGoroutineLeaks(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -235,12 +220,34 @@ func TestSafeChannel_Close_ProperShutdownSequence(t *testing.T) {
 	require.NoError(t, ch.Write(1))
 	require.NoError(t, ch.Write(2))
 
-	// Proper shutdown sequence
+	// Trigger the waitable
 	cancel()
-	<-ctx.Done()
-	ch.Close()
 
-	// Should still be able to read existing items
+	// Channel should be automatically closed
+	// Read existing items first
+	assert.Equal(t, 1, <-ch.Chan())
+	assert.Equal(t, 2, <-ch.Chan())
+
+	// Eventually the channel should be closed
+	val, ok := <-ch.Chan()
+	assert.False(t, ok, "channel should be automatically closed")
+	assert.Equal(t, 0, val)
+}
+
+func TestSafeChannel_AutoClose_PreservesBufferedData(t *testing.T) {
+	defer goleak.AssertNoGoroutineLeaks(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := NewChannel[int](5, ctx)
+
+	// Write some items
+	require.NoError(t, ch.Write(1))
+	require.NoError(t, ch.Write(2))
+
+	// Trigger shutdown
+	cancel()
+
+	// Should still be able to read existing items even after auto-close
 	assert.Equal(t, 1, <-ch.Chan())
 	assert.Equal(t, 2, <-ch.Chan())
 
@@ -275,11 +282,9 @@ func TestSafeChannel_ConcurrentWrites(t *testing.T) {
 		}(i)
 	}
 
-	// Reads are possible after we call Close
+	// Reads are possible after waitable is triggered (auto-close)
 	wg.Wait()
 	cancel()
-	<-ctx.Done()
-	ch.Close()
 
 	// Read all items in another goroutine
 	received := set.NewIntSet()
@@ -297,10 +302,10 @@ func TestSafeChannel_ConcurrentWrites(t *testing.T) {
 	assert.Len(t, received, numGoroutines*numWrites)
 }
 
-func TestSafeChannel_ConcurrentWritesAndClose(t *testing.T) {
+func TestSafeChannel_ConcurrentWritesAndAutoClose(t *testing.T) {
 	defer goleak.AssertNoGoroutineLeaks(t)
 
-	// This test ensures there are no panics when writing and closing concurrently
+	// This test ensures there are no panics when writing while auto-close happens
 	for range 100 {
 		ctx, cancel := context.WithCancel(context.Background())
 		ch := NewChannel[int](10, ctx)
@@ -321,13 +326,11 @@ func TestSafeChannel_ConcurrentWritesAndClose(t *testing.T) {
 			}
 		}()
 
-		// Closer goroutine - wait for writes to start, then close while writing
+		// Cancel goroutine - wait for writes to start, then trigger auto-close
 		go func() {
 			defer wg.Done()
 			<-writeStarted.Done()
 			cancel()
-			<-ctx.Done()
-			ch.Close()
 		}()
 
 		wg.Wait()
@@ -375,18 +378,4 @@ func TestSafeChannel_NewSafeChannel_PanicsOnNilWaitable(t *testing.T) {
 	assert.Panics(t, func() {
 		NewChannel[int](5, nil)
 	}, "NewChannel should panic when waitable is nil")
-}
-
-func TestSafeChannel_Close_PanicsOnUntriggeredWaitable(t *testing.T) {
-	defer goleak.AssertNoGoroutineLeaks(t)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ch := NewChannel[int](5, ctx)
-
-	// Calling Close without triggering the waitable should panic
-	assert.Panics(t, func() {
-		ch.Close()
-	}, "Close should panic when waitable has not been triggered")
 }

--- a/pkg/safe/channel_test.go
+++ b/pkg/safe/channel_test.go
@@ -407,3 +407,13 @@ func TestSafeChannel_NewSafeChannel_PanicsOnNilWaitable(t *testing.T) {
 		NewChannel[int](5, nil)
 	}, "NewChannel should panic when waitable is nil")
 }
+
+func TestSafeChannel_NewSafeChannel_PanicsOnNilDone(t *testing.T) {
+	defer goleak.AssertNoGoroutineLeaks(t)
+
+	// Creating a Channel with a waitable that has nil Done() should panic
+	// context.Background() returns nil from Done() since it can never be canceled
+	assert.Panics(t, func() {
+		NewChannel[int](5, context.Background())
+	}, "NewChannel should panic when waitable.Done() is nil")
+}

--- a/pkg/safe/channel_test.go
+++ b/pkg/safe/channel_test.go
@@ -399,6 +399,25 @@ func TestSafeChannel_WriteBlockedThenWaitableTriggered(t *testing.T) {
 	})
 }
 
+func TestSafeChannel_ContextCancelledBeforeCreation(t *testing.T) {
+	defer goleak.AssertNoGoroutineLeaks(t)
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		ch := NewChannel[int](5, ctx)
+		synctest.Wait()
+
+		assert.ErrorIs(t, ch.Write(1), ErrWaitableTriggered)
+		assert.ErrorIs(t, ch.TryWrite(1), ErrWaitableTriggered)
+
+		val, ok := <-ch.Chan()
+		assert.False(t, ok, "channel should be closed")
+		assert.Equal(t, 0, val)
+	})
+}
+
 func TestSafeChannel_NewSafeChannel_PanicsOnNilWaitable(t *testing.T) {
 	defer goleak.AssertNoGoroutineLeaks(t)
 

--- a/sensor/common/pubsub/consumer/buffered.go
+++ b/sensor/common/pubsub/consumer/buffered.go
@@ -109,7 +109,7 @@ func (c *BufferedConsumer) consume(waitable concurrency.Waitable, event pubsub.E
 func (c *BufferedConsumer) Stop() {
 	c.stopper.Client().Stop()
 	<-c.stopper.Client().Stopped().Done()
-	c.buffer.Close()
+	// Channel will be closed automatically when the waitable is done
 	// Drain events and close their errC
 	for ev := range c.buffer.Chan() {
 		close(ev.errC)

--- a/sensor/common/pubsub/lane/blocking.go
+++ b/sensor/common/pubsub/lane/blocking.go
@@ -139,9 +139,8 @@ func (l *blockingLane) RegisterConsumer(consumerID pubsub.ConsumerID, topic pubs
 
 func (l *blockingLane) Stop() {
 	l.stopper.Client().Stop()
-	// Wait for the run() goroutine to fully exit before closing the channel.
-	// This ensures an orderly shutdown where event processing is complete.
+	// Wait for the run() goroutine to fully exit.
+	// The channel will be closed automatically when the waitable is done.
 	<-l.stopper.Client().Stopped().Done()
-	l.ch.Close()
 	l.Lane.Stop()
 }

--- a/sensor/common/pubsub/lane/blocking.go
+++ b/sensor/common/pubsub/lane/blocking.go
@@ -140,7 +140,7 @@ func (l *blockingLane) RegisterConsumer(consumerID pubsub.ConsumerID, topic pubs
 func (l *blockingLane) Stop() {
 	l.stopper.Client().Stop()
 	// Wait for the run() goroutine to fully exit.
-	// The channel will be closed automatically when the waitable is done.
+	// The channel will be closed automatically when the stop request signal triggers.
 	<-l.stopper.Client().Stopped().Done()
 	l.Lane.Stop()
 }

--- a/sensor/common/pubsub/lane/concurrent.go
+++ b/sensor/common/pubsub/lane/concurrent.go
@@ -152,9 +152,8 @@ func (l *concurrentLane) RegisterConsumer(consumerID pubsub.ConsumerID, topic pu
 
 func (l *concurrentLane) Stop() {
 	l.stopper.Client().Stop()
-	// Wait for the run() goroutine to fully exit before closing the channel.
-	// This ensures an orderly shutdown where event processing is complete.
+	// Wait for the run() goroutine to fully exit.
+	// The channel will be closed automatically when the waitable is done.
 	<-l.stopper.Client().Stopped().Done()
-	l.ch.Close()
 	l.Lane.Stop()
 }

--- a/sensor/common/pubsub/lane/concurrent.go
+++ b/sensor/common/pubsub/lane/concurrent.go
@@ -153,7 +153,7 @@ func (l *concurrentLane) RegisterConsumer(consumerID pubsub.ConsumerID, topic pu
 func (l *concurrentLane) Stop() {
 	l.stopper.Client().Stop()
 	// Wait for the run() goroutine to fully exit.
-	// The channel will be closed automatically when the waitable is done.
+	// The channel will be closed automatically when the stop request signal triggers.
 	<-l.stopper.Client().Stopped().Done()
 	l.Lane.Stop()
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The current implementation of the `safe.Channel` relies on the user to triggered waitable (and wait for it) before calling `Close`. This PR removes the `Close` function in favor a internal goroutine that waits for the waitable to be triggered and then closes the internal channel.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Unit tests
