### PR TITLE
ROX-34020: Add ContainerType enum to Container proto

### DIFF
--- a/central/deployment/datastore/internal/store/postgres/store.go
+++ b/central/deployment/datastore/internal/store/postgres/store.go
@@ -197,9 +197,10 @@ func insertIntoDeploymentsContainers(batch *pgx.Batch, obj *storage.Container, d
 		obj.GetResources().GetCpuCoresLimit(),
 		obj.GetResources().GetMemoryMbRequest(),
 		obj.GetResources().GetMemoryMbLimit(),
+		obj.GetType(),
 	}
 
-	finalStr := "INSERT INTO deployments_containers (deployments_Id, idx, Image_Id, Image_Name_Registry, Image_Name_Remote, Image_Name_Tag, Image_Name_FullName, Image_IdV2, SecurityContext_Privileged, SecurityContext_DropCapabilities, SecurityContext_AddCapabilities, SecurityContext_ReadOnlyRootFilesystem, Resources_CpuCoresRequest, Resources_CpuCoresLimit, Resources_MemoryMbRequest, Resources_MemoryMbLimit) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) ON CONFLICT(deployments_Id, idx) DO UPDATE SET deployments_Id = EXCLUDED.deployments_Id, idx = EXCLUDED.idx, Image_Id = EXCLUDED.Image_Id, Image_Name_Registry = EXCLUDED.Image_Name_Registry, Image_Name_Remote = EXCLUDED.Image_Name_Remote, Image_Name_Tag = EXCLUDED.Image_Name_Tag, Image_Name_FullName = EXCLUDED.Image_Name_FullName, Image_IdV2 = EXCLUDED.Image_IdV2, SecurityContext_Privileged = EXCLUDED.SecurityContext_Privileged, SecurityContext_DropCapabilities = EXCLUDED.SecurityContext_DropCapabilities, SecurityContext_AddCapabilities = EXCLUDED.SecurityContext_AddCapabilities, SecurityContext_ReadOnlyRootFilesystem = EXCLUDED.SecurityContext_ReadOnlyRootFilesystem, Resources_CpuCoresRequest = EXCLUDED.Resources_CpuCoresRequest, Resources_CpuCoresLimit = EXCLUDED.Resources_CpuCoresLimit, Resources_MemoryMbRequest = EXCLUDED.Resources_MemoryMbRequest, Resources_MemoryMbLimit = EXCLUDED.Resources_MemoryMbLimit"
+	finalStr := "INSERT INTO deployments_containers (deployments_Id, idx, Image_Id, Image_Name_Registry, Image_Name_Remote, Image_Name_Tag, Image_Name_FullName, Image_IdV2, SecurityContext_Privileged, SecurityContext_DropCapabilities, SecurityContext_AddCapabilities, SecurityContext_ReadOnlyRootFilesystem, Resources_CpuCoresRequest, Resources_CpuCoresLimit, Resources_MemoryMbRequest, Resources_MemoryMbLimit, Type) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) ON CONFLICT(deployments_Id, idx) DO UPDATE SET deployments_Id = EXCLUDED.deployments_Id, idx = EXCLUDED.idx, Image_Id = EXCLUDED.Image_Id, Image_Name_Registry = EXCLUDED.Image_Name_Registry, Image_Name_Remote = EXCLUDED.Image_Name_Remote, Image_Name_Tag = EXCLUDED.Image_Name_Tag, Image_Name_FullName = EXCLUDED.Image_Name_FullName, Image_IdV2 = EXCLUDED.Image_IdV2, SecurityContext_Privileged = EXCLUDED.SecurityContext_Privileged, SecurityContext_DropCapabilities = EXCLUDED.SecurityContext_DropCapabilities, SecurityContext_AddCapabilities = EXCLUDED.SecurityContext_AddCapabilities, SecurityContext_ReadOnlyRootFilesystem = EXCLUDED.SecurityContext_ReadOnlyRootFilesystem, Resources_CpuCoresRequest = EXCLUDED.Resources_CpuCoresRequest, Resources_CpuCoresLimit = EXCLUDED.Resources_CpuCoresLimit, Resources_MemoryMbRequest = EXCLUDED.Resources_MemoryMbRequest, Resources_MemoryMbLimit = EXCLUDED.Resources_MemoryMbLimit, Type = EXCLUDED.Type"
 	batch.Queue(finalStr, values...)
 
 	var query string
@@ -444,6 +445,7 @@ var copyColsDeploymentsContainers = []string{
 	"resources_cpucoreslimit",
 	"resources_memorymbrequest",
 	"resources_memorymblimit",
+	"type",
 }
 
 func copyFromDeploymentsContainers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, deploymentID string, objs ...*storage.Container) error {
@@ -476,6 +478,7 @@ func copyFromDeploymentsContainers(ctx context.Context, s pgSearch.Deleter, tx *
 			obj.GetResources().GetCpuCoresLimit(),
 			obj.GetResources().GetMemoryMbRequest(),
 			obj.GetResources().GetMemoryMbLimit(),
+			obj.GetType(),
 		}, nil
 	})
 

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -519,6 +519,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"resources: Resources",
 		"secrets: [EmbeddedSecret]!",
 		"securityContext: SecurityContext",
+		"type: ContainerType!",
 		"volumes: [Volume]!",
 	}))
 	utils.Must(builder.AddType("ContainerConfig", []string{
@@ -564,6 +565,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"type: ContainerRuntime!",
 		"version: String!",
 	}))
+	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.ContainerType(0)))
 	utils.Must(builder.AddType("CosignSignature", []string{
 	}))
 	utils.Must(builder.AddType("DataSource", []string{
@@ -6494,6 +6496,11 @@ func (resolver *containerResolver) SecurityContext(ctx context.Context) (*securi
 	return resolver.root.wrapSecurityContext(value, true, nil)
 }
 
+func (resolver *containerResolver) Type(ctx context.Context) string {
+	value := resolver.data.GetType()
+	return value.String()
+}
+
 func (resolver *containerResolver) Volumes(ctx context.Context) ([]*volumeResolver, error) {
 	value := resolver.data.GetVolumes()
 	return resolver.root.wrapVolumes(value, nil)
@@ -6930,6 +6937,24 @@ func (resolver *containerRuntimeInfoResolver) Type(ctx context.Context) string {
 func (resolver *containerRuntimeInfoResolver) Version(ctx context.Context) string {
 	value := resolver.data.GetVersion()
 	return value
+}
+
+func toContainerType(value *string) storage.ContainerType {
+	if value != nil {
+		return storage.ContainerType(storage.ContainerType_value[*value])
+	}
+	return storage.ContainerType(0)
+}
+
+func toContainerTypes(values *[]string) []storage.ContainerType {
+	if values == nil {
+		return nil
+	}
+	output := make([]storage.ContainerType, len(*values))
+	for i, v := range *values {
+		output[i] = toContainerType(&v)
+	}
+	return output
 }
 
 type cosignSignatureResolver struct {

--- a/generated/api/v1/deployment_service.swagger.json
+++ b/generated/api/v1/deployment_service.swagger.json
@@ -667,6 +667,9 @@
         },
         "readinessProbe": {
           "$ref": "#/definitions/storageReadinessProbe"
+        },
+        "type": {
+          "$ref": "#/definitions/storageContainerType"
         }
       }
     },
@@ -742,6 +745,14 @@
         }
       },
       "description": "`ContainerNameAndBaselineStatus` represents a cached result\nof process evaluation on a specific container name."
+    },
+    "storageContainerType": {
+      "type": "string",
+      "enum": [
+        "REGULAR",
+        "INIT"
+      ],
+      "default": "REGULAR"
     },
     "storageDeployment": {
       "type": "object",

--- a/generated/api/v1/detection_service.swagger.json
+++ b/generated/api/v1/detection_service.swagger.json
@@ -770,6 +770,9 @@
         },
         "readinessProbe": {
           "$ref": "#/definitions/storageReadinessProbe"
+        },
+        "type": {
+          "$ref": "#/definitions/storageContainerType"
         }
       }
     },
@@ -830,6 +833,14 @@
         }
       },
       "title": "Next tag: 13"
+    },
+    "storageContainerType": {
+      "type": "string",
+      "enum": [
+        "REGULAR",
+        "INIT"
+      ],
+      "default": "REGULAR"
     },
     "storageDeployment": {
       "type": "object",

--- a/generated/api/v1/vuln_mgmt_service.swagger.json
+++ b/generated/api/v1/vuln_mgmt_service.swagger.json
@@ -576,6 +576,9 @@
         },
         "readinessProbe": {
           "$ref": "#/definitions/storageReadinessProbe"
+        },
+        "type": {
+          "$ref": "#/definitions/storageContainerType"
         }
       }
     },
@@ -636,6 +639,14 @@
         }
       },
       "title": "Next tag: 13"
+    },
+    "storageContainerType": {
+      "type": "string",
+      "enum": [
+        "REGULAR",
+        "INIT"
+      ],
+      "default": "REGULAR"
     },
     "storageCosignSignature": {
       "type": "object",

--- a/generated/storage/deployment.pb.go
+++ b/generated/storage/deployment.pb.go
@@ -22,6 +22,52 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type ContainerType int32
+
+const (
+	ContainerType_REGULAR ContainerType = 0
+	ContainerType_INIT    ContainerType = 1
+)
+
+// Enum value maps for ContainerType.
+var (
+	ContainerType_name = map[int32]string{
+		0: "REGULAR",
+		1: "INIT",
+	}
+	ContainerType_value = map[string]int32{
+		"REGULAR": 0,
+		"INIT":    1,
+	}
+)
+
+func (x ContainerType) Enum() *ContainerType {
+	p := new(ContainerType)
+	*p = x
+	return p
+}
+
+func (x ContainerType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ContainerType) Descriptor() protoreflect.EnumDescriptor {
+	return file_storage_deployment_proto_enumTypes[0].Descriptor()
+}
+
+func (ContainerType) Type() protoreflect.EnumType {
+	return &file_storage_deployment_proto_enumTypes[0]
+}
+
+func (x ContainerType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ContainerType.Descriptor instead.
+func (ContainerType) EnumDescriptor() ([]byte, []int) {
+	return file_storage_deployment_proto_rawDescGZIP(), []int{0}
+}
+
 type Volume_MountPropagation int32
 
 const (
@@ -55,11 +101,11 @@ func (x Volume_MountPropagation) String() string {
 }
 
 func (Volume_MountPropagation) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_deployment_proto_enumTypes[0].Descriptor()
+	return file_storage_deployment_proto_enumTypes[1].Descriptor()
 }
 
 func (Volume_MountPropagation) Type() protoreflect.EnumType {
-	return &file_storage_deployment_proto_enumTypes[0]
+	return &file_storage_deployment_proto_enumTypes[1]
 }
 
 func (x Volume_MountPropagation) Number() protoreflect.EnumNumber {
@@ -113,11 +159,11 @@ func (x PortConfig_ExposureLevel) String() string {
 }
 
 func (PortConfig_ExposureLevel) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_deployment_proto_enumTypes[1].Descriptor()
+	return file_storage_deployment_proto_enumTypes[2].Descriptor()
 }
 
 func (PortConfig_ExposureLevel) Type() protoreflect.EnumType {
-	return &file_storage_deployment_proto_enumTypes[1]
+	return &file_storage_deployment_proto_enumTypes[2]
 }
 
 func (x PortConfig_ExposureLevel) Number() protoreflect.EnumNumber {
@@ -175,11 +221,11 @@ func (x ContainerConfig_EnvironmentConfig_EnvVarSource) String() string {
 }
 
 func (ContainerConfig_EnvironmentConfig_EnvVarSource) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_deployment_proto_enumTypes[2].Descriptor()
+	return file_storage_deployment_proto_enumTypes[3].Descriptor()
 }
 
 func (ContainerConfig_EnvironmentConfig_EnvVarSource) Type() protoreflect.EnumType {
-	return &file_storage_deployment_proto_enumTypes[2]
+	return &file_storage_deployment_proto_enumTypes[3]
 }
 
 func (x ContainerConfig_EnvironmentConfig_EnvVarSource) Number() protoreflect.EnumNumber {
@@ -224,11 +270,11 @@ func (x SecurityContext_SeccompProfile_ProfileType) String() string {
 }
 
 func (SecurityContext_SeccompProfile_ProfileType) Descriptor() protoreflect.EnumDescriptor {
-	return file_storage_deployment_proto_enumTypes[3].Descriptor()
+	return file_storage_deployment_proto_enumTypes[4].Descriptor()
 }
 
 func (SecurityContext_SeccompProfile_ProfileType) Type() protoreflect.EnumType {
-	return &file_storage_deployment_proto_enumTypes[3]
+	return &file_storage_deployment_proto_enumTypes[4]
 }
 
 func (x SecurityContext_SeccompProfile_ProfileType) Number() protoreflect.EnumNumber {
@@ -617,6 +663,7 @@ type Container struct {
 	Name            string                 `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty" policy:"Container Name"` // @gotags: policy:"Container Name"
 	LivenessProbe   *LivenessProbe         `protobuf:"bytes,11,opt,name=liveness_probe,json=livenessProbe,proto3" json:"liveness_probe,omitempty"`
 	ReadinessProbe  *ReadinessProbe        `protobuf:"bytes,12,opt,name=readiness_probe,json=readinessProbe,proto3" json:"readiness_probe,omitempty"`
+	Type            ContainerType          `protobuf:"varint,13,opt,name=type,proto3,enum=storage.ContainerType" json:"type,omitempty" search:"Container Type" hash:"ignore" sensorhash:"ignore"` // @gotags: search:"Container Type" hash:"ignore" sensorhash:"ignore"
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -726,6 +773,13 @@ func (x *Container) GetReadinessProbe() *ReadinessProbe {
 		return x.ReadinessProbe
 	}
 	return nil
+}
+
+func (x *Container) GetType() ContainerType {
+	if x != nil {
+		return x.Type
+	}
+	return ContainerType_REGULAR
 }
 
 type Resources struct {
@@ -2066,7 +2120,7 @@ const file_storage_deployment_proto_rawDesc = "" +
 	" \x01(\bR\vnotPullable\x12(\n" +
 	"\x10is_cluster_local\x18\v \x01(\bR\x0eisClusterLocal\x12\x13\n" +
 	"\x05id_v2\x18\f \x01(\tR\x04idV2J\x04\b\x02\x10\x03J\x04\b\x03\x10\x04J\x04\b\x05\x10\x06J\x04\b\x06\x10\aJ\x04\b\a\x10\bJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
-	"\"\x97\x04\n" +
+	"\"\xc3\x04\n" +
 	"\tContainer\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x120\n" +
 	"\x06config\x18\x02 \x01(\v2\x18.storage.ContainerConfigR\x06config\x12-\n" +
@@ -2079,7 +2133,8 @@ const file_storage_deployment_proto_rawDesc = "" +
 	"\x04name\x18\n" +
 	" \x01(\tR\x04name\x12=\n" +
 	"\x0eliveness_probe\x18\v \x01(\v2\x16.storage.LivenessProbeR\rlivenessProbe\x12@\n" +
-	"\x0freadiness_probe\x18\f \x01(\v2\x17.storage.ReadinessProbeR\x0ereadinessProbeJ\x04\b\t\x10\n" +
+	"\x0freadiness_probe\x18\f \x01(\v2\x17.storage.ReadinessProbeR\x0ereadinessProbe\x12*\n" +
+	"\x04type\x18\r \x01(\x0e2\x16.storage.ContainerTypeR\x04typeJ\x04\b\t\x10\n" +
 	"\"\xb3\x01\n" +
 	"\tResources\x12*\n" +
 	"\x11cpu_cores_request\x18\x01 \x01(\x02R\x0fcpuCoresRequest\x12&\n" +
@@ -2209,7 +2264,10 @@ const file_storage_deployment_proto_rawDesc = "" +
 	"cluster_id\x18\x04 \x01(\tR\tclusterId\x12\x1c\n" +
 	"\tnamespace\x18\x05 \x01(\tR\tnamespace\x124\n" +
 	"\acreated\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\acreated\x12\x1a\n" +
-	"\bpriority\x18\a \x01(\x03R\bpriorityB.\n" +
+	"\bpriority\x18\a \x01(\x03R\bpriority*&\n" +
+	"\rContainerType\x12\v\n" +
+	"\aREGULAR\x10\x00\x12\b\n" +
+	"\x04INIT\x10\x01B.\n" +
 	"\x19io.stackrox.proto.storageZ\x11./storage;storageb\x06proto3"
 
 var (
@@ -2224,86 +2282,88 @@ func file_storage_deployment_proto_rawDescGZIP() []byte {
 	return file_storage_deployment_proto_rawDescData
 }
 
-var file_storage_deployment_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_storage_deployment_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
 var file_storage_deployment_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_storage_deployment_proto_goTypes = []any{
-	(Volume_MountPropagation)(0),                        // 0: storage.Volume.MountPropagation
-	(PortConfig_ExposureLevel)(0),                       // 1: storage.PortConfig.ExposureLevel
-	(ContainerConfig_EnvironmentConfig_EnvVarSource)(0), // 2: storage.ContainerConfig.EnvironmentConfig.EnvVarSource
-	(SecurityContext_SeccompProfile_ProfileType)(0),     // 3: storage.SecurityContext.SeccompProfile.ProfileType
-	(*Deployment)(nil),                                  // 4: storage.Deployment
-	(*ContainerImage)(nil),                              // 5: storage.ContainerImage
-	(*Container)(nil),                                   // 6: storage.Container
-	(*Resources)(nil),                                   // 7: storage.Resources
-	(*Volume)(nil),                                      // 8: storage.Volume
-	(*LivenessProbe)(nil),                               // 9: storage.LivenessProbe
-	(*ReadinessProbe)(nil),                              // 10: storage.ReadinessProbe
-	(*Pod)(nil),                                         // 11: storage.Pod
-	(*ContainerInstance)(nil),                           // 12: storage.ContainerInstance
-	(*ContainerInstanceID)(nil),                         // 13: storage.ContainerInstanceID
-	(*EmbeddedSecret)(nil),                              // 14: storage.EmbeddedSecret
-	(*PortConfig)(nil),                                  // 15: storage.PortConfig
-	(*ContainerConfig)(nil),                             // 16: storage.ContainerConfig
-	(*SecurityContext)(nil),                             // 17: storage.SecurityContext
-	(*ListDeployment)(nil),                              // 18: storage.ListDeployment
-	nil,                                                 // 19: storage.Deployment.LabelsEntry
-	nil,                                                 // 20: storage.Deployment.PodLabelsEntry
-	nil,                                                 // 21: storage.Deployment.AnnotationsEntry
-	(*Pod_ContainerInstanceList)(nil),                   // 22: storage.Pod.ContainerInstanceList
-	(*PortConfig_ExposureInfo)(nil),                     // 23: storage.PortConfig.ExposureInfo
-	(*ContainerConfig_EnvironmentConfig)(nil),           // 24: storage.ContainerConfig.EnvironmentConfig
-	(*SecurityContext_SELinux)(nil),                     // 25: storage.SecurityContext.SELinux
-	(*SecurityContext_SeccompProfile)(nil),              // 26: storage.SecurityContext.SeccompProfile
-	(*LabelSelector)(nil),                               // 27: storage.LabelSelector
-	(*timestamppb.Timestamp)(nil),                       // 28: google.protobuf.Timestamp
-	(PermissionLevel)(0),                                // 29: storage.PermissionLevel
-	(*Toleration)(nil),                                  // 30: storage.Toleration
-	(*ImageName)(nil),                                   // 31: storage.ImageName
-	(ContainerRuntime)(0),                               // 32: storage.ContainerRuntime
+	(ContainerType)(0),                                  // 0: storage.ContainerType
+	(Volume_MountPropagation)(0),                        // 1: storage.Volume.MountPropagation
+	(PortConfig_ExposureLevel)(0),                       // 2: storage.PortConfig.ExposureLevel
+	(ContainerConfig_EnvironmentConfig_EnvVarSource)(0), // 3: storage.ContainerConfig.EnvironmentConfig.EnvVarSource
+	(SecurityContext_SeccompProfile_ProfileType)(0),     // 4: storage.SecurityContext.SeccompProfile.ProfileType
+	(*Deployment)(nil),                                  // 5: storage.Deployment
+	(*ContainerImage)(nil),                              // 6: storage.ContainerImage
+	(*Container)(nil),                                   // 7: storage.Container
+	(*Resources)(nil),                                   // 8: storage.Resources
+	(*Volume)(nil),                                      // 9: storage.Volume
+	(*LivenessProbe)(nil),                               // 10: storage.LivenessProbe
+	(*ReadinessProbe)(nil),                              // 11: storage.ReadinessProbe
+	(*Pod)(nil),                                         // 12: storage.Pod
+	(*ContainerInstance)(nil),                           // 13: storage.ContainerInstance
+	(*ContainerInstanceID)(nil),                         // 14: storage.ContainerInstanceID
+	(*EmbeddedSecret)(nil),                              // 15: storage.EmbeddedSecret
+	(*PortConfig)(nil),                                  // 16: storage.PortConfig
+	(*ContainerConfig)(nil),                             // 17: storage.ContainerConfig
+	(*SecurityContext)(nil),                             // 18: storage.SecurityContext
+	(*ListDeployment)(nil),                              // 19: storage.ListDeployment
+	nil,                                                 // 20: storage.Deployment.LabelsEntry
+	nil,                                                 // 21: storage.Deployment.PodLabelsEntry
+	nil,                                                 // 22: storage.Deployment.AnnotationsEntry
+	(*Pod_ContainerInstanceList)(nil),                   // 23: storage.Pod.ContainerInstanceList
+	(*PortConfig_ExposureInfo)(nil),                     // 24: storage.PortConfig.ExposureInfo
+	(*ContainerConfig_EnvironmentConfig)(nil),           // 25: storage.ContainerConfig.EnvironmentConfig
+	(*SecurityContext_SELinux)(nil),                     // 26: storage.SecurityContext.SELinux
+	(*SecurityContext_SeccompProfile)(nil),              // 27: storage.SecurityContext.SeccompProfile
+	(*LabelSelector)(nil),                               // 28: storage.LabelSelector
+	(*timestamppb.Timestamp)(nil),                       // 29: google.protobuf.Timestamp
+	(PermissionLevel)(0),                                // 30: storage.PermissionLevel
+	(*Toleration)(nil),                                  // 31: storage.Toleration
+	(*ImageName)(nil),                                   // 32: storage.ImageName
+	(ContainerRuntime)(0),                               // 33: storage.ContainerRuntime
 }
 var file_storage_deployment_proto_depIdxs = []int32{
-	19, // 0: storage.Deployment.labels:type_name -> storage.Deployment.LabelsEntry
-	20, // 1: storage.Deployment.pod_labels:type_name -> storage.Deployment.PodLabelsEntry
-	27, // 2: storage.Deployment.label_selector:type_name -> storage.LabelSelector
-	28, // 3: storage.Deployment.created:type_name -> google.protobuf.Timestamp
-	6,  // 4: storage.Deployment.containers:type_name -> storage.Container
-	21, // 5: storage.Deployment.annotations:type_name -> storage.Deployment.AnnotationsEntry
-	29, // 6: storage.Deployment.service_account_permission_level:type_name -> storage.PermissionLevel
-	30, // 7: storage.Deployment.tolerations:type_name -> storage.Toleration
-	15, // 8: storage.Deployment.ports:type_name -> storage.PortConfig
-	31, // 9: storage.ContainerImage.name:type_name -> storage.ImageName
-	16, // 10: storage.Container.config:type_name -> storage.ContainerConfig
-	5,  // 11: storage.Container.image:type_name -> storage.ContainerImage
-	17, // 12: storage.Container.security_context:type_name -> storage.SecurityContext
-	8,  // 13: storage.Container.volumes:type_name -> storage.Volume
-	15, // 14: storage.Container.ports:type_name -> storage.PortConfig
-	14, // 15: storage.Container.secrets:type_name -> storage.EmbeddedSecret
-	7,  // 16: storage.Container.resources:type_name -> storage.Resources
-	9,  // 17: storage.Container.liveness_probe:type_name -> storage.LivenessProbe
-	10, // 18: storage.Container.readiness_probe:type_name -> storage.ReadinessProbe
-	0,  // 19: storage.Volume.mount_propagation:type_name -> storage.Volume.MountPropagation
-	12, // 20: storage.Pod.live_instances:type_name -> storage.ContainerInstance
-	22, // 21: storage.Pod.terminated_instances:type_name -> storage.Pod.ContainerInstanceList
-	28, // 22: storage.Pod.started:type_name -> google.protobuf.Timestamp
-	13, // 23: storage.ContainerInstance.instance_id:type_name -> storage.ContainerInstanceID
-	28, // 24: storage.ContainerInstance.started:type_name -> google.protobuf.Timestamp
-	28, // 25: storage.ContainerInstance.finished:type_name -> google.protobuf.Timestamp
-	32, // 26: storage.ContainerInstanceID.container_runtime:type_name -> storage.ContainerRuntime
-	1,  // 27: storage.PortConfig.exposure:type_name -> storage.PortConfig.ExposureLevel
-	23, // 28: storage.PortConfig.exposure_infos:type_name -> storage.PortConfig.ExposureInfo
-	24, // 29: storage.ContainerConfig.env:type_name -> storage.ContainerConfig.EnvironmentConfig
-	25, // 30: storage.SecurityContext.selinux:type_name -> storage.SecurityContext.SELinux
-	26, // 31: storage.SecurityContext.seccomp_profile:type_name -> storage.SecurityContext.SeccompProfile
-	28, // 32: storage.ListDeployment.created:type_name -> google.protobuf.Timestamp
-	12, // 33: storage.Pod.ContainerInstanceList.instances:type_name -> storage.ContainerInstance
-	1,  // 34: storage.PortConfig.ExposureInfo.level:type_name -> storage.PortConfig.ExposureLevel
-	2,  // 35: storage.ContainerConfig.EnvironmentConfig.env_var_source:type_name -> storage.ContainerConfig.EnvironmentConfig.EnvVarSource
-	3,  // 36: storage.SecurityContext.SeccompProfile.type:type_name -> storage.SecurityContext.SeccompProfile.ProfileType
-	37, // [37:37] is the sub-list for method output_type
-	37, // [37:37] is the sub-list for method input_type
-	37, // [37:37] is the sub-list for extension type_name
-	37, // [37:37] is the sub-list for extension extendee
-	0,  // [0:37] is the sub-list for field type_name
+	20, // 0: storage.Deployment.labels:type_name -> storage.Deployment.LabelsEntry
+	21, // 1: storage.Deployment.pod_labels:type_name -> storage.Deployment.PodLabelsEntry
+	28, // 2: storage.Deployment.label_selector:type_name -> storage.LabelSelector
+	29, // 3: storage.Deployment.created:type_name -> google.protobuf.Timestamp
+	7,  // 4: storage.Deployment.containers:type_name -> storage.Container
+	22, // 5: storage.Deployment.annotations:type_name -> storage.Deployment.AnnotationsEntry
+	30, // 6: storage.Deployment.service_account_permission_level:type_name -> storage.PermissionLevel
+	31, // 7: storage.Deployment.tolerations:type_name -> storage.Toleration
+	16, // 8: storage.Deployment.ports:type_name -> storage.PortConfig
+	32, // 9: storage.ContainerImage.name:type_name -> storage.ImageName
+	17, // 10: storage.Container.config:type_name -> storage.ContainerConfig
+	6,  // 11: storage.Container.image:type_name -> storage.ContainerImage
+	18, // 12: storage.Container.security_context:type_name -> storage.SecurityContext
+	9,  // 13: storage.Container.volumes:type_name -> storage.Volume
+	16, // 14: storage.Container.ports:type_name -> storage.PortConfig
+	15, // 15: storage.Container.secrets:type_name -> storage.EmbeddedSecret
+	8,  // 16: storage.Container.resources:type_name -> storage.Resources
+	10, // 17: storage.Container.liveness_probe:type_name -> storage.LivenessProbe
+	11, // 18: storage.Container.readiness_probe:type_name -> storage.ReadinessProbe
+	0,  // 19: storage.Container.type:type_name -> storage.ContainerType
+	1,  // 20: storage.Volume.mount_propagation:type_name -> storage.Volume.MountPropagation
+	13, // 21: storage.Pod.live_instances:type_name -> storage.ContainerInstance
+	23, // 22: storage.Pod.terminated_instances:type_name -> storage.Pod.ContainerInstanceList
+	29, // 23: storage.Pod.started:type_name -> google.protobuf.Timestamp
+	14, // 24: storage.ContainerInstance.instance_id:type_name -> storage.ContainerInstanceID
+	29, // 25: storage.ContainerInstance.started:type_name -> google.protobuf.Timestamp
+	29, // 26: storage.ContainerInstance.finished:type_name -> google.protobuf.Timestamp
+	33, // 27: storage.ContainerInstanceID.container_runtime:type_name -> storage.ContainerRuntime
+	2,  // 28: storage.PortConfig.exposure:type_name -> storage.PortConfig.ExposureLevel
+	24, // 29: storage.PortConfig.exposure_infos:type_name -> storage.PortConfig.ExposureInfo
+	25, // 30: storage.ContainerConfig.env:type_name -> storage.ContainerConfig.EnvironmentConfig
+	26, // 31: storage.SecurityContext.selinux:type_name -> storage.SecurityContext.SELinux
+	27, // 32: storage.SecurityContext.seccomp_profile:type_name -> storage.SecurityContext.SeccompProfile
+	29, // 33: storage.ListDeployment.created:type_name -> google.protobuf.Timestamp
+	13, // 34: storage.Pod.ContainerInstanceList.instances:type_name -> storage.ContainerInstance
+	2,  // 35: storage.PortConfig.ExposureInfo.level:type_name -> storage.PortConfig.ExposureLevel
+	3,  // 36: storage.ContainerConfig.EnvironmentConfig.env_var_source:type_name -> storage.ContainerConfig.EnvironmentConfig.EnvVarSource
+	4,  // 37: storage.SecurityContext.SeccompProfile.type:type_name -> storage.SecurityContext.SeccompProfile.ProfileType
+	38, // [38:38] is the sub-list for method output_type
+	38, // [38:38] is the sub-list for method input_type
+	38, // [38:38] is the sub-list for extension type_name
+	38, // [38:38] is the sub-list for extension extendee
+	0,  // [0:38] is the sub-list for field type_name
 }
 
 func init() { file_storage_deployment_proto_init() }
@@ -2321,7 +2381,7 @@ func file_storage_deployment_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_storage_deployment_proto_rawDesc), len(file_storage_deployment_proto_rawDesc)),
-			NumEnums:      4,
+			NumEnums:      5,
 			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/generated/storage/deployment_vtproto.pb.go
+++ b/generated/storage/deployment_vtproto.pb.go
@@ -145,6 +145,7 @@ func (m *Container) CloneVT() *Container {
 	r.Name = m.Name
 	r.LivenessProbe = m.LivenessProbe.CloneVT()
 	r.ReadinessProbe = m.ReadinessProbe.CloneVT()
+	r.Type = m.Type
 	if rhs := m.Volumes; rhs != nil {
 		tmpContainer := make([]*Volume, len(rhs))
 		for k, v := range rhs {
@@ -881,6 +882,9 @@ func (this *Container) EqualVT(that *Container) bool {
 		return false
 	}
 	if !this.ReadinessProbe.EqualVT(that.ReadinessProbe) {
+		return false
+	}
+	if this.Type != that.Type {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1980,6 +1984,11 @@ func (m *Container) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Type != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Type))
+		i--
+		dAtA[i] = 0x68
 	}
 	if m.ReadinessProbe != nil {
 		size, err := m.ReadinessProbe.MarshalToSizedBufferVT(dAtA[:i])
@@ -3485,6 +3494,9 @@ func (m *Container) SizeVT() (n int) {
 	if m.ReadinessProbe != nil {
 		l = m.ReadinessProbe.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Type != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Type))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5754,6 +5766,25 @@ func (m *Container) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			m.Type = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Type |= ContainerType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10757,6 +10788,25 @@ func (m *Container) UnmarshalVTUnsafe(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 13:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			m.Type = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Type |= ContainerType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/postgres/schema/deployments.go
+++ b/pkg/postgres/schema/deployments.go
@@ -129,23 +129,24 @@ type Deployments struct {
 
 // DeploymentsContainers holds the Gorm model for Postgres table `deployments_containers`.
 type DeploymentsContainers struct {
-	DeploymentsID                         string          `gorm:"column:deployments_id;type:uuid;primaryKey"`
-	Idx                                   int             `gorm:"column:idx;type:integer;primaryKey;index:deploymentscontainers_idx,type:btree"`
-	ImageID                               string          `gorm:"column:image_id;type:varchar;index:deploymentscontainers_image_id,type:hash"`
-	ImageNameRegistry                     string          `gorm:"column:image_name_registry;type:varchar"`
-	ImageNameRemote                       string          `gorm:"column:image_name_remote;type:varchar"`
-	ImageNameTag                          string          `gorm:"column:image_name_tag;type:varchar"`
-	ImageNameFullName                     string          `gorm:"column:image_name_fullname;type:varchar"`
-	ImageIDV2                             string          `gorm:"column:image_idv2;type:varchar;index:deploymentscontainers_image_idv2,type:btree"`
-	SecurityContextPrivileged             bool            `gorm:"column:securitycontext_privileged;type:bool"`
-	SecurityContextDropCapabilities       *pq.StringArray `gorm:"column:securitycontext_dropcapabilities;type:text[]"`
-	SecurityContextAddCapabilities        *pq.StringArray `gorm:"column:securitycontext_addcapabilities;type:text[]"`
-	SecurityContextReadOnlyRootFilesystem bool            `gorm:"column:securitycontext_readonlyrootfilesystem;type:bool"`
-	ResourcesCPUCoresRequest              float32         `gorm:"column:resources_cpucoresrequest;type:numeric"`
-	ResourcesCPUCoresLimit                float32         `gorm:"column:resources_cpucoreslimit;type:numeric"`
-	ResourcesMemoryMbRequest              float32         `gorm:"column:resources_memorymbrequest;type:numeric"`
-	ResourcesMemoryMbLimit                float32         `gorm:"column:resources_memorymblimit;type:numeric"`
-	DeploymentsRef                        Deployments     `gorm:"foreignKey:deployments_id;references:id;belongsTo;constraint:OnDelete:CASCADE"`
+	DeploymentsID                         string                `gorm:"column:deployments_id;type:uuid;primaryKey"`
+	Idx                                   int                   `gorm:"column:idx;type:integer;primaryKey;index:deploymentscontainers_idx,type:btree"`
+	ImageID                               string                `gorm:"column:image_id;type:varchar;index:deploymentscontainers_image_id,type:hash"`
+	ImageNameRegistry                     string                `gorm:"column:image_name_registry;type:varchar"`
+	ImageNameRemote                       string                `gorm:"column:image_name_remote;type:varchar"`
+	ImageNameTag                          string                `gorm:"column:image_name_tag;type:varchar"`
+	ImageNameFullName                     string                `gorm:"column:image_name_fullname;type:varchar"`
+	ImageIDV2                             string                `gorm:"column:image_idv2;type:varchar;index:deploymentscontainers_image_idv2,type:btree"`
+	SecurityContextPrivileged             bool                  `gorm:"column:securitycontext_privileged;type:bool"`
+	SecurityContextDropCapabilities       *pq.StringArray       `gorm:"column:securitycontext_dropcapabilities;type:text[]"`
+	SecurityContextAddCapabilities        *pq.StringArray       `gorm:"column:securitycontext_addcapabilities;type:text[]"`
+	SecurityContextReadOnlyRootFilesystem bool                  `gorm:"column:securitycontext_readonlyrootfilesystem;type:bool"`
+	ResourcesCPUCoresRequest              float32               `gorm:"column:resources_cpucoresrequest;type:numeric"`
+	ResourcesCPUCoresLimit                float32               `gorm:"column:resources_cpucoreslimit;type:numeric"`
+	ResourcesMemoryMbRequest              float32               `gorm:"column:resources_memorymbrequest;type:numeric"`
+	ResourcesMemoryMbLimit                float32               `gorm:"column:resources_memorymblimit;type:numeric"`
+	Type                                  storage.ContainerType `gorm:"column:type;type:integer"`
+	DeploymentsRef                        Deployments           `gorm:"foreignKey:deployments_id;references:id;belongsTo;constraint:OnDelete:CASCADE"`
 }
 
 // DeploymentsContainersEnvs holds the Gorm model for Postgres table `deployments_containers_envs`.

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -143,6 +143,7 @@ var (
 	ContainerID                  = newFieldLabel("Container ID")
 	ContainerImageDigest         = newFieldLabel("Container Image Digest")
 	ContainerName                = newFieldLabel("Container Name")
+	ContainerType                = newFieldLabel("Container Type")
 	DeploymentID                 = newFieldLabel("Deployment ID")
 	DeploymentHash               = newFieldLabel("Deployment Hash")
 	DeploymentName               = newFieldLabel("Deployment")

--- a/proto/storage/deployment.proto
+++ b/proto/storage/deployment.proto
@@ -67,6 +67,11 @@ message ContainerImage {
   string id_v2 = 12; // @gotags: search:"Image ID,hidden" sql:"fk(ImageV2:id),no-fk-constraint,index=btree,allow-null"
 }
 
+enum ContainerType {
+  REGULAR = 0;
+  INIT = 1;
+}
+
 message Container {
   string id = 1;
   ContainerConfig config = 2;
@@ -83,6 +88,8 @@ message Container {
 
   LivenessProbe liveness_probe = 11;
   ReadinessProbe readiness_probe = 12;
+
+  ContainerType type = 13; // @gotags: search:"Container Type" hash:"ignore" sensorhash:"ignore"
 }
 
 message Resources {

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -7239,6 +7239,18 @@
       "def": {
         "enums": [
           {
+            "name": "ContainerType",
+            "enum_fields": [
+              {
+                "name": "REGULAR"
+              },
+              {
+                "name": "INIT",
+                "integer": 1
+              }
+            ]
+          },
+          {
             "name": "Volume.MountPropagation",
             "enum_fields": [
               {
@@ -7617,6 +7629,11 @@
                 "id": 12,
                 "name": "readiness_probe",
                 "type": "ReadinessProbe"
+              },
+              {
+                "id": 13,
+                "name": "type",
+                "type": "ContainerType"
               }
             ],
             "reserved_ids": [

--- a/tests/options_test.go
+++ b/tests/options_test.go
@@ -46,7 +46,7 @@ func TestOptionsMapExist(t *testing.T) {
 func TestOptionsMap(t *testing.T) {
 	expectedOptions := []string{
 		"Add Capabilities", "Advisory Link", "Advisory Name", "CPU Cores Limit", "CPU Cores Request", "CVE", "CVE Published On", "CVE Snoozed", "CVSS",
-		"Cluster", "Component", "Component Version", "Deployment", "Deployment Annotation", "Deployment Label",
+		"Cluster", "Component", "Component Version", "Container Type", "Deployment", "Deployment Annotation", "Deployment Label",
 		"Deployment Type", "Dockerfile Instruction Keyword", "Dockerfile Instruction Value", "Drop Capabilities",
 		"EPSS Probability", "Environment Key", "Environment Value", "Environment Variable Source", "Exposed Node Port", "Exposing Service",
 		"Exposing Service Port", "Exposure Level", "External Hostname", "External IP", "Image", "Image CVE Count", "Image Command",


### PR DESCRIPTION
## Description

Adds a ContainerType enum to the Container protobuf message in proto/storage/deployment.proto, enabling StackRox to distinguish between regular, init, and other containers within a deployment.

Files to review:
- proto/storage/deployment.proto — the actual change (enum + field)
- proto/storage/proto.lock — protolock update
- pkg/search/options.go — register "Container Type" as a search field label

Everything else is generated by our build tools.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Verified that protobuf code generation (make proto-generated-srcs and make go-generated-srcs) completes successfully and produces the expected output.
