### PR TITLE
ROX-33599: Migrate sensitive Cypress.env() to cy.env()

### DIFF
--- a/ui/apps/platform/cypress/helpers/basicAuth.js
+++ b/ui/apps/platform/cypress/helpers/basicAuth.js
@@ -1,9 +1,10 @@
 // This function sets up auth headers for each test in the current test group.
 export default () => {
-    const token = Cypress.env('ROX_AUTH_TOKEN');
-    if (token) {
-        beforeEach(() => {
-            localStorage.setItem('access_token', token);
+    beforeEach(() => {
+        cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+            if (ROX_AUTH_TOKEN) {
+                localStorage.setItem('access_token', ROX_AUTH_TOKEN);
+            }
         });
-    }
+    });
 };

--- a/ui/apps/platform/cypress/helpers/basicAuth.js
+++ b/ui/apps/platform/cypress/helpers/basicAuth.js
@@ -4,6 +4,8 @@ export default () => {
         cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
             if (ROX_AUTH_TOKEN) {
                 localStorage.setItem('access_token', ROX_AUTH_TOKEN);
+            } else {
+                cy.log('WARNING: ROX_AUTH_TOKEN is not set, tests will run unauthenticated');
             }
         });
     });

--- a/ui/apps/platform/cypress/helpers/ocpAuth.ts
+++ b/ui/apps/platform/cypress/helpers/ocpAuth.ts
@@ -1,20 +1,32 @@
 export function withOcpAuth() {
     // Establish a cookie based session for the OCP web console
     cy.session('ocp-session-auth', () => {
-        cy.visit('/');
+        cy.env([
+            'OCP_BRIDGE_AUTH_DISABLED',
+            'OPENSHIFT_CONSOLE_USERNAME',
+            'OPENSHIFT_CONSOLE_PASSWORD',
+        ]).then(
+            ({
+                OCP_BRIDGE_AUTH_DISABLED,
+                OPENSHIFT_CONSOLE_USERNAME,
+                OPENSHIFT_CONSOLE_PASSWORD,
+            }) => {
+                cy.visit('/');
 
-        if (!Cypress.env('OCP_BRIDGE_AUTH_DISABLED')) {
-            cy.url().should('contain', '/login?');
-            cy.get('input[name="username"]').type(Cypress.env('OPENSHIFT_CONSOLE_USERNAME'));
-            cy.get('input[name="password"]').type(Cypress.env('OPENSHIFT_CONSOLE_PASSWORD'));
-            cy.get('button[type="submit"]').click();
-        }
+                if (!OCP_BRIDGE_AUTH_DISABLED) {
+                    cy.url().should('contain', '/login?');
+                    cy.get('input[name="username"]').type(OPENSHIFT_CONSOLE_USERNAME);
+                    cy.get('input[name="password"]').type(OPENSHIFT_CONSOLE_PASSWORD);
+                    cy.get('button[type="submit"]').click();
+                }
 
-        // Wait for the page to load
-        cy.url().should('contain', '/dashboards');
-        cy.get('h1:contains("Overview")');
+                // Wait for the page to load
+                cy.url().should('contain', '/dashboards');
+                cy.get('h1:contains("Overview")');
 
-        // Pressing Escape closes the welcome modal if it exists, and silently does nothing if it doesn't
-        cy.get('body').type('{esc}');
+                // Pressing Escape closes the welcome modal if it exists, and silently does nothing if it doesn't
+                cy.get('body').type('{esc}');
+            }
+        );
     });
 }

--- a/ui/apps/platform/cypress/helpers/ocpAuth.ts
+++ b/ui/apps/platform/cypress/helpers/ocpAuth.ts
@@ -16,7 +16,9 @@ export function withOcpAuth() {
                 if (!OCP_BRIDGE_AUTH_DISABLED) {
                     cy.url().should('contain', '/login?');
                     cy.get('input[name="username"]').type(OPENSHIFT_CONSOLE_USERNAME);
-                    cy.get('input[name="password"]').type(OPENSHIFT_CONSOLE_PASSWORD);
+                    cy.get('input[name="password"]').type(OPENSHIFT_CONSOLE_PASSWORD, {
+                        log: false,
+                    });
                     cy.get('button[type="submit"]').click();
                 }
 

--- a/ui/apps/platform/cypress/helpers/policies.js
+++ b/ui/apps/platform/cypress/helpers/policies.js
@@ -170,19 +170,21 @@ export function importPolicyFromFixture(fileName, contentsInterceptor = (c) => c
 }
 
 export function deletePolicyIfExists(policyName) {
-    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+        const auth = { bearer: ROX_AUTH_TOKEN };
 
-    cy.request({
-        url: api.policies.policies,
-        auth,
-    }).as('listPolicies');
+        cy.request({
+            url: api.policies.policies,
+            auth,
+        }).as('listPolicies');
 
-    cy.get('@listPolicies').then((res) => {
-        const policy = res.body.policies.find(({ name }) => name === policyName);
-        if (policy) {
-            const { id } = policy;
-            const url = `/v1/policies/${id}`;
-            cy.request({ url, auth, method: 'DELETE' });
-        }
+        cy.get('@listPolicies').then((res) => {
+            const policy = res.body.policies.find(({ name }) => name === policyName);
+            if (policy) {
+                const { id } = policy;
+                const url = `/v1/policies/${id}`;
+                cy.request({ url, auth, method: 'DELETE' });
+            }
+        });
     });
 }

--- a/ui/apps/platform/cypress/helpers/policies.js
+++ b/ui/apps/platform/cypress/helpers/policies.js
@@ -170,7 +170,7 @@ export function importPolicyFromFixture(fileName, contentsInterceptor = (c) => c
 }
 
 export function deletePolicyIfExists(policyName) {
-    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+    return cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
         const auth = { bearer: ROX_AUTH_TOKEN };
 
         cy.request({

--- a/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.helpers.ts
+++ b/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.helpers.ts
@@ -1,3 +1,5 @@
+import type { ClusterRegistrationSecret } from 'services/ClustersService';
+
 export function cleanupClusterRegistrationSecretsWithName(nameToDelete: string) {
     // Clean up existing CRSs, if they exist
     cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
@@ -5,15 +7,19 @@ export function cleanupClusterRegistrationSecretsWithName(nameToDelete: string) 
 
         cy.request({ url: '/v1/cluster-init/crs', auth }).as('listCrs');
 
-        return cy.get('@listCrs').then((res: any) => {
-            const automationTokens = res.body.items.filter(({ name }) => name === nameToDelete);
-            const body = { ids: automationTokens.map(({ id }) => id) };
-            return cy.request({
-                url: '/v1/cluster-init/crs/revoke',
-                body,
-                auth,
-                method: 'PATCH',
-            });
-        });
+        return cy.get('@listCrs').then(
+            (res: Cypress.Response<{ items: ClusterRegistrationSecret[] }>) => {
+                const automationTokens = res.body.items.filter(
+                    ({ name }) => name === nameToDelete
+                );
+                const body = { ids: automationTokens.map(({ id }) => id) };
+                return cy.request({
+                    url: '/v1/cluster-init/crs/revoke',
+                    body,
+                    auth,
+                    method: 'PATCH',
+                });
+            }
+        );
     });
 }

--- a/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.helpers.ts
+++ b/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.helpers.ts
@@ -1,12 +1,19 @@
 export function cleanupClusterRegistrationSecretsWithName(nameToDelete: string) {
     // Clean up existing CRSs, if they exist
-    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+        const auth = { bearer: ROX_AUTH_TOKEN };
 
-    cy.request({ url: '/v1/cluster-init/crs', auth }).as('listCrs');
+        cy.request({ url: '/v1/cluster-init/crs', auth }).as('listCrs');
 
-    return cy.get('@listCrs').then((res: any) => {
-        const automationTokens = res.body.items.filter(({ name }) => name === nameToDelete);
-        const body = { ids: automationTokens.map(({ id }) => id) };
-        return cy.request({ url: '/v1/cluster-init/crs/revoke', body, auth, method: 'PATCH' });
+        return cy.get('@listCrs').then((res: any) => {
+            const automationTokens = res.body.items.filter(({ name }) => name === nameToDelete);
+            const body = { ids: automationTokens.map(({ id }) => id) };
+            return cy.request({
+                url: '/v1/cluster-init/crs/revoke',
+                body,
+                auth,
+                method: 'PATCH',
+            });
+        });
     });
 }

--- a/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.helpers.ts
+++ b/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.helpers.ts
@@ -7,11 +7,10 @@ export function cleanupClusterRegistrationSecretsWithName(nameToDelete: string) 
 
         cy.request({ url: '/v1/cluster-init/crs', auth }).as('listCrs');
 
-        return cy.get('@listCrs').then(
-            (res: Cypress.Response<{ items: ClusterRegistrationSecret[] }>) => {
-                const automationTokens = res.body.items.filter(
-                    ({ name }) => name === nameToDelete
-                );
+        return cy
+            .get('@listCrs')
+            .then((res: Cypress.Response<{ items: ClusterRegistrationSecret[] }>) => {
+                const automationTokens = res.body.items.filter(({ name }) => name === nameToDelete);
                 const body = { ids: automationTokens.map(({ id }) => id) };
                 return cy.request({
                     url: '/v1/cluster-init/crs/revoke',
@@ -19,7 +18,6 @@ export function cleanupClusterRegistrationSecretsWithName(nameToDelete: string) 
                     auth,
                     method: 'PATCH',
                 });
-            }
-        );
+            });
     });
 }

--- a/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.helpers.ts
+++ b/ui/apps/platform/cypress/integration/clusters/cluster-registration-secrets/ClusterRegistrationSecrets.helpers.ts
@@ -2,7 +2,7 @@ import type { ClusterRegistrationSecret } from 'services/ClustersService';
 
 export function cleanupClusterRegistrationSecretsWithName(nameToDelete: string) {
     // Clean up existing CRSs, if they exist
-    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+    return cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
         const auth = { bearer: ROX_AUTH_TOKEN };
 
         cy.request({ url: '/v1/cluster-init/crs', auth }).as('listCrs');

--- a/ui/apps/platform/cypress/integration/collections/Collections.helpers.js
+++ b/ui/apps/platform/cypress/integration/collections/Collections.helpers.js
@@ -53,44 +53,48 @@ export function tryCreateCollection(
     embeddedCollectionIds = [],
     resourceSelectors = []
 ) {
-    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+        const auth = { bearer: ROX_AUTH_TOKEN };
 
-    cy.request({
-        url: `${baseApiUrl}?query.query=Collection Name:"${name}"`,
-        auth,
-    }).as('listCollections');
+        cy.request({
+            url: `${baseApiUrl}?query.query=Collection Name:"${name}"`,
+            auth,
+        }).as('listCollections');
 
-    cy.get('@listCollections').then((res) => {
-        if (res.body.collections.some((c) => c.name === name)) {
-            // Collection already exists
-            return;
-        }
-        const body = {
-            name,
-            description,
-            embeddedCollectionIds,
-            resourceSelectors,
-        };
-        cy.request({ url: baseApiUrl, body, auth, method: 'POST' });
+        cy.get('@listCollections').then((res) => {
+            if (res.body.collections.some((c) => c.name === name)) {
+                // Collection already exists
+                return;
+            }
+            const body = {
+                name,
+                description,
+                embeddedCollectionIds,
+                resourceSelectors,
+            };
+            cy.request({ url: baseApiUrl, body, auth, method: 'POST' });
+        });
     });
 }
 
 // Cleanup an existing collection via API call
 export function tryDeleteCollection(collectionName) {
-    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+        const auth = { bearer: ROX_AUTH_TOKEN };
 
-    cy.request({
-        url: `${baseApiUrl}?query.query=Collection Name:"${collectionName}"`,
-        auth,
-    }).as('listCollections');
+        cy.request({
+            url: `${baseApiUrl}?query.query=Collection Name:"${collectionName}"`,
+            auth,
+        }).as('listCollections');
 
-    cy.get('@listCollections').then((res) => {
-        const collection = res.body.collections.find(({ name }) => name === collectionName);
-        if (collection) {
-            const { id } = collection;
-            const url = `${baseApiUrl}/${id}`;
-            cy.request({ url, auth, method: 'DELETE' });
-        }
+        cy.get('@listCollections').then((res) => {
+            const collection = res.body.collections.find(({ name }) => name === collectionName);
+            if (collection) {
+                const { id } = collection;
+                const url = `${baseApiUrl}/${id}`;
+                cy.request({ url, auth, method: 'DELETE' });
+            }
+        });
     });
 }
 

--- a/ui/apps/platform/cypress/integration/collections/Collections.helpers.js
+++ b/ui/apps/platform/cypress/integration/collections/Collections.helpers.js
@@ -53,7 +53,7 @@ export function tryCreateCollection(
     embeddedCollectionIds = [],
     resourceSelectors = []
 ) {
-    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+    return cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
         const auth = { bearer: ROX_AUTH_TOKEN };
 
         cy.request({
@@ -79,7 +79,7 @@ export function tryCreateCollection(
 
 // Cleanup an existing collection via API call
 export function tryDeleteCollection(collectionName) {
-    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+    return cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
         const auth = { bearer: ROX_AUTH_TOKEN };
 
         cy.request({

--- a/ui/apps/platform/cypress/integration/exceptionConfiguration/ExceptionConfig.helpers.js
+++ b/ui/apps/platform/cypress/integration/exceptionConfiguration/ExceptionConfig.helpers.js
@@ -27,7 +27,7 @@ export function visitExceptionConfigWithPermissions(category, resourceToAccess) 
  * Sets the exception config to the expected default as defined in the requirements document.
  */
 export function resetExceptionConfig() {
-    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+    return cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
         const auth = { bearer: ROX_AUTH_TOKEN };
         const config = {
             expiryOptions: {

--- a/ui/apps/platform/cypress/integration/exceptionConfiguration/ExceptionConfig.helpers.js
+++ b/ui/apps/platform/cypress/integration/exceptionConfiguration/ExceptionConfig.helpers.js
@@ -27,27 +27,29 @@ export function visitExceptionConfigWithPermissions(category, resourceToAccess) 
  * Sets the exception config to the expected default as defined in the requirements document.
  */
 export function resetExceptionConfig() {
-    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
-    const config = {
-        expiryOptions: {
-            dayOptions: [
-                { numDays: 14, enabled: true },
-                { numDays: 30, enabled: true },
-                { numDays: 90, enabled: true },
-            ],
-            fixableCveOptions: {
-                allFixable: true,
-                anyFixable: true,
+    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+        const auth = { bearer: ROX_AUTH_TOKEN };
+        const config = {
+            expiryOptions: {
+                dayOptions: [
+                    { numDays: 14, enabled: true },
+                    { numDays: 30, enabled: true },
+                    { numDays: 90, enabled: true },
+                ],
+                fixableCveOptions: {
+                    allFixable: true,
+                    anyFixable: true,
+                },
+                customDate: false,
+                indefinite: false,
             },
-            customDate: false,
-            indefinite: false,
-        },
-    };
+        };
 
-    cy.request({
-        url: `/v1/config/private/exception/vulnerabilities`,
-        auth,
-        method: 'PUT',
-        body: { config },
+        cy.request({
+            url: `/v1/config/private/exception/vulnerabilities`,
+            auth,
+            method: 'PUT',
+            body: { config },
+        });
     });
 }

--- a/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
+++ b/ui/apps/platform/cypress/integration/integrations/integrations.helpers.js
@@ -605,34 +605,3 @@ export function testIntegrationInFormWithoutStoredCredentials(
         staticResponseForTest
     );
 }
-
-/**
- * Attempts to delete an integration via the API given a source and name, if it exists.
- * @param {'notifiers'} integrationSource The type of integration
- * @param {string} integrationName The name of the integration
- */
-export function tryDeleteIntegration(integrationSource, integrationName) {
-    // This list is not complete - add other integration sources as needed
-    const integrationResponseKeys = {
-        notifiers: 'notifiers',
-    };
-    if (!integrationResponseKeys[integrationSource]) {
-        throw new Error(
-            `A JSON response key for ${integrationSource} was not defined in Cypress test helper.`
-        );
-    }
-    const baseUrl = `/v1/${integrationSource}`;
-    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
-
-    cy.request({ url: baseUrl, auth }).as('listIntegrations');
-
-    cy.get('@listIntegrations').then((res) => {
-        const jsonKey = integrationResponseKeys[integrationSource];
-        res.body[jsonKey].forEach(({ id, name }) => {
-            if (name === integrationName) {
-                const url = `${baseUrl}/${id}`;
-                cy.request({ url, auth, method: 'DELETE' });
-            }
-        });
-    });
-}

--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/VulnerabilityReporting.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/VulnerabilityReporting.helpers.js
@@ -104,7 +104,7 @@ export function assertNextDisabledAndHelperTextError(text) {
 export function tryDeleteReportConfiguration(reportConfigName) {
     const baseApiUrl = '/v2/reports/configurations';
 
-    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+    return cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
         const auth = { bearer: ROX_AUTH_TOKEN };
 
         cy.request({

--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/VulnerabilityReporting.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/VulnerabilityReporting.helpers.js
@@ -103,20 +103,25 @@ export function assertNextDisabledAndHelperTextError(text) {
 
 export function tryDeleteReportConfiguration(reportConfigName) {
     const baseApiUrl = '/v2/reports/configurations';
-    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
 
-    cy.request({
-        url: `${baseApiUrl}?query=Report Name:${reportConfigName}`,
-        auth,
-    }).as('listReports');
+    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+        const auth = { bearer: ROX_AUTH_TOKEN };
 
-    return cy.get('@listReports').then((res) => {
-        const reportConfig = res.body.reportConfigs.find(({ name }) => name === reportConfigName);
-        if (reportConfig) {
-            const { id } = reportConfig;
-            const url = `${baseApiUrl}/${id}`;
-            return cy.request({ url, auth, method: 'DELETE' });
-        }
-        return Promise.resolve();
+        cy.request({
+            url: `${baseApiUrl}?query=Report Name:${reportConfigName}`,
+            auth,
+        }).as('listReports');
+
+        return cy.get('@listReports').then((res) => {
+            const reportConfig = res.body.reportConfigs.find(
+                ({ name }) => name === reportConfigName
+            );
+            if (reportConfig) {
+                const { id } = reportConfig;
+                const url = `${baseApiUrl}/${id}`;
+                return cy.request({ url, auth, method: 'DELETE' });
+            }
+            return Promise.resolve();
+        });
     });
 }

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -161,22 +161,24 @@ export function extractNonZeroSeverityFromCount(severityCountText) {
 }
 
 export function cancelAllCveExceptions() {
-    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+        const auth = { bearer: ROX_AUTH_TOKEN };
 
-    cy.request({ url: '/v2/vulnerability-exceptions', auth }).as('vulnExceptions');
+        cy.request({ url: '/v2/vulnerability-exceptions', auth }).as('vulnExceptions');
 
-    return cy.get('@vulnExceptions').then((res) => {
-        return Promise.all(
-            res.body.exceptions.map(({ id, expired, requester }) => {
-                return requester?.name === 'ui_tests' && !expired
-                    ? cy.request({
-                          url: `/v2/vulnerability-exceptions/${id}/cancel`,
-                          auth,
-                          method: 'POST',
-                      })
-                    : Promise.resolve();
-            })
-        );
+        return cy.get('@vulnExceptions').then((res) => {
+            return Promise.all(
+                res.body.exceptions.map(({ id, expired, requester }) => {
+                    return requester?.name === 'ui_tests' && !expired
+                        ? cy.request({
+                              url: `/v2/vulnerability-exceptions/${id}/cancel`,
+                              auth,
+                              method: 'POST',
+                          })
+                        : Promise.resolve();
+                })
+            );
+        });
     });
 }
 
@@ -339,13 +341,15 @@ export function verifyExceptionConfirmationDetails(params) {
  * Clean up any existing watched images via API
  */
 export function unwatchAllImages() {
-    const auth = { bearer: Cypress.env('ROX_AUTH_TOKEN') };
+    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+        const auth = { bearer: ROX_AUTH_TOKEN };
 
-    cy.request({ url: '/v1/watchedimages', auth }).as('listWatchedImages');
+        cy.request({ url: '/v1/watchedimages', auth }).as('listWatchedImages');
 
-    cy.get('@listWatchedImages').then((res) => {
-        res.body.watchedImages.forEach(({ name }) => {
-            cy.request({ url: `/v1/watchedimages?name=${name}`, auth, method: 'DELETE' });
+        cy.get('@listWatchedImages').then((res) => {
+            res.body.watchedImages.forEach(({ name }) => {
+                cy.request({ url: `/v1/watchedimages?name=${name}`, auth, method: 'DELETE' });
+            });
         });
     });
 }

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -341,7 +341,7 @@ export function verifyExceptionConfirmationDetails(params) {
  * Clean up any existing watched images via API
  */
 export function unwatchAllImages() {
-    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+    return cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
         const auth = { bearer: ROX_AUTH_TOKEN };
 
         cy.request({ url: '/v1/watchedimages', auth }).as('listWatchedImages');

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -161,7 +161,7 @@ export function extractNonZeroSeverityFromCount(severityCountText) {
 }
 
 export function cancelAllCveExceptions() {
-    cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
+    return cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
         const auth = { bearer: ROX_AUTH_TOKEN };
 
         cy.request({ url: '/v2/vulnerability-exceptions', auth }).as('vulnExceptions');


### PR DESCRIPTION
## Description

**Jira:** [ROX-33599](https://issues.redhat.com/browse/ROX-33599)

Cypress 15.10.0 deprecated `Cypress.env()` for sensitive values in favor of `cy.env()`, which avoids hydrating secrets into the browser context. This PR migrates all sensitive `Cypress.env()` calls (auth tokens, OCP credentials) to the new async `cy.env()` API.

- Moved `ROX_AUTH_TOKEN` reads inside `cy.env().then()` across 8 helper files
- Batched OCP credential reads (`OCP_BRIDGE_AUTH_DISABLED`, `OPENSHIFT_CONSOLE_USERNAME`, `OPENSHIFT_CONSOLE_PASSWORD`) into a single `cy.env()` call in `ocpAuth.ts`
- Restructured `basicAuth.js` to always register `beforeEach` (no-op when token is absent)
- Deleted dead `tryDeleteIntegration` function from `integrations.helpers.js`
- Typed the CRS response object in the Cypress helper to replace `any`
- Hid OCP password from Cypress command log output (`log: false`)
- Added `cy.log` warning in `basicAuth` when `ROX_AUTH_TOKEN` is absent

Non-sensitive values (`ORCHESTRATOR_FLAVOR`, feature flags, `AXE_CORE_PATH`) remain on `Cypress.env()` and will be migrated to `Cypress.expose()` in ROX-33598.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Verified ESLint passes on all 9 changed files
- Confirmed zero `Cypress.env('ROX_AUTH_TOKEN')` and OCP credential calls remain
- Remaining `Cypress.env()` calls are only non-sensitive values (out of scope, ROX-33598)
- Full validation requires running Cypress E2E tests against a cluster (CI)

[ROX-33599]: https://redhat.atlassian.net/browse/ROX-33599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ