### PR TITLE
refactor(chore): Decouple v1 API from storage.Cluster protobuf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,4 +197,24 @@ When working on specific areas, refer to these detailed guides:
 - Integration tests in `/qa-tests-backend/` use Groovy/Spock framework
 - Tests marked with `//go:build sql_integration` require database connectivity
 
+# TDD Development Rules
+
+## Core Workflow (Red-Green-Refactor)
+YOU MUST follow these steps in order for every feature or bug fix:
+
+1. **RED Phase**:
+   - Write a failing test that reproduces the bug or defines the new feature.
+   - Run the test and confirm it FAILS.
+   - **DO NOT** write any implementation code during this phase.
+2. **GREEN Phase**:
+   - Write the MINIMAL code required to make the tests pass.
+   - Run tests until they are 100% successful.
+3. **REFACTOR Phase**:
+   - Clean up the code (remove duplication, improve naming).
+   - Run tests again to ensure the "Green" state remains intact.
+
+## Testing Guidelines
+- **Framework**: Use [e.g., Vitest/Pytest/Jest].
+- **Naming**: Tests should follow the pattern `feature.test.ts` or `test_feature.py`.
+- **Approval**: Pause and ask for user confirmation after the RED phase before proceeding to GREEN.
 

--- a/central/cluster/service/convert.go
+++ b/central/cluster/service/convert.go
@@ -3,54 +3,14 @@ package service
 import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	clusterutil "github.com/stackrox/rox/pkg/cluster"
 )
 
-// convertStorageClusterToAPI converts a storage.Cluster to the API representation.
-// All fields are copied 1:1. The API type is structurally identical to the storage
-// type today; they are separated to allow independent evolution in the future.
-func convertStorageClusterToAPI(cluster *storage.Cluster) *v1.ClusterConfig {
-	if cluster == nil {
-		return nil
-	}
-	return &v1.ClusterConfig{
-		Id:                             cluster.GetId(),
-		Name:                           cluster.GetName(),
-		Type:                           cluster.GetType(),
-		Labels:                         cluster.GetLabels(),
-		MainImage:                      cluster.GetMainImage(),
-		CollectorImage:                 cluster.GetCollectorImage(),
-		CentralApiEndpoint:             cluster.GetCentralApiEndpoint(),
-		CollectionMethod:               cluster.GetCollectionMethod(),
-		AdmissionController:            cluster.GetAdmissionController(),
-		AdmissionControllerUpdates:     cluster.GetAdmissionControllerUpdates(),
-		AdmissionControllerEvents:      cluster.GetAdmissionControllerEvents(),
-		AdmissionControllerFailOnError: cluster.GetAdmissionControllerFailOnError(),
-		DynamicConfig:                  cluster.GetDynamicConfig(),
-		TolerationsConfig:              cluster.GetTolerationsConfig(),
-		SlimCollector:                  cluster.GetSlimCollector(),
-		Priority:                       cluster.GetPriority(),
-		ManagedBy:                      cluster.GetManagedBy(),
-		Status:                         cluster.GetStatus(),
-		HealthStatus:                   cluster.GetHealthStatus(),
-		HelmConfig:                     cluster.GetHelmConfig(),
-		MostRecentSensorId:             cluster.GetMostRecentSensorId(),
-		AuditLogState:                  cluster.GetAuditLogState(),
-		InitBundleId:                   cluster.GetInitBundleId(),
-		SensorCapabilities:             cluster.GetSensorCapabilities(),
-	}
-}
+// convertStorageClusterToAPI delegates to the shared conversion in pkg/cluster.
+var convertStorageClusterToAPI = clusterutil.StorageClusterToAPIClusterConfig
 
-// convertStorageClustersToAPI converts a slice of storage.Cluster to API representations.
-func convertStorageClustersToAPI(clusters []*storage.Cluster) []*v1.ClusterConfig {
-	if clusters == nil {
-		return nil
-	}
-	result := make([]*v1.ClusterConfig, len(clusters))
-	for i, c := range clusters {
-		result[i] = convertStorageClusterToAPI(c)
-	}
-	return result
-}
+// convertStorageClustersToAPI delegates to the shared conversion in pkg/cluster.
+var convertStorageClustersToAPI = clusterutil.StorageClustersToAPIClusterConfigs
 
 // convertAPIClusterToStorage converts an API ClusterConfig to storage.Cluster for persistence.
 //

--- a/central/cluster/service/convert.go
+++ b/central/cluster/service/convert.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+// convertStorageClusterToAPI converts a storage.Cluster to the API representation.
+// All fields are copied 1:1. The API type is structurally identical to the storage
+// type today; they are separated to allow independent evolution in the future.
+func convertStorageClusterToAPI(cluster *storage.Cluster) *v1.ClusterConfig {
+	if cluster == nil {
+		return nil
+	}
+	return &v1.ClusterConfig{
+		Id:                             cluster.GetId(),
+		Name:                           cluster.GetName(),
+		Type:                           cluster.GetType(),
+		Labels:                         cluster.GetLabels(),
+		MainImage:                      cluster.GetMainImage(),
+		CollectorImage:                 cluster.GetCollectorImage(),
+		CentralApiEndpoint:             cluster.GetCentralApiEndpoint(),
+		CollectionMethod:               cluster.GetCollectionMethod(),
+		AdmissionController:            cluster.GetAdmissionController(),
+		AdmissionControllerUpdates:     cluster.GetAdmissionControllerUpdates(),
+		AdmissionControllerEvents:      cluster.GetAdmissionControllerEvents(),
+		AdmissionControllerFailOnError: cluster.GetAdmissionControllerFailOnError(),
+		DynamicConfig:                  cluster.GetDynamicConfig(),
+		TolerationsConfig:              cluster.GetTolerationsConfig(),
+		SlimCollector:                  cluster.GetSlimCollector(),
+		Priority:                       cluster.GetPriority(),
+		ManagedBy:                      cluster.GetManagedBy(),
+		Status:                         cluster.GetStatus(),
+		HealthStatus:                   cluster.GetHealthStatus(),
+		HelmConfig:                     cluster.GetHelmConfig(),
+		MostRecentSensorId:             cluster.GetMostRecentSensorId(),
+		AuditLogState:                  cluster.GetAuditLogState(),
+		InitBundleId:                   cluster.GetInitBundleId(),
+		SensorCapabilities:             cluster.GetSensorCapabilities(),
+	}
+}
+
+// convertStorageClustersToAPI converts a slice of storage.Cluster to API representations.
+func convertStorageClustersToAPI(clusters []*storage.Cluster) []*v1.ClusterConfig {
+	if clusters == nil {
+		return nil
+	}
+	result := make([]*v1.ClusterConfig, len(clusters))
+	for i, c := range clusters {
+		result[i] = convertStorageClusterToAPI(c)
+	}
+	return result
+}
+
+// convertAPIClusterToStorage converts an API ClusterConfig to storage.Cluster for persistence.
+//
+// Server-managed fields (status, health_status, most_recent_sensor_id,
+// sensor_capabilities, audit_log_state, helm_config, init_bundle_id) are
+// intentionally NOT copied from the API request. If a client sends values
+// for these fields, they are silently ignored. This preserves backward
+// compatibility with older clients that may send the full object on update,
+// while ensuring server-authoritative fields are never overwritten by clients.
+// The server always populates these fields from its own state.
+func convertAPIClusterToStorage(config *v1.ClusterConfig) *storage.Cluster {
+	if config == nil {
+		return nil
+	}
+	return &storage.Cluster{
+		Id:                             config.GetId(),
+		Name:                           config.GetName(),
+		Type:                           config.GetType(),
+		Labels:                         config.GetLabels(),
+		MainImage:                      config.GetMainImage(),
+		CollectorImage:                 config.GetCollectorImage(),
+		CentralApiEndpoint:             config.GetCentralApiEndpoint(),
+		CollectionMethod:               config.GetCollectionMethod(),
+		AdmissionController:            config.GetAdmissionController(),
+		AdmissionControllerUpdates:     config.GetAdmissionControllerUpdates(),
+		AdmissionControllerEvents:      config.GetAdmissionControllerEvents(),
+		AdmissionControllerFailOnError: config.GetAdmissionControllerFailOnError(),
+		DynamicConfig:                  config.GetDynamicConfig(),
+		TolerationsConfig:              config.GetTolerationsConfig(),
+		SlimCollector:                  config.GetSlimCollector(),
+		Priority:                       config.GetPriority(),
+		ManagedBy:                      config.GetManagedBy(),
+		// Server-managed fields below are intentionally omitted.
+		// Values sent by clients for these fields are silently discarded:
+		// - Status
+		// - HealthStatus
+		// - HelmConfig
+		// - MostRecentSensorId
+		// - AuditLogState
+		// - InitBundleId
+		// - SensorCapabilities
+	}
+}

--- a/central/cluster/service/convert_test.go
+++ b/central/cluster/service/convert_test.go
@@ -9,91 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConvertStorageClusterToAPI_Nil(t *testing.T) {
-	assert.Nil(t, convertStorageClusterToAPI(nil))
-}
-
 func TestConvertAPIClusterToStorage_Nil(t *testing.T) {
 	assert.Nil(t, convertAPIClusterToStorage(nil))
-}
-
-func TestConvertStorageClustersToAPI_Nil(t *testing.T) {
-	assert.Nil(t, convertStorageClustersToAPI(nil))
-}
-
-func TestConvertStorageClustersToAPI_Empty(t *testing.T) {
-	result := convertStorageClustersToAPI([]*storage.Cluster{})
-	assert.NotNil(t, result)
-	assert.Empty(t, result)
-}
-
-func TestConvertStorageClusterToAPI_AllFields(t *testing.T) {
-	cluster := &storage.Cluster{
-		Id:                             "test-id",
-		Name:                           "test-cluster",
-		Type:                           storage.ClusterType_OPENSHIFT4_CLUSTER,
-		Labels:                         map[string]string{"env": "prod"},
-		MainImage:                      "quay.io/stackrox/main:latest",
-		CollectorImage:                 "quay.io/stackrox/collector:latest",
-		CentralApiEndpoint:             "central.stackrox:443",
-		CollectionMethod:               storage.CollectionMethod_CORE_BPF,
-		AdmissionController:            true,
-		AdmissionControllerUpdates:     true,
-		AdmissionControllerEvents:      true,
-		AdmissionControllerFailOnError: true,
-		DynamicConfig: &storage.DynamicClusterConfig{
-			DisableAuditLogs: false,
-		},
-		TolerationsConfig: &storage.TolerationsConfig{
-			Disabled: true,
-		},
-		SlimCollector: true,
-		Priority:      10,
-		ManagedBy:     storage.ManagerType_MANAGER_TYPE_HELM_CHART,
-		Status: &storage.ClusterStatus{
-			SensorVersion: "3.0.0",
-		},
-		HealthStatus: &storage.ClusterHealthStatus{
-			SensorHealthStatus: storage.ClusterHealthStatus_HEALTHY,
-		},
-		HelmConfig: &storage.CompleteClusterConfig{
-			ClusterLabels: map[string]string{"helm": "true"},
-		},
-		MostRecentSensorId: &storage.SensorDeploymentIdentification{
-			SystemNamespaceId: "ns-id",
-		},
-		AuditLogState: map[string]*storage.AuditLogFileState{
-			"node1": {CollectLogsSince: nil},
-		},
-		InitBundleId:       "init-bundle-123",
-		SensorCapabilities: []string{"cap1", "cap2"},
-	}
-
-	result := convertStorageClusterToAPI(cluster)
-
-	assert.Equal(t, cluster.GetId(), result.GetId())
-	assert.Equal(t, cluster.GetName(), result.GetName())
-	assert.Equal(t, cluster.GetType(), result.GetType())
-	assert.Equal(t, cluster.GetLabels(), result.GetLabels())
-	assert.Equal(t, cluster.GetMainImage(), result.GetMainImage())
-	assert.Equal(t, cluster.GetCollectorImage(), result.GetCollectorImage())
-	assert.Equal(t, cluster.GetCentralApiEndpoint(), result.GetCentralApiEndpoint())
-	assert.Equal(t, cluster.GetCollectionMethod(), result.GetCollectionMethod())
-	assert.Equal(t, cluster.GetAdmissionController(), result.GetAdmissionController())
-	assert.Equal(t, cluster.GetAdmissionControllerUpdates(), result.GetAdmissionControllerUpdates())
-	assert.Equal(t, cluster.GetAdmissionControllerEvents(), result.GetAdmissionControllerEvents())
-	assert.Equal(t, cluster.GetAdmissionControllerFailOnError(), result.GetAdmissionControllerFailOnError())
-	protoassert.Equal(t, cluster.GetDynamicConfig(), result.GetDynamicConfig())
-	protoassert.Equal(t, cluster.GetTolerationsConfig(), result.GetTolerationsConfig())
-	assert.Equal(t, cluster.GetSlimCollector(), result.GetSlimCollector())
-	assert.Equal(t, cluster.GetPriority(), result.GetPriority())
-	assert.Equal(t, cluster.GetManagedBy(), result.GetManagedBy())
-	protoassert.Equal(t, cluster.GetStatus(), result.GetStatus())
-	protoassert.Equal(t, cluster.GetHealthStatus(), result.GetHealthStatus())
-	protoassert.Equal(t, cluster.GetHelmConfig(), result.GetHelmConfig())
-	protoassert.Equal(t, cluster.GetMostRecentSensorId(), result.GetMostRecentSensorId())
-	assert.Equal(t, cluster.GetInitBundleId(), result.GetInitBundleId())
-	assert.Equal(t, cluster.GetSensorCapabilities(), result.GetSensorCapabilities())
 }
 
 func TestConvertAPIClusterToStorage_UserSettableFields(t *testing.T) {
@@ -177,20 +94,4 @@ func TestConvertAPIClusterToStorage_ServerManagedFieldsIgnored(t *testing.T) {
 	assert.Nil(t, result.GetAuditLogState())
 	assert.Empty(t, result.GetInitBundleId())
 	assert.Nil(t, result.GetSensorCapabilities())
-}
-
-func TestConvertStorageClustersToAPI_Multiple(t *testing.T) {
-	clusters := []*storage.Cluster{
-		{Id: "id-1", Name: "cluster-1"},
-		{Id: "id-2", Name: "cluster-2"},
-		{Id: "id-3", Name: "cluster-3"},
-	}
-
-	result := convertStorageClustersToAPI(clusters)
-
-	assert.Len(t, result, 3)
-	for i, c := range clusters {
-		assert.Equal(t, c.GetId(), result[i].GetId())
-		assert.Equal(t, c.GetName(), result[i].GetName())
-	}
 }

--- a/central/cluster/service/convert_test.go
+++ b/central/cluster/service/convert_test.go
@@ -1,0 +1,196 @@
+package service
+
+import (
+	"testing"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertStorageClusterToAPI_Nil(t *testing.T) {
+	assert.Nil(t, convertStorageClusterToAPI(nil))
+}
+
+func TestConvertAPIClusterToStorage_Nil(t *testing.T) {
+	assert.Nil(t, convertAPIClusterToStorage(nil))
+}
+
+func TestConvertStorageClustersToAPI_Nil(t *testing.T) {
+	assert.Nil(t, convertStorageClustersToAPI(nil))
+}
+
+func TestConvertStorageClustersToAPI_Empty(t *testing.T) {
+	result := convertStorageClustersToAPI([]*storage.Cluster{})
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+}
+
+func TestConvertStorageClusterToAPI_AllFields(t *testing.T) {
+	cluster := &storage.Cluster{
+		Id:                             "test-id",
+		Name:                           "test-cluster",
+		Type:                           storage.ClusterType_OPENSHIFT4_CLUSTER,
+		Labels:                         map[string]string{"env": "prod"},
+		MainImage:                      "quay.io/stackrox/main:latest",
+		CollectorImage:                 "quay.io/stackrox/collector:latest",
+		CentralApiEndpoint:             "central.stackrox:443",
+		CollectionMethod:               storage.CollectionMethod_CORE_BPF,
+		AdmissionController:            true,
+		AdmissionControllerUpdates:     true,
+		AdmissionControllerEvents:      true,
+		AdmissionControllerFailOnError: true,
+		DynamicConfig: &storage.DynamicClusterConfig{
+			DisableAuditLogs: false,
+		},
+		TolerationsConfig: &storage.TolerationsConfig{
+			Disabled: true,
+		},
+		SlimCollector: true,
+		Priority:      10,
+		ManagedBy:     storage.ManagerType_MANAGER_TYPE_HELM_CHART,
+		Status: &storage.ClusterStatus{
+			SensorVersion: "3.0.0",
+		},
+		HealthStatus: &storage.ClusterHealthStatus{
+			SensorHealthStatus: storage.ClusterHealthStatus_HEALTHY,
+		},
+		HelmConfig: &storage.CompleteClusterConfig{
+			ClusterLabels: map[string]string{"helm": "true"},
+		},
+		MostRecentSensorId: &storage.SensorDeploymentIdentification{
+			SystemNamespaceId: "ns-id",
+		},
+		AuditLogState: map[string]*storage.AuditLogFileState{
+			"node1": {CollectLogsSince: nil},
+		},
+		InitBundleId:       "init-bundle-123",
+		SensorCapabilities: []string{"cap1", "cap2"},
+	}
+
+	result := convertStorageClusterToAPI(cluster)
+
+	assert.Equal(t, cluster.GetId(), result.GetId())
+	assert.Equal(t, cluster.GetName(), result.GetName())
+	assert.Equal(t, cluster.GetType(), result.GetType())
+	assert.Equal(t, cluster.GetLabels(), result.GetLabels())
+	assert.Equal(t, cluster.GetMainImage(), result.GetMainImage())
+	assert.Equal(t, cluster.GetCollectorImage(), result.GetCollectorImage())
+	assert.Equal(t, cluster.GetCentralApiEndpoint(), result.GetCentralApiEndpoint())
+	assert.Equal(t, cluster.GetCollectionMethod(), result.GetCollectionMethod())
+	assert.Equal(t, cluster.GetAdmissionController(), result.GetAdmissionController())
+	assert.Equal(t, cluster.GetAdmissionControllerUpdates(), result.GetAdmissionControllerUpdates())
+	assert.Equal(t, cluster.GetAdmissionControllerEvents(), result.GetAdmissionControllerEvents())
+	assert.Equal(t, cluster.GetAdmissionControllerFailOnError(), result.GetAdmissionControllerFailOnError())
+	protoassert.Equal(t, cluster.GetDynamicConfig(), result.GetDynamicConfig())
+	protoassert.Equal(t, cluster.GetTolerationsConfig(), result.GetTolerationsConfig())
+	assert.Equal(t, cluster.GetSlimCollector(), result.GetSlimCollector())
+	assert.Equal(t, cluster.GetPriority(), result.GetPriority())
+	assert.Equal(t, cluster.GetManagedBy(), result.GetManagedBy())
+	protoassert.Equal(t, cluster.GetStatus(), result.GetStatus())
+	protoassert.Equal(t, cluster.GetHealthStatus(), result.GetHealthStatus())
+	protoassert.Equal(t, cluster.GetHelmConfig(), result.GetHelmConfig())
+	protoassert.Equal(t, cluster.GetMostRecentSensorId(), result.GetMostRecentSensorId())
+	assert.Equal(t, cluster.GetInitBundleId(), result.GetInitBundleId())
+	assert.Equal(t, cluster.GetSensorCapabilities(), result.GetSensorCapabilities())
+}
+
+func TestConvertAPIClusterToStorage_UserSettableFields(t *testing.T) {
+	config := &v1.ClusterConfig{
+		Id:                             "test-id",
+		Name:                           "test-cluster",
+		Type:                           storage.ClusterType_KUBERNETES_CLUSTER,
+		Labels:                         map[string]string{"env": "dev"},
+		MainImage:                      "quay.io/stackrox/main:latest",
+		CollectorImage:                 "quay.io/stackrox/collector:latest",
+		CentralApiEndpoint:             "central.stackrox:443",
+		CollectionMethod:               storage.CollectionMethod_CORE_BPF,
+		AdmissionController:            true,
+		AdmissionControllerUpdates:     true,
+		AdmissionControllerEvents:      true,
+		AdmissionControllerFailOnError: true,
+		DynamicConfig: &storage.DynamicClusterConfig{
+			DisableAuditLogs: true,
+		},
+		TolerationsConfig: &storage.TolerationsConfig{
+			Disabled: true,
+		},
+		SlimCollector: true,
+		Priority:      5,
+		ManagedBy:     storage.ManagerType_MANAGER_TYPE_HELM_CHART,
+	}
+
+	result := convertAPIClusterToStorage(config)
+
+	assert.Equal(t, config.GetId(), result.GetId())
+	assert.Equal(t, config.GetName(), result.GetName())
+	assert.Equal(t, config.GetType(), result.GetType())
+	assert.Equal(t, config.GetLabels(), result.GetLabels())
+	assert.Equal(t, config.GetMainImage(), result.GetMainImage())
+	assert.Equal(t, config.GetCollectorImage(), result.GetCollectorImage())
+	assert.Equal(t, config.GetCentralApiEndpoint(), result.GetCentralApiEndpoint())
+	assert.Equal(t, config.GetCollectionMethod(), result.GetCollectionMethod())
+	assert.Equal(t, config.GetAdmissionController(), result.GetAdmissionController())
+	assert.Equal(t, config.GetAdmissionControllerUpdates(), result.GetAdmissionControllerUpdates())
+	assert.Equal(t, config.GetAdmissionControllerEvents(), result.GetAdmissionControllerEvents())
+	assert.Equal(t, config.GetAdmissionControllerFailOnError(), result.GetAdmissionControllerFailOnError())
+	protoassert.Equal(t, config.GetDynamicConfig(), result.GetDynamicConfig())
+	protoassert.Equal(t, config.GetTolerationsConfig(), result.GetTolerationsConfig())
+	assert.Equal(t, config.GetSlimCollector(), result.GetSlimCollector())
+	assert.Equal(t, config.GetPriority(), result.GetPriority())
+	assert.Equal(t, config.GetManagedBy(), result.GetManagedBy())
+}
+
+func TestConvertAPIClusterToStorage_ServerManagedFieldsIgnored(t *testing.T) {
+	config := &v1.ClusterConfig{
+		Id:   "test-id",
+		Name: "test-cluster",
+		// Server-managed fields that should be silently discarded
+		Status: &storage.ClusterStatus{
+			SensorVersion: "3.0.0",
+		},
+		HealthStatus: &storage.ClusterHealthStatus{
+			SensorHealthStatus: storage.ClusterHealthStatus_HEALTHY,
+		},
+		HelmConfig: &storage.CompleteClusterConfig{
+			ClusterLabels: map[string]string{"helm": "true"},
+		},
+		MostRecentSensorId: &storage.SensorDeploymentIdentification{
+			SystemNamespaceId: "ns-id",
+		},
+		AuditLogState: map[string]*storage.AuditLogFileState{
+			"node1": {CollectLogsSince: nil},
+		},
+		InitBundleId:       "init-bundle-123",
+		SensorCapabilities: []string{"cap1", "cap2"},
+	}
+
+	result := convertAPIClusterToStorage(config)
+
+	assert.Equal(t, "test-id", result.GetId())
+	assert.Equal(t, "test-cluster", result.GetName())
+	assert.Nil(t, result.GetStatus())
+	assert.Nil(t, result.GetHealthStatus())
+	assert.Nil(t, result.GetHelmConfig())
+	assert.Nil(t, result.GetMostRecentSensorId())
+	assert.Nil(t, result.GetAuditLogState())
+	assert.Empty(t, result.GetInitBundleId())
+	assert.Nil(t, result.GetSensorCapabilities())
+}
+
+func TestConvertStorageClustersToAPI_Multiple(t *testing.T) {
+	clusters := []*storage.Cluster{
+		{Id: "id-1", Name: "cluster-1"},
+		{Id: "id-2", Name: "cluster-2"},
+		{Id: "id-3", Name: "cluster-3"},
+	}
+
+	result := convertStorageClustersToAPI(clusters)
+
+	assert.Len(t, result, 3)
+	for i, c := range clusters {
+		assert.Equal(t, c.GetId(), result[i].GetId())
+		assert.Equal(t, c.GetName(), result[i].GetName())
+	}
+}

--- a/central/cluster/service/service_impl.go
+++ b/central/cluster/service/service_impl.go
@@ -69,24 +69,25 @@ func (s *serviceImpl) AuthFuncOverride(ctx context.Context, fullMethodName strin
 }
 
 // PostCluster creates a new cluster.
-func (s *serviceImpl) PostCluster(ctx context.Context, request *storage.Cluster) (*v1.ClusterResponse, error) {
+func (s *serviceImpl) PostCluster(ctx context.Context, request *v1.ClusterConfig) (*v1.ClusterResponse, error) {
 	if request.GetId() != "" {
 		return nil, errors.Wrap(errox.InvalidArgs, "Id field should be empty when posting a new cluster")
 	}
-	id, err := s.datastore.AddCluster(ctx, request)
+	cluster := convertAPIClusterToStorage(request)
+	id, err := s.datastore.AddCluster(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}
-	request.Id = id
-	return s.getCluster(ctx, request.GetId())
+	return s.getCluster(ctx, id)
 }
 
 // PutCluster updates an existing cluster.
-func (s *serviceImpl) PutCluster(ctx context.Context, request *storage.Cluster) (*v1.ClusterResponse, error) {
+func (s *serviceImpl) PutCluster(ctx context.Context, request *v1.ClusterConfig) (*v1.ClusterResponse, error) {
 	if request.GetId() == "" {
 		return nil, errors.Wrap(errox.InvalidArgs, "Id must be provided")
 	}
-	err := s.datastore.UpdateCluster(ctx, request)
+	cluster := convertAPIClusterToStorage(request)
+	err := s.datastore.UpdateCluster(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +117,7 @@ func (s *serviceImpl) getCluster(ctx context.Context, id string) (*v1.ClusterRes
 	}
 
 	return &v1.ClusterResponse{
-		Cluster:              cluster,
+		Cluster:              convertStorageClusterToAPI(cluster),
 		ClusterRetentionInfo: clusterRetentionInfo,
 	}, nil
 }
@@ -190,7 +191,7 @@ func (s *serviceImpl) GetClusters(ctx context.Context, req *v1.GetClustersReques
 	}
 
 	return &v1.ClustersList{
-		Clusters:                 clusters,
+		Clusters:                 convertStorageClustersToAPI(clusters),
 		ClusterIdToRetentionInfo: clusterIDToRetentionInfoMap,
 	}, nil
 }

--- a/config-controller/pkg/client/client.go
+++ b/config-controller/pkg/client/client.go
@@ -96,7 +96,7 @@ type CentralClient interface {
 	PutPolicy(context.Context, *storage.Policy) error
 	DeletePolicy(ctx context.Context, id string) error
 	ListNotifiers(ctx context.Context) ([]*storage.Notifier, error)
-	ListClusters(ctx context.Context) ([]*storage.Cluster, error)
+	ListClusters(ctx context.Context) ([]*v1.ClusterConfig, error)
 	TokenExchange(ctx context.Context) error
 }
 
@@ -165,10 +165,10 @@ func (gc *grpcClient) ListNotifiers(ctx context.Context) ([]*storage.Notifier, e
 	return allNotifiers.GetNotifiers(), nil
 }
 
-func (gc *grpcClient) ListClusters(ctx context.Context) ([]*storage.Cluster, error) {
+func (gc *grpcClient) ListClusters(ctx context.Context) ([]*v1.ClusterConfig, error) {
 	allClusters, err := gc.clusterSvc.GetClusters(ctx, &v1.GetClustersRequest{})
 	if err != nil {
-		return []*storage.Cluster{}, errors.Wrap(err, "Failed to list clusters from grpc client")
+		return []*v1.ClusterConfig{}, errors.Wrap(err, "Failed to list clusters from grpc client")
 	}
 
 	return allClusters.GetClusters(), nil

--- a/config-controller/pkg/client/client_test.go
+++ b/config-controller/pkg/client/client_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/config-controller/pkg/client/mocks"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stretchr/testify/assert"
@@ -69,8 +70,8 @@ func listNotifiers() []*storage.Notifier {
 	}
 }
 
-func listClusters() []*storage.Cluster {
-	return []*storage.Cluster{
+func listClusters() []*v1.ClusterConfig {
+	return []*v1.ClusterConfig{
 		{
 			Id:   "cluster-1",
 			Name: "Cluster1",

--- a/config-controller/pkg/client/mocks/client.go
+++ b/config-controller/pkg/client/mocks/client.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -225,10 +226,10 @@ func (mr *MockCentralClientMockRecorder) GetPolicy(ctx, id any) *gomock.Call {
 }
 
 // ListClusters mocks base method.
-func (m *MockCentralClient) ListClusters(ctx context.Context) ([]*storage.Cluster, error) {
+func (m *MockCentralClient) ListClusters(ctx context.Context) ([]*v1.ClusterConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListClusters", ctx)
-	ret0, _ := ret[0].([]*storage.Cluster)
+	ret0, _ := ret[0].([]*v1.ClusterConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/generated/api/v1/cluster_service.pb.go
+++ b/generated/api/v1/cluster_service.pb.go
@@ -124,6 +124,270 @@ func (LoadBalancerType) EnumDescriptor() ([]byte, []int) {
 	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{1}
 }
 
+// ClusterConfig is the API-specific representation of a cluster.
+// It is field-number-identical to storage.Cluster to maintain gRPC wire
+// compatibility with older clients that send storage.Cluster directly.
+// This decoupling allows the storage representation to evolve independently
+// from the API contract in the future.
+//
+// Note: Server-managed fields (status, health_status, most_recent_sensor_id,
+// sensor_capabilities, audit_log_state, helm_config, init_bundle_id) are
+// accepted in create/update requests for backward compatibility, but their
+// values are silently ignored by the server. The server always uses its own
+// authoritative values for these fields.
+// Next tag: 33
+type ClusterConfig struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Id                 string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name               string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Type               storage.ClusterType    `protobuf:"varint,3,opt,name=type,proto3,enum=storage.ClusterType" json:"type,omitempty"`
+	MainImage          string                 `protobuf:"bytes,4,opt,name=main_image,json=mainImage,proto3" json:"main_image,omitempty"`
+	CentralApiEndpoint string                 `protobuf:"bytes,5,opt,name=central_api_endpoint,json=centralApiEndpoint,proto3" json:"central_api_endpoint,omitempty"`
+	// Deprecated: Marked as deprecated in api/v1/cluster_service.proto.
+	RuntimeSupport      bool `protobuf:"varint,7,opt,name=runtime_support,json=runtimeSupport,proto3" json:"runtime_support,omitempty"`
+	AdmissionController bool `protobuf:"varint,13,opt,name=admission_controller,json=admissionController,proto3" json:"admission_controller,omitempty"`
+	// Server-managed: accepted in requests for backward compatibility but
+	// ignored by the server. The server populates this from its own state.
+	Status                     *storage.ClusterStatus        `protobuf:"bytes,15,opt,name=status,proto3" json:"status,omitempty"`
+	CollectorImage             string                        `protobuf:"bytes,16,opt,name=collector_image,json=collectorImage,proto3" json:"collector_image,omitempty"`
+	CollectionMethod           storage.CollectionMethod      `protobuf:"varint,17,opt,name=collection_method,json=collectionMethod,proto3,enum=storage.CollectionMethod" json:"collection_method,omitempty"`
+	DynamicConfig              *storage.DynamicClusterConfig `protobuf:"bytes,18,opt,name=dynamic_config,json=dynamicConfig,proto3" json:"dynamic_config,omitempty"`
+	TolerationsConfig          *storage.TolerationsConfig    `protobuf:"bytes,19,opt,name=tolerations_config,json=tolerationsConfig,proto3" json:"tolerations_config,omitempty"`
+	Priority                   int64                         `protobuf:"varint,20,opt,name=priority,proto3" json:"priority,omitempty"`
+	AdmissionControllerUpdates bool                          `protobuf:"varint,21,opt,name=admission_controller_updates,json=admissionControllerUpdates,proto3" json:"admission_controller_updates,omitempty"`
+	// Server-managed: accepted in requests for backward compatibility but
+	// ignored by the server. The server populates this from its own state.
+	HealthStatus  *storage.ClusterHealthStatus `protobuf:"bytes,22,opt,name=health_status,json=healthStatus,proto3" json:"health_status,omitempty"`
+	SlimCollector bool                         `protobuf:"varint,23,opt,name=slim_collector,json=slimCollector,proto3" json:"slim_collector,omitempty"`
+	// Server-managed: accepted in requests for backward compatibility but
+	// ignored by the server.
+	HelmConfig                *storage.CompleteClusterConfig `protobuf:"bytes,24,opt,name=helm_config,json=helmConfig,proto3" json:"helm_config,omitempty"`
+	AdmissionControllerEvents bool                           `protobuf:"varint,25,opt,name=admission_controller_events,json=admissionControllerEvents,proto3" json:"admission_controller_events,omitempty"`
+	// Server-managed: accepted in requests for backward compatibility but
+	// ignored by the server.
+	MostRecentSensorId *storage.SensorDeploymentIdentification `protobuf:"bytes,26,opt,name=most_recent_sensor_id,json=mostRecentSensorId,proto3" json:"most_recent_sensor_id,omitempty"`
+	Labels             map[string]string                       `protobuf:"bytes,27,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Server-managed: accepted in requests for backward compatibility but
+	// ignored by the server.
+	AuditLogState map[string]*storage.AuditLogFileState `protobuf:"bytes,28,rep,name=audit_log_state,json=auditLogState,proto3" json:"audit_log_state,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Server-managed: accepted in requests for backward compatibility but
+	// ignored by the server.
+	InitBundleId string              `protobuf:"bytes,29,opt,name=init_bundle_id,json=initBundleId,proto3" json:"init_bundle_id,omitempty"`
+	ManagedBy    storage.ManagerType `protobuf:"varint,30,opt,name=managed_by,json=managedBy,proto3,enum=storage.ManagerType" json:"managed_by,omitempty"`
+	// Server-managed: accepted in requests for backward compatibility but
+	// ignored by the server.
+	SensorCapabilities             []string `protobuf:"bytes,31,rep,name=sensor_capabilities,json=sensorCapabilities,proto3" json:"sensor_capabilities,omitempty"`
+	AdmissionControllerFailOnError bool     `protobuf:"varint,32,opt,name=admission_controller_fail_on_error,json=admissionControllerFailOnError,proto3" json:"admission_controller_fail_on_error,omitempty"`
+	unknownFields                  protoimpl.UnknownFields
+	sizeCache                      protoimpl.SizeCache
+}
+
+func (x *ClusterConfig) Reset() {
+	*x = ClusterConfig{}
+	mi := &file_api_v1_cluster_service_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClusterConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClusterConfig) ProtoMessage() {}
+
+func (x *ClusterConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v1_cluster_service_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClusterConfig.ProtoReflect.Descriptor instead.
+func (*ClusterConfig) Descriptor() ([]byte, []int) {
+	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *ClusterConfig) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ClusterConfig) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ClusterConfig) GetType() storage.ClusterType {
+	if x != nil {
+		return x.Type
+	}
+	return storage.ClusterType(0)
+}
+
+func (x *ClusterConfig) GetMainImage() string {
+	if x != nil {
+		return x.MainImage
+	}
+	return ""
+}
+
+func (x *ClusterConfig) GetCentralApiEndpoint() string {
+	if x != nil {
+		return x.CentralApiEndpoint
+	}
+	return ""
+}
+
+// Deprecated: Marked as deprecated in api/v1/cluster_service.proto.
+func (x *ClusterConfig) GetRuntimeSupport() bool {
+	if x != nil {
+		return x.RuntimeSupport
+	}
+	return false
+}
+
+func (x *ClusterConfig) GetAdmissionController() bool {
+	if x != nil {
+		return x.AdmissionController
+	}
+	return false
+}
+
+func (x *ClusterConfig) GetStatus() *storage.ClusterStatus {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+func (x *ClusterConfig) GetCollectorImage() string {
+	if x != nil {
+		return x.CollectorImage
+	}
+	return ""
+}
+
+func (x *ClusterConfig) GetCollectionMethod() storage.CollectionMethod {
+	if x != nil {
+		return x.CollectionMethod
+	}
+	return storage.CollectionMethod(0)
+}
+
+func (x *ClusterConfig) GetDynamicConfig() *storage.DynamicClusterConfig {
+	if x != nil {
+		return x.DynamicConfig
+	}
+	return nil
+}
+
+func (x *ClusterConfig) GetTolerationsConfig() *storage.TolerationsConfig {
+	if x != nil {
+		return x.TolerationsConfig
+	}
+	return nil
+}
+
+func (x *ClusterConfig) GetPriority() int64 {
+	if x != nil {
+		return x.Priority
+	}
+	return 0
+}
+
+func (x *ClusterConfig) GetAdmissionControllerUpdates() bool {
+	if x != nil {
+		return x.AdmissionControllerUpdates
+	}
+	return false
+}
+
+func (x *ClusterConfig) GetHealthStatus() *storage.ClusterHealthStatus {
+	if x != nil {
+		return x.HealthStatus
+	}
+	return nil
+}
+
+func (x *ClusterConfig) GetSlimCollector() bool {
+	if x != nil {
+		return x.SlimCollector
+	}
+	return false
+}
+
+func (x *ClusterConfig) GetHelmConfig() *storage.CompleteClusterConfig {
+	if x != nil {
+		return x.HelmConfig
+	}
+	return nil
+}
+
+func (x *ClusterConfig) GetAdmissionControllerEvents() bool {
+	if x != nil {
+		return x.AdmissionControllerEvents
+	}
+	return false
+}
+
+func (x *ClusterConfig) GetMostRecentSensorId() *storage.SensorDeploymentIdentification {
+	if x != nil {
+		return x.MostRecentSensorId
+	}
+	return nil
+}
+
+func (x *ClusterConfig) GetLabels() map[string]string {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
+}
+
+func (x *ClusterConfig) GetAuditLogState() map[string]*storage.AuditLogFileState {
+	if x != nil {
+		return x.AuditLogState
+	}
+	return nil
+}
+
+func (x *ClusterConfig) GetInitBundleId() string {
+	if x != nil {
+		return x.InitBundleId
+	}
+	return ""
+}
+
+func (x *ClusterConfig) GetManagedBy() storage.ManagerType {
+	if x != nil {
+		return x.ManagedBy
+	}
+	return storage.ManagerType(0)
+}
+
+func (x *ClusterConfig) GetSensorCapabilities() []string {
+	if x != nil {
+		return x.SensorCapabilities
+	}
+	return nil
+}
+
+func (x *ClusterConfig) GetAdmissionControllerFailOnError() bool {
+	if x != nil {
+		return x.AdmissionControllerFailOnError
+	}
+	return false
+}
+
 // next available tag: 3
 type DecommissionedClusterRetentionInfo struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -138,7 +402,7 @@ type DecommissionedClusterRetentionInfo struct {
 
 func (x *DecommissionedClusterRetentionInfo) Reset() {
 	*x = DecommissionedClusterRetentionInfo{}
-	mi := &file_api_v1_cluster_service_proto_msgTypes[0]
+	mi := &file_api_v1_cluster_service_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -150,7 +414,7 @@ func (x *DecommissionedClusterRetentionInfo) String() string {
 func (*DecommissionedClusterRetentionInfo) ProtoMessage() {}
 
 func (x *DecommissionedClusterRetentionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_cluster_service_proto_msgTypes[0]
+	mi := &file_api_v1_cluster_service_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -163,7 +427,7 @@ func (x *DecommissionedClusterRetentionInfo) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use DecommissionedClusterRetentionInfo.ProtoReflect.Descriptor instead.
 func (*DecommissionedClusterRetentionInfo) Descriptor() ([]byte, []int) {
-	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{0}
+	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *DecommissionedClusterRetentionInfo) GetRetentionInfo() isDecommissionedClusterRetentionInfo_RetentionInfo {
@@ -213,7 +477,7 @@ func (*DecommissionedClusterRetentionInfo_DaysUntilDeletion) isDecommissionedClu
 
 type ClusterResponse struct {
 	state                protoimpl.MessageState              `protogen:"open.v1"`
-	Cluster              *storage.Cluster                    `protobuf:"bytes,1,opt,name=cluster,proto3" json:"cluster,omitempty"`
+	Cluster              *ClusterConfig                      `protobuf:"bytes,1,opt,name=cluster,proto3" json:"cluster,omitempty"`
 	ClusterRetentionInfo *DecommissionedClusterRetentionInfo `protobuf:"bytes,2,opt,name=cluster_retention_info,json=clusterRetentionInfo,proto3" json:"cluster_retention_info,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
@@ -221,7 +485,7 @@ type ClusterResponse struct {
 
 func (x *ClusterResponse) Reset() {
 	*x = ClusterResponse{}
-	mi := &file_api_v1_cluster_service_proto_msgTypes[1]
+	mi := &file_api_v1_cluster_service_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -233,7 +497,7 @@ func (x *ClusterResponse) String() string {
 func (*ClusterResponse) ProtoMessage() {}
 
 func (x *ClusterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_cluster_service_proto_msgTypes[1]
+	mi := &file_api_v1_cluster_service_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -246,10 +510,10 @@ func (x *ClusterResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterResponse.ProtoReflect.Descriptor instead.
 func (*ClusterResponse) Descriptor() ([]byte, []int) {
-	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{1}
+	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *ClusterResponse) GetCluster() *storage.Cluster {
+func (x *ClusterResponse) GetCluster() *ClusterConfig {
 	if x != nil {
 		return x.Cluster
 	}
@@ -274,7 +538,7 @@ type ClusterDefaultsResponse struct {
 
 func (x *ClusterDefaultsResponse) Reset() {
 	*x = ClusterDefaultsResponse{}
-	mi := &file_api_v1_cluster_service_proto_msgTypes[2]
+	mi := &file_api_v1_cluster_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -286,7 +550,7 @@ func (x *ClusterDefaultsResponse) String() string {
 func (*ClusterDefaultsResponse) ProtoMessage() {}
 
 func (x *ClusterDefaultsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_cluster_service_proto_msgTypes[2]
+	mi := &file_api_v1_cluster_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -299,7 +563,7 @@ func (x *ClusterDefaultsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClusterDefaultsResponse.ProtoReflect.Descriptor instead.
 func (*ClusterDefaultsResponse) Descriptor() ([]byte, []int) {
-	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{2}
+	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *ClusterDefaultsResponse) GetMainImageRepository() string {
@@ -325,7 +589,7 @@ func (x *ClusterDefaultsResponse) GetKernelSupportAvailable() bool {
 
 type ClustersList struct {
 	state    protoimpl.MessageState `protogen:"open.v1"`
-	Clusters []*storage.Cluster     `protobuf:"bytes,1,rep,name=clusters,proto3" json:"clusters,omitempty"`
+	Clusters []*ClusterConfig       `protobuf:"bytes,1,rep,name=clusters,proto3" json:"clusters,omitempty"`
 	// Maps 'UNHEALTHY' clusters' IDs to their retention info
 	ClusterIdToRetentionInfo map[string]*DecommissionedClusterRetentionInfo `protobuf:"bytes,2,rep,name=cluster_id_to_retention_info,json=clusterIdToRetentionInfo,proto3" json:"cluster_id_to_retention_info,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields            protoimpl.UnknownFields
@@ -334,7 +598,7 @@ type ClustersList struct {
 
 func (x *ClustersList) Reset() {
 	*x = ClustersList{}
-	mi := &file_api_v1_cluster_service_proto_msgTypes[3]
+	mi := &file_api_v1_cluster_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -346,7 +610,7 @@ func (x *ClustersList) String() string {
 func (*ClustersList) ProtoMessage() {}
 
 func (x *ClustersList) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_cluster_service_proto_msgTypes[3]
+	mi := &file_api_v1_cluster_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -359,10 +623,10 @@ func (x *ClustersList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClustersList.ProtoReflect.Descriptor instead.
 func (*ClustersList) Descriptor() ([]byte, []int) {
-	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{3}
+	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *ClustersList) GetClusters() []*storage.Cluster {
+func (x *ClustersList) GetClusters() []*ClusterConfig {
 	if x != nil {
 		return x.Clusters
 	}
@@ -385,7 +649,7 @@ type GetClustersRequest struct {
 
 func (x *GetClustersRequest) Reset() {
 	*x = GetClustersRequest{}
-	mi := &file_api_v1_cluster_service_proto_msgTypes[4]
+	mi := &file_api_v1_cluster_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -397,7 +661,7 @@ func (x *GetClustersRequest) String() string {
 func (*GetClustersRequest) ProtoMessage() {}
 
 func (x *GetClustersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_cluster_service_proto_msgTypes[4]
+	mi := &file_api_v1_cluster_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -410,7 +674,7 @@ func (x *GetClustersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetClustersRequest.ProtoReflect.Descriptor instead.
 func (*GetClustersRequest) Descriptor() ([]byte, []int) {
-	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{4}
+	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *GetClustersRequest) GetQuery() string {
@@ -430,7 +694,7 @@ type KernelSupportAvailableResponse struct {
 
 func (x *KernelSupportAvailableResponse) Reset() {
 	*x = KernelSupportAvailableResponse{}
-	mi := &file_api_v1_cluster_service_proto_msgTypes[5]
+	mi := &file_api_v1_cluster_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -442,7 +706,7 @@ func (x *KernelSupportAvailableResponse) String() string {
 func (*KernelSupportAvailableResponse) ProtoMessage() {}
 
 func (x *KernelSupportAvailableResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v1_cluster_service_proto_msgTypes[5]
+	mi := &file_api_v1_cluster_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -455,7 +719,7 @@ func (x *KernelSupportAvailableResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KernelSupportAvailableResponse.ProtoReflect.Descriptor instead.
 func (*KernelSupportAvailableResponse) Descriptor() ([]byte, []int) {
-	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{5}
+	return file_api_v1_cluster_service_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *KernelSupportAvailableResponse) GetKernelSupportAvailable() bool {
@@ -469,21 +733,58 @@ var File_api_v1_cluster_service_proto protoreflect.FileDescriptor
 
 const file_api_v1_cluster_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1capi/v1/cluster_service.proto\x12\x02v1\x1a\x13api/v1/common.proto\x1a\x12api/v1/empty.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x15storage/cluster.proto\"\x8a\x01\n" +
+	"\x1capi/v1/cluster_service.proto\x12\x02v1\x1a\x13api/v1/common.proto\x1a\x12api/v1/empty.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x15storage/cluster.proto\"\x85\f\n" +
+	"\rClusterConfig\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12(\n" +
+	"\x04type\x18\x03 \x01(\x0e2\x14.storage.ClusterTypeR\x04type\x12\x1d\n" +
+	"\n" +
+	"main_image\x18\x04 \x01(\tR\tmainImage\x120\n" +
+	"\x14central_api_endpoint\x18\x05 \x01(\tR\x12centralApiEndpoint\x12+\n" +
+	"\x0fruntime_support\x18\a \x01(\bB\x02\x18\x01R\x0eruntimeSupport\x121\n" +
+	"\x14admission_controller\x18\r \x01(\bR\x13admissionController\x12.\n" +
+	"\x06status\x18\x0f \x01(\v2\x16.storage.ClusterStatusR\x06status\x12'\n" +
+	"\x0fcollector_image\x18\x10 \x01(\tR\x0ecollectorImage\x12F\n" +
+	"\x11collection_method\x18\x11 \x01(\x0e2\x19.storage.CollectionMethodR\x10collectionMethod\x12D\n" +
+	"\x0edynamic_config\x18\x12 \x01(\v2\x1d.storage.DynamicClusterConfigR\rdynamicConfig\x12I\n" +
+	"\x12tolerations_config\x18\x13 \x01(\v2\x1a.storage.TolerationsConfigR\x11tolerationsConfig\x12\x1a\n" +
+	"\bpriority\x18\x14 \x01(\x03R\bpriority\x12@\n" +
+	"\x1cadmission_controller_updates\x18\x15 \x01(\bR\x1aadmissionControllerUpdates\x12A\n" +
+	"\rhealth_status\x18\x16 \x01(\v2\x1c.storage.ClusterHealthStatusR\fhealthStatus\x12%\n" +
+	"\x0eslim_collector\x18\x17 \x01(\bR\rslimCollector\x12?\n" +
+	"\vhelm_config\x18\x18 \x01(\v2\x1e.storage.CompleteClusterConfigR\n" +
+	"helmConfig\x12>\n" +
+	"\x1badmission_controller_events\x18\x19 \x01(\bR\x19admissionControllerEvents\x12Z\n" +
+	"\x15most_recent_sensor_id\x18\x1a \x01(\v2'.storage.SensorDeploymentIdentificationR\x12mostRecentSensorId\x125\n" +
+	"\x06labels\x18\x1b \x03(\v2\x1d.v1.ClusterConfig.LabelsEntryR\x06labels\x12L\n" +
+	"\x0faudit_log_state\x18\x1c \x03(\v2$.v1.ClusterConfig.AuditLogStateEntryR\rauditLogState\x12$\n" +
+	"\x0einit_bundle_id\x18\x1d \x01(\tR\finitBundleId\x123\n" +
+	"\n" +
+	"managed_by\x18\x1e \x01(\x0e2\x14.storage.ManagerTypeR\tmanagedBy\x12/\n" +
+	"\x13sensor_capabilities\x18\x1f \x03(\tR\x12sensorCapabilities\x12J\n" +
+	"\"admission_controller_fail_on_error\x18  \x01(\bR\x1eadmissionControllerFailOnError\x1a9\n" +
+	"\vLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a\\\n" +
+	"\x12AuditLogStateEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
+	"\x05value\x18\x02 \x01(\v2\x1a.storage.AuditLogFileStateR\x05value:\x028\x01J\x04\b\x06\x10\aJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
+	"J\x04\b\n" +
+	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rJ\x04\b\x0e\x10\x0f\"\x8a\x01\n" +
 	"\"DecommissionedClusterRetentionInfo\x12!\n" +
 	"\vis_excluded\x18\x01 \x01(\bH\x00R\n" +
 	"isExcluded\x120\n" +
 	"\x13days_until_deletion\x18\x02 \x01(\x05H\x00R\x11daysUntilDeletionB\x0f\n" +
-	"\rRetentionInfo\"\x9b\x01\n" +
-	"\x0fClusterResponse\x12*\n" +
-	"\acluster\x18\x01 \x01(\v2\x10.storage.ClusterR\acluster\x12\\\n" +
+	"\rRetentionInfo\"\x9c\x01\n" +
+	"\x0fClusterResponse\x12+\n" +
+	"\acluster\x18\x01 \x01(\v2\x11.v1.ClusterConfigR\acluster\x12\\\n" +
 	"\x16cluster_retention_info\x18\x02 \x01(\v2&.v1.DecommissionedClusterRetentionInfoR\x14clusterRetentionInfo\"\xc5\x01\n" +
 	"\x17ClusterDefaultsResponse\x122\n" +
 	"\x15main_image_repository\x18\x01 \x01(\tR\x13mainImageRepository\x12<\n" +
 	"\x1acollector_image_repository\x18\x02 \x01(\tR\x18collectorImageRepository\x128\n" +
-	"\x18kernel_support_available\x18\x03 \x01(\bR\x16kernelSupportAvailable\"\xa1\x02\n" +
-	"\fClustersList\x12,\n" +
-	"\bclusters\x18\x01 \x03(\v2\x10.storage.ClusterR\bclusters\x12n\n" +
+	"\x18kernel_support_available\x18\x03 \x01(\bR\x16kernelSupportAvailable\"\xa2\x02\n" +
+	"\fClustersList\x12-\n" +
+	"\bclusters\x18\x01 \x03(\v2\x11.v1.ClusterConfigR\bclusters\x12n\n" +
 	"\x1ccluster_id_to_retention_info\x18\x02 \x03(\v2..v1.ClustersList.ClusterIdToRetentionInfoEntryR\x18clusterIdToRetentionInfo\x1as\n" +
 	"\x1dClusterIdToRetentionInfoEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12<\n" +
@@ -500,14 +801,14 @@ const file_api_v1_cluster_service_proto_rawDesc = "" +
 	"\x04NONE\x10\x00\x12\x11\n" +
 	"\rLOAD_BALANCER\x10\x01\x12\r\n" +
 	"\tNODE_PORT\x10\x02\x12\t\n" +
-	"\x05ROUTE\x10\x032\xff\x04\n" +
+	"\x05ROUTE\x10\x032\x81\x05\n" +
 	"\x0fClustersService\x12M\n" +
 	"\vGetClusters\x12\x16.v1.GetClustersRequest\x1a\x10.v1.ClustersList\"\x14\x82\xd3\xe4\x93\x02\x0e\x12\f/v1/clusters\x12N\n" +
 	"\n" +
-	"GetCluster\x12\x10.v1.ResourceByID\x1a\x13.v1.ClusterResponse\"\x19\x82\xd3\xe4\x93\x02\x13\x12\x11/v1/clusters/{id}\x12M\n" +
-	"\vPostCluster\x12\x10.storage.Cluster\x1a\x13.v1.ClusterResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\"\f/v1/clusters\x12Q\n" +
+	"GetCluster\x12\x10.v1.ResourceByID\x1a\x13.v1.ClusterResponse\"\x19\x82\xd3\xe4\x93\x02\x13\x12\x11/v1/clusters/{id}\x12N\n" +
+	"\vPostCluster\x12\x11.v1.ClusterConfig\x1a\x13.v1.ClusterResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\"\f/v1/clusters\x12R\n" +
 	"\n" +
-	"PutCluster\x12\x10.storage.Cluster\x1a\x13.v1.ClusterResponse\"\x1c\x82\xd3\xe4\x93\x02\x16:\x01*\x1a\x11/v1/clusters/{id}\x12G\n" +
+	"PutCluster\x12\x11.v1.ClusterConfig\x1a\x13.v1.ClusterResponse\"\x1c\x82\xd3\xe4\x93\x02\x16:\x01*\x1a\x11/v1/clusters/{id}\x12G\n" +
 	"\rDeleteCluster\x12\x10.v1.ResourceByID\x1a\t.v1.Empty\"\x19\x82\xd3\xe4\x93\x02\x13*\x11/v1/clusters/{id}\x12\x80\x01\n" +
 	"\x19GetKernelSupportAvailable\x12\t.v1.Empty\x1a\".v1.KernelSupportAvailableResponse\"4\x82\xd3\xe4\x93\x02+\x12)/v1/clusters-env/kernel-support-available\x88\x02\x01\x12_\n" +
 	"\x17GetClusterDefaultValues\x12\t.v1.Empty\x1a\x1b.v1.ClusterDefaultsResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\x12\x14/v1/cluster-defaultsB'\n" +
@@ -526,46 +827,70 @@ func file_api_v1_cluster_service_proto_rawDescGZIP() []byte {
 }
 
 var file_api_v1_cluster_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_api_v1_cluster_service_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_api_v1_cluster_service_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_api_v1_cluster_service_proto_goTypes = []any{
-	(DeploymentFormat)(0),                      // 0: v1.DeploymentFormat
-	(LoadBalancerType)(0),                      // 1: v1.LoadBalancerType
-	(*DecommissionedClusterRetentionInfo)(nil), // 2: v1.DecommissionedClusterRetentionInfo
-	(*ClusterResponse)(nil),                    // 3: v1.ClusterResponse
-	(*ClusterDefaultsResponse)(nil),            // 4: v1.ClusterDefaultsResponse
-	(*ClustersList)(nil),                       // 5: v1.ClustersList
-	(*GetClustersRequest)(nil),                 // 6: v1.GetClustersRequest
-	(*KernelSupportAvailableResponse)(nil),     // 7: v1.KernelSupportAvailableResponse
-	nil,                                        // 8: v1.ClustersList.ClusterIdToRetentionInfoEntry
-	(*storage.Cluster)(nil),                    // 9: storage.Cluster
-	(*ResourceByID)(nil),                       // 10: v1.ResourceByID
-	(*Empty)(nil),                              // 11: v1.Empty
+	(DeploymentFormat)(0),                          // 0: v1.DeploymentFormat
+	(LoadBalancerType)(0),                          // 1: v1.LoadBalancerType
+	(*ClusterConfig)(nil),                          // 2: v1.ClusterConfig
+	(*DecommissionedClusterRetentionInfo)(nil),     // 3: v1.DecommissionedClusterRetentionInfo
+	(*ClusterResponse)(nil),                        // 4: v1.ClusterResponse
+	(*ClusterDefaultsResponse)(nil),                // 5: v1.ClusterDefaultsResponse
+	(*ClustersList)(nil),                           // 6: v1.ClustersList
+	(*GetClustersRequest)(nil),                     // 7: v1.GetClustersRequest
+	(*KernelSupportAvailableResponse)(nil),         // 8: v1.KernelSupportAvailableResponse
+	nil,                                            // 9: v1.ClusterConfig.LabelsEntry
+	nil,                                            // 10: v1.ClusterConfig.AuditLogStateEntry
+	nil,                                            // 11: v1.ClustersList.ClusterIdToRetentionInfoEntry
+	(storage.ClusterType)(0),                       // 12: storage.ClusterType
+	(*storage.ClusterStatus)(nil),                  // 13: storage.ClusterStatus
+	(storage.CollectionMethod)(0),                  // 14: storage.CollectionMethod
+	(*storage.DynamicClusterConfig)(nil),           // 15: storage.DynamicClusterConfig
+	(*storage.TolerationsConfig)(nil),              // 16: storage.TolerationsConfig
+	(*storage.ClusterHealthStatus)(nil),            // 17: storage.ClusterHealthStatus
+	(*storage.CompleteClusterConfig)(nil),          // 18: storage.CompleteClusterConfig
+	(*storage.SensorDeploymentIdentification)(nil), // 19: storage.SensorDeploymentIdentification
+	(storage.ManagerType)(0),                       // 20: storage.ManagerType
+	(*storage.AuditLogFileState)(nil),              // 21: storage.AuditLogFileState
+	(*ResourceByID)(nil),                           // 22: v1.ResourceByID
+	(*Empty)(nil),                                  // 23: v1.Empty
 }
 var file_api_v1_cluster_service_proto_depIdxs = []int32{
-	9,  // 0: v1.ClusterResponse.cluster:type_name -> storage.Cluster
-	2,  // 1: v1.ClusterResponse.cluster_retention_info:type_name -> v1.DecommissionedClusterRetentionInfo
-	9,  // 2: v1.ClustersList.clusters:type_name -> storage.Cluster
-	8,  // 3: v1.ClustersList.cluster_id_to_retention_info:type_name -> v1.ClustersList.ClusterIdToRetentionInfoEntry
-	2,  // 4: v1.ClustersList.ClusterIdToRetentionInfoEntry.value:type_name -> v1.DecommissionedClusterRetentionInfo
-	6,  // 5: v1.ClustersService.GetClusters:input_type -> v1.GetClustersRequest
-	10, // 6: v1.ClustersService.GetCluster:input_type -> v1.ResourceByID
-	9,  // 7: v1.ClustersService.PostCluster:input_type -> storage.Cluster
-	9,  // 8: v1.ClustersService.PutCluster:input_type -> storage.Cluster
-	10, // 9: v1.ClustersService.DeleteCluster:input_type -> v1.ResourceByID
-	11, // 10: v1.ClustersService.GetKernelSupportAvailable:input_type -> v1.Empty
-	11, // 11: v1.ClustersService.GetClusterDefaultValues:input_type -> v1.Empty
-	5,  // 12: v1.ClustersService.GetClusters:output_type -> v1.ClustersList
-	3,  // 13: v1.ClustersService.GetCluster:output_type -> v1.ClusterResponse
-	3,  // 14: v1.ClustersService.PostCluster:output_type -> v1.ClusterResponse
-	3,  // 15: v1.ClustersService.PutCluster:output_type -> v1.ClusterResponse
-	11, // 16: v1.ClustersService.DeleteCluster:output_type -> v1.Empty
-	7,  // 17: v1.ClustersService.GetKernelSupportAvailable:output_type -> v1.KernelSupportAvailableResponse
-	4,  // 18: v1.ClustersService.GetClusterDefaultValues:output_type -> v1.ClusterDefaultsResponse
-	12, // [12:19] is the sub-list for method output_type
-	5,  // [5:12] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	12, // 0: v1.ClusterConfig.type:type_name -> storage.ClusterType
+	13, // 1: v1.ClusterConfig.status:type_name -> storage.ClusterStatus
+	14, // 2: v1.ClusterConfig.collection_method:type_name -> storage.CollectionMethod
+	15, // 3: v1.ClusterConfig.dynamic_config:type_name -> storage.DynamicClusterConfig
+	16, // 4: v1.ClusterConfig.tolerations_config:type_name -> storage.TolerationsConfig
+	17, // 5: v1.ClusterConfig.health_status:type_name -> storage.ClusterHealthStatus
+	18, // 6: v1.ClusterConfig.helm_config:type_name -> storage.CompleteClusterConfig
+	19, // 7: v1.ClusterConfig.most_recent_sensor_id:type_name -> storage.SensorDeploymentIdentification
+	9,  // 8: v1.ClusterConfig.labels:type_name -> v1.ClusterConfig.LabelsEntry
+	10, // 9: v1.ClusterConfig.audit_log_state:type_name -> v1.ClusterConfig.AuditLogStateEntry
+	20, // 10: v1.ClusterConfig.managed_by:type_name -> storage.ManagerType
+	2,  // 11: v1.ClusterResponse.cluster:type_name -> v1.ClusterConfig
+	3,  // 12: v1.ClusterResponse.cluster_retention_info:type_name -> v1.DecommissionedClusterRetentionInfo
+	2,  // 13: v1.ClustersList.clusters:type_name -> v1.ClusterConfig
+	11, // 14: v1.ClustersList.cluster_id_to_retention_info:type_name -> v1.ClustersList.ClusterIdToRetentionInfoEntry
+	21, // 15: v1.ClusterConfig.AuditLogStateEntry.value:type_name -> storage.AuditLogFileState
+	3,  // 16: v1.ClustersList.ClusterIdToRetentionInfoEntry.value:type_name -> v1.DecommissionedClusterRetentionInfo
+	7,  // 17: v1.ClustersService.GetClusters:input_type -> v1.GetClustersRequest
+	22, // 18: v1.ClustersService.GetCluster:input_type -> v1.ResourceByID
+	2,  // 19: v1.ClustersService.PostCluster:input_type -> v1.ClusterConfig
+	2,  // 20: v1.ClustersService.PutCluster:input_type -> v1.ClusterConfig
+	22, // 21: v1.ClustersService.DeleteCluster:input_type -> v1.ResourceByID
+	23, // 22: v1.ClustersService.GetKernelSupportAvailable:input_type -> v1.Empty
+	23, // 23: v1.ClustersService.GetClusterDefaultValues:input_type -> v1.Empty
+	6,  // 24: v1.ClustersService.GetClusters:output_type -> v1.ClustersList
+	4,  // 25: v1.ClustersService.GetCluster:output_type -> v1.ClusterResponse
+	4,  // 26: v1.ClustersService.PostCluster:output_type -> v1.ClusterResponse
+	4,  // 27: v1.ClustersService.PutCluster:output_type -> v1.ClusterResponse
+	23, // 28: v1.ClustersService.DeleteCluster:output_type -> v1.Empty
+	8,  // 29: v1.ClustersService.GetKernelSupportAvailable:output_type -> v1.KernelSupportAvailableResponse
+	5,  // 30: v1.ClustersService.GetClusterDefaultValues:output_type -> v1.ClusterDefaultsResponse
+	24, // [24:31] is the sub-list for method output_type
+	17, // [17:24] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_api_v1_cluster_service_proto_init() }
@@ -575,7 +900,7 @@ func file_api_v1_cluster_service_proto_init() {
 	}
 	file_api_v1_common_proto_init()
 	file_api_v1_empty_proto_init()
-	file_api_v1_cluster_service_proto_msgTypes[0].OneofWrappers = []any{
+	file_api_v1_cluster_service_proto_msgTypes[1].OneofWrappers = []any{
 		(*DecommissionedClusterRetentionInfo_IsExcluded)(nil),
 		(*DecommissionedClusterRetentionInfo_DaysUntilDeletion)(nil),
 	}
@@ -585,7 +910,7 @@ func file_api_v1_cluster_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v1_cluster_service_proto_rawDesc), len(file_api_v1_cluster_service_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   7,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/generated/api/v1/cluster_service.pb.gw.go
+++ b/generated/api/v1/cluster_service.pb.gw.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
-	"github.com/stackrox/rox/generated/storage"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -112,7 +111,7 @@ func local_request_ClustersService_GetCluster_0(ctx context.Context, marshaler r
 
 func request_ClustersService_PostCluster_0(ctx context.Context, marshaler runtime.Marshaler, client ClustersServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq storage.Cluster
+		protoReq ClusterConfig
 		metadata runtime.ServerMetadata
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
@@ -127,7 +126,7 @@ func request_ClustersService_PostCluster_0(ctx context.Context, marshaler runtim
 
 func local_request_ClustersService_PostCluster_0(ctx context.Context, marshaler runtime.Marshaler, server ClustersServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq storage.Cluster
+		protoReq ClusterConfig
 		metadata runtime.ServerMetadata
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
@@ -139,7 +138,7 @@ func local_request_ClustersService_PostCluster_0(ctx context.Context, marshaler 
 
 func request_ClustersService_PutCluster_0(ctx context.Context, marshaler runtime.Marshaler, client ClustersServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq storage.Cluster
+		protoReq ClusterConfig
 		metadata runtime.ServerMetadata
 		err      error
 	)
@@ -163,7 +162,7 @@ func request_ClustersService_PutCluster_0(ctx context.Context, marshaler runtime
 
 func local_request_ClustersService_PutCluster_0(ctx context.Context, marshaler runtime.Marshaler, server ClustersServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
-		protoReq storage.Cluster
+		protoReq ClusterConfig
 		metadata runtime.ServerMetadata
 		err      error
 	)

--- a/generated/api/v1/cluster_service.swagger.json
+++ b/generated/api/v1/cluster_service.swagger.json
@@ -86,10 +86,11 @@
         "parameters": [
           {
             "name": "body",
+            "description": "ClusterConfig is the API-specific representation of a cluster.\nIt is field-number-identical to storage.Cluster to maintain gRPC wire\ncompatibility with older clients that send storage.Cluster directly.\nThis decoupling allows the storage representation to evolve independently\nfrom the API contract in the future.\n\nNote: Server-managed fields (status, health_status, most_recent_sensor_id,\nsensor_capabilities, audit_log_state, helm_config, init_bundle_id) are\naccepted in create/update requests for backward compatibility, but their\nvalues are silently ignored by the server. The server always uses its own\nauthoritative values for these fields.\nNext tag: 33",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/storageCluster"
+              "$ref": "#/definitions/v1ClusterConfig"
             }
           }
         ],
@@ -278,16 +279,7 @@
         "type": {
           "$ref": "#/definitions/storageClusterType"
         },
-        "labels": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
         "mainImage": {
-          "type": "string"
-        },
-        "collectorImage": {
           "type": "string"
         },
         "centralApiEndpoint": {
@@ -296,20 +288,18 @@
         "runtimeSupport": {
           "type": "boolean"
         },
-        "collectionMethod": {
-          "$ref": "#/definitions/storageCollectionMethod"
-        },
         "admissionController": {
           "type": "boolean"
         },
-        "admissionControllerUpdates": {
-          "type": "boolean"
-        },
-        "admissionControllerEvents": {
-          "type": "boolean"
-        },
         "status": {
-          "$ref": "#/definitions/storageClusterStatus"
+          "$ref": "#/definitions/storageClusterStatus",
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server. The server populates this from its own state."
+        },
+        "collectorImage": {
+          "type": "string"
+        },
+        "collectionMethod": {
+          "$ref": "#/definitions/storageCollectionMethod"
         },
         "dynamicConfig": {
           "$ref": "#/definitions/storageDynamicClusterConfig"
@@ -321,29 +311,43 @@
           "type": "string",
           "format": "int64"
         },
+        "admissionControllerUpdates": {
+          "type": "boolean"
+        },
         "healthStatus": {
-          "$ref": "#/definitions/storageClusterHealthStatus"
+          "$ref": "#/definitions/storageClusterHealthStatus",
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server. The server populates this from its own state."
         },
         "slimCollector": {
           "type": "boolean"
         },
         "helmConfig": {
           "$ref": "#/definitions/storageCompleteClusterConfig",
-          "description": "The Helm configuration of a cluster is only present in case the cluster is Helm- or Operator-managed."
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server."
+        },
+        "admissionControllerEvents": {
+          "type": "boolean"
         },
         "mostRecentSensorId": {
           "$ref": "#/definitions/storageSensorDeploymentIdentification",
-          "description": "most_recent_sensor_id is the current or most recent identification of a successfully connected sensor (if any)."
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server."
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "auditLogState": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/storageAuditLogFileState"
           },
-          "description": "For internal use only."
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server."
         },
         "initBundleId": {
-          "type": "string"
+          "type": "string",
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server."
         },
         "managedBy": {
           "$ref": "#/definitions/storageManagerType"
@@ -352,13 +356,14 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server."
         },
         "admissionControllerFailOnError": {
           "type": "boolean"
         }
       },
-      "title": "Next tag: 33"
+      "description": "ClusterConfig is the API-specific representation of a cluster.\nIt is field-number-identical to storage.Cluster to maintain gRPC wire\ncompatibility with older clients that send storage.Cluster directly.\nThis decoupling allows the storage representation to evolve independently\nfrom the API contract in the future.\n\nNote: Server-managed fields (status, health_status, most_recent_sensor_id,\nsensor_capabilities, audit_log_state, helm_config, init_bundle_id) are\naccepted in create/update requests for backward compatibility, but their\nvalues are silently ignored by the server. The server always uses its own\nauthoritative values for these fields.\nNext tag: 33"
     },
     "DynamicClusterConfigProcessIndicatorsConfig": {
       "type": "object",
@@ -517,100 +522,6 @@
           "type": "string"
         }
       }
-    },
-    "storageCluster": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "type": {
-          "$ref": "#/definitions/storageClusterType"
-        },
-        "labels": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "mainImage": {
-          "type": "string"
-        },
-        "collectorImage": {
-          "type": "string"
-        },
-        "centralApiEndpoint": {
-          "type": "string"
-        },
-        "runtimeSupport": {
-          "type": "boolean"
-        },
-        "collectionMethod": {
-          "$ref": "#/definitions/storageCollectionMethod"
-        },
-        "admissionController": {
-          "type": "boolean"
-        },
-        "admissionControllerUpdates": {
-          "type": "boolean"
-        },
-        "admissionControllerEvents": {
-          "type": "boolean"
-        },
-        "status": {
-          "$ref": "#/definitions/storageClusterStatus"
-        },
-        "dynamicConfig": {
-          "$ref": "#/definitions/storageDynamicClusterConfig"
-        },
-        "tolerationsConfig": {
-          "$ref": "#/definitions/storageTolerationsConfig"
-        },
-        "priority": {
-          "type": "string",
-          "format": "int64"
-        },
-        "healthStatus": {
-          "$ref": "#/definitions/storageClusterHealthStatus"
-        },
-        "slimCollector": {
-          "type": "boolean"
-        },
-        "helmConfig": {
-          "$ref": "#/definitions/storageCompleteClusterConfig",
-          "description": "The Helm configuration of a cluster is only present in case the cluster is Helm- or Operator-managed."
-        },
-        "mostRecentSensorId": {
-          "$ref": "#/definitions/storageSensorDeploymentIdentification",
-          "description": "most_recent_sensor_id is the current or most recent identification of a successfully connected sensor (if any)."
-        },
-        "auditLogState": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/storageAuditLogFileState"
-          },
-          "description": "For internal use only."
-        },
-        "initBundleId": {
-          "type": "string"
-        },
-        "managedBy": {
-          "$ref": "#/definitions/storageManagerType"
-        },
-        "sensorCapabilities": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "admissionControllerFailOnError": {
-          "type": "boolean"
-        }
-      },
-      "title": "Next tag: 33"
     },
     "storageClusterCertExpiryStatus": {
       "type": "object",
@@ -1015,6 +926,104 @@
         }
       }
     },
+    "v1ClusterConfig": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/storageClusterType"
+        },
+        "mainImage": {
+          "type": "string"
+        },
+        "centralApiEndpoint": {
+          "type": "string"
+        },
+        "runtimeSupport": {
+          "type": "boolean"
+        },
+        "admissionController": {
+          "type": "boolean"
+        },
+        "status": {
+          "$ref": "#/definitions/storageClusterStatus",
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server. The server populates this from its own state."
+        },
+        "collectorImage": {
+          "type": "string"
+        },
+        "collectionMethod": {
+          "$ref": "#/definitions/storageCollectionMethod"
+        },
+        "dynamicConfig": {
+          "$ref": "#/definitions/storageDynamicClusterConfig"
+        },
+        "tolerationsConfig": {
+          "$ref": "#/definitions/storageTolerationsConfig"
+        },
+        "priority": {
+          "type": "string",
+          "format": "int64"
+        },
+        "admissionControllerUpdates": {
+          "type": "boolean"
+        },
+        "healthStatus": {
+          "$ref": "#/definitions/storageClusterHealthStatus",
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server. The server populates this from its own state."
+        },
+        "slimCollector": {
+          "type": "boolean"
+        },
+        "helmConfig": {
+          "$ref": "#/definitions/storageCompleteClusterConfig",
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server."
+        },
+        "admissionControllerEvents": {
+          "type": "boolean"
+        },
+        "mostRecentSensorId": {
+          "$ref": "#/definitions/storageSensorDeploymentIdentification",
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server."
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "auditLogState": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/storageAuditLogFileState"
+          },
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server."
+        },
+        "initBundleId": {
+          "type": "string",
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server."
+        },
+        "managedBy": {
+          "$ref": "#/definitions/storageManagerType"
+        },
+        "sensorCapabilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Server-managed: accepted in requests for backward compatibility but\nignored by the server."
+        },
+        "admissionControllerFailOnError": {
+          "type": "boolean"
+        }
+      },
+      "description": "ClusterConfig is the API-specific representation of a cluster.\nIt is field-number-identical to storage.Cluster to maintain gRPC wire\ncompatibility with older clients that send storage.Cluster directly.\nThis decoupling allows the storage representation to evolve independently\nfrom the API contract in the future.\n\nNote: Server-managed fields (status, health_status, most_recent_sensor_id,\nsensor_capabilities, audit_log_state, helm_config, init_bundle_id) are\naccepted in create/update requests for backward compatibility, but their\nvalues are silently ignored by the server. The server always uses its own\nauthoritative values for these fields.\nNext tag: 33"
+    },
     "v1ClusterDefaultsResponse": {
       "type": "object",
       "properties": {
@@ -1033,7 +1042,7 @@
       "type": "object",
       "properties": {
         "cluster": {
-          "$ref": "#/definitions/storageCluster"
+          "$ref": "#/definitions/v1ClusterConfig"
         },
         "clusterRetentionInfo": {
           "$ref": "#/definitions/v1DecommissionedClusterRetentionInfo"
@@ -1047,7 +1056,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/storageCluster"
+            "$ref": "#/definitions/v1ClusterConfig"
           }
         },
         "clusterIdToRetentionInfo": {

--- a/generated/api/v1/cluster_service_grpc.pb.go
+++ b/generated/api/v1/cluster_service_grpc.pb.go
@@ -8,7 +8,6 @@ package v1
 
 import (
 	context "context"
-	storage "github.com/stackrox/rox/generated/storage"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -35,8 +34,8 @@ const (
 type ClustersServiceClient interface {
 	GetClusters(ctx context.Context, in *GetClustersRequest, opts ...grpc.CallOption) (*ClustersList, error)
 	GetCluster(ctx context.Context, in *ResourceByID, opts ...grpc.CallOption) (*ClusterResponse, error)
-	PostCluster(ctx context.Context, in *storage.Cluster, opts ...grpc.CallOption) (*ClusterResponse, error)
-	PutCluster(ctx context.Context, in *storage.Cluster, opts ...grpc.CallOption) (*ClusterResponse, error)
+	PostCluster(ctx context.Context, in *ClusterConfig, opts ...grpc.CallOption) (*ClusterResponse, error)
+	PutCluster(ctx context.Context, in *ClusterConfig, opts ...grpc.CallOption) (*ClusterResponse, error)
 	DeleteCluster(ctx context.Context, in *ResourceByID, opts ...grpc.CallOption) (*Empty, error)
 	// Deprecated: Do not use.
 	// GetKernelSupportAvailable is deprecated in favor of GetClusterDefaultValues.
@@ -72,7 +71,7 @@ func (c *clustersServiceClient) GetCluster(ctx context.Context, in *ResourceByID
 	return out, nil
 }
 
-func (c *clustersServiceClient) PostCluster(ctx context.Context, in *storage.Cluster, opts ...grpc.CallOption) (*ClusterResponse, error) {
+func (c *clustersServiceClient) PostCluster(ctx context.Context, in *ClusterConfig, opts ...grpc.CallOption) (*ClusterResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ClusterResponse)
 	err := c.cc.Invoke(ctx, ClustersService_PostCluster_FullMethodName, in, out, cOpts...)
@@ -82,7 +81,7 @@ func (c *clustersServiceClient) PostCluster(ctx context.Context, in *storage.Clu
 	return out, nil
 }
 
-func (c *clustersServiceClient) PutCluster(ctx context.Context, in *storage.Cluster, opts ...grpc.CallOption) (*ClusterResponse, error) {
+func (c *clustersServiceClient) PutCluster(ctx context.Context, in *ClusterConfig, opts ...grpc.CallOption) (*ClusterResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ClusterResponse)
 	err := c.cc.Invoke(ctx, ClustersService_PutCluster_FullMethodName, in, out, cOpts...)
@@ -129,8 +128,8 @@ func (c *clustersServiceClient) GetClusterDefaultValues(ctx context.Context, in 
 type ClustersServiceServer interface {
 	GetClusters(context.Context, *GetClustersRequest) (*ClustersList, error)
 	GetCluster(context.Context, *ResourceByID) (*ClusterResponse, error)
-	PostCluster(context.Context, *storage.Cluster) (*ClusterResponse, error)
-	PutCluster(context.Context, *storage.Cluster) (*ClusterResponse, error)
+	PostCluster(context.Context, *ClusterConfig) (*ClusterResponse, error)
+	PutCluster(context.Context, *ClusterConfig) (*ClusterResponse, error)
 	DeleteCluster(context.Context, *ResourceByID) (*Empty, error)
 	// Deprecated: Do not use.
 	// GetKernelSupportAvailable is deprecated in favor of GetClusterDefaultValues.
@@ -151,10 +150,10 @@ func (UnimplementedClustersServiceServer) GetClusters(context.Context, *GetClust
 func (UnimplementedClustersServiceServer) GetCluster(context.Context, *ResourceByID) (*ClusterResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetCluster not implemented")
 }
-func (UnimplementedClustersServiceServer) PostCluster(context.Context, *storage.Cluster) (*ClusterResponse, error) {
+func (UnimplementedClustersServiceServer) PostCluster(context.Context, *ClusterConfig) (*ClusterResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PostCluster not implemented")
 }
-func (UnimplementedClustersServiceServer) PutCluster(context.Context, *storage.Cluster) (*ClusterResponse, error) {
+func (UnimplementedClustersServiceServer) PutCluster(context.Context, *ClusterConfig) (*ClusterResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PutCluster not implemented")
 }
 func (UnimplementedClustersServiceServer) DeleteCluster(context.Context, *ResourceByID) (*Empty, error) {
@@ -223,7 +222,7 @@ func _ClustersService_GetCluster_Handler(srv interface{}, ctx context.Context, d
 }
 
 func _ClustersService_PostCluster_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(storage.Cluster)
+	in := new(ClusterConfig)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -235,13 +234,13 @@ func _ClustersService_PostCluster_Handler(srv interface{}, ctx context.Context, 
 		FullMethod: ClustersService_PostCluster_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ClustersServiceServer).PostCluster(ctx, req.(*storage.Cluster))
+		return srv.(ClustersServiceServer).PostCluster(ctx, req.(*ClusterConfig))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _ClustersService_PutCluster_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(storage.Cluster)
+	in := new(ClusterConfig)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -253,7 +252,7 @@ func _ClustersService_PutCluster_Handler(srv interface{}, ctx context.Context, d
 		FullMethod: ClustersService_PutCluster_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ClustersServiceServer).PutCluster(ctx, req.(*storage.Cluster))
+		return srv.(ClustersServiceServer).PutCluster(ctx, req.(*ClusterConfig))
 	}
 	return interceptor(ctx, in, info, handler)
 }

--- a/generated/api/v1/cluster_service_vtproto.pb.go
+++ b/generated/api/v1/cluster_service_vtproto.pb.go
@@ -21,6 +21,115 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+func (m *ClusterConfig) CloneVT() *ClusterConfig {
+	if m == nil {
+		return (*ClusterConfig)(nil)
+	}
+	r := new(ClusterConfig)
+	r.Id = m.Id
+	r.Name = m.Name
+	r.Type = m.Type
+	r.MainImage = m.MainImage
+	r.CentralApiEndpoint = m.CentralApiEndpoint
+	r.RuntimeSupport = m.RuntimeSupport
+	r.AdmissionController = m.AdmissionController
+	r.CollectorImage = m.CollectorImage
+	r.CollectionMethod = m.CollectionMethod
+	r.Priority = m.Priority
+	r.AdmissionControllerUpdates = m.AdmissionControllerUpdates
+	r.SlimCollector = m.SlimCollector
+	r.AdmissionControllerEvents = m.AdmissionControllerEvents
+	r.InitBundleId = m.InitBundleId
+	r.ManagedBy = m.ManagedBy
+	r.AdmissionControllerFailOnError = m.AdmissionControllerFailOnError
+	if rhs := m.Status; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *storage.ClusterStatus }); ok {
+			r.Status = vtpb.CloneVT()
+		} else {
+			r.Status = proto.Clone(rhs).(*storage.ClusterStatus)
+		}
+	}
+	if rhs := m.DynamicConfig; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface {
+			CloneVT() *storage.DynamicClusterConfig
+		}); ok {
+			r.DynamicConfig = vtpb.CloneVT()
+		} else {
+			r.DynamicConfig = proto.Clone(rhs).(*storage.DynamicClusterConfig)
+		}
+	}
+	if rhs := m.TolerationsConfig; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface {
+			CloneVT() *storage.TolerationsConfig
+		}); ok {
+			r.TolerationsConfig = vtpb.CloneVT()
+		} else {
+			r.TolerationsConfig = proto.Clone(rhs).(*storage.TolerationsConfig)
+		}
+	}
+	if rhs := m.HealthStatus; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface {
+			CloneVT() *storage.ClusterHealthStatus
+		}); ok {
+			r.HealthStatus = vtpb.CloneVT()
+		} else {
+			r.HealthStatus = proto.Clone(rhs).(*storage.ClusterHealthStatus)
+		}
+	}
+	if rhs := m.HelmConfig; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface {
+			CloneVT() *storage.CompleteClusterConfig
+		}); ok {
+			r.HelmConfig = vtpb.CloneVT()
+		} else {
+			r.HelmConfig = proto.Clone(rhs).(*storage.CompleteClusterConfig)
+		}
+	}
+	if rhs := m.MostRecentSensorId; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface {
+			CloneVT() *storage.SensorDeploymentIdentification
+		}); ok {
+			r.MostRecentSensorId = vtpb.CloneVT()
+		} else {
+			r.MostRecentSensorId = proto.Clone(rhs).(*storage.SensorDeploymentIdentification)
+		}
+	}
+	if rhs := m.Labels; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.Labels = tmpContainer
+	}
+	if rhs := m.AuditLogState; rhs != nil {
+		tmpContainer := make(map[string]*storage.AuditLogFileState, len(rhs))
+		for k, v := range rhs {
+			if vtpb, ok := interface{}(v).(interface {
+				CloneVT() *storage.AuditLogFileState
+			}); ok {
+				tmpContainer[k] = vtpb.CloneVT()
+			} else {
+				tmpContainer[k] = proto.Clone(v).(*storage.AuditLogFileState)
+			}
+		}
+		r.AuditLogState = tmpContainer
+	}
+	if rhs := m.SensorCapabilities; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.SensorCapabilities = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ClusterConfig) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *DecommissionedClusterRetentionInfo) CloneVT() *DecommissionedClusterRetentionInfo {
 	if m == nil {
 		return (*DecommissionedClusterRetentionInfo)(nil)
@@ -65,14 +174,8 @@ func (m *ClusterResponse) CloneVT() *ClusterResponse {
 		return (*ClusterResponse)(nil)
 	}
 	r := new(ClusterResponse)
+	r.Cluster = m.Cluster.CloneVT()
 	r.ClusterRetentionInfo = m.ClusterRetentionInfo.CloneVT()
-	if rhs := m.Cluster; rhs != nil {
-		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *storage.Cluster }); ok {
-			r.Cluster = vtpb.CloneVT()
-		} else {
-			r.Cluster = proto.Clone(rhs).(*storage.Cluster)
-		}
-	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -109,13 +212,9 @@ func (m *ClustersList) CloneVT() *ClustersList {
 	}
 	r := new(ClustersList)
 	if rhs := m.Clusters; rhs != nil {
-		tmpContainer := make([]*storage.Cluster, len(rhs))
+		tmpContainer := make([]*ClusterConfig, len(rhs))
 		for k, v := range rhs {
-			if vtpb, ok := interface{}(v).(interface{ CloneVT() *storage.Cluster }); ok {
-				tmpContainer[k] = vtpb.CloneVT()
-			} else {
-				tmpContainer[k] = proto.Clone(v).(*storage.Cluster)
-			}
+			tmpContainer[k] = v.CloneVT()
 		}
 		r.Clusters = tmpContainer
 	}
@@ -171,6 +270,171 @@ func (m *KernelSupportAvailableResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (this *ClusterConfig) EqualVT(that *ClusterConfig) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Id != that.Id {
+		return false
+	}
+	if this.Name != that.Name {
+		return false
+	}
+	if this.Type != that.Type {
+		return false
+	}
+	if this.MainImage != that.MainImage {
+		return false
+	}
+	if this.CentralApiEndpoint != that.CentralApiEndpoint {
+		return false
+	}
+	if this.RuntimeSupport != that.RuntimeSupport {
+		return false
+	}
+	if this.AdmissionController != that.AdmissionController {
+		return false
+	}
+	if equal, ok := interface{}(this.Status).(interface {
+		EqualVT(*storage.ClusterStatus) bool
+	}); ok {
+		if !equal.EqualVT(that.Status) {
+			return false
+		}
+	} else if !proto.Equal(this.Status, that.Status) {
+		return false
+	}
+	if this.CollectorImage != that.CollectorImage {
+		return false
+	}
+	if this.CollectionMethod != that.CollectionMethod {
+		return false
+	}
+	if equal, ok := interface{}(this.DynamicConfig).(interface {
+		EqualVT(*storage.DynamicClusterConfig) bool
+	}); ok {
+		if !equal.EqualVT(that.DynamicConfig) {
+			return false
+		}
+	} else if !proto.Equal(this.DynamicConfig, that.DynamicConfig) {
+		return false
+	}
+	if equal, ok := interface{}(this.TolerationsConfig).(interface {
+		EqualVT(*storage.TolerationsConfig) bool
+	}); ok {
+		if !equal.EqualVT(that.TolerationsConfig) {
+			return false
+		}
+	} else if !proto.Equal(this.TolerationsConfig, that.TolerationsConfig) {
+		return false
+	}
+	if this.Priority != that.Priority {
+		return false
+	}
+	if this.AdmissionControllerUpdates != that.AdmissionControllerUpdates {
+		return false
+	}
+	if equal, ok := interface{}(this.HealthStatus).(interface {
+		EqualVT(*storage.ClusterHealthStatus) bool
+	}); ok {
+		if !equal.EqualVT(that.HealthStatus) {
+			return false
+		}
+	} else if !proto.Equal(this.HealthStatus, that.HealthStatus) {
+		return false
+	}
+	if this.SlimCollector != that.SlimCollector {
+		return false
+	}
+	if equal, ok := interface{}(this.HelmConfig).(interface {
+		EqualVT(*storage.CompleteClusterConfig) bool
+	}); ok {
+		if !equal.EqualVT(that.HelmConfig) {
+			return false
+		}
+	} else if !proto.Equal(this.HelmConfig, that.HelmConfig) {
+		return false
+	}
+	if this.AdmissionControllerEvents != that.AdmissionControllerEvents {
+		return false
+	}
+	if equal, ok := interface{}(this.MostRecentSensorId).(interface {
+		EqualVT(*storage.SensorDeploymentIdentification) bool
+	}); ok {
+		if !equal.EqualVT(that.MostRecentSensorId) {
+			return false
+		}
+	} else if !proto.Equal(this.MostRecentSensorId, that.MostRecentSensorId) {
+		return false
+	}
+	if len(this.Labels) != len(that.Labels) {
+		return false
+	}
+	for i, vx := range this.Labels {
+		vy, ok := that.Labels[i]
+		if !ok {
+			return false
+		}
+		if vx != vy {
+			return false
+		}
+	}
+	if len(this.AuditLogState) != len(that.AuditLogState) {
+		return false
+	}
+	for i, vx := range this.AuditLogState {
+		vy, ok := that.AuditLogState[i]
+		if !ok {
+			return false
+		}
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &storage.AuditLogFileState{}
+			}
+			if q == nil {
+				q = &storage.AuditLogFileState{}
+			}
+			if equal, ok := interface{}(p).(interface {
+				EqualVT(*storage.AuditLogFileState) bool
+			}); ok {
+				if !equal.EqualVT(q) {
+					return false
+				}
+			} else if !proto.Equal(p, q) {
+				return false
+			}
+		}
+	}
+	if this.InitBundleId != that.InitBundleId {
+		return false
+	}
+	if this.ManagedBy != that.ManagedBy {
+		return false
+	}
+	if len(this.SensorCapabilities) != len(that.SensorCapabilities) {
+		return false
+	}
+	for i, vx := range this.SensorCapabilities {
+		vy := that.SensorCapabilities[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if this.AdmissionControllerFailOnError != that.AdmissionControllerFailOnError {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ClusterConfig) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ClusterConfig)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *DecommissionedClusterRetentionInfo) EqualVT(that *DecommissionedClusterRetentionInfo) bool {
 	if this == that {
 		return true
@@ -239,11 +503,7 @@ func (this *ClusterResponse) EqualVT(that *ClusterResponse) bool {
 	} else if this == nil || that == nil {
 		return false
 	}
-	if equal, ok := interface{}(this.Cluster).(interface{ EqualVT(*storage.Cluster) bool }); ok {
-		if !equal.EqualVT(that.Cluster) {
-			return false
-		}
-	} else if !proto.Equal(this.Cluster, that.Cluster) {
+	if !this.Cluster.EqualVT(that.Cluster) {
 		return false
 	}
 	if !this.ClusterRetentionInfo.EqualVT(that.ClusterRetentionInfo) {
@@ -297,16 +557,12 @@ func (this *ClustersList) EqualVT(that *ClustersList) bool {
 		vy := that.Clusters[i]
 		if p, q := vx, vy; p != q {
 			if p == nil {
-				p = &storage.Cluster{}
+				p = &ClusterConfig{}
 			}
 			if q == nil {
-				q = &storage.Cluster{}
+				q = &ClusterConfig{}
 			}
-			if equal, ok := interface{}(p).(interface{ EqualVT(*storage.Cluster) bool }); ok {
-				if !equal.EqualVT(q) {
-					return false
-				}
-			} else if !proto.Equal(p, q) {
+			if !p.EqualVT(q) {
 				return false
 			}
 		}
@@ -379,6 +635,389 @@ func (this *KernelSupportAvailableResponse) EqualMessageVT(thatMsg proto.Message
 	}
 	return this.EqualVT(that)
 }
+func (m *ClusterConfig) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ClusterConfig) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ClusterConfig) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.AdmissionControllerFailOnError {
+		i--
+		if m.AdmissionControllerFailOnError {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x2
+		i--
+		dAtA[i] = 0x80
+	}
+	if len(m.SensorCapabilities) > 0 {
+		for iNdEx := len(m.SensorCapabilities) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.SensorCapabilities[iNdEx])
+			copy(dAtA[i:], m.SensorCapabilities[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SensorCapabilities[iNdEx])))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xfa
+		}
+	}
+	if m.ManagedBy != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.ManagedBy))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xf0
+	}
+	if len(m.InitBundleId) > 0 {
+		i -= len(m.InitBundleId)
+		copy(dAtA[i:], m.InitBundleId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.InitBundleId)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xea
+	}
+	if len(m.AuditLogState) > 0 {
+		for k := range m.AuditLogState {
+			v := m.AuditLogState[k]
+			baseI := i
+			if vtmsg, ok := interface{}(v).(interface {
+				MarshalToSizedBufferVT([]byte) (int, error)
+			}); ok {
+				size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			} else {
+				encoded, err := proto.Marshal(v)
+				if err != nil {
+					return 0, err
+				}
+				i -= len(encoded)
+				copy(dAtA[i:], encoded)
+				i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			}
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xe2
+		}
+	}
+	if len(m.Labels) > 0 {
+		for k := range m.Labels {
+			v := m.Labels[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0xda
+		}
+	}
+	if m.MostRecentSensorId != nil {
+		if vtmsg, ok := interface{}(m.MostRecentSensorId).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.MostRecentSensorId)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xd2
+	}
+	if m.AdmissionControllerEvents {
+		i--
+		if m.AdmissionControllerEvents {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xc8
+	}
+	if m.HelmConfig != nil {
+		if vtmsg, ok := interface{}(m.HelmConfig).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.HelmConfig)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xc2
+	}
+	if m.SlimCollector {
+		i--
+		if m.SlimCollector {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb8
+	}
+	if m.HealthStatus != nil {
+		if vtmsg, ok := interface{}(m.HealthStatus).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.HealthStatus)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xb2
+	}
+	if m.AdmissionControllerUpdates {
+		i--
+		if m.AdmissionControllerUpdates {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa8
+	}
+	if m.Priority != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Priority))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xa0
+	}
+	if m.TolerationsConfig != nil {
+		if vtmsg, ok := interface{}(m.TolerationsConfig).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.TolerationsConfig)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x9a
+	}
+	if m.DynamicConfig != nil {
+		if vtmsg, ok := interface{}(m.DynamicConfig).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.DynamicConfig)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x92
+	}
+	if m.CollectionMethod != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.CollectionMethod))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x88
+	}
+	if len(m.CollectorImage) > 0 {
+		i -= len(m.CollectorImage)
+		copy(dAtA[i:], m.CollectorImage)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CollectorImage)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x82
+	}
+	if m.Status != nil {
+		if vtmsg, ok := interface{}(m.Status).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.Status)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
+		i--
+		dAtA[i] = 0x7a
+	}
+	if m.AdmissionController {
+		i--
+		if m.AdmissionController {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.RuntimeSupport {
+		i--
+		if m.RuntimeSupport {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x38
+	}
+	if len(m.CentralApiEndpoint) > 0 {
+		i -= len(m.CentralApiEndpoint)
+		copy(dAtA[i:], m.CentralApiEndpoint)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.CentralApiEndpoint)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.MainImage) > 0 {
+		i -= len(m.MainImage)
+		copy(dAtA[i:], m.MainImage)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MainImage)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.Type != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Type))
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *DecommissionedClusterRetentionInfo) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -491,24 +1130,12 @@ func (m *ClusterResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		dAtA[i] = 0x12
 	}
 	if m.Cluster != nil {
-		if vtmsg, ok := interface{}(m.Cluster).(interface {
-			MarshalToSizedBufferVT([]byte) (int, error)
-		}); ok {
-			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
-			if err != nil {
-				return 0, err
-			}
-			i -= size
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
-		} else {
-			encoded, err := proto.Marshal(m.Cluster)
-			if err != nil {
-				return 0, err
-			}
-			i -= len(encoded)
-			copy(dAtA[i:], encoded)
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		size, err := m.Cluster.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
 		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
 		dAtA[i] = 0xa
 	}
@@ -626,24 +1253,12 @@ func (m *ClustersList) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	}
 	if len(m.Clusters) > 0 {
 		for iNdEx := len(m.Clusters) - 1; iNdEx >= 0; iNdEx-- {
-			if vtmsg, ok := interface{}(m.Clusters[iNdEx]).(interface {
-				MarshalToSizedBufferVT([]byte) (int, error)
-			}); ok {
-				size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
-				if err != nil {
-					return 0, err
-				}
-				i -= size
-				i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
-			} else {
-				encoded, err := proto.Marshal(m.Clusters[iNdEx])
-				if err != nil {
-					return 0, err
-				}
-				i -= len(encoded)
-				copy(dAtA[i:], encoded)
-				i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			size, err := m.Clusters[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
 			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 			i--
 			dAtA[i] = 0xa
 		}
@@ -734,6 +1349,163 @@ func (m *KernelSupportAvailableResponse) MarshalToSizedBufferVT(dAtA []byte) (in
 	return len(dAtA) - i, nil
 }
 
+func (m *ClusterConfig) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Type != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Type))
+	}
+	l = len(m.MainImage)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.CentralApiEndpoint)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.RuntimeSupport {
+		n += 2
+	}
+	if m.AdmissionController {
+		n += 2
+	}
+	if m.Status != nil {
+		if size, ok := interface{}(m.Status).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.Status)
+		}
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.CollectorImage)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.CollectionMethod != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.CollectionMethod))
+	}
+	if m.DynamicConfig != nil {
+		if size, ok := interface{}(m.DynamicConfig).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.DynamicConfig)
+		}
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.TolerationsConfig != nil {
+		if size, ok := interface{}(m.TolerationsConfig).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.TolerationsConfig)
+		}
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Priority != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.Priority))
+	}
+	if m.AdmissionControllerUpdates {
+		n += 3
+	}
+	if m.HealthStatus != nil {
+		if size, ok := interface{}(m.HealthStatus).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.HealthStatus)
+		}
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.SlimCollector {
+		n += 3
+	}
+	if m.HelmConfig != nil {
+		if size, ok := interface{}(m.HelmConfig).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.HelmConfig)
+		}
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.AdmissionControllerEvents {
+		n += 3
+	}
+	if m.MostRecentSensorId != nil {
+		if size, ok := interface{}(m.MostRecentSensorId).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.MostRecentSensorId)
+		}
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Labels) > 0 {
+		for k, v := range m.Labels {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 2 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if len(m.AuditLogState) > 0 {
+		for k, v := range m.AuditLogState {
+			_ = k
+			_ = v
+			l = 0
+			if v != nil {
+				if size, ok := interface{}(v).(interface {
+					SizeVT() int
+				}); ok {
+					l = size.SizeVT()
+				} else {
+					l = proto.Size(v)
+				}
+			}
+			l += 1 + protohelpers.SizeOfVarint(uint64(l))
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + l
+			n += mapEntrySize + 2 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	l = len(m.InitBundleId)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.ManagedBy != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.ManagedBy))
+	}
+	if len(m.SensorCapabilities) > 0 {
+		for _, s := range m.SensorCapabilities {
+			l = len(s)
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if m.AdmissionControllerFailOnError {
+		n += 3
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *DecommissionedClusterRetentionInfo) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -772,13 +1544,7 @@ func (m *ClusterResponse) SizeVT() (n int) {
 	var l int
 	_ = l
 	if m.Cluster != nil {
-		if size, ok := interface{}(m.Cluster).(interface {
-			SizeVT() int
-		}); ok {
-			l = size.SizeVT()
-		} else {
-			l = proto.Size(m.Cluster)
-		}
+		l = m.Cluster.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if m.ClusterRetentionInfo != nil {
@@ -818,13 +1584,7 @@ func (m *ClustersList) SizeVT() (n int) {
 	_ = l
 	if len(m.Clusters) > 0 {
 		for _, e := range m.Clusters {
-			if size, ok := interface{}(e).(interface {
-				SizeVT() int
-			}); ok {
-				l = size.SizeVT()
-			} else {
-				l = proto.Size(e)
-			}
+			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
@@ -872,6 +1632,1005 @@ func (m *KernelSupportAvailableResponse) SizeVT() (n int) {
 	return n
 }
 
+func (m *ClusterConfig) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ClusterConfig: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ClusterConfig: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			m.Type = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Type |= storage.ClusterType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MainImage", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MainImage = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CentralApiEndpoint", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CentralApiEndpoint = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RuntimeSupport", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.RuntimeSupport = bool(v != 0)
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AdmissionController", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AdmissionController = bool(v != 0)
+		case 15:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Status == nil {
+				m.Status = &storage.ClusterStatus{}
+			}
+			if unmarshal, ok := interface{}(m.Status).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Status); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 16:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CollectorImage", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CollectorImage = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 17:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CollectionMethod", wireType)
+			}
+			m.CollectionMethod = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CollectionMethod |= storage.CollectionMethod(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 18:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DynamicConfig", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DynamicConfig == nil {
+				m.DynamicConfig = &storage.DynamicClusterConfig{}
+			}
+			if unmarshal, ok := interface{}(m.DynamicConfig).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.DynamicConfig); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 19:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TolerationsConfig", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.TolerationsConfig == nil {
+				m.TolerationsConfig = &storage.TolerationsConfig{}
+			}
+			if unmarshal, ok := interface{}(m.TolerationsConfig).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.TolerationsConfig); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 20:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Priority", wireType)
+			}
+			m.Priority = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Priority |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 21:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AdmissionControllerUpdates", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AdmissionControllerUpdates = bool(v != 0)
+		case 22:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HealthStatus", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.HealthStatus == nil {
+				m.HealthStatus = &storage.ClusterHealthStatus{}
+			}
+			if unmarshal, ok := interface{}(m.HealthStatus).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.HealthStatus); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 23:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SlimCollector", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.SlimCollector = bool(v != 0)
+		case 24:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HelmConfig", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.HelmConfig == nil {
+				m.HelmConfig = &storage.CompleteClusterConfig{}
+			}
+			if unmarshal, ok := interface{}(m.HelmConfig).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.HelmConfig); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 25:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AdmissionControllerEvents", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AdmissionControllerEvents = bool(v != 0)
+		case 26:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MostRecentSensorId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.MostRecentSensorId == nil {
+				m.MostRecentSensorId = &storage.SensorDeploymentIdentification{}
+			}
+			if unmarshal, ok := interface{}(m.MostRecentSensorId).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.MostRecentSensorId); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 27:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Labels == nil {
+				m.Labels = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Labels[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 28:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AuditLogState", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.AuditLogState == nil {
+				m.AuditLogState = make(map[string]*storage.AuditLogFileState)
+			}
+			var mapkey string
+			var mapvalue *storage.AuditLogFileState
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if postmsgIndex < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &storage.AuditLogFileState{}
+					if unmarshal, ok := interface{}(mapvalue).(interface {
+						UnmarshalVT([]byte) error
+					}); ok {
+						if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postmsgIndex]); err != nil {
+							return err
+						}
+					} else {
+						if err := proto.Unmarshal(dAtA[iNdEx:postmsgIndex], mapvalue); err != nil {
+							return err
+						}
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.AuditLogState[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 29:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InitBundleId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.InitBundleId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 30:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ManagedBy", wireType)
+			}
+			m.ManagedBy = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ManagedBy |= storage.ManagerType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 31:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SensorCapabilities", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SensorCapabilities = append(m.SensorCapabilities, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 32:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AdmissionControllerFailOnError", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AdmissionControllerFailOnError = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *DecommissionedClusterRetentionInfo) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1023,18 +2782,10 @@ func (m *ClusterResponse) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Cluster == nil {
-				m.Cluster = &storage.Cluster{}
+				m.Cluster = &ClusterConfig{}
 			}
-			if unmarshal, ok := interface{}(m.Cluster).(interface {
-				UnmarshalVT([]byte) error
-			}); ok {
-				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
-					return err
-				}
-			} else {
-				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Cluster); err != nil {
-					return err
-				}
+			if err := m.Cluster.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
 			iNdEx = postIndex
 		case 2:
@@ -1288,17 +3039,9 @@ func (m *ClustersList) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Clusters = append(m.Clusters, &storage.Cluster{})
-			if unmarshal, ok := interface{}(m.Clusters[len(m.Clusters)-1]).(interface {
-				UnmarshalVT([]byte) error
-			}); ok {
-				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
-					return err
-				}
-			} else {
-				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Clusters[len(m.Clusters)-1]); err != nil {
-					return err
-				}
+			m.Clusters = append(m.Clusters, &ClusterConfig{})
+			if err := m.Clusters[len(m.Clusters)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
 			iNdEx = postIndex
 		case 2:
@@ -1606,6 +3349,1045 @@ func (m *KernelSupportAvailableResponse) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *ClusterConfig) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ClusterConfig: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ClusterConfig: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Id = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Name = stringValue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			m.Type = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Type |= storage.ClusterType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MainImage", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.MainImage = stringValue
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CentralApiEndpoint", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.CentralApiEndpoint = stringValue
+			iNdEx = postIndex
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RuntimeSupport", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.RuntimeSupport = bool(v != 0)
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AdmissionController", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AdmissionController = bool(v != 0)
+		case 15:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Status == nil {
+				m.Status = &storage.ClusterStatus{}
+			}
+			if unmarshal, ok := interface{}(m.Status).(interface {
+				UnmarshalVTUnsafe([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Status); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 16:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CollectorImage", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.CollectorImage = stringValue
+			iNdEx = postIndex
+		case 17:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CollectionMethod", wireType)
+			}
+			m.CollectionMethod = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.CollectionMethod |= storage.CollectionMethod(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 18:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DynamicConfig", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DynamicConfig == nil {
+				m.DynamicConfig = &storage.DynamicClusterConfig{}
+			}
+			if unmarshal, ok := interface{}(m.DynamicConfig).(interface {
+				UnmarshalVTUnsafe([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.DynamicConfig); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 19:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TolerationsConfig", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.TolerationsConfig == nil {
+				m.TolerationsConfig = &storage.TolerationsConfig{}
+			}
+			if unmarshal, ok := interface{}(m.TolerationsConfig).(interface {
+				UnmarshalVTUnsafe([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.TolerationsConfig); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 20:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Priority", wireType)
+			}
+			m.Priority = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Priority |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 21:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AdmissionControllerUpdates", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AdmissionControllerUpdates = bool(v != 0)
+		case 22:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HealthStatus", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.HealthStatus == nil {
+				m.HealthStatus = &storage.ClusterHealthStatus{}
+			}
+			if unmarshal, ok := interface{}(m.HealthStatus).(interface {
+				UnmarshalVTUnsafe([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.HealthStatus); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 23:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SlimCollector", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.SlimCollector = bool(v != 0)
+		case 24:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HelmConfig", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.HelmConfig == nil {
+				m.HelmConfig = &storage.CompleteClusterConfig{}
+			}
+			if unmarshal, ok := interface{}(m.HelmConfig).(interface {
+				UnmarshalVTUnsafe([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.HelmConfig); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 25:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AdmissionControllerEvents", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AdmissionControllerEvents = bool(v != 0)
+		case 26:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MostRecentSensorId", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.MostRecentSensorId == nil {
+				m.MostRecentSensorId = &storage.SensorDeploymentIdentification{}
+			}
+			if unmarshal, ok := interface{}(m.MostRecentSensorId).(interface {
+				UnmarshalVTUnsafe([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.MostRecentSensorId); err != nil {
+					return err
+				}
+			}
+			iNdEx = postIndex
+		case 27:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Labels == nil {
+				m.Labels = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapkey == 0 {
+						mapkey = ""
+					} else {
+						mapkey = unsafe.String(&dAtA[iNdEx], intStringLenmapkey)
+					}
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapvalue == 0 {
+						mapvalue = ""
+					} else {
+						mapvalue = unsafe.String(&dAtA[iNdEx], intStringLenmapvalue)
+					}
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Labels[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 28:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AuditLogState", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.AuditLogState == nil {
+				m.AuditLogState = make(map[string]*storage.AuditLogFileState)
+			}
+			var mapkey string
+			var mapvalue *storage.AuditLogFileState
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapkey == 0 {
+						mapkey = ""
+					} else {
+						mapkey = unsafe.String(&dAtA[iNdEx], intStringLenmapkey)
+					}
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if postmsgIndex < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &storage.AuditLogFileState{}
+					if unmarshal, ok := interface{}(mapvalue).(interface {
+						UnmarshalVTUnsafe([]byte) error
+					}); ok {
+						if err := unmarshal.UnmarshalVTUnsafe(dAtA[iNdEx:postmsgIndex]); err != nil {
+							return err
+						}
+					} else {
+						if err := proto.Unmarshal(dAtA[iNdEx:postmsgIndex], mapvalue); err != nil {
+							return err
+						}
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.AuditLogState[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 29:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InitBundleId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.InitBundleId = stringValue
+			iNdEx = postIndex
+		case 30:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ManagedBy", wireType)
+			}
+			m.ManagedBy = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ManagedBy |= storage.ManagerType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 31:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SensorCapabilities", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.SensorCapabilities = append(m.SensorCapabilities, stringValue)
+			iNdEx = postIndex
+		case 32:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AdmissionControllerFailOnError", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.AdmissionControllerFailOnError = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *DecommissionedClusterRetentionInfo) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -1757,18 +4539,10 @@ func (m *ClusterResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Cluster == nil {
-				m.Cluster = &storage.Cluster{}
+				m.Cluster = &ClusterConfig{}
 			}
-			if unmarshal, ok := interface{}(m.Cluster).(interface {
-				UnmarshalVTUnsafe([]byte) error
-			}); ok {
-				if err := unmarshal.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
-					return err
-				}
-			} else {
-				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Cluster); err != nil {
-					return err
-				}
+			if err := m.Cluster.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
 			iNdEx = postIndex
 		case 2:
@@ -2030,17 +4804,9 @@ func (m *ClustersList) UnmarshalVTUnsafe(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Clusters = append(m.Clusters, &storage.Cluster{})
-			if unmarshal, ok := interface{}(m.Clusters[len(m.Clusters)-1]).(interface {
-				UnmarshalVTUnsafe([]byte) error
-			}); ok {
-				if err := unmarshal.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
-					return err
-				}
-			} else {
-				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Clusters[len(m.Clusters)-1]); err != nil {
-					return err
-				}
+			m.Clusters = append(m.Clusters, &ClusterConfig{})
+			if err := m.Clusters[len(m.Clusters)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
 			}
 			iNdEx = postIndex
 		case 2:

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/pkg/cluster/convert.go
+++ b/pkg/cluster/convert.go
@@ -1,0 +1,53 @@
+package cluster
+
+import (
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+// StorageClusterToAPIClusterConfig converts a storage.Cluster to the API representation.
+// All fields are copied 1:1. The API type is structurally identical to the storage
+// type today; they are separated to allow independent evolution in the future.
+func StorageClusterToAPIClusterConfig(cluster *storage.Cluster) *v1.ClusterConfig {
+	if cluster == nil {
+		return nil
+	}
+	return &v1.ClusterConfig{
+		Id:                             cluster.GetId(),
+		Name:                           cluster.GetName(),
+		Type:                           cluster.GetType(),
+		Labels:                         cluster.GetLabels(),
+		MainImage:                      cluster.GetMainImage(),
+		CollectorImage:                 cluster.GetCollectorImage(),
+		CentralApiEndpoint:             cluster.GetCentralApiEndpoint(),
+		CollectionMethod:               cluster.GetCollectionMethod(),
+		AdmissionController:            cluster.GetAdmissionController(),
+		AdmissionControllerUpdates:     cluster.GetAdmissionControllerUpdates(),
+		AdmissionControllerEvents:      cluster.GetAdmissionControllerEvents(),
+		AdmissionControllerFailOnError: cluster.GetAdmissionControllerFailOnError(),
+		DynamicConfig:                  cluster.GetDynamicConfig(),
+		TolerationsConfig:              cluster.GetTolerationsConfig(),
+		SlimCollector:                  cluster.GetSlimCollector(),
+		Priority:                       cluster.GetPriority(),
+		ManagedBy:                      cluster.GetManagedBy(),
+		Status:                         cluster.GetStatus(),
+		HealthStatus:                   cluster.GetHealthStatus(),
+		HelmConfig:                     cluster.GetHelmConfig(),
+		MostRecentSensorId:             cluster.GetMostRecentSensorId(),
+		AuditLogState:                  cluster.GetAuditLogState(),
+		InitBundleId:                   cluster.GetInitBundleId(),
+		SensorCapabilities:             cluster.GetSensorCapabilities(),
+	}
+}
+
+// StorageClustersToAPIClusterConfigs converts a slice of storage.Cluster to API representations.
+func StorageClustersToAPIClusterConfigs(clusters []*storage.Cluster) []*v1.ClusterConfig {
+	if clusters == nil {
+		return nil
+	}
+	result := make([]*v1.ClusterConfig, len(clusters))
+	for i, c := range clusters {
+		result[i] = StorageClusterToAPIClusterConfig(c)
+	}
+	return result
+}

--- a/pkg/cluster/convert_test.go
+++ b/pkg/cluster/convert_test.go
@@ -1,0 +1,108 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStorageClusterToAPIClusterConfig_Nil(t *testing.T) {
+	assert.Nil(t, StorageClusterToAPIClusterConfig(nil))
+}
+
+func TestStorageClustersToAPIClusterConfigs_Nil(t *testing.T) {
+	assert.Nil(t, StorageClustersToAPIClusterConfigs(nil))
+}
+
+func TestStorageClustersToAPIClusterConfigs_Empty(t *testing.T) {
+	result := StorageClustersToAPIClusterConfigs([]*storage.Cluster{})
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+}
+
+func TestStorageClusterToAPIClusterConfig_AllFields(t *testing.T) {
+	cluster := &storage.Cluster{
+		Id:                             "test-id",
+		Name:                           "test-cluster",
+		Type:                           storage.ClusterType_OPENSHIFT4_CLUSTER,
+		Labels:                         map[string]string{"env": "prod"},
+		MainImage:                      "quay.io/stackrox/main:latest",
+		CollectorImage:                 "quay.io/stackrox/collector:latest",
+		CentralApiEndpoint:             "central.stackrox:443",
+		CollectionMethod:               storage.CollectionMethod_CORE_BPF,
+		AdmissionController:            true,
+		AdmissionControllerUpdates:     true,
+		AdmissionControllerEvents:      true,
+		AdmissionControllerFailOnError: true,
+		DynamicConfig: &storage.DynamicClusterConfig{
+			DisableAuditLogs: false,
+		},
+		TolerationsConfig: &storage.TolerationsConfig{
+			Disabled: true,
+		},
+		SlimCollector: true,
+		Priority:      10,
+		ManagedBy:     storage.ManagerType_MANAGER_TYPE_HELM_CHART,
+		Status: &storage.ClusterStatus{
+			SensorVersion: "3.0.0",
+		},
+		HealthStatus: &storage.ClusterHealthStatus{
+			SensorHealthStatus: storage.ClusterHealthStatus_HEALTHY,
+		},
+		HelmConfig: &storage.CompleteClusterConfig{
+			ClusterLabels: map[string]string{"helm": "true"},
+		},
+		MostRecentSensorId: &storage.SensorDeploymentIdentification{
+			SystemNamespaceId: "ns-id",
+		},
+		AuditLogState: map[string]*storage.AuditLogFileState{
+			"node1": {CollectLogsSince: nil},
+		},
+		InitBundleId:       "init-bundle-123",
+		SensorCapabilities: []string{"cap1", "cap2"},
+	}
+
+	result := StorageClusterToAPIClusterConfig(cluster)
+
+	assert.Equal(t, cluster.GetId(), result.GetId())
+	assert.Equal(t, cluster.GetName(), result.GetName())
+	assert.Equal(t, cluster.GetType(), result.GetType())
+	assert.Equal(t, cluster.GetLabels(), result.GetLabels())
+	assert.Equal(t, cluster.GetMainImage(), result.GetMainImage())
+	assert.Equal(t, cluster.GetCollectorImage(), result.GetCollectorImage())
+	assert.Equal(t, cluster.GetCentralApiEndpoint(), result.GetCentralApiEndpoint())
+	assert.Equal(t, cluster.GetCollectionMethod(), result.GetCollectionMethod())
+	assert.Equal(t, cluster.GetAdmissionController(), result.GetAdmissionController())
+	assert.Equal(t, cluster.GetAdmissionControllerUpdates(), result.GetAdmissionControllerUpdates())
+	assert.Equal(t, cluster.GetAdmissionControllerEvents(), result.GetAdmissionControllerEvents())
+	assert.Equal(t, cluster.GetAdmissionControllerFailOnError(), result.GetAdmissionControllerFailOnError())
+	protoassert.Equal(t, cluster.GetDynamicConfig(), result.GetDynamicConfig())
+	protoassert.Equal(t, cluster.GetTolerationsConfig(), result.GetTolerationsConfig())
+	assert.Equal(t, cluster.GetSlimCollector(), result.GetSlimCollector())
+	assert.Equal(t, cluster.GetPriority(), result.GetPriority())
+	assert.Equal(t, cluster.GetManagedBy(), result.GetManagedBy())
+	protoassert.Equal(t, cluster.GetStatus(), result.GetStatus())
+	protoassert.Equal(t, cluster.GetHealthStatus(), result.GetHealthStatus())
+	protoassert.Equal(t, cluster.GetHelmConfig(), result.GetHelmConfig())
+	protoassert.Equal(t, cluster.GetMostRecentSensorId(), result.GetMostRecentSensorId())
+	assert.Equal(t, cluster.GetInitBundleId(), result.GetInitBundleId())
+	assert.Equal(t, cluster.GetSensorCapabilities(), result.GetSensorCapabilities())
+}
+
+func TestStorageClustersToAPIClusterConfigs_Multiple(t *testing.T) {
+	clusters := []*storage.Cluster{
+		{Id: "id-1", Name: "cluster-1"},
+		{Id: "id-2", Name: "cluster-2"},
+		{Id: "id-3", Name: "cluster-3"},
+	}
+
+	result := StorageClustersToAPIClusterConfigs(clusters)
+
+	assert.Len(t, result, 3)
+	for i, c := range clusters {
+		assert.Equal(t, c.GetId(), result[i].GetId())
+		assert.Equal(t, c.GetName(), result[i].GetName())
+	}
+}

--- a/proto/api/v1/cluster_service.proto
+++ b/proto/api/v1/cluster_service.proto
@@ -23,6 +23,76 @@ enum LoadBalancerType {
   ROUTE = 3;
 }
 
+// ClusterConfig is the API-specific representation of a cluster.
+// It is field-number-identical to storage.Cluster to maintain gRPC wire
+// compatibility with older clients that send storage.Cluster directly.
+// This decoupling allows the storage representation to evolve independently
+// from the API contract in the future.
+//
+// Note: Server-managed fields (status, health_status, most_recent_sensor_id,
+// sensor_capabilities, audit_log_state, helm_config, init_bundle_id) are
+// accepted in create/update requests for backward compatibility, but their
+// values are silently ignored by the server. The server always uses its own
+// authoritative values for these fields.
+//Next tag: 33
+message ClusterConfig {
+  string id = 1;
+  string name = 2;
+  storage.ClusterType type = 3;
+  string main_image = 4;
+  string central_api_endpoint = 5;
+  reserved 6;
+  bool runtime_support = 7 [deprecated = true];
+  reserved 8;
+  reserved 9, 10, 11, 12, 14;
+  bool admission_controller = 13;
+
+  // Server-managed: accepted in requests for backward compatibility but
+  // ignored by the server. The server populates this from its own state.
+  storage.ClusterStatus status = 15;
+
+  string collector_image = 16;
+  storage.CollectionMethod collection_method = 17;
+  storage.DynamicClusterConfig dynamic_config = 18;
+  storage.TolerationsConfig tolerations_config = 19;
+  int64 priority = 20;
+  bool admission_controller_updates = 21;
+
+  // Server-managed: accepted in requests for backward compatibility but
+  // ignored by the server. The server populates this from its own state.
+  storage.ClusterHealthStatus health_status = 22;
+
+  bool slim_collector = 23;
+
+  // Server-managed: accepted in requests for backward compatibility but
+  // ignored by the server.
+  storage.CompleteClusterConfig helm_config = 24;
+
+  bool admission_controller_events = 25;
+
+  // Server-managed: accepted in requests for backward compatibility but
+  // ignored by the server.
+  storage.SensorDeploymentIdentification most_recent_sensor_id = 26;
+
+  map<string, string> labels = 27;
+
+  // Server-managed: accepted in requests for backward compatibility but
+  // ignored by the server.
+  map<string, storage.AuditLogFileState> audit_log_state = 28;
+
+  // Server-managed: accepted in requests for backward compatibility but
+  // ignored by the server.
+  string init_bundle_id = 29;
+
+  storage.ManagerType managed_by = 30;
+
+  // Server-managed: accepted in requests for backward compatibility but
+  // ignored by the server.
+  repeated string sensor_capabilities = 31;
+
+  bool admission_controller_fail_on_error = 32;
+}
+
 // next available tag: 3
 message DecommissionedClusterRetentionInfo {
   oneof RetentionInfo {
@@ -34,7 +104,7 @@ message DecommissionedClusterRetentionInfo {
 }
 
 message ClusterResponse {
-  storage.Cluster cluster = 1;
+  ClusterConfig cluster = 1;
   DecommissionedClusterRetentionInfo cluster_retention_info = 2;
 }
 
@@ -45,7 +115,7 @@ message ClusterDefaultsResponse {
 }
 
 message ClustersList {
-  repeated storage.Cluster clusters = 1;
+  repeated ClusterConfig clusters = 1;
   // Maps 'UNHEALTHY' clusters' IDs to their retention info
   map<string, DecommissionedClusterRetentionInfo> cluster_id_to_retention_info = 2;
 }
@@ -68,14 +138,14 @@ service ClustersService {
     option (google.api.http) = {get: "/v1/clusters/{id}"};
   }
 
-  rpc PostCluster(storage.Cluster) returns (ClusterResponse) {
+  rpc PostCluster(ClusterConfig) returns (ClusterResponse) {
     option (google.api.http) = {
       post: "/v1/clusters"
       body: "*"
     };
   }
 
-  rpc PutCluster(storage.Cluster) returns (ClusterResponse) {
+  rpc PutCluster(ClusterConfig) returns (ClusterResponse) {
     option (google.api.http) = {
       put: "/v1/clusters/{id}"
       body: "*"

--- a/qa-tests-backend/src/main/groovy/services/ClusterService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ClusterService.groovy
@@ -3,12 +3,12 @@ package services
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 
+import io.stackrox.proto.api.v1.ClusterService.ClusterConfig
 import io.stackrox.proto.api.v1.ClusterService.GetClustersRequest
 import io.stackrox.proto.api.v1.ClustersServiceGrpc
 import io.stackrox.proto.api.v1.Common
 import io.stackrox.proto.storage.ClusterOuterClass
 import io.stackrox.proto.storage.ClusterOuterClass.AdmissionControllerConfig
-import io.stackrox.proto.storage.ClusterOuterClass.Cluster
 import io.stackrox.proto.storage.ClusterOuterClass.ClusterMetadata.Type
 import io.stackrox.proto.storage.ClusterOuterClass.DynamicClusterConfig
 
@@ -21,11 +21,11 @@ class ClusterService extends BaseService {
         return ClustersServiceGrpc.newBlockingStub(getChannel())
     }
 
-    static List<Cluster> getClusters() {
+    static List<ClusterConfig> getClusters() {
         return getClusterServiceClient().getClusters(null).clustersList
     }
 
-    static Cluster getCluster() {
+    static ClusterConfig getCluster() {
         String clusterId = getClusterId()
         return getClusterServiceClient().getCluster(Common.ResourceByID.newBuilder().setId(clusterId).build()).cluster
     }
@@ -37,7 +37,7 @@ class ClusterService extends BaseService {
     }
 
     static createCluster(String name, String mainImage, String centralEndpoint) {
-        return getClusterServiceClient().postCluster(Cluster.newBuilder()
+        return getClusterServiceClient().postCluster(ClusterConfig.newBuilder()
                 .setName(name)
                 .setMainImage(mainImage)
                 .setCentralApiEndpoint(centralEndpoint)
@@ -50,13 +50,13 @@ class ClusterService extends BaseService {
     }
 
     static Boolean updateAdmissionController(AdmissionControllerConfig config) {
-        Cluster currentCluster = getCluster()
+        ClusterConfig currentCluster = getCluster()
         if (currentCluster == null) {
             return false
         }
-        Cluster.Builder builder = currentCluster.toBuilder()
+        ClusterConfig.Builder builder = currentCluster.toBuilder()
 
-        Cluster cluster = builder.setDynamicConfig(
+        ClusterConfig cluster = builder.setDynamicConfig(
                 DynamicClusterConfig.newBuilder()
                         .setAdmissionControllerConfig(config)
                         .build()
@@ -66,13 +66,13 @@ class ClusterService extends BaseService {
     }
 
     static Boolean updateAuditLogDynamicConfig(boolean disableAuditLogs) {
-        Cluster currentCluster = getCluster()
+        ClusterConfig currentCluster = getCluster()
         if (currentCluster == null) {
             return false
         }
-        Cluster.Builder builder = currentCluster.toBuilder()
+        ClusterConfig.Builder builder = currentCluster.toBuilder()
 
-        Cluster cluster = builder.setDynamicConfig(
+        ClusterConfig cluster = builder.setDynamicConfig(
                 DynamicClusterConfig.newBuilder()
                         .setDisableAuditLogs(disableAuditLogs)
                         .build()
@@ -81,7 +81,7 @@ class ClusterService extends BaseService {
         return updateCluster(cluster)
     }
 
-    static Boolean updateCluster(Cluster cluster) {
+    static Boolean updateCluster(ClusterConfig cluster) {
         try {
             getClusterServiceClient().putCluster(cluster)
             return true
@@ -102,7 +102,7 @@ class ClusterService extends BaseService {
     static Boolean isEKS() {
         try {
             return ClusterService.getClusters().every {
-                Cluster cluster ->
+                ClusterConfig cluster ->
                     cluster.getStatus().getProviderMetadata().hasAws() &&
                             cluster.getStatus().getOrchestratorMetadata().getVersion().contains("eks")
             }
@@ -115,7 +115,7 @@ class ClusterService extends BaseService {
     static Boolean isAzure() {
         try {
             return ClusterService.getClusters().every {
-                Cluster cluster -> cluster.getStatus().getProviderMetadata().hasAzure()
+                ClusterConfig cluster -> cluster.getStatus().getProviderMetadata().hasAzure()
             }
         } catch (Exception e) {
             log.error("Error getting cluster info", e)
@@ -126,7 +126,7 @@ class ClusterService extends BaseService {
     static Boolean isAKS() {
         try {
             return ClusterService.getClusters().every {
-                Cluster cluster -> cluster.getStatus().getProviderMetadata().getCluster().getType() == Type.AKS
+                ClusterConfig cluster -> cluster.getStatus().getProviderMetadata().getCluster().getType() == Type.AKS
             }
         } catch (Exception e) {
             log.error("Error getting cluster info", e)

--- a/roxctl/cluster/delete/delete.go
+++ b/roxctl/cluster/delete/delete.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
@@ -74,7 +73,7 @@ func (cmd *clusterDeleteCommand) Delete() error {
 	}
 
 	validClusters := make([]string, 0, len(clusters))
-	var cluster *storage.Cluster
+	var cluster *v1.ClusterConfig
 	for _, cl := range clusters {
 		validClusters = append(validClusters, cl.GetName())
 		if strings.EqualFold(cl.GetName(), cmd.name) {
@@ -98,7 +97,7 @@ func (cmd *clusterDeleteCommand) Delete() error {
 	return nil
 }
 
-func (cmd *clusterDeleteCommand) getClusters(svc v1.ClustersServiceClient) ([]*storage.Cluster, error) {
+func (cmd *clusterDeleteCommand) getClusters(svc v1.ClustersServiceClient) ([]*v1.ClusterConfig, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), cmd.timeout)
 	defer cancel()
 	clusterResponse, err := svc.GetClusters(ctx, &v1.GetClustersRequest{})

--- a/roxctl/cluster/delete/delete_test.go
+++ b/roxctl/cluster/delete/delete_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common/environment/mocks"
@@ -32,7 +31,7 @@ type clusterDeleteTestSuite struct {
 type mockClustersServiceServer struct {
 	v1.UnimplementedClustersServiceServer
 
-	clusters []*storage.Cluster
+	clusters []*v1.ClusterConfig
 }
 
 func (m *mockClustersServiceServer) GetClusters(_ context.Context, _ *v1.GetClustersRequest) (*v1.ClustersList, error) {
@@ -43,7 +42,7 @@ func (m *mockClustersServiceServer) DeleteCluster(_ context.Context, _ *v1.Resou
 	return &v1.Empty{}, nil
 }
 
-func (c *clusterDeleteTestSuite) createGRPCMockClustersService(clusters []*storage.Cluster) (*grpc.ClientConn, func()) {
+func (c *clusterDeleteTestSuite) createGRPCMockClustersService(clusters []*v1.ClusterConfig) (*grpc.ClientConn, func()) {
 	buffer := 1024 * 1024
 	listener := bufconn.Listen(buffer)
 
@@ -76,7 +75,7 @@ func (c *clusterDeleteTestSuite) SetupTest() {
 	os.Stderr = nil
 }
 
-func (c *clusterDeleteTestSuite) setupCommand(clusters []*storage.Cluster) (*cobra.Command, func(), *bytes.Buffer, *bytes.Buffer) {
+func (c *clusterDeleteTestSuite) setupCommand(clusters []*v1.ClusterConfig) (*cobra.Command, func(), *bytes.Buffer, *bytes.Buffer) {
 	conn, closeFunction := c.createGRPCMockClustersService(clusters)
 	mockedEnv, stdout, stderr := mocks.NewEnvWithConn(conn, c.T())
 	cbr := Command(mockedEnv)
@@ -87,7 +86,7 @@ func (c *clusterDeleteTestSuite) setupCommand(clusters []*storage.Cluster) (*cob
 }
 
 func (c *clusterDeleteTestSuite) TestCommandHappyPath() {
-	clusters := []*storage.Cluster{{Name: "dummy"}}
+	clusters := []*v1.ClusterConfig{{Name: "dummy"}}
 	cbr, closeFunction, stdout, _ := c.setupCommand(clusters)
 	defer closeFunction()
 
@@ -99,7 +98,7 @@ func (c *clusterDeleteTestSuite) TestCommandHappyPath() {
 }
 
 func (c *clusterDeleteTestSuite) TestCommandRequiresName() {
-	clusters := []*storage.Cluster{{Name: "dummy"}}
+	clusters := []*v1.ClusterConfig{{Name: "dummy"}}
 	cbr, closeFunction, _, _ := c.setupCommand(clusters)
 	defer closeFunction()
 
@@ -110,7 +109,7 @@ func (c *clusterDeleteTestSuite) TestCommandRequiresName() {
 }
 
 func (c *clusterDeleteTestSuite) TestCommandFailsIfClusterNotFound() {
-	clusters := []*storage.Cluster{}
+	clusters := []*v1.ClusterConfig{}
 	cbr, closeFunction, _, _ := c.setupCommand(clusters)
 	defer closeFunction()
 

--- a/roxctl/sensor/generate/convert.go
+++ b/roxctl/sensor/generate/convert.go
@@ -1,0 +1,34 @@
+package generate
+
+import (
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+// clusterConfigToStorage converts a v1.ClusterConfig to storage.Cluster for use
+// with validation functions that accept storage.Cluster.
+func clusterConfigToStorage(config *v1.ClusterConfig) *storage.Cluster {
+	if config == nil {
+		return nil
+	}
+	return &storage.Cluster{
+		Id:                             config.GetId(),
+		Name:                           config.GetName(),
+		Type:                           config.GetType(),
+		Labels:                         config.GetLabels(),
+		MainImage:                      config.GetMainImage(),
+		CollectorImage:                 config.GetCollectorImage(),
+		CentralApiEndpoint:             config.GetCentralApiEndpoint(),
+		CollectionMethod:               config.GetCollectionMethod(),
+		AdmissionController:            config.GetAdmissionController(),
+		AdmissionControllerUpdates:     config.GetAdmissionControllerUpdates(),
+		AdmissionControllerEvents:      config.GetAdmissionControllerEvents(),
+		AdmissionControllerFailOnError: config.GetAdmissionControllerFailOnError(),
+		DynamicConfig:                  config.GetDynamicConfig(),
+		TolerationsConfig:              config.GetTolerationsConfig(),
+		SlimCollector:                  config.GetSlimCollector(),
+		Priority:                       config.GetPriority(),
+		ManagedBy:                      config.GetManagedBy(),
+		HelmConfig:                     config.GetHelmConfig(),
+	}
+}

--- a/roxctl/sensor/generate/convert_test.go
+++ b/roxctl/sensor/generate/convert_test.go
@@ -1,0 +1,64 @@
+package generate
+
+import (
+	"testing"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterConfigToStorage_Nil(t *testing.T) {
+	assert.Nil(t, clusterConfigToStorage(nil))
+}
+
+func TestClusterConfigToStorage_AllFields(t *testing.T) {
+	config := &v1.ClusterConfig{
+		Id:                             "test-id",
+		Name:                           "test-cluster",
+		Type:                           storage.ClusterType_OPENSHIFT4_CLUSTER,
+		Labels:                         map[string]string{"env": "prod"},
+		MainImage:                      "quay.io/stackrox/main:latest",
+		CollectorImage:                 "quay.io/stackrox/collector:latest",
+		CentralApiEndpoint:             "central.stackrox:443",
+		CollectionMethod:               storage.CollectionMethod_CORE_BPF,
+		AdmissionController:            true,
+		AdmissionControllerUpdates:     true,
+		AdmissionControllerEvents:      true,
+		AdmissionControllerFailOnError: true,
+		DynamicConfig: &storage.DynamicClusterConfig{
+			DisableAuditLogs: false,
+		},
+		TolerationsConfig: &storage.TolerationsConfig{
+			Disabled: true,
+		},
+		SlimCollector: true,
+		Priority:      10,
+		ManagedBy:     storage.ManagerType_MANAGER_TYPE_HELM_CHART,
+		HelmConfig: &storage.CompleteClusterConfig{
+			ClusterLabels: map[string]string{"helm": "true"},
+		},
+	}
+
+	result := clusterConfigToStorage(config)
+
+	assert.Equal(t, config.GetId(), result.GetId())
+	assert.Equal(t, config.GetName(), result.GetName())
+	assert.Equal(t, config.GetType(), result.GetType())
+	assert.Equal(t, config.GetLabels(), result.GetLabels())
+	assert.Equal(t, config.GetMainImage(), result.GetMainImage())
+	assert.Equal(t, config.GetCollectorImage(), result.GetCollectorImage())
+	assert.Equal(t, config.GetCentralApiEndpoint(), result.GetCentralApiEndpoint())
+	assert.Equal(t, config.GetCollectionMethod(), result.GetCollectionMethod())
+	assert.Equal(t, config.GetAdmissionController(), result.GetAdmissionController())
+	assert.Equal(t, config.GetAdmissionControllerUpdates(), result.GetAdmissionControllerUpdates())
+	assert.Equal(t, config.GetAdmissionControllerEvents(), result.GetAdmissionControllerEvents())
+	assert.Equal(t, config.GetAdmissionControllerFailOnError(), result.GetAdmissionControllerFailOnError())
+	protoassert.Equal(t, config.GetDynamicConfig(), result.GetDynamicConfig())
+	protoassert.Equal(t, config.GetTolerationsConfig(), result.GetTolerationsConfig())
+	assert.Equal(t, config.GetSlimCollector(), result.GetSlimCollector())
+	assert.Equal(t, config.GetPriority(), result.GetPriority())
+	assert.Equal(t, config.GetManagedBy(), result.GetManagedBy())
+	protoassert.Equal(t, config.GetHelmConfig(), result.GetHelmConfig())
+}

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -47,13 +47,13 @@ type sensorGenerateCommand struct {
 	enablePodSecurityPolicies bool
 
 	// injected or constructed values
-	cluster     *storage.Cluster
+	cluster     *v1.ClusterConfig
 	env         environment.Environment
 	getBundleFn util.GetBundleFn
 }
 
-func defaultCluster() *storage.Cluster {
-	return &storage.Cluster{
+func defaultCluster() *v1.ClusterConfig {
+	return &v1.ClusterConfig{
 		AdmissionController:            true,
 		AdmissionControllerEvents:      true,
 		AdmissionControllerUpdates:     true,

--- a/roxctl/sensor/generate/generate_test.go
+++ b/roxctl/sensor/generate/generate_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/apiparams"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/version/testutils"
@@ -31,13 +30,13 @@ type mockClustersServiceServer struct {
 	postClusterInjectedFn      postClusterFn
 
 	// spy properties
-	clusterSent                     []*storage.Cluster
+	clusterSent                     []*v1.ClusterConfig
 	getClusterCalled                bool
 	getKernelSupportAvailableCalled bool
 }
 
 type getKernelSupportFn func() (*v1.KernelSupportAvailableResponse, error)
-type postClusterFn func(cluster *storage.Cluster) (*v1.ClusterResponse, error)
+type postClusterFn func(cluster *v1.ClusterConfig) (*v1.ClusterResponse, error)
 type getDefaultsFn func() (*v1.ClusterDefaultsResponse, error)
 
 func (m *mockClustersServiceServer) GetClusterDefaultValues(_ context.Context, _ *v1.Empty) (*v1.ClusterDefaultsResponse, error) {
@@ -49,7 +48,7 @@ func (m *mockClustersServiceServer) GetKernelSupportAvailable(_ context.Context,
 	return m.getKernelSupportInjectedFn()
 }
 
-func (m *mockClustersServiceServer) PostCluster(_ context.Context, cluster *storage.Cluster) (*v1.ClusterResponse, error) {
+func (m *mockClustersServiceServer) PostCluster(_ context.Context, cluster *v1.ClusterConfig) (*v1.ClusterResponse, error) {
 	m.clusterSent = append(m.clusterSent, cluster)
 	return m.postClusterInjectedFn(cluster)
 }
@@ -57,7 +56,7 @@ func (m *mockClustersServiceServer) PostCluster(_ context.Context, cluster *stor
 func (m *mockClustersServiceServer) GetClusters(_ context.Context, _ *v1.GetClustersRequest) (*v1.ClustersList, error) {
 	m.getClusterCalled = true
 	return &v1.ClustersList{
-		Clusters: []*storage.Cluster{
+		Clusters: []*v1.ClusterConfig{
 			{
 				Name: "test-cluster",
 				Id:   "cluster-id",
@@ -116,7 +115,7 @@ func (s *sensorGenerateTestSuite) createMockedCommand(getDefaultsF getDefaultsFn
 	var out, errOut *bytes.Buffer
 	conn, closeF, mock := s.createGRPCMockClustersService(getDefaultsF, postClusterF)
 	cmd := sensorGenerateCommand{
-		cluster: &storage.Cluster{},
+		cluster: &v1.ClusterConfig{},
 	}
 	cmd.env, out, errOut = s.newTestMockEnvironmentWithConn(conn)
 	return out, errOut, closeF, cmd, mock
@@ -153,7 +152,7 @@ func getDefaultsFake(kernelSupport bool) func() (*v1.ClusterDefaultsResponse, er
 }
 
 // postClusterFake base fake function for service.PostCluster that returns the same cluster with fake id
-func postClusterFake(cluster *storage.Cluster) (*v1.ClusterResponse, error) {
+func postClusterFake(cluster *v1.ClusterConfig) (*v1.ClusterResponse, error) {
 	cluster.Id = "test-id"
 	return &v1.ClusterResponse{
 		Cluster: cluster,
@@ -161,7 +160,7 @@ func postClusterFake(cluster *storage.Cluster) (*v1.ClusterResponse, error) {
 }
 
 // postClusterAlreadyExistsFake fake function for service.PostCluster that always returns error codes.AlreadyExists
-func postClusterAlreadyExistsFake(_ *storage.Cluster) (*v1.ClusterResponse, error) {
+func postClusterAlreadyExistsFake(_ *v1.ClusterConfig) (*v1.ClusterResponse, error) {
 	return nil, status.Error(codes.AlreadyExists, "Cluster Exists")
 }
 

--- a/roxctl/sensor/generate/k8s.go
+++ b/roxctl/sensor/generate/k8s.go
@@ -30,7 +30,7 @@ func k8s(generateCmd *sensorGenerateCommand) *cobra.Command {
 		RunE: util.RunENoArgs(func(c *cobra.Command) error {
 			k8sCommand.ConstructK8s()
 
-			if err := clusterValidation.ValidatePartial(k8sCommand.cluster); err.ToError() != nil {
+			if err := clusterValidation.ValidatePartial(clusterConfigToStorage(k8sCommand.cluster)); err.ToError() != nil {
 				return err.ToError()
 			}
 			return k8sCommand.fullClusterCreation()

--- a/roxctl/sensor/generate/openshift.go
+++ b/roxctl/sensor/generate/openshift.go
@@ -52,7 +52,7 @@ func openshift(generateCmd *sensorGenerateCommand) *cobra.Command {
 				return err
 			}
 
-			if err := clusterValidation.ValidatePartial(openshiftCommand.cluster).ToError(); err != nil {
+			if err := clusterValidation.ValidatePartial(clusterConfigToStorage(openshiftCommand.cluster)).ToError(); err != nil {
 				return errors.Wrap(err, "cluster validation failed")
 			}
 			return openshiftCommand.fullClusterCreation()

--- a/tests/common.go
+++ b/tests/common.go
@@ -1373,7 +1373,7 @@ func isOpenshift() bool {
 }
 
 // mustGetCluster returns the details of the one and only known secured cluster.
-func mustGetCluster(t *testing.T, ctx context.Context) *storage.Cluster {
+func mustGetCluster(t *testing.T, ctx context.Context) *v1.ClusterConfig {
 	conn := centralgrpc.GRPCConnectionToCentral(t)
 
 	cluster, err := getCluster(ctx, conn)
@@ -1383,7 +1383,7 @@ func mustGetCluster(t *testing.T, ctx context.Context) *storage.Cluster {
 }
 
 // getCluster returns the details of the one and only known secured cluster.
-func getCluster(ctx context.Context, conn *grpc.ClientConn) (*storage.Cluster, error) {
+func getCluster(ctx context.Context, conn *grpc.ClientConn) (*v1.ClusterConfig, error) {
 	clustersSvc := v1.NewClustersServiceClient(conn)
 
 	clusters, err := clustersSvc.GetClusters(ctx, &v1.GetClustersRequest{})

--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -63,7 +63,7 @@ type PolicyAsCodeSuite struct {
 	informerfactory   dynamicinformer.DynamicSharedInformerFactory
 	informer          informers.GenericInformer
 	policies          []*storage.Policy
-	cluster           *storage.Cluster
+	cluster           *v1.ClusterConfig
 	notifier          *storage.Notifier
 	ctx               context.Context
 	cleanupCtx        context.Context
@@ -282,9 +282,9 @@ func (pc *PolicyAsCodeSuite) createPolicyInCentral() *storage.Policy {
 	return policy
 }
 
-func (pc *PolicyAsCodeSuite) createClusterInCentral() *storage.Cluster {
+func (pc *PolicyAsCodeSuite) createClusterInCentral() *v1.ClusterConfig {
 	pc.T().Logf("Adding cluster with name \"%s\"", clusterName)
-	cluster, err := pc.clusterClient.PostCluster(pc.ctx, &storage.Cluster{Name: fixtureconsts.ClusterName1, MainImage: "docker.io/stackrox/rox:latest", CentralApiEndpoint: "central.stackrox:443"})
+	cluster, err := pc.clusterClient.PostCluster(pc.ctx, &v1.ClusterConfig{Name: fixtureconsts.ClusterName1, MainImage: "docker.io/stackrox/rox:latest", CentralApiEndpoint: "central.stackrox:443"})
 	pc.NoError(err)
 	return cluster.GetCluster()
 }


### PR DESCRIPTION
Introduce a dedicated v1.ClusterConfig message in cluster_service.proto  that is field-number-identical to storage.Cluster, ensuring full gRPC  wire and REST/JSON backward compatibility across version-skewed  Central/roxctl/Sensor deployments.

- Define v1.ClusterConfig with all 32 fields matching storage.Cluster  field numbers and types; shared sub-messages and enums remain in  storage package to limit blast radius
- Add conversion layer in central/cluster/service/convert.go between  storage.Cluster and v1.ClusterConfig; server-managed fields  (status, health_status, etc.) are accepted in requests but ignored
- Update service_impl.go RPCs to use v1.ClusterConfig at the API  boundary while keeping storage.Cluster internally
- Update all consumers: roxctl (sensor generate, cluster delete),  config-controller client and mocks
- Add roxctl/sensor/generate/convert.go helper for validation calls  that still require storage.Cluster

Co-Authored-By: Claude Opus 4.6 noreply@anthropic.com

User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

Testing and quality

- [x] the change is production ready
- [ ] CI results are inspected

Automated testing

- [x] added unit tests
- [x] modified existing tests

How I validated my change

- go build ./... passes with zero errors
- All unit tests pass for changed packages: central/cluster/service, roxctl/sensor/generate, roxctl/cluster/delete, config-controller/pkg/client
- v1.ClusterConfig is field-number-identical to storage.Cluster, verified by inspection of the proto definition, ensuring wire compatibility