### PR TITLE
ROX-33402: Change permission from modify to view for view based reports

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -980,7 +980,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 	// Append report custom routes
 	customRoutes = append(customRoutes, routes.CustomRoute{
 		Route:         "/api/reports/jobs/download",
-		Authorizer:    user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Image)),
+		Authorizer:    user.With(permissions.View(resources.WorkflowAdministration), permissions.View(resources.Image)),
 		ServerHandler: v2Service.NewDownloadHandler(),
 		Compression:   true,
 	})

--- a/central/main.go
+++ b/central/main.go
@@ -980,7 +980,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 	// Append report custom routes
 	customRoutes = append(customRoutes, routes.CustomRoute{
 		Route:         "/api/reports/jobs/download",
-		Authorizer:    user.With(permissions.View(resources.WorkflowAdministration), permissions.View(resources.Image)),
+		Authorizer:    user.With(permissions.View(resources.Image), permissions.View(resources.Deployment)),
 		ServerHandler: v2Service.NewDownloadHandler(),
 		Compression:   true,
 	})

--- a/central/main.go
+++ b/central/main.go
@@ -980,7 +980,7 @@ func customRoutes() (customRoutes []routes.CustomRoute) {
 	// Append report custom routes
 	customRoutes = append(customRoutes, routes.CustomRoute{
 		Route:         "/api/reports/jobs/download",
-		Authorizer:    user.With(permissions.View(resources.Image), permissions.View(resources.Deployment)),
+		Authorizer:    user.With(permissions.View(resources.Image)),
 		ServerHandler: v2Service.NewDownloadHandler(),
 		Compression:   true,
 	})

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -608,7 +608,14 @@ func (s *scheduler) validateAndPersistSnapshot(ctx context.Context, snapshot *st
 			}
 		}
 
-		snapshot.ReportId, err = s.reportSnapshotStore.AddReportSnapshot(ctx, snapshot)
+		// View-based reports are authorized at the gRPC layer with only Image+Deployment
+		// view permissions (no WorkflowAdministration write required). The snapshot datastore
+		// requires WorkflowAdministration write, so we elevate to a privileged context here.
+		persistCtx := ctx
+		if snapshot.GetViewBasedVulnReportFilters() != nil {
+			persistCtx = sac.WithAllAccess(ctx)
+		}
+		snapshot.ReportId, err = s.reportSnapshotStore.AddReportSnapshot(persistCtx, snapshot)
 	} else {
 		err = s.reportSnapshotStore.UpdateReportSnapshot(ctx, snapshot)
 	}

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -59,12 +59,12 @@ var (
 			apiV2.ReportService_GetMyReportHistory_FullMethodName,
 			apiV2.ReportService_GetViewBasedReportHistory_FullMethodName,
 			apiV2.ReportService_GetViewBasedMyReportHistory_FullMethodName,
+			apiV2.ReportService_PostViewBasedReport_FullMethodName,
 		},
 		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Image)): {
 			apiV2.ReportService_RunReport_FullMethodName,
 			apiV2.ReportService_CancelReport_FullMethodName,
 			apiV2.ReportService_DeleteReport_FullMethodName,
-			apiV2.ReportService_PostViewBasedReport_FullMethodName,
 		},
 	})
 )

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -64,7 +64,8 @@ var (
 			apiV2.ReportService_PostViewBasedReport_FullMethodName,
 			apiV2.ReportService_CancelReport_FullMethodName,
 		},
-		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Image), permissions.View(resources.Deployment)): {
+		// view permissions are enough if user is deleting a job created by the user
+		user.With(permissions.View(resources.Image), permissions.View(resources.Deployment)): {
 			apiV2.ReportService_RunReport_FullMethodName,
 			apiV2.ReportService_DeleteReport_FullMethodName,
 		},

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -41,29 +41,31 @@ var (
 
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 		// V2 API authorization
-		user.With(permissions.View(resources.WorkflowAdministration), permissions.View(resources.Image)): {
+		user.With(permissions.View(resources.WorkflowAdministration), permissions.View(resources.Image), permissions.View(resources.Deployment)): {
 			apiV2.ReportService_ListReportConfigurations_FullMethodName,
 			apiV2.ReportService_GetReportConfiguration_FullMethodName,
 			apiV2.ReportService_CountReportConfigurations_FullMethodName,
 		},
-		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Integration), permissions.View(resources.Image)): {
+		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Integration), permissions.View(resources.Image), permissions.View(resources.Deployment)): {
 			apiV2.ReportService_PostReportConfiguration_FullMethodName,
 			apiV2.ReportService_UpdateReportConfiguration_FullMethodName,
 		},
-		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Image)): {
+		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Image), permissions.View(resources.Deployment)): {
 			apiV2.ReportService_DeleteReportConfiguration_FullMethodName,
 		},
-		user.With(permissions.View(resources.WorkflowAdministration), permissions.View(resources.Image)): {
+		user.With(permissions.View(resources.WorkflowAdministration), permissions.View(resources.Image), permissions.View(resources.Deployment)): {
 			apiV2.ReportService_GetReportStatus_FullMethodName,
 			apiV2.ReportService_GetReportHistory_FullMethodName,
 			apiV2.ReportService_GetMyReportHistory_FullMethodName,
+		},
+		user.With(permissions.View(resources.Image), permissions.View(resources.Deployment)): {
 			apiV2.ReportService_GetViewBasedReportHistory_FullMethodName,
 			apiV2.ReportService_GetViewBasedMyReportHistory_FullMethodName,
 			apiV2.ReportService_PostViewBasedReport_FullMethodName,
-		},
-		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Image)): {
-			apiV2.ReportService_RunReport_FullMethodName,
 			apiV2.ReportService_CancelReport_FullMethodName,
+		},
+		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Image), permissions.View(resources.Deployment)): {
+			apiV2.ReportService_RunReport_FullMethodName,
 			apiV2.ReportService_DeleteReport_FullMethodName,
 		},
 	})
@@ -465,11 +467,6 @@ func (s *serviceImpl) PostViewBasedReport(ctx context.Context, req *apiV2.Report
 	// Check if view-based reports feature is enabled
 	if !features.VulnerabilityViewBasedReports.Enabled() {
 		return nil, errors.Wrap(errox.NotImplemented, "View-based vulnerability reports are not enabled. Please enable the ROX_VULNERABILITY_VIEW_BASED_REPORTS feature flag.")
-	}
-
-	// Authorisation: must have write access on workflow administration.
-	if err := sac.VerifyAuthzOK(workflowSAC.WriteAllowed(ctx)); err != nil {
-		return nil, err
 	}
 
 	if req == nil {

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -52,6 +52,7 @@ var (
 		},
 		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Image), permissions.View(resources.Deployment)): {
 			apiV2.ReportService_DeleteReportConfiguration_FullMethodName,
+			apiV2.ReportService_RunReport_FullMethodName,
 		},
 		user.With(permissions.View(resources.WorkflowAdministration), permissions.View(resources.Image), permissions.View(resources.Deployment)): {
 			apiV2.ReportService_GetReportStatus_FullMethodName,
@@ -66,7 +67,6 @@ var (
 		},
 		// view permissions are enough if user is deleting a job created by the user
 		user.With(permissions.View(resources.Image), permissions.View(resources.Deployment)): {
-			apiV2.ReportService_RunReport_FullMethodName,
 			apiV2.ReportService_DeleteReport_FullMethodName,
 		},
 	})

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -514,8 +514,15 @@ func (s *serviceImpl) GetViewBasedReportHistory(ctx context.Context, req *apiV2.
 	paginated.FillPaginationV2(conjunctionQuery, req.GetReportParamQuery().GetPagination(), maxPaginationLimit)
 
 	// View-based history endpoints are authorized with only Image+Deployment view.
-	// The snapshot datastore requires WorkflowAdministration read, so elevate here.
-	results, err := s.snapshotDatastore.SearchReportSnapshots(sac.WithAllAccess(ctx), conjunctionQuery)
+	// The snapshot datastore requires WorkflowAdministration read, so elevate the
+	// context to that single read scope instead of granting unrestricted access.
+	snapshotReadCtx := sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.WorkflowAdministration),
+		),
+	)
+	results, err := s.snapshotDatastore.SearchReportSnapshots(snapshotReadCtx, conjunctionQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -562,9 +569,16 @@ func (s *serviceImpl) GetViewBasedMyReportHistory(ctx context.Context, req *apiV
 	paginated.FillPaginationV2(conjunctionQuery, req.GetReportParamQuery().GetPagination(), maxPaginationLimit)
 
 	// View-based history endpoints are authorized with only Image+Deployment view.
-	// The snapshot datastore requires WorkflowAdministration read, so elevate here.
-	// Results are already scoped to the requesting user via the UserID query filter above.
-	results, err := s.snapshotDatastore.SearchReportSnapshots(sac.WithAllAccess(ctx), conjunctionQuery)
+	// The snapshot datastore requires WorkflowAdministration read, so elevate the
+	// context to that single read scope. Results are already scoped to the requesting
+	// user via the UserID query filter above.
+	snapshotReadCtx := sac.WithGlobalAccessScopeChecker(ctx,
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+			sac.ResourceScopeKeys(resources.WorkflowAdministration),
+		),
+	)
+	results, err := s.snapshotDatastore.SearchReportSnapshots(snapshotReadCtx, conjunctionQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -41,20 +41,21 @@ var (
 
 	authorizer = perrpc.FromMap(map[authz.Authorizer][]string{
 		// V2 API authorization
-		user.With(permissions.View(resources.WorkflowAdministration), permissions.View(resources.Image), permissions.View(resources.Deployment)): {
+		// TO DO ROX-35954: add view deployment permission to report config APIs
+		user.With(permissions.View(resources.WorkflowAdministration), permissions.View(resources.Image)): {
 			apiV2.ReportService_ListReportConfigurations_FullMethodName,
 			apiV2.ReportService_GetReportConfiguration_FullMethodName,
 			apiV2.ReportService_CountReportConfigurations_FullMethodName,
 		},
-		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Integration), permissions.View(resources.Image), permissions.View(resources.Deployment)): {
+		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Integration), permissions.View(resources.Image)): {
 			apiV2.ReportService_PostReportConfiguration_FullMethodName,
 			apiV2.ReportService_UpdateReportConfiguration_FullMethodName,
 		},
-		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Image), permissions.View(resources.Deployment)): {
+		user.With(permissions.Modify(resources.WorkflowAdministration), permissions.View(resources.Image)): {
 			apiV2.ReportService_DeleteReportConfiguration_FullMethodName,
 			apiV2.ReportService_RunReport_FullMethodName,
 		},
-		user.With(permissions.View(resources.WorkflowAdministration), permissions.View(resources.Image), permissions.View(resources.Deployment)): {
+		user.With(permissions.View(resources.WorkflowAdministration), permissions.View(resources.Image)): {
 			apiV2.ReportService_GetReportStatus_FullMethodName,
 			apiV2.ReportService_GetReportHistory_FullMethodName,
 			apiV2.ReportService_GetMyReportHistory_FullMethodName,
@@ -63,11 +64,12 @@ var (
 			apiV2.ReportService_GetViewBasedReportHistory_FullMethodName,
 			apiV2.ReportService_GetViewBasedMyReportHistory_FullMethodName,
 			apiV2.ReportService_PostViewBasedReport_FullMethodName,
-			apiV2.ReportService_CancelReport_FullMethodName,
 		},
 		// view permissions are enough if user is deleting a job created by the user
-		user.With(permissions.View(resources.Image), permissions.View(resources.Deployment)): {
+		// TO DO ROX-35954: add view deployment permission
+		user.With(permissions.View(resources.Image)): {
 			apiV2.ReportService_DeleteReport_FullMethodName,
+			apiV2.ReportService_CancelReport_FullMethodName,
 		},
 	})
 )
@@ -388,9 +390,6 @@ func (s *serviceImpl) RunReport(ctx context.Context, req *apiV2.RunReportRequest
 }
 
 func (s *serviceImpl) CancelReport(ctx context.Context, req *apiV2.ResourceByID) (*apiV2.Empty, error) {
-	if err := sac.VerifyAuthzOK(workflowSAC.WriteAllowed(ctx)); err != nil {
-		return nil, err
-	}
 	if req.GetId() == "" {
 		return nil, errors.Wrap(errox.InvalidArgs, "Report job ID is empty")
 	}
@@ -514,7 +513,9 @@ func (s *serviceImpl) GetViewBasedReportHistory(ctx context.Context, req *apiV2.
 	// Fill in pagination.
 	paginated.FillPaginationV2(conjunctionQuery, req.GetReportParamQuery().GetPagination(), maxPaginationLimit)
 
-	results, err := s.snapshotDatastore.SearchReportSnapshots(ctx, conjunctionQuery)
+	// View-based history endpoints are authorized with only Image+Deployment view.
+	// The snapshot datastore requires WorkflowAdministration read, so elevate here.
+	results, err := s.snapshotDatastore.SearchReportSnapshots(sac.WithAllAccess(ctx), conjunctionQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +561,10 @@ func (s *serviceImpl) GetViewBasedMyReportHistory(ctx context.Context, req *apiV
 	// Fill in pagination.
 	paginated.FillPaginationV2(conjunctionQuery, req.GetReportParamQuery().GetPagination(), maxPaginationLimit)
 
-	results, err := s.snapshotDatastore.SearchReportSnapshots(ctx, conjunctionQuery)
+	// View-based history endpoints are authorized with only Image+Deployment view.
+	// The snapshot datastore requires WorkflowAdministration read, so elevate here.
+	// Results are already scoped to the requesting user via the UserID query filter above.
+	results, err := s.snapshotDatastore.SearchReportSnapshots(sac.WithAllAccess(ctx), conjunctionQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -845,6 +845,106 @@ func (s *ReportServiceTestSuite) TestAuthz() {
 	testutils.AssertAuthzWorks(s.T(), &svc)
 }
 
+// TestAuthzPermissions verifies that each reporting API method enforces the correct permissions.
+// View-based report methods require only View Image + View Deployment (matching the CVE Results
+// page) while collection-based report management requires WorkflowAdministration.
+func (s *ReportServiceTestSuite) TestAuthzPermissions() {
+	svc := &serviceImpl{}
+
+	ctxWithPerms := func(perms map[string]storage.Access) context.Context {
+		mockID := mockIdentity.NewMockIdentity(s.mockCtrl)
+		mockID.EXPECT().Permissions().Return(perms).AnyTimes()
+		return authn.ContextWithIdentity(context.Background(), mockID, s.T())
+	}
+
+	// viewImageDeployment is the minimum permission set for view-based report APIs —
+	// the same permissions required to view CVE results in the UI.
+	viewImageDeployment := map[string]storage.Access{
+		"Image":      storage.Access_READ_ACCESS,
+		"Deployment": storage.Access_READ_ACCESS,
+	}
+	// modifyWorkflow is required for collection-based report lifecycle operations.
+	modifyWorkflow := map[string]storage.Access{
+		"WorkflowAdministration": storage.Access_READ_WRITE_ACCESS,
+		"Image":                  storage.Access_READ_ACCESS,
+		"Deployment":             storage.Access_READ_ACCESS,
+	}
+	// viewWorkflow is required for read-only collection-based report APIs.
+	viewWorkflow := map[string]storage.Access{
+		"WorkflowAdministration": storage.Access_READ_ACCESS,
+		"Image":                  storage.Access_READ_ACCESS,
+		"Deployment":             storage.Access_READ_ACCESS,
+	}
+	// viewImageOnly is insufficient for any report API since Deployment access is missing.
+	viewImageOnly := map[string]storage.Access{
+		"Image": storage.Access_READ_ACCESS,
+	}
+
+	testCases := map[string]struct {
+		method       string
+		allowedPerms map[string]storage.Access
+		deniedPerms  map[string]storage.Access
+	}{
+		// View-based report APIs require only View Image + View Deployment; no WorkflowAdministration needed.
+		"PostViewBasedReport allowed with View Image+Deployment, denied without Deployment": {
+			method:       apiV2.ReportService_PostViewBasedReport_FullMethodName,
+			allowedPerms: viewImageDeployment,
+			deniedPerms:  viewImageOnly,
+		},
+		"GetViewBasedReportHistory allowed with View Image+Deployment, denied without Deployment": {
+			method:       apiV2.ReportService_GetViewBasedReportHistory_FullMethodName,
+			allowedPerms: viewImageDeployment,
+			deniedPerms:  viewImageOnly,
+		},
+		"GetViewBasedMyReportHistory allowed with View Image+Deployment, denied without Deployment": {
+			method:       apiV2.ReportService_GetViewBasedMyReportHistory_FullMethodName,
+			allowedPerms: viewImageDeployment,
+			deniedPerms:  viewImageOnly,
+		},
+		"CancelReport allowed with View Image+Deployment, denied without Deployment": {
+			method:       apiV2.ReportService_CancelReport_FullMethodName,
+			allowedPerms: viewImageDeployment,
+			deniedPerms:  viewImageOnly,
+		},
+		// Collection-based report APIs require WorkflowAdministration; View Image+Deployment alone is insufficient.
+		"RunReport requires Modify WorkflowAdministration, denied with View Image+Deployment only": {
+			method:       apiV2.ReportService_RunReport_FullMethodName,
+			allowedPerms: modifyWorkflow,
+			deniedPerms:  viewImageDeployment,
+		},
+		"DeleteReport requires Modify WorkflowAdministration, denied with View Image+Deployment only": {
+			method:       apiV2.ReportService_DeleteReport_FullMethodName,
+			allowedPerms: modifyWorkflow,
+			deniedPerms:  viewImageDeployment,
+		},
+		"ListReportConfigurations requires View WorkflowAdministration, denied without it": {
+			method:       apiV2.ReportService_ListReportConfigurations_FullMethodName,
+			allowedPerms: viewWorkflow,
+			deniedPerms:  viewImageDeployment,
+		},
+		"GetReportStatus requires View WorkflowAdministration, denied without it": {
+			method:       apiV2.ReportService_GetReportStatus_FullMethodName,
+			allowedPerms: viewWorkflow,
+			deniedPerms:  viewImageDeployment,
+		},
+		"GetReportHistory requires View WorkflowAdministration, denied without it": {
+			method:       apiV2.ReportService_GetReportHistory_FullMethodName,
+			allowedPerms: viewWorkflow,
+			deniedPerms:  viewImageDeployment,
+		},
+	}
+
+	for name, tc := range testCases {
+		s.T().Run(name, func(t *testing.T) {
+			_, err := svc.AuthFuncOverride(ctxWithPerms(tc.allowedPerms), tc.method)
+			assert.NoError(t, err, "should be allowed with sufficient permissions")
+
+			_, err = svc.AuthFuncOverride(ctxWithPerms(tc.deniedPerms), tc.method)
+			assert.Error(t, err, "should be denied with insufficient permissions")
+		})
+	}
+}
+
 func (s *ReportServiceTestSuite) TestRunReport() {
 	reportConfig := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
 	notifierIDs := make([]string, 0, len(reportConfig.GetNotifiers()))

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -914,13 +914,13 @@ func (s *ReportServiceTestSuite) TestAuthzPermissions() {
 		},
 		"DeleteReport requires Modify WorkflowAdministration, denied with View Image+Deployment only": {
 			method:       apiV2.ReportService_DeleteReport_FullMethodName,
-			allowedPerms: modifyWorkflow,
-			deniedPerms:  viewImageDeployment,
+			allowedPerms: viewImageDeployment,
+			deniedPerms:  viewImageOnly,
 		},
 		"ListReportConfigurations requires View WorkflowAdministration, denied without it": {
 			method:       apiV2.ReportService_ListReportConfigurations_FullMethodName,
 			allowedPerms: viewWorkflow,
-			deniedPerms:  viewImageDeployment,
+			deniedPerms:  viewImageOnly,
 		},
 		"GetReportStatus requires View WorkflowAdministration, denied without it": {
 			method:       apiV2.ReportService_GetReportStatus_FullMethodName,

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -875,9 +875,13 @@ func (s *ReportServiceTestSuite) TestAuthzPermissions() {
 		"Image":                  storage.Access_READ_ACCESS,
 		"Deployment":             storage.Access_READ_ACCESS,
 	}
-	// viewImageOnly is insufficient for any report API since Deployment access is missing.
+	// viewImageOnly is insufficient for view-based report APIs since Deployment access is missing.
 	viewImageOnly := map[string]storage.Access{
 		"Image": storage.Access_READ_ACCESS,
+	}
+	// deploymentOnly has no Image access, so it is denied by any report API that requires View Image.
+	deploymentOnly := map[string]storage.Access{
+		"Deployment": storage.Access_READ_ACCESS,
 	}
 
 	testCases := map[string]struct {
@@ -885,7 +889,7 @@ func (s *ReportServiceTestSuite) TestAuthzPermissions() {
 		allowedPerms map[string]storage.Access
 		deniedPerms  map[string]storage.Access
 	}{
-		// View-based report APIs require only View Image + View Deployment; no WorkflowAdministration needed.
+		// View-based report APIs require View Image + View Deployment; no WorkflowAdministration needed.
 		"PostViewBasedReport allowed with View Image+Deployment, denied without Deployment": {
 			method:       apiV2.ReportService_PostViewBasedReport_FullMethodName,
 			allowedPerms: viewImageDeployment,
@@ -901,10 +905,11 @@ func (s *ReportServiceTestSuite) TestAuthzPermissions() {
 			allowedPerms: viewImageDeployment,
 			deniedPerms:  viewImageOnly,
 		},
-		"CancelReport allowed with View Image+Deployment, denied without Deployment": {
+		// CancelReport and DeleteReport only require View Image (per-user job operations).
+		"CancelReport allowed with View Image, denied without Image": {
 			method:       apiV2.ReportService_CancelReport_FullMethodName,
-			allowedPerms: viewImageDeployment,
-			deniedPerms:  viewImageOnly,
+			allowedPerms: viewImageOnly,
+			deniedPerms:  deploymentOnly,
 		},
 		// Collection-based report APIs require WorkflowAdministration; View Image+Deployment alone is insufficient.
 		"RunReport requires Modify WorkflowAdministration, denied with View Image+Deployment only": {
@@ -912,10 +917,10 @@ func (s *ReportServiceTestSuite) TestAuthzPermissions() {
 			allowedPerms: modifyWorkflow,
 			deniedPerms:  viewImageDeployment,
 		},
-		"DeleteReport requires Modify WorkflowAdministration, denied with View Image+Deployment only": {
+		"DeleteReport allowed with View Image, denied without Image": {
 			method:       apiV2.ReportService_DeleteReport_FullMethodName,
-			allowedPerms: viewImageDeployment,
-			deniedPerms:  viewImageOnly,
+			allowedPerms: viewImageOnly,
+			deniedPerms:  deploymentOnly,
 		},
 		"ListReportConfigurations requires View WorkflowAdministration, denied without it": {
 			method:       apiV2.ReportService_ListReportConfigurations_FullMethodName,


### PR DESCRIPTION
Currently starting a view based report job and downloading a view based report requires `Modify WorkflowAdministration` permission. However report should be downloadable for users that can view CVEs on the Results page which requires `View Image ` and `View Deployment` permission only. This PR updates the permission set for view based reports  to match the API that returns CVE Results and removes `Modify WorkflowAdministration` permission for view based reporting APIs

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
Added unit tests and manually tested by deploying branch with UI and backend changes.

