### PR TITLE
ROX-34133: Use ImageVulnerabilityReportConfiguration for feature work

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersView.tsx
@@ -26,7 +26,7 @@ function ImageVulnerabilityFiltersView({
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
             <FlexItem>
-                <Title headingLevel={headingLevel}>Parameters</Title>
+                <Title headingLevel={headingLevel}>Filters</Title>
             </FlexItem>
             <FlexItem>
                 <DescriptionList isCompact isHorizontal>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersView.tsx
@@ -9,18 +9,18 @@ import {
     Title,
 } from '@patternfly/react-core';
 
-import type { ImageVulnerabilityParametersConfiguration } from '../imageVulnerabilityReports.types';
+import type { ImageVulnerabilityFiltersConfiguration } from '../imageVulnerabilityReports.types';
 import { getTextForCvesSince } from '../imageVulnerabilityReports.utils';
 
-export type ImageVulnerabilityParametersViewProps = {
+export type ImageVulnerabilityFiltersViewProps = {
     headingLevel: 'h2' | 'h3';
-    values: ImageVulnerabilityParametersConfiguration;
+    values: ImageVulnerabilityFiltersConfiguration;
 };
 
-function ImageVulnerabilityParametersView({
+function ImageVulnerabilityFiltersView({
     headingLevel,
     values,
-}: ImageVulnerabilityParametersViewProps): ReactElement {
+}: ImageVulnerabilityFiltersViewProps): ReactElement {
     const { vulnReportFilters } = values;
 
     return (
@@ -43,4 +43,4 @@ function ImageVulnerabilityParametersView({
     );
 }
 
-export default ImageVulnerabilityParametersView;
+export default ImageVulnerabilityFiltersView;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersViewForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersViewForCollection.tsx
@@ -13,18 +13,18 @@ import {
 import { fixabilityLabels } from 'constants/reportConstants';
 import { vulnerabilitySeverityLabels } from 'messages/common';
 
-import type { ImageVulnerabilityParametersForCollectionConfiguration } from '../imageVulnerabilityReports.types';
+import type { ImageVulnerabilityFiltersConfigurationForCollection } from '../imageVulnerabilityReports.types';
 import { getTextForCvesSince } from '../imageVulnerabilityReports.utils';
 
-export type ImageVulnerabilityParametersViewForCollectionProps = {
+export type ImageVulnerabilityFiltersViewForCollectionProps = {
     headingLevel: 'h2' | 'h3';
-    values: ImageVulnerabilityParametersForCollectionConfiguration;
+    values: ImageVulnerabilityFiltersConfigurationForCollection;
 };
 
-function ImageVulnerabilityParametersViewForCollection({
+function ImageVulnerabilityFiltersViewForCollection({
     headingLevel,
     values,
-}: ImageVulnerabilityParametersViewForCollectionProps): ReactElement {
+}: ImageVulnerabilityFiltersViewForCollectionProps): ReactElement {
     const { vulnReportFilters } = values;
     const { fixability, severities } = vulnReportFilters;
 
@@ -65,4 +65,4 @@ function ImageVulnerabilityParametersViewForCollection({
     );
 }
 
-export default ImageVulnerabilityParametersViewForCollection;
+export default ImageVulnerabilityFiltersViewForCollection;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersViewForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersViewForCollection.tsx
@@ -31,7 +31,7 @@ function ImageVulnerabilityFiltersViewForCollection({
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
             <FlexItem>
-                <Title headingLevel={headingLevel}>Parameters</Title>
+                <Title headingLevel={headingLevel}>Filters</Title>
             </FlexItem>
             <FlexItem>
                 <DescriptionList isCompact isHorizontal>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityResourcesView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityResourcesView.tsx
@@ -22,7 +22,9 @@ function ImageVulnerabilityResourcesView({
     headingLevel,
     values,
 }: ImageVulnerabilityResourcesViewProps): ReactElement {
-    const { imageTypes, resourceScope } = values;
+    const { resourceScope, vulnReportFilters } = values;
+    const { imageTypes } = vulnReportFilters;
+
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
             <FlexItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
@@ -1,18 +1,18 @@
 import type { ReactElement } from 'react';
 import { Divider, Flex, PageSection, Title } from '@patternfly/react-core';
 
-// import type { ImageVulnerabilityParametersForCollectionConfiguration } from '../../imageVulnerabilityReports.types';
+// import type { ImageVulnerabilityFiltersConfiguration } from '../../imageVulnerabilityReports.types';
 
-function ImageVulnerabilityParametersForCollectionStep(): ReactElement {
+function ImageVulnerabilityFiltersStep(): ReactElement {
     return (
         <PageSection>
             <Flex direction={{ default: 'column' }}>
                 <Title headingLevel="h2">Parameters</Title>
                 <Divider component="div" />
-                {/* TODO Form includes fixability, severities, and cvesSince */}
+                {/* TODO Form includes query and cvesSince */}
             </Flex>
         </PageSection>
     );
 }
 
-export default ImageVulnerabilityParametersForCollectionStep;
+export default ImageVulnerabilityFiltersStep;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
@@ -7,7 +7,7 @@ function ImageVulnerabilityFiltersStep(): ReactElement {
     return (
         <PageSection>
             <Flex direction={{ default: 'column' }}>
-                <Title headingLevel="h2">Parameters</Title>
+                <Title headingLevel="h2">Filters</Title>
                 <Divider component="div" />
                 {/* TODO Form includes query and cvesSince */}
             </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
@@ -7,7 +7,7 @@ function ImageVulnerabilityFiltersStepForCollection(): ReactElement {
     return (
         <PageSection>
             <Flex direction={{ default: 'column' }}>
-                <Title headingLevel="h2">Parameters</Title>
+                <Title headingLevel="h2">Filters</Title>
                 <Divider component="div" />
                 {/* TODO Form includes fixability, severities, and cvesSince */}
             </Flex>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { Divider, Flex, PageSection, Title } from '@patternfly/react-core';
 
-// import type { ImageVulnerabilityFtersConfigurationForCollection } from '../../imageVulnerabilityReports.types';
+// import type { ImageVulnerabilityFiltersConfigurationForCollection } from '../../imageVulnerabilityReports.types';
 
 function ImageVulnerabilityFiltersStepForCollection(): ReactElement {
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
@@ -1,18 +1,18 @@
 import type { ReactElement } from 'react';
 import { Divider, Flex, PageSection, Title } from '@patternfly/react-core';
 
-// import type { ImageVulnerabilityParametersConfiguration } from '../../imageVulnerabilityReports.types';
+// import type { ImageVulnerabilityFtersConfigurationForCollection } from '../../imageVulnerabilityReports.types';
 
-function ImageVulnerabilityParametersStep(): ReactElement {
+function ImageVulnerabilityFiltersStepForCollection(): ReactElement {
     return (
         <PageSection>
             <Flex direction={{ default: 'column' }}>
                 <Title headingLevel="h2">Parameters</Title>
                 <Divider component="div" />
-                {/* TODO Form includes query and cvesSince */}
+                {/* TODO Form includes fixability, severities, and cvesSince */}
             </Flex>
         </PageSection>
     );
 }
 
-export default ImageVulnerabilityParametersStep;
+export default ImageVulnerabilityFiltersStepForCollection;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.types.ts
@@ -1,45 +1,14 @@
 import type {
     CollectionScope,
     CvesSince,
+    EntityScope,
     Fixability,
     ImageType,
     NotifierConfiguration,
+    ReportType,
 } from 'services/ReportsService.types';
 import type { VulnerabilitySeverity } from 'types/cve.proto';
 import type { Schedule } from 'types/schedule.proto';
-
-// TODO move final type to ReportsService.types.ts file when merged into report_service.proto file
-
-type EntityScope = {
-    rules: EntityScopeRule[];
-};
-
-type EntityScopeRule = {
-    entity: ScopeEntity;
-    field: ScopeField;
-    values: RuleValue[];
-};
-
-type ScopeEntity = 'SCOPE_ENTITY_DEPLOYMENT' | 'SCOPE_ENTITY_NAMESPACE' | 'SCOPE_ENTITY_CLUSTER';
-
-type ScopeField =
-    | 'SCOPE_FIELD_ID'
-    | 'SCOPE_FIELD_NAME'
-    | 'SCOPE_FIELD_LABEL'
-    | 'SCOPE_FIELD_ANNOTATION';
-
-type RuleValue = {
-    value: string;
-    matchType: MatchType;
-};
-
-type MatchType = 'EXACT' | 'REGEX';
-
-export type ResourcesConfiguration = {
-    resourceScope: {
-        entityScope: EntityScope;
-    };
-};
 
 export type ImageVulnerabilityResourceScope =
     | {
@@ -50,17 +19,17 @@ export type ImageVulnerabilityResourceScope =
       };
 
 export type ImageVulnerabilityResourcesConfiguration = {
-    imageTypes: ImageType[];
+    imageTypes: ImageType[]; // more closely related to resources although in vulnReportFilters
     resourceScope: ImageVulnerabilityResourceScope;
 };
 
-export type ImageVulnerabilityParametersConfiguration = {
+export type ImageVulnerabilityFiltersConfiguration = {
     vulnReportFilters: {
         query: string;
     } & CvesSince;
 };
 
-export type ImageVulnerabilityParametersForCollectionConfiguration = {
+export type ImageVulnerabilityFiltersConfigurationForCollection = {
     vulnReportFilters: {
         fixability: Fixability;
         severities: VulnerabilitySeverity[];
@@ -69,5 +38,41 @@ export type ImageVulnerabilityParametersForCollectionConfiguration = {
 
 export type DestinationsConfiguration = {
     notifiers: NotifierConfiguration[];
-    schedule: Schedule;
+    schedule: Schedule | null;
 };
+
+// Move to src/services/ReportService.types.ts file when we delete ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING
+
+export type ImageVulnerabilityReportConfigurationBase = {
+    id: string;
+    name: string;
+    description: string;
+    type: ReportType;
+    notifiers: NotifierConfiguration[];
+    schedule: Schedule | null;
+};
+
+export type ImageVulnerabilityReportConfigurationForEntity = {
+    vulnReportFilters: {
+        imageTypes: ImageType[];
+        query: string;
+    } & CvesSince;
+    resourceScope: {
+        entityScope: EntityScope;
+    };
+} & ImageVulnerabilityReportConfigurationBase;
+
+export type ImageVulnerabilityReportConfigurationForCollection = {
+    vulnReportFilters: {
+        fixability: Fixability;
+        severities: VulnerabilitySeverity[];
+        imageTypes: ImageType[];
+    } & CvesSince;
+    resourceScope: {
+        collectionScope: CollectionScope;
+    };
+} & ImageVulnerabilityReportConfigurationBase;
+
+export type ImageVulnerabilityReportConfiguration =
+    | ImageVulnerabilityReportConfigurationForEntity
+    | ImageVulnerabilityReportConfigurationForCollection;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.types.ts
@@ -19,8 +19,10 @@ export type ImageVulnerabilityResourceScope =
       };
 
 export type ImageVulnerabilityResourcesConfiguration = {
-    imageTypes: ImageType[]; // more closely related to resources although in vulnReportFilters
     resourceScope: ImageVulnerabilityResourceScope;
+    vulnReportFilters: {
+        imageTypes: ImageType[]; // more closely related to resources although in vulnReportFilters
+    };
 };
 
 export type ImageVulnerabilityFiltersConfiguration = {
@@ -52,11 +54,13 @@ export type ImageVulnerabilityReportConfigurationBase = {
     schedule: Schedule | null;
 };
 
+export type ImageVulnerabilityReportFiltersForEntity = {
+    imageTypes: ImageType[];
+    query: string;
+} & CvesSince;
+
 export type ImageVulnerabilityReportConfigurationForEntity = {
-    vulnReportFilters: {
-        imageTypes: ImageType[];
-        query: string;
-    } & CvesSince;
+    vulnReportFilters: ImageVulnerabilityReportFiltersForEntity;
     resourceScope: {
         entityScope: EntityScope;
     };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
@@ -51,6 +51,8 @@ export const initialImageVulnerabilityReportConfiguration: ImageVulnerabilityRep
     } as const;
 
 // TypeScript needs help because entityScope and vulnReportFilters have mutual dependencies.
+// entityScope implies query but not fixibility nore severities
+// collectionScope implies fixibility and severities but not query
 export function hasConfigurationForEntity(
     values: ImageVulnerabilityReportConfiguration
 ): values is ImageVulnerabilityReportConfigurationForEntity {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
@@ -1,9 +1,61 @@
-import type { CvesSince, ImageType } from 'services/ReportsService.types';
+import type {
+    CvesSince,
+    ImageType,
+    VulnerabilityReportFilters,
+} from 'services/ReportsService.types';
 import type { SearchFilter } from 'types/search';
 import { getDate } from 'utils/dateUtils';
 import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
+
+import type {
+    ImageVulnerabilityReportConfiguration,
+    ImageVulnerabilityReportConfigurationForEntity,
+    ImageVulnerabilityReportFiltersForEntity,
+} from './imageVulnerabilityReports.types';
+
+export const initialImageVulnerabilityReportFiltersForCollection: VulnerabilityReportFilters = {
+    fixability: 'FIXABLE',
+    severities: ['CRITICAL_VULNERABILITY_SEVERITY', 'IMPORTANT_VULNERABILITY_SEVERITY'],
+    imageTypes: ['DEPLOYED', 'WATCHED'],
+    allVuln: true,
+    // TO BE DELETED
+    includeAdvisory: false,
+    includeEpssProbability: false,
+    // includeKnownExploit: false, // ROX_CISA_KEV
+    includeNvdCvss: false,
+} as const;
+
+export const initialVulnerabilityReportFiltersForEntity: ImageVulnerabilityReportFiltersForEntity =
+    {
+        imageTypes: ['DEPLOYED', 'WATCHED'],
+        query: '',
+        allVuln: true,
+    } as const;
+
+export const initialImageVulnerabilityReportConfiguration: ImageVulnerabilityReportConfigurationForEntity =
+    {
+        id: '',
+        name: '',
+        description: '',
+        type: 'VULNERABILITY',
+        vulnReportFilters: initialVulnerabilityReportFiltersForEntity,
+        notifiers: [],
+        schedule: null,
+        resourceScope: {
+            entityScope: {
+                rules: [],
+            },
+        },
+    } as const;
+
+// TypeScript needs help because entityScope and vulnReportFilters have mutual dependencies.
+export function hasConfigurationForEntity(
+    values: ImageVulnerabilityReportConfiguration
+): values is ImageVulnerabilityReportConfigurationForEntity {
+    return 'entityScope' in values.resourceScope;
+}
 
 export function getTextForCvesSince(vulnReportFilters: CvesSince) {
     if ('allVuln' in vulnReportFilters) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeVulnerabilityReports/nodeVulnerabilityReports.types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeVulnerabilityReports/nodeVulnerabilityReports.types.ts
@@ -1,0 +1,24 @@
+import type { CvesSince, EntityScope, NotifierConfiguration } from 'services/ReportsService.types';
+import type { Schedule } from 'types/schedule.proto';
+
+export type NodeVulnerabilityResourcesConfiguration = {
+    resourceScope: {
+        entityScope: EntityScope;
+    };
+};
+
+export type NodeVulnerabilityFiltersConfiguration = {
+    vulnReportFilters: {
+        query: string;
+    } & CvesSince;
+};
+
+export type NodeVulnerabilityReportConfiguration = {
+    id: string;
+    name: string;
+    description: string;
+    type: 'NODE_VULNERABILITY';
+    notifiers: NotifierConfiguration[];
+    schedule: Schedule | null;
+} & NodeVulnerabilityResourcesConfiguration &
+    NodeVulnerabilityFiltersConfiguration;

--- a/ui/apps/platform/src/services/ReportsService.types.ts
+++ b/ui/apps/platform/src/services/ReportsService.types.ts
@@ -104,6 +104,36 @@ export type CollectionScope = {
     collectionName: string;
 };
 
+export type EntityScope = {
+    rules: EntityScopeRule[];
+};
+
+export type MatchType = 'EXACT' | 'REGEX';
+
+export type RuleValue = {
+    value: string;
+    matchType: MatchType;
+};
+
+export type EntityScopeRule = {
+    entity: ScopeEntity;
+    field: ScopeField;
+    values: RuleValue[];
+};
+
+export type ScopeEntity =
+    | 'SCOPE_ENTITY_UNSET'
+    | 'SCOPE_ENTITY_DEPLOYMENT'
+    | 'SCOPE_ENTITY_NAMESPACE'
+    | 'SCOPE_ENTITY_CLUSTER';
+
+export type ScopeField =
+    | 'FIELD_UNSET'
+    | 'FIELD_ID'
+    | 'FIELD_NAME'
+    | 'FIELD_LABEL'
+    | 'FIELD_ANNOTATION';
+
 export type CollectionSnapshot = {
     id: string;
     name: string;


### PR DESCRIPTION
## Description

Frontend counterpart to backend proto changes in #19699

Additional changes:

* Omit `includeWhatever` properties, because all columns become required.

* Rename **Parameters** as **Filters** (decided in cross-team meeting).

    Decision about **Destinations** is pending.

### Objective

Provide equivalent filter for scheduled reports as view-based reports.

### Analysis

Find in Files `ReportConfiguraiton` with Match Whole Word has 39 results in 12 files

### Solution

1. Move `EntityScope` and associated types to src/services/ReportService.ts file.

2. Add `ImageVulnerabilityReportConfiguration` type in imageVulnerabilityReports.types.ts file for feature work.

   When we delete `ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING` feature flag, either delete `ReportConfiguration` or factor minimal common properties. 

3. Add corresponding subset of changes for `NodeVulnerabilityReportConfiguration` type in NodeVulnerabilityReports.types.ts file for future work.

### Residue

1. After cross-team decision about **Delivery** versus alternatives, factor out it and **Detail** type and files.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.