### PR TITLE
ROX-34151: Add Reports subfolder to Components folder

### DIFF
--- a/ui/apps/platform/src/Components/Reports/Step/DetailsStep.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/DetailsStep.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { Divider, Flex, PageSection, Title } from '@patternfly/react-core';
 
-// import type { DetailsType } from '../../imageVulnerabilityReports.types';
+// import type { DetailsType } from '../reports.types';
 
 function DetailsStep(): ReactElement {
     return (

--- a/ui/apps/platform/src/Components/Reports/View/DetailsView.tsx
+++ b/ui/apps/platform/src/Components/Reports/View/DetailsView.tsx
@@ -9,7 +9,7 @@ import {
     Title,
 } from '@patternfly/react-core';
 
-import type { DetailsType } from '../imageVulnerabilityReports.types';
+import type { DetailsType } from '../reports.types';
 
 export type DetailsViewProps = {
     headingLevel: 'h2' | 'h3';

--- a/ui/apps/platform/src/Components/Reports/reports.types.ts
+++ b/ui/apps/platform/src/Components/Reports/reports.types.ts
@@ -1,0 +1,4 @@
+export type DetailsType = {
+    name: string;
+    description: string;
+};

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.types.ts
@@ -8,11 +8,6 @@ import type {
 import type { VulnerabilitySeverity } from 'types/cve.proto';
 import type { Schedule } from 'types/schedule.proto';
 
-export type DetailsType = {
-    name: string;
-    description: string;
-};
-
 // TODO move final type to ReportsService.types.ts file when merged into report_service.proto file
 
 type EntityScope = {


### PR DESCRIPTION
## Description

### Objective

Provide equivalent filter for scheduled reports as view-based reports

### Analysis

**Details** and (deferred pending decision about its name) **Destinations** or **Delivery** files are reusable for both **image** and **node** vulnerability report configuraiton (not to mention **violations**).

### Solution

Factor out as discussed in office hours similar to CompoundSearchFilter subfolder.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.