### PR TITLE
ROX-20016: Processes listening on ports test fix ci

### DIFF
--- a/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessesListeningOnPortsTest.groovy
@@ -23,6 +23,12 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
     static final private String TCPCONNECTIONTARGET2 = "tcp-connection-target-2"
     static final private String TCPCONNECTIONTARGET3 = "tcp-connection-target-3"
 
+    // Ports
+    static final private int PORT1 = 8079
+    static final private int PORT2 = 8080
+    static final private int PORT3 = 8081
+    static final private int PORT4 = 8082
+
     // Other namespace
     static final private String TEST_NAMESPACE = "qa-plop"
 
@@ -36,33 +42,33 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
                     .setNamespace(TEST_NAMESPACE)
                     .setImagePrefetcherAffinity()
                     .setImage("quay.io/rhacs-eng/qa-multi-arch:socat")
-                    .addPort(80)
-                    .addPort(8080)
+                    .addPort(PORT1)
+                    .addPort(PORT2)
                     .addLabel("app", TCPCONNECTIONTARGET1)
                     .setExposeAsService(true)
                     .setCommand(["/bin/sh", "-c",])
-                    .setArgs(["(socat "+SOCAT_DEBUG+" TCP-LISTEN:80,fork STDOUT & " +
-                                      "socat "+SOCAT_DEBUG+" TCP-LISTEN:8080,fork STDOUT)" as String,]),
+                    .setArgs(["(socat "+SOCAT_DEBUG+" TCP-LISTEN:"+PORT1+",fork STDOUT & " +
+                                      "socat "+SOCAT_DEBUG+" TCP-LISTEN:"+PORT2+",fork STDOUT)" as String,]),
             new Deployment()
                     .setName(TCPCONNECTIONTARGET2)
                     .setNamespace(TEST_NAMESPACE)
                     .setImagePrefetcherAffinity()
                     .setImage("quay.io/rhacs-eng/qa-multi-arch:socat")
-                    .addPort(8081, "TCP")
+                    .addPort(PORT3, "TCP")
                     .addLabel("app", TCPCONNECTIONTARGET2)
                     .setExposeAsService(true)
                     .setCommand(["/bin/sh", "-c",])
-                    .setArgs(["(socat "+SOCAT_DEBUG+" TCP-LISTEN:8081,fork STDOUT)" as String,]),
+                    .setArgs(["(socat "+SOCAT_DEBUG+" TCP-LISTEN:"+PORT3+",fork STDOUT)" as String,]),
             new Deployment()
                     .setName(TCPCONNECTIONTARGET3)
                     .setNamespace(TEST_NAMESPACE)
                     .setImagePrefetcherAffinity()
                     .setImage("quay.io/rhacs-eng/qa-multi-arch:socat")
-                    .addPort(8082, "TCP")
+                    .addPort(PORT4, "TCP")
                     .addLabel("app", TCPCONNECTIONTARGET3)
                     .setExposeAsService(true)
                     .setCommand(["/bin/sh", "-c",])
-                    .setArgs(["(socat "+SOCAT_DEBUG+" TCP-LISTEN:8082,fork STDOUT & " +
+                    .setArgs(["(socat "+SOCAT_DEBUG+" TCP-LISTEN:"+PORT4+",fork STDOUT & " +
                             "sleep 90 && pkill socat && sleep 3600)" as String,]),
                     // The 8082 port is opened. 90 seconds later the process is killed. After that we sleep forever
         ]
@@ -127,8 +133,8 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
                 containerName == TCPCONNECTIONTARGET1
                 signal.name == "socat"
                 signal.execFilePath == "/usr/bin/socat"
-                signal.args == "-d -d -v TCP-LISTEN:80,fork STDOUT"
-                endpoint.port == 80
+                signal.args == "-d -d -v TCP-LISTEN:"+PORT1+",fork STDOUT"
+                endpoint.port == PORT1
         }
 
         def endpoint2 = list[1]
@@ -142,8 +148,8 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
                 containerName == TCPCONNECTIONTARGET1
                 signal.name == "socat"
                 signal.execFilePath == "/usr/bin/socat"
-                signal.args == "-d -d -v TCP-LISTEN:8080,fork STDOUT"
-                endpoint.port == 8080
+                signal.args == "-d -d -v TCP-LISTEN:"+PORT2+",fork STDOUT"
+                endpoint.port == PORT2
         }
 
         processesListeningOnPorts = waitForResponseToHaveNumElements(1, deploymentId2, 240)
@@ -154,7 +160,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         assert list.size() == 1
         assert processesListeningOnPorts.totalListeningEndpoints == 1
 
-        def endpoint = list.find { it.endpoint.port == 8081 }
+        def endpoint = list.find { it.endpoint.port == PORT3 }
 
         verifyAll(endpoint) {
                 deploymentId
@@ -165,7 +171,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
                 containerName == TCPCONNECTIONTARGET2
                 signal.name == "socat"
                 signal.execFilePath == "/usr/bin/socat"
-                signal.args == "-d -d -v TCP-LISTEN:8081,fork STDOUT"
+                signal.args == "-d -d -v TCP-LISTEN:"+PORT3+",fork STDOUT"
         }
     }
 
@@ -208,7 +214,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         assert list.size() == 1
         assert processesListeningOnPorts.totalListeningEndpoints == 1
 
-        def endpoint = list.find { it.endpoint.port == 8082 }
+        def endpoint = list.find { it.endpoint.port == PORT4 }
 
         verifyAll(endpoint) {
                 deploymentId
@@ -219,7 +225,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
                 containerName == TCPCONNECTIONTARGET3
                 signal.name == "socat"
                 signal.execFilePath == "/usr/bin/socat"
-                signal.args == "-d -d -v TCP-LISTEN:8082,fork STDOUT"
+                signal.args == "-d -d -v TCP-LISTEN:"+PORT4+",fork STDOUT"
         }
 
         // Allow enough time for the process and port to close and check that it is not in the API response
@@ -244,7 +250,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
         def list = processesListeningOnPorts.listeningEndpointsList
         assert list.size() == 1
 
-        def endpoint = list.find { it.endpoint.port == 8081 }
+        def endpoint = list.find { it.endpoint.port == PORT3 }
 
         verifyAll(endpoint) {
                 deploymentId
@@ -255,7 +261,7 @@ class ProcessesListeningOnPortsTest extends BaseSpecification {
                 containerName == TCPCONNECTIONTARGET2
                 signal.name == "socat"
                 signal.execFilePath == "/usr/bin/socat"
-                signal.args == "-d -d -v TCP-LISTEN:8081,fork STDOUT"
+                signal.args == "-d -d -v TCP-LISTEN:"+PORT3+",fork STDOUT"
         }
 
         sleep 65000 // Sleep for 65 seconds


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The "ProcessesListeningOnPortsTest / Verify networking endpoints with processes appear in API at the deployment level" is flaky. When it fails the test pod has the following error

```
2026/02/16 02:33:07 socat[1] N listening on AF=2 0.0.0.0:8080
2026/02/16 02:33:07 socat[2] E bind(5, {AF=2 0.0.0.0:80}, 16): Permission denied
2026/02/16 02:33:07 socat[2] N exit(1)
2026/02/16 02:33:07 socat[1] N childdied(): handling signal 17
```

To resolve this flake a none privileged port, 8079, will be used instead of the current privileged port.

There are alternatives that can be implemented later. The socat command could be run with the root user. Then the port could be changed back to 80.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI is sufficient.
