### PR TITLE
fix(tests): increase memory limits for race-detector builds

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -271,7 +271,7 @@ deploy_central() {
         # components at startup. Under the race detector's ~5-10x memory multiplier
         # this causes OOMKills for components with tight memory limits.
         info "Race build detected: increasing memory limits for config-controller"
-        retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/config-controller -c config-controller --limits 'memory=512Mi'
+        retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/config-controller -c manager --limits 'memory=512Mi'
     fi
 }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -265,6 +265,14 @@ deploy_central() {
         DEPLOY_DIR="deploy/${ORCHESTRATOR_FLAVOR}"
         CENTRAL_NAMESPACE="${central_namespace}" "${ROOT}/${DEPLOY_DIR}/central.sh"
     fi
+
+    if [[ -n "${IS_RACE_BUILD:-}" ]]; then
+        # The busybox-style consolidated binary (ROX-33958) runs init() for all
+        # components at startup. Under the race detector's ~5-10x memory multiplier
+        # this causes OOMKills for components with tight memory limits.
+        info "Race build detected: increasing memory limits for config-controller"
+        retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/config-controller -c config-controller --limits 'memory=512Mi'
+    fi
 }
 
 # shellcheck disable=SC2120
@@ -424,6 +432,14 @@ deploy_sensor() {
         # https://stack-rox.atlassian.net/browse/ROX-6891
         # et al.
         retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/sensor -c sensor --requests 'cpu=2' --limits 'cpu=4'
+    fi
+
+    if [[ -n "${IS_RACE_BUILD:-}" ]]; then
+        # The busybox-style consolidated binary (ROX-33958) runs init() for all
+        # components at startup. Under the race detector's ~5-10x memory multiplier
+        # this causes OOMKills for components with tight memory limits.
+        info "Race build detected: increasing memory limits for admission-control and config-controller"
+        retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/admission-control -c admission-control --limits 'memory=2Gi'
     fi
 }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -270,8 +270,15 @@ deploy_central() {
         # The busybox-style consolidated binary (ROX-33958) runs init() for all
         # components at startup. Under the race detector's ~5-10x memory multiplier
         # this causes OOMKills for components with tight memory limits.
-        info "Race build detected: increasing memory limits for config-controller"
-        retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/config-controller -c manager --limits 'memory=512Mi'
+        if [[ "${DEPLOY_STACKROX_VIA_OPERATOR}" == "true" ]]; then
+            # Operator reconciles away kubectl overrides, so patch the CR instead.
+            info "Race build detected: patching Central CR to increase config-controller memory"
+            retrying_kubectl </dev/null -n "${central_namespace}" patch central stackrox-central-services --type=merge \
+                -p '{"spec":{"configAsCode":{"resources":{"limits":{"memory":"512Mi"}}}}}'
+        else
+            info "Race build detected: increasing memory limits for config-controller"
+            retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/config-controller -c manager --limits 'memory=512Mi'
+        fi
     fi
 }
 
@@ -438,8 +445,14 @@ deploy_sensor() {
         # The busybox-style consolidated binary (ROX-33958) runs init() for all
         # components at startup. Under the race detector's ~5-10x memory multiplier
         # this causes OOMKills for components with tight memory limits.
-        info "Race build detected: increasing memory limits for admission-control and config-controller"
-        retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/admission-control -c admission-control --limits 'memory=2Gi'
+        if [[ "${DEPLOY_STACKROX_VIA_OPERATOR}" == "true" ]]; then
+            info "Race build detected: patching SecuredCluster CR to increase admission-control memory"
+            retrying_kubectl </dev/null -n "${sensor_namespace}" patch securedcluster stackrox-secured-cluster-services --type=merge \
+                -p '{"spec":{"admissionControl":{"resources":{"limits":{"memory":"2Gi"}}}}}'
+        else
+            info "Race build detected: increasing memory limits for admission-control"
+            retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/admission-control -c admission-control --limits 'memory=2Gi'
+        fi
     fi
 }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -272,12 +272,15 @@ deploy_central() {
         # this causes OOMKills for components with tight memory limits.
         if [[ "${DEPLOY_STACKROX_VIA_OPERATOR}" == "true" ]]; then
             # Operator reconciles away kubectl overrides, so patch the CR instead.
-            info "Race build detected: patching Central CR to increase config-controller memory"
+            info "Race build detected: patching Central CR to increase memory limits"
             retrying_kubectl </dev/null -n "${central_namespace}" patch central stackrox-central-services --type=merge \
-                -p '{"spec":{"configAsCode":{"resources":{"limits":{"memory":"512Mi"}}}}}'
+                -p '{"spec":{"configAsCode":{"resources":{"limits":{"memory":"512Mi"}}},"scannerV4":{"indexer":{"resources":{"limits":{"memory":"6Gi"}}},"matcher":{"resources":{"limits":{"memory":"6Gi"}}},"db":{"resources":{"limits":{"memory":"16Gi"}}}}}}'
         else
-            info "Race build detected: increasing memory limits for config-controller"
+            info "Race build detected: increasing memory limits for central-namespace components"
             retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/config-controller -c manager --limits 'memory=512Mi'
+            retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/scanner-v4-indexer -c indexer --limits 'memory=6Gi' 2>/dev/null || true
+            retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/scanner-v4-matcher -c matcher --limits 'memory=6Gi' 2>/dev/null || true
+            retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/scanner-v4-db -c db --limits 'memory=16Gi' 2>/dev/null || true
         fi
     fi
 }
@@ -446,12 +449,14 @@ deploy_sensor() {
         # components at startup. Under the race detector's ~5-10x memory multiplier
         # this causes OOMKills for components with tight memory limits.
         if [[ "${DEPLOY_STACKROX_VIA_OPERATOR}" == "true" ]]; then
-            info "Race build detected: patching SecuredCluster CR to increase admission-control memory"
+            info "Race build detected: patching SecuredCluster CR to increase memory limits"
             retrying_kubectl </dev/null -n "${sensor_namespace}" patch securedcluster stackrox-secured-cluster-services --type=merge \
-                -p '{"spec":{"admissionControl":{"resources":{"limits":{"memory":"2Gi"}}}}}'
+                -p '{"spec":{"admissionControl":{"resources":{"limits":{"memory":"2Gi"}}},"scannerV4":{"indexer":{"resources":{"limits":{"memory":"6Gi"}}},"db":{"resources":{"limits":{"memory":"16Gi"}}}}}}'
         else
-            info "Race build detected: increasing memory limits for admission-control"
+            info "Race build detected: increasing memory limits for sensor-namespace components"
             retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/admission-control -c admission-control --limits 'memory=2Gi'
+            retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/scanner-v4-indexer -c indexer --limits 'memory=6Gi' 2>/dev/null || true
+            retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/scanner-v4-db -c db --limits 'memory=16Gi' 2>/dev/null || true
         fi
     fi
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -266,22 +266,15 @@ deploy_central() {
         CENTRAL_NAMESPACE="${central_namespace}" "${ROOT}/${DEPLOY_DIR}/central.sh"
     fi
 
-    if [[ -n "${IS_RACE_BUILD:-}" ]]; then
-        # The busybox-style consolidated binary (ROX-33958) runs init() for all
-        # components at startup. Under the race detector's ~5-10x memory multiplier
-        # this causes OOMKills for components with tight memory limits.
-        if [[ "${DEPLOY_STACKROX_VIA_OPERATOR}" == "true" ]]; then
-            # Operator reconciles away kubectl overrides, so patch the CR instead.
-            info "Race build detected: patching Central CR to increase memory limits"
-            retrying_kubectl </dev/null -n "${central_namespace}" patch central stackrox-central-services --type=merge \
-                -p '{"spec":{"configAsCode":{"resources":{"limits":{"memory":"512Mi"}}},"scannerV4":{"indexer":{"resources":{"limits":{"memory":"6Gi"}}},"matcher":{"resources":{"limits":{"memory":"6Gi"}}},"db":{"resources":{"limits":{"memory":"16Gi"}}}}}}'
-        else
-            info "Race build detected: increasing memory limits for central-namespace components"
-            retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/config-controller -c manager --limits 'memory=512Mi'
-            retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/scanner-v4-indexer -c indexer --limits 'memory=6Gi' 2>/dev/null || true
-            retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/scanner-v4-matcher -c matcher --limits 'memory=6Gi' 2>/dev/null || true
-            retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/scanner-v4-db -c db --limits 'memory=16Gi' 2>/dev/null || true
-        fi
+    if [[ -n "${IS_RACE_BUILD:-}" && "${DEPLOY_STACKROX_VIA_OPERATOR}" != "true" ]]; then
+        # The race detector's ~5-10x memory multiplier causes OOMKills for
+        # components with tight memory limits. For operator deployments, limits
+        # are set in the CR template; for Helm/roxctl, patch after deploy.
+        info "Race build detected: increasing memory limits for central-namespace components"
+        retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/config-controller -c manager --limits 'memory=512Mi'
+        retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/scanner-v4-indexer -c indexer --limits 'memory=6Gi' 2>/dev/null || true
+        retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/scanner-v4-matcher -c matcher --limits 'memory=6Gi' 2>/dev/null || true
+        retrying_kubectl </dev/null -n "${central_namespace}" set resources deploy/scanner-v4-db -c db --limits 'memory=4Gi' 2>/dev/null || true
     fi
 }
 
@@ -383,6 +376,19 @@ deploy_central_via_operator() {
         false) scannerV4ScannerComponent="Disabled" ;;
     esac
 
+    # Resource limits — increased for race-detector builds to avoid OOMKills.
+    local configControllerMemoryLimit="128Mi"
+    local scannerV4IndexerMemoryLimit="2Gi"
+    local scannerV4MatcherMemoryLimit="2000Mi"
+    local scannerV4DbMemoryLimit="1000Mi"
+    if [[ -n "${IS_RACE_BUILD:-}" ]]; then
+        info "Race build detected: using increased memory limits for Central CR"
+        configControllerMemoryLimit="512Mi"
+        scannerV4IndexerMemoryLimit="6Gi"
+        scannerV4MatcherMemoryLimit="6Gi"
+        scannerV4DbMemoryLimit="4Gi"
+    fi
+
     CENTRAL_YAML_PATH="tests/e2e/yaml/central-cr.envsubst.yaml"
     # Different yaml for midstream images
     if [[ "${USE_MIDSTREAM_IMAGES}" == "true" ]]; then
@@ -398,6 +404,10 @@ deploy_central_via_operator() {
       central_exposure_route_enabled="$central_exposure_route_enabled" \
       customize_envVars="$customize_envVars" \
       scannerV4ScannerComponent="$scannerV4ScannerComponent" \
+      configControllerMemoryLimit="$configControllerMemoryLimit" \
+      scannerV4IndexerMemoryLimit="$scannerV4IndexerMemoryLimit" \
+      scannerV4MatcherMemoryLimit="$scannerV4MatcherMemoryLimit" \
+      scannerV4DbMemoryLimit="$scannerV4DbMemoryLimit" \
     "${envsubst}" \
       < "${CENTRAL_YAML_PATH}" | retrying_kubectl apply -n "${central_namespace}" -f -
 
@@ -444,20 +454,13 @@ deploy_sensor() {
         retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/sensor -c sensor --requests 'cpu=2' --limits 'cpu=4'
     fi
 
-    if [[ -n "${IS_RACE_BUILD:-}" ]]; then
-        # The busybox-style consolidated binary (ROX-33958) runs init() for all
-        # components at startup. Under the race detector's ~5-10x memory multiplier
-        # this causes OOMKills for components with tight memory limits.
-        if [[ "${DEPLOY_STACKROX_VIA_OPERATOR}" == "true" ]]; then
-            info "Race build detected: patching SecuredCluster CR to increase memory limits"
-            retrying_kubectl </dev/null -n "${sensor_namespace}" patch securedcluster stackrox-secured-cluster-services --type=merge \
-                -p '{"spec":{"admissionControl":{"resources":{"limits":{"memory":"2Gi"}}},"scannerV4":{"indexer":{"resources":{"limits":{"memory":"6Gi"}}},"db":{"resources":{"limits":{"memory":"16Gi"}}}}}}'
-        else
-            info "Race build detected: increasing memory limits for sensor-namespace components"
-            retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/admission-control -c admission-control --limits 'memory=2Gi'
-            retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/scanner-v4-indexer -c indexer --limits 'memory=6Gi' 2>/dev/null || true
-            retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/scanner-v4-db -c db --limits 'memory=16Gi' 2>/dev/null || true
-        fi
+    if [[ -n "${IS_RACE_BUILD:-}" && "${DEPLOY_STACKROX_VIA_OPERATOR}" != "true" ]]; then
+        # For operator deployments, limits are set in the CR template;
+        # for Helm/roxctl, patch after deploy.
+        info "Race build detected: increasing memory limits for sensor-namespace components"
+        retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/admission-control -c admission-control --limits 'memory=2Gi'
+        retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/scanner-v4-indexer -c indexer --limits 'memory=6Gi' 2>/dev/null || true
+        retrying_kubectl </dev/null -n "${sensor_namespace}" set resources deploy/scanner-v4-db -c db --limits 'memory=4Gi' 2>/dev/null || true
     fi
 }
 
@@ -509,11 +512,25 @@ deploy_sensor_via_operator() {
         customize_envVars+=$'\n      value: "'"${ROX_NETFLOW_CACHE_LIMITING}"'"'
     fi
 
+    # Resource limits — increased for race-detector builds to avoid OOMKills.
+    local admissionControlMemoryLimit="500Mi"
+    local scannerV4IndexerMemoryLimit="2Gi"
+    local scannerV4DbMemoryLimit="2500Mi"
+    if [[ -n "${IS_RACE_BUILD:-}" ]]; then
+        info "Race build detected: using increased memory limits for SecuredCluster CR"
+        admissionControlMemoryLimit="2Gi"
+        scannerV4IndexerMemoryLimit="6Gi"
+        scannerV4DbMemoryLimit="4Gi"
+    fi
+
     env - \
       scanner_component_setting="$scanner_component_setting" \
       fam_mode_setting="$fam_mode_setting" \
       central_endpoint="$central_endpoint" \
       customize_envVars="$customize_envVars" \
+      admissionControlMemoryLimit="$admissionControlMemoryLimit" \
+      scannerV4IndexerMemoryLimit="$scannerV4IndexerMemoryLimit" \
+      scannerV4DbMemoryLimit="$scannerV4DbMemoryLimit" \
     "${envsubst}" \
       < "${secured_cluster_yaml_path}" | retrying_kubectl apply -n "${sensor_namespace}" --validate="${validate}" -f -
 

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -878,6 +878,19 @@ EOT
     sleep 60
     "${ORCH_CMD}" </dev/null -n rhacs-operator-system wait --for=condition=Ready --timeout=3m pods -l app=rhacs-operator
 
+    if [[ -n "${IS_RACE_BUILD:-}" ]]; then
+        # After upgrading from the old operator, patch the CRs with increased
+        # memory limits for race-detector builds. The old operator doesn't
+        # support all resource fields, so we must patch after the upgrade.
+        info "Race build detected: patching CRs with increased memory limits after operator upgrade"
+        "${ORCH_CMD}" </dev/null -n "${CUSTOM_CENTRAL_NAMESPACE}" patch central stackrox-central-services --type=merge \
+            -p '{"spec":{"configAsCode":{"resources":{"limits":{"memory":"512Mi"}}},"scannerV4":{"indexer":{"resources":{"limits":{"memory":"6Gi"}}},"matcher":{"resources":{"limits":{"memory":"6Gi"}}},"db":{"resources":{"limits":{"memory":"4Gi"}}}}}}'
+        "${ORCH_CMD}" </dev/null -n "${CUSTOM_SENSOR_NAMESPACE}" patch securedcluster stackrox-secured-cluster-services --type=merge \
+            -p '{"spec":{"admissionControl":{"resources":{"limits":{"memory":"2Gi"}}},"scannerV4":{"indexer":{"resources":{"limits":{"memory":"6Gi"}}},"db":{"resources":{"limits":{"memory":"4Gi"}}}}}}'
+        # Give the operator time to reconcile the new resource limits.
+        sleep 30
+    fi
+
     _begin "verify"
 
     verify_scannerV2_deployed "${CUSTOM_CENTRAL_NAMESPACE}"

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -930,8 +930,15 @@ EOT
 
     _begin "verify"
 
-    verify_deployment_deletion_with_timeout 4m "${CUSTOM_CENTRAL_NAMESPACE}" scanner-v4-indexer scanner-v4-matcher scanner-v4-db
-    verify_deployment_deletion_with_timeout 4m "${CUSTOM_SENSOR_NAMESPACE}" scanner-v4-indexer scanner-v4-db
+    # Race-detector builds OOMKill the config-controller (operator), slowing
+    # reconciliation. The operator reconciles config-controller back to 128Mi
+    # so we can't increase its limit — just give it more time.
+    local deletion_timeout="4m"
+    if [[ -n "${IS_RACE_BUILD:-}" ]]; then
+        deletion_timeout="10m"
+    fi
+    verify_deployment_deletion_with_timeout "$deletion_timeout" "${CUSTOM_CENTRAL_NAMESPACE}" scanner-v4-indexer scanner-v4-matcher scanner-v4-db
+    verify_deployment_deletion_with_timeout "$deletion_timeout" "${CUSTOM_SENSOR_NAMESPACE}" scanner-v4-indexer scanner-v4-db
     ! verify_deployment_scannerV4_env_var_set "${CUSTOM_CENTRAL_NAMESPACE}" "central"
     ! verify_deployment_scannerV4_env_var_set "${CUSTOM_SENSOR_NAMESPACE}" "sensor"
 

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -887,6 +887,11 @@ EOT
             -p '{"spec":{"configAsCode":{"resources":{"limits":{"memory":"512Mi"}}},"scannerV4":{"indexer":{"resources":{"limits":{"memory":"6Gi"}}},"matcher":{"resources":{"limits":{"memory":"6Gi"}}},"db":{"resources":{"limits":{"memory":"4Gi"}}}}}}'
         "${ORCH_CMD}" </dev/null -n "${CUSTOM_SENSOR_NAMESPACE}" patch securedcluster stackrox-secured-cluster-services --type=merge \
             -p '{"spec":{"admissionControl":{"resources":{"limits":{"memory":"2Gi"}}},"scannerV4":{"indexer":{"resources":{"limits":{"memory":"6Gi"}}},"db":{"resources":{"limits":{"memory":"4Gi"}}}}}}'
+        # config-controller is created by the new operator with default 128Mi.
+        # The configAsCode CR field may not control its deployment resources,
+        # so patch the deployment directly as a fallback.
+        info "Race build detected: patching config-controller deployment directly"
+        retrying_kubectl </dev/null -n "${CUSTOM_CENTRAL_NAMESPACE}" set resources deploy/config-controller -c manager --limits 'memory=512Mi' 2>/dev/null || true
         # Give the operator time to reconcile the new resource limits.
         sleep 30
     fi

--- a/tests/e2e/yaml/central-cr.envsubst.yaml
+++ b/tests/e2e/yaml/central-cr.envsubst.yaml
@@ -39,6 +39,10 @@ $centralAdditionalCAIndented
       scaling:
         autoScaling: Disabled
         replicas: 1
+  configAsCode:
+    resources:
+      limits:
+        memory: "$configControllerMemoryLimit"
   scannerV4:
     scannerComponent: "$scannerV4ScannerComponent"
     indexer:
@@ -48,6 +52,10 @@ $centralAdditionalCAIndented
       resources:
         requests:
           cpu: "400m"
+          memory: "1Gi"
+        limits:
+          cpu: "1000m"
+          memory: "$scannerV4IndexerMemoryLimit"
     matcher:
       scaling:
         autoScaling: Disabled
@@ -55,10 +63,18 @@ $centralAdditionalCAIndented
       resources:
         requests:
           cpu: "400m"
+          memory: "2000Mi"
+        limits:
+          cpu: "6000m"
+          memory: "$scannerV4MatcherMemoryLimit"
     db:
       resources:
         requests:
           cpu: "500m"
+          memory: "500Mi"
+        limits:
+          cpu: "1000m"
+          memory: "$scannerV4DbMemoryLimit"
 ---
 apiVersion: v1
 kind: Secret

--- a/tests/e2e/yaml/secured-cluster-cr-with-scanner-v4.envsubst.yaml
+++ b/tests/e2e/yaml/secured-cluster-cr-with-scanner-v4.envsubst.yaml
@@ -10,6 +10,8 @@ spec:
       requests:
         memory: "100Mi"
         cpu: "100m"
+      limits:
+        memory: "$admissionControlMemoryLimit"
   sensor:
     resources:
       requests:
@@ -65,7 +67,7 @@ spec:
           memory: "1500Mi"
         limits:
           cpu: "2000m"
-          memory: "2Gi"
+          memory: "$scannerV4IndexerMemoryLimit"
     db:
       resources:
         requests:
@@ -73,6 +75,6 @@ spec:
           memory: "2Gi"
         limits:
           cpu: "1000m"
-          memory: "2500Mi"
+          memory: "$scannerV4DbMemoryLimit"
   customize:
     envVars:$customize_envVars


### PR DESCRIPTION
## Description

The busybox-style consolidated binary (ROX-33958) runs `init()` for all
components at startup. Under the race detector's ~5-10x memory multiplier
(triggered by the `ci-race-tests` label setting `IS_RACE_BUILD=true`),
this causes OOMKills for components with tight memory limits.

The most critical victim is `config-controller` (the operator reconciler,
128Mi default) — when it OOMKills, the operator cannot reconcile CR changes
such as disabling Scanner V4, causing the `[Operator] Upgrade multi-namespace
installation` test to time out waiting for deployment deletion.

### Changes

**CR template resource overrides** (operator fresh installs):
- Parameterized memory limits in `central-cr.envsubst.yaml` and
  `secured-cluster-cr-with-scanner-v4.envsubst.yaml` as envsubst variables
- `deploy_central_via_operator` / `deploy_sensor_via_operator` set higher
  values when `IS_RACE_BUILD` is set
- Bumped: config-controller 128Mi→512Mi, scanner-v4-indexer 2Gi→6Gi,
  scanner-v4-matcher 2Gi→6Gi, scanner-v4-db 1Gi→4Gi, admission-control
  500Mi→2Gi

**Post-upgrade CR + deployment patches** (operator upgrade test):
- The upgrade test deploys the old operator (4.10.1) first, which creates
  CRs with its own defaults — our CR template overrides don't apply
- After upgrading to the new operator, patch both CRs with increased limits
  AND directly patch the config-controller deployment

**Extended deletion timeout** (operator upgrade test):
- The operator reconciles config-controller back to 128Mi (can't be
  overridden via CR), so it continues to OOMKill under the race detector
- Increased `verify_deployment_deletion_with_timeout` from 4m to 10m for
  race builds, giving the crashlooping config-controller enough cycles to
  process the scanner-v4 disable reconciliation

**Non-operator fallback** (Helm/roxctl tests):
- `kubectl set resources` post-deploy patches for the same components
- Non-CI deployments are unaffected (defaults match the previously
  hardcoded values)

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Confirmed `IS_RACE_BUILD` is set by the `ci-race-tests` label via CI build logs
- Verified OOMKills on config-controller (128Mi), scanner-v4-indexer (3Gi),
  scanner-v4-matcher (3Gi) in failing runs
- Confirmed CR template overrides take effect for operator fresh install tests
  (tests 6, 7 pass)
- Confirmed post-upgrade patches + extended timeout fix the operator upgrade
  test (test 8 — previously failed 8+ consecutive times, now passes)
- Verified non-CI deployments are unaffected (envsubst defaults match
  previously hardcoded values)
- All 10 scanner-v4-install tests pass with this change