### PR TITLE
ROX-33649: Fix misleading MISSING_SCAN_DATA message

### DIFF
--- a/ui/apps/platform/src/messages/vulnMgmt.messages.ts
+++ b/ui/apps/platform/src/messages/vulnMgmt.messages.ts
@@ -9,8 +9,8 @@ export const imageScanMessages = {
         body: 'Check the registry connection.',
     },
     missingScanData: {
-        header: 'Failed to get the base OS information.',
-        body: 'The integrated scanner can’t find the OS, or the base OS is unidentifiable.',
+        header: 'Failed to get scan data.',
+        body: 'There may have been an error scanning the image. Check scanner integration and image accessibility.',
     },
     osUnavailable: {
         header: 'The scanner doesn’t provide OS information.',


### PR DESCRIPTION
## Description

**Jira:** [ROX-33649](https://issues.redhat.com/browse/ROX-33649)

The `MISSING_SCAN_DATA` image note is set for any scan failure (network errors, layer fetch
failures, no scanner configured, etc.), but the UI message incorrectly said "Failed to get the
base OS information." This misleads users into investigating OS-related issues. A separate
`OS_UNAVAILABLE` note already handles the OS-specific case.

- Updated `missingScanData` header to "Failed to get scan data."
- Updated `missingScanData` body to generic, actionable guidance
- `osUnavailable` message unchanged

**Note:** This is a targeted fix to stop users from going down the wrong path when investigating scan failures. It removes the misleading OS-specific wording but doesn't tell users the exact failure reason. A larger effort to improve scan error messaging (e.g. passing more specific error context from the backend through scan notes) should be tracked separately.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Existing unit tests in both `WorkloadCves` and `VulnMgmt` pass without modification (17/17 tests pass)
- Tests compare against `imageScanMessages.missingScanData` by object reference, not string value
- All consumers reference the message object by key, so the update propagates automatically

## Screenshots

<!-- Add before/after screenshots or screen recordings to demonstrate the visual changes -->

| Before | After |
|--------|-------|
|        |       |

[ROX-33649]: https://redhat.atlassian.net/browse/ROX-33649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ