### PR TITLE
ROX-19064: Scanner V4 Automated Tests (Common Test Image + Compliance)

### DIFF
--- a/qa-tests-backend/src/main/groovy/objects/ImageIntegration.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/ImageIntegration.groovy
@@ -2,11 +2,15 @@ package objects
 
 import common.Constants
 import io.stackrox.proto.storage.ImageIntegrationOuterClass
+import services.FeatureFlagService
 import services.ImageIntegrationService
 import util.Env
 
 trait ImageIntegration {
     abstract static ImageIntegrationOuterClass.ImageIntegration.Builder getCustomBuilder(Map customArgs)
+
+    // Returns true for integrations that can be deleted, false otherwise.
+    static boolean isDeletable() { true }
 }
 
 class StackroxScannerIntegration implements ImageIntegration {
@@ -14,7 +18,7 @@ class StackroxScannerIntegration implements ImageIntegration {
     static String name() { Constants.AUTO_REGISTERED_STACKROX_SCANNER_INTEGRATION }
 
     static Boolean isTestable() {
-        return true
+        return !FeatureFlagService.isFeatureFlagEnabled("ROX_SCANNER_V4")
     }
 
     static String createDefaultIntegration() {
@@ -425,6 +429,28 @@ class GoogleArtifactRegistry implements ImageIntegration {
                 .addAllCategories(ImageIntegrationService.getIntegrationCategories(false))
                 .setGoogle(config)
                 .setSkipTestIntegration(args.skipTestIntegration as Boolean)
+    }
+}
+
+class ScannerV4Integration implements ImageIntegration {
+
+    static String name() { "Scanner V4" }
+
+    static Boolean isTestable() {
+        return FeatureFlagService.isFeatureFlagEnabled("ROX_SCANNER_V4")
+    }
+
+    static boolean isDeletable() { false }
+
+    // The Scanner V4 integration is auto-registered and cannot be deleted.
+    // createDefaultIntegration() looks up the existing integration rather than creating one.
+    static String createDefaultIntegration() {
+        ImageIntegrationOuterClass.ImageIntegration existing =
+                ImageIntegrationService.getImageIntegrationByName(name())
+        if (!existing) {
+            return ""
+        }
+        return existing.id
     }
 }
 

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -26,6 +26,7 @@ import objects.K8sServiceAccount
 import objects.Secret
 import services.BaseService
 import services.ClusterService
+import services.FeatureFlagService
 import services.ImageIntegrationService
 import services.MetadataService
 import services.RoleService
@@ -72,6 +73,8 @@ class BaseSpecification extends Specification {
     private static Map<String, List<String>> resourceRecord = [:]
 
     public static String coreImageIntegrationId = null
+
+    public static boolean scannerV4Enabled = false
 
     private static synchronizedGlobalSetup() {
         synchronized(BaseSpecification) {
@@ -127,6 +130,9 @@ class BaseSpecification extends Specification {
                 throw(ex)
             }
         }
+
+        scannerV4Enabled = FeatureFlagService.isFeatureFlagEnabled("ROX_SCANNER_V4")
+        LOG.info "Scanner V4 enabled: ${scannerV4Enabled}"
 
         if (ClusterService.isOpenShift4()) {
             assert Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT,

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -45,9 +45,9 @@ class BaseSpecification extends Specification {
 
     static final Logger LOG = LoggerFactory.getLogger("test." + BaseSpecification.getSimpleName())
 
-    static final String TEST_IMAGE = "quay.io/rhacs-eng/qa-multi-arch:nginx-1.12@$TEST_IMAGE_SHA"
+    static final String TEST_IMAGE = "quay.io/rhacs-eng/qa-multi-arch:nginx-2.0.3@$TEST_IMAGE_SHA"
     static final String TEST_IMAGE_NAME_WITH_SHA = TEST_IMAGE
-    static final String TEST_IMAGE_SHA = "sha256:72daaf46f11cc753c4eab981cbf869919bd1fee3d2170a2adeac12400f494728"
+    static final String TEST_IMAGE_SHA = "sha256:ebecc1ad41054eaef19ef9c84e0d95551dfbdebbf0875fd407aee697e4be3860"
 
     static final String RUN_ID
 

--- a/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ComplianceTest.groovy
@@ -624,6 +624,13 @@ class ComplianceTest extends BaseSpecification {
         ]
 
         given:
+        "skip if Scanner V4 is enabled"
+        // The Scanner V4 integration is auto-registered and cannot be deleted via the API.
+        // The no-scanner compliance state (COMPLIANCE_STATE_FAILURE) is therefore unreachable.
+        Assume.assumeFalse("Skipping: Scanner V4 integration cannot be deleted, no-scanner scenario is not testable",
+                scannerV4Enabled)
+
+        and:
         "remove image integrations"
         def gcrRemoved = ImageIntegrationService.deleteImageIntegration(gcrId)
         ImageIntegrationService.deleteStackRoxScannerIntegrationIfExists()
@@ -1055,12 +1062,12 @@ class ComplianceTest extends BaseSpecification {
         def controls = [
                 new Control(
                         "PCI_DSS_3_2:6_2",
-                        ["Image $TEST_IMAGE has \\d{2}\\d+ fixed CVEs. " +
+                        ["Image $TEST_IMAGE has \\d+ fixed CVEs. " +
                                  "An image upgrade is required."],
                         ComplianceState.COMPLIANCE_STATE_FAILURE),
                 new Control(
                         "HIPAA_164:306_e",
-                        ["Image $TEST_IMAGE has \\d{2}\\d+ fixed CVEs. " +
+                        ["Image $TEST_IMAGE has \\d+ fixed CVEs. " +
                                  "An image upgrade is required."],
                         ComplianceState.COMPLIANCE_STATE_FAILURE),
         ]

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -540,7 +540,7 @@ class Services extends BaseService {
         Timer t = new Timer(retries, interval)
         while (t.IsValid()) {
             def found = ImageService.getImages().find { it.name.endsWith(imageName) }
-            if (found.hasCves() || found.hasFixableCves()) {
+            if (found?.hasCves() || found?.hasFixableCves()) {
                 LOG.info "SR found vulnerabilities for the image ${imageName} within ${t.SecondsSince()}s"
                 return true
             }


### PR DESCRIPTION
## Description

Part of a series of changes that modify groovy tests to work with both `StackRox Scanner` and `Scanner V4`.

Scanner V4 is not enabled yet, this is prep work so that it can be enabled in a future PR.

Updated the shared `TEST_IMAGE` to one that both scanners will report vulnerabilities for (the old image was based on `debian:9` which is not supported by Scanner V4)

The `ComplianceTest` had to be updated to work with the new image and both scanners as a result.

Stacked on top of 

- #19640

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Against StackROX Scanner these changes will be tested by CI as part of this PR

Against Scanner V4 these changes were validated in https://github.com/stackrox/stackrox/pull/19236