### PR TITLE
ROX-31047: Refactor file activity pipeline to use pub/sub

### DIFF
--- a/sensor/common/filesystem/pipeline/pipeline.go
+++ b/sensor/common/filesystem/pipeline/pipeline.go
@@ -74,7 +74,7 @@ func NewFileSystemPipeline(detector detector.Detector, clusterEntities *clustere
 
 	if features.SensorInternalPubSub.Enabled() && pubSubDispatcher != nil {
 		if err := pubSubDispatcher.RegisterConsumerToLane(
-			pubsub.EnrichedProcessConsumer,
+			pubsub.FileActivityEnrichedProcessConsumer,
 			pubsub.EnrichedProcessIndicatorTopic,
 			pubsub.EnrichedProcessIndicatorLane,
 			p.processEnrichedIndicator,

--- a/sensor/common/filesystem/pipeline/pipeline.go
+++ b/sensor/common/filesystem/pipeline/pipeline.go
@@ -82,14 +82,14 @@ func NewFileSystemPipeline(detector detector.Detector, clusterEntities *clustere
 			log.Errorf("Failed to register consumer for enriched process indicators, falling back to legacy mode: %v", err)
 			p.pubSubDispatcher = nil
 		} else {
-			log.Info("File system pipeline using pub/sub mode for process enrichment")
+			log.Debug("File system pipeline using pub/sub mode for process enrichment")
 			p.wg.Add(1)
 			go p.cleanupExpiredBuffers()
 		}
 	}
 
 	if p.pubSubDispatcher == nil {
-		log.Info("File system pipeline using legacy mode (direct enrichment)")
+		log.Debug("File system pipeline using legacy mode (direct enrichment)")
 	}
 
 	p.wg.Add(1)
@@ -199,7 +199,7 @@ func (p *Pipeline) buildIndicator(fs *sensorAPI.FileActivity) *storage.ProcessIn
 }
 
 func cacheKey(containerID, processSignalID string) string {
-	return fmt.Sprintf("%s:%s", containerID, processSignalID)
+	return containerID + ":" + processSignalID
 }
 
 func (p *Pipeline) bufferActivity(fs *sensorAPI.FileActivity) {

--- a/sensor/common/filesystem/pipeline/pipeline.go
+++ b/sensor/common/filesystem/pipeline/pipeline.go
@@ -223,6 +223,7 @@ func (p *Pipeline) bufferActivity(fs *sensorAPI.FileActivity) {
 	if !exists {
 		entry = &bufferedActivityEntry{
 			activities: make([]*sensorAPI.FileActivity, 0, 10),
+			timestamp:  time.Now(),
 		}
 		p.bufferedActivity[key] = entry
 	}
@@ -235,7 +236,6 @@ func (p *Pipeline) bufferActivity(fs *sensorAPI.FileActivity) {
 	}
 
 	entry.activities = append(entry.activities, fs)
-	entry.timestamp = time.Now()
 	p.totalBufferedActivity++
 	metrics.SetFileActivityBufferSize(p.totalBufferedActivity)
 }
@@ -303,9 +303,13 @@ func (p *Pipeline) processFileActivity(fs *sensorAPI.FileActivity) {
 		p.bufferActivity(fs)
 		event := processsignal.NewUnenrichedProcessIndicatorEvent(p.msgCtx, indicator)
 		if err := p.pubSubDispatcher.Publish(event); err != nil {
-			log.Errorf("Failed to publish unenriched process indicator for file activity: %v", err)
+			log.Errorf("Failed to publish unenriched process indicator for file activity: %v, falling back to legacy enrichment", err)
+			// Remove the buffered activity and fall through to legacy path.
+			key := cacheKey(process.GetContainerId(), process.GetId())
+			_ = p.popBufferedActivity(key)
+		} else {
+			return
 		}
-		return
 	}
 
 	// Legacy path: enrich directly from cluster entities store.
@@ -356,6 +360,7 @@ func (p *Pipeline) pruneExpiredBuffers() {
 	}
 
 	if p.totalBufferedActivity < 0 {
+		log.Warnf("totalBufferedActivity went negative (%d), resetting to 0 (possible accounting bug)", p.totalBufferedActivity)
 		p.totalBufferedActivity = 0
 	}
 

--- a/sensor/common/filesystem/pipeline/pipeline.go
+++ b/sensor/common/filesystem/pipeline/pipeline.go
@@ -2,21 +2,44 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	sensorAPI "github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/detector"
 	detectorMetrics "github.com/stackrox/rox/sensor/common/detector/metrics"
+	"github.com/stackrox/rox/sensor/common/metrics"
+	"github.com/stackrox/rox/sensor/common/processsignal"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+)
+
+const (
+	// Maximum number of file activities to buffer per process
+	maxBufferedActivitiesPerProcess = 100
+	// Maximum total number of buffered file activities across all processes
+	maxTotalBufferedActivities = 10000
+	// How long to keep buffered activities before dropping them
+	bufferedActivityTTL = 5 * time.Minute
+	// How often to run cleanup of expired buffers
+	bufferCleanupInterval = 1 * time.Minute
 )
 
 var (
 	log = logging.LoggerForModule()
 )
+
+type bufferedActivityEntry struct {
+	activities []*sensorAPI.FileActivity
+	timestamp  time.Time
+}
 
 type Pipeline struct {
 	detector detector.Detector
@@ -25,28 +48,63 @@ type Pipeline struct {
 	activityChan    chan *sensorAPI.FileActivity
 	clusterEntities *clusterentities.Store
 
+	bufferedActivity      map[string]*bufferedActivityEntry
+	totalBufferedActivity int
+	activityMutex         sync.Mutex
+
+	pubSubDispatcher common.PubSubDispatcher
+
+	wg     sync.WaitGroup
 	msgCtx context.Context
 }
 
-func NewFileSystemPipeline(detector detector.Detector, clusterEntities *clusterentities.Store, activityChan chan *sensorAPI.FileActivity) *Pipeline {
+func NewFileSystemPipeline(detector detector.Detector, clusterEntities *clusterentities.Store, activityChan chan *sensorAPI.FileActivity, pubSubDispatcher common.PubSubDispatcher) *Pipeline {
 	msgCtx := context.Background()
 
 	p := &Pipeline{
-		detector:        detector,
-		activityChan:    activityChan,
-		clusterEntities: clusterEntities,
-		stopper:         concurrency.NewStopper(),
-		msgCtx:          msgCtx,
+		detector:              detector,
+		activityChan:          activityChan,
+		clusterEntities:       clusterEntities,
+		pubSubDispatcher:      pubSubDispatcher,
+		stopper:               concurrency.NewStopper(),
+		msgCtx:                msgCtx,
+		bufferedActivity:      make(map[string]*bufferedActivityEntry),
+		totalBufferedActivity: 0,
 	}
 
+	if features.SensorInternalPubSub.Enabled() && pubSubDispatcher != nil {
+		if err := pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.EnrichedProcessConsumer,
+			pubsub.EnrichedProcessIndicatorTopic,
+			pubsub.EnrichedProcessIndicatorLane,
+			p.processEnrichedIndicator,
+		); err != nil {
+			log.Errorf("Failed to register consumer for enriched process indicators, falling back to legacy mode: %v", err)
+			p.pubSubDispatcher = nil
+		} else {
+			log.Info("File system pipeline using pub/sub mode for process enrichment")
+			p.wg.Add(1)
+			go p.cleanupExpiredBuffers()
+		}
+	}
+
+	if p.pubSubDispatcher == nil {
+		log.Info("File system pipeline using legacy mode (direct enrichment)")
+	}
+
+	p.wg.Add(1)
 	go p.run()
 	return p
 }
 
-func (p *Pipeline) translate(fs *sensorAPI.FileActivity) *storage.FileAccess {
+func (p *Pipeline) Stop() {
+	p.stopper.Client().Stop()
+	p.wg.Wait()
+}
 
+func (p *Pipeline) translateWithIndicator(fs *sensorAPI.FileActivity, indicator *storage.ProcessIndicator) *storage.FileAccess {
 	access := &storage.FileAccess{
-		Process:   p.getIndicator(fs.GetProcess()),
+		Process:   indicator,
 		Hostname:  fs.GetHostname(),
 		Timestamp: fs.GetTimestamp(),
 	}
@@ -109,7 +167,8 @@ func (p *Pipeline) translate(fs *sensorAPI.FileActivity) *storage.FileAccess {
 	return access
 }
 
-func (p *Pipeline) getIndicator(process *sensorAPI.ProcessSignal) *storage.ProcessIndicator {
+func (p *Pipeline) buildIndicator(fs *sensorAPI.FileActivity) *storage.ProcessIndicator {
+	process := fs.GetProcess()
 	signal := &storage.ProcessSignal{
 		Id:           process.GetId(),
 		Uid:          process.GetUid(),
@@ -133,40 +192,181 @@ func (p *Pipeline) getIndicator(process *sensorAPI.ProcessSignal) *storage.Proce
 		)
 	}
 
-	pi := &storage.ProcessIndicator{
+	return &storage.ProcessIndicator{
 		Id:     uuid.NewV4().String(),
 		Signal: signal,
 	}
-
-	if process.GetContainerId() == "" {
-		// Process is running on the host (not in a container)
-		return pi
-	}
-
-	metadata, ok, _ := p.clusterEntities.LookupByContainerID(process.GetContainerId())
-	if !ok {
-		// unexpected - process should exist before file activity is
-		// reported
-		log.Warnf("Container ID: %s not found for file activity", process.GetContainerId())
-	} else {
-		pi.DeploymentId = metadata.DeploymentID
-		pi.ContainerName = metadata.ContainerName
-		pi.PodId = metadata.PodID
-		pi.PodUid = metadata.PodUID
-		pi.Namespace = metadata.Namespace
-		pi.ContainerStartTime = protocompat.ConvertTimeToTimestampOrNil(metadata.StartTime)
-		pi.ImageId = metadata.ImageID
-	}
-
-	return pi
 }
 
-func (p *Pipeline) Stop() {
-	p.stopper.Client().Stop()
-	<-p.stopper.Client().Stopped().Done()
+func cacheKey(containerID, processSignalID string) string {
+	return fmt.Sprintf("%s:%s", containerID, processSignalID)
+}
+
+func (p *Pipeline) bufferActivity(fs *sensorAPI.FileActivity) {
+	process := fs.GetProcess()
+	if process == nil {
+		return
+	}
+
+	key := cacheKey(process.GetContainerId(), process.GetId())
+	p.activityMutex.Lock()
+	defer p.activityMutex.Unlock()
+
+	if p.totalBufferedActivity >= maxTotalBufferedActivities {
+		log.Warnf("File activity buffer is full (%d activities), dropping file activity for process %s",
+			maxTotalBufferedActivities, process.GetId())
+		metrics.IncrementFileActivityBufferDrops()
+		return
+	}
+
+	entry, exists := p.bufferedActivity[key]
+	if !exists {
+		entry = &bufferedActivityEntry{
+			activities: make([]*sensorAPI.FileActivity, 0, 10),
+		}
+		p.bufferedActivity[key] = entry
+	}
+
+	if len(entry.activities) >= maxBufferedActivitiesPerProcess {
+		log.Warnf("Too many buffered activities for process %s (limit: %d), dropping file activity",
+			process.GetId(), maxBufferedActivitiesPerProcess)
+		metrics.IncrementFileActivityBufferDrops()
+		return
+	}
+
+	entry.activities = append(entry.activities, fs)
+	entry.timestamp = time.Now()
+	p.totalBufferedActivity++
+	metrics.SetFileActivityBufferSize(p.totalBufferedActivity)
+}
+
+func (p *Pipeline) popBufferedActivity(key string) []*sensorAPI.FileActivity {
+	p.activityMutex.Lock()
+	defer p.activityMutex.Unlock()
+
+	entry := p.bufferedActivity[key]
+	if entry == nil {
+		return nil
+	}
+
+	activities := entry.activities
+	p.totalBufferedActivity -= len(activities)
+	delete(p.bufferedActivity, key)
+	metrics.SetFileActivityBufferSize(p.totalBufferedActivity)
+	return activities
+}
+
+func (p *Pipeline) processEnrichedIndicator(event pubsub.Event) error {
+	enrichedEvent, ok := event.(*processsignal.EnrichedProcessIndicatorEvent)
+	if !ok {
+		log.Errorf("File system pipeline received unexpected event type: %T", event)
+		return fmt.Errorf("unexpected event type: %T", event)
+	}
+
+	indicator := enrichedEvent.Indicator
+	if indicator == nil || indicator.GetSignal() == nil {
+		return nil
+	}
+
+	key := cacheKey(indicator.GetSignal().GetContainerId(), indicator.GetSignal().GetId())
+	buffered := p.popBufferedActivity(key)
+	for _, fs := range buffered {
+		access := p.translateWithIndicator(fs, indicator)
+		if access != nil {
+			p.detector.ProcessFileAccess(enrichedEvent.Context, access)
+		}
+	}
+
+	return nil
+}
+
+func (p *Pipeline) processFileActivity(fs *sensorAPI.FileActivity) {
+	process := fs.GetProcess()
+	if process == nil {
+		return
+	}
+
+	indicator := p.buildIndicator(fs)
+
+	// Host processes (no container ID) bypass enrichment entirely.
+	if process.GetContainerId() == "" {
+		if access := p.translateWithIndicator(fs, indicator); access != nil {
+			p.detector.ProcessFileAccess(p.msgCtx, access)
+		}
+		return
+	}
+
+	if features.SensorInternalPubSub.Enabled() && p.pubSubDispatcher != nil {
+		// Buffer the file activity BEFORE publishing the unenriched event
+		// to avoid a TOCTOU race where the enriched callback fires before
+		// the activity is buffered.
+		p.bufferActivity(fs)
+		event := processsignal.NewUnenrichedProcessIndicatorEvent(p.msgCtx, indicator)
+		if err := p.pubSubDispatcher.Publish(event); err != nil {
+			log.Errorf("Failed to publish unenriched process indicator for file activity: %v", err)
+		}
+		return
+	}
+
+	// Legacy path: enrich directly from cluster entities store.
+	metadata, ok, _ := p.clusterEntities.LookupByContainerID(process.GetContainerId())
+	if !ok {
+		log.Warnf("Container ID: %s not found for file activity", process.GetContainerId())
+	} else {
+		processsignal.PopulateIndicatorFromContainer(indicator, metadata)
+	}
+
+	if access := p.translateWithIndicator(fs, indicator); access != nil {
+		p.detector.ProcessFileAccess(p.msgCtx, access)
+	}
+}
+
+func (p *Pipeline) cleanupExpiredBuffers() {
+	defer p.wg.Done()
+	ticker := time.NewTicker(bufferCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.stopper.Flow().StopRequested():
+			return
+		case <-ticker.C:
+			p.pruneExpiredBuffers()
+		}
+	}
+}
+
+func (p *Pipeline) pruneExpiredBuffers() {
+	p.activityMutex.Lock()
+	defer p.activityMutex.Unlock()
+
+	now := time.Now()
+	expiredKeys := make([]string, 0)
+
+	for key, entry := range p.bufferedActivity {
+		if now.Sub(entry.timestamp) > bufferedActivityTTL {
+			expiredKeys = append(expiredKeys, key)
+			p.totalBufferedActivity -= len(entry.activities)
+			metrics.IncrementFileActivityBufferDropsBy(len(entry.activities))
+		}
+	}
+
+	for _, key := range expiredKeys {
+		delete(p.bufferedActivity, key)
+	}
+
+	if p.totalBufferedActivity < 0 {
+		p.totalBufferedActivity = 0
+	}
+
+	if len(expiredKeys) > 0 {
+		log.Debugf("Pruned %d expired file activity buffers (TTL: %v)", len(expiredKeys), bufferedActivityTTL)
+		metrics.SetFileActivityBufferSize(p.totalBufferedActivity)
+	}
 }
 
 func (p *Pipeline) run() {
+	defer p.wg.Done()
 	defer p.stopper.Flow().ReportStopped()
 	for {
 		select {
@@ -178,13 +378,7 @@ func (p *Pipeline) run() {
 				return
 			}
 			detectorMetrics.FileAccessEventsReceived.Inc()
-			event := p.translate(fs)
-			if event == nil {
-				detectorMetrics.DetectorFileAccessDroppedCount.Inc()
-				continue
-			}
-
-			p.detector.ProcessFileAccess(p.msgCtx, event)
+			p.processFileActivity(fs)
 		}
 	}
 }

--- a/sensor/common/filesystem/pipeline/pipeline.go
+++ b/sensor/common/filesystem/pipeline/pipeline.go
@@ -257,6 +257,12 @@ func (p *Pipeline) popBufferedActivity(key string) []*sensorAPI.FileActivity {
 }
 
 func (p *Pipeline) processEnrichedIndicator(event pubsub.Event) error {
+	select {
+	case <-p.stopper.Flow().StopRequested():
+		return nil
+	default:
+	}
+
 	enrichedEvent, ok := event.(*processsignal.EnrichedProcessIndicatorEvent)
 	if !ok {
 		log.Errorf("File system pipeline received unexpected event type: %T", event)
@@ -272,9 +278,11 @@ func (p *Pipeline) processEnrichedIndicator(event pubsub.Event) error {
 	buffered := p.popBufferedActivity(key)
 	for _, fs := range buffered {
 		access := p.translateWithIndicator(fs, indicator)
-		if access != nil {
-			p.detector.ProcessFileAccess(enrichedEvent.Context, access)
+		if access == nil {
+			detectorMetrics.DetectorFileAccessDroppedCount.Inc()
+			continue
 		}
+		p.detector.ProcessFileAccess(enrichedEvent.Context, access)
 	}
 
 	return nil
@@ -320,9 +328,12 @@ func (p *Pipeline) processFileActivity(fs *sensorAPI.FileActivity) {
 		processsignal.PopulateIndicatorFromContainer(indicator, metadata)
 	}
 
-	if access := p.translateWithIndicator(fs, indicator); access != nil {
-		p.detector.ProcessFileAccess(p.msgCtx, access)
+	access := p.translateWithIndicator(fs, indicator)
+	if access == nil {
+		detectorMetrics.DetectorFileAccessDroppedCount.Inc()
+		return
 	}
+	p.detector.ProcessFileAccess(p.msgCtx, access)
 }
 
 func (p *Pipeline) cleanupExpiredBuffers() {
@@ -345,18 +356,15 @@ func (p *Pipeline) pruneExpiredBuffers() {
 	defer p.activityMutex.Unlock()
 
 	now := time.Now()
-	expiredKeys := make([]string, 0)
+	pruned := 0
 
 	for key, entry := range p.bufferedActivity {
 		if now.Sub(entry.timestamp) > bufferedActivityTTL {
-			expiredKeys = append(expiredKeys, key)
 			p.totalBufferedActivity -= len(entry.activities)
 			metrics.IncrementFileActivityBufferDropsBy(len(entry.activities))
+			delete(p.bufferedActivity, key)
+			pruned++
 		}
-	}
-
-	for _, key := range expiredKeys {
-		delete(p.bufferedActivity, key)
 	}
 
 	if p.totalBufferedActivity < 0 {
@@ -364,15 +372,14 @@ func (p *Pipeline) pruneExpiredBuffers() {
 		p.totalBufferedActivity = 0
 	}
 
-	if len(expiredKeys) > 0 {
-		log.Debugf("Pruned %d expired file activity buffers (TTL: %v)", len(expiredKeys), bufferedActivityTTL)
+	if pruned > 0 {
+		log.Debugf("Pruned %d expired file activity buffers (TTL: %v)", pruned, bufferedActivityTTL)
 		metrics.SetFileActivityBufferSize(p.totalBufferedActivity)
 	}
 }
 
 func (p *Pipeline) run() {
 	defer p.wg.Done()
-	defer p.stopper.Flow().ReportStopped()
 	for {
 		select {
 		case <-p.stopper.Flow().StopRequested():

--- a/sensor/common/filesystem/pipeline/pipeline_test.go
+++ b/sensor/common/filesystem/pipeline/pipeline_test.go
@@ -1,0 +1,287 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sensorAPI "github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stackrox/rox/sensor/common/clusterentities"
+	"github.com/stackrox/rox/sensor/common/detector/mocks"
+	"github.com/stackrox/rox/sensor/common/processsignal"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	testContainerID  = "test-container-1"
+	testDeploymentID = "test-deployment-1"
+	testSignalID     = "test-signal-1"
+)
+
+func newTestDispatcher(t *testing.T) common.PubSubDispatcher {
+	t.Helper()
+	d, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+		lane.NewBlockingLane(pubsub.EnrichedProcessIndicatorLane),
+		lane.NewBlockingLane(pubsub.UnenrichedProcessIndicatorLane),
+	}))
+	require.NoError(t, err)
+	t.Cleanup(func() { d.Stop() })
+	return d
+}
+
+func newTestFileActivity(containerID, signalID, path string) *sensorAPI.FileActivity {
+	return &sensorAPI.FileActivity{
+		Hostname: "test-host",
+		Process: &sensorAPI.ProcessSignal{
+			Id:          signalID,
+			ContainerId: containerID,
+			Name:        "test-process",
+		},
+		File: &sensorAPI.FileActivity_Open{
+			Open: &sensorAPI.FileOpen{
+				Activity: &sensorAPI.FileActivityBase{
+					Path:     path,
+					HostPath: "/host" + path,
+				},
+			},
+		},
+	}
+}
+
+func TestFileSystemPipelinePubSubBufferingAndDrain(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	mockCtrl := gomock.NewController(t)
+	mockDetector := mocks.NewMockDetector(mockCtrl)
+	clusterStore := clusterentities.NewStore(0, nil, false)
+	dispatcher := newTestDispatcher(t)
+
+	activityChan := make(chan *sensorAPI.FileActivity, 10)
+	p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
+	t.Cleanup(func() { p.Stop() })
+
+	// Send a file activity — in pub/sub mode with no container metadata,
+	// it should be buffered and an unenriched event published.
+	fa := newTestFileActivity(testContainerID, testSignalID, "/etc/passwd")
+
+	// The enricher subscriber will receive the unenriched event,
+	// but we simulate the enrichment by directly publishing an enriched event.
+	// First, send the file activity through the pipeline.
+	activityChan <- fa
+
+	// Give the pipeline time to process and buffer the activity.
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify the activity was buffered.
+	p.activityMutex.Lock()
+	key := cacheKey(testContainerID, testSignalID)
+	entry := p.bufferedActivity[key]
+	require.NotNil(t, entry, "file activity should be buffered")
+	assert.Len(t, entry.activities, 1)
+	p.activityMutex.Unlock()
+
+	// Now simulate the enriched process indicator arriving via pub/sub.
+	enrichedIndicator := &storage.ProcessIndicator{
+		Id:           "enriched-indicator-1",
+		DeploymentId: testDeploymentID,
+		Signal: &storage.ProcessSignal{
+			Id:          testSignalID,
+			ContainerId: testContainerID,
+			Name:        "test-process",
+		},
+	}
+
+	// Expect the detector to receive the file access with the enriched indicator.
+	fileAccessReceived := make(chan *storage.FileAccess, 1)
+	mockDetector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, access *storage.FileAccess) {
+			fileAccessReceived <- access
+		},
+	)
+
+	enrichedEvent := processsignal.NewEnrichedProcessIndicatorEvent(context.Background(), enrichedIndicator)
+	require.NoError(t, dispatcher.Publish(enrichedEvent))
+
+	select {
+	case access := <-fileAccessReceived:
+		assert.Equal(t, testDeploymentID, access.GetProcess().GetDeploymentId())
+		assert.Equal(t, "/etc/passwd", access.GetFile().GetEffectivePath())
+		assert.Equal(t, storage.FileAccess_OPEN, access.GetOperation())
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for file access to be processed")
+	}
+
+	// Verify the buffer was drained.
+	p.activityMutex.Lock()
+	assert.Empty(t, p.bufferedActivity)
+	assert.Equal(t, 0, p.totalBufferedActivity)
+	p.activityMutex.Unlock()
+}
+
+func TestFileSystemPipelinePubSubMultipleActivitiesSameProcess(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	mockCtrl := gomock.NewController(t)
+	mockDetector := mocks.NewMockDetector(mockCtrl)
+	clusterStore := clusterentities.NewStore(0, nil, false)
+	dispatcher := newTestDispatcher(t)
+
+	activityChan := make(chan *sensorAPI.FileActivity, 10)
+	p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
+	t.Cleanup(func() { p.Stop() })
+
+	// Send multiple file activities for the same process.
+	paths := []string{"/etc/passwd", "/etc/shadow", "/etc/hosts"}
+	for _, path := range paths {
+		activityChan <- newTestFileActivity(testContainerID, testSignalID, path)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify all activities are buffered under the same key.
+	p.activityMutex.Lock()
+	key := cacheKey(testContainerID, testSignalID)
+	entry := p.bufferedActivity[key]
+	require.NotNil(t, entry)
+	assert.Len(t, entry.activities, 3)
+	p.activityMutex.Unlock()
+
+	// All three should be dispatched when the enriched indicator arrives.
+	var received []*storage.FileAccess
+	done := make(chan struct{})
+	mockDetector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).Times(3).DoAndReturn(
+		func(_ context.Context, access *storage.FileAccess) {
+			received = append(received, access)
+			if len(received) == 3 {
+				close(done)
+			}
+		},
+	)
+
+	enrichedIndicator := &storage.ProcessIndicator{
+		Id:           "enriched-indicator-1",
+		DeploymentId: testDeploymentID,
+		Signal: &storage.ProcessSignal{
+			Id:          testSignalID,
+			ContainerId: testContainerID,
+		},
+	}
+	require.NoError(t, dispatcher.Publish(processsignal.NewEnrichedProcessIndicatorEvent(context.Background(), enrichedIndicator)))
+
+	select {
+	case <-done:
+		expectedPaths := map[string]bool{"/etc/passwd": true, "/etc/shadow": true, "/etc/hosts": true}
+		for _, access := range received {
+			assert.True(t, expectedPaths[access.GetFile().GetEffectivePath()],
+				"unexpected path: %s", access.GetFile().GetEffectivePath())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for all file accesses to be processed")
+	}
+}
+
+func TestFileSystemPipelineHostProcessBypassesPubSub(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	mockCtrl := gomock.NewController(t)
+	mockDetector := mocks.NewMockDetector(mockCtrl)
+	clusterStore := clusterentities.NewStore(0, nil, false)
+	dispatcher := newTestDispatcher(t)
+
+	activityChan := make(chan *sensorAPI.FileActivity, 10)
+	p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
+	t.Cleanup(func() { p.Stop() })
+
+	// Host process (empty container ID) should bypass pub/sub and process directly.
+	fa := newTestFileActivity("", testSignalID, "/etc/passwd")
+
+	fileAccessReceived := make(chan struct{})
+	mockDetector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, access *storage.FileAccess) {
+			assert.Equal(t, "/etc/passwd", access.GetFile().GetEffectivePath())
+			close(fileAccessReceived)
+		},
+	)
+
+	activityChan <- fa
+
+	select {
+	case <-fileAccessReceived:
+		// Success — host process was handled directly.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for host process file access")
+	}
+
+	// Nothing should be buffered.
+	p.activityMutex.Lock()
+	assert.Empty(t, p.bufferedActivity)
+	p.activityMutex.Unlock()
+}
+
+func TestFileSystemPipelineBufferExpiration(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	mockCtrl := gomock.NewController(t)
+	mockDetector := mocks.NewMockDetector(mockCtrl)
+	clusterStore := clusterentities.NewStore(0, nil, false)
+	dispatcher := newTestDispatcher(t)
+
+	activityChan := make(chan *sensorAPI.FileActivity, 10)
+	p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
+	t.Cleanup(func() { p.Stop() })
+
+	// Send a file activity to get it buffered.
+	activityChan <- newTestFileActivity(testContainerID, testSignalID, "/etc/passwd")
+	time.Sleep(100 * time.Millisecond)
+
+	// Manually backdate the buffer entry to simulate expiration.
+	p.activityMutex.Lock()
+	key := cacheKey(testContainerID, testSignalID)
+	entry := p.bufferedActivity[key]
+	require.NotNil(t, entry)
+	entry.timestamp = time.Now().Add(-bufferedActivityTTL - time.Second)
+	p.activityMutex.Unlock()
+
+	// Trigger pruning manually.
+	p.pruneExpiredBuffers()
+
+	// Verify the buffer was cleaned up.
+	p.activityMutex.Lock()
+	assert.Empty(t, p.bufferedActivity)
+	assert.Equal(t, 0, p.totalBufferedActivity)
+	p.activityMutex.Unlock()
+}
+
+func TestFileSystemPipelineStopWaitsForAllGoroutines(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	mockCtrl := gomock.NewController(t)
+	mockDetector := mocks.NewMockDetector(mockCtrl)
+	clusterStore := clusterentities.NewStore(0, nil, false)
+	dispatcher := newTestDispatcher(t)
+
+	activityChan := make(chan *sensorAPI.FileActivity, 10)
+	p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
+
+	// Stop should return without hanging, proving both goroutines exit.
+	done := make(chan struct{})
+	go func() {
+		p.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() did not return in time — goroutine leak suspected")
+	}
+}

--- a/sensor/common/filesystem/pipeline/pipeline_test.go
+++ b/sensor/common/filesystem/pipeline/pipeline_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	sensorAPI "github.com/stackrox/rox/generated/internalapi/sensor"
@@ -59,229 +60,217 @@ func newTestFileActivity(containerID, signalID, path string) *sensorAPI.FileActi
 func TestFileSystemPipelinePubSubBufferingAndDrain(t *testing.T) {
 	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
 
-	mockCtrl := gomock.NewController(t)
-	mockDetector := mocks.NewMockDetector(mockCtrl)
-	clusterStore := clusterentities.NewStore(0, nil, false)
-	dispatcher := newTestDispatcher(t)
+	synctest.Test(t, func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockDetector := mocks.NewMockDetector(mockCtrl)
+		clusterStore := clusterentities.NewStore(0, nil, false)
+		dispatcher := newTestDispatcher(t)
 
-	activityChan := make(chan *sensorAPI.FileActivity, 10)
-	p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
-	t.Cleanup(func() { p.Stop() })
+		activityChan := make(chan *sensorAPI.FileActivity, 10)
+		p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
+		t.Cleanup(func() { p.Stop() })
 
-	// Send a file activity — in pub/sub mode with no container metadata,
-	// it should be buffered and an unenriched event published.
-	fa := newTestFileActivity(testContainerID, testSignalID, "/etc/passwd")
+		// Send a file activity — in pub/sub mode with no container metadata,
+		// it should be buffered and an unenriched event published.
+		fa := newTestFileActivity(testContainerID, testSignalID, "/etc/passwd")
 
-	// The enricher subscriber will receive the unenriched event,
-	// but we simulate the enrichment by directly publishing an enriched event.
-	// First, send the file activity through the pipeline.
-	activityChan <- fa
+		// The enricher subscriber will receive the unenriched event,
+		// but we simulate the enrichment by directly publishing an enriched event.
+		// First, send the file activity through the pipeline.
+		activityChan <- fa
 
-	// Give the pipeline time to process and buffer the activity.
-	time.Sleep(100 * time.Millisecond)
+		// Wait for all goroutines to settle.
+		synctest.Wait()
 
-	// Verify the activity was buffered.
-	p.activityMutex.Lock()
-	key := cacheKey(testContainerID, testSignalID)
-	entry := p.bufferedActivity[key]
-	require.NotNil(t, entry, "file activity should be buffered")
-	assert.Len(t, entry.activities, 1)
-	p.activityMutex.Unlock()
+		// Verify the activity was buffered.
+		p.activityMutex.Lock()
+		key := cacheKey(testContainerID, testSignalID)
+		entry := p.bufferedActivity[key]
+		require.NotNil(t, entry, "file activity should be buffered")
+		assert.Len(t, entry.activities, 1)
+		p.activityMutex.Unlock()
 
-	// Now simulate the enriched process indicator arriving via pub/sub.
-	enrichedIndicator := &storage.ProcessIndicator{
-		Id:           "enriched-indicator-1",
-		DeploymentId: testDeploymentID,
-		Signal: &storage.ProcessSignal{
-			Id:          testSignalID,
-			ContainerId: testContainerID,
-			Name:        "test-process",
-		},
-	}
+		// Now simulate the enriched process indicator arriving via pub/sub.
+		enrichedIndicator := &storage.ProcessIndicator{
+			Id:           "enriched-indicator-1",
+			DeploymentId: testDeploymentID,
+			Signal: &storage.ProcessSignal{
+				Id:          testSignalID,
+				ContainerId: testContainerID,
+				Name:        "test-process",
+			},
+		}
 
-	// Expect the detector to receive the file access with the enriched indicator.
-	fileAccessReceived := make(chan *storage.FileAccess, 1)
-	mockDetector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, access *storage.FileAccess) {
-			fileAccessReceived <- access
-		},
-	)
+		// Expect the detector to receive the file access with the enriched indicator.
+		mockDetector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, access *storage.FileAccess) {
+				assert.Equal(t, testDeploymentID, access.GetProcess().GetDeploymentId())
+				assert.Equal(t, "/etc/passwd", access.GetFile().GetEffectivePath())
+				assert.Equal(t, storage.FileAccess_OPEN, access.GetOperation())
+			},
+		)
 
-	enrichedEvent := processsignal.NewEnrichedProcessIndicatorEvent(context.Background(), enrichedIndicator)
-	require.NoError(t, dispatcher.Publish(enrichedEvent))
+		enrichedEvent := processsignal.NewEnrichedProcessIndicatorEvent(context.Background(), enrichedIndicator)
+		require.NoError(t, dispatcher.Publish(enrichedEvent))
 
-	select {
-	case access := <-fileAccessReceived:
-		assert.Equal(t, testDeploymentID, access.GetProcess().GetDeploymentId())
-		assert.Equal(t, "/etc/passwd", access.GetFile().GetEffectivePath())
-		assert.Equal(t, storage.FileAccess_OPEN, access.GetOperation())
-	case <-time.After(2 * time.Second):
-		t.Fatal("Timeout waiting for file access to be processed")
-	}
+		synctest.Wait()
 
-	// Verify the buffer was drained.
-	p.activityMutex.Lock()
-	assert.Empty(t, p.bufferedActivity)
-	assert.Equal(t, 0, p.totalBufferedActivity)
-	p.activityMutex.Unlock()
+		// Verify the buffer was drained.
+		p.activityMutex.Lock()
+		assert.Empty(t, p.bufferedActivity)
+		assert.Equal(t, 0, p.totalBufferedActivity)
+		p.activityMutex.Unlock()
+	})
 }
 
 func TestFileSystemPipelinePubSubMultipleActivitiesSameProcess(t *testing.T) {
 	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
 
-	mockCtrl := gomock.NewController(t)
-	mockDetector := mocks.NewMockDetector(mockCtrl)
-	clusterStore := clusterentities.NewStore(0, nil, false)
-	dispatcher := newTestDispatcher(t)
+	synctest.Test(t, func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockDetector := mocks.NewMockDetector(mockCtrl)
+		clusterStore := clusterentities.NewStore(0, nil, false)
+		dispatcher := newTestDispatcher(t)
 
-	activityChan := make(chan *sensorAPI.FileActivity, 10)
-	p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
-	t.Cleanup(func() { p.Stop() })
+		activityChan := make(chan *sensorAPI.FileActivity, 10)
+		p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
+		t.Cleanup(func() { p.Stop() })
 
-	// Send multiple file activities for the same process.
-	paths := []string{"/etc/passwd", "/etc/shadow", "/etc/hosts"}
-	for _, path := range paths {
-		activityChan <- newTestFileActivity(testContainerID, testSignalID, path)
-	}
+		// Send multiple file activities for the same process.
+		paths := []string{"/etc/passwd", "/etc/shadow", "/etc/hosts"}
+		for _, path := range paths {
+			activityChan <- newTestFileActivity(testContainerID, testSignalID, path)
+		}
 
-	time.Sleep(100 * time.Millisecond)
+		synctest.Wait()
 
-	// Verify all activities are buffered under the same key.
-	p.activityMutex.Lock()
-	key := cacheKey(testContainerID, testSignalID)
-	entry := p.bufferedActivity[key]
-	require.NotNil(t, entry)
-	assert.Len(t, entry.activities, 3)
-	p.activityMutex.Unlock()
+		// Verify all activities are buffered under the same key.
+		p.activityMutex.Lock()
+		key := cacheKey(testContainerID, testSignalID)
+		entry := p.bufferedActivity[key]
+		require.NotNil(t, entry)
+		assert.Len(t, entry.activities, 3)
+		p.activityMutex.Unlock()
 
-	// All three should be dispatched when the enriched indicator arrives.
-	var received []*storage.FileAccess
-	done := make(chan struct{})
-	mockDetector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).Times(3).DoAndReturn(
-		func(_ context.Context, access *storage.FileAccess) {
-			received = append(received, access)
-			if len(received) == 3 {
-				close(done)
-			}
-		},
-	)
+		// All three should be dispatched when the enriched indicator arrives.
+		var received []*storage.FileAccess
+		mockDetector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).Times(3).DoAndReturn(
+			func(_ context.Context, access *storage.FileAccess) {
+				received = append(received, access)
+			},
+		)
 
-	enrichedIndicator := &storage.ProcessIndicator{
-		Id:           "enriched-indicator-1",
-		DeploymentId: testDeploymentID,
-		Signal: &storage.ProcessSignal{
-			Id:          testSignalID,
-			ContainerId: testContainerID,
-		},
-	}
-	require.NoError(t, dispatcher.Publish(processsignal.NewEnrichedProcessIndicatorEvent(context.Background(), enrichedIndicator)))
+		enrichedIndicator := &storage.ProcessIndicator{
+			Id:           "enriched-indicator-1",
+			DeploymentId: testDeploymentID,
+			Signal: &storage.ProcessSignal{
+				Id:          testSignalID,
+				ContainerId: testContainerID,
+			},
+		}
+		require.NoError(t, dispatcher.Publish(processsignal.NewEnrichedProcessIndicatorEvent(context.Background(), enrichedIndicator)))
 
-	select {
-	case <-done:
+		synctest.Wait()
+
+		require.Len(t, received, 3)
 		expectedPaths := map[string]bool{"/etc/passwd": true, "/etc/shadow": true, "/etc/hosts": true}
 		for _, access := range received {
 			assert.True(t, expectedPaths[access.GetFile().GetEffectivePath()],
 				"unexpected path: %s", access.GetFile().GetEffectivePath())
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Timeout waiting for all file accesses to be processed")
-	}
+	})
 }
 
 func TestFileSystemPipelineHostProcessBypassesPubSub(t *testing.T) {
 	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
 
-	mockCtrl := gomock.NewController(t)
-	mockDetector := mocks.NewMockDetector(mockCtrl)
-	clusterStore := clusterentities.NewStore(0, nil, false)
-	dispatcher := newTestDispatcher(t)
+	synctest.Test(t, func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockDetector := mocks.NewMockDetector(mockCtrl)
+		clusterStore := clusterentities.NewStore(0, nil, false)
+		dispatcher := newTestDispatcher(t)
 
-	activityChan := make(chan *sensorAPI.FileActivity, 10)
-	p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
-	t.Cleanup(func() { p.Stop() })
+		activityChan := make(chan *sensorAPI.FileActivity, 10)
+		p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
+		t.Cleanup(func() { p.Stop() })
 
-	// Host process (empty container ID) should bypass pub/sub and process directly.
-	fa := newTestFileActivity("", testSignalID, "/etc/passwd")
+		// Host process (empty container ID) should bypass pub/sub and process directly.
+		fa := newTestFileActivity("", testSignalID, "/etc/passwd")
 
-	fileAccessReceived := make(chan struct{})
-	mockDetector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, access *storage.FileAccess) {
-			assert.Equal(t, "/etc/passwd", access.GetFile().GetEffectivePath())
-			close(fileAccessReceived)
-		},
-	)
+		mockDetector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, access *storage.FileAccess) {
+				assert.Equal(t, "/etc/passwd", access.GetFile().GetEffectivePath())
+			},
+		)
 
-	activityChan <- fa
+		activityChan <- fa
 
-	select {
-	case <-fileAccessReceived:
-		// Success — host process was handled directly.
-	case <-time.After(2 * time.Second):
-		t.Fatal("Timeout waiting for host process file access")
-	}
+		synctest.Wait()
 
-	// Nothing should be buffered.
-	p.activityMutex.Lock()
-	assert.Empty(t, p.bufferedActivity)
-	p.activityMutex.Unlock()
+		// Nothing should be buffered.
+		p.activityMutex.Lock()
+		assert.Empty(t, p.bufferedActivity)
+		p.activityMutex.Unlock()
+	})
 }
 
 func TestFileSystemPipelineBufferExpiration(t *testing.T) {
 	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
 
-	mockCtrl := gomock.NewController(t)
-	mockDetector := mocks.NewMockDetector(mockCtrl)
-	clusterStore := clusterentities.NewStore(0, nil, false)
-	dispatcher := newTestDispatcher(t)
+	synctest.Test(t, func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockDetector := mocks.NewMockDetector(mockCtrl)
+		clusterStore := clusterentities.NewStore(0, nil, false)
+		dispatcher := newTestDispatcher(t)
 
-	activityChan := make(chan *sensorAPI.FileActivity, 10)
-	p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
-	t.Cleanup(func() { p.Stop() })
+		activityChan := make(chan *sensorAPI.FileActivity, 10)
+		p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
+		t.Cleanup(func() { p.Stop() })
 
-	// Send a file activity to get it buffered.
-	activityChan <- newTestFileActivity(testContainerID, testSignalID, "/etc/passwd")
-	time.Sleep(100 * time.Millisecond)
+		// Send a file activity to get it buffered.
+		activityChan <- newTestFileActivity(testContainerID, testSignalID, "/etc/passwd")
 
-	// Manually backdate the buffer entry to simulate expiration.
-	p.activityMutex.Lock()
-	key := cacheKey(testContainerID, testSignalID)
-	entry := p.bufferedActivity[key]
-	require.NotNil(t, entry)
-	entry.timestamp = time.Now().Add(-bufferedActivityTTL - time.Second)
-	p.activityMutex.Unlock()
+		synctest.Wait()
 
-	// Trigger pruning manually.
-	p.pruneExpiredBuffers()
+		// Manually backdate the buffer entry to simulate expiration.
+		p.activityMutex.Lock()
+		key := cacheKey(testContainerID, testSignalID)
+		entry := p.bufferedActivity[key]
+		require.NotNil(t, entry)
+		entry.timestamp = time.Now().Add(-bufferedActivityTTL - time.Second)
+		p.activityMutex.Unlock()
 
-	// Verify the buffer was cleaned up.
-	p.activityMutex.Lock()
-	assert.Empty(t, p.bufferedActivity)
-	assert.Equal(t, 0, p.totalBufferedActivity)
-	p.activityMutex.Unlock()
+		// Trigger pruning manually.
+		p.pruneExpiredBuffers()
+
+		// Verify the buffer was cleaned up.
+		p.activityMutex.Lock()
+		assert.Empty(t, p.bufferedActivity)
+		assert.Equal(t, 0, p.totalBufferedActivity)
+		p.activityMutex.Unlock()
+	})
 }
 
 func TestFileSystemPipelineStopWaitsForAllGoroutines(t *testing.T) {
 	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
 
-	mockCtrl := gomock.NewController(t)
-	mockDetector := mocks.NewMockDetector(mockCtrl)
-	clusterStore := clusterentities.NewStore(0, nil, false)
-	dispatcher := newTestDispatcher(t)
+	synctest.Test(t, func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockDetector := mocks.NewMockDetector(mockCtrl)
+		clusterStore := clusterentities.NewStore(0, nil, false)
+		dispatcher := newTestDispatcher(t)
 
-	activityChan := make(chan *sensorAPI.FileActivity, 10)
-	p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
+		activityChan := make(chan *sensorAPI.FileActivity, 10)
+		p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
 
-	// Stop should return without hanging, proving both goroutines exit.
-	done := make(chan struct{})
-	go func() {
-		p.Stop()
-		close(done)
-	}()
+		// Stop should return without hanging, proving both goroutines exit.
+		stopped := false
+		go func() {
+			p.Stop()
+			stopped = true
+		}()
 
-	select {
-	case <-done:
-		// Success.
-	case <-time.After(5 * time.Second):
-		t.Fatal("Stop() did not return in time — goroutine leak suspected")
-	}
+		synctest.Wait()
+		assert.True(t, stopped, "Stop() did not return — goroutine leak suspected")
+	})
 }

--- a/sensor/common/filesystem/pipeline/pipeline_test.go
+++ b/sensor/common/filesystem/pipeline/pipeline_test.go
@@ -9,6 +9,7 @@ import (
 	sensorAPI "github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/testutils/goleak"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/detector/mocks"
@@ -57,18 +58,36 @@ func newTestFileActivity(containerID, signalID, path string) *sensorAPI.FileActi
 	}
 }
 
+type testPipeline struct {
+	*Pipeline
+	detector     *mocks.MockDetector
+	dispatcher   common.PubSubDispatcher
+	activityChan chan *sensorAPI.FileActivity
+}
+
+func newTestPipeline(t *testing.T) *testPipeline {
+	t.Helper()
+	mockCtrl := gomock.NewController(t)
+	mockDetector := mocks.NewMockDetector(mockCtrl)
+	clusterStore := clusterentities.NewStore(0, nil, false)
+	dispatcher := newTestDispatcher(t)
+	activityChan := make(chan *sensorAPI.FileActivity, 10)
+	p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
+	t.Cleanup(func() { p.Stop() })
+	return &testPipeline{
+		Pipeline:     p,
+		detector:     mockDetector,
+		dispatcher:   dispatcher,
+		activityChan: activityChan,
+	}
+}
+
 func TestFileSystemPipelinePubSubBufferingAndDrain(t *testing.T) {
 	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+	defer goleak.AssertNoGoroutineLeaks(t)
 
 	synctest.Test(t, func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		mockDetector := mocks.NewMockDetector(mockCtrl)
-		clusterStore := clusterentities.NewStore(0, nil, false)
-		dispatcher := newTestDispatcher(t)
-
-		activityChan := make(chan *sensorAPI.FileActivity, 10)
-		p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
-		t.Cleanup(func() { p.Stop() })
+		tp := newTestPipeline(t)
 
 		// Send a file activity — in pub/sub mode with no container metadata,
 		// it should be buffered and an unenriched event published.
@@ -77,18 +96,18 @@ func TestFileSystemPipelinePubSubBufferingAndDrain(t *testing.T) {
 		// The enricher subscriber will receive the unenriched event,
 		// but we simulate the enrichment by directly publishing an enriched event.
 		// First, send the file activity through the pipeline.
-		activityChan <- fa
+		tp.activityChan <- fa
 
 		// Wait for all goroutines to settle.
 		synctest.Wait()
 
 		// Verify the activity was buffered.
-		p.activityMutex.Lock()
+		tp.activityMutex.Lock()
 		key := cacheKey(testContainerID, testSignalID)
-		entry := p.bufferedActivity[key]
+		entry := tp.bufferedActivity[key]
 		require.NotNil(t, entry, "file activity should be buffered")
 		assert.Len(t, entry.activities, 1)
-		p.activityMutex.Unlock()
+		tp.activityMutex.Unlock()
 
 		// Now simulate the enriched process indicator arriving via pub/sub.
 		enrichedIndicator := &storage.ProcessIndicator{
@@ -102,7 +121,7 @@ func TestFileSystemPipelinePubSubBufferingAndDrain(t *testing.T) {
 		}
 
 		// Expect the detector to receive the file access with the enriched indicator.
-		mockDetector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).DoAndReturn(
+		tp.detector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ context.Context, access *storage.FileAccess) {
 				assert.Equal(t, testDeploymentID, access.GetProcess().GetDeploymentId())
 				assert.Equal(t, "/etc/passwd", access.GetFile().GetEffectivePath())
@@ -111,50 +130,44 @@ func TestFileSystemPipelinePubSubBufferingAndDrain(t *testing.T) {
 		)
 
 		enrichedEvent := processsignal.NewEnrichedProcessIndicatorEvent(context.Background(), enrichedIndicator)
-		require.NoError(t, dispatcher.Publish(enrichedEvent))
+		require.NoError(t, tp.dispatcher.Publish(enrichedEvent))
 
 		synctest.Wait()
 
 		// Verify the buffer was drained.
-		p.activityMutex.Lock()
-		assert.Empty(t, p.bufferedActivity)
-		assert.Equal(t, 0, p.totalBufferedActivity)
-		p.activityMutex.Unlock()
+		tp.activityMutex.Lock()
+		assert.Empty(t, tp.bufferedActivity)
+		assert.Equal(t, 0, tp.totalBufferedActivity)
+		tp.activityMutex.Unlock()
 	})
 }
 
 func TestFileSystemPipelinePubSubMultipleActivitiesSameProcess(t *testing.T) {
 	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+	defer goleak.AssertNoGoroutineLeaks(t)
 
 	synctest.Test(t, func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		mockDetector := mocks.NewMockDetector(mockCtrl)
-		clusterStore := clusterentities.NewStore(0, nil, false)
-		dispatcher := newTestDispatcher(t)
-
-		activityChan := make(chan *sensorAPI.FileActivity, 10)
-		p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
-		t.Cleanup(func() { p.Stop() })
+		tp := newTestPipeline(t)
 
 		// Send multiple file activities for the same process.
 		paths := []string{"/etc/passwd", "/etc/shadow", "/etc/hosts"}
 		for _, path := range paths {
-			activityChan <- newTestFileActivity(testContainerID, testSignalID, path)
+			tp.activityChan <- newTestFileActivity(testContainerID, testSignalID, path)
 		}
 
 		synctest.Wait()
 
 		// Verify all activities are buffered under the same key.
-		p.activityMutex.Lock()
+		tp.activityMutex.Lock()
 		key := cacheKey(testContainerID, testSignalID)
-		entry := p.bufferedActivity[key]
+		entry := tp.bufferedActivity[key]
 		require.NotNil(t, entry)
 		assert.Len(t, entry.activities, 3)
-		p.activityMutex.Unlock()
+		tp.activityMutex.Unlock()
 
 		// All three should be dispatched when the enriched indicator arrives.
 		var received []*storage.FileAccess
-		mockDetector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).Times(3).DoAndReturn(
+		tp.detector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).Times(3).DoAndReturn(
 			func(_ context.Context, access *storage.FileAccess) {
 				received = append(received, access)
 			},
@@ -168,7 +181,7 @@ func TestFileSystemPipelinePubSubMultipleActivitiesSameProcess(t *testing.T) {
 				ContainerId: testContainerID,
 			},
 		}
-		require.NoError(t, dispatcher.Publish(processsignal.NewEnrichedProcessIndicatorEvent(context.Background(), enrichedIndicator)))
+		require.NoError(t, tp.dispatcher.Publish(processsignal.NewEnrichedProcessIndicatorEvent(context.Background(), enrichedIndicator)))
 
 		synctest.Wait()
 
@@ -183,90 +196,71 @@ func TestFileSystemPipelinePubSubMultipleActivitiesSameProcess(t *testing.T) {
 
 func TestFileSystemPipelineHostProcessBypassesPubSub(t *testing.T) {
 	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+	defer goleak.AssertNoGoroutineLeaks(t)
 
 	synctest.Test(t, func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		mockDetector := mocks.NewMockDetector(mockCtrl)
-		clusterStore := clusterentities.NewStore(0, nil, false)
-		dispatcher := newTestDispatcher(t)
-
-		activityChan := make(chan *sensorAPI.FileActivity, 10)
-		p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
-		t.Cleanup(func() { p.Stop() })
+		tp := newTestPipeline(t)
 
 		// Host process (empty container ID) should bypass pub/sub and process directly.
 		fa := newTestFileActivity("", testSignalID, "/etc/passwd")
 
-		mockDetector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).DoAndReturn(
+		tp.detector.EXPECT().ProcessFileAccess(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ context.Context, access *storage.FileAccess) {
 				assert.Equal(t, "/etc/passwd", access.GetFile().GetEffectivePath())
 			},
 		)
 
-		activityChan <- fa
+		tp.activityChan <- fa
 
 		synctest.Wait()
 
 		// Nothing should be buffered.
-		p.activityMutex.Lock()
-		assert.Empty(t, p.bufferedActivity)
-		p.activityMutex.Unlock()
+		tp.activityMutex.Lock()
+		assert.Empty(t, tp.bufferedActivity)
+		tp.activityMutex.Unlock()
 	})
 }
 
 func TestFileSystemPipelineBufferExpiration(t *testing.T) {
 	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+	defer goleak.AssertNoGoroutineLeaks(t)
 
 	synctest.Test(t, func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		mockDetector := mocks.NewMockDetector(mockCtrl)
-		clusterStore := clusterentities.NewStore(0, nil, false)
-		dispatcher := newTestDispatcher(t)
-
-		activityChan := make(chan *sensorAPI.FileActivity, 10)
-		p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
-		t.Cleanup(func() { p.Stop() })
+		tp := newTestPipeline(t)
 
 		// Send a file activity to get it buffered.
-		activityChan <- newTestFileActivity(testContainerID, testSignalID, "/etc/passwd")
+		tp.activityChan <- newTestFileActivity(testContainerID, testSignalID, "/etc/passwd")
 
 		synctest.Wait()
 
-		// Manually backdate the buffer entry to simulate expiration.
-		p.activityMutex.Lock()
-		key := cacheKey(testContainerID, testSignalID)
-		entry := p.bufferedActivity[key]
-		require.NotNil(t, entry)
-		entry.timestamp = time.Now().Add(-bufferedActivityTTL - time.Second)
-		p.activityMutex.Unlock()
+		tp.activityMutex.Lock()
+		require.NotEmpty(t, tp.bufferedActivity)
+		tp.activityMutex.Unlock()
 
-		// Trigger pruning manually.
-		p.pruneExpiredBuffers()
+		// Advance the fake clock past the TTL and cleanup interval
+		// so the cleanup goroutine prunes the expired entry.
+		time.Sleep(bufferedActivityTTL + bufferCleanupInterval)
+		synctest.Wait()
 
 		// Verify the buffer was cleaned up.
-		p.activityMutex.Lock()
-		assert.Empty(t, p.bufferedActivity)
-		assert.Equal(t, 0, p.totalBufferedActivity)
-		p.activityMutex.Unlock()
+		tp.activityMutex.Lock()
+		assert.Empty(t, tp.bufferedActivity)
+		assert.Equal(t, 0, tp.totalBufferedActivity)
+		tp.activityMutex.Unlock()
 	})
 }
 
 func TestFileSystemPipelineStopWaitsForAllGoroutines(t *testing.T) {
 	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+	defer goleak.AssertNoGoroutineLeaks(t)
 
 	synctest.Test(t, func(t *testing.T) {
-		mockCtrl := gomock.NewController(t)
-		mockDetector := mocks.NewMockDetector(mockCtrl)
-		clusterStore := clusterentities.NewStore(0, nil, false)
-		dispatcher := newTestDispatcher(t)
-
-		activityChan := make(chan *sensorAPI.FileActivity, 10)
-		p := NewFileSystemPipeline(mockDetector, clusterStore, activityChan, dispatcher)
+		tp := newTestPipeline(t)
 
 		// Stop should return without hanging, proving both goroutines exit.
 		stopped := false
 		go func() {
-			p.Stop()
+			tp.Stop()
 			stopped = true
 		}()
 

--- a/sensor/common/metrics/init.go
+++ b/sensor/common/metrics/init.go
@@ -47,5 +47,7 @@ func init() {
 		InformersPendingCurrent,
 		informerSyncDurationMs,
 		informerInitialObjectPopulationDurationSeconds,
+		fileActivityBufferDrops,
+		fileActivityBufferSize,
 	)
 }

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -77,6 +77,20 @@ var (
 		Help:      "Current number of container entries waiting in the process-enrichment LRU cache",
 	})
 
+	fileActivityBufferDrops = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "file_activity_buffer_drops",
+		Help:      "Count of file activities dropped due to buffer limits or expiration",
+	})
+
+	fileActivityBufferSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.SensorSubsystem.String(),
+		Name:      "file_activity_buffer_size",
+		Help:      "Current number of file activities buffered waiting for process enrichment",
+	})
+
 	sensorIndicatorChannelFullCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
@@ -477,6 +491,21 @@ const (
 func SetProcessPipelineMode(mode string) {
 	processPipelineModeGauge.Reset()
 	processPipelineModeGauge.WithLabelValues(mode).Set(1)
+}
+
+// IncrementFileActivityBufferDrops increments the number of file activities dropped.
+func IncrementFileActivityBufferDrops() {
+	fileActivityBufferDrops.Inc()
+}
+
+// IncrementFileActivityBufferDropsBy increments the number of file activities dropped by the given count.
+func IncrementFileActivityBufferDropsBy(count int) {
+	fileActivityBufferDrops.Add(float64(count))
+}
+
+// SetFileActivityBufferSize sets the file activity buffer size.
+func SetFileActivityBufferSize(size int) {
+	fileActivityBufferSize.Set(float64(size))
 }
 
 // IncK8sEventCount increments the number of objects we're receiving from k8s

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -7,8 +7,8 @@ const (
 	DefaultConsumer
 	ResolverConsumer
 	EnrichedProcessConsumer
-	FileActivityEnrichedProcessConsumer
 	UnenrichedProcessConsumer
+	FileActivityEnrichedProcessConsumer
 )
 
 var (

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -7,16 +7,18 @@ const (
 	DefaultConsumer
 	ResolverConsumer
 	EnrichedProcessConsumer
+	FileActivityEnrichedProcessConsumer
 	UnenrichedProcessConsumer
 )
 
 var (
 	consumerToString = map[ConsumerID]string{
-		NoConsumers:               "NoConsumers",
-		DefaultConsumer:           "Default",
-		ResolverConsumer:          "Resolver",
-		EnrichedProcessConsumer:   "EnrichedProcess",
-		UnenrichedProcessConsumer: "UnenrichedProcess",
+		NoConsumers:                         "NoConsumers",
+		DefaultConsumer:                     "Default",
+		ResolverConsumer:                    "Resolver",
+		EnrichedProcessConsumer:             "EnrichedProcess",
+		FileActivityEnrichedProcessConsumer: "FileActivityEnrichedProcess",
+		UnenrichedProcessConsumer:           "UnenrichedProcess",
 	}
 )
 

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -289,7 +289,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 
 	if features.SensitiveFileActivity.Enabled() {
 		activityChan := make(chan *sensorInternal.FileActivity)
-		fileSystemPipeline := filesystemPipeline.NewFileSystemPipeline(policyDetector, storeProvider.Entities(), activityChan)
+		fileSystemPipeline := filesystemPipeline.NewFileSystemPipeline(policyDetector, storeProvider.Entities(), activityChan, internalMessageDispatcher)
 		fileSystemService := filesystemService.NewService(fileSystemPipeline, activityChan)
 		apiServices = append(apiServices, fileSystemService)
 	}


### PR DESCRIPTION
## Description

The file activity pipeline now subscribes to enriched and unenriched process indicator events via the internal pub/sub system, rather than performing its own process enrichment. This allows file activities to be correlated with process indicators that have already been enriched by the process pipeline.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Validated together with the process pipeline, outlined in #18546 
