### PR TITLE
chore(berserker): Use stackrox-io repo berserker image

### DIFF
--- a/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
@@ -49,9 +49,6 @@ jobs:
       - objectTemplate: service.yml
         replicas: 10
 
-      - objectTemplate: secret.yml
-        replicas: 10
-
       - objectTemplate: berserker-configmap-endpoints-zipf.yml
         replicas: 10
 

--- a/scripts/release-tools/kube-burner-configs/berserker-load/connection-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/connection-load-daemonset.yml
@@ -21,7 +21,7 @@ spec:
         app: connection-load-{{.Replica}}
     spec:
       containers:
-      - image: quay.io/stackrox-io/berserker:network-1.0-86-g3464e60064
+      - image: quay.io/stackrox-io/berserker:network-1.0-85-g1b7ab034aa
         resources:
           requests:
             memory: "100Mi"

--- a/scripts/release-tools/kube-burner-configs/berserker-load/connection-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/connection-load-daemonset.yml
@@ -20,8 +20,6 @@ spec:
       labels:
         app: connection-load-{{.Replica}}
     spec:
-      imagePullSecrets:
-      - name: {{.JobName}}-{{.Replica}}
       containers:
       - image: quay.io/stackrox-io/berserker:network-1.0-86-g3464e60064
         resources:

--- a/scripts/release-tools/kube-burner-configs/berserker-load/connection-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/connection-load-daemonset.yml
@@ -23,7 +23,7 @@ spec:
       imagePullSecrets:
       - name: {{.JobName}}-{{.Replica}}
       containers:
-      - image: quay.io/rhacs-eng/qa:berserker-network-1.0-85-g1b7ab034aa
+      - image: quay.io/stackrox-io/berserker:network-1.0-86-g3464e60064
         resources:
           requests:
             memory: "100Mi"

--- a/scripts/release-tools/kube-burner-configs/berserker-load/endpoint-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/endpoint-load-daemonset.yml
@@ -15,7 +15,7 @@ spec:
       imagePullSecrets:
       - name: {{.JobName}}-{{.Replica}}
       containers:
-      - image: quay.io/rhacs-eng/qa:berserker-1.0-40-ge3bd96aa5a
+      - image: quay.io/stackrox-io/berserker:1.0-86-g3464e60064
         resources:
           requests:
             memory: "100Mi"

--- a/scripts/release-tools/kube-burner-configs/berserker-load/endpoint-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/endpoint-load-daemonset.yml
@@ -12,8 +12,6 @@ spec:
       labels:
         app: endpoint-load-{{.Replica}}
     spec:
-      imagePullSecrets:
-      - name: {{.JobName}}-{{.Replica}}
       containers:
       - image: quay.io/stackrox-io/berserker:1.0-86-g3464e60064
         resources:

--- a/scripts/release-tools/kube-burner-configs/berserker-load/process-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/process-load-daemonset.yml
@@ -12,8 +12,6 @@ spec:
       labels:
         app: process-load-{{.Replica}}
     spec:
-      imagePullSecrets:
-        - name: {{.JobName}}-{{.Replica}}
       containers:
       - args:
         - sleep

--- a/scripts/release-tools/kube-burner-configs/berserker-load/process-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/process-load-daemonset.yml
@@ -18,7 +18,7 @@ spec:
       - args:
         - sleep
         - infinity
-        image: quay.io/rhacs-eng/qa:berserker-1.0-63-g7b0a20bf5f
+        image: quay.io/stackrox-io/berserker:1.0-86-g3464e60064
         resources:
           requests:
             memory: "10Mi"


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Currently the berserker images used by the long running clusters are in the private rhacs-eng image repository. This requires setting up an image pull secret, which is a complication. To simplify things, switch to using the public images in the stackrox-io repository.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Created jv-use-stackrox-io-berserker branches in the stackrox/actions and stackrox/test-gh-actions repositories. 

Ran the following steps

Went to https://github.com/stackrox/test-gh-actions/actions/workflows/create-clusters.yml
Clicked on "Run workflow"
Selected jv-use-stackrox-io-berserker as the branch
Selected 4.11.x-628-g0d69df3da2 as the image which corresponds to this branch
Selected Create a long-running cluster on RC1
Clicked on "Run workflow"

The workflow succeeded.
Downloaded the artifacts for the cluster with real workload. Checked the namespaces in the cluster.

```
$ kc get ns
NAME                          STATUS   AGE
berserker-1                   Active   19m
berserker-2                   Active   10s
berserker-3                   Active   6s
berserker-4                   Active   4s
berserker-5                   Active   1s
default                       Active   122m
gke-managed-cim               Active   120m
gke-managed-system            Active   120m
gke-managed-volumepopulator   Active   120m
gmp-public                    Active   120m
gmp-system                    Active   120m
kube-burner                   Active   20m
kube-node-lease               Active   122m
kube-public                   Active   122m
kube-system                   Active   122m
stackrox                      Active   22m
```

Checked the berserker pods in the namespaces. Here is one of the namespaces

```
$ kc -n berserker-1 get pod
NAME                      READY   STATUS    RESTARTS   AGE
connection-load-1-5hxv9   1/1     Running   0          2m41s
connection-load-1-8r69j   1/1     Running   0          2m40s
connection-load-1-jgkzd   1/1     Running   0          2m42s
connection-load-1-nqhk4   1/1     Running   0          2m41s
connection-load-1-sclxr   1/1     Running   0          2m41s
connection-load-2-b2dcs   1/1     Running   0          2m33s
connection-load-2-bkxhr   1/1     Running   0          2m35s
connection-load-2-kzkcj   1/1     Running   0          2m32s
connection-load-2-mtq9z   1/1     Running   0          2m32s
connection-load-2-xnsfj   1/1     Running   0          2m33s
connection-load-3-2v2jp   1/1     Running   0          2m35s
connection-load-3-7wzpp   1/1     Running   0          2m36s
connection-load-3-gthqr   1/1     Running   0          2m37s
connection-load-3-k44ls   1/1     Running   0          2m35s
connection-load-3-tttbh   1/1     Running   0          2m36s
connection-load-4-4mslq   1/1     Running   0          2m33s
connection-load-4-95xdg   1/1     Running   0          2m33s
connection-load-4-gsr4l   1/1     Running   0          2m35s
connection-load-4-hlx9l   1/1     Running   0          2m35s
connection-load-4-kl655   1/1     Running   0          2m35s
connection-load-5-58vmj   1/1     Running   0          2m33s
connection-load-5-7s22z   1/1     Running   0          2m33s
connection-load-5-b9ksj   1/1     Running   0          2m35s
connection-load-5-nth98   1/1     Running   0          2m34s
connection-load-5-ss4cr   1/1     Running   0          2m34s
connection-load-6-29zp9   1/1     Running   0          2m36s
connection-load-6-5gpv4   1/1     Running   0          2m36s
connection-load-6-bwb2m   1/1     Running   0          2m37s
connection-load-6-cf7r9   1/1     Running   0          2m37s
connection-load-6-crkcf   1/1     Running   0          2m40s
endpoint-load-1-6fwjr     1/1     Running   0          2m42s
endpoint-load-1-rx9m8     1/1     Running   0          2m41s
endpoint-load-1-s7nbf     1/1     Running   0          2m42s
endpoint-load-1-x24hs     1/1     Running   0          2m41s
endpoint-load-1-z9tjk     1/1     Running   0          2m42s
endpoint-load-2-88fqj     1/1     Running   0          2m41s
endpoint-load-2-8hxdk     1/1     Running   0          2m42s
endpoint-load-2-cgd6m     1/1     Running   0          2m42s
endpoint-load-2-kjv67     1/1     Running   0          2m41s
endpoint-load-2-rbvk2     1/1     Running   0          2m42s
endpoint-load-3-788xb     1/1     Running   0          2m37s
endpoint-load-3-hrlrq     1/1     Running   0          2m38s
endpoint-load-3-p2mh6     1/1     Running   0          2m36s
endpoint-load-3-v7mzq     1/1     Running   0          2m38s
endpoint-load-3-w56z7     1/1     Running   0          2m37s
endpoint-load-4-4lr4r     1/1     Running   0          2m38s
endpoint-load-4-8lp7d     1/1     Running   0          2m37s
endpoint-load-4-dgdjc     1/1     Running   0          2m36s
endpoint-load-4-gmqh8     1/1     Running   0          2m40s
endpoint-load-4-h59jr     1/1     Running   0          2m36s
endpoint-load-5-9fxp2     1/1     Running   0          2m40s
endpoint-load-5-dz6g8     1/1     Running   0          2m42s
endpoint-load-5-gxw8z     1/1     Running   0          2m42s
endpoint-load-5-kndzl     1/1     Running   0          2m41s
endpoint-load-5-lgxcl     1/1     Running   0          2m42s
endpoint-load-6-4rcs7     1/1     Running   0          2m39s
endpoint-load-6-bpgch     1/1     Running   0          2m40s
endpoint-load-6-lcv5z     1/1     Running   0          2m39s
endpoint-load-6-mf8rj     1/1     Running   0          2m38s
endpoint-load-6-zwqsw     1/1     Running   0          2m37s
process-load-1-2ztvq      1/1     Running   0          2m42s
process-load-1-6fq8n      1/1     Running   0          2m41s
process-load-1-l8s2d      1/1     Running   0          2m42s
process-load-1-nk7j6      1/1     Running   0          2m41s
process-load-1-pt7b8      1/1     Running   0          2m43s
process-load-2-2r54h      1/1     Running   0          2m43s
process-load-2-2zzth      1/1     Running   0          2m44s
process-load-2-5d7rb      1/1     Running   0          2m43s
process-load-2-dn5m9      1/1     Running   0          2m44s
process-load-2-vlgqp      1/1     Running   0          2m44s
process-load-3-685wt      1/1     Running   0          2m44s
process-load-3-8wpb2      1/1     Running   0          2m44s
process-load-3-9zwxx      1/1     Running   0          2m43s
process-load-3-gbsjz      1/1     Running   0          2m43s
process-load-3-j9w22      1/1     Running   0          2m44s
process-load-4-4gbtf      1/1     Running   0          2m44s
process-load-4-927gx      1/1     Running   0          2m44s
process-load-4-hh5g8      1/1     Running   0          2m44s
process-load-4-t2vjr      1/1     Running   0          2m43s
process-load-4-z4ckr      1/1     Running   0          2m43s
process-load-5-4rbjp      1/1     Running   0          2m43s
process-load-5-dkd8z      1/1     Running   0          2m44s
process-load-5-hndzn      1/1     Running   0          2m44s
process-load-5-s4tcv      1/1     Running   0          2m44s
process-load-5-xgv8v      1/1     Running   0          2m43s
process-load-6-5bdgm      1/1     Running   0          2m44s
process-load-6-75pmk      1/1     Running   0          2m44s
process-load-6-ccwpw      1/1     Running   0          2m43s
process-load-6-fb8bn      1/1     Running   0          2m44s
process-load-6-k6qk6      1/1     Running   0          2m43s
```

Checked the image in one of the pods

```
$ kc -n berserker-1 describe pod connection-load-1-5hxv9 | grep image
  Normal   Pulled       21m   kubelet            Container image "quay.io/stackrox-io/berserker:network-1.0-85-g1b7ab034aa" already present on machine
```