### PR TITLE
ROX-34021: Add init container feature flag and capability

### DIFF
--- a/central/sensor/service/service_impl.go
+++ b/central/sensor/service/service_impl.go
@@ -152,6 +152,9 @@ func (s *serviceImpl) Communicate(server central.SensorService_CommunicateServer
 		if features.FlattenImageData.Enabled() {
 			capabilities = append(capabilities, centralsensor.FlattenImageData)
 		}
+		if features.InitContainerSupport.Enabled() {
+			capabilities = append(capabilities, centralsensor.InitContainerSupport)
+		}
 		if features.OCPConsoleIntegration.Enabled() {
 			capabilities = append(capabilities, centralsensor.InternalTokenAPISupported.String())
 			capabilities = append(capabilities, centralsensor.CentralProxyPathFiltering.String())

--- a/pkg/centralsensor/caps_list.go
+++ b/pkg/centralsensor/caps_list.go
@@ -101,4 +101,8 @@ const (
 	// per-image cache invalidation keys to the admission controller instead of
 	// flushing the entire image cache.
 	TargetedImageCacheInvalidation SensorCapability = "TargetedImageCacheInvalidation"
+
+	// InitContainerSupport identifies the capability of Sensor to extract init containers from pod specs
+	// and of Central to handle init container data in deployments.
+	InitContainerSupport = "InitContainerSupport"
 )

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -133,6 +133,9 @@ var (
 
 	// TailoredProfiles enables support for compliance tailored profiles
 	TailoredProfiles = registerFeature("Enable support for tailored profiles", "ROX_TAILORED_PROFILES")
+
+	// InitContainerSupport enables extraction, scanning, and evaluation of init containers in deployments.
+	InitContainerSupport = registerFeature("Enable init container support", "ROX_INIT_CONTAINER_SUPPORT")
 )
 
 // The following feature flags are related to Scanner V4.

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -156,6 +156,9 @@ func (s *centralCommunicationImpl) sendEvents(client central.SensorServiceClient
 	if features.FlattenImageData.Enabled() {
 		capsSet.Add(centralsensor.FlattenImageData)
 	}
+	if features.InitContainerSupport.Enabled() {
+		capsSet.Add(centralsensor.InitContainerSupport)
+	}
 	sensorHello.Capabilities = sliceutils.StringSlice(capsSet.AsSlice()...)
 
 	// Inject desired Helm configuration, if any.


### PR DESCRIPTION
## Description

Adds the `ROX_INIT_CONTAINER_SUPPORT` feature flag and corresponding `InitContainerSupport` Central-Sensor capability, gating init container extraction, scanning, and evaluation functionality behind a tech preview flag (OFF by default).

Addresses ROX-34021 and ROX-34022

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Followed established patterns stemming from `pkg/features/list.go` and `pkg/centralsensor/caps_list.go`.

CI validation pending.
