### PR TITLE
ROX-33361: Per-namespace persistence for process indicators

### DIFF
--- a/central/cluster/datastore/datastore.go
+++ b/central/cluster/datastore/datastore.go
@@ -73,6 +73,8 @@ type DataStore interface {
 	SearchResults(ctx context.Context, q *v1.Query) ([]*v1.SearchResult, error)
 
 	LookupOrCreateClusterFromConfig(ctx context.Context, clusterID, bundleID string, hello *central.SensorHello) (*storage.Cluster, error)
+
+	MatchProcessIndicator(ctx context.Context, indicator *storage.ProcessIndicator) (bool, error)
 }
 
 // New returns an instance of DataStore.
@@ -120,6 +122,7 @@ func New(
 		clusterRanker:             clusterRanker,
 		networkBaselineMgr:        networkBaselineMgr,
 		idToNameCache:             simplecache.New(),
+		idToNamespaceFilterCache:  simplecache.New(),
 		nameToIDCache:             simplecache.New(),
 		compliancePruner:          compliancePruner,
 		clusterInitStore:          clusterInitStore,

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -34,7 +35,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
-	clusterValidation "github.com/stackrox/rox/pkg/cluster"
+	clusterPkg "github.com/stackrox/rox/pkg/cluster"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
@@ -94,8 +95,9 @@ type datastoreImpl struct {
 	notifier      notifierProcessor.Processor
 	clusterRanker *ranking.Ranker
 
-	idToNameCache simplecache.Cache
-	nameToIDCache simplecache.Cache
+	idToNameCache            simplecache.Cache
+	idToNamespaceFilterCache simplecache.Cache
+	nameToIDCache            simplecache.Cache
 
 	lock sync.Mutex
 }
@@ -180,6 +182,22 @@ func (ds *datastoreImpl) buildCache(ctx context.Context) error {
 	for _, c := range clusters {
 		ds.idToNameCache.Add(c.GetId(), c.GetName())
 		ds.nameToIDCache.Add(c.GetName(), c.GetId())
+
+		if filter := clusterPkg.GetNamespaceFilter(c); filter != nil {
+			compiledFilter, err := regexp.Compile(*filter)
+
+			if err == nil {
+				ds.idToNamespaceFilterCache.Add(c.GetId(), compiledFilter)
+			} else {
+				log.Errorf("Could not compile filter regexp: %v", err)
+			}
+		} else {
+			// We got empty filter building the cluster. There should be no
+			// prior cache at this point, but just in case make sure it's
+			// invalidated.
+			ds.idToNamespaceFilterCache.Remove(c.GetId())
+		}
+
 		c.HealthStatus = clusterHealthStatuses[c.GetId()]
 	}
 	return nil
@@ -331,6 +349,26 @@ func (ds *datastoreImpl) GetClusterName(ctx context.Context, id string) (string,
 		return "", false, nil
 	}
 	return val.(string), true, nil
+}
+
+// Figure out if an indicator matches provided namespace filter. We consider
+// SAC errors or failure to find the pre-compiled filter regex as not matching
+// cases.
+func (ds *datastoreImpl) MatchProcessIndicator(ctx context.Context,
+	indicator *storage.ProcessIndicator) (bool, error) {
+
+	id := indicator.GetClusterId()
+
+	if ok, err := clusterSAC.ReadAllowed(ctx, sac.ClusterScopeKey(id)); err != nil || !ok {
+		return false, err
+	}
+
+	filter, ok := ds.idToNamespaceFilterCache.Get(id)
+	if !ok {
+		return false, nil
+	}
+
+	return filter.(*regexp.Regexp).MatchString(indicator.GetNamespace()), nil
 }
 
 func (ds *datastoreImpl) Exists(ctx context.Context, id string) (bool, error) {
@@ -585,6 +623,7 @@ func (ds *datastoreImpl) RemoveCluster(ctx context.Context, id string, done *con
 		return errors.Wrapf(err, "failed to remove cluster %q", id)
 	}
 	ds.idToNameCache.Remove(id)
+	ds.idToNamespaceFilterCache.Remove(id)
 	ds.nameToIDCache.Remove(cluster.GetName())
 
 	deleteRelatedCtx := sac.WithAllAccess(context.Background())
@@ -893,6 +932,20 @@ func (ds *datastoreImpl) updateClusterNoLock(ctx context.Context, cluster *stora
 	}
 	ds.idToNameCache.Add(cluster.GetId(), cluster.GetName())
 	ds.nameToIDCache.Add(cluster.GetName(), cluster.GetId())
+
+	if filter := clusterPkg.GetNamespaceFilter(cluster); filter != nil {
+		compiledFilter, err := regexp.Compile(*filter)
+
+		if err == nil {
+			ds.idToNamespaceFilterCache.Add(cluster.GetId(), compiledFilter)
+		} else {
+			log.Errorf("Could not compile filter regexp: %v", err)
+		}
+	} else {
+		// We got empty filter updating the cluster. Make sure the cache is
+		// invalidated.
+		ds.idToNamespaceFilterCache.Remove(cluster.GetId())
+	}
 	return nil
 }
 
@@ -1097,7 +1150,7 @@ func normalizeCluster(cluster *storage.Cluster) error {
 }
 
 func validateInput(cluster *storage.Cluster) error {
-	return clusterValidation.Validate(cluster).ToError()
+	return clusterPkg.Validate(cluster).ToError()
 }
 
 // addDefaults enriches the provided non-nil cluster object with defaults for

--- a/central/cluster/datastore/datastore_impl_test.go
+++ b/central/cluster/datastore/datastore_impl_test.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"errors"
+	"regexp"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	serviceAccountDataStoreMocks "github.com/stackrox/rox/central/serviceaccount/datastore/mocks"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	clusterPkg "github.com/stackrox/rox/pkg/cluster"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
@@ -129,12 +131,18 @@ func (s *clusterDataStoreTestSuite) SetupTest() {
 		networkBaselineMgr:        s.networkBaselineMgr,
 		compliancePruner:          s.compliancePruner,
 		idToNameCache:             simplecache.New(),
+		idToNamespaceFilterCache:  simplecache.New(),
 		nameToIDCache:             simplecache.New(),
 	}
 }
 
 func (s *clusterDataStoreTestSuite) TearDownTest() {
 	s.mockCtrl.Finish()
+
+	// reset caches
+	s.datastore.idToNameCache = simplecache.New()
+	s.datastore.idToNamespaceFilterCache = simplecache.New()
+	s.datastore.nameToIDCache = simplecache.New()
 }
 
 type lookupResult struct {
@@ -825,4 +833,169 @@ func (s *clusterDataStoreTestSuite) TestGetClusterLabels() {
 			}
 		})
 	}
+}
+
+func (s *clusterDataStoreTestSuite) TestProcessMatching() {
+	clusterID := fixtureconsts.Cluster1
+	testCluster := &storage.Cluster{
+		Id:        clusterID,
+		Name:      "test",
+		ManagedBy: storage.ManagerType_MANAGER_TYPE_HELM_CHART,
+		HelmConfig: &storage.CompleteClusterConfig{
+			DynamicConfig: &storage.DynamicClusterConfig{
+				ProcessIndicators: &storage.DynamicClusterConfig_ProcessIndicatorsConfig{
+					ExcludeNamespaceFilter: "test-.*",
+					NoPersistence:          false,
+				},
+			},
+		},
+	}
+
+	ctx := sac.WithAllAccess(s.T().Context())
+
+	// populate regexp cache
+	filter := clusterPkg.GetNamespaceFilter(testCluster)
+	s.datastore.idToNamespaceFilterCache.Add(clusterID, regexp.MustCompile(*filter))
+
+	indicator := &storage.ProcessIndicator{
+		Id:            uuid.NewV4().String(),
+		DeploymentId:  uuid.NewV4().String(),
+		ContainerName: uuid.NewV4().String(),
+		PodId:         uuid.NewV4().String(),
+		ClusterId:     clusterID,
+		Namespace:     "test-namespace",
+	}
+
+	// The process with matching namespace should be found
+	match, err := s.datastore.MatchProcessIndicator(ctx, indicator)
+	s.NoError(err)
+	assert.True(s.T(), match)
+
+	// We change the namespace to not match anymore, and the process passes
+	indicator.Namespace = "other-namespace"
+	match, err = s.datastore.MatchProcessIndicator(ctx, indicator)
+	s.NoError(err)
+	assert.False(s.T(), match)
+
+	// We change the namespace to match the openshift pattern,
+	// and ask to exclude it
+	indicator.Namespace = "openshift-test"
+	testCluster.HelmConfig.DynamicConfig.ProcessIndicators.ExcludeOpenshiftNs = true
+
+	// We need to update the cache to take persistence into account
+	filter = clusterPkg.GetNamespaceFilter(testCluster)
+	s.datastore.idToNamespaceFilterCache.Add(clusterID, regexp.MustCompile(*filter))
+
+	match, err = s.datastore.MatchProcessIndicator(ctx, indicator)
+	s.NoError(err)
+	assert.True(s.T(), match)
+
+	// No matter how the namespace looks like, if no persistence is requested,
+	// the process will match
+	indicator.Namespace = "something-completely-different"
+	testCluster.HelmConfig.DynamicConfig.ProcessIndicators.NoPersistence = true
+
+	// We need to update the cache to take persistence into account
+	filter = clusterPkg.GetNamespaceFilter(testCluster)
+	s.datastore.idToNamespaceFilterCache.Add(clusterID, regexp.MustCompile(*filter))
+
+	match, err = s.datastore.MatchProcessIndicator(ctx, indicator)
+	s.NoError(err)
+	assert.True(s.T(), match)
+}
+
+func (s *clusterDataStoreTestSuite) TestUpdateCluster() {
+	clusterID := fixtureconsts.Cluster1
+	testCluster := &storage.Cluster{
+		Id:        clusterID,
+		Name:      "test",
+		ManagedBy: storage.ManagerType_MANAGER_TYPE_HELM_CHART,
+		MainImage: "docker.io/stackrox/rox:latest",
+		HelmConfig: &storage.CompleteClusterConfig{
+			DynamicConfig: &storage.DynamicClusterConfig{
+				ProcessIndicators: &storage.DynamicClusterConfig_ProcessIndicatorsConfig{
+					ExcludeNamespaceFilter: "test-.*",
+					NoPersistence:          false,
+				},
+			},
+		},
+	}
+
+	ctx := sac.WithAllAccess(s.T().Context())
+
+	s.clusterStore.EXPECT().
+		Upsert(gomock.Any(), gomock.Any()).
+		Return(nil)
+
+	err := s.datastore.updateClusterNoLock(ctx, testCluster)
+	s.NoError(err)
+
+	filter, ok := s.datastore.idToNamespaceFilterCache.Get(clusterID)
+	assert.True(s.T(), ok)
+	assert.Equal(s.T(), filter.(*regexp.Regexp).String(), "test-.*")
+}
+
+func (s *clusterDataStoreTestSuite) TestUpdateClusterIncorrectFilter() {
+	clusterID := fixtureconsts.Cluster1
+	testCluster := &storage.Cluster{
+		Id:        clusterID,
+		Name:      "test",
+		ManagedBy: storage.ManagerType_MANAGER_TYPE_HELM_CHART,
+		MainImage: "docker.io/stackrox/rox:latest",
+		HelmConfig: &storage.CompleteClusterConfig{
+			DynamicConfig: &storage.DynamicClusterConfig{
+				ProcessIndicators: &storage.DynamicClusterConfig_ProcessIndicatorsConfig{
+					ExcludeNamespaceFilter: "[",
+					NoPersistence:          false,
+				},
+			},
+		},
+	}
+
+	ctx := sac.WithAllAccess(s.T().Context())
+
+	s.clusterStore.EXPECT().
+		Upsert(gomock.Any(), gomock.Any()).
+		Return(nil)
+
+	err := s.datastore.updateClusterNoLock(ctx, testCluster)
+	s.NoError(err)
+
+	filter, ok := s.datastore.idToNamespaceFilterCache.Get(clusterID)
+	assert.False(s.T(), ok)
+	assert.Nil(s.T(), filter)
+}
+
+func (s *clusterDataStoreTestSuite) TestUpdateClusterCleanupCache() {
+	clusterID := fixtureconsts.Cluster1
+	testCluster := &storage.Cluster{
+		Id:        clusterID,
+		Name:      "test",
+		ManagedBy: storage.ManagerType_MANAGER_TYPE_HELM_CHART,
+		MainImage: "docker.io/stackrox/rox:latest",
+		HelmConfig: &storage.CompleteClusterConfig{
+			DynamicConfig: &storage.DynamicClusterConfig{
+				ProcessIndicators: &storage.DynamicClusterConfig_ProcessIndicatorsConfig{
+					ExcludeNamespaceFilter: "",
+					NoPersistence:          false,
+				},
+			},
+		},
+	}
+
+	ctx := sac.WithAllAccess(s.T().Context())
+
+	s.clusterStore.EXPECT().
+		Upsert(gomock.Any(), gomock.Any()).
+		Return(nil)
+
+	// populate regexp cache
+	s.datastore.idToNamespaceFilterCache.Add(clusterID, regexp.MustCompile("test-.*"))
+
+	err := s.datastore.updateClusterNoLock(ctx, testCluster)
+	s.NoError(err)
+
+	filter, ok := s.datastore.idToNamespaceFilterCache.Get(clusterID)
+	assert.False(s.T(), ok)
+	assert.Nil(s.T(), filter)
 }

--- a/central/cluster/datastore/mocks/datastore.go
+++ b/central/cluster/datastore/mocks/datastore.go
@@ -198,6 +198,21 @@ func (mr *MockDataStoreMockRecorder) LookupOrCreateClusterFromConfig(ctx, cluste
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupOrCreateClusterFromConfig", reflect.TypeOf((*MockDataStore)(nil).LookupOrCreateClusterFromConfig), ctx, clusterID, bundleID, hello)
 }
 
+// MatchProcessIndicator mocks base method.
+func (m *MockDataStore) MatchProcessIndicator(ctx context.Context, indicator *storage.ProcessIndicator) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchProcessIndicator", ctx, indicator)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MatchProcessIndicator indicates an expected call of MatchProcessIndicator.
+func (mr *MockDataStoreMockRecorder) MatchProcessIndicator(ctx, indicator any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchProcessIndicator", reflect.TypeOf((*MockDataStore)(nil).MatchProcessIndicator), ctx, indicator)
+}
+
 // RemoveCluster mocks base method.
 func (m *MockDataStore) RemoveCluster(ctx context.Context, id string, done *concurrency.Signal) error {
 	m.ctrl.T.Helper()

--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -209,7 +209,8 @@ func (m *managerImpl) autoLockProcessBaselines(baselines []*storage.ProcessBasel
 	}
 }
 
-// Perhaps the cluster config should be kept in memory and calling the database should not be needed
+// Lifecycle manager uses cachedStorage for cluster datastore,
+// thus repeated calls are memoized
 func (m *managerImpl) isAutoLockEnabledForCluster(clusterId string) bool {
 	if !features.AutoLockProcessBaselines.Enabled() {
 		return false
@@ -252,7 +253,21 @@ func (m *managerImpl) flushIndicatorQueue() {
 		if m.deletedDeploymentsCache.Contains(indicator.GetDeploymentId()) {
 			continue
 		}
-		indicatorSlice = append(indicatorSlice, indicator)
+
+		match, err := m.clusterDataStore.MatchProcessIndicator(lifecycleMgrCtx, indicator)
+
+		if err != nil || !match {
+			// Add the indicator if not matching, or in the presence of an error
+			// (we consider any errors from MatchProcessIndicator as non-blocking).
+			//
+			// The only scenario when the indicator is not persisted is when it
+			// matches and we got no errors.
+			if err != nil {
+				log.Errorf("Cannot match indicator %s: %v", indicator.GetId(), err)
+			}
+
+			indicatorSlice = append(indicatorSlice, indicator)
+		}
 	}
 
 	// Index the process indicators in batch

--- a/central/detection/lifecycle/manager_impl_test.go
+++ b/central/detection/lifecycle/manager_impl_test.go
@@ -7,9 +7,12 @@ import (
 
 	"github.com/pkg/errors"
 	clusterDataStoreMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
+	"github.com/stackrox/rox/central/deployment/cache"
 	queueMocks "github.com/stackrox/rox/central/deployment/queue/mocks"
 	alertManagerMocks "github.com/stackrox/rox/central/detection/alertmanager/mocks"
 	processBaselineDataStoreMocks "github.com/stackrox/rox/central/processbaseline/datastore/mocks"
+	processIndicatorsDataStoreMocks "github.com/stackrox/rox/central/processindicator/datastore/mocks"
+	piFilter "github.com/stackrox/rox/central/processindicator/filter"
 	reprocessorMocks "github.com/stackrox/rox/central/reprocessor/mocks"
 	connectionMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
 	"github.com/stackrox/rox/generated/storage"
@@ -17,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stackrox/rox/pkg/process/filter"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/set"
@@ -82,6 +86,8 @@ type ManagerTestSuite struct {
 	mockCtrl                   *gomock.Controller
 	connectionManager          *connectionMocks.MockManager
 	cluster                    *clusterDataStoreMocks.MockDataStore
+	indicators                 *processIndicatorsDataStoreMocks.MockDataStore
+	filter                     filter.Filter
 }
 
 func (suite *ManagerTestSuite) SetupTest() {
@@ -93,6 +99,8 @@ func (suite *ManagerTestSuite) SetupTest() {
 	suite.deploymentObservationQueue = queueMocks.NewMockDeploymentObservationQueue(suite.mockCtrl)
 	suite.connectionManager = connectionMocks.NewMockManager(suite.mockCtrl)
 	suite.cluster = clusterDataStoreMocks.NewMockDataStore(suite.mockCtrl)
+	suite.filter = piFilter.Singleton()
+	suite.indicators = processIndicatorsDataStoreMocks.NewMockDataStore(suite.mockCtrl)
 
 	suite.manager = &managerImpl{
 		baselines:                  suite.baselines,
@@ -101,11 +109,21 @@ func (suite *ManagerTestSuite) SetupTest() {
 		deploymentObservationQueue: suite.deploymentObservationQueue,
 		connectionManager:          suite.connectionManager,
 		clusterDataStore:           suite.cluster,
+		processFilter:              suite.filter,
+		processesDataStore:         suite.indicators,
+		queuedIndicators:           make(map[string]*storage.ProcessIndicator),
+		deletedDeploymentsCache:    cache.DeletedDeploymentsSingleton(),
 	}
 }
 
 func (suite *ManagerTestSuite) TearDownTest() {
 	suite.mockCtrl.Finish()
+
+	// reset the state
+	suite.filter = piFilter.Singleton()
+	suite.manager.processFilter = suite.filter
+	suite.manager.queuedIndicators = make(map[string]*storage.ProcessIndicator)
+	suite.manager.deletedDeploymentsCache = cache.DeletedDeploymentsSingleton()
 }
 
 func makeIndicator() (*storage.ProcessBaselineKey, *storage.ProcessIndicator) {
@@ -330,4 +348,47 @@ func (suite *ManagerTestSuite) TestAutoLockProcessBaselinesNoCluster() {
 	suite.cluster.EXPECT().GetCluster(gomock.Any(), clusterId).Return(nil, false, nil)
 	enabled := suite.manager.isAutoLockEnabledForCluster(clusterId)
 	suite.False(enabled)
+}
+
+func (suite *ManagerTestSuite) TestFlushIndicators() {
+	_, indicator1 := makeIndicator()
+	_, indicator2 := makeIndicator()
+
+	// Make first indicator to match and be filtered out
+	suite.cluster.EXPECT().MatchProcessIndicator(gomock.Any(), indicator1).
+		Return(true, nil)
+
+	// The second indicator should pass through
+	suite.cluster.EXPECT().MatchProcessIndicator(gomock.Any(), indicator2).
+		Return(false, nil)
+
+	// The second indicator will cause reading of the corresponding baseline...
+	suite.baselines.EXPECT().GetProcessBaseline(gomock.Any(), gomock.Any()).
+		Return(nil, false, nil)
+
+	// ... as well as new deployment in the observation queue ...
+	suite.deploymentObservationQueue.EXPECT().
+		InObservation(gomock.Any())
+
+	// ... and update of the corresponding baseline
+	suite.baselines.EXPECT().UpsertProcessBaseline(
+		gomock.Any(), gomock.Any(), gomock.Any(), true, true).
+		Return(nil, nil)
+
+	// Only the second indicator is getting stored
+	suite.indicators.EXPECT().
+		AddProcessIndicators(gomock.Any(), indicator2).
+		Return(nil)
+
+	// Unfortunately it's not easy to test new indicators in the lifecycle
+	// manager at the higher level, since flushIndicatorQueue is executed in a
+	// separate go routine, which makes mock expectation checking complicated
+	// (we have to somehow wait for this routine to end). Thus we test at
+	// flushIndicatorQueue level, and manually prepare the indicator queue.
+	//
+	// TODO: Is it possible to incorporate testing/synctest here on top of testify?
+	suite.manager.queuedIndicators[indicator1.GetId()] = indicator1
+	suite.manager.queuedIndicators[indicator2.GetId()] = indicator2
+
+	suite.manager.flushIndicatorQueue()
 }

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -609,7 +609,13 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"admissionControllerConfig: AdmissionControllerConfig",
 		"autoLockProcessBaselinesConfig: AutoLockProcessBaselinesConfig",
 		"disableAuditLogs: Boolean!",
+		"processIndicators: DynamicClusterConfig_ProcessIndicatorsConfig",
 		"registryOverride: String!",
+	}))
+	utils.Must(builder.AddType("DynamicClusterConfig_ProcessIndicatorsConfig", []string{
+		"excludeNamespaceFilter: String!",
+		"excludeOpenshiftNs: Boolean!",
+		"noPersistence: Boolean!",
 	}))
 	utils.Must(builder.AddType("EPSS", []string{
 		"epssPercentile: Float!",
@@ -7390,8 +7396,70 @@ func (resolver *dynamicClusterConfigResolver) DisableAuditLogs(ctx context.Conte
 	return value
 }
 
+func (resolver *dynamicClusterConfigResolver) ProcessIndicators(ctx context.Context) (*dynamicClusterConfig_ProcessIndicatorsConfigResolver, error) {
+	value := resolver.data.GetProcessIndicators()
+	return resolver.root.wrapDynamicClusterConfig_ProcessIndicatorsConfig(value, true, nil)
+}
+
 func (resolver *dynamicClusterConfigResolver) RegistryOverride(ctx context.Context) string {
 	value := resolver.data.GetRegistryOverride()
+	return value
+}
+
+type dynamicClusterConfig_ProcessIndicatorsConfigResolver struct {
+	ctx  context.Context
+	root *Resolver
+	data *storage.DynamicClusterConfig_ProcessIndicatorsConfig
+}
+
+func (resolver *Resolver) wrapDynamicClusterConfig_ProcessIndicatorsConfig(value *storage.DynamicClusterConfig_ProcessIndicatorsConfig, ok bool, err error) (*dynamicClusterConfig_ProcessIndicatorsConfigResolver, error) {
+	if !ok || err != nil || value == nil {
+		return nil, err
+	}
+	return &dynamicClusterConfig_ProcessIndicatorsConfigResolver{root: resolver, data: value}, nil
+}
+
+func (resolver *Resolver) wrapDynamicClusterConfig_ProcessIndicatorsConfigs(values []*storage.DynamicClusterConfig_ProcessIndicatorsConfig, err error) ([]*dynamicClusterConfig_ProcessIndicatorsConfigResolver, error) {
+	if err != nil || len(values) == 0 {
+		return nil, err
+	}
+	output := make([]*dynamicClusterConfig_ProcessIndicatorsConfigResolver, len(values))
+	for i, v := range values {
+		output[i] = &dynamicClusterConfig_ProcessIndicatorsConfigResolver{root: resolver, data: v}
+	}
+	return output, nil
+}
+
+func (resolver *Resolver) wrapDynamicClusterConfig_ProcessIndicatorsConfigWithContext(ctx context.Context, value *storage.DynamicClusterConfig_ProcessIndicatorsConfig, ok bool, err error) (*dynamicClusterConfig_ProcessIndicatorsConfigResolver, error) {
+	if !ok || err != nil || value == nil {
+		return nil, err
+	}
+	return &dynamicClusterConfig_ProcessIndicatorsConfigResolver{ctx: ctx, root: resolver, data: value}, nil
+}
+
+func (resolver *Resolver) wrapDynamicClusterConfig_ProcessIndicatorsConfigsWithContext(ctx context.Context, values []*storage.DynamicClusterConfig_ProcessIndicatorsConfig, err error) ([]*dynamicClusterConfig_ProcessIndicatorsConfigResolver, error) {
+	if err != nil || len(values) == 0 {
+		return nil, err
+	}
+	output := make([]*dynamicClusterConfig_ProcessIndicatorsConfigResolver, len(values))
+	for i, v := range values {
+		output[i] = &dynamicClusterConfig_ProcessIndicatorsConfigResolver{ctx: ctx, root: resolver, data: v}
+	}
+	return output, nil
+}
+
+func (resolver *dynamicClusterConfig_ProcessIndicatorsConfigResolver) ExcludeNamespaceFilter(ctx context.Context) string {
+	value := resolver.data.GetExcludeNamespaceFilter()
+	return value
+}
+
+func (resolver *dynamicClusterConfig_ProcessIndicatorsConfigResolver) ExcludeOpenshiftNs(ctx context.Context) bool {
+	value := resolver.data.GetExcludeOpenshiftNs()
+	return value
+}
+
+func (resolver *dynamicClusterConfig_ProcessIndicatorsConfigResolver) NoPersistence(ctx context.Context) bool {
+	value := resolver.data.GetNoPersistence()
 	return value
 }
 

--- a/generated/api/v1/cluster_service.swagger.json
+++ b/generated/api/v1/cluster_service.swagger.json
@@ -360,6 +360,24 @@
       },
       "title": "Next tag: 33"
     },
+    "DynamicClusterConfigProcessIndicatorsConfig": {
+      "type": "object",
+      "properties": {
+        "noPersistence": {
+          "type": "boolean",
+          "description": "Specifies whether to persist process indicators independently from\nother configuratons. If true, the filters above are ignored, and no\nprocess indicators are persisted. If false (the protobuf default for\nbooleans), process indicators are persisted according to\nnamespace_filter and exclude_openshift_ns."
+        },
+        "excludeNamespaceFilter": {
+          "type": "string",
+          "description": "A regex specifying to not persist process indicators from specified\nnamespaces. E.g. namespace_filter: \"test-.*\" will instruct Central to\nnot persist any process indicator coming from the \"test-filtering\"\nnamespace."
+        },
+        "excludeOpenshiftNs": {
+          "type": "boolean",
+          "description": "A short-cut to not persist process indicators from openshift namespaces.\nEquivalent to namespace_filter: \"openshift-.*\"."
+        }
+      },
+      "title": "Configure per-namespace persistence for ProcessIndicators"
+    },
     "UpgradeProcessStatusUpgradeProcessType": {
       "type": "string",
       "enum": [
@@ -806,6 +824,9 @@
         },
         "autoLockProcessBaselinesConfig": {
           "$ref": "#/definitions/storageAutoLockProcessBaselinesConfig"
+        },
+        "processIndicators": {
+          "$ref": "#/definitions/DynamicClusterConfigProcessIndicatorsConfig"
         }
       },
       "description": "The difference between Static and Dynamic cluster config is that Dynamic values are sent over the Central to Sensor gRPC connection. This has the benefit of allowing for \"hot reloading\" of values without restarting Secured cluster components."

--- a/generated/storage/cluster.pb.go
+++ b/generated/storage/cluster.pb.go
@@ -1223,11 +1223,12 @@ func (x *AutoLockProcessBaselinesConfig) GetEnabled() bool {
 
 // The difference between Static and Dynamic cluster config is that Dynamic values are sent over the Central to Sensor gRPC connection. This has the benefit of allowing for "hot reloading" of values without restarting Secured cluster components.
 type DynamicClusterConfig struct {
-	state                          protoimpl.MessageState          `protogen:"open.v1"`
-	AdmissionControllerConfig      *AdmissionControllerConfig      `protobuf:"bytes,1,opt,name=admission_controller_config,json=admissionControllerConfig,proto3" json:"admission_controller_config,omitempty"`
-	RegistryOverride               string                          `protobuf:"bytes,2,opt,name=registry_override,json=registryOverride,proto3" json:"registry_override,omitempty"`
-	DisableAuditLogs               bool                            `protobuf:"varint,3,opt,name=disable_audit_logs,json=disableAuditLogs,proto3" json:"disable_audit_logs,omitempty"`
-	AutoLockProcessBaselinesConfig *AutoLockProcessBaselinesConfig `protobuf:"bytes,4,opt,name=auto_lock_process_baselines_config,json=autoLockProcessBaselinesConfig,proto3" json:"auto_lock_process_baselines_config,omitempty"`
+	state                          protoimpl.MessageState                        `protogen:"open.v1"`
+	AdmissionControllerConfig      *AdmissionControllerConfig                    `protobuf:"bytes,1,opt,name=admission_controller_config,json=admissionControllerConfig,proto3" json:"admission_controller_config,omitempty"`
+	RegistryOverride               string                                        `protobuf:"bytes,2,opt,name=registry_override,json=registryOverride,proto3" json:"registry_override,omitempty"`
+	DisableAuditLogs               bool                                          `protobuf:"varint,3,opt,name=disable_audit_logs,json=disableAuditLogs,proto3" json:"disable_audit_logs,omitempty"`
+	AutoLockProcessBaselinesConfig *AutoLockProcessBaselinesConfig               `protobuf:"bytes,4,opt,name=auto_lock_process_baselines_config,json=autoLockProcessBaselinesConfig,proto3" json:"auto_lock_process_baselines_config,omitempty"`
+	ProcessIndicators              *DynamicClusterConfig_ProcessIndicatorsConfig `protobuf:"bytes,5,opt,name=process_indicators,json=processIndicators,proto3" json:"process_indicators,omitempty"`
 	unknownFields                  protoimpl.UnknownFields
 	sizeCache                      protoimpl.SizeCache
 }
@@ -1286,6 +1287,13 @@ func (x *DynamicClusterConfig) GetDisableAuditLogs() bool {
 func (x *DynamicClusterConfig) GetAutoLockProcessBaselinesConfig() *AutoLockProcessBaselinesConfig {
 	if x != nil {
 		return x.AutoLockProcessBaselinesConfig
+	}
+	return nil
+}
+
+func (x *DynamicClusterConfig) GetProcessIndicators() *DynamicClusterConfig_ProcessIndicatorsConfig {
+	if x != nil {
+		return x.ProcessIndicators
 	}
 	return nil
 }
@@ -2569,6 +2577,78 @@ type ScannerHealthInfo_TotalReadyDbPods struct {
 
 func (*ScannerHealthInfo_TotalReadyDbPods) isScannerHealthInfo_TotalReadyDbPodsOpt() {}
 
+// Configure per-namespace persistence for ProcessIndicators
+type DynamicClusterConfig_ProcessIndicatorsConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Specifies whether to persist process indicators independently from
+	// other configuratons. If true, the filters above are ignored, and no
+	// process indicators are persisted. If false (the protobuf default for
+	// booleans), process indicators are persisted according to
+	// namespace_filter and exclude_openshift_ns.
+	NoPersistence bool `protobuf:"varint,1,opt,name=no_persistence,json=noPersistence,proto3" json:"no_persistence,omitempty"`
+	// A regex specifying to not persist process indicators from specified
+	// namespaces. E.g. namespace_filter: "test-.*" will instruct Central to
+	// not persist any process indicator coming from the "test-filtering"
+	// namespace.
+	ExcludeNamespaceFilter string `protobuf:"bytes,2,opt,name=exclude_namespace_filter,json=excludeNamespaceFilter,proto3" json:"exclude_namespace_filter,omitempty"`
+	// A short-cut to not persist process indicators from openshift namespaces.
+	// Equivalent to namespace_filter: "openshift-.*".
+	ExcludeOpenshiftNs bool `protobuf:"varint,3,opt,name=exclude_openshift_ns,json=excludeOpenshiftNs,proto3" json:"exclude_openshift_ns,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *DynamicClusterConfig_ProcessIndicatorsConfig) Reset() {
+	*x = DynamicClusterConfig_ProcessIndicatorsConfig{}
+	mi := &file_storage_cluster_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DynamicClusterConfig_ProcessIndicatorsConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DynamicClusterConfig_ProcessIndicatorsConfig) ProtoMessage() {}
+
+func (x *DynamicClusterConfig_ProcessIndicatorsConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_storage_cluster_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DynamicClusterConfig_ProcessIndicatorsConfig.ProtoReflect.Descriptor instead.
+func (*DynamicClusterConfig_ProcessIndicatorsConfig) Descriptor() ([]byte, []int) {
+	return file_storage_cluster_proto_rawDescGZIP(), []int{10, 0}
+}
+
+func (x *DynamicClusterConfig_ProcessIndicatorsConfig) GetNoPersistence() bool {
+	if x != nil {
+		return x.NoPersistence
+	}
+	return false
+}
+
+func (x *DynamicClusterConfig_ProcessIndicatorsConfig) GetExcludeNamespaceFilter() string {
+	if x != nil {
+		return x.ExcludeNamespaceFilter
+	}
+	return ""
+}
+
+func (x *DynamicClusterConfig_ProcessIndicatorsConfig) GetExcludeOpenshiftNs() bool {
+	if x != nil {
+		return x.ExcludeOpenshiftNs
+	}
+	return false
+}
+
 type ClusterUpgradeStatus_UpgradeProcessStatus struct {
 	state         protoimpl.MessageState                                       `protogen:"open.v1"`
 	Active        bool                                                         `protobuf:"varint,1,opt,name=active,proto3" json:"active,omitempty"`
@@ -2584,7 +2664,7 @@ type ClusterUpgradeStatus_UpgradeProcessStatus struct {
 
 func (x *ClusterUpgradeStatus_UpgradeProcessStatus) Reset() {
 	*x = ClusterUpgradeStatus_UpgradeProcessStatus{}
-	mi := &file_storage_cluster_proto_msgTypes[26]
+	mi := &file_storage_cluster_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2596,7 +2676,7 @@ func (x *ClusterUpgradeStatus_UpgradeProcessStatus) String() string {
 func (*ClusterUpgradeStatus_UpgradeProcessStatus) ProtoMessage() {}
 
 func (x *ClusterUpgradeStatus_UpgradeProcessStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_storage_cluster_proto_msgTypes[26]
+	mi := &file_storage_cluster_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2728,12 +2808,17 @@ const file_storage_cluster_proto_rawDesc = "" +
 	" \x01(\bR\x19admissionControllerEvents\x12J\n" +
 	"\"admission_controller_fail_on_error\x18\v \x01(\bR\x1eadmissionControllerFailOnError\":\n" +
 	"\x1eAutoLockProcessBaselinesConfig\x12\x18\n" +
-	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xca\x02\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xdf\x04\n" +
 	"\x14DynamicClusterConfig\x12b\n" +
 	"\x1badmission_controller_config\x18\x01 \x01(\v2\".storage.AdmissionControllerConfigR\x19admissionControllerConfig\x12+\n" +
 	"\x11registry_override\x18\x02 \x01(\tR\x10registryOverride\x12,\n" +
 	"\x12disable_audit_logs\x18\x03 \x01(\bR\x10disableAuditLogs\x12s\n" +
-	"\"auto_lock_process_baselines_config\x18\x04 \x01(\v2'.storage.AutoLockProcessBaselinesConfigR\x1eautoLockProcessBaselinesConfig\"\xeb\x02\n" +
+	"\"auto_lock_process_baselines_config\x18\x04 \x01(\v2'.storage.AutoLockProcessBaselinesConfigR\x1eautoLockProcessBaselinesConfig\x12d\n" +
+	"\x12process_indicators\x18\x05 \x01(\v25.storage.DynamicClusterConfig.ProcessIndicatorsConfigR\x11processIndicators\x1a\xac\x01\n" +
+	"\x17ProcessIndicatorsConfig\x12%\n" +
+	"\x0eno_persistence\x18\x01 \x01(\bR\rnoPersistence\x128\n" +
+	"\x18exclude_namespace_filter\x18\x02 \x01(\tR\x16excludeNamespaceFilter\x120\n" +
+	"\x14exclude_openshift_ns\x18\x03 \x01(\bR\x12excludeOpenshiftNs\"\xeb\x02\n" +
 	"\x15CompleteClusterConfig\x12D\n" +
 	"\x0edynamic_config\x18\x01 \x01(\v2\x1d.storage.DynamicClusterConfigR\rdynamicConfig\x12A\n" +
 	"\rstatic_config\x18\x02 \x01(\v2\x1c.storage.StaticClusterConfigR\fstaticConfig\x12-\n" +
@@ -2915,7 +3000,7 @@ func file_storage_cluster_proto_rawDescGZIP() []byte {
 }
 
 var file_storage_cluster_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_storage_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
+var file_storage_cluster_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
 var file_storage_cluster_proto_goTypes = []any{
 	(ClusterType)(0),                        // 0: storage.ClusterType
 	(CollectionMethod)(0),                   // 1: storage.CollectionMethod
@@ -2948,11 +3033,12 @@ var file_storage_cluster_proto_goTypes = []any{
 	(*CollectorHealthInfo)(nil),                                       // 28: storage.CollectorHealthInfo
 	(*AdmissionControlHealthInfo)(nil),                                // 29: storage.AdmissionControlHealthInfo
 	(*ScannerHealthInfo)(nil),                                         // 30: storage.ScannerHealthInfo
-	nil,                                                               // 31: storage.CompleteClusterConfig.ClusterLabelsEntry
-	nil,                                                               // 32: storage.Cluster.LabelsEntry
-	nil,                                                               // 33: storage.Cluster.AuditLogStateEntry
-	(*ClusterUpgradeStatus_UpgradeProcessStatus)(nil),                 // 34: storage.ClusterUpgradeStatus.UpgradeProcessStatus
-	(*timestamppb.Timestamp)(nil),                                     // 35: google.protobuf.Timestamp
+	(*DynamicClusterConfig_ProcessIndicatorsConfig)(nil),              // 31: storage.DynamicClusterConfig.ProcessIndicatorsConfig
+	nil, // 32: storage.CompleteClusterConfig.ClusterLabelsEntry
+	nil, // 33: storage.Cluster.LabelsEntry
+	nil, // 34: storage.Cluster.AuditLogStateEntry
+	(*ClusterUpgradeStatus_UpgradeProcessStatus)(nil), // 35: storage.ClusterUpgradeStatus.UpgradeProcessStatus
+	(*timestamppb.Timestamp)(nil),                     // 36: google.protobuf.Timestamp
 }
 var file_storage_cluster_proto_depIdxs = []int32{
 	3,  // 0: storage.ClusterMetadata.type:type_name -> storage.ClusterMetadata.Type
@@ -2960,56 +3046,57 @@ var file_storage_cluster_proto_depIdxs = []int32{
 	10, // 2: storage.ProviderMetadata.aws:type_name -> storage.AWSProviderMetadata
 	11, // 3: storage.ProviderMetadata.azure:type_name -> storage.AzureProviderMetadata
 	8,  // 4: storage.ProviderMetadata.cluster:type_name -> storage.ClusterMetadata
-	35, // 5: storage.OrchestratorMetadata.build_date:type_name -> google.protobuf.Timestamp
+	36, // 5: storage.OrchestratorMetadata.build_date:type_name -> google.protobuf.Timestamp
 	0,  // 6: storage.StaticClusterConfig.type:type_name -> storage.ClusterType
 	1,  // 7: storage.StaticClusterConfig.collection_method:type_name -> storage.CollectionMethod
 	15, // 8: storage.StaticClusterConfig.tolerations_config:type_name -> storage.TolerationsConfig
 	14, // 9: storage.DynamicClusterConfig.admission_controller_config:type_name -> storage.AdmissionControllerConfig
 	17, // 10: storage.DynamicClusterConfig.auto_lock_process_baselines_config:type_name -> storage.AutoLockProcessBaselinesConfig
-	18, // 11: storage.CompleteClusterConfig.dynamic_config:type_name -> storage.DynamicClusterConfig
-	16, // 12: storage.CompleteClusterConfig.static_config:type_name -> storage.StaticClusterConfig
-	31, // 13: storage.CompleteClusterConfig.cluster_labels:type_name -> storage.CompleteClusterConfig.ClusterLabelsEntry
-	0,  // 14: storage.Cluster.type:type_name -> storage.ClusterType
-	32, // 15: storage.Cluster.labels:type_name -> storage.Cluster.LabelsEntry
-	1,  // 16: storage.Cluster.collection_method:type_name -> storage.CollectionMethod
-	23, // 17: storage.Cluster.status:type_name -> storage.ClusterStatus
-	18, // 18: storage.Cluster.dynamic_config:type_name -> storage.DynamicClusterConfig
-	15, // 19: storage.Cluster.tolerations_config:type_name -> storage.TolerationsConfig
-	27, // 20: storage.Cluster.health_status:type_name -> storage.ClusterHealthStatus
-	19, // 21: storage.Cluster.helm_config:type_name -> storage.CompleteClusterConfig
-	20, // 22: storage.Cluster.most_recent_sensor_id:type_name -> storage.SensorDeploymentIdentification
-	33, // 23: storage.Cluster.audit_log_state:type_name -> storage.Cluster.AuditLogStateEntry
-	2,  // 24: storage.Cluster.managed_by:type_name -> storage.ManagerType
-	35, // 25: storage.ClusterCertExpiryStatus.sensor_cert_expiry:type_name -> google.protobuf.Timestamp
-	35, // 26: storage.ClusterCertExpiryStatus.sensor_cert_not_before:type_name -> google.protobuf.Timestamp
-	35, // 27: storage.ClusterStatus.DEPRECATED_last_contact:type_name -> google.protobuf.Timestamp
-	12, // 28: storage.ClusterStatus.provider_metadata:type_name -> storage.ProviderMetadata
-	13, // 29: storage.ClusterStatus.orchestrator_metadata:type_name -> storage.OrchestratorMetadata
-	24, // 30: storage.ClusterStatus.upgrade_status:type_name -> storage.ClusterUpgradeStatus
-	22, // 31: storage.ClusterStatus.cert_expiry_status:type_name -> storage.ClusterCertExpiryStatus
-	4,  // 32: storage.ClusterUpgradeStatus.upgradability:type_name -> storage.ClusterUpgradeStatus.Upgradability
-	34, // 33: storage.ClusterUpgradeStatus.most_recent_process:type_name -> storage.ClusterUpgradeStatus.UpgradeProcessStatus
-	6,  // 34: storage.UpgradeProgress.upgrade_state:type_name -> storage.UpgradeProgress.UpgradeState
-	35, // 35: storage.UpgradeProgress.since:type_name -> google.protobuf.Timestamp
-	35, // 36: storage.AuditLogFileState.collect_logs_since:type_name -> google.protobuf.Timestamp
-	28, // 37: storage.ClusterHealthStatus.collector_health_info:type_name -> storage.CollectorHealthInfo
-	29, // 38: storage.ClusterHealthStatus.admission_control_health_info:type_name -> storage.AdmissionControlHealthInfo
-	30, // 39: storage.ClusterHealthStatus.scanner_health_info:type_name -> storage.ScannerHealthInfo
-	7,  // 40: storage.ClusterHealthStatus.sensor_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	7,  // 41: storage.ClusterHealthStatus.collector_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	7,  // 42: storage.ClusterHealthStatus.overall_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	7,  // 43: storage.ClusterHealthStatus.admission_control_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	7,  // 44: storage.ClusterHealthStatus.scanner_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	35, // 45: storage.ClusterHealthStatus.last_contact:type_name -> google.protobuf.Timestamp
-	26, // 46: storage.Cluster.AuditLogStateEntry.value:type_name -> storage.AuditLogFileState
-	35, // 47: storage.ClusterUpgradeStatus.UpgradeProcessStatus.initiated_at:type_name -> google.protobuf.Timestamp
-	25, // 48: storage.ClusterUpgradeStatus.UpgradeProcessStatus.progress:type_name -> storage.UpgradeProgress
-	5,  // 49: storage.ClusterUpgradeStatus.UpgradeProcessStatus.type:type_name -> storage.ClusterUpgradeStatus.UpgradeProcessStatus.UpgradeProcessType
-	50, // [50:50] is the sub-list for method output_type
-	50, // [50:50] is the sub-list for method input_type
-	50, // [50:50] is the sub-list for extension type_name
-	50, // [50:50] is the sub-list for extension extendee
-	0,  // [0:50] is the sub-list for field type_name
+	31, // 11: storage.DynamicClusterConfig.process_indicators:type_name -> storage.DynamicClusterConfig.ProcessIndicatorsConfig
+	18, // 12: storage.CompleteClusterConfig.dynamic_config:type_name -> storage.DynamicClusterConfig
+	16, // 13: storage.CompleteClusterConfig.static_config:type_name -> storage.StaticClusterConfig
+	32, // 14: storage.CompleteClusterConfig.cluster_labels:type_name -> storage.CompleteClusterConfig.ClusterLabelsEntry
+	0,  // 15: storage.Cluster.type:type_name -> storage.ClusterType
+	33, // 16: storage.Cluster.labels:type_name -> storage.Cluster.LabelsEntry
+	1,  // 17: storage.Cluster.collection_method:type_name -> storage.CollectionMethod
+	23, // 18: storage.Cluster.status:type_name -> storage.ClusterStatus
+	18, // 19: storage.Cluster.dynamic_config:type_name -> storage.DynamicClusterConfig
+	15, // 20: storage.Cluster.tolerations_config:type_name -> storage.TolerationsConfig
+	27, // 21: storage.Cluster.health_status:type_name -> storage.ClusterHealthStatus
+	19, // 22: storage.Cluster.helm_config:type_name -> storage.CompleteClusterConfig
+	20, // 23: storage.Cluster.most_recent_sensor_id:type_name -> storage.SensorDeploymentIdentification
+	34, // 24: storage.Cluster.audit_log_state:type_name -> storage.Cluster.AuditLogStateEntry
+	2,  // 25: storage.Cluster.managed_by:type_name -> storage.ManagerType
+	36, // 26: storage.ClusterCertExpiryStatus.sensor_cert_expiry:type_name -> google.protobuf.Timestamp
+	36, // 27: storage.ClusterCertExpiryStatus.sensor_cert_not_before:type_name -> google.protobuf.Timestamp
+	36, // 28: storage.ClusterStatus.DEPRECATED_last_contact:type_name -> google.protobuf.Timestamp
+	12, // 29: storage.ClusterStatus.provider_metadata:type_name -> storage.ProviderMetadata
+	13, // 30: storage.ClusterStatus.orchestrator_metadata:type_name -> storage.OrchestratorMetadata
+	24, // 31: storage.ClusterStatus.upgrade_status:type_name -> storage.ClusterUpgradeStatus
+	22, // 32: storage.ClusterStatus.cert_expiry_status:type_name -> storage.ClusterCertExpiryStatus
+	4,  // 33: storage.ClusterUpgradeStatus.upgradability:type_name -> storage.ClusterUpgradeStatus.Upgradability
+	35, // 34: storage.ClusterUpgradeStatus.most_recent_process:type_name -> storage.ClusterUpgradeStatus.UpgradeProcessStatus
+	6,  // 35: storage.UpgradeProgress.upgrade_state:type_name -> storage.UpgradeProgress.UpgradeState
+	36, // 36: storage.UpgradeProgress.since:type_name -> google.protobuf.Timestamp
+	36, // 37: storage.AuditLogFileState.collect_logs_since:type_name -> google.protobuf.Timestamp
+	28, // 38: storage.ClusterHealthStatus.collector_health_info:type_name -> storage.CollectorHealthInfo
+	29, // 39: storage.ClusterHealthStatus.admission_control_health_info:type_name -> storage.AdmissionControlHealthInfo
+	30, // 40: storage.ClusterHealthStatus.scanner_health_info:type_name -> storage.ScannerHealthInfo
+	7,  // 41: storage.ClusterHealthStatus.sensor_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	7,  // 42: storage.ClusterHealthStatus.collector_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	7,  // 43: storage.ClusterHealthStatus.overall_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	7,  // 44: storage.ClusterHealthStatus.admission_control_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	7,  // 45: storage.ClusterHealthStatus.scanner_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	36, // 46: storage.ClusterHealthStatus.last_contact:type_name -> google.protobuf.Timestamp
+	26, // 47: storage.Cluster.AuditLogStateEntry.value:type_name -> storage.AuditLogFileState
+	36, // 48: storage.ClusterUpgradeStatus.UpgradeProcessStatus.initiated_at:type_name -> google.protobuf.Timestamp
+	25, // 49: storage.ClusterUpgradeStatus.UpgradeProcessStatus.progress:type_name -> storage.UpgradeProgress
+	5,  // 50: storage.ClusterUpgradeStatus.UpgradeProcessStatus.type:type_name -> storage.ClusterUpgradeStatus.UpgradeProcessStatus.UpgradeProcessType
+	51, // [51:51] is the sub-list for method output_type
+	51, // [51:51] is the sub-list for method input_type
+	51, // [51:51] is the sub-list for extension type_name
+	51, // [51:51] is the sub-list for extension extendee
+	0,  // [0:51] is the sub-list for field type_name
 }
 
 func init() { file_storage_cluster_proto_init() }
@@ -3046,7 +3133,7 @@ func file_storage_cluster_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_storage_cluster_proto_rawDesc), len(file_storage_cluster_proto_rawDesc)),
 			NumEnums:      8,
-			NumMessages:   27,
+			NumMessages:   28,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/generated/storage/cluster_vtproto.pb.go
+++ b/generated/storage/cluster_vtproto.pb.go
@@ -264,6 +264,25 @@ func (m *AutoLockProcessBaselinesConfig) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *DynamicClusterConfig_ProcessIndicatorsConfig) CloneVT() *DynamicClusterConfig_ProcessIndicatorsConfig {
+	if m == nil {
+		return (*DynamicClusterConfig_ProcessIndicatorsConfig)(nil)
+	}
+	r := new(DynamicClusterConfig_ProcessIndicatorsConfig)
+	r.NoPersistence = m.NoPersistence
+	r.ExcludeNamespaceFilter = m.ExcludeNamespaceFilter
+	r.ExcludeOpenshiftNs = m.ExcludeOpenshiftNs
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *DynamicClusterConfig_ProcessIndicatorsConfig) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *DynamicClusterConfig) CloneVT() *DynamicClusterConfig {
 	if m == nil {
 		return (*DynamicClusterConfig)(nil)
@@ -273,6 +292,7 @@ func (m *DynamicClusterConfig) CloneVT() *DynamicClusterConfig {
 	r.RegistryOverride = m.RegistryOverride
 	r.DisableAuditLogs = m.DisableAuditLogs
 	r.AutoLockProcessBaselinesConfig = m.AutoLockProcessBaselinesConfig.CloneVT()
+	r.ProcessIndicators = m.ProcessIndicators.CloneVT()
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1103,6 +1123,31 @@ func (this *AutoLockProcessBaselinesConfig) EqualMessageVT(thatMsg proto.Message
 	}
 	return this.EqualVT(that)
 }
+func (this *DynamicClusterConfig_ProcessIndicatorsConfig) EqualVT(that *DynamicClusterConfig_ProcessIndicatorsConfig) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.NoPersistence != that.NoPersistence {
+		return false
+	}
+	if this.ExcludeNamespaceFilter != that.ExcludeNamespaceFilter {
+		return false
+	}
+	if this.ExcludeOpenshiftNs != that.ExcludeOpenshiftNs {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *DynamicClusterConfig_ProcessIndicatorsConfig) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DynamicClusterConfig_ProcessIndicatorsConfig)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *DynamicClusterConfig) EqualVT(that *DynamicClusterConfig) bool {
 	if this == that {
 		return true
@@ -1119,6 +1164,9 @@ func (this *DynamicClusterConfig) EqualVT(that *DynamicClusterConfig) bool {
 		return false
 	}
 	if !this.AutoLockProcessBaselinesConfig.EqualVT(that.AutoLockProcessBaselinesConfig) {
+		return false
+	}
+	if !this.ProcessIndicators.EqualVT(that.ProcessIndicators) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -2574,6 +2622,66 @@ func (m *AutoLockProcessBaselinesConfig) MarshalToSizedBufferVT(dAtA []byte) (in
 	return len(dAtA) - i, nil
 }
 
+func (m *DynamicClusterConfig_ProcessIndicatorsConfig) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DynamicClusterConfig_ProcessIndicatorsConfig) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *DynamicClusterConfig_ProcessIndicatorsConfig) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.ExcludeOpenshiftNs {
+		i--
+		if m.ExcludeOpenshiftNs {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.ExcludeNamespaceFilter) > 0 {
+		i -= len(m.ExcludeNamespaceFilter)
+		copy(dAtA[i:], m.ExcludeNamespaceFilter)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ExcludeNamespaceFilter)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.NoPersistence {
+		i--
+		if m.NoPersistence {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *DynamicClusterConfig) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -2603,6 +2711,16 @@ func (m *DynamicClusterConfig) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.ProcessIndicators != nil {
+		size, err := m.ProcessIndicators.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x2a
 	}
 	if m.AutoLockProcessBaselinesConfig != nil {
 		size, err := m.AutoLockProcessBaselinesConfig.MarshalToSizedBufferVT(dAtA[:i])
@@ -4198,6 +4316,26 @@ func (m *AutoLockProcessBaselinesConfig) SizeVT() (n int) {
 	return n
 }
 
+func (m *DynamicClusterConfig_ProcessIndicatorsConfig) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.NoPersistence {
+		n += 2
+	}
+	l = len(m.ExcludeNamespaceFilter)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.ExcludeOpenshiftNs {
+		n += 2
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *DynamicClusterConfig) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -4217,6 +4355,10 @@ func (m *DynamicClusterConfig) SizeVT() (n int) {
 	}
 	if m.AutoLockProcessBaselinesConfig != nil {
 		l = m.AutoLockProcessBaselinesConfig.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.ProcessIndicators != nil {
+		l = m.ProcessIndicators.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -6263,6 +6405,129 @@ func (m *AutoLockProcessBaselinesConfig) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *DynamicClusterConfig_ProcessIndicatorsConfig) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DynamicClusterConfig_ProcessIndicatorsConfig: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DynamicClusterConfig_ProcessIndicatorsConfig: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NoPersistence", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.NoPersistence = bool(v != 0)
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExcludeNamespaceFilter", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ExcludeNamespaceFilter = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExcludeOpenshiftNs", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ExcludeOpenshiftNs = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *DynamicClusterConfig) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -6413,6 +6678,42 @@ func (m *DynamicClusterConfig) UnmarshalVT(dAtA []byte) error {
 				m.AutoLockProcessBaselinesConfig = &AutoLockProcessBaselinesConfig{}
 			}
 			if err := m.AutoLockProcessBaselinesConfig.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ProcessIndicators", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ProcessIndicators == nil {
+				m.ProcessIndicators = &DynamicClusterConfig_ProcessIndicatorsConfig{}
+			}
+			if err := m.ProcessIndicators.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -11309,6 +11610,133 @@ func (m *AutoLockProcessBaselinesConfig) UnmarshalVTUnsafe(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *DynamicClusterConfig_ProcessIndicatorsConfig) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DynamicClusterConfig_ProcessIndicatorsConfig: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DynamicClusterConfig_ProcessIndicatorsConfig: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NoPersistence", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.NoPersistence = bool(v != 0)
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExcludeNamespaceFilter", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ExcludeNamespaceFilter = stringValue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExcludeOpenshiftNs", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.ExcludeOpenshiftNs = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *DynamicClusterConfig) UnmarshalVTUnsafe(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -11463,6 +11891,42 @@ func (m *DynamicClusterConfig) UnmarshalVTUnsafe(dAtA []byte) error {
 				m.AutoLockProcessBaselinesConfig = &AutoLockProcessBaselinesConfig{}
 			}
 			if err := m.AutoLockProcessBaselinesConfig.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ProcessIndicators", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.ProcessIndicators == nil {
+				m.ProcessIndicators = &DynamicClusterConfig_ProcessIndicatorsConfig{}
+			}
+			if err := m.ProcessIndicators.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/pkg/cluster/filtering.go
+++ b/pkg/cluster/filtering.go
@@ -1,0 +1,52 @@
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/pointers"
+)
+
+const (
+	openshiftFilter = "^openshift$|^openshift-.*"
+	noPersistence   = ".*"
+)
+
+func GetNamespaceFilter(cluster *storage.Cluster) *string {
+	var config *storage.DynamicClusterConfig_ProcessIndicatorsConfig
+
+	if cluster.GetManagedBy() == storage.ManagerType_MANAGER_TYPE_MANUAL || cluster.GetManagedBy() == storage.ManagerType_MANAGER_TYPE_UNKNOWN {
+		config = cluster.GetDynamicConfig().GetProcessIndicators()
+	} else {
+		config = cluster.GetHelmConfig().GetDynamicConfig().GetProcessIndicators()
+	}
+
+	// No configuration for runtime data means no filter
+	if config == nil {
+		return nil
+	}
+
+	// Persistence filter has highest priority, since any other
+	// option is only its subset
+	if config.GetNoPersistence() {
+		return pointers.String(noPersistence)
+	}
+
+	filter := config.GetExcludeNamespaceFilter()
+
+	if config.GetExcludeOpenshiftNs() {
+		// Openshift exclusion filter could be combined with the custom filter
+		if filter != "" {
+			filter = fmt.Sprintf("%s|%s", filter, openshiftFilter)
+		} else {
+			filter = openshiftFilter
+		}
+	}
+
+	// If everything is present, but empty, set no filter
+	if filter == "" {
+		return nil
+	}
+
+	return pointers.String(filter)
+}

--- a/pkg/cluster/filtering_test.go
+++ b/pkg/cluster/filtering_test.go
@@ -1,0 +1,106 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/pointers"
+	"github.com/stretchr/testify/assert"
+)
+
+var cluster = &storage.Cluster{
+	Name:               "cluster-name",
+	MainImage:          "stackrox.io/main:3.0.55.0",
+	CentralApiEndpoint: "central.stackrox:443",
+	Type:               storage.ClusterType_OPENSHIFT4_CLUSTER,
+	DynamicConfig: &storage.DynamicClusterConfig{
+		ProcessIndicators: &storage.DynamicClusterConfig_ProcessIndicatorsConfig{
+			NoPersistence: false,
+		},
+	},
+	HelmConfig: &storage.CompleteClusterConfig{
+		DynamicConfig: &storage.DynamicClusterConfig{
+			ProcessIndicators: &storage.DynamicClusterConfig_ProcessIndicatorsConfig{
+				NoPersistence: false,
+			},
+		},
+	},
+}
+
+func TestNamespaceFilter(t *testing.T) {
+	cases := map[string]struct {
+		configureClusterFn func(*storage.Cluster)
+		expectedFilter     *string
+	}{
+		"Empty filter configuration": {
+			configureClusterFn: func(*storage.Cluster) {},
+			expectedFilter:     nil,
+		},
+		"Custom filter configuration": {
+			configureClusterFn: func(cluster *storage.Cluster) {
+				cluster.HelmConfig.DynamicConfig.ProcessIndicators.ExcludeNamespaceFilter = "test-.*"
+
+				cluster.DynamicConfig.ProcessIndicators.ExcludeNamespaceFilter = "test-.*"
+			},
+			expectedFilter: pointers.String("test-.*"),
+		},
+		"No openshift": {
+			configureClusterFn: func(cluster *storage.Cluster) {
+				cluster.HelmConfig.DynamicConfig.ProcessIndicators.ExcludeOpenshiftNs = true
+
+				cluster.DynamicConfig.ProcessIndicators.ExcludeOpenshiftNs = true
+			},
+			expectedFilter: pointers.String("^openshift$|^openshift-.*"),
+		},
+		"Custom filter and no openshift": {
+			configureClusterFn: func(cluster *storage.Cluster) {
+				cluster.HelmConfig.DynamicConfig.ProcessIndicators.ExcludeNamespaceFilter = "test-.*"
+				cluster.HelmConfig.DynamicConfig.ProcessIndicators.ExcludeOpenshiftNs = true
+
+				cluster.DynamicConfig.ProcessIndicators.ExcludeNamespaceFilter = "test-.*"
+				cluster.DynamicConfig.ProcessIndicators.ExcludeOpenshiftNs = true
+			},
+			expectedFilter: pointers.String("test-.*|^openshift$|^openshift-.*"),
+		},
+		"Custom filter and no persistence": {
+			configureClusterFn: func(cluster *storage.Cluster) {
+				cluster.HelmConfig.DynamicConfig.ProcessIndicators.ExcludeNamespaceFilter = "test-.*"
+				cluster.HelmConfig.DynamicConfig.ProcessIndicators.NoPersistence = true
+
+				cluster.DynamicConfig.ProcessIndicators.ExcludeNamespaceFilter = "test-.*"
+				cluster.DynamicConfig.ProcessIndicators.NoPersistence = true
+			},
+			expectedFilter: pointers.String(".*"),
+		},
+		"No persistence and no openshift": {
+			configureClusterFn: func(cluster *storage.Cluster) {
+				cluster.HelmConfig.DynamicConfig.ProcessIndicators.ExcludeOpenshiftNs = true
+				cluster.HelmConfig.DynamicConfig.ProcessIndicators.NoPersistence = true
+
+				cluster.DynamicConfig.ProcessIndicators.ExcludeOpenshiftNs = true
+				cluster.DynamicConfig.ProcessIndicators.NoPersistence = true
+			},
+			expectedFilter: pointers.String(".*"),
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Helm managed cluster
+			cluster.ManagedBy = storage.ManagerType_MANAGER_TYPE_HELM_CHART
+			cluster := cluster.CloneVT()
+			c.configureClusterFn(cluster)
+
+			filter := GetNamespaceFilter(cluster)
+			assert.Equal(t, c.expectedFilter, filter)
+
+			// Manually managed cluster
+			cluster.ManagedBy = storage.ManagerType_MANAGER_TYPE_MANUAL
+			cluster = cluster.CloneVT()
+			c.configureClusterFn(cluster)
+
+			filter = GetNamespaceFilter(cluster)
+			assert.Equal(t, c.expectedFilter, filter)
+		})
+	}
+}

--- a/proto/storage/cluster.proto
+++ b/proto/storage/cluster.proto
@@ -121,10 +121,31 @@ message AutoLockProcessBaselinesConfig {
 
 // The difference between Static and Dynamic cluster config is that Dynamic values are sent over the Central to Sensor gRPC connection. This has the benefit of allowing for "hot reloading" of values without restarting Secured cluster components.
 message DynamicClusterConfig {
+  // Configure per-namespace persistence for ProcessIndicators
+  message ProcessIndicatorsConfig {
+    // Specifies whether to persist process indicators independently from
+    // other configuratons. If true, the filters above are ignored, and no
+    // process indicators are persisted. If false (the protobuf default for
+    // booleans), process indicators are persisted according to
+    // namespace_filter and exclude_openshift_ns.
+    bool no_persistence = 1;
+
+    // A regex specifying to not persist process indicators from specified
+    // namespaces. E.g. namespace_filter: "test-.*" will instruct Central to
+    // not persist any process indicator coming from the "test-filtering"
+    // namespace.
+    string exclude_namespace_filter = 2;
+
+    // A short-cut to not persist process indicators from openshift namespaces.
+    // Equivalent to namespace_filter: "openshift-.*".
+    bool exclude_openshift_ns = 3;
+  }
+
   AdmissionControllerConfig admission_controller_config = 1;
   string registry_override = 2;
   bool disable_audit_logs = 3;
   AutoLockProcessBaselinesConfig auto_lock_process_baselines_config = 4;
+  ProcessIndicatorsConfig process_indicators = 5;
 }
 
 // Encodes a complete cluster configuration minus ID/Name identifiers

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -2319,6 +2319,33 @@
                 "id": 4,
                 "name": "auto_lock_process_baselines_config",
                 "type": "AutoLockProcessBaselinesConfig"
+              },
+              {
+                "id": 5,
+                "name": "process_indicators",
+                "type": "ProcessIndicatorsConfig"
+              }
+            ],
+            "messages": [
+              {
+                "name": "ProcessIndicatorsConfig",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "no_persistence",
+                    "type": "bool"
+                  },
+                  {
+                    "id": 2,
+                    "name": "exclude_namespace_filter",
+                    "type": "string"
+                  },
+                  {
+                    "id": 3,
+                    "name": "exclude_openshift_ns",
+                    "type": "bool"
+                  }
+                ]
               }
             ]
           },


### PR DESCRIPTION
## Description

**NOTE**: It's been split from https://github.com/stackrox/stackrox/pull/19455, for the purposes of simplifying the review. The PR contains only the first commit, introducing the actual machinery. The implementation is exactly the same as in the original PR.

Allow to configure per-namespace persistence for process indicators, so that Central wouldn't need to store information, which never will be used.

It could be configured via DynamicConfig of the cluster configuration in the form:

```
message ProcessIndicators {
  string namespace_filter = 1;
  bool exclude_openshift_ns = 2;
  bool persistence = 3;
}
```

Where `namespace_filter` allows to specify a custom regex to filter out processes by matching namespace, `exclude_openshift_ns` instructs Central to exclude anything from openshift-* namespaces, and `persistence` can be used to disable storing process indicators at all.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Manual validation (creating an operator-managed cluster and modifying the configuration), as well as E2E tests. Split from https://github.com/stackrox/stackrox/pull/19455 to simplify the review.