### PR TITLE
ROX-33123: Bump apollo-ci from 0.5.3 to 0.5.4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image":"quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3",
+	"image":"quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4",
 	"containerEnv":{
 		"CI":"true"
 	},

--- a/.github/workflows/batch-load-test-metrics.yml
+++ b/.github/workflows/batch-load-test-metrics.yml
@@ -12,7 +12,7 @@ jobs:
     if:  ${{ github.repository_owner == 'stackrox' }}
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -176,7 +176,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -218,7 +218,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt

--- a/.github/workflows/check-crd-compatibility.yaml
+++ b/.github/workflows/check-crd-compatibility.yaml
@@ -20,7 +20,7 @@ jobs:
   check-crd-compatibility:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
     outputs:
       released_version: ${{ steps.get_previous_released_version.outputs.released_version }}
     steps:

--- a/.github/workflows/ci-failures-report.yml
+++ b/.github/workflows/ci-failures-report.yml
@@ -15,7 +15,7 @@ jobs:
     if:  ${{ github.repository_owner == 'stackrox' }}
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/fixxxer.yaml
+++ b/.github/workflows/fixxxer.yaml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '/fixxx' }}
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
     steps:
 
     - name: Fetch PR metadata

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -86,7 +86,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).pre_build_scanner_go_binary }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.4
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -148,7 +148,7 @@ jobs:
     needs: pre-build-scanner-go-binary
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.4
     if: contains(github.event.pull_request.labels.*.name, 'scan-go-binaries')
     env:
       ARTIFACT_DIR: junit-reports/
@@ -203,7 +203,7 @@ jobs:
       # race-condition-debug - built with -race
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).build_and_push_scanner }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.4
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -281,7 +281,7 @@ jobs:
       # race-condition-debug
       matrix: ${{ fromJson(needs.define-scanner-job-matrix.outputs.matrix).push_scanner_manifests }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.4
       env:
         QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
         QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -17,7 +17,7 @@ jobs:
   db-integration-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.4
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -198,7 +198,7 @@ jobs:
     - prepare-environment
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.4
       volumes:
       # The updater makes heavy use of /tmp files.
       - /tmp:/tmp
@@ -291,7 +291,7 @@ jobs:
     - prepare-environment
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.4
       volumes:
       # The updater makes heavy use of /tmp files.
       - /tmp:/tmp

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       BUILD_TAG: 0.0.0
       SHORTCOMMIT: "0000000"
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -116,7 +116,7 @@ jobs:
       BUILD_TAG: 0.0.0
       SHORTCOMMIT: "0000000"
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -179,7 +179,7 @@ jobs:
   go-bench:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -229,7 +229,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -266,7 +266,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-0.5.4
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -310,7 +310,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -355,7 +355,7 @@ jobs:
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -390,7 +390,7 @@ jobs:
   openshift-ci-unit-tests:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/BUILD_IMAGE_VERSION
+++ b/BUILD_IMAGE_VERSION
@@ -1,1 +1,1 @@
-stackrox-build-0.5.3
+stackrox-build-0.5.4

--- a/operator/bundle_helpers/requirements.txt
+++ b/operator/bundle_helpers/requirements.txt
@@ -1,4 +1,4 @@
 # PyYAML > 6.0 requires Python > 3.6.
 PyYAML==6.0.1
-# pytest==7.0.1 is the latest available for the quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3 job container's Python.
+# pytest==7.0.1 is the latest available for the quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4 job container's Python.
 pytest==7.0.1

--- a/scale/signatures/deploy.yaml
+++ b/scale/signatures/deploy.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: update-signature
-            image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+            image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4
             imagePullPolicy: IfNotPresent
             command:
             - /bin/bash

--- a/tests/e2e/run-e2e-tests.sh
+++ b/tests/e2e/run-e2e-tests.sh
@@ -148,7 +148,7 @@ if [[ ! -f "/i-am-rox-ci-image" ]]; then
       --platform linux/amd64 \
       --rm -it \
       --entrypoint="$0" \
-      quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3 "$@"
+      quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.4 "$@"
     exit 0
 fi
 


### PR DESCRIPTION
## Description

Updates all apollo-ci container image references from version 0.5.3 to 0.5.4. This includes stackrox-test, scanner-test, stackrox-ui-test, and stackrox-build variants.
Preparation for [ROX-33123](https://redhat.atlassian.net/browse/ROX-33123).



[ROX-33123]: https://redhat.atlassian.net/browse/ROX-33123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ