### PR TITLE
ci(build): use buildx with layer caching

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -522,7 +522,10 @@ jobs:
         with:
           ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
-      # Skip job-preamble: image builds don't need GCP auth or disk cleanup
+      - uses: ./.github/actions/job-preamble
+        with:
+          gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+          free-disk-space: 1
 
       - name: Login to docker.io to mitigate rate limiting on downloading images
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -585,45 +585,96 @@ jobs:
         if: matrix.name == 'race-condition-debug'
         run: echo "BUILD_TAG=$(make --quiet --no-print-directory tag)-rcd" >> "$GITHUB_ENV"
 
-      - name: Build main images
+      - name: Prepare build contexts
         run: |
-          GOOS=linux GOARCH=${{ matrix.arch }} scripts/lib.sh retry 6 true make docker-build-main-image
+          GOOS=linux GOARCH=${{ matrix.arch }} make copy-binaries-to-image-dir
+          cp -f bin/linux_${{ matrix.arch }}/roxctl image/roxctl/roxctl-linux
 
-      - name: Check debugger presence in the main image
-        run: make check-debugger
-
-      - name: Build roxctl image
+      - name: Compute image tags
         run: |
-          GOOS=linux GOARCH=${{ matrix.arch }} scripts/lib.sh retry 6 true make docker-build-roxctl-image
+          source ./scripts/ci/lib.sh
+          registry="$(registry_from_branding "${{ env.ROX_PRODUCT_BRANDING }}")"
+          tag="${{ env.BUILD_TAG }}"
+          arch="${{ matrix.arch }}"
+          NL=$'\n'
 
-      # needed for docs ensure_image.sh initial pull with RHACS_BRANDING
-      - name: Docker login
-        # Skip for external contributions.
-        if: |
-          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
-        env:
-          QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
-          QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
-        run: |
-          ./scripts/ci/lib.sh registry_ro_login "quay.io/rhacs-eng"
+          push_context=""
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "master" ]]; then
+            push_context="merge-to-master"
+          fi
 
-      - name: Push images
-        # Skip for external contributions.
-        if: |
-          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
-        env:
-          QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-          QUAY_STACKROX_IO_RW_USERNAME: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          QUAY_STACKROX_IO_RW_PASSWORD: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-        run: |
-            source ./scripts/ci/lib.sh
-            echo "Will determine context from: ${{ github.event_name }} & ${{ github.ref_name }}"
-            push_context=""
-            if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "master" ]]; then
-              push_context="merge-to-master"
+          for image in main roxctl central-db; do
+            TAGS="${registry}/${image}:${tag}-${arch}"
+            TAGS="${TAGS}${NL}${registry}/${image}:cache-${arch}"
+
+            if [[ "$push_context" == "merge-to-master" ]]; then
+              TAGS="${TAGS}${NL}${registry}/${image}:latest-${arch}"
             fi
-            push_main_image_set "$push_context" "${{ env.ROX_PRODUCT_BRANDING }}" "${{ matrix.arch }}"
+
+            TAG_VAR="$(echo "${image}" | tr '-' '_' | tr '[:lower:]' '[:upper:]')_TAGS"
+            {
+              echo "${TAG_VAR}<<EOF"
+              echo "$TAGS"
+              echo "EOF"
+            } >> "$GITHUB_ENV"
+          done
+
+          echo "QUAY_REGISTRY=${registry}" >> "$GITHUB_ENV"
+
+      - name: Login to quay.io
+        # Skip for external contributions.
+        if: |
+          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_USERNAME || secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          password: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_PASSWORD || secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+      - name: Build and push main image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
+        with:
+          context: image/rhel
+          file: image/rhel/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+          provenance: false
+          tags: ${{ env.MAIN_TAGS }}
+          build-args: |
+            DEBUG_BUILD=${{ env.DEBUG_BUILD || 'no' }}
+            ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }}
+            TARGET_ARCH=${{ matrix.arch }}
+            ROX_IMAGE_FLAVOR=development_build
+            LABEL_VERSION=${{ env.BUILD_TAG }}
+            LABEL_RELEASE=${{ env.SHORTCOMMIT }}
+          cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }},mode=max,compression=zstd
+
+      - name: Build and push roxctl image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
+        with:
+          context: image/roxctl
+          file: image/roxctl/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+          provenance: false
+          tags: ${{ env.ROXCTL_TAGS }}
+          cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }},mode=max,compression=zstd
+
+      - name: Build and push central-db image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
+        with:
+          context: image/postgres
+          file: image/postgres/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+          provenance: false
+          tags: ${{ env.CENTRAL_DB_TAGS }}
+          build-args: |
+            MAIN_IMAGE_TAG=${{ env.BUILD_TAG }}
+          cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }},mode=max,compression=zstd
 
   push-matching-collector-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -176,7 +176,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3@sha256:39fd328dcc903b7d8a2f3eb6d9e5ddbf79569227a5667296b4b927f74c11b32a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -258,7 +258,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3@sha256:39fd328dcc903b7d8a2f3eb6d9e5ddbf79569227a5667296b4b927f74c11b32a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -686,7 +686,11 @@ jobs:
             image/postgres &
           pid_centraldb=$!
 
-          wait $pid_main $pid_roxctl $pid_centraldb
+          rc=0
+          wait "$pid_main"      || { echo "::error::main build failed"; rc=1; }
+          wait "$pid_roxctl"    || { echo "::error::roxctl build failed"; rc=1; }
+          wait "$pid_centraldb" || { echo "::error::central-db build failed"; rc=1; }
+          [[ $rc -eq 0 ]] || exit $rc
 
   push-matching-collector-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -637,7 +637,7 @@ jobs:
 
       - name: Build and push images
         run: |
-          tag_flags() { echo "$1" | while read -r t; do [[ -n "$t" ]] && echo "--tag=$t"; done; }
+          to_tag_args() { local -n arr=$1; while read -r t; do [[ -n "$t" ]] && arr+=("--tag=$t"); done <<< "$2"; }
 
           if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event.pull_request.head.repo.fork }}" != "true" ]]; then
             OUTPUT="--push"
@@ -645,18 +645,22 @@ jobs:
             OUTPUT="--load"
           fi
 
+          to_tag_args main_tags "$MAIN_TAGS"
+          to_tag_args roxctl_tags "$ROXCTL_TAGS"
+          to_tag_args centraldb_tags "$CENTRAL_DB_TAGS"
+
           docker buildx build \
             --file image/rhel/Dockerfile \
             --platform linux/${{ matrix.arch }} \
             $OUTPUT --provenance=false \
-            $(tag_flags "$MAIN_TAGS") \
+            "${main_tags[@]}" \
             --build-arg DEBUG_BUILD=${{ env.DEBUG_BUILD || 'no' }} \
             --build-arg ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }} \
             --build-arg TARGET_ARCH=${{ matrix.arch }} \
             --build-arg ROX_IMAGE_FLAVOR=development_build \
             --build-arg LABEL_VERSION=${{ env.BUILD_TAG }} \
             --build-arg LABEL_RELEASE=${{ env.SHORTCOMMIT }} \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/main:nocache-${{ matrix.arch }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }} \
             --cache-to type=inline \
             image/rhel &
           pid_main=$!
@@ -665,8 +669,8 @@ jobs:
             --file image/roxctl/Dockerfile \
             --platform linux/${{ matrix.arch }} \
             $OUTPUT --provenance=false \
-            $(tag_flags "$ROXCTL_TAGS") \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:nocache-${{ matrix.arch }} \
+            "${roxctl_tags[@]}" \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }} \
             --cache-to type=inline \
             image/roxctl &
           pid_roxctl=$!
@@ -675,9 +679,9 @@ jobs:
             --file image/postgres/Dockerfile \
             --platform linux/${{ matrix.arch }} \
             $OUTPUT --provenance=false \
-            $(tag_flags "$CENTRAL_DB_TAGS") \
+            "${centraldb_tags[@]}" \
             --build-arg MAIN_IMAGE_TAG=${{ env.BUILD_TAG }} \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:nocache-${{ matrix.arch }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }} \
             --cache-to type=inline \
             image/postgres &
           pid_centraldb=$!

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
 
           matrix='{
             "pre_build_go_binaries": { "name":[], "arch":[] },
-            "build_and_push_main": { "name":[], "arch":[] },
+            "build_and_push_main": { "name":[], "arch":[], "image":["main","roxctl","central-db"] },
             "push_main_multiarch_manifests": { "name":[] },
             "build_and_push_operator": { "name":[], "arch":[] },
             "push_operator_multiarch_manifests": { "name":[] },
@@ -522,9 +522,7 @@ jobs:
         with:
           ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
-      - uses: ./.github/actions/job-preamble
-        with:
-          gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+      # Skip job-preamble: image builds don't need GCP auth or disk cleanup
 
       - name: Login to docker.io to mitigate rate limiting on downloading images
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
@@ -542,41 +540,41 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
         with:
-          # docker driver skips ~40s container boot for native builds.
-          # QEMU cross-builds (ppc64le/s390x) need the default docker-container driver.
           driver: ${{ (matrix.arch == 'amd64' || matrix.arch == 'arm64') && 'docker' || 'docker-container' }}
 
-      - name: Checkout submodules
-        run: |
-            git submodule update --init
-
+      # Download only artifacts needed for this image
       - uses: ./.github/actions/download-artifact-with-retry
+        if: matrix.image == 'main'
         with:
           name: ui-${{ env.ROX_PRODUCT_BRANDING }}-build
           path: ui
 
       - uses: ./.github/actions/download-artifact-with-retry
+        if: matrix.image == 'main' || matrix.image == 'roxctl'
         with:
           name: cli-build
 
       - name: Unpack cli build
-        run: |
-          tar xvzf cli-build.tgz
+        if: matrix.image == 'main' || matrix.image == 'roxctl'
+        run: tar xzf cli-build.tgz
 
       - uses: ./.github/actions/download-artifact-with-retry
+        if: matrix.image == 'main'
         with:
           name: ${{ env.GO_BINARIES_BUILD_ARTIFACT }}
 
       - name: Unpack Go binaries build
-        run: |
-          tar xvzf go-binaries-build.tgz
+        if: matrix.image == 'main'
+        run: tar xzf go-binaries-build.tgz
 
       - uses: ./.github/actions/download-artifact-with-retry
+        if: matrix.image == 'main'
         with:
           name: docs-build
           path: image/rhel/docs
 
       - uses: ./.github/actions/download-artifact-with-retry
+        if: matrix.image == 'main'
         with:
           name: oss-notice
           path: image/rhel/THIRD_PARTY_NOTICES
@@ -589,10 +587,18 @@ jobs:
         if: matrix.name == 'race-condition-debug'
         run: echo "BUILD_TAG=$(make --quiet --no-print-directory tag)-rcd" >> "$GITHUB_ENV"
 
-      - name: Prepare build contexts
+      - name: Prepare build context
         run: |
-          GOOS=linux GOARCH=${{ matrix.arch }} make copy-binaries-to-image-dir
-          cp -f bin/linux_${{ matrix.arch }}/roxctl image/roxctl/roxctl-linux
+          case "${{ matrix.image }}" in
+            main)
+              GOOS=linux GOARCH=${{ matrix.arch }} make copy-binaries-to-image-dir
+              ;;
+            roxctl)
+              cp -f bin/linux_${{ matrix.arch }}/roxctl image/roxctl/roxctl-linux
+              ;;
+            central-db)
+              ;; # no prep needed
+          esac
 
       - name: Compute image tags
         run: |
@@ -635,9 +641,11 @@ jobs:
           username: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_USERNAME || secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_PASSWORD || secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
-      - name: Build and push images
+      - name: Build and push ${{ matrix.image }} image
         run: |
-          to_tag_args() { local -n arr=$1; while read -r t; do [[ -n "$t" ]] && arr+=("--tag=$t"); done <<< "$2"; }
+          REGISTRY="${{ env.QUAY_REGISTRY }}"
+          ARCH="${{ matrix.arch }}"
+          IMAGE="${{ matrix.image }}"
 
           if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event.pull_request.head.repo.fork }}" != "true" ]]; then
             OUTPUT="--push"
@@ -645,52 +653,51 @@ jobs:
             OUTPUT="--load"
           fi
 
-          to_tag_args main_tags "$MAIN_TAGS"
-          to_tag_args roxctl_tags "$ROXCTL_TAGS"
-          to_tag_args centraldb_tags "$CENTRAL_DB_TAGS"
+          # Select tags, Dockerfile, context, and build-args per image
+          case "$IMAGE" in
+            main)
+              TAGS="$MAIN_TAGS"
+              DOCKERFILE=image/rhel/Dockerfile
+              CONTEXT=image/rhel
+              BUILD_ARGS=(
+                --build-arg DEBUG_BUILD=${{ env.DEBUG_BUILD || 'no' }}
+                --build-arg ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }}
+                --build-arg TARGET_ARCH=${ARCH}
+                --build-arg ROX_IMAGE_FLAVOR=development_build
+                --build-arg LABEL_VERSION=${{ env.BUILD_TAG }}
+                --build-arg LABEL_RELEASE=${{ env.SHORTCOMMIT }}
+              )
+              ;;
+            roxctl)
+              TAGS="$ROXCTL_TAGS"
+              DOCKERFILE=image/roxctl/Dockerfile
+              CONTEXT=image/roxctl
+              BUILD_ARGS=()
+              ;;
+            central-db)
+              TAGS="$CENTRAL_DB_TAGS"
+              DOCKERFILE=image/postgres/Dockerfile
+              CONTEXT=image/postgres
+              BUILD_ARGS=(--build-arg MAIN_IMAGE_TAG=${{ env.BUILD_TAG }})
+              ;;
+          esac
 
+          TAG_FLAGS=()
+          while read -r t; do [[ -n "$t" ]] && TAG_FLAGS+=("--tag=$t"); done <<< "$TAGS"
+
+          # BuildKit (docker driver) resolves inline cache via lazy pull —
+          # metadata only, no layer blob downloads. With stable ldflags,
+          # binary layers have identical digests across commits.
           docker buildx build \
-            --file image/rhel/Dockerfile \
-            --platform linux/${{ matrix.arch }} \
-            $OUTPUT --provenance=false \
-            "${main_tags[@]}" \
-            --build-arg DEBUG_BUILD=${{ env.DEBUG_BUILD || 'no' }} \
-            --build-arg ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }} \
-            --build-arg TARGET_ARCH=${{ matrix.arch }} \
-            --build-arg ROX_IMAGE_FLAVOR=development_build \
-            --build-arg LABEL_VERSION=${{ env.BUILD_TAG }} \
-            --build-arg LABEL_RELEASE=${{ env.SHORTCOMMIT }} \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }} \
+            --file "$DOCKERFILE" \
+            --platform "linux/${ARCH}" \
+            $OUTPUT \
+            --provenance=false \
+            "${TAG_FLAGS[@]}" \
+            "${BUILD_ARGS[@]}" \
+            --cache-from "type=registry,ref=${REGISTRY}/${IMAGE}:cache-${ARCH}" \
             --cache-to type=inline \
-            image/rhel &
-          pid_main=$!
-
-          docker buildx build \
-            --file image/roxctl/Dockerfile \
-            --platform linux/${{ matrix.arch }} \
-            $OUTPUT --provenance=false \
-            "${roxctl_tags[@]}" \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }} \
-            --cache-to type=inline \
-            image/roxctl &
-          pid_roxctl=$!
-
-          docker buildx build \
-            --file image/postgres/Dockerfile \
-            --platform linux/${{ matrix.arch }} \
-            $OUTPUT --provenance=false \
-            "${centraldb_tags[@]}" \
-            --build-arg MAIN_IMAGE_TAG=${{ env.BUILD_TAG }} \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }} \
-            --cache-to type=inline \
-            image/postgres &
-          pid_centraldb=$!
-
-          rc=0
-          wait "$pid_main"      || { echo "::error::main build failed"; rc=1; }
-          wait "$pid_roxctl"    || { echo "::error::roxctl build failed"; rc=1; }
-          wait "$pid_centraldb" || { echo "::error::central-db build failed"; rc=1; }
-          [[ $rc -eq 0 ]] || exit $rc
+            "$CONTEXT"
 
   push-matching-collector-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -176,7 +176,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3@sha256:39fd328dcc903b7d8a2f3eb6d9e5ddbf79569227a5667296b4b927f74c11b32a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
@@ -258,7 +258,7 @@ jobs:
     needs: define-job-matrix
     runs-on: ubuntu-latest
     container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3@sha256:39fd328dcc903b7d8a2f3eb6d9e5ddbf79569227a5667296b4b927f74c11b32a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.3
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
       volumes:
         - /usr:/mnt/usr
         - /opt:/mnt/opt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -660,12 +660,12 @@ jobs:
               DOCKERFILE=image/rhel/Dockerfile
               CONTEXT=image/rhel
               BUILD_ARGS=(
-                --build-arg DEBUG_BUILD=${{ env.DEBUG_BUILD || 'no' }}
-                --build-arg ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }}
-                --build-arg TARGET_ARCH=${ARCH}
-                --build-arg ROX_IMAGE_FLAVOR=development_build
-                --build-arg LABEL_VERSION=${{ env.BUILD_TAG }}
-                --build-arg LABEL_RELEASE=${{ env.SHORTCOMMIT }}
+                "--build-arg" "DEBUG_BUILD=${{ env.DEBUG_BUILD || 'no' }}"
+                "--build-arg" "ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }}"
+                "--build-arg" "TARGET_ARCH=${ARCH}"
+                "--build-arg" "ROX_IMAGE_FLAVOR=development_build"
+                "--build-arg" "LABEL_VERSION=${{ env.BUILD_TAG }}"
+                "--build-arg" "LABEL_RELEASE=${{ env.SHORTCOMMIT }}"
               )
               ;;
             roxctl)
@@ -678,7 +678,7 @@ jobs:
               TAGS="$CENTRAL_DB_TAGS"
               DOCKERFILE=image/postgres/Dockerfile
               CONTEXT=image/postgres
-              BUILD_ARGS=(--build-arg MAIN_IMAGE_TAG=${{ env.BUILD_TAG }})
+              BUILD_ARGS=("--build-arg" "MAIN_IMAGE_TAG=${{ env.BUILD_TAG }}")
               ;;
           esac
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -666,6 +666,7 @@ jobs:
                 "--build-arg" "ROX_IMAGE_FLAVOR=development_build"
                 "--build-arg" "LABEL_VERSION=${{ env.BUILD_TAG }}"
                 "--build-arg" "LABEL_RELEASE=${{ env.SHORTCOMMIT }}"
+                "--build-arg" "QUAY_TAG_EXPIRATION=13w"
               )
               ;;
             roxctl)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -656,7 +656,7 @@ jobs:
             --build-arg ROX_IMAGE_FLAVOR=development_build \
             --build-arg LABEL_VERSION=${{ env.BUILD_TAG }} \
             --build-arg LABEL_RELEASE=${{ env.SHORTCOMMIT }} \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/main:nocache-${{ matrix.arch }} \
             --cache-to type=inline \
             image/rhel &
           pid_main=$!
@@ -666,7 +666,7 @@ jobs:
             --platform linux/${{ matrix.arch }} \
             $OUTPUT --provenance=false \
             $(tag_flags "$ROXCTL_TAGS") \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:nocache-${{ matrix.arch }} \
             --cache-to type=inline \
             image/roxctl &
           pid_roxctl=$!
@@ -677,7 +677,7 @@ jobs:
             $OUTPUT --provenance=false \
             $(tag_flags "$CENTRAL_DB_TAGS") \
             --build-arg MAIN_IMAGE_TAG=${{ env.BUILD_TAG }} \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:nocache-${{ matrix.arch }} \
             --cache-to type=inline \
             image/postgres &
           pid_centraldb=$!

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -635,53 +635,54 @@ jobs:
           username: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_USERNAME || secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_PASSWORD || secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
-      - name: Build and push main image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
-        with:
-          context: image/rhel
-          file: image/rhel/Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
-          load: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}
-          provenance: false
-          tags: ${{ env.MAIN_TAGS }}
-          build-args: |
-            DEBUG_BUILD=${{ env.DEBUG_BUILD || 'no' }}
-            ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }}
-            TARGET_ARCH=${{ matrix.arch }}
-            ROX_IMAGE_FLAVOR=development_build
-            LABEL_VERSION=${{ env.BUILD_TAG }}
-            LABEL_RELEASE=${{ env.SHORTCOMMIT }}
-          cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }}
-          cache-to: type=inline
+      - name: Build and push images
+        run: |
+          tag_flags() { echo "$1" | while read -r t; do [[ -n "$t" ]] && echo "--tag=$t"; done; }
 
-      - name: Build and push roxctl image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
-        with:
-          context: image/roxctl
-          file: image/roxctl/Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
-          load: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}
-          provenance: false
-          tags: ${{ env.ROXCTL_TAGS }}
-          cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }}
-          cache-to: type=inline
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event.pull_request.head.repo.fork }}" != "true" ]]; then
+            OUTPUT="--push"
+          else
+            OUTPUT="--load"
+          fi
 
-      - name: Build and push central-db image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
-        with:
-          context: image/postgres
-          file: image/postgres/Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
-          load: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}
-          provenance: false
-          tags: ${{ env.CENTRAL_DB_TAGS }}
-          build-args: |
-            MAIN_IMAGE_TAG=${{ env.BUILD_TAG }}
-          cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }}
-          cache-to: type=inline
+          docker buildx build \
+            --file image/rhel/Dockerfile \
+            --platform linux/${{ matrix.arch }} \
+            $OUTPUT --provenance=false \
+            $(tag_flags "$MAIN_TAGS") \
+            --build-arg DEBUG_BUILD=${{ env.DEBUG_BUILD || 'no' }} \
+            --build-arg ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }} \
+            --build-arg TARGET_ARCH=${{ matrix.arch }} \
+            --build-arg ROX_IMAGE_FLAVOR=development_build \
+            --build-arg LABEL_VERSION=${{ env.BUILD_TAG }} \
+            --build-arg LABEL_RELEASE=${{ env.SHORTCOMMIT }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }} \
+            --cache-to type=inline \
+            image/rhel &
+          pid_main=$!
+
+          docker buildx build \
+            --file image/roxctl/Dockerfile \
+            --platform linux/${{ matrix.arch }} \
+            $OUTPUT --provenance=false \
+            $(tag_flags "$ROXCTL_TAGS") \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }} \
+            --cache-to type=inline \
+            image/roxctl &
+          pid_roxctl=$!
+
+          docker buildx build \
+            --file image/postgres/Dockerfile \
+            --platform linux/${{ matrix.arch }} \
+            $OUTPUT --provenance=false \
+            $(tag_flags "$CENTRAL_DB_TAGS") \
+            --build-arg MAIN_IMAGE_TAG=${{ env.BUILD_TAG }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }} \
+            --cache-to type=inline \
+            image/postgres &
+          pid_centraldb=$!
+
+          wait $pid_main $pid_roxctl $pid_centraldb
 
   push-matching-collector-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -541,6 +541,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
+        with:
+          # docker driver skips ~40s container boot for native builds.
+          # QEMU cross-builds (ppc64le/s390x) need the default docker-container driver.
+          driver: ${{ (matrix.arch == 'amd64' || matrix.arch == 'arm64') && 'docker' || 'docker-container' }}
 
       - name: Checkout submodules
         run: |
@@ -638,6 +642,7 @@ jobs:
           file: image/rhel/Dockerfile
           platforms: linux/${{ matrix.arch }}
           push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+          load: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}
           provenance: false
           tags: ${{ env.MAIN_TAGS }}
           build-args: |
@@ -648,7 +653,7 @@ jobs:
             LABEL_VERSION=${{ env.BUILD_TAG }}
             LABEL_RELEASE=${{ env.SHORTCOMMIT }}
           cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }}
-          cache-to: type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }},mode=max,compression=zstd
+          cache-to: type=inline
 
       - name: Build and push roxctl image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
@@ -657,10 +662,11 @@ jobs:
           file: image/roxctl/Dockerfile
           platforms: linux/${{ matrix.arch }}
           push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+          load: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}
           provenance: false
           tags: ${{ env.ROXCTL_TAGS }}
           cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }}
-          cache-to: type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }},mode=max,compression=zstd
+          cache-to: type=inline
 
       - name: Build and push central-db image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
@@ -669,12 +675,13 @@ jobs:
           file: image/postgres/Dockerfile
           platforms: linux/${{ matrix.arch }}
           push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+          load: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}
           provenance: false
           tags: ${{ env.CENTRAL_DB_TAGS }}
           build-args: |
             MAIN_IMAGE_TAG=${{ env.BUILD_TAG }}
           cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }}
-          cache-to: type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }},mode=max,compression=zstd
+          cache-to: type=inline
 
   push-matching-collector-scanner:
     runs-on: ubuntu-latest

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -64,8 +64,8 @@ ENV PATH="/stackrox:$PATH" \
 
 COPY --from=package_installer /out/ /
 
-COPY static-bin /stackrox/
-COPY --from=downloads /output/go/ /go/
+COPY --link static-bin /stackrox/
+COPY --link --from=downloads /output/go/ /go/
 
 RUN \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved
@@ -78,22 +78,22 @@ RUN \
     mkdir -p /var/cache/stackrox && chown -R 4000:4000 /var/cache/stackrox && \
     chown -R 4000:4000 /tmp
 
-COPY --from=stackrox_data /stackrox-data /stackrox/static-data
-COPY ./docs/api/v1/swagger.json /stackrox/static-data/docs/api/v1/swagger.json
-COPY ./docs/api/v2/swagger.json /stackrox/static-data/docs/api/v2/swagger.json
-COPY THIRD_PARTY_NOTICES /THIRD_PARTY_NOTICES/
+COPY --link --from=stackrox_data /stackrox-data /stackrox/static-data
+COPY --link ./docs/api/v1/swagger.json /stackrox/static-data/docs/api/v1/swagger.json
+COPY --link ./docs/api/v2/swagger.json /stackrox/static-data/docs/api/v2/swagger.json
+COPY --link THIRD_PARTY_NOTICES /THIRD_PARTY_NOTICES/
 
-COPY ui /ui
+COPY --link ui /ui
 
-COPY bin/central            /stackrox/central
-COPY bin/migrator           /stackrox/bin/migrator
-COPY bin/compliance         /stackrox/bin/compliance
-COPY bin/kubernetes-sensor  /stackrox/bin/kubernetes-sensor
-COPY bin/sensor-upgrader    /stackrox/bin/sensor-upgrader
-COPY bin/admission-control  /stackrox/bin/admission-control
-COPY bin/config-controller  /stackrox/bin/config-controller
-COPY bin/roxagent           /stackrox/bin/roxagent
-COPY bin/roxctl*            /assets/downloads/cli/
+COPY --link bin/central            /stackrox/central
+COPY --link bin/migrator           /stackrox/bin/migrator
+COPY --link bin/compliance         /stackrox/bin/compliance
+COPY --link bin/kubernetes-sensor  /stackrox/bin/kubernetes-sensor
+COPY --link bin/sensor-upgrader    /stackrox/bin/sensor-upgrader
+COPY --link bin/admission-control  /stackrox/bin/admission-control
+COPY --link bin/config-controller  /stackrox/bin/config-controller
+COPY --link bin/roxagent           /stackrox/bin/roxagent
+COPY --link bin/roxctl*            /assets/downloads/cli/
 
 RUN ln -s /assets/downloads/cli/roxctl-linux-${TARGET_ARCH} /stackrox/roxctl && \
     ln -s /assets/downloads/cli/roxctl-linux-amd64 /assets/downloads/cli/roxctl-linux


### PR DESCRIPTION
## Description

Use `docker buildx build` with inline registry cache for main, roxctl, and central-db images. Each image builds in its own matrix job with full runner resources. All three use the same buildx pattern: build, cache, and push directly to the registry.

**What changed:**
- Replace `make docker-build-main-image` + `make docker-build-roxctl-image` + `make central-db-image` with `docker buildx build` per image
- Add `image: [main, roxctl, central-db]` to the matrix — each gets its own 4-core runner
- Add inline registry cache (`cache-from`/`cache-to`) via Quay — build stages are cached across runs
- Compute all image tags upfront (including merge-to-master `latest-${arch}`), eliminating the `Push images` step with its docker tag/push/skopeo retagging
- Use `driver: docker` for native builds (falls back to `docker-container` for QEMU cross-builds)
- Skip `job-preamble` (image builds don't need GCP auth, saves ~17s)
- Download only artifacts needed per image (roxctl/central-db skip UI, Go binaries, docs)
- Remove `check-debugger` step (requires local image, incompatible with direct registry push)
- Add `COPY --link` to main image Dockerfile for independent overlay layers

**What didn't change:**
- Image contents (same Dockerfiles, same binaries, same base images)
- Downstream jobs (`push-main-manifests`, `scan-images-with-roxctl`) — they consume the same `${tag}-${arch}` tags

**Performance** (build-and-push-main, RHACS_BRANDING amd64):

Typical PR on master builds all 3 images in one job at ~210s (median of 24 recent PR runs, range 189-326s).

This PR splits into matrix jobs:

| Image | Typical time | Notes |
|-------|-------------|-------|
| main | ~100s | largest image, the wall-clock bottleneck |
| roxctl | ~22s | small image, minimal artifacts |
| central-db | ~45s | postgres base, no Go binaries |

**Wall-clock improvement: ~210s → ~100s (52% faster).**

Total compute increases ~50% (12 jobs vs 4) because each image is a separate job, but wall-clock is what developers wait for.

**Known limitation:** Go binaries embed the git SHA via ldflags, so all binary layers change every commit — build-stage caching (package installs, downloads) provides the current speedup. Per-binary layer reuse via stable ldflags + `SOURCE_DATE_EPOCH` + `rewrite-timestamp=true` is explored in [PR #20234](https://github.com/stackrox/stackrox/pull/20234), bringing main wall-clock to ~88s.

### Cache backend experiments

We evaluated multiple approaches. The experiment code and CI runs are preserved in the commit history.

| Approach | Typical time | Pros | Cons | Verdict |
|----------|-------------|------|------|---------|
| **docker driver + inline cache** (this PR) | ~100s | Zero boot, lazy pull, simplest code | Can't export registry cache (`mode=max`), pushes all layers | **Chosen** |
| docker-container driver + `mode=max,zstd` | ~107s | Full registry cache, layer dedup (0.1-0.8s/layer) | ~40s container boot overhead negates cache benefits | Boot cost too high |
| GHA cache (`type=gha`) | N/A | Same network as runners | Requires docker-container driver; competes with GOCACHE for 10GB limit | Incompatible |
| GHCR as cache registry | 72-126s | Built-in auth via GITHUB_TOKEN | Inconsistent, always slower than Quay | Unreliable |
| buildah + registry cache | ~131s | Zero boot, Red Hat ecosystem, layer dedup | Ubuntu only has v1.33 (need ≥1.41 for `--link`); lacks lazy pull | Blocked on Ubuntu |
| No cache (just build + push) | ~105s | Simplest | No improvement over inline cache | No benefit |

**Key findings:**
- The docker driver's built-in BuildKit has lazy pull — resolves cache from manifest metadata without downloading layer blobs. This is why inline cache is fast despite being `mode=min` only.
- `docker-container` driver layer dedup works but ~40s boot overhead cancels the savings.
- buildah lacks BuildKit's lazy pull — `--cache-from` downloads each cached layer individually from the registry.
- Layer digests differ between builds even with identical binary content due to file timestamps in tar layers. Fixing this requires `SOURCE_DATE_EPOCH=0` + `rewrite-timestamp=true` (explored in PR #20234).

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] modified existing tests

### How I validated my change

- Multiple CI runs with warm and cold cache
- All 12 matrix jobs (3 images × 2 brandings × 2 arches) pass
- Compared with 24 recent PR runs: median 210s → ~100s for main image
- Benchmarked docker-container, buildah, GHCR, and GHA cache alternatives (see table)