### PR TITLE
ROX-19064: Scanner V4 CI Wait for Vulns to Load

### DIFF
--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -48,6 +48,11 @@ config_part_1() {
     image_prefetcher_system_await
 
     deploy_stackrox "$ROOT/$DEPLOY_DIR/client_TLS_certs"
+
+    if [[ "${ROX_SCANNER_V4:-}" == "true" ]]; then
+        wait_for_scanner_v4_vuln_load
+    fi
+
     deploy_optional_e2e_components
     setup_workload_identities
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1256,9 +1256,6 @@ wait_for_scanner_v4_vuln_load() {
             die "wait_for_scanner_v4_vuln_load() timed out after ${max_seconds}s."
         fi
 
-        info "--- Pod resources at ${elapsed}s ---"
-        kubectl top pods -n stackrox --no-headers 2>/dev/null || true
-
         sleep 30
     done
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1206,6 +1206,63 @@ wait_for_scanner_V4() {
     wait_for_ready_deployment "$namespace" "scanner-v4-matcher" "$max_seconds"
 }
 
+# wait_for_scanner_v4_vuln_load waits until the Scanner V4 matcher has completed
+# its initial vulnerability load, verified via Central's integration health API.
+# This is distinct from wait_for_scanner_V4, which only waits for pod readiness
+# (i.e. database connectivity). Call this separately in jobs that verify scan
+# results, after deploy_stackrox has returned.
+wait_for_scanner_v4_vuln_load() {
+    local max_seconds="${SCANNER_V4_VULN_LOAD_TIMEOUT:-2400}"
+    info "Waiting for Scanner V4 to finish loading vulnerabilities..."
+
+    info "--- Available storage classes on this cluster ---"
+    kubectl describe storageclasses 2>/dev/null || true
+    info "SCANNER_V4_DB_STORAGE_CLASS=${SCANNER_V4_DB_STORAGE_CLASS:-<unset>}"
+
+    require_environment "API_ENDPOINT"
+    require_environment "ROX_ADMIN_PASSWORD"
+
+    local start_time elapsed
+    start_time="$(date '+%s')"
+    while true; do
+        # -w '\n%{http_code}' appends a newline and the HTTP status code after the
+        # response body, letting us capture both in a single variable.
+        local response http_code body
+        response=$(curl -sk \
+            --config <(curl_cfg user "admin:${ROX_ADMIN_PASSWORD}") \
+            -w '\n%{http_code}' \
+            "https://${API_ENDPOINT}/v1/integrationhealth/vulndefinitions?component=SCANNER_V4")
+        # ##*$'\n' strips up to and including the last newline (leaving just the 3-digit code).
+        http_code="${response##*$'\n'}"
+        # %$'\n'* strips the trailing newline+code (leaving just the body).
+        body="${response%$'\n'*}"
+
+        elapsed=$(( $(date '+%s') - start_time ))
+
+        if [[ "${http_code}" != "200" ]]; then
+            # Try to extract the message field from a JSON error body; fall back to
+            # the raw body if it's not JSON or the field is absent.
+            local err_detail
+            err_detail=$(jq -r '.message // empty' <<< "${body}" 2>/dev/null)
+            info "Scanner V4 vuln load check: HTTP ${http_code} (${elapsed}s/${max_seconds}s): ${err_detail:-${body}}"
+        elif echo "${body}" | jq -e '.lastUpdatedTimestamp != null' >/dev/null 2>&1; then
+            info "Scanner V4 vulnerability loading complete (${elapsed}s elapsed)."
+            return
+        else
+            info "Scanner V4 vuln load check: HTTP 200, lastUpdatedTimestamp not set yet (${elapsed}s/${max_seconds}s)"
+        fi
+
+        if (( elapsed > max_seconds )); then
+            die "wait_for_scanner_v4_vuln_load() timed out after ${max_seconds}s."
+        fi
+
+        info "--- Pod resources at ${elapsed}s ---"
+        kubectl top pods -n stackrox --no-headers 2>/dev/null || true
+
+        sleep 30
+    done
+}
+
 # shellcheck disable=SC2120
 wait_for_api() {
     local central_namespace=${1:-stackrox}

--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -74,6 +74,10 @@ test_ui_e2e() {
         enable_console_plugin
     fi
 
+    if [[ "${ROX_SCANNER_V4:-}" == "true" ]]; then
+        wait_for_scanner_v4_vuln_load
+    fi
+
     run_ui_e2e_tests
 }
 

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -41,6 +41,10 @@ test_e2e() {
     deploy_optional_e2e_components
     deploy_stackrox
 
+    if [[ "${ROX_SCANNER_V4:-}" == "true" ]]; then
+        wait_for_scanner_v4_vuln_load
+    fi
+
     rm -f FAIL
 
     prepare_for_endpoints_test


### PR DESCRIPTION
## Description

Alternative: https://github.com/stackrox/stackrox/pull/19930 (only one is needed)

Adds the rails for CI jobs to wait for vuln loads to finish before starting tests.

This PR polls the Central API to determine if vulns are loaded (same API that is used by System Health). 

Another option was considered to use the 'readiness' setting in Scanner V4 matcher so that the pod does not reach a readiness state until vulns are loaded.  The polling approach was favor because it does not require making changes in CI for each different install type (manifest, helm, operator, etc.) and the cause of timeouts would be 'less obvious' when jobs fail - with polling the failure reason is directly in the build logs (amongst other things).

Prior to polling the available storage classes are listed for the cluster to assist troubleshooting if loads are slow (to verify if the DB PVC is using an SSD).


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

The changes themselves are tests

### How I validated my change

Against StackRox Scanner these changes will be tested by CI as part of this PR

Against Scanner V4 these changes were validated in https://github.com/stackrox/stackrox/pull/19236 and will be validated again in a future PR when Scanner V4 is officially turned on in CI.

```
Available storage classes on this cluster:
Name:                  premium-rwo
IsDefaultClass:        No
Annotations:           components.gke.io/component-name=pdcsi,components.gke.io/component-version=0.22.49,components.gke.io/layer=addon
Provisioner:           pd.csi.storage.gke.io
Parameters:            type=pd-ssd
AllowVolumeExpansion:  True
MountOptions:          <none>
ReclaimPolicy:         Delete
VolumeBindingMode:     WaitForFirstConsumer
Events:                <none>


Name:                  standard
IsDefaultClass:        No
Annotations:           components.gke.io/component-name=pdcsi,components.gke.io/component-version=0.22.49,components.gke.io/layer=addon,storageclass.kubernetes.io/is-default-class=false
Provisioner:           kubernetes.io/gce-pd
Parameters:            type=pd-standard
AllowVolumeExpansion:  True
MountOptions:          <none>
ReclaimPolicy:         Delete
VolumeBindingMode:     Immediate
Events:                <none>


Name:                  standard-rwo
IsDefaultClass:        Yes
Annotations:           components.gke.io/component-name=pdcsi,components.gke.io/component-version=0.22.49,components.gke.io/layer=addon,storageclass.kubernetes.io/is-default-class=true
Provisioner:           pd.csi.storage.gke.io
Parameters:            type=pd-balanced
AllowVolumeExpansion:  True
MountOptions:          <none>
ReclaimPolicy:         Delete
VolumeBindingMode:     WaitForFirstConsumer
Events:                <none>
...

INFO: Sun Apr  5 23:11:29 UTC 2026: Scanner V4 vuln load check: HTTP 500 (0s/2400s): failed to obtain 

INFO: Sun Apr  5 23:34:26 UTC 2026: Scanner V4 vuln load check: HTTP 500 (1377s/2400s): failed to obtain vulnerability definitions information: no timestamp available

INFO: Sun Apr  5 23:34:57 UTC 2026: Scanner V4 vulnerability loading complete (1408s elapsed).
```