### PR TITLE
fix(telemetry): reverse the order of HTTP and gateway user agents

### DIFF
--- a/pkg/grpc/requestinfo/requestinfo_test.go
+++ b/pkg/grpc/requestinfo/requestinfo_test.go
@@ -146,11 +146,27 @@ func Test_gRPCGateway(t *testing.T) {
 	assert.Equal(t, "test agent", receivedRI.HTTPRequest.Headers.Get(userAgentKey))
 	assert.Equal(t, "test value", receivedRI.HTTPRequest.Headers.Get("test-key"))
 
+	// Verify that metadata contains both the gateway's own User-Agent
+	// (from grpc.WithUserAgent) and the original HTTP User-Agent
+	// (forwarded by the grpc-gateway under a prefixed key).
 	assert.NotNil(t, receivedRI.Metadata)
 	assert.Equal(t, []string{"application/grpc"}, receivedRI.Metadata.Get("content-type"))
-	assert.Contains(t, receivedRI.Metadata.Get(userAgentKey)[0], "gateway agent")
+
+	// The gRPC transport User-Agent (gateway + grpc-go version).
+	mdUserAgents := receivedRI.Metadata.Get(userAgentKey)
+	require.Len(t, mdUserAgents, 1)
+	assert.Contains(t, mdUserAgents[0], "gateway agent")
+
+	// The original HTTP User-Agent is forwarded under the grpc-gateway
+	// prefixed key, not under "user-agent" directly.
 	prefixedUserAgentKey, _ := runtime.DefaultHeaderMatcher(userAgentKey)
-	assert.Contains(t, receivedRI.Metadata.Get(prefixedUserAgentKey)[0], "test agent")
+	gwUserAgents := receivedRI.Metadata.Get(prefixedUserAgentKey)
+	require.Len(t, gwUserAgents, 1)
+	assert.Equal(t, "test agent", gwUserAgents[0])
+
+	// The original HTTP User-Agent is also preserved in the embedded
+	// HTTP request (via AnnotateMD/RequestInfo).
+	assert.Equal(t, "test agent", receivedRI.HTTPRequest.Headers.Get(userAgentKey))
 }
 
 func Test_Conversions(t *testing.T) {

--- a/pkg/telemetry/phonehome/headers_multimap.go
+++ b/pkg/telemetry/phonehome/headers_multimap.go
@@ -83,8 +83,9 @@ func (h Headers) GetMatching(canonicalKey glob.Pattern, value glob.Pattern) map[
 	return result
 }
 
-// Set implements the setter interface.
+// Set overrides the current value(s) or deletes the key if no values provided.
 func (h Headers) Set(key string, values ...string) {
+	http.Header(h).Del(key)
 	for i, value := range values {
 		if i == 0 {
 			http.Header(h).Set(key, value)

--- a/pkg/telemetry/phonehome/interceptor.go
+++ b/pkg/telemetry/phonehome/interceptor.go
@@ -66,22 +66,18 @@ func getGRPCRequestDetails(ctx context.Context, err error, grpcFullMethod string
 		if ri.HTTPRequest.URL != nil {
 			path = ri.HTTPRequest.URL.Path
 		}
-		// Override the User-Agent with the gRPC client or the grpc-gateway user agent.
-		grpcClientAgent := ri.Metadata.Get(userAgentHeaderKey)
-		if clientAgent := ri.HTTPRequest.Headers.Get(userAgentHeaderKey); clientAgent != "" {
-			grpcClientAgent = append(grpcClientAgent, clientAgent)
+		// Append the gRPC transport User-Agent from metadata to the
+		// original HTTP headers so all User-Agent values are under one key.
+		for _, ua := range ri.Metadata.Get(userAgentHeaderKey) {
+			ri.HTTPRequest.Headers.Add(userAgentHeaderKey, ua)
 		}
-		header := Headers(ri.HTTPRequest.Headers)
-		// The request has already been processed (we've got the result), so the
-		// headers are ok to modify to avoid cloning.
-		header.Set(userAgentHeaderKey, grpcClientAgent...)
 		return &RequestParams{
 			UserID:  id,
 			Method:  ri.HTTPRequest.Method,
 			Path:    path,
 			Code:    grpcError.ErrToHTTPStatus(err),
 			GRPCReq: req,
-			Headers: header,
+			Headers: Headers(ri.HTTPRequest.Headers),
 		}
 	}
 

--- a/pkg/telemetry/phonehome/interceptor_test.go
+++ b/pkg/telemetry/phonehome/interceptor_test.go
@@ -174,6 +174,7 @@ func (s *interceptorTestSuite) TestGrpcWithHTTPRequestInfo() {
 	rih := requestinfo.NewRequestInfoHandler()
 	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &net.UnixAddr{Net: "pipe"}})
 	md := rih.AnnotateMD(ctx, req)
+	// Simulate the gRPC transport User-Agent (set via grpc.WithUserAgent).
 	md.Set(userAgentHeaderKey, "gateway")
 
 	ctx, err := rih.UpdateContextForGRPC(metadata.NewIncomingContext(ctx, md))
@@ -181,11 +182,58 @@ func (s *interceptorTestSuite) TestGrpcWithHTTPRequestInfo() {
 
 	rp := getGRPCRequestDetails(ctx, err, "ignored grpc method", "request")
 	s.Equal(http.StatusOK, rp.Code)
-	s.Equal([]string{"gateway", "user"}, rp.Headers.Get(userAgentHeaderKey))
+	// Original HTTP User-Agent + gRPC transport agent merged under one key.
+	s.Equal([]string{"user", "gateway"}, rp.Headers.Get(userAgentHeaderKey))
 	s.Nil(rp.UserID)
 	s.Equal("request", rp.GRPCReq)
 	s.Equal("/wrapped/http", rp.Path)
 	s.Equal(http.MethodPatch, rp.Method)
+}
+
+func (s *interceptorTestSuite) TestGrpcWithHTTPRequestInfo_UserAgentVariants() {
+	cases := map[string]struct {
+		httpUserAgent []string // User-Agent values on the HTTP request.
+		mdUserAgent   []string // User-Agent values in gRPC metadata (transport agent).
+		expected      []string // Expected merged User-Agent values in the result.
+	}{
+		"HTTP and gRPC transport User-Agent": {
+			httpUserAgent: []string{"curl/8.0"},
+			mdUserAgent:   []string{"Rox Central/4.11 grpc-go/1.80.0"},
+			expected:      []string{"curl/8.0", "Rox Central/4.11 grpc-go/1.80.0"},
+		},
+		"only HTTP User-Agent": {
+			httpUserAgent: []string{"curl/8.0"},
+			expected:      []string{"curl/8.0"},
+		},
+		"only gRPC transport User-Agent": {
+			mdUserAgent: []string{"grpc-go/1.80.0"},
+			expected:    []string{"grpc-go/1.80.0"},
+		},
+		"no User-Agent anywhere": {
+			expected: nil,
+		},
+	}
+	for name, tc := range cases {
+		s.Run(name, func() {
+			req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Del(userAgentHeaderKey)
+			for _, ua := range tc.httpUserAgent {
+				req.Header.Add(userAgentHeaderKey, ua)
+			}
+			rih := requestinfo.NewRequestInfoHandler()
+			ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &net.UnixAddr{Net: "pipe"}})
+			md := rih.AnnotateMD(ctx, req)
+			if tc.mdUserAgent != nil {
+				md.Set(userAgentHeaderKey, tc.mdUserAgent...)
+			}
+
+			ctx, err := rih.UpdateContextForGRPC(metadata.NewIncomingContext(ctx, md))
+			s.NoError(err)
+
+			rp := getGRPCRequestDetails(ctx, err, "ignored", "request")
+			s.Equal(tc.expected, rp.Headers.Get(userAgentHeaderKey))
+		})
+	}
 }
 
 type testBody struct {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR refactors the user-agent calculation and btw changes the order of gRPC request user agents in the captured request parameters so that the original HTTP user agent goes first, and the grpc-gateway goes after.

Why important? Not much, but as the values for the header a stored in an array, a RequestParams reader might consider the first value to be the source user-agent.

It also fixes the `Set` method, that should delete the existing value if no new values are provided.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI, manual.

Example from the #18080 (see 2 user-agents joined with ;):
```
rox_central_api_request_unknown{Status="200",UserAgent="kube-probe/1.35; Rox Central/4.11.x-570-g6c0ad01b24 (linux; amd64) grpc-go/1.80.0",UserID=""} 30
```

<!-- GHIT dependencies begin -->
Current dependencies on/for this PR:

* [master](../tree/master)
  * **PR #19821** 👈
    * **PR #21131**
    * **PR #21132**
      * **PR #21133**
        * **PR #21134**
<!-- GHIT dependencies end -->