### PR TITLE
fix(ci): work around preloaded image use problem in recent k8s

### DIFF
--- a/qa-tests-backend/scripts/images-to-prefetch.txt
+++ b/qa-tests-backend/scripts/images-to-prefetch.txt
@@ -29,6 +29,8 @@ quay.io/rhacs-eng/qa-multi-arch:nginx-204a9a8e65061b10b92ad361dd6f406248404fe60e
 quay.io/rhacs-eng/qa-multi-arch:nginx-1-15-4-alpine
 quay.io/rhacs-eng/qa-multi-arch:nginx-1-17-1
 quay.io/rhacs-eng/qa-multi-arch:nginx-1-19-alpine
+quay.io/rhacs-eng/qa-multi-arch:nginx-1.12
+quay.io/rhacs-eng/qa-multi-arch:nginx-1.12@sha256:72daaf46f11cc753c4eab981cbf869919bd1fee3d2170a2adeac12400f494728
 quay.io/rhacs-eng/qa-multi-arch:nginx-1.21.1
 quay.io/rhacs-eng/qa-multi-arch:nginx-2.0.3
 quay.io/rhacs-eng/qa-multi-arch:nginx-3.21-1

--- a/qa-tests-backend/scripts/images-to-prefetch.txt
+++ b/qa-tests-backend/scripts/images-to-prefetch.txt
@@ -32,6 +32,8 @@ quay.io/rhacs-eng/qa-multi-arch:nginx-1-19-alpine
 quay.io/rhacs-eng/qa-multi-arch:nginx-1.12
 quay.io/rhacs-eng/qa-multi-arch:nginx-1.12@sha256:72daaf46f11cc753c4eab981cbf869919bd1fee3d2170a2adeac12400f494728
 quay.io/rhacs-eng/qa-multi-arch:nginx-1.21.1
+us.gcr.io/acs-san-stackroxci/qa-multi-arch:nginx-1.12
+us.gcr.io/acs-san-stackroxci/qa/registry-image:0.3
 quay.io/rhacs-eng/qa-multi-arch:nginx-2.0.3
 quay.io/rhacs-eng/qa-multi-arch:nginx-3.21-1
 quay.io/rhacs-eng/qa-multi-arch:nginx-latest

--- a/qa-tests-backend/scripts/images-to-prefetch.txt
+++ b/qa-tests-backend/scripts/images-to-prefetch.txt
@@ -32,8 +32,11 @@ quay.io/rhacs-eng/qa-multi-arch:nginx-1-19-alpine
 quay.io/rhacs-eng/qa-multi-arch:nginx-1.12
 quay.io/rhacs-eng/qa-multi-arch:nginx-1.12@sha256:72daaf46f11cc753c4eab981cbf869919bd1fee3d2170a2adeac12400f494728
 quay.io/rhacs-eng/qa-multi-arch:nginx-1.21.1
+
+# gcr.io images (filtered out on non-GKE clusters by scripts/ci/lib.sh:image_prefetcher_start_set)
 us.gcr.io/acs-san-stackroxci/qa-multi-arch:nginx-1.12
 us.gcr.io/acs-san-stackroxci/qa/registry-image:0.3
+
 quay.io/rhacs-eng/qa-multi-arch:nginx-2.0.3
 quay.io/rhacs-eng/qa-multi-arch:nginx-3.21-1
 quay.io/rhacs-eng/qa-multi-arch:nginx-latest

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -139,8 +139,8 @@ create_cluster() {
     GCP_IMAGE_TYPE="${GCP_IMAGE_TYPE:-UBUNTU_CONTAINERD}"
     POD_SECURITY_POLICIES="${POD_SECURITY_POLICIES:-false}"
     GKE_RELEASE_CHANNEL="${GKE_RELEASE_CHANNEL:-stable}"
-    MACHINE_TYPE="${MACHINE_TYPE:-e2-standard-4}"
-    DISK_SIZE_GB=${DISK_SIZE_GB:-80}
+    MACHINE_TYPE="${MACHINE_TYPE:-e2-standard-8}"
+    DISK_SIZE_GB=${DISK_SIZE_GB:-200}
 
     echo "Creating ${NUM_NODES} node cluster with image type \"${GCP_IMAGE_TYPE}\" and ${DISK_SIZE_GB}GB disks."
 

--- a/scripts/ci/gke.sh
+++ b/scripts/ci/gke.sh
@@ -139,7 +139,7 @@ create_cluster() {
     GCP_IMAGE_TYPE="${GCP_IMAGE_TYPE:-UBUNTU_CONTAINERD}"
     POD_SECURITY_POLICIES="${POD_SECURITY_POLICIES:-false}"
     GKE_RELEASE_CHANNEL="${GKE_RELEASE_CHANNEL:-stable}"
-    MACHINE_TYPE="${MACHINE_TYPE:-e2-standard-8}"
+    MACHINE_TYPE="${MACHINE_TYPE:-e2-standard-4}"
     DISK_SIZE_GB=${DISK_SIZE_GB:-200}
 
     echo "Creating ${NUM_NODES} node cluster with image type \"${GCP_IMAGE_TYPE}\" and ${DISK_SIZE_GB}GB disks."

--- a/scripts/ci/jobs/aks_qa_e2e_tests.py
+++ b/scripts/ci/jobs/aks_qa_e2e_tests.py
@@ -9,6 +9,7 @@ from clusters import AutomationFlavorsCluster
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "aks"
 
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"

--- a/scripts/ci/jobs/aro_qa_e2e_tests.py
+++ b/scripts/ci/jobs/aro_qa_e2e_tests.py
@@ -9,6 +9,7 @@ from clusters import AutomationFlavorsCluster
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"

--- a/scripts/ci/jobs/eks_qa_e2e_tests.py
+++ b/scripts/ci/jobs/eks_qa_e2e_tests.py
@@ -9,6 +9,7 @@ from clusters import AutomationFlavorsCluster
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "eks"
 
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"

--- a/scripts/ci/jobs/gke_external_pg_17_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_external_pg_17_qa_e2e_tests.py
@@ -12,6 +12,7 @@ from post_tests import PostClusterTest, FinalPost
 
 # set test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["POSTGRES_VERSION"] = "17"
 os.environ["BYODB_TEST"] = "true"
 

--- a/scripts/ci/jobs/gke_nongroovy_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_nongroovy_compatibility_tests.py
@@ -12,6 +12,7 @@ from compatibility_test import (
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["SCANNER_V4_DB_STORAGE_CLASS"] = "stackrox-gke-ssd"
 
 # Run supported central and sensor version tuples against QaE2eGoCompatibilityTest (nongroovy compatibility tests)

--- a/scripts/ci/jobs/gke_nongroovy_e2e_tests.py
+++ b/scripts/ci/jobs/gke_nongroovy_e2e_tests.py
@@ -12,6 +12,7 @@ from post_tests import PostClusterTest, FinalPost
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["SCANNER_V4_DB_STORAGE_CLASS"] = "faster"
 
 # delegated scanning support in the secured cluster

--- a/scripts/ci/jobs/gke_operator_e2e_tests.py
+++ b/scripts/ci/jobs/gke_operator_e2e_tests.py
@@ -11,6 +11,7 @@ from pre_tests import PreSystemTests
 from post_tests import PostClusterTest, FinalPost
 
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "gke"
 
 ClusterTestRunner(
     cluster=GKECluster("operator-e2e-test", num_nodes=4),

--- a/scripts/ci/jobs/gke_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_qa_e2e_tests.py
@@ -9,6 +9,7 @@ from clusters import GKECluster
 
 # set test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["GCP_IMAGE_TYPE"] = "cos_containerd"
 os.environ["OUTPUT_FORMAT"] = "helm"
 

--- a/scripts/ci/jobs/gke_race_condition_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_race_condition_qa_e2e_tests.py
@@ -9,6 +9,7 @@ from clusters import GKECluster
 
 # set test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["GCP_IMAGE_TYPE"] = "cos_containerd"
 os.environ["SCANNER_V4_DB_STORAGE_CLASS"] = "faster"
 

--- a/scripts/ci/jobs/gke_scale_tests.py
+++ b/scripts/ci/jobs/gke_scale_tests.py
@@ -12,6 +12,7 @@ from post_tests import PostClusterTest, FinalPost
 
 os.environ["COMPARISON_METRICS"] = "scale-test/gke"
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["OUTPUT_FORMAT"] = "helm"
 os.environ["STORAGE"] = "pvc"
 os.environ["STORAGE_CLASS"] = "faster"

--- a/scripts/ci/jobs/gke_scanner_v4_install_tests.py
+++ b/scripts/ci/jobs/gke_scanner_v4_install_tests.py
@@ -11,6 +11,7 @@ from ci_tests import ScannerV4InstallTest
 from post_tests import PostClusterTest, FinalPost
 
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["STORE_METRICS"] = "true"
 os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
 os.environ["ROX_SCANNER_V4"] = "true"

--- a/scripts/ci/jobs/gke_sensor_integration_tests.py
+++ b/scripts/ci/jobs/gke_sensor_integration_tests.py
@@ -11,6 +11,7 @@ from ci_tests import SensorIntegration
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["SCANNER_V4_DB_STORAGE_CLASS"] = "faster"
 
 ClusterTestRunner(

--- a/scripts/ci/jobs/gke_ui_e2e_tests.py
+++ b/scripts/ci/jobs/gke_ui_e2e_tests.py
@@ -12,6 +12,7 @@ from post_tests import PostClusterTest, FinalPost
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "gke"
 
 # Override test env defaults here:
 # (for defaults see: tests/e2e/lib.sh export_test_environment())

--- a/scripts/ci/jobs/gke_upgrade_tests.py
+++ b/scripts/ci/jobs/gke_upgrade_tests.py
@@ -11,6 +11,7 @@ from ci_tests import UpgradeTest
 from post_tests import PostClusterTest, FinalPost
 
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["SCANNER_V4_DB_STORAGE_CLASS"] = "faster"
 
 ClusterTestRunner(

--- a/scripts/ci/jobs/gke_version_compatibility_tests.py
+++ b/scripts/ci/jobs/gke_version_compatibility_tests.py
@@ -12,6 +12,7 @@ from compatibility_test import (
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "k8s"
+os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["SCANNER_V4_DB_STORAGE_CLASS"] = "stackrox-gke-ssd"
 
 # Run supported central and sensor version tuples against QaE2eTestCompatibility (groovy compatibility tests)

--- a/scripts/ci/jobs/ibmcloudz_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ibmcloudz_qa_e2e_tests.py
@@ -12,6 +12,7 @@ from clusters import AutomationFlavorsCluster
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["LOAD_BALANCER"] = "route"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 os.environ["USE_MIDSTREAM_IMAGES"] = "true"
 os.environ["REMOTE_CLUSTER_ARCH"] = "s390x"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"

--- a/scripts/ci/jobs/ocp_compliance_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_compliance_e2e_tests.py
@@ -14,6 +14,7 @@ from post_tests import PostClusterTest, FinalPost
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["INSTALL_COMPLIANCE_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 os.environ["ROX_COMPLIANCE_ENHANCEMENTS"] = "true"
 
 ClusterTestRunner(

--- a/scripts/ci/jobs/ocp_nongroovy_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_nongroovy_e2e_tests.py
@@ -13,6 +13,7 @@ from post_tests import PostClusterTest, FinalPost
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 
 # delegated scanning support in the secured cluster
 os.environ["SENSOR_SCANNER_SUPPORT"] = "true"

--- a/scripts/ci/jobs/ocp_operator_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_operator_e2e_tests.py
@@ -11,6 +11,7 @@ from pre_tests import PreSystemTests
 from post_tests import PostClusterTest, FinalPost
 
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 
 ClusterTestRunner(
     cluster=AutomationFlavorsCluster(),

--- a/scripts/ci/jobs/ocp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_qa_e2e_tests.py
@@ -11,6 +11,7 @@ from clusters import AutomationFlavorsCluster
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 # Workload identities are only set up for `openshift-4` infra clusters.
 if 'openshift-4' in os.environ.get('CLUSTER_FLAVOR_VARIANT', ''):
     os.environ["SETUP_WORKLOAD_IDENTITIES"] = "true"

--- a/scripts/ci/jobs/ocp_scanner_v4_install_tests.py
+++ b/scripts/ci/jobs/ocp_scanner_v4_install_tests.py
@@ -12,6 +12,7 @@ from pre_tests import PreSystemTests
 from post_tests import PostClusterTest, FinalPost
 
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 os.environ["STORE_METRICS"] = "true"
 os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
 os.environ["ROX_SCANNER_V4"] = "true"

--- a/scripts/ci/jobs/ocp_sensor_integration_tests.py
+++ b/scripts/ci/jobs/ocp_sensor_integration_tests.py
@@ -11,6 +11,7 @@ from ci_tests import SensorIntegrationOCP
 
 # set required test parameters
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 

--- a/scripts/ci/jobs/ocp_ui_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_ui_e2e_tests.py
@@ -14,6 +14,7 @@ from post_tests import PostClusterTest, FinalPost
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["INSTALL_COMPLIANCE_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 
 ClusterTestRunner(
     cluster=AutomationFlavorsCluster(),

--- a/scripts/ci/jobs/osd_aws_qa_e2e_tests.py
+++ b/scripts/ci/jobs/osd_aws_qa_e2e_tests.py
@@ -10,6 +10,7 @@ from clusters import AutomationFlavorsCluster
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"

--- a/scripts/ci/jobs/osd_gcp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/osd_gcp_qa_e2e_tests.py
@@ -10,6 +10,7 @@ from clusters import AutomationFlavorsCluster
 # set required test parameters
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"

--- a/scripts/ci/jobs/powervs_qa_e2e_tests.py
+++ b/scripts/ci/jobs/powervs_qa_e2e_tests.py
@@ -12,6 +12,7 @@ from clusters import AutomationFlavorsCluster
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["LOAD_BALANCER"] = "route"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 os.environ["USE_MIDSTREAM_IMAGES"] = "true"
 os.environ["REMOTE_CLUSTER_ARCH"] = "ppc64le"
 os.environ["COLLECTION_METHOD"] = "ebpf"

--- a/scripts/ci/jobs/rosa_qa_e2e_tests.py
+++ b/scripts/ci/jobs/rosa_qa_e2e_tests.py
@@ -11,6 +11,7 @@ from clusters import AutomationFlavorsCluster
 os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
 os.environ["LOAD_BALANCER"] = "route"
 os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["KUBERNETES_PROVIDER"] = "ocp"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 if "-hcp-" in os.environ["JOB_NAME"]:

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -723,6 +723,14 @@ image_prefetcher_start_set() {
     local image_list
     image_list=$(mktemp)
     populate_prefetcher_image_list "$name" "${image_list}"
+
+    # Filter out gcr.io images on non-GKE clusters (they require GKE-specific credentials)
+    if [[ "${ORCHESTRATOR_FLAVOR}" != "k8s" ]]; then
+        info "Filtering out *.gcr.io images for non-GKE cluster"
+        grep -v -E '^([^/]+\.)?gcr\.io/' "${image_list}" > "${image_list}.tmp" || true
+        mv "${image_list}.tmp" "${image_list}"
+    fi
+
     echo "---" >> "$manifest"
     kubectl create --dry-run=client -o yaml configmap "$name" --from-file="images.txt=$image_list" >> "$manifest"
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -695,17 +695,21 @@ image_prefetcher_start_set() {
     manifest=$(mktemp)
 
     local kubelet_image_creds
-    case "${ORCHESTRATOR_FLAVOR}" in
-    k8s)
+    case "${KUBERNETES_PROVIDER}" in
+    gke)
         flavor=vanilla
         kubelet_image_creds=GKE
         ;;
-    openshift)
+    eks|aks)
+        flavor=vanilla
+        kubelet_image_creds="" # i.e. disabled
+        ;;
+    ocp)
         flavor=ocp
         kubelet_image_creds="" # i.e. disabled
         ;;
     *)
-        die "unsupported ORCHESTRATOR: ${ORCHESTRATOR_FLAVOR}"
+        die "unsupported KUBERNETES_PROVIDER: ${KUBERNETES_PROVIDER}"
         ;;
     esac
 
@@ -725,7 +729,7 @@ image_prefetcher_start_set() {
     populate_prefetcher_image_list "$name" "${image_list}"
 
     # Filter out gcr.io images on non-GKE clusters (they require GKE-specific credentials)
-    if [[ "${ORCHESTRATOR_FLAVOR}" != "k8s" ]]; then
+    if [[ "${KUBERNETES_PROVIDER}" != "gke" ]]; then
         local filtered_image_list
         filtered_image_list=$(mktemp)
         info "Filtering out *.gcr.io images for non-GKE cluster"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -726,9 +726,11 @@ image_prefetcher_start_set() {
 
     # Filter out gcr.io images on non-GKE clusters (they require GKE-specific credentials)
     if [[ "${ORCHESTRATOR_FLAVOR}" != "k8s" ]]; then
+        local filtered_image_list
+        filtered_image_list=$(mktemp)
         info "Filtering out *.gcr.io images for non-GKE cluster"
-        grep -v -E '^([^/]+\.)?gcr\.io/' "${image_list}" > "${image_list}.tmp" || true
-        mv "${image_list}.tmp" "${image_list}"
+        grep -v -E '^([^/]+\.)?gcr\.io/' "${image_list}" > "${filtered_image_list}" || true
+        mv "${filtered_image_list}" "${image_list}"
     fi
 
     echo "---" >> "$manifest"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -694,12 +694,15 @@ image_prefetcher_start_set() {
     local manifest
     manifest=$(mktemp)
 
+    local kubelet_image_creds
     case "${ORCHESTRATOR_FLAVOR}" in
     k8s)
         flavor=vanilla
+        kubelet_image_creds=GKE
         ;;
     openshift)
         flavor=ocp
+        kubelet_image_creds="" # i.e. disabled
         ;;
     *)
         die "unsupported ORCHESTRATOR: ${ORCHESTRATOR_FLAVOR}"
@@ -708,6 +711,7 @@ image_prefetcher_start_set() {
 
     # daemonset, etc
     ${image_prefetcher_deploy_bin} \
+        --use-kubelet-image-credential-integration="${kubelet_image_creds}" \
         --version="${image_prefetcher_version}" \
         --k8s-flavor="$flavor" \
         --secret=stackrox \

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
-	github.com/stackrox/image-prefetcher/deploy v0.4.3
+	github.com/stackrox/image-prefetcher/deploy v0.4.4-0.20260414111710-fea1abfad7b1
 	github.com/stackrox/prometheus-metric-parser v0.0.0-20240718111853-be492d554cd5
 )
 

--- a/tools/test/go.mod
+++ b/tools/test/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
-	github.com/stackrox/image-prefetcher/deploy v0.4.4-0.20260414111710-fea1abfad7b1
+	github.com/stackrox/image-prefetcher/deploy v0.5.0
 	github.com/stackrox/prometheus-metric-parser v0.0.0-20240718111853-be492d554cd5
 )
 

--- a/tools/test/go.sum
+++ b/tools/test/go.sum
@@ -94,8 +94,8 @@ github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stackrox/image-prefetcher/deploy v0.4.3 h1:c1P7qJUBbs6rBg6L4cY+6Bf70SZShBEXHNgILdBzhno=
-github.com/stackrox/image-prefetcher/deploy v0.4.3/go.mod h1:bAhl/GuKJnAchWpAYkEaoqfaJHqCkbBKhLDWHm1GXLs=
+github.com/stackrox/image-prefetcher/deploy v0.4.4-0.20260414111710-fea1abfad7b1 h1:4zQ+ekEkAqHGQPDaH/qh1GUujQjOjn2d1/JFcaU2ioA=
+github.com/stackrox/image-prefetcher/deploy v0.4.4-0.20260414111710-fea1abfad7b1/go.mod h1:bAhl/GuKJnAchWpAYkEaoqfaJHqCkbBKhLDWHm1GXLs=
 github.com/stackrox/prometheus-metric-parser v0.0.0-20240718111853-be492d554cd5 h1:gAg8XyBlWRq8Ia4uTPmhNUnVYtiDN4eiqviJ+tD87xw=
 github.com/stackrox/prometheus-metric-parser v0.0.0-20240718111853-be492d554cd5/go.mod h1:y4d4bwvOygvByIxM/g0XCzBKMryqXilCk4Lj+mMBsVM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/tools/test/go.sum
+++ b/tools/test/go.sum
@@ -94,8 +94,8 @@ github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stackrox/image-prefetcher/deploy v0.4.4-0.20260414111710-fea1abfad7b1 h1:4zQ+ekEkAqHGQPDaH/qh1GUujQjOjn2d1/JFcaU2ioA=
-github.com/stackrox/image-prefetcher/deploy v0.4.4-0.20260414111710-fea1abfad7b1/go.mod h1:bAhl/GuKJnAchWpAYkEaoqfaJHqCkbBKhLDWHm1GXLs=
+github.com/stackrox/image-prefetcher/deploy v0.5.0 h1:xuh3dTckY1KEU4i1d4PayM8t1Pz35/Uv5YSJPiIMB68=
+github.com/stackrox/image-prefetcher/deploy v0.5.0/go.mod h1:bAhl/GuKJnAchWpAYkEaoqfaJHqCkbBKhLDWHm1GXLs=
 github.com/stackrox/prometheus-metric-parser v0.0.0-20240718111853-be492d554cd5 h1:gAg8XyBlWRq8Ia4uTPmhNUnVYtiDN4eiqviJ+tD87xw=
 github.com/stackrox/prometheus-metric-parser v0.0.0-20240718111853-be492d554cd5/go.mod h1:y4d4bwvOygvByIxM/g0XCzBKMryqXilCk4Lj+mMBsVM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This is a workaround for a kubernetes issue with image pull authorization. See:
- https://github.com/kubernetes/kubernetes/issues/138175 for the background
- https://redhat.atlassian.net/browse/ROX-33174 for an example how it affects stackrox CI
- https://github.com/stackrox/image-prefetcher/pull/166 and https://github.com/stackrox/stackrox/pull/19218 for previous attempts at fixing the issue before it was fully understood
- RH slack channel [#tmp-acs-gke-latest-image-prefetching](https://redhat.enterprise.slack.com/archives/C0AQ1QNH7PB) for history of investigation

This change:
- increases disk size on GKE to make sure we're nowhere near the threshold for triggering GC
- bumps image prefetcher to version that includes https://github.com/stackrox/image-prefetcher/pull/184
- activates `kubelet-image-credential-integration` when running on GKE
- adds the problematic GCR-hosted images to prefetch list
- skips prefetching GCR hosted images when running on OpenShift

TODO:
- [x] merge https://github.com/stackrox/image-prefetcher/pull/184
- [x] release new image-prefetcher
- [x] change `go.mod` here to point at the released version

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI is enough.
