### PR TITLE
ROX-33635: Delete ROX_BASE_IMAGE_DETECTION in ui

### DIFF
--- a/ui/apps/platform/cypress/integration/baseImages/baseImages.test.ts
+++ b/ui/apps/platform/cypress/integration/baseImages/baseImages.test.ts
@@ -1,5 +1,4 @@
 import withAuth from '../../helpers/basicAuth';
-import { hasFeatureFlag } from '../../helpers/features';
 import { interactAndWaitForResponses } from '../../helpers/request';
 import { getRegExpForTitleWithBranding } from '../../helpers/title';
 
@@ -7,12 +6,6 @@ import { addBaseImage, visitBaseImages, visitBaseImagesFromLeftNav } from './bas
 
 describe('Base Images', () => {
     withAuth();
-
-    before(function () {
-        if (!hasFeatureFlag('ROX_BASE_IMAGE_DETECTION')) {
-            this.skip();
-        }
-    });
 
     it('should navigate to Base Images page from left nav', () => {
         visitBaseImagesFromLeftNav();

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
@@ -349,8 +349,6 @@ describe('Workload CVE overview page tests', () => {
 
     describe('Layer type filter tests', () => {
         it('should apply Layer type filter correctly', () => {
-            interceptAndOverrideFeatureFlags({ ROX_BASE_IMAGE_DETECTION: true });
-
             visitWorkloadCveOverview();
 
             addCheckboxSelectFilter('Image component', 'Layer type', 'Base image');

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageComponent.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageComponent.ts
@@ -34,7 +34,6 @@ export const LayerType: CompoundSearchFilterAttribute = {
     filterChipLabel: 'Image component layer type',
     searchTerm: 'Component Layer Type',
     inputType: 'select',
-    featureFlagDependency: ['ROX_SCANNER_V4'],
     inputProps: {
         options: [
             { label: 'Application', value: 'APPLICATION' },

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageComponent.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/imageComponent.ts
@@ -34,7 +34,7 @@ export const LayerType: CompoundSearchFilterAttribute = {
     filterChipLabel: 'Image component layer type',
     searchTerm: 'Component Layer Type',
     inputType: 'select',
-    featureFlagDependency: ['ROX_BASE_IMAGE_DETECTION'],
+    featureFlagDependency: ['ROX_SCANNER_V4'],
     inputProps: {
         options: [
             { label: 'Application', value: 'APPLICATION' },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -152,7 +152,7 @@ function ImagePageVulnerabilities({
     setSearchFilter,
 }: ImagePageVulnerabilitiesProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isBaseImageDetectionEnabled = isFeatureFlagEnabled('ROX_BASE_IMAGE_DETECTION');
+    const isBaseImageDetectionEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
     const isNewImageDataModelEnabled = isFeatureFlagEnabled('ROX_FLATTEN_IMAGE_DATA');
 
     const { analyticsTrack } = useAnalytics();

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -152,7 +152,6 @@ function ImagePageVulnerabilities({
     setSearchFilter,
 }: ImagePageVulnerabilitiesProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isBaseImageDetectionEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
     const isNewImageDataModelEnabled = isFeatureFlagEnabled('ROX_FLATTEN_IMAGE_DATA');
 
     const { analyticsTrack } = useAnalytics();
@@ -298,7 +297,7 @@ function ImagePageVulnerabilities({
                 </Content>
             </PageSection>
             <Divider component="div" />
-            {isBaseImageDetectionEnabled && baseImage && (
+            {baseImage && (
                 <PageSection component="div">
                     <BaseImageAssessmentCard baseImage={baseImage} />
                 </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.cy.jsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.cy.jsx
@@ -5,8 +5,7 @@ import ImageComponentVulnerabilitiesTable from './ImageComponentVulnerabilitiesT
 const MockFeatureFlagsProvider = ({ children }) => (
     <FeatureFlagsContext.Provider
         value={{
-            isFeatureFlagEnabled: (flag) =>
-                flag === 'ROX_BASE_IMAGE_DETECTION' || flag === 'ROX_SCANNER_V4',
+            isFeatureFlagEnabled: (flag) => flag === 'ROX_SCANNER_V4',
             isLoadingFeatureFlags: false,
             error: undefined,
         }}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -54,10 +54,8 @@ function ImageComponentVulnerabilitiesTable({
 }: ImageComponentVulnerabilitiesTableProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isAdvisoryColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const isLayerTypeColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
 
-    const colSpanForDockerfileLayer =
-        5 + (isAdvisoryColumnEnabled ? 1 : 0) + (isLayerTypeColumnEnabled ? 1 : 0);
+    const colSpanForDockerfileLayer = 6 + (isAdvisoryColumnEnabled ? 1 : 0);
 
     const { sortOption, getSortParams } = useTableSort({ sortFields, defaultSortOption });
     const componentVulns = flattenImageComponentVulns(
@@ -75,7 +73,7 @@ function ImageComponentVulnerabilitiesTable({
                     <Th>CVE fixed in</Th>
                     {isAdvisoryColumnEnabled && <Th>Advisory</Th>}
                     <Th>Source</Th>
-                    {isLayerTypeColumnEnabled && <Th>Layer type</Th>}
+                    <Th>Layer type</Th>
                     <Th>Location</Th>
                 </Tr>
             </Thead>
@@ -114,13 +112,11 @@ function ImageComponentVulnerabilitiesTable({
                                 </Td>
                             )}
                             <Td dataLabel="Source">{source}</Td>
-                            {isLayerTypeColumnEnabled && (
-                                <Td dataLabel="Layer type">
-                                    <Label color={inBaseImageLayer ? 'blue' : 'grey'} isCompact>
-                                        {inBaseImageLayer ? 'Base image' : 'Application'}
-                                    </Label>
-                                </Td>
-                            )}
+                            <Td dataLabel="Layer type">
+                                <Label color={inBaseImageLayer ? 'blue' : 'grey'} isCompact>
+                                    {inBaseImageLayer ? 'Base image' : 'Application'}
+                                </Label>
+                            </Td>
                             <Td dataLabel="Location">
                                 <ComponentLocation location={location} source={source} />
                             </Td>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageComponentVulnerabilitiesTable.tsx
@@ -54,7 +54,7 @@ function ImageComponentVulnerabilitiesTable({
 }: ImageComponentVulnerabilitiesTableProps) {
     const { isFeatureFlagEnabled } = useFeatureFlags();
     const isAdvisoryColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
-    const isLayerTypeColumnEnabled = isFeatureFlagEnabled('ROX_BASE_IMAGE_DETECTION');
+    const isLayerTypeColumnEnabled = isFeatureFlagEnabled('ROX_SCANNER_V4');
 
     const colSpanForDockerfileLayer =
         5 + (isAdvisoryColumnEnabled ? 1 : 0) + (isLayerTypeColumnEnabled ? 1 : 0);

--- a/ui/apps/platform/src/routePaths.test.ts
+++ b/ui/apps/platform/src/routePaths.test.ts
@@ -19,14 +19,14 @@ describe('routePaths', () => {
                 (resource) => resource === 'ImageAdministration'
             );
             const isFeatureFlagEnabled: IsFeatureFlagEnabled = vi.fn(
-                (flag) => flag === 'ROX_BASE_IMAGE_DETECTION'
+                (flag) => flag === 'ROX_SCANNER_V4'
             );
 
             const enabled = isRouteEnabled({ hasReadAccess, isFeatureFlagEnabled }, 'base-images');
 
             expect(enabled).toBe(true);
             expect(hasReadAccess).toHaveBeenCalledWith('ImageAdministration');
-            expect(isFeatureFlagEnabled).toHaveBeenCalledWith('ROX_BASE_IMAGE_DETECTION');
+            expect(isFeatureFlagEnabled).toHaveBeenCalledWith('ROX_SCANNER_V4');
         });
 
         it('should disable route when feature flag is disabled', () => {

--- a/ui/apps/platform/src/routePaths.test.ts
+++ b/ui/apps/platform/src/routePaths.test.ts
@@ -14,28 +14,16 @@ import { getLinkToDeploymentInNetworkGraph, isRouteEnabled } from './routePaths'
  */
 describe('routePaths', () => {
     describe('isRouteEnabled for base-images', () => {
-        it('should enable route when feature flag is enabled and user has ImageAdministration read access', () => {
+        it('should enable route when user has ImageAdministration read access', () => {
             const hasReadAccess: HasReadAccess = vi.fn(
                 (resource) => resource === 'ImageAdministration'
             );
-            const isFeatureFlagEnabled: IsFeatureFlagEnabled = vi.fn(
-                (flag) => flag === 'ROX_SCANNER_V4'
-            );
+            const isFeatureFlagEnabled: IsFeatureFlagEnabled = vi.fn(() => false);
 
             const enabled = isRouteEnabled({ hasReadAccess, isFeatureFlagEnabled }, 'base-images');
 
             expect(enabled).toBe(true);
             expect(hasReadAccess).toHaveBeenCalledWith('ImageAdministration');
-            expect(isFeatureFlagEnabled).toHaveBeenCalledWith('ROX_SCANNER_V4');
-        });
-
-        it('should disable route when feature flag is disabled', () => {
-            const hasReadAccess: HasReadAccess = vi.fn(() => true);
-            const isFeatureFlagEnabled: IsFeatureFlagEnabled = vi.fn(() => false);
-
-            const enabled = isRouteEnabled({ hasReadAccess, isFeatureFlagEnabled }, 'base-images');
-
-            expect(enabled).toBe(false);
         });
 
         it('should disable route when user lacks ImageAdministration read access', () => {

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -373,7 +373,7 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         resourceAccessRequirements: everyResource(['Cluster']),
     },
     'base-images': {
-        featureFlagRequirements: allEnabled(['ROX_BASE_IMAGE_DETECTION']),
+        featureFlagRequirements: allEnabled(['ROX_SCANNER_V4']),
         resourceAccessRequirements: everyResource(['ImageAdministration']),
     },
     'vulnerability-management': {

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -373,7 +373,6 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         resourceAccessRequirements: everyResource(['Cluster']),
     },
     'base-images': {
-        featureFlagRequirements: allEnabled(['ROX_SCANNER_V4']),
         resourceAccessRequirements: everyResource(['ImageAdministration']),
     },
     'vulnerability-management': {

--- a/ui/apps/platform/src/types/featureFlag.ts
+++ b/ui/apps/platform/src/types/featureFlag.ts
@@ -2,7 +2,6 @@
 // However, add strings in alphabetical order to minimize merge conflicts when multiple people add or delete strings.
 // prettier-ignore
 export type FeatureFlagEnvVar =
-    | 'ROX_BASE_IMAGE_DETECTION'
     | 'ROX_CISA_KEV'
     | 'ROX_CVE_FIX_TIMESTAMP'
     | 'ROX_FLATTEN_IMAGE_DATA'


### PR DESCRIPTION
## Description

Thank you, **J. Victor** for confirmation:

> I doesn't depend on V4.

**Review**: Hide space because indentation changes.

Feature flag was enabled for 4.10 release on 2026-02-03 in #18809

https://github.com/stackrox/stackrox/tree/master/ui/apps/platform#delete-a-feature-flag-from-frontend-code

### Analysis

Find in Files `ROX_BASE_IMAGE_DETECTION` has 10 results in 9 files.

### Solution

Some conditional logic depended **only** on `'ROX_BASE_IMAGE_DETECTION'` but also needed `'ROX_SCANNER_V4'` therefore I replaced instead of deleted.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] edited unit tests
- [x] edited e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/inactive-images click **Images** toggle, filter **Image component Layer type Base image** and click an image link, and then expand **Base image assessment**

    See gray label that does not have link
    <img width="1440" height="894" alt="Base_image_assessment" src="https://github.com/user-attachments/assets/7a8d37fd-27b8-4239-93a1-040ba122e8db" />

    Expand vulnerability to see **Layer type** column in component table
    <img width="1440" height="894" alt="Layer_type" src="https://github.com/user-attachments/assets/41f3f29b-4561-4926-9bbc-f36d8697695c" />

2. Visit /main/base-images
    <img width="1440" height="898" alt="Base_Images" src="https://github.com/user-attachments/assets/ed8dcda2-71a9-4985-85b7-7f365a64ad81" />
