### PR TITLE
ROX-33108, ROX-34407:  Add component version columns to vulnerability reports and remove optional columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 - ROX-33673: A new default policy has been added to detect missing egress NetworkPolicy associated with deployments. The policy is disabled by default.
 - ROX-33336: The Operator now reads the cluster-wide TLS profile from `apiserver.config.openshift.io/cluster` on OpenShift and propagates it to all managed ACS components via environment variables. The Operator's own metrics server always honors the cluster TLS profile when running on OpenShift.
 - ROX-26033: Compliance now tracks tailored profiles and custom rules from the Compliance Operator. Tailored profiles can be included in scan configurations, and their check results are shown in the Coverage page and CSV reports.
+- ROX-34407: Deprecated fields to select optional columns NVD CVSS, EPSS Probability and Advisory from Vulnerability Reporting. These columns will be included by default next to similar columns. This change also affects column order in reports. 
+- ROX-33108: Added Component Version Column in Vulnerability Reporting.
 
 ### Removed Features
 

--- a/central/reports/scheduler/v2/reportgenerator/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/csv_gen.go
@@ -20,11 +20,9 @@ var (
 		"Deployment",
 		"Image",
 		"Component",
-		"CVE",
-		"Advisory Name",
-		"Advisory Link",
-		"Fixable",
 		"Component Version",
+		"CVE",
+		"Fixable",
 		"CVE Fixed In",
 		"Severity",
 		"CVSS",
@@ -32,6 +30,8 @@ var (
 		"EPSS Probability Percentage",
 		"Discovered At",
 		"Reference",
+		"Advisory Name",
+		"Advisory Link",
 	}
 )
 
@@ -53,16 +53,18 @@ func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string) (*byt
 			r.GetDeployment(),
 			r.GetImage(),
 			r.GetComponent(),
+			r.GetComponentVersion(),
 			r.GetCVE(),
-			r.GetAdvisoryName(),
-			r.GetAdvisoryLink(),
 			strconv.FormatBool(r.GetFixable()),
 			r.GetFixedByVersion(),
 			strings.ToTitle(stringutils.GetUpTo(r.GetSeverity().String(), "_")),
 			strconv.FormatFloat(r.GetCVSS(), 'f', 2, 64),
+			strconv.FormatFloat(r.GetNVDCVSS(), 'f', 2, 64),
 			epssScore,
 			r.GetDiscoveredAtImage(),
 			r.Link,
+			r.GetAdvisoryName(),
+			r.GetAdvisoryLink(),
 		}
 		csvWriter.AddValue(row)
 	}

--- a/central/reports/scheduler/v2/reportgenerator/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/csv_gen.go
@@ -65,6 +65,8 @@ func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string, repor
 		} else {
 			addOptionalColumnstoRow(reportFilters, &row, csvWriter, r)
 		}
+		//add component version column to reports
+		csvWriter.AppendToValue(&row, r.GetComponentVersion())
 		csvWriter.AddValue(row)
 	}
 

--- a/central/reports/scheduler/v2/reportgenerator/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/csv_gen.go
@@ -44,7 +44,10 @@ func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string, repor
 	} else {
 		csvHeaderClone = addOptionalColumnstoHeader(csvHeaderClone, reportFilters)
 	}
+	// add header for component version
+	csvHeaderClone = append(csvHeaderClone, "Component Version")
 	csvWriter := csv.NewGenericWriter(csvHeaderClone, true)
+
 	for _, r := range cveResponses {
 		row := csv.Value{
 			r.GetCluster(),

--- a/central/reports/scheduler/v2/reportgenerator/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/csv_gen.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/csv"
 	"github.com/stackrox/rox/pkg/stringutils"
 )
@@ -22,33 +21,32 @@ var (
 		"Image",
 		"Component",
 		"CVE",
+		"Advisory Name",
+		"Advisory Link",
 		"Fixable",
+		"Component Version",
 		"CVE Fixed In",
 		"Severity",
 		"CVSS",
+		"NVDCVSS",
+		"EPSS Probability Percentage",
 		"Discovered At",
 		"Reference",
 	}
 )
 
 // GenerateCSV takes in the results of vuln report query, converts to CSV and returns zipped data
-func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string, reportSnapshot *storage.ReportSnapshot) (*bytes.Buffer, error) {
-	reportFilters := reportSnapshot.GetVulnReportFilters()
-	csvHeaderClone := make([]string, len(csvHeader))
-	copy(csvHeaderClone, csvHeader)
-	if reportSnapshot.GetViewBasedVulnReportFilters() != nil {
-		csvHeaderClone = append(csvHeaderClone, "NVDCVSS")
-		csvHeaderClone = append(csvHeaderClone, "EPSS Probability Percentage")
-		csvHeaderClone = append(csvHeaderClone, "Advisory Name")
-		csvHeaderClone = append(csvHeaderClone, "Advisory Link")
-	} else {
-		csvHeaderClone = addOptionalColumnstoHeader(csvHeaderClone, reportFilters)
-	}
+func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string) (*bytes.Buffer, error) {
 	// add header for component version
-	csvHeaderClone = append(csvHeaderClone, "Component Version")
-	csvWriter := csv.NewGenericWriter(csvHeaderClone, true)
+	csvWriter := csv.NewGenericWriter(csvHeader, true)
 
 	for _, r := range cveResponses {
+		var epssScore string
+		if r.GetEPSSProbability() != nil {
+			epssScore = strconv.FormatFloat(*r.GetEPSSProbability()*100, 'f', 3, 64)
+		} else {
+			epssScore = "Not Available"
+		}
 		row := csv.Value{
 			r.GetCluster(),
 			r.GetNamespace(),
@@ -56,20 +54,16 @@ func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string, repor
 			r.GetImage(),
 			r.GetComponent(),
 			r.GetCVE(),
+			r.GetAdvisoryName(),
+			r.GetAdvisoryLink(),
 			strconv.FormatBool(r.GetFixable()),
 			r.GetFixedByVersion(),
 			strings.ToTitle(stringutils.GetUpTo(r.GetSeverity().String(), "_")),
 			strconv.FormatFloat(r.GetCVSS(), 'f', 2, 64),
+			epssScore,
 			r.GetDiscoveredAtImage(),
 			r.Link,
 		}
-		if reportSnapshot.GetViewBasedVulnReportFilters() != nil {
-			addOtherColumns(&row, csvWriter, r)
-		} else {
-			addOptionalColumnstoRow(reportFilters, &row, csvWriter, r)
-		}
-		// add component version column to reports
-		csvWriter.AppendToValue(&row, r.GetComponentVersion())
 		csvWriter.AddValue(row)
 	}
 
@@ -100,50 +94,4 @@ func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string, repor
 		return nil, errors.Wrapf(err, "unable to close the zip file for report config %s", configName)
 	}
 	return &zipBuf, nil
-}
-
-func addOptionalColumnstoHeader(csvHeaderClone []string, optionalColumns *storage.VulnerabilityReportFilters) []string {
-	if optionalColumns.GetIncludeNvdCvss() {
-		csvHeaderClone = append(csvHeaderClone, "NVDCVSS")
-	}
-	if optionalColumns.GetIncludeEpssProbability() {
-		csvHeaderClone = append(csvHeaderClone, "EPSS Probability Percentage")
-	}
-	if optionalColumns.GetIncludeAdvisory() {
-		csvHeaderClone = append(csvHeaderClone, "Advisory Name")
-		csvHeaderClone = append(csvHeaderClone, "Advisory Link")
-	}
-	return csvHeaderClone
-}
-
-func addOptionalColumnstoRow(optionalColumns *storage.VulnerabilityReportFilters, row *csv.Value, csvWriter *csv.GenericWriter, resp *ImageCVEQueryResponse) {
-	if optionalColumns.GetIncludeNvdCvss() {
-		csvWriter.AppendToValue(row, strconv.FormatFloat(resp.GetNVDCVSS(), 'f', 2, 64))
-	}
-	if optionalColumns.GetIncludeEpssProbability() {
-		epssScore := resp.GetEPSSProbability()
-		if epssScore != nil {
-			csvWriter.AppendToValue(row, strconv.FormatFloat(*resp.GetEPSSProbability()*100, 'f', 3, 64))
-		} else {
-			csvWriter.AppendToValue(row, "Not Available")
-		}
-	}
-	if optionalColumns.GetIncludeAdvisory() {
-		csvWriter.AppendToValue(row, resp.GetAdvisoryName())
-		csvWriter.AppendToValue(row, resp.GetAdvisoryLink())
-
-	}
-}
-
-func addOtherColumns(row *csv.Value, csvWriter *csv.GenericWriter, resp *ImageCVEQueryResponse) {
-	csvWriter.AppendToValue(row, strconv.FormatFloat(resp.GetNVDCVSS(), 'f', 2, 64))
-	epssScore := resp.GetEPSSProbability()
-	if epssScore != nil {
-		csvWriter.AppendToValue(row, strconv.FormatFloat(*resp.GetEPSSProbability()*100, 'f', 3, 64))
-	} else {
-		csvWriter.AppendToValue(row, "Not Available")
-	}
-	csvWriter.AppendToValue(row, resp.GetAdvisoryName())
-	csvWriter.AppendToValue(row, resp.GetAdvisoryLink())
-
 }

--- a/central/reports/scheduler/v2/reportgenerator/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/csv_gen.go
@@ -65,7 +65,7 @@ func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string, repor
 		} else {
 			addOptionalColumnstoRow(reportFilters, &row, csvWriter, r)
 		}
-		//add component version column to reports
+		// add component version column to reports
 		csvWriter.AppendToValue(&row, r.GetComponentVersion())
 		csvWriter.AddValue(row)
 	}

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -527,6 +527,7 @@ func getSelectsWatchedImages() []*v1.QuerySelect {
 	ret := []*v1.QuerySelect{
 		search.NewQuerySelect(search.ImageName).Proto(),
 		search.NewQuerySelect(search.Component).Proto(),
+		search.NewQuerySelect(search.ComponentVersion).Proto(),
 		search.NewQuerySelect(search.CVEID).Proto(),
 		search.NewQuerySelect(search.CVE).Proto(),
 		search.NewQuerySelect(search.Fixable).Proto(),
@@ -538,7 +539,6 @@ func getSelectsWatchedImages() []*v1.QuerySelect {
 		search.NewQuerySelect(search.EPSSProbablity).Proto(),
 		search.NewQuerySelect(search.AdvisoryName).Proto(),
 		search.NewQuerySelect(search.AdvisoryLink).Proto(),
-		search.NewQuerySelect(search.ComponentVersion).Proto(),
 	}
 	return ret
 }
@@ -547,6 +547,7 @@ func getSelectsDeployedImages() []*v1.QuerySelect {
 	ret := []*v1.QuerySelect{
 		search.NewQuerySelect(search.ImageName).Proto(),
 		search.NewQuerySelect(search.Component).Proto(),
+		search.NewQuerySelect(search.ComponentVersion).Proto(),
 		search.NewQuerySelect(search.CVEID).Proto(),
 		search.NewQuerySelect(search.CVE).Proto(),
 		search.NewQuerySelect(search.Fixable).Proto(),
@@ -561,7 +562,6 @@ func getSelectsDeployedImages() []*v1.QuerySelect {
 		search.NewQuerySelect(search.EPSSProbablity).Proto(),
 		search.NewQuerySelect(search.AdvisoryName).Proto(),
 		search.NewQuerySelect(search.AdvisoryLink).Proto(),
-		search.NewQuerySelect(search.ComponentVersion).Proto(),
 	}
 	return ret
 }

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -147,7 +147,7 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 	}
 
 	// Format results into CSV
-	zippedCSVData, err := GenerateCSV(reportData.CVEResponses, req.ReportSnapshot.GetName(), req.ReportSnapshot)
+	zippedCSVData, err := GenerateCSV(reportData.CVEResponses, req.ReportSnapshot.GetName())
 	if err != nil {
 		return err
 	}

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -538,6 +538,7 @@ func getSelectsWatchedImages() []*v1.QuerySelect {
 		search.NewQuerySelect(search.EPSSProbablity).Proto(),
 		search.NewQuerySelect(search.AdvisoryName).Proto(),
 		search.NewQuerySelect(search.AdvisoryLink).Proto(),
+		search.NewQuerySelect(search.ComponentVersion).Proto(),
 	}
 	return ret
 }
@@ -546,6 +547,7 @@ func getSelectsDeployedImages() []*v1.QuerySelect {
 	ret := []*v1.QuerySelect{
 		search.NewQuerySelect(search.ImageName).Proto(),
 		search.NewQuerySelect(search.Component).Proto(),
+		search.NewQuerySelect(search.ComponentVersion).Proto(),
 		search.NewQuerySelect(search.CVEID).Proto(),
 		search.NewQuerySelect(search.CVE).Proto(),
 		search.NewQuerySelect(search.Fixable).Proto(),
@@ -560,6 +562,7 @@ func getSelectsDeployedImages() []*v1.QuerySelect {
 		search.NewQuerySelect(search.EPSSProbablity).Proto(),
 		search.NewQuerySelect(search.AdvisoryName).Proto(),
 		search.NewQuerySelect(search.AdvisoryLink).Proto(),
+		search.NewQuerySelect(search.ComponentVersion).Proto(),
 	}
 	return ret
 }

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -547,7 +547,6 @@ func getSelectsDeployedImages() []*v1.QuerySelect {
 	ret := []*v1.QuerySelect{
 		search.NewQuerySelect(search.ImageName).Proto(),
 		search.NewQuerySelect(search.Component).Proto(),
-		search.NewQuerySelect(search.ComponentVersion).Proto(),
 		search.NewQuerySelect(search.CVEID).Proto(),
 		search.NewQuerySelect(search.CVE).Proto(),
 		search.NewQuerySelect(search.Fixable).Proto(),

--- a/central/reports/scheduler/v2/reportgenerator/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/types.go
@@ -32,6 +32,7 @@ type ImageCVEQueryResponse struct {
 	Deployment        *string                        `db:"deployment"`
 	Image             *string                        `db:"image"`
 	Component         *string                        `db:"component"`
+	ComponentVersion  *string                        `db:"component_version"`
 	CVEID             *string                        `db:"cve_id"`
 	CVE               *string                        `db:"cve"`
 	Fixable           *bool                          `db:"fixable"`
@@ -44,8 +45,7 @@ type ImageCVEQueryResponse struct {
 	AdvisoryName      *string                        `db:"advisory_name"`
 	AdvisoryLink      *string                        `db:"advisory_link"`
 
-	Link             string
-	ComponentVersion *string `db:"component_version"`
+	Link string
 }
 
 func (res *ImageCVEQueryResponse) GetCluster() string {

--- a/central/reports/scheduler/v2/reportgenerator/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/types.go
@@ -44,7 +44,8 @@ type ImageCVEQueryResponse struct {
 	AdvisoryName      *string                        `db:"advisory_name"`
 	AdvisoryLink      *string                        `db:"advisory_link"`
 
-	Link string
+	Link             string
+	ComponentVersion *string `db:"component_version"`
 }
 
 func (res *ImageCVEQueryResponse) GetCluster() string {
@@ -80,6 +81,13 @@ func (res *ImageCVEQueryResponse) GetComponent() string {
 		return ""
 	}
 	return *res.Component
+}
+
+func (res *ImageCVEQueryResponse) GetComponentVersion() string {
+	if res.ComponentVersion == nil {
+		return ""
+	}
+	return *res.ComponentVersion
 }
 
 func (res *ImageCVEQueryResponse) GetCVEID() string {

--- a/generated/api/v2/report_service.pb.go
+++ b/generated/api/v2/report_service.pb.go
@@ -744,6 +744,14 @@ type VulnerabilityReportFilters struct {
 	//	*VulnerabilityReportFilters_SinceLastSentScheduledReport
 	//	*VulnerabilityReportFilters_SinceStartDate
 	CvesSince isVulnerabilityReportFilters_CvesSince `protobuf_oneof:"cves_since"`
+	// deprecating optional column fields
+	//
+	// Deprecated: Marked as deprecated in api/v2/report_service.proto.
+	IncludeNvdCvss bool `protobuf:"varint,7,opt,name=include_nvd_cvss,json=includeNvdCvss,proto3" json:"include_nvd_cvss,omitempty"`
+	// Deprecated: Marked as deprecated in api/v2/report_service.proto.
+	IncludeEpssProbability bool `protobuf:"varint,8,opt,name=include_epss_probability,json=includeEpssProbability,proto3" json:"include_epss_probability,omitempty"`
+	// Deprecated: Marked as deprecated in api/v2/report_service.proto.
+	IncludeAdvisory bool `protobuf:"varint,9,opt,name=include_advisory,json=includeAdvisory,proto3" json:"include_advisory,omitempty"`
 	// Filters related to image, cve etc for non-collection-based scopes
 	Query         string `protobuf:"bytes,12,opt,name=query,proto3" json:"query,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -833,6 +841,30 @@ func (x *VulnerabilityReportFilters) GetSinceStartDate() *timestamppb.Timestamp 
 		}
 	}
 	return nil
+}
+
+// Deprecated: Marked as deprecated in api/v2/report_service.proto.
+func (x *VulnerabilityReportFilters) GetIncludeNvdCvss() bool {
+	if x != nil {
+		return x.IncludeNvdCvss
+	}
+	return false
+}
+
+// Deprecated: Marked as deprecated in api/v2/report_service.proto.
+func (x *VulnerabilityReportFilters) GetIncludeEpssProbability() bool {
+	if x != nil {
+		return x.IncludeEpssProbability
+	}
+	return false
+}
+
+// Deprecated: Marked as deprecated in api/v2/report_service.proto.
+func (x *VulnerabilityReportFilters) GetIncludeAdvisory() bool {
+	if x != nil {
+		return x.IncludeAdvisory
+	}
+	return false
 }
 
 func (x *VulnerabilityReportFilters) GetQuery() string {
@@ -2415,7 +2447,7 @@ const file_api_v2_report_service_proto_rawDesc = "" +
 	"\n" +
 	"ReportType\x12\x11\n" +
 	"\rVULNERABILITY\x10\x00B\b\n" +
-	"\x06filter\"\x99\x06\n" +
+	"\x06filter\"\xa2\a\n" +
 	"\x1aVulnerabilityReportFilters\x12I\n" +
 	"\n" +
 	"fixability\x18\x01 \x01(\x0e2).v2.VulnerabilityReportFilters.FixabilityR\n" +
@@ -2427,7 +2459,10 @@ const file_api_v2_report_service_proto_rawDesc = "" +
 	"imageTypes\x12\x1b\n" +
 	"\ball_vuln\x18\x04 \x01(\bH\x00R\aallVuln\x12H\n" +
 	" since_last_sent_scheduled_report\x18\x05 \x01(\bH\x00R\x1csinceLastSentScheduledReport\x12F\n" +
-	"\x10since_start_date\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\x0esinceStartDate\x12\x14\n" +
+	"\x10since_start_date\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\x0esinceStartDate\x12,\n" +
+	"\x10include_nvd_cvss\x18\a \x01(\bB\x02\x18\x01R\x0eincludeNvdCvss\x12<\n" +
+	"\x18include_epss_probability\x18\b \x01(\bB\x02\x18\x01R\x16includeEpssProbability\x12-\n" +
+	"\x10include_advisory\x18\t \x01(\bB\x02\x18\x01R\x0fincludeAdvisory\x12\x14\n" +
 	"\x05query\x18\f \x01(\tR\x05query\"4\n" +
 	"\n" +
 	"Fixability\x12\b\n" +
@@ -2444,8 +2479,7 @@ const file_api_v2_report_service_proto_rawDesc = "" +
 	"\bDEPLOYED\x10\x00\x12\v\n" +
 	"\aWATCHED\x10\x01B\f\n" +
 	"\n" +
-	"cves_sinceJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
-	"\";\n" +
+	"cves_since\";\n" +
 	"#ViewBasedVulnerabilityReportFilters\x12\x14\n" +
 	"\x05query\x18\x05 \x01(\tR\x05query\"\x9b\x03\n" +
 	"\x0eReportSchedule\x12D\n" +

--- a/generated/api/v2/report_service.pb.go
+++ b/generated/api/v2/report_service.pb.go
@@ -744,7 +744,8 @@ type VulnerabilityReportFilters struct {
 	//	*VulnerabilityReportFilters_SinceLastSentScheduledReport
 	//	*VulnerabilityReportFilters_SinceStartDate
 	CvesSince isVulnerabilityReportFilters_CvesSince `protobuf_oneof:"cves_since"`
-	// deprecating optional column fields
+	// Deprecated: These fields are no longer used.
+	// NVD CVSS, EPSS Probability and Advisory columns are always included in reports.
 	//
 	// Deprecated: Marked as deprecated in api/v2/report_service.proto.
 	IncludeNvdCvss bool `protobuf:"varint,7,opt,name=include_nvd_cvss,json=includeNvdCvss,proto3" json:"include_nvd_cvss,omitempty"`

--- a/generated/api/v2/report_service.pb.go
+++ b/generated/api/v2/report_service.pb.go
@@ -743,10 +743,7 @@ type VulnerabilityReportFilters struct {
 	//	*VulnerabilityReportFilters_AllVuln
 	//	*VulnerabilityReportFilters_SinceLastSentScheduledReport
 	//	*VulnerabilityReportFilters_SinceStartDate
-	CvesSince              isVulnerabilityReportFilters_CvesSince `protobuf_oneof:"cves_since"`
-	IncludeNvdCvss         bool                                   `protobuf:"varint,7,opt,name=include_nvd_cvss,json=includeNvdCvss,proto3" json:"include_nvd_cvss,omitempty"`
-	IncludeEpssProbability bool                                   `protobuf:"varint,8,opt,name=include_epss_probability,json=includeEpssProbability,proto3" json:"include_epss_probability,omitempty"`
-	IncludeAdvisory        bool                                   `protobuf:"varint,9,opt,name=include_advisory,json=includeAdvisory,proto3" json:"include_advisory,omitempty"`
+	CvesSince isVulnerabilityReportFilters_CvesSince `protobuf_oneof:"cves_since"`
 	// Filters related to image, cve etc for non-collection-based scopes
 	Query         string `protobuf:"bytes,12,opt,name=query,proto3" json:"query,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -836,27 +833,6 @@ func (x *VulnerabilityReportFilters) GetSinceStartDate() *timestamppb.Timestamp 
 		}
 	}
 	return nil
-}
-
-func (x *VulnerabilityReportFilters) GetIncludeNvdCvss() bool {
-	if x != nil {
-		return x.IncludeNvdCvss
-	}
-	return false
-}
-
-func (x *VulnerabilityReportFilters) GetIncludeEpssProbability() bool {
-	if x != nil {
-		return x.IncludeEpssProbability
-	}
-	return false
-}
-
-func (x *VulnerabilityReportFilters) GetIncludeAdvisory() bool {
-	if x != nil {
-		return x.IncludeAdvisory
-	}
-	return false
 }
 
 func (x *VulnerabilityReportFilters) GetQuery() string {
@@ -2439,7 +2415,7 @@ const file_api_v2_report_service_proto_rawDesc = "" +
 	"\n" +
 	"ReportType\x12\x11\n" +
 	"\rVULNERABILITY\x10\x00B\b\n" +
-	"\x06filter\"\x96\a\n" +
+	"\x06filter\"\x99\x06\n" +
 	"\x1aVulnerabilityReportFilters\x12I\n" +
 	"\n" +
 	"fixability\x18\x01 \x01(\x0e2).v2.VulnerabilityReportFilters.FixabilityR\n" +
@@ -2451,10 +2427,7 @@ const file_api_v2_report_service_proto_rawDesc = "" +
 	"imageTypes\x12\x1b\n" +
 	"\ball_vuln\x18\x04 \x01(\bH\x00R\aallVuln\x12H\n" +
 	" since_last_sent_scheduled_report\x18\x05 \x01(\bH\x00R\x1csinceLastSentScheduledReport\x12F\n" +
-	"\x10since_start_date\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\x0esinceStartDate\x12(\n" +
-	"\x10include_nvd_cvss\x18\a \x01(\bR\x0eincludeNvdCvss\x128\n" +
-	"\x18include_epss_probability\x18\b \x01(\bR\x16includeEpssProbability\x12)\n" +
-	"\x10include_advisory\x18\t \x01(\bR\x0fincludeAdvisory\x12\x14\n" +
+	"\x10since_start_date\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\x0esinceStartDate\x12\x14\n" +
 	"\x05query\x18\f \x01(\tR\x05query\"4\n" +
 	"\n" +
 	"Fixability\x12\b\n" +
@@ -2471,7 +2444,8 @@ const file_api_v2_report_service_proto_rawDesc = "" +
 	"\bDEPLOYED\x10\x00\x12\v\n" +
 	"\aWATCHED\x10\x01B\f\n" +
 	"\n" +
-	"cves_since\";\n" +
+	"cves_sinceJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
+	"\";\n" +
 	"#ViewBasedVulnerabilityReportFilters\x12\x14\n" +
 	"\x05query\x18\x05 \x01(\tR\x05query\"\x9b\x03\n" +
 	"\x0eReportSchedule\x12D\n" +

--- a/generated/api/v2/report_service.swagger.json
+++ b/generated/api/v2/report_service.swagger.json
@@ -1397,7 +1397,7 @@
         },
         "includeNvdCvss": {
           "type": "boolean",
-          "title": "deprecating optional column fields"
+          "description": "Deprecated: These fields are no longer used.\nNVD CVSS, EPSS Probability and Advisory columns are always included in reports."
         },
         "includeEpssProbability": {
           "type": "boolean"

--- a/generated/api/v2/report_service.swagger.json
+++ b/generated/api/v2/report_service.swagger.json
@@ -1395,15 +1395,6 @@
           "type": "string",
           "format": "date-time"
         },
-        "includeNvdCvss": {
-          "type": "boolean"
-        },
-        "includeEpssProbability": {
-          "type": "boolean"
-        },
-        "includeAdvisory": {
-          "type": "boolean"
-        },
         "query": {
           "type": "string",
           "title": "Filters related to image, cve etc for non-collection-based scopes"

--- a/generated/api/v2/report_service.swagger.json
+++ b/generated/api/v2/report_service.swagger.json
@@ -1395,6 +1395,16 @@
           "type": "string",
           "format": "date-time"
         },
+        "includeNvdCvss": {
+          "type": "boolean",
+          "title": "deprecating optional column fields"
+        },
+        "includeEpssProbability": {
+          "type": "boolean"
+        },
+        "includeAdvisory": {
+          "type": "boolean"
+        },
         "query": {
           "type": "string",
           "title": "Filters related to image, cve etc for non-collection-based scopes"

--- a/generated/api/v2/report_service_vtproto.pb.go
+++ b/generated/api/v2/report_service_vtproto.pb.go
@@ -71,6 +71,9 @@ func (m *VulnerabilityReportFilters) CloneVT() *VulnerabilityReportFilters {
 	}
 	r := new(VulnerabilityReportFilters)
 	r.Fixability = m.Fixability
+	r.IncludeNvdCvss = m.IncludeNvdCvss
+	r.IncludeEpssProbability = m.IncludeEpssProbability
+	r.IncludeAdvisory = m.IncludeAdvisory
 	r.Query = m.Query
 	if rhs := m.Severities; rhs != nil {
 		tmpContainer := make([]VulnerabilityReportFilters_VulnerabilitySeverity, len(rhs))
@@ -844,6 +847,15 @@ func (this *VulnerabilityReportFilters) EqualVT(that *VulnerabilityReportFilters
 		if vx != vy {
 			return false
 		}
+	}
+	if this.IncludeNvdCvss != that.IncludeNvdCvss {
+		return false
+	}
+	if this.IncludeEpssProbability != that.IncludeEpssProbability {
+		return false
+	}
+	if this.IncludeAdvisory != that.IncludeAdvisory {
+		return false
 	}
 	if this.Query != that.Query {
 		return false
@@ -1995,6 +2007,36 @@ func (m *VulnerabilityReportFilters) MarshalToSizedBufferVT(dAtA []byte) (int, e
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Query)))
 		i--
 		dAtA[i] = 0x62
+	}
+	if m.IncludeAdvisory {
+		i--
+		if m.IncludeAdvisory {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x48
+	}
+	if m.IncludeEpssProbability {
+		i--
+		if m.IncludeEpssProbability {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x40
+	}
+	if m.IncludeNvdCvss {
+		i--
+		if m.IncludeNvdCvss {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x38
 	}
 	if len(m.ImageTypes) > 0 {
 		var pksize2 int
@@ -3678,6 +3720,15 @@ func (m *VulnerabilityReportFilters) SizeVT() (n int) {
 	if vtmsg, ok := m.CvesSince.(interface{ SizeVT() int }); ok {
 		n += vtmsg.SizeVT()
 	}
+	if m.IncludeNvdCvss {
+		n += 2
+	}
+	if m.IncludeEpssProbability {
+		n += 2
+	}
+	if m.IncludeAdvisory {
+		n += 2
+	}
 	l = len(m.Query)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
@@ -4898,6 +4949,66 @@ func (m *VulnerabilityReportFilters) UnmarshalVT(dAtA []byte) error {
 				m.CvesSince = &VulnerabilityReportFilters_SinceStartDate{SinceStartDate: v}
 			}
 			iNdEx = postIndex
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IncludeNvdCvss", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IncludeNvdCvss = bool(v != 0)
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IncludeEpssProbability", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IncludeEpssProbability = bool(v != 0)
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IncludeAdvisory", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IncludeAdvisory = bool(v != 0)
 		case 12:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
@@ -8843,6 +8954,66 @@ func (m *VulnerabilityReportFilters) UnmarshalVTUnsafe(dAtA []byte) error {
 				m.CvesSince = &VulnerabilityReportFilters_SinceStartDate{SinceStartDate: v}
 			}
 			iNdEx = postIndex
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IncludeNvdCvss", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IncludeNvdCvss = bool(v != 0)
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IncludeEpssProbability", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IncludeEpssProbability = bool(v != 0)
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field IncludeAdvisory", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.IncludeAdvisory = bool(v != 0)
 		case 12:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)

--- a/generated/api/v2/report_service_vtproto.pb.go
+++ b/generated/api/v2/report_service_vtproto.pb.go
@@ -71,9 +71,6 @@ func (m *VulnerabilityReportFilters) CloneVT() *VulnerabilityReportFilters {
 	}
 	r := new(VulnerabilityReportFilters)
 	r.Fixability = m.Fixability
-	r.IncludeNvdCvss = m.IncludeNvdCvss
-	r.IncludeEpssProbability = m.IncludeEpssProbability
-	r.IncludeAdvisory = m.IncludeAdvisory
 	r.Query = m.Query
 	if rhs := m.Severities; rhs != nil {
 		tmpContainer := make([]VulnerabilityReportFilters_VulnerabilitySeverity, len(rhs))
@@ -847,15 +844,6 @@ func (this *VulnerabilityReportFilters) EqualVT(that *VulnerabilityReportFilters
 		if vx != vy {
 			return false
 		}
-	}
-	if this.IncludeNvdCvss != that.IncludeNvdCvss {
-		return false
-	}
-	if this.IncludeEpssProbability != that.IncludeEpssProbability {
-		return false
-	}
-	if this.IncludeAdvisory != that.IncludeAdvisory {
-		return false
 	}
 	if this.Query != that.Query {
 		return false
@@ -2007,36 +1995,6 @@ func (m *VulnerabilityReportFilters) MarshalToSizedBufferVT(dAtA []byte) (int, e
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Query)))
 		i--
 		dAtA[i] = 0x62
-	}
-	if m.IncludeAdvisory {
-		i--
-		if m.IncludeAdvisory {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x48
-	}
-	if m.IncludeEpssProbability {
-		i--
-		if m.IncludeEpssProbability {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x40
-	}
-	if m.IncludeNvdCvss {
-		i--
-		if m.IncludeNvdCvss {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i--
-		dAtA[i] = 0x38
 	}
 	if len(m.ImageTypes) > 0 {
 		var pksize2 int
@@ -3720,15 +3678,6 @@ func (m *VulnerabilityReportFilters) SizeVT() (n int) {
 	if vtmsg, ok := m.CvesSince.(interface{ SizeVT() int }); ok {
 		n += vtmsg.SizeVT()
 	}
-	if m.IncludeNvdCvss {
-		n += 2
-	}
-	if m.IncludeEpssProbability {
-		n += 2
-	}
-	if m.IncludeAdvisory {
-		n += 2
-	}
 	l = len(m.Query)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
@@ -4949,66 +4898,6 @@ func (m *VulnerabilityReportFilters) UnmarshalVT(dAtA []byte) error {
 				m.CvesSince = &VulnerabilityReportFilters_SinceStartDate{SinceStartDate: v}
 			}
 			iNdEx = postIndex
-		case 7:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeNvdCvss", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeNvdCvss = bool(v != 0)
-		case 8:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeEpssProbability", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeEpssProbability = bool(v != 0)
-		case 9:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeAdvisory", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeAdvisory = bool(v != 0)
 		case 12:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
@@ -8954,66 +8843,6 @@ func (m *VulnerabilityReportFilters) UnmarshalVTUnsafe(dAtA []byte) error {
 				m.CvesSince = &VulnerabilityReportFilters_SinceStartDate{SinceStartDate: v}
 			}
 			iNdEx = postIndex
-		case 7:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeNvdCvss", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeNvdCvss = bool(v != 0)
-		case 8:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeEpssProbability", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeEpssProbability = bool(v != 0)
-		case 9:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field IncludeAdvisory", wireType)
-			}
-			var v int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return protohelpers.ErrIntOverflow
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				v |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			m.IncludeAdvisory = bool(v != 0)
 		case 12:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)

--- a/generated/storage/report_configuration.pb.go
+++ b/generated/storage/report_configuration.pb.go
@@ -576,11 +576,14 @@ type VulnerabilityReportFilters struct {
 	//	*VulnerabilityReportFilters_AllVuln
 	//	*VulnerabilityReportFilters_SinceLastSentScheduledReport
 	//	*VulnerabilityReportFilters_SinceStartDate
-	CvesSince              isVulnerabilityReportFilters_CvesSince `protobuf_oneof:"cves_since"`
-	AccessScopeRules       []*SimpleAccessScope_Rules             `protobuf:"bytes,8,rep,name=access_scope_rules,json=accessScopeRules,proto3" json:"access_scope_rules,omitempty"`
-	IncludeNvdCvss         bool                                   `protobuf:"varint,9,opt,name=include_nvd_cvss,json=includeNvdCvss,proto3" json:"include_nvd_cvss,omitempty"`
-	IncludeEpssProbability bool                                   `protobuf:"varint,10,opt,name=include_epss_probability,json=includeEpssProbability,proto3" json:"include_epss_probability,omitempty"`
-	IncludeAdvisory        bool                                   `protobuf:"varint,11,opt,name=include_advisory,json=includeAdvisory,proto3" json:"include_advisory,omitempty"`
+	CvesSince        isVulnerabilityReportFilters_CvesSince `protobuf_oneof:"cves_since"`
+	AccessScopeRules []*SimpleAccessScope_Rules             `protobuf:"bytes,8,rep,name=access_scope_rules,json=accessScopeRules,proto3" json:"access_scope_rules,omitempty"`
+	// Deprecated: Marked as deprecated in storage/report_configuration.proto.
+	IncludeNvdCvss bool `protobuf:"varint,9,opt,name=include_nvd_cvss,json=includeNvdCvss,proto3" json:"include_nvd_cvss,omitempty"`
+	// Deprecated: Marked as deprecated in storage/report_configuration.proto.
+	IncludeEpssProbability bool `protobuf:"varint,10,opt,name=include_epss_probability,json=includeEpssProbability,proto3" json:"include_epss_probability,omitempty"`
+	// Deprecated: Marked as deprecated in storage/report_configuration.proto.
+	IncludeAdvisory bool `protobuf:"varint,11,opt,name=include_advisory,json=includeAdvisory,proto3" json:"include_advisory,omitempty"`
 	// this field stores enhanced filters related to image, cve etc for non collection based scopes
 	Query         string `protobuf:"bytes,12,opt,name=query,proto3" json:"query,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -686,6 +689,7 @@ func (x *VulnerabilityReportFilters) GetAccessScopeRules() []*SimpleAccessScope_
 	return nil
 }
 
+// Deprecated: Marked as deprecated in storage/report_configuration.proto.
 func (x *VulnerabilityReportFilters) GetIncludeNvdCvss() bool {
 	if x != nil {
 		return x.IncludeNvdCvss
@@ -693,6 +697,7 @@ func (x *VulnerabilityReportFilters) GetIncludeNvdCvss() bool {
 	return false
 }
 
+// Deprecated: Marked as deprecated in storage/report_configuration.proto.
 func (x *VulnerabilityReportFilters) GetIncludeEpssProbability() bool {
 	if x != nil {
 		return x.IncludeEpssProbability
@@ -700,6 +705,7 @@ func (x *VulnerabilityReportFilters) GetIncludeEpssProbability() bool {
 	return false
 }
 
+// Deprecated: Marked as deprecated in storage/report_configuration.proto.
 func (x *VulnerabilityReportFilters) GetIncludeAdvisory() bool {
 	if x != nil {
 		return x.IncludeAdvisory
@@ -1010,7 +1016,7 @@ const file_storage_report_configuration_proto_rawDesc = "" +
 	"\terror_msg\x18\x03 \x01(\tR\berrorMsg\"%\n" +
 	"\tRunStatus\x12\v\n" +
 	"\aSUCCESS\x10\x00\x12\v\n" +
-	"\aFAILURE\x10\x01\"\xb8\x06\n" +
+	"\aFAILURE\x10\x01\"\xc4\x06\n" +
 	"\x1aVulnerabilityReportFilters\x12N\n" +
 	"\n" +
 	"fixability\x18\x01 \x01(\x0e2..storage.VulnerabilityReportFilters.FixabilityR\n" +
@@ -1024,11 +1030,11 @@ const file_storage_report_configuration_proto_rawDesc = "" +
 	"\ball_vuln\x18\x05 \x01(\bH\x00R\aallVuln\x12H\n" +
 	" since_last_sent_scheduled_report\x18\x06 \x01(\bH\x00R\x1csinceLastSentScheduledReport\x12F\n" +
 	"\x10since_start_date\x18\a \x01(\v2\x1a.google.protobuf.TimestampH\x00R\x0esinceStartDate\x12N\n" +
-	"\x12access_scope_rules\x18\b \x03(\v2 .storage.SimpleAccessScope.RulesR\x10accessScopeRules\x12(\n" +
-	"\x10include_nvd_cvss\x18\t \x01(\bR\x0eincludeNvdCvss\x128\n" +
+	"\x12access_scope_rules\x18\b \x03(\v2 .storage.SimpleAccessScope.RulesR\x10accessScopeRules\x12,\n" +
+	"\x10include_nvd_cvss\x18\t \x01(\bB\x02\x18\x01R\x0eincludeNvdCvss\x12<\n" +
 	"\x18include_epss_probability\x18\n" +
-	" \x01(\bR\x16includeEpssProbability\x12)\n" +
-	"\x10include_advisory\x18\v \x01(\bR\x0fincludeAdvisory\x12\x14\n" +
+	" \x01(\bB\x02\x18\x01R\x16includeEpssProbability\x12-\n" +
+	"\x10include_advisory\x18\v \x01(\bB\x02\x18\x01R\x0fincludeAdvisory\x12\x14\n" +
 	"\x05query\x18\f \x01(\tR\x05query\"4\n" +
 	"\n" +
 	"Fixability\x12\b\n" +

--- a/proto/api/v2/report_service.proto
+++ b/proto/api/v2/report_service.proto
@@ -56,9 +56,8 @@ message VulnerabilityReportFilters {
     bool since_last_sent_scheduled_report = 5;
     google.protobuf.Timestamp since_start_date = 6;
   }
-  bool include_nvd_cvss = 7;
-  bool include_epss_probability = 8;
-  bool include_advisory = 9;
+  //deprecating optional column fields
+  reserved 7, 8, 9;
   // Filters related to image, cve etc for non-collection-based scopes
   string query = 12;
 }

--- a/proto/api/v2/report_service.proto
+++ b/proto/api/v2/report_service.proto
@@ -56,7 +56,8 @@ message VulnerabilityReportFilters {
     bool since_last_sent_scheduled_report = 5;
     google.protobuf.Timestamp since_start_date = 6;
   }
-  //deprecating optional column fields
+  // Deprecated: These fields are no longer used.
+  // NVD CVSS, EPSS Probability and Advisory columns are always included in reports.
   bool include_nvd_cvss = 7 [deprecated = true];
   bool include_epss_probability = 8 [deprecated = true];
   bool include_advisory = 9 [deprecated = true];

--- a/proto/api/v2/report_service.proto
+++ b/proto/api/v2/report_service.proto
@@ -57,7 +57,9 @@ message VulnerabilityReportFilters {
     google.protobuf.Timestamp since_start_date = 6;
   }
   //deprecating optional column fields
-  reserved 7, 8, 9;
+  bool include_nvd_cvss = 7 [deprecated = true];
+  bool include_epss_probability = 8 [deprecated = true];
+  bool include_advisory = 9 [deprecated = true];
   // Filters related to image, cve etc for non-collection-based scopes
   string query = 12;
 }

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -15615,17 +15615,35 @@
               {
                 "id": 9,
                 "name": "include_nvd_cvss",
-                "type": "bool"
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 10,
                 "name": "include_epss_probability",
-                "type": "bool"
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 11,
                 "name": "include_advisory",
-                "type": "bool"
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "deprecated",
+                    "value": "true"
+                  }
+                ]
               },
               {
                 "id": 12,

--- a/proto/storage/report_configuration.proto
+++ b/proto/storage/report_configuration.proto
@@ -70,9 +70,9 @@ message VulnerabilityReportFilters {
     google.protobuf.Timestamp since_start_date = 7;
   }
   repeated SimpleAccessScope.Rules access_scope_rules = 8;
-  bool include_nvd_cvss = 9;
-  bool include_epss_probability = 10;
-  bool include_advisory = 11;
+  bool include_nvd_cvss = 9 [deprecated = true];
+  bool include_epss_probability = 10 [deprecated = true];
+  bool include_advisory = 11 [deprecated = true];
   // this field stores enhanced filters related to image, cve etc for non collection based scopes
   string query = 12;
 }


### PR DESCRIPTION
This PR adds a Component Version column to VM scheduled reports and View based reports. The column is added after any optional columns. 

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing
This PR is tested manually by generating 
### How I validated my change

Tested this change manually by deploying ACS and downloading reports
[RHACS_Vulnerability_Report_test-surabhi_28_April_2026.csv](https://github.com/user-attachments/files/27173609/RHACS_Vulnerability_Report_test-surabhi_28_April_2026.csv)


