### PR TITLE
ROX-31227: Add and store tailored profiles equivalence hash

### DIFF
--- a/central/convert/internaltov2storage/compliance_operator_profile.go
+++ b/central/convert/internaltov2storage/compliance_operator_profile.go
@@ -18,21 +18,22 @@ func ComplianceOperatorProfileV2(internalMsg *central.ComplianceOperatorProfileV
 	productType := internalMsg.GetAnnotations()[v1alpha1.ProductTypeAnnotation]
 
 	return &storage.ComplianceOperatorProfileV2{
-		Id:             internalMsg.GetId(),
-		ProfileId:      internalMsg.GetProfileId(),
-		Name:           internalMsg.GetName(),
-		ProfileVersion: internalMsg.GetProfileVersion(),
-		ProductType:    productType,
-		Labels:         internalMsg.GetLabels(),
-		Annotations:    internalMsg.GetAnnotations(),
-		Description:    internalMsg.GetDescription(),
-		Rules:          rules,
-		Product:        internalMsg.GetAnnotations()[v1alpha1.ProductAnnotation],
-		Title:          internalMsg.GetTitle(),
-		Values:         internalMsg.GetValues(),
-		ClusterId:      clusterID,
-		ProfileRefId:   BuildProfileRefID(clusterID, internalMsg.GetProfileId(), productType),
-		OperatorKind:   centralToStorageProfileKind(internalMsg.GetOperatorKind()),
+		Id:              internalMsg.GetId(),
+		ProfileId:       internalMsg.GetProfileId(),
+		Name:            internalMsg.GetName(),
+		ProfileVersion:  internalMsg.GetProfileVersion(),
+		ProductType:     productType,
+		Labels:          internalMsg.GetLabels(),
+		Annotations:     internalMsg.GetAnnotations(),
+		Description:     internalMsg.GetDescription(),
+		Rules:           rules,
+		Product:         internalMsg.GetAnnotations()[v1alpha1.ProductAnnotation],
+		Title:           internalMsg.GetTitle(),
+		Values:          internalMsg.GetValues(),
+		ClusterId:       clusterID,
+		ProfileRefId:    BuildProfileRefID(clusterID, internalMsg.GetProfileId(), productType),
+		OperatorKind:    centralToStorageProfileKind(internalMsg.GetOperatorKind()),
+		EquivalenceHash: internalMsg.GetEquivalenceHash(),
 	}
 }
 

--- a/generated/internalapi/central/compliance_operator.pb.go
+++ b/generated/internalapi/central/compliance_operator.pb.go
@@ -1118,7 +1118,7 @@ func (x *ComplianceOperatorCheckResultV2) GetWarnings() []string {
 }
 
 // ComplianceOperatorProfileV2 is a message from Sensor (to Central) representing a compliance check profile.
-// Next tag: 12.
+// Next tag: 13.
 type ComplianceOperatorProfileV2 struct {
 	state          protoimpl.MessageState                   `protogen:"open.v1"`
 	Id             string                                   `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -1132,8 +1132,14 @@ type ComplianceOperatorProfileV2 struct {
 	Title          string                                   `protobuf:"bytes,9,opt,name=title,proto3" json:"title,omitempty"`
 	Values         []string                                 `protobuf:"bytes,10,rep,name=values,proto3" json:"values,omitempty"`
 	OperatorKind   ComplianceOperatorProfileV2_OperatorKind `protobuf:"varint,11,opt,name=operator_kind,json=operatorKind,proto3,enum=central.ComplianceOperatorProfileV2_OperatorKind" json:"operator_kind,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// equivalence_hash is set by sensor for tailored profiles; it identifies the effective
+	// content of the profile (name, namespace, description, title, sorted rule names) so that
+	// Central can determine whether the same tailored profile name is content-equivalent
+	// across multiple clusters. Left empty for out-of-box (non-tailored) profiles.
+	// Next tag: 13.
+	EquivalenceHash string `protobuf:"bytes,12,opt,name=equivalence_hash,json=equivalenceHash,proto3" json:"equivalence_hash,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ComplianceOperatorProfileV2) Reset() {
@@ -1241,6 +1247,13 @@ func (x *ComplianceOperatorProfileV2) GetOperatorKind() ComplianceOperatorProfil
 		return x.OperatorKind
 	}
 	return ComplianceOperatorProfileV2_OPERATOR_KIND_UNSPECIFIED
+}
+
+func (x *ComplianceOperatorProfileV2) GetEquivalenceHash() string {
+	if x != nil {
+		return x.EquivalenceHash
+	}
+	return ""
 }
 
 // ComplianceOperatorRuleV2 is a message from Sensor (to Central) representing a compliance check rule.
@@ -2951,7 +2964,7 @@ const file_internalapi_central_compliance_operator_proto_rawDesc = "" +
 	"\n" +
 	"\x06MANUAL\x10\x05\x12\x12\n" +
 	"\x0eNOT_APPLICABLE\x10\x06\x12\x10\n" +
-	"\fINCONSISTENT\x10\aJ\x04\b\f\x10\rJ\x04\b\r\x10\x0e\"\x87\x06\n" +
+	"\fINCONSISTENT\x10\aJ\x04\b\f\x10\rJ\x04\b\r\x10\x0e\"\xb2\x06\n" +
 	"\x1bComplianceOperatorProfileV2\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
@@ -2965,7 +2978,8 @@ const file_internalapi_central_compliance_operator_proto_rawDesc = "" +
 	"\x05title\x18\t \x01(\tR\x05title\x12\x16\n" +
 	"\x06values\x18\n" +
 	" \x03(\tR\x06values\x12V\n" +
-	"\roperator_kind\x18\v \x01(\x0e21.central.ComplianceOperatorProfileV2.OperatorKindR\foperatorKind\x1a9\n" +
+	"\roperator_kind\x18\v \x01(\x0e21.central.ComplianceOperatorProfileV2.OperatorKindR\foperatorKind\x12)\n" +
+	"\x10equivalence_hash\x18\f \x01(\tR\x0fequivalenceHash\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +

--- a/generated/internalapi/central/compliance_operator_vtproto.pb.go
+++ b/generated/internalapi/central/compliance_operator_vtproto.pb.go
@@ -696,6 +696,7 @@ func (m *ComplianceOperatorProfileV2) CloneVT() *ComplianceOperatorProfileV2 {
 	r.Description = m.Description
 	r.Title = m.Title
 	r.OperatorKind = m.OperatorKind
+	r.EquivalenceHash = m.EquivalenceHash
 	if rhs := m.Labels; rhs != nil {
 		tmpContainer := make(map[string]string, len(rhs))
 		for k, v := range rhs {
@@ -2185,6 +2186,9 @@ func (this *ComplianceOperatorProfileV2) EqualVT(that *ComplianceOperatorProfile
 		}
 	}
 	if this.OperatorKind != that.OperatorKind {
+		return false
+	}
+	if this.EquivalenceHash != that.EquivalenceHash {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -4252,6 +4256,13 @@ func (m *ComplianceOperatorProfileV2) MarshalToSizedBufferVT(dAtA []byte) (int, 
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.EquivalenceHash) > 0 {
+		i -= len(m.EquivalenceHash)
+		copy(dAtA[i:], m.EquivalenceHash)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.EquivalenceHash)))
+		i--
+		dAtA[i] = 0x62
+	}
 	if m.OperatorKind != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OperatorKind))
 		i--
@@ -5931,6 +5942,10 @@ func (m *ComplianceOperatorProfileV2) SizeVT() (n int) {
 	}
 	if m.OperatorKind != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.OperatorKind))
+	}
+	l = len(m.EquivalenceHash)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -10386,6 +10401,38 @@ func (m *ComplianceOperatorProfileV2) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EquivalenceHash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.EquivalenceHash = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -17572,6 +17619,42 @@ func (m *ComplianceOperatorProfileV2) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EquivalenceHash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.EquivalenceHash = stringValue
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/storage/compliance_operator_v2.pb.go
+++ b/generated/storage/compliance_operator_v2.pb.go
@@ -572,8 +572,13 @@ type ComplianceOperatorProfileV2 struct {
 	ClusterId      string                                   `protobuf:"bytes,14,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty" search:"Cluster ID,hidden" sql:"type(uuid)"`            // @gotags: search:"Cluster ID,hidden" sql:"type(uuid)"
 	ProfileRefId   string                                   `protobuf:"bytes,15,opt,name=profile_ref_id,json=profileRefId,proto3" json:"profile_ref_id,omitempty" search:"Profile Ref ID,hidden" sql:"type(uuid)"` // @gotags: search:"Profile Ref ID,hidden" sql:"type(uuid)"
 	OperatorKind   ComplianceOperatorProfileV2_OperatorKind `protobuf:"varint,16,opt,name=operator_kind,json=operatorKind,proto3,enum=storage.ComplianceOperatorProfileV2_OperatorKind" json:"operator_kind,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// equivalence_hash is computed by sensor for tailored profiles and persisted as-is by Central.
+	// It encodes the effective content of the profile (name, namespace, description, title, sorted
+	// rule names) so Central can determine cross-cluster equivalence without additional DB columns.
+	// Empty for out-of-box profiles.
+	EquivalenceHash string `protobuf:"bytes,17,opt,name=equivalence_hash,json=equivalenceHash,proto3" json:"equivalence_hash,omitempty"` // Next tag: 18.
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ComplianceOperatorProfileV2) Reset() {
@@ -716,6 +721,13 @@ func (x *ComplianceOperatorProfileV2) GetOperatorKind() ComplianceOperatorProfil
 		return x.OperatorKind
 	}
 	return ComplianceOperatorProfileV2_OPERATOR_KIND_UNSPECIFIED
+}
+
+func (x *ComplianceOperatorProfileV2) GetEquivalenceHash() string {
+	if x != nil {
+		return x.EquivalenceHash
+	}
+	return ""
 }
 
 // Next tag: 19
@@ -3016,7 +3028,7 @@ const file_storage_compliance_operator_v2_proto_rawDesc = "" +
 	"\vProfileShim\x12\x1d\n" +
 	"\n" +
 	"profile_id\x18\x01 \x01(\tR\tprofileId\x12$\n" +
-	"\x0eprofile_ref_id\x18\x02 \x01(\tR\fprofileRefId\"\xa5\a\n" +
+	"\x0eprofile_ref_id\x18\x02 \x01(\tR\fprofileRefId\"\xd0\a\n" +
 	"\x1bComplianceOperatorProfileV2\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
@@ -3036,7 +3048,8 @@ const file_storage_compliance_operator_v2_proto_rawDesc = "" +
 	"\n" +
 	"cluster_id\x18\x0e \x01(\tR\tclusterId\x12$\n" +
 	"\x0eprofile_ref_id\x18\x0f \x01(\tR\fprofileRefId\x12V\n" +
-	"\roperator_kind\x18\x10 \x01(\x0e21.storage.ComplianceOperatorProfileV2.OperatorKindR\foperatorKind\x1a9\n" +
+	"\roperator_kind\x18\x10 \x01(\x0e21.storage.ComplianceOperatorProfileV2.OperatorKindR\foperatorKind\x12)\n" +
+	"\x10equivalence_hash\x18\x11 \x01(\tR\x0fequivalenceHash\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +

--- a/generated/storage/compliance_operator_v2_vtproto.pb.go
+++ b/generated/storage/compliance_operator_v2_vtproto.pb.go
@@ -74,6 +74,7 @@ func (m *ComplianceOperatorProfileV2) CloneVT() *ComplianceOperatorProfileV2 {
 	r.ClusterId = m.ClusterId
 	r.ProfileRefId = m.ProfileRefId
 	r.OperatorKind = m.OperatorKind
+	r.EquivalenceHash = m.EquivalenceHash
 	if rhs := m.Labels; rhs != nil {
 		tmpContainer := make(map[string]string, len(rhs))
 		for k, v := range rhs {
@@ -966,6 +967,9 @@ func (this *ComplianceOperatorProfileV2) EqualVT(that *ComplianceOperatorProfile
 		return false
 	}
 	if this.OperatorKind != that.OperatorKind {
+		return false
+	}
+	if this.EquivalenceHash != that.EquivalenceHash {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -2278,6 +2282,15 @@ func (m *ComplianceOperatorProfileV2) MarshalToSizedBufferVT(dAtA []byte) (int, 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.EquivalenceHash) > 0 {
+		i -= len(m.EquivalenceHash)
+		copy(dAtA[i:], m.EquivalenceHash)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.EquivalenceHash)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x8a
 	}
 	if m.OperatorKind != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OperatorKind))
@@ -4798,6 +4811,10 @@ func (m *ComplianceOperatorProfileV2) SizeVT() (n int) {
 	if m.OperatorKind != 0 {
 		n += 2 + protohelpers.SizeOfVarint(uint64(m.OperatorKind))
 	}
+	l = len(m.EquivalenceHash)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -6684,6 +6701,38 @@ func (m *ComplianceOperatorProfileV2) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 17:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EquivalenceHash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.EquivalenceHash = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -15078,6 +15127,42 @@ func (m *ComplianceOperatorProfileV2) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 17:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EquivalenceHash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.EquivalenceHash = stringValue
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/proto/internalapi/central/compliance_operator.proto
+++ b/proto/internalapi/central/compliance_operator.proto
@@ -190,7 +190,7 @@ message ComplianceOperatorCheckResultV2 {
 }
 
 // ComplianceOperatorProfileV2 is a message from Sensor (to Central) representing a compliance check profile.
-// Next tag: 12.
+// Next tag: 13.
 message ComplianceOperatorProfileV2 {
   string id = 1;
   string profile_id = 2;
@@ -212,6 +212,11 @@ message ComplianceOperatorProfileV2 {
     TAILORED_PROFILE = 2;
   }
   OperatorKind operator_kind = 11;
+  // equivalence_hash identifies whether two profiles with the same name carry equivalent
+  // content across clusters. Central uses it to enforce content consistency before
+  // creating multi-cluster scan configurations.
+  // Next tag: 13.
+  string equivalence_hash = 12;
 }
 
 // ComplianceOperatorRuleV2 is a message from Sensor (to Central) representing a compliance check rule.

--- a/proto/storage/compliance_operator_v2.proto
+++ b/proto/storage/compliance_operator_v2.proto
@@ -68,11 +68,14 @@ message ComplianceOperatorProfileV2 {
     TAILORED_PROFILE = 2;
   }
   OperatorKind operator_kind = 16;
+  // equivalence_hash identifies whether two profiles with the same name carry equivalent
+  // content across clusters. Central uses it to enforce content consistency before
+  // creating multi-cluster scan configurations.
+  string equivalence_hash = 17; // Next tag: 18.
 }
 
 // Next tag: 19
-message ComplianceOperatorRuleV2 {
-  string id = 1; // @gotags: sql:"pk"
+message ComplianceOperatorRuleV2 {  string id = 1; // @gotags: sql:"pk"
   string rule_id = 2;
   string name = 3; // @gotags: search:"Compliance Rule Name,hidden"
   string rule_type = 4; // @gotags: search:"Compliance Rule Type,hidden"

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -1,6 +1,10 @@
 package dispatchers
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"slices"
+
 	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -125,9 +129,19 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 			OperatorKind: central.ComplianceOperatorProfileV2_TAILORED_PROFILE,
 		}
 
+		var ruleNames []string
 		for _, rule := range protoProfile.GetRules() {
 			protoProfileV2.Rules = append(protoProfileV2.Rules, &central.ComplianceOperatorProfileV2_Rule{RuleName: rule.GetName()})
+			ruleNames = append(ruleNames, rule.GetName())
 		}
+
+		protoProfileV2.EquivalenceHash = computeProfileEquivalenceHash(
+			tailoredProfile.GetName(),
+			tailoredProfile.GetNamespace(),
+			tailoredProfile.Spec.Description,
+			tailoredProfile.Spec.Title,
+			ruleNames,
+		)
 
 		events = append(events, &central.SensorEvent{
 			Id:     protoProfileV2.GetId(),
@@ -139,4 +153,24 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 	}
 
 	return component.NewEvent(events...)
+}
+
+// computeProfileEquivalenceHash returns a SHA-256 hex digest that identifies whether two
+// profiles with the same name carry equivalent content. Fields are NUL-separated to prevent
+// collisions between adjacent values; rule names are sorted for order independence.
+func computeProfileEquivalenceHash(name, namespace, description, title string, ruleNames []string) string {
+	sorted := make([]string, len(ruleNames))
+	copy(sorted, ruleNames)
+	slices.Sort(sorted)
+
+	h := sha256.New()
+	for _, s := range []string{name, namespace, description, title} {
+		_, _ = h.Write([]byte(s))
+		_, _ = h.Write([]byte{0})
+	}
+	for _, r := range sorted {
+		_, _ = h.Write([]byte(r))
+		_, _ = h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -159,6 +159,14 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 // computeProfileEquivalenceHash returns a SHA-256 hex digest that identifies whether two
 // profiles with the same name carry equivalent content. Fields are NUL-separated to prevent
 // collisions between adjacent values; rule names are sorted for order independence.
+//
+// IMPORTANT — rolling-upgrade impact: changing the inputs or serialization of this function
+// changes the hash for every tailored profile. During a rolling sensor upgrade, clusters
+// running different sensor versions will produce different hashes for the same TP, causing
+// those TPs to be filtered out of the multi-cluster profile picker and rejected from scan
+// config creation/update until all sensors converge to the new version.
+// Remediation: set ROX_COMPLIANCE_SKIP_TAILORED_PROFILE_EQUIVALENCE_CHECK=true on Central
+// while sensor versions are mixed, then disable it once all sensors are upgraded.
 func computeProfileEquivalenceHash(name, namespace, description, title string, ruleNames []string) string {
 	sorted := make([]string, len(ruleNames))
 	copy(sorted, ruleNames)

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -142,6 +142,7 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 			tailoredProfile.Spec.Description,
 			tailoredProfile.Spec.Title,
 			ruleNames,
+			tailoredProfile.Spec.SetValues,
 		)
 
 		events = append(events, &central.SensorEvent{
@@ -158,7 +159,8 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 
 // computeProfileEquivalenceHash returns a SHA-256 hex digest that identifies whether two
 // profiles with the same name carry equivalent content. Fields are NUL-separated to prevent
-// collisions between adjacent values; rule names are sorted for order independence.
+// collisions between adjacent values; rule names and setValues entries are sorted for order
+// independence.
 //
 // IMPORTANT — rolling-upgrade impact: changing the inputs or serialization of this function
 // changes the hash for every tailored profile. During a rolling sensor upgrade, clusters
@@ -167,19 +169,36 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 // config creation/update until all sensors converge to the new version.
 // Remediation: set ROX_COMPLIANCE_SKIP_TAILORED_PROFILE_EQUIVALENCE_CHECK=true on Central
 // while sensor versions are mixed, then disable it once all sensors are upgraded.
-func computeProfileEquivalenceHash(name, namespace, description, title string, ruleNames []string) string {
-	sorted := make([]string, len(ruleNames))
-	copy(sorted, ruleNames)
-	slices.Sort(sorted)
+func computeProfileEquivalenceHash(name, namespace, description, title string, ruleNames []string, setValues []v1alpha1.VariableValueSpec) string {
+	sortedRules := make([]string, len(ruleNames))
+	copy(sortedRules, ruleNames)
+	slices.Sort(sortedRules)
+
+	sortedVals := slices.Clone(setValues)
+	slices.SortFunc(sortedVals, func(a, b v1alpha1.VariableValueSpec) int {
+		if c := strings.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.Rationale, b.Rationale); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Value, b.Value)
+	})
 
 	h := sha256.New()
 	for _, s := range []string{name, namespace, description, title} {
 		_, _ = h.Write([]byte(s))
 		_, _ = h.Write([]byte{0})
 	}
-	for _, r := range sorted {
+	for _, r := range sortedRules {
 		_, _ = h.Write([]byte(r))
 		_, _ = h.Write([]byte{0})
+	}
+	for _, v := range sortedVals {
+		for _, s := range []string{v.Name, v.Rationale, v.Value} {
+			_, _ = h.Write([]byte(s))
+			_, _ = h.Write([]byte{0})
+		}
 	}
 	hash := hex.EncodeToString(h.Sum(nil))
 	// Example output:
@@ -193,14 +212,23 @@ func computeProfileEquivalenceHash(name, namespace, description, title string, r
 	//       - api_server_anonymous_auth
 	//       - api_server_audit_log_maxage
 	//       - api_server_audit_log_maxbackup
+	//     setValues (1) =
+	//       - var-some-name=value (rationale: because)
 	//   Resulting hash: a3f7c2d9e1b4f8a06c5d2e7b3f9a1c4d8e2b5f7a0c3d6e9b2f5a8c1d4e7b0f3
+	setValLines := make([]string, 0, len(sortedVals))
+	for _, v := range sortedVals {
+		setValLines = append(setValLines, v.Name+"="+v.Value+" (rationale: "+v.Rationale+")")
+	}
 	log.Debugf("Tailored profile %q equivalence hash computed with the following fields:"+
-		"\n  name        = %q"+
-		"\n  namespace   = %q"+
-		"\n  title       = %q"+
-		"\n  description = %q"+
-		"\n  rules (%d)  =\n    - %s"+
+		"\n  name          = %q"+
+		"\n  namespace     = %q"+
+		"\n  title         = %q"+
+		"\n  description   = %q"+
+		"\n  rules (%d)    =\n    - %s"+
+		"\n  setValues (%d) =\n    - %s"+
 		"\nResulting hash: %s",
-		name, name, namespace, title, description, len(sorted), strings.Join(sorted, "\n    - "), hash)
+		name, name, namespace, title, description,
+		len(sortedRules), strings.Join(sortedRules, "\n    - "),
+		len(sortedVals), strings.Join(setValLines, "\n    - "), hash)
 	return hash
 }

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"slices"
+	"strings"
 
 	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -172,5 +173,26 @@ func computeProfileEquivalenceHash(name, namespace, description, title string, r
 		_, _ = h.Write([]byte(r))
 		_, _ = h.Write([]byte{0})
 	}
-	return hex.EncodeToString(h.Sum(nil))
+	hash := hex.EncodeToString(h.Sum(nil))
+	// Example output:
+	//
+	//   Tailored profile "ocp4-cis-custom" equivalence hash computed with the following fields:
+	//     name        = "ocp4-cis-custom"
+	//     namespace   = "openshift-compliance"
+	//     title       = "CIS OpenShift 4 Benchmark (tailored)"
+	//     description = "My custom tailored profile"
+	//     rules (3)   =
+	//       - api_server_anonymous_auth
+	//       - api_server_audit_log_maxage
+	//       - api_server_audit_log_maxbackup
+	//   Resulting hash: a3f7c2d9e1b4f8a06c5d2e7b3f9a1c4d8e2b5f7a0c3d6e9b2f5a8c1d4e7b0f3
+	log.Debugf("Tailored profile %q equivalence hash computed with the following fields:"+
+		"\n  name        = %q"+
+		"\n  namespace   = %q"+
+		"\n  title       = %q"+
+		"\n  description = %q"+
+		"\n  rules (%d)  =\n    - %s"+
+		"\nResulting hash: %s",
+		name, name, namespace, title, description, len(sorted), strings.Join(sorted, "\n    - "), hash)
+	return hash
 }

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -268,13 +268,16 @@ func TestProcessEvent_NoStatusID(t *testing.T) {
 
 // TestProcessEvent_EquivalenceHash verifies that the V2 event carries a non-empty
 // equivalence_hash derived from the tailored profile's effective content, and that
-// changing any input field (name, namespace, description, title, rules) produces a
+// changing any input field (name, namespace, description, title, rules, setValues) produces a
 // different hash.
 func TestProcessEvent_EquivalenceHash(t *testing.T) {
-	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.ComplianceV2Integrations})
+	centralcaps.Set([]centralsensor.CentralCapability{
+		centralsensor.ComplianceV2Integrations,
+		centralsensor.ComplianceV2TailoredProfiles,
+	})
 	t.Cleanup(func() { centralcaps.Set(nil) })
 
-	makeTP := func(name, ns, desc, title string, enableRules []string) *v1alpha1.TailoredProfile {
+	makeTP := func(name, ns, desc, title string, enableRules []string, setValues []v1alpha1.VariableValueSpec) *v1alpha1.TailoredProfile {
 		tp := &v1alpha1.TailoredProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -284,6 +287,7 @@ func TestProcessEvent_EquivalenceHash(t *testing.T) {
 			Spec: v1alpha1.TailoredProfileSpec{
 				Description: desc,
 				Title:       title,
+				SetValues:   slices.Clone(setValues),
 			},
 			Status: v1alpha1.TailoredProfileStatus{
 				ID:    "xccdf_compliance.openshift.io_profile_" + name,
@@ -308,25 +312,46 @@ func TestProcessEvent_EquivalenceHash(t *testing.T) {
 		return v2.GetEquivalenceHash()
 	}
 
-	base := makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"})
+	base := makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}, nil)
 	baseHash := getV2Hash(t, base)
 	assert.Len(t, baseHash, 64, "hash should be hex-encoded SHA-256")
 
 	// Expected value: same inputs must produce same hash as the standalone function.
-	expected := computeProfileEquivalenceHash("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"})
+	expected := computeProfileEquivalenceHash("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}, nil)
 	assert.Equal(t, expected, baseHash)
 
 	// Each field change must produce a different hash.
-	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("other-name", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"})), "name change")
-	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "other-ns", "desc", "title", []string{"rule-a", "rule-b"})), "namespace change")
-	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "other-desc", "title", []string{"rule-a", "rule-b"})), "description change")
-	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "other-title", []string{"rule-a", "rule-b"})), "title change")
-	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-c"})), "rule change")
+	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("other-name", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}, nil)), "name change")
+	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "other-ns", "desc", "title", []string{"rule-a", "rule-b"}, nil)), "namespace change")
+	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "other-desc", "title", []string{"rule-a", "rule-b"}, nil)), "description change")
+	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "other-title", []string{"rule-a", "rule-b"}, nil)), "title change")
+	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-c"}, nil)), "rule change")
+	v1 := v1alpha1.VariableValueSpec{Name: "var-foo", Rationale: "r1", Value: "x"}
+	v2 := v1alpha1.VariableValueSpec{Name: "var-foo", Rationale: "r1", Value: "y"}
+	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}, []v1alpha1.VariableValueSpec{v1})), "setValues change")
 
 	// Rule order must not affect the hash.
-	h1 := getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}))
-	h2 := getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-b", "rule-a"}))
+	h1 := getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}, nil))
+	h2 := getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-b", "rule-a"}, nil))
 	assert.Equal(t, h1, h2, "rule order should not affect hash")
+
+	// setValues order must not affect the hash.
+	svA := v1alpha1.VariableValueSpec{Name: "var-a", Rationale: "ra", Value: "va"}
+	svB := v1alpha1.VariableValueSpec{Name: "var-b", Rationale: "rb", Value: "vb"}
+	hashAB := getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}, []v1alpha1.VariableValueSpec{svA, svB}))
+	hashBA := getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}, []v1alpha1.VariableValueSpec{svB, svA}))
+	assert.Equal(t, hashAB, hashBA, "setValues order should not affect hash")
+
+	// Distinct setValues must change the hash.
+	assert.NotEqual(t, hashAB, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}, []v1alpha1.VariableValueSpec{svA})))
+	assert.NotEqual(t, hashAB, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}, []v1alpha1.VariableValueSpec{
+		svA, svB, {Name: "var-a", Rationale: "other", Value: "va"},
+	})))
+	assert.NotEqual(t, hashAB, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}, []v1alpha1.VariableValueSpec{
+		svA, svB, {Name: "var-a", Rationale: "ra", Value: "other"},
+	})))
+
+	assert.NotEqual(t, hashAB, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}, []v1alpha1.VariableValueSpec{svA, v2})))
 }
 
 // TestProcessEvent_NonTailoredProfileNoHash verifies that non-tailored profiles do not set an equivalence hash.

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -266,6 +266,97 @@ func TestProcessEvent_NoStatusID(t *testing.T) {
 	assert.Nil(t, event)
 }
 
+// TestProcessEvent_EquivalenceHash verifies that the V2 event carries a non-empty
+// equivalence_hash derived from the tailored profile's effective content, and that
+// changing any input field (name, namespace, description, title, rules) produces a
+// different hash.
+func TestProcessEvent_EquivalenceHash(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.ComplianceV2Integrations})
+	t.Cleanup(func() { centralcaps.Set(nil) })
+
+	makeTP := func(name, ns, desc, title string, enableRules []string) *v1alpha1.TailoredProfile {
+		tp := &v1alpha1.TailoredProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				UID:       "uid-hash-test",
+			},
+			Spec: v1alpha1.TailoredProfileSpec{
+				Description: desc,
+				Title:       title,
+			},
+			Status: v1alpha1.TailoredProfileStatus{
+				ID:    "xccdf_compliance.openshift.io_profile_" + name,
+				State: "READY",
+			},
+		}
+		for _, r := range enableRules {
+			tp.Spec.EnableRules = append(tp.Spec.EnableRules, v1alpha1.RuleReferenceSpec{Name: r})
+		}
+		return tp
+	}
+
+	getV2Hash := func(t *testing.T, tp *v1alpha1.TailoredProfile) string {
+		t.Helper()
+		dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+		event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+		require.NotNil(t, event)
+		// The V2 event is the second message in ForwardMessages.
+		require.Len(t, event.ForwardMessages, 2)
+		v2 := event.ForwardMessages[1].GetComplianceOperatorProfileV2()
+		require.NotNil(t, v2)
+		return v2.GetEquivalenceHash()
+	}
+
+	base := makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"})
+	baseHash := getV2Hash(t, base)
+	assert.Len(t, baseHash, 64, "hash should be hex-encoded SHA-256")
+
+	// Expected value: same inputs must produce same hash as the standalone function.
+	expected := computeProfileEquivalenceHash("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"})
+	assert.Equal(t, expected, baseHash)
+
+	// Each field change must produce a different hash.
+	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("other-name", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"})), "name change")
+	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "other-ns", "desc", "title", []string{"rule-a", "rule-b"})), "namespace change")
+	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "other-desc", "title", []string{"rule-a", "rule-b"})), "description change")
+	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "other-title", []string{"rule-a", "rule-b"})), "title change")
+	assert.NotEqual(t, baseHash, getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-c"})), "rule change")
+
+	// Rule order must not affect the hash.
+	h1 := getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b"}))
+	h2 := getV2Hash(t, makeTP("my-tp", "openshift-compliance", "desc", "title", []string{"rule-b", "rule-a"}))
+	assert.Equal(t, h1, h2, "rule order should not affect hash")
+}
+
+// TestProcessEvent_NonTailoredProfileNoHash verifies that non-tailored profiles do not set an equivalence hash.
+func TestProcessEvent_NonTailoredProfileNoHash(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.ComplianceV2Integrations})
+	t.Cleanup(func() { centralcaps.Set(nil) })
+
+	// Use the non-tailored profile dispatcher (ProfileDispatcher).
+	profile := &v1alpha1.Profile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ocp4-cis",
+			Namespace: "openshift-compliance",
+			UID:       "standard-uid",
+		},
+		ProfilePayload: v1alpha1.ProfilePayload{
+			ID:    "xccdf_org.ssgproject.content_profile_cis",
+			Title: "CIS Benchmark",
+		},
+	}
+	dispatcher := NewProfileDispatcher()
+	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(profile)
+	require.NoError(t, err)
+	event := dispatcher.ProcessEvent(&unstructured.Unstructured{Object: unstructuredObj}, nil, central.ResourceAction_CREATE_RESOURCE)
+	require.NotNil(t, event)
+	require.Len(t, event.ForwardMessages, 2)
+	v2 := event.ForwardMessages[1].GetComplianceOperatorProfileV2()
+	require.NotNil(t, v2)
+	assert.Empty(t, v2.GetEquivalenceHash(), "non-tailored profiles must not carry an equivalence_hash")
+}
+
 // TestProcessEvent_BaseProfileNotFound tests that TPs with missing base profile are skipped
 func TestProcessEvent_BaseProfileNotFound(t *testing.T) {
 	tp := &v1alpha1.TailoredProfile{


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->
While StackRox considers non-tailored compliance profiles equivalent if they share the same name, tailored profiles have added equivalence requirements. They must share:
- name
- namespace
- description
- title 
- rules
- setValues

To enable efficient profile comparison, an `EquivalenceHash` is calculated from those fields and added to `ComplianceOperatorProfileV2`.

This PR only adds the new field and its computation . Upcoming changes will take it into use to restrict the profiles that can be scheduled to run in a set of clusters based on their equivalence across those clusters.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
