### PR TITLE
perf(ci): skip go-bench on PRs unless labeled

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -177,6 +177,11 @@ jobs:
         directory: 'junit-reports'
 
   go-bench:
+    # Benchmarks are uncacheable (~20m). Run on master/release pushes
+    # or when a PR has the ci-bench-tests label.
+    if: |
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'ci-bench-tests')
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3


### PR DESCRIPTION
## Description

Skip `go-bench` on pull requests unless the PR has the `ci-bench-tests` label. Benchmarks are uncacheable (~20m) and don't provide signal for typical PR changes.

Follows the existing label pattern: `ci-race-tests`, `ci-release-build`.

## Testing and quality

- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### How I validated my change

CI — go-bench should be run or skipped on this PR (depending on `ci-bench-tests` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)