### PR TITLE
ROX-19064: Scanner V4 Vuln Load Reduce Wait

### DIFF
--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -338,10 +338,9 @@ func (u *Updater) Start() error {
 			}
 			zlog.Info(ctx).Msg("completed update")
 
-			// Skip jitter when vulns have never been loaded, so that a
-			// failed first attempt (e.g. Central not yet ready at startup)
-			// retries after the base interval rather than base+jitter
-			// (10-25 min), which can exceed the CI readiness timeout.
+			// Skip jitter when vulns have never been loaded, so that
+			// failed initial attempts (e.g. Central not yet ready at startup)
+			// retry quicker to get the matcher into a functional state.
 			interval := u.updateInterval + jitter()
 			if !u.Initialized(ctx) {
 				interval = u.updateInterval

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -42,7 +42,7 @@ const (
 	defaultUpdateRetention = libvuln.DefaultUpdateRetention
 	defaultFullGCInterval  = 24 * time.Hour
 
-	defaultRetryMax   = 4
+	defaultRetryMax   = 12
 	defaultRetryDelay = 10 * time.Second
 )
 
@@ -338,7 +338,15 @@ func (u *Updater) Start() error {
 			}
 			zlog.Info(ctx).Msg("completed update")
 
-			timer.Reset(u.updateInterval + jitter())
+			// Skip jitter when vulns have never been loaded, so that a
+			// failed first attempt (e.g. Central not yet ready at startup)
+			// retries after the base interval rather than base+jitter
+			// (10-25 min), which can exceed the CI readiness timeout.
+			interval := u.updateInterval + jitter()
+			if !u.Initialized(ctx) {
+				interval = u.updateInterval
+			}
+			timer.Reset(interval)
 		}
 	}
 }
@@ -610,7 +618,7 @@ func (u *Updater) fetchFromURL(ctx context.Context, url string, prevTimestamp ti
 		req.Header.Set(ifModifiedSinceHeader, prevTimestamp.Format(http.TimeFormat))
 		req.Header.Set("X-Scanner-V4-Accept", "application/vnd.stackrox.scanner-v4.multi-bundle+zip")
 		resp, err = u.client.Do(req)
-		if attempt < u.retryMax && isConnectionRefused(err) {
+		if attempt < u.retryMax && isRetryableDialError(err) {
 			zlog.Error(ctx).
 				Err(err).
 				Str("delay", u.retryDelay.String()).
@@ -633,9 +641,13 @@ func closeResponse(resp *http.Response) {
 	}
 }
 
-func isConnectionRefused(err error) bool {
+func isRetryableDialError(err error) bool {
 	var opErr *net.OpError
-	return errors.As(err, &opErr) && opErr.Op == "dial" && strings.Contains(opErr.Err.Error(), "connection refused")
+	if !errors.As(err, &opErr) || opErr.Op != "dial" {
+		return false
+	}
+	msg := opErr.Err.Error()
+	return strings.Contains(msg, "connection refused") || strings.Contains(msg, "i/o timeout")
 }
 
 // normalizeAllowlist trims whitespace from each entry and drops empty strings.

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -645,8 +646,7 @@ func isRetryableDialError(err error) bool {
 	if !errors.As(err, &opErr) || opErr.Op != "dial" {
 		return false
 	}
-	msg := opErr.Err.Error()
-	return strings.Contains(msg, "connection refused") || strings.Contains(msg, "i/o timeout")
+	return errors.Is(err, syscall.ECONNREFUSED) || opErr.Timeout()
 }
 
 // normalizeAllowlist trims whitespace from each entry and drops empty strings.

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -355,6 +356,43 @@ func TestIsBundleAllowed(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			u := &Updater{vulnBundleAllowlist: tc.allowlist}
 			assert.Equal(t, tc.want, u.isBundleAllowed(tc.filename))
+		})
+	}
+}
+
+func TestIsRetryableDialError(t *testing.T) {
+	testCases := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil": {
+			err:  nil,
+			want: false,
+		},
+		"non-OpError": {
+			err:  errors.New("connection refused"),
+			want: false,
+		},
+		"read op": {
+			err:  &net.OpError{Op: "read", Err: errors.New("connection refused")},
+			want: false,
+		},
+		"connection refused": {
+			err:  &net.OpError{Op: "dial", Err: errors.New("connection refused")},
+			want: true,
+		},
+		"i/o timeout": {
+			err:  &net.OpError{Op: "dial", Err: errors.New("i/o timeout")},
+			want: true,
+		},
+		"other dial error": {
+			err:  &net.OpError{Op: "dial", Err: errors.New("no route to host")},
+			want: false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isRetryableDialError(tc.err))
 		})
 	}
 }

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -10,7 +10,9 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -378,11 +380,11 @@ func TestIsRetryableDialError(t *testing.T) {
 			want: false,
 		},
 		"connection refused": {
-			err:  &net.OpError{Op: "dial", Err: errors.New("connection refused")},
+			err:  &net.OpError{Op: "dial", Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}},
 			want: true,
 		},
 		"i/o timeout": {
-			err:  &net.OpError{Op: "dial", Err: errors.New("i/o timeout")},
+			err:  &net.OpError{Op: "dial", Err: &net.DNSError{IsTimeout: true}},
 			want: true,
 		},
 		"other dial error": {


### PR DESCRIPTION
## Description

Scanner V4 CI jobs were inconsistently timing out while waiting for initial vulns to load. 

Matcher's initial attempts to GET latest vuln bundle from Central may fail when Central is not yet ready. When this happens Matcher will wait between 10-25 mins (random due to [jitter](https://github.com/stackrox/stackrox/blob/9dec822f5ed739d14dc0d414b7afeda6dd337737/scanner/matcher/updater/vuln/updater.go#L50)) before trying again. This is a needless delay in CI.

### Increase the retries to fetch vulns
Four attempts are made to contact Central before the long wait - this is not enough for CI - 'connection refused' was observed for all 4 attempts on multiple jobs, and separately `i/o timeout` errors were observed which short-circuit the retries.

The number of retries was increased to 12 and `i/o timeout` is now considered a retryable error to address this.

### No jitter before initial load
The jitter time has been removed from the long wait if vulns have not yet been initialized, this reduces the initial wait to a predictable 5 mins instead of random 10-25 mins. The jitter was kept in-tact for attempts after the initial load completes.


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new automated tests added

### How I validated my change

Against StackRox Scanner these changes will be tested by CI as part of this PR

Against Scanner V4 these changes were validated in https://github.com/stackrox/stackrox/pull/19236 and will be validated again in a future PR when Scanner V4 is officially turned on in CI.
