### PR TITLE
ROX-33555: Forward Central VM ACK/NACK to compliance

### DIFF
--- a/sensor/common/virtualmachine/index/handler.go
+++ b/sensor/common/virtualmachine/index/handler.go
@@ -23,6 +23,7 @@ type Handler interface {
 //
 //go:generate mockgen-wrapper
 type VirtualMachineStore interface {
+	Get(id virtualmachine.VMID) *virtualmachine.Info
 	GetFromCID(cid uint32) *virtualmachine.Info
 }
 

--- a/sensor/common/virtualmachine/index/handler.go
+++ b/sensor/common/virtualmachine/index/handler.go
@@ -11,8 +11,10 @@ import (
 )
 
 // Handler provides functionality to send virtual machine index reports to Central.
+// It embeds ComplianceComponent (which itself embeds SensorComponent) so that
+// compliance channel wiring is part of the compile-time contract.
 type Handler interface {
-	common.SensorComponent
+	common.ComplianceComponent
 
 	Send(ctx context.Context, vm *v1.IndexReport) error
 }

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -129,7 +129,7 @@ func (h *handlerImpl) Accepts(msg *central.MsgToSensor) bool {
 }
 
 // ProcessMessage handles SensorACK messages for VM index reports.
-func (h *handlerImpl) ProcessMessage(_ context.Context, msg *central.MsgToSensor) error {
+func (h *handlerImpl) ProcessMessage(ctx context.Context, msg *central.MsgToSensor) error {
 	sensorAck := msg.GetSensorAck()
 	if sensorAck == nil || sensorAck.GetMessageType() != central.SensorACK_VM_INDEX_REPORT {
 		return nil
@@ -138,7 +138,7 @@ func (h *handlerImpl) ProcessMessage(_ context.Context, msg *central.MsgToSensor
 	vmID := sensorAck.GetResourceId()
 	action := sensorAck.GetAction()
 	reason := sensorAck.GetReason()
-	h.forwardToCompliance(vmID, action, reason)
+	h.forwardToCompliance(ctx, vmID, action, reason)
 
 	metrics.IndexReportAcksReceived.WithLabelValues(action.String()).Inc()
 
@@ -217,6 +217,7 @@ func (h *handlerImpl) run(indexReports <-chan *v1.IndexReport) (toCentral <-chan
 }
 
 func (h *handlerImpl) forwardToCompliance(
+	ctx context.Context,
 	resourceID string,
 	action central.SensorACK_Action,
 	reason string,
@@ -237,10 +238,7 @@ func (h *handlerImpl) forwardToCompliance(
 		return
 	}
 
-	select {
-	case <-h.stopper.Flow().StopRequested():
-		log.Debugf("Dropping VM ACK/NACK (resourceID=%s) during shutdown", resourceID)
-	case h.toCompliance <- common.MessageToComplianceWithAddress{
+	msg := common.MessageToComplianceWithAddress{
 		Msg: &sensor.MsgToCompliance{
 			Msg: &sensor.MsgToCompliance_ComplianceAck{
 				ComplianceAck: &sensor.MsgToCompliance_ComplianceACK{
@@ -256,7 +254,16 @@ func (h *handlerImpl) forwardToCompliance(
 		// (e.g. bulk ACK), broadcast to all compliance connections.
 		Hostname:  resourceID,
 		Broadcast: resourceID == "",
-	}:
+	}
+
+	select {
+	case <-ctx.Done():
+		log.Warnf("Dropping VM ACK/NACK (resourceID=%s): %v", resourceID, ctx.Err())
+	case <-h.stopper.Flow().StopRequested():
+		log.Debugf("Dropping VM ACK/NACK (resourceID=%s) during shutdown", resourceID)
+	case h.toCompliance <- msg:
+	default:
+		log.Warnf("Dropping VM ACK/NACK (resourceID=%s): compliance queue is full", resourceID)
 	}
 }
 

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -141,6 +141,8 @@ func (h *handlerImpl) ProcessMessage(ctx context.Context, msg *central.MsgToSens
 	reason := sensorAck.GetReason()
 	h.forwardToCompliance(ctx, vmID, action, reason)
 
+	// Not limiting to ACK & NACK and recording all types of actions for better debuggability.
+	// The risk of prometheus label cardinality explosion is considered low and accepted hereby.
 	metrics.IndexReportAcksReceived.WithLabelValues(action.String()).Inc()
 
 	return nil
@@ -269,8 +271,14 @@ func (h *handlerImpl) forwardToCompliance(
 	select {
 	case <-ctx.Done():
 		log.Warnf("Dropping VM ACK/NACK (resourceID=%s): %v", resourceID, ctx.Err())
+		return
 	case <-h.stopper.Flow().StopRequested():
 		log.Debugf("Dropping VM ACK/NACK (resourceID=%s) during shutdown", resourceID)
+		return
+	default:
+	}
+
+	select {
 	case h.toCompliance <- msg:
 	default:
 		log.Warnf("Dropping VM ACK/NACK (resourceID=%s): compliance queue is full", resourceID)

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/virtualmachine"
 	"github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
 )
 
@@ -238,6 +239,16 @@ func (h *handlerImpl) forwardToCompliance(
 		return
 	}
 
+	// Resolve the VM's host node so the compliance multiplexer can route to
+	// the correct compliance connection. If the VM is unknown (e.g. deleted
+	// between send and ACK), broadcast to all connections as a fallback.
+	var nodeName string
+	if resourceID != "" {
+		if vmInfo := h.store.Get(virtualmachine.VMID(resourceID)); vmInfo != nil {
+			nodeName = vmInfo.NodeName
+		}
+	}
+
 	msg := common.MessageToComplianceWithAddress{
 		Msg: &sensor.MsgToCompliance{
 			Msg: &sensor.MsgToCompliance_ComplianceAck{
@@ -249,11 +260,10 @@ func (h *handlerImpl) forwardToCompliance(
 				},
 			},
 		},
-		// Hostname is the VM resource ID used by the compliance multiplexer to
-		// route the message to the correct compliance connection. When empty
-		// (e.g. bulk ACK), broadcast to all compliance connections.
-		Hostname:  resourceID,
-		Broadcast: resourceID == "",
+		// Hostname is the node name (not the VM resource ID) used by the
+		// compliance multiplexer to route to the correct compliance connection.
+		Hostname:  nodeName,
+		Broadcast: nodeName == "",
 	}
 
 	select {

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -164,7 +164,7 @@ func (h *handlerImpl) Start() error {
 		return errStartMoreThanOnce
 	}
 	h.indexReports = make(chan *v1.IndexReport, env.VirtualMachinesIndexReportsBufferSize.IntegerSetting())
-	h.toCompliance = make(chan common.MessageToComplianceWithAddress)
+	h.toCompliance = make(chan common.MessageToComplianceWithAddress, 1)
 	h.toCentral = h.run(h.indexReports)
 	return nil
 }
@@ -239,6 +239,7 @@ func (h *handlerImpl) forwardToCompliance(
 
 	select {
 	case <-h.stopper.Flow().StopRequested():
+		log.Debugf("Dropping VM ACK/NACK (resourceID=%s) during shutdown", resourceID)
 	case h.toCompliance <- common.MessageToComplianceWithAddress{
 		Msg: &sensor.MsgToCompliance{
 			Msg: &sensor.MsgToCompliance_ComplianceAck{
@@ -250,6 +251,9 @@ func (h *handlerImpl) forwardToCompliance(
 				},
 			},
 		},
+		// Hostname is the VM resource ID used by the compliance multiplexer to
+		// route the message to the correct compliance connection. When empty
+		// (e.g. bulk ACK), broadcast to all compliance connections.
 		Hostname:  resourceID,
 		Broadcast: resourceID == "",
 	}:

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -488,8 +488,7 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DoesNotBlockWhenSto
 	err := s.handler.Start()
 	s.Require().NoError(err)
 
-	// Fill the compliance channel to capacity so the next send would block
-	// without the StopRequested guard.
+	// Fill the compliance channel to capacity.
 	s.handler.toCompliance <- common.MessageToComplianceWithAddress{}
 
 	s.handler.Stop()
@@ -504,23 +503,25 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DoesNotBlockWhenSto
 		}},
 	}
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		_ = s.handler.ProcessMessage(ctx, msg)
-	}()
+	// Non-blocking: the default branch drops immediately when the channel
+	// is full, regardless of stopper state.
+	err = s.handler.ProcessMessage(ctx, msg)
+	s.Require().NoError(err)
 
+	// Only the pre-filled message should be in the channel.
 	select {
-	case <-done:
-	case <-time.After(time.Second):
-		s.Fail("ProcessMessage blocked on full toCompliance channel after Stop")
+	case <-s.handler.ComplianceC():
+	default:
+		s.Fail("expected the pre-filled message")
+	}
+	select {
+	case <-s.handler.ComplianceC():
+		s.Fail("the second message should have been dropped")
+	default:
 	}
 }
 
-func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DeadlockDetection() {
-	// Verify that an unbuffered channel would block when the consumer is slow,
-	// and that our buffer of 1 absorbs exactly one send without blocking.
-	// If someone removes the buffer, this test will time out.
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DropsWhenQueueFull() {
 	err := s.handler.Start()
 	s.Require().NoError(err)
 	defer s.handler.Stop()
@@ -536,37 +537,67 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DeadlockDetection()
 		}
 	}
 
-	// First send should succeed without blocking (fills the buffer).
+	// First send fills the buffer (capacity 1).
 	err = s.handler.ProcessMessage(ctx, makeMsg("vm-first"))
 	s.Require().NoError(err)
 
-	// Second send without draining: must not block indefinitely.
-	// With buffer=1, the channel is now full. The second send races
-	// with the stopper. We run it in a goroutine to detect the block.
-	secondDone := make(chan struct{})
-	go func() {
-		defer close(secondDone)
-		_ = s.handler.ProcessMessage(ctx, makeMsg("vm-second"))
-	}()
+	// Second send without draining: hits the default branch, drops
+	// immediately instead of blocking. This protects ProcessMessage
+	// from stalling if compliance is slow.
+	err = s.handler.ProcessMessage(ctx, makeMsg("vm-second"))
+	s.Require().NoError(err)
 
-	// Drain the first message so the second can proceed.
+	// Only the first message is in the channel.
 	select {
-	case <-s.handler.ComplianceC():
+	case got := <-s.handler.ComplianceC():
+		s.Equal("vm-first", got.Msg.GetComplianceAck().GetResourceId())
 	case <-time.After(time.Second):
 		s.Fail("first message should be available in the buffer")
 	}
 
-	select {
-	case <-secondDone:
-	case <-time.After(time.Second):
-		s.Fail("second ProcessMessage blocked — potential deadlock if buffer is removed")
-	}
-
-	// Drain second message.
+	// Channel should now be empty (second was dropped).
 	select {
 	case <-s.handler.ComplianceC():
-	case <-time.After(time.Second):
-		s.Fail("second message should arrive after draining first")
+		s.Fail("second message should have been dropped when queue was full")
+	default:
+	}
+}
+
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DropsOnCancelledContext() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	defer s.handler.Stop()
+
+	// Fill the buffer so the send would need to block.
+	s.handler.toCompliance <- common.MessageToComplianceWithAddress{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	msg := &central.MsgToSensor{
+		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
+			Action:      central.SensorACK_ACK,
+			MessageType: central.SensorACK_VM_INDEX_REPORT,
+			ResourceId:  "vm-cancelled",
+		}},
+	}
+
+	// With a cancelled context and a full buffer, ProcessMessage must
+	// not block. The default branch fires before ctx.Done() is even
+	// checked, but either path results in a drop.
+	err = s.handler.ProcessMessage(ctx, msg)
+	s.Require().NoError(err)
+
+	// Drain the pre-filled message; the cancelled one was dropped.
+	select {
+	case <-s.handler.ComplianceC():
+	default:
+		s.Fail("expected the pre-filled message")
+	}
+	select {
+	case <-s.handler.ComplianceC():
+		s.Fail("the message with cancelled context should have been dropped")
+	default:
 	}
 }
 

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -348,6 +348,9 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_ACK() {
 	s.Require().NoError(err)
 	defer s.handler.Stop()
 
+	s.store.EXPECT().Get(virtualmachine.VMID("vm-123")).Return(
+		&virtualmachine.Info{ID: "vm-123", NodeName: "node-a"})
+
 	ctx := context.Background()
 	msg := &central.MsgToSensor{
 		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
@@ -369,7 +372,7 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_ACK() {
 		s.Equal(sensor.MsgToCompliance_ComplianceACK_VM_INDEX_REPORT, ack.GetMessageType())
 		s.Equal("vm-123", ack.GetResourceId())
 		s.Equal("all good", ack.GetReason())
-		s.Equal("vm-123", got.Hostname)
+		s.Equal("node-a", got.Hostname)
 		s.False(got.Broadcast)
 	case <-time.After(time.Second):
 		s.Fail("timed out waiting for compliance ACK")
@@ -380,6 +383,9 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_NACK() {
 	err := s.handler.Start()
 	s.Require().NoError(err)
 	defer s.handler.Stop()
+
+	s.store.EXPECT().Get(virtualmachine.VMID("vm-456")).Return(
+		&virtualmachine.Info{ID: "vm-456", NodeName: "node-b"})
 
 	ctx := context.Background()
 	msg := &central.MsgToSensor{
@@ -402,7 +408,7 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_NACK() {
 		s.Equal(sensor.MsgToCompliance_ComplianceACK_VM_INDEX_REPORT, ack.GetMessageType())
 		s.Equal("vm-456", ack.GetResourceId())
 		s.Equal("validation failed", ack.GetReason())
-		s.Equal("vm-456", got.Hostname)
+		s.Equal("node-b", got.Hostname)
 		s.False(got.Broadcast)
 	case <-time.After(time.Second):
 		s.Fail("timed out waiting for compliance NACK")
@@ -428,6 +434,35 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_BroadcastWhenResour
 
 	select {
 	case got := <-s.handler.ComplianceC():
+		s.Empty(got.Hostname)
+		s.True(got.Broadcast)
+	case <-time.After(time.Second):
+		s.Fail("timed out waiting for broadcast compliance ACK")
+	}
+}
+
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance_BroadcastWhenVMNotInStore() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	defer s.handler.Stop()
+
+	s.store.EXPECT().Get(virtualmachine.VMID("vm-deleted")).Return(nil)
+
+	ctx := context.Background()
+	msg := &central.MsgToSensor{
+		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
+			Action:      central.SensorACK_ACK,
+			MessageType: central.SensorACK_VM_INDEX_REPORT,
+			ResourceId:  "vm-deleted",
+		}},
+	}
+
+	err = s.handler.ProcessMessage(ctx, msg)
+	s.Require().NoError(err)
+
+	select {
+	case got := <-s.handler.ComplianceC():
+		s.Equal("vm-deleted", got.Msg.GetComplianceAck().GetResourceId())
 		s.Empty(got.Hostname)
 		s.True(got.Broadcast)
 	case <-time.After(time.Second):
@@ -493,6 +528,9 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DoesNotBlockWhenSto
 
 	s.handler.Stop()
 
+	s.store.EXPECT().Get(virtualmachine.VMID("vm-stopped")).Return(
+		&virtualmachine.Info{ID: "vm-stopped", NodeName: "node-x"})
+
 	ctx := context.Background()
 	msg := &central.MsgToSensor{
 		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
@@ -525,6 +563,11 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DropsWhenQueueFull(
 	err := s.handler.Start()
 	s.Require().NoError(err)
 	defer s.handler.Stop()
+
+	s.store.EXPECT().Get(virtualmachine.VMID("vm-first")).Return(
+		&virtualmachine.Info{ID: "vm-first", NodeName: "node-1"})
+	s.store.EXPECT().Get(virtualmachine.VMID("vm-second")).Return(
+		&virtualmachine.Info{ID: "vm-second", NodeName: "node-2"})
 
 	ctx := context.Background()
 	makeMsg := func(id string) *central.MsgToSensor {
@@ -570,6 +613,9 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DropsOnCancelledCon
 
 	// Fill the buffer so the send would need to block.
 	s.handler.toCompliance <- common.MessageToComplianceWithAddress{}
+
+	s.store.EXPECT().Get(virtualmachine.VMID("vm-cancelled")).Return(
+		&virtualmachine.Info{ID: "vm-cancelled", NodeName: "node-c"})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -227,7 +227,8 @@ func (s *virtualMachineHandlerSuite) TestStop() {
 
 func (s *virtualMachineHandlerSuite) TestCapabilities() {
 	caps := s.handler.Capabilities()
-	s.Require().Empty(caps)
+	s.Require().Len(caps, 1)
+	s.Contains(caps, centralsensor.SensorACKSupport)
 }
 
 func (s *virtualMachineHandlerSuite) TestAccepts() {

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -87,7 +87,7 @@ func (s *virtualMachineHandlerSuite) TestSend() {
 		s.Assert().Equal(central.ResourceAction_SYNC_RESOURCE, sensorEvent.GetAction())
 		s.Assert().NotNil(sensorEvent.GetVirtualMachineIndexReport())
 		s.Assert().Equal("test-vm", sensorEvent.GetVirtualMachineIndexReport().GetId())
-	case <-time.After(time.Second):
+	case <-time.After(100 * time.Millisecond):
 		s.Fail("Expected message to be sent to central")
 	}
 }
@@ -143,7 +143,7 @@ func (s *virtualMachineHandlerSuite) TestConcurrentSends() {
 		select {
 		case <-s.handler.toCentral:
 			totalResponses++
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(100 * time.Millisecond):
 			s.T().Logf("Timeout waiting for response, got %d responses", totalResponses)
 			return // Don't fail, just exit
 		}
@@ -177,7 +177,7 @@ func (s *virtualMachineHandlerSuite) TestVirtualMachineNotFound() {
 	select {
 	case <-s.handler.ResponsesC():
 		s.Fail("Unexpected message to be sent to central")
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 
@@ -206,7 +206,7 @@ func (s *virtualMachineHandlerSuite) TestInvalidCID() {
 	select {
 	case <-s.handler.ResponsesC():
 		s.Fail("Unexpected message to be sent to central")
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 
@@ -221,7 +221,7 @@ func (s *virtualMachineHandlerSuite) TestStop() {
 	select {
 	case <-s.handler.stopper.Client().Stopped().Done():
 		// Expected.
-	case <-time.After(time.Second):
+	case <-time.After(100 * time.Millisecond):
 		s.Fail("handler should have stopped")
 	}
 }
@@ -340,133 +340,115 @@ func (s *virtualMachineHandlerSuite) TestComplianceC_AfterStart() {
 	defer s.handler.Stop()
 
 	ch := s.handler.ComplianceC()
-	s.Require().NotNil(ch)
+	s.Require().NotNil(ch, "ComplianceC channel should be not nil after start")
 }
 
-func (s *virtualMachineHandlerSuite) TestForwardToCompliance_ACK() {
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance() {
 	err := s.handler.Start()
 	s.Require().NoError(err)
 	defer s.handler.Stop()
 
-	s.store.EXPECT().Get(virtualmachine.VMID("vm-123")).Return(
-		&virtualmachine.Info{ID: "vm-123", NodeName: "node-a"})
-
-	ctx := context.Background()
-	msg := &central.MsgToSensor{
-		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
-			Action:      central.SensorACK_ACK,
-			MessageType: central.SensorACK_VM_INDEX_REPORT,
-			ResourceId:  "vm-123",
-			Reason:      "all good",
-		}},
+	cases := map[string]struct {
+		centralAction  central.SensorACK_Action
+		resourceID     string
+		nodeName       string
+		reason         string
+		expectedAction sensor.MsgToCompliance_ComplianceACK_Action
+	}{
+		"should forward ACK to compliance": {
+			centralAction:  central.SensorACK_ACK,
+			resourceID:     "vm-123",
+			nodeName:       "node-a",
+			reason:         "all good",
+			expectedAction: sensor.MsgToCompliance_ComplianceACK_ACK,
+		},
+		"should forward NACK to compliance": {
+			centralAction:  central.SensorACK_NACK,
+			resourceID:     "vm-456",
+			nodeName:       "node-b",
+			reason:         "validation failed",
+			expectedAction: sensor.MsgToCompliance_ComplianceACK_NACK,
+		},
 	}
 
-	err = s.handler.ProcessMessage(ctx, msg)
-	s.Require().NoError(err)
+	for name, tc := range cases {
+		s.Run(name, func() {
+			s.store.EXPECT().Get(virtualmachine.VMID(tc.resourceID)).Return(
+				&virtualmachine.Info{ID: virtualmachine.VMID(tc.resourceID), NodeName: tc.nodeName})
 
-	select {
-	case got := <-s.handler.ComplianceC():
-		ack := got.Msg.GetComplianceAck()
-		s.Require().NotNil(ack)
-		s.Equal(sensor.MsgToCompliance_ComplianceACK_ACK, ack.GetAction())
-		s.Equal(sensor.MsgToCompliance_ComplianceACK_VM_INDEX_REPORT, ack.GetMessageType())
-		s.Equal("vm-123", ack.GetResourceId())
-		s.Equal("all good", ack.GetReason())
-		s.Equal("node-a", got.Hostname)
-		s.False(got.Broadcast)
-	case <-time.After(time.Second):
-		s.Fail("timed out waiting for compliance ACK")
+			ctx := context.Background()
+			msg := &central.MsgToSensor{
+				Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
+					Action:      tc.centralAction,
+					MessageType: central.SensorACK_VM_INDEX_REPORT,
+					ResourceId:  tc.resourceID,
+					Reason:      tc.reason,
+				}},
+			}
+
+			err := s.handler.ProcessMessage(ctx, msg)
+			s.Require().NoError(err)
+
+			select {
+			case got := <-s.handler.ComplianceC():
+				ack := got.Msg.GetComplianceAck()
+				s.Require().NotNil(ack)
+				s.Equal(tc.expectedAction, ack.GetAction())
+				s.Equal(sensor.MsgToCompliance_ComplianceACK_VM_INDEX_REPORT, ack.GetMessageType())
+				s.Equal(tc.resourceID, ack.GetResourceId())
+				s.Equal(tc.reason, ack.GetReason())
+				s.Equal(tc.nodeName, got.Hostname)
+				s.False(got.Broadcast)
+			case <-time.After(100 * time.Millisecond):
+				s.Fail("timed out waiting for compliance message")
+			}
+		})
 	}
 }
 
-func (s *virtualMachineHandlerSuite) TestForwardToCompliance_NACK() {
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance_Broadcast() {
 	err := s.handler.Start()
 	s.Require().NoError(err)
 	defer s.handler.Stop()
 
-	s.store.EXPECT().Get(virtualmachine.VMID("vm-456")).Return(
-		&virtualmachine.Info{ID: "vm-456", NodeName: "node-b"})
-
-	ctx := context.Background()
-	msg := &central.MsgToSensor{
-		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
-			Action:      central.SensorACK_NACK,
-			MessageType: central.SensorACK_VM_INDEX_REPORT,
-			ResourceId:  "vm-456",
-			Reason:      "validation failed",
-		}},
+	cases := map[string]struct {
+		resourceID string
+	}{
+		"should broadcast when resource ID is empty": {
+			resourceID: "",
+		},
+		"should broadcast when VM not in store": {
+			resourceID: "vm-deleted",
+		},
 	}
 
-	err = s.handler.ProcessMessage(ctx, msg)
-	s.Require().NoError(err)
+	for name, tc := range cases {
+		s.Run(name, func() {
+			if tc.resourceID != "" {
+				s.store.EXPECT().Get(virtualmachine.VMID(tc.resourceID)).Return(nil)
+			}
 
-	select {
-	case got := <-s.handler.ComplianceC():
-		ack := got.Msg.GetComplianceAck()
-		s.Require().NotNil(ack)
-		s.Equal(sensor.MsgToCompliance_ComplianceACK_NACK, ack.GetAction())
-		s.Equal(sensor.MsgToCompliance_ComplianceACK_VM_INDEX_REPORT, ack.GetMessageType())
-		s.Equal("vm-456", ack.GetResourceId())
-		s.Equal("validation failed", ack.GetReason())
-		s.Equal("node-b", got.Hostname)
-		s.False(got.Broadcast)
-	case <-time.After(time.Second):
-		s.Fail("timed out waiting for compliance NACK")
-	}
-}
+			ctx := context.Background()
+			msg := &central.MsgToSensor{
+				Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
+					Action:      central.SensorACK_ACK,
+					MessageType: central.SensorACK_VM_INDEX_REPORT,
+					ResourceId:  tc.resourceID,
+				}},
+			}
 
-func (s *virtualMachineHandlerSuite) TestForwardToCompliance_BroadcastWhenResourceIDEmpty() {
-	err := s.handler.Start()
-	s.Require().NoError(err)
-	defer s.handler.Stop()
+			err := s.handler.ProcessMessage(ctx, msg)
+			s.Require().NoError(err)
 
-	ctx := context.Background()
-	msg := &central.MsgToSensor{
-		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
-			Action:      central.SensorACK_ACK,
-			MessageType: central.SensorACK_VM_INDEX_REPORT,
-			ResourceId:  "",
-		}},
-	}
-
-	err = s.handler.ProcessMessage(ctx, msg)
-	s.Require().NoError(err)
-
-	select {
-	case got := <-s.handler.ComplianceC():
-		s.Empty(got.Hostname)
-		s.True(got.Broadcast)
-	case <-time.After(time.Second):
-		s.Fail("timed out waiting for broadcast compliance ACK")
-	}
-}
-
-func (s *virtualMachineHandlerSuite) TestForwardToCompliance_BroadcastWhenVMNotInStore() {
-	err := s.handler.Start()
-	s.Require().NoError(err)
-	defer s.handler.Stop()
-
-	s.store.EXPECT().Get(virtualmachine.VMID("vm-deleted")).Return(nil)
-
-	ctx := context.Background()
-	msg := &central.MsgToSensor{
-		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
-			Action:      central.SensorACK_ACK,
-			MessageType: central.SensorACK_VM_INDEX_REPORT,
-			ResourceId:  "vm-deleted",
-		}},
-	}
-
-	err = s.handler.ProcessMessage(ctx, msg)
-	s.Require().NoError(err)
-
-	select {
-	case got := <-s.handler.ComplianceC():
-		s.Equal("vm-deleted", got.Msg.GetComplianceAck().GetResourceId())
-		s.Empty(got.Hostname)
-		s.True(got.Broadcast)
-	case <-time.After(time.Second):
-		s.Fail("timed out waiting for broadcast compliance ACK")
+			select {
+			case got := <-s.handler.ComplianceC():
+				s.Equal(tc.resourceID, got.Msg.GetComplianceAck().GetResourceId())
+				s.Empty(got.Hostname)
+				s.True(got.Broadcast)
+			case <-time.After(100 * time.Millisecond):
+				s.Fail("timed out waiting for broadcast compliance ACK")
+			}
+		})
 	}
 }
 
@@ -488,7 +470,7 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_NoStartDoesNotPanic
 
 	select {
 	case <-done:
-	case <-time.After(time.Second):
+	case <-time.After(100 * time.Millisecond):
 		s.Fail("ProcessMessage should not block when Start() has not been called")
 	}
 
@@ -594,7 +576,7 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DropsWhenQueueFull(
 	select {
 	case got := <-s.handler.ComplianceC():
 		s.Equal("vm-first", got.Msg.GetComplianceAck().GetResourceId())
-	case <-time.After(time.Second):
+	case <-time.After(100 * time.Millisecond):
 		s.Fail("first message should be available in the buffer")
 	}
 

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -137,7 +137,9 @@ func (s *virtualMachineHandlerSuite) TestConcurrentSends() {
 		}(i)
 	}
 
-	// Collect all responses with shorter timeout.
+	// Collect all responses. The timeout breaks the loop so the Assert
+	// below reports the actual vs expected count — do not fail inside
+	// the select; that would abort before the diagnostic assertion.
 	totalResponses := 0
 	for range numGoroutines * numVMsPerGoroutine {
 		select {
@@ -145,7 +147,8 @@ func (s *virtualMachineHandlerSuite) TestConcurrentSends() {
 			totalResponses++
 		case <-time.After(500 * time.Millisecond):
 			s.T().Logf("Timeout waiting for response, got %d responses", totalResponses)
-			return // Don't fail, just exit
+			s.Assert().Equal(numGoroutines*numVMsPerGoroutine, totalResponses)
+			return
 		}
 	}
 	s.Assert().Equal(numGoroutines*numVMsPerGoroutine, totalResponses)
@@ -523,8 +526,8 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DoesNotBlockWhenSto
 		}},
 	}
 
-	// Non-blocking: the default branch drops immediately when the channel
-	// is full, regardless of stopper state.
+	// The first select in forwardToCompliance sees StopRequested and
+	// returns before attempting the channel send.
 	err = s.handler.ProcessMessage(ctx, msg)
 	s.Require().NoError(err)
 
@@ -610,9 +613,8 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DropsOnCancelledCon
 		}},
 	}
 
-	// With a cancelled context and a full buffer, ProcessMessage must
-	// not block. The default branch fires before ctx.Done() is even
-	// checked, but either path results in a drop.
+	// The first select in forwardToCompliance sees ctx.Done() and
+	// returns before attempting the channel send.
 	err = s.handler.ProcessMessage(ctx, msg)
 	s.Require().NoError(err)
 
@@ -642,4 +644,37 @@ func (s *virtualMachineHandlerSuite) TestSend_CapabilityNotSupported() {
 	s.Require().ErrorIs(err, errCapabilityNotSupported)
 	s.Require().ErrorIs(err, errox.NotImplemented)
 	s.Assert().ErrorContains(err, "Central does not have virtual machine capability")
+}
+
+func (s *virtualMachineHandlerSuite) TestSend_AfterStop() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	s.handler.Stop()
+
+	vm := &v1.IndexReport{VsockCid: "1"}
+	err = s.handler.Send(context.Background(), vm)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, errInputChanClosed)
+	s.Require().ErrorIs(err, errox.InvariantViolation)
+}
+
+func (s *virtualMachineHandlerSuite) TestSend_CentralNotReachable() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	defer s.handler.Stop()
+
+	vm := &v1.IndexReport{VsockCid: "1"}
+	err = s.handler.Send(context.Background(), vm)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, errCentralNotReachable)
+	s.Require().ErrorIs(err, errox.ResourceExhausted)
+}
+
+func (s *virtualMachineHandlerSuite) TestStart_CalledTwice() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	defer s.handler.Stop()
+
+	err = s.handler.Start()
+	s.Require().ErrorIs(err, errStartMoreThanOnce)
 }

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/internalapi/sensor"
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -331,6 +332,242 @@ func (s *virtualMachineHandlerSuite) TestResponsesC_AfterStart() {
 
 	ch := s.handler.ResponsesC()
 	s.Require().NotNil(ch)
+}
+
+func (s *virtualMachineHandlerSuite) TestComplianceC_AfterStart() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	defer s.handler.Stop()
+
+	ch := s.handler.ComplianceC()
+	s.Require().NotNil(ch)
+}
+
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance_ACK() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	defer s.handler.Stop()
+
+	ctx := context.Background()
+	msg := &central.MsgToSensor{
+		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
+			Action:      central.SensorACK_ACK,
+			MessageType: central.SensorACK_VM_INDEX_REPORT,
+			ResourceId:  "vm-123",
+			Reason:      "all good",
+		}},
+	}
+
+	err = s.handler.ProcessMessage(ctx, msg)
+	s.Require().NoError(err)
+
+	select {
+	case got := <-s.handler.ComplianceC():
+		ack := got.Msg.GetComplianceAck()
+		s.Require().NotNil(ack)
+		s.Equal(sensor.MsgToCompliance_ComplianceACK_ACK, ack.GetAction())
+		s.Equal(sensor.MsgToCompliance_ComplianceACK_VM_INDEX_REPORT, ack.GetMessageType())
+		s.Equal("vm-123", ack.GetResourceId())
+		s.Equal("all good", ack.GetReason())
+		s.Equal("vm-123", got.Hostname)
+		s.False(got.Broadcast)
+	case <-time.After(time.Second):
+		s.Fail("timed out waiting for compliance ACK")
+	}
+}
+
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance_NACK() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	defer s.handler.Stop()
+
+	ctx := context.Background()
+	msg := &central.MsgToSensor{
+		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
+			Action:      central.SensorACK_NACK,
+			MessageType: central.SensorACK_VM_INDEX_REPORT,
+			ResourceId:  "vm-456",
+			Reason:      "validation failed",
+		}},
+	}
+
+	err = s.handler.ProcessMessage(ctx, msg)
+	s.Require().NoError(err)
+
+	select {
+	case got := <-s.handler.ComplianceC():
+		ack := got.Msg.GetComplianceAck()
+		s.Require().NotNil(ack)
+		s.Equal(sensor.MsgToCompliance_ComplianceACK_NACK, ack.GetAction())
+		s.Equal(sensor.MsgToCompliance_ComplianceACK_VM_INDEX_REPORT, ack.GetMessageType())
+		s.Equal("vm-456", ack.GetResourceId())
+		s.Equal("validation failed", ack.GetReason())
+		s.Equal("vm-456", got.Hostname)
+		s.False(got.Broadcast)
+	case <-time.After(time.Second):
+		s.Fail("timed out waiting for compliance NACK")
+	}
+}
+
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance_BroadcastWhenResourceIDEmpty() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	defer s.handler.Stop()
+
+	ctx := context.Background()
+	msg := &central.MsgToSensor{
+		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
+			Action:      central.SensorACK_ACK,
+			MessageType: central.SensorACK_VM_INDEX_REPORT,
+			ResourceId:  "",
+		}},
+	}
+
+	err = s.handler.ProcessMessage(ctx, msg)
+	s.Require().NoError(err)
+
+	select {
+	case got := <-s.handler.ComplianceC():
+		s.Empty(got.Hostname)
+		s.True(got.Broadcast)
+	case <-time.After(time.Second):
+		s.Fail("timed out waiting for broadcast compliance ACK")
+	}
+}
+
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance_NoStartDoesNotPanic() {
+	ctx := context.Background()
+	msg := &central.MsgToSensor{
+		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
+			Action:      central.SensorACK_ACK,
+			MessageType: central.SensorACK_VM_INDEX_REPORT,
+			ResourceId:  "vm-no-start",
+		}},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = s.handler.ProcessMessage(ctx, msg)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		s.Fail("ProcessMessage should not block when Start() has not been called")
+	}
+
+	s.Nil(s.handler.ComplianceC())
+}
+
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance_UnknownActionDropped() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	defer s.handler.Stop()
+
+	ctx := context.Background()
+	msg := &central.MsgToSensor{
+		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
+			Action:      central.SensorACK_Action(999),
+			MessageType: central.SensorACK_VM_INDEX_REPORT,
+			ResourceId:  "vm-unknown",
+		}},
+	}
+
+	err = s.handler.ProcessMessage(ctx, msg)
+	s.Require().NoError(err)
+
+	select {
+	case <-s.handler.ComplianceC():
+		s.Fail("unexpected message on ComplianceC for unknown SensorACK action")
+	default:
+	}
+}
+
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DoesNotBlockWhenStopped() {
+	err := s.handler.Start()
+	s.Require().NoError(err)
+
+	// Fill the compliance channel to capacity so the next send would block
+	// without the StopRequested guard.
+	s.handler.toCompliance <- common.MessageToComplianceWithAddress{}
+
+	s.handler.Stop()
+
+	ctx := context.Background()
+	msg := &central.MsgToSensor{
+		Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
+			Action:      central.SensorACK_NACK,
+			MessageType: central.SensorACK_VM_INDEX_REPORT,
+			ResourceId:  "vm-stopped",
+			Reason:      "after stop",
+		}},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = s.handler.ProcessMessage(ctx, msg)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		s.Fail("ProcessMessage blocked on full toCompliance channel after Stop")
+	}
+}
+
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DeadlockDetection() {
+	// Verify that an unbuffered channel would block when the consumer is slow,
+	// and that our buffer of 1 absorbs exactly one send without blocking.
+	// If someone removes the buffer, this test will time out.
+	err := s.handler.Start()
+	s.Require().NoError(err)
+	defer s.handler.Stop()
+
+	ctx := context.Background()
+	makeMsg := func(id string) *central.MsgToSensor {
+		return &central.MsgToSensor{
+			Msg: &central.MsgToSensor_SensorAck{SensorAck: &central.SensorACK{
+				Action:      central.SensorACK_ACK,
+				MessageType: central.SensorACK_VM_INDEX_REPORT,
+				ResourceId:  id,
+			}},
+		}
+	}
+
+	// First send should succeed without blocking (fills the buffer).
+	err = s.handler.ProcessMessage(ctx, makeMsg("vm-first"))
+	s.Require().NoError(err)
+
+	// Second send without draining: must not block indefinitely.
+	// With buffer=1, the channel is now full. The second send races
+	// with the stopper. We run it in a goroutine to detect the block.
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		_ = s.handler.ProcessMessage(ctx, makeMsg("vm-second"))
+	}()
+
+	// Drain the first message so the second can proceed.
+	select {
+	case <-s.handler.ComplianceC():
+	case <-time.After(time.Second):
+		s.Fail("first message should be available in the buffer")
+	}
+
+	select {
+	case <-secondDone:
+	case <-time.After(time.Second):
+		s.Fail("second ProcessMessage blocked — potential deadlock if buffer is removed")
+	}
+
+	// Drain second message.
+	select {
+	case <-s.handler.ComplianceC():
+	case <-time.After(time.Second):
+		s.Fail("second message should arrive after draining first")
+	}
 }
 
 func (s *virtualMachineHandlerSuite) TestSend_CapabilityNotSupported() {

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -87,7 +87,7 @@ func (s *virtualMachineHandlerSuite) TestSend() {
 		s.Assert().Equal(central.ResourceAction_SYNC_RESOURCE, sensorEvent.GetAction())
 		s.Assert().NotNil(sensorEvent.GetVirtualMachineIndexReport())
 		s.Assert().Equal("test-vm", sensorEvent.GetVirtualMachineIndexReport().GetId())
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		s.Fail("Expected message to be sent to central")
 	}
 }
@@ -143,7 +143,7 @@ func (s *virtualMachineHandlerSuite) TestConcurrentSends() {
 		select {
 		case <-s.handler.toCentral:
 			totalResponses++
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(500 * time.Millisecond):
 			s.T().Logf("Timeout waiting for response, got %d responses", totalResponses)
 			return // Don't fail, just exit
 		}
@@ -177,7 +177,7 @@ func (s *virtualMachineHandlerSuite) TestVirtualMachineNotFound() {
 	select {
 	case <-s.handler.ResponsesC():
 		s.Fail("Unexpected message to be sent to central")
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 	}
 }
 
@@ -206,7 +206,7 @@ func (s *virtualMachineHandlerSuite) TestInvalidCID() {
 	select {
 	case <-s.handler.ResponsesC():
 		s.Fail("Unexpected message to be sent to central")
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 	}
 }
 
@@ -221,7 +221,7 @@ func (s *virtualMachineHandlerSuite) TestStop() {
 	select {
 	case <-s.handler.stopper.Client().Stopped().Done():
 		// Expected.
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
 		s.Fail("handler should have stopped")
 	}
 }

--- a/sensor/common/virtualmachine/index/mocks/handler.go
+++ b/sensor/common/virtualmachine/index/mocks/handler.go
@@ -16,6 +16,7 @@ import (
 	central "github.com/stackrox/rox/generated/internalapi/central"
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	centralsensor "github.com/stackrox/rox/pkg/centralsensor"
+	concurrency "github.com/stackrox/rox/pkg/concurrency"
 	common "github.com/stackrox/rox/sensor/common"
 	message "github.com/stackrox/rox/sensor/common/message"
 	virtualmachine "github.com/stackrox/rox/sensor/common/virtualmachine"
@@ -72,6 +73,20 @@ func (m *MockHandler) Capabilities() []centralsensor.SensorCapability {
 func (mr *MockHandlerMockRecorder) Capabilities() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capabilities", reflect.TypeOf((*MockHandler)(nil).Capabilities))
+}
+
+// ComplianceC mocks base method.
+func (m *MockHandler) ComplianceC() <-chan common.MessageToComplianceWithAddress {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ComplianceC")
+	ret0, _ := ret[0].(<-chan common.MessageToComplianceWithAddress)
+	return ret0
+}
+
+// ComplianceC indicates an expected call of ComplianceC.
+func (mr *MockHandlerMockRecorder) ComplianceC() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComplianceC", reflect.TypeOf((*MockHandler)(nil).ComplianceC))
 }
 
 // Name mocks base method.
@@ -166,6 +181,20 @@ func (m *MockHandler) Stop() {
 func (mr *MockHandlerMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockHandler)(nil).Stop))
+}
+
+// Stopped mocks base method.
+func (m *MockHandler) Stopped() concurrency.ReadOnlyErrorSignal {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stopped")
+	ret0, _ := ret[0].(concurrency.ReadOnlyErrorSignal)
+	return ret0
+}
+
+// Stopped indicates an expected call of Stopped.
+func (mr *MockHandlerMockRecorder) Stopped() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stopped", reflect.TypeOf((*MockHandler)(nil).Stopped))
 }
 
 // MockVirtualMachineStore is a mock of VirtualMachineStore interface.

--- a/sensor/common/virtualmachine/index/mocks/handler.go
+++ b/sensor/common/virtualmachine/index/mocks/handler.go
@@ -221,6 +221,20 @@ func (m *MockVirtualMachineStore) EXPECT() *MockVirtualMachineStoreMockRecorder 
 	return m.recorder
 }
 
+// Get mocks base method.
+func (m *MockVirtualMachineStore) Get(id virtualmachine.VMID) *virtualmachine.Info {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", id)
+	ret0, _ := ret[0].(*virtualmachine.Info)
+	return ret0
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockVirtualMachineStoreMockRecorder) Get(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockVirtualMachineStore)(nil).Get), id)
+}
+
 // GetFromCID mocks base method.
 func (m *MockVirtualMachineStore) GetFromCID(cid uint32) *virtualmachine.Info {
 	m.ctrl.T.Helper()

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -205,7 +205,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	if features.VirtualMachines.Enabled() {
 		virtualMachineHandler = vmIndex.NewHandler(storeProvider.VirtualMachines())
 		components = append(components, virtualMachineHandler)
-		complianceMultiplexer.AddComponentWithComplianceC(virtualMachineHandler.(common.ComplianceComponent))
+		complianceMultiplexer.AddComponentWithComplianceC(virtualMachineHandler)
 	}
 
 	matcher := compliance.NewNodeIDMatcher(storeProvider.Nodes())

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -205,6 +205,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	if features.VirtualMachines.Enabled() {
 		virtualMachineHandler = vmIndex.NewHandler(storeProvider.VirtualMachines())
 		components = append(components, virtualMachineHandler)
+		complianceMultiplexer.AddComponentWithComplianceC(virtualMachineHandler.(common.ComplianceComponent))
 	}
 
 	matcher := compliance.NewNodeIDMatcher(storeProvider.Nodes())


### PR DESCRIPTION
## Description

Adds forwarding Central's `SensorACK` responses back to compliance through Sensor.

**Before:** Sensor received ACK/NACK from Central for VM index reports but only logged them. The
compliance relay had no visibility into whether Central accepted or rejected a report, so it could
not adjust retry behavior accordingly.

**After:** Sensor translates `central.SensorACK` into `sensor.MsgToCompliance_ComplianceACK` with
message type `VM_INDEX_REPORT` and sends it to compliance via a dedicated `toCompliance` channel.
Compliance's `handleVMIndexACK` (from another PR) will forward it to the relay's UMH, which updates
per-VM retry state.

AI-assisted: code was extracted from the feature branch by AI, with test fix
for updated Capabilities return value. Reviewed and verified by the author.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests, no but https://github.com/stackrox/stackrox/pull/20042 (or its child PRs) covers this
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- [x] CI
- [x] Manually on a cluster - as follows:


**Cluster:** OCP 4.21.8 (6 nodes), `ROX_VIRTUAL_MACHINES=true`
**Image:** `quay.io/stackrox-io/main:4.11.x-611-gb0e1c76f28`
**VMs:** `vm-rhel9` on `worker-c`, `vm-rhel10` on `worker-b`

I deployed ACS, 2 VMs with agents and triggered 2 scans manually on each. After that, I looked at the metrics and logs.

#### ACK forwarding metric

```
rox_sensor_virtual_machine_index_report_acks_received_total{action="ACK"} 4
```

This metric is incremented **after** `forwardToCompliance()` runs ([`handler_impl.go:142-145`](https://github.com/stackrox/stackrox/blob/b0e1c76f28/sensor/common/virtualmachine/index/handler_impl.go)), confirming all 4 ACKs from Central entered the compliance forwarding path.

#### No ACKs dropped

Zero instances of any `forwardToCompliance` error path in Sensor logs:

```
$ grep -E "Dropping VM ACK|Compliance channel not initialized|Unknown SensorACK action|compliance queue is full" sensor.log
(no output)
```

The forwarding `select` has four branches - context cancelled, shutdown, happy-path send, and queue-full - each with a log line except the happy path. Absence of all error logs confirms all 4 ACKs were successfully sent to the `toCompliance` channel.

#### Compliance connections established for VM host nodes

```
common/compliance: 11:23:50 service_impl.go:196: Info: Received connection from "pr-04-13-vm-btxwz-worker-b-42647.c.acs-team-temp-dev.internal"
common/compliance: 11:23:54 service_impl.go:196: Info: Received connection from "pr-04-13-vm-btxwz-worker-c-rwh4q.c.acs-team-temp-dev.internal"
```

Both VM host nodes (`worker-b` = `vm-rhel10`, `worker-c` = `vm-rhel9`) have active compliance connections, so the compliance multiplexer has valid routes to deliver the forwarded ACKs.

#### Central accepted all VM index reports (no rate limiting)

```
rox_central_rate_limiter_requests_total{outcome="accepted",workload="vm_index_reports"} 12
rox_central_rate_limiter_requests_total{outcome="rejected",workload="vm_index_reports"} 0
```