### PR TITLE
ROX:34136, ROX:34137: Fix tagless images' name and link display under CVE and Deployment pages

### DIFF
--- a/central/graphql/resolvers/images.go
+++ b/central/graphql/resolvers/images.go
@@ -118,6 +118,10 @@ func init() {
 			"scanTime: Time",
 			"scannerVersion: String!",
 
+			// Image digest (SHA). For V1 images this equals the image ID;
+			// for V2 images this is the separate SHA digest.
+			"digest: String!",
+
 			// Image signature-related fields.
 			"signatureCount: Int!",
 		}),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/ImageResourceTable.tsx
@@ -10,6 +10,7 @@ export type ImageResources = {
     imageCount: number;
     images: {
         id: string;
+        digest: string;
         name: {
             registry: string;
             remote: string;
@@ -26,6 +27,7 @@ export const imageResourcesFragment = gql`
         imageCount(query: $query)
         images(query: $query, pagination: $pagination) {
             id
+            digest
             name {
                 registry
                 remote
@@ -55,12 +57,16 @@ function ImageResourceTable({ data, getSortParams }: ImageResourceTableProps) {
                 </Tr>
             </Thead>
             {data.images.length === 0 && <EmptyTableResults colSpan={4} />}
-            {data.images.map(({ id, name, deploymentCount, operatingSystem, scanTime }) => {
+            {data.images.map(({ id, digest, name, deploymentCount, operatingSystem, scanTime }) => {
                 return (
                     <Tbody key={id}>
                         <Tr>
                             <Td dataLabel="Name" width={50}>
-                                {name ? <ImageNameLink id={id} name={name} /> : 'NAME UNKNOWN'}
+                                {name ? (
+                                    <ImageNameLink id={id} name={name} digest={digest} />
+                                ) : (
+                                    'NAME UNKNOWN'
+                                )}
                             </Td>
                             {/* Given that this is in the context of a deployment, when would `deploymentCount` ever be less than zero? */}
                             <Td dataLabel="Image status">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/table.utils.ts
@@ -34,6 +34,7 @@ export type ImageMetadataContext = {
 export const imageMetadataContextFragment = gql`
     fragment ImageMetadataContext on Image {
         id
+        digest
         name {
             registry
             remote


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

When `FlattenImageData` is enabled, the image id field becomes a UUID instead of a SHA digest. Several views in Workload CVEs used the id field as a fallback display value for tagless images (via `ImageNameLink` and `getImageBaseNameDisplay`), causing UUIDs to appear instead of digests.                                                                                          
                  
This PR adds a digest field to the Image GraphQL type and passes it to the UI so that tagless images always display the SHA digest regardless of the FlattenImageData flag.            
                  
 
### Changes                                                                                                                                                                                      
                  
  _Backend — central/graphql/resolvers/images.go_                                                                                                                                                
  - Exposes a new digest: String! field on the Image GraphQL type. For V1 images this equals the image ID; for V2 (flattened) images this is the separate SHA digest.
                                                                                                                                                                                               
  _UI — ImageResourceTable.tsx (Deployment single page → Resources tab)_
  - Adds digest to the imageResourcesFragment GraphQL query and ImageResources type.                                                                                                           
  - Passes digest to ImageNameLink so tagless images display remote@sha256:... instead of remote@<uuid>.                                                                                       
                                                                                                                                                                                               
  _UI — table.utils.ts (Workload CVE single page)_                                                                                                                                               
  - Adds digest to the imageMetadataContextFragment GraphQL fragment. This fragment is consumed by AffectedImagesTable and other CVE-scoped tables, so the digest is available wherever        
  ImageNameLink renders an image name.                                                                                                                                                         
                                                                                                                                                                                               
  The ImageNameLink component (ImageNameLink.tsx:30) already prefers digest over id when present (const imageShaForDisplay = digest || id), so the fix is purely about fetching and passing the
   new field. 

## User-facing documentation

- [X] CHANGELOG update is not needed
- [X] documentation is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

 - Deployed with FlattenImageData enabled, navigated to a Workload CVE single page and verified tagless images display SHA instead of a UUID.                                
  - Verified the same fix on the Deployment single page → Resources tab.
  - Confirmed no regression with FlattenImageData disabled — behavior is unchanged since digest equals id for V1 images. 
