### PR TITLE
ROX-19064: Scanner V4 CI Wait for Vulns to Load (readiness version)

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -415,6 +415,12 @@ function launch_central {
         )
       fi
 
+      if [[ "${SCANNER_V4_VULN_READINESS:-false}" == "true" && "${ROX_SCANNER_V4:-}" != "false" ]]; then
+        helm_args+=(
+          --set customize.envVars.SCANNER_V4_MATCHER_READINESS=vulnerability
+        )
+      fi
+
       if [[ -n "$EXTERNAL_DB" ]]; then
           helm_args+=(
             --set "central.db.password.value=${EXTERNAL_DB_PASSWORD}"
@@ -543,6 +549,9 @@ function launch_central {
                 ${ORCH_CMD} -n stackrox patch deployment scanner-v4-indexer --patch "$(cat "${common_dir}/scanner-v4-indexer-patch.yaml")"
                 ${ORCH_CMD} -n stackrox patch deployment scanner-v4-matcher --patch "$(cat "${common_dir}/scanner-v4-matcher-patch.yaml")"
                 ${ORCH_CMD} -n stackrox patch deployment scanner-v4-db --patch "$(cat "${common_dir}/scanner-v4-db-patch.yaml")"
+                if [[ "${SCANNER_V4_VULN_READINESS:-false}" == "true" ]]; then
+                  ${ORCH_CMD} -n stackrox set env deploy/scanner-v4-matcher SCANNER_V4_MATCHER_READINESS=vulnerability
+                fi
               fi
             else
               echo >&2 "WARNING: Deployment bundle does not seem to contain support for Scanner V4."

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -415,7 +415,7 @@ function launch_central {
         )
       fi
 
-      if [[ "${SCANNER_V4_VULN_READINESS:-false}" == "true" && "${ROX_SCANNER_V4:-}" != "false" ]]; then
+      if [[ "${SCANNER_V4_VULN_READINESS:-false}" == "true" && "${ROX_SCANNER_V4:-false}" != "false" ]]; then
         helm_args+=(
           --set customize.envVars.SCANNER_V4_MATCHER_READINESS=vulnerability
         )

--- a/scripts/ci/jobs/gke_scanner_v4_install_tests.py
+++ b/scripts/ci/jobs/gke_scanner_v4_install_tests.py
@@ -15,6 +15,7 @@ os.environ["KUBERNETES_PROVIDER"] = "gke"
 os.environ["STORE_METRICS"] = "true"
 os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
 os.environ["ROX_SCANNER_V4"] = "true"
+os.environ["SCANNER_V4_VULN_READINESS"] = "false"
 
 ClusterTestRunner(
     cluster=GKECluster("scanner-v4-install-test", machine_type="e2-standard-8"),

--- a/scripts/ci/jobs/ocp_scanner_v4_install_tests.py
+++ b/scripts/ci/jobs/ocp_scanner_v4_install_tests.py
@@ -16,6 +16,7 @@ os.environ["KUBERNETES_PROVIDER"] = "ocp"
 os.environ["STORE_METRICS"] = "true"
 os.environ["ROX_BASELINE_GENERATION_DURATION"] = "5m"
 os.environ["ROX_SCANNER_V4"] = "true"
+os.environ["SCANNER_V4_VULN_READINESS"] = "false"
 os.environ["ENABLE_OPERATOR_TESTS"] = "true"
 
 enable_sfa_for_ocp()

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -201,6 +201,7 @@ export_test_environment() {
     ci_export ROX_NETFLOW_CACHE_LIMITING "${ROX_NETFLOW_CACHE_LIMITING:-true}"
     ci_export ROX_TAILORED_PROFILES "${ROX_TAILORED_PROFILES:-true}"
     ci_export ROX_INIT_CONTAINER_SUPPORT "${ROX_INIT_CONTAINER_SUPPORT:-true}"
+    ci_export SCANNER_V4_VULN_READINESS "${SCANNER_V4_VULN_READINESS:-true}"
 
     if is_in_PR_context && pr_has_label ci-fail-fast; then
         ci_export FAIL_FAST "true"
@@ -380,6 +381,11 @@ deploy_central_via_operator() {
         true)  scannerV4ScannerComponent="Enabled"  ;;
         false) scannerV4ScannerComponent="Disabled" ;;
     esac
+
+    if [[ "${SCANNER_V4_VULN_READINESS:-false}" == "true" && "$scannerV4ScannerComponent" != "Disabled" ]]; then
+        customize_envVars+=$'\n      - name: SCANNER_V4_MATCHER_READINESS'
+        customize_envVars+=$'\n        value: "vulnerability"'
+    fi
 
     local scannerV4DbPersistenceYaml
     scannerV4DbPersistenceYaml="$(_scanner_v4_db_persistence_yaml)"
@@ -1194,16 +1200,29 @@ wait_for_ready_deployment() {
 wait_for_scanner_V4() {
     local namespace="$1"
     local max_seconds=${MAX_WAIT_SECONDS:-300}
+    local matcher_max_seconds="$max_seconds"
     info "Waiting for Scanner V4 to become ready..."
     if [[ "${ORCHESTRATOR_FLAVOR:-}" == "openshift" ]]; then
         # OCP Interop tests are run on minimal instances and will take longer
         # Allow override with MAX_WAIT_SECONDS
         max_seconds=${MAX_WAIT_SECONDS:-600}
+        matcher_max_seconds="$max_seconds"
         info "Waiting ${max_seconds}s (increased for openshift-ci provisioned clusters) for central api and $(( max_seconds * 6 )) for ingress..."
+    fi
+    if [[ "${SCANNER_V4_VULN_READINESS:-false}" == "true" ]]; then
+        # Slowness or timeout may indicate that a low performance disk is used by
+        # the Scanner V4 DB PVC. If storage class is unset the cluster default
+        # storage class is used.
+        info "SCANNER_V4_DB_STORAGE_CLASS=${SCANNER_V4_DB_STORAGE_CLASS:-<unset>}"
+        info "Listing available storage classes:"
+        kubectl describe storageclasses 2>/dev/null || true
+
+        matcher_max_seconds=${SCANNER_V4_VULN_READINESS_TIMEOUT:-2400}
+        info "Waiting ${matcher_max_seconds}s for matcher vulnerability readiness..."
     fi
 
     wait_for_ready_deployment "$namespace" "scanner-v4-indexer" "$max_seconds"
-    wait_for_ready_deployment "$namespace" "scanner-v4-matcher" "$max_seconds"
+    wait_for_ready_deployment "$namespace" "scanner-v4-matcher" "$matcher_max_seconds"
 }
 
 # shellcheck disable=SC2120


### PR DESCRIPTION
## Description

Alternative to: https://github.com/stackrox/stackrox/pull/19836 (only one is needed)

Adds the rails for CI jobs to wait for vuln loads to finish before starting tests.

This PR modifies Scanner V4 Matcher behavior such that the pod will not become ready until vulns fully loaded by default. Jobs that do not want this behavior must explicitly set `SCANNER_V4_VULN_READINESS `to `false` (assumes the majority of jobs will want this behavior once Scanner V4 is enabled for all)

Prior to polling the available storage classes are listed for the cluster to assist troubleshooting if loads are slow (to verify if the DB PVC is using an SSD)

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

CI
