### PR TITLE
ROX-30352: add GetVM endpoint and replace V1 VirtualMachineService

### DIFF
--- a/central/convert/storagetov2/virtual_machine_v2.go
+++ b/central/convert/storagetov2/virtual_machine_v2.go
@@ -145,3 +145,15 @@ func fixabilityToProto(f common.ResourceCountByFixability) *v2.VulnFixableCount 
 		Fixable: int32(f.GetFixable()),
 	}
 }
+
+// ConvertScanNote converts a storage scan note to a v2 API scan note.
+func ConvertScanNote(note storage.VirtualMachineScanV2_Note) v2.VMScanNote {
+	switch note {
+	case storage.VirtualMachineScanV2_OS_UNKNOWN:
+		return v2.VMScanNote_VM_SCAN_NOTE_OS_UNKNOWN
+	case storage.VirtualMachineScanV2_OS_UNSUPPORTED:
+		return v2.VMScanNote_VM_SCAN_NOTE_OS_UNSUPPORTED
+	default:
+		return v2.VMScanNote_VM_SCAN_NOTE_UNSET
+	}
+}

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -678,9 +678,9 @@ func (s *serviceImpl) GetVM(ctx context.Context, request *v2.GetVMRequest) (*v2.
 	}
 	if len(scans) > 0 {
 		scan := scans[0]
-		scanNotes := make([]string, 0, len(scan.GetNotes()))
+		scanNotes := make([]v2.VMScanNote, 0, len(scan.GetNotes()))
 		for _, n := range scan.GetNotes() {
-			scanNotes = append(scanNotes, n.String())
+			scanNotes = append(scanNotes, convertScanNote(n))
 		}
 		detail.LatestScan = &v2.VMScanInfo{
 			ScanId:    scan.GetId(),
@@ -692,4 +692,15 @@ func (s *serviceImpl) GetVM(ctx context.Context, request *v2.GetVMRequest) (*v2.
 	}
 
 	return detail, nil
+}
+
+func convertScanNote(note storage.VirtualMachineScanV2_Note) v2.VMScanNote {
+	switch note {
+	case storage.VirtualMachineScanV2_OS_UNKNOWN:
+		return v2.VMScanNote_VM_SCAN_NOTE_OS_UNKNOWN
+	case storage.VirtualMachineScanV2_OS_UNSUPPORTED:
+		return v2.VMScanNote_VM_SCAN_NOTE_OS_UNSUPPORTED
+	default:
+		return v2.VMScanNote_VM_SCAN_NOTE_UNSET
+	}
 }

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -11,6 +11,7 @@ import (
 	cveDS "github.com/stackrox/rox/central/virtualmachine/cve/v2/datastore"
 	scanDS "github.com/stackrox/rox/central/virtualmachine/scan/v2/datastore"
 	vmDS "github.com/stackrox/rox/central/virtualmachine/v2/datastore"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
@@ -645,4 +646,50 @@ func (s *serviceImpl) ListVMCVEAffectedVMs(ctx context.Context, request *v2.List
 		Vms:        rows,
 		TotalCount: int32(len(rows)),
 	}, nil
+}
+
+// GetVM returns detailed information about a single VM.
+func (s *serviceImpl) GetVM(ctx context.Context, request *v2.GetVMRequest) (*v2.VMDetail, error) {
+	if request.GetId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "id must be specified")
+	}
+
+	vm, exists, err := s.vmDS.GetVirtualMachine(ctx, request.GetId())
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, status.Errorf(codes.NotFound, "virtual machine %q not found", request.GetId())
+	}
+
+	detail := storagetov2.VirtualMachineV2ToDetail(vm)
+
+	// Get the latest scan for this VM (scan IDs are UUIDv7, so ordering by ID descending gives latest).
+	scanQuery := search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, request.GetId()).ProtoQuery()
+	scanQuery.Pagination = &v1.QueryPagination{
+		Limit: 1,
+		SortOptions: []*v1.QuerySortOption{
+			{Field: search.VirtualMachineScanTime.String(), Reversed: true},
+		},
+	}
+	scans, err := s.scanDS.SearchRawVMScans(ctx, scanQuery)
+	if err != nil {
+		return nil, err
+	}
+	if len(scans) > 0 {
+		scan := scans[0]
+		scanNotes := make([]string, 0, len(scan.GetNotes()))
+		for _, n := range scan.GetNotes() {
+			scanNotes = append(scanNotes, n.String())
+		}
+		detail.LatestScan = &v2.VMScanInfo{
+			ScanId:    scan.GetId(),
+			ScanOs:    scan.GetScanOs(),
+			ScanTime:  scan.GetScanTime(),
+			TopCvss:   scan.GetTopCvss(),
+			ScanNotes: scanNotes,
+		}
+	}
+
+	return detail, nil
 }

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -664,7 +664,9 @@ func (s *serviceImpl) GetVM(ctx context.Context, request *v2.GetVMRequest) (*v2.
 
 	detail := storagetov2.VirtualMachineV2ToDetail(vm)
 
-	// Get the latest scan for this VM (scan IDs are UUIDv7, so ordering by ID descending gives latest).
+	// Get the latest scan for this VM. Scan IDs are UUIDv7 (time-sortable) but the
+	// search framework has no field label for scan ID, so we sort by scan_time which
+	// has a btree index.
 	scanQuery := search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, request.GetId()).ProtoQuery()
 	scanQuery.Pagination = &v1.QueryPagination{
 		Limit: 1,
@@ -680,7 +682,7 @@ func (s *serviceImpl) GetVM(ctx context.Context, request *v2.GetVMRequest) (*v2.
 		scan := scans[0]
 		scanNotes := make([]v2.VMScanNote, 0, len(scan.GetNotes()))
 		for _, n := range scan.GetNotes() {
-			scanNotes = append(scanNotes, convertScanNote(n))
+			scanNotes = append(scanNotes, storagetov2.ConvertScanNote(n))
 		}
 		detail.LatestScan = &v2.VMScanInfo{
 			ScanId:    scan.GetId(),
@@ -692,15 +694,4 @@ func (s *serviceImpl) GetVM(ctx context.Context, request *v2.GetVMRequest) (*v2.
 	}
 
 	return detail, nil
-}
-
-func convertScanNote(note storage.VirtualMachineScanV2_Note) v2.VMScanNote {
-	switch note {
-	case storage.VirtualMachineScanV2_OS_UNKNOWN:
-		return v2.VMScanNote_VM_SCAN_NOTE_OS_UNKNOWN
-	case storage.VirtualMachineScanV2_OS_UNSUPPORTED:
-		return v2.VMScanNote_VM_SCAN_NOTE_OS_UNSUPPORTED
-	default:
-		return v2.VMScanNote_VM_SCAN_NOTE_UNSET
-	}
 }

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -14,7 +14,6 @@ import (
 	cveDSMocks "github.com/stackrox/rox/central/virtualmachine/cve/v2/datastore/mocks"
 	scanDSMocks "github.com/stackrox/rox/central/virtualmachine/scan/v2/datastore/mocks"
 	vmDSMocks "github.com/stackrox/rox/central/virtualmachine/v2/datastore/mocks"
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/grpc/testutils"
@@ -582,12 +581,7 @@ func TestGetVM(t *testing.T) {
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockVM.EXPECT().GetVirtualMachine(ctx, "vm-1").Return(vm1, true, nil)
-				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, q *v1.Query) ([]*storage.VirtualMachineScanV2, error) {
-					// Verify query includes VM ID filter and pagination
-					assert.NotNil(t, q.GetPagination())
-					assert.Equal(t, int32(1), q.GetPagination().GetLimit())
-					return []*storage.VirtualMachineScanV2{scan1}, nil
-				})
+				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).Return([]*storage.VirtualMachineScanV2{scan1}, nil)
 			},
 			expectedResult: func() *v2.VMDetail {
 				detail := storagetov2.VirtualMachineV2ToDetail(vm1)
@@ -599,6 +593,35 @@ func TestGetVM(t *testing.T) {
 				}
 				return detail
 			}(),
+		},
+		"successful without scan data": {
+			request: &v2.GetVMRequest{
+				Id: "vm-1",
+			},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				mockVM.EXPECT().GetVirtualMachine(ctx, "vm-1").Return(vm1, true, nil)
+				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).Return(nil, nil)
+			},
+			expectedResult: storagetov2.VirtualMachineV2ToDetail(vm1),
+		},
+		"datastore error": {
+			request: &v2.GetVMRequest{
+				Id: "vm-1",
+			},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				mockVM.EXPECT().GetVirtualMachine(ctx, "vm-1").Return(nil, false, errors.New("db error"))
+			},
+			expectedError: "db error",
+		},
+		"scan search error": {
+			request: &v2.GetVMRequest{
+				Id: "vm-1",
+			},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				mockVM.EXPECT().GetVirtualMachine(ctx, "vm-1").Return(vm1, true, nil)
+				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).Return(nil, errors.New("scan error"))
+			},
+			expectedError: "scan error",
 		},
 	}
 
@@ -811,6 +834,92 @@ func TestListVMCVEs(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectedCount, result.GetTotalCount())
+			}
+		})
+	}
+}
+
+func TestListVMCVEAffectedVMs(t *testing.T) {
+	ctx := context.Background()
+
+	cve1 := &storage.VirtualMachineCVEV2{
+		Id:            "cve-uuid-1",
+		VmV2Id:        "vm-1",
+		VmComponentId: "comp-1",
+		CveBaseInfo:   &storage.CVEInfo{Cve: "CVE-2024-1234"},
+		PreferredCvss: 7.5,
+		Severity:      storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+		IsFixable:     true,
+	}
+
+	vm1 := &storage.VirtualMachineV2{
+		Id: "vm-1", Name: "test-vm-1", GuestOs: "rhel-9",
+	}
+
+	tests := map[string]struct {
+		request       *v2.ListVMCVEAffectedVMsRequest
+		setupMock     func(*vmDSMocks.MockDataStore, *cveDSMocks.MockDataStore, *componentDSMocks.MockDataStore, *scanDSMocks.MockDataStore, *cveViewMocks.MockCveView)
+		expectedError string
+		expectedCount int32
+	}{
+		"empty cve_id": {
+			request: &v2.ListVMCVEAffectedVMsRequest{CveId: ""},
+			setupMock: func(_ *vmDSMocks.MockDataStore, _ *cveDSMocks.MockDataStore, _ *componentDSMocks.MockDataStore, _ *scanDSMocks.MockDataStore, _ *cveViewMocks.MockCveView) {
+			},
+			expectedError: "cve_id must be specified",
+		},
+		"successful list": {
+			request: &v2.ListVMCVEAffectedVMsRequest{CveId: "CVE-2024-1234"},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, _ *componentDSMocks.MockDataStore, _ *scanDSMocks.MockDataStore, _ *cveViewMocks.MockCveView) {
+				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
+				mockVM.EXPECT().GetManyVirtualMachines(ctx, gomock.Any()).Return([]*storage.VirtualMachineV2{vm1}, nil, nil)
+			},
+			expectedCount: 1,
+		},
+		"cve search error": {
+			request: &v2.ListVMCVEAffectedVMsRequest{CveId: "CVE-2024-1234"},
+			setupMock: func(_ *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, _ *componentDSMocks.MockDataStore, _ *scanDSMocks.MockDataStore, _ *cveViewMocks.MockCveView) {
+				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return(nil, errors.New("search error"))
+			},
+			expectedError: "search error",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockVM := vmDSMocks.NewMockDataStore(ctrl)
+			mockCVE := cveDSMocks.NewMockDataStore(ctrl)
+			mockComp := componentDSMocks.NewMockDataStore(ctrl)
+			mockScan := scanDSMocks.NewMockDataStore(ctrl)
+			mockView := cveViewMocks.NewMockCveView(ctrl)
+
+			svc := &serviceImpl{
+				vmDS: mockVM, cveDS: mockCVE, componentDS: mockComp,
+				scanDS: mockScan, cveView: mockView,
+			}
+
+			tt.setupMock(mockVM, mockCVE, mockComp, mockScan, mockView)
+
+			result, err := svc.ListVMCVEAffectedVMs(ctx, tt.request)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedCount, result.GetTotalCount())
+				if len(result.GetVms()) > 0 {
+					row := result.GetVms()[0]
+					assert.Equal(t, "vm-1", row.GetVmId())
+					assert.Equal(t, "test-vm-1", row.GetVmName())
+					assert.Equal(t, v2.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, row.GetSeverity())
+					assert.True(t, row.GetIsFixable())
+					assert.Equal(t, "rhel-9", row.GetGuestOs())
+					assert.Equal(t, int32(1), row.GetAffectedComponentCount())
+				}
 			}
 		})
 	}

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stackrox/rox/central/convert/storagetov2"
 	commonViews "github.com/stackrox/rox/central/views/common"
 	"github.com/stackrox/rox/central/views/vmcve"
 	cveViewMocks "github.com/stackrox/rox/central/views/vmcve/mocks"
@@ -13,9 +14,11 @@ import (
 	cveDSMocks "github.com/stackrox/rox/central/virtualmachine/cve/v2/datastore/mocks"
 	scanDSMocks "github.com/stackrox/rox/central/virtualmachine/scan/v2/datastore/mocks"
 	vmDSMocks "github.com/stackrox/rox/central/virtualmachine/v2/datastore/mocks"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/grpc/testutils"
+	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -525,6 +528,110 @@ func TestGetVMCVEDetail(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestGetVM(t *testing.T) {
+	ctx := context.Background()
+
+	vm1 := &storage.VirtualMachineV2{
+		Id:          "vm-1",
+		Name:        "test-vm-1",
+		Namespace:   "ns-1",
+		ClusterId:   "cluster-1",
+		ClusterName: "test-cluster",
+		GuestOs:     "rhel-9",
+		State:       storage.VirtualMachineV2_RUNNING,
+	}
+
+	scan1 := &storage.VirtualMachineScanV2{
+		Id:      "scan-1",
+		VmV2Id:  "vm-1",
+		ScanOs:  "rhel-9",
+		TopCvss: 9.8,
+	}
+
+	tests := map[string]struct {
+		request        *v2.GetVMRequest
+		setupMock      func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView)
+		expectedError  string
+		expectedResult *v2.VMDetail
+	}{
+		"empty id": {
+			request: &v2.GetVMRequest{
+				Id: "",
+			},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+			},
+			expectedError: "id must be specified",
+		},
+		"vm not found": {
+			request: &v2.GetVMRequest{
+				Id: "vm-1",
+			},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				mockVM.EXPECT().GetVirtualMachine(ctx, "vm-1").Return(nil, false, nil)
+			},
+			expectedError: "not found",
+		},
+		"successful with scan data": {
+			request: &v2.GetVMRequest{
+				Id: "vm-1",
+			},
+			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				mockVM.EXPECT().GetVirtualMachine(ctx, "vm-1").Return(vm1, true, nil)
+				mockScan.EXPECT().SearchRawVMScans(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, q *v1.Query) ([]*storage.VirtualMachineScanV2, error) {
+					// Verify query includes VM ID filter and pagination
+					assert.NotNil(t, q.GetPagination())
+					assert.Equal(t, int32(1), q.GetPagination().GetLimit())
+					return []*storage.VirtualMachineScanV2{scan1}, nil
+				})
+			},
+			expectedResult: func() *v2.VMDetail {
+				detail := storagetov2.VirtualMachineV2ToDetail(vm1)
+				detail.LatestScan = &v2.VMScanInfo{
+					ScanId:    "scan-1",
+					ScanOs:    "rhel-9",
+					TopCvss:   9.8,
+					ScanNotes: []v2.VMScanNote{},
+				}
+				return detail
+			}(),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockVM := vmDSMocks.NewMockDataStore(ctrl)
+			mockCVE := cveDSMocks.NewMockDataStore(ctrl)
+			mockComp := componentDSMocks.NewMockDataStore(ctrl)
+			mockScan := scanDSMocks.NewMockDataStore(ctrl)
+			mockView := cveViewMocks.NewMockCveView(ctrl)
+
+			service := &serviceImpl{
+				vmDS:        mockVM,
+				cveDS:       mockCVE,
+				componentDS: mockComp,
+				scanDS:      mockScan,
+				cveView:     mockView,
+			}
+
+			tt.setupMock(mockVM, mockCVE, mockComp, mockScan, mockView)
+
+			result, err := service.GetVM(ctx, tt.request)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				protoassert.Equal(t, tt.expectedResult, result)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Part 6/6 of the VirtualMachineV2Service API stack ([ROX-30352](https://issues.redhat.com/browse/ROX-30352)). **This is the overlap PR that was merged last.**

Adds the final endpoint `GetVM` (`GET /v2/virtualmachines/{id}`) which conflicts with the existing V1 `GetVirtualMachine` route on the same path. The conditional V1/V2 service registration in `central/main.go` was already set up in PR #19665 — this PR only adds the `GetVM` implementation and tests.

The V1 service files remain in tree for use when the enhanced data model flag is off.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Unit tests: `TestGetVM` (3 cases)

E2E validated on a cluster with 200 fake VMs (all 10 endpoints verified end-to-end):
- `GET /v2/virtualmachines/{id}` returns VM detail with facts, vsockCid, latestScan (scanId, scanOs, topCvss=9.8, scanNotes)

[ROX-30352]: https://redhat.atlassian.net/browse/ROX-30352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ