### PR TITLE
ROX-34014: Fix label search filter formatting for key=value pairs

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/AutocompleteSelect.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/AutocompleteSelect.tsx
@@ -18,7 +18,12 @@ import { SearchIcon, TimesIcon } from '@patternfly/react-icons';
 import { useQuery } from '@apollo/client';
 import SEARCH_AUTOCOMPLETE_QUERY from 'queries/searchAutocomplete';
 import type { SearchAutocompleteQueryResponse } from 'queries/searchAutocomplete';
-import { getRequestQueryStringForSearchFilter, wrapInQuotes } from 'utils/searchUtils';
+import {
+    formatLabelValue,
+    getRequestQueryStringForSearchFilter,
+    isLabelSearchTerm,
+    wrapInQuotes,
+} from 'utils/searchUtils';
 import type { SearchFilter } from 'types/search';
 import { ensureString } from 'utils/ensure';
 
@@ -113,7 +118,11 @@ function AutocompleteSelect({
         []
     );
 
-    const autocompleteSearchString = `${searchTerm}:${filterValue ? `r/${filterValue}` : ''}`;
+    let autocompleteFilterValue = filterValue ? `r/${filterValue}` : '';
+    if (filterValue && isLabelSearchTerm(searchTerm)) {
+        autocompleteFilterValue = formatLabelValue(filterValue, (v) => `r/${v}`).join(',');
+    }
+    const autocompleteSearchString = `${searchTerm}:${autocompleteFilterValue}`;
 
     const searchContext = {
         ...searchFilter,

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/AutocompleteSelect.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/AutocompleteSelect.tsx
@@ -19,9 +19,9 @@ import { useQuery } from '@apollo/client';
 import SEARCH_AUTOCOMPLETE_QUERY from 'queries/searchAutocomplete';
 import type { SearchAutocompleteQueryResponse } from 'queries/searchAutocomplete';
 import {
-    formatLabelValue,
+    formatKeyValue,
     getRequestQueryStringForSearchFilter,
-    isLabelSearchTerm,
+    isKeyValueSearchTerm,
     wrapInQuotes,
 } from 'utils/searchUtils';
 import type { SearchFilter } from 'types/search';
@@ -119,8 +119,8 @@ function AutocompleteSelect({
     );
 
     let autocompleteFilterValue = filterValue ? `r/${filterValue}` : '';
-    if (filterValue && isLabelSearchTerm(searchTerm)) {
-        autocompleteFilterValue = formatLabelValue(filterValue, (v) => `r/${v}`).join(',');
+    if (filterValue && isKeyValueSearchTerm(searchTerm)) {
+        autocompleteFilterValue = formatKeyValue(filterValue, (v) => `r/${v}`).join(',');
     }
     const autocompleteSearchString = `${searchTerm}:${autocompleteFilterValue}`;
 

--- a/ui/apps/platform/src/utils/searchUtils.test.ts
+++ b/ui/apps/platform/src/utils/searchUtils.test.ts
@@ -475,6 +475,13 @@ describe('searchUtils', () => {
         it('escapes internal double quotes in key and value', () => {
             expect(formatKeyValue('k"ey=v"al', wrapInQuotes)).toEqual(['"k\\"ey"="v\\"al"']);
         });
+
+        it('uses wildcard for empty key or value around equals sign', () => {
+            expect(formatKeyValue('=value', (v) => `r/${v}`)).toEqual(['r/.*=r/value']);
+            expect(formatKeyValue('key=', (v) => `r/${v}`)).toEqual(['r/key=r/.*']);
+            expect(formatKeyValue('=value', wrapInQuotes)).toEqual(['r/.*="value"']);
+            expect(formatKeyValue('key=', wrapInQuotes)).toEqual(['"key"=r/.*']);
+        });
     });
 
     describe('wrapInQuotes', () => {

--- a/ui/apps/platform/src/utils/searchUtils.test.ts
+++ b/ui/apps/platform/src/utils/searchUtils.test.ts
@@ -6,11 +6,13 @@ import {
     convertToExactMatch,
     convertToRestSearch,
     deleteKeysCaseInsensitive,
+    formatLabelValue,
     getListQueryParams,
     getPaginationParams,
     getSearchFilterFromSearchString,
     getViewStateFromSearch,
     hasSearchKeyValue,
+    isLabelSearchTerm,
     searchValueAsArray,
     wrapInQuotes,
 } from './searchUtils';
@@ -433,6 +435,53 @@ describe('searchUtils', () => {
         });
     });
 
+    describe('isLabelSearchTerm', () => {
+        it('returns true for label search terms', () => {
+            expect(isLabelSearchTerm('Deployment Label')).toBe(true);
+            expect(isLabelSearchTerm('Image Label')).toBe(true);
+            expect(isLabelSearchTerm('Node Label')).toBe(true);
+            expect(isLabelSearchTerm('Namespace Label')).toBe(true);
+            expect(isLabelSearchTerm('Cluster Label')).toBe(true);
+        });
+
+        it('returns true for label search terms in any case', () => {
+            expect(isLabelSearchTerm('deployment label')).toBe(true);
+            expect(isLabelSearchTerm('DEPLOYMENT LABEL')).toBe(true);
+            expect(isLabelSearchTerm('dEpLoYmEnT lAbEl')).toBe(true);
+        });
+
+        it('returns false for non-label search terms', () => {
+            expect(isLabelSearchTerm('Cluster')).toBe(false);
+            expect(isLabelSearchTerm('Deployment')).toBe(false);
+            expect(isLabelSearchTerm('Image')).toBe(false);
+        });
+    });
+
+    describe('formatLabelValue', () => {
+        it('splits on first equals sign and applies formatter to each part', () => {
+            expect(formatLabelValue('app=reporting', wrapInQuotes)).toEqual(['"app"="reporting"']);
+            expect(formatLabelValue('app=reporting', (v) => `r/${v}`)).toEqual([
+                'r/app=r/reporting',
+            ]);
+        });
+
+        it('handles values with multiple equals signs by splitting on the first', () => {
+            expect(formatLabelValue('key=val=extra', wrapInQuotes)).toEqual(['"key"="val=extra"']);
+        });
+
+        it('returns two entries for key OR value matching when no equals sign is present', () => {
+            expect(formatLabelValue('visa', wrapInQuotes)).toEqual(['"visa"=r/.*', 'r/.*="visa"']);
+            expect(formatLabelValue('visa', (v) => `r/${v}`)).toEqual([
+                'r/visa=r/.*',
+                'r/.*=r/visa',
+            ]);
+        });
+
+        it('escapes internal double quotes in key and value', () => {
+            expect(formatLabelValue('k"ey=v"al', wrapInQuotes)).toEqual(['"k\\"ey"="v\\"al"']);
+        });
+    });
+
     describe('wrapInQuotes', () => {
         it('wraps a string in double quotes', () => {
             expect(wrapInQuotes('hello')).toBe('"hello"');
@@ -498,6 +547,58 @@ describe('searchUtils', () => {
             const result = applyRegexSearchModifiers(searchFilter);
             expect(result.Cluster).toEqual(['r/production']);
             expect(result['Random Field']).toEqual('value'); // should not be modified
+        });
+
+        it('formats label regex values with equals sign by prefixing both sides', () => {
+            const searchFilter = { 'Deployment Label': 'app=reporting' };
+            const result = applyRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({ 'Deployment Label': ['r/app=r/reporting'] });
+        });
+
+        it('formats label regex values without equals sign as two entries for key OR value match', () => {
+            const searchFilter = { 'Deployment Label': 'visa' };
+            const result = applyRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({ 'Deployment Label': ['r/visa=r/.*', 'r/.*=r/visa'] });
+        });
+
+        it('formats quoted label values with equals sign by quoting each side separately', () => {
+            const searchFilter = { 'Deployment Label': '"app=reporting"' };
+            const result = applyRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({ 'Deployment Label': ['"app"="reporting"'] });
+        });
+
+        it('formats quoted label values without equals sign as two entries for key OR value match', () => {
+            const searchFilter = { 'Deployment Label': '"visa"' };
+            const result = applyRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({ 'Deployment Label': ['"visa"=r/.*', 'r/.*="visa"'] });
+        });
+
+        it('applies label formatting to all label search terms', () => {
+            const searchFilter = {
+                'Image Label': 'env=prod',
+                'Node Label': 'role=worker',
+                'Cluster Label': 'team=platform',
+                'Namespace Label': 'app=web',
+            };
+            const result = applyRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({
+                'Image Label': ['r/env=r/prod'],
+                'Node Label': ['r/role=r/worker'],
+                'Cluster Label': ['r/team=r/platform'],
+                'Namespace Label': ['r/app=r/web'],
+            });
+        });
+
+        it('does not apply label formatting to non-label search terms', () => {
+            const searchFilter = {
+                Cluster: 'production',
+                'Deployment Label': 'app=reporting',
+            };
+            const result = applyRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({
+                Cluster: ['r/production'],
+                'Deployment Label': ['r/app=r/reporting'],
+            });
         });
     });
 });

--- a/ui/apps/platform/src/utils/searchUtils.test.ts
+++ b/ui/apps/platform/src/utils/searchUtils.test.ts
@@ -6,13 +6,13 @@ import {
     convertToExactMatch,
     convertToRestSearch,
     deleteKeysCaseInsensitive,
-    formatLabelValue,
+    formatKeyValue,
     getListQueryParams,
     getPaginationParams,
     getSearchFilterFromSearchString,
     getViewStateFromSearch,
     hasSearchKeyValue,
-    isLabelSearchTerm,
+    isKeyValueSearchTerm,
     searchValueAsArray,
     wrapInQuotes,
 } from './searchUtils';
@@ -435,50 +435,45 @@ describe('searchUtils', () => {
         });
     });
 
-    describe('isLabelSearchTerm', () => {
+    describe('isKeyValueSearchTerm', () => {
         it('returns true for label search terms', () => {
-            expect(isLabelSearchTerm('Deployment Label')).toBe(true);
-            expect(isLabelSearchTerm('Image Label')).toBe(true);
-            expect(isLabelSearchTerm('Node Label')).toBe(true);
-            expect(isLabelSearchTerm('Namespace Label')).toBe(true);
-            expect(isLabelSearchTerm('Cluster Label')).toBe(true);
+            expect(isKeyValueSearchTerm('Deployment Label')).toBe(true);
+            expect(isKeyValueSearchTerm('Image Label')).toBe(true);
+            expect(isKeyValueSearchTerm('Node Label')).toBe(true);
+            expect(isKeyValueSearchTerm('Namespace Label')).toBe(true);
+            expect(isKeyValueSearchTerm('Cluster Label')).toBe(true);
         });
 
         it('returns true for label search terms in any case', () => {
-            expect(isLabelSearchTerm('deployment label')).toBe(true);
-            expect(isLabelSearchTerm('DEPLOYMENT LABEL')).toBe(true);
-            expect(isLabelSearchTerm('dEpLoYmEnT lAbEl')).toBe(true);
+            expect(isKeyValueSearchTerm('deployment label')).toBe(true);
+            expect(isKeyValueSearchTerm('DEPLOYMENT LABEL')).toBe(true);
+            expect(isKeyValueSearchTerm('dEpLoYmEnT lAbEl')).toBe(true);
         });
 
         it('returns false for non-label search terms', () => {
-            expect(isLabelSearchTerm('Cluster')).toBe(false);
-            expect(isLabelSearchTerm('Deployment')).toBe(false);
-            expect(isLabelSearchTerm('Image')).toBe(false);
+            expect(isKeyValueSearchTerm('Cluster')).toBe(false);
+            expect(isKeyValueSearchTerm('Deployment')).toBe(false);
+            expect(isKeyValueSearchTerm('Image')).toBe(false);
         });
     });
 
-    describe('formatLabelValue', () => {
+    describe('formatKeyValue', () => {
         it('splits on first equals sign and applies formatter to each part', () => {
-            expect(formatLabelValue('app=reporting', wrapInQuotes)).toEqual(['"app"="reporting"']);
-            expect(formatLabelValue('app=reporting', (v) => `r/${v}`)).toEqual([
-                'r/app=r/reporting',
-            ]);
+            expect(formatKeyValue('app=reporting', wrapInQuotes)).toEqual(['"app"="reporting"']);
+            expect(formatKeyValue('app=reporting', (v) => `r/${v}`)).toEqual(['r/app=r/reporting']);
         });
 
         it('handles values with multiple equals signs by splitting on the first', () => {
-            expect(formatLabelValue('key=val=extra', wrapInQuotes)).toEqual(['"key"="val=extra"']);
+            expect(formatKeyValue('key=val=extra', wrapInQuotes)).toEqual(['"key"="val=extra"']);
         });
 
         it('returns two entries for key OR value matching when no equals sign is present', () => {
-            expect(formatLabelValue('visa', wrapInQuotes)).toEqual(['"visa"=r/.*', 'r/.*="visa"']);
-            expect(formatLabelValue('visa', (v) => `r/${v}`)).toEqual([
-                'r/visa=r/.*',
-                'r/.*=r/visa',
-            ]);
+            expect(formatKeyValue('visa', wrapInQuotes)).toEqual(['"visa"=r/.*', 'r/.*="visa"']);
+            expect(formatKeyValue('visa', (v) => `r/${v}`)).toEqual(['r/visa=r/.*', 'r/.*=r/visa']);
         });
 
         it('escapes internal double quotes in key and value', () => {
-            expect(formatLabelValue('k"ey=v"al', wrapInQuotes)).toEqual(['"k\\"ey"="v\\"al"']);
+            expect(formatKeyValue('k"ey=v"al', wrapInQuotes)).toEqual(['"k\\"ey"="v\\"al"']);
         });
     });
 

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -428,6 +428,20 @@ const regexSearchOptions = [
     .filter(({ inputType }) => inputType === 'text' || inputType === 'autocomplete')
     .map(({ searchTerm }) => searchTerm);
 
+/*
+ Search terms that use the key=value label format and need special handling
+ in both regex and exact-match search modes.
+*/
+const labelSearchOptions: Set<string> = new Set(
+    ['Cluster Label', 'Deployment Label', 'Image Label', 'Namespace Label', 'Node Label'].map(
+        (label) => label.toLowerCase()
+    )
+);
+
+export function isLabelSearchTerm(searchTerm: string): boolean {
+    return labelSearchOptions.has(searchTerm.toLowerCase());
+}
+
 function isQuotedString(value: string): boolean {
     return value.startsWith('"') && value.endsWith('"') && value.length >= 2;
 }
@@ -442,17 +456,50 @@ export function wrapInQuotes(value: string): string {
 }
 
 /**
+ * Formats a label value by splitting on the first '=' and applying a formatter
+ * to each half. If no '=' is present, the value is used for both sides with
+ * a `r/.*` regex wildcard on the opposite side.
+ *
+ * Used for both exact-match (formatter = wrapInQuotes) and regex (formatter = r/ prefix)
+ * label formatting.
+ */
+export function formatLabelValue(value: string, formatPart: (part: string) => string): string[] {
+    const eqIndex = value.indexOf('=');
+    if (eqIndex !== -1) {
+        const key = value.slice(0, eqIndex);
+        const val = value.slice(eqIndex + 1);
+        return [`${formatPart(key)}=${formatPart(val)}`];
+    }
+    // No '=' present — emit two entries to match the value against either the
+    // label key or the label value (OR semantics via comma-joined values).
+    // The wildcard 'r/.*' always uses regex so it matches anything regardless of
+    // whether the user's value is exact-match or regex.
+    return [`${formatPart(value)}=r/.*`, `r/.*=${formatPart(value)}`];
+}
+
+/**
  * Adds the regex search modifier to the search filter for any search options that support it.
  * Skips regex wrapping for values that are already quoted (exact-match strings).
+ *
+ * Label search terms (e.g. "Deployment Label") receive special formatting because the
+ * search API treats labels as key=value pairs:
+ *   - With "=": app=reporting -> r/app=r/reporting (regex), "app"="reporting" (exact)
+ *   - Without "=": visa -> [r/visa=r/.*, r/.*=r/visa] (matches key OR value)
  */
 export function applyRegexSearchModifiers(searchFilter: SearchFilter): SearchFilter {
     const regexSearchFilter = cloneDeep(searchFilter);
 
     Object.entries(regexSearchFilter).forEach(([key, value]) => {
         if (regexSearchOptions.some((option) => option.toLowerCase() === key.toLowerCase())) {
-            regexSearchFilter[key] = searchValueAsArray(value).map((val) =>
-                isQuotedString(val) ? val : `r/${val}`
-            );
+            const isLabel = isLabelSearchTerm(key);
+            regexSearchFilter[key] = searchValueAsArray(value).flatMap((val) => {
+                if (isLabel) {
+                    const rawValue = isQuotedString(val) ? val.slice(1, -1) : val;
+                    const formatter = isQuotedString(val) ? wrapInQuotes : (v: string) => `r/${v}`;
+                    return formatLabelValue(rawValue, formatter);
+                }
+                return isQuotedString(val) ? val : `r/${val}`;
+            });
         }
     });
 

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -433,9 +433,21 @@ const regexSearchOptions = [
  in both regex and exact-match search modes.
 */
 const labelSearchOptions: Set<string> = new Set(
-    ['Cluster Label', 'Deployment Label', 'Image Label', 'Namespace Label', 'Node Label'].map(
-        (label) => label.toLowerCase()
-    )
+    [
+        'Cluster Label',
+        'Deployment Annotation',
+        'Deployment Label',
+        'Image Label',
+        'Namespace Annotation',
+        'Namespace Label',
+        'Node Annotation',
+        'Node Label',
+        'Pod Label',
+        'Role Annotation',
+        'Role Binding Annotation',
+        'Role Binding Label',
+        'Role Label',
+    ].map((label) => label.toLowerCase())
 );
 
 export function isLabelSearchTerm(searchTerm: string): boolean {

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -432,7 +432,7 @@ const regexSearchOptions = [
  Search terms that use the key=value label format and need special handling
  in both regex and exact-match search modes.
 */
-const labelSearchOptions: Set<string> = new Set(
+const keyValueSearchOptions: Set<string> = new Set(
     [
         'Cluster Label',
         'Deployment Annotation',
@@ -450,8 +450,8 @@ const labelSearchOptions: Set<string> = new Set(
     ].map((label) => label.toLowerCase())
 );
 
-export function isLabelSearchTerm(searchTerm: string): boolean {
-    return labelSearchOptions.has(searchTerm.toLowerCase());
+export function isKeyValueSearchTerm(searchTerm: string): boolean {
+    return keyValueSearchOptions.has(searchTerm.toLowerCase());
 }
 
 function isQuotedString(value: string): boolean {
@@ -475,7 +475,7 @@ export function wrapInQuotes(value: string): string {
  * Used for both exact-match (formatter = wrapInQuotes) and regex (formatter = r/ prefix)
  * label formatting.
  */
-export function formatLabelValue(value: string, formatPart: (part: string) => string): string[] {
+export function formatKeyValue(value: string, formatPart: (part: string) => string): string[] {
     const eqIndex = value.indexOf('=');
     if (eqIndex !== -1) {
         const key = value.slice(0, eqIndex);
@@ -503,12 +503,12 @@ export function applyRegexSearchModifiers(searchFilter: SearchFilter): SearchFil
 
     Object.entries(regexSearchFilter).forEach(([key, value]) => {
         if (regexSearchOptions.some((option) => option.toLowerCase() === key.toLowerCase())) {
-            const isLabel = isLabelSearchTerm(key);
+            const isLabel = isKeyValueSearchTerm(key);
             regexSearchFilter[key] = searchValueAsArray(value).flatMap((val) => {
                 if (isLabel) {
                     const rawValue = isQuotedString(val) ? val.slice(1, -1) : val;
                     const formatter = isQuotedString(val) ? wrapInQuotes : (v: string) => `r/${v}`;
-                    return formatLabelValue(rawValue, formatter);
+                    return formatKeyValue(rawValue, formatter);
                 }
                 return isQuotedString(val) ? val : `r/${val}`;
             });

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -480,7 +480,9 @@ export function formatKeyValue(value: string, formatPart: (part: string) => stri
     if (eqIndex !== -1) {
         const key = value.slice(0, eqIndex);
         const val = value.slice(eqIndex + 1);
-        return [`${formatPart(key)}=${formatPart(val)}`];
+        const formattedKey = key ? formatPart(key) : 'r/.*';
+        const formattedVal = val ? formatPart(val) : 'r/.*';
+        return [`${formattedKey}=${formattedVal}`];
     }
     // No '=' present — emit two entries to match the value against either the
     // label key or the label value (OR semantics via comma-joined values).
@@ -507,8 +509,8 @@ export function applyRegexSearchModifiers(searchFilter: SearchFilter): SearchFil
             regexSearchFilter[key] = searchValueAsArray(value).flatMap((val) => {
                 if (isLabel) {
                     const rawValue = isQuotedString(val) ? val.slice(1, -1) : val;
-                    const formatter = isQuotedString(val) ? wrapInQuotes : (v: string) => `r/${v}`;
-                    return formatKeyValue(rawValue, formatter);
+                    const formatPart = isQuotedString(val) ? wrapInQuotes : (v: string) => `r/${v}`;
+                    return formatKeyValue(rawValue, formatPart);
                 }
                 return isQuotedString(val) ? val : `r/${val}`;
             });


### PR DESCRIPTION
## Description

Fixes label search filters (Deployment Label, Image Label, Node Label, Namespace Label, Cluster Label) to properly format key=value pairs for the search API.

**Problem:** Label search filters were not correctly handling the key=value format required by the backend. Labels need special quoting where each side of the equals sign is processed separately.

**Solution:** Added `formatLabelValue` utility that splits on the first `=` and applies formatting to each part:
- Exact match: `app=reporting` → `"app"="reporting"`
- Regex: `app=reporting` → `r/app=r/reporting`
- No equals sign: value is used for both sides to match an appearance in either (`report` → `r/.*=r/report` + `r/report=r/.*`). This is used to preserve the free-form text entry being a substring match of the target search, while working with the segmented key/value implementation of labels by the backend.

**Why this approach:** The backend treats labels as key=value pairs. Previous implementation wrapped the entire string in quotes or regex prefix, breaking the semantic meaning.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Added comprehensive unit tests for `formatLabelValue`, `isLabelSearchTerm`, and integration with `applyRegexSearchModifiers`
- Added Cypress component test verifying autocomplete selection formatting for label fields
- Manual testing in UI against staging to verify functionality

Selecting a label from the dropdown for an exact match:
<img width="1594" height="1082" alt="image" src="https://github.com/user-attachments/assets/d2753823-87fb-4178-9214-94ef12f40188" />

Using a directly entered value as a regex match:
<img width="1594" height="1082" alt="image" src="https://github.com/user-attachments/assets/8f6aec26-8592-4ff7-a36f-4093ca869c75" />
Note that autocomplete options match multiple deployments:
<img width="1594" height="1082" alt="image" src="https://github.com/user-attachments/assets/7a36bd8b-4113-44bd-bdca-12d0bc29bdfa" />

Using a directly entered value **without** an equal sign delimiter:

Doesn't work correctly for autocomplete *values*, which is an API bug: https://redhat.atlassian.net/browse/ROX-34166
<img width="1594" height="1082" alt="image" src="https://github.com/user-attachments/assets/739231ae-a037-480a-be08-7e1ac636cb57" />

but does return the correct results for search:
<img width="1594" height="1082" alt="image" src="https://github.com/user-attachments/assets/a6c62a8a-deb4-482f-81cf-3af94b069706" />

A key/value formatted search regex does return the correct autocomplete results, showing the multiple matched deployments in the previous screenshot:
<img width="1594" height="1082" alt="image" src="https://github.com/user-attachments/assets/d1adb577-c642-4488-8215-391f367bb44b" />





