### PR TITLE
ROX-33741: Add component for filter in image vulnerability report

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups.tsx
@@ -3,8 +3,8 @@ import {
     DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
-    Label,
-    LabelGroup,
+    Flex,
+    FlexItem,
 } from '@patternfly/react-core';
 
 import type { SearchFilter } from 'types/search';
@@ -33,13 +33,11 @@ function CompoundSearchFilterDescriptionListGroups({
                     <DescriptionListGroup key={group.label}>
                         <DescriptionListTerm>{group.label}</DescriptionListTerm>
                         <DescriptionListDescription>
-                            <LabelGroup categoryName={group.label}>
+                            <Flex direction={{ default: 'column' }}>
                                 {items.map((item) => (
-                                    <Label key={item.label} variant="outline">
-                                        {item.label}
-                                    </Label>
+                                    <FlexItem key={item.label}>{item.label}</FlexItem>
                                 ))}
-                            </LabelGroup>
+                            </Flex>
                         </DescriptionListDescription>
                     </DescriptionListGroup>
                 );

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups.tsx
@@ -1,0 +1,51 @@
+import type { ReactElement } from 'react';
+import {
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Label,
+    LabelGroup,
+} from '@patternfly/react-core';
+
+import type { SearchFilter } from 'types/search';
+
+import type { CompoundSearchFilterAttribute } from '../types';
+import { getCompoundSearchFilterLabelDescriptions } from '../utils/utils';
+
+export type CompoundSearchFilterDescriptionListGroupsProps = {
+    attributes: CompoundSearchFilterAttribute[];
+    searchFilter: SearchFilter;
+};
+
+function CompoundSearchFilterDescriptionListGroups({
+    attributes,
+    searchFilter,
+}: CompoundSearchFilterDescriptionListGroupsProps): ReactElement {
+    const labelGroupDescriptions = getCompoundSearchFilterLabelDescriptions(
+        attributes,
+        searchFilter
+    );
+
+    return (
+        <>
+            {labelGroupDescriptions.map(({ group, items }) => {
+                return (
+                    <DescriptionListGroup key={group.label}>
+                        <DescriptionListTerm>{group.label}</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            <LabelGroup categoryName={group.label}>
+                                {items.map((item) => (
+                                    <Label key={item.label} variant="outline">
+                                        {item.label}
+                                    </Label>
+                                ))}
+                            </LabelGroup>
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                );
+            })}
+        </>
+    );
+}
+
+export default CompoundSearchFilterDescriptionListGroups;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups.tsx
@@ -17,6 +17,9 @@ export type CompoundSearchFilterDescriptionListGroupsProps = {
     searchFilter: SearchFilter;
 };
 
+// For maximum composability and reusability:
+// Render description list groups instead of description list.
+// If rules array is empty, caller is reponsible for conditional rendering, like a warning alert.
 function CompoundSearchFilterDescriptionListGroups({
     attributes,
     searchFilter,

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterLabels.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterLabels.tsx
@@ -5,10 +5,8 @@ import { Globe } from 'react-feather'; // eslint-disable-line limited/no-feather
 import type { SearchFilter } from 'types/search';
 
 import type { CompoundSearchFilterAttribute, CompoundSearchFilterConfig } from '../types';
-import { getCompoundSearchFilterLabelDescriptionOrNull, updateSearchFilter } from '../utils/utils';
-import type { CompoundSearchFilterLabelDescription, IsGlobalPredicate } from '../utils/utils';
-
-const isGlobalPredicateFalse: IsGlobalPredicate = () => false;
+import { getCompoundSearchFilterLabelDescriptions, updateSearchFilter } from '../utils/utils';
+import type { IsGlobalPredicate } from '../utils/utils';
 
 const iconGlobe = <Globe height="15px" />;
 
@@ -23,7 +21,7 @@ export type CompoundSearchFilterLabelsProps = {
 function CompoundSearchFilterLabels({
     attributesSeparateFromConfig,
     config,
-    isGlobalPredicate = isGlobalPredicateFalse,
+    isGlobalPredicate,
     onFilterChange,
     searchFilter,
 }: CompoundSearchFilterLabelsProps): ReactElement {
@@ -31,18 +29,11 @@ function CompoundSearchFilterLabels({
     const attributesFromConfig = config.flatMap(({ attributes }) => attributes);
     const attributes = [...attributesSeparateFromConfig, ...attributesFromConfig];
 
-    const labelGroupDescriptions: CompoundSearchFilterLabelDescription[] = [];
-    attributes.forEach((attribute) => {
-        const labelDescriptionOrNull = getCompoundSearchFilterLabelDescriptionOrNull(
-            attribute,
-            searchFilter,
-            isGlobalPredicate
-        );
-        if (labelDescriptionOrNull !== null) {
-            // Attribute has one or more values in the search filter.
-            labelGroupDescriptions.push(labelDescriptionOrNull);
-        }
-    });
+    const labelGroupDescriptions = getCompoundSearchFilterLabelDescriptions(
+        attributes,
+        searchFilter,
+        isGlobalPredicate
+    );
 
     return (
         <Flex className="search-filter-labels" spaceItems={{ default: 'spaceItemsXs' }}>

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
@@ -355,7 +355,7 @@ export function getCompoundSearchFilterLabelDescriptions(
     attributes: CompoundSearchFilterAttribute[],
     searchFilter: SearchFilter,
     isGlobalPredicate: IsGlobalPredicate = isGlobalPredicateFalse // for certain values in AdvancedFilterToolbar.tsx file
-) {
+): CompoundSearchFilterLabelDescription[] {
     const labelGroupDescriptions: CompoundSearchFilterLabelDescription[] = [];
 
     attributes.forEach((attribute) => {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
@@ -200,7 +200,7 @@ export type CompoundSearchFilterLabelDescription = {
 export type IsGlobalPredicate = (category: string, value: string) => boolean;
 
 // If attribute has any values in search filter return description else null.
-export function getCompoundSearchFilterLabelDescriptionOrNull(
+function getCompoundSearchFilterLabelDescriptionOrNull(
     attribute: CompoundSearchFilterAttribute,
     searchFilter: SearchFilter,
     isGlobalPredicate: IsGlobalPredicate
@@ -346,6 +346,31 @@ export function getCompoundSearchFilterLabelDescriptionOrNull(
 // Return internal value if untrusted page address search query does not have a valid option.
 function getLabelForOption(option: SelectSearchFilterOption | undefined, value: string) {
     return option ? option.label : value;
+}
+
+const isGlobalPredicateFalse: IsGlobalPredicate = () => false;
+
+// Return descriptions for compound search filter and also for report configurations.
+export function getCompoundSearchFilterLabelDescriptions(
+    attributes: CompoundSearchFilterAttribute[],
+    searchFilter: SearchFilter,
+    isGlobalPredicate: IsGlobalPredicate = isGlobalPredicateFalse // for certain values in AdvancedFilterToolbar.tsx file
+) {
+    const labelGroupDescriptions: CompoundSearchFilterLabelDescription[] = [];
+
+    attributes.forEach((attribute) => {
+        const labelDescriptionOrNull = getCompoundSearchFilterLabelDescriptionOrNull(
+            attribute,
+            searchFilter,
+            isGlobalPredicate
+        );
+        if (labelDescriptionOrNull !== null) {
+            // Attribute has one or more values in the search filter.
+            labelGroupDescriptions.push(labelDescriptionOrNull);
+        }
+    });
+
+    return labelGroupDescriptions;
 }
 
 // Given predicate function from useFeatureFlags hook in component

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
@@ -8,7 +8,7 @@ import {
 } from '@patternfly/react-core';
 
 import type { ViewBasedReportSnapshot } from 'services/ReportsService.types';
-import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
+import CompoundSearchFilterDescriptionListGroups from 'Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups';
 import { getSearchFilterFromSearchString } from 'utils/searchUtils';
 import {
     attributesSeparateFromConfigForViewBasedReport,
@@ -20,53 +20,42 @@ export type ViewBasedReportJobDetailsProps = {
 };
 
 function ViewBasedReportJobDetails({ reportSnapshot }: ViewBasedReportJobDetailsProps) {
-    const query = getSearchFilterFromSearchString(reportSnapshot.viewBasedVulnReportFilters.query);
+    const { name, viewBasedVulnReportFilters } = reportSnapshot;
+    const { query } = viewBasedVulnReportFilters;
+
+    const searchFilter = getSearchFilterFromSearchString(query);
+
+    // Render separate attributes (more likely to be specified) preceding config.
+    const attributesFromConfig = configForViewBasedReport.flatMap(({ attributes }) => attributes);
+    const attributes = [...attributesSeparateFromConfigForViewBasedReport, ...attributesFromConfig];
 
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
-            <Title headingLevel="h2">Report details</Title>
+            <Title headingLevel="h2">Details</Title>
             <DescriptionList
-                columnModifier={{
-                    default: '3Col',
-                }}
+                isCompact
+                isHorizontal
+                horizontalTermWidthModifier={{ default: '20ch' }}
             >
                 <DescriptionListGroup>
                     <DescriptionListTerm>Name</DescriptionListTerm>
-                    <DescriptionListDescription>{reportSnapshot.name}</DescriptionListDescription>
+                    <DescriptionListDescription>{name}</DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
-                    <DescriptionListTerm>Results type</DescriptionListTerm>
-                    <DescriptionListDescription>Vulnerabilities</DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                    <DescriptionListTerm>Area of concern</DescriptionListTerm>
-                    <DescriptionListDescription>
-                        {reportSnapshot.areaOfConcern}
-                    </DescriptionListDescription>
+                    <DescriptionListTerm>Report type</DescriptionListTerm>
+                    <DescriptionListDescription>Image vulnerabilities</DescriptionListDescription>
                 </DescriptionListGroup>
             </DescriptionList>
-            <Title headingLevel="h2">Scope details</Title>
+            <Title headingLevel="h2">Filters</Title>
             <DescriptionList
-                columnModifier={{
-                    default: '1Col',
-                }}
+                isCompact
+                isHorizontal
+                horizontalTermWidthModifier={{ default: '20ch' }}
             >
-                <DescriptionListGroup>
-                    <DescriptionListTerm>Scoping method</DescriptionListTerm>
-                    <DescriptionListDescription>Using filters</DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                    <DescriptionListTerm>Scope filters</DescriptionListTerm>
-                    <DescriptionListDescription>
-                        <CompoundSearchFilterLabels
-                            attributesSeparateFromConfig={
-                                attributesSeparateFromConfigForViewBasedReport
-                            }
-                            config={configForViewBasedReport}
-                            searchFilter={query}
-                        />
-                    </DescriptionListDescription>
-                </DescriptionListGroup>
+                <CompoundSearchFilterDescriptionListGroups
+                    attributes={attributes}
+                    searchFilter={searchFilter}
+                />
             </DescriptionList>
         </Flex>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -237,8 +237,8 @@ export const configForViewBasedReport = [
 ];
 
 export const attributeForPlatformComponent: SelectSearchFilterAttribute = {
-    displayName: 'View context', // corresponds to horizontal navigation
-    filterChipLabel: 'View context',
+    displayName: 'Area of concern', // corresponds to horizontal navigation
+    filterChipLabel: 'Area of concern',
     searchTerm: 'Platform Component',
     inputType: 'select',
     inputProps: {
@@ -266,7 +266,7 @@ export const attributeForVulnerabilityState: SelectSearchFilterAttribute = {
 
 export const attributesSeparateFromConfigForViewBasedReport = [
     attributeForPlatformComponent,
-    attributeForFixableInBackendAndViewBasedReport,
     attributeForVulnerabilityState,
     attributeForSeverityInBackendAndViewBasedReport, // Formerly under Vulnerability parameters
+    attributeForFixableInBackendAndViewBasedReport,
 ];


### PR DESCRIPTION
## Description

**Review**: Hide space in case refactoring becomes clearer.

### Objective

Provide equivalent filter for scheduled reports as view-based reports

### Analysis

1. ViewBasedReportJobDetails.tsx file renders `CompoundSearchFilterLabels` element for consistency with results page.

2. CompoundSearchFilterLabels.tsx file computes `labelGroupDescriptions` array that is also relevant for:

    * ImageVulnerabilityFiltersView
    * ImageVulnerabilityFiltersStep

### Solution part 1

1. Edit src/Components/CompoundSearchFilter/utils/utils.tsx file.

    * Write `getCompoundSearchFilterLabelDescriptions` function.

2. Add src/Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups.tsx file.

### Solution part 2

1. Replace `LabelGroup` with `Flex` column layout for attribute values.

2. Simplify headings and description lists in ViewBasedReportJobDetails.tsx file.

    Replace placeholder `CompoundSearchFilterLabels` with ` CompoundSearchFilterDescriptionListGroups` element.

3. Replace temporary label with **Area of concern** and reorder attributes for view-based report in searchConfig.ts file.

### Residue

1. Investigate more consistent layout for view-based report job details.

4. Investigate pro and con of modal versus page.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready and the functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
5. `npm run start` in ui/apps/platform folder with staging demo as central

### Manual testing

1. Visit /main/vulnerabilities/platform

    Select search filter criteria to see `CompoundSearchFilterLabels` element after refactor.
    <img width="1440" height="730" alt="CompoundSearchFilterLabels" src="https://github.com/user-attachments/assets/feceb59b-4de4-44f4-8999-b52518260937" />

2. Visit /main/vulnerabilities/reports/view-based and then click a link.

    Before changes with compound search filter labels:
    <img width="1440" height="730" alt="ViewBasedReportJobDetails_baseline" src="https://github.com/user-attachments/assets/3bb2d93a-8b02-4977-98c7-5feed7f607a0" />

    After changes with description list groups:
    <img width="559" height="590" alt="ViewBasedReportJobDetails_improved" src="https://github.com/user-attachments/assets/1cab2145-408d-47aa-aad8-f3057138359d" />
