### PR TITLE
ROX-33328: Avoid cache re-poisoning during coalesced fetches 

### DIFF
--- a/sensor/admission-control/manager/images.go
+++ b/sensor/admission-control/manager/images.go
@@ -184,14 +184,19 @@ func (m *manager) fetchImage(ctx context.Context, s *state, resultChan chan<- fe
 		if cached := m.getCachedImage(image, s, false); cached != nil {
 			return cached, nil
 		}
+		gen, cacheVer := m.imageCacheGen.Snapshot(imgKey)
 		img, err := m.getImageFromSensorOrCentral(ctx, s, image, deployment)
 		if err != nil {
 			return nil, err
 		}
 		// Caching inside the Coalesce callback ensures only the leader goroutine
-		// writes to imageCache. Waiters receive the result from the coalescer,
-		// avoiding N-1 redundant cache writes under concurrent bursts.
-		m.cacheImage(img, image.GetName().GetFullName(), s)
+		// writes to imageCache, avoiding N-1 redundant writes under bursts.
+		// Skip caching if an invalidation or purge happened during this fetch.
+		if !m.imageCacheGen.Changed(imgKey, gen, cacheVer) {
+			m.cacheImage(img, image.GetName().GetFullName(), s)
+		} else {
+			log.Warnf("Stale fetch detected for %q (key=%s): gen or cacheVersion changed during in-flight fetch, discarding result", image.GetName().GetFullName(), imgKey)
+		}
 		return img, nil
 	})
 

--- a/sensor/admission-control/manager/images_test.go
+++ b/sensor/admission-control/manager/images_test.go
@@ -45,7 +45,7 @@ func (s *ImageCacheTestSuite) SetupSuite() {
 func (s *ImageCacheTestSuite) SetupTest() {
 	s.manager.imageCache.Purge()
 	s.manager.imageNameToImageCacheKey.Purge()
-	s.manager.imageCacheGen.Clear()
+	s.manager.imageCacheGen.Clear(s.T())
 	s.manager.state.Store(nil)
 }
 
@@ -320,8 +320,8 @@ func (s *ImageCacheTestSuite) TestProcessImageInvalidation_IncrementsGeneration(
 		ImageId: "sha256:abc", ImageFullName: "docker.io/library/nginx:1.25",
 	})
 
-	s.Equal(uint64(1), s.manager.imageCacheGen.Get("sha256:abc"))
-	s.Equal(uint64(1), s.manager.imageCacheGen.Get("docker.io/library/nginx:1.25"))
+	s.Equal(uint64(1), s.manager.imageCacheGen.Get(s.T(), "sha256:abc"))
+	s.Equal(uint64(1), s.manager.imageCacheGen.Get(s.T(), "docker.io/library/nginx:1.25"))
 }
 
 func (s *ImageCacheTestSuite) TestProcessImageInvalidation_MultipleKeys() {
@@ -372,7 +372,7 @@ func (s *ImageCacheTestSuite) TestGenerationCounter() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			s.manager.imageCache.Purge()
-			s.manager.imageCacheGen.Clear()
+			s.manager.imageCacheGen.Clear(s.T())
 
 			gen, cacheVer := s.manager.imageCacheGen.Snapshot("sha256:abc")
 			tt.mutate()
@@ -390,9 +390,9 @@ func (s *ImageCacheTestSuite) TestClearImageCacheGen() {
 	s.manager.imageCacheGen.Inc("sha256:b")
 	s.manager.imageCacheGen.UpdateCacheVersion("v1")
 
-	s.manager.imageCacheGen.Clear()
+	s.manager.imageCacheGen.Clear(s.T())
 
-	s.Equal(uint64(0), s.manager.imageCacheGen.Get("sha256:a"))
-	s.Equal(uint64(0), s.manager.imageCacheGen.Get("sha256:b"))
+	s.Equal(uint64(0), s.manager.imageCacheGen.Get(s.T(), "sha256:a"))
+	s.Equal(uint64(0), s.manager.imageCacheGen.Get(s.T(), "sha256:b"))
 	s.Equal("", s.manager.imageCacheGen.CacheVersion())
 }

--- a/sensor/admission-control/manager/images_test.go
+++ b/sensor/admission-control/manager/images_test.go
@@ -5,8 +5,10 @@ import (
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/coalescer"
 	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/sizeboundedcache"
 	"github.com/stretchr/testify/require"
@@ -35,12 +37,16 @@ func (s *ImageCacheTestSuite) SetupSuite() {
 		imageCache:               cache,
 		imageNameToImageCacheKey: nameCache,
 		imageNameCacheEnabled:    true,
+		imageFetchGroup:          coalescer.New[*storage.Image](),
+		imageCacheGen:            newImageGenTracker(),
 	}
 }
 
 func (s *ImageCacheTestSuite) SetupTest() {
 	s.manager.imageCache.Purge()
 	s.manager.imageNameToImageCacheKey.Purge()
+	s.manager.imageCacheGen.Clear()
+	s.manager.state.Store(nil)
 }
 
 func createTestState(flattenImageData bool) *state {
@@ -246,4 +252,147 @@ func (s *ImageCacheTestSuite) TestCacheImage() {
 			}
 		})
 	}
+}
+
+// --- test helpers ---
+
+func (s *ImageCacheTestSuite) addCacheEntry(key string, img *storage.Image) {
+	s.manager.imageCache.Add(key, imageCacheEntry{Image: img, timestamp: time.Now()})
+}
+
+func (s *ImageCacheTestSuite) addNameMapping(name, key string) {
+	s.manager.imageNameToImageCacheKey.Add(name, key)
+}
+
+func (s *ImageCacheTestSuite) assertCached(key string, expected bool, msgAndArgs ...interface{}) {
+	_, ok := s.manager.imageCache.Get(key)
+	s.Equal(expected, ok, msgAndArgs...)
+}
+
+func (s *ImageCacheTestSuite) assertNameMapped(name string, expected bool, msgAndArgs ...interface{}) {
+	_, ok := s.manager.imageNameToImageCacheKey.Get(name)
+	s.Equal(expected, ok, msgAndArgs...)
+}
+
+func (s *ImageCacheTestSuite) invalidate(keys ...*central.ImageKey) {
+	s.manager.processImageCacheInvalidation(&sensor.AdmCtrlImageCacheInvalidation{ImageKeys: keys})
+}
+
+// --- invalidation tests ---
+
+func (s *ImageCacheTestSuite) TestProcessImageInvalidation_RemovesTargetedEntry() {
+	s.manager.state.Store(createTestState(false))
+
+	s.addCacheEntry("sha256:nginx", &storage.Image{Id: "sha256:nginx"})
+	s.addCacheEntry("sha256:redis", &storage.Image{Id: "sha256:redis"})
+	s.addNameMapping("docker.io/library/nginx:1.25", "sha256:nginx")
+	s.addNameMapping("docker.io/library/redis:7", "sha256:redis")
+
+	s.invalidate(&central.ImageKey{
+		ImageId: "sha256:nginx", ImageFullName: "docker.io/library/nginx:1.25",
+	})
+
+	s.assertCached("sha256:nginx", false, "nginx should be removed")
+	s.assertNameMapped("docker.io/library/nginx:1.25", false, "nginx name mapping should be removed")
+	s.assertCached("sha256:redis", true, "redis should remain")
+	s.assertNameMapped("docker.io/library/redis:7", true, "redis name mapping should remain")
+}
+
+func (s *ImageCacheTestSuite) TestProcessImageInvalidation_WithFlattenImageData() {
+	s.manager.state.Store(createTestState(true))
+	v2Key := "v2-uuid-for-nginx"
+
+	s.addCacheEntry(v2Key, &storage.Image{Id: "sha256:nginx"})
+	s.addNameMapping("docker.io/library/nginx:1.25", v2Key)
+
+	s.invalidate(&central.ImageKey{
+		ImageId: "sha256:nginx", ImageIdV2: v2Key, ImageFullName: "docker.io/library/nginx:1.25",
+	})
+
+	s.assertCached(v2Key, false, "V2 cache entry should be removed")
+	s.assertNameMapped("docker.io/library/nginx:1.25", false, "name mapping should be removed")
+}
+
+func (s *ImageCacheTestSuite) TestProcessImageInvalidation_IncrementsGeneration() {
+	s.manager.state.Store(createTestState(false))
+
+	s.invalidate(&central.ImageKey{
+		ImageId: "sha256:abc", ImageFullName: "docker.io/library/nginx:1.25",
+	})
+
+	s.Equal(uint64(1), s.manager.imageCacheGen.Get("sha256:abc"))
+	s.Equal(uint64(1), s.manager.imageCacheGen.Get("docker.io/library/nginx:1.25"))
+}
+
+func (s *ImageCacheTestSuite) TestProcessImageInvalidation_MultipleKeys() {
+	s.manager.state.Store(createTestState(false))
+	for _, id := range []string{"sha256:a", "sha256:b", "sha256:c"} {
+		s.addCacheEntry(id, &storage.Image{Id: id})
+	}
+
+	s.invalidate(
+		&central.ImageKey{ImageId: "sha256:a"},
+		&central.ImageKey{ImageId: "sha256:c"},
+	)
+
+	s.assertCached("sha256:a", false)
+	s.assertCached("sha256:b", true, "sha256:b should not be invalidated")
+	s.assertCached("sha256:c", false)
+}
+
+// --- generation counter tests ---
+
+func (s *ImageCacheTestSuite) TestGenerationCounter() {
+	st := createTestState(false)
+	imgName := &storage.ImageName{FullName: "docker.io/library/nginx:1.25"}
+	img := &storage.Image{Id: "sha256:abc", Name: imgName}
+
+	tests := []struct {
+		name        string
+		mutate      func()
+		expectCache bool
+	}{
+		{
+			name:        "allows cache when unchanged",
+			mutate:      func() {},
+			expectCache: true,
+		},
+		{
+			name:        "prevents stale cache after per-key Inc",
+			mutate:      func() { s.manager.imageCacheGen.Inc("sha256:abc") },
+			expectCache: false,
+		},
+		{
+			name:        "prevents stale cache after CacheVersion change",
+			mutate:      func() { s.manager.imageCacheGen.UpdateCacheVersion("new-uuid") },
+			expectCache: false,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.manager.imageCache.Purge()
+			s.manager.imageCacheGen.Clear()
+
+			gen, cacheVer := s.manager.imageCacheGen.Snapshot("sha256:abc")
+			tt.mutate()
+			if !s.manager.imageCacheGen.Changed("sha256:abc", gen, cacheVer) {
+				s.manager.cacheImage(img, imgName.GetFullName(), st)
+			}
+			s.assertCached("sha256:abc", tt.expectCache)
+		})
+	}
+}
+
+func (s *ImageCacheTestSuite) TestClearImageCacheGen() {
+	s.manager.imageCacheGen.Inc("sha256:a")
+	s.manager.imageCacheGen.Inc("sha256:a")
+	s.manager.imageCacheGen.Inc("sha256:b")
+	s.manager.imageCacheGen.UpdateCacheVersion("v1")
+
+	s.manager.imageCacheGen.Clear()
+
+	s.Equal(uint64(0), s.manager.imageCacheGen.Get("sha256:a"))
+	s.Equal(uint64(0), s.manager.imageCacheGen.Get("sha256:b"))
+	s.Equal("", s.manager.imageCacheGen.CacheVersion())
 }

--- a/sensor/admission-control/manager/manager_impl.go
+++ b/sensor/admission-control/manager/manager_impl.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -97,7 +98,7 @@ const (
 // imageGenTracker tracks per-key generation counters to prevent stale in-flight
 // fetches from re-caching data after an invalidation or full purge.
 type imageGenTracker struct {
-	mu           sync.Mutex
+	mu           sync.RWMutex
 	gen          map[string]uint64
 	cacheVersion string
 }
@@ -108,15 +109,15 @@ func newImageGenTracker() *imageGenTracker {
 
 // Snapshot captures the per-key generation and CacheVersion before a fetch.
 func (t *imageGenTracker) Snapshot(key string) (gen uint64, cacheVersion string) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	return t.gen[key], t.cacheVersion
 }
 
 // Changed returns true if the generation or CacheVersion moved since the snapshot.
 func (t *imageGenTracker) Changed(key string, gen uint64, cacheVersion string) bool {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	return t.gen[key] != gen || t.cacheVersion != cacheVersion
 }
 
@@ -129,8 +130,8 @@ func (t *imageGenTracker) Inc(key string) {
 
 // CacheVersion returns the current cache version.
 func (t *imageGenTracker) CacheVersion() string {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	return t.cacheVersion
 }
 
@@ -142,15 +143,15 @@ func (t *imageGenTracker) UpdateCacheVersion(v string) {
 	clear(t.gen)
 }
 
-// Get returns the per-key generation counter (for testing).
-func (t *imageGenTracker) Get(key string) uint64 {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+// Get returns the per-key generation counter (for testing only).
+func (t *imageGenTracker) Get(_ testing.TB, key string) uint64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	return t.gen[key]
 }
 
-// Clear resets all per-key counters and the cache version (for testing).
-func (t *imageGenTracker) Clear() {
+// Clear resets all per-key counters and the cache version (for testing only).
+func (t *imageGenTracker) Clear(_ testing.TB) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.cacheVersion = ""
@@ -470,9 +471,12 @@ func (m *manager) ProcessNewSettings(newSettings *sensor.AdmissionControlSetting
 	if newSettings.GetCacheVersion() != m.imageCacheGen.CacheVersion() {
 		log.Infof("CacheVersion changed (%s -> %s): purging image cache and resetting gen counters",
 			m.imageCacheGen.CacheVersion(), newSettings.GetCacheVersion())
+		// UpdateCacheVersion must precede Purge so that any in-flight fetch that
+		// snapshotted the old cacheVersion sees the mismatch in Changed() and
+		// discards its result instead of re-caching stale data.
+		m.imageCacheGen.UpdateCacheVersion(newSettings.GetCacheVersion())
 		m.imageCache.Purge()
 		m.imageNameToImageCacheKey.Purge()
-		m.imageCacheGen.UpdateCacheVersion(newSettings.GetCacheVersion())
 	}
 
 	m.state.Store(newState)

--- a/sensor/admission-control/manager/manager_impl.go
+++ b/sensor/admission-control/manager/manager_impl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/size"
 	"github.com/stackrox/rox/pkg/sizeboundedcache"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/admission-control/errors"
 	"github.com/stackrox/rox/sensor/admission-control/resources"
@@ -93,11 +94,75 @@ const (
 	imageNameCacheSize = 8192
 )
 
+// imageGenTracker tracks per-key generation counters to prevent stale in-flight
+// fetches from re-caching data after an invalidation or full purge.
+type imageGenTracker struct {
+	mu           sync.Mutex
+	gen          map[string]uint64
+	cacheVersion string
+}
+
+func newImageGenTracker() *imageGenTracker {
+	return &imageGenTracker{gen: make(map[string]uint64)}
+}
+
+// Snapshot captures the per-key generation and CacheVersion before a fetch.
+func (t *imageGenTracker) Snapshot(key string) (gen uint64, cacheVersion string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.gen[key], t.cacheVersion
+}
+
+// Changed returns true if the generation or CacheVersion moved since the snapshot.
+func (t *imageGenTracker) Changed(key string, gen uint64, cacheVersion string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.gen[key] != gen || t.cacheVersion != cacheVersion
+}
+
+// Inc bumps the per-key generation counter.
+func (t *imageGenTracker) Inc(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.gen[key]++
+}
+
+// CacheVersion returns the current cache version.
+func (t *imageGenTracker) CacheVersion() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.cacheVersion
+}
+
+// UpdateCacheVersion sets a new CacheVersion and clears all per-key counters.
+func (t *imageGenTracker) UpdateCacheVersion(v string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.cacheVersion = v
+	clear(t.gen)
+}
+
+// Get returns the per-key generation counter (for testing).
+func (t *imageGenTracker) Get(key string) uint64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.gen[key]
+}
+
+// Clear resets all per-key counters and the cache version (for testing).
+func (t *imageGenTracker) Clear() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.cacheVersion = ""
+	clear(t.gen)
+}
+
 type manager struct {
 	stopper concurrency.Stopper
 
-	client     sensor.ImageServiceClient
-	imageCache sizeboundedcache.Cache[string, imageCacheEntry]
+	client        sensor.ImageServiceClient
+	imageCache    sizeboundedcache.Cache[string, imageCacheEntry]
+	imageCacheGen *imageGenTracker
 	// imageNameToImageCacheKey resolves image full names (e.g. "docker.io/library/nginx:1.25")
 	// to their cache keys in imageCache. This is needed because admission requests for CREATE/UPDATE
 	// operations only contain image names (no digest/ID), so imageKey() returns the full name as the
@@ -108,14 +173,13 @@ type manager struct {
 	imageNameCacheEnabled    bool
 	imageFetchGroup          *coalescer.Coalescer[*storage.Image]
 
+	depClient               sensor.DeploymentServiceClient
+	resourceUpdatesC        chan *sensor.AdmCtrlUpdateResourceRequest
 	imageCacheInvalidationC chan *sensor.AdmCtrlImageCacheInvalidation
-
-	depClient        sensor.DeploymentServiceClient
-	resourceUpdatesC chan *sensor.AdmCtrlUpdateResourceRequest
-	namespaces       *resources.NamespaceStore
-	deployments      *resources.DeploymentStore
-	pods             *resources.PodStore
-	initialSyncSig   concurrency.Signal
+	namespaces              *resources.NamespaceStore
+	deployments             *resources.DeploymentStore
+	pods                    *resources.PodStore
+	initialSyncSig          concurrency.Signal
 
 	settingsStream     *concurrency.ValueStream[*sensor.AdmissionControlSettings]
 	settingsC          chan *sensor.AdmissionControlSettings
@@ -125,8 +189,6 @@ type manager struct {
 
 	state         atomic.Pointer[state]
 	clusterLabels atomic.Pointer[map[string]string]
-
-	cacheVersion string
 
 	sensorConnStatus concurrency.Flag
 
@@ -159,6 +221,7 @@ func NewManager(namespace string, maxImageCacheSize int64, imageNameCacheEnabled
 		imageNameToImageCacheKey: nameCache,
 		imageNameCacheEnabled:    imageNameCacheEnabled,
 		imageFetchGroup:          coalescer.New[*storage.Image](),
+		imageCacheGen:            newImageGenTracker(),
 
 		alertsC: make(chan []*storage.Alert),
 
@@ -404,10 +467,12 @@ func (m *manager) ProcessNewSettings(newSettings *sensor.AdmissionControlSetting
 		}
 	}
 
-	if newSettings.GetCacheVersion() != m.cacheVersion {
+	if newSettings.GetCacheVersion() != m.imageCacheGen.CacheVersion() {
+		log.Infof("CacheVersion changed (%s -> %s): purging image cache and resetting gen counters",
+			m.imageCacheGen.CacheVersion(), newSettings.GetCacheVersion())
 		m.imageCache.Purge()
 		m.imageNameToImageCacheKey.Purge()
-		m.cacheVersion = newSettings.GetCacheVersion()
+		m.imageCacheGen.UpdateCacheVersion(newSettings.GetCacheVersion())
 	}
 
 	m.state.Store(newState)
@@ -529,6 +594,9 @@ func (m *manager) getDeploymentForPod(namespace, podName string) *storage.Deploy
 	return m.deployments.Get(namespace, m.pods.GetDeploymentID(namespace, podName))
 }
 
+// processImageCacheInvalidation removes targeted entries from the image cache
+// and bumps generation counters for both the digest key and full name to
+// prevent in-flight fetches from re-caching stale data.
 func (m *manager) processImageCacheInvalidation(inv *sensor.AdmCtrlImageCacheInvalidation) {
 	s := m.currentState()
 	flatten := s != nil && s.GetFlattenImageData()
@@ -542,11 +610,13 @@ func (m *manager) processImageCacheInvalidation(inv *sensor.AdmCtrlImageCacheInv
 		fullName := key.GetImageFullName()
 
 		if cacheKey != "" {
+			m.imageCacheGen.Inc(cacheKey)
 			m.imageCache.Remove(cacheKey)
 			m.imageFetchGroup.Forget(cacheKey)
 			invalidated++
 		}
 		if fullName != "" {
+			m.imageCacheGen.Inc(fullName)
 			m.imageNameToImageCacheKey.Remove(fullName)
 			m.imageFetchGroup.Forget(fullName)
 		}

--- a/sensor/admission-control/manager/manager_impl_test.go
+++ b/sensor/admission-control/manager/manager_impl_test.go
@@ -46,7 +46,7 @@ func (s *ManagerImplSuite) SetupSuite() {
 func (s *ManagerImplSuite) SetupTest() {
 	s.mgr.imageCache.Purge()
 	s.mgr.imageNameToImageCacheKey.Purge()
-	s.mgr.imageCacheGen.Clear()
+	s.mgr.imageCacheGen.Clear(s.T())
 	s.mgr.clusterLabels.Store(nil)
 
 	depStore := resources.NewDeploymentStore(nil)

--- a/sensor/admission-control/manager/manager_impl_test.go
+++ b/sensor/admission-control/manager/manager_impl_test.go
@@ -39,12 +39,14 @@ func (s *ManagerImplSuite) SetupSuite() {
 		imageCache:               cache,
 		imageNameToImageCacheKey: nameCache,
 		imageFetchGroup:          coalescer.New[*storage.Image](),
+		imageCacheGen:            newImageGenTracker(),
 	}
 }
 
 func (s *ManagerImplSuite) SetupTest() {
 	s.mgr.imageCache.Purge()
 	s.mgr.imageNameToImageCacheKey.Purge()
+	s.mgr.imageCacheGen.Clear()
 	s.mgr.clusterLabels.Store(nil)
 
 	depStore := resources.NewDeploymentStore(nil)


### PR DESCRIPTION
## Description

Generation counter for stale-write prevention: A targeted invalidation or full cache flush can race with an in-flight fetch: the fetch starts before the invalidation, the invalidation clears the cache, then the fetch completes and writes stale data back. Admittedly this window is very small, however it is possible. And aggravates the stale data problem when we increase/remove the TTL concept from the admission controller image cache.

To prevent this, a per-key generation counter (`imageGenTracker`) is incremented on invalidation. In-flight fetches capture a generation snapshot before the fetch call and compare it after — if the generation changed, the result is not cached. This ensures invalidation takes effect immediately rather than being masked for the duration of the cache entry's lifetime.

The generation counters get wiped out every reprocessing interval, because the periodic reprocessing triggers a full flush of the admission controller cache.  

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
Tested this as a part of the stack, along with PR #19837 and #19840.