### PR TITLE
DO NOT REVIEW: experiment

### DIFF
--- a/central/deployment/datastore/datastore_impl.go
+++ b/central/deployment/datastore/datastore_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/deployment/cache"
 	deploymentStore "github.com/stackrox/rox/central/deployment/datastore/internal/store"
+	storeTypes "github.com/stackrox/rox/central/deployment/datastore/internal/store/types"
 	"github.com/stackrox/rox/central/deployment/views"
 	"github.com/stackrox/rox/central/globaldb"
 	imageDS "github.com/stackrox/rox/central/image/datastore"
@@ -96,16 +97,16 @@ func (ds *datastoreImpl) initializeRanker() {
 	clusterScores := make(map[string]float32)
 	nsScores := make(map[string]float32)
 	// The store search function does not use select fields, only views do. Hence empty query is used in the walk below
-	err := ds.deploymentStore.WalkByQuery(readCtx, pkgSearch.EmptyQuery(), func(deployment *storage.Deployment) error {
-		riskScore := deployment.GetRiskScore()
-		ds.deploymentRanker.Add(deployment.GetId(), riskScore)
+	err := ds.deploymentStore.WalkByQuery(readCtx, pkgSearch.EmptyQuery(), func(storedDeployment *storage.StoredDeployment) error {
+		riskScore := storedDeployment.GetRiskScore()
+		ds.deploymentRanker.Add(storedDeployment.GetId(), riskScore)
 
 		// TODO: ROX-6235: account for nodes in cluster risk
 		// aggregate deployment risk scores to get cluster risk score
-		clusterScores[deployment.GetClusterId()] += riskScore
+		clusterScores[storedDeployment.GetClusterId()] += riskScore
 
 		// aggregate deployment risk scores to obtain namespace risk score
-		nsScores[deployment.GetNamespaceId()] += riskScore
+		nsScores[storedDeployment.GetNamespaceId()] += riskScore
 
 		return nil
 	})
@@ -201,8 +202,8 @@ func (ds *datastoreImpl) SearchRawDeployments(ctx context.Context, q *v1.Query) 
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Deployment", "SearchRawDeployments")
 
 	var deployments []*storage.Deployment
-	err := ds.deploymentStore.WalkByQuery(ctx, q, func(deployment *storage.Deployment) error {
-		deployments = append(deployments, deployment)
+	err := ds.deploymentStore.WalkByQuery(ctx, q, func(storedDeployment *storage.StoredDeployment) error {
+		deployments = append(deployments, storeTypes.FromStoredDeployment(storedDeployment))
 		return nil
 	})
 	if err != nil {
@@ -215,10 +216,11 @@ func (ds *datastoreImpl) SearchRawDeployments(ctx context.Context, q *v1.Query) 
 
 // GetDeployment
 func (ds *datastoreImpl) GetDeployment(ctx context.Context, id string) (*storage.Deployment, bool, error) {
-	deployment, found, err := ds.deploymentStore.Get(ctx, id)
+	storedDeployment, found, err := ds.deploymentStore.Get(ctx, id)
 	if err != nil || !found {
 		return nil, false, err
 	}
+	deployment := storeTypes.FromStoredDeployment(storedDeployment)
 
 	if ok, err := deploymentsSAC.ReadAllowed(ctx, sac.KeyForNSScopedObj(deployment)...); err != nil || !ok {
 		return nil, false, err
@@ -229,17 +231,19 @@ func (ds *datastoreImpl) GetDeployment(ctx context.Context, id string) (*storage
 
 // GetDeployments
 func (ds *datastoreImpl) GetDeployments(ctx context.Context, ids []string) ([]*storage.Deployment, error) {
-	var deployments []*storage.Deployment
-	var err error
 	if ok, err := deploymentsSAC.ReadAllowed(ctx); err != nil {
 		return nil, err
 	} else if !ok {
 		return ds.SearchRawDeployments(ctx, pkgSearch.NewQueryBuilder().AddDocIDs(ids...).ProtoQuery())
 	}
 
-	deployments, _, err = ds.deploymentStore.GetMany(ctx, ids)
+	storedDeployments, _, err := ds.deploymentStore.GetMany(ctx, ids)
 	if err != nil {
 		return nil, err
+	}
+	deployments := make([]*storage.Deployment, 0, len(storedDeployments))
+	for _, sd := range storedDeployments {
+		deployments = append(deployments, storeTypes.FromStoredDeployment(sd))
 	}
 	ds.updateDeploymentPriority(deployments...)
 	return deployments, nil
@@ -254,7 +258,8 @@ func (ds *datastoreImpl) CountDeployments(ctx context.Context) (int, error) {
 }
 
 func (ds *datastoreImpl) WalkByQuery(ctx context.Context, query *v1.Query, fn func(deployment *storage.Deployment) error) error {
-	wrappedFn := func(deployment *storage.Deployment) error {
+	wrappedFn := func(storedDeployment *storage.StoredDeployment) error {
+		deployment := storeTypes.FromStoredDeployment(storedDeployment)
 		ds.updateDeploymentPriority(deployment)
 		return fn(deployment)
 	}
@@ -284,13 +289,14 @@ func (ds *datastoreImpl) mergeCronJobs(ctx context.Context, deployment *storage.
 	if allImagesAreSpecifiedByDigest(deployment) {
 		return nil
 	}
-	oldDeployment, exists, err := ds.deploymentStore.Get(ctx, deployment.GetId())
+	storedOldDeployment, exists, err := ds.deploymentStore.Get(ctx, deployment.GetId())
 	if err != nil {
 		return err
 	}
 	if !exists {
 		return nil
 	}
+	oldDeployment := storeTypes.FromStoredDeployment(storedOldDeployment)
 	// Major changes to spec, just upsert
 	if len(oldDeployment.GetContainers()) != len(deployment.GetContainers()) {
 		return nil
@@ -345,7 +351,7 @@ func (ds *datastoreImpl) upsertDeployment(ctx context.Context, deployment *stora
 		deployment.PlatformComponent = match
 	}
 
-	if err := ds.deploymentStore.Upsert(ctx, deployment); err != nil {
+	if err := ds.deploymentStore.Upsert(ctx, storeTypes.ToStoredDeployment(deployment)); err != nil {
 		return errors.Wrapf(err, "inserting deployment '%s' to store", deployment.GetId())
 	}
 	return nil

--- a/central/deployment/datastore/datastore_impl_test.go
+++ b/central/deployment/datastore/datastore_impl_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	storeMocks "github.com/stackrox/rox/central/deployment/datastore/internal/store/mocks"
+	storeTypes "github.com/stackrox/rox/central/deployment/datastore/internal/store/types"
 	matcherMocks "github.com/stackrox/rox/central/platform/matcher/mocks"
 	"github.com/stackrox/rox/central/ranking"
 	riskMocks "github.com/stackrox/rox/central/risk/datastore/mocks"
@@ -59,7 +60,7 @@ func (suite *DeploymentDataStoreTestSuite) TestInitializeRanker() {
 
 	ds := newDatastoreImpl(suite.storage, nil, nil, nil, nil, suite.riskStore, nil, suite.filter, clusterRanker, nsRanker, deploymentRanker, suite.matcher)
 
-	deployments := []*storage.Deployment{
+	storedDeployments := []*storage.StoredDeployment{
 		{
 			Id:          "1",
 			RiskScore:   float32(1.0),
@@ -84,7 +85,7 @@ func (suite *DeploymentDataStoreTestSuite) TestInitializeRanker() {
 			Id: "5",
 		},
 	}
-	suite.storage.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(walkMockFunc(deployments))
+	suite.storage.EXPECT().WalkByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(walkMockFunc(storedDeployments))
 	ds.initializeRanker()
 
 	suite.Equal(int64(1), clusterRanker.GetRankForID("c1"))
@@ -98,8 +99,8 @@ func (suite *DeploymentDataStoreTestSuite) TestInitializeRanker() {
 	suite.Equal(int64(3), deploymentRanker.GetRankForID("3"))
 }
 
-func walkMockFunc(deployments []*storage.Deployment) func(_ context.Context, _ *v1.Query, fn func(group *storage.Deployment) error) error {
-	return func(_ context.Context, _ *v1.Query, fn func(deployment *storage.Deployment) error) error {
+func walkMockFunc(deployments []*storage.StoredDeployment) func(_ context.Context, _ *v1.Query, fn func(group *storage.StoredDeployment) error) error {
+	return func(_ context.Context, _ *v1.Query, fn func(deployment *storage.StoredDeployment) error) error {
 		for _, g := range deployments {
 			if err := fn(g); err != nil {
 				return err
@@ -151,7 +152,7 @@ func (suite *DeploymentDataStoreTestSuite) TestMergeCronJobs() {
 	returnedDep := dep.CloneVT()
 	returnedDep.Containers = returnedDep.GetContainers()[:1]
 
-	suite.storage.EXPECT().Get(ctx, "id").Return(returnedDep, true, nil)
+	suite.storage.EXPECT().Get(ctx, "id").Return(storeTypes.ToStoredDeployment(returnedDep), true, nil)
 	suite.NoError(ds.mergeCronJobs(ctx, dep))
 	protoassert.Equal(suite.T(), expectedDep, dep)
 
@@ -161,7 +162,7 @@ func (suite *DeploymentDataStoreTestSuite) TestMergeCronJobs() {
 	returnedDep.Containers[1].Image.Name = &storage.ImageName{
 		FullName: "fullname",
 	}
-	suite.storage.EXPECT().Get(ctx, "id").Return(returnedDep, true, nil)
+	suite.storage.EXPECT().Get(ctx, "id").Return(storeTypes.ToStoredDeployment(returnedDep), true, nil)
 	suite.NoError(ds.mergeCronJobs(ctx, dep))
 	protoassert.Equal(suite.T(), expectedDep, dep)
 
@@ -169,7 +170,7 @@ func (suite *DeploymentDataStoreTestSuite) TestMergeCronJobs() {
 	dep.Containers[1].Image.Name = returnedDep.GetContainers()[1].GetImage().GetName()
 	expectedDep.Containers[1].Image.Name = returnedDep.GetContainers()[1].GetImage().GetName()
 	expectedDep.Containers[1].Image.Id = "xyz"
-	suite.storage.EXPECT().Get(ctx, "id").Return(returnedDep, true, nil)
+	suite.storage.EXPECT().Get(ctx, "id").Return(storeTypes.ToStoredDeployment(returnedDep), true, nil)
 	suite.NoError(ds.mergeCronJobs(ctx, dep))
 	if features.FlattenImageData.Enabled() {
 		expectedDep.GetContainers()[1].GetImage().IdV2 = utils.NewImageV2ID(expectedDep.GetContainers()[1].GetImage().GetName(), expectedDep.GetContainers()[1].GetImage().GetId())
@@ -192,30 +193,22 @@ func (suite *DeploymentDataStoreTestSuite) TestUpsert_PlatformComponentAssignmen
 		Id:        "id",
 		Namespace: "my-namespace",
 	}
-	expectedDeployment := &storage.Deployment{
-		Id:                "id",
-		Namespace:         "my-namespace",
-		PlatformComponent: false,
-	}
 
-	suite.storage.EXPECT().Upsert(gomock.Any(), expectedDeployment).Return(nil).Times(1)
+	suite.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	suite.matcher.EXPECT().MatchDeployment(deployment).Return(false, nil).Times(1)
 	err := ds.UpsertDeployment(ctx, deployment)
 	suite.Require().NoError(err)
+	suite.False(deployment.GetPlatformComponent())
 
 	// Case: Deployment matching platform rules
 	deployment = &storage.Deployment{
 		Id:        "id",
 		Namespace: "kube-123",
 	}
-	expectedDeployment = &storage.Deployment{
-		Id:                "id",
-		Namespace:         "kube-123",
-		PlatformComponent: true,
-	}
 
-	suite.storage.EXPECT().Upsert(gomock.Any(), expectedDeployment).Return(nil).Times(1)
+	suite.storage.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	suite.matcher.EXPECT().MatchDeployment(deployment).Return(true, nil).Times(1)
 	err = ds.UpsertDeployment(ctx, deployment)
 	suite.Require().NoError(err)
+	suite.True(deployment.GetPlatformComponent())
 }

--- a/central/deployment/datastore/internal/store/mocks/store.go
+++ b/central/deployment/datastore/internal/store/mocks/store.go
@@ -74,10 +74,10 @@ func (mr *MockStoreMockRecorder) Delete(ctx, id any) *gomock.Call {
 }
 
 // Get mocks base method.
-func (m *MockStore) Get(ctx context.Context, id string) (*storage.Deployment, bool, error) {
+func (m *MockStore) Get(ctx context.Context, id string) (*storage.StoredDeployment, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", ctx, id)
-	ret0, _ := ret[0].(*storage.Deployment)
+	ret0, _ := ret[0].(*storage.StoredDeployment)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -136,10 +136,10 @@ func (mr *MockStoreMockRecorder) GetListDeployment(ctx, id any) *gomock.Call {
 }
 
 // GetMany mocks base method.
-func (m *MockStore) GetMany(ctx context.Context, ids []string) ([]*storage.Deployment, []int, error) {
+func (m *MockStore) GetMany(ctx context.Context, ids []string) ([]*storage.StoredDeployment, []int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMany", ctx, ids)
-	ret0, _ := ret[0].([]*storage.Deployment)
+	ret0, _ := ret[0].([]*storage.StoredDeployment)
 	ret1, _ := ret[1].([]int)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -203,7 +203,7 @@ func (mr *MockStoreMockRecorder) SearchListDeployments(ctx, q any) *gomock.Call 
 }
 
 // Upsert mocks base method.
-func (m *MockStore) Upsert(ctx context.Context, deployment *storage.Deployment) error {
+func (m *MockStore) Upsert(ctx context.Context, deployment *storage.StoredDeployment) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Upsert", ctx, deployment)
 	ret0, _ := ret[0].(error)
@@ -217,7 +217,7 @@ func (mr *MockStoreMockRecorder) Upsert(ctx, deployment any) *gomock.Call {
 }
 
 // Walk mocks base method.
-func (m *MockStore) Walk(ctx context.Context, fn func(*storage.Deployment) error) error {
+func (m *MockStore) Walk(ctx context.Context, fn func(*storage.StoredDeployment) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Walk", ctx, fn)
 	ret0, _ := ret[0].(error)
@@ -231,7 +231,7 @@ func (mr *MockStoreMockRecorder) Walk(ctx, fn any) *gomock.Call {
 }
 
 // WalkByQuery mocks base method.
-func (m *MockStore) WalkByQuery(ctx context.Context, query *v1.Query, fn func(*storage.Deployment) error) error {
+func (m *MockStore) WalkByQuery(ctx context.Context, query *v1.Query, fn func(*storage.StoredDeployment) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WalkByQuery", ctx, query, fn)
 	ret0, _ := ret[0].(error)

--- a/central/deployment/datastore/internal/store/postgres/full_store_test.go
+++ b/central/deployment/datastore/internal/store/postgres/full_store_test.go
@@ -21,7 +21,7 @@ func TestGetListDeployment(t *testing.T) {
 	testDB := pgtest.ForT(t)
 	fullStore := NewFullStore(testDB.DB)
 
-	dep := &storage.Deployment{
+	dep := &storage.StoredDeployment{
 		Id:          uuid.NewV4().String(),
 		Hash:        1234567890,
 		Name:        "test-deployment",
@@ -62,7 +62,7 @@ func TestGetManyListDeployments(t *testing.T) {
 	fullStore := NewFullStore(testDB.DB)
 
 	// Create test deployments
-	dep1 := &storage.Deployment{
+	dep1 := &storage.StoredDeployment{
 		Id:          uuid.NewV4().String(),
 		Hash:        1111111111,
 		Name:        "deployment-1",
@@ -71,7 +71,7 @@ func TestGetManyListDeployments(t *testing.T) {
 		Namespace:   "namespace-1",
 		NamespaceId: "cluster-1namespace-1",
 	}
-	dep2 := &storage.Deployment{
+	dep2 := &storage.StoredDeployment{
 		Id:          uuid.NewV4().String(),
 		Hash:        2222222222,
 		Name:        "deployment-2",
@@ -80,7 +80,7 @@ func TestGetManyListDeployments(t *testing.T) {
 		Namespace:   "namespace-2",
 		NamespaceId: "cluster-1namespace-2",
 	}
-	dep3 := &storage.Deployment{
+	dep3 := &storage.StoredDeployment{
 		Id:          uuid.NewV4().String(),
 		Hash:        3333333333,
 		Name:        "deployment-3",

--- a/central/deployment/datastore/internal/store/postgres/gen.go
+++ b/central/deployment/datastore/internal/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.Deployment --cached-store --search-category DEPLOYMENTS --references=storage.Image,namespaces:storage.NamespaceMetadata,imagesV2:storage.ImageV2 --search-scope IMAGE_VULNERABILITIES_V2,IMAGE_COMPONENTS_V2,IMAGES,IMAGES_V2,DEPLOYMENTS,NAMESPACES,CLUSTERS,PROCESS_INDICATORS,PODS --default-sort search.DeploymentPriority.String() --transform-sort-options DeploymentsSchema.OptionsMap
+//go:generate pg-table-bindings-wrapper --type=storage.StoredDeployment --table=deployments --cached-store --search-category DEPLOYMENTS --references=storage.Image,namespaces:storage.NamespaceMetadata,imagesV2:storage.ImageV2 --search-scope IMAGE_VULNERABILITIES_V2,IMAGE_COMPONENTS_V2,IMAGES,IMAGES_V2,DEPLOYMENTS,NAMESPACES,CLUSTERS,PROCESS_INDICATORS,PODS --default-sort search.DeploymentPriority.String() --transform-sort-options DeploymentsSchema.OptionsMap

--- a/central/deployment/datastore/internal/store/postgres/store.go
+++ b/central/deployment/datastore/internal/store/postgres/store.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	baseTable = "deployments"
-	storeName = "Deployment"
+	storeName = "StoredDeployment"
 )
 
 var (
@@ -36,11 +36,11 @@ var (
 )
 
 type (
-	storeType = storage.Deployment
+	storeType = storage.StoredDeployment
 	callback  = func(obj *storeType) error
 )
 
-// Store is the interface to interact with the storage for storage.Deployment
+// Store is the interface to interact with the storage for storage.StoredDeployment
 type Store interface {
 	Upsert(ctx context.Context, obj *storeType) error
 	UpsertMany(ctx context.Context, objs []*storeType) error
@@ -117,12 +117,12 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 		}
 	}
 	if len(deniedIDs) != 0 {
-		return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying deployments with IDs [%s] was denied", strings.Join(deniedIDs, ", "))
+		return errors.Wrapf(sac.ErrResourceAccessDenied, "modifying storedDeployments with IDs [%s] was denied", strings.Join(deniedIDs, ", "))
 	}
 	return nil
 }
 
-func insertIntoDeployments(batch *pgx.Batch, obj *storage.Deployment) error {
+func insertIntoDeployments(batch *pgx.Batch, obj *storage.StoredDeployment) error {
 
 	serialized, marshalErr := obj.MarshalVT()
 	if marshalErr != nil {
@@ -177,7 +177,7 @@ func insertIntoDeployments(batch *pgx.Batch, obj *storage.Deployment) error {
 	return nil
 }
 
-func insertIntoDeploymentsContainers(batch *pgx.Batch, obj *storage.Container, deploymentID string, idx int) error {
+func insertIntoDeploymentsContainers(batch *pgx.Batch, obj *storage.StoredContainer, deploymentID string, idx int) error {
 
 	values := []interface{}{
 		// parent primary keys start
@@ -197,9 +197,10 @@ func insertIntoDeploymentsContainers(batch *pgx.Batch, obj *storage.Container, d
 		obj.GetResources().GetCpuCoresLimit(),
 		obj.GetResources().GetMemoryMbRequest(),
 		obj.GetResources().GetMemoryMbLimit(),
+		obj.GetContainerType(),
 	}
 
-	finalStr := "INSERT INTO deployments_containers (deployments_Id, idx, Image_Id, Image_Name_Registry, Image_Name_Remote, Image_Name_Tag, Image_Name_FullName, Image_IdV2, SecurityContext_Privileged, SecurityContext_DropCapabilities, SecurityContext_AddCapabilities, SecurityContext_ReadOnlyRootFilesystem, Resources_CpuCoresRequest, Resources_CpuCoresLimit, Resources_MemoryMbRequest, Resources_MemoryMbLimit) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) ON CONFLICT(deployments_Id, idx) DO UPDATE SET deployments_Id = EXCLUDED.deployments_Id, idx = EXCLUDED.idx, Image_Id = EXCLUDED.Image_Id, Image_Name_Registry = EXCLUDED.Image_Name_Registry, Image_Name_Remote = EXCLUDED.Image_Name_Remote, Image_Name_Tag = EXCLUDED.Image_Name_Tag, Image_Name_FullName = EXCLUDED.Image_Name_FullName, Image_IdV2 = EXCLUDED.Image_IdV2, SecurityContext_Privileged = EXCLUDED.SecurityContext_Privileged, SecurityContext_DropCapabilities = EXCLUDED.SecurityContext_DropCapabilities, SecurityContext_AddCapabilities = EXCLUDED.SecurityContext_AddCapabilities, SecurityContext_ReadOnlyRootFilesystem = EXCLUDED.SecurityContext_ReadOnlyRootFilesystem, Resources_CpuCoresRequest = EXCLUDED.Resources_CpuCoresRequest, Resources_CpuCoresLimit = EXCLUDED.Resources_CpuCoresLimit, Resources_MemoryMbRequest = EXCLUDED.Resources_MemoryMbRequest, Resources_MemoryMbLimit = EXCLUDED.Resources_MemoryMbLimit"
+	finalStr := "INSERT INTO deployments_containers (deployments_Id, idx, Image_Id, Image_Name_Registry, Image_Name_Remote, Image_Name_Tag, Image_Name_FullName, Image_IdV2, SecurityContext_Privileged, SecurityContext_DropCapabilities, SecurityContext_AddCapabilities, SecurityContext_ReadOnlyRootFilesystem, Resources_CpuCoresRequest, Resources_CpuCoresLimit, Resources_MemoryMbRequest, Resources_MemoryMbLimit, ContainerType) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) ON CONFLICT(deployments_Id, idx) DO UPDATE SET deployments_Id = EXCLUDED.deployments_Id, idx = EXCLUDED.idx, Image_Id = EXCLUDED.Image_Id, Image_Name_Registry = EXCLUDED.Image_Name_Registry, Image_Name_Remote = EXCLUDED.Image_Name_Remote, Image_Name_Tag = EXCLUDED.Image_Name_Tag, Image_Name_FullName = EXCLUDED.Image_Name_FullName, Image_IdV2 = EXCLUDED.Image_IdV2, SecurityContext_Privileged = EXCLUDED.SecurityContext_Privileged, SecurityContext_DropCapabilities = EXCLUDED.SecurityContext_DropCapabilities, SecurityContext_AddCapabilities = EXCLUDED.SecurityContext_AddCapabilities, SecurityContext_ReadOnlyRootFilesystem = EXCLUDED.SecurityContext_ReadOnlyRootFilesystem, Resources_CpuCoresRequest = EXCLUDED.Resources_CpuCoresRequest, Resources_CpuCoresLimit = EXCLUDED.Resources_CpuCoresLimit, Resources_MemoryMbRequest = EXCLUDED.Resources_MemoryMbRequest, Resources_MemoryMbLimit = EXCLUDED.Resources_MemoryMbLimit, ContainerType = EXCLUDED.ContainerType"
 	batch.Queue(finalStr, values...)
 
 	var query string
@@ -357,7 +358,7 @@ var copyColsDeployments = []string{
 	"serialized",
 }
 
-func copyFromDeployments(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.Deployment) error {
+func copyFromDeployments(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, objs ...*storage.StoredDeployment) error {
 	if len(objs) == 0 {
 		return nil
 	}
@@ -444,9 +445,10 @@ var copyColsDeploymentsContainers = []string{
 	"resources_cpucoreslimit",
 	"resources_memorymbrequest",
 	"resources_memorymblimit",
+	"containertype",
 }
 
-func copyFromDeploymentsContainers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, deploymentID string, objs ...*storage.Container) error {
+func copyFromDeploymentsContainers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, deploymentID string, objs ...*storage.StoredContainer) error {
 	if len(objs) == 0 {
 		return nil
 	}
@@ -476,6 +478,7 @@ func copyFromDeploymentsContainers(ctx context.Context, s pgSearch.Deleter, tx *
 			obj.GetResources().GetCpuCoresLimit(),
 			obj.GetResources().GetMemoryMbRequest(),
 			obj.GetResources().GetMemoryMbLimit(),
+			obj.GetContainerType(),
 		}, nil
 	})
 

--- a/central/deployment/datastore/internal/store/postgres/store_test.go
+++ b/central/deployment/datastore/internal/store/postgres/store_test.go
@@ -49,67 +49,67 @@ func (s *DeploymentsStoreSuite) TestStore() {
 
 	store := s.store
 
-	deployment := &storage.Deployment{}
-	s.NoError(testutils.FullInit(deployment, testutils.SimpleInitializer(), testutils.JSONFieldsFilter))
+	storedDeployment := &storage.StoredDeployment{}
+	s.NoError(testutils.FullInit(storedDeployment, testutils.SimpleInitializer(), testutils.JSONFieldsFilter))
 
-	foundDeployment, exists, err := store.Get(ctx, deployment.GetId())
+	foundStoredDeployment, exists, err := store.Get(ctx, storedDeployment.GetId())
 	s.NoError(err)
 	s.False(exists)
-	s.Nil(foundDeployment)
+	s.Nil(foundStoredDeployment)
 
 	withNoAccessCtx := sac.WithNoAccess(ctx)
 
-	s.NoError(store.Upsert(ctx, deployment))
-	foundDeployment, exists, err = store.Get(ctx, deployment.GetId())
+	s.NoError(store.Upsert(ctx, storedDeployment))
+	foundStoredDeployment, exists, err = store.Get(ctx, storedDeployment.GetId())
 	s.NoError(err)
 	s.True(exists)
-	protoassert.Equal(s.T(), deployment, foundDeployment)
+	protoassert.Equal(s.T(), storedDeployment, foundStoredDeployment)
 
-	deploymentCount, err := store.Count(ctx, search.EmptyQuery())
+	storedDeploymentCount, err := store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
-	s.Equal(1, deploymentCount)
-	deploymentCount, err = store.Count(withNoAccessCtx, search.EmptyQuery())
+	s.Equal(1, storedDeploymentCount)
+	storedDeploymentCount, err = store.Count(withNoAccessCtx, search.EmptyQuery())
 	s.NoError(err)
-	s.Zero(deploymentCount)
+	s.Zero(storedDeploymentCount)
 
-	deploymentExists, err := store.Exists(ctx, deployment.GetId())
+	storedDeploymentExists, err := store.Exists(ctx, storedDeployment.GetId())
 	s.NoError(err)
-	s.True(deploymentExists)
-	s.NoError(store.Upsert(ctx, deployment))
-	s.ErrorIs(store.Upsert(withNoAccessCtx, deployment), sac.ErrResourceAccessDenied)
+	s.True(storedDeploymentExists)
+	s.NoError(store.Upsert(ctx, storedDeployment))
+	s.ErrorIs(store.Upsert(withNoAccessCtx, storedDeployment), sac.ErrResourceAccessDenied)
 
-	s.NoError(store.Delete(ctx, deployment.GetId()))
-	foundDeployment, exists, err = store.Get(ctx, deployment.GetId())
+	s.NoError(store.Delete(ctx, storedDeployment.GetId()))
+	foundStoredDeployment, exists, err = store.Get(ctx, storedDeployment.GetId())
 	s.NoError(err)
 	s.False(exists)
-	s.Nil(foundDeployment)
-	s.NoError(store.Delete(withNoAccessCtx, deployment.GetId()))
+	s.Nil(foundStoredDeployment)
+	s.NoError(store.Delete(withNoAccessCtx, storedDeployment.GetId()))
 
-	var deployments []*storage.Deployment
-	var deploymentIDs []string
+	var storedDeployments []*storage.StoredDeployment
+	var storedDeploymentIDs []string
 	for i := 0; i < 200; i++ {
-		deployment := &storage.Deployment{}
-		s.NoError(testutils.FullInit(deployment, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
-		deployments = append(deployments, deployment)
-		deploymentIDs = append(deploymentIDs, deployment.GetId())
+		storedDeployment := &storage.StoredDeployment{}
+		s.NoError(testutils.FullInit(storedDeployment, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
+		storedDeployments = append(storedDeployments, storedDeployment)
+		storedDeploymentIDs = append(storedDeploymentIDs, storedDeployment.GetId())
 	}
 
-	s.NoError(store.UpsertMany(ctx, deployments))
+	s.NoError(store.UpsertMany(ctx, storedDeployments))
 
-	foundDeployments, missing, err := store.GetMany(ctx, deploymentIDs)
+	foundStoredDeployments, missing, err := store.GetMany(ctx, storedDeploymentIDs)
 	s.NoError(err)
 	s.Empty(missing)
-	protoassert.ElementsMatch(s.T(), deployments, foundDeployments)
+	protoassert.ElementsMatch(s.T(), storedDeployments, foundStoredDeployments)
 
-	deploymentCount, err = store.Count(ctx, search.EmptyQuery())
+	storedDeploymentCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
-	s.Equal(200, deploymentCount)
+	s.Equal(200, storedDeploymentCount)
 
-	s.NoError(store.DeleteMany(ctx, deploymentIDs))
+	s.NoError(store.DeleteMany(ctx, storedDeploymentIDs))
 
-	deploymentCount, err = store.Count(ctx, search.EmptyQuery())
+	storedDeploymentCount, err = store.Count(ctx, search.EmptyQuery())
 	s.NoError(err)
-	s.Equal(0, deploymentCount)
+	s.Equal(0, storedDeploymentCount)
 }
 
 const (
@@ -131,15 +131,15 @@ type testCase struct {
 	expectedObjIDs         []string
 	expectedIdentifiers    []string
 	expectedMissingIndices []int
-	expectedObjects        []*storage.Deployment
+	expectedObjects        []*storage.StoredDeployment
 	expectedWriteError     error
 }
 
-func (s *DeploymentsStoreSuite) getTestData(access ...storage.Access) (*storage.Deployment, *storage.Deployment, map[string]testCase) {
-	objA := &storage.Deployment{}
+func (s *DeploymentsStoreSuite) getTestData(access ...storage.Access) (*storage.StoredDeployment, *storage.StoredDeployment, map[string]testCase) {
+	objA := &storage.StoredDeployment{}
 	s.NoError(testutils.FullInit(objA, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
-	objB := &storage.Deployment{}
+	objB := &storage.StoredDeployment{}
 	s.NoError(testutils.FullInit(objB, testutils.UniqueInitializer(), testutils.JSONFieldsFilter))
 
 	testCases := map[string]testCase{
@@ -148,7 +148,7 @@ func (s *DeploymentsStoreSuite) getTestData(access ...storage.Access) (*storage.
 			expectedObjIDs:         []string{objA.GetId(), objB.GetId()},
 			expectedIdentifiers:    []string{objA.GetId(), objB.GetId()},
 			expectedMissingIndices: []int{},
-			expectedObjects:        []*storage.Deployment{objA, objB},
+			expectedObjects:        []*storage.StoredDeployment{objA, objB},
 			expectedWriteError:     nil,
 		},
 		withNoAccess: {
@@ -156,7 +156,7 @@ func (s *DeploymentsStoreSuite) getTestData(access ...storage.Access) (*storage.
 			expectedObjIDs:         []string{},
 			expectedIdentifiers:    []string{},
 			expectedMissingIndices: []int{0, 1},
-			expectedObjects:        []*storage.Deployment{},
+			expectedObjects:        []*storage.StoredDeployment{},
 			expectedWriteError:     sac.ErrResourceAccessDenied,
 		},
 		withNoAccessToCluster: {
@@ -169,7 +169,7 @@ func (s *DeploymentsStoreSuite) getTestData(access ...storage.Access) (*storage.
 			expectedObjIDs:         []string{},
 			expectedIdentifiers:    []string{},
 			expectedMissingIndices: []int{0, 1},
-			expectedObjects:        []*storage.Deployment{},
+			expectedObjects:        []*storage.StoredDeployment{},
 			expectedWriteError:     sac.ErrResourceAccessDenied,
 		},
 		withAccess: {
@@ -183,7 +183,7 @@ func (s *DeploymentsStoreSuite) getTestData(access ...storage.Access) (*storage.
 			expectedObjIDs:         []string{objA.GetId()},
 			expectedIdentifiers:    []string{objA.GetId()},
 			expectedMissingIndices: []int{1},
-			expectedObjects:        []*storage.Deployment{objA},
+			expectedObjects:        []*storage.StoredDeployment{objA},
 			expectedWriteError:     nil,
 		},
 		withAccessToCluster: {
@@ -196,7 +196,7 @@ func (s *DeploymentsStoreSuite) getTestData(access ...storage.Access) (*storage.
 			expectedObjIDs:         []string{objA.GetId()},
 			expectedIdentifiers:    []string{objA.GetId()},
 			expectedMissingIndices: []int{1},
-			expectedObjects:        []*storage.Deployment{objA},
+			expectedObjects:        []*storage.StoredDeployment{objA},
 			expectedWriteError:     nil,
 		},
 		withAccessToDifferentCluster: {
@@ -209,7 +209,7 @@ func (s *DeploymentsStoreSuite) getTestData(access ...storage.Access) (*storage.
 			expectedObjIDs:         []string{},
 			expectedIdentifiers:    []string{},
 			expectedMissingIndices: []int{0, 1},
-			expectedObjects:        []*storage.Deployment{},
+			expectedObjects:        []*storage.StoredDeployment{},
 			expectedWriteError:     sac.ErrResourceAccessDenied,
 		},
 		withAccessToDifferentNs: {
@@ -223,7 +223,7 @@ func (s *DeploymentsStoreSuite) getTestData(access ...storage.Access) (*storage.
 			expectedObjIDs:         []string{},
 			expectedIdentifiers:    []string{},
 			expectedMissingIndices: []int{0, 1},
-			expectedObjects:        []*storage.Deployment{},
+			expectedObjects:        []*storage.StoredDeployment{},
 			expectedWriteError:     sac.ErrResourceAccessDenied,
 		},
 	}
@@ -244,7 +244,7 @@ func (s *DeploymentsStoreSuite) TestSACUpsertMany() {
 	obj, _, testCases := s.getTestData(storage.Access_READ_WRITE_ACCESS)
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
-			assert.ErrorIs(t, s.store.UpsertMany(testCase.context, []*storage.Deployment{obj}), testCase.expectedWriteError)
+			assert.ErrorIs(t, s.store.UpsertMany(testCase.context, []*storage.StoredDeployment{obj}), testCase.expectedWriteError)
 		})
 	}
 }
@@ -272,7 +272,7 @@ func (s *DeploymentsStoreSuite) TestSACWalk() {
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers := []string{}
-			getIDs := func(obj *storage.Deployment) error {
+			getIDs := func(obj *storage.StoredDeployment) error {
 				identifiers = append(identifiers, obj.GetId())
 				return nil
 			}
@@ -291,7 +291,7 @@ func (s *DeploymentsStoreSuite) TestSACGetByQueryFn() {
 	for name, testCase := range testCases {
 		s.T().Run(fmt.Sprintf("with %s", name), func(t *testing.T) {
 			identifiers := []string{}
-			getIDs := func(obj *storage.Deployment) error {
+			getIDs := func(obj *storage.StoredDeployment) error {
 				identifiers = append(identifiers, obj.GetId())
 				return nil
 			}

--- a/central/deployment/datastore/internal/store/store.go
+++ b/central/deployment/datastore/internal/store/store.go
@@ -17,14 +17,14 @@ type Store interface {
 	GetManyListDeployments(ctx context.Context, ids ...string) ([]*storage.ListDeployment, []int, error)
 	SearchListDeployments(ctx context.Context, q *v1.Query) ([]*storage.ListDeployment, error)
 
-	Get(ctx context.Context, id string) (*storage.Deployment, bool, error)
-	GetMany(ctx context.Context, ids []string) ([]*storage.Deployment, []int, error)
-	Walk(ctx context.Context, fn func(deployment *storage.Deployment) error) error
-	WalkByQuery(ctx context.Context, query *v1.Query, fn func(deployment *storage.Deployment) error) error
+	Get(ctx context.Context, id string) (*storage.StoredDeployment, bool, error)
+	GetMany(ctx context.Context, ids []string) ([]*storage.StoredDeployment, []int, error)
+	Walk(ctx context.Context, fn func(deployment *storage.StoredDeployment) error) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn func(deployment *storage.StoredDeployment) error) error
 
 	Count(ctx context.Context, q *v1.Query) (int, error)
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
-	Upsert(ctx context.Context, deployment *storage.Deployment) error
+	Upsert(ctx context.Context, deployment *storage.StoredDeployment) error
 	Delete(ctx context.Context, id string) error
 
 	GetIDs(ctx context.Context) ([]string, error)

--- a/central/deployment/datastore/internal/store/types/convert.go
+++ b/central/deployment/datastore/internal/store/types/convert.go
@@ -1,0 +1,183 @@
+package types
+
+import "github.com/stackrox/rox/generated/storage"
+
+// ToStoredDeployment converts a storage.Deployment (API type) to a storage.StoredDeployment (storage type).
+// It merges containers, init_containers, and ephemeral_containers into a single containers list
+// with ContainerType set on each StoredContainer.
+func ToStoredDeployment(d *storage.Deployment) *storage.StoredDeployment {
+	if d == nil {
+		return nil
+	}
+
+	sd := &storage.StoredDeployment{
+		Id:                            d.GetId(),
+		Name:                          d.GetName(),
+		Hash:                          d.GetHash(),
+		Type:                          d.GetType(),
+		Namespace:                     d.GetNamespace(),
+		NamespaceId:                   d.GetNamespaceId(),
+		OrchestratorComponent:         d.GetOrchestratorComponent(),
+		Replicas:                      d.GetReplicas(),
+		Labels:                        d.GetLabels(),
+		PodLabels:                     d.GetPodLabels(),
+		LabelSelector:                 d.GetLabelSelector(),
+		Created:                       d.GetCreated(),
+		ClusterId:                     d.GetClusterId(),
+		ClusterName:                   d.GetClusterName(),
+		Annotations:                   d.GetAnnotations(),
+		Priority:                      d.GetPriority(),
+		Inactive:                      d.GetInactive(),
+		ImagePullSecrets:              d.GetImagePullSecrets(),
+		ServiceAccount:                d.GetServiceAccount(),
+		ServiceAccountPermissionLevel: d.GetServiceAccountPermissionLevel(),
+		AutomountServiceAccountToken:  d.GetAutomountServiceAccountToken(),
+		HostNetwork:                   d.GetHostNetwork(),
+		HostPid:                       d.GetHostPid(),
+		HostIpc:                       d.GetHostIpc(),
+		RuntimeClass:                  d.GetRuntimeClass(),
+		Tolerations:                   d.GetTolerations(),
+		Ports:                         d.GetPorts(),
+		StateTimestamp:                d.GetStateTimestamp(),
+		RiskScore:                     d.GetRiskScore(),
+		PlatformComponent:             d.GetPlatformComponent(),
+	}
+
+	// Merge all container types into a single list with ContainerType set.
+	var containers []*storage.StoredContainer
+	for _, c := range d.GetContainers() {
+		containers = append(containers, toStoredContainer(c, storage.ContainerType_STANDARD))
+	}
+	for _, c := range d.GetInitContainers() {
+		containers = append(containers, toStoredContainer(c, storage.ContainerType_INIT))
+	}
+	for _, c := range d.GetEphemeralContainers() {
+		containers = append(containers, toStoredContainer(c, storage.ContainerType_EPHEMERAL))
+	}
+	sd.Containers = containers
+
+	return sd
+}
+
+// FromStoredDeployment converts a storage.StoredDeployment (storage type) to a storage.Deployment (API type).
+// It splits the single containers list by ContainerType into containers, init_containers, and ephemeral_containers.
+func FromStoredDeployment(sd *storage.StoredDeployment) *storage.Deployment {
+	if sd == nil {
+		return nil
+	}
+
+	d := &storage.Deployment{
+		Id:                            sd.GetId(),
+		Name:                          sd.GetName(),
+		Hash:                          sd.GetHash(),
+		Type:                          sd.GetType(),
+		Namespace:                     sd.GetNamespace(),
+		NamespaceId:                   sd.GetNamespaceId(),
+		OrchestratorComponent:         sd.GetOrchestratorComponent(),
+		Replicas:                      sd.GetReplicas(),
+		Labels:                        sd.GetLabels(),
+		PodLabels:                     sd.GetPodLabels(),
+		LabelSelector:                 sd.GetLabelSelector(),
+		Created:                       sd.GetCreated(),
+		ClusterId:                     sd.GetClusterId(),
+		ClusterName:                   sd.GetClusterName(),
+		Annotations:                   sd.GetAnnotations(),
+		Priority:                      sd.GetPriority(),
+		Inactive:                      sd.GetInactive(),
+		ImagePullSecrets:              sd.GetImagePullSecrets(),
+		ServiceAccount:                sd.GetServiceAccount(),
+		ServiceAccountPermissionLevel: sd.GetServiceAccountPermissionLevel(),
+		AutomountServiceAccountToken:  sd.GetAutomountServiceAccountToken(),
+		HostNetwork:                   sd.GetHostNetwork(),
+		HostPid:                       sd.GetHostPid(),
+		HostIpc:                       sd.GetHostIpc(),
+		RuntimeClass:                  sd.GetRuntimeClass(),
+		Tolerations:                   sd.GetTolerations(),
+		Ports:                         sd.GetPorts(),
+		StateTimestamp:                sd.GetStateTimestamp(),
+		RiskScore:                     sd.GetRiskScore(),
+		PlatformComponent:             sd.GetPlatformComponent(),
+	}
+
+	// Split containers by type.
+	for _, sc := range sd.GetContainers() {
+		c := fromStoredContainer(sc)
+		switch sc.GetContainerType() {
+		case storage.ContainerType_INIT:
+			d.InitContainers = append(d.InitContainers, c)
+		case storage.ContainerType_EPHEMERAL:
+			d.EphemeralContainers = append(d.EphemeralContainers, c)
+		default:
+			// STANDARD and UNSPECIFIED both map to regular containers.
+			// Old data has UNSPECIFIED (0), treated as STANDARD.
+			d.Containers = append(d.Containers, c)
+		}
+	}
+
+	return d
+}
+
+func toStoredContainer(c *storage.Container, ct storage.ContainerType) *storage.StoredContainer {
+	if c == nil {
+		return nil
+	}
+	return &storage.StoredContainer{
+		Id:              c.GetId(),
+		Config:          c.GetConfig(),
+		Image:           toStoredContainerImage(c.GetImage()),
+		SecurityContext: c.GetSecurityContext(),
+		Volumes:         c.GetVolumes(),
+		Ports:           c.GetPorts(),
+		Secrets:         c.GetSecrets(),
+		Resources:       c.GetResources(),
+		Name:            c.GetName(),
+		LivenessProbe:   c.GetLivenessProbe(),
+		ReadinessProbe:  c.GetReadinessProbe(),
+		ContainerType:   ct,
+	}
+}
+
+func fromStoredContainer(sc *storage.StoredContainer) *storage.Container {
+	if sc == nil {
+		return nil
+	}
+	return &storage.Container{
+		Id:              sc.GetId(),
+		Config:          sc.GetConfig(),
+		Image:           fromStoredContainerImage(sc.GetImage()),
+		SecurityContext: sc.GetSecurityContext(),
+		Volumes:         sc.GetVolumes(),
+		Ports:           sc.GetPorts(),
+		Secrets:         sc.GetSecrets(),
+		Resources:       sc.GetResources(),
+		Name:            sc.GetName(),
+		LivenessProbe:   sc.GetLivenessProbe(),
+		ReadinessProbe:  sc.GetReadinessProbe(),
+	}
+}
+
+func toStoredContainerImage(img *storage.ContainerImage) *storage.StoredContainerImage {
+	if img == nil {
+		return nil
+	}
+	return &storage.StoredContainerImage{
+		Id:             img.GetId(),
+		Name:           img.GetName(),
+		NotPullable:    img.GetNotPullable(),
+		IsClusterLocal: img.GetIsClusterLocal(),
+		IdV2:           img.GetIdV2(),
+	}
+}
+
+func fromStoredContainerImage(img *storage.StoredContainerImage) *storage.ContainerImage {
+	if img == nil {
+		return nil
+	}
+	return &storage.ContainerImage{
+		Id:             img.GetId(),
+		Name:           img.GetName(),
+		NotPullable:    img.GetNotPullable(),
+		IsClusterLocal: img.GetIsClusterLocal(),
+		IdV2:           img.GetIdV2(),
+	}
+}

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -578,12 +578,14 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"clusterName: String!",
 		"containers: [Container]!",
 		"created: Time",
+		"ephemeralContainers: [Container]!",
 		"hostIpc: Boolean!",
 		"hostNetwork: Boolean!",
 		"hostPid: Boolean!",
 		"id: ID!",
 		"imagePullSecrets: [String!]!",
 		"inactive: Boolean!",
+		"initContainers: [Container]!",
 		"labelSelector: LabelSelector",
 		"labels: [Label!]!",
 		"name: String!",
@@ -7154,6 +7156,12 @@ func (resolver *deploymentResolver) Created(ctx context.Context) (*graphql.Time,
 	return protocompat.ConvertTimestampToGraphqlTimeOrError(value)
 }
 
+func (resolver *deploymentResolver) EphemeralContainers(ctx context.Context) ([]*containerResolver, error) {
+	resolver.ensureData(ctx)
+	value := resolver.data.GetEphemeralContainers()
+	return resolver.root.wrapContainers(value, nil)
+}
+
 func (resolver *deploymentResolver) HostIpc(ctx context.Context) bool {
 	resolver.ensureData(ctx)
 	value := resolver.data.GetHostIpc()
@@ -7190,6 +7198,12 @@ func (resolver *deploymentResolver) Inactive(ctx context.Context) bool {
 	resolver.ensureData(ctx)
 	value := resolver.data.GetInactive()
 	return value
+}
+
+func (resolver *deploymentResolver) InitContainers(ctx context.Context) ([]*containerResolver, error) {
+	resolver.ensureData(ctx)
+	value := resolver.data.GetInitContainers()
+	return resolver.root.wrapContainers(value, nil)
 }
 
 func (resolver *deploymentResolver) LabelSelector(ctx context.Context) (*labelSelectorResolver, error) {

--- a/generated/api/v1/deployment_service.swagger.json
+++ b/generated/api/v1/deployment_service.swagger.json
@@ -869,9 +869,23 @@
         },
         "platformComponent": {
           "type": "boolean"
+        },
+        "initContainers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/storageContainer"
+          }
+        },
+        "ephemeralContainers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/storageContainer"
+          }
         }
       },
-      "title": "Next available tag: 36"
+      "title": "Next available tag: 38"
     },
     "storageEmbeddedSecret": {
       "type": "object",

--- a/generated/api/v1/detection_service.swagger.json
+++ b/generated/api/v1/detection_service.swagger.json
@@ -957,9 +957,23 @@
         },
         "platformComponent": {
           "type": "boolean"
+        },
+        "initContainers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/storageContainer"
+          }
+        },
+        "ephemeralContainers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/storageContainer"
+          }
         }
       },
-      "title": "Next available tag: 36"
+      "title": "Next available tag: 38"
     },
     "storageEmbeddedSecret": {
       "type": "object",

--- a/generated/api/v1/vuln_mgmt_service.swagger.json
+++ b/generated/api/v1/vuln_mgmt_service.swagger.json
@@ -802,9 +802,23 @@
         },
         "platformComponent": {
           "type": "boolean"
+        },
+        "initContainers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/storageContainer"
+          }
+        },
+        "ephemeralContainers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/storageContainer"
+          }
         }
       },
-      "title": "Next available tag: 36"
+      "title": "Next available tag: 38"
     },
     "storageEPSS": {
       "type": "object",

--- a/generated/storage/deployment.pb.go
+++ b/generated/storage/deployment.pb.go
@@ -22,6 +22,58 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type ContainerType int32
+
+const (
+	ContainerType_CONTAINER_TYPE_UNSPECIFIED ContainerType = 0
+	ContainerType_STANDARD                   ContainerType = 1
+	ContainerType_INIT                       ContainerType = 2
+	ContainerType_EPHEMERAL                  ContainerType = 3
+)
+
+// Enum value maps for ContainerType.
+var (
+	ContainerType_name = map[int32]string{
+		0: "CONTAINER_TYPE_UNSPECIFIED",
+		1: "STANDARD",
+		2: "INIT",
+		3: "EPHEMERAL",
+	}
+	ContainerType_value = map[string]int32{
+		"CONTAINER_TYPE_UNSPECIFIED": 0,
+		"STANDARD":                   1,
+		"INIT":                       2,
+		"EPHEMERAL":                  3,
+	}
+)
+
+func (x ContainerType) Enum() *ContainerType {
+	p := new(ContainerType)
+	*p = x
+	return p
+}
+
+func (x ContainerType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ContainerType) Descriptor() protoreflect.EnumDescriptor {
+	return file_storage_deployment_proto_enumTypes[0].Descriptor()
+}
+
+func (ContainerType) Type() protoreflect.EnumType {
+	return &file_storage_deployment_proto_enumTypes[0]
+}
+
+func (x ContainerType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ContainerType.Descriptor instead.
+func (ContainerType) EnumDescriptor() ([]byte, []int) {
+	return file_storage_deployment_proto_rawDescGZIP(), []int{0}
+}
+
 type Volume_MountPropagation int32
 
 const (
@@ -55,11 +107,11 @@ func (x Volume_MountPropagation) String() string {
 }
 
 func (Volume_MountPropagation) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_deployment_proto_enumTypes[0].Descriptor()
+	return file_storage_deployment_proto_enumTypes[1].Descriptor()
 }
 
 func (Volume_MountPropagation) Type() protoreflect.EnumType {
-	return &file_storage_deployment_proto_enumTypes[0]
+	return &file_storage_deployment_proto_enumTypes[1]
 }
 
 func (x Volume_MountPropagation) Number() protoreflect.EnumNumber {
@@ -68,7 +120,7 @@ func (x Volume_MountPropagation) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Volume_MountPropagation.Descriptor instead.
 func (Volume_MountPropagation) EnumDescriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{4, 0}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{7, 0}
 }
 
 type PortConfig_ExposureLevel int32
@@ -113,11 +165,11 @@ func (x PortConfig_ExposureLevel) String() string {
 }
 
 func (PortConfig_ExposureLevel) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_deployment_proto_enumTypes[1].Descriptor()
+	return file_storage_deployment_proto_enumTypes[2].Descriptor()
 }
 
 func (PortConfig_ExposureLevel) Type() protoreflect.EnumType {
-	return &file_storage_deployment_proto_enumTypes[1]
+	return &file_storage_deployment_proto_enumTypes[2]
 }
 
 func (x PortConfig_ExposureLevel) Number() protoreflect.EnumNumber {
@@ -126,7 +178,7 @@ func (x PortConfig_ExposureLevel) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PortConfig_ExposureLevel.Descriptor instead.
 func (PortConfig_ExposureLevel) EnumDescriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{11, 0}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{14, 0}
 }
 
 // For any update to EnvVarSource, please also update 'ui/src/messages/common.js'
@@ -175,11 +227,11 @@ func (x ContainerConfig_EnvironmentConfig_EnvVarSource) String() string {
 }
 
 func (ContainerConfig_EnvironmentConfig_EnvVarSource) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_deployment_proto_enumTypes[2].Descriptor()
+	return file_storage_deployment_proto_enumTypes[3].Descriptor()
 }
 
 func (ContainerConfig_EnvironmentConfig_EnvVarSource) Type() protoreflect.EnumType {
-	return &file_storage_deployment_proto_enumTypes[2]
+	return &file_storage_deployment_proto_enumTypes[3]
 }
 
 func (x ContainerConfig_EnvironmentConfig_EnvVarSource) Number() protoreflect.EnumNumber {
@@ -188,7 +240,7 @@ func (x ContainerConfig_EnvironmentConfig_EnvVarSource) Number() protoreflect.En
 
 // Deprecated: Use ContainerConfig_EnvironmentConfig_EnvVarSource.Descriptor instead.
 func (ContainerConfig_EnvironmentConfig_EnvVarSource) EnumDescriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{12, 0, 0}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{15, 0, 0}
 }
 
 type SecurityContext_SeccompProfile_ProfileType int32
@@ -224,11 +276,11 @@ func (x SecurityContext_SeccompProfile_ProfileType) String() string {
 }
 
 func (SecurityContext_SeccompProfile_ProfileType) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_deployment_proto_enumTypes[3].Descriptor()
+	return file_storage_deployment_proto_enumTypes[4].Descriptor()
 }
 
 func (SecurityContext_SeccompProfile_ProfileType) Type() protoreflect.EnumType {
-	return &file_storage_deployment_proto_enumTypes[3]
+	return &file_storage_deployment_proto_enumTypes[4]
 }
 
 func (x SecurityContext_SeccompProfile_ProfileType) Number() protoreflect.EnumNumber {
@@ -237,25 +289,25 @@ func (x SecurityContext_SeccompProfile_ProfileType) Number() protoreflect.EnumNu
 
 // Deprecated: Use SecurityContext_SeccompProfile_ProfileType.Descriptor instead.
 func (SecurityContext_SeccompProfile_ProfileType) EnumDescriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{13, 1, 0}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{16, 1, 0}
 }
 
-// Next available tag: 36
+// Next available tag: 38
 type Deployment struct {
 	state                         protoimpl.MessageState `protogen:"open.v1"`
-	Id                            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Deployment ID,hidden" sql:"pk,type(uuid)"`                                                                                                           // @gotags: search:"Deployment ID,hidden" sql:"pk,type(uuid)"
+	Id                            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Deployment ID,hidden"`                                                                                                           // @gotags: search:"Deployment ID,hidden"
 	Name                          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" search:"Deployment"`                                                                                                       // @gotags: search:"Deployment"
 	Hash                          uint64                 `protobuf:"varint,26,opt,name=hash,proto3" json:"hash,omitempty" search:"Deployment Hash,hidden" hash:"ignore" sensorhash:"ignore"`                                                                                                     // @gotags: search:"Deployment Hash,hidden" hash:"ignore" sensorhash:"ignore"
 	Type                          string                 `protobuf:"bytes,4,opt,name=type,proto3" json:"type,omitempty" search:"Deployment Type"`                                                                                                       // @gotags: search:"Deployment Type"
 	Namespace                     string                 `protobuf:"bytes,5,opt,name=namespace,proto3" json:"namespace,omitempty" search:"Namespace"`                                                                                             // @gotags: search:"Namespace"
-	NamespaceId                   string                 `protobuf:"bytes,23,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty" search:"Namespace ID" sql:"fk(NamespaceMetadata:id),no-fk-constraint,type(uuid)"`                                                                     // @gotags: search:"Namespace ID" sql:"fk(NamespaceMetadata:id),no-fk-constraint,type(uuid)"
+	NamespaceId                   string                 `protobuf:"bytes,23,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty" search:"Namespace ID"`                                                                     // @gotags: search:"Namespace ID"
 	OrchestratorComponent         bool                   `protobuf:"varint,33,opt,name=orchestrator_component,json=orchestratorComponent,proto3" json:"orchestrator_component,omitempty" search:"Orchestrator Component"`                                      // @gotags: search:"Orchestrator Component"
 	Replicas                      int64                  `protobuf:"varint,6,opt,name=replicas,proto3" json:"replicas,omitempty" policy:"Replicas"`                                                                                              // @gotags: policy:"Replicas"
 	Labels                        map[string]string      `protobuf:"bytes,7,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" search:"Deployment Label"`                         // @gotags: search:"Deployment Label"
 	PodLabels                     map[string]string      `protobuf:"bytes,19,rep,name=pod_labels,json=podLabels,proto3" json:"pod_labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" search:"Pod Label"` // @gotags: search:"Pod Label"
 	LabelSelector                 *LabelSelector         `protobuf:"bytes,20,opt,name=label_selector,json=labelSelector,proto3" json:"label_selector,omitempty"`
 	Created                       *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created,proto3" json:"created,omitempty" search:"Created,hidden" hash:"ignore"`                             // @gotags: search:"Created,hidden" hash:"ignore"
-	ClusterId                     string                 `protobuf:"bytes,9,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty" search:"Cluster ID,hidden" sql:"type(uuid)"`        // @gotags: search:"Cluster ID,hidden" sql:"type(uuid)"
+	ClusterId                     string                 `protobuf:"bytes,9,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty" search:"Cluster ID,hidden"`        // @gotags: search:"Cluster ID,hidden"
 	ClusterName                   string                 `protobuf:"bytes,10,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty" search:"Cluster"` // @gotags: search:"Cluster"
 	Containers                    []*Container           `protobuf:"bytes,11,rep,name=containers,proto3" json:"containers,omitempty"`
 	Annotations                   map[string]string      `protobuf:"bytes,14,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" search:"Deployment Annotation"` // @gotags: search:"Deployment Annotation"
@@ -272,8 +324,10 @@ type Deployment struct {
 	Tolerations                   []*Toleration          `protobuf:"bytes,22,rep,name=tolerations,proto3" json:"tolerations,omitempty" search:"-"`                                                                                                            // @gotags: search:"-"
 	Ports                         []*PortConfig          `protobuf:"bytes,24,rep,name=ports,proto3" json:"ports,omitempty" policy:"Ports"`                                                                                                                        // @gotags: policy:"Ports"
 	StateTimestamp                int64                  `protobuf:"varint,27,opt,name=state_timestamp,json=stateTimestamp,proto3" json:"state_timestamp,omitempty" hash:"ignore" sensorhash:"ignore"`                                                                               // Internal use only @gotags: hash:"ignore" sensorhash:"ignore"
-	RiskScore                     float32                `protobuf:"fixed32,29,opt,name=risk_score,json=riskScore,proto3" json:"risk_score,omitempty" search:"Deployment Risk Score,hidden" policy:",ignore" sql:"index=btree"`                                                                                             // @gotags: search:"Deployment Risk Score,hidden" policy:",ignore" sql:"index=btree"
+	RiskScore                     float32                `protobuf:"fixed32,29,opt,name=risk_score,json=riskScore,proto3" json:"risk_score,omitempty" search:"Deployment Risk Score,hidden" policy:",ignore"`                                                                                             // @gotags: search:"Deployment Risk Score,hidden" policy:",ignore"
 	PlatformComponent             bool                   `protobuf:"varint,35,opt,name=platform_component,json=platformComponent,proto3" json:"platform_component,omitempty" search:"Platform Component"`                                                                      // @gotags: search:"Platform Component"
+	InitContainers                []*Container           `protobuf:"bytes,36,rep,name=init_containers,json=initContainers,proto3" json:"init_containers,omitempty"`
+	EphemeralContainers           []*Container           `protobuf:"bytes,37,rep,name=ephemeral_containers,json=ephemeralContainers,proto3" json:"ephemeral_containers,omitempty"`
 	unknownFields                 protoimpl.UnknownFields
 	sizeCache                     protoimpl.SizeCache
 }
@@ -525,15 +579,29 @@ func (x *Deployment) GetPlatformComponent() bool {
 	return false
 }
 
+func (x *Deployment) GetInitContainers() []*Container {
+	if x != nil {
+		return x.InitContainers
+	}
+	return nil
+}
+
+func (x *Deployment) GetEphemeralContainers() []*Container {
+	if x != nil {
+		return x.EphemeralContainers
+	}
+	return nil
+}
+
 // Next tag: 13
 type ContainerImage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Deprecated: Marked as deprecated in storage/deployment.proto.
-	Id             string     `protobuf:"bytes,4,opt,name=id,proto3" json:"id,omitempty" search:"Image Sha,hidden" sql:"fk(Image:id),no-fk-constraint,index=hash"` // @gotags: search:"Image Sha,hidden" sql:"fk(Image:id),no-fk-constraint,index=hash"
+	Id             string     `protobuf:"bytes,4,opt,name=id,proto3" json:"id,omitempty" search:"Image Sha,hidden"` // @gotags: search:"Image Sha,hidden"
 	Name           *ImageName `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	NotPullable    bool       `protobuf:"varint,10,opt,name=not_pullable,json=notPullable,proto3" json:"not_pullable,omitempty"`
 	IsClusterLocal bool       `protobuf:"varint,11,opt,name=is_cluster_local,json=isClusterLocal,proto3" json:"is_cluster_local,omitempty"`
-	IdV2           string     `protobuf:"bytes,12,opt,name=id_v2,json=idV2,proto3" json:"id_v2,omitempty" search:"Image ID,hidden" sql:"fk(ImageV2:id),no-fk-constraint,index=btree,allow-null"` // @gotags: search:"Image ID,hidden" sql:"fk(ImageV2:id),no-fk-constraint,index=btree,allow-null"
+	IdV2           string     `protobuf:"bytes,12,opt,name=id_v2,json=idV2,proto3" json:"id_v2,omitempty" search:"Image ID,hidden"` // @gotags: search:"Image ID,hidden"
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -604,6 +672,85 @@ func (x *ContainerImage) GetIdV2() string {
 	return ""
 }
 
+// StoredContainerImage is the storage-only version of ContainerImage with SQL tags for persistence.
+type StoredContainerImage struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Deprecated: Marked as deprecated in storage/deployment.proto.
+	Id             string     `protobuf:"bytes,4,opt,name=id,proto3" json:"id,omitempty" search:"Image Sha,hidden" sql:"fk(Image:id),no-fk-constraint,index=hash"` // @gotags: search:"Image Sha,hidden" sql:"fk(Image:id),no-fk-constraint,index=hash"
+	Name           *ImageName `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	NotPullable    bool       `protobuf:"varint,10,opt,name=not_pullable,json=notPullable,proto3" json:"not_pullable,omitempty"`
+	IsClusterLocal bool       `protobuf:"varint,11,opt,name=is_cluster_local,json=isClusterLocal,proto3" json:"is_cluster_local,omitempty"`
+	IdV2           string     `protobuf:"bytes,12,opt,name=id_v2,json=idV2,proto3" json:"id_v2,omitempty" search:"Image ID,hidden" sql:"fk(ImageV2:id),no-fk-constraint,index=btree,allow-null"` // @gotags: search:"Image ID,hidden" sql:"fk(ImageV2:id),no-fk-constraint,index=btree,allow-null"
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *StoredContainerImage) Reset() {
+	*x = StoredContainerImage{}
+	mi := &file_storage_deployment_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StoredContainerImage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StoredContainerImage) ProtoMessage() {}
+
+func (x *StoredContainerImage) ProtoReflect() protoreflect.Message {
+	mi := &file_storage_deployment_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StoredContainerImage.ProtoReflect.Descriptor instead.
+func (*StoredContainerImage) Descriptor() ([]byte, []int) {
+	return file_storage_deployment_proto_rawDescGZIP(), []int{2}
+}
+
+// Deprecated: Marked as deprecated in storage/deployment.proto.
+func (x *StoredContainerImage) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *StoredContainerImage) GetName() *ImageName {
+	if x != nil {
+		return x.Name
+	}
+	return nil
+}
+
+func (x *StoredContainerImage) GetNotPullable() bool {
+	if x != nil {
+		return x.NotPullable
+	}
+	return false
+}
+
+func (x *StoredContainerImage) GetIsClusterLocal() bool {
+	if x != nil {
+		return x.IsClusterLocal
+	}
+	return false
+}
+
+func (x *StoredContainerImage) GetIdV2() string {
+	if x != nil {
+		return x.IdV2
+	}
+	return ""
+}
+
 type Container struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	Id              string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -623,7 +770,7 @@ type Container struct {
 
 func (x *Container) Reset() {
 	*x = Container{}
-	mi := &file_storage_deployment_proto_msgTypes[2]
+	mi := &file_storage_deployment_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -635,7 +782,7 @@ func (x *Container) String() string {
 func (*Container) ProtoMessage() {}
 
 func (x *Container) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[2]
+	mi := &file_storage_deployment_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -648,7 +795,7 @@ func (x *Container) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Container.ProtoReflect.Descriptor instead.
 func (*Container) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{2}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Container) GetId() string {
@@ -728,6 +875,427 @@ func (x *Container) GetReadinessProbe() *ReadinessProbe {
 	return nil
 }
 
+// StoredContainer is the storage-only version of Container with ContainerType for persistence.
+// Next available tag: 14
+type StoredContainer struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Id              string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Config          *ContainerConfig       `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
+	Image           *StoredContainerImage  `protobuf:"bytes,3,opt,name=image,proto3" json:"image,omitempty"`
+	SecurityContext *SecurityContext       `protobuf:"bytes,4,opt,name=security_context,json=securityContext,proto3" json:"security_context,omitempty"`
+	Volumes         []*Volume              `protobuf:"bytes,5,rep,name=volumes,proto3" json:"volumes,omitempty"`
+	Ports           []*PortConfig          `protobuf:"bytes,6,rep,name=ports,proto3" json:"ports,omitempty" policy:",ignore" search:"-"` // Policies use the port config on the top-level deployment. @gotags: policy:",ignore" search:"-"
+	Secrets         []*EmbeddedSecret      `protobuf:"bytes,7,rep,name=secrets,proto3" json:"secrets,omitempty"`
+	Resources       *Resources             `protobuf:"bytes,8,opt,name=resources,proto3" json:"resources,omitempty"`
+	Name            string                 `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty" policy:"Container Name"` // @gotags: policy:"Container Name"
+	LivenessProbe   *LivenessProbe         `protobuf:"bytes,11,opt,name=liveness_probe,json=livenessProbe,proto3" json:"liveness_probe,omitempty"`
+	ReadinessProbe  *ReadinessProbe        `protobuf:"bytes,12,opt,name=readiness_probe,json=readinessProbe,proto3" json:"readiness_probe,omitempty"`
+	ContainerType   ContainerType          `protobuf:"varint,13,opt,name=container_type,json=containerType,proto3,enum=storage.ContainerType" json:"container_type,omitempty" search:"Container Type"` // @gotags: search:"Container Type"
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *StoredContainer) Reset() {
+	*x = StoredContainer{}
+	mi := &file_storage_deployment_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StoredContainer) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StoredContainer) ProtoMessage() {}
+
+func (x *StoredContainer) ProtoReflect() protoreflect.Message {
+	mi := &file_storage_deployment_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StoredContainer.ProtoReflect.Descriptor instead.
+func (*StoredContainer) Descriptor() ([]byte, []int) {
+	return file_storage_deployment_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *StoredContainer) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *StoredContainer) GetConfig() *ContainerConfig {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+func (x *StoredContainer) GetImage() *StoredContainerImage {
+	if x != nil {
+		return x.Image
+	}
+	return nil
+}
+
+func (x *StoredContainer) GetSecurityContext() *SecurityContext {
+	if x != nil {
+		return x.SecurityContext
+	}
+	return nil
+}
+
+func (x *StoredContainer) GetVolumes() []*Volume {
+	if x != nil {
+		return x.Volumes
+	}
+	return nil
+}
+
+func (x *StoredContainer) GetPorts() []*PortConfig {
+	if x != nil {
+		return x.Ports
+	}
+	return nil
+}
+
+func (x *StoredContainer) GetSecrets() []*EmbeddedSecret {
+	if x != nil {
+		return x.Secrets
+	}
+	return nil
+}
+
+func (x *StoredContainer) GetResources() *Resources {
+	if x != nil {
+		return x.Resources
+	}
+	return nil
+}
+
+func (x *StoredContainer) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *StoredContainer) GetLivenessProbe() *LivenessProbe {
+	if x != nil {
+		return x.LivenessProbe
+	}
+	return nil
+}
+
+func (x *StoredContainer) GetReadinessProbe() *ReadinessProbe {
+	if x != nil {
+		return x.ReadinessProbe
+	}
+	return nil
+}
+
+func (x *StoredContainer) GetContainerType() ContainerType {
+	if x != nil {
+		return x.ContainerType
+	}
+	return ContainerType_CONTAINER_TYPE_UNSPECIFIED
+}
+
+// StoredDeployment is the storage-only version of Deployment used at the postgres store boundary.
+// It uses the same field numbers as Deployment for protobuf wire compatibility.
+// Next available tag: 36
+type StoredDeployment struct {
+	state                         protoimpl.MessageState `protogen:"open.v1"`
+	Id                            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Deployment ID,hidden" sql:"pk,type(uuid)"`                                                                                                           // @gotags: search:"Deployment ID,hidden" sql:"pk,type(uuid)"
+	Name                          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" search:"Deployment"`                                                                                                       // @gotags: search:"Deployment"
+	Hash                          uint64                 `protobuf:"varint,26,opt,name=hash,proto3" json:"hash,omitempty" search:"Deployment Hash,hidden" hash:"ignore" sensorhash:"ignore"`                                                                                                     // @gotags: search:"Deployment Hash,hidden" hash:"ignore" sensorhash:"ignore"
+	Type                          string                 `protobuf:"bytes,4,opt,name=type,proto3" json:"type,omitempty" search:"Deployment Type"`                                                                                                       // @gotags: search:"Deployment Type"
+	Namespace                     string                 `protobuf:"bytes,5,opt,name=namespace,proto3" json:"namespace,omitempty" search:"Namespace"`                                                                                             // @gotags: search:"Namespace"
+	NamespaceId                   string                 `protobuf:"bytes,23,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty" search:"Namespace ID" sql:"fk(NamespaceMetadata:id),no-fk-constraint,type(uuid)"`                                                                     // @gotags: search:"Namespace ID" sql:"fk(NamespaceMetadata:id),no-fk-constraint,type(uuid)"
+	OrchestratorComponent         bool                   `protobuf:"varint,33,opt,name=orchestrator_component,json=orchestratorComponent,proto3" json:"orchestrator_component,omitempty" search:"Orchestrator Component"`                                      // @gotags: search:"Orchestrator Component"
+	Replicas                      int64                  `protobuf:"varint,6,opt,name=replicas,proto3" json:"replicas,omitempty" policy:"Replicas"`                                                                                              // @gotags: policy:"Replicas"
+	Labels                        map[string]string      `protobuf:"bytes,7,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" search:"Deployment Label"`                         // @gotags: search:"Deployment Label"
+	PodLabels                     map[string]string      `protobuf:"bytes,19,rep,name=pod_labels,json=podLabels,proto3" json:"pod_labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" search:"Pod Label"` // @gotags: search:"Pod Label"
+	LabelSelector                 *LabelSelector         `protobuf:"bytes,20,opt,name=label_selector,json=labelSelector,proto3" json:"label_selector,omitempty"`
+	Created                       *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created,proto3" json:"created,omitempty" search:"Created,hidden" hash:"ignore"`                             // @gotags: search:"Created,hidden" hash:"ignore"
+	ClusterId                     string                 `protobuf:"bytes,9,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty" search:"Cluster ID,hidden" sql:"type(uuid)"`        // @gotags: search:"Cluster ID,hidden" sql:"type(uuid)"
+	ClusterName                   string                 `protobuf:"bytes,10,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty" search:"Cluster"` // @gotags: search:"Cluster"
+	Containers                    []*StoredContainer     `protobuf:"bytes,11,rep,name=containers,proto3" json:"containers,omitempty"`
+	Annotations                   map[string]string      `protobuf:"bytes,14,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value" search:"Deployment Annotation"` // @gotags: search:"Deployment Annotation"
+	Priority                      int64                  `protobuf:"varint,15,opt,name=priority,proto3" json:"priority,omitempty" search:"Deployment Risk Priority,hidden" hash:"ignore"`                                                                                // @gotags: search:"Deployment Risk Priority,hidden" hash:"ignore"
+	Inactive                      bool                   `protobuf:"varint,16,opt,name=inactive,proto3" json:"inactive,omitempty"`
+	ImagePullSecrets              []string               `protobuf:"bytes,17,rep,name=image_pull_secrets,json=imagePullSecrets,proto3" json:"image_pull_secrets,omitempty" search:"Image Pull Secret"`                                                                        // @gotags: search:"Image Pull Secret"
+	ServiceAccount                string                 `protobuf:"bytes,18,opt,name=service_account,json=serviceAccount,proto3" json:"service_account,omitempty" search:"Service Account"`                                                                                // @gotags: search:"Service Account"
+	ServiceAccountPermissionLevel PermissionLevel        `protobuf:"varint,28,opt,name=service_account_permission_level,json=serviceAccountPermissionLevel,proto3,enum=storage.PermissionLevel" json:"service_account_permission_level,omitempty" search:"Service Account Permission Level"` // @gotags: search:"Service Account Permission Level"
+	AutomountServiceAccountToken  bool                   `protobuf:"varint,25,opt,name=automount_service_account_token,json=automountServiceAccountToken,proto3" json:"automount_service_account_token,omitempty" policy:"Automount Service Account Token"`                                 // @gotags: policy:"Automount Service Account Token"
+	HostNetwork                   bool                   `protobuf:"varint,21,opt,name=host_network,json=hostNetwork,proto3" json:"host_network,omitempty" policy:"Host Network"`                                                                                        // @gotags: policy:"Host Network"
+	HostPid                       bool                   `protobuf:"varint,31,opt,name=host_pid,json=hostPid,proto3" json:"host_pid,omitempty" policy:"Host PID"`                                                                                                    // @gotags: policy:"Host PID"
+	HostIpc                       bool                   `protobuf:"varint,32,opt,name=host_ipc,json=hostIpc,proto3" json:"host_ipc,omitempty" policy:"Host IPC"`                                                                                                    // @gotags: policy:"Host IPC"
+	RuntimeClass                  string                 `protobuf:"bytes,34,opt,name=runtime_class,json=runtimeClass,proto3" json:"runtime_class,omitempty" policy:"Runtime Class"`                                                                                      // @gotags: policy:"Runtime Class"
+	Tolerations                   []*Toleration          `protobuf:"bytes,22,rep,name=tolerations,proto3" json:"tolerations,omitempty" search:"-"`                                                                                                            // @gotags: search:"-"
+	Ports                         []*PortConfig          `protobuf:"bytes,24,rep,name=ports,proto3" json:"ports,omitempty" policy:"Ports"`                                                                                                                        // @gotags: policy:"Ports"
+	StateTimestamp                int64                  `protobuf:"varint,27,opt,name=state_timestamp,json=stateTimestamp,proto3" json:"state_timestamp,omitempty" hash:"ignore" sensorhash:"ignore"`                                                                               // Internal use only @gotags: hash:"ignore" sensorhash:"ignore"
+	RiskScore                     float32                `protobuf:"fixed32,29,opt,name=risk_score,json=riskScore,proto3" json:"risk_score,omitempty" search:"Deployment Risk Score,hidden" policy:",ignore" sql:"index=btree"`                                                                                             // @gotags: search:"Deployment Risk Score,hidden" policy:",ignore" sql:"index=btree"
+	PlatformComponent             bool                   `protobuf:"varint,35,opt,name=platform_component,json=platformComponent,proto3" json:"platform_component,omitempty" search:"Platform Component"`                                                                      // @gotags: search:"Platform Component"
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
+}
+
+func (x *StoredDeployment) Reset() {
+	*x = StoredDeployment{}
+	mi := &file_storage_deployment_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StoredDeployment) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StoredDeployment) ProtoMessage() {}
+
+func (x *StoredDeployment) ProtoReflect() protoreflect.Message {
+	mi := &file_storage_deployment_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StoredDeployment.ProtoReflect.Descriptor instead.
+func (*StoredDeployment) Descriptor() ([]byte, []int) {
+	return file_storage_deployment_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *StoredDeployment) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *StoredDeployment) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *StoredDeployment) GetHash() uint64 {
+	if x != nil {
+		return x.Hash
+	}
+	return 0
+}
+
+func (x *StoredDeployment) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *StoredDeployment) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *StoredDeployment) GetNamespaceId() string {
+	if x != nil {
+		return x.NamespaceId
+	}
+	return ""
+}
+
+func (x *StoredDeployment) GetOrchestratorComponent() bool {
+	if x != nil {
+		return x.OrchestratorComponent
+	}
+	return false
+}
+
+func (x *StoredDeployment) GetReplicas() int64 {
+	if x != nil {
+		return x.Replicas
+	}
+	return 0
+}
+
+func (x *StoredDeployment) GetLabels() map[string]string {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
+}
+
+func (x *StoredDeployment) GetPodLabels() map[string]string {
+	if x != nil {
+		return x.PodLabels
+	}
+	return nil
+}
+
+func (x *StoredDeployment) GetLabelSelector() *LabelSelector {
+	if x != nil {
+		return x.LabelSelector
+	}
+	return nil
+}
+
+func (x *StoredDeployment) GetCreated() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Created
+	}
+	return nil
+}
+
+func (x *StoredDeployment) GetClusterId() string {
+	if x != nil {
+		return x.ClusterId
+	}
+	return ""
+}
+
+func (x *StoredDeployment) GetClusterName() string {
+	if x != nil {
+		return x.ClusterName
+	}
+	return ""
+}
+
+func (x *StoredDeployment) GetContainers() []*StoredContainer {
+	if x != nil {
+		return x.Containers
+	}
+	return nil
+}
+
+func (x *StoredDeployment) GetAnnotations() map[string]string {
+	if x != nil {
+		return x.Annotations
+	}
+	return nil
+}
+
+func (x *StoredDeployment) GetPriority() int64 {
+	if x != nil {
+		return x.Priority
+	}
+	return 0
+}
+
+func (x *StoredDeployment) GetInactive() bool {
+	if x != nil {
+		return x.Inactive
+	}
+	return false
+}
+
+func (x *StoredDeployment) GetImagePullSecrets() []string {
+	if x != nil {
+		return x.ImagePullSecrets
+	}
+	return nil
+}
+
+func (x *StoredDeployment) GetServiceAccount() string {
+	if x != nil {
+		return x.ServiceAccount
+	}
+	return ""
+}
+
+func (x *StoredDeployment) GetServiceAccountPermissionLevel() PermissionLevel {
+	if x != nil {
+		return x.ServiceAccountPermissionLevel
+	}
+	return PermissionLevel_UNSET
+}
+
+func (x *StoredDeployment) GetAutomountServiceAccountToken() bool {
+	if x != nil {
+		return x.AutomountServiceAccountToken
+	}
+	return false
+}
+
+func (x *StoredDeployment) GetHostNetwork() bool {
+	if x != nil {
+		return x.HostNetwork
+	}
+	return false
+}
+
+func (x *StoredDeployment) GetHostPid() bool {
+	if x != nil {
+		return x.HostPid
+	}
+	return false
+}
+
+func (x *StoredDeployment) GetHostIpc() bool {
+	if x != nil {
+		return x.HostIpc
+	}
+	return false
+}
+
+func (x *StoredDeployment) GetRuntimeClass() string {
+	if x != nil {
+		return x.RuntimeClass
+	}
+	return ""
+}
+
+func (x *StoredDeployment) GetTolerations() []*Toleration {
+	if x != nil {
+		return x.Tolerations
+	}
+	return nil
+}
+
+func (x *StoredDeployment) GetPorts() []*PortConfig {
+	if x != nil {
+		return x.Ports
+	}
+	return nil
+}
+
+func (x *StoredDeployment) GetStateTimestamp() int64 {
+	if x != nil {
+		return x.StateTimestamp
+	}
+	return 0
+}
+
+func (x *StoredDeployment) GetRiskScore() float32 {
+	if x != nil {
+		return x.RiskScore
+	}
+	return 0
+}
+
+func (x *StoredDeployment) GetPlatformComponent() bool {
+	if x != nil {
+		return x.PlatformComponent
+	}
+	return false
+}
+
 type Resources struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	CpuCoresRequest float32                `protobuf:"fixed32,1,opt,name=cpu_cores_request,json=cpuCoresRequest,proto3" json:"cpu_cores_request,omitempty" search:"CPU Cores Request"` // @gotags: search:"CPU Cores Request"
@@ -740,7 +1308,7 @@ type Resources struct {
 
 func (x *Resources) Reset() {
 	*x = Resources{}
-	mi := &file_storage_deployment_proto_msgTypes[3]
+	mi := &file_storage_deployment_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -752,7 +1320,7 @@ func (x *Resources) String() string {
 func (*Resources) ProtoMessage() {}
 
 func (x *Resources) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[3]
+	mi := &file_storage_deployment_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -765,7 +1333,7 @@ func (x *Resources) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Resources.ProtoReflect.Descriptor instead.
 func (*Resources) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{3}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *Resources) GetCpuCoresRequest() float32 {
@@ -810,7 +1378,7 @@ type Volume struct {
 
 func (x *Volume) Reset() {
 	*x = Volume{}
-	mi := &file_storage_deployment_proto_msgTypes[4]
+	mi := &file_storage_deployment_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -822,7 +1390,7 @@ func (x *Volume) String() string {
 func (*Volume) ProtoMessage() {}
 
 func (x *Volume) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[4]
+	mi := &file_storage_deployment_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -835,7 +1403,7 @@ func (x *Volume) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Volume.ProtoReflect.Descriptor instead.
 func (*Volume) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{4}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Volume) GetName() string {
@@ -889,7 +1457,7 @@ type LivenessProbe struct {
 
 func (x *LivenessProbe) Reset() {
 	*x = LivenessProbe{}
-	mi := &file_storage_deployment_proto_msgTypes[5]
+	mi := &file_storage_deployment_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -901,7 +1469,7 @@ func (x *LivenessProbe) String() string {
 func (*LivenessProbe) ProtoMessage() {}
 
 func (x *LivenessProbe) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[5]
+	mi := &file_storage_deployment_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -914,7 +1482,7 @@ func (x *LivenessProbe) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LivenessProbe.ProtoReflect.Descriptor instead.
 func (*LivenessProbe) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{5}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *LivenessProbe) GetDefined() bool {
@@ -933,7 +1501,7 @@ type ReadinessProbe struct {
 
 func (x *ReadinessProbe) Reset() {
 	*x = ReadinessProbe{}
-	mi := &file_storage_deployment_proto_msgTypes[6]
+	mi := &file_storage_deployment_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -945,7 +1513,7 @@ func (x *ReadinessProbe) String() string {
 func (*ReadinessProbe) ProtoMessage() {}
 
 func (x *ReadinessProbe) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[6]
+	mi := &file_storage_deployment_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -958,7 +1526,7 @@ func (x *ReadinessProbe) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadinessProbe.ProtoReflect.Descriptor instead.
 func (*ReadinessProbe) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{6}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ReadinessProbe) GetDefined() bool {
@@ -989,7 +1557,7 @@ type Pod struct {
 
 func (x *Pod) Reset() {
 	*x = Pod{}
-	mi := &file_storage_deployment_proto_msgTypes[7]
+	mi := &file_storage_deployment_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1001,7 +1569,7 @@ func (x *Pod) String() string {
 func (*Pod) ProtoMessage() {}
 
 func (x *Pod) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[7]
+	mi := &file_storage_deployment_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1014,7 +1582,7 @@ func (x *Pod) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Pod.ProtoReflect.Descriptor instead.
 func (*Pod) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{7}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *Pod) GetId() string {
@@ -1100,7 +1668,7 @@ type ContainerInstance struct {
 
 func (x *ContainerInstance) Reset() {
 	*x = ContainerInstance{}
-	mi := &file_storage_deployment_proto_msgTypes[8]
+	mi := &file_storage_deployment_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1112,7 +1680,7 @@ func (x *ContainerInstance) String() string {
 func (*ContainerInstance) ProtoMessage() {}
 
 func (x *ContainerInstance) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[8]
+	mi := &file_storage_deployment_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1125,7 +1693,7 @@ func (x *ContainerInstance) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerInstance.ProtoReflect.Descriptor instead.
 func (*ContainerInstance) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{8}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ContainerInstance) GetInstanceId() *ContainerInstanceID {
@@ -1205,7 +1773,7 @@ type ContainerInstanceID struct {
 
 func (x *ContainerInstanceID) Reset() {
 	*x = ContainerInstanceID{}
-	mi := &file_storage_deployment_proto_msgTypes[9]
+	mi := &file_storage_deployment_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1217,7 +1785,7 @@ func (x *ContainerInstanceID) String() string {
 func (*ContainerInstanceID) ProtoMessage() {}
 
 func (x *ContainerInstanceID) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[9]
+	mi := &file_storage_deployment_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1230,7 +1798,7 @@ func (x *ContainerInstanceID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerInstanceID.ProtoReflect.Descriptor instead.
 func (*ContainerInstanceID) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{9}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ContainerInstanceID) GetContainerRuntime() ContainerRuntime {
@@ -1264,7 +1832,7 @@ type EmbeddedSecret struct {
 
 func (x *EmbeddedSecret) Reset() {
 	*x = EmbeddedSecret{}
-	mi := &file_storage_deployment_proto_msgTypes[10]
+	mi := &file_storage_deployment_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1276,7 +1844,7 @@ func (x *EmbeddedSecret) String() string {
 func (*EmbeddedSecret) ProtoMessage() {}
 
 func (x *EmbeddedSecret) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[10]
+	mi := &file_storage_deployment_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1289,7 +1857,7 @@ func (x *EmbeddedSecret) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EmbeddedSecret.ProtoReflect.Descriptor instead.
 func (*EmbeddedSecret) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{10}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *EmbeddedSecret) GetName() string {
@@ -1322,7 +1890,7 @@ type PortConfig struct {
 
 func (x *PortConfig) Reset() {
 	*x = PortConfig{}
-	mi := &file_storage_deployment_proto_msgTypes[11]
+	mi := &file_storage_deployment_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1334,7 +1902,7 @@ func (x *PortConfig) String() string {
 func (*PortConfig) ProtoMessage() {}
 
 func (x *PortConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[11]
+	mi := &file_storage_deployment_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1347,7 +1915,7 @@ func (x *PortConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PortConfig.ProtoReflect.Descriptor instead.
 func (*PortConfig) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{11}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *PortConfig) GetName() string {
@@ -1408,7 +1976,7 @@ type ContainerConfig struct {
 
 func (x *ContainerConfig) Reset() {
 	*x = ContainerConfig{}
-	mi := &file_storage_deployment_proto_msgTypes[12]
+	mi := &file_storage_deployment_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1420,7 +1988,7 @@ func (x *ContainerConfig) String() string {
 func (*ContainerConfig) ProtoMessage() {}
 
 func (x *ContainerConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[12]
+	mi := &file_storage_deployment_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1433,7 +2001,7 @@ func (x *ContainerConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerConfig.ProtoReflect.Descriptor instead.
 func (*ContainerConfig) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{12}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ContainerConfig) GetEnv() []*ContainerConfig_EnvironmentConfig {
@@ -1500,7 +2068,7 @@ type SecurityContext struct {
 
 func (x *SecurityContext) Reset() {
 	*x = SecurityContext{}
-	mi := &file_storage_deployment_proto_msgTypes[13]
+	mi := &file_storage_deployment_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1512,7 +2080,7 @@ func (x *SecurityContext) String() string {
 func (*SecurityContext) ProtoMessage() {}
 
 func (x *SecurityContext) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[13]
+	mi := &file_storage_deployment_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1525,7 +2093,7 @@ func (x *SecurityContext) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecurityContext.ProtoReflect.Descriptor instead.
 func (*SecurityContext) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{13}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SecurityContext) GetPrivileged() bool {
@@ -1594,7 +2162,7 @@ type ListDeployment struct {
 
 func (x *ListDeployment) Reset() {
 	*x = ListDeployment{}
-	mi := &file_storage_deployment_proto_msgTypes[14]
+	mi := &file_storage_deployment_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1606,7 +2174,7 @@ func (x *ListDeployment) String() string {
 func (*ListDeployment) ProtoMessage() {}
 
 func (x *ListDeployment) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[14]
+	mi := &file_storage_deployment_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1619,7 +2187,7 @@ func (x *ListDeployment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDeployment.ProtoReflect.Descriptor instead.
 func (*ListDeployment) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{14}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ListDeployment) GetId() string {
@@ -1687,7 +2255,7 @@ type Pod_ContainerInstanceList struct {
 
 func (x *Pod_ContainerInstanceList) Reset() {
 	*x = Pod_ContainerInstanceList{}
-	mi := &file_storage_deployment_proto_msgTypes[18]
+	mi := &file_storage_deployment_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1699,7 +2267,7 @@ func (x *Pod_ContainerInstanceList) String() string {
 func (*Pod_ContainerInstanceList) ProtoMessage() {}
 
 func (x *Pod_ContainerInstanceList) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[18]
+	mi := &file_storage_deployment_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1712,7 +2280,7 @@ func (x *Pod_ContainerInstanceList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Pod_ContainerInstanceList.ProtoReflect.Descriptor instead.
 func (*Pod_ContainerInstanceList) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{7, 0}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{10, 0}
 }
 
 func (x *Pod_ContainerInstanceList) GetInstances() []*ContainerInstance {
@@ -1742,7 +2310,7 @@ type PortConfig_ExposureInfo struct {
 
 func (x *PortConfig_ExposureInfo) Reset() {
 	*x = PortConfig_ExposureInfo{}
-	mi := &file_storage_deployment_proto_msgTypes[19]
+	mi := &file_storage_deployment_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1754,7 +2322,7 @@ func (x *PortConfig_ExposureInfo) String() string {
 func (*PortConfig_ExposureInfo) ProtoMessage() {}
 
 func (x *PortConfig_ExposureInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[19]
+	mi := &file_storage_deployment_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1767,7 +2335,7 @@ func (x *PortConfig_ExposureInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PortConfig_ExposureInfo.ProtoReflect.Descriptor instead.
 func (*PortConfig_ExposureInfo) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{11, 0}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{14, 0}
 }
 
 func (x *PortConfig_ExposureInfo) GetLevel() PortConfig_ExposureLevel {
@@ -1837,7 +2405,7 @@ type ContainerConfig_EnvironmentConfig struct {
 
 func (x *ContainerConfig_EnvironmentConfig) Reset() {
 	*x = ContainerConfig_EnvironmentConfig{}
-	mi := &file_storage_deployment_proto_msgTypes[20]
+	mi := &file_storage_deployment_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1849,7 +2417,7 @@ func (x *ContainerConfig_EnvironmentConfig) String() string {
 func (*ContainerConfig_EnvironmentConfig) ProtoMessage() {}
 
 func (x *ContainerConfig_EnvironmentConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[20]
+	mi := &file_storage_deployment_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1862,7 +2430,7 @@ func (x *ContainerConfig_EnvironmentConfig) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ContainerConfig_EnvironmentConfig.ProtoReflect.Descriptor instead.
 func (*ContainerConfig_EnvironmentConfig) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{12, 0}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{15, 0}
 }
 
 func (x *ContainerConfig_EnvironmentConfig) GetKey() string {
@@ -1898,7 +2466,7 @@ type SecurityContext_SELinux struct {
 
 func (x *SecurityContext_SELinux) Reset() {
 	*x = SecurityContext_SELinux{}
-	mi := &file_storage_deployment_proto_msgTypes[21]
+	mi := &file_storage_deployment_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1910,7 +2478,7 @@ func (x *SecurityContext_SELinux) String() string {
 func (*SecurityContext_SELinux) ProtoMessage() {}
 
 func (x *SecurityContext_SELinux) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[21]
+	mi := &file_storage_deployment_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1923,7 +2491,7 @@ func (x *SecurityContext_SELinux) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecurityContext_SELinux.ProtoReflect.Descriptor instead.
 func (*SecurityContext_SELinux) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{13, 0}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{16, 0}
 }
 
 func (x *SecurityContext_SELinux) GetUser() string {
@@ -1964,7 +2532,7 @@ type SecurityContext_SeccompProfile struct {
 
 func (x *SecurityContext_SeccompProfile) Reset() {
 	*x = SecurityContext_SeccompProfile{}
-	mi := &file_storage_deployment_proto_msgTypes[22]
+	mi := &file_storage_deployment_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1976,7 +2544,7 @@ func (x *SecurityContext_SeccompProfile) String() string {
 func (*SecurityContext_SeccompProfile) ProtoMessage() {}
 
 func (x *SecurityContext_SeccompProfile) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_deployment_proto_msgTypes[22]
+	mi := &file_storage_deployment_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1989,7 +2557,7 @@ func (x *SecurityContext_SeccompProfile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecurityContext_SeccompProfile.ProtoReflect.Descriptor instead.
 func (*SecurityContext_SeccompProfile) Descriptor() ([]byte, []int) {
-	return file_storage_deployment_proto_rawDescGZIP(), []int{13, 1}
+	return file_storage_deployment_proto_rawDescGZIP(), []int{16, 1}
 }
 
 func (x *SecurityContext_SeccompProfile) GetType() SecurityContext_SeccompProfile_ProfileType {
@@ -2010,7 +2578,7 @@ var File_storage_deployment_proto protoreflect.FileDescriptor
 
 const file_storage_deployment_proto_rawDesc = "" +
 	"\n" +
-	"\x18storage/deployment.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1fstorage/container_runtime.proto\x1a\x13storage/image.proto\x1a\x14storage/labels.proto\x1a\x12storage/rbac.proto\x1a\x14storage/taints.proto\"\xf6\v\n" +
+	"\x18storage/deployment.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1fstorage/container_runtime.proto\x1a\x13storage/image.proto\x1a\x14storage/labels.proto\x1a\x12storage/rbac.proto\x1a\x14storage/taints.proto\"\xfa\f\n" +
 	"\n" +
 	"Deployment\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
@@ -2049,7 +2617,9 @@ const file_storage_deployment_proto_rawDesc = "" +
 	"\x0fstate_timestamp\x18\x1b \x01(\x03R\x0estateTimestamp\x12\x1d\n" +
 	"\n" +
 	"risk_score\x18\x1d \x01(\x02R\triskScore\x12-\n" +
-	"\x12platform_component\x18# \x01(\bR\x11platformComponent\x1a9\n" +
+	"\x12platform_component\x18# \x01(\bR\x11platformComponent\x12;\n" +
+	"\x0finit_containers\x18$ \x03(\v2\x12.storage.ContainerR\x0einitContainers\x12E\n" +
+	"\x14ephemeral_containers\x18% \x03(\v2\x12.storage.ContainerR\x13ephemeralContainers\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a<\n" +
@@ -2060,6 +2630,14 @@ const file_storage_deployment_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x03\x10\x04J\x04\b\f\x10\rJ\x04\b\x1e\x10\x1f\"\xd8\x01\n" +
 	"\x0eContainerImage\x12\x12\n" +
+	"\x02id\x18\x04 \x01(\tB\x02\x18\x01R\x02id\x12&\n" +
+	"\x04name\x18\x01 \x01(\v2\x12.storage.ImageNameR\x04name\x12!\n" +
+	"\fnot_pullable\x18\n" +
+	" \x01(\bR\vnotPullable\x12(\n" +
+	"\x10is_cluster_local\x18\v \x01(\bR\x0eisClusterLocal\x12\x13\n" +
+	"\x05id_v2\x18\f \x01(\tR\x04idV2J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
+	"\"\xde\x01\n" +
+	"\x14StoredContainerImage\x12\x12\n" +
 	"\x02id\x18\x04 \x01(\tB\x02\x18\x01R\x02id\x12&\n" +
 	"\x04name\x18\x01 \x01(\v2\x12.storage.ImageNameR\x04name\x12!\n" +
 	"\fnot_pullable\x18\n" +
@@ -2080,7 +2658,69 @@ const file_storage_deployment_proto_rawDesc = "" +
 	" \x01(\tR\x04name\x12=\n" +
 	"\x0eliveness_probe\x18\v \x01(\v2\x16.storage.LivenessProbeR\rlivenessProbe\x12@\n" +
 	"\x0freadiness_probe\x18\f \x01(\v2\x17.storage.ReadinessProbeR\x0ereadinessProbeJ\x04\b\t\x10\n" +
-	"\"\xb3\x01\n" +
+	"\"\xe2\x04\n" +
+	"\x0fStoredContainer\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x120\n" +
+	"\x06config\x18\x02 \x01(\v2\x18.storage.ContainerConfigR\x06config\x123\n" +
+	"\x05image\x18\x03 \x01(\v2\x1d.storage.StoredContainerImageR\x05image\x12C\n" +
+	"\x10security_context\x18\x04 \x01(\v2\x18.storage.SecurityContextR\x0fsecurityContext\x12)\n" +
+	"\avolumes\x18\x05 \x03(\v2\x0f.storage.VolumeR\avolumes\x12)\n" +
+	"\x05ports\x18\x06 \x03(\v2\x13.storage.PortConfigR\x05ports\x121\n" +
+	"\asecrets\x18\a \x03(\v2\x17.storage.EmbeddedSecretR\asecrets\x120\n" +
+	"\tresources\x18\b \x01(\v2\x12.storage.ResourcesR\tresources\x12\x12\n" +
+	"\x04name\x18\n" +
+	" \x01(\tR\x04name\x12=\n" +
+	"\x0eliveness_probe\x18\v \x01(\v2\x16.storage.LivenessProbeR\rlivenessProbe\x12@\n" +
+	"\x0freadiness_probe\x18\f \x01(\v2\x17.storage.ReadinessProbeR\x0ereadinessProbe\x12=\n" +
+	"\x0econtainer_type\x18\r \x01(\x0e2\x16.storage.ContainerTypeR\rcontainerTypeJ\x04\b\t\x10\n" +
+	"\"\x94\f\n" +
+	"\x10StoredDeployment\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x12\n" +
+	"\x04hash\x18\x1a \x01(\x04R\x04hash\x12\x12\n" +
+	"\x04type\x18\x04 \x01(\tR\x04type\x12\x1c\n" +
+	"\tnamespace\x18\x05 \x01(\tR\tnamespace\x12!\n" +
+	"\fnamespace_id\x18\x17 \x01(\tR\vnamespaceId\x125\n" +
+	"\x16orchestrator_component\x18! \x01(\bR\x15orchestratorComponent\x12\x1a\n" +
+	"\breplicas\x18\x06 \x01(\x03R\breplicas\x12=\n" +
+	"\x06labels\x18\a \x03(\v2%.storage.StoredDeployment.LabelsEntryR\x06labels\x12G\n" +
+	"\n" +
+	"pod_labels\x18\x13 \x03(\v2(.storage.StoredDeployment.PodLabelsEntryR\tpodLabels\x12=\n" +
+	"\x0elabel_selector\x18\x14 \x01(\v2\x16.storage.LabelSelectorR\rlabelSelector\x124\n" +
+	"\acreated\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\acreated\x12\x1d\n" +
+	"\n" +
+	"cluster_id\x18\t \x01(\tR\tclusterId\x12!\n" +
+	"\fcluster_name\x18\n" +
+	" \x01(\tR\vclusterName\x128\n" +
+	"\n" +
+	"containers\x18\v \x03(\v2\x18.storage.StoredContainerR\n" +
+	"containers\x12L\n" +
+	"\vannotations\x18\x0e \x03(\v2*.storage.StoredDeployment.AnnotationsEntryR\vannotations\x12\x1a\n" +
+	"\bpriority\x18\x0f \x01(\x03R\bpriority\x12\x1a\n" +
+	"\binactive\x18\x10 \x01(\bR\binactive\x12,\n" +
+	"\x12image_pull_secrets\x18\x11 \x03(\tR\x10imagePullSecrets\x12'\n" +
+	"\x0fservice_account\x18\x12 \x01(\tR\x0eserviceAccount\x12a\n" +
+	" service_account_permission_level\x18\x1c \x01(\x0e2\x18.storage.PermissionLevelR\x1dserviceAccountPermissionLevel\x12E\n" +
+	"\x1fautomount_service_account_token\x18\x19 \x01(\bR\x1cautomountServiceAccountToken\x12!\n" +
+	"\fhost_network\x18\x15 \x01(\bR\vhostNetwork\x12\x19\n" +
+	"\bhost_pid\x18\x1f \x01(\bR\ahostPid\x12\x19\n" +
+	"\bhost_ipc\x18  \x01(\bR\ahostIpc\x12#\n" +
+	"\rruntime_class\x18\" \x01(\tR\fruntimeClass\x125\n" +
+	"\vtolerations\x18\x16 \x03(\v2\x13.storage.TolerationR\vtolerations\x12)\n" +
+	"\x05ports\x18\x18 \x03(\v2\x13.storage.PortConfigR\x05ports\x12'\n" +
+	"\x0fstate_timestamp\x18\x1b \x01(\x03R\x0estateTimestamp\x12\x1d\n" +
+	"\n" +
+	"risk_score\x18\x1d \x01(\x02R\triskScore\x12-\n" +
+	"\x12platform_component\x18# \x01(\bR\x11platformComponent\x1a9\n" +
+	"\vLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a<\n" +
+	"\x0ePodLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +
+	"\x10AnnotationsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x03\x10\x04J\x04\b\f\x10\rJ\x04\b\x1e\x10\x1f\"\xb3\x01\n" +
 	"\tResources\x12*\n" +
 	"\x11cpu_cores_request\x18\x01 \x01(\x02R\x0fcpuCoresRequest\x12&\n" +
 	"\x0fcpu_cores_limit\x18\x02 \x01(\x02R\rcpuCoresLimit\x12*\n" +
@@ -2209,7 +2849,12 @@ const file_storage_deployment_proto_rawDesc = "" +
 	"cluster_id\x18\x04 \x01(\tR\tclusterId\x12\x1c\n" +
 	"\tnamespace\x18\x05 \x01(\tR\tnamespace\x124\n" +
 	"\acreated\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\acreated\x12\x1a\n" +
-	"\bpriority\x18\a \x01(\x03R\bpriorityB.\n" +
+	"\bpriority\x18\a \x01(\x03R\bpriority*V\n" +
+	"\rContainerType\x12\x1e\n" +
+	"\x1aCONTAINER_TYPE_UNSPECIFIED\x10\x00\x12\f\n" +
+	"\bSTANDARD\x10\x01\x12\b\n" +
+	"\x04INIT\x10\x02\x12\r\n" +
+	"\tEPHEMERAL\x10\x03B.\n" +
 	"\x19io.stackrox.proto.storageZ\x11./storage;storageb\x06proto3"
 
 var (
@@ -2224,86 +2869,115 @@ func file_storage_deployment_proto_rawDescGZIP() []byte {
 	return file_storage_deployment_proto_rawDescData
 }
 
-var file_storage_deployment_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_storage_deployment_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_storage_deployment_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_storage_deployment_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_storage_deployment_proto_goTypes = []any{
-	(Volume_MountPropagation)(0),                        // 0: storage.Volume.MountPropagation
-	(PortConfig_ExposureLevel)(0),                       // 1: storage.PortConfig.ExposureLevel
-	(ContainerConfig_EnvironmentConfig_EnvVarSource)(0), // 2: storage.ContainerConfig.EnvironmentConfig.EnvVarSource
-	(SecurityContext_SeccompProfile_ProfileType)(0),     // 3: storage.SecurityContext.SeccompProfile.ProfileType
-	(*Deployment)(nil),                                  // 4: storage.Deployment
-	(*ContainerImage)(nil),                              // 5: storage.ContainerImage
-	(*Container)(nil),                                   // 6: storage.Container
-	(*Resources)(nil),                                   // 7: storage.Resources
-	(*Volume)(nil),                                      // 8: storage.Volume
-	(*LivenessProbe)(nil),                               // 9: storage.LivenessProbe
-	(*ReadinessProbe)(nil),                              // 10: storage.ReadinessProbe
-	(*Pod)(nil),                                         // 11: storage.Pod
-	(*ContainerInstance)(nil),                           // 12: storage.ContainerInstance
-	(*ContainerInstanceID)(nil),                         // 13: storage.ContainerInstanceID
-	(*EmbeddedSecret)(nil),                              // 14: storage.EmbeddedSecret
-	(*PortConfig)(nil),                                  // 15: storage.PortConfig
-	(*ContainerConfig)(nil),                             // 16: storage.ContainerConfig
-	(*SecurityContext)(nil),                             // 17: storage.SecurityContext
-	(*ListDeployment)(nil),                              // 18: storage.ListDeployment
-	nil,                                                 // 19: storage.Deployment.LabelsEntry
-	nil,                                                 // 20: storage.Deployment.PodLabelsEntry
-	nil,                                                 // 21: storage.Deployment.AnnotationsEntry
-	(*Pod_ContainerInstanceList)(nil),                   // 22: storage.Pod.ContainerInstanceList
-	(*PortConfig_ExposureInfo)(nil),                     // 23: storage.PortConfig.ExposureInfo
-	(*ContainerConfig_EnvironmentConfig)(nil),           // 24: storage.ContainerConfig.EnvironmentConfig
-	(*SecurityContext_SELinux)(nil),                     // 25: storage.SecurityContext.SELinux
-	(*SecurityContext_SeccompProfile)(nil),              // 26: storage.SecurityContext.SeccompProfile
-	(*LabelSelector)(nil),                               // 27: storage.LabelSelector
-	(*timestamppb.Timestamp)(nil),                       // 28: google.protobuf.Timestamp
-	(PermissionLevel)(0),                                // 29: storage.PermissionLevel
-	(*Toleration)(nil),                                  // 30: storage.Toleration
-	(*ImageName)(nil),                                   // 31: storage.ImageName
-	(ContainerRuntime)(0),                               // 32: storage.ContainerRuntime
+	(ContainerType)(0),                                  // 0: storage.ContainerType
+	(Volume_MountPropagation)(0),                        // 1: storage.Volume.MountPropagation
+	(PortConfig_ExposureLevel)(0),                       // 2: storage.PortConfig.ExposureLevel
+	(ContainerConfig_EnvironmentConfig_EnvVarSource)(0), // 3: storage.ContainerConfig.EnvironmentConfig.EnvVarSource
+	(SecurityContext_SeccompProfile_ProfileType)(0),     // 4: storage.SecurityContext.SeccompProfile.ProfileType
+	(*Deployment)(nil),                                  // 5: storage.Deployment
+	(*ContainerImage)(nil),                              // 6: storage.ContainerImage
+	(*StoredContainerImage)(nil),                        // 7: storage.StoredContainerImage
+	(*Container)(nil),                                   // 8: storage.Container
+	(*StoredContainer)(nil),                             // 9: storage.StoredContainer
+	(*StoredDeployment)(nil),                            // 10: storage.StoredDeployment
+	(*Resources)(nil),                                   // 11: storage.Resources
+	(*Volume)(nil),                                      // 12: storage.Volume
+	(*LivenessProbe)(nil),                               // 13: storage.LivenessProbe
+	(*ReadinessProbe)(nil),                              // 14: storage.ReadinessProbe
+	(*Pod)(nil),                                         // 15: storage.Pod
+	(*ContainerInstance)(nil),                           // 16: storage.ContainerInstance
+	(*ContainerInstanceID)(nil),                         // 17: storage.ContainerInstanceID
+	(*EmbeddedSecret)(nil),                              // 18: storage.EmbeddedSecret
+	(*PortConfig)(nil),                                  // 19: storage.PortConfig
+	(*ContainerConfig)(nil),                             // 20: storage.ContainerConfig
+	(*SecurityContext)(nil),                             // 21: storage.SecurityContext
+	(*ListDeployment)(nil),                              // 22: storage.ListDeployment
+	nil,                                                 // 23: storage.Deployment.LabelsEntry
+	nil,                                                 // 24: storage.Deployment.PodLabelsEntry
+	nil,                                                 // 25: storage.Deployment.AnnotationsEntry
+	nil,                                                 // 26: storage.StoredDeployment.LabelsEntry
+	nil,                                                 // 27: storage.StoredDeployment.PodLabelsEntry
+	nil,                                                 // 28: storage.StoredDeployment.AnnotationsEntry
+	(*Pod_ContainerInstanceList)(nil),                   // 29: storage.Pod.ContainerInstanceList
+	(*PortConfig_ExposureInfo)(nil),                     // 30: storage.PortConfig.ExposureInfo
+	(*ContainerConfig_EnvironmentConfig)(nil), // 31: storage.ContainerConfig.EnvironmentConfig
+	(*SecurityContext_SELinux)(nil),           // 32: storage.SecurityContext.SELinux
+	(*SecurityContext_SeccompProfile)(nil),    // 33: storage.SecurityContext.SeccompProfile
+	(*LabelSelector)(nil),                     // 34: storage.LabelSelector
+	(*timestamppb.Timestamp)(nil),             // 35: google.protobuf.Timestamp
+	(PermissionLevel)(0),                      // 36: storage.PermissionLevel
+	(*Toleration)(nil),                        // 37: storage.Toleration
+	(*ImageName)(nil),                         // 38: storage.ImageName
+	(ContainerRuntime)(0),                     // 39: storage.ContainerRuntime
 }
 var file_storage_deployment_proto_depIdxs = []int32{
-	19, // 0: storage.Deployment.labels:type_name -> storage.Deployment.LabelsEntry
-	20, // 1: storage.Deployment.pod_labels:type_name -> storage.Deployment.PodLabelsEntry
-	27, // 2: storage.Deployment.label_selector:type_name -> storage.LabelSelector
-	28, // 3: storage.Deployment.created:type_name -> google.protobuf.Timestamp
-	6,  // 4: storage.Deployment.containers:type_name -> storage.Container
-	21, // 5: storage.Deployment.annotations:type_name -> storage.Deployment.AnnotationsEntry
-	29, // 6: storage.Deployment.service_account_permission_level:type_name -> storage.PermissionLevel
-	30, // 7: storage.Deployment.tolerations:type_name -> storage.Toleration
-	15, // 8: storage.Deployment.ports:type_name -> storage.PortConfig
-	31, // 9: storage.ContainerImage.name:type_name -> storage.ImageName
-	16, // 10: storage.Container.config:type_name -> storage.ContainerConfig
-	5,  // 11: storage.Container.image:type_name -> storage.ContainerImage
-	17, // 12: storage.Container.security_context:type_name -> storage.SecurityContext
-	8,  // 13: storage.Container.volumes:type_name -> storage.Volume
-	15, // 14: storage.Container.ports:type_name -> storage.PortConfig
-	14, // 15: storage.Container.secrets:type_name -> storage.EmbeddedSecret
-	7,  // 16: storage.Container.resources:type_name -> storage.Resources
-	9,  // 17: storage.Container.liveness_probe:type_name -> storage.LivenessProbe
-	10, // 18: storage.Container.readiness_probe:type_name -> storage.ReadinessProbe
-	0,  // 19: storage.Volume.mount_propagation:type_name -> storage.Volume.MountPropagation
-	12, // 20: storage.Pod.live_instances:type_name -> storage.ContainerInstance
-	22, // 21: storage.Pod.terminated_instances:type_name -> storage.Pod.ContainerInstanceList
-	28, // 22: storage.Pod.started:type_name -> google.protobuf.Timestamp
-	13, // 23: storage.ContainerInstance.instance_id:type_name -> storage.ContainerInstanceID
-	28, // 24: storage.ContainerInstance.started:type_name -> google.protobuf.Timestamp
-	28, // 25: storage.ContainerInstance.finished:type_name -> google.protobuf.Timestamp
-	32, // 26: storage.ContainerInstanceID.container_runtime:type_name -> storage.ContainerRuntime
-	1,  // 27: storage.PortConfig.exposure:type_name -> storage.PortConfig.ExposureLevel
-	23, // 28: storage.PortConfig.exposure_infos:type_name -> storage.PortConfig.ExposureInfo
-	24, // 29: storage.ContainerConfig.env:type_name -> storage.ContainerConfig.EnvironmentConfig
-	25, // 30: storage.SecurityContext.selinux:type_name -> storage.SecurityContext.SELinux
-	26, // 31: storage.SecurityContext.seccomp_profile:type_name -> storage.SecurityContext.SeccompProfile
-	28, // 32: storage.ListDeployment.created:type_name -> google.protobuf.Timestamp
-	12, // 33: storage.Pod.ContainerInstanceList.instances:type_name -> storage.ContainerInstance
-	1,  // 34: storage.PortConfig.ExposureInfo.level:type_name -> storage.PortConfig.ExposureLevel
-	2,  // 35: storage.ContainerConfig.EnvironmentConfig.env_var_source:type_name -> storage.ContainerConfig.EnvironmentConfig.EnvVarSource
-	3,  // 36: storage.SecurityContext.SeccompProfile.type:type_name -> storage.SecurityContext.SeccompProfile.ProfileType
-	37, // [37:37] is the sub-list for method output_type
-	37, // [37:37] is the sub-list for method input_type
-	37, // [37:37] is the sub-list for extension type_name
-	37, // [37:37] is the sub-list for extension extendee
-	0,  // [0:37] is the sub-list for field type_name
+	23, // 0: storage.Deployment.labels:type_name -> storage.Deployment.LabelsEntry
+	24, // 1: storage.Deployment.pod_labels:type_name -> storage.Deployment.PodLabelsEntry
+	34, // 2: storage.Deployment.label_selector:type_name -> storage.LabelSelector
+	35, // 3: storage.Deployment.created:type_name -> google.protobuf.Timestamp
+	8,  // 4: storage.Deployment.containers:type_name -> storage.Container
+	25, // 5: storage.Deployment.annotations:type_name -> storage.Deployment.AnnotationsEntry
+	36, // 6: storage.Deployment.service_account_permission_level:type_name -> storage.PermissionLevel
+	37, // 7: storage.Deployment.tolerations:type_name -> storage.Toleration
+	19, // 8: storage.Deployment.ports:type_name -> storage.PortConfig
+	8,  // 9: storage.Deployment.init_containers:type_name -> storage.Container
+	8,  // 10: storage.Deployment.ephemeral_containers:type_name -> storage.Container
+	38, // 11: storage.ContainerImage.name:type_name -> storage.ImageName
+	38, // 12: storage.StoredContainerImage.name:type_name -> storage.ImageName
+	20, // 13: storage.Container.config:type_name -> storage.ContainerConfig
+	6,  // 14: storage.Container.image:type_name -> storage.ContainerImage
+	21, // 15: storage.Container.security_context:type_name -> storage.SecurityContext
+	12, // 16: storage.Container.volumes:type_name -> storage.Volume
+	19, // 17: storage.Container.ports:type_name -> storage.PortConfig
+	18, // 18: storage.Container.secrets:type_name -> storage.EmbeddedSecret
+	11, // 19: storage.Container.resources:type_name -> storage.Resources
+	13, // 20: storage.Container.liveness_probe:type_name -> storage.LivenessProbe
+	14, // 21: storage.Container.readiness_probe:type_name -> storage.ReadinessProbe
+	20, // 22: storage.StoredContainer.config:type_name -> storage.ContainerConfig
+	7,  // 23: storage.StoredContainer.image:type_name -> storage.StoredContainerImage
+	21, // 24: storage.StoredContainer.security_context:type_name -> storage.SecurityContext
+	12, // 25: storage.StoredContainer.volumes:type_name -> storage.Volume
+	19, // 26: storage.StoredContainer.ports:type_name -> storage.PortConfig
+	18, // 27: storage.StoredContainer.secrets:type_name -> storage.EmbeddedSecret
+	11, // 28: storage.StoredContainer.resources:type_name -> storage.Resources
+	13, // 29: storage.StoredContainer.liveness_probe:type_name -> storage.LivenessProbe
+	14, // 30: storage.StoredContainer.readiness_probe:type_name -> storage.ReadinessProbe
+	0,  // 31: storage.StoredContainer.container_type:type_name -> storage.ContainerType
+	26, // 32: storage.StoredDeployment.labels:type_name -> storage.StoredDeployment.LabelsEntry
+	27, // 33: storage.StoredDeployment.pod_labels:type_name -> storage.StoredDeployment.PodLabelsEntry
+	34, // 34: storage.StoredDeployment.label_selector:type_name -> storage.LabelSelector
+	35, // 35: storage.StoredDeployment.created:type_name -> google.protobuf.Timestamp
+	9,  // 36: storage.StoredDeployment.containers:type_name -> storage.StoredContainer
+	28, // 37: storage.StoredDeployment.annotations:type_name -> storage.StoredDeployment.AnnotationsEntry
+	36, // 38: storage.StoredDeployment.service_account_permission_level:type_name -> storage.PermissionLevel
+	37, // 39: storage.StoredDeployment.tolerations:type_name -> storage.Toleration
+	19, // 40: storage.StoredDeployment.ports:type_name -> storage.PortConfig
+	1,  // 41: storage.Volume.mount_propagation:type_name -> storage.Volume.MountPropagation
+	16, // 42: storage.Pod.live_instances:type_name -> storage.ContainerInstance
+	29, // 43: storage.Pod.terminated_instances:type_name -> storage.Pod.ContainerInstanceList
+	35, // 44: storage.Pod.started:type_name -> google.protobuf.Timestamp
+	17, // 45: storage.ContainerInstance.instance_id:type_name -> storage.ContainerInstanceID
+	35, // 46: storage.ContainerInstance.started:type_name -> google.protobuf.Timestamp
+	35, // 47: storage.ContainerInstance.finished:type_name -> google.protobuf.Timestamp
+	39, // 48: storage.ContainerInstanceID.container_runtime:type_name -> storage.ContainerRuntime
+	2,  // 49: storage.PortConfig.exposure:type_name -> storage.PortConfig.ExposureLevel
+	30, // 50: storage.PortConfig.exposure_infos:type_name -> storage.PortConfig.ExposureInfo
+	31, // 51: storage.ContainerConfig.env:type_name -> storage.ContainerConfig.EnvironmentConfig
+	32, // 52: storage.SecurityContext.selinux:type_name -> storage.SecurityContext.SELinux
+	33, // 53: storage.SecurityContext.seccomp_profile:type_name -> storage.SecurityContext.SeccompProfile
+	35, // 54: storage.ListDeployment.created:type_name -> google.protobuf.Timestamp
+	16, // 55: storage.Pod.ContainerInstanceList.instances:type_name -> storage.ContainerInstance
+	2,  // 56: storage.PortConfig.ExposureInfo.level:type_name -> storage.PortConfig.ExposureLevel
+	3,  // 57: storage.ContainerConfig.EnvironmentConfig.env_var_source:type_name -> storage.ContainerConfig.EnvironmentConfig.EnvVarSource
+	4,  // 58: storage.SecurityContext.SeccompProfile.type:type_name -> storage.SecurityContext.SeccompProfile.ProfileType
+	59, // [59:59] is the sub-list for method output_type
+	59, // [59:59] is the sub-list for method input_type
+	59, // [59:59] is the sub-list for extension type_name
+	59, // [59:59] is the sub-list for extension extendee
+	0,  // [0:59] is the sub-list for field type_name
 }
 
 func init() { file_storage_deployment_proto_init() }
@@ -2321,8 +2995,8 @@ func file_storage_deployment_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_storage_deployment_proto_rawDesc), len(file_storage_deployment_proto_rawDesc)),
-			NumEnums:      4,
-			NumMessages:   23,
+			NumEnums:      5,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/generated/storage/deployment.pb.go
+++ b/generated/storage/deployment.pb.go
@@ -326,8 +326,8 @@ type Deployment struct {
 	StateTimestamp                int64                  `protobuf:"varint,27,opt,name=state_timestamp,json=stateTimestamp,proto3" json:"state_timestamp,omitempty" hash:"ignore" sensorhash:"ignore"`                                                                               // Internal use only @gotags: hash:"ignore" sensorhash:"ignore"
 	RiskScore                     float32                `protobuf:"fixed32,29,opt,name=risk_score,json=riskScore,proto3" json:"risk_score,omitempty" search:"Deployment Risk Score,hidden" policy:",ignore"`                                                                                             // @gotags: search:"Deployment Risk Score,hidden" policy:",ignore"
 	PlatformComponent             bool                   `protobuf:"varint,35,opt,name=platform_component,json=platformComponent,proto3" json:"platform_component,omitempty" search:"Platform Component"`                                                                      // @gotags: search:"Platform Component"
-	InitContainers                []*Container           `protobuf:"bytes,36,rep,name=init_containers,json=initContainers,proto3" json:"init_containers,omitempty"`
-	EphemeralContainers           []*Container           `protobuf:"bytes,37,rep,name=ephemeral_containers,json=ephemeralContainers,proto3" json:"ephemeral_containers,omitempty"`
+	InitContainers                []*Container           `protobuf:"bytes,36,rep,name=init_containers,json=initContainers,proto3" json:"init_containers,omitempty" search:"-"`                                                                                // @gotags: search:"-"
+	EphemeralContainers           []*Container           `protobuf:"bytes,37,rep,name=ephemeral_containers,json=ephemeralContainers,proto3" json:"ephemeral_containers,omitempty" search:"-"`                                                                 // @gotags: search:"-"
 	unknownFields                 protoimpl.UnknownFields
 	sizeCache                     protoimpl.SizeCache
 }

--- a/generated/storage/deployment_vtproto.pb.go
+++ b/generated/storage/deployment_vtproto.pb.go
@@ -100,6 +100,20 @@ func (m *Deployment) CloneVT() *Deployment {
 		}
 		r.Ports = tmpContainer
 	}
+	if rhs := m.InitContainers; rhs != nil {
+		tmpContainer := make([]*Container, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.InitContainers = tmpContainer
+	}
+	if rhs := m.EphemeralContainers; rhs != nil {
+		tmpContainer := make([]*Container, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.EphemeralContainers = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -129,6 +143,27 @@ func (m *ContainerImage) CloneVT() *ContainerImage {
 }
 
 func (m *ContainerImage) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *StoredContainerImage) CloneVT() *StoredContainerImage {
+	if m == nil {
+		return (*StoredContainerImage)(nil)
+	}
+	r := new(StoredContainerImage)
+	r.Id = m.Id
+	r.Name = m.Name.CloneVT()
+	r.NotPullable = m.NotPullable
+	r.IsClusterLocal = m.IsClusterLocal
+	r.IdV2 = m.IdV2
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *StoredContainerImage) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -174,6 +209,139 @@ func (m *Container) CloneVT() *Container {
 }
 
 func (m *Container) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *StoredContainer) CloneVT() *StoredContainer {
+	if m == nil {
+		return (*StoredContainer)(nil)
+	}
+	r := new(StoredContainer)
+	r.Id = m.Id
+	r.Config = m.Config.CloneVT()
+	r.Image = m.Image.CloneVT()
+	r.SecurityContext = m.SecurityContext.CloneVT()
+	r.Resources = m.Resources.CloneVT()
+	r.Name = m.Name
+	r.LivenessProbe = m.LivenessProbe.CloneVT()
+	r.ReadinessProbe = m.ReadinessProbe.CloneVT()
+	r.ContainerType = m.ContainerType
+	if rhs := m.Volumes; rhs != nil {
+		tmpContainer := make([]*Volume, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Volumes = tmpContainer
+	}
+	if rhs := m.Ports; rhs != nil {
+		tmpContainer := make([]*PortConfig, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Ports = tmpContainer
+	}
+	if rhs := m.Secrets; rhs != nil {
+		tmpContainer := make([]*EmbeddedSecret, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Secrets = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *StoredContainer) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *StoredDeployment) CloneVT() *StoredDeployment {
+	if m == nil {
+		return (*StoredDeployment)(nil)
+	}
+	r := new(StoredDeployment)
+	r.Id = m.Id
+	r.Name = m.Name
+	r.Hash = m.Hash
+	r.Type = m.Type
+	r.Namespace = m.Namespace
+	r.NamespaceId = m.NamespaceId
+	r.OrchestratorComponent = m.OrchestratorComponent
+	r.Replicas = m.Replicas
+	r.LabelSelector = m.LabelSelector.CloneVT()
+	r.Created = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.Created).CloneVT())
+	r.ClusterId = m.ClusterId
+	r.ClusterName = m.ClusterName
+	r.Priority = m.Priority
+	r.Inactive = m.Inactive
+	r.ServiceAccount = m.ServiceAccount
+	r.ServiceAccountPermissionLevel = m.ServiceAccountPermissionLevel
+	r.AutomountServiceAccountToken = m.AutomountServiceAccountToken
+	r.HostNetwork = m.HostNetwork
+	r.HostPid = m.HostPid
+	r.HostIpc = m.HostIpc
+	r.RuntimeClass = m.RuntimeClass
+	r.StateTimestamp = m.StateTimestamp
+	r.RiskScore = m.RiskScore
+	r.PlatformComponent = m.PlatformComponent
+	if rhs := m.Labels; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.Labels = tmpContainer
+	}
+	if rhs := m.PodLabels; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.PodLabels = tmpContainer
+	}
+	if rhs := m.Containers; rhs != nil {
+		tmpContainer := make([]*StoredContainer, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Containers = tmpContainer
+	}
+	if rhs := m.Annotations; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.Annotations = tmpContainer
+	}
+	if rhs := m.ImagePullSecrets; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.ImagePullSecrets = tmpContainer
+	}
+	if rhs := m.Tolerations; rhs != nil {
+		tmpContainer := make([]*Toleration, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Tolerations = tmpContainer
+	}
+	if rhs := m.Ports; rhs != nil {
+		tmpContainer := make([]*PortConfig, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Ports = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *StoredDeployment) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -761,6 +929,40 @@ func (this *Deployment) EqualVT(that *Deployment) bool {
 	if this.PlatformComponent != that.PlatformComponent {
 		return false
 	}
+	if len(this.InitContainers) != len(that.InitContainers) {
+		return false
+	}
+	for i, vx := range this.InitContainers {
+		vy := that.InitContainers[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &Container{}
+			}
+			if q == nil {
+				q = &Container{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if len(this.EphemeralContainers) != len(that.EphemeralContainers) {
+		return false
+	}
+	for i, vx := range this.EphemeralContainers {
+		vy := that.EphemeralContainers[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &Container{}
+			}
+			if q == nil {
+				q = &Container{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -797,6 +999,37 @@ func (this *ContainerImage) EqualVT(that *ContainerImage) bool {
 
 func (this *ContainerImage) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*ContainerImage)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *StoredContainerImage) EqualVT(that *StoredContainerImage) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.Name.EqualVT(that.Name) {
+		return false
+	}
+	if this.Id != that.Id {
+		return false
+	}
+	if this.NotPullable != that.NotPullable {
+		return false
+	}
+	if this.IsClusterLocal != that.IsClusterLocal {
+		return false
+	}
+	if this.IdV2 != that.IdV2 {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *StoredContainerImage) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*StoredContainerImage)
 	if !ok {
 		return false
 	}
@@ -888,6 +1121,284 @@ func (this *Container) EqualVT(that *Container) bool {
 
 func (this *Container) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*Container)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *StoredContainer) EqualVT(that *StoredContainer) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Id != that.Id {
+		return false
+	}
+	if !this.Config.EqualVT(that.Config) {
+		return false
+	}
+	if !this.Image.EqualVT(that.Image) {
+		return false
+	}
+	if !this.SecurityContext.EqualVT(that.SecurityContext) {
+		return false
+	}
+	if len(this.Volumes) != len(that.Volumes) {
+		return false
+	}
+	for i, vx := range this.Volumes {
+		vy := that.Volumes[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &Volume{}
+			}
+			if q == nil {
+				q = &Volume{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if len(this.Ports) != len(that.Ports) {
+		return false
+	}
+	for i, vx := range this.Ports {
+		vy := that.Ports[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &PortConfig{}
+			}
+			if q == nil {
+				q = &PortConfig{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if len(this.Secrets) != len(that.Secrets) {
+		return false
+	}
+	for i, vx := range this.Secrets {
+		vy := that.Secrets[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &EmbeddedSecret{}
+			}
+			if q == nil {
+				q = &EmbeddedSecret{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if !this.Resources.EqualVT(that.Resources) {
+		return false
+	}
+	if this.Name != that.Name {
+		return false
+	}
+	if !this.LivenessProbe.EqualVT(that.LivenessProbe) {
+		return false
+	}
+	if !this.ReadinessProbe.EqualVT(that.ReadinessProbe) {
+		return false
+	}
+	if this.ContainerType != that.ContainerType {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *StoredContainer) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*StoredContainer)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *StoredDeployment) EqualVT(that *StoredDeployment) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Id != that.Id {
+		return false
+	}
+	if this.Name != that.Name {
+		return false
+	}
+	if this.Type != that.Type {
+		return false
+	}
+	if this.Namespace != that.Namespace {
+		return false
+	}
+	if this.Replicas != that.Replicas {
+		return false
+	}
+	if len(this.Labels) != len(that.Labels) {
+		return false
+	}
+	for i, vx := range this.Labels {
+		vy, ok := that.Labels[i]
+		if !ok {
+			return false
+		}
+		if vx != vy {
+			return false
+		}
+	}
+	if !(*timestamppb1.Timestamp)(this.Created).EqualVT((*timestamppb1.Timestamp)(that.Created)) {
+		return false
+	}
+	if this.ClusterId != that.ClusterId {
+		return false
+	}
+	if this.ClusterName != that.ClusterName {
+		return false
+	}
+	if len(this.Containers) != len(that.Containers) {
+		return false
+	}
+	for i, vx := range this.Containers {
+		vy := that.Containers[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &StoredContainer{}
+			}
+			if q == nil {
+				q = &StoredContainer{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if len(this.Annotations) != len(that.Annotations) {
+		return false
+	}
+	for i, vx := range this.Annotations {
+		vy, ok := that.Annotations[i]
+		if !ok {
+			return false
+		}
+		if vx != vy {
+			return false
+		}
+	}
+	if this.Priority != that.Priority {
+		return false
+	}
+	if this.Inactive != that.Inactive {
+		return false
+	}
+	if len(this.ImagePullSecrets) != len(that.ImagePullSecrets) {
+		return false
+	}
+	for i, vx := range this.ImagePullSecrets {
+		vy := that.ImagePullSecrets[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if this.ServiceAccount != that.ServiceAccount {
+		return false
+	}
+	if len(this.PodLabels) != len(that.PodLabels) {
+		return false
+	}
+	for i, vx := range this.PodLabels {
+		vy, ok := that.PodLabels[i]
+		if !ok {
+			return false
+		}
+		if vx != vy {
+			return false
+		}
+	}
+	if !this.LabelSelector.EqualVT(that.LabelSelector) {
+		return false
+	}
+	if this.HostNetwork != that.HostNetwork {
+		return false
+	}
+	if len(this.Tolerations) != len(that.Tolerations) {
+		return false
+	}
+	for i, vx := range this.Tolerations {
+		vy := that.Tolerations[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &Toleration{}
+			}
+			if q == nil {
+				q = &Toleration{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if this.NamespaceId != that.NamespaceId {
+		return false
+	}
+	if len(this.Ports) != len(that.Ports) {
+		return false
+	}
+	for i, vx := range this.Ports {
+		vy := that.Ports[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &PortConfig{}
+			}
+			if q == nil {
+				q = &PortConfig{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	if this.AutomountServiceAccountToken != that.AutomountServiceAccountToken {
+		return false
+	}
+	if this.Hash != that.Hash {
+		return false
+	}
+	if this.StateTimestamp != that.StateTimestamp {
+		return false
+	}
+	if this.ServiceAccountPermissionLevel != that.ServiceAccountPermissionLevel {
+		return false
+	}
+	if this.RiskScore != that.RiskScore {
+		return false
+	}
+	if this.HostPid != that.HostPid {
+		return false
+	}
+	if this.HostIpc != that.HostIpc {
+		return false
+	}
+	if this.OrchestratorComponent != that.OrchestratorComponent {
+		return false
+	}
+	if this.RuntimeClass != that.RuntimeClass {
+		return false
+	}
+	if this.PlatformComponent != that.PlatformComponent {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *StoredDeployment) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*StoredDeployment)
 	if !ok {
 		return false
 	}
@@ -1547,6 +2058,34 @@ func (m *Deployment) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.EphemeralContainers) > 0 {
+		for iNdEx := len(m.EphemeralContainers) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.EphemeralContainers[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xaa
+		}
+	}
+	if len(m.InitContainers) > 0 {
+		for iNdEx := len(m.InitContainers) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.InitContainers[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xa2
+		}
+	}
 	if m.PlatformComponent {
 		i--
 		if m.PlatformComponent {
@@ -1951,6 +2490,83 @@ func (m *ContainerImage) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *StoredContainerImage) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StoredContainerImage) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *StoredContainerImage) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.IdV2) > 0 {
+		i -= len(m.IdV2)
+		copy(dAtA[i:], m.IdV2)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.IdV2)))
+		i--
+		dAtA[i] = 0x62
+	}
+	if m.IsClusterLocal {
+		i--
+		if m.IsClusterLocal {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x58
+	}
+	if m.NotPullable {
+		i--
+		if m.NotPullable {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x50
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.Name != nil {
+		size, err := m.Name.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Container) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -2081,6 +2697,511 @@ func (m *Container) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		}
 		i -= size
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StoredContainer) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StoredContainer) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *StoredContainer) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.ContainerType != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.ContainerType))
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.ReadinessProbe != nil {
+		size, err := m.ReadinessProbe.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x62
+	}
+	if m.LivenessProbe != nil {
+		size, err := m.LivenessProbe.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x5a
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0x52
+	}
+	if m.Resources != nil {
+		size, err := m.Resources.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x42
+	}
+	if len(m.Secrets) > 0 {
+		for iNdEx := len(m.Secrets) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Secrets[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x3a
+		}
+	}
+	if len(m.Ports) > 0 {
+		for iNdEx := len(m.Ports) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Ports[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x32
+		}
+	}
+	if len(m.Volumes) > 0 {
+		for iNdEx := len(m.Volumes) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Volumes[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
+	if m.SecurityContext != nil {
+		size, err := m.SecurityContext.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.Image != nil {
+		size, err := m.Image.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Config != nil {
+		size, err := m.Config.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StoredDeployment) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StoredDeployment) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *StoredDeployment) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.PlatformComponent {
+		i--
+		if m.PlatformComponent {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x98
+	}
+	if len(m.RuntimeClass) > 0 {
+		i -= len(m.RuntimeClass)
+		copy(dAtA[i:], m.RuntimeClass)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.RuntimeClass)))
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x92
+	}
+	if m.OrchestratorComponent {
+		i--
+		if m.OrchestratorComponent {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x88
+	}
+	if m.HostIpc {
+		i--
+		if m.HostIpc {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x80
+	}
+	if m.HostPid {
+		i--
+		if m.HostPid {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xf8
+	}
+	if m.RiskScore != 0 {
+		i -= 4
+		binary.LittleEndian.PutUint32(dAtA[i:], uint32(math.Float32bits(float32(m.RiskScore))))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xed
+	}
+	if m.ServiceAccountPermissionLevel != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.ServiceAccountPermissionLevel))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xe0
+	}
+	if m.StateTimestamp != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.StateTimestamp))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xd8
+	}
+	if m.Hash != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Hash))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xd0
+	}
+	if m.AutomountServiceAccountToken {
+		i--
+		if m.AutomountServiceAccountToken {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xc8
+	}
+	if len(m.Ports) > 0 {
+		for iNdEx := len(m.Ports) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Ports[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xc2
+		}
+	}
+	if len(m.NamespaceId) > 0 {
+		i -= len(m.NamespaceId)
+		copy(dAtA[i:], m.NamespaceId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.NamespaceId)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xba
+	}
+	if len(m.Tolerations) > 0 {
+		for iNdEx := len(m.Tolerations) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Tolerations[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xb2
+		}
+	}
+	if m.HostNetwork {
+		i--
+		if m.HostNetwork {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.LabelSelector != nil {
+		size, err := m.LabelSelector.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa2
+	}
+	if len(m.PodLabels) > 0 {
+		for k := range m.PodLabels {
+			v := m.PodLabels[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0x9a
+		}
+	}
+	if len(m.ServiceAccount) > 0 {
+		i -= len(m.ServiceAccount)
+		copy(dAtA[i:], m.ServiceAccount)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ServiceAccount)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x92
+	}
+	if len(m.ImagePullSecrets) > 0 {
+		for iNdEx := len(m.ImagePullSecrets) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.ImagePullSecrets[iNdEx])
+			copy(dAtA[i:], m.ImagePullSecrets[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ImagePullSecrets[iNdEx])))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0x8a
+		}
+	}
+	if m.Inactive {
+		i--
+		if m.Inactive {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x80
+	}
+	if m.Priority != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Priority))
+		i--
+		dAtA[i] = 0x78
+	}
+	if len(m.Annotations) > 0 {
+		for k := range m.Annotations {
+			v := m.Annotations[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x72
+		}
+	}
+	if len(m.Containers) > 0 {
+		for iNdEx := len(m.Containers) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Containers[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x5a
+		}
+	}
+	if len(m.ClusterName) > 0 {
+		i -= len(m.ClusterName)
+		copy(dAtA[i:], m.ClusterName)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ClusterName)))
+		i--
+		dAtA[i] = 0x52
+	}
+	if len(m.ClusterId) > 0 {
+		i -= len(m.ClusterId)
+		copy(dAtA[i:], m.ClusterId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ClusterId)))
+		i--
+		dAtA[i] = 0x4a
+	}
+	if m.Created != nil {
+		size, err := (*timestamppb1.Timestamp)(m.Created).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x42
+	}
+	if len(m.Labels) > 0 {
+		for k := range m.Labels {
+			v := m.Labels[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x3a
+		}
+	}
+	if m.Replicas != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Replicas))
+		i--
+		dAtA[i] = 0x30
+	}
+	if len(m.Namespace) > 0 {
+		i -= len(m.Namespace)
+		copy(dAtA[i:], m.Namespace)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Namespace)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.Type) > 0 {
+		i -= len(m.Type)
+		copy(dAtA[i:], m.Type)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Type)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Name)))
 		i--
 		dAtA[i] = 0x12
 	}
@@ -3398,11 +4519,51 @@ func (m *Deployment) SizeVT() (n int) {
 	if m.PlatformComponent {
 		n += 3
 	}
+	if len(m.InitContainers) > 0 {
+		for _, e := range m.InitContainers {
+			l = e.SizeVT()
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.EphemeralContainers) > 0 {
+		for _, e := range m.EphemeralContainers {
+			l = e.SizeVT()
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
 	n += len(m.unknownFields)
 	return n
 }
 
 func (m *ContainerImage) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Name != nil {
+		l = m.Name.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.NotPullable {
+		n += 2
+	}
+	if m.IsClusterLocal {
+		n += 2
+	}
+	l = len(m.IdV2)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *StoredContainerImage) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -3485,6 +4646,210 @@ func (m *Container) SizeVT() (n int) {
 	if m.ReadinessProbe != nil {
 		l = m.ReadinessProbe.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *StoredContainer) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Config != nil {
+		l = m.Config.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Image != nil {
+		l = m.Image.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.SecurityContext != nil {
+		l = m.SecurityContext.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Volumes) > 0 {
+		for _, e := range m.Volumes {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.Ports) > 0 {
+		for _, e := range m.Ports {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.Secrets) > 0 {
+		for _, e := range m.Secrets {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if m.Resources != nil {
+		l = m.Resources.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.LivenessProbe != nil {
+		l = m.LivenessProbe.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.ReadinessProbe != nil {
+		l = m.ReadinessProbe.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.ContainerType != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.ContainerType))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *StoredDeployment) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Type)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Namespace)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Replicas != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Replicas))
+	}
+	if len(m.Labels) > 0 {
+		for k, v := range m.Labels {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if m.Created != nil {
+		l = (*timestamppb1.Timestamp)(m.Created).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ClusterId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ClusterName)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Containers) > 0 {
+		for _, e := range m.Containers {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.Annotations) > 0 {
+		for k, v := range m.Annotations {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if m.Priority != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Priority))
+	}
+	if m.Inactive {
+		n += 3
+	}
+	if len(m.ImagePullSecrets) > 0 {
+		for _, s := range m.ImagePullSecrets {
+			l = len(s)
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	l = len(m.ServiceAccount)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.PodLabels) > 0 {
+		for k, v := range m.PodLabels {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 2 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if m.LabelSelector != nil {
+		l = m.LabelSelector.SizeVT()
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.HostNetwork {
+		n += 3
+	}
+	if len(m.Tolerations) > 0 {
+		for _, e := range m.Tolerations {
+			l = e.SizeVT()
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	l = len(m.NamespaceId)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Ports) > 0 {
+		for _, e := range m.Ports {
+			l = e.SizeVT()
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if m.AutomountServiceAccountToken {
+		n += 3
+	}
+	if m.Hash != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.Hash))
+	}
+	if m.StateTimestamp != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.StateTimestamp))
+	}
+	if m.ServiceAccountPermissionLevel != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.ServiceAccountPermissionLevel))
+	}
+	if m.RiskScore != 0 {
+		n += 6
+	}
+	if m.HostPid {
+		n += 3
+	}
+	if m.HostIpc {
+		n += 3
+	}
+	if m.OrchestratorComponent {
+		n += 3
+	}
+	l = len(m.RuntimeClass)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.PlatformComponent {
+		n += 3
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5130,6 +6495,74 @@ func (m *Deployment) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.PlatformComponent = bool(v != 0)
+		case 36:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InitContainers", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.InitContainers = append(m.InitContainers, &Container{})
+			if err := m.InitContainers[len(m.InitContainers)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 37:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EphemeralContainers", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.EphemeralContainers = append(m.EphemeralContainers, &Container{})
+			if err := m.EphemeralContainers[len(m.EphemeralContainers)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -5179,6 +6612,197 @@ func (m *ContainerImage) UnmarshalVT(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: ContainerImage: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Name == nil {
+				m.Name = &ImageName{}
+			}
+			if err := m.Name.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NotPullable", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.NotPullable = bool(v != 0)
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IsClusterLocal", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IsClusterLocal = bool(v != 0)
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IdV2", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.IdV2 = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StoredContainerImage) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StoredContainerImage: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StoredContainerImage: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -5754,6 +7378,1630 @@ func (m *Container) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StoredContainer) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StoredContainer: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StoredContainer: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Config", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Config == nil {
+				m.Config = &ContainerConfig{}
+			}
+			if err := m.Config.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Image", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Image == nil {
+				m.Image = &StoredContainerImage{}
+			}
+			if err := m.Image.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SecurityContext", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.SecurityContext == nil {
+				m.SecurityContext = &SecurityContext{}
+			}
+			if err := m.SecurityContext.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Volumes", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Volumes = append(m.Volumes, &Volume{})
+			if err := m.Volumes[len(m.Volumes)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ports", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Ports = append(m.Ports, &PortConfig{})
+			if err := m.Ports[len(m.Ports)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Secrets", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Secrets = append(m.Secrets, &EmbeddedSecret{})
+			if err := m.Secrets[len(m.Secrets)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Resources", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Resources == nil {
+				m.Resources = &Resources{}
+			}
+			if err := m.Resources.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LivenessProbe", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LivenessProbe == nil {
+				m.LivenessProbe = &LivenessProbe{}
+			}
+			if err := m.LivenessProbe.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReadinessProbe", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ReadinessProbe == nil {
+				m.ReadinessProbe = &ReadinessProbe{}
+			}
+			if err := m.ReadinessProbe.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContainerType", wireType)
+			}
+			m.ContainerType = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ContainerType |= ContainerType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StoredDeployment) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StoredDeployment: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StoredDeployment: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Type = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Namespace = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Replicas", wireType)
+			}
+			m.Replicas = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Replicas |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Labels == nil {
+				m.Labels = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Labels[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Created", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Created == nil {
+				m.Created = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.Created).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ClusterId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ClusterName = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Containers", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Containers = append(m.Containers, &StoredContainer{})
+			if err := m.Containers[len(m.Containers)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 14:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Annotations", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Annotations == nil {
+				m.Annotations = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Annotations[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 15:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Priority", wireType)
+			}
+			m.Priority = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Priority |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 16:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Inactive", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Inactive = bool(v != 0)
+		case 17:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ImagePullSecrets", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ImagePullSecrets = append(m.ImagePullSecrets, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 18:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ServiceAccount", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ServiceAccount = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 19:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PodLabels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.PodLabels == nil {
+				m.PodLabels = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.PodLabels[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 20:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LabelSelector", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LabelSelector == nil {
+				m.LabelSelector = &LabelSelector{}
+			}
+			if err := m.LabelSelector.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 21:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HostNetwork", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.HostNetwork = bool(v != 0)
+		case 22:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Tolerations", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Tolerations = append(m.Tolerations, &Toleration{})
+			if err := m.Tolerations[len(m.Tolerations)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 23:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NamespaceId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NamespaceId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 24:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ports", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Ports = append(m.Ports, &PortConfig{})
+			if err := m.Ports[len(m.Ports)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 25:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AutomountServiceAccountToken", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AutomountServiceAccountToken = bool(v != 0)
+		case 26:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Hash", wireType)
+			}
+			m.Hash = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Hash |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 27:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StateTimestamp", wireType)
+			}
+			m.StateTimestamp = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.StateTimestamp |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 28:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ServiceAccountPermissionLevel", wireType)
+			}
+			m.ServiceAccountPermissionLevel = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ServiceAccountPermissionLevel |= PermissionLevel(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 29:
+			if wireType != 5 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RiskScore", wireType)
+			}
+			var v uint32
+			if (iNdEx + 4) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint32(binary.LittleEndian.Uint32(dAtA[iNdEx:]))
+			iNdEx += 4
+			m.RiskScore = float32(math.Float32frombits(v))
+		case 31:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HostPid", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.HostPid = bool(v != 0)
+		case 32:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HostIpc", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.HostIpc = bool(v != 0)
+		case 33:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OrchestratorComponent", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.OrchestratorComponent = bool(v != 0)
+		case 34:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RuntimeClass", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.RuntimeClass = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 35:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PlatformComponent", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.PlatformComponent = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10117,6 +13365,74 @@ func (m *Deployment) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 			}
 			m.PlatformComponent = bool(v != 0)
+		case 36:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InitContainers", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.InitContainers = append(m.InitContainers, &Container{})
+			if err := m.InitContainers[len(m.InitContainers)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 37:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EphemeralContainers", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.EphemeralContainers = append(m.EphemeralContainers, &Container{})
+			if err := m.EphemeralContainers[len(m.EphemeralContainers)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10166,6 +13482,205 @@ func (m *ContainerImage) UnmarshalVTUnsafe(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: ContainerImage: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Name == nil {
+				m.Name = &ImageName{}
+			}
+			if err := m.Name.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Id = stringValue
+			iNdEx = postIndex
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NotPullable", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.NotPullable = bool(v != 0)
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IsClusterLocal", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IsClusterLocal = bool(v != 0)
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IdV2", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.IdV2 = stringValue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StoredContainerImage) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StoredContainerImage: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StoredContainerImage: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -10757,6 +14272,1702 @@ func (m *Container) UnmarshalVTUnsafe(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StoredContainer) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StoredContainer: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StoredContainer: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Id = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Config", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Config == nil {
+				m.Config = &ContainerConfig{}
+			}
+			if err := m.Config.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Image", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Image == nil {
+				m.Image = &StoredContainerImage{}
+			}
+			if err := m.Image.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SecurityContext", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.SecurityContext == nil {
+				m.SecurityContext = &SecurityContext{}
+			}
+			if err := m.SecurityContext.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Volumes", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Volumes = append(m.Volumes, &Volume{})
+			if err := m.Volumes[len(m.Volumes)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ports", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Ports = append(m.Ports, &PortConfig{})
+			if err := m.Ports[len(m.Ports)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Secrets", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Secrets = append(m.Secrets, &EmbeddedSecret{})
+			if err := m.Secrets[len(m.Secrets)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Resources", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Resources == nil {
+				m.Resources = &Resources{}
+			}
+			if err := m.Resources.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Name = stringValue
+			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LivenessProbe", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LivenessProbe == nil {
+				m.LivenessProbe = &LivenessProbe{}
+			}
+			if err := m.LivenessProbe.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ReadinessProbe", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ReadinessProbe == nil {
+				m.ReadinessProbe = &ReadinessProbe{}
+			}
+			if err := m.ReadinessProbe.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ContainerType", wireType)
+			}
+			m.ContainerType = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ContainerType |= ContainerType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StoredDeployment) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StoredDeployment: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StoredDeployment: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Id = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Name = stringValue
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Type = stringValue
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Namespace = stringValue
+			iNdEx = postIndex
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Replicas", wireType)
+			}
+			m.Replicas = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Replicas |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Labels == nil {
+				m.Labels = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapkey == 0 {
+						mapkey = ""
+					} else {
+						mapkey = unsafe.String(&dAtA[iNdEx], intStringLenmapkey)
+					}
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapvalue == 0 {
+						mapvalue = ""
+					} else {
+						mapvalue = unsafe.String(&dAtA[iNdEx], intStringLenmapvalue)
+					}
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Labels[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Created", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Created == nil {
+				m.Created = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.Created).UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ClusterId = stringValue
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ClusterName = stringValue
+			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Containers", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Containers = append(m.Containers, &StoredContainer{})
+			if err := m.Containers[len(m.Containers)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 14:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Annotations", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Annotations == nil {
+				m.Annotations = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapkey == 0 {
+						mapkey = ""
+					} else {
+						mapkey = unsafe.String(&dAtA[iNdEx], intStringLenmapkey)
+					}
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapvalue == 0 {
+						mapvalue = ""
+					} else {
+						mapvalue = unsafe.String(&dAtA[iNdEx], intStringLenmapvalue)
+					}
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Annotations[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 15:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Priority", wireType)
+			}
+			m.Priority = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Priority |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 16:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Inactive", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Inactive = bool(v != 0)
+		case 17:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ImagePullSecrets", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ImagePullSecrets = append(m.ImagePullSecrets, stringValue)
+			iNdEx = postIndex
+		case 18:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ServiceAccount", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ServiceAccount = stringValue
+			iNdEx = postIndex
+		case 19:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PodLabels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.PodLabels == nil {
+				m.PodLabels = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapkey == 0 {
+						mapkey = ""
+					} else {
+						mapkey = unsafe.String(&dAtA[iNdEx], intStringLenmapkey)
+					}
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapvalue == 0 {
+						mapvalue = ""
+					} else {
+						mapvalue = unsafe.String(&dAtA[iNdEx], intStringLenmapvalue)
+					}
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.PodLabels[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 20:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LabelSelector", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LabelSelector == nil {
+				m.LabelSelector = &LabelSelector{}
+			}
+			if err := m.LabelSelector.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 21:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HostNetwork", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.HostNetwork = bool(v != 0)
+		case 22:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Tolerations", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Tolerations = append(m.Tolerations, &Toleration{})
+			if err := m.Tolerations[len(m.Tolerations)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 23:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NamespaceId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.NamespaceId = stringValue
+			iNdEx = postIndex
+		case 24:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ports", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Ports = append(m.Ports, &PortConfig{})
+			if err := m.Ports[len(m.Ports)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 25:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AutomountServiceAccountToken", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AutomountServiceAccountToken = bool(v != 0)
+		case 26:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Hash", wireType)
+			}
+			m.Hash = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Hash |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 27:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StateTimestamp", wireType)
+			}
+			m.StateTimestamp = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.StateTimestamp |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 28:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ServiceAccountPermissionLevel", wireType)
+			}
+			m.ServiceAccountPermissionLevel = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ServiceAccountPermissionLevel |= PermissionLevel(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 29:
+			if wireType != 5 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RiskScore", wireType)
+			}
+			var v uint32
+			if (iNdEx + 4) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint32(binary.LittleEndian.Uint32(dAtA[iNdEx:]))
+			iNdEx += 4
+			m.RiskScore = float32(math.Float32frombits(v))
+		case 31:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HostPid", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.HostPid = bool(v != 0)
+		case 32:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HostIpc", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.HostIpc = bool(v != 0)
+		case 33:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OrchestratorComponent", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.OrchestratorComponent = bool(v != 0)
+		case 34:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RuntimeClass", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.RuntimeClass = stringValue
+			iNdEx = postIndex
+		case 35:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PlatformComponent", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.PlatformComponent = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/postgres/schema/deployments.go
+++ b/pkg/postgres/schema/deployments.go
@@ -57,7 +57,7 @@ var (
 		if schema != nil {
 			return schema
 		}
-		schema = walker.Walk(reflect.TypeOf((*storage.Deployment)(nil)), "deployments")
+		schema = walker.Walk(reflect.TypeOf((*storage.StoredDeployment)(nil)), "deployments")
 		referencedSchemas := map[string]*walker.Schema{
 			"storage.Image":             ImagesSchema,
 			"storage.NamespaceMetadata": NamespacesSchema,
@@ -67,7 +67,7 @@ var (
 		schema.ResolveReferences(func(messageTypeName string) *walker.Schema {
 			return referencedSchemas[fmt.Sprintf("storage.%s", messageTypeName)]
 		})
-		schema.SetOptionsMap(search.Walk(v1.SearchCategory_DEPLOYMENTS, "deployment", (*storage.Deployment)(nil)))
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory_DEPLOYMENTS, "storeddeployment", (*storage.StoredDeployment)(nil)))
 		schema.SetSearchScope([]v1.SearchCategory{
 			v1.SearchCategory_IMAGE_VULNERABILITIES_V2,
 			v1.SearchCategory_IMAGE_COMPONENTS_V2,
@@ -129,23 +129,24 @@ type Deployments struct {
 
 // DeploymentsContainers holds the Gorm model for Postgres table `deployments_containers`.
 type DeploymentsContainers struct {
-	DeploymentsID                         string          `gorm:"column:deployments_id;type:uuid;primaryKey"`
-	Idx                                   int             `gorm:"column:idx;type:integer;primaryKey;index:deploymentscontainers_idx,type:btree"`
-	ImageID                               string          `gorm:"column:image_id;type:varchar;index:deploymentscontainers_image_id,type:hash"`
-	ImageNameRegistry                     string          `gorm:"column:image_name_registry;type:varchar"`
-	ImageNameRemote                       string          `gorm:"column:image_name_remote;type:varchar"`
-	ImageNameTag                          string          `gorm:"column:image_name_tag;type:varchar"`
-	ImageNameFullName                     string          `gorm:"column:image_name_fullname;type:varchar"`
-	ImageIDV2                             string          `gorm:"column:image_idv2;type:varchar;index:deploymentscontainers_image_idv2,type:btree"`
-	SecurityContextPrivileged             bool            `gorm:"column:securitycontext_privileged;type:bool"`
-	SecurityContextDropCapabilities       *pq.StringArray `gorm:"column:securitycontext_dropcapabilities;type:text[]"`
-	SecurityContextAddCapabilities        *pq.StringArray `gorm:"column:securitycontext_addcapabilities;type:text[]"`
-	SecurityContextReadOnlyRootFilesystem bool            `gorm:"column:securitycontext_readonlyrootfilesystem;type:bool"`
-	ResourcesCPUCoresRequest              float32         `gorm:"column:resources_cpucoresrequest;type:numeric"`
-	ResourcesCPUCoresLimit                float32         `gorm:"column:resources_cpucoreslimit;type:numeric"`
-	ResourcesMemoryMbRequest              float32         `gorm:"column:resources_memorymbrequest;type:numeric"`
-	ResourcesMemoryMbLimit                float32         `gorm:"column:resources_memorymblimit;type:numeric"`
-	DeploymentsRef                        Deployments     `gorm:"foreignKey:deployments_id;references:id;belongsTo;constraint:OnDelete:CASCADE"`
+	DeploymentsID                         string                `gorm:"column:deployments_id;type:uuid;primaryKey"`
+	Idx                                   int                   `gorm:"column:idx;type:integer;primaryKey;index:deploymentscontainers_idx,type:btree"`
+	ImageID                               string                `gorm:"column:image_id;type:varchar;index:deploymentscontainers_image_id,type:hash"`
+	ImageNameRegistry                     string                `gorm:"column:image_name_registry;type:varchar"`
+	ImageNameRemote                       string                `gorm:"column:image_name_remote;type:varchar"`
+	ImageNameTag                          string                `gorm:"column:image_name_tag;type:varchar"`
+	ImageNameFullName                     string                `gorm:"column:image_name_fullname;type:varchar"`
+	ImageIDV2                             string                `gorm:"column:image_idv2;type:varchar;index:deploymentscontainers_image_idv2,type:btree"`
+	SecurityContextPrivileged             bool                  `gorm:"column:securitycontext_privileged;type:bool"`
+	SecurityContextDropCapabilities       *pq.StringArray       `gorm:"column:securitycontext_dropcapabilities;type:text[]"`
+	SecurityContextAddCapabilities        *pq.StringArray       `gorm:"column:securitycontext_addcapabilities;type:text[]"`
+	SecurityContextReadOnlyRootFilesystem bool                  `gorm:"column:securitycontext_readonlyrootfilesystem;type:bool"`
+	ResourcesCPUCoresRequest              float32               `gorm:"column:resources_cpucoresrequest;type:numeric"`
+	ResourcesCPUCoresLimit                float32               `gorm:"column:resources_cpucoreslimit;type:numeric"`
+	ResourcesMemoryMbRequest              float32               `gorm:"column:resources_memorymbrequest;type:numeric"`
+	ResourcesMemoryMbLimit                float32               `gorm:"column:resources_memorymblimit;type:numeric"`
+	ContainerType                         storage.ContainerType `gorm:"column:containertype;type:integer"`
+	DeploymentsRef                        Deployments           `gorm:"foreignKey:deployments_id;references:id;belongsTo;constraint:OnDelete:CASCADE"`
 }
 
 // DeploymentsContainersEnvs holds the Gorm model for Postgres table `deployments_containers_envs`.

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -143,6 +143,7 @@ var (
 	ContainerID                  = newFieldLabel("Container ID")
 	ContainerImageDigest         = newFieldLabel("Container Image Digest")
 	ContainerName                = newFieldLabel("Container Name")
+	ContainerType                = newFieldLabel("Container Type")
 	DeploymentID                 = newFieldLabel("Deployment ID")
 	DeploymentHash               = newFieldLabel("Deployment Hash")
 	DeploymentName               = newFieldLabel("Deployment")

--- a/proto/storage/deployment.proto
+++ b/proto/storage/deployment.proto
@@ -59,8 +59,8 @@ message Deployment {
 
   bool platform_component = 35; // @gotags: search:"Platform Component"
 
-  repeated Container init_containers = 36;
-  repeated Container ephemeral_containers = 37;
+  repeated Container init_containers = 36; // @gotags: search:"-"
+  repeated Container ephemeral_containers = 37; // @gotags: search:"-"
 }
 
 // Next tag: 13

--- a/proto/storage/deployment.proto
+++ b/proto/storage/deployment.proto
@@ -12,22 +12,29 @@ import "storage/taints.proto";
 option go_package = "./storage;storage";
 option java_package = "io.stackrox.proto.storage";
 
-// Next available tag: 36
+enum ContainerType {
+  CONTAINER_TYPE_UNSPECIFIED = 0;
+  STANDARD = 1;
+  INIT = 2;
+  EPHEMERAL = 3;
+}
+
+// Next available tag: 38
 message Deployment {
-  string id = 1; // @gotags: search:"Deployment ID,hidden" sql:"pk,type(uuid)"
+  string id = 1; // @gotags: search:"Deployment ID,hidden"
   string name = 2; // @gotags: search:"Deployment"
   reserved 3;
   uint64 hash = 26; // @gotags: search:"Deployment Hash,hidden" hash:"ignore" sensorhash:"ignore"
   string type = 4; // @gotags: search:"Deployment Type"
   string namespace = 5; // @gotags: search:"Namespace"
-  string namespace_id = 23; // @gotags: search:"Namespace ID" sql:"fk(NamespaceMetadata:id),no-fk-constraint,type(uuid)"
+  string namespace_id = 23; // @gotags: search:"Namespace ID"
   bool orchestrator_component = 33; // @gotags: search:"Orchestrator Component"
   int64 replicas = 6; // @gotags: policy:"Replicas"
   map<string, string> labels = 7; // @gotags: search:"Deployment Label"
   map<string, string> pod_labels = 19; // @gotags: search:"Pod Label"
   LabelSelector label_selector = 20;
   google.protobuf.Timestamp created = 8; // @gotags: search:"Created,hidden" hash:"ignore"
-  string cluster_id = 9; // @gotags: search:"Cluster ID,hidden" sql:"type(uuid)"
+  string cluster_id = 9; // @gotags: search:"Cluster ID,hidden"
   string cluster_name = 10; // @gotags: search:"Cluster"
   repeated Container containers = 11;
   reserved 12;
@@ -46,17 +53,32 @@ message Deployment {
   repeated PortConfig ports = 24; // @gotags: policy:"Ports"
 
   int64 state_timestamp = 27; // Internal use only @gotags: hash:"ignore" sensorhash:"ignore"
-  float risk_score = 29; // @gotags: search:"Deployment Risk Score,hidden" policy:",ignore" sql:"index=btree"
+  float risk_score = 29; // @gotags: search:"Deployment Risk Score,hidden" policy:",ignore"
 
   reserved 30; // was tags
 
   bool platform_component = 35; // @gotags: search:"Platform Component"
+
+  repeated Container init_containers = 36;
+  repeated Container ephemeral_containers = 37;
 }
 
 // Next tag: 13
 message ContainerImage {
   // These tags maintain backwards compatibility with the previously embedded storage.Image
   // Tags after 10 may be used as needed
+  reserved 2, 3, 5, 6, 7, 8, 9;
+  string id = 4 [deprecated = true]; // @gotags: search:"Image Sha,hidden"
+  ImageName name = 1;
+  bool not_pullable = 10;
+
+  bool is_cluster_local = 11;
+
+  string id_v2 = 12; // @gotags: search:"Image ID,hidden"
+}
+
+// StoredContainerImage is the storage-only version of ContainerImage with SQL tags for persistence.
+message StoredContainerImage {
   reserved 2, 3, 5, 6, 7, 8, 9;
   string id = 4 [deprecated = true]; // @gotags: search:"Image Sha,hidden" sql:"fk(Image:id),no-fk-constraint,index=hash"
   ImageName name = 1;
@@ -83,6 +105,71 @@ message Container {
 
   LivenessProbe liveness_probe = 11;
   ReadinessProbe readiness_probe = 12;
+}
+
+// StoredContainer is the storage-only version of Container with ContainerType for persistence.
+// Next available tag: 14
+message StoredContainer {
+  string id = 1;
+  ContainerConfig config = 2;
+
+  StoredContainerImage image = 3;
+  SecurityContext security_context = 4;
+  repeated Volume volumes = 5;
+  repeated PortConfig ports = 6; // Policies use the port config on the top-level deployment. @gotags: policy:",ignore" search:"-"
+  repeated EmbeddedSecret secrets = 7;
+  Resources resources = 8;
+
+  reserved 9; // previously instances
+  string name = 10; // @gotags: policy:"Container Name"
+
+  LivenessProbe liveness_probe = 11;
+  ReadinessProbe readiness_probe = 12;
+
+  ContainerType container_type = 13; // @gotags: search:"Container Type"
+}
+
+// StoredDeployment is the storage-only version of Deployment used at the postgres store boundary.
+// It uses the same field numbers as Deployment for protobuf wire compatibility.
+// Next available tag: 36
+message StoredDeployment {
+  string id = 1; // @gotags: search:"Deployment ID,hidden" sql:"pk,type(uuid)"
+  string name = 2; // @gotags: search:"Deployment"
+  reserved 3;
+  uint64 hash = 26; // @gotags: search:"Deployment Hash,hidden" hash:"ignore" sensorhash:"ignore"
+  string type = 4; // @gotags: search:"Deployment Type"
+  string namespace = 5; // @gotags: search:"Namespace"
+  string namespace_id = 23; // @gotags: search:"Namespace ID" sql:"fk(NamespaceMetadata:id),no-fk-constraint,type(uuid)"
+  bool orchestrator_component = 33; // @gotags: search:"Orchestrator Component"
+  int64 replicas = 6; // @gotags: policy:"Replicas"
+  map<string, string> labels = 7; // @gotags: search:"Deployment Label"
+  map<string, string> pod_labels = 19; // @gotags: search:"Pod Label"
+  LabelSelector label_selector = 20;
+  google.protobuf.Timestamp created = 8; // @gotags: search:"Created,hidden" hash:"ignore"
+  string cluster_id = 9; // @gotags: search:"Cluster ID,hidden" sql:"type(uuid)"
+  string cluster_name = 10; // @gotags: search:"Cluster"
+  repeated StoredContainer containers = 11;
+  reserved 12;
+  map<string, string> annotations = 14; // @gotags: search:"Deployment Annotation"
+  int64 priority = 15; // @gotags: search:"Deployment Risk Priority,hidden" hash:"ignore"
+  bool inactive = 16;
+  repeated string image_pull_secrets = 17; // @gotags: search:"Image Pull Secret"
+  string service_account = 18; // @gotags: search:"Service Account"
+  PermissionLevel service_account_permission_level = 28; // @gotags: search:"Service Account Permission Level"
+  bool automount_service_account_token = 25; // @gotags: policy:"Automount Service Account Token"
+  bool host_network = 21; // @gotags: policy:"Host Network"
+  bool host_pid = 31; // @gotags: policy:"Host PID"
+  bool host_ipc = 32; // @gotags: policy:"Host IPC"
+  string runtime_class = 34; // @gotags: policy:"Runtime Class"
+  repeated Toleration tolerations = 22; // @gotags: search:"-"
+  repeated PortConfig ports = 24; // @gotags: policy:"Ports"
+
+  int64 state_timestamp = 27; // Internal use only @gotags: hash:"ignore" sensorhash:"ignore"
+  float risk_score = 29; // @gotags: search:"Deployment Risk Score,hidden" policy:",ignore" sql:"index=btree"
+
+  reserved 30; // was tags
+
+  bool platform_component = 35; // @gotags: search:"Platform Component"
 }
 
 message Resources {

--- a/tools/generate-helpers/pg-table-bindings/list.go
+++ b/tools/generate-helpers/pg-table-bindings/list.go
@@ -56,6 +56,7 @@ func init() {
 		&storage.DeclarativeConfigHealth{}:                      resources.Integration,
 		&storage.DelegatedRegistryConfig{}:                      resources.Administration,
 		&storage.Deployment{}:                                   resources.Deployment,
+		&storage.StoredDeployment{}:                             resources.Deployment,
 		&storage.DiscoveredCluster{}:                            resources.Administration,
 		&storage.ExternalBackup{}:                               resources.Integration,
 		&storage.Group{}:                                        resources.Access,


### PR DESCRIPTION
Introduce storage.StoredDeployment as the persistence-only type used at
the postgres store boundary, keeping storage.Deployment as the API type
used by all consumers (~250+ files unchanged).

This separation enables independent evolution of the storage schema
(e.g., init/ephemeral container support, table normalization) without
impacting sensor, detection, API, or policy evaluation consumers.

Key changes:
- Add ContainerType enum (STANDARD, INIT, EPHEMERAL) to proto
- Add StoredDeployment, StoredContainer, StoredContainerImage messages
  with SQL tags for persistence
- Add init_containers and ephemeral_containers fields to Deployment
- Remove SQL tags from Deployment and ContainerImage (API-only types)
- Internal Store interface now uses StoredDeployment; public DataStore
  interface unchanged
- Conversion layer (ToStoredDeployment/FromStoredDeployment) merges and
  splits containers by type at the store boundary
- No migration needed: same table name, same field numbers, GORM
  auto-creates new container_type column

Code partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
