### PR TITLE
ROX-33533: User actionable logs for Sensor connectivity

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -165,7 +165,7 @@ linters:
         - policy\.NewErr.*
         - retry\.MakeRetryable
         - retry\.WithRetry
-        - sensor\.ProbeStreamForConnectionError
+        - sensor\.DiagnoseConnectionFailure
         - status\.Error
         - utils\.Should
     modernize:

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -217,7 +217,7 @@ func (s *centralCommunicationImpl) hello(stream central.SensorService_Communicat
 	}
 
 	if metautils.MD(rawHdr).Get(centralsensor.SensorHelloMetadataKey) != "true" {
-		return ProbeStreamForConnectionError(stream, "the credentials may be revoked or expired")
+		return DiagnoseConnectionFailure(stream, "the credentials may be revoked or expired")
 	}
 
 	var centralHello *central.CentralHello

--- a/sensor/common/sensor/central_communication_test.go
+++ b/sensor/common/sensor/central_communication_test.go
@@ -126,18 +126,18 @@ func (c *centralCommunicationSuite) Test_HelloMissingSensorHelloKey() {
 		recvErr error
 		wantMsg string
 	}{
-		"PermissionDenied error suggests revoked or expired credentials": {
+		"PermissionDenied error returns wrapped gRPC error": {
 			recvErr: status.Error(codes.PermissionDenied, "not authorized: no authorizer could authorize this request"),
-			wantMsg: "may be revoked or expired",
+			wantMsg: "permission denied by central",
 		},
-		"Other gRPC error includes networking suggestion": {
+		"Other gRPC error returns raw gRPC error": {
 			recvErr: status.Error(codes.Internal, "unexpected HTTP status code received from server"),
-			wantMsg: "likely due to a networking or TLS configuration issue",
+			wantMsg: "unexpected HTTP status code",
 		},
-		"No error from Recv falls back to networking suggestion": {
+		"No error from Recv returns SensorHello not acknowledged": {
 			recvMsg: &central.MsgToSensor{},
 			recvErr: nil,
-			wantMsg: "likely due to a networking or TLS configuration issue",
+			wantMsg: "central did not acknowledge SensorHello",
 		},
 	}
 

--- a/sensor/common/sensor/handshake.go
+++ b/sensor/common/sensor/handshake.go
@@ -11,11 +11,11 @@ const networkingOrTLSMsg = "Connection to Central failed," +
 	" likely due to a networking or TLS configuration issue" +
 	" (e.g., re-encrypt routes or TLS termination)."
 
-// ProbeStreamForConnectionError probes a stream via Recv() to retrieve the
-// actual server-side error when central did not echo the SensorHello metadata
-// key. It logs a user-actionable message (credential issue for PermissionDenied,
-// networking/TLS suggestion otherwise) and returns the underlying error.
-func ProbeStreamForConnectionError(stream central.SensorService_CommunicateClient, deniedMsg string) error {
+// DiagnoseConnectionFailure probes the stream to retrieve the actual server-side error
+// when central did not acknowledge the SensorHello message. It logs a user-actionable
+// message (credential issue for PermissionDenied, networking/TLS suggestion otherwise)
+// and returns an error.
+func DiagnoseConnectionFailure(stream central.SensorService_CommunicateClient, deniedMsg string) error {
 	_, err := stream.Recv()
 
 	if err != nil {

--- a/sensor/common/sensor/handshake.go
+++ b/sensor/common/sensor/handshake.go
@@ -7,22 +7,26 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const sensorHelloNotAcknowledgedMsg = "central did not acknowledge SensorHello," +
+const networkingOrTLSMsg = "Connection to Central failed," +
 	" likely due to a networking or TLS configuration issue" +
-	" (e.g., re-encrypt routes or TLS termination)"
+	" (e.g., re-encrypt routes or TLS termination)."
 
 // ProbeStreamForConnectionError probes a stream via Recv() to retrieve the
 // actual server-side error when central did not echo the SensorHello metadata
-// key. When central responds with PermissionDenied (e.g. revoked or expired credentials),
-// the returned error incorporates deniedMsg. For any other error, or when Recv()
-// succeeds without an error, this function returns a generic networking/TLS suggestion.
+// key. It logs a user-actionable message (credential issue for PermissionDenied,
+// networking/TLS suggestion otherwise) and returns the underlying error.
 func ProbeStreamForConnectionError(stream central.SensorService_CommunicateClient, deniedMsg string) error {
-	if _, recvErr := stream.Recv(); recvErr != nil {
-		if st, ok := status.FromError(recvErr); ok && st.Code() == codes.PermissionDenied {
-			return errors.Wrapf(recvErr, "central rejected the connection: %s."+
-				" Check central logs for details", deniedMsg)
+	_, err := stream.Recv()
+
+	if err != nil {
+		if st, ok := status.FromError(err); ok && st.Code() == codes.PermissionDenied {
+			log.Errorf("Central rejected the connection: %s. Check central logs for details.", deniedMsg)
+			return errors.Wrap(err, "permission denied by central")
 		}
-		return errors.Wrap(recvErr, sensorHelloNotAcknowledgedMsg)
+	} else {
+		err = errors.New("central did not acknowledge SensorHello")
 	}
-	return errors.New(sensorHelloNotAcknowledgedMsg)
+
+	log.Error(networkingOrTLSMsg)
+	return err
 }

--- a/sensor/kubernetes/crs/crs.go
+++ b/sensor/kubernetes/crs/crs.go
@@ -213,7 +213,7 @@ func centralHandshake(ctx context.Context, k8sClient kubernetes.Interface, centr
 
 	hdr := metautils.MD(rawHdr)
 	if hdr.Get(centralsensor.SensorHelloMetadataKey) != "true" {
-		return nil, sensorCommon.ProbeStreamForConnectionError(stream,
+		return nil, sensorCommon.DiagnoseConnectionFailure(stream,
 			"the cluster registration secret may be revoked or expired")
 	}
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Improve SensorHello handshake error handling by separating:
- a user-facing log with actionable guidance
- a developer-facing error chain that still preserves the underlying gRPC error

Follow-up of https://github.com/stackrox/stackrox/pull/19635

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

#### Revoked CRS
```
common/sensor: 2026/04/14 17:33:26.457915 handshake.go:23: Error: Central rejected the connection: the cluster registration secret may be revoked or expired. Check central logs for details.

kubernetes/app: 2026/04/14 17:33:26.458026 app.go:56: Error: Ensuring presence of service certificates for this cluster failed: registering secured cluster: handshake with central: permission denied by central: rpc error: code = PermissionDenied desc = not authorized: no authorizer could authorize this
     request: errors: [credentials not found: service: cannot extract identity: client certificate validation failed, credentials not found: service: cannot extract identity: client certificate validation failed]
```

#### Revoked init bundle
```
common/sensor: 2026/04/14 17:49:52.102519 handshake.go:23: Error: Central rejected the connection: the credentials may be revoked or expired. Check central logs for details.

common/sensor: 2026/04/14 17:49:52.102716 sensor.go:521: Info: Communication with Central stopped: error while executing the sensor hello protocol: permission denied by central: rpc error: code = PermissionDenied desc = not authorized: no authorizer could authorize this request: errors: [credentials not found: service: cannot extract identity: client certificate validation failed, credentials not found: service: cannot extract identity: client certificate validation failed]. Retrying.
```

#### Re-encrypt route (w/CRS)
```
common/sensor: 2026/04/14 17:42:00.701571 handshake.go:30: Error: Connection to Central failed, likely due to a networking or TLS configuration issue (e.g., re-encrypt routes or TLS termination).

kubernetes/app: 2026/04/14 17:42:00.701692 app.go:56: Error: Ensuring presence of service certificates for this cluster failed: registering secured cluster: handshake with central: rpc error: code = Internal desc = unexpected HTTP status code received from server: 400 (Bad Request); transport: received
     unexpected content-type "text/html"
```

#### Re-encrypt route (w/init bundle)
```
common/sensor: 2026/04/14 17:45:53.897174 handshake.go:30: Error: Connection to Central failed, likely due to a networking or TLS configuration issue (e.g., re-encrypt routes or TLS termination).

common/sensor: 2026/04/14 17:45:53.897327 sensor.go:521: Info: Communication with Central stopped: error while executing the sensor hello protocol: rpc error: code = Internal desc = unexpected HTTP status code received from server: 400 (Bad Request); transport: received unexpected content-type "text/html". Retrying.
```