### PR TITLE
ROX-33571: Improve container display components

### DIFF
--- a/ui/apps/platform/src/Components/ContainerArgumentsInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerArgumentsInfo.tsx
@@ -1,24 +1,19 @@
-import type { CSSProperties, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { Card, CardBody, CardTitle, EmptyState, List, ListItem } from '@patternfly/react-core';
 
 type ContainerArgumentsInfoProps = {
     args: string[];
 };
 
-const styleConstant = {
-    overflow: 'scroll',
-    '--pf-v6-u-max-height--MaxHeight': '12ch',
-} as CSSProperties;
-
 function ContainerArgumentsInfo({ args }: ContainerArgumentsInfoProps): ReactElement {
     return (
         <Card>
             <CardTitle>Arguments</CardTitle>
             {args.length > 0 ? (
-                <CardBody className="pf-v6-u-pt-lg pf-v6-u-mx-lg pf-v6-u-mb-lg">
-                    <List isPlain className="pf-v6-u-max-height" style={styleConstant}>
+                <CardBody>
+                    <List isPlain>
                         {args.map((arg) => (
-                            <ListItem>--{arg}</ListItem>
+                            <ListItem key={arg}>--{arg}</ListItem>
                         ))}
                     </List>
                 </CardBody>

--- a/ui/apps/platform/src/Components/ContainerResourcesInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerResourcesInfo.tsx
@@ -18,7 +18,7 @@ function ContainerResourcesInfo({ resources }: ContainerResourcesInfoProps) {
     return (
         <Card>
             <CardTitle>Resources</CardTitle>
-            <CardBody className="pf-v6-u-pt-xl pf-v6-u-mx-lg pf-v6-u-mb-lg">
+            <CardBody>
                 <DescriptionList columnModifier={{ default: '2Col' }} isCompact>
                     <DescriptionListGroup>
                         <DescriptionListTerm>CPU requests (cores)</DescriptionListTerm>

--- a/ui/apps/platform/src/Components/ContainerSecretsInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerSecretsInfo.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
     Card,
     CardBody,
@@ -7,8 +6,9 @@ import {
     DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
+    Divider,
     EmptyState,
-    ExpandableSection,
+    Label,
     Stack,
     StackItem,
 } from '@patternfly/react-core';
@@ -20,45 +20,44 @@ type ContainerSecretsInfoProps = {
 };
 
 function ContainerSecretsInfo({ secrets }: ContainerSecretsInfoProps) {
-    const initialToggleValues = Array.from({ length: secrets.length }, () => true);
-    const [secretToggles, setSecretToggles] = useState(initialToggleValues);
-
-    function setToggleAtIndex(i: number) {
-        const newToggles = [...secretToggles];
-        newToggles[i] = !newToggles[i];
-
-        setSecretToggles(newToggles);
-    }
-
     return (
         <Card>
             <CardTitle>Secrets</CardTitle>
             <CardBody>
-                <Stack hasGutter>
-                    {secrets.length > 0 ? (
-                        secrets.map((secret, index) => (
+                {secrets.length > 0 ? (
+                    <Stack hasGutter>
+                        {secrets.map((secret, index) => (
                             <StackItem key={secret.name}>
-                                <ExpandableSection
-                                    toggleText={secret.name}
-                                    onToggle={() => setToggleAtIndex(index)}
-                                    isExpanded={secretToggles[index]}
-                                    className="pf-expandable-not-large"
-                                >
-                                    <DescriptionList isCompact className="pf-v6-u-p-md">
-                                        <DescriptionListGroup>
-                                            <DescriptionListTerm>Source</DescriptionListTerm>
-                                            <DescriptionListDescription>
-                                                {secret.path}
-                                            </DescriptionListDescription>
-                                        </DescriptionListGroup>
-                                    </DescriptionList>
-                                </ExpandableSection>
+                                <Stack hasGutter>
+                                    <StackItem>
+                                        <Label color="blue" isCompact variant="outline">
+                                            {secret.name}
+                                        </Label>
+                                    </StackItem>
+                                    <StackItem>
+                                        <DescriptionList isCompact>
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>
+                                                    Container path
+                                                </DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {secret.path}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                        </DescriptionList>
+                                    </StackItem>
+                                    {index < secrets.length - 1 && (
+                                        <StackItem>
+                                            <Divider />
+                                        </StackItem>
+                                    )}
+                                </Stack>
                             </StackItem>
-                        ))
-                    ) : (
-                        <EmptyState>No secrets</EmptyState>
-                    )}
-                </Stack>
+                        ))}
+                    </Stack>
+                ) : (
+                    <EmptyState>No secrets</EmptyState>
+                )}
             </CardBody>
         </Card>
     );

--- a/ui/apps/platform/src/Components/ContainerVolumesInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerVolumesInfo.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
     Card,
     CardBody,
@@ -7,8 +6,9 @@ import {
     DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
+    Divider,
     EmptyState,
-    ExpandableSection,
+    Label,
     Stack,
     StackItem,
 } from '@patternfly/react-core';
@@ -20,75 +20,73 @@ type ContainerVolumesInfoProps = {
 };
 
 function ContainerVolumesInfo({ volumes }: ContainerVolumesInfoProps) {
-    const initialToggleValues = Array.from({ length: volumes.length }, () => true);
-    const [volumeToggles, setVolumeToggles] = useState(initialToggleValues);
-
-    function setToggleAtIndex(i: number) {
-        const newToggles = [...volumeToggles];
-        newToggles[i] = !newToggles[i];
-
-        setVolumeToggles(newToggles);
-    }
-
     return (
         <Card>
             <CardTitle>Volumes</CardTitle>
             <CardBody>
-                <Stack hasGutter>
-                    {volumes.length > 0 ? (
-                        volumes.map((volume, index) => (
+                {volumes.length > 0 ? (
+                    <Stack hasGutter>
+                        {volumes.map((volume, index) => (
                             <StackItem key={volume.name}>
-                                <ExpandableSection
-                                    toggleText={volume.name}
-                                    onToggle={() => setToggleAtIndex(index)}
-                                    isExpanded={volumeToggles[index]}
-                                    className="pf-expandable-not-large"
-                                >
-                                    <DescriptionList
-                                        columnModifier={{ default: '2Col' }}
-                                        isCompact
-                                        className="pf-v6-u-p-md"
-                                    >
-                                        <DescriptionListGroup>
-                                            <DescriptionListTerm>Source</DescriptionListTerm>
-                                            <DescriptionListDescription>
-                                                {volume.source || '-'}
-                                            </DescriptionListDescription>
-                                        </DescriptionListGroup>
-                                        <DescriptionListGroup>
-                                            <DescriptionListTerm>Destination</DescriptionListTerm>
-                                            <DescriptionListDescription>
-                                                {volume.destination || '-'}
-                                            </DescriptionListDescription>
-                                        </DescriptionListGroup>
-                                        <DescriptionListGroup>
-                                            <DescriptionListTerm>Read only</DescriptionListTerm>
-                                            <DescriptionListDescription>
-                                                {volume.readOnly || 'false'}
-                                            </DescriptionListDescription>
-                                        </DescriptionListGroup>
-                                        <DescriptionListGroup>
-                                            <DescriptionListTerm>Type</DescriptionListTerm>
-                                            <DescriptionListDescription>
-                                                {volume.type}
-                                            </DescriptionListDescription>
-                                        </DescriptionListGroup>
-                                        <DescriptionListGroup>
-                                            <DescriptionListTerm>
-                                                Mount propagation
-                                            </DescriptionListTerm>
-                                            <DescriptionListDescription>
-                                                {volume.mountPropagation}
-                                            </DescriptionListDescription>
-                                        </DescriptionListGroup>
-                                    </DescriptionList>
-                                </ExpandableSection>
+                                <Stack hasGutter>
+                                    <StackItem>
+                                        <Label color="blue" isCompact variant="outline">
+                                            {volume.name}
+                                        </Label>
+                                    </StackItem>
+                                    <StackItem>
+                                        <DescriptionList
+                                            columnModifier={{ default: '2Col' }}
+                                            isCompact
+                                        >
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>Source</DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {volume.source || '-'}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>
+                                                    Destination
+                                                </DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {volume.destination || '-'}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>Read only</DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {volume.readOnly ? 'true' : 'false'}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>Type</DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {volume.type}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                            <DescriptionListGroup>
+                                                <DescriptionListTerm>
+                                                    Mount propagation
+                                                </DescriptionListTerm>
+                                                <DescriptionListDescription>
+                                                    {volume.mountPropagation}
+                                                </DescriptionListDescription>
+                                            </DescriptionListGroup>
+                                        </DescriptionList>
+                                    </StackItem>
+                                    {index < volumes.length - 1 && (
+                                        <StackItem>
+                                            <Divider />
+                                        </StackItem>
+                                    )}
+                                </Stack>
                             </StackItem>
-                        ))
-                    ) : (
-                        <EmptyState>No volumes</EmptyState>
-                    )}
-                </Stack>
+                        ))}
+                    </Stack>
+                ) : (
+                    <EmptyState>No volumes</EmptyState>
+                )}
             </CardBody>
         </Card>
     );

--- a/ui/apps/platform/src/Components/DeploymentContainerConfig.tsx
+++ b/ui/apps/platform/src/Components/DeploymentContainerConfig.tsx
@@ -28,7 +28,6 @@ function DeploymentContainerConfig({ container }: DeploymentContainerConfigProps
             toggleText={toggleText}
             onToggle={(_event, _isExpanded: boolean) => onToggle(_isExpanded)}
             isExpanded={isExpanded}
-            displaySize="lg"
             isWidthLimited
             data-testid="deployment-container-config"
         >

--- a/ui/apps/platform/src/Components/DeploymentPortConfig.tsx
+++ b/ui/apps/platform/src/Components/DeploymentPortConfig.tsx
@@ -33,7 +33,6 @@ function DeploymentPortConfig({ port }: DeploymentPortConfigProps) {
             toggleText={toggleText}
             onToggle={(_event, _isExpanded: boolean) => onToggle(_isExpanded)}
             isExpanded={isExpanded}
-            displaySize="lg"
             isWidthLimited
         >
             <Stack hasGutter>

--- a/ui/apps/platform/src/Components/SecurityContext.tsx
+++ b/ui/apps/platform/src/Components/SecurityContext.tsx
@@ -22,10 +22,10 @@ function SecurityContext({ securityContext }: SecurityContextProps) {
     return (
         <Card>
             <CardTitle>Security context</CardTitle>
-            <CardBody className="pf-v6-u-pt-xl pf-v6-u-mx-lg pf-v6-u-mb-lg">
-                {filteredValues.size > 0 ? (
+            <CardBody>
+                {filteredValues.length > 0 ? (
                     <DescriptionList columnModifier={{ default: '2Col' }} isCompact>
-                        {Array.from(filteredValues.entries()).map(([key, value]) => {
+                        {filteredValues.map(([key, value]) => {
                             return (
                                 <DescriptionListGroup key={key}>
                                     <DescriptionListTerm>{key}</DescriptionListTerm>

--- a/ui/apps/platform/src/types/deployment.proto.ts
+++ b/ui/apps/platform/src/types/deployment.proto.ts
@@ -99,6 +99,7 @@ export type ContainerSecurityContext = {
     addCapabilities: string[];
     readOnlyRootFilesystem: boolean;
     seccompProfile: SeccompProfile | null;
+    allowPrivilegeEscalation: boolean;
 };
 
 export type SELinux = {

--- a/ui/apps/platform/src/utils/securityContextUtils.test.js
+++ b/ui/apps/platform/src/utils/securityContextUtils.test.js
@@ -2,7 +2,7 @@ import { getFilteredSecurityContextMap } from './securityContextUtils';
 
 describe('securityContextUtils', () => {
     describe('getFilteredSecurityContextMap', () => {
-        it('should return an empty array when there all security context values are falsy', () => {
+        it('should return an empty array when all security context values are falsy', () => {
             const securityContext = {
                 privileged: false,
                 selinux: null,

--- a/ui/apps/platform/src/utils/securityContextUtils.test.js
+++ b/ui/apps/platform/src/utils/securityContextUtils.test.js
@@ -2,7 +2,7 @@ import { getFilteredSecurityContextMap } from './securityContextUtils';
 
 describe('securityContextUtils', () => {
     describe('getFilteredSecurityContextMap', () => {
-        it('should return an empty Map when there all security context values are falsy', () => {
+        it('should return an empty array when there all security context values are falsy', () => {
             const securityContext = {
                 privileged: false,
                 selinux: null,
@@ -15,10 +15,10 @@ describe('securityContextUtils', () => {
 
             const filteredValues = getFilteredSecurityContextMap(securityContext);
 
-            expect(filteredValues.size).toEqual(0);
+            expect(filteredValues.length).toEqual(0);
         });
 
-        it('should return a Map of only those security context values which are set', () => {
+        it('should return an array of only those security context values which are set', () => {
             const securityContext = {
                 privileged: false,
                 selinux: null,
@@ -31,13 +31,10 @@ describe('securityContextUtils', () => {
 
             const filteredValues = getFilteredSecurityContextMap(securityContext);
 
-            const expectedMap = new Map();
-            expectedMap.set('readOnlyRootFilesystem', 'true');
-
-            expect(filteredValues).toEqual(expectedMap);
+            expect(filteredValues).toEqual([['Read only root filesystem', 'true']]);
         });
 
-        it('should return a Map which includes array and object security context values which are set', () => {
+        it('should return an array which includes array and object security context values which are set', () => {
             const securityContext = {
                 privileged: false,
                 selinux: {
@@ -55,15 +52,61 @@ describe('securityContextUtils', () => {
 
             const filteredValues = getFilteredSecurityContextMap(securityContext);
 
-            const expectedMap = new Map();
-            expectedMap.set('readOnlyRootFilesystem', 'true');
-            expectedMap.set(
-                'selinux',
-                '{"user":"","role":"","type":"container_runtime_t","level":""}'
-            );
-            expectedMap.set('dropCapabilities', 'NET_RAW,CAP_SYS_TIME');
+            expect(filteredValues).toEqual([
+                ['Drop capabilities', 'NET_RAW,CAP_SYS_TIME'],
+                ['Read only root filesystem', 'true'],
+                ['SELinux', '{"user":"","role":"","type":"container_runtime_t","level":""}'],
+            ]);
+        });
 
-            expect(filteredValues).toEqual(expectedMap);
+        it('should map every known key to a sentence-case label when all are set', () => {
+            const seccomp = { type: 'UNCONFINED', localhostProfile: '' };
+            const selinux = {
+                user: 'u',
+                role: 'r',
+                type: 't',
+                level: 'l',
+            };
+
+            const filteredValues = getFilteredSecurityContextMap({
+                privileged: true,
+                selinux,
+                dropCapabilities: ['NET_RAW'],
+                addCapabilities: ['NET_ADMIN'],
+                readOnlyRootFilesystem: true,
+                seccompProfile: seccomp,
+                allowPrivilegeEscalation: true,
+            });
+
+            expect(filteredValues).toEqual([
+                ['Add capabilities', 'NET_ADMIN'],
+                ['Allow privilege escalation', 'true'],
+                ['Drop capabilities', 'NET_RAW'],
+                ['Privileged', 'true'],
+                ['Read only root filesystem', 'true'],
+                ['Seccomp profile', JSON.stringify(seccomp)],
+                ['SELinux', JSON.stringify(selinux)],
+            ]);
+        });
+
+        it('should use the raw key as the label for unknown future fields', () => {
+            const withExtra = {
+                privileged: true,
+                selinux: null,
+                dropCapabilities: [],
+                addCapabilities: [],
+                readOnlyRootFilesystem: false,
+                seccompProfile: null,
+                allowPrivilegeEscalation: false,
+                futureFieldName: 1,
+            };
+
+            const filteredValues = getFilteredSecurityContextMap(withExtra);
+
+            expect(filteredValues).toEqual([
+                ['futureFieldName', '1'],
+                ['Privileged', 'true'],
+            ]);
         });
     });
 });

--- a/ui/apps/platform/src/utils/securityContextUtils.ts
+++ b/ui/apps/platform/src/utils/securityContextUtils.ts
@@ -2,21 +2,43 @@ import isEmpty from 'lodash/isEmpty';
 
 import type { ContainerSecurityContext } from 'types/deployment.proto';
 
+// Sentence case (first word capitalized; proper nouns like SELinux excepted).
+const securityContextFieldLabels: Record<keyof ContainerSecurityContext, string> = {
+    privileged: 'Privileged',
+    selinux: 'SELinux',
+    dropCapabilities: 'Drop capabilities',
+    addCapabilities: 'Add capabilities',
+    readOnlyRootFilesystem: 'Read only root filesystem',
+    seccompProfile: 'Seccomp profile',
+    allowPrivilegeEscalation: 'Allow privilege escalation',
+};
+
+function isKeyofContainerSecurityContext(key: string): key is keyof ContainerSecurityContext {
+    return key in securityContextFieldLabels;
+}
+
+function labelForSecurityContextKey(key: string): string {
+    if (!isKeyofContainerSecurityContext(key)) {
+        return key;
+    }
+    return securityContextFieldLabels[key];
+}
+
 export function getFilteredSecurityContextMap(
     securityContext: ContainerSecurityContext
-): Map<string, string> {
+): [string, string][] {
     // sort the keys of the security context, so any properties are shown in alpha order
     const sortedKeys = Object.keys(securityContext).sort();
 
-    // build a map of only those properties that actually have values
-    const filteredValues = new Map<string, string>();
+    // build an array of only those properties that actually have values
+    const filteredValues: [string, string][] = [];
     sortedKeys.forEach((key) => {
         const currentValue = securityContext[key];
 
         if (Array.isArray(currentValue) && !isEmpty(currentValue)) {
             // ensure any array has elements
             const stringifiedArray = currentValue.toString();
-            filteredValues.set(key, stringifiedArray);
+            filteredValues.push([labelForSecurityContextKey(key), stringifiedArray]);
         } else if (
             // ensure any object value has at least one property that has a value
             typeof currentValue === 'object' &&
@@ -25,14 +47,14 @@ export function getFilteredSecurityContextMap(
         ) {
             try {
                 const stringifiedObject = JSON.stringify(currentValue);
-                filteredValues.set(key, stringifiedObject);
+                filteredValues.push([labelForSecurityContextKey(key), stringifiedObject]);
             } catch {
-                filteredValues.set(key, currentValue.toString()); // fallback, if corrupt data prevent JSON parsing
+                filteredValues.push([labelForSecurityContextKey(key), currentValue.toString()]); // fallback, if corrupt data prevent JSON parsing
             }
         } else if (!Array.isArray(currentValue) && (currentValue || currentValue === 0)) {
             // otherwise, check for truthy or numeric 0
             const stringifiedPrimitive = currentValue.toString();
-            filteredValues.set(key, stringifiedPrimitive);
+            filteredValues.push([labelForSecurityContextKey(key), stringifiedPrimitive]);
         }
     });
 


### PR DESCRIPTION
## Description

A minor refactor of the Container display components used in the Network Graph, in preparation for:
- Using the same components in Risk and Violations
- Using the same components to display init containers

Minor changes noted inline, but otherwise collapsing expandable containers and removing extraneous PatternFly utility classes make up the majority of the changes.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed - UI refactor, no user-facing changes
- [x] documentation PR is created and is linked above **OR** is not needed - no docs needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag - UI refactor only
- [ ] CI results are inspected

### Automated testing

- [ ] added unit tests - existing component tests cover this
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Before this change:
<img width="1665" height="1100" alt="image" src="https://github.com/user-attachments/assets/95972aef-2db2-4598-8a10-7bce846ff0c8" />


Revised, collapsed display in the Network Graph side panel:
<img width="1665" height="1100" alt="image" src="https://github.com/user-attachments/assets/6de9342f-878d-4c70-88aa-f4caefbfa36d" />

Expand an item:
<img width="1665" height="1100" alt="image" src="https://github.com/user-attachments/assets/9b76bd0a-3a69-410a-a4cb-bd66e73e015c" />
<img width="1665" height="1100" alt="image" src="https://github.com/user-attachments/assets/efd2c332-8820-468f-86cd-aa0f67574666" />

