### PR TITLE
ROX-33168: Expand 'dry-run' of vuln bundle workflow

### DIFF
--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -378,8 +378,10 @@ jobs:
   upload-definitions:
     needs:
     - build-and-run
-    if: ${{ (failure() || success()) && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')) }}
+    if: ${{ (failure() || success()) && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
+    env:
+      DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
     steps:
     # Checkout to run ./.github/actions/download-artifact-with-retry
     - uses: actions/checkout@v6
@@ -446,14 +448,26 @@ jobs:
         # Upload all bundle directories (preserving the `<verions>/<file>` structure).
         bucket="gs://definitions.stackrox.io/v4/vulnerability-bundles"
         echo "Uploading all dir(s) to $bucket/"
-        gsutil -m cp -r . "$bucket/"
+
+        RUN=""
+        if [ "$DRY_RUN" = "true" ]; then
+          RUN="echo [DRY-RUN] Would execute:"
+        fi
+
+        $RUN gsutil -m cp -r . "$bucket/"
 
     - name: Update downstream dev
       # Run on schedule or when dispatched to build "dev" (only possible if RC was not requested).
       if: github.event_name == 'schedule' || (github.event.inputs.rc_ref == '' && github.event.inputs.stream == 'dev')
       run: |
         echo "Copy upstream dev (dev) to downstream dev (1.0.0)"
-        gsutil cp -r gs://definitions.stackrox.io/v4/vulnerability-bundles/dev/* gs://definitions.stackrox.io/v4/vulnerability-bundles/1.0.0/
+
+        RUN=""
+        if [ "$DRY_RUN" = "true" ]; then
+          RUN="echo [DRY-RUN] Would execute:"
+        fi
+
+        $RUN gsutil cp -r gs://definitions.stackrox.io/v4/vulnerability-bundles/dev/* gs://definitions.stackrox.io/v4/vulnerability-bundles/1.0.0/
 
     - name: Copy v1 to pre-versioned bundles
       # Run on schedule or when dispatched to build "GA" (only possible if RC was not requested).
@@ -464,6 +478,12 @@ jobs:
            echo "error: no definition files for v1 were created: skipping..."
            exit 0
         fi
+
+        RUN=""
+        if [ "$DRY_RUN" = "true" ]; then
+          RUN="echo [DRY-RUN] Would execute:"
+        fi
+
         # Using v1 bundle for released versions listed in RELEASE_VERSION.
         single=gs://definitions.stackrox.io/v4/vulnerability-bundles/v1/vulns.json.zst
         multi=gs://definitions.stackrox.io/v4/vulnerability-bundles/v1/vulnerabilities.zip
@@ -472,11 +492,11 @@ jobs:
         grep -E "^4\.(4|5)\.[0-9]+$" scanner/updater/version/RELEASE_VERSION | while read -r release; do
           case "$release" in
           4.4.*)
-            gsutil cp "$single" "gs://definitions.stackrox.io/v4/vulnerability-bundles/$release/"
+            $RUN gsutil cp "$single" "gs://definitions.stackrox.io/v4/vulnerability-bundles/$release/"
             ;;
           4.5.*)
-            gsutil cp "$single" "gs://definitions.stackrox.io/v4/vulnerability-bundles/$release/"
-            gsutil cp "$multi" "gs://definitions.stackrox.io/v4/vulnerability-bundles/$release/"
+            $RUN gsutil cp "$single" "gs://definitions.stackrox.io/v4/vulnerability-bundles/$release/"
+            $RUN gsutil cp "$multi" "gs://definitions.stackrox.io/v4/vulnerability-bundles/$release/"
             ;;
           *)
             echo "Should not happen!"


### PR DESCRIPTION
## Description

The initial implementation of `dry_run` in the `Scanner versioned vulnerabilities update` workflow did not allow for validating the state changing commands of the `upload-definitions` job.

This PR allows the job to run and prints the state changing commands that would be executed.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
