### PR TITLE
Fix(compliance): Handle tailored profiles with enabled and disabled rules

### DIFF
--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -53,7 +53,7 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 		}
 		unstructuredObject, ok = profileObj.(*unstructured.Unstructured)
 		if !ok {
-			log.Errorf("Fetched profile not of type 'unstructured': %T", obj)
+			log.Errorf("Fetched profile not of type 'unstructured': %T", profileObj)
 			return nil
 		}
 

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -44,21 +44,23 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 		return nil
 	}
 
-	profileObj, err := c.profileLister.ByNamespace(tailoredProfile.GetNamespace()).Get(tailoredProfile.Spec.Extends)
-	if err != nil {
-		log.Errorf("error getting profile %s: %v", tailoredProfile.Spec.Extends, err)
-		return nil
-	}
-	unstructuredObject, ok = profileObj.(*unstructured.Unstructured)
-	if !ok {
-		log.Errorf("Fetched profile not of type 'unstructured': %T", obj)
-		return nil
-	}
+	var baseProfile v1alpha1.Profile
+	if tailoredProfile.Spec.Extends != "" {
+		profileObj, err := c.profileLister.ByNamespace(tailoredProfile.GetNamespace()).Get(tailoredProfile.Spec.Extends)
+		if err != nil {
+			log.Errorf("error getting profile %s: %v", tailoredProfile.Spec.Extends, err)
+			return nil
+		}
+		unstructuredObject, ok = profileObj.(*unstructured.Unstructured)
+		if !ok {
+			log.Errorf("Fetched profile not of type 'unstructured': %T", obj)
+			return nil
+		}
 
-	var complianceProfile v1alpha1.Profile
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObject.Object, &complianceProfile); err != nil {
-		log.Errorf("error converting unstructured to compliance profile: %v", err)
-		return nil
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObject.Object, &baseProfile); err != nil {
+			log.Errorf("error converting unstructured to compliance profile: %v", err)
+			return nil
+		}
 	}
 
 	protoProfile := &storage.ComplianceOperatorProfile{
@@ -66,16 +68,16 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 		ProfileId: tailoredProfile.Status.ID,
 		Name:      tailoredProfile.Name,
 		// We want to use the original compliance profiles labels and annotations as they hold data about the type of profile
-		Labels:      complianceProfile.Labels,
-		Annotations: complianceProfile.Annotations,
-		Description: stringutils.FirstNonEmpty(tailoredProfile.Spec.Description, complianceProfile.Description),
+		Labels:      baseProfile.Labels,
+		Annotations: baseProfile.Annotations,
+		Description: stringutils.FirstNonEmpty(tailoredProfile.Spec.Description, baseProfile.Description),
 	}
 	removedRules := set.NewStringSet()
 	for _, rule := range tailoredProfile.Spec.DisableRules {
 		removedRules.Add(rule.Name)
 	}
 
-	for _, r := range complianceProfile.Rules {
+	for _, r := range baseProfile.Rules {
 		if removedRules.Contains(string(r)) {
 			continue
 		}
@@ -98,5 +100,6 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 			},
 		},
 	}
+
 	return component.NewEvent(events...)
 }

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -63,13 +63,22 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 		}
 	}
 
+	// Use TP's labels/annotations if present, otherwise fall back to base profile.
+	labels := tailoredProfile.GetLabels()
+	if len(labels) == 0 {
+		labels = baseProfile.GetLabels()
+	}
+	annotations := tailoredProfile.GetAnnotations()
+	if len(annotations) == 0 {
+		annotations = baseProfile.GetAnnotations()
+	}
+
 	protoProfile := &storage.ComplianceOperatorProfile{
-		Id:        string(tailoredProfile.UID),
-		ProfileId: tailoredProfile.Status.ID,
-		Name:      tailoredProfile.Name,
-		// We want to use the original compliance profiles labels and annotations as they hold data about the type of profile
-		Labels:      baseProfile.Labels,
-		Annotations: baseProfile.Annotations,
+		Id:          string(tailoredProfile.UID),
+		ProfileId:   tailoredProfile.Status.ID,
+		Name:        tailoredProfile.Name,
+		Labels:      labels,
+		Annotations: annotations,
 		Description: stringutils.FirstNonEmpty(tailoredProfile.Spec.Description, baseProfile.Description),
 	}
 

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -73,22 +73,26 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 		Description: stringutils.FirstNonEmpty(tailoredProfile.Spec.Description, baseProfile.Description),
 	}
 
+	baseRules := set.NewStringSet()
+	for _, rule := range baseProfile.Rules {
+		baseRules.Add(string(rule))
+	}
+
+	addedRules := set.NewStringSet()
+	for _, rule := range tailoredProfile.Spec.EnableRules {
+		addedRules.Add(rule.Name)
+	}
+
 	removedRules := set.NewStringSet()
 	for _, rule := range tailoredProfile.Spec.DisableRules {
 		removedRules.Add(rule.Name)
 	}
 
-	for _, r := range baseProfile.Rules {
-		if removedRules.Contains(string(r)) {
-			continue
-		}
+	effectiveRules := baseRules.Union(addedRules).Difference(removedRules)
+
+	for rule := range effectiveRules {
 		protoProfile.Rules = append(protoProfile.Rules, &storage.ComplianceOperatorProfile_Rule{
-			Name: string(r),
-		})
-	}
-	for _, rule := range tailoredProfile.Spec.EnableRules {
-		protoProfile.Rules = append(protoProfile.Rules, &storage.ComplianceOperatorProfile_Rule{
-			Name: rule.Name,
+			Name: rule,
 		})
 	}
 

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -72,6 +72,7 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 		Annotations: baseProfile.Annotations,
 		Description: stringutils.FirstNonEmpty(tailoredProfile.Spec.Description, baseProfile.Description),
 	}
+
 	removedRules := set.NewStringSet()
 	for _, rule := range tailoredProfile.Spec.DisableRules {
 		removedRules.Add(rule.Name)

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -21,7 +21,7 @@ type mockNamespaceLister struct {
 }
 
 func (m *mockNamespaceLister) List(_ labels.Selector) ([]runtime.Object, error) {
-	return nil, nil
+	panic("List should not be called in these tests")
 }
 
 func (m *mockNamespaceLister) Get(name string) (runtime.Object, error) {
@@ -37,11 +37,11 @@ type mockProfileLister struct {
 }
 
 func (m *mockProfileLister) List(_ labels.Selector) ([]runtime.Object, error) {
-	return nil, nil
+	panic("List should not be called in these tests")
 }
 
 func (m *mockProfileLister) Get(_ string) (runtime.Object, error) {
-	return nil, nil
+	panic("Get should not be called in these tests")
 }
 
 func (m *mockProfileLister) ByNamespace(ns string) cache.GenericNamespaceLister {
@@ -73,16 +73,25 @@ func toUnstructured(t *testing.T, tp *v1alpha1.TailoredProfile) *unstructured.Un
 	return &unstructured.Unstructured{Object: unstructuredObj}
 }
 
-// TestProcessEvent_ExtendsProfile tests rule computation when extending a base profile:
-// effective rules = base rules - disabled rules + enabled rules
+// TestProcessEvent_ExtendsProfile tests rule computation and metadata inheritance when extending a base profile:
+// - effective rules = base rules - disabled rules + enabled rules
+// - labels, annotations, description inherited from base profile
 func TestProcessEvent_ExtendsProfile(t *testing.T) {
 	baseProfile := &v1alpha1.Profile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "ocp4-cis",
 			Namespace: "openshift-compliance",
+			Labels: map[string]string{
+				"compliance.openshift.io/profile-bundle": "ocp4",
+			},
+			Annotations: map[string]string{
+				v1alpha1.ProductTypeAnnotation: "Platform",
+				v1alpha1.ProductAnnotation:     "ocp4",
+			},
 		},
 		ProfilePayload: v1alpha1.ProfilePayload{
-			ID: "xccdf_org.ssgproject.content_profile_cis",
+			ID:          "xccdf_org.ssgproject.content_profile_cis",
+			Description: "Base profile description from CIS benchmark",
 			Rules: []v1alpha1.ProfileRule{
 				"ocp4-api-server-anonymous-auth",
 				"ocp4-api-server-audit-log-path",
@@ -102,6 +111,7 @@ func TestProcessEvent_ExtendsProfile(t *testing.T) {
 		},
 		Spec: v1alpha1.TailoredProfileSpec{
 			Extends: "ocp4-cis",
+			// Description intentionally empty to test inheritance
 			DisableRules: []v1alpha1.RuleReferenceSpec{
 				{Name: "ocp4-api-server-audit-log-path"},
 			},
@@ -120,6 +130,12 @@ func TestProcessEvent_ExtendsProfile(t *testing.T) {
 
 	require.NotNil(t, event)
 	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+
+	// Verify metadata inheritance from base profile
+	assert.Equal(t, "ocp4", profile.GetLabels()["compliance.openshift.io/profile-bundle"])
+	assert.Equal(t, "Platform", profile.GetAnnotations()[v1alpha1.ProductTypeAnnotation])
+	assert.Equal(t, "ocp4", profile.GetAnnotations()[v1alpha1.ProductAnnotation])
+	assert.Equal(t, "Base profile description from CIS benchmark", profile.GetDescription())
 
 	// Verify rule computation: 3 base - 1 disabled + 1 enabled = 3 rules
 	ruleNames := make([]string, len(profile.GetRules()))
@@ -169,7 +185,6 @@ func TestProcessEvent_FromScratch(t *testing.T) {
 	assert.Len(t, profile.GetRules(), 2)
 	assert.Contains(t, ruleNames, "ocp4-api-server-anonymous-auth")
 	assert.Contains(t, ruleNames, "ocp4-api-server-encryption-provider-cipher")
-
 }
 
 // TestProcessEvent_NoStatusID tests that non-ready TPs (no Status.ID) are skipped

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -1,0 +1,219 @@
+package dispatchers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+// mockNamespaceLister implements cache.GenericNamespaceLister
+type mockNamespaceLister struct {
+	objects map[string]runtime.Object
+}
+
+func (m *mockNamespaceLister) List(_ labels.Selector) ([]runtime.Object, error) {
+	return nil, nil
+}
+
+func (m *mockNamespaceLister) Get(name string) (runtime.Object, error) {
+	if obj, ok := m.objects[name]; ok {
+		return obj, nil
+	}
+	return nil, fmt.Errorf("not found: %s", name)
+}
+
+// mockProfileLister implements cache.GenericLister
+type mockProfileLister struct {
+	namespaces map[string]*mockNamespaceLister
+}
+
+func (m *mockProfileLister) List(_ labels.Selector) ([]runtime.Object, error) {
+	return nil, nil
+}
+
+func (m *mockProfileLister) Get(_ string) (runtime.Object, error) {
+	return nil, nil
+}
+
+func (m *mockProfileLister) ByNamespace(ns string) cache.GenericNamespaceLister {
+	if nsl, ok := m.namespaces[ns]; ok {
+		return nsl
+	}
+	return &mockNamespaceLister{objects: map[string]runtime.Object{}}
+}
+
+func newMockProfileLister() *mockProfileLister {
+	return &mockProfileLister{
+		namespaces: make(map[string]*mockNamespaceLister),
+	}
+}
+
+func (m *mockProfileLister) addProfile(namespace string, profile *v1alpha1.Profile) {
+	if m.namespaces[namespace] == nil {
+		m.namespaces[namespace] = &mockNamespaceLister{
+			objects: make(map[string]runtime.Object),
+		}
+	}
+	unstructuredObj, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(profile)
+	m.namespaces[namespace].objects[profile.Name] = &unstructured.Unstructured{Object: unstructuredObj}
+}
+
+func toUnstructured(t *testing.T, tp *v1alpha1.TailoredProfile) *unstructured.Unstructured {
+	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tp)
+	require.NoError(t, err)
+	return &unstructured.Unstructured{Object: unstructuredObj}
+}
+
+// TestProcessEvent_ExtendsProfile tests rule computation when extending a base profile:
+// effective rules = base rules - disabled rules + enabled rules
+func TestProcessEvent_ExtendsProfile(t *testing.T) {
+	baseProfile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ocp4-cis",
+			Namespace: "openshift-compliance",
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			ID: "xccdf_org.ssgproject.content_profile_cis",
+			Rules: []v1alpha1.ProfileRule{
+				"ocp4-api-server-anonymous-auth",
+				"ocp4-api-server-audit-log-path",
+				"ocp4-api-server-encryption-provider-cipher",
+			},
+		},
+	}
+
+	lister := newMockProfileLister()
+	lister.addProfile("openshift-compliance", baseProfile)
+
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ocp4-cis-tailored",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			Extends: "ocp4-cis",
+			DisableRules: []v1alpha1.RuleReferenceSpec{
+				{Name: "ocp4-api-server-audit-log-path"},
+			},
+			EnableRules: []v1alpha1.RuleReferenceSpec{
+				{Name: "ocp4-audit-log-forwarding-enabled"},
+			},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_ocp4-cis-tailored",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(lister)
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+
+	// Verify rule computation: 3 base - 1 disabled + 1 enabled = 3 rules
+	ruleNames := make([]string, len(profile.GetRules()))
+	for i, r := range profile.GetRules() {
+		ruleNames[i] = r.GetName()
+	}
+	assert.Len(t, ruleNames, 3)
+	assert.Contains(t, ruleNames, "ocp4-api-server-anonymous-auth")
+	assert.Contains(t, ruleNames, "ocp4-api-server-encryption-provider-cipher")
+	assert.Contains(t, ruleNames, "ocp4-audit-log-forwarding-enabled")
+	assert.NotContains(t, ruleNames, "ocp4-api-server-audit-log-path")
+}
+
+// TestProcessEvent_FromScratch tests that TPs without Extends work (only EnableRules)
+func TestProcessEvent_FromScratch(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tp-from-scratch",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			// No Extends
+			EnableRules: []v1alpha1.RuleReferenceSpec{
+				{Name: "ocp4-api-server-anonymous-auth"},
+				{Name: "ocp4-api-server-encryption-provider-cipher"},
+			},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_tp-from-scratch",
+			State: "READY",
+		},
+	}
+
+	lister := newMockProfileLister() // No base profile needed
+	dispatcher := NewTailoredProfileDispatcher(lister)
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+
+	// Only enabled rules should be present
+	ruleNames := make([]string, len(profile.GetRules()))
+	for i, r := range profile.GetRules() {
+		ruleNames[i] = r.GetName()
+	}
+	assert.Len(t, profile.GetRules(), 2)
+	assert.Contains(t, ruleNames, "ocp4-api-server-anonymous-auth")
+	assert.Contains(t, ruleNames, "ocp4-api-server-encryption-provider-cipher")
+
+}
+
+// TestProcessEvent_NoStatusID tests that non-ready TPs (no Status.ID) are skipped
+func TestProcessEvent_NoStatusID(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-profile",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			Extends: "ocp4-cis",
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			// ID is empty - not yet processed by CO
+			State: "PENDING",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	assert.Nil(t, event)
+}
+
+// TestProcessEvent_BaseProfileNotFound tests that TPs with missing base profile are skipped
+func TestProcessEvent_BaseProfileNotFound(t *testing.T) {
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "orphan-profile",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			Extends: "non-existent-profile",
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_orphan-profile",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	assert.Nil(t, event)
+}

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -152,6 +152,72 @@ func TestProcessEvent_ExtendsProfile(t *testing.T) {
 	}, ruleNames)
 }
 
+// TestProcessEvent_TPMetadataTakesPrecedence tests that TP's own labels/annotations
+// take precedence over base profile's when present
+func TestProcessEvent_TPMetadataTakesPrecedence(t *testing.T) {
+	baseProfile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ocp4-cis",
+			Namespace: "openshift-compliance",
+			Labels: map[string]string{
+				"compliance.openshift.io/profile-bundle": "ocp4",
+				"base-only-label":                        "from-base",
+			},
+			Annotations: map[string]string{
+				v1alpha1.ProductTypeAnnotation: "Platform",
+			},
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			ID:          "xccdf_org.ssgproject.content_profile_cis",
+			Description: "Base profile description",
+			Rules:       []v1alpha1.ProfileRule{"ocp4-rule1"},
+		},
+	}
+
+	lister := newMockProfileLister()
+	lister.addProfile("openshift-compliance", baseProfile)
+
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ocp4-cis-custom",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+			Labels: map[string]string{
+				"custom-label": "custom-value",
+			},
+			Annotations: map[string]string{
+				"custom-annotation": "custom-value",
+			},
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			Extends:     "ocp4-cis",
+			Description: "Custom description",
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_ocp4-cis-custom",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(lister)
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
+	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
+
+	// TP's labels should be used, not base profile's
+	assert.Equal(t, "custom-value", profile.GetLabels()["custom-label"])
+	assert.Empty(t, profile.GetLabels()["compliance.openshift.io/profile-bundle"]) // Base profile label not present
+
+	// TP's annotations should be used, not base profile's
+	assert.Equal(t, "custom-value", profile.GetAnnotations()["custom-annotation"])
+	assert.Empty(t, profile.GetAnnotations()[v1alpha1.ProductTypeAnnotation]) // Base profile annotation not present
+
+	// TP's description should be used
+	assert.Equal(t, "Custom description", profile.GetDescription())
+}
+
 // TestProcessEvent_FromScratch tests that TPs without Extends work (only EnableRules)
 func TestProcessEvent_FromScratch(t *testing.T) {
 	tp := &v1alpha1.TailoredProfile{

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -2,6 +2,7 @@ package dispatchers
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
@@ -143,11 +144,12 @@ func TestProcessEvent_ExtendsProfile(t *testing.T) {
 	for i, r := range profile.GetRules() {
 		ruleNames[i] = r.GetName()
 	}
-	assert.Len(t, ruleNames, 3)
-	assert.Contains(t, ruleNames, "ocp4-api-server-anonymous-auth")
-	assert.Contains(t, ruleNames, "ocp4-api-server-encryption-provider-cipher")
-	assert.Contains(t, ruleNames, "ocp4-audit-log-forwarding-enabled")
-	assert.NotContains(t, ruleNames, "ocp4-api-server-audit-log-path")
+	slices.Sort(ruleNames)
+	assert.Equal(t, []string{
+		"ocp4-api-server-anonymous-auth",
+		"ocp4-api-server-encryption-provider-cipher",
+		"ocp4-audit-log-forwarding-enabled",
+	}, ruleNames)
 }
 
 // TestProcessEvent_FromScratch tests that TPs without Extends work (only EnableRules)
@@ -184,9 +186,11 @@ func TestProcessEvent_FromScratch(t *testing.T) {
 	for i, r := range profile.GetRules() {
 		ruleNames[i] = r.GetName()
 	}
-	assert.Len(t, profile.GetRules(), 2)
-	assert.Contains(t, ruleNames, "ocp4-api-server-anonymous-auth")
-	assert.Contains(t, ruleNames, "ocp4-api-server-encryption-provider-cipher")
+	slices.Sort(ruleNames)
+	assert.Equal(t, []string{
+		"ocp4-api-server-anonymous-auth",
+		"ocp4-api-server-encryption-provider-cipher",
+	}, ruleNames)
 }
 
 // TestProcessEvent_NoStatusID tests that non-ready TPs (no Status.ID) are skipped

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -129,6 +129,7 @@ func TestProcessEvent_ExtendsProfile(t *testing.T) {
 	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
 
 	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
 	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
 
 	// Verify metadata inheritance from base profile
@@ -175,6 +176,7 @@ func TestProcessEvent_FromScratch(t *testing.T) {
 	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
 
 	require.NotNil(t, event)
+	require.NotEmpty(t, event.ForwardMessages)
 	profile := event.ForwardMessages[0].GetComplianceOperatorProfile()
 
 	// Only enabled rules should be present


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Previously, we were calculating effective rules incorrectly in cases where the same rule is both added and deleted. A profile that adds rules A and B and removes rule A would be shown as containing rules A and B, because we were handling rule removal before addition.

This is an edge case that should not be possible to implement in practice because CO does not allow listing the same rule in both `enableRules` and `disableRules`. However there's yet another edge case where editing a profile to be invalid after being already tracked as valid could end up in this scenario. While this additional edge case will also be fixed in Stackrox, it is good to make the code robust and more clear.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI
