### PR TITLE
ROX-34110: Ignore AC label scoping test while investigating

### DIFF
--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -10,6 +10,7 @@ import services.ImageService
 import services.PolicyService
 import util.Timer
 
+import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
@@ -233,6 +234,7 @@ class AdmissionControllerTest extends BaseSpecification {
 
     @Unroll
     @Tag("BAT")
+    @Ignore("Temporarily skipped while investigating ROX-34110, ROX-34111, ROX-34112")
     def "Verify AC enforcement with label scoping: #desc"() {
         given:
         "Set up namespace with labels"
@@ -292,6 +294,7 @@ class AdmissionControllerTest extends BaseSpecification {
 
     @Unroll
     @Tag("BAT")
+    @Ignore("Temporarily skipped while investigating ROX-34110, ROX-34111, ROX-34112")
     def "Verify AC respects label hot-reload: #desc"() {
         given:
         "Set up namespace with initial label"
@@ -343,7 +346,7 @@ class AdmissionControllerTest extends BaseSpecification {
             ns.metadata.labels = ["team": changedValue]
         }
         orchestrator.client.namespaces().withName(testNs).replace(ns)
-        // Wait for namespace label change to propagate to Sensor
+        // Wait for namespace label change to propagate
         withRetry(10, 1) {
             def updatedNs = orchestrator.client.namespaces().withName(testNs).get()
             if (changedValue == null) {


### PR DESCRIPTION
Ignore these tests for now while we investigate ROX-34110, ROX-34111, and ROX-34112.