### PR TITLE
ROX-33656: Benchmark for enhanced filters

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/report_gen_bench_flat_data_model_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_bench_flat_data_model_test.go
@@ -257,6 +257,8 @@ func BenchmarkEntityScopeReportGenerator(b *testing.B) {
 		expectedRowCount := 1000
 		reportSnap := testEntityScopeReportSnapshot(entityScope, "CVSS:>=7.0", allImageTypes, scopeRules)
 
+		b.ReportAllocs()
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			reportData, err := reportGenerator.getReportDataSQF(reportSnap, nil, sinceStartDate)
 			require.NoError(b, err)
@@ -284,6 +286,8 @@ func BenchmarkEntityScopeReportGenerator(b *testing.B) {
 		expectedRowCount := 700
 		reportSnap := testEntityScopeReportSnapshot(entityScope, "EPSS Probability:>=0.5", allImageTypes, scopeRules)
 
+		b.ReportAllocs()
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			reportData, err := reportGenerator.getReportDataSQF(reportSnap, nil, sinceStartDate)
 			require.NoError(b, err)
@@ -311,6 +315,8 @@ func BenchmarkEntityScopeReportGenerator(b *testing.B) {
 		expectedRowCount := 1500
 		reportSnap := testEntityScopeReportSnapshot(entityScope, "CVSS:>=7.0", allImageTypes, scopeRules)
 
+		b.ReportAllocs()
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			reportData, err := reportGenerator.getReportDataSQF(reportSnap, nil, sinceStartDate)
 			require.NoError(b, err)

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_bench_flat_data_model_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_bench_flat_data_model_test.go
@@ -11,6 +11,7 @@ import (
 	clusterDSMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	"github.com/stackrox/rox/central/graphql/resolvers"
 	"github.com/stackrox/rox/central/graphql/resolvers/loaders"
+	namespaceDS "github.com/stackrox/rox/central/namespace/datastore"
 	namespaceDSMocks "github.com/stackrox/rox/central/namespace/datastore/mocks"
 	collectionDS "github.com/stackrox/rox/central/resourcecollection/datastore"
 	collectionPostgres "github.com/stackrox/rox/central/resourcecollection/datastore/store/postgres"
@@ -127,6 +128,195 @@ func (bts *FlatDataModelReportGeneratorBenchmarkTestSuite) setupTestSuite() {
 	bts.reportGenerator = newReportGeneratorImpl(bts.testDB, nil, bts.resolver.DeploymentDataStore,
 		bts.watchedImageDatastore, collectionQueryResolver, nil, nil, bts.clusterDatastore,
 		bts.namespaceDatastore, bts.resolver.ImageCVEV2DataStore, schema)
+}
+
+func BenchmarkEntityScopeReportGenerator(b *testing.B) {
+	ctx := loaders.WithLoaderContext(sac.WithAllAccess(context.Background()))
+	mockCtrl := gomock.NewController(b)
+	testDB := pgtest.ForT(b)
+
+	watchedImageDatastore := watchedImageDS.GetTestPostgresDataStore(b, testDB.DB)
+	var schema *graphql.Schema
+	var resolver *resolvers.Resolver
+	if features.FlattenImageData.Enabled() {
+		imgV2DataStore := resolvers.CreateTestImageV2Datastore(b, testDB, mockCtrl)
+		resolver, schema = resolvers.SetupTestResolver(b,
+			imagesView.NewImageView(testDB.DB),
+			imgV2DataStore,
+			resolvers.CreateTestImageComponentV2Datastore(b, testDB, mockCtrl),
+			resolvers.CreateTestImageCVEV2Datastore(b, testDB),
+			resolvers.CreateTestDeploymentDatastoreWithImageV2(b, testDB, mockCtrl, imgV2DataStore),
+			deploymentsView.NewDeploymentView(testDB.DB),
+		)
+	} else {
+		imageDataStore := resolvers.CreateTestImageDatastore(b, testDB, mockCtrl)
+		resolver, schema = resolvers.SetupTestResolver(b,
+			imagesView.NewImageView(testDB.DB),
+			imageDataStore,
+			resolvers.CreateTestImageComponentV2Datastore(b, testDB, mockCtrl),
+			resolvers.CreateTestImageCVEV2Datastore(b, testDB),
+			resolvers.CreateTestDeploymentDatastore(b, testDB, mockCtrl, imageDataStore),
+			deploymentsView.NewDeploymentView(testDB.DB),
+		)
+	}
+
+	clusterDatastore := clusterDSMocks.NewMockDataStore(mockCtrl)
+	nsDatastore, err := namespaceDS.GetTestPostgresDataStore(b, testDB.DB)
+	require.NoError(b, err)
+
+	reportGenerator := newReportGeneratorImpl(testDB, nil, resolver.DeploymentDataStore,
+		watchedImageDatastore, nil, nil, nil, clusterDatastore,
+		nsDatastore, resolver.ImageCVEV2DataStore, schema)
+
+	clusters := []*storage.Cluster{
+		{Id: uuid.NewV4().String(), Name: "c1"},
+		{Id: uuid.NewV4().String(), Name: "c2"},
+	}
+
+	namespaces := testNamespaces(clusters, 10)
+
+	// Add labels to first 5 namespaces of each cluster (ns1-ns5 get team=backend)
+	for i, ns := range namespaces {
+		if i%10 < 5 {
+			ns.Labels = map[string]string{"team": "backend"}
+		} else {
+			ns.Labels = map[string]string{"team": "frontend"}
+		}
+		err := nsDatastore.AddNamespace(ctx, ns)
+		require.NoError(b, err)
+	}
+
+	deployments, images := testDeploymentsWithImages(namespaces, 100)
+	if features.FlattenImageData.Enabled() {
+		for _, img := range images {
+			require.NoError(b, resolver.ImageV2DataStore.UpsertImage(ctx, imageUtils.ConvertToV2(img)))
+		}
+	} else {
+		for _, img := range images {
+			require.NoError(b, resolver.ImageDataStore.UpsertImage(ctx, img))
+		}
+	}
+	for _, dep := range deployments {
+		require.NoError(b, resolver.DeploymentDataStore.UpsertDeployment(ctx, dep))
+	}
+
+	watchedImages := testWatchedImages(500)
+	if features.FlattenImageData.Enabled() {
+		for _, img := range watchedImages {
+			require.NoError(b, resolver.ImageV2DataStore.UpsertImage(ctx, imageUtils.ConvertToV2(img)))
+		}
+	} else {
+		for _, img := range watchedImages {
+			require.NoError(b, resolver.ImageDataStore.UpsertImage(ctx, img))
+		}
+	}
+	for _, img := range watchedImages {
+		require.NoError(b, watchedImageDatastore.UpsertWatchedImage(ctx, img.GetName().GetFullName()))
+	}
+
+	clusterDatastore.EXPECT().GetClusters(gomock.Any()).
+		Return(clusters, nil).AnyTimes()
+
+	allImageTypes := []storage.VulnerabilityReportFilters_ImageType{
+		storage.VulnerabilityReportFilters_DEPLOYED,
+		storage.VulnerabilityReportFilters_WATCHED,
+	}
+	sinceStartDate := time.Now().AddDate(-1, 0, 0)
+
+	// c1: 10 namespaces × 100 deployments = 1000 deployed images (2 CVEs each)
+	// c2: 10 namespaces × 100 deployments = 1000 deployed images (2 CVEs each)
+	// ns1-ns5 per cluster have label team=backend (5 ns × 100 deps = 500 per cluster)
+	// 500 watched images (2 CVEs each): registry=quay.io, label=app:watch
+	// Each image has: 1 fixable_critical CVE (CVSS=9.0, EPSS=0.7) + 1 nonFixable_low CVE (CVSS=2.0, EPSS=0.1)
+
+	b.Run("EntityScope_ClusterScope_WithNamespaceLabel", func(b *testing.B) {
+		entityScope := &storage.EntityScope{
+			Rules: []*storage.EntityScopeRule{
+				{
+					Entity: storage.EntityType_ENTITY_TYPE_CLUSTER,
+					Field:  storage.EntityField_FIELD_NAME,
+					Values: []*storage.RuleValue{
+						{Value: "c1", MatchType: storage.MatchType_EXACT},
+					},
+				},
+				{
+					Entity: storage.EntityType_ENTITY_TYPE_NAMESPACE,
+					Field:  storage.EntityField_FIELD_LABEL,
+					Values: []*storage.RuleValue{
+						{Value: "team=backend", MatchType: storage.MatchType_EXACT},
+					},
+				},
+			},
+		}
+		scopeRules := []*storage.SimpleAccessScope_Rules{
+			{IncludedClusters: []string{"c1"}},
+		}
+		// CVSS>=7.0 matches fixable_critical only
+		// Entity scope: cluster=c1 AND namespace label team=backend
+		// Deployed: c1 ns1-ns5 = 500 images × 1 CVE = 500; Watched: 500 × 1 CVE = 500
+		expectedRowCount := 1000
+		reportSnap := testEntityScopeReportSnapshot(entityScope, "CVSS:>=7.0", allImageTypes, scopeRules)
+
+		for i := 0; i < b.N; i++ {
+			reportData, err := reportGenerator.getReportDataSQF(reportSnap, nil, sinceStartDate)
+			require.NoError(b, err)
+			require.Equal(b, expectedRowCount, len(reportData.CVEResponses))
+		}
+	})
+
+	b.Run("EntityScope_NamespaceScope_WithEPSSFilter", func(b *testing.B) {
+		entityScope := &storage.EntityScope{
+			Rules: []*storage.EntityScopeRule{
+				{
+					Entity: storage.EntityType_ENTITY_TYPE_NAMESPACE,
+					Field:  storage.EntityField_FIELD_NAME,
+					Values: []*storage.RuleValue{
+						{Value: "ns1", MatchType: storage.MatchType_EXACT},
+					},
+				},
+			},
+		}
+		scopeRules := []*storage.SimpleAccessScope_Rules{
+			{IncludedClusters: []string{"c1", "c2"}},
+		}
+		// EPSS>=0.5 matches fixable_critical only (EPSS=0.7)
+		// Deployed: ns1 across 2 clusters = 200 images × 1 CVE = 200; Watched: 500 × 1 CVE = 500
+		expectedRowCount := 700
+		reportSnap := testEntityScopeReportSnapshot(entityScope, "EPSS Probability:>=0.5", allImageTypes, scopeRules)
+
+		for i := 0; i < b.N; i++ {
+			reportData, err := reportGenerator.getReportDataSQF(reportSnap, nil, sinceStartDate)
+			require.NoError(b, err)
+			require.Equal(b, expectedRowCount, len(reportData.CVEResponses))
+		}
+	})
+
+	b.Run("EntityScope_DeploymentRegex_WithCVSSFilter", func(b *testing.B) {
+		entityScope := &storage.EntityScope{
+			Rules: []*storage.EntityScopeRule{
+				{
+					Entity: storage.EntityType_ENTITY_TYPE_DEPLOYMENT,
+					Field:  storage.EntityField_FIELD_NAME,
+					Values: []*storage.RuleValue{
+						{Value: "c1_.*", MatchType: storage.MatchType_REGEX},
+					},
+				},
+			},
+		}
+		scopeRules := []*storage.SimpleAccessScope_Rules{
+			{IncludedClusters: []string{"c1"}},
+		}
+		// CVSS>=7.0 matches fixable_critical only
+		// Deployed: 1000 c1 deployments matching c1_.* × 1 CVE = 1000; Watched: 500 × 1 CVE = 500
+		expectedRowCount := 1500
+		reportSnap := testEntityScopeReportSnapshot(entityScope, "CVSS:>=7.0", allImageTypes, scopeRules)
+
+		for i := 0; i < b.N; i++ {
+			reportData, err := reportGenerator.getReportDataSQF(reportSnap, nil, sinceStartDate)
+			require.NoError(b, err)
+			require.Equal(b, expectedRowCount, len(reportData.CVEResponses))
+		}
+	})
 }
 
 func (bts *FlatDataModelReportGeneratorBenchmarkTestSuite) upsertManyImages(images []*storage.Image) {


### PR DESCRIPTION
This PR adds benchmark tests for enhanced filter reporting . Test creates 2000 deployed images and 500 watched images and queries data using enhanced filters, entity scope filters and access scope  filter. For each test case query is run multiple times using Gos benchmark framework.

Results from the test run 
BenchmarkEntityScopeReportGenerator/EntityScope_ClusterScope_WithNamespaceLabel-14         	      60	  17004049 ns/op	 4114145 B/op	   72615 allocs/op
BenchmarkEntityScopeReportGenerator/EntityScope_NamespaceScope_WithEPSSFilter-14           	     111	  12219521 ns/op	 3011807 B/op	   54459 allocs/op
BenchmarkEntityScopeReportGenerator/EntityScope_DeploymentRegex_WithCVSSFilter-14          	      58	  17379843 ns/op	 5526819 B/op	  102496 allocs/op

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
