### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Table of Contents
 
+[![gitcgr](https://gitcgr.com/badge/stackrox/stackrox.svg)](https://gitcgr.com/stackrox/stackrox)
+
 - [StackRox Kubernetes Security Platform](#stackrox-kubernetes-security-platform)
     - [Table of Contents](#table-of-contents)
     - [Community](#community)


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/stackrox/stackrox.svg)](https://gitcgr.com/stackrox/stackrox)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).