### PR TITLE
chore(scale): Add online/offline transition cycle to fake workloads

### DIFF
--- a/scale/workloads/high-node-count.yaml
+++ b/scale/workloads/high-node-count.yaml
@@ -1,0 +1,42 @@
+numNamespaces: 5
+matchLabels: true
+
+offlineModeInterval: 10m0s
+
+nodeWorkload:
+  numNodes: 600
+
+serviceWorkload:
+  numClusterIPs: 10
+  numNodePorts: 10
+  numLoadBalancers: 0
+
+deploymentWorkload:
+  - deploymentType: Deployment
+    numDeployments: 2000
+    numLabels: 2
+    randomLabels: false
+    podWorkload:
+      numPods: 4
+      numContainers: 1
+      lifecycleDuration: 4m
+      containerWorkload:
+        numImages: 1
+      processWorkload:
+        processInterval: 0s
+        alertRate: 0
+        activeProcesses: false
+    updateInterval: 5m
+    lifecycleDuration: 8m
+    numLifecycles: 0
+
+networkPolicyWorkload: []
+
+networkWorkload:
+  flowInterval: 0s
+  batchSize: 0
+
+rbacWorkload:
+  numRoles: 5
+  numBindings: 5
+  numServiceAccounts: 5

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -405,23 +405,22 @@ func (s *Sensor) Stop() {
 // DO NOT CALL IT IN PRODUCTION CODE.
 //
 // Only triggers when the sensor is not already in OfflineMode (i.e. Central
-// is reachable). The state transitions are not atomic: the real connection
-// retry loop could interleave between individual changeState calls.
+// is reachable). The lock is held for the entire sequence so the real
+// connection retry loop cannot interleave between transitions.
 func (s *Sensor) TriggerOfflineMode(reason string) {
-	var currentState common.SensorComponentEvent
-	concurrency.WithLock(s.currentStateMtx, func() {
-		currentState = s.currentState
-	})
-	if currentState == common.SensorComponentEventOfflineMode {
-		log.Errorf("Cannot trigger synthetic offline mode: sensor is already offline. Reason: %s", reason)
+	s.currentStateMtx.Lock()
+	defer s.currentStateMtx.Unlock()
+
+	if s.currentState == common.SensorComponentEventOfflineMode {
+		log.Warnf("Skipping synthetic offline mode cycle: sensor is already offline. Reason: %s", reason)
 		return
 	}
 
 	log.Infof("Synthetic offline mode triggered: %s", reason)
-	s.changeState(common.SensorComponentEventOfflineMode)
-	s.changeState(common.SensorComponentEventCentralReachableHTTP)
-	s.changeState(common.SensorComponentEventCentralReachable)
-	s.changeState(common.SensorComponentEventSyncFinished)
+	s.changeStateNoLock(common.SensorComponentEventOfflineMode)
+	s.changeStateNoLock(common.SensorComponentEventCentralReachableHTTP)
+	s.changeStateNoLock(common.SensorComponentEventCentralReachable)
+	s.changeStateNoLock(common.SensorComponentEventSyncFinished)
 }
 
 func (s *Sensor) changeState(state common.SensorComponentEvent) {

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -407,6 +407,12 @@ func (s *Sensor) Stop() {
 // Only triggers when the sensor is not already in OfflineMode (i.e. Central
 // is reachable). The lock is held for the entire sequence so the real
 // connection retry loop cannot interleave between transitions.
+//
+// The state-persistence model mirrors the real reconnect path:
+// OfflineMode and CentralReachableHTTP are persisted to currentState (via
+// changeStateNoLock), while CentralReachable and SyncFinished are delivered
+// as notifications only (via notifyAllComponents) — exactly as
+// communicationWithCentral + notifySyncDone do in production.
 func (s *Sensor) TriggerOfflineMode(reason string) {
 	s.currentStateMtx.Lock()
 	defer s.currentStateMtx.Unlock()
@@ -419,8 +425,7 @@ func (s *Sensor) TriggerOfflineMode(reason string) {
 	log.Infof("Synthetic offline mode triggered: %s", reason)
 	s.changeStateNoLock(common.SensorComponentEventOfflineMode)
 	s.changeStateNoLock(common.SensorComponentEventCentralReachableHTTP)
-	s.changeStateNoLock(common.SensorComponentEventCentralReachable)
-	s.changeStateNoLock(common.SensorComponentEventSyncFinished)
+	s.notifyAllComponents(common.SensorComponentEventCentralReachable, common.SensorComponentEventSyncFinished)
 }
 
 func (s *Sensor) changeState(state common.SensorComponentEvent) {

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -395,6 +395,32 @@ func (s *Sensor) Stop() {
 	log.Info("Sensor shutdown complete")
 }
 
+// TriggerOfflineMode simulates a full offline→online state transition by
+// notifying all components of OfflineMode, CentralReachable, and SyncFinished
+// events. The gRPC stream and Central communication remain unaffected.
+//
+// This method is exclusively for fake workload testing in local-sensor.
+// DO NOT CALL IT IN PRODUCTION CODE.
+//
+// Only triggers when the sensor is not already in OfflineMode (i.e. Central
+// is reachable). The state transitions are not atomic: the real connection
+// retry loop could interleave between individual changeState calls.
+func (s *Sensor) TriggerOfflineMode(reason string) {
+	var currentState common.SensorComponentEvent
+	concurrency.WithLock(s.currentStateMtx, func() {
+		currentState = s.currentState
+	})
+	if currentState == common.SensorComponentEventOfflineMode {
+		log.Errorf("Cannot trigger synthetic offline mode: sensor is already offline. Reason: %s", reason)
+		return
+	}
+
+	log.Infof("Synthetic offline mode triggered: %s", reason)
+	s.changeState(common.SensorComponentEventOfflineMode)
+	s.changeState(common.SensorComponentEventCentralReachable)
+	s.changeState(common.SensorComponentEventSyncFinished)
+}
+
 func (s *Sensor) changeState(state common.SensorComponentEvent) {
 	s.currentStateMtx.Lock()
 	defer s.currentStateMtx.Unlock()

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -396,8 +396,10 @@ func (s *Sensor) Stop() {
 }
 
 // TriggerOfflineMode simulates a full offline→online state transition by
-// notifying all components of OfflineMode, CentralReachable, and SyncFinished
-// events. The gRPC stream and Central communication remain unaffected.
+// notifying all components of OfflineMode, CentralReachableHTTP,
+// CentralReachable, and SyncFinished events — the same sequence as a real
+// Central reconnect. The gRPC stream and Central communication remain
+// unaffected.
 //
 // This method is exclusively for fake workload testing in local-sensor.
 // DO NOT CALL IT IN PRODUCTION CODE.
@@ -417,6 +419,7 @@ func (s *Sensor) TriggerOfflineMode(reason string) {
 
 	log.Infof("Synthetic offline mode triggered: %s", reason)
 	s.changeState(common.SensorComponentEventOfflineMode)
+	s.changeState(common.SensorComponentEventCentralReachableHTTP)
 	s.changeState(common.SensorComponentEventCentralReachable)
 	s.changeState(common.SensorComponentEventSyncFinished)
 }

--- a/sensor/common/sensor/sensor.go
+++ b/sensor/common/sensor/sensor.go
@@ -402,7 +402,11 @@ func (s *Sensor) Stop() {
 // unaffected.
 //
 // This method is exclusively for fake workload testing in local-sensor.
-// DO NOT CALL IT IN PRODUCTION CODE.
+//
+// Deprecated: DO NOT CALL IT IN PRODUCTION CODE. This bypasses the real gRPC
+// reconnect path and will cause inconsistent state if used against a real
+// Central connection (e.g. components observe SyncFinished without an actual
+// sync having occurred).
 //
 // Only triggers when the sensor is not already in OfflineMode (i.e. Central
 // is reachable). The lock is held for the entire sequence so the real
@@ -413,6 +417,13 @@ func (s *Sensor) Stop() {
 // changeStateNoLock), while CentralReachable and SyncFinished are delivered
 // as notifications only (via notifyAllComponents) — exactly as
 // communicationWithCentral + notifySyncDone do in production.
+//
+// Note: after this call s.currentState is CentralReachableHTTP, not
+// SyncFinished. Components still receive the CentralReachable and
+// SyncFinished notifications but the persisted state does not advance
+// beyond CentralReachableHTTP. This matches the real reconnect path where
+// communicationWithCentral sets CentralReachableHTTP and notifySyncDone
+// only broadcasts without persisting state.
 func (s *Sensor) TriggerOfflineMode(reason string) {
 	s.currentStateMtx.Lock()
 	defer s.currentStateMtx.Unlock()
@@ -425,6 +436,12 @@ func (s *Sensor) TriggerOfflineMode(reason string) {
 	log.Infof("Synthetic offline mode triggered: %s", reason)
 	s.changeStateNoLock(common.SensorComponentEventOfflineMode)
 	s.changeStateNoLock(common.SensorComponentEventCentralReachableHTTP)
+	// CentralReachable and SyncFinished are broadcast without persisting to
+	// s.currentState. This means s.currentState remains CentralReachableHTTP.
+	// This is intentional and mirrors the real path (see doc comment above).
+	// If used against a real Central connection, components may act on
+	// SyncFinished despite no real sync having completed — use only with
+	// fake workloads.
 	s.notifyAllComponents(common.SensorComponentEventCentralReachable, common.SensorComponentEventSyncFinished)
 }
 

--- a/sensor/common/sensor/sensor_test.go
+++ b/sensor/common/sensor/sensor_test.go
@@ -1,0 +1,57 @@
+package sensor
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeNotifiable struct {
+	events []common.SensorComponentEvent
+}
+
+func (f *fakeNotifiable) Notify(e common.SensorComponentEvent) {
+	f.events = append(f.events, e)
+}
+
+func TestTriggerOfflineMode(t *testing.T) {
+	tests := map[string]struct {
+		initialState   common.SensorComponentEvent
+		expectedEvents []common.SensorComponentEvent
+		expectedState  common.SensorComponentEvent
+	}{
+		"already offline is a no-op": {
+			initialState:   common.SensorComponentEventOfflineMode,
+			expectedEvents: nil,
+			expectedState:  common.SensorComponentEventOfflineMode,
+		},
+		"emits full reconnect sequence but persists state only up to CentralReachableHTTP": {
+			initialState: common.SensorComponentEventCentralReachable,
+			expectedEvents: []common.SensorComponentEvent{
+				common.SensorComponentEventOfflineMode,
+				common.SensorComponentEventCentralReachableHTTP,
+				common.SensorComponentEventCentralReachable,
+				common.SensorComponentEventSyncFinished,
+			},
+			expectedState: common.SensorComponentEventCentralReachableHTTP,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			notified := &fakeNotifiable{}
+			s := &Sensor{
+				currentStateMtx: &sync.Mutex{},
+				currentState:    tc.initialState,
+				notifyList:      []common.Notifiable{notified},
+			}
+
+			s.TriggerOfflineMode("test")
+
+			assert.Equal(t, tc.expectedEvents, notified.events)
+			assert.Equal(t, tc.expectedState, s.currentState)
+		})
+	}
+}

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -266,6 +266,15 @@ func (w *WorkloadManager) Client() client.Interface {
 	return w.client
 }
 
+// OfflineModeInterval returns how often local-sensor should trigger a synthetic
+// offline→online state transition, or 0 if disabled.
+func (w *WorkloadManager) OfflineModeInterval() time.Duration {
+	if w == nil || w.workload == nil {
+		return 0
+	}
+	return w.workload.OfflineModeInterval
+}
+
 // NewWorkloadManager returns a fake kubernetes client interface that will be managed with the passed Workload
 func NewWorkloadManager(config *WorkloadManagerConfig) *WorkloadManager {
 	data, err := os.ReadFile(config.workloadFile)
@@ -323,6 +332,10 @@ func NewWorkloadManager(config *WorkloadManagerConfig) *WorkloadManager {
 }
 
 func validateWorkload(workload *Workload) error {
+	if workload.OfflineModeInterval < 0 {
+		workload.OfflineModeInterval = 0
+		return errors.New("negative offlineModeInterval, clamped to 0")
+	}
 	if workload.NetworkWorkload.OpenPortReuseProbability < 0.0 || workload.NetworkWorkload.OpenPortReuseProbability > 1.0 {
 		corrected := math.Min(1.0, math.Max(0.0, workload.NetworkWorkload.OpenPortReuseProbability))
 		workload.NetworkWorkload.OpenPortReuseProbability = corrected

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -322,7 +322,7 @@ func NewWorkloadManager(config *WorkloadManagerConfig) *WorkloadManager {
 	mgr.initializePreexistingResources()
 
 	if warn := validateWorkload(&workload); warn != nil {
-		log.Warnf("Validaing workload: %s", warn)
+		log.Warnf("Validating workload: %s", warn)
 	}
 
 	log.Info("Created Workload manager for workload")
@@ -334,7 +334,7 @@ func NewWorkloadManager(config *WorkloadManagerConfig) *WorkloadManager {
 func validateWorkload(workload *Workload) error {
 	if workload.OfflineModeInterval < 0 {
 		workload.OfflineModeInterval = 0
-		return errors.New("negative offlineModeInterval, clamped to 0")
+		log.Warn("negative offlineModeInterval in workload; clamped to 0")
 	}
 	if workload.NetworkWorkload.OpenPortReuseProbability < 0.0 || workload.NetworkWorkload.OpenPortReuseProbability > 1.0 {
 		corrected := math.Min(1.0, math.Max(0.0, workload.NetworkWorkload.OpenPortReuseProbability))

--- a/sensor/kubernetes/fake/fake.go
+++ b/sensor/kubernetes/fake/fake.go
@@ -332,9 +332,13 @@ func NewWorkloadManager(config *WorkloadManagerConfig) *WorkloadManager {
 }
 
 func validateWorkload(workload *Workload) error {
+	const minOfflineModeInterval = 10 * time.Second
 	if workload.OfflineModeInterval < 0 {
 		workload.OfflineModeInterval = 0
 		log.Warn("negative offlineModeInterval in workload; clamped to 0")
+	} else if workload.OfflineModeInterval > 0 && workload.OfflineModeInterval < minOfflineModeInterval {
+		workload.OfflineModeInterval = minOfflineModeInterval
+		log.Warnf("offlineModeInterval too small; clamped to %s", minOfflineModeInterval)
 	}
 	if workload.NetworkWorkload.OpenPortReuseProbability < 0.0 || workload.NetworkWorkload.OpenPortReuseProbability > 1.0 {
 		corrected := math.Min(1.0, math.Max(0.0, workload.NetworkWorkload.OpenPortReuseProbability))

--- a/sensor/kubernetes/fake/workload.go
+++ b/sensor/kubernetes/fake/workload.go
@@ -126,6 +126,7 @@ type Workload struct {
 	ServiceWorkload        ServiceWorkload         `yaml:"serviceWorkload"`
 	SecretWorkload         SecretWorkload          `yaml:"secretWorkload"`
 	VirtualMachineWorkload VirtualMachineWorkload  `yaml:"virtualMachineWorkload"`
+	OfflineModeInterval    time.Duration           `yaml:"offlineModeInterval"`
 	NumNamespaces          int                     `yaml:"numNamespaces"`
 	MatchLabels            bool                    `yaml:"matchLabels"`
 }

--- a/sensor/kubernetes/fake/workload_test.go
+++ b/sensor/kubernetes/fake/workload_test.go
@@ -1,0 +1,75 @@
+package fake
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateWorkload(t *testing.T) {
+	tests := map[string]struct {
+		input       Workload
+		expected    Workload
+		expectError bool
+	}{
+		"valid workload passes unchanged": {
+			input: Workload{
+				OfflineModeInterval: time.Minute,
+				NetworkWorkload:     NetworkWorkload{OpenPortReuseProbability: 0.5},
+			},
+			expected: Workload{
+				OfflineModeInterval: time.Minute,
+				NetworkWorkload:     NetworkWorkload{OpenPortReuseProbability: 0.5},
+			},
+			expectError: false,
+		},
+		"negative offlineModeInterval is clamped to disabled": {
+			input:    Workload{OfflineModeInterval: -5 * time.Second},
+			expected: Workload{OfflineModeInterval: 0},
+		},
+		"offlineModeInterval below minimum is clamped to minimum": {
+			input:    Workload{OfflineModeInterval: time.Second},
+			expected: Workload{OfflineModeInterval: 10 * time.Second},
+		},
+		"offlineModeInterval at minimum is left unchanged": {
+			input:    Workload{OfflineModeInterval: 10 * time.Second},
+			expected: Workload{OfflineModeInterval: 10 * time.Second},
+		},
+		"openPortReuseProbability below 0 is clamped and errors": {
+			input:       Workload{NetworkWorkload: NetworkWorkload{OpenPortReuseProbability: -0.5}},
+			expected:    Workload{NetworkWorkload: NetworkWorkload{OpenPortReuseProbability: 0}},
+			expectError: true,
+		},
+		"openPortReuseProbability above 1 is clamped and errors": {
+			input:       Workload{NetworkWorkload: NetworkWorkload{OpenPortReuseProbability: 1.5}},
+			expected:    Workload{NetworkWorkload: NetworkWorkload{OpenPortReuseProbability: 1}},
+			expectError: true,
+		},
+		"negative numDockerCfgSecrets is clamped and errors": {
+			input:       Workload{SecretWorkload: SecretWorkload{NumDockerCfgSecrets: -3}},
+			expected:    Workload{SecretWorkload: SecretWorkload{NumDockerCfgSecrets: 0}},
+			expectError: true,
+		},
+		"negative numOpaqueSecrets is clamped and errors": {
+			input:       Workload{SecretWorkload: SecretWorkload{NumOpaqueSecrets: -3}},
+			expected:    Workload{SecretWorkload: SecretWorkload{NumOpaqueSecrets: 0}},
+			expectError: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			workload := tc.input
+
+			err := validateWorkload(&workload)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expected, workload)
+		})
+	}
+}

--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -518,6 +518,10 @@ func main() {
 	go s.Start()
 
 	durationExpired := false
+	if workloadManager != nil {
+		startOfflineModeCycle(ctx, workloadManager.OfflineModeInterval(), s)
+	}
+
 	if spyCentral != nil {
 		select {
 		case <-spyCentral.ConnectionStarted.Done():
@@ -648,4 +652,23 @@ func setupCentralWithFakeConnection(localConfig localSensorConfig) (centralclien
 	fakeConnectionFactory := centralDebug.MakeFakeConnectionFactory(conn)
 
 	return fakeConnectionFactory, centralclient.EmptyCertLoader(), spyCentral
+}
+
+func startOfflineModeCycle(ctx context.Context, interval time.Duration, sensor *commonSensor.Sensor) {
+	if interval <= 0 || sensor == nil {
+		return
+	}
+	log.Printf("Offline mode cycle enabled every %s", interval)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				sensor.TriggerOfflineMode("workload offlineModeInterval")
+			}
+		}
+	}()
 }


### PR DESCRIPTION
## Description

Add an `offlineModeInterval` duration field to fake workload profiles and use it in `local-sensor` to trigger a synthetic offline->online transition cycle.

This is a local testing and scale tooling change to help reproduce [ROX-33474] without forcing real network failures.

Key changes:
- add `offlineModeInterval` to fake workload YAML and expose it via `WorkloadManager`
- add `Sensor.TriggerOfflineMode(reason)` to emit the component notifications used during a reconnect
- start the cycle from `tools/local-sensor/main.go` only when a fake workload enables it
- add `scale/workloads/high-node-count.yaml` as an example profile using the new setting

Reviewer context:
- this is a `local-sensor` / fake workload hook only; it does not tear down the gRPC stream or Central communication
- the synthetic transition sequence is not atomic and can interleave with the real retry loop
- the first synthetic cycle fires after the configured interval, not immediately at startup

[ROX-33474]: https://redhat.atlassian.net/browse/ROX-33474

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- ran `local-sensor` with `scale/workloads/high-node-count.yaml` and observed periodic synthetic offline/online transitions in logs