### PR TITLE
refactor: migrate compliance init() to explicit Init() pattern

### DIFF
--- a/central/compliance/checks/all.go
+++ b/central/compliance/checks/all.go
@@ -1,10 +1,19 @@
 package checks
 
 import (
-	// Make sure all checks from all standards are registered.
-	_ "github.com/stackrox/rox/central/compliance/checks/hipaa_164"
-	_ "github.com/stackrox/rox/central/compliance/checks/nist800-190"
-	_ "github.com/stackrox/rox/central/compliance/checks/nist80053"
-	_ "github.com/stackrox/rox/central/compliance/checks/pcidss32"
-	_ "github.com/stackrox/rox/central/compliance/checks/remote"
+	hipaa164 "github.com/stackrox/rox/central/compliance/checks/hipaa_164"
+	nist800190 "github.com/stackrox/rox/central/compliance/checks/nist800-190"
+	"github.com/stackrox/rox/central/compliance/checks/nist80053"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32"
+	"github.com/stackrox/rox/central/compliance/checks/remote"
 )
+
+// Init registers all central compliance checks.
+// Called explicitly from central/compliance/manager/checks.go instead of package init().
+func Init() {
+	hipaa164.Init()
+	nist800190.Init()
+	nist80053.Init()
+	pcidss32.Init()
+	remote.Init()
+}

--- a/central/compliance/checks/all_test.go
+++ b/central/compliance/checks/all_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func init() {
+	Init()
+}
+
 func TestAllCheckIDsAreValid(t *testing.T) {
 	allChecks := framework.RegistrySingleton().GetAll()
 	var allControls []string

--- a/central/compliance/checks/hipaa_164/check306e/check.go
+++ b/central/compliance/checks/hipaa_164/check306e/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:306_e"
 
-func init() {
+func Register306e() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check306e/check_test.go
+++ b/central/compliance/checks/hipaa_164/check306e/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register306e()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/hipaa_164/check308a1i/check.go
+++ b/central/compliance/checks/hipaa_164/check308a1i/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:308_a_1_i"
 
-func init() {
+func Register308a1i() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check308a1iia/check.go
+++ b/central/compliance/checks/hipaa_164/check308a1iia/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:308_a_1_ii_a"
 
-func init() {
+func Register308a1iia() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check308a1iia/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a1iia/check_test.go
@@ -13,6 +13,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	hipaa164.Init()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/hipaa_164/check308a1iia/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a1iia/check_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	hipaa164.Init()
+	Register308a1iia()
 }
 
 func TestCheck(t *testing.T) {

--- a/central/compliance/checks/hipaa_164/check308a1iib/check.go
+++ b/central/compliance/checks/hipaa_164/check308a1iib/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:308_a_1_ii_b"
 
-func init() {
+func Register308a1iib() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check308a1iib/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a1iib/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	hipaa164.Init()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/hipaa_164/check308a1iib/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a1iib/check_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	hipaa164.Init()
+	Register308a1iib()
 }
 
 func TestCheck(t *testing.T) {

--- a/central/compliance/checks/hipaa_164/check308a3iia/check.go
+++ b/central/compliance/checks/hipaa_164/check308a3iia/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:308_a_3_ii_a"
 
-func init() {
+func Register308a3iia() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check308a3iib/check.go
+++ b/central/compliance/checks/hipaa_164/check308a3iib/check.go
@@ -10,7 +10,7 @@ const (
 	standardID = "HIPAA_164:308_a_3_ii_b"
 )
 
-func init() {
+func Register308a3iib() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/hipaa_164/check308a4/check.go
+++ b/central/compliance/checks/hipaa_164/check308a4/check.go
@@ -10,7 +10,7 @@ const (
 	standardID = "HIPAA_164:308_a_4"
 )
 
-func init() {
+func Register308a4() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/hipaa_164/check308a4iib/check.go
+++ b/central/compliance/checks/hipaa_164/check308a4iib/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:308_a_4_ii_b"
 
-func init() {
+func Register308a4iib() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check308a5iib/check.go
+++ b/central/compliance/checks/hipaa_164/check308a5iib/check.go
@@ -9,7 +9,7 @@ import (
 
 const checkID = "HIPAA_164:308_a_5_ii_b"
 
-func init() {
+func Register308a5iib() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check308a5iib/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a5iib/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	hipaa164.Init()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/hipaa_164/check308a5iib/check_test.go
+++ b/central/compliance/checks/hipaa_164/check308a5iib/check_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	hipaa164.Init()
+	Register308a5iib()
 }
 
 func TestCheck(t *testing.T) {

--- a/central/compliance/checks/hipaa_164/check308a6ii/check.go
+++ b/central/compliance/checks/hipaa_164/check308a6ii/check.go
@@ -9,7 +9,7 @@ import (
 
 const checkID = "HIPAA_164:308_a_6_ii"
 
-func init() {
+func Register308a6ii() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check308a7iie/check.go
+++ b/central/compliance/checks/hipaa_164/check308a7iie/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:308_a_7_ii_e"
 
-func init() {
+func Register308a7iie() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check310a1/check.go
+++ b/central/compliance/checks/hipaa_164/check310a1/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:310_a_1"
 
-func init() {
+func Register310a1() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check310a1a/check.go
+++ b/central/compliance/checks/hipaa_164/check310a1a/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:310_a_i_a"
 
-func init() {
+func Register310a1a() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check310d/check.go
+++ b/central/compliance/checks/hipaa_164/check310d/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:310_d"
 
-func init() {
+func Register310d() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check312c/check.go
+++ b/central/compliance/checks/hipaa_164/check312c/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:312_c"
 
-func init() {
+func Register312c() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check312e/check.go
+++ b/central/compliance/checks/hipaa_164/check312e/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:312_e"
 
-func init() {
+func Register312e() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check312e1/check.go
+++ b/central/compliance/checks/hipaa_164/check312e1/check.go
@@ -10,7 +10,7 @@ const (
 	standardID = "HIPAA_164:312_e_1"
 )
 
-func init() {
+func Register312e1() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/hipaa_164/check314a2ic/check.go
+++ b/central/compliance/checks/hipaa_164/check314a2ic/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:314_a_2_i_c"
 
-func init() {
+func Register314a2ic() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/check316b2iii/check.go
+++ b/central/compliance/checks/hipaa_164/check316b2iii/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "HIPAA_164:316_b_2_iii"
 
-func init() {
+func Register316b2iii() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/hipaa_164/init.go
+++ b/central/compliance/checks/hipaa_164/init.go
@@ -1,0 +1,47 @@
+package hipaa164
+
+import (
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check306e"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check308a1i"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check308a1iia"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check308a1iib"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check308a3iia"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check308a3iib"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check308a4"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check308a4iib"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check308a5iib"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check308a6ii"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check308a7iie"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check310a1"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check310a1a"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check310d"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check312c"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check312e"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check312e1"
+	"github.com/stackrox/rox/central/compliance/checks/hipaa_164/check314a2ic"
+	check316b2iii "github.com/stackrox/rox/central/compliance/checks/hipaa_164/check316b2iii"
+)
+
+// Init registers all central HIPAA 164 compliance checks.
+// Called explicitly from central/compliance/checks/all.go instead of package init().
+func Init() {
+	check306e.Register306e()
+	check308a1i.Register308a1i()
+	check308a1iia.Register308a1iia()
+	check308a1iib.Register308a1iib()
+	check308a3iia.Register308a3iia()
+	check308a3iib.Register308a3iib()
+	check308a4.Register308a4()
+	check308a4iib.Register308a4iib()
+	check308a5iib.Register308a5iib()
+	check308a6ii.Register308a6ii()
+	check308a7iie.Register308a7iie()
+	check310a1.Register310a1()
+	check310a1a.Register310a1a()
+	check310d.Register310d()
+	check312c.Register312c()
+	check312e.Register312e()
+	check312e1.Register312e1()
+	check314a2ic.Register314a2ic()
+	check316b2iii.Register316b2iii()
+}

--- a/central/compliance/checks/nist800-190/check411/check.go
+++ b/central/compliance/checks/nist800-190/check411/check.go
@@ -13,7 +13,7 @@ const (
 	standardID = "NIST_800_190:4_1_1"
 )
 
-func init() {
+func Register411() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check411/check_test.go
+++ b/central/compliance/checks/nist800-190/check411/check_test.go
@@ -15,6 +15,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register411()
+}
+
 var (
 	testCluster = &storage.Cluster{
 		Id: uuid.NewV4().String(),

--- a/central/compliance/checks/nist800-190/check412/check.go
+++ b/central/compliance/checks/nist800-190/check412/check.go
@@ -19,7 +19,7 @@ var (
 	log = logging.ModuleForName("NIST_800_190:4_1_2").Logger()
 )
 
-func init() {
+func Register412() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check412/check_test.go
+++ b/central/compliance/checks/nist800-190/check412/check_test.go
@@ -16,6 +16,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register412()
+}
+
 var (
 	testCluster = &storage.Cluster{
 		Id: uuid.NewV4().String(),

--- a/central/compliance/checks/nist800-190/check414/check.go
+++ b/central/compliance/checks/nist800-190/check414/check.go
@@ -10,7 +10,7 @@ const (
 	standardID = "NIST_800_190:4_1_4"
 )
 
-func init() {
+func Register414() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check414/check_test.go
+++ b/central/compliance/checks/nist800-190/check414/check_test.go
@@ -15,6 +15,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register414()
+}
+
 var (
 	testCluster = &storage.Cluster{
 		Id: uuid.NewV4().String(),

--- a/central/compliance/checks/nist800-190/check422/check.go
+++ b/central/compliance/checks/nist800-190/check422/check.go
@@ -14,7 +14,7 @@ const (
 	standardID = "NIST_800_190:4_2_2"
 )
 
-func init() {
+func Register422() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check422/check_test.go
+++ b/central/compliance/checks/nist800-190/check422/check_test.go
@@ -15,6 +15,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register422()
+}
+
 var (
 	testCluster = &storage.Cluster{
 		Id: uuid.NewV4().String(),

--- a/central/compliance/checks/nist800-190/check431/check.go
+++ b/central/compliance/checks/nist800-190/check431/check.go
@@ -10,7 +10,7 @@ const (
 	standardID = "NIST_800_190:4_3_1"
 )
 
-func init() {
+func Register431() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check432/check.go
+++ b/central/compliance/checks/nist800-190/check432/check.go
@@ -10,7 +10,7 @@ const (
 	standardID = "NIST_800_190:4_3_2"
 )
 
-func init() {
+func Register432() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check433/check.go
+++ b/central/compliance/checks/nist800-190/check433/check.go
@@ -10,7 +10,7 @@ const (
 	standardID = "NIST_800_190:4_3_3"
 )
 
-func init() {
+func Register433() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check433/check_test.go
+++ b/central/compliance/checks/nist800-190/check433/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register433()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/nist800-190/check435/check.go
+++ b/central/compliance/checks/nist800-190/check435/check.go
@@ -10,7 +10,7 @@ const (
 	standardID = "NIST_800_190:4_3_5"
 )
 
-func init() {
+func Register435() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check442/check.go
+++ b/central/compliance/checks/nist800-190/check442/check.go
@@ -10,7 +10,7 @@ const (
 	standardID = "NIST_800_190:4_4_2"
 )
 
-func init() {
+func Register442() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check442/check_test.go
+++ b/central/compliance/checks/nist800-190/check442/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register442()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/nist800-190/check443/check.go
+++ b/central/compliance/checks/nist800-190/check443/check.go
@@ -10,7 +10,7 @@ const (
 	standardID = "NIST_800_190:4_4_3"
 )
 
-func init() {
+func Register443() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check443/check_test.go
+++ b/central/compliance/checks/nist800-190/check443/check_test.go
@@ -13,6 +13,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register443()
+}
+
 var (
 	testCluster = &storage.Cluster{
 		Id: uuid.NewV4().String(),

--- a/central/compliance/checks/nist800-190/check444/check.go
+++ b/central/compliance/checks/nist800-190/check444/check.go
@@ -11,7 +11,7 @@ const (
 	standardID = "NIST_800_190:4_4_4"
 )
 
-func init() {
+func Register444() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check444/check_test.go
+++ b/central/compliance/checks/nist800-190/check444/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register444()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/nist800-190/check451/check.go
+++ b/central/compliance/checks/nist800-190/check451/check.go
@@ -10,7 +10,7 @@ const (
 	standardID = "NIST_800_190:4_5_1"
 )
 
-func init() {
+func Register451() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check455/check.go
+++ b/central/compliance/checks/nist800-190/check455/check.go
@@ -12,7 +12,7 @@ const (
 	standardID = "NIST_800_190:4_5_5"
 )
 
-func init() {
+func Register455() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 standardID,

--- a/central/compliance/checks/nist800-190/check455/check_test.go
+++ b/central/compliance/checks/nist800-190/check455/check_test.go
@@ -15,6 +15,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register455()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/nist800-190/init.go
+++ b/central/compliance/checks/nist800-190/init.go
@@ -1,0 +1,35 @@
+package nist800190
+
+import (
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check411"
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check412"
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check414"
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check422"
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check431"
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check432"
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check433"
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check435"
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check442"
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check443"
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check444"
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check451"
+	"github.com/stackrox/rox/central/compliance/checks/nist800-190/check455"
+)
+
+// Init registers all central NIST 800-190 compliance checks.
+// Called explicitly from central/compliance/checks/all.go instead of package init().
+func Init() {
+	check411.Register411()
+	check412.Register412()
+	check414.Register414()
+	check422.Register422()
+	check431.Register431()
+	check432.Register432()
+	check433.Register433()
+	check435.Register435()
+	check442.Register442()
+	check443.Register443()
+	check444.Register444()
+	check451.Register451()
+	check455.Register455()
+}

--- a/central/compliance/checks/nist80053/check_ac_14/check.go
+++ b/central/compliance/checks/nist80053/check_ac_14/check.go
@@ -106,7 +106,7 @@ func checkNoExtraPrivilegesForUnauthenticated(ctx framework.ComplianceContext) {
 	}
 }
 
-func init() {
+func RegisterAC14() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_ac_14/check_test.go
+++ b/central/compliance/checks/nist80053/check_ac_14/check_test.go
@@ -10,6 +10,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	RegisterAC14()
+}
+
 func setupMockCtx(ctrl *gomock.Controller, k8sRoles []*storage.K8SRole, roleBindings []*storage.K8SRoleBinding) (framework.ComplianceContext, *testutils.EvidenceRecords) {
 	mockCtx, mockData, records := testutils.SetupMockCtxAndMockData(ctrl)
 

--- a/central/compliance/checks/nist80053/check_ca_9/check.go
+++ b/central/compliance/checks/nist80053/check_ca_9/check.go
@@ -12,7 +12,7 @@ const (
 	interpretationText = common.CheckNetworkPoliciesByDeploymentInterpretation
 )
 
-func init() {
+func RegisterCA9() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_cm_11/check.go
+++ b/central/compliance/checks/nist80053/check_cm_11/check.go
@@ -70,7 +70,7 @@ func checkAllDefaultRuntimePackageManagementPoliciesEnabled(ctx framework.Compli
 	}
 }
 
-func init() {
+func RegisterCM11() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_cm_11/check_test.go
+++ b/central/compliance/checks/nist80053/check_cm_11/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	RegisterCM11()
+}
+
 func TestDefaultPoliciesListUpToDate(t *testing.T) {
 	defaultPolicies, err := policies.DefaultPolicies()
 	require.NoError(t, err)

--- a/central/compliance/checks/nist80053/check_cm_2/check.go
+++ b/central/compliance/checks/nist80053/check_cm_2/check.go
@@ -19,7 +19,7 @@ var (
 For this control, ` + common.AnyPolicyInLifeCycleInterpretation(phase)
 )
 
-func init() {
+func RegisterCM2() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_cm_3/check.go
+++ b/central/compliance/checks/nist80053/check_cm_3/check.go
@@ -19,7 +19,7 @@ var (
 For this control, ` + common.AnyPolicyInLifecycleStageEnforcedInterpretation(phase)
 )
 
-func init() {
+func RegisterCM3() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_cm_5/check.go
+++ b/central/compliance/checks/nist80053/check_cm_5/check.go
@@ -15,7 +15,7 @@ const (
 ` + common.LimitedUsersAndGroupsWithClusterAdminInterpretation
 )
 
-func init() {
+func RegisterCM5() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_cm_6/check.go
+++ b/central/compliance/checks/nist80053/check_cm_6/check.go
@@ -16,7 +16,7 @@ For this control, ` + common.CheckNoViolationsForDeployPhasePoliciesInterpretati
 To approve a deviation, resolve the policy violation or adjust the scope or exclusions for the policy.`
 )
 
-func init() {
+func RegisterCM6() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_cm_7/check.go
+++ b/central/compliance/checks/nist80053/check_cm_7/check.go
@@ -19,7 +19,7 @@ For this control, StackRox validates that at least one policy is enabled and enf
   2) runtime behavior.`
 )
 
-func init() {
+func RegisterCM7() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_cm_8/check.go
+++ b/central/compliance/checks/nist80053/check_cm_8/check.go
@@ -14,7 +14,7 @@ const (
 For this control, ` + common.AllDeployedImagesHaveMatchingIntegrationsInterpretation
 )
 
-func init() {
+func RegisterCM8() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_ir_4_5/check.go
+++ b/central/compliance/checks/nist80053/check_ir_4_5/check.go
@@ -19,7 +19,7 @@ var (
 For this control, ` + common.AnyPolicyInLifecycleStageEnforcedInterpretation(phase)
 )
 
-func init() {
+func RegisterIR45() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_ir_5/check.go
+++ b/central/compliance/checks/nist80053/check_ir_5/check.go
@@ -19,7 +19,7 @@ var (
 For this control, ` + common.AnyPolicyInLifeCycleInterpretation(phase)
 )
 
-func init() {
+func RegisterIR5() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_ir_6_1/check.go
+++ b/central/compliance/checks/nist80053/check_ir_6_1/check.go
@@ -15,7 +15,7 @@ const (
 For this control, StackRox checks that at least one runtime policy is set to notify at least one workflow tool.`
 )
 
-func init() {
+func RegisterIR61() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_ra_3/check.go
+++ b/central/compliance/checks/nist80053/check_ra_3/check.go
@@ -13,7 +13,7 @@ const (
 For this control, StackRox checks that StackRox components are installed in each cluster, providing continuous multi-factor risk assessment.`
 )
 
-func init() {
+func RegisterRA3() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_ra_5/check.go
+++ b/central/compliance/checks/nist80053/check_ra_5/check.go
@@ -33,7 +33,7 @@ func checkNoUnresolvedAlertsForPolicies(ctx framework.ComplianceContext, policyI
 	}
 }
 
-func init() {
+func RegisterRA5() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_ra_5/check_test.go
+++ b/central/compliance/checks/nist80053/check_ra_5/check_test.go
@@ -9,6 +9,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	RegisterRA5()
+}
+
 type alert struct {
 	policyID string
 }

--- a/central/compliance/checks/nist80053/check_sa_10/check.go
+++ b/central/compliance/checks/nist80053/check_sa_10/check.go
@@ -19,7 +19,7 @@ var (
 For this control, ` + common.AnyPolicyInLifeCycleInterpretation(phase)
 )
 
-func init() {
+func RegisterSA10() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_sc_6/check.go
+++ b/central/compliance/checks/nist80053/check_sc_6/check.go
@@ -16,7 +16,7 @@ const (
 For this control, StackRox checks that at least one policy requiring CPU limits and memory limits is enabled and enforced.`
 )
 
-func init() {
+func RegisterSC6() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_sc_7/check.go
+++ b/central/compliance/checks/nist80053/check_sc_7/check.go
@@ -12,7 +12,7 @@ const (
 	interpretationText = common.CheckNetworkPoliciesByDeploymentInterpretation
 )
 
-func init() {
+func RegisterSC7() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_si_2_2/check.go
+++ b/central/compliance/checks/nist80053/check_si_2_2/check.go
@@ -16,7 +16,7 @@ For this control, ` + common.AllDeployedImagesHaveMatchingIntegrationsInterpreta
 Also, ` + common.CheckAtLeastOnePolicyEnabledReferringToVulnsInterpretation
 )
 
-func init() {
+func RegisterSI22() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_si_3_8/check.go
+++ b/central/compliance/checks/nist80053/check_si_3_8/check.go
@@ -19,7 +19,7 @@ var (
 For this control, ` + common.AnyPolicyInLifeCycleInterpretation(phase)
 )
 
-func init() {
+func RegisterSI38() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_si_4/check.go
+++ b/central/compliance/checks/nist80053/check_si_4/check.go
@@ -38,7 +38,7 @@ func checkClusterCheckedInInThePastHour(ctx framework.ComplianceContext) {
 	}
 }
 
-func init() {
+func RegisterSI4() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 controlID,

--- a/central/compliance/checks/nist80053/check_si_4/check_test.go
+++ b/central/compliance/checks/nist80053/check_si_4/check_test.go
@@ -10,6 +10,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	RegisterSI4()
+}
+
 func getClusterWithLastContactTime(timestamp *time.Time) *storage.Cluster {
 	if timestamp == nil {
 		return &storage.Cluster{

--- a/central/compliance/checks/nist80053/init.go
+++ b/central/compliance/checks/nist80053/init.go
@@ -1,0 +1,49 @@
+package nist80053
+
+import (
+	checkac14 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_ac_14"
+	checkca9 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_ca_9"
+	checkcm11 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_cm_11"
+	checkcm2 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_cm_2"
+	checkcm3 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_cm_3"
+	checkcm5 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_cm_5"
+	checkcm6 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_cm_6"
+	checkcm7 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_cm_7"
+	checkcm8 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_cm_8"
+	checkir45 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_ir_4_5"
+	checkir5 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_ir_5"
+	checkir61 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_ir_6_1"
+	checkra3 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_ra_3"
+	checkra5 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_ra_5"
+	checksa10 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_sa_10"
+	checksc6 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_sc_6"
+	checksc7 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_sc_7"
+	checksi22 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_si_2_2"
+	checksi38 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_si_3_8"
+	checksi4 "github.com/stackrox/rox/central/compliance/checks/nist80053/check_si_4"
+)
+
+// Init registers all central NIST 800-53 compliance checks.
+// Called explicitly from central/compliance/checks/all.go instead of package init().
+func Init() {
+	checkac14.RegisterAC14()
+	checkca9.RegisterCA9()
+	checkcm11.RegisterCM11()
+	checkcm2.RegisterCM2()
+	checkcm3.RegisterCM3()
+	checkcm5.RegisterCM5()
+	checkcm6.RegisterCM6()
+	checkcm7.RegisterCM7()
+	checkcm8.RegisterCM8()
+	checkir45.RegisterIR45()
+	checkir5.RegisterIR5()
+	checkir61.RegisterIR61()
+	checkra3.RegisterRA3()
+	checkra5.RegisterRA5()
+	checksa10.RegisterSA10()
+	checksc6.RegisterSC6()
+	checksc7.RegisterSC7()
+	checksi22.RegisterSI22()
+	checksi38.RegisterSI38()
+	checksi4.RegisterSI4()
+}

--- a/central/compliance/checks/pcidss32/check112/check.go
+++ b/central/compliance/checks/pcidss32/check112/check.go
@@ -7,7 +7,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:1_1_2"
 
-func init() {
+func Register112() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check1121/check.go
+++ b/central/compliance/checks/pcidss32/check1121/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:11_2_1"
 
-func init() {
+func Register1121() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check114/check.go
+++ b/central/compliance/checks/pcidss32/check114/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:1_1_4"
 
-func init() {
+func Register114() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check12/check.go
+++ b/central/compliance/checks/pcidss32/check12/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:1_2"
 
-func init() {
+func Register12() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check121/check.go
+++ b/central/compliance/checks/pcidss32/check121/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:1_2_1"
 
-func init() {
+func Register121() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check121/check_test.go
+++ b/central/compliance/checks/pcidss32/check121/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register121()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/pcidss32/check132/check.go
+++ b/central/compliance/checks/pcidss32/check132/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:1_3_2"
 
-func init() {
+func Register132() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check132/check_test.go
+++ b/central/compliance/checks/pcidss32/check132/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register132()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/pcidss32/check134/check.go
+++ b/central/compliance/checks/pcidss32/check134/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:1_3_4"
 
-func init() {
+func Register134() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check134/check_test.go
+++ b/central/compliance/checks/pcidss32/check134/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register134()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/pcidss32/check135/check.go
+++ b/central/compliance/checks/pcidss32/check135/check.go
@@ -10,7 +10,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:1_3_5"
 
-func init() {
+func Register135() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check135/check_test.go
+++ b/central/compliance/checks/pcidss32/check135/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register135()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/pcidss32/check21/check.go
+++ b/central/compliance/checks/pcidss32/check21/check.go
@@ -7,7 +7,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:2_1"
 
-func init() {
+func Register21() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check22/check.go
+++ b/central/compliance/checks/pcidss32/check22/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:2_2"
 
-func init() {
+func Register22() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check225/check.go
+++ b/central/compliance/checks/pcidss32/check225/check.go
@@ -9,7 +9,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:2_2_5"
 
-func init() {
+func Register225() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check225/check_test.go
+++ b/central/compliance/checks/pcidss32/check225/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register225()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/pcidss32/check23/check.go
+++ b/central/compliance/checks/pcidss32/check23/check.go
@@ -7,7 +7,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:2_3"
 
-func init() {
+func Register23() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check24/check.go
+++ b/central/compliance/checks/pcidss32/check24/check.go
@@ -7,7 +7,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:2_4"
 
-func init() {
+func Register24() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check362/check.go
+++ b/central/compliance/checks/pcidss32/check362/check.go
@@ -9,7 +9,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:3_6_2"
 
-func init() {
+func Register362() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check61/check.go
+++ b/central/compliance/checks/pcidss32/check61/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:6_1"
 
-func init() {
+func Register61() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check61/check_test.go
+++ b/central/compliance/checks/pcidss32/check61/check_test.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func init() {
+	Register61()
+}
+
 func TestCheck(t *testing.T) {
 	suite.Run(t, new(suiteImpl))
 }

--- a/central/compliance/checks/pcidss32/check62/check.go
+++ b/central/compliance/checks/pcidss32/check62/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:6_2"
 
-func init() {
+func Register62() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check656/check.go
+++ b/central/compliance/checks/pcidss32/check656/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:6_5_6"
 
-func init() {
+func Register656() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check71/check.go
+++ b/central/compliance/checks/pcidss32/check71/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:7_1"
 
-func init() {
+func Register71() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check712/check.go
+++ b/central/compliance/checks/pcidss32/check712/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:7_1_2"
 
-func init() {
+func Register712() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check713/check.go
+++ b/central/compliance/checks/pcidss32/check713/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:7_1_3"
 
-func init() {
+func Register713() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check722/check.go
+++ b/central/compliance/checks/pcidss32/check722/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:7_2_2"
 
-func init() {
+func Register722() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check723/check.go
+++ b/central/compliance/checks/pcidss32/check723/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:7_2_3"
 
-func init() {
+func Register723() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check811/check.go
+++ b/central/compliance/checks/pcidss32/check811/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:8_1_1"
 
-func init() {
+func Register811() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/check85/check.go
+++ b/central/compliance/checks/pcidss32/check85/check.go
@@ -8,7 +8,7 @@ import (
 
 const checkID = "PCI_DSS_3_2:8_5"
 
-func init() {
+func Register85() {
 	framework.MustRegisterNewCheck(
 		framework.CheckMetadata{
 			ID:                 checkID,

--- a/central/compliance/checks/pcidss32/init.go
+++ b/central/compliance/checks/pcidss32/init.go
@@ -1,0 +1,57 @@
+package pcidss32
+
+import (
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check112"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check1121"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check114"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check12"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check121"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check132"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check134"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check135"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check21"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check22"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check225"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check23"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check24"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check362"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check61"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check62"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check656"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check71"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check712"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check713"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check722"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check723"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check811"
+	"github.com/stackrox/rox/central/compliance/checks/pcidss32/check85"
+)
+
+// Init registers all central PCI DSS 3.2 compliance checks.
+// Called explicitly from central/compliance/checks/all.go instead of package init().
+func Init() {
+	check112.Register112()
+	check1121.Register1121()
+	check114.Register114()
+	check12.Register12()
+	check121.Register121()
+	check132.Register132()
+	check134.Register134()
+	check135.Register135()
+	check21.Register21()
+	check22.Register22()
+	check225.Register225()
+	check23.Register23()
+	check24.Register24()
+	check362.Register362()
+	check61.Register61()
+	check62.Register62()
+	check656.Register656()
+	check71.Register71()
+	check712.Register712()
+	check713.Register713()
+	check722.Register722()
+	check723.Register723()
+	check811.Register811()
+	check85.Register85()
+}

--- a/central/compliance/checks/remote/all.go
+++ b/central/compliance/checks/remote/all.go
@@ -2,11 +2,14 @@ package remote
 
 import (
 	"github.com/stackrox/rox/central/compliance/framework"
-	_ "github.com/stackrox/rox/pkg/compliance/checks" // Make sure all checks are available
+	"github.com/stackrox/rox/pkg/compliance/checks"
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+// Init registers remote compliance checks.
+// Called explicitly from central/compliance/checks/all.go instead of package init().
+func Init() {
+	checks.Init() // Ensure pkg compliance checks are registered first
 	framework.MustRegisterChecks(makeChecksFromRemoteFuncs()...)
 }
 

--- a/central/compliance/standards/metadata/cis_kubernetes.go
+++ b/central/compliance/standards/metadata/cis_kubernetes.go
@@ -722,6 +722,6 @@ var cisKubernetes = Standard{
 	},
 }
 
-func init() {
+func RegisterCISKubernetes() {
 	AllStandards = append(AllStandards, cisKubernetes)
 }

--- a/central/compliance/standards/metadata/hipaa_164.go
+++ b/central/compliance/standards/metadata/hipaa_164.go
@@ -141,6 +141,6 @@ var hipaa164 = Standard{
 	},
 }
 
-func init() {
+func RegisterHIPAA164() {
 	AllStandards = append(AllStandards, hipaa164)
 }

--- a/central/compliance/standards/metadata/init.go
+++ b/central/compliance/standards/metadata/init.go
@@ -1,0 +1,9 @@
+package metadata
+
+func Init() {
+	RegisterCISKubernetes()
+	RegisterHIPAA164()
+	RegisterNIST80053()
+	RegisterNIST800190()
+	RegisterPCIDSS32()
+}

--- a/central/compliance/standards/metadata/nist_800_190.go
+++ b/central/compliance/standards/metadata/nist_800_190.go
@@ -194,6 +194,6 @@ var nist800_190 = Standard{
 	},
 }
 
-func init() {
+func RegisterNIST800190() {
 	AllStandards = append(AllStandards, nist800_190)
 }

--- a/central/compliance/standards/metadata/nist_800_53.go
+++ b/central/compliance/standards/metadata/nist_800_53.go
@@ -173,6 +173,6 @@ var nist800_53 = Standard{
 	},
 }
 
-func init() {
+func RegisterNIST80053() {
 	AllStandards = append(AllStandards, nist800_53)
 }

--- a/central/compliance/standards/metadata/pci_dss_3_2.go
+++ b/central/compliance/standards/metadata/pci_dss_3_2.go
@@ -1410,6 +1410,6 @@ var pciDss3_2 = Standard{
 	},
 }
 
-func init() {
+func RegisterPCIDSS32() {
 	AllStandards = append(AllStandards, pciDss3_2)
 }

--- a/pkg/compliance/checks/hipaa_164/check308a3iib/check.go
+++ b/pkg/compliance/checks/hipaa_164/check308a3iib/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck308a3iib() {
 	standards.RegisterChecksForStandard(standards.Hipaa164, map[string]*standards.CheckAndMetadata{
 		standards.HIPAA164CheckName("308_a_3_ii_b"): clusterIsCompliant(),
 	})

--- a/pkg/compliance/checks/hipaa_164/check308a4/check.go
+++ b/pkg/compliance/checks/hipaa_164/check308a4/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck308a4() {
 	standards.RegisterChecksForStandard(standards.Hipaa164, map[string]*standards.CheckAndMetadata{
 		standards.HIPAA164CheckName("308_a_4"): clusterIsCompliant(),
 	})

--- a/pkg/compliance/checks/hipaa_164/check312e1/check.go
+++ b/pkg/compliance/checks/hipaa_164/check312e1/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck312e1() {
 	standards.RegisterChecksForStandard(standards.Hipaa164, map[string]*standards.CheckAndMetadata{
 		standards.HIPAA164CheckName("312_e_1"): clusterIsCompliant(),
 	})

--- a/pkg/compliance/checks/hipaa_164/init.go
+++ b/pkg/compliance/checks/hipaa_164/init.go
@@ -1,0 +1,15 @@
+package hipaa164
+
+import (
+	"github.com/stackrox/rox/pkg/compliance/checks/hipaa_164/check308a3iib"
+	"github.com/stackrox/rox/pkg/compliance/checks/hipaa_164/check308a4"
+	"github.com/stackrox/rox/pkg/compliance/checks/hipaa_164/check312e1"
+)
+
+// Init registers all HIPAA 164 compliance checks.
+// Called explicitly from pkg/compliance/checks/init.go instead of package init().
+func Init() {
+	check308a3iib.RegisterCheck308a3iib()
+	check308a4.RegisterCheck308a4()
+	check312e1.RegisterCheck312e1()
+}

--- a/pkg/compliance/checks/init.go
+++ b/pkg/compliance/checks/init.go
@@ -1,0 +1,19 @@
+package checks
+
+import (
+	hipaa164 "github.com/stackrox/rox/pkg/compliance/checks/hipaa_164"
+	"github.com/stackrox/rox/pkg/compliance/checks/kubernetes"
+	nist800190 "github.com/stackrox/rox/pkg/compliance/checks/nist800-190"
+	"github.com/stackrox/rox/pkg/compliance/checks/nist80053"
+	"github.com/stackrox/rox/pkg/compliance/checks/pcidss32"
+)
+
+// Init registers all compliance checks.
+// Called explicitly from central/app/app.go instead of package init().
+func Init() {
+	hipaa164.Init()
+	kubernetes.Init()
+	nist800190.Init()
+	nist80053.Init()
+	pcidss32.Init()
+}

--- a/pkg/compliance/checks/kubernetes/control_plane_config.go
+++ b/pkg/compliance/checks/kubernetes/control_plane_config.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func registerControlPlaneConfig() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("3_1_1"): common.NoteCheck("Client certificate authentication should not be used for users"),
 		standards.CISKubeCheckName("3_2_1"): common.MasterAPIServerCommandLine("--audit-policy-file", "", "", common.Set),

--- a/pkg/compliance/checks/kubernetes/etcd.go
+++ b/pkg/compliance/checks/kubernetes/etcd.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func registerEtcd() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("2_1"): multipleFlagsSetCheck("etcd", nil, "cert-file", "key-file"),
 		standards.CISKubeCheckName("2_2"): etcdCommandLineCheck("client-cert-auth", "true", "false", common.Matches),

--- a/pkg/compliance/checks/kubernetes/init.go
+++ b/pkg/compliance/checks/kubernetes/init.go
@@ -1,0 +1,20 @@
+package kubernetes
+
+// Init registers all Kubernetes compliance checks.
+// Called explicitly from pkg/compliance/checks/init.go instead of package init().
+func Init() {
+	registerControlPlaneConfig()
+	registerEtcd()
+	registerKubeletCommand()
+	registerMasterAPIServer()
+	registerMasterConfig()
+	registerMasterControllerManager()
+	registerMasterScheduler()
+	registerPoliciesAdmissionControl()
+	registerPoliciesGeneral()
+	registerPoliciesNetworkCNI()
+	registerPoliciesPodSecurity()
+	registerPoliciesRBAC()
+	registerPoliciesSecretsManagement()
+	registerWorkerNodeConfig()
+}

--- a/pkg/compliance/checks/kubernetes/kubelet_command.go
+++ b/pkg/compliance/checks/kubernetes/kubelet_command.go
@@ -33,7 +33,7 @@ var tlsCipherSet = set.NewStringSet(
 	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
 )
 
-func init() {
+func registerKubeletCommand() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("4_2_1"):  wrapKubeletCheck(authenticationCheck),
 		standards.CISKubeCheckName("4_2_2"):  wrapKubeletCheck(authorizationCheck),

--- a/pkg/compliance/checks/kubernetes/master_api_server.go
+++ b/pkg/compliance/checks/kubernetes/master_api_server.go
@@ -17,7 +17,7 @@ const tlsCiphers = "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256," +
 	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305," +
 	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,"
 
-func init() {
+func registerMasterAPIServer() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("1_2_1"):  common.MasterAPIServerCommandLine("anonymous-auth", "false", "true", common.Matches),
 		standards.CISKubeCheckName("1_2_2"):  common.MasterAPIServerCommandLine("basic-auth-file", "", "", common.Unset),

--- a/pkg/compliance/checks/kubernetes/master_config.go
+++ b/pkg/compliance/checks/kubernetes/master_config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/framework"
 )
 
-func init() {
+func registerMasterConfig() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("1_1_1"): common.OptionalPermissionCheck("/etc/kubernetes/manifests/kube-apiserver.yaml", 0644),
 		standards.CISKubeCheckName("1_1_2"): common.OptionalOwnershipCheck("/etc/kubernetes/manifests/kube-apiserver.yaml", "root", "root"),

--- a/pkg/compliance/checks/kubernetes/master_controller_manager.go
+++ b/pkg/compliance/checks/kubernetes/master_controller_manager.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func registerMasterControllerManager() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("1_3_1"): masterControllerManagerCommandLine("terminated-pod-gc-threshold", "", "12500", common.Set),
 		standards.CISKubeCheckName("1_3_2"): masterControllerManagerCommandLine("profiling", "false", "true", common.Matches),

--- a/pkg/compliance/checks/kubernetes/master_scheduler.go
+++ b/pkg/compliance/checks/kubernetes/master_scheduler.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func registerMasterScheduler() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("1_4_1"): masterSchedulerCommandLine("profiling", "false", "true", common.Matches),
 		standards.CISKubeCheckName("1_4_2"): masterSchedulerCommandLine("bind-address", "127.0.0.1", "127.0.0.1", common.Matches),

--- a/pkg/compliance/checks/kubernetes/policies_admission_control.go
+++ b/pkg/compliance/checks/kubernetes/policies_admission_control.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func registerPoliciesAdmissionControl() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("5_5_1"): common.NoteCheck("Configure Image Provenance using ImagePolicyWebhook admission controller"),
 	})

--- a/pkg/compliance/checks/kubernetes/policies_general.go
+++ b/pkg/compliance/checks/kubernetes/policies_general.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func registerPoliciesGeneral() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("5_6_1"): common.NoteCheck("Create administrative boundaries between resources using namespaces"),
 		standards.CISKubeCheckName("5_6_2"): common.NoteCheck("Ensure that the seccomp profile is set to docker/default in your pod definitions"),

--- a/pkg/compliance/checks/kubernetes/policies_network_cni.go
+++ b/pkg/compliance/checks/kubernetes/policies_network_cni.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func registerPoliciesNetworkCNI() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("5_3_1"): common.NoteCheck("Ensure that the CNI in use supports Network Policies"),
 		// TODO: @boo - implement the check below

--- a/pkg/compliance/checks/kubernetes/policies_pod_security.go
+++ b/pkg/compliance/checks/kubernetes/policies_pod_security.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func registerPoliciesPodSecurity() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("5_2_1"): common.NoteCheck("Minimize the admission of privileged containers"),
 		standards.CISKubeCheckName("5_2_2"): common.NoteCheck("Minimize the admission of containers wishing to share the host process ID namespace"),

--- a/pkg/compliance/checks/kubernetes/policies_rbac.go
+++ b/pkg/compliance/checks/kubernetes/policies_rbac.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func registerPoliciesRBAC() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("5_1_1"): common.NoteCheck("Ensure that the cluster-admin role is only used where required"),
 		standards.CISKubeCheckName("5_1_2"): common.NoteCheck("Minimize access to secrets"),

--- a/pkg/compliance/checks/kubernetes/policies_secrets_management.go
+++ b/pkg/compliance/checks/kubernetes/policies_secrets_management.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func registerPoliciesSecretsManagement() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("5_4_1"): common.NoteCheck("Prefer using secrets as files over secrets as environment variables"),
 		standards.CISKubeCheckName("5_4_2"): common.NoteCheck("Consider external secret storage"),

--- a/pkg/compliance/checks/kubernetes/worker_node_config.go
+++ b/pkg/compliance/checks/kubernetes/worker_node_config.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func registerWorkerNodeConfig() {
 	standards.RegisterChecksForStandard(standards.CISKubernetes, map[string]*standards.CheckAndMetadata{
 		standards.CISKubeCheckName("4_1_1"): common.OptionalPermissionCheck("/etc/systemd/system/kubelet.service.d/10-kubeadm.conf", 0644),
 		standards.CISKubeCheckName("4_1_2"): common.OptionalOwnershipCheck("/etc/systemd/system/kubelet.service.d/10-kubeadm.conf", "root", "root"),

--- a/pkg/compliance/checks/nist800-190/check421/check.go
+++ b/pkg/compliance/checks/nist800-190/check421/check.go
@@ -10,7 +10,7 @@ const (
 	checkID = "4_2_1"
 )
 
-func init() {
+func RegisterCheck421() {
 	standards.RegisterChecksForStandard(standards.NIST800190, map[string]*standards.CheckAndMetadata{
 		standards.NIST800190CheckName(checkID): {
 			CheckFunc: common.CheckNoInsecureRegistries,

--- a/pkg/compliance/checks/nist800-190/check431/check.go
+++ b/pkg/compliance/checks/nist800-190/check431/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck431() {
 	standards.RegisterChecksForStandard(standards.NIST800190, map[string]*standards.CheckAndMetadata{
 		standards.NIST800190CheckName("4_3_1"): clusterIsCompliant(),
 	})

--- a/pkg/compliance/checks/nist800-190/check432/check.go
+++ b/pkg/compliance/checks/nist800-190/check432/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck432() {
 	standards.RegisterChecksForStandard(standards.NIST800190, map[string]*standards.CheckAndMetadata{
 		standards.NIST800190CheckName("4_3_2"): clusterIsCompliant(),
 	})

--- a/pkg/compliance/checks/nist800-190/init.go
+++ b/pkg/compliance/checks/nist800-190/init.go
@@ -1,0 +1,15 @@
+package nist800190
+
+import (
+	"github.com/stackrox/rox/pkg/compliance/checks/nist800-190/check421"
+	"github.com/stackrox/rox/pkg/compliance/checks/nist800-190/check431"
+	"github.com/stackrox/rox/pkg/compliance/checks/nist800-190/check432"
+)
+
+// Init registers all NIST 800-190 compliance checks.
+// Called explicitly from pkg/compliance/checks/init.go instead of package init().
+func Init() {
+	check421.RegisterCheck421()
+	check431.RegisterCheck431()
+	check432.RegisterCheck432()
+}

--- a/pkg/compliance/checks/nist80053/check_ac_14/check.go
+++ b/pkg/compliance/checks/nist80053/check_ac_14/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheckAC14() {
 	standards.RegisterChecksForStandard(standards.NIST80053, map[string]*standards.CheckAndMetadata{
 		// This is a partial check.  The evidence from this check will be folded together with evidence generated in central
 		standards.NIST80053CheckName("AC_14"): common.MasterAPIServerCommandLine("authorization-mode", "RBAC", "RBAC", common.Contains),

--- a/pkg/compliance/checks/nist80053/check_ac_24/check.go
+++ b/pkg/compliance/checks/nist80053/check_ac_24/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheckAC24() {
 	standards.RegisterChecksForStandard(standards.NIST80053, map[string]*standards.CheckAndMetadata{
 		standards.NIST80053CheckName("AC_24"): common.MasterAPIServerRBACConfigurationCommandLine(),
 	})

--- a/pkg/compliance/checks/nist80053/check_ac_3_7/check.go
+++ b/pkg/compliance/checks/nist80053/check_ac_3_7/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheckAC37() {
 	standards.RegisterChecksForStandard(standards.NIST80053, map[string]*standards.CheckAndMetadata{
 		standards.NIST80053CheckName("AC_3_(7)"): common.MasterAPIServerRBACConfigurationCommandLine(),
 	})

--- a/pkg/compliance/checks/nist80053/check_cm_5/check.go
+++ b/pkg/compliance/checks/nist80053/check_cm_5/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheckCM5() {
 	standards.RegisterChecksForStandard(standards.NIST80053, map[string]*standards.CheckAndMetadata{
 		// This is a partial check.  The evidence from this check will be folded together with evidence generated in central
 		standards.NIST80053CheckName("CM_5"): common.MasterAPIServerCommandLine("authorization-mode", "RBAC", "RBAC", common.Contains),

--- a/pkg/compliance/checks/nist80053/init.go
+++ b/pkg/compliance/checks/nist80053/init.go
@@ -1,0 +1,17 @@
+package nist80053
+
+import (
+	checkac14 "github.com/stackrox/rox/pkg/compliance/checks/nist80053/check_ac_14"
+	checkac24 "github.com/stackrox/rox/pkg/compliance/checks/nist80053/check_ac_24"
+	checkac37 "github.com/stackrox/rox/pkg/compliance/checks/nist80053/check_ac_3_7"
+	checkcm5 "github.com/stackrox/rox/pkg/compliance/checks/nist80053/check_cm_5"
+)
+
+// Init registers all NIST 800-53 compliance checks.
+// Called explicitly from pkg/compliance/checks/init.go instead of package init().
+func Init() {
+	checkac14.RegisterCheckAC14()
+	checkac24.RegisterCheckAC24()
+	checkac37.RegisterCheckAC37()
+	checkcm5.RegisterCheckCM5()
+}

--- a/pkg/compliance/checks/pcidss32/check362/check.go
+++ b/pkg/compliance/checks/pcidss32/check362/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck362() {
 	standards.RegisterChecksForStandard(standards.PCIDSS32, map[string]*standards.CheckAndMetadata{
 		standards.PCIDSS32CheckName("3_6_2"): clusterIsCompliant(),
 	})

--- a/pkg/compliance/checks/pcidss32/check71/check.go
+++ b/pkg/compliance/checks/pcidss32/check71/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck71() {
 
 	standards.RegisterChecksForStandard(standards.PCIDSS32, map[string]*standards.CheckAndMetadata{
 		standards.PCIDSS32CheckName("7_1"): clusterIsCompliant(),

--- a/pkg/compliance/checks/pcidss32/check712/check.go
+++ b/pkg/compliance/checks/pcidss32/check712/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck712() {
 	standards.RegisterChecksForStandard(standards.PCIDSS32, map[string]*standards.CheckAndMetadata{
 		standards.PCIDSS32CheckName("7_1_2"): clusterIsCompliant(),
 	})

--- a/pkg/compliance/checks/pcidss32/check713/check.go
+++ b/pkg/compliance/checks/pcidss32/check713/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck713() {
 	standards.RegisterChecksForStandard(standards.PCIDSS32, map[string]*standards.CheckAndMetadata{
 		standards.PCIDSS32CheckName("7_1_3"): clusterIsCompliant(),
 	})

--- a/pkg/compliance/checks/pcidss32/check722/check.go
+++ b/pkg/compliance/checks/pcidss32/check722/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck722() {
 	standards.RegisterChecksForStandard(standards.PCIDSS32, map[string]*standards.CheckAndMetadata{
 		standards.PCIDSS32CheckName("7_2_2"): clusterIsCompliant(),
 	})

--- a/pkg/compliance/checks/pcidss32/check723/check.go
+++ b/pkg/compliance/checks/pcidss32/check723/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck723() {
 	standards.RegisterChecksForStandard(standards.PCIDSS32, map[string]*standards.CheckAndMetadata{
 		standards.PCIDSS32CheckName("7_2_3"): clusterIsCompliant(),
 	})

--- a/pkg/compliance/checks/pcidss32/check811/check.go
+++ b/pkg/compliance/checks/pcidss32/check811/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck811() {
 	standards.RegisterChecksForStandard(standards.PCIDSS32, map[string]*standards.CheckAndMetadata{
 		standards.PCIDSS32CheckName("8_1_1"): clusterIsCompliant(),
 	})

--- a/pkg/compliance/checks/pcidss32/check85/check.go
+++ b/pkg/compliance/checks/pcidss32/check85/check.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stackrox/rox/pkg/compliance/checks/standards"
 )
 
-func init() {
+func RegisterCheck85() {
 	standards.RegisterChecksForStandard(standards.PCIDSS32, map[string]*standards.CheckAndMetadata{
 		standards.PCIDSS32CheckName("8_5"): clusterIsCompliant(),
 	})

--- a/pkg/compliance/checks/pcidss32/init.go
+++ b/pkg/compliance/checks/pcidss32/init.go
@@ -1,0 +1,25 @@
+package pcidss32
+
+import (
+	"github.com/stackrox/rox/pkg/compliance/checks/pcidss32/check362"
+	"github.com/stackrox/rox/pkg/compliance/checks/pcidss32/check71"
+	"github.com/stackrox/rox/pkg/compliance/checks/pcidss32/check712"
+	"github.com/stackrox/rox/pkg/compliance/checks/pcidss32/check713"
+	"github.com/stackrox/rox/pkg/compliance/checks/pcidss32/check722"
+	"github.com/stackrox/rox/pkg/compliance/checks/pcidss32/check723"
+	"github.com/stackrox/rox/pkg/compliance/checks/pcidss32/check811"
+	"github.com/stackrox/rox/pkg/compliance/checks/pcidss32/check85"
+)
+
+// Init registers all PCI DSS 3.2 compliance checks.
+// Called explicitly from pkg/compliance/checks/init.go instead of package init().
+func Init() {
+	check362.RegisterCheck362()
+	check71.RegisterCheck71()
+	check712.RegisterCheck712()
+	check713.RegisterCheck713()
+	check722.RegisterCheck722()
+	check723.RegisterCheck723()
+	check811.RegisterCheck811()
+	check85.RegisterCheck85()
+}


### PR DESCRIPTION
## Description

Convert compliance checks and standards from package-level init() to explicit Init() calls to prevent registration in non-central components.

Changes:
- pkg/compliance/checks: 32 kubernetes checks init() → Register*() + consolidated Init()
- central/compliance/checks: 77 checks (hipaa_164, nist80053, pcidss32, nist800-190, remote) init() → Register*()
- central/compliance/standards/metadata: 5 standards init() → Register*()
- Created Init() consolidation functions in init.go files
- Convert blank imports to explicit Init() calls

With busybox consolidation, compliance check registration was happening for all components. This change makes it conditional - only central registers compliance checks.

Expected impact:
- Prevents ~146 compliance check registrations in non-central components
- Reduces memory usage in sensor, admission-control, config-controller
- Central-only: compliance checks remain fully functional

Files changed: 131 (32 pkg/compliance + 77 central/compliance checks + 5 standards + init files)

Refs:
- https://github.com/stackrox/stackrox/pull/19986
- https://github.com/stackrox/stackrox/pull/19980
- https://github.com/stackrox/stackrox/pull/19984
- https://github.com/stackrox/stackrox/pull/19983

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI