### PR TITLE
ROX-34146: Delete key prop from WizardStep elements

### DIFF
--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigWizardForm.tsx
@@ -222,7 +222,6 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
                     <WizardStep
                         name={PARAMETERS}
                         id={PARAMETERS_ID}
-                        key={PARAMETERS_ID}
                         body={{ hasNoPadding: true }}
                         footer={
                             <CustomWizardFooter
@@ -238,7 +237,6 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
                     <WizardStep
                         name={SELECT_CLUSTERS}
                         id={SELECT_CLUSTERS_ID}
-                        key={SELECT_CLUSTERS_ID}
                         body={{ hasNoPadding: true }}
                         isDisabled={!canJumpToSelectClusters()}
                         footer={
@@ -260,7 +258,6 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
                     <WizardStep
                         name={SELECT_PROFILES}
                         id={SELECT_PROFILES_ID}
-                        key={SELECT_PROFILES_ID}
                         body={{ hasNoPadding: true }}
                         isDisabled={!canJumpToSelectProfiles()}
                         footer={
@@ -281,7 +278,6 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
                     <WizardStep
                         name={CONFIGURE_REPORT}
                         id={CONFIGURE_REPORT_ID}
-                        key={CONFIGURE_REPORT_ID}
                         body={{ hasNoPadding: true }}
                         isDisabled={!canJumpToConfigureReport()}
                         footer={
@@ -298,7 +294,6 @@ function ScanConfigWizardForm({ initialFormValues }: ScanConfigWizardFormProps):
                     <WizardStep
                         name={REVIEW_CONFIG}
                         id={REVIEW_CONFIG_ID}
-                        key={REVIEW_CONFIG_ID}
                         body={{ hasNoPadding: true }}
                         isDisabled={!canJumpToReviewConfig()}
                         footer={{

--- a/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Wizard/PolicyWizard.tsx
@@ -192,7 +192,6 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
                                 <WizardStep
                                     name="Details"
                                     id={POLICY_DEFINITION_DETAILS_ID}
-                                    key={POLICY_DEFINITION_DETAILS_ID}
                                     body={{ hasNoPadding: true }}
                                     footer={{ isNextDisabled: !isValidOnClient }}
                                 >
@@ -204,7 +203,6 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
                                 <WizardStep
                                     name="Lifecycle"
                                     id={POLICY_DEFINITION_LIFECYCLE_ID}
-                                    key={POLICY_DEFINITION_LIFECYCLE_ID}
                                     body={{ hasNoPadding: true }}
                                     footer={{ isNextDisabled: !isValidOnClient }}
                                 >
@@ -213,7 +211,6 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
                                 <WizardStep
                                     name="Rules"
                                     id={POLICY_DEFINITION_RULES_ID}
-                                    key={POLICY_DEFINITION_RULES_ID}
                                     body={{ hasNoPadding: true }}
                                     footer={{ isNextDisabled: !isValidOnClient }}
                                 >
@@ -229,7 +226,6 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
                                 <WizardStep
                                     name="Scope"
                                     id={POLICY_BEHAVIOR_SCOPE_ID}
-                                    key={POLICY_BEHAVIOR_SCOPE_ID}
                                     body={{ hasNoPadding: true }}
                                     footer={{ isNextDisabled: !isValidOnClient }}
                                 >
@@ -238,7 +234,6 @@ function PolicyWizard({ pageAction, policy }: PolicyWizardProps): ReactElement {
                                 <WizardStep
                                     name="Actions"
                                     id={POLICY_BEHAVIOR_ACTIONS_ID}
-                                    key={POLICY_BEHAVIOR_ACTIONS_ID}
                                     body={{ hasNoPadding: true }}
                                     footer={{ isNextDisabled: !isValidOnClient }}
                                 >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ModifyVulnReport/ReportFormWizard.tsx
@@ -56,7 +56,6 @@ function ReportFormWizard({ formik, onSave, isSaving }: ReportFormWizardProps) {
                 <WizardStep
                     name={wizardStepNames[0]}
                     id={wizardStepNames[0]}
-                    key={wizardStepNames[0]}
                     body={{ hasNoPadding: true }}
                     footer={{
                         isNextDisabled: isStepDisabled(wizardStepNames[1]),
@@ -68,7 +67,6 @@ function ReportFormWizard({ formik, onSave, isSaving }: ReportFormWizardProps) {
                 <WizardStep
                     name={wizardStepNames[1]}
                     id={wizardStepNames[1]}
-                    key={wizardStepNames[1]}
                     body={{ hasNoPadding: true }}
                     isDisabled={isStepDisabled(wizardStepNames[1])}
                     footer={{
@@ -81,7 +79,6 @@ function ReportFormWizard({ formik, onSave, isSaving }: ReportFormWizardProps) {
                 <WizardStep
                     name={wizardStepNames[2]}
                     id={wizardStepNames[2]}
-                    key={wizardStepNames[2]}
                     body={{ hasNoPadding: true }}
                     isDisabled={isStepDisabled(wizardStepNames[2])}
                     footer={{


### PR DESCRIPTION
## Description

Thank you, **Brad** for observing that wizard sub-steps are **array elements**.

### Problem

While studying patterns from existing wizards for image vulnerability report configuration wizard, I noticed `key` in addition to `id` props (except for super-steps of policy wizard) and became curious whether or not they need React keys.

### Analysis

If I comment out `key` prop of `WizardStep` element, no browser console errors.

To make sure about settings, I temporarily deleted `key` prop of an element in a `map` method to see expected errors.

Furthermore, the following code snippet suggests that PatternFly renders `key` prop from `id` prop:

https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Wizard/WizardToggle.tsx#L74-L82

Although wizard steps were array elements in PatternFly 4, even the examples in the web site did not include `key` prop.

### Solution

Delete `key` props from `WizardStep` elements.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/compliance/schedules?action=create

    Verify expected error when I delete `key` prop of `Button` element in `actions` array of `Modal` element.

2. Visit /main/vulnerabilities/reports/configuration?action=create

    Why not expected error when I delete `key` prop of `Button` element in `actions` array of `Modal` element?

    It seems like error only appears on first occurrence, but not after I clear the console or navigate back and forward. Confusing! Even concerning.

3. Visit /main/policy-management/policies/?action=create

    Verify expected error when I delete `key` prop of `Label` element in policy categories select field **and then** select a category.

    Also when I delete `key` props in policy fields side bar.