### PR TITLE
ROX-30650: Update trusted Red Hat public keys periodically

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -456,7 +456,8 @@ jobs:
           make -C operator/ docker-push-index | cat
 
   build-and-push-main:
-    runs-on: ubuntu-latest
+    # Use native arm64 runner to avoid QEMU emulation overhead (~2x slower).
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-latest' }}
     needs:
       - define-job-matrix
       - pre-build-cli
@@ -535,7 +536,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_CI_ACCOUNT_PASSWORD }}
 
       - name: Set up QEMU
-        if: matrix.arch != 'amd64'
+        if: matrix.arch != 'amd64' && matrix.arch != 'arm64'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
@@ -784,7 +785,7 @@ jobs:
         message-path: build-comment.md
 
   build-and-push-operator:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-latest' }}
     needs:
       - define-job-matrix
       - pre-build-go-binaries
@@ -862,7 +863,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_CI_ACCOUNT_PASSWORD }}
 
       - name: Set up QEMU
-        if: matrix.arch != 'amd64'
+        if: matrix.arch != 'amd64' && matrix.arch != 'arm64'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
       - name: Check that Operator image is runnable

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/globaldb"
@@ -10,6 +11,7 @@ import (
 	"github.com/stackrox/rox/central/signatureintegration/store"
 	pgStore "github.com/stackrox/rox/central/signatureintegration/store/postgres"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/signatures"
 	"github.com/stackrox/rox/pkg/sync"
@@ -17,8 +19,10 @@ import (
 )
 
 var (
-	once     sync.Once
-	instance DataStore
+	once           sync.Once
+	instance       DataStore
+	keyUpdater     *updater
+	keyUpdaterLock sync.Mutex
 )
 
 func upsertDefaultRedHatSignatureIntegration(siStore store.SignatureIntegrationStore) {
@@ -40,7 +44,10 @@ func startRedHatSigningKeyUpdater() {
 	}
 
 	u, err := newUpdater(
-		&http.Client{},
+		&http.Client{
+			Timeout:   30 * time.Second,
+			Transport: proxy.RoundTripper(),
+		},
 		manifestURL,
 		env.RedHatSigningKeysRuntimeDir.Setting(),
 		env.RedHatSigningKeyUpdateInterval.DurationSetting(),
@@ -49,7 +56,23 @@ func startRedHatSigningKeyUpdater() {
 		utils.Should(errors.Wrap(err, "creating Red Hat signing key updater"))
 		return
 	}
+
+	keyUpdaterLock.Lock()
+	keyUpdater = u
+	keyUpdaterLock.Unlock()
+
 	u.Start()
+}
+
+// StopRedHatSigningKeyUpdater stops the background key updater if running.
+func StopRedHatSigningKeyUpdater() {
+	keyUpdaterLock.Lock()
+	u := keyUpdater
+	keyUpdaterLock.Unlock()
+
+	if u != nil {
+		u.Stop()
+	}
 }
 
 // Singleton returns the sole instance of the DataStore service.

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -2,12 +2,14 @@ package datastore
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/globaldb"
 	policyDataStore "github.com/stackrox/rox/central/policy/datastore"
 	"github.com/stackrox/rox/central/signatureintegration/store"
 	pgStore "github.com/stackrox/rox/central/signatureintegration/store/postgres"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/signatures"
 	"github.com/stackrox/rox/pkg/sync"
@@ -30,12 +32,33 @@ func upsertDefaultRedHatSignatureIntegration(siStore store.SignatureIntegrationS
 	utils.Should(errors.Wrap(err, "upserting default Red Hat signature integration"))
 }
 
+func startRedHatSigningKeyUpdater() {
+	manifestURL := env.RedHatSigningKeyManifestURL.Setting()
+	if manifestURL == "" {
+		log.Info("Red Hat signing key manifest URL not configured, skipping key updater")
+		return
+	}
+
+	u, err := newUpdater(
+		&http.Client{},
+		manifestURL,
+		env.RedHatSigningKeysRuntimeDir.Setting(),
+		env.RedHatSigningKeyUpdateInterval.DurationSetting(),
+	)
+	if err != nil {
+		utils.Should(errors.Wrap(err, "creating Red Hat signing key updater"))
+		return
+	}
+	u.Start()
+}
+
 // Singleton returns the sole instance of the DataStore service.
 func Singleton() DataStore {
 	once.Do(func() {
 		storage := pgStore.New(globaldb.GetPostgres())
 		upsertDefaultRedHatSignatureIntegration(storage)
 		instance = New(storage, policyDataStore.Singleton())
+		startRedHatSigningKeyUpdater()
 	})
 	return instance
 }

--- a/central/signatureintegration/datastore/updater.go
+++ b/central/signatureintegration/datastore/updater.go
@@ -1,0 +1,295 @@
+package datastore
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+const defaultUpdateInterval = 4 * time.Hour
+
+type manifest struct {
+	Keys []manifestKey `json:"keys"`
+}
+
+type manifestKey struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type keyRef struct {
+	name string
+	url  string
+}
+
+type updater struct {
+	client      *http.Client
+	interval    time.Duration
+	manifestURL string
+	targetDir   string
+	once        sync.Once
+	stopSig     concurrency.Signal
+}
+
+func newUpdater(client *http.Client, manifestURL, targetDir string, interval time.Duration) (*updater, error) {
+	if client == nil {
+		return nil, errors.New("http client must be provided")
+	}
+	if interval <= 0 {
+		interval = defaultUpdateInterval
+	}
+
+	return &updater{
+		client:      client,
+		interval:    interval,
+		manifestURL: manifestURL,
+		targetDir:   targetDir,
+		stopSig:     concurrency.NewSignal(),
+	}, nil
+}
+
+func (u *updater) Stop() {
+	u.stopSig.Signal()
+}
+
+func (u *updater) Start() {
+	u.once.Do(func() {
+		go u.runForever()
+	})
+}
+
+func (u *updater) runForever() {
+	log.Infof("Starting Red Hat key file updater every %v", u.interval)
+	u.doUpdate()
+
+	t := time.NewTimer(u.interval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			u.doUpdate()
+			t.Reset(u.interval)
+		case <-u.stopSig.Done():
+			return
+		}
+	}
+}
+
+func (u *updater) doUpdate() {
+	if err := u.update(); err != nil {
+		log.Errorf("Failed to download Red Hat key files from manifest %q into %q: %v", u.manifestURL, u.targetDir, err)
+	}
+}
+
+func (u *updater) update() error {
+	manifest, err := u.downloadManifest(u.manifestURL)
+	if err != nil {
+		return errors.Wrapf(err, "downloading manifest from URL %q", u.manifestURL)
+	}
+
+	keyRefs, err := resolveKeyRefsFromManifest(u.manifestURL, manifest)
+	if err != nil {
+		return errors.Wrap(err, "resolving key references from manifest")
+	}
+	if err := os.MkdirAll(u.targetDir, 0o755); err != nil {
+		return errors.Wrapf(err, "creating target directory %q", u.targetDir)
+	}
+	stagingDir, err := os.MkdirTemp(filepath.Dir(u.targetDir), ".redhat-keys-staging-*")
+	if err != nil {
+		return errors.Wrapf(err, "creating staging directory for target %q", u.targetDir)
+	}
+	defer func() {
+		_ = os.RemoveAll(stagingDir)
+	}()
+
+	if err := u.downloadKeys(keyRefs, stagingDir); err != nil {
+		return errors.Wrap(err, "downloading keys to staging")
+	}
+	if err := replaceDirectoryContents(u.targetDir, stagingDir); err != nil {
+		return errors.Wrapf(err, "replacing target directory %q contents", u.targetDir)
+	}
+
+	return nil
+}
+
+// resolveKeyRefsFromManifest resolves the key references from a manifest.
+func resolveKeyRefsFromManifest(manifestURL string, manifest manifest) ([]keyRef, error) {
+	if len(manifest.Keys) == 0 {
+		return nil, errors.Errorf("manifest at %q does not contain any files", manifestURL)
+	}
+
+	keyRefs := make([]keyRef, 0, len(manifest.Keys))
+	for _, key := range manifest.Keys {
+		resolvedURL, err := resolveKeyURL(manifestURL, key.URL)
+		if err != nil {
+			return nil, errors.Wrapf(err, "resolving URL %q", key.URL)
+		}
+		keyRefs = append(keyRefs, keyRef{
+			name: key.Name,
+			url:  resolvedURL,
+		})
+	}
+	return keyRefs, nil
+}
+
+func (u *updater) downloadKeys(keys []keyRef, stagingDir string) error {
+	successes := 0
+	failures := 0
+
+	for _, key := range keys {
+		destination := filepath.Join(stagingDir, key.name)
+		if err := u.downloadFile(key.url, destination); err != nil {
+			failures++
+			log.Warnf("Skipping manifest entry %q: %v", key.url, err)
+			continue
+		}
+		successes++
+	}
+
+	if successes == 0 {
+		return errors.New("failed to download any keys")
+	}
+	if failures > 0 {
+		log.Warnf("Downloaded %d keys to staging %q, skipped %d entries", successes, stagingDir, failures)
+	} else {
+		log.Debugf("Downloaded %d keys to staging %q", successes, stagingDir)
+	}
+
+	return nil
+}
+
+func (u *updater) downloadFile(url string, destination string) error {
+	contents, err := u.downloadBytes(url)
+	if err != nil {
+		return errors.Wrapf(err, "failed to download file from URL %q", url)
+	}
+
+	if err := os.WriteFile(destination, contents, 0o600); err != nil {
+		_ = os.Remove(destination)
+		return errors.Wrapf(err, "failed to write file %q", destination)
+	}
+
+	return nil
+}
+
+func replaceDirectoryContents(targetDir, sourceDir string) error {
+	if err := clearDirectory(targetDir); err != nil {
+		return errors.Wrap(err, "clearing target directory")
+	}
+
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return errors.Wrap(err, "reading source directory")
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(sourceDir, entry.Name())
+		targetPath := filepath.Join(targetDir, entry.Name())
+		if err := os.Rename(sourcePath, targetPath); err != nil {
+			return errors.Wrapf(err, "moving %q to target directory", entry.Name())
+		}
+	}
+
+	return nil
+}
+
+func clearDirectory(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return errors.Wrap(err, "reading directory entries")
+	}
+	for _, entry := range entries {
+		entryPath := filepath.Join(dir, entry.Name())
+		if err := os.RemoveAll(entryPath); err != nil {
+			return errors.Wrapf(err, "removing %q", entryPath)
+		}
+	}
+
+	return nil
+}
+
+func (u *updater) downloadBytes(rawURL string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "constructing request")
+	}
+
+	resp, err := u.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "executing request")
+	}
+	defer utils.IgnoreError(resp.Body.Close)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("HTTP response code was %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading response body")
+	}
+
+	return body, nil
+}
+
+func (u *updater) downloadManifest(manifestURL string) (manifest, error) {
+	manifestBytes, err := u.downloadBytes(manifestURL)
+	if err != nil {
+		return manifest{}, err
+	}
+
+	var parsedManifest manifest
+	if err = json.Unmarshal(manifestBytes, &parsedManifest); err != nil {
+		return manifest{}, errors.Wrap(err, "unmarshalling manifest")
+	}
+
+	return parsedManifest, nil
+}
+
+// resolveKeyURL resolves a key URL relative to a manifest URL.
+// The key URL can be absolute or relative.
+// If it is relative, it is resolved relative to the manifest URL.
+// If it is absolute, it is returned as is.
+func resolveKeyURL(manifestURL, keyURL string) (string, error) {
+	keyURL = strings.TrimSpace(keyURL)
+
+	var resolved string
+	if strings.HasPrefix(keyURL, "http://") || strings.HasPrefix(keyURL, "https://") {
+		resolved = keyURL
+	} else {
+		base, err := url.Parse(manifestURL)
+		if err != nil {
+			return "", errors.Wrap(err, "parsing manifest URL")
+		}
+		base.Path = strings.TrimSuffix(base.Path, "/")
+		if idx := strings.LastIndex(base.Path, "/"); idx >= 0 {
+			base.Path = base.Path[:idx+1]
+		}
+
+		ref, err := url.Parse(keyURL)
+		if err != nil {
+			return "", errors.Wrap(err, "parsing key entry")
+		}
+		resolved = base.ResolveReference(ref).String()
+	}
+
+	parsed, err := url.Parse(resolved)
+	if err != nil {
+		return "", errors.Wrap(err, "parsing resolved URL")
+	}
+	if strings.HasSuffix(parsed.Path, "/") || parsed.Path == "" {
+		return "", errors.Errorf("URL must point to a file, not a directory: %s", resolved)
+	}
+
+	return resolved, nil
+}

--- a/central/signatureintegration/datastore/updater.go
+++ b/central/signatureintegration/datastore/updater.go
@@ -1,12 +1,14 @@
 package datastore
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -184,42 +186,29 @@ func (u *updater) downloadFile(url string, destination string) error {
 }
 
 func replaceDirectoryContents(targetDir, sourceDir string) error {
-	if err := clearDirectory(targetDir); err != nil {
-		return errors.Wrap(err, "clearing target directory")
+	backupDir := targetDir + ".backup-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	if err := os.Rename(targetDir, backupDir); err != nil {
+		return errors.Wrap(err, "moving current target directory to backup")
 	}
-
-	entries, err := os.ReadDir(sourceDir)
-	if err != nil {
-		return errors.Wrap(err, "reading source directory")
-	}
-	for _, entry := range entries {
-		sourcePath := filepath.Join(sourceDir, entry.Name())
-		targetPath := filepath.Join(targetDir, entry.Name())
-		if err := os.Rename(sourcePath, targetPath); err != nil {
-			return errors.Wrapf(err, "moving %q to target directory", entry.Name())
+	if err := os.Rename(sourceDir, targetDir); err != nil {
+		rollbackErr := os.Rename(backupDir, targetDir)
+		if rollbackErr != nil {
+			return errors.Wrapf(err, "moving staged directory into target failed and rollback failed: %v", rollbackErr)
 		}
+		return errors.Wrap(err, "moving staged directory into target")
 	}
-
-	return nil
-}
-
-func clearDirectory(dir string) error {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return errors.Wrap(err, "reading directory entries")
-	}
-	for _, entry := range entries {
-		entryPath := filepath.Join(dir, entry.Name())
-		if err := os.RemoveAll(entryPath); err != nil {
-			return errors.Wrapf(err, "removing %q", entryPath)
-		}
+	if err := os.RemoveAll(backupDir); err != nil {
+		return errors.Wrap(err, "removing backup directory")
 	}
 
 	return nil
 }
 
 func (u *updater) downloadBytes(rawURL string) ([]byte, error) {
-	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	reqCtx, cancel := u.newRequestContext()
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing request")
 	}
@@ -231,7 +220,7 @@ func (u *updater) downloadBytes(rawURL string) ([]byte, error) {
 	defer utils.IgnoreError(resp.Body.Close)
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("HTTP response code was %d", resp.StatusCode)
+		return nil, errors.Errorf("HTTP %d for %q", resp.StatusCode, rawURL)
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -240,6 +229,27 @@ func (u *updater) downloadBytes(rawURL string) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+func (u *updater) newRequestContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	select {
+	case <-u.stopSig.Done():
+		cancel()
+		return ctx, cancel
+	default:
+	}
+
+	go func() {
+		select {
+		case <-u.stopSig.Done():
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	return ctx, cancel
 }
 
 func (u *updater) downloadManifest(manifestURL string) (manifest, error) {

--- a/central/signatureintegration/datastore/updater.go
+++ b/central/signatureintegration/datastore/updater.go
@@ -18,8 +18,6 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 )
 
-const defaultUpdateInterval = 4 * time.Hour
-
 type manifest struct {
 	Keys []manifestKey `json:"keys"`
 }
@@ -48,7 +46,7 @@ func newUpdater(client *http.Client, manifestURL, targetDir string, interval tim
 		return nil, errors.New("http client must be provided")
 	}
 	if interval <= 0 {
-		interval = defaultUpdateInterval
+		return nil, errors.New("update interval must be positive")
 	}
 
 	return &updater{
@@ -95,12 +93,12 @@ func (u *updater) doUpdate() {
 }
 
 func (u *updater) update() error {
-	manifest, err := u.downloadManifest(u.manifestURL)
+	mf, err := u.downloadManifest(u.manifestURL)
 	if err != nil {
 		return errors.Wrapf(err, "downloading manifest from URL %q", u.manifestURL)
 	}
 
-	keyRefs, err := resolveKeyRefsFromManifest(u.manifestURL, manifest)
+	keyRefs, err := resolveKeyRefsFromManifest(u.manifestURL, mf)
 	if err != nil {
 		return errors.Wrap(err, "resolving key references from manifest")
 	}
@@ -115,60 +113,73 @@ func (u *updater) update() error {
 		_ = os.RemoveAll(stagingDir)
 	}()
 
-	if err := u.downloadKeys(keyRefs, stagingDir); err != nil {
+	n, err := u.downloadKeys(keyRefs, stagingDir)
+	if err != nil {
 		return errors.Wrap(err, "downloading keys to staging")
 	}
 	if err := replaceDirectoryContents(u.targetDir, stagingDir); err != nil {
 		return errors.Wrapf(err, "replacing target directory %q contents", u.targetDir)
 	}
 
+	log.Infof("Successfully updated Red Hat signing keys from %q: %d keys written to %q", u.manifestURL, n, u.targetDir)
 	return nil
 }
 
 // resolveKeyRefsFromManifest resolves the key references from a manifest.
-func resolveKeyRefsFromManifest(manifestURL string, manifest manifest) ([]keyRef, error) {
-	if len(manifest.Keys) == 0 {
+func resolveKeyRefsFromManifest(manifestURL string, mf manifest) ([]keyRef, error) {
+	if len(mf.Keys) == 0 {
 		return nil, errors.Errorf("manifest at %q does not contain any files", manifestURL)
 	}
 
-	keyRefs := make([]keyRef, 0, len(manifest.Keys))
-	for _, key := range manifest.Keys {
+	keyRefs := make([]keyRef, 0, len(mf.Keys))
+	for _, key := range mf.Keys {
+		name := strings.TrimSpace(key.Name)
+		if name == "" {
+			return nil, errors.New("manifest entry has empty name")
+		}
+		if strings.ContainsAny(name, "/\\") {
+			return nil, errors.Errorf("manifest entry name %q contains path separator", name)
+		}
 		resolvedURL, err := resolveKeyURL(manifestURL, key.URL)
 		if err != nil {
 			return nil, errors.Wrapf(err, "resolving URL %q", key.URL)
 		}
 		keyRefs = append(keyRefs, keyRef{
-			name: key.Name,
+			name: name,
 			url:  resolvedURL,
 		})
 	}
 	return keyRefs, nil
 }
 
-func (u *updater) downloadKeys(keys []keyRef, stagingDir string) error {
+func (u *updater) downloadKeys(keys []keyRef, stagingDir string) (int, error) {
 	successes := 0
 	failures := 0
 
+	cleanStagingDir := filepath.Clean(stagingDir) + string(os.PathSeparator)
 	for _, key := range keys {
 		destination := filepath.Join(stagingDir, key.name)
+		if !strings.HasPrefix(filepath.Clean(destination)+string(os.PathSeparator), cleanStagingDir) {
+			failures++
+			log.Warnf("Skipping manifest entry %q (URL %q): resolved path escapes staging directory", key.name, key.url)
+			continue
+		}
 		if err := u.downloadFile(key.url, destination); err != nil {
 			failures++
-			log.Warnf("Skipping manifest entry %q: %v", key.url, err)
+			log.Warnf("Skipping manifest entry %q (URL %q): %v", key.name, key.url, err)
 			continue
 		}
 		successes++
 	}
 
 	if successes == 0 {
-		return errors.New("failed to download any keys")
+		return 0, errors.New("failed to download any keys")
 	}
 	if failures > 0 {
-		log.Warnf("Downloaded %d keys to staging %q, skipped %d entries", successes, stagingDir, failures)
-	} else {
-		log.Debugf("Downloaded %d keys to staging %q", successes, stagingDir)
+		log.Warnf("Downloaded %d keys, skipped %d entries", successes, failures)
 	}
 
-	return nil
+	return successes, nil
 }
 
 func (u *updater) downloadFile(url string, destination string) error {
@@ -177,7 +188,7 @@ func (u *updater) downloadFile(url string, destination string) error {
 		return errors.Wrapf(err, "failed to download file from URL %q", url)
 	}
 
-	if err := os.WriteFile(destination, contents, 0o600); err != nil {
+	if err := os.WriteFile(destination, contents, 0o644); err != nil {
 		_ = os.Remove(destination)
 		return errors.Wrapf(err, "failed to write file %q", destination)
 	}
@@ -198,11 +209,14 @@ func replaceDirectoryContents(targetDir, sourceDir string) error {
 		return errors.Wrap(err, "moving staged directory into target")
 	}
 	if err := os.RemoveAll(backupDir); err != nil {
-		return errors.Wrap(err, "removing backup directory")
+		log.Warnf("Failed to remove backup directory %q: %v", backupDir, err)
 	}
 
 	return nil
 }
+
+// maxResponseBodySize is the maximum size of a response body (manifest or key file) we will read.
+const maxResponseBodySize = 5 * 1024 * 1024 // 5 MB
 
 func (u *updater) downloadBytes(rawURL string) ([]byte, error) {
 	reqCtx, cancel := u.newRequestContext()
@@ -223,32 +237,22 @@ func (u *updater) downloadBytes(rawURL string) ([]byte, error) {
 		return nil, errors.Errorf("HTTP %d for %q", resp.StatusCode, rawURL)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize+1))
 	if err != nil {
 		return nil, errors.Wrap(err, "reading response body")
+	}
+	if len(body) > maxResponseBodySize {
+		return nil, errors.Errorf("response body from %q exceeds maximum size of %d bytes", rawURL, maxResponseBodySize)
 	}
 
 	return body, nil
 }
 
+const requestTimeout = 60 * time.Second
+
 func (u *updater) newRequestContext() (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	select {
-	case <-u.stopSig.Done():
-		cancel()
-		return ctx, cancel
-	default:
-	}
-
-	go func() {
-		select {
-		case <-u.stopSig.Done():
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
-
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	concurrency.CancelContextOnSignal(ctx, cancel, &u.stopSig)
 	return ctx, cancel
 }
 
@@ -296,6 +300,9 @@ func resolveKeyURL(manifestURL, keyURL string) (string, error) {
 	parsed, err := url.Parse(resolved)
 	if err != nil {
 		return "", errors.Wrap(err, "parsing resolved URL")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", errors.Errorf("unsupported URL scheme %q in %s", parsed.Scheme, resolved)
 	}
 	if strings.HasSuffix(parsed.Path, "/") || parsed.Path == "" {
 		return "", errors.Errorf("URL must point to a file, not a directory: %s", resolved)

--- a/central/signatureintegration/datastore/updater_test.go
+++ b/central/signatureintegration/datastore/updater_test.go
@@ -1,0 +1,214 @@
+package datastore
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func validPEM(t *testing.T) string {
+	t.Helper()
+	return goodCosignConfig.GetPublicKeys()[0].GetPublicKeyPemEnc()
+}
+
+func newTestUpdater(t *testing.T, manifestURL, targetDir string) *updater {
+	t.Helper()
+	u, err := newUpdater(&http.Client{Timeout: 5 * time.Second}, manifestURL, targetDir, time.Second)
+	require.NoError(t, err)
+	return u
+}
+
+func TestResolveKeyURL(t *testing.T) {
+	tests := []struct {
+		manifestURL string
+		keyURL      string
+		want        string
+		wantErr     bool
+	}{
+		{"https://a.com/dir/manifest.json", "https://b.com/key.pub", "https://b.com/key.pub", false},
+		{"https://a.com/dir/manifest.json", "http://b.com/key.pub", "http://b.com/key.pub", false},
+		{"https://example.com/keys/manifest.json", "release-key.pub", "https://example.com/keys/release-key.pub", false},
+		{"https://example.com/keys/manifest.json", "sub/key.pub", "https://example.com/keys/sub/key.pub", false},
+		{"https://example.com/manifest.json", "key.pub", "https://example.com/key.pub", false},
+		{"https://example.com/keys/manifest.json", "https://example.com/keys/", "", true},
+		{"https://example.com/keys/manifest.json", "keys/", "", true},
+		{"://invalid", "key.pub", "", true},
+	}
+
+	for _, tt := range tests {
+		got, err := resolveKeyURL(tt.manifestURL, tt.keyURL)
+		if tt.wantErr {
+			require.Error(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+			continue
+		}
+		require.NoError(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+		require.Equal(t, tt.want, got, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+	}
+}
+
+func TestUpdateDownloadsAllFiles(t *testing.T) {
+	pem := validPEM(t)
+	targetDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "stale.pub"), []byte("stale"), 0o600))
+
+	manifest := manifest{
+		Keys: []manifestKey{
+			{Name: "key-a.pub", URL: "key-a.pub"},
+			{Name: "key-b.pub", URL: "nested/key-b.pub"},
+		},
+	}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(manifestBody)
+		case "/key-a.pub", "/nested/key-b.pub":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(pem))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.NoError(t, u.update())
+
+	entries, err := os.ReadDir(targetDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	a, err := os.ReadFile(filepath.Join(targetDir, "key-a.pub"))
+	require.NoError(t, err)
+	require.Equal(t, pem, string(a))
+
+	b, err := os.ReadFile(filepath.Join(targetDir, "key-b.pub"))
+	require.NoError(t, err)
+	require.Equal(t, pem, string(b))
+
+	_, err = os.Stat(filepath.Join(targetDir, "stale.pub"))
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestNewUpdaterRequiresClient(t *testing.T) {
+	_, err := newUpdater(nil, "https://example.com/manifest.json", t.TempDir(), time.Second)
+	require.Error(t, err)
+}
+
+func TestUpdateAllowsPartialDownloads(t *testing.T) {
+	pem := validPEM(t)
+	targetDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "stale.pub"), []byte("stale"), 0o600))
+
+	manifest := manifest{
+		Keys: []manifestKey{
+			{Name: "key-a.pub", URL: "key-a.pub"},
+			{Name: "missing.pub", URL: "missing.pub"},
+		},
+	}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(manifestBody)
+		case "/key-a.pub":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(pem))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.NoError(t, u.update())
+
+	entries, err := os.ReadDir(targetDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	a, err := os.ReadFile(filepath.Join(targetDir, "key-a.pub"))
+	require.NoError(t, err)
+	require.Equal(t, pem, string(a))
+
+	_, err = os.Stat(filepath.Join(targetDir, "stale.pub"))
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestUpdateAllowsDuplicateOutputFileNames_LastWriteWins(t *testing.T) {
+	pem := validPEM(t)
+	targetDir := t.TempDir()
+
+	manifest := manifest{
+		Keys: []manifestKey{
+			{Name: "key.pub", URL: "keys/key.pub"},
+			{Name: "key.pub", URL: "other/key.pub"},
+		},
+	}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(manifestBody)
+		case "/keys/key.pub", "/other/key.pub":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(pem))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.NoError(t, u.update())
+	content, err := os.ReadFile(filepath.Join(targetDir, "key.pub"))
+	require.NoError(t, err)
+	require.Equal(t, pem, string(content))
+}
+
+func TestUpdateFailsWhenNoFilesCanBeDownloaded(t *testing.T) {
+	targetDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "existing.pub"), []byte("existing"), 0o600))
+	manifest := manifest{
+		Keys: []manifestKey{
+			{Name: "Missing A", URL: "a.pub"},
+			{Name: "Missing B", URL: "b.pub"},
+		},
+	}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/manifest.json" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(manifestBody)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.Error(t, u.update())
+
+	existing, err := os.ReadFile(filepath.Join(targetDir, "existing.pub"))
+	require.NoError(t, err)
+	require.Equal(t, "existing", string(existing))
+}

--- a/central/signatureintegration/datastore/updater_test.go
+++ b/central/signatureintegration/datastore/updater_test.go
@@ -34,6 +34,7 @@ func TestResolveKeyURL(t *testing.T) {
 		{"https://a.com/dir/manifest.json", "https://b.com/key.pub", "https://b.com/key.pub", false},
 		{"https://a.com/dir/manifest.json", "http://b.com/key.pub", "http://b.com/key.pub", false},
 		{"https://example.com/keys/manifest.json", "release-key.pub", "https://example.com/keys/release-key.pub", false},
+		{"https://example.com/keys/manifest.json", "  key.pub \n", "https://example.com/keys/key.pub", false},
 		{"https://example.com/keys/manifest.json", "sub/key.pub", "https://example.com/keys/sub/key.pub", false},
 		{"https://example.com/manifest.json", "key.pub", "https://example.com/key.pub", false},
 		{"https://example.com/keys/manifest.json", "https://example.com/keys/", "", true},
@@ -44,11 +45,11 @@ func TestResolveKeyURL(t *testing.T) {
 	for _, tt := range tests {
 		got, err := resolveKeyURL(tt.manifestURL, tt.keyURL)
 		if tt.wantErr {
-			require.Error(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+			require.Errorf(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
 			continue
 		}
-		require.NoError(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
-		require.Equal(t, tt.want, got, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+		require.NoErrorf(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+		require.Equalf(t, tt.want, got, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
 	}
 }
 

--- a/central/signatureintegration/datastore/updater_test.go
+++ b/central/signatureintegration/datastore/updater_test.go
@@ -2,10 +2,12 @@ package datastore
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,16 +42,20 @@ func TestResolveKeyURL(t *testing.T) {
 		{"https://example.com/keys/manifest.json", "https://example.com/keys/", "", true},
 		{"https://example.com/keys/manifest.json", "keys/", "", true},
 		{"://invalid", "key.pub", "", true},
+		{"https://example.com/keys/manifest.json", "file:///etc/shadow", "", true},
+		{"https://example.com/keys/manifest.json", "gopher://evil.com/key", "", true},
 	}
 
 	for _, tt := range tests {
-		got, err := resolveKeyURL(tt.manifestURL, tt.keyURL)
-		if tt.wantErr {
-			require.Errorf(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
-			continue
-		}
-		require.NoErrorf(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
-		require.Equalf(t, tt.want, got, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+		t.Run(fmt.Sprintf("%s_%s", tt.manifestURL, tt.keyURL), func(t *testing.T) {
+			got, err := resolveKeyURL(tt.manifestURL, tt.keyURL)
+			if tt.wantErr {
+				require.Errorf(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+				return
+			}
+			require.NoErrorf(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+			require.Equalf(t, tt.want, got, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+		})
 	}
 }
 
@@ -295,4 +301,41 @@ func TestUpdateFailsWhenNoFilesCanBeDownloaded(t *testing.T) {
 	existing, err := os.ReadFile(filepath.Join(targetDir, "existing.pub"))
 	require.NoError(t, err)
 	require.Equal(t, "existing", string(existing))
+}
+
+func TestNewUpdaterRejectsZeroInterval(t *testing.T) {
+	_, err := newUpdater(&http.Client{}, "https://example.com/manifest.json", t.TempDir(), 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "interval must be positive")
+}
+
+func TestResolveKeyRefsRejectsEmptyName(t *testing.T) {
+	_, err := resolveKeyRefsFromManifest("https://example.com/manifest.json", manifest{
+		Keys: []manifestKey{{Name: "", URL: "key.pub"}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty name")
+}
+
+func TestResolveKeyRefsRejectsPathSeparatorInName(t *testing.T) {
+	_, err := resolveKeyRefsFromManifest("https://example.com/manifest.json", manifest{
+		Keys: []manifestKey{{Name: "../etc/evil", URL: "key.pub"}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "path separator")
+}
+
+func TestDownloadBytesRejectsOversizedResponse(t *testing.T) {
+	// Serve a response that exceeds maxResponseBodySize.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Write maxResponseBodySize + 100 bytes.
+		_, _ = w.Write([]byte(strings.Repeat("x", maxResponseBodySize+100)))
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", t.TempDir())
+	_, err := u.downloadBytes(server.URL + "/big-file")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum size")
 }

--- a/central/signatureintegration/datastore/updater_test.go
+++ b/central/signatureintegration/datastore/updater_test.go
@@ -184,6 +184,89 @@ func TestUpdateAllowsDuplicateOutputFileNames_LastWriteWins(t *testing.T) {
 	require.Equal(t, pem, string(content))
 }
 
+func TestUpdateFailsOnEmptyManifest(t *testing.T) {
+	targetDir := t.TempDir()
+	manifest := manifest{Keys: []manifestKey{}}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(manifestBody)
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.Error(t, u.update())
+}
+
+func TestUpdateFailsOnInvalidManifestJSON(t *testing.T) {
+	targetDir := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.Error(t, u.update())
+}
+
+func TestUpdateFailsOnManifestHTTPError(t *testing.T) {
+	targetDir := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.Error(t, u.update())
+}
+
+func TestReplaceDirectoryContentsIsAtomic(t *testing.T) {
+	targetDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "old.txt"), []byte("old"), 0o600))
+
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "new.txt"), []byte("new"), 0o600))
+
+	require.NoError(t, replaceDirectoryContents(targetDir, sourceDir))
+
+	content, err := os.ReadFile(filepath.Join(targetDir, "new.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "new", string(content))
+
+	_, err = os.Stat(filepath.Join(targetDir, "old.txt"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestStartStopLifecycle(t *testing.T) {
+	pem := validPEM(t)
+	targetDir := t.TempDir()
+	manifest := manifest{
+		Keys: []manifestKey{{Name: "key.pub", URL: "key.pub"}},
+	}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			_, _ = w.Write(manifestBody)
+		case "/key.pub":
+			_, _ = w.Write([]byte(pem))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	u.Start()
+	u.Start() // second call should be no-op (sync.Once)
+	u.Stop()
+}
+
 func TestUpdateFailsWhenNoFilesCanBeDownloaded(t *testing.T) {
 	targetDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "existing.pub"), []byte("existing"), 0o600))

--- a/pkg/env/signature.go
+++ b/pkg/env/signature.go
@@ -1,6 +1,18 @@
 package env
 
+import "time"
+
 var (
 	// DisableSignatureFetching disables signature fetching within the reprocessing loop.
 	DisableSignatureFetching = RegisterBooleanSetting("ROX_DISABLE_SIGNATURE_FETCHING", false)
+
+	// RedHatSigningKeyManifestURL is the URL of the manifest listing trusted Red Hat signing keys.
+	RedHatSigningKeyManifestURL = RegisterSetting("ROX_REDHAT_SIGNING_KEY_MANIFEST_URL")
+
+	// RedHatSigningKeyUpdateInterval controls how often the signing key updater runs.
+	RedHatSigningKeyUpdateInterval = registerDurationSetting("ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL", 4*time.Hour)
+
+	// RedHatSigningKeysRuntimeDir is the writable directory where downloaded Red Hat signing keys are stored.
+	RedHatSigningKeysRuntimeDir = RegisterSetting("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR",
+		WithDefault("/var/lib/stackrox/signature-keys/redhat"))
 )


### PR DESCRIPTION
## Description

Adds a periodic background updater to Central that downloads Red Hat public signing keys from a GCS-hosted JSON manifest and writes them atomically to a local directory. Central reloads those keys via the filesystem watcher (introduced in the companion PR).

- `updater.go`: fetches manifest JSON, downloads each key into a staging dir, validates no path escapes the staging dir, then atomically replaces the target directory. Limits response body to 5 MB. Uses `concurrency.Signal` for clean shutdown.
- `singleton.go`: wires in `startRedHatSigningKeyUpdater` to the Central lifecycle.
- `pkg/env/signature.go`: adds env vars `ROX_REDHAT_SIGNING_KEY_MANIFEST_URL`, `ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL`, `ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR`.

The updater is a no-op when `ROX_REDHAT_SIGNING_KEY_MANIFEST_URL` is unset, so this is safe to land before the Helm volume mount PR (#20145) and the filesystem watcher PR.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Unit tests cover: manifest download, partial failures, path traversal rejection, oversized response rejection, atomic directory replacement, and updater lifecycle (Start/Stop).

E2E validation requires the Helm volume mount from PR #20145 to provide a writable directory; will be validated once that lands.