### PR TITLE
ROX-32714: Update groovy tests for ImageV2

### DIFF
--- a/qa-tests-backend/build.gradle.kts
+++ b/qa-tests-backend/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
     implementation(libs.picocontainer)
 
     implementation(libs.commons.codec)
+    implementation(libs.uuid.creator)
 
     implementation(projects.annotations)
 }

--- a/qa-tests-backend/gradle/libs.versions.toml
+++ b/qa-tests-backend/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ jaxb-runtime = { module = "org.glassfish.jaxb:jaxb-runtime", version = "4.0.7" }
 javers-core = { module = "org.javers:javers-core", version = "7.11.0" }
 picocontainer = { module = "org.picocontainer:picocontainer", version = "2.15.2" }
 commons-codec = { module = "commons-codec:commons-codec", version = "1.20.0" }
+uuid-creator = { module = "com.github.f4b6a3:uuid-creator", version = "6.1.1" }
 
 [plugins]
 protobuf = { id = "com.google.protobuf", version = "0.8.19" }

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -1,7 +1,9 @@
 package util
 
+import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.security.MessageDigest
 import java.text.SimpleDateFormat
 
 import groovy.transform.CompileDynamic
@@ -192,6 +194,42 @@ class Helpers {
                  " QA_TEST_DEBUG_LOGS: ${Env.QA_TEST_DEBUG_LOGS}]")
 
         return false
+    }
+
+    // Mirrors Go's pkg/uuid.NewV5FromNonUUIDs: SHA-256 the namespace string to derive
+    // a UUID namespace, then produce a standard UUIDv5 (SHA-1) from that namespace and name.
+    static String newV5FromNonUUIDs(String ns, String name) {
+        byte[] sha256 = MessageDigest.getInstance("SHA-256").digest(ns.getBytes("UTF-8"))
+        long msb = ByteBuffer.wrap(sha256, 0, 8).getLong()
+        long lsb = ByteBuffer.wrap(sha256, 8, 8).getLong()
+        UUID nsUUID = new UUID(msb, lsb)
+
+        MessageDigest sha1 = MessageDigest.getInstance("SHA-1")
+        sha1.update(uuidToBytes(nsUUID))
+        sha1.update(name.getBytes("UTF-8"))
+        byte[] hash = sha1.digest()
+
+        hash[6] = (byte) ((hash[6] & 0x0F) | 0x50) // version 5
+        hash[8] = (byte) ((hash[8] & 0x3F) | 0x80) // variant RFC 4122
+        long msbResult = ByteBuffer.wrap(hash, 0, 8).getLong()
+        long lsbResult = ByteBuffer.wrap(hash, 8, 8).getLong()
+        return new UUID(msbResult, lsbResult).toString()
+    }
+
+    private static byte[] uuidToBytes(UUID uuid) {
+        ByteBuffer bb = ByteBuffer.allocate(16)
+        bb.putLong(uuid.getMostSignificantBits())
+        bb.putLong(uuid.getLeastSignificantBits())
+        return bb.array()
+    }
+
+    // Mirrors Go's pkg/images/utils.NewImageV2ID: generates a deterministic UUIDv5
+    // from the image full name and digest.
+    static String generateImageV2ID(String fullName, String digest) {
+        if (!fullName || !digest) {
+            return ""
+        }
+        return newV5FromNonUUIDs(fullName, digest)
     }
 
     private static final Set<String> VOLATILE_ANNOTATIONS_TO_IGNORE = [

--- a/qa-tests-backend/src/main/groovy/util/Helpers.groovy
+++ b/qa-tests-backend/src/main/groovy/util/Helpers.groovy
@@ -1,10 +1,11 @@
 package util
 
-import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.security.MessageDigest
 import java.text.SimpleDateFormat
+
+import com.github.f4b6a3.uuid.UuidCreator
 
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
@@ -200,27 +201,8 @@ class Helpers {
     // a UUID namespace, then produce a standard UUIDv5 (SHA-1) from that namespace and name.
     static String newV5FromNonUUIDs(String ns, String name) {
         byte[] sha256 = MessageDigest.getInstance("SHA-256").digest(ns.getBytes("UTF-8"))
-        long msb = ByteBuffer.wrap(sha256, 0, 8).getLong()
-        long lsb = ByteBuffer.wrap(sha256, 8, 8).getLong()
-        UUID nsUUID = new UUID(msb, lsb)
-
-        MessageDigest sha1 = MessageDigest.getInstance("SHA-1")
-        sha1.update(uuidToBytes(nsUUID))
-        sha1.update(name.getBytes("UTF-8"))
-        byte[] hash = sha1.digest()
-
-        hash[6] = (byte) ((hash[6] & 0x0F) | 0x50) // version 5
-        hash[8] = (byte) ((hash[8] & 0x3F) | 0x80) // variant RFC 4122
-        long msbResult = ByteBuffer.wrap(hash, 0, 8).getLong()
-        long lsbResult = ByteBuffer.wrap(hash, 8, 8).getLong()
-        return new UUID(msbResult, lsbResult).toString()
-    }
-
-    private static byte[] uuidToBytes(UUID uuid) {
-        ByteBuffer bb = ByteBuffer.allocate(16)
-        bb.putLong(uuid.getMostSignificantBits())
-        bb.putLong(uuid.getLeastSignificantBits())
-        return bb.array()
+        UUID nsUUID = UuidCreator.fromBytes(Arrays.copyOf(sha256, 16))
+        return UuidCreator.getNameBasedSha1(nsUUID, name).toString()
     }
 
     // Mirrors Go's pkg/images/utils.NewImageV2ID: generates a deterministic UUIDv5

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -83,7 +83,8 @@ class AdmissionControllerTest extends BaseSpecification {
         // Pre-scan the image so Central has cached scan results for CVE-based policy evaluation.
         ImageService.scanImage(SCAN_INLINE_IMAGE_NAME_WITH_SHA)
 
-        ImageOuterClass.Image image = ImageService.getImage(SCAN_INLINE_IMAGE_SHA, false)
+        def imageId = flattenImageDataEnabled ? TEST_IMAGE_V2_ID : SCAN_INLINE_IMAGE_SHA
+        ImageOuterClass.Image image = ImageService.getImage(imageId, false)
         assert image
         assert !image.getNotesList().contains(ImageOuterClass.Image.Note.MISSING_METADATA)
 

--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -48,6 +48,8 @@ class BaseSpecification extends Specification {
     static final String TEST_IMAGE = "quay.io/rhacs-eng/qa-multi-arch:nginx-2.0.3@$TEST_IMAGE_SHA"
     static final String TEST_IMAGE_NAME_WITH_SHA = TEST_IMAGE
     static final String TEST_IMAGE_SHA = "sha256:ebecc1ad41054eaef19ef9c84e0d95551dfbdebbf0875fd407aee697e4be3860"
+    // UUIDv5 of TEST_IMAGE (full name) and TEST_IMAGE_SHA (digest), used as image ID when FlattenImageData is enabled.
+    static final String TEST_IMAGE_V2_ID = Helpers.generateImageV2ID(TEST_IMAGE, TEST_IMAGE_SHA)
 
     static final String RUN_ID
 
@@ -75,6 +77,7 @@ class BaseSpecification extends Specification {
     public static String coreImageIntegrationId = null
 
     public static boolean scannerV4Enabled = false
+    public static boolean flattenImageDataEnabled = false
 
     private static synchronizedGlobalSetup() {
         synchronized(BaseSpecification) {
@@ -133,6 +136,9 @@ class BaseSpecification extends Specification {
 
         scannerV4Enabled = FeatureFlagService.isFeatureFlagEnabled("ROX_SCANNER_V4")
         LOG.info "Scanner V4 enabled: ${scannerV4Enabled}"
+
+        flattenImageDataEnabled = Env.get("ROX_FLATTEN_IMAGE_DATA") == "true"
+        LOG.info "Flatten Image Data enabled: ${flattenImageDataEnabled}"
 
         if (ClusterService.isOpenShift4()) {
             assert Env.mustGetOrchestratorType() == OrchestratorTypes.OPENSHIFT,

--- a/qa-tests-backend/src/test/groovy/CSVTest.groovy
+++ b/qa-tests-backend/src/test/groovy/CSVTest.groovy
@@ -134,6 +134,19 @@ class CSVTest extends BaseSpecification {
         return "CVE Type:IMAGE_CVE+"
     }
 
+    def getTestImageId() {
+        return flattenImageDataEnabled ? TEST_IMAGE_V2_ID : TEST_IMAGE_SHA
+    }
+
+    def getDeploymentUid() {
+        return CVE_DEPLOYMENT.deploymentUid
+    }
+
+    def getFixableCvesInImageQuery() {
+        def imageFilter = flattenImageDataEnabled ? "Image ID" : "Image Sha"
+        return "${imageFilter}:${getTestImageId()}+Fixable:true"
+    }
+
     Map<String, Object> payload(String id) {
         def pagination = new Pagination(0, 0, new SortOption("cvss", true))
         return [
@@ -227,10 +240,9 @@ class CSVTest extends BaseSpecification {
         where:
         "Data is"
 
-        description                        | id                           | query
-        "FIXABLE_CVES_IN_IMAGE_QUERY"      | TEST_IMAGE_SHA               | "Image Sha:${TEST_IMAGE_SHA}+Fixable:true"
-        "FIXABLE_CVES_IN_DEPLOYMENT_QUERY" | CVE_DEPLOYMENT.deploymentUid |
-                "Deployment ID:${CVE_DEPLOYMENT.deploymentUid}+Fixable:true"
+        description                        | id                 | query
+        "FIXABLE_CVES_IN_IMAGE_QUERY"      | getTestImageId()   | getFixableCvesInImageQuery()
+        "FIXABLE_CVES_IN_DEPLOYMENT_QUERY" | getDeploymentUid() | "Deployment ID:${getDeploymentUid()}+Fixable:true"
     }
 
     @EqualsAndHashCode(includeFields = true)

--- a/qa-tests-backend/src/test/groovy/GlobalSearch.groovy
+++ b/qa-tests-backend/src/test/groovy/GlobalSearch.groovy
@@ -34,6 +34,10 @@ class GlobalSearch extends BaseSpecification {
                                      SearchServiceOuterClass.SearchCategory.NAMESPACES,
                                      SearchServiceOuterClass.SearchCategory.IMAGES,
                                      SearchServiceOuterClass.SearchCategory.DEPLOYMENTS)
+        if (flattenImageDataEnabled) {
+            EXPECTED_DEPLOYMENT_CATEGORIES.add(SearchServiceOuterClass.SearchCategory.IMAGES_V2)
+            EXPECTED_IMAGE_CATEGORIES.add(SearchServiceOuterClass.SearchCategory.IMAGES_V2)
+        }
 
         orchestrator.createDeployment(DEPLOYMENT)
         assert Services.waitForDeployment(DEPLOYMENT)

--- a/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ImageManagementTest.groovy
@@ -218,7 +218,8 @@ class ImageManagementTest extends BaseSpecification {
         then:
         "Assert that riskScore is non-zero"
         withRetry(10, 3) {
-            def image = ImageService.getImage(TEST_IMAGE_SHA)
+            def imageId = flattenImageDataEnabled ? TEST_IMAGE_V2_ID : TEST_IMAGE_SHA
+            def image = ImageService.getImage(imageId)
             assert image != null && image.riskScore != 0
         }
     }
@@ -241,7 +242,8 @@ class ImageManagementTest extends BaseSpecification {
         then:
         "Assert that riskScore is non-zero"
         withRetry(10, 3) {
-            def image = ImageService.getImage(TEST_IMAGE_SHA)
+            def imageId = flattenImageDataEnabled ? TEST_IMAGE_V2_ID : TEST_IMAGE_SHA
+            def image = ImageService.getImage(imageId)
             assert image != null && image.riskScore != 0
         }
 

--- a/qa-tests-backend/src/test/groovy/SACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/SACTest.groovy
@@ -404,7 +404,7 @@ class SACTest extends BaseSpecification {
         tokenName                | category     | numResults
         NOACCESSTOKEN            | "Cluster"    | 0
         "searchDeploymentsToken" | "Deployment" | 1
-        "searchImagesToken"      | "Image"      | 1
+        "searchImagesToken"      | "Image"      | (flattenImageDataEnabled ? 2 : 1)
     }
 
     @Unroll

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -1,4 +1,4 @@
-import static util.Helpers.evaluateWithRetry
+import static util.Helpers.withRetry
 
 import com.google.protobuf.util.JsonFormat
 import groovy.io.FileType
@@ -86,14 +86,9 @@ class UpgradesTest extends BaseSpecification {
         def nodes = NodeService.getNodes()
         assert nodes.size() != 0
         "Image API returns non-zero values on upgrade"
-        if (flattenImageDataEnabled) {
-            // When FlattenImageData is enabled, the reprocessor moves images from the
-            // images table to images_v2 after upgrade, which may take some time.
-            evaluateWithRetry(30, 10) {
-                def images = ImageService.getImages()
-                assert images.size() != 0
-            }
-        } else {
+        // When FlattenImageData is enabled, the reprocessor moves images from the
+        // images table to images_v2 after upgrade, which may take some time.
+        withRetry(30, 10) {
             def images = ImageService.getImages()
             assert images.size() != 0
         }
@@ -111,19 +106,13 @@ class UpgradesTest extends BaseSpecification {
 
         then:
         "Check that we got the correct number of #resourceType from GraphQL "
-        assert resultRet.getValue() != null
-        if (flattenImageDataEnabled) {
-            // When FlattenImageData is enabled, the reprocessor moves images from the
-            // images table to images_v2 after upgrade, which may take some time.
-            evaluateWithRetry(30, 10) {
-                def retryResultRet = gqlService.Call(getQuery(resourceType), [ query: searchQuery ])
-                assert retryResultRet.getCode() == 200
-                assert retryResultRet.getValue() != null
-                def retryItems = retryResultRet.getValue()[resourceType]
-                assert retryItems.size() >= minResults
-            }
-        } else {
-            def items = resultRet.getValue()[resourceType]
+        // When FlattenImageData is enabled, the reprocessor moves images from the
+        // images table to images_v2 after upgrade, which may take some time.
+        withRetry(30, 10) {
+            def retryResultRet = gqlService.Call(getQuery(resourceType), [ query: searchQuery ])
+            assert retryResultRet.getCode() == 200
+            assert retryResultRet.getValue() != null
+            def items = retryResultRet.getValue()[resourceType]
             assert items.size() >= minResults
         }
 

--- a/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
+++ b/qa-tests-backend/src/test/groovy/UpgradesTest.groovy
@@ -1,3 +1,5 @@
+import static util.Helpers.evaluateWithRetry
+
 import com.google.protobuf.util.JsonFormat
 import groovy.io.FileType
 import io.grpc.StatusRuntimeException
@@ -84,8 +86,17 @@ class UpgradesTest extends BaseSpecification {
         def nodes = NodeService.getNodes()
         assert nodes.size() != 0
         "Image API returns non-zero values on upgrade"
-        def images = ImageService.getImages()
-        assert images.size() != 0
+        if (flattenImageDataEnabled) {
+            // When FlattenImageData is enabled, the reprocessor moves images from the
+            // images table to images_v2 after upgrade, which may take some time.
+            evaluateWithRetry(30, 10) {
+                def images = ImageService.getImages()
+                assert images.size() != 0
+            }
+        } else {
+            def images = ImageService.getImages()
+            assert images.size() != 0
+        }
     }
 
     @Unroll
@@ -101,8 +112,20 @@ class UpgradesTest extends BaseSpecification {
         then:
         "Check that we got the correct number of #resourceType from GraphQL "
         assert resultRet.getValue() != null
-        def items = resultRet.getValue()[resourceType]
-        assert items.size() >= minResults
+        if (flattenImageDataEnabled) {
+            // When FlattenImageData is enabled, the reprocessor moves images from the
+            // images table to images_v2 after upgrade, which may take some time.
+            evaluateWithRetry(30, 10) {
+                def retryResultRet = gqlService.Call(getQuery(resourceType), [ query: searchQuery ])
+                assert retryResultRet.getCode() == 200
+                assert retryResultRet.getValue() != null
+                def retryItems = retryResultRet.getValue()[resourceType]
+                assert retryItems.size() >= minResults
+            }
+        } else {
+            def items = resultRet.getValue()[resourceType]
+            assert items.size() >= minResults
+        }
 
         where:
         "Data Inputs Are:"

--- a/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
@@ -3,6 +3,7 @@ import io.stackrox.proto.storage.Cve.VulnerabilitySeverity
 import org.junit.Assume
 import services.GraphQLService
 import services.ImageService
+import util.Helpers
 
 import spock.lang.Tag
 import spock.lang.Unroll
@@ -28,6 +29,9 @@ class VulnMgmtTest extends BaseSpecification {
             "sha256:c9672795a48854502d9dc0f1b719ac36dd99259a2f8ce425904a5cb4ae0d60d2"
     static final private String UBUNTU_IMAGE =
             "quay.io/rhacs-eng/qa:ubuntu-22.04-amd64"
+
+    static final private MODERATE = VulnerabilitySeverity.MODERATE_VULNERABILITY_SEVERITY
+    static final private LOW = VulnerabilitySeverity.LOW_VULNERABILITY_SEVERITY
 
     private static final EMBEDDED_IMAGE_QUERY = """
     query getImage(\$id: ID!, \$query: String) {
@@ -187,14 +191,14 @@ query getComponentId(\$imageId: ID!, \$componentQuery: String) {
         Assume.assumeFalse(scannerV4Enabled)
 
         expect:
-        verifySeveritiesAndCvss(imageDigest, component, cve, severity, cvss)
+        verifySeveritiesAndCvss(imageDigest, imageName, component, cve, severity, cvss)
 
         where:
         "Data inputs are: "
 
-        imageDigest              | component | cve              | severity                                        | cvss
-        RHEL_IMAGE_LEGACY_DIGEST | "glib2"   | "CVE-2019-13012" | VulnerabilitySeverity.LOW_VULNERABILITY_SEVERITY | 4.4
-        UBUNTU_IMAGE_DIGEST      | "gnupg2"  | "CVE-2022-3219"  | VulnerabilitySeverity.LOW_VULNERABILITY_SEVERITY | 3.3
+        imageDigest               | imageName           | component | cve              | severity | cvss
+        RHEL_IMAGE_LEGACY_DIGEST  | RHEL_IMAGE_LEGACY   | "glib2"   | "CVE-2019-13012" | LOW      | 4.4
+        UBUNTU_IMAGE_DIGEST       | UBUNTU_IMAGE        | "gnupg2"  | "CVE-2022-3219"  | LOW      | 3.3
     }
 
     @Unroll
@@ -203,27 +207,28 @@ query getComponentId(\$imageId: ID!, \$componentQuery: String) {
         Assume.assumeTrue(scannerV4Enabled)
 
         expect:
-        verifySeveritiesAndCvss(imageDigest, component, cve, severity, cvss)
+        verifySeveritiesAndCvss(imageDigest, imageName, component, cve, severity, cvss)
 
         where:
         "Data inputs are: "
 
-        imageDigest         | component | cve              | severity                                             | cvss
-        RHEL_IMAGE_DIGEST   | "python3" | "CVE-2025-11468" | VulnerabilitySeverity.MODERATE_VULNERABILITY_SEVERITY | 4.5
-        UBUNTU_IMAGE_DIGEST | "gpgv"    | "CVE-2022-3219"  | VulnerabilitySeverity.LOW_VULNERABILITY_SEVERITY      | 3.3
+        imageDigest         | imageName    | component | cve              | severity | cvss
+        RHEL_IMAGE_DIGEST   | RHEL_IMAGE   | "python3" | "CVE-2025-11468" | MODERATE | 4.5
+        UBUNTU_IMAGE_DIGEST | UBUNTU_IMAGE | "gpgv"    | "CVE-2022-3219"  | LOW      | 3.3
     }
 
-    private void verifySeveritiesAndCvss(String imageDigest, String component, String cve,
+    private void verifySeveritiesAndCvss(String imageDigest, String imageName, String component, String cve,
                                           VulnerabilitySeverity severity, double cvss) {
         def gqlService = new GraphQLService()
 
         def query = "CVE:${cve}"
+        def imageId = flattenImageDataEnabled ? Helpers.generateImageV2ID(imageName, imageDigest) : imageDigest
 
         // Fetch the component ID dynamically since IDs now include image ID and index
-        def componentID = getComponentIDForImage(gqlService, imageDigest, component)
+        def componentID = getComponentIDForImage(gqlService, imageId, component)
 
         def embeddedImageRes = gqlService.Call(getEmbeddedImageQuery(),
-                [id: imageDigest, query: query])
+                [id: imageId, query: query])
 
         // Expanded instead of using hasErrors() for easier debugging if there are errors
         // as the test framework will actually print out the errors now
@@ -235,12 +240,12 @@ query getComponentId(\$imageId: ID!, \$componentQuery: String) {
         def embeddedImageResVuln = embeddedImageRes.value.result.scan.imageComponents[0].imageVulnerabilities[0]
 
         def topLevelImageRes = gqlService.Call(getTopLevelImageQuery(),
-                [id: imageDigest, query: query])
+                [id: imageId, query: query])
         assert topLevelImageRes.hasNoErrors()
         def topLevelImageResVuln = topLevelImageRes.value.result.vulns[0]
 
         def fixableCVEImageRes = gqlService.Call(getImageFixableCVEQuery(),
-                [id: imageDigest, vulnQuery: query, scopeQuery: "Image SHA:${imageDigest}"])
+                [id: imageId, vulnQuery: query, scopeQuery: "Image SHA:${imageDigest}"])
         assert fixableCVEImageRes.hasNoErrors()
         def fixableCVEImageResVuln = fixableCVEImageRes.value.result.vulnerabilities[0]
 


### PR DESCRIPTION
## Description

Update groovy E2E tests under `qa-tests-backend/` to work correctly when
`FlattenImageData` is enabled (ImageV2).

When `FlattenImageData` is enabled, images are stored in a new `images_v2`
table and their IDs change from the image digest (SHA) to a deterministic
UUIDv5 derived from the full image name and digest. These changes update
the tests to handle both ID schemes:

- Add `Helpers.generateImageV2ID()` and `newV5FromNonUUIDs()` to mirror the
  Go-side `pkg/images/utils.NewImageV2ID` UUID generation logic
- Add `flattenImageDataEnabled` flag to `BaseSpecification` (read from
  `ROX_FLATTEN_IMAGE_DATA` env var) and a pre-computed `TEST_IMAGE_V2_ID`
- Update `AdmissionControllerTest`, `ImageManagementTest`, and `CSVTest` to
  use the V2 image ID when the flag is enabled
- Update `VulnMgmtTest` to pass image name alongside digest so it can
  compute the correct image ID for GraphQL queries
- Update `SACTest` to expect an additional search result (IMAGES_V2 category)
- Update `GlobalSearch` to include the `IMAGES_V2` search category
- Add retry logic in `UpgradesTest` for `getImages` and GraphQL queries,
  since the reprocessor may take time to migrate images to `images_v2`
  after an upgrade

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Ran tests with and without the FlattenImageData enabled