### PR TITLE
ROX-33564: Add gzip, less, and tar packages to ubi-micro images

### DIFF
--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -31,6 +31,9 @@ RUN rpm --import /tmp/RPM-GPG-KEY-CentOS-Official && \
         --nodocs \
         findutils \
         ca-certificates \
+        gzip \
+        less \
+        tar \
         /tmp/postgres-libs.rpm \
         /tmp/postgres.rpm && \
     dnf clean all --installroot=/out/ && \

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -80,8 +80,11 @@ RUN dnf module enable -y \
         --nodocs \
         ca-certificates \
         findutils \
+        gzip \
+        less \
         openssl \
-        postgresql && \
+        postgresql \
+        tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/dnf /out/var/cache/yum
 

--- a/image/roxctl/Dockerfile
+++ b/image/roxctl/Dockerfile
@@ -11,7 +11,10 @@ RUN dnf install -y \
     --releasever=9 \
     --setopt=install_weak_deps=False \
     --nodocs \
-    ca-certificates gzip less tar && \
+    ca-certificates \
+    gzip \
+    less \
+    tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/dnf /out/var/cache/yum
 

--- a/image/roxctl/Dockerfile
+++ b/image/roxctl/Dockerfile
@@ -11,7 +11,7 @@ RUN dnf install -y \
     --releasever=9 \
     --setopt=install_weak_deps=False \
     --nodocs \
-    ca-certificates && \
+    ca-certificates gzip less tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/dnf /out/var/cache/yum
 

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -41,7 +41,7 @@ RUN dnf install -y \
     --setopt=install_weak_deps=False \
     --setopt=reposdir=/etc/yum.repos.d \
     --nodocs \
-    ca-certificates openssl && \
+    ca-certificates gzip less openssl tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/*
 

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -41,7 +41,11 @@ RUN dnf install -y \
     --setopt=install_weak_deps=False \
     --setopt=reposdir=/etc/yum.repos.d \
     --nodocs \
-    ca-certificates gzip less openssl tar && \
+    ca-certificates \
+    gzip \
+    less \
+    openssl \
+    tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/*
 

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -35,7 +35,10 @@ RUN dnf install -y \
     --setopt=reposdir=/etc/yum.repos.d \
     --nodocs \
     ca-certificates \
-    openssl && \
+    gzip \
+    less \
+    openssl \
+    tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/*
 

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -11,7 +11,10 @@ packages:
 - python3.12-pyyaml
 # package_installer stage in operator/konflux.Dockerfile, image/roxctl/konflux.Dockerfile, and scanner/image/scanner/konflux.Dockerfile
 - ca-certificates
+- gzip
+- less
 - openssl
+- tar
 moduleEnable:
 # final stage in image/rhel/konflux.Dockerfile
 - postgresql:15

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -46,20 +46,20 @@ arches:
     name: postgresql-private-libs
     evr: 15.17-1.module+el9.7.0+24029+ef6a2953
     sourcerpm: postgresql-15.17-1.module+el9.7.0+24029+ef6a2953.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.1.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.2.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 32556
-    checksum: sha256:0d360b72d46221e6c67bf4911523c7f63ce394e1d10d33d0ed1fe1f584989781
+    size: 32669
+    checksum: sha256:e4b898a306c9199feb6d72ec8f3c6fb6736e339a9a9e787a19732decb9c2c4c6
     name: python3.12
-    evr: 3.12.12-4.el9_7.1
-    sourcerpm: python3.12-3.12.12-4.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.1.aarch64.rpm
+    evr: 3.12.12-4.el9_7.2
+    sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.2.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 10139241
-    checksum: sha256:79f41e3b0dc48884c4d7de8339ba9462862e645d5a53a2f61f970469c1a70395
+    size: 10140707
+    checksum: sha256:6cc853fb09b9b81fe4da67619cd8b879e2ccfd9d16f617e597cb0759e62fbb0c
     name: python3.12-libs
-    evr: 3.12.12-4.el9_7.1
-    sourcerpm: python3.12-3.12.12-4.el9_7.1.src.rpm
+    evr: 3.12.12-4.el9_7.2
+    sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 1527128
@@ -221,6 +221,13 @@ arches:
     name: grep
     evr: 3.6-5.el9
     sourcerpm: grep-3.6-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/g/gzip-1.12-1.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 169809
+    checksum: sha256:45710df49b439ddc4a2848fd3877367761b574234ae28b6be46f1cf54f3fcdca
+    name: gzip
+    evr: 1.12-1.el9
+    sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/j/jq-1.6-19.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 185334
@@ -242,6 +249,13 @@ arches:
     name: krb5-libs
     evr: 1.21.1-8.el9_6
     sourcerpm: krb5-1.21.1-8.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/less-590-6.el9.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 165028
+    checksum: sha256:fa762484ba40e0b7eb1c25531a66a0b578b6141cabb6f73d865c13ccdf75c1c9
+    name: less
+    evr: 590-6.el9
+    sourcerpm: less-590-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libacl-2.3.1-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 24374
@@ -515,6 +529,13 @@ arches:
     name: sqlite-libs
     evr: 3.34.1-9.el9_7
     sourcerpm: sqlite-3.34.1-9.el9_7.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/t/tar-1.34-9.el9_7.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-rpms
+    size: 898317
+    checksum: sha256:2d0bd44116c3f5c229d25fdc6458f6ce24a7ad4fdb463767eea48dcab78c5062
+    name: tar
+    evr: 2:1.34-9.el9_7
+    sourcerpm: tar-1.34-9.el9_7.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/t/tzdata-2026a-1.el9.noarch.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 933237
@@ -561,12 +582,12 @@ arches:
     checksum: sha256:b89dc91bc68b60b6d439aec4846b36a129ab806506272724a6d1022bd0f14263
     name: postgresql
     evr: 15.17-1.module+el9.7.0+24029+ef6a2953
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.2.src.rpm
     repoid: rhel-9-for-aarch64-appstream-source-rpms
-    size: 20878981
-    checksum: sha256:5fa971ae08c44c59bee11855de099a683c81b02bc3c6f94be7b7efae0508a83f
+    size: 20880557
+    checksum: sha256:0d4494e18c3a6b5c62c96ef5786561fc6fab96cd50f2380c1471d2eaeabd06fd
     name: python3.12
-    evr: 3.12.12-4.el9_7.1
+    evr: 3.12.12-4.el9_7.2
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/source/SRPMS/Packages/p/python3.12-pip-23.2.1-5.el9.src.rpm
     repoid: rhel-9-for-aarch64-appstream-source-rpms
     size: 9384965
@@ -705,6 +726,12 @@ arches:
     checksum: sha256:81b14432ebe1645b74b57592f1dcde8fab15ec13632f483f72ff2407ed16c33e
     name: grep
     evr: 3.6-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/g/gzip-1.12-1.el9.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 856147
+    checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
+    name: gzip
+    evr: 1.12-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/j/jq-1.6-19.el9.src.rpm
     repoid: rhel-9-for-aarch64-baseos-source-rpms
     size: 1505339
@@ -723,6 +750,12 @@ arches:
     checksum: sha256:23c749362fb5f9a342900022b42457009a56333aa423ee68de460b7f13ceb6a9
     name: krb5
     evr: 1.21.1-8.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/l/less-590-6.el9.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 382338
+    checksum: sha256:4a5023846942905da4226503f6a9da91a66bf6c179dc21d2e4210b3371399b17
+    name: less
+    evr: 590-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/l/libcap-2.48-10.el9.src.rpm
     repoid: rhel-9-for-aarch64-baseos-source-rpms
     size: 200754
@@ -891,6 +924,12 @@ arches:
     checksum: sha256:1d89566fe2e33bbd86fe1d024e3dbb7e800aef138f8d8d99ab65b15a6f6c2c5a
     name: sqlite
     evr: 3.34.1-9.el9_7
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/t/tar-1.34-9.el9_7.src.rpm
+    repoid: rhel-9-for-aarch64-baseos-source-rpms
+    size: 2282680
+    checksum: sha256:9b84935c6072500fa28674521fe13816a8be44c50bb8eaf5ec73994782161250
+    name: tar
+    evr: 2:1.34-9.el9_7
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/source/SRPMS/Packages/t/tzdata-2026a-1.el9.src.rpm
     repoid: rhel-9-for-aarch64-baseos-source-rpms
     size: 926120
@@ -916,10 +955,10 @@ arches:
     name: zlib
     evr: 1.2.11-40.el9
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/repodata/b01fb0a5f6041de7fd2965f2830f9d97044a12df93f9c3c4c63d48451d65b0ad-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/repodata/3f9ce78ae1f7577b0599d300734a914f68c5b5f898b3f79097747deea33f7874-modules.yaml.gz
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 43533
-    checksum: sha256:b01fb0a5f6041de7fd2965f2830f9d97044a12df93f9c3c4c63d48451d65b0ad
+    size: 45439
+    checksum: sha256:3f9ce78ae1f7577b0599d300734a914f68c5b5f898b3f79097747deea33f7874
 - arch: ppc64le
   packages:
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/g/gawk-all-langpacks-5.1.0-6.el9.ppc64le.rpm
@@ -964,20 +1003,20 @@ arches:
     name: postgresql-private-libs
     evr: 15.17-1.module+el9.7.0+24029+ef6a2953
     sourcerpm: postgresql-15.17-1.module+el9.7.0+24029+ef6a2953.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.1.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.2.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 32611
-    checksum: sha256:bbdb5fd1db7376531291fccbdbc6054e215e7c27c7c1c7be4811a4890ff49b51
+    size: 32721
+    checksum: sha256:df48b88f619974806aa26e56218b32e86b1996718c9e1dfd9ca1d9a77d039ec3
     name: python3.12
-    evr: 3.12.12-4.el9_7.1
-    sourcerpm: python3.12-3.12.12-4.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.1.ppc64le.rpm
+    evr: 3.12.12-4.el9_7.2
+    sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.2.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 10078807
-    checksum: sha256:818cae0b74e9d7c65f599e42d39241588d50332103be6a1995722b32ad3dce37
+    size: 10083489
+    checksum: sha256:b9b9d3119c30def6fb374bc43594af52bd0ab6cb54465d83f10b8f73fc9563d0
     name: python3.12-libs
-    evr: 3.12.12-4.el9_7.1
-    sourcerpm: python3.12-3.12.12-4.el9_7.1.src.rpm
+    evr: 3.12.12-4.el9_7.2
+    sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 1527128
@@ -1139,6 +1178,13 @@ arches:
     name: grep
     evr: 3.6-5.el9
     sourcerpm: grep-3.6-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/g/gzip-1.12-1.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 175705
+    checksum: sha256:55b983f08d8b2a0741b07f114cdba89a8ecb207064c001e90e4c76a13836d458
+    name: gzip
+    evr: 1.12-1.el9
+    sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/j/jq-1.6-19.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 204601
@@ -1160,6 +1206,13 @@ arches:
     name: krb5-libs
     evr: 1.21.1-8.el9_6
     sourcerpm: krb5-1.21.1-8.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/less-590-6.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 177816
+    checksum: sha256:f909dc6be219e81adf5971c832be097d06296fabdff67688f701e3437b55d4dc
+    name: less
+    evr: 590-6.el9
+    sourcerpm: less-590-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libacl-2.3.1-4.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 26589
@@ -1433,6 +1486,13 @@ arches:
     name: sqlite-libs
     evr: 3.34.1-9.el9_7
     sourcerpm: sqlite-3.34.1-9.el9_7.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/t/tar-1.34-9.el9_7.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 938310
+    checksum: sha256:6b32b0c5b960f836c91fae329c0d2786d932a44b9e44711639646b5e55146c8b
+    name: tar
+    evr: 2:1.34-9.el9_7
+    sourcerpm: tar-1.34-9.el9_7.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/t/tzdata-2026a-1.el9.noarch.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 933237
@@ -1479,12 +1539,12 @@ arches:
     checksum: sha256:b89dc91bc68b60b6d439aec4846b36a129ab806506272724a6d1022bd0f14263
     name: postgresql
     evr: 15.17-1.module+el9.7.0+24029+ef6a2953
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.2.src.rpm
     repoid: rhel-9-for-ppc64le-appstream-source-rpms
-    size: 20878981
-    checksum: sha256:5fa971ae08c44c59bee11855de099a683c81b02bc3c6f94be7b7efae0508a83f
+    size: 20880557
+    checksum: sha256:0d4494e18c3a6b5c62c96ef5786561fc6fab96cd50f2380c1471d2eaeabd06fd
     name: python3.12
-    evr: 3.12.12-4.el9_7.1
+    evr: 3.12.12-4.el9_7.2
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/source/SRPMS/Packages/p/python3.12-pip-23.2.1-5.el9.src.rpm
     repoid: rhel-9-for-ppc64le-appstream-source-rpms
     size: 9384965
@@ -1623,6 +1683,12 @@ arches:
     checksum: sha256:81b14432ebe1645b74b57592f1dcde8fab15ec13632f483f72ff2407ed16c33e
     name: grep
     evr: 3.6-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/g/gzip-1.12-1.el9.src.rpm
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
+    size: 856147
+    checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
+    name: gzip
+    evr: 1.12-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/j/jq-1.6-19.el9.src.rpm
     repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 1505339
@@ -1641,6 +1707,12 @@ arches:
     checksum: sha256:23c749362fb5f9a342900022b42457009a56333aa423ee68de460b7f13ceb6a9
     name: krb5
     evr: 1.21.1-8.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/less-590-6.el9.src.rpm
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
+    size: 382338
+    checksum: sha256:4a5023846942905da4226503f6a9da91a66bf6c179dc21d2e4210b3371399b17
+    name: less
+    evr: 590-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/l/libcap-2.48-10.el9.src.rpm
     repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 200754
@@ -1809,6 +1881,12 @@ arches:
     checksum: sha256:1d89566fe2e33bbd86fe1d024e3dbb7e800aef138f8d8d99ab65b15a6f6c2c5a
     name: sqlite
     evr: 3.34.1-9.el9_7
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/t/tar-1.34-9.el9_7.src.rpm
+    repoid: rhel-9-for-ppc64le-baseos-source-rpms
+    size: 2282680
+    checksum: sha256:9b84935c6072500fa28674521fe13816a8be44c50bb8eaf5ec73994782161250
+    name: tar
+    evr: 2:1.34-9.el9_7
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/source/SRPMS/Packages/t/tzdata-2026a-1.el9.src.rpm
     repoid: rhel-9-for-ppc64le-baseos-source-rpms
     size: 926120
@@ -1834,10 +1912,10 @@ arches:
     name: zlib
     evr: 1.2.11-40.el9
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/repodata/04032c239e78ae852bb334abe7224258db37dadddbb137afdac682c1fb99d76e-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/repodata/991a4e0aece8d78d15c8b8ca704852e7b0ee38010d64a0150624d34ddab4e39f-modules.yaml.gz
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 40714
-    checksum: sha256:04032c239e78ae852bb334abe7224258db37dadddbb137afdac682c1fb99d76e
+    size: 42369
+    checksum: sha256:991a4e0aece8d78d15c8b8ca704852e7b0ee38010d64a0150624d34ddab4e39f
 - arch: s390x
   packages:
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/g/gawk-all-langpacks-5.1.0-6.el9.s390x.rpm
@@ -1882,20 +1960,20 @@ arches:
     name: postgresql-private-libs
     evr: 15.17-1.module+el9.7.0+24029+ef6a2953
     sourcerpm: postgresql-15.17-1.module+el9.7.0+24029+ef6a2953.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.1.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.2.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 32416
-    checksum: sha256:0571271237e964c415a1e250b2231a661593ab624634df7bda88b437798015a0
+    size: 32522
+    checksum: sha256:119db15b5df8df92bed4dd15c26d5d04cdf8e1d36dfebf732165818c6742751b
     name: python3.12
-    evr: 3.12.12-4.el9_7.1
-    sourcerpm: python3.12-3.12.12-4.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.1.s390x.rpm
+    evr: 3.12.12-4.el9_7.2
+    sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.2.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 9973559
-    checksum: sha256:9ff71df093ae61b010222e30821e0044c42e92c7e8f69c0d6574ac0e30ca21e1
+    size: 9960665
+    checksum: sha256:01d5e75e5d85f769c03d24e9a80456b0330f3f8c9353115cd8364a482043d041
     name: python3.12-libs
-    evr: 3.12.12-4.el9_7.1
-    sourcerpm: python3.12-3.12.12-4.el9_7.1.src.rpm
+    evr: 3.12.12-4.el9_7.2
+    sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
     size: 1527128
@@ -2057,6 +2135,13 @@ arches:
     name: grep
     evr: 3.6-5.el9
     sourcerpm: grep-3.6-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/g/gzip-1.12-1.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 173101
+    checksum: sha256:50034ee6281864a218a5f3bc47de5afb434400fb8415907fd31d8351adbdc5a6
+    name: gzip
+    evr: 1.12-1.el9
+    sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/j/jq-1.6-19.el9.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
     size: 200998
@@ -2078,6 +2163,13 @@ arches:
     name: krb5-libs
     evr: 1.21.1-8.el9_6
     sourcerpm: krb5-1.21.1-8.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/less-590-6.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 166698
+    checksum: sha256:63241d59d1ce7164d516ff360b6186ab8c7b49e642a48ed0f09c55451ea26beb
+    name: less
+    evr: 590-6.el9
+    sourcerpm: less-590-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libacl-2.3.1-4.el9.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
     size: 24699
@@ -2351,6 +2443,13 @@ arches:
     name: sqlite-libs
     evr: 3.34.1-9.el9_7
     sourcerpm: sqlite-3.34.1-9.el9_7.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/t/tar-1.34-9.el9_7.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 900131
+    checksum: sha256:ae335ed3e594cdb4123c6732c5dd9d4250050e96117e2593b31f8c4ee4ee2b8f
+    name: tar
+    evr: 2:1.34-9.el9_7
+    sourcerpm: tar-1.34-9.el9_7.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/t/tzdata-2026a-1.el9.noarch.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
     size: 933237
@@ -2397,12 +2496,12 @@ arches:
     checksum: sha256:b89dc91bc68b60b6d439aec4846b36a129ab806506272724a6d1022bd0f14263
     name: postgresql
     evr: 15.17-1.module+el9.7.0+24029+ef6a2953
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.2.src.rpm
     repoid: rhel-9-for-s390x-appstream-source-rpms
-    size: 20878981
-    checksum: sha256:5fa971ae08c44c59bee11855de099a683c81b02bc3c6f94be7b7efae0508a83f
+    size: 20880557
+    checksum: sha256:0d4494e18c3a6b5c62c96ef5786561fc6fab96cd50f2380c1471d2eaeabd06fd
     name: python3.12
-    evr: 3.12.12-4.el9_7.1
+    evr: 3.12.12-4.el9_7.2
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/source/SRPMS/Packages/p/python3.12-pip-23.2.1-5.el9.src.rpm
     repoid: rhel-9-for-s390x-appstream-source-rpms
     size: 9384965
@@ -2541,6 +2640,12 @@ arches:
     checksum: sha256:81b14432ebe1645b74b57592f1dcde8fab15ec13632f483f72ff2407ed16c33e
     name: grep
     evr: 3.6-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/g/gzip-1.12-1.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 856147
+    checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
+    name: gzip
+    evr: 1.12-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/j/jq-1.6-19.el9.src.rpm
     repoid: rhel-9-for-s390x-baseos-source-rpms
     size: 1505339
@@ -2559,6 +2664,12 @@ arches:
     checksum: sha256:23c749362fb5f9a342900022b42457009a56333aa423ee68de460b7f13ceb6a9
     name: krb5
     evr: 1.21.1-8.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/less-590-6.el9.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 382338
+    checksum: sha256:4a5023846942905da4226503f6a9da91a66bf6c179dc21d2e4210b3371399b17
+    name: less
+    evr: 590-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/l/libcap-2.48-10.el9.src.rpm
     repoid: rhel-9-for-s390x-baseos-source-rpms
     size: 200754
@@ -2727,6 +2838,12 @@ arches:
     checksum: sha256:1d89566fe2e33bbd86fe1d024e3dbb7e800aef138f8d8d99ab65b15a6f6c2c5a
     name: sqlite
     evr: 3.34.1-9.el9_7
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/t/tar-1.34-9.el9_7.src.rpm
+    repoid: rhel-9-for-s390x-baseos-source-rpms
+    size: 2282680
+    checksum: sha256:9b84935c6072500fa28674521fe13816a8be44c50bb8eaf5ec73994782161250
+    name: tar
+    evr: 2:1.34-9.el9_7
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/source/SRPMS/Packages/t/tzdata-2026a-1.el9.src.rpm
     repoid: rhel-9-for-s390x-baseos-source-rpms
     size: 926120
@@ -2752,10 +2869,10 @@ arches:
     name: zlib
     evr: 1.2.11-40.el9
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/repodata/dc519ec2ac397f4549c8c225211e9b169393d18cb567bd4e84c365ceb380256f-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/repodata/16622afc70ec2afe2abc2fe54a06de52804c8e3805751dd3d328023b7e49519d-modules.yaml.gz
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 42385
-    checksum: sha256:dc519ec2ac397f4549c8c225211e9b169393d18cb567bd4e84c365ceb380256f
+    size: 44076
+    checksum: sha256:16622afc70ec2afe2abc2fe54a06de52804c8e3805751dd3d328023b7e49519d
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/g/gawk-all-langpacks-5.1.0-6.el9.x86_64.rpm
@@ -2800,20 +2917,20 @@ arches:
     name: postgresql-private-libs
     evr: 15.17-1.module+el9.7.0+24029+ef6a2953
     sourcerpm: postgresql-15.17-1.module+el9.7.0+24029+ef6a2953.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3.12-3.12.12-4.el9_7.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 32599
-    checksum: sha256:320e0811e1a64e9ac607c666b41d69fbd9917cf83befd52d88cf55396a2f0f6b
+    size: 32706
+    checksum: sha256:37b577f725f5ccc863f6d651585954153754e7e6bcbe9058d80f9d6e70f7c439
     name: python3.12
-    evr: 3.12.12-4.el9_7.1
-    sourcerpm: python3.12-3.12.12-4.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.1.x86_64.rpm
+    evr: 3.12.12-4.el9_7.2
+    sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3.12-libs-3.12.12-4.el9_7.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 10214024
-    checksum: sha256:3c63141ada03d7512b5e068309d0a067503601d9dfae060dd06dd69478943b82
+    size: 10208752
+    checksum: sha256:b585cdcc008fb29fbccec4f0bc7cf1478930bd7c3103b380ea04ab66a7dac414
     name: python3.12-libs
-    evr: 3.12.12-4.el9_7.1
-    sourcerpm: python3.12-3.12.12-4.el9_7.1.src.rpm
+    evr: 3.12.12-4.el9_7.2
+    sourcerpm: python3.12-3.12.12-4.el9_7.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/p/python3.12-pip-wheel-23.2.1-5.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 1527128
@@ -2975,6 +3092,13 @@ arches:
     name: grep
     evr: 3.6-5.el9
     sourcerpm: grep-3.6-5.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 171206
+    checksum: sha256:c8b3e0414d55b1eedb0185a564ac6cb2368bee2fd5f995447d045f6a714488ac
+    name: gzip
+    evr: 1.12-1.el9
+    sourcerpm: gzip-1.12-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/j/jq-1.6-19.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 191662
@@ -2996,6 +3120,13 @@ arches:
     name: krb5-libs
     evr: 1.21.1-8.el9_6
     sourcerpm: krb5-1.21.1-8.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/less-590-6.el9.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 166025
+    checksum: sha256:5bd040f9dd813167935fc390d546c119d90e0a9c77447a3d9ed1ef69c6f5a32a
+    name: less
+    evr: 590-6.el9
+    sourcerpm: less-590-6.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libacl-2.3.1-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 24627
@@ -3269,6 +3400,13 @@ arches:
     name: sqlite-libs
     evr: 3.34.1-9.el9_7
     sourcerpm: sqlite-3.34.1-9.el9_7.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tar-1.34-9.el9_7.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-rpms
+    size: 906521
+    checksum: sha256:4c0beb933074a5254c297e8968b3f41ec5a02b23056997ddcf526fe7e6166482
+    name: tar
+    evr: 2:1.34-9.el9_7
+    sourcerpm: tar-1.34-9.el9_7.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/t/tzdata-2026a-1.el9.noarch.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 933237
@@ -3315,12 +3453,12 @@ arches:
     checksum: sha256:b89dc91bc68b60b6d439aec4846b36a129ab806506272724a6d1022bd0f14263
     name: postgresql
     evr: 15.17-1.module+el9.7.0+24029+ef6a2953
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/python3.12-3.12.12-4.el9_7.2.src.rpm
     repoid: rhel-9-for-x86_64-appstream-source-rpms
-    size: 20878981
-    checksum: sha256:5fa971ae08c44c59bee11855de099a683c81b02bc3c6f94be7b7efae0508a83f
+    size: 20880557
+    checksum: sha256:0d4494e18c3a6b5c62c96ef5786561fc6fab96cd50f2380c1471d2eaeabd06fd
     name: python3.12
-    evr: 3.12.12-4.el9_7.1
+    evr: 3.12.12-4.el9_7.2
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/source/SRPMS/Packages/p/python3.12-pip-23.2.1-5.el9.src.rpm
     repoid: rhel-9-for-x86_64-appstream-source-rpms
     size: 9384965
@@ -3459,6 +3597,12 @@ arches:
     checksum: sha256:81b14432ebe1645b74b57592f1dcde8fab15ec13632f483f72ff2407ed16c33e
     name: grep
     evr: 3.6-5.el9
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/g/gzip-1.12-1.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 856147
+    checksum: sha256:a05f582ec42e89258ee5e10af96dee4300bcb2a6a69a76bfb5b46f79e6a6a47b
+    name: gzip
+    evr: 1.12-1.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/j/jq-1.6-19.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 1505339
@@ -3477,6 +3621,12 @@ arches:
     checksum: sha256:23c749362fb5f9a342900022b42457009a56333aa423ee68de460b7f13ceb6a9
     name: krb5
     evr: 1.21.1-8.el9_6
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/less-590-6.el9.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 382338
+    checksum: sha256:4a5023846942905da4226503f6a9da91a66bf6c179dc21d2e4210b3371399b17
+    name: less
+    evr: 590-6.el9
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/l/libcap-2.48-10.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 200754
@@ -3645,6 +3795,12 @@ arches:
     checksum: sha256:1d89566fe2e33bbd86fe1d024e3dbb7e800aef138f8d8d99ab65b15a6f6c2c5a
     name: sqlite
     evr: 3.34.1-9.el9_7
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/t/tar-1.34-9.el9_7.src.rpm
+    repoid: rhel-9-for-x86_64-baseos-source-rpms
+    size: 2282680
+    checksum: sha256:9b84935c6072500fa28674521fe13816a8be44c50bb8eaf5ec73994782161250
+    name: tar
+    evr: 2:1.34-9.el9_7
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/source/SRPMS/Packages/t/tzdata-2026a-1.el9.src.rpm
     repoid: rhel-9-for-x86_64-baseos-source-rpms
     size: 926120
@@ -3670,7 +3826,7 @@ arches:
     name: zlib
     evr: 1.2.11-40.el9
   module_metadata:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/repodata/fc1d52c8a75a935b79826891bdcd04795740c527e0715d99982c043c56071592-modules.yaml.gz
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/repodata/cb1d4dbbc263d97b4e14168e8f1c7de9d8191fd05c7c4e8c8dc9ff124ff1bf72-modules.yaml.gz
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 44284
-    checksum: sha256:fc1d52c8a75a935b79826891bdcd04795740c527e0715d99982c043c56071592
+    size: 45535
+    checksum: sha256:cb1d4dbbc263d97b4e14168e8f1c7de9d8191fd05c7c4e8c8dc9ff124ff1bf72

--- a/scanner/image/scanner/Dockerfile
+++ b/scanner/image/scanner/Dockerfile
@@ -22,7 +22,10 @@ RUN dnf install -y \
     --releasever=9 \
     --setopt=install_weak_deps=0 \
     --nodocs \
-    ca-certificates gzip less tar && \
+    ca-certificates \
+    gzip \
+    less \
+    tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/dnf /out/var/cache/yum
 

--- a/scanner/image/scanner/Dockerfile
+++ b/scanner/image/scanner/Dockerfile
@@ -22,7 +22,7 @@ RUN dnf install -y \
     --releasever=9 \
     --setopt=install_weak_deps=0 \
     --nodocs \
-    ca-certificates && \
+    ca-certificates gzip less tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/dnf /out/var/cache/yum
 

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -28,7 +28,11 @@ RUN dnf install -y \
     --setopt=install_weak_deps=0 \
     --setopt=reposdir=/etc/yum.repos.d \
     --nodocs \
-    ca-certificates gzip less openssl tar && \
+    ca-certificates \
+    gzip \
+    less \
+    openssl \
+    tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/dnf /out/var/cache/yum
 

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -28,7 +28,7 @@ RUN dnf install -y \
     --setopt=install_weak_deps=0 \
     --setopt=reposdir=/etc/yum.repos.d \
     --nodocs \
-    ca-certificates openssl && \
+    ca-certificates gzip less openssl tar && \
     dnf clean all --installroot=/out/ && \
     rm -rf /out/var/cache/dnf /out/var/cache/yum
 


### PR DESCRIPTION
These common Unix utilities are useful for debugging, log inspection, and file operations within containers. Adding them to all ubi-micro-based images (main, roxctl, scanner, operator) provides consistent tooling across the platform.

- https://github.com/stackrox/collector/pull/3220

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change


