### PR TITLE
ci: split Go unit test job into parallel shards

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,85 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  go:
+  go-unit-tests:
+    name: "Go Unit Tests (${{ matrix.component.name }}, ${{ matrix.gotags }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
+        component:
+          - name: central
+            pkg_include: 'stackrox/rox/central/'
+            pkg_exclude: '^$'
+          - name: pkg
+            pkg_include: 'stackrox/rox/pkg/'
+            pkg_exclude: '^$'
+          - name: sensor
+            pkg_include: 'stackrox/rox/(sensor|compliance)/'
+            pkg_exclude: '^$'
+          - name: other
+            pkg_include: '.'
+            pkg_exclude: 'stackrox/rox/(central|pkg|sensor|compliance)/'
+    runs-on: ubuntu-latest
+    outputs:
+      new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
+    container:
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      volumes:
+        - /usr:/mnt/usr
+        - /opt:/mnt/opt
+    env:
+      UNIT_TEST_PKG_INCLUDE: ${{ matrix.component.pkg_include }}
+      UNIT_TEST_PKG_EXCLUDE: ${{ matrix.component.pkg_exclude }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - uses: ./.github/actions/job-preamble
+      with:
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+        free-disk-space: 30
+
+    - name: Cache Go dependencies
+      uses: ./.github/actions/cache-go-dependencies
+
+    - name: Go Unit Tests (${{ matrix.component.name }})
+      run: ${{ matrix.gotags }} make go-unit-tests
+
+    - uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: go-unit-tests
+
+    - name: Go Log Level Tests
+      if: matrix.component.name == 'pkg'
+      run: ${{ matrix.gotags }} make go-log-level-tests
+
+    - name: Generate junit report
+      if: always()
+      run: make generate-junit-reports
+
+    - name: Publish Test Report
+      uses: test-summary/action@v2
+      if: always()
+      with:
+        paths: 'junit-reports/report.xml'
+
+    - name: Report test failures to Jira
+      if: (!cancelled())
+      id: junit2jira
+      uses: ./.github/actions/junit2jira
+      with:
+        create-jiras: ${{ github.event_name == 'push' }}
+        jira-user: ${{ secrets.JIRA_USER }}
+        jira-token: ${{ secrets.JIRA_TOKEN }}
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+        directory: 'junit-reports'
+
+  go-extra-tests:
+    name: "Go Extra Tests (${{ matrix.gotags }})"
     strategy:
       fail-fast: false
       matrix:
@@ -43,24 +121,6 @@ jobs:
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
-
-    - name: Go Unit Tests
-      run: ${{ matrix.gotags }} make go-unit-tests
-
-    - uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        flags: go-unit-tests
-
-    - name: Generate junit report
-      if: always()
-      run: make generate-junit-reports
-
-    - name: Publish Test Report
-      uses: test-summary/action@v2
-      if: always()
-      with:
-        paths: 'junit-reports/report.xml'
 
     - name: Go Integration Unit Tests
       run: ${{ matrix.gotags }} make integration-unit-tests
@@ -481,7 +541,8 @@ jobs:
     name: Post failure message to Slack
     runs-on: ubuntu-latest
     needs:
-      - go
+      - go-unit-tests
+      - go-extra-tests
       - go-bench
       - go-postgres
       - local-roxctl-tests
@@ -499,7 +560,7 @@ jobs:
     - name: Slack message
       env:
         GITHUB_CONTEXT: ${{ toJSON(github) }}
-        mention_author: ${{ needs.go.outputs.new-jiras || needs.go-postgres.outputs.new-jiras || needs.local-roxctl-tests.outputs.new-jiras || needs.ui.outputs.new-jiras || needs.go.outputs.new-jiras || needs.shell-unit-tests.outputs.new-jiras || needs.sensor-integration-tests.outputs.new-jiras }}
+        mention_author: ${{ needs.go-unit-tests.outputs.new-jiras || needs.go-extra-tests.outputs.new-jiras || needs.go-postgres.outputs.new-jiras || needs.local-roxctl-tests.outputs.new-jiras || needs.ui.outputs.new-jiras || needs.shell-unit-tests.outputs.new-jiras || needs.sensor-integration-tests.outputs.new-jiras }}
       run: |
         source scripts/ci/lib.sh
         slack_workflow_failure

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ SILENT ?= @
 # TODO: [ROX-19070] Update postgres store test generation to work for foreign keys
 UNIT_TEST_IGNORE := "stackrox/rox/sensor/tests|stackrox/rox/operator/tests|stackrox/rox/central/reports/config/store/postgres|stackrox/rox/central/complianceoperator/v2/scanconfigurations/store/postgres|stackrox/rox/central/auth/store/postgres|stackrox/rox/scanner/e2etests"
 
+# UNIT_TEST_PKG_INCLUDE/EXCLUDE allow filtering the package list for parallel CI sharding.
+# UNIT_TEST_PKG_INCLUDE: grep -E pattern to include only matching packages (default: match all)
+# UNIT_TEST_PKG_EXCLUDE: grep -Ev pattern to exclude matching packages (default: match none)
+UNIT_TEST_PKG_INCLUDE ?= .
+UNIT_TEST_PKG_EXCLUDE ?= ^$$
+
 GOBUILD := $(CURDIR)/scripts/go-build.sh
 DOCKERBUILD := $(CURDIR)/scripts/docker-build.sh
 GO_TEST_OUTPUT_PATH=$(CURDIR)/test-output/test.log
@@ -533,9 +539,12 @@ test-prep:
 go-unit-tests: build-prep test-prep
 	set -o pipefail ; \
 	CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test scripts/go-test.sh -timeout 25m -race -cover -coverprofile test-output/coverage.out -v \
-		$(shell git ls-files -- '*_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		$(shell git ls-files -- '*_test.go' | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list| grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE) | grep -E "$(UNIT_TEST_PKG_INCLUDE)" | grep -Ev "$(UNIT_TEST_PKG_EXCLUDE)") \
 		| tee $(GO_TEST_OUTPUT_PATH)
-	# Exercise the logging package for all supported logging levels to make sure that initialization works properly
+
+# Exercise the logging package for all supported logging levels to make sure that initialization works properly.
+.PHONY: go-log-level-tests
+go-log-level-tests:
 	@echo "Run log tests"
 	for encoding in console json; do \
 		for level in debug info warn error fatal panic; do \
@@ -555,12 +564,12 @@ sensor-pipeline-benchmark: build-prep test-prep
 go-postgres-unit-tests: build-prep test-prep
 	set -o pipefail ; \
 	CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test,sql_integration scripts/go-test.sh -timeout 15m  -race -cover -coverprofile test-output/coverage.out -v \
-		$(shell git grep -rl "//go:build sql_integration" central pkg tools | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list -tags sql_integration | grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		$(shell git grep -rl "//go:build sql_integration" central pkg tools | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list -tags sql_integration | grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE) | grep -E "$(UNIT_TEST_PKG_INCLUDE)" | grep -Ev "$(UNIT_TEST_PKG_EXCLUDE)") \
 		| tee $(GO_TEST_OUTPUT_PATH)
 	@# The -p 1 passed to go test is required to ensure that tests of different packages are not run in parallel, so as to avoid conflicts when interacting with the DB.
 	set -o pipefail ; \
 	CGO_ENABLED=1 GOEXPERIMENT=cgocheck2 MUTEX_WATCHDOG_TIMEOUT_SECS=30 GOTAGS=$(GOTAGS),test,sql_integration scripts/go-test.sh -p 1 -race -cover -coverprofile test-output/migrator-coverage.out -v \
-		$(shell git grep -rl "//go:build sql_integration" migrator | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list -tags sql_integration | grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE)) \
+		$(shell git grep -rl "//go:build sql_integration" migrator | sed -e 's@^@./@g' | xargs -n 1 dirname | sort | uniq | xargs go list -tags sql_integration | grep -v '^github.com/stackrox/rox/tests$$' | grep -Ev $(UNIT_TEST_IGNORE) | grep -E "$(UNIT_TEST_PKG_INCLUDE)" | grep -Ev "$(UNIT_TEST_PKG_EXCLUDE)") \
 		| tee -a $(GO_TEST_OUTPUT_PATH)
 
 .PHONY: go-postgres-bench-tests
@@ -595,7 +604,7 @@ ui-component-tests:
 	make -C ui test-component
 
 .PHONY: test
-test: go-unit-tests ui-test shell-unit-tests
+test: go-unit-tests go-log-level-tests ui-test shell-unit-tests
 
 .PHONY: integration-unit-tests
 integration-unit-tests: build-prep test-prep

--- a/Makefile
+++ b/Makefile
@@ -544,7 +544,7 @@ go-unit-tests: build-prep test-prep
 
 # Exercise the logging package for all supported logging levels to make sure that initialization works properly.
 .PHONY: go-log-level-tests
-go-log-level-tests:
+go-log-level-tests: build-prep test-prep
 	@echo "Run log tests"
 	for encoding in console json; do \
 		for level in debug info warn error fatal panic; do \

--- a/sensor/common/sensor/ci_shard_probe_test.go
+++ b/sensor/common/sensor/ci_shard_probe_test.go
@@ -1,0 +1,8 @@
+package sensor
+
+import "testing"
+
+// Temporary test to validate CI shard isolation - will be reverted.
+func TestCIShardIsolationProbe(t *testing.T) {
+	t.Fatal("deliberate failure to prove shard isolation")
+}

--- a/sensor/common/sensor/ci_shard_probe_test.go
+++ b/sensor/common/sensor/ci_shard_probe_test.go
@@ -1,8 +1,0 @@
-package sensor
-
-import "testing"
-
-// Temporary test to validate CI shard isolation - will be reverted.
-func TestCIShardIsolationProbe(t *testing.T) {
-	t.Fatal("deliberate failure to prove shard isolation")
-}


### PR DESCRIPTION
## Description

Split the single `go` unit test CI job into 4 parallel component shards to
reduce wall-clock feedback time. Each shard runs independently.

### Measured impact

**Wall-clock time (first start to last finish):**

| Metric | Baseline (monolithic) | Split (sharded) | Delta |
|--------|----------------------|-----------------|-------|
| Average | 35.2 min | 19.5 min | -45% |
| Range | 32.0 - 39.1 min | 19.5 min | - |

*Baseline: 10 measurements from 5 recent master runs (2 gotags x 5 runs).
Split: first clean run on this PR.*

**Per-shard timings:**

| Shard | Packages | Time |
|-------|----------|------|
| central | 469 | 18.8 - 19.5 min |
| pkg | 244 | 17.8 - 18.7 min |
| sensor + compliance | 90 | 10.8 - 11.0 min |
| other | 137 | 10.9 - 11.4 min |
| extra (integration + operator) | - | 10.5 - 10.6 min |

**Baseline monolithic job step breakdown (one representative run):**
- Go Unit Tests step: 29.3 min
- Go Integration + Operator tests: 3.3 min
- Setup (container, checkout, cache): 3.0 min

**Failure isolation (validated with deliberate test failure):**
- Introduced a failing test in `sensor/common/sensor/`
- Only the sensor shard failed (~11 min); central, pkg, other, and extra shards all passed independently
- Failure was immediately identifiable from the job name (`Go Unit Tests (sensor, ...)`)

### Trade-offs

- Codecov project check may need configuration to handle multiple partial coverage uploads (currently shows as failing).

### Reasons for this change (validated)

1. **Faster feedback (validated):** Wall-clock time drops 45% (35 min to 19.5 min). Developers see results ~15 minutes sooner.
2. **Faster failure identification (validated):** A sensor test failure is surfaced in ~11 min vs ~35 min. The job name immediately tells you which component failed.
3. **Cheaper re-runs (validated):** Re-running a failed sensor shard costs ~11 min vs re-running the full monolithic job at ~35 min. GitHub Actions re-run failed jobs only re-runs the failed matrix combinations.
4. **Narrower blast radius (structural):** A flaky test in one component does not block or delay results from other components.

### What changed

- **Makefile:** Added `UNIT_TEST_PKG_INCLUDE`/`UNIT_TEST_PKG_EXCLUDE` grep filter variables with no-op defaults. Local `make test` behavior is unchanged. Extracted `go-log-level-tests` into its own target (still included in `make test`).
- **Workflow:** Replaced single `go` job with `go-unit-tests` (4-component matrix x 2 gotags = 8 jobs) and `go-extra-tests` (integration + operator tests, 2 jobs). Updated slack notification references.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

1. Verified filter patterns cover all 940 packages exactly: 469 + 244 + 90 + 137 = 940 (no gaps, no overlaps).
2. First clean CI run: all 10 Go test jobs passed.
3. Deliberate failure test: introduced a failing test in `sensor/common/sensor/`, confirmed only the sensor shard failed while all other shards passed.
4. Compared wall-clock times against 5 recent master runs (10 data points).