### PR TITLE
ROX-33655: Query changes for enhanced filters

### DIFF
--- a/central/reports/common/query_builder.go
+++ b/central/reports/common/query_builder.go
@@ -76,8 +76,8 @@ func (q *queryBuilder) BuildQuery(
 	}, nil
 }
 
-// addSeverityFixabilityFiltersCollectionScopedReports adds severity, fixability filters for collection scoped reports
-func (q *queryBuilder) addSeverityFixabilityFiltersCollectionScopedReports() []string {
+// buildLegacyFilterQuery() adds severity, fixability filters for collection scoped reports
+func (q *queryBuilder) buildLegacyFilterQuery() []string {
 
 	vulnReportFilters := q.vulnFilters
 	var conjuncts []string
@@ -108,7 +108,7 @@ func (q *queryBuilder) buildCVEAttributesQuery() (string, error) {
 
 	if q.collection != nil {
 		// for collections only add fixability, severity filters for CVE
-		conjuncts = q.addSeverityFixabilityFiltersCollectionScopedReports()
+		conjuncts = q.buildLegacyFilterQuery()
 	} else if q.entityScope != nil {
 		// for entity scoped reports add all the search filters from query string
 		conjuncts = append(conjuncts, q.vulnFilters.GetQuery())

--- a/central/reports/common/query_builder.go
+++ b/central/reports/common/query_builder.go
@@ -163,6 +163,10 @@ func (q *queryBuilder) buildEntityScopeQuery() (*v1.Query, error) {
 
 	var conjuncts []*v1.Query
 	for _, rule := range rules {
+		if len(rule.GetValues()) == 0 {
+			continue
+		}
+
 		fieldLabel, err := entityScopeRuleToFieldLabel(rule)
 		if err != nil {
 			return nil, err
@@ -172,10 +176,6 @@ func (q *queryBuilder) buildEntityScopeQuery() (*v1.Query, error) {
 			fieldLabel == search.ClusterLabel ||
 			fieldLabel == search.DeploymentAnnotation ||
 			fieldLabel == search.NamespaceAnnotation
-
-		if len(rule.GetValues()) == 0 {
-			continue
-		}
 
 		if isMapField {
 			mapQueries := make([]*v1.Query, 0, len(rule.GetValues()))

--- a/central/reports/common/query_builder.go
+++ b/central/reports/common/query_builder.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	collectionDataStore "github.com/stackrox/rox/central/resourcecollection/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -27,17 +28,20 @@ type queryBuilder struct {
 	collection              *storage.ResourceCollection
 	collectionQueryResolver collectionDataStore.QueryResolver
 	dataStartTime           time.Time
+	entityScope             *storage.EntityScope
 }
 
 // NewVulnReportQueryBuilder builds a query builder to build scope and cve filtering queries for vuln reporting
-func NewVulnReportQueryBuilder(collection *storage.ResourceCollection, vulnFilters *storage.VulnerabilityReportFilters,
+func NewVulnReportQueryBuilder(collection *storage.ResourceCollection, entityScope *storage.EntityScope, vulnFilters *storage.VulnerabilityReportFilters,
 	collectionQueryRes collectionDataStore.QueryResolver, dataStartTime time.Time) *queryBuilder {
 	return &queryBuilder{
-		vulnFilters:             vulnFilters,
 		collection:              collection,
+		entityScope:             entityScope,
+		vulnFilters:             vulnFilters,
 		collectionQueryResolver: collectionQueryRes,
 		dataStartTime:           dataStartTime,
 	}
+
 }
 
 // BuildQuery builds scope and cve filtering queries for vuln reporting
@@ -46,7 +50,13 @@ func (q *queryBuilder) BuildQuery(
 	clusters []effectiveaccessscope.Cluster,
 	namespaces []effectiveaccessscope.Namespace,
 ) (*ReportQuery, error) {
-	deploymentsQuery, err := q.collectionQueryResolver.ResolveCollectionQuery(ctx, q.collection)
+	deploymentsQuery := search.EmptyQuery()
+	var err error
+	if q.collection != nil {
+		deploymentsQuery, err = q.collectionQueryResolver.ResolveCollectionQuery(ctx, q.collection)
+	} else if q.entityScope != nil {
+		deploymentsQuery, err = q.buildEntityScopeQuery()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +76,9 @@ func (q *queryBuilder) BuildQuery(
 	}, nil
 }
 
-func (q *queryBuilder) buildCVEAttributesQuery() (string, error) {
+// addSeverityFixabilityFiltersCollectionScopedReports adds severity, fixability filters for collection scoped reports
+func (q *queryBuilder) addSeverityFixabilityFiltersCollectionScopedReports() []string {
+
 	vulnReportFilters := q.vulnFilters
 	var conjuncts []string
 
@@ -86,13 +98,26 @@ func (q *queryBuilder) buildCVEAttributesQuery() (string, error) {
 	if len(severities) > 0 {
 		conjuncts = append(conjuncts, search.NewQueryBuilder().AddExactMatches(search.Severity, severities...).Query())
 	}
+	return conjuncts
+}
 
+func (q *queryBuilder) buildCVEAttributesQuery() (string, error) {
+
+	vulnReportFilters := q.vulnFilters
+	var conjuncts []string
+
+	if q.collection != nil {
+		// for collections only add fixability, severity filters for CVE
+		conjuncts = q.addSeverityFixabilityFiltersCollectionScopedReports()
+	} else if q.entityScope != nil {
+		// for entity scoped reports add all the search filters from query string
+		conjuncts = append(conjuncts, q.vulnFilters.GetQuery())
+	}
 	if filterVulnsByFirstOccurrenceTime(vulnReportFilters) {
 		startTimeStr := fmt.Sprintf(">=%s", q.dataStartTime.Format("01/02/2006 3:04:05 PM MST"))
 		tsQ := search.NewQueryBuilder().AddStrings(search.FirstImageOccurrenceTimestamp, startTimeStr).Query()
 		conjuncts = append(conjuncts, tsQ)
 	}
-
 	return strings.Join(conjuncts, "+"), nil
 }
 
@@ -129,6 +154,100 @@ func (q *queryBuilder) buildAccessScopeQuery(
 	return scopeQuery, nil
 }
 
+// buildEntityScopeQuery uses entity scope object to build v1 query
+func (q *queryBuilder) buildEntityScopeQuery() (*v1.Query, error) {
+	rules := q.entityScope.GetRules()
+	if len(rules) == 0 {
+		return search.EmptyQuery(), nil
+	}
+
+	var conjuncts []*v1.Query
+	for _, rule := range rules {
+		fieldLabel, err := entityScopeRuleToFieldLabel(rule)
+		if err != nil {
+			return nil, err
+		}
+		isMapField := fieldLabel == search.DeploymentLabel ||
+			fieldLabel == search.NamespaceLabel ||
+			fieldLabel == search.ClusterLabel ||
+			fieldLabel == search.DeploymentAnnotation ||
+			fieldLabel == search.NamespaceAnnotation
+
+		values := make([]string, 0, len(rule.GetValues()))
+		for _, rv := range rule.GetValues() {
+			val := rv.GetValue()
+			if rv.GetMatchType() == storage.MatchType_REGEX {
+				val = search.RegexPrefix + val
+			}
+			values = append(values, val)
+		}
+
+		if len(values) == 0 {
+			continue
+		}
+
+		if isMapField {
+			for _, v := range values {
+				key, value := splitLabelValue(v)
+				conjuncts = append(conjuncts,
+					search.NewQueryBuilder().AddMapQuery(fieldLabel, key, value).ProtoQuery())
+			}
+		} else if rule.GetValues()[0].GetMatchType() == storage.MatchType_REGEX {
+			conjuncts = append(conjuncts,
+				search.NewQueryBuilder().AddStrings(fieldLabel, values...).ProtoQuery())
+		} else {
+			conjuncts = append(conjuncts,
+				search.NewQueryBuilder().AddExactMatches(fieldLabel, values...).ProtoQuery())
+		}
+	}
+
+	if len(conjuncts) == 0 {
+		return search.EmptyQuery(), nil
+	}
+	return search.ConjunctionQuery(conjuncts...), nil
+}
+
+// entityScopeRuleToFieldLabel returns search filter for given entity field pair
+func entityScopeRuleToFieldLabel(rule *storage.EntityScopeRule) (search.FieldLabel, error) {
+	switch rule.GetEntity() {
+	case storage.EntityType_ENTITY_TYPE_DEPLOYMENT:
+		switch rule.GetField() {
+		case storage.EntityField_FIELD_NAME:
+			return search.DeploymentName, nil
+		case storage.EntityField_FIELD_LABEL:
+			return search.DeploymentLabel, nil
+		case storage.EntityField_FIELD_ANNOTATION:
+			return search.DeploymentAnnotation, nil
+		}
+	case storage.EntityType_ENTITY_TYPE_NAMESPACE:
+		switch rule.GetField() {
+		case storage.EntityField_FIELD_NAME:
+			return search.Namespace, nil
+		case storage.EntityField_FIELD_LABEL:
+			return search.NamespaceLabel, nil
+		case storage.EntityField_FIELD_ANNOTATION:
+			return search.NamespaceAnnotation, nil
+		}
+	case storage.EntityType_ENTITY_TYPE_CLUSTER:
+		switch rule.GetField() {
+		case storage.EntityField_FIELD_NAME:
+			return search.Cluster, nil
+		case storage.EntityField_FIELD_LABEL:
+			return search.ClusterLabel, nil
+		}
+	}
+	return "", errors.Errorf("Unsupported entity/field combination %s/%s", rule.GetEntity(), rule.GetField())
+}
+
 func filterVulnsByFirstOccurrenceTime(vulnReportFilters *storage.VulnerabilityReportFilters) bool {
 	return vulnReportFilters.GetSinceLastSentScheduledReport() || vulnReportFilters.GetSinceStartDate() != nil
+}
+
+// split map field values like namespace labels(key=val) to key,val pair
+func splitLabelValue(labelVal string) (string, string) {
+	parts := strings.SplitN(labelVal, "=", 2)
+	if len(parts) == 2 {
+		return fmt.Sprintf("%q", parts[0]), fmt.Sprintf("%q", parts[1])
+	}
+	return fmt.Sprintf("%q", labelVal), fmt.Sprintf("%q", "")
 }

--- a/central/reports/common/query_builder.go
+++ b/central/reports/common/query_builder.go
@@ -173,31 +173,33 @@ func (q *queryBuilder) buildEntityScopeQuery() (*v1.Query, error) {
 			fieldLabel == search.DeploymentAnnotation ||
 			fieldLabel == search.NamespaceAnnotation
 
-		values := make([]string, 0, len(rule.GetValues()))
-		for _, rv := range rule.GetValues() {
-			val := rv.GetValue()
-			if rv.GetMatchType() == storage.MatchType_REGEX {
-				val = search.RegexPrefix + val
-			}
-			values = append(values, val)
-		}
-
-		if len(values) == 0 {
+		if len(rule.GetValues()) == 0 {
 			continue
 		}
 
 		if isMapField {
-			for _, v := range values {
-				key, value := splitLabelValue(v)
-				conjuncts = append(conjuncts,
+			mapQueries := make([]*v1.Query, 0, len(rule.GetValues()))
+			for _, rv := range rule.GetValues() {
+				val := rv.GetValue()
+				key, value := splitLabelValue(val)
+				mapQueries = append(mapQueries,
 					search.NewQueryBuilder().AddMapQuery(fieldLabel, key, value).ProtoQuery())
 			}
-		} else if rule.GetValues()[0].GetMatchType() == storage.MatchType_REGEX {
-			conjuncts = append(conjuncts,
-				search.NewQueryBuilder().AddStrings(fieldLabel, values...).ProtoQuery())
+			conjuncts = append(conjuncts, search.DisjunctionQuery(mapQueries...))
 		} else {
-			conjuncts = append(conjuncts,
-				search.NewQueryBuilder().AddExactMatches(fieldLabel, values...).ProtoQuery())
+			var ruleQueries []*v1.Query
+			for _, rv := range rule.GetValues() {
+				val := rv.GetValue()
+				if rv.GetMatchType() == storage.MatchType_REGEX {
+					val = search.RegexPrefix + val
+					ruleQueries = append(ruleQueries,
+						search.NewQueryBuilder().AddStrings(fieldLabel, val).ProtoQuery())
+				} else {
+					ruleQueries = append(ruleQueries,
+						search.NewQueryBuilder().AddExactMatches(fieldLabel, val).ProtoQuery())
+				}
+			}
+			conjuncts = append(conjuncts, search.DisjunctionQuery(ruleQueries...))
 		}
 	}
 

--- a/central/reports/common/query_builder_test.go
+++ b/central/reports/common/query_builder_test.go
@@ -197,3 +197,189 @@ func TestBuildAccessScopeQuery(t *testing.T) {
 func assertByDirectComparison(t testing.TB, expected *v1.Query, actual *v1.Query) {
 	protoassert.Equal(t, expected, actual)
 }
+
+func TestBuildEntityScopeQuery(t *testing.T) {
+	testCases := []struct {
+		name          string
+		scope         *storage.EntityScope
+		expected      *v1.Query
+		assertQueries func(t testing.TB, expected *v1.Query, actual *v1.Query)
+		hasError      bool
+	}{
+		{
+			name:          "Empty rules returns empty query (match all)",
+			scope:         &storage.EntityScope{},
+			expected:      search.EmptyQuery(),
+			assertQueries: assertByDirectComparison,
+		},
+		{
+			name: "Namespace rule",
+			scope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_NAMESPACE,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "prod", MatchType: storage.MatchType_EXACT},
+							{Value: "staging", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			expected:      search.NewQueryBuilder().AddExactMatches(search.Namespace, "prod", "staging").ProtoQuery(),
+			assertQueries: assertByDirectComparison,
+		},
+		{
+			name: "Single deployment name rule",
+			scope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_DEPLOYMENT,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "web-server", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			expected:      search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "web-server").ProtoQuery(),
+			assertQueries: assertByDirectComparison,
+		},
+		{
+			name: "Cluster name rule",
+			scope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_CLUSTER,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "prod-us", MatchType: storage.MatchType_EXACT},
+							{Value: "prod-eu", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			expected:      search.NewQueryBuilder().AddExactMatches(search.Cluster, "prod-us", "prod-eu").ProtoQuery(),
+			assertQueries: assertByDirectComparison,
+		},
+		{
+			name: "Multiple rules are ANDed",
+			scope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_NAMESPACE,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "prod", MatchType: storage.MatchType_EXACT},
+						},
+					},
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_DEPLOYMENT,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "backend", MatchType: storage.MatchType_EXACT},
+							{Value: "frontend", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			expected: search.ConjunctionQuery(
+				search.NewQueryBuilder().AddExactMatches(search.Namespace, "prod").ProtoQuery(),
+				search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "backend", "frontend").ProtoQuery(),
+			),
+			assertQueries: assertByDirectComparison,
+		},
+		{
+			name: "Label rule uses map query",
+			scope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_NAMESPACE,
+						Field:  storage.EntityField_FIELD_LABEL,
+						Values: []*storage.RuleValue{
+							{Value: "env=prod", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			expected:      search.NewQueryBuilder().AddMapQuery(search.NamespaceLabel, `"env"`, `"prod"`).ProtoQuery(),
+			assertQueries: assertByDirectComparison,
+		},
+		{
+			name: "Regex match type adds r/ prefix",
+			scope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_DEPLOYMENT,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "web-.*", MatchType: storage.MatchType_REGEX},
+						},
+					},
+				},
+			},
+			expected:      search.NewQueryBuilder().AddStrings(search.DeploymentName, "r/web-.*").ProtoQuery(),
+			assertQueries: assertByDirectComparison,
+		},
+		{
+			name: "Rule with empty values is skipped",
+			scope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_NAMESPACE,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{},
+					},
+				},
+			},
+			expected:      search.EmptyQuery(),
+			assertQueries: assertByDirectComparison,
+		},
+		{
+			name: "Unsupported entity/field returns error",
+			scope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_CLUSTER,
+						Field:  storage.EntityField_FIELD_ANNOTATION,
+						Values: []*storage.RuleValue{
+							{Value: "team=infra", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			hasError: true,
+		},
+		{
+			name: "Deployment annotation rule",
+			scope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_DEPLOYMENT,
+						Field:  storage.EntityField_FIELD_ANNOTATION,
+						Values: []*storage.RuleValue{
+							{Value: "owner=team-a", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			expected:      search.NewQueryBuilder().AddMapQuery(search.DeploymentAnnotation, `"owner"`, `"team-a"`).ProtoQuery(),
+			assertQueries: assertByDirectComparison,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			qb := &queryBuilder{
+				entityScope: tc.scope,
+			}
+			result, err := qb.buildEntityScopeQuery()
+			if tc.hasError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			tc.assertQueries(t, tc.expected, result)
+		})
+	}
+}

--- a/central/reports/common/query_builder_test.go
+++ b/central/reports/common/query_builder_test.go
@@ -226,7 +226,10 @@ func TestBuildEntityScopeQuery(t *testing.T) {
 					},
 				},
 			},
-			expected:      search.NewQueryBuilder().AddExactMatches(search.Namespace, "prod", "staging").ProtoQuery(),
+			expected: search.DisjunctionQuery(
+				search.NewQueryBuilder().AddExactMatches(search.Namespace, "prod").ProtoQuery(),
+				search.NewQueryBuilder().AddExactMatches(search.Namespace, "staging").ProtoQuery(),
+			),
 			assertQueries: assertByDirectComparison,
 		},
 		{
@@ -259,7 +262,10 @@ func TestBuildEntityScopeQuery(t *testing.T) {
 					},
 				},
 			},
-			expected:      search.NewQueryBuilder().AddExactMatches(search.Cluster, "prod-us", "prod-eu").ProtoQuery(),
+			expected: search.DisjunctionQuery(
+				search.NewQueryBuilder().AddExactMatches(search.Cluster, "prod-us").ProtoQuery(),
+				search.NewQueryBuilder().AddExactMatches(search.Cluster, "prod-eu").ProtoQuery(),
+			),
 			assertQueries: assertByDirectComparison,
 		},
 		{
@@ -285,7 +291,10 @@ func TestBuildEntityScopeQuery(t *testing.T) {
 			},
 			expected: search.ConjunctionQuery(
 				search.NewQueryBuilder().AddExactMatches(search.Namespace, "prod").ProtoQuery(),
-				search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "backend", "frontend").ProtoQuery(),
+				search.DisjunctionQuery(
+					search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "backend").ProtoQuery(),
+					search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "frontend").ProtoQuery(),
+				),
 			),
 			assertQueries: assertByDirectComparison,
 		},

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -361,7 +361,7 @@ func (s *scheduler) getReportData(ctx context.Context, rc *storage.ReportConfigu
 
 func (s *scheduler) buildReportQuery(ctx context.Context, rc *storage.ReportConfiguration,
 	collection *storage.ResourceCollection) (*common.ReportQuery, error) {
-	qb := common.NewVulnReportQueryBuilder(collection, rc.GetVulnReportFilters(), s.collectionQueryResolver,
+	qb := common.NewVulnReportQueryBuilder(collection, rc.GetResourceScope().GetEntityScope(), rc.GetVulnReportFilters(), s.collectionQueryResolver,
 		timestamp.FromProtobuf(rc.GetLastSuccessfulRunTime()).GoTime())
 	rQuery, err := qb.BuildQuery(ctx, nil, nil)
 	if err != nil {

--- a/central/reports/scheduler/schedule.go
+++ b/central/reports/scheduler/schedule.go
@@ -361,7 +361,7 @@ func (s *scheduler) getReportData(ctx context.Context, rc *storage.ReportConfigu
 
 func (s *scheduler) buildReportQuery(ctx context.Context, rc *storage.ReportConfiguration,
 	collection *storage.ResourceCollection) (*common.ReportQuery, error) {
-	qb := common.NewVulnReportQueryBuilder(collection, rc.GetResourceScope().GetEntityScope(), rc.GetVulnReportFilters(), s.collectionQueryResolver,
+	qb := common.NewVulnReportQueryBuilder(collection, nil, rc.GetVulnReportFilters(), s.collectionQueryResolver,
 		timestamp.FromProtobuf(rc.GetLastSuccessfulRunTime()).GoTime())
 	rQuery, err := qb.BuildQuery(ctx, nil, nil)
 	if err != nil {

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -389,7 +389,7 @@ func (rg *reportGeneratorImpl) buildReportQueryViewBased(snap *storage.ReportSna
 
 func (rg *reportGeneratorImpl) buildReportQuery(snap *storage.ReportSnapshot,
 	collection *storage.ResourceCollection, dataStartTime time.Time) (*common.ReportQuery, error) {
-	qb := common.NewVulnReportQueryBuilder(collection, snap.GetVulnReportFilters(), rg.collectionQueryResolver,
+	qb := common.NewVulnReportQueryBuilder(collection, snap.GetResourceScope().GetEntityScope(), snap.GetVulnReportFilters(), rg.collectionQueryResolver,
 		dataStartTime)
 	allClusters, allNamespaces, err := rg.getClustersAndNamespacesForSAC()
 	if err != nil {

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl_flat_data_model_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl_flat_data_model_test.go
@@ -54,7 +54,7 @@ type NewDataModelEnhancedReportingTestSuite struct {
 	reportGenerator       *reportGeneratorImpl
 }
 
-func (s *NewDataModelEnhancedReportingTestSuite) TearDownTest() {
+func (s *NewDataModelEnhancedReportingTestSuite) TearDownSuite() {
 	s.truncateTable(postgresSchema.DeploymentsTableName)
 	s.truncateTable(postgresSchema.ImagesTableName)
 	s.truncateTable(postgresSchema.ImageComponentV2TableName)
@@ -240,5 +240,338 @@ func collectVulnReportDataSQFNewDataModel(cveResponses []*ImageCVEQueryResponse)
 		componentNames:  componentNames.AsSlice(),
 		cveNames:        cveNames,
 		cvss:            cvss,
+	}
+}
+
+func (s *NewDataModelEnhancedReportingTestSuite) TestGetReportDataWithEntityScopeAndQueryFilters() {
+	allImageTypes := []storage.VulnerabilityReportFilters_ImageType{
+		storage.VulnerabilityReportFilters_DEPLOYED,
+		storage.VulnerabilityReportFilters_WATCHED,
+	}
+	deployedOnly := []storage.VulnerabilityReportFilters_ImageType{
+		storage.VulnerabilityReportFilters_DEPLOYED,
+	}
+
+	testCases := map[string]struct {
+		entityScope   *storage.EntityScope
+		query         string
+		imageTypes    []storage.VulnerabilityReportFilters_ImageType
+		scopeRules    []*storage.SimpleAccessScope_Rules
+		dataStartTime time.Time
+		expected      *vulnReportDataNewDataModel
+	}{
+		"Cluster scope with CVSS filter narrows by scope and score": {
+			entityScope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_CLUSTER,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "c1", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			query:      "CVSS:>=7.0",
+			imageTypes: allImageTypes,
+			scopeRules: []*storage.SimpleAccessScope_Rules{
+				{IncludedClusters: []string{"c1"}},
+			},
+			expected: &vulnReportDataNewDataModel{
+				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
+				},
+			},
+		},
+		"Namespace scope with EPSS probability filter and c1 access scope": {
+			entityScope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_NAMESPACE,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "ns1", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			query:      "EPSS Probability:>=0.5",
+			imageTypes: allImageTypes,
+			scopeRules: []*storage.SimpleAccessScope_Rules{
+				{IncludedClusters: []string{"c1"}},
+			},
+			expected: &vulnReportDataNewDataModel{
+				deploymentNames: []string{"c1_ns1_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
+				},
+			},
+		},
+		"Deployment scope with low NVD CVSS filter": {
+			entityScope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_DEPLOYMENT,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "c1_ns1_dep0", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			query:      "NVD CVSS:<=5.0",
+			imageTypes: allImageTypes,
+			scopeRules: []*storage.SimpleAccessScope_Rules{
+				{IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
+					{ClusterName: "c1", NamespaceName: "ns1"},
+				}},
+			},
+			expected: &vulnReportDataNewDataModel{
+				deploymentNames: []string{"c1_ns1_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				cveNames: []string{
+					"CVE-nonFixable_low-c1_ns1_dep0_img_comp",
+					"CVE-nonFixable_low-w0_img_comp",
+					"CVE-nonFixable_low-w1_img_comp",
+				},
+			},
+		},
+		"Cluster and namespace AND rules with fixability filter": {
+			entityScope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_CLUSTER,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "c1", MatchType: storage.MatchType_EXACT},
+						},
+					},
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_NAMESPACE,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "ns1", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			query:      "Fixable:true",
+			imageTypes: allImageTypes,
+			scopeRules: []*storage.SimpleAccessScope_Rules{
+				{IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
+					{ClusterName: "c1", NamespaceName: "ns1"},
+				}},
+			},
+			expected: &vulnReportDataNewDataModel{
+				deploymentNames: []string{"c1_ns1_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
+				},
+			},
+		},
+		"Deployment scope deployed-only with component source filter": {
+			entityScope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_DEPLOYMENT,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "c1_ns1_dep0", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			query:      "Component Source:OS",
+			imageTypes: deployedOnly,
+			scopeRules: []*storage.SimpleAccessScope_Rules{
+				{IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
+					{ClusterName: "c1", NamespaceName: "ns1"},
+				}},
+			},
+			expected: &vulnReportDataNewDataModel{
+				deploymentNames: []string{"c1_ns1_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
+					"CVE-nonFixable_low-c1_ns1_dep0_img_comp",
+				},
+			},
+		},
+		"Deployment regex scope with CVSS filter": {
+			entityScope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_DEPLOYMENT,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "c1_.*", MatchType: storage.MatchType_REGEX},
+						},
+					},
+				},
+			},
+			query:      "CVSS:>=7.0",
+			imageTypes: allImageTypes,
+			scopeRules: []*storage.SimpleAccessScope_Rules{
+				{IncludedClusters: []string{"c1"}},
+			},
+			expected: &vulnReportDataNewDataModel{
+				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
+					"CVE-fixable_critical-w0_img_comp",
+					"CVE-fixable_critical-w1_img_comp",
+				},
+			},
+		},
+		"Multiple deployment values AND with low EPSS filter": {
+			entityScope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_DEPLOYMENT,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "c1_ns1_dep0", MatchType: storage.MatchType_EXACT},
+							{Value: "c2_ns1_dep0", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			query:      "EPSS Probability:<=0.5",
+			imageTypes: allImageTypes,
+			scopeRules: []*storage.SimpleAccessScope_Rules{
+				{IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
+					{ClusterName: "c1", NamespaceName: "ns1"},
+					{ClusterName: "c2", NamespaceName: "ns1"},
+				}},
+			},
+			expected: &vulnReportDataNewDataModel{
+				deploymentNames: []string{"c1_ns1_dep0", "c2_ns1_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c2_ns1_dep0_img", "w0_img", "w1_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c2_ns1_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				cveNames: []string{
+					"CVE-nonFixable_low-c1_ns1_dep0_img_comp",
+					"CVE-nonFixable_low-c2_ns1_dep0_img_comp",
+					"CVE-nonFixable_low-w0_img_comp",
+					"CVE-nonFixable_low-w1_img_comp",
+				},
+			},
+		},
+		"Namespace scope with image registry and CVSS combined filter": {
+			entityScope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_NAMESPACE,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "ns1", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			query:      "Image Registry:docker.io+CVSS:>=7.0",
+			imageTypes: allImageTypes,
+			scopeRules: []*storage.SimpleAccessScope_Rules{
+				{IncludedClusters: []string{"c1", "c2"}},
+			},
+			expected: &vulnReportDataNewDataModel{
+				deploymentNames: []string{"c1_ns1_dep0", "c2_ns1_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c2_ns1_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c2_ns1_dep0_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c2_ns1_dep0_img_comp",
+				},
+			},
+		},
+		"Deployment scope with image label filter": {
+			entityScope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_DEPLOYMENT,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "c1_ns1_dep0", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			query:      "Image Label:app=test",
+			imageTypes: allImageTypes,
+			scopeRules: []*storage.SimpleAccessScope_Rules{
+				{IncludedNamespaces: []*storage.SimpleAccessScope_Rules_Namespace{
+					{ClusterName: "c1", NamespaceName: "ns1"},
+				}},
+			},
+			expected: &vulnReportDataNewDataModel{
+				deploymentNames: []string{"c1_ns1_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
+				},
+			},
+		},
+		"Cluster scope deployed-only with image regex and EPSS combined filter": {
+			entityScope: &storage.EntityScope{
+				Rules: []*storage.EntityScopeRule{
+					{
+						Entity: storage.EntityType_ENTITY_TYPE_CLUSTER,
+						Field:  storage.EntityField_FIELD_NAME,
+						Values: []*storage.RuleValue{
+							{Value: "c1", MatchType: storage.MatchType_EXACT},
+							{Value: "c2", MatchType: storage.MatchType_EXACT},
+						},
+					},
+				},
+			},
+			query:      "Image:r/c1_.*+EPSS Probability:>=0.5",
+			imageTypes: deployedOnly,
+			scopeRules: []*storage.SimpleAccessScope_Rules{
+				{IncludedClusters: []string{"c1", "c2"}},
+			},
+			expected: &vulnReportDataNewDataModel{
+				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp"},
+				cveNames: []string{
+					"CVE-fixable_critical-c1_ns1_dep0_img_comp",
+					"CVE-fixable_critical-c1_ns2_dep0_img_comp",
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		s.T().Run(name, func(t *testing.T) {
+			reportSnap := testEntityScopeReportSnapshot(tc.entityScope, tc.query, tc.imageTypes, tc.scopeRules)
+			reportData, err := s.reportGenerator.getReportDataSQF(reportSnap, nil, time.Time{})
+			s.NoError(err)
+			collected := collectVulnReportDataSQFNewDataModel(reportData.CVEResponses)
+			s.ElementsMatch(tc.expected.deploymentNames, collected.deploymentNames)
+			s.ElementsMatch(tc.expected.imageNames, collected.imageNames)
+			s.ElementsMatch(tc.expected.componentNames, collected.componentNames)
+			s.ElementsMatch(tc.expected.cveNames, collected.cveNames)
+			s.Equal(len(tc.expected.cveNames), reportData.NumDeployedImageResults+reportData.NumWatchedImageResults)
+			s.Equal(len(tc.expected.cveNames), len(collected.cvss))
+		})
 	}
 }

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -292,15 +292,13 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			query: "Image Registry:docker.io",
 			expected: &viewBasedReportData{
 				deploymentNames: []string{"c1_ns1_dep0", "c1_ns2_dep0", "c2_ns1_dep0", "c2_ns2_dep0"},
-				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img", "w0_img", "w1_img"},
-				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp", "w0_img_comp", "w1_img_comp"},
+				imageNames:      []string{"c1_ns1_dep0_img", "c1_ns2_dep0_img", "c2_ns1_dep0_img", "c2_ns2_dep0_img"},
+				componentNames:  []string{"c1_ns1_dep0_img_comp", "c1_ns2_dep0_img_comp", "c2_ns1_dep0_img_comp", "c2_ns2_dep0_img_comp"},
 				cveNames: []string{
 					"CVE-fixable_critical-c1_ns1_dep0_img_comp", "CVE-nonFixable_low-c1_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c1_ns2_dep0_img_comp", "CVE-nonFixable_low-c1_ns2_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns1_dep0_img_comp", "CVE-nonFixable_low-c2_ns1_dep0_img_comp",
 					"CVE-fixable_critical-c2_ns2_dep0_img_comp", "CVE-nonFixable_low-c2_ns2_dep0_img_comp",
-					"CVE-fixable_critical-w0_img_comp", "CVE-nonFixable_low-w0_img_comp",
-					"CVE-fixable_critical-w1_img_comp", "CVE-nonFixable_low-w1_img_comp",
 				},
 			},
 		},

--- a/central/reports/scheduler/v2/reportgenerator/testutils.go
+++ b/central/reports/scheduler/v2/reportgenerator/testutils.go
@@ -46,7 +46,7 @@ func testDeploymentsWithImages(namespaces []*storage.NamespaceMetadata, numDeplo
 	for _, namespace := range namespaces {
 		for i := 0; i < numDeploymentsPerNamespace; i++ {
 			depName := fmt.Sprintf("%s_%s_dep%d", namespace.GetClusterName(), namespace.GetName(), i)
-			image := testImage(depName)
+			image := testImage(depName, map[string]string{"app": "test"}, "docker.io")
 			deployment := testDeployment(depName, namespace, image)
 			deployments = append(deployments, deployment)
 			images = append(images, image)
@@ -76,13 +76,13 @@ func testWatchedImages(numImages int) []*storage.Image {
 	images := make([]*storage.Image, 0, numImages)
 	for i := 0; i < numImages; i++ {
 		imgNamePrefix := fmt.Sprintf("w%d", i)
-		image := testImage(imgNamePrefix)
+		image := testImage(imgNamePrefix, map[string]string{"app": "watch"}, "quay.io")
 		images = append(images, image)
 	}
 	return images
 }
 
-func testImage(prefix string) *storage.Image {
+func testImage(prefix string, labels map[string]string, registry string) *storage.Image {
 	t, err := protocompat.ConvertTimeToTimestampOrError(time.Unix(0, 1000))
 	utils.CrashOnError(err)
 	nvdCvss := &storage.CVSSScore{
@@ -97,9 +97,14 @@ func testImage(prefix string) *storage.Image {
 		Id: fmt.Sprintf("%s_img", prefix),
 		Name: &storage.ImageName{
 			FullName: fmt.Sprintf("%s_img", prefix),
-			Registry: "docker.io",
+			Registry: registry,
 			Remote:   fmt.Sprintf("library/%s_img", prefix),
 			Tag:      "latest",
+		},
+		Metadata: &storage.ImageMetadata{
+			V1: &storage.V1Metadata{
+				Labels: labels,
+			},
 		},
 		SetComponents: &storage.Image_Components{
 			Components: 1,
@@ -275,5 +280,26 @@ func testViewBasedReportSnapshot(query string, scopeRules []*storage.SimpleAcces
 			AccessScopeRules: scopeRules,
 		},
 	}
+	return snap
+}
+
+func testEntityScopeReportSnapshot(entityScope *storage.EntityScope, query string,
+	imageTypes []storage.VulnerabilityReportFilters_ImageType,
+	scopeRules []*storage.SimpleAccessScope_Rules) *storage.ReportSnapshot {
+	snap := fixtures.GetReportSnapshot()
+	filters := &storage.VulnerabilityReportFilters{
+		ImageTypes:       imageTypes,
+		AccessScopeRules: scopeRules,
+		Query:            query,
+	}
+	snap.Filter = &storage.ReportSnapshot_VulnReportFilters{
+		VulnReportFilters: filters,
+	}
+	snap.ResourceScope = &storage.ResourceScope{
+		ScopeReference: &storage.ResourceScope_EntityScope{
+			EntityScope: entityScope,
+		},
+	}
+	snap.Collection = nil
 	return snap
 }


### PR DESCRIPTION
This PR is part 1 of ROX-33655 that updates the query builder to use the new `entityScope` method combined with a `query `string containing enhanced filters for building report data queries. When a user selects entity scope for scoping reports, the new path is used; when a user selects a collection as the scoping method, report generation continues to work as previously implemented with legacy filters and collections.
There will be follow up PRs for  scheduler changes and benchmark test 

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality
Added integration tests and unit tests

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
