### PR TITLE
fix(deploy): increase memory limits for admission-control and config-controller

### DIFF
--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -121,7 +121,7 @@ defaults:
         memory: "64Mi"
         cpu: "10m"
       limits:
-        memory: "128Mi"
+        memory: "256Mi"
         cpu: "500m"
   scanner:
     disable: false

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/40-resources.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/40-resources.yaml
@@ -15,7 +15,7 @@ admissionControl:
       memory: "100Mi"
       cpu: "50m"
     limits:
-      memory: "500Mi"
+      memory: "1Gi"
       cpu: "500m"
 
 collector:

--- a/operator/internal/securedcluster/defaults/admission_controller.go
+++ b/operator/internal/securedcluster/defaults/admission_controller.go
@@ -22,9 +22,9 @@ var (
 		},
 	}
 
-	// defaultResourcesEnforcementEnabled defines resource requirements when enforcement is enabled.
-	// The memory limit matches the enforcement-disabled default since the busybox-style
-	// consolidated binary requires sufficient headroom for all components' init overhead.
+	// defaultResourcesEnforcementEnabled has a higher memory limit to accommodate the
+	// in-process image cache used by the policy-evaluation webhook during enforcement.
+	// Only the memory limit differs; requests stay the same so scheduling is unaffected.
 	defaultResourcesEnforcementEnabled = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),

--- a/operator/internal/securedcluster/defaults/admission_controller.go
+++ b/operator/internal/securedcluster/defaults/admission_controller.go
@@ -18,13 +18,13 @@ var (
 		},
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("500Mi"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
 		},
 	}
 
-	// defaultResourcesEnforcementEnabled has a higher memory limit to accommodate the
-	// in-process image cache used by the policy-evaluation webhook during enforcement.
-	// Only the memory limit differs; requests stay the same so scheduling is unaffected.
+	// defaultResourcesEnforcementEnabled defines resource requirements when enforcement is enabled.
+	// The memory limit matches the enforcement-disabled default since the busybox-style
+	// consolidated binary requires sufficient headroom for all components' init overhead.
 	defaultResourcesEnforcementEnabled = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),

--- a/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
+++ b/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
@@ -32,11 +32,11 @@ var (
 		},
 		Limits: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("500Mi"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
 		},
 	}
 
-	// Expected resources when enforcement is enabled (only memory limit differs).
+	// Expected resources when enforcement is enabled.
 	expectedResourcesEnforcementEnabled = &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),

--- a/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
+++ b/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
@@ -36,7 +36,7 @@ var (
 		},
 	}
 
-	// Expected resources when enforcement is enabled.
+	// Expected resources when enforcement is enabled (only memory limit differs).
 	expectedResourcesEnforcementEnabled = &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),


### PR DESCRIPTION
## Description

The busybox-style binary consolidation (ROX-33958, PR #19819) increased init-time
memory usage for all components. Go eagerly runs `init()` for all transitively
imported packages, so the consolidated binary's ~4600 transitive deps all initialize
at startup regardless of which component is actually running.

Profiling on Linux amd64 shows:
- Standalone admission-control: ~8 MB heap after init
- Standalone config-controller: ~5.5 MB heap after init
- Busybox binary (all components): ~15 MB heap after init

Under the race detector (~5-10x memory multiplier), the busybox init overhead
causes OOMKills for components with tight limits:
- config-controller (128Mi): 7 OOMKilled restarts in nightly RCD tests
- admission-control (500Mi): 6-7 OOMKilled restarts across all 3 replicas

Changes:
- config-controller: 128Mi → 256Mi
- admission-control: 500Mi → 1Gi (aligns enforcement-disabled with enforcement-enabled default)

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Operator defaulting test updated and passes (`TestReconcileAdmissionControllerDef`)
- Memory profiling confirmed busybox init overhead via measurement binaries run in Linux containers
- Values are conservative: config-controller 256Mi is 2x the old limit with ~15 MB actual usage; admission-control 1Gi matches the existing enforcement-enabled default

🤖 Generated with [Claude Code](https://claude.com/claude-code)