### PR TITLE
ROX-33352: Add histogram of lineage size

### DIFF
--- a/central/processindicator/datastore/metrics.go
+++ b/central/processindicator/datastore/metrics.go
@@ -85,7 +85,7 @@ var (
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "process_indicators_lineage_size_total",
-		Help:      "Total process lineage sizes in characters by cluster and namespace",
+		Help:      "Total upserted process lineage sizes in characters by cluster and namespace",
 	}, []string{"cluster", "namespace"})
 )
 

--- a/central/processindicator/datastore/metrics.go
+++ b/central/processindicator/datastore/metrics.go
@@ -72,6 +72,14 @@ var (
 		Name:      "process_indicators_removed_total",
 		Help:      "Total number of process indicators removed from the database across all reasons",
 	})
+
+	processIndicatorsLineageSizeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "process_indicators_lineage_size",
+		Help:      "Distribution of process lineage sizes in characters for upserted indicators",
+		Buckets:   []float64{0, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
+	}, []string{"cluster", "namespace"})
 )
 
 func recordProcessIndicatorsRemoved(num int, reason string) {
@@ -100,16 +108,39 @@ func getProcessArgsSizeChars(indicator *storage.ProcessIndicator) int {
 	return utf8.RuneCountInString(indicator.GetSignal().GetArgs())
 }
 
+// getProcessLineageSizeChars safely calculates the total size of process lineage in characters (runes).
+// Returns 0 if signal or lineage are nil/empty.
+func getProcessLineageSizeChars(indicator *storage.ProcessIndicator) int {
+	if indicator == nil || indicator.GetSignal() == nil {
+		return 0
+	}
+
+	lineageInfo := indicator.GetSignal().GetLineageInfo()
+	if len(lineageInfo) == 0 {
+		return 0
+	}
+
+	totalChars := 0
+	for _, info := range lineageInfo {
+		if info != nil {
+			totalChars += utf8.RuneCountInString(info.GetParentExecFilePath())
+		}
+	}
+
+	return totalChars
+}
+
 // recordProcessIndicatorsBatchAdded records metrics for a batch of process indicators successfully written to DB.
 func recordProcessIndicatorsBatchAdded(indicators []*storage.ProcessIndicator) {
 	for _, indicator := range indicators {
 		argsSizeChars := getProcessArgsSizeChars(indicator)
+		lineageSizeChars := getProcessLineageSizeChars(indicator)
 		clusterID := indicator.GetClusterId()
 		namespace := indicator.GetNamespace()
-
 		processUpsertedArgsSizeHistogram.Observe(float64(argsSizeChars))
 		processUpsertedArgsSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(argsSizeChars))
 		processUpsertedCount.WithLabelValues(clusterID, namespace).Inc()
+		processIndicatorsLineageSizeHistogram.WithLabelValues(clusterID, namespace).Observe(float64(lineageSizeChars))
 	}
 }
 
@@ -122,5 +153,6 @@ func init() {
 		processUpsertedCount,
 		processIndicatorsRemoved,
 		processIndicatorsRemovedTotal,
+		processIndicatorsLineageSizeHistogram,
 	)
 }

--- a/central/processindicator/datastore/metrics.go
+++ b/central/processindicator/datastore/metrics.go
@@ -59,7 +59,6 @@ var (
 		Help:      "Number of process indicators upserted by cluster and namespace",
 	}, []string{"cluster", "namespace"})
 
-<<<<<<< HEAD
 	processIndicatorsRemoved = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),

--- a/central/processindicator/datastore/metrics.go
+++ b/central/processindicator/datastore/metrics.go
@@ -79,7 +79,7 @@ var (
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "process_upserted_lineage_size",
 		Help:      "Distribution of process lineage sizes in characters for upserted indicators",
-		Buckets:   []float64{0, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
+		Buckets:   []float64{0, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
 	})
 
 	processUpsertedLineageSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/central/processindicator/datastore/metrics.go
+++ b/central/processindicator/datastore/metrics.go
@@ -59,6 +59,7 @@ var (
 		Help:      "Number of process indicators upserted by cluster and namespace",
 	}, []string{"cluster", "namespace"})
 
+<<<<<<< HEAD
 	processIndicatorsRemoved = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
@@ -73,18 +74,18 @@ var (
 		Help:      "Total number of process indicators removed from the database across all reasons",
 	})
 
-	processIndicatorsLineageSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+	processUpsertedLineageSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "process_indicators_lineage_size",
+		Name:      "process_upserted_lineage_size",
 		Help:      "Distribution of process lineage sizes in characters for upserted indicators",
 		Buckets:   []float64{0, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
 	})
 
-	processIndicatorsLineageSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	processUpsertedLineageSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "process_indicators_lineage_size_total",
+		Name:      "process_upserted_lineage_size_total",
 		Help:      "Total upserted process lineage sizes in characters by cluster and namespace",
 	}, []string{"cluster", "namespace"})
 )
@@ -148,8 +149,8 @@ func recordProcessIndicatorsBatchAdded(indicators []*storage.ProcessIndicator) {
 		processUpsertedArgsSizeHistogram.Observe(float64(argsSizeChars))
 		processUpsertedArgsSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(argsSizeChars))
 		processUpsertedCount.WithLabelValues(clusterID, namespace).Inc()
-		processIndicatorsLineageSizeHistogram.Observe(float64(lineageSizeChars))
-		processIndicatorsLineageSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(lineageSizeChars))
+		processUpsertedLineageSizeHistogram.Observe(float64(lineageSizeChars))
+		processUpsertedLineageSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(lineageSizeChars))
 	}
 }
 
@@ -162,7 +163,7 @@ func init() {
 		processUpsertedCount,
 		processIndicatorsRemoved,
 		processIndicatorsRemovedTotal,
-		processIndicatorsLineageSizeHistogram,
-		processIndicatorsLineageSizeTotal,
+		processUpsertedLineageSizeHistogram,
+		processUpsertedLineageSizeTotal,
 	)
 }

--- a/central/processindicator/datastore/metrics.go
+++ b/central/processindicator/datastore/metrics.go
@@ -73,12 +73,19 @@ var (
 		Help:      "Total number of process indicators removed from the database across all reasons",
 	})
 
-	processIndicatorsLineageSizeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	processIndicatorsLineageSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "process_indicators_lineage_size",
 		Help:      "Distribution of process lineage sizes in characters for upserted indicators",
 		Buckets:   []float64{0, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
+	})
+
+	processIndicatorsLineageSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "process_indicators_lineage_size_total",
+		Help:      "Total process lineage sizes in characters by cluster and namespace",
 	}, []string{"cluster", "namespace"})
 )
 
@@ -137,10 +144,12 @@ func recordProcessIndicatorsBatchAdded(indicators []*storage.ProcessIndicator) {
 		lineageSizeChars := getProcessLineageSizeChars(indicator)
 		clusterID := indicator.GetClusterId()
 		namespace := indicator.GetNamespace()
+
 		processUpsertedArgsSizeHistogram.Observe(float64(argsSizeChars))
 		processUpsertedArgsSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(argsSizeChars))
 		processUpsertedCount.WithLabelValues(clusterID, namespace).Inc()
-		processIndicatorsLineageSizeHistogram.WithLabelValues(clusterID, namespace).Observe(float64(lineageSizeChars))
+		processIndicatorsLineageSizeHistogram.Observe(float64(lineageSizeChars))
+		processIndicatorsLineageSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(lineageSizeChars))
 	}
 }
 
@@ -154,5 +163,6 @@ func init() {
 		processIndicatorsRemoved,
 		processIndicatorsRemovedTotal,
 		processIndicatorsLineageSizeHistogram,
+		processIndicatorsLineageSizeTotal,
 	)
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Adds a metric that keeps track of a histogram of the size of process lineages in characters.

See the related PR for a metric for process arguments. https://github.com/stackrox/stackrox/pull/18794

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

```
# HELP rox_central_process_indicators_lineage_size Distribution of process lineage sizes in characters for upserted indicators
# TYPE rox_central_process_indicators_lineage_size histogram 
rox_central_process_indicators_lineage_size_bucket{le="0"} 155
rox_central_process_indicators_lineage_size_bucket{le="128"} 457
rox_central_process_indicators_lineage_size_bucket{le="256"} 457 
rox_central_process_indicators_lineage_size_bucket{le="512"} 457
rox_central_process_indicators_lineage_size_bucket{le="1024"} 457
rox_central_process_indicators_lineage_size_bucket{le="2048"} 457
rox_central_process_indicators_lineage_size_bucket{le="4096"} 457
rox_central_process_indicators_lineage_size_bucket{le="8192"} 457
rox_central_process_indicators_lineage_size_bucket{le="16384"} 457
rox_central_process_indicators_lineage_size_bucket{le="32768"} 457
rox_central_process_indicators_lineage_size_bucket{le="65536"} 457
rox_central_process_indicators_lineage_size_bucket{le="+Inf"} 457 
rox_central_process_indicators_lineage_size_sum 13417
rox_central_process_indicators_lineage_size_count 457
# HELP rox_central_process_indicators_lineage_size_total Total process lineage sizes in characters by cluster and namespace
# TYPE rox_central_process_indicators_lineage_size_total counter
rox_central_process_indicators_lineage_size_total{cluster="ab949c19-54ca-4397-8fa9-955d494d9e3d",namespace="default"} 0
rox_central_process_indicators_lineage_size_total{cluster="ab949c19-54ca-4397-8fa9-955d494d9e3d",namespace="gke-managed-cim"} 0
rox_central_process_indicators_lineage_size_total{cluster="ab949c19-54ca-4397-8fa9-955d494d9e3d",namespace="gmp-system"} 0
rox_central_process_indicators_lineage_size_total{cluster="ab949c19-54ca-4397-8fa9-955d494d9e3d",namespace="kube-system"} 11562
rox_central_process_indicators_lineage_size_total{cluster="ab949c19-54ca-4397-8fa9-955d494d9e3d",namespace="stackrox"} 1855
```
