### PR TITLE
fix(ci): docker manifest push docker/oci mixed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -550,6 +550,9 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Checkout submodules
       run: |
         git submodule update --init
@@ -782,6 +785,9 @@ jobs:
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - uses: ./.github/actions/handle-tagged-build
 

--- a/scripts/ci/push-as-multiarch-manifest-list.sh
+++ b/scripts/ci/push-as-multiarch-manifest-list.sh
@@ -22,7 +22,7 @@ do
     image_list+=("$arch_image")
 done
 
-docker manifest create "$image" "${image_list[@]}"
+docker manifest create --amend "$image" "${image_list[@]}"
 
 # Try pushing manifest a few times for the case when quay.io has issues
 pushed=0

--- a/scripts/ci/push-as-multiarch-manifest-list.sh
+++ b/scripts/ci/push-as-multiarch-manifest-list.sh
@@ -14,12 +14,28 @@ IFS=',' read -ra architectures <<< "$2"
 [[ -n "$image" ]] || die "No image specified"
 [[ "$image" == *:* ]] || die "Must specify a tagged image reference when using this script"
 
-# Try pushing manifest a few times for the case when quay.io has issues.
-# Each attempt re-pulls and re-fetches arch manifests from the registry to
-# avoid retrying with a stale or inconsistent manifest from a previous attempt.
+# Push a multi-arch manifest index using docker buildx imagetools create, which
+# produces an OCI image index (application/vnd.oci.image.index.v1+json) rather
+# than a Docker manifest list (application/vnd.docker.distribution.manifest.list.v2+json).
+#
+# The Docker manifest list approach was abandoned because quay's
+# DockerSchema2ManifestList validator strictly requires all referenced manifests
+# to use Docker v2 mediaTypes. When amd64 and arm64 builds land on different
+# GitHub Actions runner generations (e.g. ubuntu24/20260201.15 using overlay2
+# vs ubuntu24/20260217.30 using the containerd image store), one arch produces a
+# Docker v2 manifest and the other an OCI manifest. The resulting mixed manifest
+# list is rejected by quay with "manifest invalid" (PROJQUAY-9687).
+#
+# docker buildx imagetools create produces an OCI index which quay validates
+# under a different, more permissive schema that accepts both OCI and Docker v2
+# manifest references regardless of their individual mediaTypes.
+#
+# Each retry re-pulls and re-inspects all arch images from the registry so that
+# any stale or inconsistent manifest served by quay on a prior attempt does not
+# poison subsequent retries.
 pushed=0
 for i in {1..5}; do
-  echo "Pushing manifest for ${image}. Attempt ${i}..."
+  echo "Pushing manifest index for ${image}. Attempt ${i}..."
 
   image_list=()
   for arch in "${architectures[@]}"; do
@@ -31,21 +47,10 @@ for i in {1..5}; do
     image_list+=("$arch_image")
   done
 
-  # Clear any previously cached manifest to force a fresh fetch from the
-  # registry on every attempt. docker manifest create caches each arch manifest
-  # locally after the first fetch and --amend reuses that cache without
-  # re-fetching. If the registry served a stale/inconsistent manifest on a
-  # prior attempt, all subsequent retries would push the same invalid manifest
-  # list without this rm.
-  docker manifest rm "$image" 2>/dev/null || true
-  docker manifest create --amend "$image" "${image_list[@]}"
-
-  echo "=== Manifest list inspect: ${image} ==="
-  docker manifest inspect "$image" || true
-  echo "========================================"
-
-  echo docker manifest push "$image"
-  if docker manifest push "$image"; then
+  if docker buildx imagetools create -t "$image" "${image_list[@]}"; then
+    echo "=== Manifest index inspect: ${image} ==="
+    docker buildx imagetools inspect "$image" || true
+    echo "========================================"
     pushed=1
     break
   fi

--- a/scripts/ci/push-as-multiarch-manifest-list.sh
+++ b/scripts/ci/push-as-multiarch-manifest-list.sh
@@ -47,7 +47,7 @@ for i in {1..5}; do
     image_list+=("$arch_image")
   done
 
-  if docker buildx imagetools create -t "$image" "${image_list[@]}"; then
+  if docker buildx imagetools create --tag "$image" "${image_list[@]}"; then
     echo "=== Manifest index inspect: ${image} ==="
     docker buildx imagetools inspect "$image" || true
     echo "========================================"

--- a/scripts/ci/push-as-multiarch-manifest-list.sh
+++ b/scripts/ci/push-as-multiarch-manifest-list.sh
@@ -14,20 +14,36 @@ IFS=',' read -ra architectures <<< "$2"
 [[ -n "$image" ]] || die "No image specified"
 [[ "$image" == *:* ]] || die "Must specify a tagged image reference when using this script"
 
-image_list=()
-for arch in "${architectures[@]}"
-do
-    arch_image="${image}-${arch}"
-    docker pull "${arch_image}"
-    image_list+=("$arch_image")
-done
-
-docker manifest create --amend "$image" "${image_list[@]}"
-
-# Try pushing manifest a few times for the case when quay.io has issues
+# Try pushing manifest a few times for the case when quay.io has issues.
+# Each attempt re-pulls and re-fetches arch manifests from the registry to
+# avoid retrying with a stale or inconsistent manifest from a previous attempt.
 pushed=0
 for i in {1..5}; do
   echo "Pushing manifest for ${image}. Attempt ${i}..."
+
+  image_list=()
+  for arch in "${architectures[@]}"; do
+    arch_image="${image}-${arch}"
+    docker pull "${arch_image}"
+    echo "=== Arch manifest inspect: ${arch_image} ==="
+    docker manifest inspect "${arch_image}" || true
+    echo "============================================="
+    image_list+=("$arch_image")
+  done
+
+  # Clear any previously cached manifest to force a fresh fetch from the
+  # registry on every attempt. docker manifest create caches each arch manifest
+  # locally after the first fetch and --amend reuses that cache without
+  # re-fetching. If the registry served a stale/inconsistent manifest on a
+  # prior attempt, all subsequent retries would push the same invalid manifest
+  # list without this rm.
+  docker manifest rm "$image" 2>/dev/null || true
+  docker manifest create --amend "$image" "${image_list[@]}"
+
+  echo "=== Manifest list inspect: ${image} ==="
+  docker manifest inspect "$image" || true
+  echo "========================================"
+
   echo docker manifest push "$image"
   if docker manifest push "$image"; then
     pushed=1

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -2,5 +2,13 @@
 
 set -e
 
+# Build for the target platform and force Docker v2 manifest format by using
+# --output type=docker explicitly. This is necessary because docker buildx
+# build --load on runners with the containerd image store (Docker 29,
+# ubuntu24/20260209.23+) produces OCI format manifests by default, which quay
+# rejects when they appear alongside Docker v2 manifests in a manifest index
+# (PROJQUAY-9687). --output type=docker forces the Docker Image Specification
+# format regardless of the builder driver or image store configuration, while
+# keeping BuildKit and the full buildx feature set available.
 echo "Building with platform linux/${GOARCH}"
-docker build --platform "linux/${GOARCH}" "$@"
+docker buildx build --platform "linux/${GOARCH}" --output "type=docker,dest=-" "$@" | docker load

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "Building with platform linux/${GOARCH}"
 if docker info | grep buildx; then
-    docker buildx build --platform "linux/${GOARCH}" --load "$@"
+    docker buildx build --platform "linux/${GOARCH}" --load --provenance=false "$@"
 else
     docker build --platform "linux/${GOARCH}" "$@"
 fi

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -3,8 +3,4 @@
 set -e
 
 echo "Building with platform linux/${GOARCH}"
-if docker info | grep buildx; then
-    docker buildx build --platform "linux/${GOARCH}" --load --provenance=false "$@"
-else
-    docker build --platform "linux/${GOARCH}" "$@"
-fi
+docker build --platform "linux/${GOARCH}" "$@"


### PR DESCRIPTION
## Description

### Root Cause

GitHub Actions began rolling out Docker 29.1.5 to `ubuntu-latest` runners starting Feb 9 2026 (runner image `ubuntu24/20260209.23+`). Docker 29 with the containerd image store causes `docker buildx build --load` to produce **OCI format** manifests (`application/vnd.oci.image.manifest.v1+json`) instead of **Docker v2** (`application/vnd.docker.distribution.manifest.v2+json`).

The rollout was non-uniform: some runner VMs stayed on the old image (`ubuntu24/20260201.15`, Docker 27/28, `overlay2` store) while others moved to the new image (`ubuntu24/20260217.30`, Docker 29, containerd store). Since `amd64` and `arm64` build matrix jobs are assigned to separate runner VMs independently, they could land on different runner generations — producing arch images in inconsistent formats.

Quay enforces strict mediaType validation:
- A **Docker manifest list** (`vnd.docker.distribution.manifest.list.v2+json`) must only reference Docker v2 manifests — OCI manifest references are rejected with `manifest invalid` ([PROJQUAY-9687](https://issues.redhat.com/browse/PROJQUAY-9687))
- An **OCI image index** (`vnd.oci.image.index.v1+json`) created by `docker buildx imagetools create` is validated under a different, more permissive schema — but quay still rejects it when the referenced manifests have mixed mediaTypes

The consequence: whenever `amd64` and `arm64` build jobs landed on different runner generations, any attempt to push a multi-arch manifest for those images was rejected by quay.

A secondary issue was also present: `docker manifest create` (the old approach) cached arch manifests locally after the first fetch and reused that cache on retries without re-fetching from the registry. If the first attempt produced an invalid manifest list, all retries would push the identical invalid content. The `--amend` flag was also missing, causing retries to fail immediately at `docker manifest create` rather than even attempting to re-push. (`--amend` can be used on a create call but allows updating instead of failing if the manifest exists)

### Investigation

Confirmed via CI log analysis that the failing runs had mixed runner generations:
- `build-and-push-operator (STACKROX_BRANDING, amd64)` on `ubuntu24/20260201.15` → Docker v2 image
- `build-and-push-operator (STACKROX_BRANDING, arm64)` on `ubuntu24/20260217.30` → OCI image
- Manifest push: quay rejects the mixed-format manifest list with `manifest invalid`

Runs where both arches landed on the same runner generation (both `overlay2` or both containerd) succeeded consistently.

GitHub has since pulled the `20260217.30` runners from the pool (apparent rollback, ~Feb 20 00:00 UTC), so CI is currently passing without this fix. Docker 29 will be re-introduced — this fix prevents the failures from recurring.

### Fix

**Three files changed:**

#### `scripts/docker-build.sh`
Replaced `docker buildx build --load` (which produces OCI format on containerd image store runners) with `docker buildx build --output type=docker,dest=- | docker load`. The `--output type=docker` flag explicitly requests Docker Image Specification v2 format regardless of the buildx driver or host image store configuration, while keeping the full BuildKit/buildx feature set. Tags specified with `-t` are embedded in the tar and restored by `docker load`.

#### `scripts/ci/push-as-multiarch-manifest-list.sh`
Replaced `docker manifest create` + `docker manifest push` with `docker buildx imagetools create --tag`. Key improvements:
- `imagetools create` creates an OCI image index rather than a Docker manifest list, bypassing quay's strict Docker manifest list validator
- Re-pulls and re-inspects each arch image on every retry attempt, preventing stale cached manifests from poisoning retries
- No local manifest cache to manage — each attempt is naturally idempotent
- Added `docker manifest inspect` and `docker buildx imagetools inspect` debug output to aid future diagnosis

#### `.github/workflows/build.yaml`
Added `docker/setup-buildx-action@v3` to `push-main-manifests` and `push-operator-manifests` jobs. The `apollo-ci` container ships an old buildx version that does not support `imagetools create --tag`; this installs a current version before the manifest push step runs.

### Alternatives considered

- **`docker manifest create --amend`**: Fixes the retry-caching bug but does not address the mixed OCI/Docker v2 format rejection from quay. Investigated and ruled out.
- **`--provenance=false`**: Prevents provenance attestations but does not force Docker v2 format on containerd image store runners. Investigated and ruled out.
- **`docker build` (no buildx)**: Also produces OCI format on Docker 29 + containerd via BuildKit default backend. Investigated and ruled out.
- **Waiting for quay to fix PROJQUAY-9687**: Unresolved, no fix version scheduled.

### How I validated my change

- Identified the root cause by comparing runner image versions (`ubuntu24/20260201.15` vs `ubuntu24/20260217.30`) and storage drivers (`overlay2` vs `overlayfs`) across failing and passing CI runs — correlation was 100% with runner mismatch causing mixed image formats
- Added `docker manifest inspect` debug output to the manifest push script and confirmed amd64 produced `vnd.docker.distribution.manifest.v2+json` while arm64 produced `vnd.oci.image.manifest.v1+json` when built on different runner generations
- Iterated through multiple fix approaches (documented in commit history and alternatives above), testing each via PR CI runs
- Confirmed full pass of all four manifest jobs (`push-operator-manifests` RHACS+STACKROX, `push-main-manifests` RHACS+STACKROX) on run [22207530520](https://github.com/stackrox/stackrox/actions/runs/22207530520) with the final fix applied
- Ran multiple subsequent heartbeat commits on the fix branch confirming consistent passes

Partially generated by AI. 🤖 

[PROJQUAY-9687]: https://redhat.atlassian.net/browse/PROJQUAY-9687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ