### PR TITLE
ROX-19064: Reset Scanner V4 DB connection pool after init

### DIFF
--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -189,6 +189,12 @@ func NewIndexer(ctx context.Context, cfg config.IndexerConfig) (Indexer, error) 
 	if err != nil {
 		return nil, fmt.Errorf("initializing postgres indexer store: %w", err)
 	}
+	// Reset the pool to force re-registration of custom PostgreSQL types (e.g.
+	// VersionRange) created by the migration above. Resetting ensures
+	// all subsequent connections see the fully-migrated schema.
+	// TODO: Remove after claircore updated to v1.5.50+.
+	pool.Reset()
+
 	defer func() {
 		if !success {
 			_ = store.Close(ctx)

--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -113,6 +113,11 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig) (Matcher, error) 
 	if err != nil {
 		return nil, fmt.Errorf("initializing postgres matcher store: %w", err)
 	}
+	// Reset the pool to force re-registration of custom PostgreSQL types (e.g.
+	// VersionRange) created by the migration above. Resetting ensures
+	// all subsequent connections see the fully-migrated schema.
+	// TODO: Remove after claircore updated to v1.5.50+.
+	pool.Reset()
 
 	locker, err := ctxlock.New(ctx, pool)
 	if err != nil {

--- a/scanner/updater/import.go
+++ b/scanner/updater/import.go
@@ -22,6 +22,12 @@ func Load(ctx context.Context, connString, vulnsURL string) error {
 	if err != nil {
 		return fmt.Errorf("initializing postgres matcher store: %w", err)
 	}
+	// Reset the pool to force re-registration of custom PostgreSQL types (e.g.
+	// VersionRange) created by the migration above. Resetting ensures
+	// all subsequent connections see the fully-migrated schema.
+	// TODO: Remove after claircore updated to v1.5.50+.
+	pool.Reset()
+
 	metadataStore, err := postgres.InitPostgresMatcherMetadataStore(ctx, pool, true)
 	if err != nil {
 		return fmt.Errorf("initializing postgres matcher metadata store: %w", err)


### PR DESCRIPTION
## Description

The Scanner V4 Indexer and Matcher perform DB migrations on startup that can introduce new PostgreSQL custom types. 

Existing connections in the connection pool may be unaware of the new types leading to errors, such as:

`unable to encode <thing> into text format for unknown type (OID 16417)`

Full error:

```
{"level":"error","host":"scanner-v4-matcher-7bd6f59ccc-hb5bn","bundle":"bundles/osv.json.zst","component":"matcher/updater/vuln/Updater.runMultiBundleUpdate","error":"importing vulnerabilities: updating vulnerability: failed to finish batch vulnerability insert: error building query \n\t\tINSERT INTO vuln (\n\t\t\thash_kind, hash,\n\t\t\tname, updater, description, issued, links, severity, normalized_severity,\n\t\t\tpackage_name, package_version, package_module, package_arch, package_kind,\n\t\t\tdist_id, dist_name, dist_version, dist_version_code_name, dist_version_id, dist_arch, dist_cpe, dist_pretty_name,\n\t\t\trepo_name, repo_key, repo_uri,\n\t\t\tfixed_in_version, arch_operation, version_kind, vulnerable_range\n\t\t) VALUES (\n\t\t  $1, $2,\n\t\t  $3, $4, $5, $6, $7, $8, $9,\n\t\t  $10, $11, $12, $13, $14,\n\t\t  $15, $16, $17, $18, $19, $20, $21, $22,\n\t\t  $23, $24, $25,\n\t\t  $26, $27, $28, COALESCE($29, VersionRange('{}', '{}', '()'))\n\t\t)\n\t\tON CONFLICT (hash_kind, hash) DO NOTHING;: failed to encode args[28]: unable to encode &claircore.Range{Lower:claircore.Version{Kind:\"\", V:[10]int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, Upper:claircore.Version{Kind:\"\", V:[10]int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}} into text format for unknown type (OID 16417): cannot find encode plan","time":"2026-03-04T02:48:49Z","message":"updating bundle failed"}
```

This was consistently observed after enabling Scanner V4 in CI.

Claircore v1.5.50+ [adds this `Reset()`](https://github.com/quay/claircore/pull/1749) into the store initialization logic. When StackRox is updated to use that version these `Reset()`'s can be removed. Adding these to StackRox enables us to backport to prior releases that will not have `Claircore` version bumps. 

Reviewing the PGX code a second called to `Reset()` is harmless in this context, keeping these after a Claircore version bump should be OK as well (outside of the smell).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new tests added

### How I validated my change

CI