### PR TITLE
ROX-34110: Turning on ROX_LABEL_BASED_POLICY_SCOPING feature flag

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -120,7 +120,7 @@ var (
 	SensorInternalPubSub = registerFeature("Enables the internal PubSub system in Sensor", "ROX_SENSOR_PUBSUB", enabled)
 
 	// LabelBasedPolicyScoping enables policy scoping based on cluster and namespace labels
-	LabelBasedPolicyScoping = registerFeature("Enable cluster and namespace label-based policy scoping", "ROX_LABEL_BASED_POLICY_SCOPING")
+	LabelBasedPolicyScoping = registerFeature("Enable cluster and namespace label-based policy scoping", "ROX_LABEL_BASED_POLICY_SCOPING", enabled)
 
 	// VulnerabilityReportsEnhancedFiltering enables filtering similar to view-based reports in scheduled vulnerability reports
 	VulnerabilityReportsEnhancedFiltering = registerFeature("Enables filtering similar to view-based reports in scheduled vulnerability reports", "ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING")

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -10,7 +10,6 @@ import services.ImageService
 import services.PolicyService
 import util.Timer
 
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
@@ -234,7 +233,6 @@ class AdmissionControllerTest extends BaseSpecification {
 
     @Unroll
     @Tag("BAT")
-    @Ignore("Temporarily skipped while investigating ROX-34110, ROX-34111, ROX-34112")
     def "Verify AC enforcement with label scoping: #desc"() {
         given:
         "Set up namespace with labels"
@@ -294,7 +292,6 @@ class AdmissionControllerTest extends BaseSpecification {
 
     @Unroll
     @Tag("BAT")
-    @Ignore("Temporarily skipped while investigating ROX-34110, ROX-34111, ROX-34112")
     def "Verify AC respects label hot-reload: #desc"() {
         given:
         "Set up namespace with initial label"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -490,10 +490,6 @@ deploy_sensor_via_operator() {
         customize_envVars+=$'\n    - name: ROX_NETFLOW_CACHE_LIMITING'
         customize_envVars+=$'\n      value: "'"${ROX_NETFLOW_CACHE_LIMITING}"'"'
     fi
-    if [[ -n "${ROX_LABEL_BASED_POLICY_SCOPING:-}" ]]; then
-        customize_envVars+=$'\n    - name: ROX_LABEL_BASED_POLICY_SCOPING'
-        customize_envVars+=$'\n      value: "'"${ROX_LABEL_BASED_POLICY_SCOPING}"'"'
-    fi
 
     local scannerV4DbPersistenceYaml
     scannerV4DbPersistenceYaml="$(_scanner_v4_db_persistence_yaml)"

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -490,6 +490,10 @@ deploy_sensor_via_operator() {
         customize_envVars+=$'\n    - name: ROX_NETFLOW_CACHE_LIMITING'
         customize_envVars+=$'\n      value: "'"${ROX_NETFLOW_CACHE_LIMITING}"'"'
     fi
+    if [[ -n "${ROX_LABEL_BASED_POLICY_SCOPING:-}" ]]; then
+        customize_envVars+=$'\n    - name: ROX_LABEL_BASED_POLICY_SCOPING'
+        customize_envVars+=$'\n      value: "'"${ROX_LABEL_BASED_POLICY_SCOPING}"'"'
+    fi
 
     local scannerV4DbPersistenceYaml
     scannerV4DbPersistenceYaml="$(_scanner_v4_db_persistence_yaml)"


### PR DESCRIPTION
## Description

The AC label scoping tests (AdmissionControllerTest.groovy) fail on OpenShift when deployed via the operator path. The root cause is that deploy_sensor_via_operator() in tests/e2e/lib.sh does not inject ROX_LABEL_BASED_POLICY_SCOPING into Sensor's environment variables. Without this flag, Sensor's detector rejects namespace-label-scoped policies at pkg/scopecomp/scope.go:75-76, so the Admission Controller never receives them. deploy_central_via_operator() already sets this flag, but the Sensor operator deploy path was missing it.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

The re-enabled Groovy tests will serve as the primary validation. These tests were failing on the OCP qa e2e tests specifically. CI results on this branch (particularly OCP QA e2e runs) need to be inspected to confirm the tests pass with the flag now injected into Sensor.