### PR TITLE
ROX-31227: Warn when TP check counts differ across clusters

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
+import { Alert } from '@patternfly/react-core';
 
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
@@ -11,7 +12,8 @@ import { addRegexPrefixToFilters } from 'utils/searchUtils';
 
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
-import { combineSearchFilterWithScanConfig } from './compliance.coverage.utils';
+import { combineSearchFilterWithScanConfig, getStatusCounts } from './compliance.coverage.utils';
+import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
 import ProfileChecksTable from './ProfileChecksTable';
 import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 
@@ -19,6 +21,7 @@ function ProfileChecksPage() {
     const { profileName } = useParams() as { profileName: string };
 
     const { selectedScanConfigName } = useContext(ScanConfigurationsContext);
+    const { scanConfigProfilesResponse } = useContext(ComplianceProfilesContext);
     const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
@@ -53,20 +56,50 @@ function ProfileChecksPage() {
         searchFilter,
     });
 
+    const selectedProfile = scanConfigProfilesResponse?.profiles.find(
+        (profile) => profile.name === profileName
+    );
+    const isTailoredProfile = selectedProfile?.operatorKind === 'TAILORED_PROFILE';
+
+    const hasInconsistentCheckCounts = useMemo(() => {
+        const results = profileChecks?.profileResults;
+        if (!results || results.length < 2) {
+            return false;
+        }
+        const totalCounts = results.map((check) => getStatusCounts(check.checkStats).totalCount);
+        return new Set(totalCounts).size > 1;
+    }, [profileChecks]);
+
     function onClearFilters() {
         setSearchFilter({});
         setPage(1);
     }
 
     return (
-        <ProfileChecksTable
-            profileChecksResultsCount={profileChecks?.totalCount ?? 0}
-            profileName={profileName}
-            pagination={pagination}
-            tableState={tableState}
-            getSortParams={getSortParams}
-            onClearFilters={onClearFilters}
-        />
+        <>
+            {isTailoredProfile && hasInconsistentCheckCounts && (
+                <Alert
+                    className="pf-v6-u-mb-md"
+                    variant="warning"
+                    isInline
+                    title="Inconsistent check results across clusters"
+                    component="p"
+                >
+                    The total number of check results differs across clusters for this tailored
+                    profile. This may indicate that the tailored profile is defined differently in
+                    each cluster, for example due to differences in Compliance Operator versions or
+                    the underlying base profile.
+                </Alert>
+            )}
+            <ProfileChecksTable
+                profileChecksResultsCount={profileChecks?.totalCount ?? 0}
+                profileName={profileName}
+                pagination={pagination}
+                tableState={tableState}
+                getSortParams={getSortParams}
+                onClearFilters={onClearFilters}
+            />
+        </>
     );
 }
 


### PR DESCRIPTION
## Description

On the Coverage page, when a tailored profile has different total check result counts across clusters, a warning banner is shown above the checks table. This indicates that the tailored profile may be defined differently across clusters, for example due to Compliance Operator version differences or varying base profile rules.

<img width="1494" height="1188" alt="banner" src="https://github.com/user-attachments/assets/16f65a44-5288-4ee6-8b22-3af7bd4f0e74" />

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

TBD

🤖 Generated with [Claude Code](https://claude.com/claude-code)