### PR TITLE
ROX-31227: Compute TP equivalence hash in Central

### DIFF
--- a/central/convert/internaltov2storage/compliance_operator_profile.go
+++ b/central/convert/internaltov2storage/compliance_operator_profile.go
@@ -1,6 +1,11 @@
 package internaltov2storage
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"slices"
+	"strings"
+
 	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
@@ -17,22 +22,30 @@ func ComplianceOperatorProfileV2(internalMsg *central.ComplianceOperatorProfileV
 
 	productType := internalMsg.GetAnnotations()[v1alpha1.ProductTypeAnnotation]
 
+	operatorKind := centralToStorageProfileKind(internalMsg.GetOperatorKind())
+
+	var equivalenceHash string
+	if operatorKind == storage.ComplianceOperatorProfileV2_TAILORED_PROFILE {
+		equivalenceHash = computeEquivalenceHash(internalMsg)
+	}
+
 	return &storage.ComplianceOperatorProfileV2{
-		Id:             internalMsg.GetId(),
-		ProfileId:      internalMsg.GetProfileId(),
-		Name:           internalMsg.GetName(),
-		ProfileVersion: internalMsg.GetProfileVersion(),
-		ProductType:    productType,
-		Labels:         internalMsg.GetLabels(),
-		Annotations:    internalMsg.GetAnnotations(),
-		Description:    internalMsg.GetDescription(),
-		Rules:          rules,
-		Product:        internalMsg.GetAnnotations()[v1alpha1.ProductAnnotation],
-		Title:          internalMsg.GetTitle(),
-		Values:         internalMsg.GetValues(),
-		ClusterId:      clusterID,
-		ProfileRefId:   BuildProfileRefID(clusterID, internalMsg.GetProfileId(), productType),
-		OperatorKind:   centralToStorageProfileKind(internalMsg.GetOperatorKind()),
+		Id:              internalMsg.GetId(),
+		ProfileId:       internalMsg.GetProfileId(),
+		Name:            internalMsg.GetName(),
+		ProfileVersion:  internalMsg.GetProfileVersion(),
+		ProductType:     productType,
+		Labels:          internalMsg.GetLabels(),
+		Annotations:     internalMsg.GetAnnotations(),
+		Description:     internalMsg.GetDescription(),
+		Rules:           rules,
+		Product:         internalMsg.GetAnnotations()[v1alpha1.ProductAnnotation],
+		Title:           internalMsg.GetTitle(),
+		Values:          internalMsg.GetValues(),
+		ClusterId:       clusterID,
+		ProfileRefId:    BuildProfileRefID(clusterID, internalMsg.GetProfileId(), productType),
+		OperatorKind:    operatorKind,
+		EquivalenceHash: equivalenceHash,
 	}
 }
 
@@ -79,6 +92,63 @@ func ScanConfigRefsToCentral(refs []*storage.ComplianceOperatorScanConfiguration
 		})
 	}
 	return centralRefs
+}
+
+// computeEquivalenceHash returns a SHA-256 hex digest that identifies whether two
+// tailored profiles carry equivalent compliance configuration. The hash covers the
+// fields that define a profile's effective content: name, namespace, description,
+// title, rules, and set_values.
+//
+// Rules and set_values are sorted for order independence. Rationale is excluded from
+// set_values hashing because it is documentation, not configuration — two profiles
+// with the same variable overrides but different rationales are functionally equivalent.
+//
+// IMPORTANT — changing the inputs or serialisation of this function changes the hash
+// for every tailored profile. This may temporarily prevent multi-cluster scan config
+// creation until all profiles are re-synced. Because the hash is computed in Central
+// (not Sensor), rolling Sensor upgrades do NOT cause hash divergence.
+func computeEquivalenceHash(msg *central.ComplianceOperatorProfileV2) string {
+	h := sha256.New()
+
+	// Write scalar fields, NUL-separated.
+	for _, s := range []string{msg.GetName(), msg.GetNamespace(), msg.GetDescription(), msg.GetTitle()} {
+		_, _ = h.Write([]byte(s))
+		_, _ = h.Write([]byte{0})
+	}
+
+	// Rules: sorted for order independence.
+	ruleNames := make([]string, 0, len(msg.GetRules()))
+	for _, r := range msg.GetRules() {
+		ruleNames = append(ruleNames, r.GetRuleName())
+	}
+	slices.Sort(ruleNames)
+	for _, r := range ruleNames {
+		_, _ = h.Write([]byte(r))
+		_, _ = h.Write([]byte{0})
+	}
+	// Section separator between rules and set_values.
+	_, _ = h.Write([]byte{0})
+
+	// SetValues: sorted by name then value for order independence.
+	type nameValue struct{ name, value string }
+	setVals := make([]nameValue, 0, len(msg.GetSetValues()))
+	for _, sv := range msg.GetSetValues() {
+		setVals = append(setVals, nameValue{name: sv.GetName(), value: sv.GetValue()})
+	}
+	slices.SortFunc(setVals, func(a, b nameValue) int {
+		if c := strings.Compare(a.name, b.name); c != 0 {
+			return c
+		}
+		return strings.Compare(a.value, b.value)
+	})
+	for _, sv := range setVals {
+		_, _ = h.Write([]byte(sv.name))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(sv.value))
+		_, _ = h.Write([]byte{0})
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func centralToStorageProfileKind(kind central.ComplianceOperatorProfileV2_OperatorKind) storage.ComplianceOperatorProfileV2_OperatorKind {

--- a/central/convert/internaltov2storage/compliance_operator_profile_test.go
+++ b/central/convert/internaltov2storage/compliance_operator_profile_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStorageToCentralProfileKind(t *testing.T) {
@@ -42,4 +43,157 @@ func TestStorageToCentralProfileKind(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+func makeProfileMsg(name, namespace, description, title string, ruleNames []string, setValues []*central.ComplianceOperatorProfileV2_SetValue, kind central.ComplianceOperatorProfileV2_OperatorKind) *central.ComplianceOperatorProfileV2 {
+	msg := &central.ComplianceOperatorProfileV2{
+		Id:           "test-uid",
+		ProfileId:    "xccdf_profile_" + name,
+		Name:         name,
+		Description:  description,
+		Title:        title,
+		Namespace:    namespace,
+		OperatorKind: kind,
+		SetValues:    setValues,
+	}
+	for _, r := range ruleNames {
+		msg.Rules = append(msg.Rules, &central.ComplianceOperatorProfileV2_Rule{RuleName: r})
+	}
+	return msg
+}
+
+func TestEquivalenceHash_TailoredProfileGetsHash(t *testing.T) {
+	msg := makeProfileMsg("my-tp", "openshift-compliance", "desc", "title",
+		[]string{"rule-a", "rule-b"}, nil,
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE)
+	result := ComplianceOperatorProfileV2(msg, "00000000-0000-0000-0000-000000000001")
+	assert.Len(t, result.GetEquivalenceHash(), 64, "should be hex-encoded SHA-256")
+}
+
+func TestEquivalenceHash_RegularProfileNoHash(t *testing.T) {
+	msg := makeProfileMsg("ocp4-cis", "openshift-compliance", "desc", "title",
+		[]string{"rule-a"}, nil,
+		central.ComplianceOperatorProfileV2_PROFILE)
+	result := ComplianceOperatorProfileV2(msg, "00000000-0000-0000-0000-000000000001")
+	assert.Empty(t, result.GetEquivalenceHash(), "regular profiles must not carry an equivalence hash")
+}
+
+func TestEquivalenceHash_UnspecifiedKindNoHash(t *testing.T) {
+	msg := makeProfileMsg("ocp4-cis", "openshift-compliance", "desc", "title",
+		[]string{"rule-a"}, nil,
+		central.ComplianceOperatorProfileV2_OPERATOR_KIND_UNSPECIFIED)
+	result := ComplianceOperatorProfileV2(msg, "00000000-0000-0000-0000-000000000001")
+	assert.Empty(t, result.GetEquivalenceHash())
+}
+
+func TestEquivalenceHash_Stability(t *testing.T) {
+	msg1 := makeProfileMsg("my-tp", "openshift-compliance", "desc", "title",
+		[]string{"rule-a", "rule-b"}, nil,
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE)
+	msg2 := makeProfileMsg("my-tp", "openshift-compliance", "desc", "title",
+		[]string{"rule-a", "rule-b"}, nil,
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE)
+	h1 := ComplianceOperatorProfileV2(msg1, "00000000-0000-0000-0000-000000000001").GetEquivalenceHash()
+	h2 := ComplianceOperatorProfileV2(msg2, "00000000-0000-0000-0000-000000000001").GetEquivalenceHash()
+	assert.Equal(t, h1, h2, "same inputs must produce same hash")
+}
+
+func TestEquivalenceHash_ClusterIndependent(t *testing.T) {
+	msg1 := makeProfileMsg("my-tp", "openshift-compliance", "desc", "title",
+		[]string{"rule-a"}, nil,
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE)
+	msg2 := makeProfileMsg("my-tp", "openshift-compliance", "desc", "title",
+		[]string{"rule-a"}, nil,
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE)
+	h1 := ComplianceOperatorProfileV2(msg1, "00000000-0000-0000-0000-000000000001").GetEquivalenceHash()
+	h2 := ComplianceOperatorProfileV2(msg2, "00000000-0000-0000-0000-000000000002").GetEquivalenceHash()
+	assert.Equal(t, h1, h2, "hash must not depend on cluster ID")
+}
+
+func TestEquivalenceHash_FieldSensitivity(t *testing.T) {
+	baseRules := []string{"rule-a", "rule-b"}
+
+	baseHash := computeEquivalenceHash(makeProfileMsg("my-tp", "openshift-compliance", "desc", "title", baseRules, nil,
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE))
+	require.Len(t, baseHash, 64)
+
+	tests := map[string]*central.ComplianceOperatorProfileV2{
+		"name change":        makeProfileMsg("other-name", "openshift-compliance", "desc", "title", baseRules, nil, central.ComplianceOperatorProfileV2_TAILORED_PROFILE),
+		"namespace change":   makeProfileMsg("my-tp", "other-ns", "desc", "title", baseRules, nil, central.ComplianceOperatorProfileV2_TAILORED_PROFILE),
+		"description change": makeProfileMsg("my-tp", "openshift-compliance", "other-desc", "title", baseRules, nil, central.ComplianceOperatorProfileV2_TAILORED_PROFILE),
+		"title change":       makeProfileMsg("my-tp", "openshift-compliance", "desc", "other-title", baseRules, nil, central.ComplianceOperatorProfileV2_TAILORED_PROFILE),
+		"rule change":        makeProfileMsg("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-c"}, nil, central.ComplianceOperatorProfileV2_TAILORED_PROFILE),
+		"rule added":         makeProfileMsg("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a", "rule-b", "rule-c"}, nil, central.ComplianceOperatorProfileV2_TAILORED_PROFILE),
+		"rule removed":       makeProfileMsg("my-tp", "openshift-compliance", "desc", "title", []string{"rule-a"}, nil, central.ComplianceOperatorProfileV2_TAILORED_PROFILE),
+		"setValue added": makeProfileMsg("my-tp", "openshift-compliance", "desc", "title", baseRules, []*central.ComplianceOperatorProfileV2_SetValue{
+			{Name: "var-foo", Value: "bar"},
+		}, central.ComplianceOperatorProfileV2_TAILORED_PROFILE),
+	}
+
+	for name, msg := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := computeEquivalenceHash(msg)
+			assert.NotEqual(t, baseHash, h, "changing %s must produce a different hash", name)
+		})
+	}
+}
+
+func TestEquivalenceHash_RuleOrderIndependent(t *testing.T) {
+	h1 := computeEquivalenceHash(makeProfileMsg("my-tp", "ns", "d", "t",
+		[]string{"rule-a", "rule-b", "rule-c"}, nil,
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE))
+	h2 := computeEquivalenceHash(makeProfileMsg("my-tp", "ns", "d", "t",
+		[]string{"rule-c", "rule-a", "rule-b"}, nil,
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE))
+	assert.Equal(t, h1, h2, "rule order must not affect hash")
+}
+
+func TestEquivalenceHash_SetValuesOrderIndependent(t *testing.T) {
+	svA := &central.ComplianceOperatorProfileV2_SetValue{Name: "var-a", Value: "va"}
+	svB := &central.ComplianceOperatorProfileV2_SetValue{Name: "var-b", Value: "vb"}
+
+	h1 := computeEquivalenceHash(makeProfileMsg("my-tp", "ns", "d", "t",
+		[]string{"rule-a"}, []*central.ComplianceOperatorProfileV2_SetValue{svA, svB},
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE))
+	h2 := computeEquivalenceHash(makeProfileMsg("my-tp", "ns", "d", "t",
+		[]string{"rule-a"}, []*central.ComplianceOperatorProfileV2_SetValue{svB, svA},
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE))
+	assert.Equal(t, h1, h2, "set_values order must not affect hash")
+}
+
+func TestEquivalenceHash_SetValuesSensitivity(t *testing.T) {
+	svA := &central.ComplianceOperatorProfileV2_SetValue{Name: "var-a", Value: "va"}
+	svB := &central.ComplianceOperatorProfileV2_SetValue{Name: "var-b", Value: "vb"}
+	baseHash := computeEquivalenceHash(makeProfileMsg("my-tp", "ns", "d", "t",
+		[]string{"rule-a"}, []*central.ComplianceOperatorProfileV2_SetValue{svA, svB},
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE))
+
+	tests := map[string][]*central.ComplianceOperatorProfileV2_SetValue{
+		"different value": {{Name: "var-a", Value: "other"}, svB},
+		"different name":  {{Name: "var-x", Value: "va"}, svB},
+		"extra entry":     {svA, svB, {Name: "var-c", Value: "vc"}},
+		"fewer entries":   {svA},
+	}
+
+	for name, svs := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := computeEquivalenceHash(makeProfileMsg("my-tp", "ns", "d", "t",
+				[]string{"rule-a"}, svs,
+				central.ComplianceOperatorProfileV2_TAILORED_PROFILE))
+			assert.NotEqual(t, baseHash, h)
+		})
+	}
+}
+
+func TestEquivalenceHash_RationaleExcluded(t *testing.T) {
+	sv1 := &central.ComplianceOperatorProfileV2_SetValue{Name: "var-a", Value: "va", Rationale: "reason-1"}
+	sv2 := &central.ComplianceOperatorProfileV2_SetValue{Name: "var-a", Value: "va", Rationale: "reason-2"}
+
+	h1 := computeEquivalenceHash(makeProfileMsg("my-tp", "ns", "d", "t",
+		[]string{"rule-a"}, []*central.ComplianceOperatorProfileV2_SetValue{sv1},
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE))
+	h2 := computeEquivalenceHash(makeProfileMsg("my-tp", "ns", "d", "t",
+		[]string{"rule-a"}, []*central.ComplianceOperatorProfileV2_SetValue{sv2},
+		central.ComplianceOperatorProfileV2_TAILORED_PROFILE))
+	assert.Equal(t, h1, h2, "rationale must not affect hash — it is documentation, not configuration")
 }

--- a/generated/internalapi/central/compliance_operator.pb.go
+++ b/generated/internalapi/central/compliance_operator.pb.go
@@ -1118,7 +1118,7 @@ func (x *ComplianceOperatorCheckResultV2) GetWarnings() []string {
 }
 
 // ComplianceOperatorProfileV2 is a message from Sensor (to Central) representing a compliance check profile.
-// Next tag: 12.
+// Next tag: 14.
 type ComplianceOperatorProfileV2 struct {
 	state          protoimpl.MessageState                   `protogen:"open.v1"`
 	Id             string                                   `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -1132,8 +1132,14 @@ type ComplianceOperatorProfileV2 struct {
 	Title          string                                   `protobuf:"bytes,9,opt,name=title,proto3" json:"title,omitempty"`
 	Values         []string                                 `protobuf:"bytes,10,rep,name=values,proto3" json:"values,omitempty"`
 	OperatorKind   ComplianceOperatorProfileV2_OperatorKind `protobuf:"varint,11,opt,name=operator_kind,json=operatorKind,proto3,enum=central.ComplianceOperatorProfileV2_OperatorKind" json:"operator_kind,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Kubernetes namespace of the profile resource. Used by Central to compute
+	// the equivalence hash for tailored profiles.
+	Namespace string `protobuf:"bytes,12,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// set_values carries variable value overrides from tailored profiles.
+	// Used by Central to include them in the equivalence hash computation.
+	SetValues     []*ComplianceOperatorProfileV2_SetValue `protobuf:"bytes,13,rep,name=set_values,json=setValues,proto3" json:"set_values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ComplianceOperatorProfileV2) Reset() {
@@ -1241,6 +1247,20 @@ func (x *ComplianceOperatorProfileV2) GetOperatorKind() ComplianceOperatorProfil
 		return x.OperatorKind
 	}
 	return ComplianceOperatorProfileV2_OPERATOR_KIND_UNSPECIFIED
+}
+
+func (x *ComplianceOperatorProfileV2) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *ComplianceOperatorProfileV2) GetSetValues() []*ComplianceOperatorProfileV2_SetValue {
+	if x != nil {
+		return x.SetValues
+	}
+	return nil
 }
 
 // ComplianceOperatorRuleV2 is a message from Sensor (to Central) representing a compliance check rule.
@@ -2770,6 +2790,67 @@ func (x *ComplianceOperatorProfileV2_Rule) GetRuleName() string {
 	return ""
 }
 
+// SetValue represents a variable value override in a tailored profile.
+type ComplianceOperatorProfileV2_SetValue struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Rationale     string                 `protobuf:"bytes,2,opt,name=rationale,proto3" json:"rationale,omitempty"`
+	Value         string                 `protobuf:"bytes,3,opt,name=value,proto3" json:"value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ComplianceOperatorProfileV2_SetValue) Reset() {
+	*x = ComplianceOperatorProfileV2_SetValue{}
+	mi := &file_internalapi_central_compliance_operator_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ComplianceOperatorProfileV2_SetValue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ComplianceOperatorProfileV2_SetValue) ProtoMessage() {}
+
+func (x *ComplianceOperatorProfileV2_SetValue) ProtoReflect() protoreflect.Message {
+	mi := &file_internalapi_central_compliance_operator_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ComplianceOperatorProfileV2_SetValue.ProtoReflect.Descriptor instead.
+func (*ComplianceOperatorProfileV2_SetValue) Descriptor() ([]byte, []int) {
+	return file_internalapi_central_compliance_operator_proto_rawDescGZIP(), []int{9, 3}
+}
+
+func (x *ComplianceOperatorProfileV2_SetValue) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ComplianceOperatorProfileV2_SetValue) GetRationale() string {
+	if x != nil {
+		return x.Rationale
+	}
+	return ""
+}
+
+func (x *ComplianceOperatorProfileV2_SetValue) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
 type ComplianceOperatorRuleV2_Fix struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Platform      string                 `protobuf:"bytes,1,opt,name=platform,proto3" json:"platform,omitempty"`
@@ -2780,7 +2861,7 @@ type ComplianceOperatorRuleV2_Fix struct {
 
 func (x *ComplianceOperatorRuleV2_Fix) Reset() {
 	*x = ComplianceOperatorRuleV2_Fix{}
-	mi := &file_internalapi_central_compliance_operator_proto_msgTypes[37]
+	mi := &file_internalapi_central_compliance_operator_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2792,7 +2873,7 @@ func (x *ComplianceOperatorRuleV2_Fix) String() string {
 func (*ComplianceOperatorRuleV2_Fix) ProtoMessage() {}
 
 func (x *ComplianceOperatorRuleV2_Fix) ProtoReflect() protoreflect.Message {
-	mi := &file_internalapi_central_compliance_operator_proto_msgTypes[37]
+	mi := &file_internalapi_central_compliance_operator_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2951,7 +3032,7 @@ const file_internalapi_central_compliance_operator_proto_rawDesc = "" +
 	"\n" +
 	"\x06MANUAL\x10\x05\x12\x12\n" +
 	"\x0eNOT_APPLICABLE\x10\x06\x12\x10\n" +
-	"\fINCONSISTENT\x10\aJ\x04\b\f\x10\rJ\x04\b\r\x10\x0e\"\x87\x06\n" +
+	"\fINCONSISTENT\x10\aJ\x04\b\f\x10\rJ\x04\b\r\x10\x0e\"\xc7\a\n" +
 	"\x1bComplianceOperatorProfileV2\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
@@ -2965,7 +3046,10 @@ const file_internalapi_central_compliance_operator_proto_rawDesc = "" +
 	"\x05title\x18\t \x01(\tR\x05title\x12\x16\n" +
 	"\x06values\x18\n" +
 	" \x03(\tR\x06values\x12V\n" +
-	"\roperator_kind\x18\v \x01(\x0e21.central.ComplianceOperatorProfileV2.OperatorKindR\foperatorKind\x1a9\n" +
+	"\roperator_kind\x18\v \x01(\x0e21.central.ComplianceOperatorProfileV2.OperatorKindR\foperatorKind\x12\x1c\n" +
+	"\tnamespace\x18\f \x01(\tR\tnamespace\x12L\n" +
+	"\n" +
+	"set_values\x18\r \x03(\v2-.central.ComplianceOperatorProfileV2.SetValueR\tsetValues\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +
@@ -2973,7 +3057,11 @@ const file_internalapi_central_compliance_operator_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a#\n" +
 	"\x04Rule\x12\x1b\n" +
-	"\trule_name\x18\x01 \x01(\tR\bruleName\"P\n" +
+	"\trule_name\x18\x01 \x01(\tR\bruleName\x1aR\n" +
+	"\bSetValue\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1c\n" +
+	"\trationale\x18\x02 \x01(\tR\trationale\x12\x14\n" +
+	"\x05value\x18\x03 \x01(\tR\x05value\"P\n" +
 	"\fOperatorKind\x12\x1d\n" +
 	"\x19OPERATOR_KIND_UNSPECIFIED\x10\x00\x12\v\n" +
 	"\aPROFILE\x10\x01\x12\x14\n" +
@@ -3095,7 +3183,7 @@ func file_internalapi_central_compliance_operator_proto_rawDescGZIP() []byte {
 }
 
 var file_internalapi_central_compliance_operator_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_internalapi_central_compliance_operator_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
+var file_internalapi_central_compliance_operator_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
 var file_internalapi_central_compliance_operator_proto_goTypes = []any{
 	(ComplianceOperatorRuleSeverity)(0),                                        // 0: central.ComplianceOperatorRuleSeverity
 	(ComplianceOperatorCheckResultV2_CheckStatus)(0),                           // 1: central.ComplianceOperatorCheckResultV2.CheckStatus
@@ -3136,14 +3224,15 @@ var file_internalapi_central_compliance_operator_proto_goTypes = []any{
 	nil,                                      // 36: central.ComplianceOperatorProfileV2.LabelsEntry
 	nil,                                      // 37: central.ComplianceOperatorProfileV2.AnnotationsEntry
 	(*ComplianceOperatorProfileV2_Rule)(nil), // 38: central.ComplianceOperatorProfileV2.Rule
-	nil,                                      // 39: central.ComplianceOperatorRuleV2.LabelsEntry
-	nil,                                      // 40: central.ComplianceOperatorRuleV2.AnnotationsEntry
-	(*ComplianceOperatorRuleV2_Fix)(nil),     // 41: central.ComplianceOperatorRuleV2.Fix
-	nil,                                      // 42: central.ComplianceOperatorScanV2.LabelsEntry
-	nil,                                      // 43: central.ComplianceOperatorScanV2.AnnotationsEntry
-	nil,                                      // 44: central.ComplianceOperatorScanSettingBindingV2.LabelsEntry
-	nil,                                      // 45: central.ComplianceOperatorScanSettingBindingV2.AnnotationsEntry
-	(*timestamppb.Timestamp)(nil),            // 46: google.protobuf.Timestamp
+	(*ComplianceOperatorProfileV2_SetValue)(nil), // 39: central.ComplianceOperatorProfileV2.SetValue
+	nil,                                  // 40: central.ComplianceOperatorRuleV2.LabelsEntry
+	nil,                                  // 41: central.ComplianceOperatorRuleV2.AnnotationsEntry
+	(*ComplianceOperatorRuleV2_Fix)(nil), // 42: central.ComplianceOperatorRuleV2.Fix
+	nil,                                  // 43: central.ComplianceOperatorScanV2.LabelsEntry
+	nil,                                  // 44: central.ComplianceOperatorScanV2.AnnotationsEntry
+	nil,                                  // 45: central.ComplianceOperatorScanSettingBindingV2.LabelsEntry
+	nil,                                  // 46: central.ComplianceOperatorScanSettingBindingV2.AnnotationsEntry
+	(*timestamppb.Timestamp)(nil),        // 47: google.protobuf.Timestamp
 }
 var file_internalapi_central_compliance_operator_proto_depIdxs = []int32{
 	8,  // 0: central.SyncComplianceScanConfigRequest.scan_configs:type_name -> central.ApplyComplianceScanConfigRequest
@@ -3165,38 +3254,39 @@ var file_internalapi_central_compliance_operator_proto_depIdxs = []int32{
 	0,  // 16: central.ComplianceOperatorCheckResultV2.severity:type_name -> central.ComplianceOperatorRuleSeverity
 	34, // 17: central.ComplianceOperatorCheckResultV2.labels:type_name -> central.ComplianceOperatorCheckResultV2.LabelsEntry
 	35, // 18: central.ComplianceOperatorCheckResultV2.annotations:type_name -> central.ComplianceOperatorCheckResultV2.AnnotationsEntry
-	46, // 19: central.ComplianceOperatorCheckResultV2.created_time:type_name -> google.protobuf.Timestamp
+	47, // 19: central.ComplianceOperatorCheckResultV2.created_time:type_name -> google.protobuf.Timestamp
 	36, // 20: central.ComplianceOperatorProfileV2.labels:type_name -> central.ComplianceOperatorProfileV2.LabelsEntry
 	37, // 21: central.ComplianceOperatorProfileV2.annotations:type_name -> central.ComplianceOperatorProfileV2.AnnotationsEntry
 	38, // 22: central.ComplianceOperatorProfileV2.rules:type_name -> central.ComplianceOperatorProfileV2.Rule
 	2,  // 23: central.ComplianceOperatorProfileV2.operator_kind:type_name -> central.ComplianceOperatorProfileV2.OperatorKind
-	0,  // 24: central.ComplianceOperatorRuleV2.severity:type_name -> central.ComplianceOperatorRuleSeverity
-	39, // 25: central.ComplianceOperatorRuleV2.labels:type_name -> central.ComplianceOperatorRuleV2.LabelsEntry
-	40, // 26: central.ComplianceOperatorRuleV2.annotations:type_name -> central.ComplianceOperatorRuleV2.AnnotationsEntry
-	41, // 27: central.ComplianceOperatorRuleV2.fixes:type_name -> central.ComplianceOperatorRuleV2.Fix
-	3,  // 28: central.ComplianceOperatorRuleV2.operator_kind:type_name -> central.ComplianceOperatorRuleV2.OperatorKind
-	42, // 29: central.ComplianceOperatorScanV2.labels:type_name -> central.ComplianceOperatorScanV2.LabelsEntry
-	43, // 30: central.ComplianceOperatorScanV2.annotations:type_name -> central.ComplianceOperatorScanV2.AnnotationsEntry
-	16, // 31: central.ComplianceOperatorScanV2.status:type_name -> central.ComplianceOperatorScanStatusV2
-	46, // 32: central.ComplianceOperatorScanStatusV2.start_time:type_name -> google.protobuf.Timestamp
-	46, // 33: central.ComplianceOperatorScanStatusV2.end_time:type_name -> google.protobuf.Timestamp
-	46, // 34: central.ComplianceOperatorScanStatusV2.last_start_time:type_name -> google.protobuf.Timestamp
-	44, // 35: central.ComplianceOperatorScanSettingBindingV2.labels:type_name -> central.ComplianceOperatorScanSettingBindingV2.LabelsEntry
-	45, // 36: central.ComplianceOperatorScanSettingBindingV2.annotations:type_name -> central.ComplianceOperatorScanSettingBindingV2.AnnotationsEntry
-	19, // 37: central.ComplianceOperatorScanSettingBindingV2.status:type_name -> central.ComplianceOperatorStatus
-	46, // 38: central.ComplianceOperatorCondition.last_transition_time:type_name -> google.protobuf.Timestamp
-	18, // 39: central.ComplianceOperatorStatus.conditions:type_name -> central.ComplianceOperatorCondition
-	19, // 40: central.ComplianceOperatorSuiteV2.status:type_name -> central.ComplianceOperatorStatus
-	29, // 41: central.ApplyComplianceScanConfigRequest.BaseScanSettings.profile_refs:type_name -> central.ApplyComplianceScanConfigRequest.BaseScanSettings.ProfileReference
-	22, // 42: central.ApplyComplianceScanConfigRequest.OneTimeScan.scan_settings:type_name -> central.ApplyComplianceScanConfigRequest.BaseScanSettings
-	22, // 43: central.ApplyComplianceScanConfigRequest.ScheduledScan.scan_settings:type_name -> central.ApplyComplianceScanConfigRequest.BaseScanSettings
-	22, // 44: central.ApplyComplianceScanConfigRequest.UpdateScheduledScan.scan_settings:type_name -> central.ApplyComplianceScanConfigRequest.BaseScanSettings
-	2,  // 45: central.ApplyComplianceScanConfigRequest.BaseScanSettings.ProfileReference.kind:type_name -> central.ComplianceOperatorProfileV2.OperatorKind
-	46, // [46:46] is the sub-list for method output_type
-	46, // [46:46] is the sub-list for method input_type
-	46, // [46:46] is the sub-list for extension type_name
-	46, // [46:46] is the sub-list for extension extendee
-	0,  // [0:46] is the sub-list for field type_name
+	39, // 24: central.ComplianceOperatorProfileV2.set_values:type_name -> central.ComplianceOperatorProfileV2.SetValue
+	0,  // 25: central.ComplianceOperatorRuleV2.severity:type_name -> central.ComplianceOperatorRuleSeverity
+	40, // 26: central.ComplianceOperatorRuleV2.labels:type_name -> central.ComplianceOperatorRuleV2.LabelsEntry
+	41, // 27: central.ComplianceOperatorRuleV2.annotations:type_name -> central.ComplianceOperatorRuleV2.AnnotationsEntry
+	42, // 28: central.ComplianceOperatorRuleV2.fixes:type_name -> central.ComplianceOperatorRuleV2.Fix
+	3,  // 29: central.ComplianceOperatorRuleV2.operator_kind:type_name -> central.ComplianceOperatorRuleV2.OperatorKind
+	43, // 30: central.ComplianceOperatorScanV2.labels:type_name -> central.ComplianceOperatorScanV2.LabelsEntry
+	44, // 31: central.ComplianceOperatorScanV2.annotations:type_name -> central.ComplianceOperatorScanV2.AnnotationsEntry
+	16, // 32: central.ComplianceOperatorScanV2.status:type_name -> central.ComplianceOperatorScanStatusV2
+	47, // 33: central.ComplianceOperatorScanStatusV2.start_time:type_name -> google.protobuf.Timestamp
+	47, // 34: central.ComplianceOperatorScanStatusV2.end_time:type_name -> google.protobuf.Timestamp
+	47, // 35: central.ComplianceOperatorScanStatusV2.last_start_time:type_name -> google.protobuf.Timestamp
+	45, // 36: central.ComplianceOperatorScanSettingBindingV2.labels:type_name -> central.ComplianceOperatorScanSettingBindingV2.LabelsEntry
+	46, // 37: central.ComplianceOperatorScanSettingBindingV2.annotations:type_name -> central.ComplianceOperatorScanSettingBindingV2.AnnotationsEntry
+	19, // 38: central.ComplianceOperatorScanSettingBindingV2.status:type_name -> central.ComplianceOperatorStatus
+	47, // 39: central.ComplianceOperatorCondition.last_transition_time:type_name -> google.protobuf.Timestamp
+	18, // 40: central.ComplianceOperatorStatus.conditions:type_name -> central.ComplianceOperatorCondition
+	19, // 41: central.ComplianceOperatorSuiteV2.status:type_name -> central.ComplianceOperatorStatus
+	29, // 42: central.ApplyComplianceScanConfigRequest.BaseScanSettings.profile_refs:type_name -> central.ApplyComplianceScanConfigRequest.BaseScanSettings.ProfileReference
+	22, // 43: central.ApplyComplianceScanConfigRequest.OneTimeScan.scan_settings:type_name -> central.ApplyComplianceScanConfigRequest.BaseScanSettings
+	22, // 44: central.ApplyComplianceScanConfigRequest.ScheduledScan.scan_settings:type_name -> central.ApplyComplianceScanConfigRequest.BaseScanSettings
+	22, // 45: central.ApplyComplianceScanConfigRequest.UpdateScheduledScan.scan_settings:type_name -> central.ApplyComplianceScanConfigRequest.BaseScanSettings
+	2,  // 46: central.ApplyComplianceScanConfigRequest.BaseScanSettings.ProfileReference.kind:type_name -> central.ComplianceOperatorProfileV2.OperatorKind
+	47, // [47:47] is the sub-list for method output_type
+	47, // [47:47] is the sub-list for method input_type
+	47, // [47:47] is the sub-list for extension type_name
+	47, // [47:47] is the sub-list for extension extendee
+	0,  // [0:47] is the sub-list for field type_name
 }
 
 func init() { file_internalapi_central_compliance_operator_proto_init() }
@@ -3246,7 +3336,7 @@ func file_internalapi_central_compliance_operator_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internalapi_central_compliance_operator_proto_rawDesc), len(file_internalapi_central_compliance_operator_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   42,
+			NumMessages:   43,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/generated/internalapi/central/compliance_operator_vtproto.pb.go
+++ b/generated/internalapi/central/compliance_operator_vtproto.pb.go
@@ -684,6 +684,25 @@ func (m *ComplianceOperatorProfileV2_Rule) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *ComplianceOperatorProfileV2_SetValue) CloneVT() *ComplianceOperatorProfileV2_SetValue {
+	if m == nil {
+		return (*ComplianceOperatorProfileV2_SetValue)(nil)
+	}
+	r := new(ComplianceOperatorProfileV2_SetValue)
+	r.Name = m.Name
+	r.Rationale = m.Rationale
+	r.Value = m.Value
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ComplianceOperatorProfileV2_SetValue) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *ComplianceOperatorProfileV2) CloneVT() *ComplianceOperatorProfileV2 {
 	if m == nil {
 		return (*ComplianceOperatorProfileV2)(nil)
@@ -696,6 +715,7 @@ func (m *ComplianceOperatorProfileV2) CloneVT() *ComplianceOperatorProfileV2 {
 	r.Description = m.Description
 	r.Title = m.Title
 	r.OperatorKind = m.OperatorKind
+	r.Namespace = m.Namespace
 	if rhs := m.Labels; rhs != nil {
 		tmpContainer := make(map[string]string, len(rhs))
 		for k, v := range rhs {
@@ -721,6 +741,13 @@ func (m *ComplianceOperatorProfileV2) CloneVT() *ComplianceOperatorProfileV2 {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
 		r.Values = tmpContainer
+	}
+	if rhs := m.SetValues; rhs != nil {
+		tmpContainer := make([]*ComplianceOperatorProfileV2_SetValue, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.SetValues = tmpContainer
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -2110,6 +2137,31 @@ func (this *ComplianceOperatorProfileV2_Rule) EqualMessageVT(thatMsg proto.Messa
 	}
 	return this.EqualVT(that)
 }
+func (this *ComplianceOperatorProfileV2_SetValue) EqualVT(that *ComplianceOperatorProfileV2_SetValue) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Name != that.Name {
+		return false
+	}
+	if this.Rationale != that.Rationale {
+		return false
+	}
+	if this.Value != that.Value {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ComplianceOperatorProfileV2_SetValue) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ComplianceOperatorProfileV2_SetValue)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *ComplianceOperatorProfileV2) EqualVT(that *ComplianceOperatorProfileV2) bool {
 	if this == that {
 		return true
@@ -2186,6 +2238,26 @@ func (this *ComplianceOperatorProfileV2) EqualVT(that *ComplianceOperatorProfile
 	}
 	if this.OperatorKind != that.OperatorKind {
 		return false
+	}
+	if this.Namespace != that.Namespace {
+		return false
+	}
+	if len(this.SetValues) != len(that.SetValues) {
+		return false
+	}
+	for i, vx := range this.SetValues {
+		vy := that.SetValues[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &ComplianceOperatorProfileV2_SetValue{}
+			}
+			if q == nil {
+				q = &ComplianceOperatorProfileV2_SetValue{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -4222,6 +4294,60 @@ func (m *ComplianceOperatorProfileV2_Rule) MarshalToSizedBufferVT(dAtA []byte) (
 	return len(dAtA) - i, nil
 }
 
+func (m *ComplianceOperatorProfileV2_SetValue) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ComplianceOperatorProfileV2_SetValue) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ComplianceOperatorProfileV2_SetValue) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Rationale) > 0 {
+		i -= len(m.Rationale)
+		copy(dAtA[i:], m.Rationale)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Rationale)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ComplianceOperatorProfileV2) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -4251,6 +4377,25 @@ func (m *ComplianceOperatorProfileV2) MarshalToSizedBufferVT(dAtA []byte) (int, 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.SetValues) > 0 {
+		for iNdEx := len(m.SetValues) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.SetValues[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x6a
+		}
+	}
+	if len(m.Namespace) > 0 {
+		i -= len(m.Namespace)
+		copy(dAtA[i:], m.Namespace)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Namespace)))
+		i--
+		dAtA[i] = 0x62
 	}
 	if m.OperatorKind != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OperatorKind))
@@ -5871,6 +6016,28 @@ func (m *ComplianceOperatorProfileV2_Rule) SizeVT() (n int) {
 	return n
 }
 
+func (m *ComplianceOperatorProfileV2_SetValue) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Rationale)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Value)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *ComplianceOperatorProfileV2) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -5931,6 +6098,16 @@ func (m *ComplianceOperatorProfileV2) SizeVT() (n int) {
 	}
 	if m.OperatorKind != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.OperatorKind))
+	}
+	l = len(m.Namespace)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.SetValues) > 0 {
+		for _, e := range m.SetValues {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -9826,6 +10003,153 @@ func (m *ComplianceOperatorProfileV2_Rule) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *ComplianceOperatorProfileV2_SetValue) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ComplianceOperatorProfileV2_SetValue: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ComplianceOperatorProfileV2_SetValue: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Rationale", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Rationale = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Value = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *ComplianceOperatorProfileV2) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -10386,6 +10710,72 @@ func (m *ComplianceOperatorProfileV2) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Namespace = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SetValues", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SetValues = append(m.SetValues, &ComplianceOperatorProfileV2_SetValue{})
+			if err := m.SetValues[len(m.SetValues)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -16968,6 +17358,165 @@ func (m *ComplianceOperatorProfileV2_Rule) UnmarshalVTUnsafe(dAtA []byte) error 
 	}
 	return nil
 }
+func (m *ComplianceOperatorProfileV2_SetValue) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ComplianceOperatorProfileV2_SetValue: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ComplianceOperatorProfileV2_SetValue: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Name = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Rationale", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Rationale = stringValue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Value = stringValue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *ComplianceOperatorProfileV2) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -17572,6 +18121,76 @@ func (m *ComplianceOperatorProfileV2) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 12:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Namespace", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Namespace = stringValue
+			iNdEx = postIndex
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SetValues", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SetValues = append(m.SetValues, &ComplianceOperatorProfileV2_SetValue{})
+			if err := m.SetValues[len(m.SetValues)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/storage/compliance_operator_v2.pb.go
+++ b/generated/storage/compliance_operator_v2.pb.go
@@ -551,7 +551,7 @@ func (x *ProfileShim) GetProfileRefId() string {
 	return ""
 }
 
-// Next Tag: 17
+// Next Tag: 18
 type ComplianceOperatorProfileV2 struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The primary key is name-profile_version as that is guaranteed unique in the operator and how
@@ -572,8 +572,13 @@ type ComplianceOperatorProfileV2 struct {
 	ClusterId      string                                   `protobuf:"bytes,14,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty" search:"Cluster ID,hidden" sql:"type(uuid)"`            // @gotags: search:"Cluster ID,hidden" sql:"type(uuid)"
 	ProfileRefId   string                                   `protobuf:"bytes,15,opt,name=profile_ref_id,json=profileRefId,proto3" json:"profile_ref_id,omitempty" search:"Profile Ref ID,hidden" sql:"type(uuid)"` // @gotags: search:"Profile Ref ID,hidden" sql:"type(uuid)"
 	OperatorKind   ComplianceOperatorProfileV2_OperatorKind `protobuf:"varint,16,opt,name=operator_kind,json=operatorKind,proto3,enum=storage.ComplianceOperatorProfileV2_OperatorKind" json:"operator_kind,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// equivalence_hash is a SHA-256 hex digest computed by Central from the profile's
+	// content fields (name, namespace, description, title, rules, set_values). It identifies
+	// whether two tailored profiles across clusters carry equivalent compliance configuration.
+	// Empty for non-tailored profiles (equivalence is by name alone).
+	EquivalenceHash string `protobuf:"bytes,17,opt,name=equivalence_hash,json=equivalenceHash,proto3" json:"equivalence_hash,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ComplianceOperatorProfileV2) Reset() {
@@ -716,6 +721,13 @@ func (x *ComplianceOperatorProfileV2) GetOperatorKind() ComplianceOperatorProfil
 		return x.OperatorKind
 	}
 	return ComplianceOperatorProfileV2_OPERATOR_KIND_UNSPECIFIED
+}
+
+func (x *ComplianceOperatorProfileV2) GetEquivalenceHash() string {
+	if x != nil {
+		return x.EquivalenceHash
+	}
+	return ""
 }
 
 // Next tag: 19
@@ -3016,7 +3028,7 @@ const file_storage_compliance_operator_v2_proto_rawDesc = "" +
 	"\vProfileShim\x12\x1d\n" +
 	"\n" +
 	"profile_id\x18\x01 \x01(\tR\tprofileId\x12$\n" +
-	"\x0eprofile_ref_id\x18\x02 \x01(\tR\fprofileRefId\"\xa5\a\n" +
+	"\x0eprofile_ref_id\x18\x02 \x01(\tR\fprofileRefId\"\xd0\a\n" +
 	"\x1bComplianceOperatorProfileV2\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
@@ -3036,7 +3048,8 @@ const file_storage_compliance_operator_v2_proto_rawDesc = "" +
 	"\n" +
 	"cluster_id\x18\x0e \x01(\tR\tclusterId\x12$\n" +
 	"\x0eprofile_ref_id\x18\x0f \x01(\tR\fprofileRefId\x12V\n" +
-	"\roperator_kind\x18\x10 \x01(\x0e21.storage.ComplianceOperatorProfileV2.OperatorKindR\foperatorKind\x1a9\n" +
+	"\roperator_kind\x18\x10 \x01(\x0e21.storage.ComplianceOperatorProfileV2.OperatorKindR\foperatorKind\x12)\n" +
+	"\x10equivalence_hash\x18\x11 \x01(\tR\x0fequivalenceHash\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +

--- a/generated/storage/compliance_operator_v2_vtproto.pb.go
+++ b/generated/storage/compliance_operator_v2_vtproto.pb.go
@@ -74,6 +74,7 @@ func (m *ComplianceOperatorProfileV2) CloneVT() *ComplianceOperatorProfileV2 {
 	r.ClusterId = m.ClusterId
 	r.ProfileRefId = m.ProfileRefId
 	r.OperatorKind = m.OperatorKind
+	r.EquivalenceHash = m.EquivalenceHash
 	if rhs := m.Labels; rhs != nil {
 		tmpContainer := make(map[string]string, len(rhs))
 		for k, v := range rhs {
@@ -966,6 +967,9 @@ func (this *ComplianceOperatorProfileV2) EqualVT(that *ComplianceOperatorProfile
 		return false
 	}
 	if this.OperatorKind != that.OperatorKind {
+		return false
+	}
+	if this.EquivalenceHash != that.EquivalenceHash {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -2278,6 +2282,15 @@ func (m *ComplianceOperatorProfileV2) MarshalToSizedBufferVT(dAtA []byte) (int, 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.EquivalenceHash) > 0 {
+		i -= len(m.EquivalenceHash)
+		copy(dAtA[i:], m.EquivalenceHash)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.EquivalenceHash)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x8a
 	}
 	if m.OperatorKind != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OperatorKind))
@@ -4798,6 +4811,10 @@ func (m *ComplianceOperatorProfileV2) SizeVT() (n int) {
 	if m.OperatorKind != 0 {
 		n += 2 + protohelpers.SizeOfVarint(uint64(m.OperatorKind))
 	}
+	l = len(m.EquivalenceHash)
+	if l > 0 {
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -6684,6 +6701,38 @@ func (m *ComplianceOperatorProfileV2) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 17:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EquivalenceHash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.EquivalenceHash = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -15078,6 +15127,42 @@ func (m *ComplianceOperatorProfileV2) UnmarshalVTUnsafe(dAtA []byte) error {
 					break
 				}
 			}
+		case 17:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EquivalenceHash", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.EquivalenceHash = stringValue
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/proto/internalapi/central/compliance_operator.proto
+++ b/proto/internalapi/central/compliance_operator.proto
@@ -190,7 +190,7 @@ message ComplianceOperatorCheckResultV2 {
 }
 
 // ComplianceOperatorProfileV2 is a message from Sensor (to Central) representing a compliance check profile.
-// Next tag: 12.
+// Next tag: 14.
 message ComplianceOperatorProfileV2 {
   string id = 1;
   string profile_id = 2;
@@ -212,6 +212,20 @@ message ComplianceOperatorProfileV2 {
     TAILORED_PROFILE = 2;
   }
   OperatorKind operator_kind = 11;
+
+  // Kubernetes namespace of the profile resource. Used by Central to compute
+  // the equivalence hash for tailored profiles.
+  string namespace = 12;
+
+  // SetValue represents a variable value override in a tailored profile.
+  message SetValue {
+    string name = 1;
+    string rationale = 2;
+    string value = 3;
+  }
+  // set_values carries variable value overrides from tailored profiles.
+  // Used by Central to include them in the equivalence hash computation.
+  repeated SetValue set_values = 13;
 }
 
 // ComplianceOperatorRuleV2 is a message from Sensor (to Central) representing a compliance check rule.

--- a/proto/storage/compliance_operator_v2.proto
+++ b/proto/storage/compliance_operator_v2.proto
@@ -39,7 +39,7 @@ message ProfileShim {
   string profile_ref_id = 2; // @gotags: search:"Profile Ref ID,hidden" sql:"fk(ComplianceOperatorProfileV2:profile_ref_id),no-fk-constraint,type(uuid)"
 }
 
-// Next Tag: 17
+// Next Tag: 18
 message ComplianceOperatorProfileV2 {
   // The primary key is name-profile_version as that is guaranteed unique in the operator and how
   // the profile is referenced in scans and settings
@@ -68,6 +68,11 @@ message ComplianceOperatorProfileV2 {
     TAILORED_PROFILE = 2;
   }
   OperatorKind operator_kind = 16;
+  // equivalence_hash is a SHA-256 hex digest computed by Central from the profile's
+  // content fields (name, namespace, description, title, rules, set_values). It identifies
+  // whether two tailored profiles across clusters carry equivalent compliance configuration.
+  // Empty for non-tailored profiles (equivalence is by name alone).
+  string equivalence_hash = 17;
 }
 
 // Next tag: 19

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles.go
@@ -123,10 +123,19 @@ func (c *TailoredProfileDispatcher) ProcessEvent(obj, _ interface{}, action cent
 			Description:  protoProfile.GetDescription(),
 			Title:        tailoredProfile.Spec.Title,
 			OperatorKind: central.ComplianceOperatorProfileV2_TAILORED_PROFILE,
+			Namespace:    tailoredProfile.GetNamespace(),
 		}
 
 		for _, rule := range protoProfile.GetRules() {
 			protoProfileV2.Rules = append(protoProfileV2.Rules, &central.ComplianceOperatorProfileV2_Rule{RuleName: rule.GetName()})
+		}
+
+		for _, sv := range tailoredProfile.Spec.SetValues {
+			protoProfileV2.SetValues = append(protoProfileV2.SetValues, &central.ComplianceOperatorProfileV2_SetValue{
+				Name:      sv.Name,
+				Rationale: sv.Rationale,
+				Value:     sv.Value,
+			})
 		}
 
 		events = append(events, &central.SensorEvent{

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatortailoredprofiles_test.go
@@ -351,3 +351,75 @@ func TestProcessEvent_V2EventHasTailoredProfileKind(t *testing.T) {
 	require.NotNil(t, v2Profile)
 	assert.Equal(t, central.ComplianceOperatorProfileV2_TAILORED_PROFILE, v2Profile.GetOperatorKind())
 }
+
+// TestProcessEvent_V2EventCarriesNamespaceAndSetValues tests that the V2 event carries
+// namespace and set_values so Central can compute the equivalence hash.
+func TestProcessEvent_V2EventCarriesNamespaceAndSetValues(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.ComplianceV2Integrations, centralsensor.ComplianceV2TailoredProfiles})
+	t.Cleanup(func() { centralcaps.Set(nil) })
+
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ocp4-cis-tailored",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
+			SetValues: []v1alpha1.VariableValueSpec{
+				{Name: "var_password_min_length", Rationale: "org policy", Value: "15"},
+				{Name: "var_session_timeout", Rationale: "compliance", Value: "600"},
+			},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_ocp4-cis-tailored",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.Len(t, event.ForwardMessages, 2)
+
+	v2Profile := event.ForwardMessages[1].GetComplianceOperatorProfileV2()
+	require.NotNil(t, v2Profile)
+
+	assert.Equal(t, "openshift-compliance", v2Profile.GetNamespace(), "namespace must be forwarded")
+
+	require.Len(t, v2Profile.GetSetValues(), 2)
+	assert.Equal(t, "var_password_min_length", v2Profile.GetSetValues()[0].GetName())
+	assert.Equal(t, "org policy", v2Profile.GetSetValues()[0].GetRationale())
+	assert.Equal(t, "15", v2Profile.GetSetValues()[0].GetValue())
+	assert.Equal(t, "var_session_timeout", v2Profile.GetSetValues()[1].GetName())
+	assert.Equal(t, "600", v2Profile.GetSetValues()[1].GetValue())
+}
+
+// TestProcessEvent_V2EventEmptySetValues tests that set_values is empty when the TP has no SetValues.
+func TestProcessEvent_V2EventEmptySetValues(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.ComplianceV2Integrations, centralsensor.ComplianceV2TailoredProfiles})
+	t.Cleanup(func() { centralcaps.Set(nil) })
+
+	tp := &v1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ocp4-cis-tailored",
+			Namespace: "openshift-compliance",
+			UID:       "tp-uid",
+		},
+		Spec: v1alpha1.TailoredProfileSpec{
+			EnableRules: []v1alpha1.RuleReferenceSpec{{Name: "some-rule"}},
+		},
+		Status: v1alpha1.TailoredProfileStatus{
+			ID:    "xccdf_compliance.openshift.io_profile_ocp4-cis-tailored",
+			State: "READY",
+		},
+	}
+
+	dispatcher := NewTailoredProfileDispatcher(newMockProfileLister())
+	event := dispatcher.ProcessEvent(toUnstructured(t, tp), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	v2Profile := event.ForwardMessages[1].GetComplianceOperatorProfileV2()
+	assert.Empty(t, v2Profile.GetSetValues())
+}


### PR DESCRIPTION
## Description

Move tailored profile equivalence hash computation from Sensor to Central.

**Problem**: PR #19561 computed the hash in Sensor. During rolling upgrades when Sensors run different versions, algorithm changes produce inconsistent hashes for identical profiles across clusters.

**Solution**: Sensor forwards namespace and set_values to Central. Central computes a SHA-256 digest from the profile's content fields (name, namespace, description, title, sorted rules, sorted set_values). The hash is stored only for tailored profiles — regular profiles use name-based equivalence.

**Alternative considered**: keeping hash in Sensor with a version field to detect mismatches. Rejected because it adds complexity and still requires Central to reconcile different versions.

**Key decisions**:
- Rationale excluded from set_values hash (documentation, not configuration)
- No DB migration needed: CO resources skip deduplication and are fully re-sent on every Sensor reconnect
- `equivalence_hash` not in internal API proto — Sensor never computes it

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Unit tests cover: hash stability, cluster independence, field sensitivity (each field change produces different hash), order independence for rules and set_values, rationale exclusion, no hash for regular profiles
- `go build ./central/... ./sensor/...` — clean
- `golangci-lint run` — 0 issues
- All existing compliance operator tests pass unchanged