### PR TITLE
ROX-33343: Automated suite for adm cntrl bench testing & profiling

### DIFF
--- a/sensor/admission-control/manager/fast_path_detection_bench_test.go
+++ b/sensor/admission-control/manager/fast_path_detection_bench_test.go
@@ -1,0 +1,413 @@
+package manager
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/detection"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/size"
+	"github.com/stackrox/rox/pkg/uuid"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	admission "k8s.io/api/admission/v1"
+	appsV1 "k8s.io/api/apps/v1"
+	coreV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+)
+
+// --- Fake gRPC clients ---
+
+type benchImageServiceClient struct {
+	latency   time.Duration
+	callCount atomic.Int64
+}
+
+func (c *benchImageServiceClient) GetImage(ctx context.Context, req *sensor.GetImageRequest, _ ...grpc.CallOption) (*sensor.GetImageResponse, error) {
+	c.callCount.Add(1)
+	select {
+	case <-time.After(c.latency):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return &sensor.GetImageResponse{
+		Image: violatingImage(req.GetImage()),
+	}, nil
+}
+
+func (c *benchImageServiceClient) Reset()           { c.callCount.Store(0) }
+func (c *benchImageServiceClient) CallCount() int64 { return c.callCount.Load() }
+
+type benchDeploymentServiceClient struct{}
+
+func (benchDeploymentServiceClient) GetDeploymentForPod(_ context.Context, _ *sensor.GetDeploymentForPodRequest, _ ...grpc.CallOption) (*storage.Deployment, error) {
+	return nil, nil
+}
+
+// --- Violating image builder ---
+
+func violatingImage(ci *storage.ContainerImage) *storage.Image {
+	oneYearAgo := time.Now().Add(-365 * 24 * time.Hour)
+	return &storage.Image{
+		Id:   ci.GetId(),
+		Name: ci.GetName(),
+		Metadata: &storage.ImageMetadata{
+			V1: &storage.V1Metadata{
+				Created: protocompat.ConvertTimeToTimestampOrNil(&oneYearAgo),
+				Layers: []*storage.ImageLayer{
+					{
+						Instruction: "COPY",
+						Value:       "app /app",
+					},
+				},
+			},
+		},
+		Scan: &storage.ImageScan{
+			Components: []*storage.EmbeddedImageScanComponent{
+				{
+					Name:    "openssl",
+					Version: "1.1.1k",
+					Vulns: []*storage.EmbeddedVulnerability{
+						{
+							Cve:        "CVE-2021-99999",
+							Cvss:       9.8,
+							SetFixedBy: &storage.EmbeddedVulnerability_FixedBy{FixedBy: "1.1.1l"},
+							Severity:   storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+						},
+					},
+				},
+			},
+			ScanTime: protocompat.ConvertTimeToTimestampOrNil(&oneYearAgo),
+		},
+		SetCves: &storage.Image_Cves{Cves: 1},
+	}
+}
+
+// --- AdmissionRequest generators ---
+
+var benchImages = []string{
+	"docker.io/library/nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	"docker.io/library/redis@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	"gcr.io/myproject/app@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+}
+
+func makeAdmissionRequest(name, namespace string, images []string, privileged bool) *admission.AdmissionRequest {
+	containers := make([]coreV1.Container, len(images))
+	for i, img := range images {
+		containers[i] = coreV1.Container{
+			Name:  fmt.Sprintf("container-%d", i),
+			Image: img,
+		}
+		if privileged {
+			containers[i].SecurityContext = &coreV1.SecurityContext{
+				Privileged: pointer.Bool(true),
+			}
+		}
+	}
+
+	dep := &appsV1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":  "bench-app",
+				"env":  "production",
+				"team": "platform",
+			},
+		},
+		Spec: appsV1.DeploymentSpec{
+			Template: coreV1.PodTemplateSpec{
+				Spec: coreV1.PodSpec{
+					Containers: containers,
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(dep)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal deployment: %v", err))
+	}
+
+	return &admission.AdmissionRequest{
+		UID:       types.UID(uuid.NewV4().String()),
+		Operation: admission.Create,
+		Kind: metav1.GroupVersionKind{
+			Group:   "apps",
+			Version: "v1",
+			Kind:    "Deployment",
+		},
+		Namespace: namespace,
+		Name:      name,
+		Object:    runtime.RawExtension{Raw: raw},
+		DryRun:    pointer.Bool(true),
+	}
+}
+
+func makeAdmissionRequests(deploymentCount int, violationPct float64, images []string) []*admission.AdmissionRequest {
+	violatingCount := int(float64(deploymentCount) * violationPct)
+	reqs := make([]*admission.AdmissionRequest, deploymentCount)
+	for i := 0; i < deploymentCount; i++ {
+		privileged := i < violatingCount
+		reqs[i] = makeAdmissionRequest(fmt.Sprintf("deploy-%d", i), "bench", images, privileged)
+	}
+	return reqs
+}
+
+// --- Policy generators ---
+
+var fastPathFields = []string{
+	"Privileged Container",
+	"Image Tag",
+	"Image Remote",
+	"Image Registry",
+	"Volume Name",
+	"Volume Type",
+	"Volume Destination",
+	"Host Network",
+	"Host PID",
+	"Container Name",
+}
+
+var slowPathFields = []string{
+	"CVE",
+	"CVSS",
+	"Image Age",
+	"Image Scan Age",
+	"Image Component",
+	"Fixed By",
+	"Severity",
+	"Dockerfile Line",
+	"Unscanned Image",
+	"Image Signature Verified By",
+}
+
+// fastPathPolicyValue returns values that do NOT match the benchmark
+// deployments. Only PrivilegedContainer is designed to fire -- and only
+// when the deployment has privileged=true. All other fast-path policies
+// use values that won't match, so they exist for compilation/evaluation
+// overhead but don't produce alerts.
+func fastPathPolicyValue(fieldName string) string {
+	switch fieldName {
+	case "Privileged Container":
+		return "true"
+	case "Image Tag":
+		return "nonexistent-tag-xyz"
+	case "Image Remote":
+		return "no-such-remote/.*"
+	case "Image Registry":
+		return "fake-registry.example.com"
+	case "Volume Name":
+		return "no-such-volume"
+	case "Volume Type":
+		return "Host Path"
+	case "Volume Destination":
+		return "/nonexistent/path/xyz"
+	case "Host Network":
+		return "true"
+	case "Host PID":
+		return "true"
+	case "Container Name":
+		return "no-such-container-.*"
+	default:
+		return "no-match-value"
+	}
+}
+
+// slowPathPolicyValue returns values that WILL match the violating image
+// returned by benchImageServiceClient, so slow-path policies actually
+// produce alerts when enrichment data is available.
+func slowPathPolicyValue(fieldName string) string {
+	switch fieldName {
+	case "CVE":
+		return "CVE-2021-.*"
+	case "CVSS":
+		return ">= 7.0"
+	case "Image Age":
+		return "30"
+	case "Image Scan Age":
+		return "7"
+	case "Image Component":
+		return "openssl="
+	case "Fixed By":
+		return ".*"
+	case "Severity":
+		return ">= CRITICAL"
+	case "Dockerfile Line":
+		return "COPY=.*"
+	case "Unscanned Image":
+		return "true"
+	case "Image Signature Verified By":
+		return "io.stackrox.signatureintegration.00000000-0000-0000-0000-000000000000"
+	default:
+		return ".*"
+	}
+}
+
+func generatePolicies(prefix string, n int, fields []string, valueFn func(string) string) []*storage.Policy {
+	policies := make([]*storage.Policy, n)
+	for i := 0; i < n; i++ {
+		field := fields[i%len(fields)]
+		policies[i] = &storage.Policy{
+			Id:              uuid.NewV4().String(),
+			Name:            fmt.Sprintf("%s-policy-%d", prefix, i),
+			Disabled:        false,
+			PolicyVersion:   "1.1",
+			LifecycleStages: []storage.LifecycleStage{storage.LifecycleStage_DEPLOY},
+			EnforcementActions: []storage.EnforcementAction{
+				storage.EnforcementAction_SCALE_TO_ZERO_ENFORCEMENT,
+			},
+			PolicySections: []*storage.PolicySection{
+				{
+					PolicyGroups: []*storage.PolicyGroup{
+						{
+							FieldName:       field,
+							BooleanOperator: storage.BooleanOperator_OR,
+							Values: []*storage.PolicyValue{
+								{Value: valueFn(field)},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	return policies
+}
+
+func fastPathPolicies(n int) []*storage.Policy {
+	return generatePolicies("fast", n, fastPathFields, fastPathPolicyValue)
+}
+
+func slowPathPolicies(n int) []*storage.Policy {
+	return generatePolicies("slow", n, slowPathFields, slowPathPolicyValue)
+}
+
+// --- Settings generator ---
+
+func benchSettings(fastPolicies, slowPolicies []*storage.Policy) *sensor.AdmissionControlSettings {
+	allPolicies := make([]*storage.Policy, 0, len(fastPolicies)+len(slowPolicies))
+	allPolicies = append(allPolicies, fastPolicies...)
+	allPolicies = append(allPolicies, slowPolicies...)
+
+	return &sensor.AdmissionControlSettings{
+		ClusterId: "bench-cluster-id",
+		EnforcedDeployTimePolicies: &storage.PolicyList{
+			Policies: allPolicies,
+		},
+		ClusterConfig: &storage.DynamicClusterConfig{
+			AdmissionControllerConfig: &storage.AdmissionControllerConfig{
+				Enabled:        true,
+				ScanInline:     true,
+				TimeoutSeconds: 10,
+			},
+		},
+		Timestamp: timestamppb.Now(),
+	}
+}
+
+// --- Pruning helpers ---
+
+func maxDeployments(fast, slow int) int {
+	if slow > fast {
+		return 1000
+	}
+	return 10000
+}
+
+func shouldSweepViolationPct(fast int) bool {
+	return fast > 0
+}
+
+func validatePoliciesCompile(b *testing.B, policies []*storage.Policy, label string) {
+	b.Helper()
+	for _, p := range policies {
+		if _, err := detection.CompilePolicy(p, nil, nil); err != nil {
+			b.Fatalf("%s policy %q failed to compile: %v", label, p.GetName(), err)
+		}
+	}
+}
+
+// --- Benchmark ---
+
+func BenchmarkDetectionSplit(b *testing.B) {
+	logging.SetGlobalLogLevel(zapcore.FatalLevel)
+	b.Cleanup(func() { logging.SetGlobalLogLevel(zapcore.InfoLevel) })
+
+	policyMixes := []struct{ fast, slow int }{
+		{40, 0},
+		{30, 10},
+		{20, 20},
+		{10, 30},
+		{0, 40},
+	}
+	deploymentCounts := []int{1, 10, 100, 1000, 10000}
+	violationPcts := []float64{0.0, 0.25, 0.50, 0.75, 1.0}
+
+	for _, mix := range policyMixes {
+		for _, depCount := range deploymentCounts {
+			if depCount > maxDeployments(mix.fast, mix.slow) {
+				continue
+			}
+
+			vPcts := violationPcts
+			if !shouldSweepViolationPct(mix.fast) {
+				vPcts = []float64{0.0}
+			}
+
+			for _, vPct := range vPcts {
+				name := fmt.Sprintf("fast=%d/slow=%d/deps=%d/viol=%.0f%%", mix.fast, mix.slow, depCount, vPct*100)
+				b.Run(name, func(b *testing.B) {
+					imgClient := &benchImageServiceClient{latency: 100 * time.Millisecond}
+					mgr := NewManager("bench-ns", 20*size.MB, true, imgClient, &benchDeploymentServiceClient{})
+
+					fp := fastPathPolicies(mix.fast)
+					sp := slowPathPolicies(mix.slow)
+					validatePoliciesCompile(b, fp, "fast-path")
+					validatePoliciesCompile(b, sp, "slow-path")
+					mgr.ProcessNewSettings(benchSettings(fp, sp))
+
+					reqs := makeAdmissionRequests(depCount, vPct, benchImages)
+
+					for b.Loop() {
+						imgClient.Reset()
+						mgr.imageCache.Purge()
+
+						totalDenials := 0
+						for _, req := range reqs {
+							resp, err := mgr.HandleValidate(req)
+							if err != nil {
+								b.Fatalf("HandleValidate error: %v", err)
+							}
+							if resp != nil && !resp.Allowed {
+								totalDenials++
+							}
+						}
+
+						rpcs := imgClient.CallCount()
+						b.ReportMetric(float64(rpcs), "rpc_count")
+						if depCount > 0 {
+							b.ReportMetric(float64(rpcs)/float64(depCount), "rpc_per_review")
+						}
+						b.ReportMetric(float64(totalDenials), "total_denials")
+					}
+				})
+			}
+		}
+	}
+}

--- a/sensor/admission-control/manager/image_coalescing_caching_bench_test.go
+++ b/sensor/admission-control/manager/image_coalescing_caching_bench_test.go
@@ -216,7 +216,7 @@ func generateWorkload(rng *rand.Rand, nDeployments, imgsPerDep, uniqueImages int
 	for i := range nDeployments {
 		images := make([]imageRef, imgsPerDep)
 		for j := range imgsPerDep {
-			images[j] = pool[rng.Intn(len(pool))]
+			images[j] = pool[rng.IntN(len(pool))]
 		}
 		dep := generateDeployment(
 			fmt.Sprintf("deploy-%d", i),

--- a/sensor/admission-control/manager/image_coalescing_caching_bench_test.go
+++ b/sensor/admission-control/manager/image_coalescing_caching_bench_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"sync/atomic"
 	"testing"
@@ -45,7 +45,7 @@ func newCoalescingBenchImageClient(latency time.Duration) *coalescingBenchImageC
 	}
 }
 
-func (c *coalescingBenchImageClient) GetImage(_ context.Context, req *sensor.GetImageRequest, _ ...grpc.CallOption) (*sensor.GetImageResponse, error) {
+func (c *coalescingBenchImageClient) GetImage(ctx context.Context, req *sensor.GetImageRequest, _ ...grpc.CallOption) (*sensor.GetImageResponse, error) {
 	c.callCount.Add(1)
 
 	imageID := req.GetImage().GetId()
@@ -59,7 +59,11 @@ func (c *coalescingBenchImageClient) GetImage(_ context.Context, req *sensor.Get
 	c.mu.Unlock()
 
 	if c.latency > 0 {
-		time.Sleep(c.latency)
+		select {
+		case <-time.After(c.latency):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 
 	return &sensor.GetImageResponse{
@@ -280,7 +284,10 @@ func setupManager(b *testing.B, imgClient sensor.ImageServiceClient) *manager {
 	mgr := NewManager("stackrox", 200*size.MB, true, imgClient, noopDeploymentServiceClient{})
 	mgr.ProcessNewSettings(cachingBenchSettings())
 	mgr.Start()
-	b.Cleanup(func() { mgr.Stop() })
+	b.Cleanup(func() {
+		mgr.Stop()
+		logging.SetGlobalLogLevel(zapcore.InfoLevel)
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -323,7 +330,7 @@ func BenchmarkAdmissionReview_BaselineColdCache(b *testing.B) {
 	defer close(done)
 	drainAlerts(mgr, done)
 
-	rng := rand.New(rand.NewSource(42))
+	rng := rand.New(rand.NewPCG(42, 0))
 	wl := generateWorkload(rng, 100, 3, 300)
 
 	for b.Loop() {
@@ -347,7 +354,7 @@ func BenchmarkAdmissionReview_ConcurrentBurst_LowDiversity(b *testing.B) {
 	defer close(done)
 	drainAlerts(mgr, done)
 
-	rng := rand.New(rand.NewSource(42))
+	rng := rand.New(rand.NewPCG(42, 0))
 	wl := generateWorkload(rng, 1000, 3, 50)
 
 	for b.Loop() {
@@ -371,7 +378,7 @@ func BenchmarkAdmissionReview_ConcurrentBurst_MediumDiversity(b *testing.B) {
 	defer close(done)
 	drainAlerts(mgr, done)
 
-	rng := rand.New(rand.NewSource(42))
+	rng := rand.New(rand.NewPCG(42, 0))
 	wl := generateWorkload(rng, 1000, 3, 200)
 
 	for b.Loop() {
@@ -395,7 +402,7 @@ func BenchmarkAdmissionReview_ConcurrentBurst_HighDiversity(b *testing.B) {
 	defer close(done)
 	drainAlerts(mgr, done)
 
-	rng := rand.New(rand.NewSource(42))
+	rng := rand.New(rand.NewPCG(42, 0))
 	wl := generateWorkload(rng, 1000, 3, 2000)
 
 	for b.Loop() {
@@ -419,7 +426,7 @@ func BenchmarkAdmissionReview_WarmCache(b *testing.B) {
 	defer close(done)
 	drainAlerts(mgr, done)
 
-	rng := rand.New(rand.NewSource(42))
+	rng := rand.New(rand.NewPCG(42, 0))
 	wl := generateWorkload(rng, 1000, 3, 100)
 
 	// Warm the cache by running all reviews once sequentially.
@@ -468,7 +475,7 @@ func BenchmarkAdmissionReview_ScaleSweep(b *testing.B) {
 				defer close(done)
 				drainAlerts(mgr, done)
 
-				rng := rand.New(rand.NewSource(42))
+				rng := rand.New(rand.NewPCG(42, 0))
 				wl := generateWorkload(rng, nDeps, imgsPerDep, uniqueImgs)
 
 				for b.Loop() {

--- a/sensor/admission-control/manager/image_coalescing_caching_bench_test.go
+++ b/sensor/admission-control/manager/image_coalescing_caching_bench_test.go
@@ -1,0 +1,507 @@
+package manager
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"sort"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/size"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+	admission "k8s.io/api/admission/v1"
+	apps "k8s.io/api/apps/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+)
+
+// --- Fake Image Service Client ---
+
+type coalescingBenchImageClient struct {
+	latency      time.Duration
+	callCount    atomic.Int64
+	mu           sync.Mutex
+	callsByImage map[string]int64
+}
+
+func newCoalescingBenchImageClient(latency time.Duration) *coalescingBenchImageClient {
+	return &coalescingBenchImageClient{
+		latency:      latency,
+		callsByImage: make(map[string]int64),
+	}
+}
+
+func (c *coalescingBenchImageClient) GetImage(_ context.Context, req *sensor.GetImageRequest, _ ...grpc.CallOption) (*sensor.GetImageResponse, error) {
+	c.callCount.Add(1)
+
+	imageID := req.GetImage().GetId()
+	if imageID == "" {
+		hash := sha256.Sum256([]byte(req.GetImage().GetName().GetFullName()))
+		imageID = fmt.Sprintf("sha256:%x", hash)
+	}
+
+	c.mu.Lock()
+	c.callsByImage[imageID]++
+	c.mu.Unlock()
+
+	if c.latency > 0 {
+		time.Sleep(c.latency)
+	}
+
+	return &sensor.GetImageResponse{
+		Image: &storage.Image{
+			Id: imageID,
+			Name: &storage.ImageName{
+				Registry: req.GetImage().GetName().GetRegistry(),
+				Remote:   req.GetImage().GetName().GetRemote(),
+				Tag:      req.GetImage().GetName().GetTag(),
+				FullName: req.GetImage().GetName().GetFullName(),
+			},
+			Scan: &storage.ImageScan{
+				ScanTime: nil,
+			},
+		},
+	}, nil
+}
+
+func (c *coalescingBenchImageClient) CallCount() int64 {
+	return c.callCount.Load()
+}
+
+func (c *coalescingBenchImageClient) CallsByImage() map[string]int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	result := make(map[string]int64, len(c.callsByImage))
+	for k, v := range c.callsByImage {
+		result[k] = v
+	}
+	return result
+}
+
+func (c *coalescingBenchImageClient) Reset() {
+	c.callCount.Store(0)
+	c.mu.Lock()
+	c.callsByImage = make(map[string]int64)
+	c.mu.Unlock()
+}
+
+// --- No-op Deployment Service Client ---
+
+type noopDeploymentServiceClient struct{}
+
+func (noopDeploymentServiceClient) GetDeploymentForPod(context.Context, *sensor.GetDeploymentForPodRequest, ...grpc.CallOption) (*storage.Deployment, error) {
+	return nil, nil
+}
+
+// --- Data Generators ---
+
+type imageRef struct {
+	id       string
+	registry string
+	remote   string
+	tag      string
+	fullName string
+}
+
+func generateImagePool(n int) []imageRef {
+	pool := make([]imageRef, n)
+	for i := range n {
+		tag := fmt.Sprintf("v1.%d.0", i)
+		remote := fmt.Sprintf("library/image-%d", i)
+		fullName := fmt.Sprintf("docker.io/%s:%s", remote, tag)
+		hash := sha256.Sum256([]byte(fullName))
+		pool[i] = imageRef{
+			id:       fmt.Sprintf("sha256:%x", hash),
+			registry: "docker.io",
+			remote:   remote,
+			tag:      tag,
+			fullName: fullName,
+		}
+	}
+	return pool
+}
+
+func generateDeployment(name, namespace string, images []imageRef) *apps.Deployment {
+	containers := make([]core.Container, len(images))
+	for i, img := range images {
+		containers[i] = core.Container{
+			Name:  fmt.Sprintf("container-%d", i),
+			Image: img.fullName,
+		}
+	}
+	replicas := int32(1)
+	return &apps.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       k8sTypes.UID(uuid.NewV4().String()),
+		},
+		Spec: apps.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: core.PodSpec{
+					Containers: containers,
+				},
+			},
+		},
+	}
+}
+
+func deploymentToAdmissionRequest(dep *apps.Deployment) *admission.AdmissionRequest {
+	raw, err := json.Marshal(dep)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal deployment: %v", err))
+	}
+	return &admission.AdmissionRequest{
+		UID: k8sTypes.UID(uuid.NewV4().String()),
+		Kind: metav1.GroupVersionKind{
+			Group:   "apps",
+			Version: "v1",
+			Kind:    "Deployment",
+		},
+		Resource: metav1.GroupVersionResource{
+			Group:    "apps",
+			Version:  "v1",
+			Resource: "deployments",
+		},
+		Name:      dep.Name,
+		Namespace: dep.Namespace,
+		Operation: admission.Create,
+		Object:    runtime.RawExtension{Raw: raw},
+		UserInfo: authenticationv1.UserInfo{
+			Username: "test-user",
+			Groups:   []string{"system:authenticated"},
+		},
+	}
+}
+
+// workload holds pre-generated admission requests and associated metadata.
+type workload struct {
+	requests     []*admission.AdmissionRequest
+	uniqueImages int
+	imgsPerDep   int
+}
+
+func generateWorkload(rng *rand.Rand, nDeployments, imgsPerDep, uniqueImages int) workload {
+	pool := generateImagePool(uniqueImages)
+	requests := make([]*admission.AdmissionRequest, nDeployments)
+	for i := range nDeployments {
+		images := make([]imageRef, imgsPerDep)
+		for j := range imgsPerDep {
+			images[j] = pool[rng.Intn(len(pool))]
+		}
+		dep := generateDeployment(
+			fmt.Sprintf("deploy-%d", i),
+			"bench-ns",
+			images,
+		)
+		requests[i] = deploymentToAdmissionRequest(dep)
+	}
+	return workload{
+		requests:     requests,
+		uniqueImages: uniqueImages,
+		imgsPerDep:   imgsPerDep,
+	}
+}
+
+// --- Benchmark Helpers ---
+
+func cachingBenchSettings() *sensor.AdmissionControlSettings {
+	return &sensor.AdmissionControlSettings{
+		ClusterId: uuid.NewDummy().String(),
+		ClusterConfig: &storage.DynamicClusterConfig{
+			AdmissionControllerConfig: &storage.AdmissionControllerConfig{
+				Enabled:          true,
+				EnforceOnUpdates: false,
+				TimeoutSeconds:   10,
+				ScanInline:       true,
+			},
+		},
+		EnforcedDeployTimePolicies: &storage.PolicyList{Policies: []*storage.Policy{
+			imageAgePolicy(),
+		}},
+		RuntimePolicies: &storage.PolicyList{},
+	}
+}
+
+func imageAgePolicy() *storage.Policy {
+	return &storage.Policy{
+		Id:              uuid.NewV4().String(),
+		PolicyVersion:   "1.1",
+		Name:            "Image Age",
+		LifecycleStages: []storage.LifecycleStage{storage.LifecycleStage_DEPLOY},
+		Severity:        storage.Severity_LOW_SEVERITY,
+		Categories:      []string{"DevOps Best Practices"},
+		PolicySections: []*storage.PolicySection{
+			{
+				PolicyGroups: []*storage.PolicyGroup{
+					{
+						FieldName: "Image Age",
+						Values: []*storage.PolicyValue{
+							{Value: "30"},
+						},
+					},
+				},
+			},
+		},
+		EnforcementActions: []storage.EnforcementAction{
+			storage.EnforcementAction_SCALE_TO_ZERO_ENFORCEMENT,
+		},
+	}
+}
+
+func setupManager(b *testing.B, imgClient sensor.ImageServiceClient) *manager {
+	b.Helper()
+	logging.SetGlobalLogLevel(zapcore.FatalLevel)
+	mgr := NewManager("stackrox", 200*size.MB, true, imgClient, noopDeploymentServiceClient{})
+	mgr.ProcessNewSettings(cachingBenchSettings())
+	mgr.Start()
+	b.Cleanup(func() { mgr.Stop() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(b, mgr.Sync(ctx))
+	return mgr
+}
+
+// drainAlerts reads any pending alerts so the alertsC channel doesn't block.
+func drainAlerts(mgr *manager, done <-chan struct{}) {
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-mgr.alertsC:
+			}
+		}
+	}()
+}
+
+// --- Latency Statistics ---
+
+func percentile(durations []time.Duration, p float64) time.Duration {
+	if len(durations) == 0 {
+		return 0
+	}
+	sorted := make([]time.Duration, len(durations))
+	copy(sorted, durations)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	idx := int(float64(len(sorted)-1) * p)
+	return sorted[idx]
+}
+
+// --- Benchmarks ---
+
+func BenchmarkAdmissionReview_BaselineColdCache(b *testing.B) {
+	imgClient := newCoalescingBenchImageClient(50 * time.Millisecond)
+	mgr := setupManager(b, imgClient)
+	done := make(chan struct{})
+	defer close(done)
+	drainAlerts(mgr, done)
+
+	rng := rand.New(rand.NewSource(42))
+	wl := generateWorkload(rng, 100, 3, 300)
+
+	for b.Loop() {
+		imgClient.Reset()
+		mgr.imageCache.Purge()
+		mgr.imageNameToImageCacheKey.Purge()
+
+		for _, req := range wl.requests {
+			_, _ = mgr.HandleValidate(req)
+		}
+
+		b.ReportMetric(float64(imgClient.CallCount()), "rpc_count")
+		b.ReportMetric(float64(imgClient.CallCount())/float64(len(wl.requests)), "rpcs/review")
+	}
+}
+
+func BenchmarkAdmissionReview_ConcurrentBurst_LowDiversity(b *testing.B) {
+	imgClient := newCoalescingBenchImageClient(100 * time.Millisecond)
+	mgr := setupManager(b, imgClient)
+	done := make(chan struct{})
+	defer close(done)
+	drainAlerts(mgr, done)
+
+	rng := rand.New(rand.NewSource(42))
+	wl := generateWorkload(rng, 1000, 3, 50)
+
+	for b.Loop() {
+		imgClient.Reset()
+		mgr.imageCache.Purge()
+		mgr.imageNameToImageCacheKey.Purge()
+
+		latencies := runConcurrentReviews(mgr, wl.requests)
+
+		b.ReportMetric(float64(imgClient.CallCount()), "rpc_count")
+		b.ReportMetric(float64(imgClient.CallCount())/float64(len(wl.requests)), "rpcs/review")
+		b.ReportMetric(float64(percentile(latencies, 0.50).Milliseconds()), "p50_ms")
+		b.ReportMetric(float64(percentile(latencies, 0.99).Milliseconds()), "p99_ms")
+	}
+}
+
+func BenchmarkAdmissionReview_ConcurrentBurst_MediumDiversity(b *testing.B) {
+	imgClient := newCoalescingBenchImageClient(100 * time.Millisecond)
+	mgr := setupManager(b, imgClient)
+	done := make(chan struct{})
+	defer close(done)
+	drainAlerts(mgr, done)
+
+	rng := rand.New(rand.NewSource(42))
+	wl := generateWorkload(rng, 1000, 3, 200)
+
+	for b.Loop() {
+		imgClient.Reset()
+		mgr.imageCache.Purge()
+		mgr.imageNameToImageCacheKey.Purge()
+
+		latencies := runConcurrentReviews(mgr, wl.requests)
+
+		b.ReportMetric(float64(imgClient.CallCount()), "rpc_count")
+		b.ReportMetric(float64(imgClient.CallCount())/float64(len(wl.requests)), "rpcs/review")
+		b.ReportMetric(float64(percentile(latencies, 0.50).Milliseconds()), "p50_ms")
+		b.ReportMetric(float64(percentile(latencies, 0.99).Milliseconds()), "p99_ms")
+	}
+}
+
+func BenchmarkAdmissionReview_ConcurrentBurst_HighDiversity(b *testing.B) {
+	imgClient := newCoalescingBenchImageClient(100 * time.Millisecond)
+	mgr := setupManager(b, imgClient)
+	done := make(chan struct{})
+	defer close(done)
+	drainAlerts(mgr, done)
+
+	rng := rand.New(rand.NewSource(42))
+	wl := generateWorkload(rng, 1000, 3, 2000)
+
+	for b.Loop() {
+		imgClient.Reset()
+		mgr.imageCache.Purge()
+		mgr.imageNameToImageCacheKey.Purge()
+
+		latencies := runConcurrentReviews(mgr, wl.requests)
+
+		b.ReportMetric(float64(imgClient.CallCount()), "rpc_count")
+		b.ReportMetric(float64(imgClient.CallCount())/float64(len(wl.requests)), "rpcs/review")
+		b.ReportMetric(float64(percentile(latencies, 0.50).Milliseconds()), "p50_ms")
+		b.ReportMetric(float64(percentile(latencies, 0.99).Milliseconds()), "p99_ms")
+	}
+}
+
+func BenchmarkAdmissionReview_WarmCache(b *testing.B) {
+	imgClient := newCoalescingBenchImageClient(100 * time.Millisecond)
+	mgr := setupManager(b, imgClient)
+	done := make(chan struct{})
+	defer close(done)
+	drainAlerts(mgr, done)
+
+	rng := rand.New(rand.NewSource(42))
+	wl := generateWorkload(rng, 1000, 3, 100)
+
+	// Warm the cache by running all reviews once sequentially.
+	for _, req := range wl.requests {
+		_, _ = mgr.HandleValidate(req)
+	}
+	imgClient.Reset()
+
+	for b.Loop() {
+		// Cache stays warm across iterations.
+		imgClient.Reset()
+
+		latencies := runConcurrentReviews(mgr, wl.requests)
+
+		b.ReportMetric(float64(imgClient.CallCount()), "rpc_count")
+		b.ReportMetric(float64(percentile(latencies, 0.50).Milliseconds()), "p50_ms")
+		b.ReportMetric(float64(percentile(latencies, 0.99).Milliseconds()), "p99_ms")
+	}
+}
+
+func BenchmarkAdmissionReview_ScaleSweep(b *testing.B) {
+	deployCounts := []int{100, 1000, 5000}
+	uniqueRatios := []struct {
+		name  string
+		ratio float64
+	}{
+		{"1pct_unique", 0.01},
+		{"10pct_unique", 0.10},
+		{"50pct_unique", 0.50},
+		{"100pct_unique", 1.0},
+	}
+
+	for _, nDeps := range deployCounts {
+		for _, ur := range uniqueRatios {
+			imgsPerDep := 3
+			totalRefs := nDeps * imgsPerDep
+			uniqueImgs := max(1, int(float64(totalRefs)*ur.ratio))
+
+			name := fmt.Sprintf("deps=%d/%s/imgs_per_dep=%d/unique=%d",
+				nDeps, ur.name, imgsPerDep, uniqueImgs)
+
+			b.Run(name, func(b *testing.B) {
+				imgClient := newCoalescingBenchImageClient(100 * time.Millisecond)
+				mgr := setupManager(b, imgClient)
+				done := make(chan struct{})
+				defer close(done)
+				drainAlerts(mgr, done)
+
+				rng := rand.New(rand.NewSource(42))
+				wl := generateWorkload(rng, nDeps, imgsPerDep, uniqueImgs)
+
+				for b.Loop() {
+					imgClient.Reset()
+					mgr.imageCache.Purge()
+					mgr.imageNameToImageCacheKey.Purge()
+
+					latencies := runConcurrentReviews(mgr, wl.requests)
+
+					b.ReportMetric(float64(imgClient.CallCount()), "rpc_count")
+					b.ReportMetric(float64(imgClient.CallCount())/float64(len(wl.requests)), "rpcs/review")
+					b.ReportMetric(float64(percentile(latencies, 0.50).Milliseconds()), "p50_ms")
+					b.ReportMetric(float64(percentile(latencies, 0.99).Milliseconds()), "p99_ms")
+				}
+			})
+		}
+	}
+}
+
+// --- Concurrent Review Runner ---
+
+func runConcurrentReviews(mgr *manager, requests []*admission.AdmissionRequest) []time.Duration {
+	latencies := make([]time.Duration, len(requests))
+	var wg sync.WaitGroup
+	wg.Add(len(requests))
+	for i, req := range requests {
+		go func(idx int, r *admission.AdmissionRequest) {
+			defer wg.Done()
+			start := time.Now()
+			_, _ = mgr.HandleValidate(r)
+			latencies[idx] = time.Since(start)
+		}(i, req)
+	}
+	wg.Wait()
+	return latencies
+}

--- a/tools/admission-control/README.md
+++ b/tools/admission-control/README.md
@@ -1,0 +1,176 @@
+# Admission Controller Tools
+
+Scripts for benchmarking and profiling the admission controller, Sensor, and
+Central around image cache and reprocessor ("reassess all") workflows.
+
+## Prerequisites
+
+- Kubernetes/OpenShift cluster with StackRox deployed
+- `admissionControl.enforcement` enabled in the SecuredCluster CR
+- `spec.monitoring.exposeEndpoint: Enabled` in the SecuredCluster CR
+
+## Common Environment Variables
+
+Shared by `bench-reassess.sh` and `profile-reassess.sh`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ROX_PASSWORD` | *(required)* | Central admin password |
+| `ROX_CENTRAL_ADDRESS` | *(required)* | Central host:port |
+| `ROX_ADMIN_USER` | `admin` | Central admin username |
+| `BURST_SIZE` | varies | Number of deployments per burst |
+| `UNIQUE_PCT` | varies | % of BURST_SIZE used as distinct images |
+| `IMAGES_FILE` | *(unset)* | File with one image per line (overrides generation) |
+| `PARALLEL` | `50` | Max concurrent `kubectl create` calls |
+| `NAMESPACE` | varies | Namespace for test deployments |
+| `ROX_NAMESPACE` | `stackrox` | StackRox namespace |
+| `REASSESS_WAIT_TIMEOUT` | `300` | Max seconds to wait for reprocessor |
+
+## Image Pool
+
+All slow-path scripts derive the unique image count from `BURST_SIZE` and
+`UNIQUE_PCT`:
+
+```
+UNIQUE_COUNT = BURST_SIZE * UNIQUE_PCT / 100
+```
+
+`generate-image-pool.sh` is called automatically to fetch exactly
+`UNIQUE_COUNT` images from `quay.io` (counts <= 20 use a hardcoded fallback,
+counts > 20 query the quay.io tag API; results cached in `/tmp` for 1 hour).
+Set `IMAGES_FILE` to skip generation and read from a file instead.
+
+## Cross-Branch Comparison
+
+All scripts follow the same pattern:
+
+1. Deploy with **master** image, run the script, save output
+2. Swap to **PR branch** image (policies persist in Central)
+3. Run again, save output
+4. `diff` the two outputs (or use `go tool pprof -diff_base` for profiles)
+
+---
+
+### `burst-test.sh`
+
+Burst of deployment creates against a live cluster with AC metric deltas.
+Run with `-h` for all options.
+
+| Mode | What it tests | Required policies |
+|------|---------------|-------------------|
+| `fast-path` | Spec-only evaluation (no image fetching) | Privileged Container, Latest tag |
+| `slow-path` | Image coalescing + caching (enrichment) | Any enrichment-required (e.g. Image Age) |
+
+Slow-path runs two phases automatically: **cold cache** (pods restarted) then
+**warm cache** (immediate re-burst).
+
+```bash
+# Fast-path
+VIOLATION_PCT=50 ./burst-test.sh fast-path
+
+# Slow-path (125 unique images = 25% of 500)
+BURST_SIZE=500 UNIQUE_PCT=25 ./burst-test.sh slow-path
+
+# Slow-path with custom images
+IMAGES_FILE=/tmp/my-images.txt BURST_SIZE=500 UNIQUE_PCT=50 ./burst-test.sh slow-path
+
+# Create persistent deployments (replicas=0) for reprocessor profiling
+BURST_SIZE=1000 UNIQUE_PCT=60 ./burst-test.sh slow-path --no-dry-run
+```
+
+---
+
+### `bench-reassess.sh`
+
+End-to-end benchmark: **burst → reassess → burst** cycle with Prometheus
+metric deltas across AC, Sensor, and Central.
+
+| Phase | What happens |
+|-------|-------------|
+| 1. Burst 1 | `--dry-run=server` deployments warm caches |
+| 2. Snapshot | Scrape pre-reassess metrics |
+| 3. Reassess | `POST /v1/policies/reassess` |
+| 4. Snapshot | Scrape post-reassess metrics |
+| 5. Burst 2 | Same manifests — measures cache survival |
+| 6. Report | Print deltas and key comparisons |
+
+```bash
+ROX_PASSWORD=<pw> ROX_CENTRAL_ADDRESS=<host:port> ./bench-reassess.sh
+
+# With more unique images or a custom list
+BURST_SIZE=200 UNIQUE_PCT=50 ROX_PASSWORD=<pw> ROX_CENTRAL_ADDRESS=<addr> ./bench-reassess.sh
+IMAGES_FILE=/tmp/my-images.txt BURST_SIZE=200 ROX_PASSWORD=<pw> ROX_CENTRAL_ADDRESS=<addr> ./bench-reassess.sh
+```
+
+Defaults: `BURST_SIZE=100`, `UNIQUE_PCT=25`, `METRICS_PORT=9090`,
+`LOCAL_PORT=9090`.
+
+**Metrics collected:**
+
+| Component | Metric | What it tells you |
+|-----------|--------|-------------------|
+| Central | `reprocessor_duration_seconds` | Wall time of the reprocessor cycle |
+| Central | `msg_to_sensor_not_sent_count` | Messages skipped due to errors |
+| Sensor | `detector_deployment_processed` | Deployment re-detections triggered |
+| Sensor | `detector_dedupe_cache_hits` | Deployments deduped (no re-detection) |
+| Sensor | `sensor_events` | Total events sent to Central |
+| Sensor | `component_process_message_duration_seconds` | Time processing Central messages |
+| AC | `image_cache_operations_total{hit,miss,skip}` | Cache effectiveness |
+| AC | `image_fetch_total` | Cold fetches from cache misses |
+| AC | `policyeval_review_duration_seconds` | Per-review latency |
+
+**Key comparisons** (master vs PR):
+
+1. `reprocessor_duration_seconds` — lower = less serialization overhead
+2. `deployment_processed` during reassess — lower = fewer redundant re-detections
+3. AC cache hit rate on burst 2 — higher = cache survived reassess
+4. AC `image_fetch_total` (burst 2) — lower = cache was warm
+5. AC `image_fetch_total` (reassess) — lower = no unnecessary re-fetches
+
+---
+
+### `profile-reassess.sh`
+
+Captures Go pprof CPU and heap profiles from Central and Sensor during reassess.
+Creates real deployments (`replicas=0`) first, then profiles.
+
+| Step | What happens |
+|------|-------------|
+| 1 | Verify pprof endpoints (fails fast if unreachable) |
+| 2 | Create `BURST_SIZE` deployments (`replicas=0`), wait 30s |
+| 3 | Capture pre-reassess heap snapshots |
+| 4 | Start CPU profiling + trigger reassess |
+| 5 | Capture post-reassess heap and goroutine snapshots |
+
+```bash
+ROX_PASSWORD=<pw> ROX_CENTRAL_ADDRESS=localhost:8000 \
+  BURST_SIZE=500 UNIQUE_PCT=60 CPU_PROFILE_SECONDS=60 \
+  ./profile-reassess.sh
+```
+
+Defaults: `BURST_SIZE=500`, `UNIQUE_PCT=60`, `CPU_PROFILE_SECONDS=60`,
+`SENSOR_LOCAL_PORT=6060`, `OUTPUT_DIR=/tmp/profiles/<branch>-<timestamp>`.
+
+**Output files:**
+
+| File | When |
+|------|------|
+| `{central,sensor}-heap-pre.pb.gz` | Before reassess |
+| `{central,sensor}-cpu.pb.gz` | During reassess |
+| `{central,sensor}-heap-post.pb.gz` | After reassess |
+| `{central,sensor}-goroutine.pb.gz` | After reassess |
+
+**Comparison:**
+
+```bash
+# CPU diff between branches
+go tool pprof -diff_base=./profiles/master-*/central-cpu.pb.gz \
+                          ./profiles/<pr-branch>-*/central-cpu.pb.gz
+
+# Heap growth within a single run
+go tool pprof -diff_base=./profiles/<branch>/central-heap-pre.pb.gz \
+                          ./profiles/<branch>/central-heap-post.pb.gz
+
+# Interactive flamegraph
+go tool pprof -http=:8080 ./profiles/<branch>/central-cpu.pb.gz
+```

--- a/tools/admission-control/bench-reassess.sh
+++ b/tools/admission-control/bench-reassess.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# bench-reassess.sh -- E2E benchmark: burst → reassess → burst cycle.
+# Collects AC, Sensor, and Central Prometheus metrics to quantify
+# reprocessor cache optimization impact. See README.md for details.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+: "${BURST_SIZE:=100}"
+: "${UNIQUE_PCT:=25}"
+: "${PARALLEL:=50}"
+: "${NAMESPACE:=burst-test}"
+: "${ROX_NAMESPACE:=stackrox}"
+: "${ROX_PASSWORD:?ROX_PASSWORD must be set}"
+: "${ROX_CENTRAL_ADDRESS:?ROX_CENTRAL_ADDRESS must be set}"
+: "${ROX_ADMIN_USER:=admin}"
+: "${REASSESS_WAIT_TIMEOUT:=300}"
+
+: "${METRICS_PORT:=9090}"
+: "${LOCAL_PORT:=9090}"
+
+DRY_RUN="true"
+export DRY_RUN
+
+WORK_DIR=$(mktemp -d)
+
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+# component-label → local-port mapping (all use the same local port, scraped sequentially)
+declare -A COMPONENTS=(
+    [admission-control]="$LOCAL_PORT"
+    [sensor]="$LOCAL_PORT"
+    [central]="$LOCAL_PORT"
+)
+declare -A COMP_SHORT=( [admission-control]=ac [sensor]=sensor [central]=central )
+
+readonly NETPOL_PREFIX="bench-reassess-metrics"
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# bench-reassess-specific helpers
+# ---------------------------------------------------------------------------
+
+cleanup() {
+    kill_port_forwards
+    for app_label in admission-control sensor central; do
+        kubectl -n "$ROX_NAMESPACE" delete networkpolicy "${NETPOL_PREFIX}-${app_label}" \
+            --ignore-not-found &>/dev/null || true
+    done
+    kubectl delete namespace "$NAMESPACE" --ignore-not-found &>/dev/null || true
+    [[ -n "${WORK_DIR:-}" ]] && rm -rf "$WORK_DIR"
+}
+
+allow_metrics_ingress() {
+    for app_label in admission-control sensor central; do
+        allow_metrics_netpol "${NETPOL_PREFIX}-${app_label}" "$app_label"
+    done
+}
+
+scrape_all() {
+    local prefix="$1"
+    for label in "${!COMPONENTS[@]}"; do
+        local short="${COMP_SHORT[$label]}"
+        echo "  Scraping ${short} metrics..."
+        scrape_component "$label" "${COMPONENTS[$label]}" \
+            "${WORK_DIR}/${prefix}_${short}.prom"
+    done
+}
+
+# read_metric <phase> <component-short> <metric> [labels]
+read_metric() {
+    extract "${WORK_DIR}/${1}_${2}.prom" "$3" "${4:-}"
+}
+
+# metric_delta <phase_a> <phase_b> <component-short> <metric> [labels]
+metric_delta() {
+    echo "$(read_metric "$2" "$3" "$4" "${5:-}") - $(read_metric "$1" "$3" "$4" "${5:-}")" | bc
+}
+
+# trigger_and_wait_for_reprocessor is now in lib.sh
+
+scrape_reprocessor_duration() {
+    echo "  Scraping reprocessor duration gauge..."
+    sleep 3
+    scrape_component "central" "${COMPONENTS[central]}" "${WORK_DIR}/poll_central.prom"
+    local duration
+    duration=$(extract "${WORK_DIR}/poll_central.prom" "rox_central_reprocessor_duration_seconds")
+    echo "  reprocessor_duration_seconds = ${duration:-N/A}"
+}
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+print_report() {
+    local pre="$1" post="$2" post2="$3"
+    local ac="rox_admission_control" s="rox_sensor" c="rox_central"
+
+    # AC burst 2 (post → post2)
+    local b2_hit b2_miss b2_skip b2_fetch b2_dur_avg
+    b2_hit=$(metric_delta "$post" "$post2" ac "${ac}_image_cache_operations_total" 'result="hit"')
+    b2_miss=$(metric_delta "$post" "$post2" ac "${ac}_image_cache_operations_total" 'result="miss"')
+    b2_skip=$(metric_delta "$post" "$post2" ac "${ac}_image_cache_operations_total" 'result="skip"')
+    b2_fetch=$(metric_delta "$post" "$post2" ac "${ac}_image_fetch_total")
+    b2_dur_avg=$(avg_or_na \
+        "$(metric_delta "$post" "$post2" ac "${ac}_policyeval_review_duration_seconds_sum")" \
+        "$(metric_delta "$post" "$post2" ac "${ac}_policyeval_review_duration_seconds_count")")
+
+    local b2_total b2_hit_pct
+    b2_total=$(echo "${b2_hit} + ${b2_miss} + ${b2_skip}" | bc)
+    b2_hit_pct=$(pct_or_na "$b2_hit" "$b2_total")
+
+    # AC reassess (pre → post)
+    local r_ac_hit r_ac_miss r_ac_skip r_ac_fetch
+    r_ac_hit=$(metric_delta "$pre" "$post" ac "${ac}_image_cache_operations_total" 'result="hit"')
+    r_ac_miss=$(metric_delta "$pre" "$post" ac "${ac}_image_cache_operations_total" 'result="miss"')
+    r_ac_skip=$(metric_delta "$pre" "$post" ac "${ac}_image_cache_operations_total" 'result="skip"')
+    r_ac_fetch=$(metric_delta "$pre" "$post" ac "${ac}_image_fetch_total")
+
+    # Sensor reassess (pre → post)
+    local r_s_depl r_s_dedupe r_s_events
+    r_s_depl=$(metric_delta "$pre" "$post" sensor "${s}_detector_deployment_processed")
+    r_s_dedupe=$(metric_delta "$pre" "$post" sensor "${s}_detector_dedupe_cache_hits")
+    r_s_events=$(metric_delta "$pre" "$post" sensor "${s}_sensor_events")
+
+    local r_s_cpm_count r_s_cpm_avg
+    r_s_cpm_count=$(metric_delta "$pre" "$post" sensor "${s}_component_process_message_duration_seconds_count")
+    r_s_cpm_avg=$(avg_or_na \
+        "$(metric_delta "$pre" "$post" sensor "${s}_component_process_message_duration_seconds_sum")" \
+        "$r_s_cpm_count")
+
+
+    # Sensor burst 2 (post → post2)
+    local b2_s_depl b2_s_dedupe b2_s_events
+    b2_s_depl=$(metric_delta "$post" "$post2" sensor "${s}_detector_deployment_processed")
+    b2_s_dedupe=$(metric_delta "$post" "$post2" sensor "${s}_detector_dedupe_cache_hits")
+    b2_s_events=$(metric_delta "$post" "$post2" sensor "${s}_sensor_events")
+
+    # Central
+    local c_dur c_notsent
+    c_dur=$(read_metric "$post" central "${c}_reprocessor_duration_seconds")
+    c_notsent=$(metric_delta "$pre" "$post" central "${c}_msg_to_sensor_not_sent_count")
+
+    # --- Output ---
+    cat <<EOF
+
+================================================================================
+  BENCH-REASSESS REPORT
+================================================================================
+  Burst size:      ${BURST_SIZE}
+  Unique images:   ${UNIQUE_COUNT} / ${POOL_SIZE}
+  Parallelism:     ${PARALLEL}
+  Central:         ${ROX_CENTRAL_ADDRESS}
+================================================================================
+
+  CENTRAL  (reassess cycle)
+  --------------------------------
+EOF
+    row "reprocessor_duration_seconds (gauge)"  "$c_dur"
+    row "msg_to_sensor_not_sent (delta)"        "$c_notsent"
+
+    cat <<EOF
+
+  SENSOR  (during reassess)
+  --------------------------------
+EOF
+    row "detector_deployment_processed (delta)"   "$r_s_depl"
+    row "detector_dedupe_cache_hits (delta)"       "$r_s_dedupe"
+    row "sensor_events (delta)"                    "$r_s_events"
+    row "component_process_message count (delta)"  "$r_s_cpm_count"
+    row "component_process_message avg (s)"        "$r_s_cpm_avg"
+
+    cat <<EOF
+
+  ADMISSION CONTROLLER  (during reassess)
+  --------------------------------
+EOF
+    row "image_cache_operations{hit} (delta)"   "$r_ac_hit"
+    row "image_cache_operations{miss} (delta)"  "$r_ac_miss"
+    row "image_cache_operations{skip} (delta)"  "$r_ac_skip"
+    row "image_fetch_total (delta)"             "$r_ac_fetch"
+
+    cat <<EOF
+
+  ADMISSION CONTROLLER  (burst 2)
+  --------------------------------
+EOF
+    row "image_cache_operations{hit} (delta)"   "$b2_hit"
+    row "image_cache_operations{miss} (delta)"  "$b2_miss"
+    row "image_cache_operations{skip} (delta)"  "$b2_skip"
+    row "image_fetch_total (delta)"             "$b2_fetch"
+    row "cache_hit_rate"                        "${b2_hit_pct}%"
+    row "review_duration avg (s)"              "$b2_dur_avg"
+
+    cat <<EOF
+
+  SENSOR  (burst 2)
+  --------------------------------
+EOF
+    row "detector_deployment_processed (delta)"  "$b2_s_depl"
+    row "detector_dedupe_cache_hits (delta)"      "$b2_s_dedupe"
+    row "sensor_events (delta)"                   "$b2_s_events"
+
+    cat <<EOF
+
+================================================================================
+  KEY COMPARISONS  (run once on master, once on PR branch)
+================================================================================
+  1. Central reprocessor_duration_seconds:   ${c_dur}
+     Lower = less time serializing/sending UpdatedImage messages.
+
+  2. Sensor deployment_processed (reassess): ${r_s_depl}
+     Lower = fewer ResolveDeploymentsByImages re-detections.
+
+  3. AC cache hit rate on burst 2:           ${b2_hit_pct}%
+     Higher = cache survived reassess (targeted invalidation).
+
+  4. AC image_fetch_total (burst 2):         ${b2_fetch}
+     Lower = fewer cold fetches (cache was warm).
+
+  5. AC image_fetch_total (reassess):        ${r_ac_fetch}
+     Lower = no unnecessary invalidation-triggered re-fetches.
+================================================================================
+
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Main flow
+# ---------------------------------------------------------------------------
+
+cat <<EOF
+================================================================================
+  bench-reassess.sh
+================================================================================
+  BURST_SIZE:            ${BURST_SIZE}
+  UNIQUE_PCT:            ${UNIQUE_PCT}%
+  PARALLEL:              ${PARALLEL}
+  ROX_CENTRAL_ADDRESS:   ${ROX_CENTRAL_ADDRESS}
+  REASSESS_WAIT_TIMEOUT: ${REASSESS_WAIT_TIMEOUT}s
+================================================================================
+
+EOF
+
+setup_namespace
+allow_metrics_ingress
+
+echo "--- Generating manifests ---"
+generate_slow_path_manifests
+
+echo ""
+echo "=== PHASE 1: Burst 1 (warm caches) ==="
+run_burst "Burst 1"
+echo "  Waiting 10s for metrics to settle..."
+sleep 10
+
+echo ""
+echo "=== PHASE 2: Snapshot pre-reassess metrics ==="
+scrape_all "pre"
+
+echo ""
+echo "=== PHASE 3: Trigger reassess ==="
+trigger_and_wait_for_reprocessor
+scrape_reprocessor_duration
+
+echo ""
+echo "=== PHASE 4: Snapshot post-reassess metrics ==="
+scrape_all "post"
+
+echo ""
+echo "=== PHASE 5: Burst 2 (measure cache survival) ==="
+run_burst "Burst 2"
+echo "  Waiting 10s for metrics to settle..."
+sleep 10
+
+echo ""
+echo "=== PHASE 6: Snapshot post-burst2 metrics ==="
+scrape_all "post2"
+
+echo ""
+echo "=== PHASE 7: Report ==="
+print_report "pre" "post" "post2"

--- a/tools/admission-control/burst-test.sh
+++ b/tools/admission-control/burst-test.sh
@@ -1,0 +1,467 @@
+#!/usr/bin/env bash
+# burst-test.sh -- Admission controller burst test rig.
+#
+# Simulates a burst of deployment creation requests (--dry-run=server) against
+# a live cluster, scrapes admission controller Prometheus metrics before and
+# after, and reports deltas.
+#
+# Two modes:
+#   fast-path  - Tests spec-only policy evaluation (no image fetching).
+#                Requires: Privileged Container + Latest tag policies enforced.
+#   slow-path  - Tests image coalescing and caching in the enrichment path.
+#                Runs two phases (cold cache, then warm cache).
+#                Requires: at least one enrichment-required policy (e.g. Image Age).
+#
+# See README.md for full prerequisites and cross-branch comparison workflow.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+MODE=""
+DRY_RUN="true"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-dry-run) DRY_RUN="false"; shift ;;
+        -h|--help)    MODE="--help"; break ;;
+        *)            MODE="$1"; shift ;;
+    esac
+done
+export DRY_RUN
+
+: "${BURST_SIZE:=500}"
+: "${VIOLATION_PCT:=50}"
+: "${UNIQUE_PCT:=25}"
+: "${NAMESPACE:=burst-test}"
+: "${IMAGES:=quay.io/centos/centos:7,quay.io/fedora/fedora:38,quay.io/centos/centos:stream9}"
+: "${ROX_NAMESPACE:=stackrox}"
+: "${METRICS_PORT:=9090}"
+: "${LOCAL_PORT:=9090}"
+: "${PARALLEL:=50}"
+
+WORK_DIR=$(mktemp -d)
+
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+usage() {
+    cat <<'EOF'
+Usage: ./burst-test.sh <mode> [options]
+
+Modes:
+  fast-path    Test spec-only policy evaluation (no image fetching).
+               Requires: Privileged Container + Latest tag policies enforced.
+  slow-path    Test image coalescing and caching in the enrichment path.
+               Runs two phases: cold cache (pods restarted) then warm cache.
+               Requires: at least one enrichment-required policy (e.g. Image Age).
+
+Options:
+  --no-dry-run Apply deployments for real (replicas=0). Useful for creating
+               persistent deployment objects for reprocessor profiling.
+  -h, --help   Show this help message.
+
+Environment variables:
+  BURST_SIZE       Number of deployments to create           (default: 500)
+  VIOLATION_PCT    % that violate policy (fast-path only)    (default: 50)
+  UNIQUE_PCT       % of BURST_SIZE used as distinct images   (default: 25)
+                   Unique count = BURST_SIZE * UNIQUE_PCT / 100.
+  IMAGES_FILE      Path to a file with one image per line.
+                   Overrides automatic pool generation.
+  NAMESPACE        Namespace for test deployments            (default: burst-test)
+  IMAGES           Comma-separated images (fast-path only)   (default: quay.io/centos/centos:7,...)
+  ROX_NAMESPACE    StackRox namespace                        (default: stackrox)
+  METRICS_PORT     Admission controller metrics port         (default: 9090)
+  LOCAL_PORT       Local port for kubectl port-forward       (default: 9090)
+  PARALLEL         Max concurrent kubectl creates            (default: 50)
+
+fast-path mode:
+  Violating deployments use privileged: true + :latest tags.
+  Clean deployments use privileged: false + pinned tags from IMAGES.
+  Correctness check: denied == VIOLATION_PCT%, allowed == rest.
+
+slow-path mode:
+  Image pool is loaded via generate-image-pool.sh (or IMAGES_FILE).
+  UNIQUE_PCT of BURST_SIZE determines how many unique images to generate.
+  Phase 1 restarts admission-control pods to flush caches.
+  Phase 2 reuses warm caches from phase 1.
+  Reports coalesce ratio, cache hit rate, and fetch counts.
+  With --no-dry-run, deployments are created with replicas=0.
+EOF
+    exit 0
+}
+
+if [[ "${MODE}" == "-h" || "${MODE}" == "--help" ]]; then
+    usage
+fi
+
+if [[ "${MODE}" != "fast-path" && "${MODE}" != "slow-path" ]]; then
+    echo "ERROR: mode must be 'fast-path' or 'slow-path'" >&2
+    echo "Run with -h for usage." >&2
+    exit 1
+fi
+
+for cmd in kubectl curl bc awk; do
+    command -v "$cmd" &>/dev/null || { echo "ERROR: '$cmd' required but not found" >&2; exit 1; }
+done
+
+readonly METRICS_NETPOL="admission-control-metrics-allow"
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# burst-test-specific helpers
+# ---------------------------------------------------------------------------
+
+cleanup() {
+    kill_port_forwards
+    kubectl -n "$ROX_NAMESPACE" delete networkpolicy "$METRICS_NETPOL" \
+        --ignore-not-found &>/dev/null || true
+    kubectl delete namespace "$NAMESPACE" --ignore-not-found &>/dev/null || true
+    [[ -n "${WORK_DIR:-}" ]] && rm -rf "$WORK_DIR"
+}
+
+allow_metrics_ingress() {
+    allow_metrics_netpol "$METRICS_NETPOL" "admission-control"
+}
+
+restart_admission_control() {
+    echo "Restarting admission-control pods..."
+    kubectl -n "$ROX_NAMESPACE" rollout restart deployment/admission-control >/dev/null
+    kubectl -n "$ROX_NAMESPACE" rollout status deployment/admission-control --timeout=120s >/dev/null
+
+    local attempts=0
+    while true; do
+        local terminating
+        terminating=$(kubectl -n "$ROX_NAMESPACE" get pod -l app=admission-control \
+            --no-headers 2>/dev/null | grep -c -v "Running" || true)
+        [[ "$terminating" -eq 0 ]] && break
+        attempts=$((attempts + 1))
+        if [[ "$attempts" -ge 60 ]]; then
+            echo "ERROR: old pods still terminating after 60s" >&2
+            exit 1
+        fi
+        sleep 1
+    done
+
+    sleep 10
+    echo "  pods restarted and ready."
+}
+
+scrape_metrics() {
+    scrape_component "admission-control" "$LOCAL_PORT" "$1"
+}
+
+# Backward-compatible wrapper used by reports.
+extract_counter() { extract "$@"; }
+
+# ---------------------------------------------------------------------------
+# Fast-path manifest generators
+# ---------------------------------------------------------------------------
+
+generate_fast_path_deployment() {
+    local name="$1" privileged="$2" outfile="$3"
+    {
+        cat <<YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${name}
+  namespace: ${NAMESPACE}
+  labels:
+    burst-test: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${name}
+  template:
+    metadata:
+      labels:
+        app: ${name}
+    spec:
+      containers:
+YAML
+        local idx=0
+        for img in "${IMAGE_LIST[@]}"; do
+            local registry="${img%%:*}"
+            local short="${registry##*/}"
+            local tag
+            if [[ "$privileged" == "true" ]]; then
+                tag="latest"
+            else
+                tag="${img#*:}"
+            fi
+            cat <<YAML
+      - name: c${idx}-${short}
+        image: ${registry}:${tag}
+        securityContext:
+          privileged: ${privileged}
+YAML
+            idx=$((idx + 1))
+        done
+    } > "$outfile"
+}
+
+generate_fast_path_manifests() {
+    for (( i = 0; i < VIOLATING_COUNT; i++ )); do
+        generate_fast_path_deployment "burst-v-${i}" "true" "${WORK_DIR}/deploy-${i}.yaml"
+    done
+    for (( i = 0; i < CLEAN_COUNT; i++ )); do
+        local j=$(( i + VIOLATING_COUNT ))
+        generate_fast_path_deployment "burst-c-${j}" "false" "${WORK_DIR}/deploy-${j}.yaml"
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Reports
+# ---------------------------------------------------------------------------
+
+compute_common_deltas() {
+    local before="$1" after="$2"
+    local m="rox_admission_control"
+
+    FETCH_D=$(delta \
+        "$(extract "$before" "${m}_image_fetch_total")" \
+        "$(extract "$after"  "${m}_image_fetch_total")")
+    DENIED_D=$(delta \
+        "$(extract "$before" "${m}_policyeval_review_total" 'result="denied"')" \
+        "$(extract "$after"  "${m}_policyeval_review_total" 'result="denied"')")
+    ALLOWED_D=$(delta \
+        "$(extract "$before" "${m}_policyeval_review_total" 'result="allowed"')" \
+        "$(extract "$after"  "${m}_policyeval_review_total" 'result="allowed"')")
+    HIT_D=$(delta \
+        "$(extract "$before" "${m}_image_cache_operations_total" 'result="hit"')" \
+        "$(extract "$after"  "${m}_image_cache_operations_total" 'result="hit"')")
+    MISS_D=$(delta \
+        "$(extract "$before" "${m}_image_cache_operations_total" 'result="miss"')" \
+        "$(extract "$after"  "${m}_image_cache_operations_total" 'result="miss"')")
+    SKIP_D=$(delta \
+        "$(extract "$before" "${m}_image_cache_operations_total" 'result="skip"')" \
+        "$(extract "$after"  "${m}_image_cache_operations_total" 'result="skip"')")
+
+    local dur_count_d dur_sum_d
+    dur_count_d=$(delta \
+        "$(extract "$before" "${m}_policyeval_review_duration_seconds_count")" \
+        "$(extract "$after"  "${m}_policyeval_review_duration_seconds_count")")
+    dur_sum_d=$(delta \
+        "$(extract "$before" "${m}_policyeval_review_duration_seconds_sum")" \
+        "$(extract "$after"  "${m}_policyeval_review_duration_seconds_sum")")
+    DUR_AVG=$(avg_or_na "$dur_sum_d" "$dur_count_d")
+
+    local fpr_count_d fpr_sum_d
+    fpr_count_d=$(delta \
+        "$(extract "$before" "${m}_image_fetches_per_review_count")" \
+        "$(extract "$after"  "${m}_image_fetches_per_review_count")")
+    fpr_sum_d=$(delta \
+        "$(extract "$before" "${m}_image_fetches_per_review_sum")" \
+        "$(extract "$after"  "${m}_image_fetches_per_review_sum")")
+    FPR_AVG=$(avg_or_na "$fpr_sum_d" "$fpr_count_d")
+}
+
+report_fast_path() {
+    local before="$1" after="$2"
+    compute_common_deltas "$before" "$after"
+
+    cat <<EOF
+
+==============================
+  FAST PATH BURST TEST REPORT
+==============================
+  Burst size:    ${BURST_SIZE}
+  Violation %:   ${VIOLATION_PCT}%
+  Expected:      ${VIOLATING_COUNT} denied, ${CLEAN_COUNT} allowed
+==============================
+
+EOF
+    printf "  %-42s %s\n" "Metric" "Delta"
+    printf "  %-42s %s\n" "------" "-----"
+    printf "  %-42s %s\n" "image_fetch_total"                "$FETCH_D"
+    printf "  %-42s %s\n" "image_fetches_per_review (avg)"   "$FPR_AVG"
+    printf "  %-42s %s\n" "policyeval_review_total{denied}"  "$DENIED_D"
+    printf "  %-42s %s\n" "policyeval_review_total{allowed}" "$ALLOWED_D"
+    printf "  %-42s %s\n" "image_cache_operations{hit}"      "$HIT_D"
+    printf "  %-42s %s\n" "image_cache_operations{miss}"     "$MISS_D"
+    printf "  %-42s %s\n" "image_cache_operations{skip}"     "$SKIP_D"
+    printf "  %-42s %s\n" "review_duration_seconds (avg)"    "${DUR_AVG}s"
+    echo ""
+
+    local pass=true
+    if [[ "$DENIED_D" -ne "$VIOLATING_COUNT" ]]; then
+        echo "  FAIL: expected ${VIOLATING_COUNT} denied, got ${DENIED_D}"
+        pass=false
+    fi
+    if [[ "$ALLOWED_D" -ne "$CLEAN_COUNT" ]]; then
+        echo "  FAIL: expected ${CLEAN_COUNT} allowed, got ${ALLOWED_D}"
+        pass=false
+    fi
+    if $pass; then
+        echo "  PASS: denied=${DENIED_D} allowed=${ALLOWED_D}"
+    fi
+    echo ""
+}
+
+report_slow_path_phase() {
+    local phase_name="$1" before="$2" after="$3"
+    compute_common_deltas "$before" "$after"
+
+    local coalesce_saved coalesce_pct cache_total cache_hit_pct
+    coalesce_saved=$(echo "${TOTAL_IMAGE_REFS} - ${FETCH_D}" | bc)
+    coalesce_pct=$(pct_or_na "$coalesce_saved" "$TOTAL_IMAGE_REFS")
+    cache_total=$(echo "${HIT_D} + ${MISS_D} + ${SKIP_D}" | bc)
+    cache_hit_pct=$(pct_or_na "$HIT_D" "$cache_total")
+
+    local review_total
+    review_total=$(echo "${DENIED_D} + ${ALLOWED_D}" | bc)
+
+    cat <<EOF
+
+  ${phase_name}
+  --------------------------------
+EOF
+    printf "  %-42s %s\n" "total_image_refs"                 "$TOTAL_IMAGE_REFS"
+    printf "  %-42s %s\n" "image_fetch_total"                "$FETCH_D"
+    printf "  %-42s %s\n" "fetches avoided"                  "$coalesce_saved"
+    printf "  %-42s %s\n" "coalesce ratio"                   "${coalesce_pct}%"
+    printf "  %-42s %s\n" "image_fetches_per_review (avg)"   "$FPR_AVG"
+    printf "  %-42s %s\n" "image_cache_operations{hit}"      "$HIT_D"
+    printf "  %-42s %s\n" "image_cache_operations{miss}"     "$MISS_D"
+    printf "  %-42s %s\n" "image_cache_operations{skip}"     "$SKIP_D"
+    printf "  %-42s %s\n" "cache_hit_rate"                   "${cache_hit_pct}%"
+    printf "  %-42s %s\n" "reviews completed"                "$review_total"
+    printf "  %-42s %s\n" "review_duration_seconds (avg)"    "${DUR_AVG}s"
+    echo ""
+
+    local pass=true
+    if [[ "$FETCH_D" -eq 0 ]]; then
+        echo "  WARN: image_fetch_total delta is 0. No enrichment-required policy may be active."
+        pass=false
+    fi
+    if [[ "$review_total" -ne "$BURST_SIZE" ]]; then
+        echo "  FAIL: expected ${BURST_SIZE} reviews, got ${review_total}"
+        pass=false
+    fi
+    if $pass; then
+        echo "  PASS: ${FETCH_D} image fetches for ${TOTAL_IMAGE_REFS} image refs, ${review_total} reviews completed"
+    fi
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Main flow
+# ---------------------------------------------------------------------------
+
+cat <<EOF
+========================================
+  Admission Controller Burst Test
+========================================
+  Mode:            ${MODE}
+  BURST_SIZE:      ${BURST_SIZE}
+  DRY_RUN:         ${DRY_RUN}
+  UNIQUE_PCT:      ${UNIQUE_PCT}%
+  Namespace:       ${NAMESPACE}
+
+EOF
+
+setup_namespace
+allow_metrics_ingress
+
+if [[ "$MODE" == "fast-path" ]]; then
+    IFS=',' read -ra IMAGE_LIST <<< "$IMAGES"
+    VIOLATING_COUNT=$(( BURST_SIZE * VIOLATION_PCT / 100 ))
+    CLEAN_COUNT=$(( BURST_SIZE - VIOLATING_COUNT ))
+
+    echo "Generating manifests (${VIOLATING_COUNT} violating, ${CLEAN_COUNT} clean)..."
+    generate_fast_path_manifests
+
+    : "${SKIP_METRICS:=false}"
+    if [[ "$SKIP_METRICS" != "true" ]]; then
+        echo "Scraping baseline metrics..."
+        scrape_metrics "${WORK_DIR}/before.prom"
+        echo "  scraped $(wc -l < "${WORK_DIR}/before.prom") lines"
+    fi
+
+    run_burst "Fast path"
+
+    if [[ "$SKIP_METRICS" != "true" ]]; then
+        echo "Waiting for metrics to settle..."
+        sleep 10
+
+        echo "Scraping post-burst metrics..."
+        scrape_metrics "${WORK_DIR}/after.prom"
+        echo "  scraped $(wc -l < "${WORK_DIR}/after.prom") lines"
+
+        report_fast_path "${WORK_DIR}/before.prom" "${WORK_DIR}/after.prom"
+    else
+        echo ""
+        echo "=============================="
+        echo "  FAST PATH BURST TEST REPORT"
+        echo "=============================="
+        echo "  Burst size:    ${BURST_SIZE}"
+        echo "  Violation %:   ${VIOLATION_PCT}%"
+        echo "  Expected:      ${VIOLATING_COUNT} denied, ${CLEAN_COUNT} allowed"
+        echo "  (metrics scraping skipped)"
+        echo "=============================="
+        echo ""
+        denied=$(grep -c "^denied" "${WORK_DIR}/results.log" 2>/dev/null || true)
+        allowed=$(grep -c "^allowed" "${WORK_DIR}/results.log" 2>/dev/null || true)
+        pass=true
+        if [[ "$denied" -ne "$VIOLATING_COUNT" ]]; then
+            echo "  FAIL: expected ${VIOLATING_COUNT} denied, got ${denied}"
+            pass=false
+        fi
+        if [[ "$allowed" -ne "$CLEAN_COUNT" ]]; then
+            echo "  FAIL: expected ${CLEAN_COUNT} allowed, got ${allowed}"
+            pass=false
+        fi
+        if $pass; then
+            echo "  PASS: denied=${denied} allowed=${allowed}"
+        fi
+        echo ""
+    fi
+
+elif [[ "$MODE" == "slow-path" ]]; then
+    generate_slow_path_manifests
+    TOTAL_IMAGE_REFS=$BURST_SIZE
+
+    cat <<EOF
+
+==========================================
+  SLOW PATH COALESCING BURST TEST REPORT
+==========================================
+  Burst size:      ${BURST_SIZE}
+  Unique pct:      ${UNIQUE_PCT}%
+  Unique images:   ${UNIQUE_COUNT} (of ${POOL_SIZE} in pool)
+  Total img refs:  ${TOTAL_IMAGE_REFS}
+==========================================
+EOF
+
+    # --- Phase 1: Cold cache ---
+    restart_admission_control
+
+    echo "Scraping baseline metrics (cold cache)..."
+    scrape_metrics "${WORK_DIR}/cold_before.prom"
+
+    run_burst "Phase 1 (cold cache)"
+
+    echo "Waiting for metrics to settle..."
+    sleep 10
+
+    echo "Scraping post-burst metrics (cold cache)..."
+    scrape_metrics "${WORK_DIR}/cold_after.prom"
+
+    report_slow_path_phase "PHASE 1: COLD CACHE" \
+        "${WORK_DIR}/cold_before.prom" "${WORK_DIR}/cold_after.prom"
+
+    # --- Phase 2: Warm cache ---
+    echo "Scraping baseline metrics (warm cache)..."
+    scrape_metrics "${WORK_DIR}/warm_before.prom"
+
+    run_burst "Phase 2 (warm cache)"
+
+    echo "Waiting for metrics to settle..."
+    sleep 10
+
+    echo "Scraping post-burst metrics (warm cache)..."
+    scrape_metrics "${WORK_DIR}/warm_after.prom"
+
+    report_slow_path_phase "PHASE 2: WARM CACHE" \
+        "${WORK_DIR}/warm_before.prom" "${WORK_DIR}/warm_after.prom"
+fi

--- a/tools/admission-control/generate-image-pool.sh
+++ b/tools/admission-control/generate-image-pool.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# generate-image-pool.sh -- Build a list of unique quay.io image refs.
+#
+# Usage:
+#   ./generate-image-pool.sh [NUM_IMAGES]
+#
+# Outputs one image ref per line to stdout. Uses the quay.io tag API to
+# enumerate tags across popular repositories. Falls back to a hardcoded
+# pool of 20 images when the API is unreachable.
+#
+# Results are cached in /tmp/image-pool-cache.txt to avoid repeated API calls.
+set -euo pipefail
+
+TARGET="${1:-20}"
+CACHE_FILE="/tmp/image-pool-cache.txt"
+CACHE_MAX_AGE_S=3600  # 1 hour
+
+FALLBACK_POOL=(
+    "quay.io/centos/centos:7"
+    "quay.io/centos/centos:stream9"
+    "quay.io/fedora/fedora:37"
+    "quay.io/fedora/fedora:38"
+    "quay.io/fedora/fedora:39"
+    "quay.io/fedora/fedora:40"
+    "quay.io/almalinux/almalinux:8"
+    "quay.io/almalinux/almalinux:9"
+    "quay.io/rockylinux/rockylinux:8"
+    "quay.io/rockylinux/rockylinux:9"
+    "quay.io/prometheus/prometheus:v2.48.0"
+    "quay.io/prometheus/prometheus:v2.45.0"
+    "quay.io/prometheus/alertmanager:v0.26.0"
+    "quay.io/prometheus/node-exporter:v1.7.0"
+    "quay.io/prometheus/blackbox-exporter:v0.24.0"
+    "quay.io/prometheus/pushgateway:v1.6.2"
+    "quay.io/coreos/etcd:v3.5.10"
+    "quay.io/coreos/etcd:v3.5.9"
+    "quay.io/strimzi/kafka:0.38.0-kafka-3.6.0"
+    "quay.io/keycloak/keycloak:23.0"
+)
+
+REPOS=(
+    centos/centos
+    fedora/fedora
+    almalinux/almalinux
+    rockylinux/rockylinux
+    prometheus/prometheus
+    prometheus/alertmanager
+    prometheus/node-exporter
+    prometheus/blackbox-exporter
+    prometheus/pushgateway
+    coreos/etcd
+    strimzi/kafka
+    keycloak/keycloak
+    jetstack/cert-manager-controller
+    jetstack/cert-manager-webhook
+    jetstack/cert-manager-cainjector
+    argoproj/argocd
+    minio/minio
+    minio/mc
+    cilium/cilium
+    cilium/operator-generic
+    cilium/hubble-relay
+    metallb/speaker
+    metallb/controller
+    grafana/grafana
+    grafana/loki
+    grafana/promtail
+    thanos-io/thanos
+    bitnami/redis
+    bitnami/nginx
+    bitnami/postgresql
+    ceph/ceph
+    quay/quay
+    quay/clair
+    calico/node
+    calico/cni
+    calico/kube-controllers
+    brancz/kube-rbac-proxy
+    coreos/flannel
+    oauth2-proxy/oauth2-proxy
+)
+
+use_fallback() {
+    printf '%s\n' "${FALLBACK_POOL[@]}" | head -n "$TARGET"
+}
+
+cache_is_fresh() {
+    [[ -f "$CACHE_FILE" ]] || return 1
+    local cache_lines
+    cache_lines=$(wc -l < "$CACHE_FILE")
+    [[ "$cache_lines" -ge "$TARGET" ]] || return 1
+    if [[ "$(uname)" == "Darwin" ]]; then
+        local mod_epoch
+        mod_epoch=$(stat -f '%m' "$CACHE_FILE")
+        local now_epoch
+        now_epoch=$(date +%s)
+        (( (now_epoch - mod_epoch) < CACHE_MAX_AGE_S ))
+    else
+        find "$CACHE_FILE" -maxdepth 0 -mmin "-$(( CACHE_MAX_AGE_S / 60 ))" | grep -q .
+    fi
+}
+
+if [[ "$TARGET" -le 20 ]]; then
+    use_fallback
+    exit 0
+fi
+
+if cache_is_fresh; then
+    head -n "$TARGET" "$CACHE_FILE"
+    exit 0
+fi
+
+command -v curl &>/dev/null || { echo "ERROR: curl required" >&2; exit 1; }
+command -v jq &>/dev/null || { echo "ERROR: jq required for pool generation > 20 images" >&2; exit 1; }
+
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+for repo in "${REPOS[@]}"; do
+    echo "Fetching tags for quay.io/${repo}..." >&2
+    tags=$(curl -sf --connect-timeout 5 --max-time 10 \
+        "https://quay.io/api/v1/repository/${repo}/tag/?limit=100&onlyActiveTags=true" \
+        | jq -r '.tags[].name // empty' 2>/dev/null || true)
+
+    if [[ -z "$tags" ]]; then
+        echo "  WARN: no tags returned for ${repo}, skipping" >&2
+        continue
+    fi
+
+    while IFS= read -r tag; do
+        [[ -z "$tag" ]] && continue
+        echo "quay.io/${repo}:${tag}" >> "$TMPFILE"
+    done <<< "$tags"
+
+    count=$(wc -l < "$TMPFILE")
+    if [[ "$count" -ge "$TARGET" ]]; then
+        break
+    fi
+done
+
+count=$(wc -l < "$TMPFILE")
+if [[ "$count" -lt "$TARGET" ]]; then
+    echo "WARN: only collected ${count} images from API (requested ${TARGET}). Using what we have." >&2
+fi
+
+cp "$TMPFILE" "$CACHE_FILE"
+head -n "$TARGET" "$CACHE_FILE"

--- a/tools/admission-control/lib.sh
+++ b/tools/admission-control/lib.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# lib.sh -- Shared functions for admission controller test scripts.
+# Source this file; do not execute directly.
+#
+# Expected variables (set by caller before sourcing):
+#   BURST_SIZE, UNIQUE_PCT, PARALLEL, NAMESPACE, ROX_NAMESPACE,
+#   METRICS_PORT, WORK_DIR
+#
+# Optional variables:
+#   IMAGES_FILE  - file with one image ref per line (overrides pool generation)
+#   DRY_RUN      - "true" (default) for --dry-run=server, "false" for real applies (replicas=0)
+#
+# Variables defined here:
+#   SCANNABLE_POOL, POOL_SIZE, UNIQUE_COUNT, PF_PIDS (if not already set)
+
+[[ -n "${_LIB_SH_SOURCED:-}" ]] && return 0
+readonly _LIB_SH_SOURCED=1
+
+for _lib_cmd in kubectl curl bc awk; do
+    command -v "$_lib_cmd" &>/dev/null || {
+        echo "ERROR: '${_lib_cmd}' is required but not found in PATH" >&2
+        exit 1
+    }
+done
+unset _lib_cmd
+
+SCANNABLE_POOL=()
+POOL_SIZE=0
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# load_image_pool <count>
+#   Populates SCANNABLE_POOL and POOL_SIZE.
+#   If IMAGES_FILE is set, reads images from that file.
+#   Otherwise, calls generate-image-pool.sh with the given count.
+#   Updates UNIQUE_COUNT if the pool has fewer images than requested.
+load_image_pool() {
+    local count="${1:?load_image_pool requires a count argument}"
+    if [[ -n "${IMAGES_FILE:-}" ]]; then
+        if [[ ! -f "$IMAGES_FILE" ]]; then
+            echo "ERROR: IMAGES_FILE='${IMAGES_FILE}' not found" >&2
+            exit 1
+        fi
+        mapfile -t SCANNABLE_POOL < "$IMAGES_FILE"
+    else
+        mapfile -t SCANNABLE_POOL < <("${LIB_DIR}/generate-image-pool.sh" "$count")
+    fi
+    POOL_SIZE=${#SCANNABLE_POOL[@]}
+    if [[ "$POOL_SIZE" -eq 0 ]]; then
+        echo "ERROR: image pool is empty" >&2
+        exit 1
+    fi
+    if [[ "$POOL_SIZE" -lt "$UNIQUE_COUNT" ]]; then
+        echo "  WARN: pool has ${POOL_SIZE} images, capping UNIQUE_COUNT from ${UNIQUE_COUNT}." >&2
+        UNIQUE_COUNT=$POOL_SIZE
+    fi
+    echo "  Pool: ${POOL_SIZE} images loaded."
+}
+
+: "${PF_PIDS:=}"
+if [[ -z "$PF_PIDS" ]]; then
+    PF_PIDS=()
+fi
+
+# ---------------------------------------------------------------------------
+# Infrastructure helpers
+# ---------------------------------------------------------------------------
+
+kill_port_forwards() {
+    for pid in "${PF_PIDS[@]}"; do
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    done
+    PF_PIDS=()
+}
+
+setup_namespace() {
+    if kubectl get namespace "$NAMESPACE" &>/dev/null; then
+        kubectl delete namespace "$NAMESPACE" --wait &>/dev/null || true
+    fi
+    kubectl create namespace "$NAMESPACE" >/dev/null
+    kubectl label namespace "$NAMESPACE" \
+        pod-security.kubernetes.io/enforce=privileged --overwrite >/dev/null
+}
+
+# allow_metrics_netpol <netpol-name> <app-label>
+allow_metrics_netpol() {
+    local name="$1" app_label="$2"
+    kubectl -n "$ROX_NAMESPACE" apply -f - <<EOF >/dev/null
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ${name}
+spec:
+  podSelector:
+    matchLabels:
+      app: ${app_label}
+  ingress:
+  - ports:
+    - port: ${METRICS_PORT}
+      protocol: TCP
+  policyTypes:
+  - Ingress
+EOF
+}
+
+# scrape_component <app-label> <local-port> <outfile>
+scrape_component() {
+    local label="$1" local_port="$2" outfile="$3"
+    kill_port_forwards
+    true > "$outfile"
+
+    local pods
+    pods=$(kubectl -n "$ROX_NAMESPACE" get pod -l "app=${label}" \
+        --field-selector=status.phase=Running \
+        -o jsonpath='{.items[*].metadata.name}')
+    if [[ -z "$pods" ]]; then
+        echo "  ERROR: no running ${label} pods in namespace ${ROX_NAMESPACE}" >&2
+        exit 1
+    fi
+
+    for pod in $pods; do
+        local scraped=false
+        for attempt in 1 2 3; do
+            kill_port_forwards
+            kubectl -n "$ROX_NAMESPACE" port-forward "$pod" \
+                "${local_port}:${METRICS_PORT}" >/dev/null 2>&1 &
+            PF_PIDS+=($!)
+            sleep 2
+
+            for _ in $(seq 1 20); do
+                if curl -sf "http://localhost:${local_port}/metrics" >> "$outfile" 2>/dev/null; then
+                    scraped=true
+                    break
+                fi
+                sleep 0.5
+            done
+            kill_port_forwards
+            sleep 1
+
+            if $scraped; then
+                break
+            fi
+            echo "  WARN: scrape attempt ${attempt}/3 failed for ${label} pod ${pod}, retrying..." >&2
+        done
+
+        if ! $scraped; then
+            echo "  ERROR: could not scrape metrics from ${label} pod ${pod} after 3 attempts" >&2
+            exit 1
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Metric math
+# ---------------------------------------------------------------------------
+
+# Sum a Prometheus counter/gauge across all lines matching metric + optional labels.
+extract() {
+    local file="$1" metric="$2" labels="${3:-}"
+    if [[ ! -f "$file" ]] || [[ ! -s "$file" ]]; then
+        echo "0"
+        return
+    fi
+    if [[ -n "$labels" ]]; then
+        { grep "^${metric}[{ ]" "$file" 2>/dev/null | grep "$labels" || true; } \
+            | awk '{s+=$NF} END{print s+0}'
+    else
+        { grep "^${metric}[{ ]" "$file" 2>/dev/null || true; } \
+            | awk '{s+=$NF} END{print s+0}'
+    fi
+}
+
+delta() { echo "$2 - $1" | bc; }
+
+avg_or_na() {
+    local sum_d="$1" count_d="$2"
+    if (( $(echo "$count_d > 0" | bc -l) )); then
+        echo "scale=4; $sum_d / $count_d" | bc
+    else
+        echo "N/A"
+    fi
+}
+
+pct_or_na() {
+    local numerator="$1" denominator="$2"
+    if (( $(echo "$denominator > 0" | bc -l) )); then
+        echo "scale=1; $numerator * 100 / $denominator" | bc
+    else
+        echo "N/A"
+    fi
+}
+
+row() { printf "  %-50s %s\n" "$1" "$2"; }
+
+# ---------------------------------------------------------------------------
+# Slow-path manifest generation
+# ---------------------------------------------------------------------------
+
+generate_slow_path_deployment() {
+    local name="$1" outfile="$2"
+    shift 2
+    local replicas=1
+    if [[ "${DRY_RUN:-true}" == "false" ]]; then
+        replicas=0
+    fi
+    {
+        cat <<YAML
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${name}
+  namespace: ${NAMESPACE}
+  labels:
+    burst-test: "true"
+YAML
+        if [[ "${DRY_RUN:-true}" == "false" ]]; then
+            cat <<YAML
+  annotations:
+    admission.stackrox.io/break-glass: "profile"
+YAML
+        fi
+        cat <<YAML
+spec:
+  replicas: ${replicas}
+  selector:
+    matchLabels:
+      app: ${name}
+  template:
+    metadata:
+      labels:
+        app: ${name}
+    spec:
+      containers:
+YAML
+        local idx=0
+        for img in "$@"; do
+            cat <<YAML
+      - name: c${idx}
+        image: ${img}
+YAML
+            idx=$((idx + 1))
+        done
+    } > "$outfile"
+}
+
+generate_slow_path_manifests() {
+    UNIQUE_COUNT=$(( BURST_SIZE * UNIQUE_PCT / 100 ))
+    [[ "$UNIQUE_COUNT" -lt 1 ]] && UNIQUE_COUNT=1
+
+    load_image_pool "$UNIQUE_COUNT"
+
+    for (( i = 0; i < BURST_SIZE; i++ )); do
+        generate_slow_path_deployment "burst-${i}" \
+            "${WORK_DIR}/deploy-${i}.yaml" \
+            "${SCANNABLE_POOL[$(( i % UNIQUE_COUNT ))]}"
+    done
+    echo "  Generated ${BURST_SIZE} manifests (${UNIQUE_COUNT} unique images)."
+}
+
+# ---------------------------------------------------------------------------
+# Reassess trigger + wait
+# ---------------------------------------------------------------------------
+
+# trigger_and_wait_for_reprocessor
+#   Requires: ROX_NAMESPACE, ROX_ADMIN_USER, ROX_PASSWORD,
+#             ROX_CENTRAL_ADDRESS, REASSESS_WAIT_TIMEOUT, WORK_DIR
+trigger_and_wait_for_reprocessor() {
+    local central_pod
+    central_pod=$(kubectl -n "$ROX_NAMESPACE" get pod -l app=central \
+        --field-selector=status.phase=Running \
+        -o jsonpath='{.items[0].metadata.name}')
+    if [[ -z "$central_pod" ]]; then
+        echo "  ERROR: no running Central pod found." >&2
+        exit 1
+    fi
+
+    local log_marker="Done sending reprocess deployments messages"
+
+    echo "  Starting Central log tail on ${central_pod}..."
+    kubectl -n "$ROX_NAMESPACE" logs -f "$central_pod" --since=10s \
+        > "${WORK_DIR}/central_logs.txt" 2>/dev/null &
+    local log_pid=$!
+    sleep 1
+
+    echo "  Triggering reassess via Central API..."
+    local http_code
+    http_code=$(curl -sk -o /dev/null -w '%{http_code}' \
+        -u "${ROX_ADMIN_USER}:${ROX_PASSWORD}" \
+        -X POST "https://${ROX_CENTRAL_ADDRESS}/v1/policies/reassess" || true)
+    if [[ "$http_code" != "200" ]]; then
+        kill "$log_pid" 2>/dev/null || true
+        echo "  ERROR: reassess returned HTTP ${http_code} (curl may have failed)" >&2
+        exit 1
+    fi
+    echo "  Reassess triggered (HTTP 200)."
+
+    echo "  Waiting for reprocessor to complete (timeout ${REASSESS_WAIT_TIMEOUT}s)..."
+    echo "  Watching for: \"${log_marker}\""
+    local start_ts
+    start_ts=$(date +%s)
+
+    while true; do
+        local elapsed=$(( $(date +%s) - start_ts ))
+        if [[ "$elapsed" -ge "$REASSESS_WAIT_TIMEOUT" ]]; then
+            echo ""
+            echo "  ERROR: timeout after ${REASSESS_WAIT_TIMEOUT}s waiting for reprocessor." >&2
+            kill "$log_pid" 2>/dev/null || true
+            exit 1
+        fi
+        if grep -q "$log_marker" "${WORK_DIR}/central_logs.txt" 2>/dev/null; then
+            echo ""
+            echo "  Detected log marker (elapsed ${elapsed}s)."
+            local summary
+            summary=$(grep "Successfully reprocessed" "${WORK_DIR}/central_logs.txt" | tail -1)
+            [[ -n "$summary" ]] && echo "  Central: ${summary##*: }"
+            break
+        fi
+        sleep 5
+        printf "\r  Watching logs... %ds elapsed" "$elapsed"
+    done
+
+    kill "$log_pid" 2>/dev/null || true
+    wait "$log_pid" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Burst runner
+# ---------------------------------------------------------------------------
+
+run_burst() {
+    local label="$1"
+    local dry_run_flag=""
+    if [[ "${DRY_RUN:-true}" == "true" ]]; then
+        dry_run_flag="--dry-run=server"
+    fi
+    echo "${label}: Applying ${BURST_SIZE} deployments (${dry_run_flag:-live}), parallelism=${PARALLEL}..."
+    true > "${WORK_DIR}/results.log"
+
+    local pids=()
+    for f in "${WORK_DIR}"/deploy-*.yaml; do
+        (
+            # shellcheck disable=SC2086
+            if kubectl create ${dry_run_flag} -f "$f" 2>/dev/null; then
+                echo "allowed"
+            else
+                echo "denied"
+            fi
+        ) >> "${WORK_DIR}/results.log" &
+        pids+=($!)
+        if [[ "${#pids[@]}" -ge "$PARALLEL" ]]; then
+            wait "${pids[@]}" 2>/dev/null || true
+            pids=()
+        fi
+    done
+    if [[ "${#pids[@]}" -gt 0 ]]; then
+        wait "${pids[@]}" 2>/dev/null || true
+    fi
+
+    local denied allowed
+    denied=$(grep -c "^denied" "${WORK_DIR}/results.log" 2>/dev/null || true)
+    allowed=$(grep -c "^allowed" "${WORK_DIR}/results.log" 2>/dev/null || true)
+    echo "  Results: ${denied} denied, ${allowed} allowed"
+}

--- a/tools/admission-control/profile-reassess.sh
+++ b/tools/admission-control/profile-reassess.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# profile-reassess.sh -- CPU and heap profiling of Central + Sensor during reassess.
+#
+# 1. Creates real deployments (replicas=0) via the shared burst infrastructure
+#    so that Central/Sensor have images to reprocess.
+# 2. Captures Go pprof profiles (heap pre, CPU during reassess, heap post).
+#
+# Run once on master, once on the PR branch, then compare with go tool pprof.
+#
+# Central pprof: main API port (8443), HTTPS, requires Admin auth.
+# Sensor pprof:  localhost:6060 inside the pod, HTTP, no auth.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+: "${ROX_PASSWORD:?ROX_PASSWORD must be set}"
+: "${ROX_CENTRAL_ADDRESS:?ROX_CENTRAL_ADDRESS must be set}"
+: "${ROX_ADMIN_USER:=admin}"
+: "${ROX_NAMESPACE:=stackrox}"
+: "${CPU_PROFILE_SECONDS:=60}"
+: "${REASSESS_WAIT_TIMEOUT:=300}"
+
+: "${BURST_SIZE:=500}"
+: "${UNIQUE_PCT:=60}"
+: "${PARALLEL:=50}"
+: "${NAMESPACE:=burst-profile}"
+: "${METRICS_PORT:=9090}"
+
+DRY_RUN="false"
+export DRY_RUN
+
+SENSOR_PPROF_PORT=6060
+SENSOR_LOCAL_PORT="${SENSOR_LOCAL_PORT:-6060}"
+
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+OUTPUT_DIR="${OUTPUT_DIR:-/tmp/profiles/${BRANCH_NAME}-$(date +%Y%m%d-%H%M%S)}"
+
+WORK_DIR=$(mktemp -d)
+
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+cleanup() {
+    kill_port_forwards
+    kubectl delete namespace "$NAMESPACE" --ignore-not-found &>/dev/null || true
+    [[ -n "${WORK_DIR:-}" ]] && rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+central_pprof() {
+    local path="$1" outfile="$2"
+    curl -sk -u "${ROX_ADMIN_USER}:${ROX_PASSWORD}" \
+        "https://${ROX_CENTRAL_ADDRESS}${path}" \
+        -o "$outfile" 2>/dev/null
+}
+
+sensor_pprof() {
+    local path="$1" outfile="$2"
+    curl -s "http://localhost:${SENSOR_LOCAL_PORT}${path}" \
+        -o "$outfile" 2>/dev/null
+}
+
+setup_sensor_pprof_port_forward() {
+    local sensor_pod
+    sensor_pod=$(kubectl -n "$ROX_NAMESPACE" get pod -l app=sensor \
+        --field-selector=status.phase=Running \
+        -o jsonpath='{.items[0].metadata.name}')
+    [[ -n "$sensor_pod" ]] || die "no running Sensor pod found"
+
+    echo "  Port-forwarding Sensor pprof: ${sensor_pod} ${SENSOR_LOCAL_PORT}:${SENSOR_PPROF_PORT}"
+    kubectl -n "$ROX_NAMESPACE" port-forward "$sensor_pod" \
+        "${SENSOR_LOCAL_PORT}:${SENSOR_PPROF_PORT}" >/dev/null 2>&1 &
+    PF_PIDS+=($!)
+
+    local reachable=false
+    for _ in $(seq 1 15); do
+        if curl -sf "http://localhost:${SENSOR_LOCAL_PORT}/debug/pprof" >/dev/null 2>&1; then
+            reachable=true
+            break
+        fi
+        sleep 1
+    done
+    $reachable || die "cannot reach Sensor pprof at localhost:${SENSOR_LOCAL_PORT} after 15s"
+    echo "  Sensor pprof reachable."
+}
+
+verify_central_pprof() {
+    echo "  Verifying Central pprof at ${ROX_CENTRAL_ADDRESS}..."
+    local http_code
+    http_code=$(curl -sk -o /dev/null -w '%{http_code}' \
+        -u "${ROX_ADMIN_USER}:${ROX_PASSWORD}" \
+        "https://${ROX_CENTRAL_ADDRESS}/debug/pprof/" || true)
+    [[ "$http_code" == "200" ]] \
+        || die "Central pprof returned HTTP ${http_code} (check ROX_CENTRAL_ADDRESS, ROX_PASSWORD)"
+    echo "  Central pprof reachable."
+}
+
+capture_heap() {
+    local label="$1"
+    echo "  Capturing ${label} heap profiles..."
+    central_pprof "/debug/heap" "${OUTPUT_DIR}/central-heap-${label}.pb.gz"
+    sensor_pprof  "/debug/heap" "${OUTPUT_DIR}/sensor-heap-${label}.pb.gz"
+    echo "  Saved: central-heap-${label}.pb.gz, sensor-heap-${label}.pb.gz"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+cat <<EOF
+================================================================================
+  profile-reassess.sh
+================================================================================
+  Branch:                ${BRANCH_NAME}
+  BURST_SIZE:            ${BURST_SIZE}
+  UNIQUE_PCT:            ${UNIQUE_PCT}%
+  CPU_PROFILE_SECONDS:   ${CPU_PROFILE_SECONDS}
+  ROX_CENTRAL_ADDRESS:   ${ROX_CENTRAL_ADDRESS}
+  REASSESS_WAIT_TIMEOUT: ${REASSESS_WAIT_TIMEOUT}s
+  Output:                ${OUTPUT_DIR}
+================================================================================
+
+EOF
+
+mkdir -p "$OUTPUT_DIR"
+
+# ---- Step 1: Verify pprof endpoints ----
+echo "=== Step 1: Verify pprof endpoints ==="
+verify_central_pprof
+setup_sensor_pprof_port_forward
+echo ""
+
+# ---- Step 2: Create burst deployments (replicas=0) ----
+echo "=== Step 2: Create burst deployments (replicas=0) ==="
+setup_namespace
+generate_slow_path_manifests
+run_burst "Creating deployments"
+
+echo "  Waiting 30s for Central/Sensor to discover deployments..."
+sleep 30
+echo ""
+
+# ---- Step 3: Pre-reassess heap ----
+echo "=== Step 3: Pre-reassess heap snapshots ==="
+capture_heap "pre"
+echo ""
+
+# ---- Step 4: Start CPU profiles + trigger reassess ----
+echo "=== Step 4: CPU profiling (${CPU_PROFILE_SECONDS}s) + reassess ==="
+
+echo "  Starting Central CPU profile (${CPU_PROFILE_SECONDS}s, background)..."
+central_pprof "/debug/pprof/profile?seconds=${CPU_PROFILE_SECONDS}" \
+    "${OUTPUT_DIR}/central-cpu.pb.gz" &
+CENTRAL_CPU_PID=$!
+
+echo "  Starting Sensor CPU profile (${CPU_PROFILE_SECONDS}s, background)..."
+sensor_pprof "/debug/pprof/profile?seconds=${CPU_PROFILE_SECONDS}" \
+    "${OUTPUT_DIR}/sensor-cpu.pb.gz" &
+SENSOR_CPU_PID=$!
+
+sleep 2
+
+trigger_and_wait_for_reprocessor
+
+echo ""
+echo "  Waiting for CPU profiles to finish..."
+wait "$CENTRAL_CPU_PID" 2>/dev/null || echo "  WARN: Central CPU profile request failed"
+wait "$SENSOR_CPU_PID" 2>/dev/null || echo "  WARN: Sensor CPU profile request failed"
+echo "  Saved: central-cpu.pb.gz, sensor-cpu.pb.gz"
+echo ""
+
+# ---- Step 5: Post-reassess heap ----
+echo "=== Step 5: Post-reassess heap snapshots ==="
+sleep 3
+capture_heap "post"
+echo ""
+
+# ---- Step 6: Goroutine snapshots ----
+echo "=== Step 6: Goroutine snapshots ==="
+echo "  Capturing goroutine profiles..."
+central_pprof "/debug/goroutine" "${OUTPUT_DIR}/central-goroutine.pb.gz"
+sensor_pprof  "/debug/goroutine" "${OUTPUT_DIR}/sensor-goroutine.pb.gz"
+echo "  Saved: central-goroutine.pb.gz, sensor-goroutine.pb.gz"
+echo ""
+
+# ---- Summary ----
+echo "=== Summary ==="
+echo ""
+echo "  Output directory: ${OUTPUT_DIR}"
+echo "  Deployments:      ${BURST_SIZE} (${UNIQUE_COUNT} unique images, replicas=0)"
+echo ""
+echo "  Files:"
+for f in "${OUTPUT_DIR}"/*.pb.gz; do
+    [[ -f "$f" ]] || continue
+    local_size=$(wc -c < "$f" | awk '{printf "%.1fK", $1/1024}')
+    printf "    %s (%s)\n" "$(basename "$f")" "$local_size"
+done
+echo ""
+
+cat <<'EOF'
+  ---- Comparison commands ----
+
+  # Interactive CPU profile (single branch):
+  go tool pprof -http=:8080 ./profiles/<branch>/central-cpu.pb.gz
+  go tool pprof -http=:8081 ./profiles/<branch>/sensor-cpu.pb.gz
+
+  # Compare CPU between master and PR (top diff):
+  go tool pprof -diff_base=./profiles/master-*/central-cpu.pb.gz \
+                            ./profiles/<pr-branch>-*/central-cpu.pb.gz
+
+  go tool pprof -diff_base=./profiles/master-*/sensor-cpu.pb.gz \
+                            ./profiles/<pr-branch>-*/sensor-cpu.pb.gz
+
+  # Compare heap growth (post - pre, single branch):
+  go tool pprof -diff_base=./profiles/<branch>/central-heap-pre.pb.gz \
+                            ./profiles/<branch>/central-heap-post.pb.gz
+
+  # Compare heap across branches:
+  go tool pprof -diff_base=./profiles/master-*/central-heap-post.pb.gz \
+                            ./profiles/<pr-branch>-*/central-heap-post.pb.gz
+
+  # Text summary (no browser):
+  go tool pprof -top ./profiles/<branch>/central-cpu.pb.gz
+  go tool pprof -top -diff_base=./profiles/master-*/sensor-cpu.pb.gz \
+                                ./profiles/<pr-branch>-*/sensor-cpu.pb.gz
+EOF
+echo ""


### PR DESCRIPTION
## Description

Adds Go benchmark tests and shell-based E2E tooling for scale testing the admission controller image cache and policy evaluation paths. These are developer-facing tools for measuring and comparing performance across branches - they are not run in CI.

### Go benchmarks (`sensor/admission-control/manager/`)

**`fast_path_detection_bench_test.go`** - Benchmarks the spec-only policy evaluation path (no image fetching). Measures detection latency across policy mixes (fast-only, slow-only, mixed) and deployment counts with violation
percentage sweeps.

**`image_coalescing_caching_bench_test.go`** - Benchmarks image fetch coalescing and cache behavior under concurrent burst load. Covers cold cache, warm cache, and a scale sweep across deployment counts and image diversity ratios. Reports RPC counts, coalesce ratios, and p50/p99 latencies.

These benchmarks are **not picked up by CI** -`go-postgres-bench-tests` only discovers packages under `central/`, `pkg/`, `migrator/`, and `tools/`.

### Shell tooling (`tools/admission-control/`)

| Script | Purpose |
|--------|---------|
| `burst-test.sh` | Burst of deployment creates against a live cluster with AC metric deltas (fast-path and slow-path modes) |
| `bench-reassess.sh` | E2E burst → reassess → burst cycle measuring AC, Sensor, and Central metrics |
| `profile-reassess.sh` | CPU and heap profiling of Central and Sensor during a reassess cycle |
| `generate-image-pool.sh` | Generates unique quay.io image refs for realistic test workloads |
| `lib.sh` | Shared functions (manifest generation, metric scraping, image pool loading) |

See `tools/admission-control/README.md` for prerequisites, usage, and cross-branch comparison workflow.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Ran all Go benchmarks locally with `go test -bench=. -benchtime=1x ./sensor/admission-control/manager/...`
- Ran `burst-test.sh` in both fast-path and slow-path modes against a live cluster
- Ran `bench-reassess.sh` on master and PR branches to validate metric collection and reporting
- Ran `profile-reassess.sh` to capture and compare CPU/heap profiles across branches
- Verified with `shellcheck` that all shell scripts pass lint checks
- Confirmed benchmarks are **not** discovered by any CI target (`go-postgres-bench-tests` searches `central pkg migrator tools` only, not `sensor/`)

Results of runs available here:
1.  [Admission Controller Burst Resilience Benchmark Results](https://docs.google.com/document/d/1wCX9LYHhfTph8q-9cHvOmBEfQI3BiNaQyCZwNrlWuyM/edit?tab=t.0#)
2. [Admission Controller Image Fetch Request Coalescing & Image Scan Caching Benchmark Results](https://docs.google.com/document/d/13B_1X5MPcrMB8qH076S-1QS_21CKhYEjh-YyH-vfbQM/edit?tab=t.0#)
3. [Reprocessor RHACS Image Cache Optimizations Benchmark Results](https://docs.google.com/document/d/1aPgiVvcRf69eANRkVqtLRPa8tn0f1EOyaMFPb5zW8zo/edit?tab=t.0#)