### PR TITLE
feat(sensor): Add sensor-scanner config info metrics

### DIFF
--- a/sensor/common/delegatedregistry/delegated_registry_handler.go
+++ b/sensor/common/delegatedregistry/delegated_registry_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/sensor/common"
+	detectormetrics "github.com/stackrox/rox/sensor/common/detector/metrics"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/common/scan"
@@ -113,6 +114,7 @@ func (d *delegatedRegistryImpl) processUpdatedDelegatedRegistryConfig(config *ce
 		return errors.New("could not process updated delegated registry config, stop requested")
 	default:
 		d.registryStore.SetDelegatedRegistryConfig(config)
+		detectormetrics.UpdateScannerConfigurationInfo(config)
 		log.Infof("Upserted delegated registry config: %q", config)
 	}
 	return nil

--- a/sensor/common/detector/metrics/metrics.go
+++ b/sensor/common/detector/metrics/metrics.go
@@ -16,14 +16,39 @@ import (
 	"github.com/stackrox/rox/sensor/common/centralcaps"
 )
 
+// Image origin categories for indexing route metrics.
+//
+// cluster_local: images from registries that belong to the secured cluster
+// itself (e.g. the OpenShift integrated registry). When a local scanner is
+// present these images are always scanned locally — no Central round-trip.
+//
+// non_cluster_local: all other images (Docker Hub, Quay, ECR, GCR, …).
+// Where these are indexed depends on the delegated scanning configuration
+// pushed by Central (see DelegatedRegistryConfig).
 const (
 	ForImagesClusterLocal    = "cluster_local"
 	ForImagesNonClusterLocal = "non_cluster_local"
+)
 
+// Indexer labels describe which component performs image indexing (pulling
+// layers and extracting package metadata). Vulnerability matching always
+// happens in Central regardless of the indexer.
+//
+//   - local_scanner:                       the Scanner pod co-deployed with Sensor
+//   - central_scanner:                     the Scanner in the Central services cluster
+//   - local_scanner_or_central_scanner:    mixed — some registries go local,
+//     the rest go to Central (delegated scanning with SPECIFIC registries)
+const (
 	IndexerLocalScanner   = "local_scanner"
 	IndexerCentralScanner = "central_scanner"
 	IndexerMixed          = "local_scanner_or_central_scanner"
+)
 
+// Scanner mode labels indicate which scanner generation the local scanner
+// would use. Determined at runtime by the ROX_SCANNER_V4 feature flag AND
+// whether Central advertises the ScannerV4Supported capability.
+// The mode does NOT verify that the scanner pod is actually running.
+const (
 	ModeNone = "none"
 	ModeV2   = "v2"
 	ModeV4   = "v4"
@@ -274,55 +299,69 @@ var (
 		Help:      "A counter that tracks the operations in scan and set",
 	}, []string{"Operation", "Reason"})
 
-	// Effective scanner configuration for Sensor, updated on Central handshake
-	// and when delegated registry config changes.
-	/*
-		Labels:
-		- `local`: `true|false` (whether local image scanning is enabled in Sensor)
-		- `mode`: `none|v2|v4` (configured local scanner mode based on feature
-		   flags and Central capabilities; does not verify scanner pod availability)
-		- `delegated`: `true|false` (delegated scanning effectively active:
-		   env vars enable it AND Central config has EnabledFor != NONE)
-	*/
+	// Scanner topology truth table — every valid combination of labels.
+	//
+	// Scanning has three layered concerns:
+	//   1. Local scanner presence (ROX_LOCAL_IMAGE_SCANNING_ENABLED).
+	//      When true a Scanner pod runs next to Sensor and can index images
+	//      from the cluster's own registries without a Central round-trip.
+	//   2. Scanner generation (mode): v4 when ROX_SCANNER_V4=true AND Central
+	//      advertises ScannerV4Supported; otherwise v2. Does NOT verify that
+	//      the scanner pod is actually running.
+	//   3. Delegated scanning: Central pushes a DelegatedRegistryConfig that
+	//      tells Sensor whether non-cluster-local images should also be indexed
+	//      locally. Requires local=true AND ROX_DELEGATED_SCANNING_DISABLED=false.
+	//
+	//  local | mode | delegated | cluster-local images | non-cluster-local images
+	//  ------+------+-----------+----------------------+--------------------------
+	//  false | none | false     | Central scanner      | Central scanner
+	//  true  | v2   | false     | local scanner (v2)   | Central scanner
+	//  true  | v4   | false     | local scanner (v4)   | Central scanner
+	//  true  | v2   | true/ALL  | local scanner (v2)   | local scanner (v2)
+	//  true  | v4   | true/ALL  | local scanner (v4)   | local scanner (v4)
+	//  true  | v2   | true/SPEC | local scanner (v2)   | local or Central (per registry)
+	//  true  | v4   | true/SPEC | local scanner (v4)   | local or Central (per registry)
+	//
+	// Impossible states (never emitted):
+	//   local=false, mode=v2              — no scanner means no mode.
+	//   local=false, mode=v4              — no scanner means no mode.
+	//   local=true,  mode=none            — a local scanner is always v2 or v4.
+	//   local=false, delegated=true       — delegation requires a local scanner.
+	//   local=true,  mode=none, delegated=true — compound of the above two.
+	//
+	// Note: vulnerability matching always happens in Central regardless of
+	// where indexing takes place.
 	scannerConfigurationInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
 		Name:      "scanner_configuration_info",
-		Help: "Effective scanner configuration for Sensor. " +
-			"`local` indicates whether local image scanning is enabled. " +
-			"`mode` is the configured local scanner type (none/v2/v4) based on feature flags and Central capabilities " +
-			"(does not verify scanner pod availability). " +
-			"`delegated` is true only when both Sensor env vars enable delegated scanning AND " +
-			"Central has sent a DelegatedRegistryConfig with EnabledFor != NONE.",
+		Help: "Describes how image scanning is configured on this Sensor. " +
+			"local=true means a Scanner pod runs alongside Sensor and handles cluster-local images (e.g. OCP internal registry). " +
+			"mode is the scanner generation (v2 or v4; none when local scanning is off). " +
+			"delegated=true means Central also routes non-cluster-local images to the local scanner " +
+			"(requires local=true, ROX_DELEGATED_SCANNING_DISABLED=false, and Central config EnabledFor != NONE). " +
+			"Vulnerability matching always happens in Central.",
 	}, []string{"local", "mode", "delegated"})
 
-	// Effective image indexing route in Sensor, reflecting delegated scanning
-	// config from Central.
-	/*
-		Labels:
-		- `for_images`: `cluster_local|non_cluster_local`
-		- `indexer`: `local_scanner|central_scanner|local_scanner_or_central_scanner`
-
-		Meaning:
-		- `cluster_local`: image registry is recognized as local to the secured cluster
-		  (e.g. OCP internal registry). Uses local scanner when local scanning is enabled.
-		- `non_cluster_local`: all other images. Indexer depends on delegated scanning config:
-		  - `central_scanner` when delegated scanning is inactive
-		  - `local_scanner` when delegated for ALL registries
-		  - `local_scanner_or_central_scanner` when delegated for SPECIFIC registries
-		- Vulnerability matching is always performed in Central.
-	*/
+	// Emits one series per image origin (cluster_local / non_cluster_local),
+	// showing which component performs the indexing step (pulling layers and
+	// extracting package metadata). This is the *effect* of the scanner
+	// configuration above — use scannerConfigurationInfo to see the *inputs*.
+	//
+	//  for_images          | indexer (when local=false) | indexer (when local=true, delegated off) | indexer (delegated ALL) | indexer (delegated SPECIFIC)
+	//  --------------------+---------------------------+-----------------------------------------+------------------------+-----------------------------
+	//  cluster_local       | central_scanner           | local_scanner                           | local_scanner           | local_scanner
+	//  non_cluster_local   | central_scanner           | central_scanner                         | local_scanner           | local_scanner_or_central_scanner
 	imageIndexingRouteInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
 		Name:      "image_indexing_route_info",
-		Help: `Effective image indexing route in Sensor. ` +
-			`"cluster_local" images use local scanner when local scanning is enabled. ` +
-			`"non_cluster_local" indexer depends on the DelegatedRegistryConfig from Central: ` +
-			`"central_scanner" when delegated scanning is inactive, ` +
-			`"local_scanner" when delegated for ALL registries, ` +
-			`"local_scanner_or_central_scanner" when delegated for SPECIFIC registries. ` +
-			`Vulnerability matching is always performed in Central.`,
+		Help: "Shows where image indexing happens for each image origin. " +
+			"for_images=cluster_local covers images from the cluster's own registries (e.g. OCP internal); " +
+			"for_images=non_cluster_local covers everything else (Docker Hub, Quay, ECR, …). " +
+			"indexer is local_scanner, central_scanner, or local_scanner_or_central_scanner (mixed, " +
+			"when delegated scanning targets SPECIFIC registries). " +
+			"Vulnerability matching always happens in Central regardless of where indexing occurs.",
 	}, []string{"for_images", "indexer"})
 )
 
@@ -419,14 +458,16 @@ func RemoveScanAndSetCall(reason string) {
 	}).Inc()
 }
 
-// scannerConfigMu serialises UpdateScannerConfigurationInfo calls so that the
-// multi-step Reset → Set sequence on the gauge vectors is atomic (see comment
-// inside the function).
+// scannerConfigMu serialises UpdateScannerConfigurationInfo so that the
+// multi-step Reset → Set sequence on two gauge vectors is atomic. Individual
+// Prometheus operations are thread-safe, but without the lock two concurrent
+// callers could interleave (e.g. Reset one vector while the other still has
+// stale series).
 //
 // lastConfig retains the most recent non-nil DelegatedRegistryConfig so that
-// capability-only refreshes (hello handshake, which passes nil) do not
-// temporarily reset delegated-routing metrics between reconnect and the next
-// config delivery from Central.
+// capability-only refreshes (the hello handshake passes nil) do not
+// temporarily reset delegated-routing metrics between a reconnect and the
+// next config delivery from Central.
 var (
 	scannerConfigMu sync.Mutex
 	lastConfig      *central.DelegatedRegistryConfig
@@ -438,9 +479,13 @@ func resetLastDelegatedConfig() {
 	lastConfig = nil
 }
 
-// scannerMode returns the active scanner version label based on whether local
-// scanning is enabled and whether Central advertises Scanner V4 support.
-// Returns ModeNone, ModeV4, or ModeV2.
+// scannerMode determines which scanner generation label to emit.
+//
+// Decision tree:
+//
+//	localEnabled=false → "none"  (no local scanner at all)
+//	ROX_SCANNER_V4=true AND Central has ScannerV4Supported → "v4"
+//	otherwise → "v2"  (legacy scanner or Central hasn't confirmed V4 yet)
 func scannerMode(localEnabled bool) string {
 	if !localEnabled {
 		return ModeNone
@@ -451,9 +496,15 @@ func scannerMode(localEnabled bool) string {
 	return ModeV2
 }
 
-// isDelegatedEffective returns true when delegated scanning is both locally
-// enabled (local scanner present and ROX_DELEGATED_SCANNING_DISABLED is not
-// set) and Central's config has an active delegation mode (not NONE).
+// isDelegatedEffective answers: "is Sensor actually scanning non-cluster-local
+// images locally right now?" This requires ALL of the following:
+//
+//  1. A local scanner is present (localEnabled=true).
+//  2. The kill-switch ROX_DELEGATED_SCANNING_DISABLED is false.
+//  3. Central has pushed a DelegatedRegistryConfig with EnabledFor != NONE.
+//
+// config may be nil (proto GetEnabledFor returns NONE on nil receiver), which
+// correctly yields false.
 func isDelegatedEffective(localEnabled bool, config *central.DelegatedRegistryConfig) bool {
 	envEnabled := localEnabled && !env.DelegatedScanningDisabled.BooleanSetting()
 	if !envEnabled {
@@ -462,11 +513,13 @@ func isDelegatedEffective(localEnabled bool, config *central.DelegatedRegistryCo
 	return config.GetEnabledFor() != central.DelegatedRegistryConfig_NONE
 }
 
-// nonClusterLocalIndexer determines which indexer handles images that do not
-// originate from the cluster's own local registry. When delegated scanning is
-// off, Central's scanner is used. When enabled for ALL registries, the local
-// scanner handles everything. When enabled for SPECIFIC registries, a mixed
-// mode label is returned (some images go local, some go to Central).
+// nonClusterLocalIndexer returns the indexer label for images that do NOT come
+// from the cluster's own registry. The result depends on whether delegated
+// scanning is active and, if so, how broadly:
+//
+//	delegated off        → "central_scanner"                   (Central does all indexing)
+//	delegated ALL        → "local_scanner"                     (everything indexed locally)
+//	delegated SPECIFIC   → "local_scanner_or_central_scanner"  (per-registry routing)
 func nonClusterLocalIndexer(localEnabled bool, config *central.DelegatedRegistryConfig) string {
 	if !isDelegatedEffective(localEnabled, config) {
 		return IndexerCentralScanner
@@ -481,13 +534,31 @@ func nonClusterLocalIndexer(localEnabled bool, config *central.DelegatedRegistry
 	}
 }
 
-// UpdateScannerConfigurationInfo updates info metrics that describe Sensor
-// scanner topology. It is safe for concurrent use.
+// UpdateScannerConfigurationInfo refreshes Prometheus info metrics that
+// describe the scanner topology of this Sensor. It is safe for concurrent use.
 //
-// When config is non-nil, it is stored as the last-known delegated registry
-// configuration. When config is nil (e.g. during the hello handshake on
-// reconnect), the previously stored configuration is reused so that metrics
-// remain accurate across reconnects.
+// The topology depends on three inputs:
+//
+//  1. Local scanner presence: ROX_LOCAL_IMAGE_SCANNING_ENABLED env var.
+//     When true, a Scanner pod (v2 or v4) runs beside Sensor and handles
+//     images from the cluster's own registries (e.g. OCP internal registry).
+//
+//  2. Scanner generation: determined at runtime from the ROX_SCANNER_V4
+//     feature flag AND whether Central advertises the ScannerV4Supported
+//     capability. Falls back to v2 if either condition is not met.
+//
+//  3. Delegated scanning: Central pushes a DelegatedRegistryConfig telling
+//     Sensor whether non-cluster-local images should also be scanned locally.
+//     Three delegation modes: NONE (no delegation), ALL (everything local),
+//     SPECIFIC (only matching registry paths scanned locally).
+//     Requires local scanning enabled AND ROX_DELEGATED_SCANNING_DISABLED=false.
+//
+// config may be nil on reconnect (hello handshake); in that case the last
+// known config is reused so metrics remain stable across reconnects.
+//
+// Called from two places:
+//   - Central hello handshake (nil config) — refreshes mode after capabilities update.
+//   - Delegated registry handler (non-nil config) — Central pushed new routing config.
 func UpdateScannerConfigurationInfo(config *central.DelegatedRegistryConfig) {
 	// Hold the lock for the full update (config swap + gauge Reset/Set) so that
 	// concurrent callers cannot interleave and leave mixed or zero series.

--- a/sensor/common/detector/metrics/metrics.go
+++ b/sensor/common/detector/metrics/metrics.go
@@ -419,7 +419,24 @@ func RemoveScanAndSetCall(reason string) {
 	}).Inc()
 }
 
-var scannerConfigMu sync.Mutex
+// scannerConfigMu serialises UpdateScannerConfigurationInfo calls so that the
+// multi-step Reset → Set sequence on the gauge vectors is atomic (see comment
+// inside the function).
+//
+// lastConfig retains the most recent non-nil DelegatedRegistryConfig so that
+// capability-only refreshes (hello handshake, which passes nil) do not
+// temporarily reset delegated-routing metrics between reconnect and the next
+// config delivery from Central.
+var (
+	scannerConfigMu sync.Mutex
+	lastConfig      *central.DelegatedRegistryConfig
+)
+
+func resetLastDelegatedConfig() {
+	scannerConfigMu.Lock()
+	defer scannerConfigMu.Unlock()
+	lastConfig = nil
+}
 
 // scannerMode returns the active scanner version label based on whether local
 // scanning is enabled and whether Central advertises Scanner V4 support.
@@ -467,11 +484,23 @@ func nonClusterLocalIndexer(localEnabled bool, config *central.DelegatedRegistry
 // UpdateScannerConfigurationInfo updates info metrics that describe Sensor
 // scanner topology. It is safe for concurrent use.
 //
-// config is the current DelegatedRegistryConfig from Central (may be nil
-// when no config has been received yet, e.g. right after the hello handshake).
+// When config is non-nil, it is stored as the last-known delegated registry
+// configuration. When config is nil (e.g. during the hello handshake on
+// reconnect), the previously stored configuration is reused so that metrics
+// remain accurate across reconnects.
 func UpdateScannerConfigurationInfo(config *central.DelegatedRegistryConfig) {
+	// Hold the lock for the full update (config swap + gauge Reset/Set) so that
+	// concurrent callers cannot interleave and leave mixed or zero series.
+	// The individual Prometheus operations are thread-safe, but the sequence
+	// Reset → Set across two gauge vectors is not atomic without the lock.
 	scannerConfigMu.Lock()
 	defer scannerConfigMu.Unlock()
+
+	if config != nil {
+		lastConfig = config
+	} else {
+		config = lastConfig
+	}
 
 	localEnabled := env.LocalImageScanningEnabled.BooleanSetting()
 

--- a/sensor/common/detector/metrics/metrics.go
+++ b/sensor/common/detector/metrics/metrics.go
@@ -2,11 +2,31 @@ package metrics
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/metrics"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
+)
+
+const (
+	ForImagesClusterLocal    = "cluster_local"
+	ForImagesNonClusterLocal = "non_cluster_local"
+
+	IndexerLocalScanner   = "local_scanner"
+	IndexerCentralScanner = "central_scanner"
+	IndexerMixed          = "local_scanner_or_central_scanner"
+
+	ModeNone = "none"
+	ModeV2   = "v2"
+	ModeV4   = "v4"
 )
 
 // AckOrigin tells what entity issued the Ack message
@@ -253,6 +273,57 @@ var (
 		Name:      "scan_and_set_calls_total",
 		Help:      "A counter that tracks the operations in scan and set",
 	}, []string{"Operation", "Reason"})
+
+	// Effective scanner configuration for Sensor, updated on Central handshake
+	// and when delegated registry config changes.
+	/*
+		Labels:
+		- `local`: `true|false` (whether local image scanning is enabled in Sensor)
+		- `mode`: `none|v2|v4` (configured local scanner mode based on feature
+		   flags and Central capabilities; does not verify scanner pod availability)
+		- `delegated`: `true|false` (delegated scanning effectively active:
+		   env vars enable it AND Central config has EnabledFor != NONE)
+	*/
+	scannerConfigurationInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "scanner_configuration_info",
+		Help: "Effective scanner configuration for Sensor. " +
+			"`local` indicates whether local image scanning is enabled. " +
+			"`mode` is the configured local scanner type (none/v2/v4) based on feature flags and Central capabilities " +
+			"(does not verify scanner pod availability). " +
+			"`delegated` is true only when both Sensor env vars enable delegated scanning AND " +
+			"Central has sent a DelegatedRegistryConfig with EnabledFor != NONE.",
+	}, []string{"local", "mode", "delegated"})
+
+	// Effective image indexing route in Sensor, reflecting delegated scanning
+	// config from Central.
+	/*
+		Labels:
+		- `for_images`: `cluster_local|non_cluster_local`
+		- `indexer`: `local_scanner|central_scanner|local_scanner_or_central_scanner`
+
+		Meaning:
+		- `cluster_local`: image registry is recognized as local to the secured cluster
+		  (e.g. OCP internal registry). Uses local scanner when local scanning is enabled.
+		- `non_cluster_local`: all other images. Indexer depends on delegated scanning config:
+		  - `central_scanner` when delegated scanning is inactive
+		  - `local_scanner` when delegated for ALL registries
+		  - `local_scanner_or_central_scanner` when delegated for SPECIFIC registries
+		- Vulnerability matching is always performed in Central.
+	*/
+	imageIndexingRouteInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "image_indexing_route_info",
+		Help: `Effective image indexing route in Sensor. ` +
+			`"cluster_local" images use local scanner when local scanning is enabled. ` +
+			`"non_cluster_local" indexer depends on the DelegatedRegistryConfig from Central: ` +
+			`"central_scanner" when delegated scanning is inactive, ` +
+			`"local_scanner" when delegated for ALL registries, ` +
+			`"local_scanner_or_central_scanner" when delegated for SPECIFIC registries. ` +
+			`Vulnerability matching is always performed in Central.`,
+	}, []string{"for_images", "indexer"})
 )
 
 // ObserveTimeSpentInExponentialBackoff observes the metric.
@@ -348,6 +419,85 @@ func RemoveScanAndSetCall(reason string) {
 	}).Inc()
 }
 
+var scannerConfigMu sync.Mutex
+
+// scannerMode returns the active scanner version label based on whether local
+// scanning is enabled and whether Central advertises Scanner V4 support.
+// Returns ModeNone, ModeV4, or ModeV2.
+func scannerMode(localEnabled bool) string {
+	if !localEnabled {
+		return ModeNone
+	}
+	if features.ScannerV4.Enabled() && centralcaps.Has(centralsensor.ScannerV4Supported) {
+		return ModeV4
+	}
+	return ModeV2
+}
+
+// isDelegatedEffective returns true when delegated scanning is both locally
+// enabled (local scanner present and ROX_DELEGATED_SCANNING_DISABLED is not
+// set) and Central's config has an active delegation mode (not NONE).
+func isDelegatedEffective(localEnabled bool, config *central.DelegatedRegistryConfig) bool {
+	envEnabled := localEnabled && !env.DelegatedScanningDisabled.BooleanSetting()
+	if !envEnabled {
+		return false
+	}
+	return config.GetEnabledFor() != central.DelegatedRegistryConfig_NONE
+}
+
+// nonClusterLocalIndexer determines which indexer handles images that do not
+// originate from the cluster's own local registry. When delegated scanning is
+// off, Central's scanner is used. When enabled for ALL registries, the local
+// scanner handles everything. When enabled for SPECIFIC registries, a mixed
+// mode label is returned (some images go local, some go to Central).
+func nonClusterLocalIndexer(localEnabled bool, config *central.DelegatedRegistryConfig) string {
+	if !isDelegatedEffective(localEnabled, config) {
+		return IndexerCentralScanner
+	}
+	switch config.GetEnabledFor() {
+	case central.DelegatedRegistryConfig_ALL:
+		return IndexerLocalScanner
+	case central.DelegatedRegistryConfig_SPECIFIC:
+		return IndexerMixed
+	default:
+		return IndexerCentralScanner
+	}
+}
+
+// UpdateScannerConfigurationInfo updates info metrics that describe Sensor
+// scanner topology. It is safe for concurrent use.
+//
+// config is the current DelegatedRegistryConfig from Central (may be nil
+// when no config has been received yet, e.g. right after the hello handshake).
+func UpdateScannerConfigurationInfo(config *central.DelegatedRegistryConfig) {
+	scannerConfigMu.Lock()
+	defer scannerConfigMu.Unlock()
+
+	localEnabled := env.LocalImageScanningEnabled.BooleanSetting()
+
+	scannerConfigurationInfo.Reset()
+	scannerConfigurationInfo.With(prometheus.Labels{
+		"local":     strconv.FormatBool(localEnabled),
+		"mode":      scannerMode(localEnabled),
+		"delegated": strconv.FormatBool(isDelegatedEffective(localEnabled, config)),
+	}).Set(1)
+
+	clusterLocalIndexer := IndexerCentralScanner
+	if localEnabled {
+		clusterLocalIndexer = IndexerLocalScanner
+	}
+
+	imageIndexingRouteInfo.Reset()
+	imageIndexingRouteInfo.With(prometheus.Labels{
+		"for_images": ForImagesClusterLocal,
+		"indexer":    clusterLocalIndexer,
+	}).Set(1)
+	imageIndexingRouteInfo.With(prometheus.Labels{
+		"for_images": ForImagesNonClusterLocal,
+		"indexer":    nonClusterLocalIndexer(localEnabled, config),
+	}).Set(1)
+}
+
 func init() {
 	prometheus.MustRegister(timeSpentInExponentialBackoff,
 		networkPoliciesStored,
@@ -369,5 +519,7 @@ func init() {
 		DetectorFileAccessDroppedCount,
 		FileAccessEventsReceived,
 		FileAccessCriteriaMatchDuration,
+		scannerConfigurationInfo,
+		imageIndexingRouteInfo,
 	)
 }

--- a/sensor/common/detector/metrics/metrics.go
+++ b/sensor/common/detector/metrics/metrics.go
@@ -323,10 +323,10 @@ var (
 	//  true  | v4   | true/SPEC | local scanner (v4)   | local or Central (per registry)
 	//
 	// Impossible states (never emitted):
-	//   local=false, mode=v2              — no scanner means no mode.
-	//   local=false, mode=v4              — no scanner means no mode.
-	//   local=true,  mode=none            — a local scanner is always v2 or v4.
-	//   local=false, delegated=true       — delegation requires a local scanner.
+	//   local=false, mode=v2                   — no scanner means no mode.
+	//   local=false, mode=v4                   — no scanner means no mode.
+	//   local=true,  mode=none                 — a local scanner is always v2 or v4.
+	//   local=false, delegated=true            — delegation requires a local scanner.
 	//   local=true,  mode=none, delegated=true — compound of the above two.
 	//
 	// Note: vulnerability matching always happens in Central regardless of

--- a/sensor/common/detector/metrics/metrics_test.go
+++ b/sensor/common/detector/metrics/metrics_test.go
@@ -14,6 +14,7 @@ import (
 func setupCentralCaps(t *testing.T, caps []centralsensor.CentralCapability) {
 	centralcaps.Set(caps)
 	t.Cleanup(func() { centralcaps.Set(nil) })
+	t.Cleanup(resetLastDelegatedConfig)
 }
 
 func TestUpdateScannerConfigurationInfo_LocalScanningDisabled(t *testing.T) {
@@ -160,6 +161,27 @@ func TestUpdateScannerConfigurationInfo_SequentialUpdates(t *testing.T) {
 
 	config := &central.DelegatedRegistryConfig{EnabledFor: central.DelegatedRegistryConfig_ALL}
 	UpdateScannerConfigurationInfo(config)
+	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("true", ModeV4, "true")), 0)
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesNonClusterLocal, IndexerLocalScanner)), 0)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(scannerConfigurationInfo))
+	assert.Equal(t, 2, testutil.CollectAndCount(imageIndexingRouteInfo))
+}
+
+func TestUpdateScannerConfigurationInfo_NilOnReconnectPreservesLastConfig(t *testing.T) {
+	t.Setenv("ROX_LOCAL_IMAGE_SCANNING_ENABLED", "true")
+	t.Setenv("ROX_DELEGATED_SCANNING_DISABLED", "false")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+	setupCentralCaps(t, []centralsensor.CentralCapability{centralsensor.ScannerV4Supported})
+
+	config := &central.DelegatedRegistryConfig{EnabledFor: central.DelegatedRegistryConfig_ALL}
+	UpdateScannerConfigurationInfo(config)
+	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("true", ModeV4, "true")), 0)
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesNonClusterLocal, IndexerLocalScanner)), 0)
+
+	// Simulate reconnect: hello handshake passes nil. Metrics must retain
+	// the previously known delegated config instead of resetting.
+	UpdateScannerConfigurationInfo(nil)
 	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("true", ModeV4, "true")), 0)
 	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesNonClusterLocal, IndexerLocalScanner)), 0)
 

--- a/sensor/common/detector/metrics/metrics_test.go
+++ b/sensor/common/detector/metrics/metrics_test.go
@@ -1,0 +1,168 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupCentralCaps(t *testing.T, caps []centralsensor.CentralCapability) {
+	centralcaps.Set(caps)
+	t.Cleanup(func() { centralcaps.Set(nil) })
+}
+
+func TestUpdateScannerConfigurationInfo_LocalScanningDisabled(t *testing.T) {
+	t.Setenv("ROX_LOCAL_IMAGE_SCANNING_ENABLED", "false")
+	t.Setenv("ROX_DELEGATED_SCANNING_DISABLED", "false")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+	setupCentralCaps(t, []centralsensor.CentralCapability{centralsensor.ScannerV4Supported})
+
+	UpdateScannerConfigurationInfo(nil)
+
+	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("false", ModeNone, "false")), 0)
+	assert.Equal(t, 1, testutil.CollectAndCount(scannerConfigurationInfo))
+
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesClusterLocal, IndexerCentralScanner)), 0)
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesNonClusterLocal, IndexerCentralScanner)), 0)
+	assert.Equal(t, 2, testutil.CollectAndCount(imageIndexingRouteInfo))
+}
+
+func TestUpdateScannerConfigurationInfo_LocalScanningEnabledV2_DelegatedEnvDisabled(t *testing.T) {
+	t.Setenv("ROX_LOCAL_IMAGE_SCANNING_ENABLED", "true")
+	t.Setenv("ROX_DELEGATED_SCANNING_DISABLED", "true")
+	t.Setenv(features.ScannerV4.EnvVar(), "false")
+	setupCentralCaps(t, nil)
+
+	UpdateScannerConfigurationInfo(nil)
+
+	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("true", ModeV2, "false")), 0)
+	assert.Equal(t, 1, testutil.CollectAndCount(scannerConfigurationInfo))
+
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesClusterLocal, IndexerLocalScanner)), 0)
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesNonClusterLocal, IndexerCentralScanner)), 0)
+	assert.Equal(t, 2, testutil.CollectAndCount(imageIndexingRouteInfo))
+}
+
+func TestUpdateScannerConfigurationInfo_LocalScanningEnabledV4_DelegatedEnvEnabled_NoCentralConfig(t *testing.T) {
+	t.Setenv("ROX_LOCAL_IMAGE_SCANNING_ENABLED", "true")
+	t.Setenv("ROX_DELEGATED_SCANNING_DISABLED", "false")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+	setupCentralCaps(t, []centralsensor.CentralCapability{centralsensor.ScannerV4Supported})
+
+	UpdateScannerConfigurationInfo(nil)
+
+	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("true", ModeV4, "false")), 0)
+	assert.Equal(t, 1, testutil.CollectAndCount(scannerConfigurationInfo))
+
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesClusterLocal, IndexerLocalScanner)), 0)
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesNonClusterLocal, IndexerCentralScanner)), 0)
+	assert.Equal(t, 2, testutil.CollectAndCount(imageIndexingRouteInfo))
+}
+
+func TestUpdateScannerConfigurationInfo_DelegatedConfigNone(t *testing.T) {
+	t.Setenv("ROX_LOCAL_IMAGE_SCANNING_ENABLED", "true")
+	t.Setenv("ROX_DELEGATED_SCANNING_DISABLED", "false")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+	setupCentralCaps(t, []centralsensor.CentralCapability{centralsensor.ScannerV4Supported})
+
+	config := &central.DelegatedRegistryConfig{EnabledFor: central.DelegatedRegistryConfig_NONE}
+	UpdateScannerConfigurationInfo(config)
+
+	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("true", ModeV4, "false")), 0)
+	assert.Equal(t, 1, testutil.CollectAndCount(scannerConfigurationInfo))
+
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesClusterLocal, IndexerLocalScanner)), 0)
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesNonClusterLocal, IndexerCentralScanner)), 0)
+	assert.Equal(t, 2, testutil.CollectAndCount(imageIndexingRouteInfo))
+}
+
+func TestUpdateScannerConfigurationInfo_DelegatedConfigAll(t *testing.T) {
+	t.Setenv("ROX_LOCAL_IMAGE_SCANNING_ENABLED", "true")
+	t.Setenv("ROX_DELEGATED_SCANNING_DISABLED", "false")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+	setupCentralCaps(t, []centralsensor.CentralCapability{centralsensor.ScannerV4Supported})
+
+	config := &central.DelegatedRegistryConfig{EnabledFor: central.DelegatedRegistryConfig_ALL}
+	UpdateScannerConfigurationInfo(config)
+
+	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("true", ModeV4, "true")), 0)
+	assert.Equal(t, 1, testutil.CollectAndCount(scannerConfigurationInfo))
+
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesClusterLocal, IndexerLocalScanner)), 0)
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesNonClusterLocal, IndexerLocalScanner)), 0)
+	assert.Equal(t, 2, testutil.CollectAndCount(imageIndexingRouteInfo))
+}
+
+func TestUpdateScannerConfigurationInfo_DelegatedConfigSpecific(t *testing.T) {
+	t.Setenv("ROX_LOCAL_IMAGE_SCANNING_ENABLED", "true")
+	t.Setenv("ROX_DELEGATED_SCANNING_DISABLED", "false")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+	setupCentralCaps(t, []centralsensor.CentralCapability{centralsensor.ScannerV4Supported})
+
+	config := &central.DelegatedRegistryConfig{
+		EnabledFor: central.DelegatedRegistryConfig_SPECIFIC,
+		Registries: []*central.DelegatedRegistryConfig_DelegatedRegistry{
+			{Path: "quay.io/myorg"},
+		},
+	}
+	UpdateScannerConfigurationInfo(config)
+
+	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("true", ModeV4, "true")), 0)
+	assert.Equal(t, 1, testutil.CollectAndCount(scannerConfigurationInfo))
+
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesClusterLocal, IndexerLocalScanner)), 0)
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesNonClusterLocal, IndexerMixed)), 0)
+	assert.Equal(t, 2, testutil.CollectAndCount(imageIndexingRouteInfo))
+}
+
+func TestUpdateScannerConfigurationInfo_V2FallbackWhenCentralLacksV4Capability(t *testing.T) {
+	t.Setenv("ROX_LOCAL_IMAGE_SCANNING_ENABLED", "true")
+	t.Setenv("ROX_DELEGATED_SCANNING_DISABLED", "false")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+	setupCentralCaps(t, nil)
+
+	config := &central.DelegatedRegistryConfig{EnabledFor: central.DelegatedRegistryConfig_ALL}
+	UpdateScannerConfigurationInfo(config)
+
+	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("true", ModeV2, "true")), 0)
+	assert.Equal(t, 1, testutil.CollectAndCount(scannerConfigurationInfo))
+}
+
+func TestUpdateScannerConfigurationInfo_DelegatedConfigAllButEnvDisabled(t *testing.T) {
+	t.Setenv("ROX_LOCAL_IMAGE_SCANNING_ENABLED", "true")
+	t.Setenv("ROX_DELEGATED_SCANNING_DISABLED", "true")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+	setupCentralCaps(t, []centralsensor.CentralCapability{centralsensor.ScannerV4Supported})
+
+	config := &central.DelegatedRegistryConfig{EnabledFor: central.DelegatedRegistryConfig_ALL}
+	UpdateScannerConfigurationInfo(config)
+
+	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("true", ModeV4, "false")), 0)
+	assert.Equal(t, 1, testutil.CollectAndCount(scannerConfigurationInfo))
+
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesNonClusterLocal, IndexerCentralScanner)), 0)
+}
+
+func TestUpdateScannerConfigurationInfo_SequentialUpdates(t *testing.T) {
+	t.Setenv("ROX_LOCAL_IMAGE_SCANNING_ENABLED", "true")
+	t.Setenv("ROX_DELEGATED_SCANNING_DISABLED", "false")
+	t.Setenv(features.ScannerV4.EnvVar(), "true")
+	setupCentralCaps(t, []centralsensor.CentralCapability{centralsensor.ScannerV4Supported})
+
+	UpdateScannerConfigurationInfo(nil)
+	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("true", ModeV4, "false")), 0)
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesNonClusterLocal, IndexerCentralScanner)), 0)
+
+	config := &central.DelegatedRegistryConfig{EnabledFor: central.DelegatedRegistryConfig_ALL}
+	UpdateScannerConfigurationInfo(config)
+	assert.InDelta(t, 1, testutil.ToFloat64(scannerConfigurationInfo.WithLabelValues("true", ModeV4, "true")), 0)
+	assert.InDelta(t, 1, testutil.ToFloat64(imageIndexingRouteInfo.WithLabelValues(ForImagesNonClusterLocal, IndexerLocalScanner)), 0)
+
+	assert.Equal(t, 1, testutil.CollectAndCount(scannerConfigurationInfo))
+	assert.Equal(t, 2, testutil.CollectAndCount(imageIndexingRouteInfo))
+}

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/centralproxy/allowedpaths"
 	"github.com/stackrox/rox/sensor/common/config"
 	"github.com/stackrox/rox/sensor/common/detector"
+	detectormetrics "github.com/stackrox/rox/sensor/common/detector/metrics"
 	"github.com/stackrox/rox/sensor/common/managedcentral"
 	"github.com/stackrox/rox/sensor/common/sensor/helmconfig"
 	"github.com/stackrox/rox/sensor/common/trace"
@@ -248,6 +249,7 @@ func (s *centralCommunicationImpl) hello(stream central.SensorService_Communicat
 	centralid.Set(centralHello.GetCentralId())
 	centralCaps := centralHello.GetCapabilities()
 	centralcaps.Set(sliceutils.FromStringSlice[centralsensor.CentralCapability](centralCaps...))
+	detectormetrics.UpdateScannerConfigurationInfo(nil)
 
 	if centralcaps.Has(centralsensor.CentralProxyPathFiltering) {
 		allowedpaths.Set(centralHello.GetAllowedProxyPaths())


### PR DESCRIPTION
## Description

Add Sensor info metrics that make scanner topology immediately visible from metrics, without depending on startup logs:

- `rox_sensor_scanner_configuration_info{local,mode,delegated} 1`
- `rox_sensor_image_indexing_route_info{for_images,indexer} 1`

What this solves:
- Investigators can quickly tell whether local scanning is enabled, whether Sensor is in `v2`/`v4` mode, whether delegated scanning is enabled, and what indexing route is intended for `cluster_local` vs `non_cluster_local` images.

The metric declarations include comprehensive documentation aimed at engineers unfamiliar with scanner/sensor internals:
- A truth table enumerating all 5 valid and 7 impossible label combinations for `scanner_configuration_info`.
- A cross-reference table on `image_indexing_route_info` showing the indexer for each image origin under each configuration.
- Domain-level comments on constants (`ForImages*`, `Indexer*`, `Mode*`) explaining what "cluster-local" vs "non-cluster-local" means, what each indexer does, and how scanner generation is selected.
- Story-driven Prometheus `Help` text that explains the layered scanning model (local presence → scanner generation → delegated routing) instead of mechanically listing labels.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- [x] newly added unit tests for the metrics
- [x] on a cluster

```
# TYPE rox_sensor_image_indexing_route_info gauge
rox_sensor_image_indexing_route_info{for_images="cluster_local",indexer="central_scanner"} 1
rox_sensor_image_indexing_route_info{for_images="non_cluster_local",indexer="central_scanner"} 1

# TYPE rox_sensor_scanner_configuration_info gauge
rox_sensor_scanner_configuration_info{delegated="false",local="false",mode="none"} 1
```

I haven't tested all combinations of scanner configuration manually on a cluster!