### PR TITLE
ROX-33465: Remove OCP3 from install and more reliable autosensing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 ### Technical Changes
 
+- OpenShift 3 support removed from all installation methods.
+
 ## [4.10.0]
 
 

--- a/central/clusters/zip/render_test.go
+++ b/central/clusters/zip/render_test.go
@@ -135,7 +135,7 @@ func TestRenderWithNoCollection(t *testing.T) {
 	cluster := &storage.Cluster{
 		Name:             "cluster",
 		MainImage:        "stackrox/main:abc",
-		Type:             storage.ClusterType_OPENSHIFT_CLUSTER,
+		Type:             storage.ClusterType_OPENSHIFT4_CLUSTER,
 		CollectionMethod: storage.CollectionMethod_NO_COLLECTION,
 	}
 

--- a/image/embed_charts.go
+++ b/image/embed_charts.go
@@ -271,7 +271,7 @@ func (i *Image) GetSensorChart(values *charts.MetaValues, certs *sensor.Certs) (
 func (i *Image) addScripts(values *charts.MetaValues) ([]*loader.BufferedFile, error) {
 	if values.ClusterType == storage.ClusterType_KUBERNETES_CLUSTER.String() {
 		return i.scripts(values, k8sScriptsFileMap)
-	} else if values.ClusterType == storage.ClusterType_OPENSHIFT_CLUSTER.String() || values.ClusterType == storage.ClusterType_OPENSHIFT4_CLUSTER.String() {
+	} else if values.ClusterType == storage.ClusterType_OPENSHIFT4_CLUSTER.String() {
 		return i.scripts(values, osScriptsFileMap)
 	}
 	return nil, errors.Errorf("unable to create sensor bundle, invalid cluster type for cluster %s",

--- a/image/templates/helm/shared/templates/02-scanner-v4-01-security.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-01-security.yaml
@@ -2,12 +2,9 @@
 
 {{- if or ._rox.scannerV4._indexerEnabled ._rox.scannerV4._matcherEnabled }}
   {{- if ._rox.env.openshift }}
-    {{- if eq ._rox.env.openshift 3 }}
-      {{ include "srox.warn" (list . "On OpenShift 3.x no SecurityContextConstraint will be configured for Scanner V4.") }}
-    {{- else }}
-      {{/* Use a default SCC that ships with OpenShift 4.x.
-           We only need to create a Role and a RoleBinding for
-           associating the SCC with the Scanner V4 deployment. */}}
+    {{/* Use a default SCC that ships with OpenShift 4.x.
+          We only need to create a Role and a RoleBinding for
+          associating the SCC with the Scanner V4 deployment. */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -47,6 +44,5 @@ subjects:
 - kind: ServiceAccount
   name: scanner-v4
   namespace: {{ .Release.Namespace }}
-    {{- end }}
   {{- end }}
 {{- end }}

--- a/image/templates/helm/shared/templates/_openshift.tpl
+++ b/image/templates/helm/shared/templates/_openshift.tpl
@@ -4,13 +4,11 @@
     This function detects the OpenShift version automatically based on the cluster the Helm chart is installed onto.
     It writes the result to ._rox.env.openshift as an integer.
     Possible results are:
-     - 3 (OpenShift 3)
      - 4 (OpenShift 4)
      - 0 (Non-Openshift cluster)
 
-    If "true" is passed for $._rox.env.openshift the OpenShift version is detected based on the Kubernetes cluster version.
-    If the Kubernetes version is not available (i.e. when using Helm template) auto-sensing falls back on OpenShift 3 to be
-    backward compatible.
+    If "true" is passed for $._rox.env.openshift, this is unconditionally mapped to OpenShift version "4", because that is the only
+    major version we currently support.
   */}}
 
 {{ define "srox.autoSenseOpenshiftVersion" }}
@@ -20,31 +18,25 @@
 
 {{/* Infer OpenShift, if needed */}}
 {{ if kindIs "invalid" $env.openshift }}
-  {{/* The API GroupVersion project.openshift.io/v1 contains the core OpenShift API 'Project' of
-       compatibility level 1, which comes with the strongest stability guarantees among the OpenShift APIs.
-       This API is available in OpenShift 3.x and 4.x. */}}
-  {{ $_ := set $env "openshift" (has "project.openshift.io/v1" $._rox._apiServer.apiResources) }}
+  {{/* This CRD API reliably indicates OpenShift 4. */}}
+  {{ $_ := set $env "openshift" (has "config.openshift.io/v1" $._rox._apiServer.apiResources) }}
+  {{- if $env.openshift -}}
+    {{- include "srox.note" (list $ (printf "Based on API server properties, we have inferred that you are deploying into an OpenShift 4.x cluster.")) -}}
+  {{- end -}}
 {{ end }}
-
-{{/* Infer openshift version */}}
 {{ if and $env.openshift (kindIs "bool" $env.openshift) }}
-  {{/* Parse and add KubeVersion as semver from built-in resources. This is necessary to compare valid integer numbers. */}}
-  {{ $kubeVersion := semver $.Capabilities.KubeVersion.Version }}
-
-  {{/* Default to OpenShift 3 if no openshift resources are available, i.e. in helm template commands */}}
-  {{ if not (has "project.openshift.io/v1" $._rox._apiServer.apiResources) }}
-    {{ $_ := set $._rox.env "openshift" 3 }}
-  {{ else if gt $kubeVersion.Minor 11 }}
-    {{ $_ := set $env "openshift" 4 }}
-  {{ else }}
-    {{ $_ := set $env "openshift" 3 }}
-  {{ end }}
-  {{ include "srox.note" (list $ (printf "Based on API server properties, we have inferred that you are deploying into an OpenShift %d.x cluster. Set the `env.openshift` property explicitly to 3 or 4 to override the auto-sensed value." $env.openshift)) }}
+  {{/* We only support OpenShift 4. */}}
+  {{ $_ := set $env "openshift" 4 }}
 {{ end }}
+
 {{ if not (kindIs "bool" $env.openshift) }}
   {{ $_ := set $env "openshift" (int $env.openshift) }}
 {{ else if not $env.openshift }}
   {{ $_ := set $env "openshift" 0 }}
 {{ end }}
+
+{{- if and (ne $env.openshift 0) (ne $env.openshift 4) -}}
+  {{- include "srox.fail" (printf "You have specified OpenShift version %d.x, but only version 4.x is currently supported." $env.openshift) -}}
+{{- end -}}
 
 {{ end }}

--- a/image/templates/helm/stackrox-secured-cluster/internal/cluster-config.yaml.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/cluster-config.yaml.tpl.htpl
@@ -7,7 +7,7 @@ clusterConfig:
     {{- if not ._rox.env.openshift }}
     type: KUBERNETES_CLUSTER
     {{- else }}
-    type: {{ if eq (int ._rox.env.openshift) 4 -}} OPENSHIFT4_CLUSTER {{- else -}} OPENSHIFT_CLUSTER {{ end }}
+    type: OPENSHIFT4_CLUSTER
     {{- end }}
     mainImage: {{ coalesce ._rox.image.main._abbrevImageRef ._rox.image.main.fullRef }}
     collectorImage: {{ coalesce ._rox.image.collector._abbrevImageRef ._rox.image.collector.fullRef }}

--- a/image/templates/helm/stackrox-secured-cluster/internal/compatibility-translation.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/compatibility-translation.yaml
@@ -12,8 +12,15 @@ cluster:
     clusterName: {{ .value }}
   type: |
     env:
-      openshift: {{ if eq .rawValue "OPENSHIFT4_CLUSTER" }} 4 {{ else }} {{ eq .rawValue "OPENSHIFT_CLUSTER" }} {{ end }}
-
+{{- if eq .rawValue "OPENSHIFT4_CLUSTER" -}}
+      openshift: 4
+{{- else if eq .rawValue "OPENSHIFT_CLUSTER" -}}
+      {{/* We don't support this anymore, but this way we are explicit about it
+           and produce a rendering error for this cluster type. */}}
+      openshift: 3
+{{- else -}}
+      openshift: false
+{{- end -}}
 endpoint:
   central: |
     centralEndpoint: {{ .value }}

--- a/image/templates/helm/stackrox-secured-cluster/internal/compatibility-translation.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/compatibility-translation.yaml
@@ -12,15 +12,8 @@ cluster:
     clusterName: {{ .value }}
   type: |
     env:
-{{- if eq .rawValue "OPENSHIFT4_CLUSTER" -}}
-      openshift: 4
-{{- else if eq .rawValue "OPENSHIFT_CLUSTER" -}}
-      {{/* We don't support this anymore, but this way we are explicit about it
-           and produce a rendering error for this cluster type. */}}
-      openshift: 3
-{{- else -}}
-      openshift: false
-{{- end -}}
+      openshift: {{ if eq .rawValue "OPENSHIFT4_CLUSTER" }} 4 {{ else }} {{ eq .rawValue "OPENSHIFT_CLUSTER" }} {{ end }}
+
 endpoint:
   central: |
     centralEndpoint: {{ .value }}

--- a/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/internal/defaults/30-base-config.yaml.htpl
@@ -60,13 +60,7 @@ admissionControl:
 [<- if .FeatureFlags.ROX_ADMISSION_CONTROLLER_CONFIG >]
   listenOnCreates: true
   listenOnUpdates: true
-  {{/* At this point, when defaults are applied, we can expect env.openshift to be false or a major version number (3, 4). */}}
-  {{- if or (not ._rox.env.openshift) (gt ._rox.env.openshift 3) }}
   listenOnEvents: true
-  {{- else }}
-  {{/* OpenShift 3.x does not support this. */}}
-  listenOnEvents: false
-  {{- end }}
 [<- else >]
   listenOnCreates: false
   listenOnUpdates: false

--- a/image/templates/helm/stackrox-secured-cluster/sensor-chart-upgrade.md.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/sensor-chart-upgrade.md.htpl
@@ -106,7 +106,7 @@ Here is the list of old and new configuration options:
 |Old configuration option |New configuration option |
 |-------------------------|-------------------------|
 | `cluster.name` | `clusterName` |
-| `cluster.type` | Set `env.openshift` to `true` for `cluster.type=OPENSHIFT_CLUSTER` and `false` for `cluster.type=KUBERNETES_CLUSTER`. Leave unset to automatically detect (recommended). |
+| `cluster.type` | Set `env.openshift` to `true` for `cluster.type=OPENSHIFT4_CLUSTER` and `false` for `cluster.type=KUBERNETES_CLUSTER`. Leave unset to automatically detect (recommended). |
 | `endpoint.central` | `centralEndpoint` |
 | `endpoint.advertised` | `sensor.endpoint` |
 | `image.repository.main` | `image.main.name` |

--- a/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_init.tpl.htpl
@@ -210,12 +210,6 @@
   {{ include "srox.warn" (list $ "Incompatible settings: 'admissionControl.dynamic.enforceOnUpdates' is set to true, while `admissionControl.listenOnUpdates` is set to false. For the feature to be active, enable both settings by setting them to true.") }}
 {{ end }}
 
-[<- if not .FeatureFlags.ROX_ADMISSION_CONTROLLER_CONFIG >]
-{{ if and (eq $._rox.env.openshift 3) $._rox.admissionControl.listenOnEvents }}
-  {{ include "srox.fail" "'admissionControl.listenOnEvents' is set to true, but the chart is being deployed in OpenShift 3.x compatibility mode, which does not work with this feature. Set 'env.openshift' to '4' in order to enable OpenShift 4.x features." }}
-{{ end }}
-[<- end >]
-
 {{ if $._rox.collector.slimMode }}
   {{ include "srox.warn" (list $ "collector.slimMode is set to true, but it has been removed in 4.7 after being deprecated since 4.5. This setting will be ignored.") }}
 {{ end }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -25,7 +25,7 @@ spec:
         {{- include "srox.podLabels" (list . "deployment" "admission-control") | nindent 8 }}
       annotations:
         {{- $annotations := dict "traffic.sidecar.istio.io/excludeInboundPorts" "8443" -}}
-        {{- if eq ._rox.env.openshift 4 }}
+        {{- if ._rox.env.openshift }}
           {{- $_ := set $annotations "openshift.io/required-scc" "restricted-v2" -}}
         {{- end }}
         {{- include "srox.podAnnotations" (list . "deployment" "admission-control" $annotations) | nindent 8 }}
@@ -215,11 +215,7 @@ spec:
   type: ClusterIP
   sessionAffinity: None
 ---
-{{- if ne ._rox.env.openshift 3 }}
 apiVersion: admissionregistration.k8s.io/v1
-{{- else }}
-apiVersion: admissionregistration.k8s.io/v1beta1
-{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
   name: stackrox
@@ -231,11 +227,9 @@ metadata:
 webhooks:
   {{- if or ._rox.admissionControl.dynamic.enforceOnCreates ._rox.admissionControl.dynamic.enforceOnUpdates }}
   - name: policyeval.stackrox.io
-    {{- if ne ._rox.env.openshift 3 }}
     sideEffects: NoneOnDryRun
     admissionReviewVersions: [ "v1", "v1beta1" ]
     timeoutSeconds: {{ add 2 ._rox.admissionControl.dynamic.timeout }}
-    {{- end }}
     rules:
       - apiGroups:
         - '*'
@@ -280,11 +274,9 @@ webhooks:
   {{- end}}
   {{- if ._rox.admissionControl.listenOnEvents }}
   - name: k8sevents.stackrox.io
-    {{- if ne ._rox.env.openshift 3 }}
     sideEffects: NoneOnDryRun
     admissionReviewVersions: [ "v1", "v1beta1" ]
     timeoutSeconds: {{ add 2 ._rox.admissionControl.dynamic.timeout }}
-    {{- end }}
     rules:
       - apiGroups:
         - '*'

--- a/image/templates/helm/stackrox-secured-cluster/values.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/values.yaml.htpl
@@ -21,11 +21,7 @@ admissionControl:
   [<- else >]
   failurePolicy: Ignore
   [<- end >]
-  [<- if eq .ClusterType "OPENSHIFT_CLUSTER" >]
-  listenOnEvents: false
-  [<- else >]
   listenOnEvents: true
-  [<- end >]
   enforce: [< or .AdmissionControllerEnabled .AdmissionControlEnforceOnUpdates >]
   disableBypass: [< default false .DisableBypass >]
 

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/central.test.yaml
@@ -79,9 +79,9 @@ tests:
 - name: "central with OpenShift 4 and stock SCCs"
   server:
     visibleSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
     availableSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
   values:
     env:
       openshift: 4

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/injected-cabundle-cm.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/injected-cabundle-cm.test.yaml
@@ -17,15 +17,6 @@ tests:
       assertThat(.configmaps["injected-cabundle-stackrox-central-services"].metadata.labels["config.openshift.io/inject-trusted-cabundle"] == "true")
 - server:
     visibleSchemas:
-    - openshift-3.11.0
-  set:
-    env.openshift: 3
-  tests:
-  - name: "No injected CA bundle on Openshift 3"
-    expect: |
-      assertThat(.configmaps["injected-cabundle-stackrox-central-services"] == null)
-- server:
-    visibleSchemas:
     - kubernetes-1.20.2
   tests:
   - name: "No injected CA bundle on Kubernetes"

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/injected-cabundle-cm.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/injected-cabundle-cm.test.yaml
@@ -7,7 +7,7 @@ values:
 tests:
 - server:
     visibleSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
   tests:
   - name: "Injected CA bundle has no data"
     expect: |

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-auth.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-auth.test.yaml
@@ -13,7 +13,7 @@ values:
 
 server:
   availableSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
 tests:
 - name: OpenShift Auth should be disabled by default
   expect: |

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-autosense.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-autosense.test.yaml
@@ -5,15 +5,6 @@ values:
     openshift:
       enabled: false
 tests:
-- name: "Detect OpenShift 3 if no openshift server resources are not visible"
-  set:
-    env.openshift: true
-  server:
-    availableSchemas:
-      - openshift-3.11.0
-  expect:
-    .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 3"))
-
 - name: "Detect OpenShift 4 if env.openshift=true and server resources are visible"
   server:
     visibleSchemas:
@@ -25,15 +16,3 @@ tests:
       version: "v1.18.0"
   expect:
     .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 4"))
-
-- name: "Detect openshift 3 if server resources are visible on kubernetes v1.11"
-  server:
-    visibleSchemas:
-      - openshift-3.11.0
-  set:
-    env.openshift: true
-  capabilities:
-    kubeVersion:
-      version: "v1.11.0"
-  expect:
-    .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 3"))

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-autosense.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-autosense.test.yaml
@@ -17,7 +17,7 @@ tests:
 - name: "Detect OpenShift 4 if env.openshift=true and server resources are visible"
   server:
     visibleSchemas:
-      - openshift-4.1.0
+      - openshift-4.12
   set:
     env.openshift: true
   capabilities:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-autosense.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-autosense.test.yaml
@@ -11,8 +11,5 @@ tests:
       - openshift-4.12
   set:
     env.openshift: true
-  capabilities:
-    kubeVersion:
-      version: "v1.18.0"
   expect:
     .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 4"))

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-autosense.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-autosense.test.yaml
@@ -5,11 +5,16 @@ values:
     openshift:
       enabled: false
 tests:
-- name: "Detect OpenShift 4 if env.openshift=true and server resources are visible"
+- name: "Detect OpenShift 4 if env.openshift is unset and server resources are visible"
   server:
     visibleSchemas:
       - openshift-4.12
-  set:
-    env.openshift: true
-  expect:
+  expect: |
     .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 4"))
+    .configmaps["injected-cabundle-stackrox-central-services"] | assertThat(. != null)
+- name: "Fail if env.openshift is set to an unsupported version"
+  set:
+    env.openshift: 3
+  expectError: true
+  expect: |
+    .error | assertThat(contains("You have specified OpenShift version 3.x, but only version 4.x is currently supported."))

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -1,6 +1,6 @@
 server:
   availableSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
   - com.coreos
 values:
   imagePullSecrets:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -143,47 +143,8 @@ tests:
     env.openshift: false
   tests: *disabled-test
 
-- name: "Disable override when on explicit OpenShift 3 environment"
-  set:
-    monitoring.openshift.enabled: true
-    env.openshift: 3
-  tests: *disabled-test
-
-- name: "Disable override with default value when on explicit OpenShift 3 environment"
-  set:
-    env.openshift: 3
-  tests: *disabled-test
-
-- name: "Disable override when on auto-detected OpenShift 3 environment"
-  set:
-    monitoring.openshift.enabled: true
-  server:
-    visibleSchemas:
-      - openshift-3.11.0
-  capabilities:
-    kubeVersion:
-      version: "v1.11.0"
-  tests: *disabled-test
-
 - name: "Disable override when on non-OpenShift environment (legacy)"
   set:
     enableOpenShiftMonitoring: true
     env.openshift: false
-  tests: *disabled-test
-
-- name: "Disable override when on explicit OpenShift 3 environment (legacy)"
-  set:
-    enableOpenShiftMonitoring: true
-    env.openshift: 3
-  tests: *disabled-test
-
-- name: "Disable override when on auto-detected OpenShift 3 environment (legacy)"
-  set:
-    enableOpenShiftMonitoring: true
-  server:
-    visibleSchemas:
-      - openshift-3.11.0
-  capabilities:
-    kubeVersion:
-      version: "v1.11.0"
   tests: *disabled-test

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner-v4.test.yaml
@@ -29,9 +29,9 @@ values:
       enabled: false
 server:
   visibleSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
   availableSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
 tests:
 - name: "matcher resources should exist"
   set:

--- a/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/helmtest/scanner.test.yaml
@@ -111,9 +111,9 @@ tests:
 - name: "scanner with OpenShift 4 and default SCCs"
   server:
     visibleSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
     availableSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
   values:
     env:
       openshift: 4

--- a/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config-disabled/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config-disabled/admission-control.test.yaml
@@ -20,17 +20,6 @@ tests:
             timeout: 7
       expect: |
         .validatingwebhookconfigurations[].webhooks[].timeoutSeconds | assertThat(. == 7 + 2)
-- name: "OpenShift3 clusters do not support admission control sideEffects"
-  server:
-    availableSchemas:
-      - openshift-3.11.0
-  set:
-    env.openshift: 3
-    admissionControl:
-      listenOnEvents: true
-      listenOnCreates: true
-      listenOnUpdates: true
-  expectError: true
 - name: "scanInline defaults to false"
   set:
     admissionControl.dynamic.scanInline: null

--- a/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config-disabled/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config-disabled/admission-control.test.yaml
@@ -6,7 +6,7 @@ values:
       enabled: false
 server:
   availableSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
 tests:
 - name: "Webhook timeout pads AdmissionController timeout by 2 seconds"
   tests:

--- a/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/feature-flags/testdata/helmtest/admission-controller-config/admission-control.test.yaml
@@ -1,17 +1,4 @@
 tests:
-- name: "Defaults for OpenShift3"
-  values:
-    admissionControl:
-      dynamic:
-        enforceOnCreates: true
-        enforceOnUpdates: false
-  set:
-    env.openshift: 3
-  expect: |
-   .validatingwebhookconfigurations[].webhooks[] | select(.name == "policyeval.stackrox.io") | .rules[0] | assertThat(.operations == ["CREATE", "UPDATE"])
-   [.validatingwebhookconfigurations[].webhooks[] | select(.name == "k8sevents.stackrox.io")] | assertThat(length == 0)
-   .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.scanInline == true)
-   .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml | .clusterConfig.dynamicConfig.admissionControllerConfig | assertThat(.timeoutSeconds == 10)
 - name: "Defaults for OpenShift4"
   values:
     admissionControl:

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/development_build-non-release/development_build.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/development_build-non-release/development_build.test.yaml
@@ -13,9 +13,9 @@ tests:
 - name: scanner image
   server:
     visibleSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
     availableSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
   set:
     scanner.disable: false
   expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/development_build-release/development_build.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/development_build-release/development_build.test.yaml
@@ -7,9 +7,9 @@ tests:
 - name: scanner image
   server:
     visibleSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
     availableSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
   set:
     scanner.disable: false
   expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/opensource-non-release/opensource.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/opensource-non-release/opensource.test.yaml
@@ -7,9 +7,9 @@ tests:
 - name: scanner image
   server:
     visibleSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
     availableSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
   set:
     scanner.disable: false
   expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/opensource-release/opensource.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/opensource-release/opensource.test.yaml
@@ -7,9 +7,9 @@ tests:
 - name: scanner image
   server:
     visibleSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
     availableSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
   set:
     scanner.disable: false
   expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/override/override.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/override/override.test.yaml
@@ -7,9 +7,9 @@ tests:
 - name: scanner image
   server:
     visibleSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
     availableSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
   set:
     scanner.disable: false
   expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/rhacs/rhacs.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/rhacs/rhacs.test.yaml
@@ -7,9 +7,9 @@ tests:
 - name: scanner image
   server:
     visibleSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
     availableSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
   set:
     scanner.disable: false
   expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/stackrox/stackrox.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/flavor/testdata/helmtest/stackrox/stackrox.test.yaml
@@ -7,9 +7,9 @@ tests:
 - name: scanner image
   server:
     visibleSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
     availableSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
   set:
     scanner.disable: false
   expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -42,21 +42,6 @@ tests:
         availableSchemas:
           - openshift-4.12
 
-- name: "Create admissionregistration.k8s.io/v1beta1 on OpenShift 3.11"
-  server:
-    availableSchemas:
-      - openshift-3.11.0
-  set:
-    env.openshift: 3
-  values:
-    admissionControl:
-      dynamic:
-        enforceOnCreates: true
-      listenOnCreates: true
-  expect: |
-    .validatingwebhookconfigurations[].apiVersion | assertThat(. == "admissionregistration.k8s.io/v1beta1")
-    .validatingwebhookconfigurations[].webhooks[] | assertThat(.admissionReviewVersions == null)
-
 - name: "Admission control deployment configuration"
   tests:
     - name: "default replicas"

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/admission-control.test.yaml
@@ -6,7 +6,7 @@ values:
       enabled: false
 server:
   availableSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
 tests:
 - name: "OpenShift4 clusters support admission control sideEffects"
   set:
@@ -40,7 +40,7 @@ tests:
     - name: "on OpenShift 4"
       server:
         availableSchemas:
-          - openshift-4.1.0
+          - openshift-4.12
 
 - name: "Create admissionregistration.k8s.io/v1beta1 on OpenShift 3.11"
   server:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/audit-logs.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/audit-logs.test.yaml
@@ -20,19 +20,9 @@ tests:
     - name: "on an explicit non-OpenShift environment"
       set:
         env.openshift: false
-    - name: "on an explicit OpenShift 3 environment"
-      set:
-        env.openshift: 3
     - name: "on an explicit OpenShift 4 environment"
       set:
         env.openshift: 4
-    - name: "on an auto-detected OpenShift 3 environment"
-      server:
-        visibleSchemas:
-        - openshift-3.11.0
-      capabilities:
-        kubeVersion:
-          version: "v1.11.0"
     - name: "on an auto-detected OpenShift 4 environment"
       server:
         visibleSchemas:
@@ -43,16 +33,6 @@ tests:
     - name: "on an explicit non-OpenShift environment"
       set:
         env.openshift: false
-    - name: "on an explicit OpenShift 3 environment"
-      set:
-        env.openshift: 3
-    - name: "on an auto-detected OpenShift 3 environment"
-      server:
-        visibleSchemas:
-        - openshift-3.11.0
-      capabilities:
-        kubeVersion:
-          version: "v1.11.0"
 - name: "Collection should be enabled"
   expect: |
     helmClusterConfig | .clusterConfig.dynamicConfig.disableAuditLogs | assertThat(. == false)
@@ -88,13 +68,3 @@ tests:
   - name: "on an explicit non-OpenShift environment"
     set:
       env.openshift: false
-  - name: "on an explicit OpenShift 3 environment"
-    set:
-      env.openshift: 3
-  - name: "on an auto-detected OpenShift 3 environment"
-    server:
-      visibleSchemas:
-      - openshift-3.11.0
-    capabilities:
-      kubeVersion:
-        version: "v1.11.0"

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/audit-logs.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/audit-logs.test.yaml
@@ -6,7 +6,7 @@ values:
       enabled: false
 server:
   availableSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
 tests:
 - name: "Collection should be disabled"
   expect: |
@@ -36,7 +36,7 @@ tests:
     - name: "on an auto-detected OpenShift 4 environment"
       server:
         visibleSchemas:
-        - openshift-4.1.0
+        - openshift-4.12
   - name: "by default"
     tests:
     - name: "on the default environment"
@@ -67,7 +67,7 @@ tests:
     - name: "on an auto-detected OpenShift 4 environment"
       server:
         visibleSchemas:
-        - openshift-4.1.0
+        - openshift-4.12
   - name: "by default"
     tests:
     - name: "on an explicit OpenShift 4 environment"
@@ -76,7 +76,7 @@ tests:
     - name: "on an auto-detected OpenShift 4 environment"
       server:
         visibleSchemas:
-        - openshift-4.1.0
+        - openshift-4.12
 - name: "An error should be raised with an explicit false setting"
   set:
     auditLogs.disableCollection: false

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/env.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/env.test.yaml
@@ -6,7 +6,7 @@ values:
       enabled: false
 server:
   availableSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
 tests:
 - name: "GRPC_ENFORCE_ALPN_ENABLED"
   tests:
@@ -25,7 +25,7 @@ tests:
   - name: "on an OpenShift server"
     server:
       visibleSchemas:
-      - openshift-4.1.0
+      - openshift-4.12
     expect: |
       .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 4"))
 
@@ -66,6 +66,6 @@ tests:
   - name: "with env.openshift=false"
     server:
       visibleSchemas:
-      - openshift-4.1.0
+      - openshift-4.12
     set:
       env.openshift: false

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/env.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/env.test.yaml
@@ -29,29 +29,10 @@ tests:
     expect: |
       .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 4"))
 
-  - name: "on an OpenShift 3 server"
-    server:
-      visibleSchemas:
-        - openshift-3.11.0
-    capabilities:
-      kubeVersion:
-        version: "v1.11.0"
-    expect: |
-      .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 3"))
-
   - name: "with env.openshift=true without openshift schemas for helm template commands"
     capabilities:
       kubeVersion:
         version: "v1.18.0"
-    set:
-      env.openshift: true
-    expect: |
-      .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 3"))
-
-  - name: "with env.openshift=true and kubernetes 1.11 should deploy to openshift 3"
-    capabilities:
-      kubeVersion:
-        version: "v1.11.0"
     set:
       env.openshift: true
     expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/env.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/env.test.yaml
@@ -30,9 +30,6 @@ tests:
       .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 4"))
 
   - name: "with env.openshift=true without openshift schemas for helm template commands"
-    capabilities:
-      kubeVersion:
-        version: "v1.18.0"
     set:
       env.openshift: true
     expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/env.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/env.test.yaml
@@ -33,7 +33,7 @@ tests:
     set:
       env.openshift: true
     expect: |
-      .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 3"))
+      .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 4"))
 
 - name: "OpenShift resources should not be created"
   expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/env.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/env.test.yaml
@@ -29,12 +29,6 @@ tests:
     expect: |
       .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 4"))
 
-  - name: "with env.openshift=true without openshift schemas for helm template commands"
-    set:
-      env.openshift: true
-    expect: |
-      .notes | assertThat(contains("we have inferred that you are deploying into an OpenShift 4"))
-
 - name: "OpenShift resources should not be created"
   expect: |
     .securitycontextconstraints == null

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/injected-cabundle-cm.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/injected-cabundle-cm.test.yaml
@@ -7,7 +7,7 @@ values:
 tests:
 - server:
     visibleSchemas:
-    - openshift-4.1.0
+    - openshift-4.12
   tests:
   - name: "Injected CA bundle has no data"
     expect: |

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/injected-cabundle-cm.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/injected-cabundle-cm.test.yaml
@@ -17,15 +17,6 @@ tests:
       assertThat(.configmaps["injected-cabundle-stackrox-secured-cluster-services"].metadata.labels["config.openshift.io/inject-trusted-cabundle"] == "true")
 - server:
     visibleSchemas:
-    - openshift-3.11.0
-  set:
-    env.openshift: 3
-  tests:
-  - name: "No injected CA bundle on Openshift 3"
-    expect: |
-      assertThat(.configmaps["injected-cabundle-stackrox-secured-cluster-services"] == null)
-- server:
-    visibleSchemas:
     - kubernetes-1.20.2
   tests:
   - name: "No injected CA bundle on Kubernetes"

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/legacy-settings.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/legacy-settings.test.yaml
@@ -91,7 +91,7 @@ tests:
       type: OPENSHIFT4_CLUSTER
   server:
     visibleSchemas:
-      - openshift-4.1.0
+      - openshift-4.12
   expect: |
     .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml |
       .clusterConfig.staticConfig.type | assertThat(. == "OPENSHIFT4_CLUSTER")

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/legacy-settings.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/legacy-settings.test.yaml
@@ -55,36 +55,6 @@ tests:
     envVars(.deployments["admission-control"]; "admission-control")["ROX_SENSOR_ENDPOINT"]
       | assertThat(. == "legacy-sensor.example.com:8443")
 
-- name: OpenShift in Legacy mode detects OpenShift 3
-  values:
-    cluster:
-      type: OPENSHIFT_CLUSTER
-  server:
-    availableSchemas:
-    - openshift-4.1.0
-  capabilities:
-    kubeVersion:
-      version: "v1.13.0"
-  expect: |
-    .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml |
-      .clusterConfig.staticConfig.type | assertThat(. == "OPENSHIFT_CLUSTER")
-    envVars(.deployments.sensor; "sensor")["ROX_OPENSHIFT_API"] | assertThat(. == "true")
-
-- name: OpenShift in Legacy mode with Kubernetes v3.11 should detect OpenShift 3
-  values:
-    cluster:
-      type: OPENSHIFT_CLUSTER
-  server:
-    visibleSchemas:
-      - openshift-4.1.0
-  capabilities:
-    kubeVersion:
-      version: "v3.11.0"
-  expect: |
-    .secrets["helm-cluster-config"].stringData["config.yaml"] | fromyaml |
-      .clusterConfig.staticConfig.type | assertThat(. == "OPENSHIFT_CLUSTER")
-    envVars(.deployments.sensor; "sensor")["ROX_OPENSHIFT_API"] | assertThat(. == "true")
-
 - name: OpenShift in Legacy mode accepts OpenShift4 cluster type
   values:
     cluster:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -3,7 +3,7 @@ values:
     allowNone: true
 server:
   availableSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
   - com.coreos
 tests:
 - name: "When enabled (legacy)"

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/openshift-monitoring.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/openshift-monitoring.test.yaml
@@ -154,49 +154,10 @@ tests:
     env.openshift: false
   tests: *disabled-test
 
-- name: "Disable override when on explicit OpenShift 3 environment"
-  set:
-    monitoring.openshift.enabled: true
-    env.openshift: 3
-  tests: *disabled-test
-
-- name: "Disable override with default value when on explicit OpenShift 3 environment"
-  set:
-    env.openshift: 3
-  tests: *disabled-test
-
-- name: "Disable override when on auto-detected OpenShift 3 environment"
-  set:
-    monitoring.openshift.enabled: true
-  server:
-    visibleSchemas:
-      - openshift-3.11.0
-  capabilities:
-    kubeVersion:
-      version: "v1.11.0"
-  tests: *disabled-test
-
 - name: "Disable override when on non-OpenShift environment (legacy)"
   set:
     enableOpenShiftMonitoring: true
     env.openshift: false
-  tests: *disabled-test
-
-- name: "Disable override when on explicit OpenShift 3 environment (legacy)"
-  set:
-    enableOpenShiftMonitoring: true
-    env.openshift: 3
-  tests: *disabled-test
-
-- name: "Disable override when on auto-detected OpenShift 3 environment (legacy)"
-  set:
-    enableOpenShiftMonitoring: true
-  server:
-    visibleSchemas:
-      - openshift-3.11.0
-  capabilities:
-    kubeVersion:
-      version: "v1.11.0"
   tests: *disabled-test
 
 - name: "Network policy is enabled"

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
@@ -4,9 +4,9 @@ values:
       enabled: false
 server:
   visibleSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
   availableSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
 tests:
 - name: "scanner with default settings is in slim mode"
   set:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-slim.test.yaml
@@ -19,9 +19,6 @@ tests:
     .deployments.["scanner"].spec.template.spec.volumes[] | select(.name == "additional-ca-volume") | assertThat(.secret.secretName == "additional-ca-sensor")
   tests:
   - name: "on openshift 4"
-  - name: "on openshift 3"
-    set:
-      env.openshift: 3
 
 - name: "scanner is enabled by default"
   set:

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -32,9 +32,6 @@ tests:
   - name: "on openshift 4"
     set:
       env.openshift: 4
-  - name: "on openshift 3"
-    set:
-      env.openshift: 3
 
 - name: "scanner V4 should be installed by default for new installations"
   release: { "isInstall": true, "isUpgrade": false }

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/scanner-v4.test.yaml
@@ -9,9 +9,9 @@ defs: |
     getVolume("scanner-v4-db"; "disk");
 server:
   visibleSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
   availableSchemas:
-  - openshift-4.1.0
+  - openshift-4.12
 tests:
 - name: "scanner v4 indexer mounts additional-ca-sensor secret"
   set:

--- a/pkg/renderer/central_db_test.go
+++ b/pkg/renderer/central_db_test.go
@@ -160,7 +160,7 @@ func (suite *centralDBTestSuite) testWithPV(t *testing.T, c Config, m mode) {
 }
 
 func (suite *centralDBTestSuite) TestRenderCentralDBBundle() {
-	for _, orch := range []storage.ClusterType{storage.ClusterType_KUBERNETES_CLUSTER, storage.ClusterType_OPENSHIFT_CLUSTER, storage.ClusterType_OPENSHIFT4_CLUSTER} {
+	for _, orch := range []storage.ClusterType{storage.ClusterType_KUBERNETES_CLUSTER, storage.ClusterType_OPENSHIFT4_CLUSTER} {
 		suite.T().Run(fmt.Sprintf("DbBundle-%s", orch), func(t *testing.T) {
 			centralFileMap := make(map[string][]byte, 4)
 			centralFileMap["central-db-password"] = []byte("Apassword")
@@ -184,4 +184,28 @@ func (suite *centralDBTestSuite) TestRenderCentralDBBundle() {
 			suite.testWithPV(t, conf, centralDBOnly)
 		})
 	}
+}
+
+func (suite *centralDBTestSuite) TestRenderCentralDBBundleFailsForOpenShift3() {
+	centralFileMap := make(map[string][]byte, 4)
+	centralFileMap["central-db-password"] = []byte("Apassword")
+	centralFileMap["central-db-cert.pem"] = suite.centralDBCert.CertPEM
+	centralFileMap["central-db-key.pem"] = suite.centralDBCert.KeyPEM
+	centralFileMap[mtls.CACertFileName] = suite.testCA.CertPEM()
+
+	conf := Config{
+		ClusterType: storage.ClusterType_KUBERNETES_CLUSTER,
+		K8sConfig: &K8sConfig{
+			CommonConfig: CommonConfig{
+				CentralDBImage: "stackrox/central-db:2.2.11.0-57-g392c0f5bed-dirty",
+			},
+			EnableCentralDB: true,
+		},
+		SecretsByteMap: centralFileMap,
+	}
+	conf.K8sConfig.DeploymentFormat = v1.DeploymentFormat_KUBECTL
+	conf.ClusterType = storage.ClusterType_OPENSHIFT_CLUSTER
+	_, err := render(conf, centralDBOnly, suite.testFlavor)
+	require.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "You have specified OpenShift version 3")
 }

--- a/pkg/renderer/kubernetes_test.go
+++ b/pkg/renderer/kubernetes_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/rox/pkg/images/defaults"
 	flavorUtils "github.com/stackrox/rox/pkg/images/defaults/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"helm.sh/helm/v3/pkg/chartutil"
 )
@@ -98,7 +99,7 @@ func (suite *renderSuite) TestRenderMultiple() {
 			IsUpgrade: true,
 		},
 	}
-	for _, orch := range []storage.ClusterType{storage.ClusterType_KUBERNETES_CLUSTER, storage.ClusterType_OPENSHIFT_CLUSTER, storage.ClusterType_OPENSHIFT4_CLUSTER} {
+	for _, orch := range []storage.ClusterType{storage.ClusterType_KUBERNETES_CLUSTER, storage.ClusterType_OPENSHIFT4_CLUSTER} {
 		for _, format := range []v1.DeploymentFormat{v1.DeploymentFormat_KUBECTL, v1.DeploymentFormat_HELM} {
 			suite.T().Run(fmt.Sprintf("%s-%s", orch, format), func(t *testing.T) {
 				conf := getBaseConfig()
@@ -114,6 +115,23 @@ func (suite *renderSuite) TestRenderMultiple() {
 			})
 		}
 	}
+}
+
+func (suite *renderSuite) TestRenderFailsForOpenShift3() {
+	orch := storage.ClusterType_OPENSHIFT_CLUSTER
+	format := v1.DeploymentFormat_KUBECTL
+	conf := getBaseConfig()
+	conf.ClusterType = orch
+	conf.K8sConfig.DeploymentFormat = format
+	conf.RenderOpts = &helmUtil.Options{
+		ReleaseOptions: chartutil.ReleaseOptions{
+			Name:      "stackrox-secured-cluster-services",
+			Namespace: "stackrox",
+		},
+	}
+	_, err := Render(conf, suite.testFlavor)
+	require.Error(suite.T(), err)
+	assert.Contains(suite.T(), err.Error(), "You have specified OpenShift version 3")
 }
 
 func (suite *renderSuite) TestRenderWithBadImage() {

--- a/roxctl/central/generate/generate_test.go
+++ b/roxctl/central/generate/generate_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/env"
-	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/images/defaults"
 	"github.com/stackrox/rox/pkg/renderer"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
@@ -232,13 +231,6 @@ func TestMonitoringConfiguration(t *testing.T) {
 		expectEnabled bool
 	}{
 		{
-			testName:      "OpenShift 3, --openshift-monitoring=true",
-			clusterType:   storage.ClusterType_OPENSHIFT_CLUSTER,
-			flagEnabled:   pointer.Bool(true),
-			expectErr:     errox.InvalidArgs,
-			expectEnabled: false,
-		},
-		{
 			testName:      "OpenShift 4, --openshift-monitoring=true",
 			clusterType:   storage.ClusterType_OPENSHIFT4_CLUSTER,
 			flagEnabled:   pointer.Bool(true),
@@ -246,23 +238,9 @@ func TestMonitoringConfiguration(t *testing.T) {
 			expectEnabled: true,
 		},
 		{
-			testName:      "OpenShift 3, --openshift-monitoring=false",
-			clusterType:   storage.ClusterType_OPENSHIFT_CLUSTER,
-			flagEnabled:   pointer.Bool(false),
-			expectErr:     nil,
-			expectEnabled: false,
-		},
-		{
 			testName:      "OpenShift 4, --openshift-monitoring=false",
 			clusterType:   storage.ClusterType_OPENSHIFT4_CLUSTER,
 			flagEnabled:   pointer.Bool(false),
-			expectEnabled: false,
-		},
-		{
-			testName:      "OpenShift 3, --openshift-monitoring=auto",
-			clusterType:   storage.ClusterType_OPENSHIFT_CLUSTER,
-			flagEnabled:   nil,
-			expectErr:     nil,
 			expectEnabled: false,
 		},
 		{

--- a/roxctl/central/generate/k8s.go
+++ b/roxctl/central/generate/k8s.go
@@ -168,11 +168,9 @@ func openshift(cliEnvironment environment.Environment) *cobra.Command {
 		clusterType := storage.ClusterType_OPENSHIFT4_CLUSTER
 		switch openshiftVersion {
 		case 0:
-		case 3:
-			clusterType = storage.ClusterType_OPENSHIFT_CLUSTER
 		case 4:
 		default:
-			return 0, errors.Errorf("invalid OpenShift version %d, supported values are '3' and '4'", openshiftVersion)
+			return 0, errox.InvalidArgs.Newf("invalid OpenShift version %d, only '4' is currently supported", openshiftVersion)
 		}
 		return clusterType, nil
 	})
@@ -185,7 +183,7 @@ func openshift(cliEnvironment environment.Environment) *cobra.Command {
 	validFormats := []string{"kubectl", "helm", "helm-values"}
 	flagWrap.Var(&fileFormatWrapper{DeploymentFormat: &k8sConfig.DeploymentFormat}, "output-format", fmt.Sprintf("The deployment tool to use (%s).", strings.Join(validFormats, ", ")), "central")
 
-	flagWrap.IntVar(&openshiftVersion, "openshift-version", 0, "The OpenShift major version (3 or 4) to deploy on.")
+	flagWrap.IntVar(&openshiftVersion, "openshift-version", 0, "The OpenShift major version to deploy on (currently only 4 is supported).")
 	flagWrap.OptBoolVar(&k8sConfig.Monitoring.OpenShiftMonitoring, "openshift-monitoring", "", "Integration with OpenShift 4 monitoring.", "auto", "central")
 	flagWrap.Var(istioSupportWrapper{&k8sConfig.IstioVersion}, "istio-support",
 		fmt.Sprintf(

--- a/roxctl/sensor/generate/openshift.go
+++ b/roxctl/sensor/generate/openshift.go
@@ -12,11 +12,6 @@ import (
 	"github.com/stackrox/rox/roxctl/common/util"
 )
 
-const (
-	errorAdmCntrlNotSupportedOnOpenShift3x  = "The --admission-controller-listen-on-events flag is not supported for OpenShift 3.11. Set --openshift-version=4 to indicate that you are deploying on OpenShift 4.x in order to use this flag."
-	errorAuditLogsNotSupportedOnOpenShift3x = "The --disable-audit-logs flag is not supported for OpenShift 3.11. Set --openshift-version=4 to indicate that you are deploying on OpenShift 4.x in order to use this flag."
-)
-
 type sensorGenerateOpenShiftCommand struct {
 	*sensorGenerateCommand
 
@@ -28,11 +23,9 @@ func (s *sensorGenerateOpenShiftCommand) ConstructOpenShift() error {
 	s.cluster.Type = storage.ClusterType_OPENSHIFT4_CLUSTER
 	switch s.openshiftVersion {
 	case 0:
-	case 3:
-		s.cluster.Type = storage.ClusterType_OPENSHIFT_CLUSTER
 	case 4:
 	default:
-		return errox.InvalidArgs.Newf("invalid OpenShift version %d, supported values are '3' and '4'", s.openshiftVersion)
+		return errox.InvalidArgs.Newf("invalid OpenShift version %d, only '4' is currently supported", s.openshiftVersion)
 	}
 
 	s.cluster.AdmissionControllerEvents = s.cluster.GetType() == storage.ClusterType_OPENSHIFT4_CLUSTER
@@ -41,8 +34,6 @@ func (s *sensorGenerateOpenShiftCommand) ConstructOpenShift() error {
 	// even if we turn off the flag before shipping.
 	if s.disableAuditLogCollection == nil {
 		s.disableAuditLogCollection = pointers.Bool(s.cluster.GetType() != storage.ClusterType_OPENSHIFT4_CLUSTER)
-	} else if !*s.disableAuditLogCollection && s.cluster.GetType() != storage.ClusterType_OPENSHIFT4_CLUSTER {
-		return errox.InvalidArgs.New(errorAuditLogsNotSupportedOnOpenShift3x)
 	}
 
 	s.cluster.DynamicConfig.DisableAuditLogs = *s.disableAuditLogCollection

--- a/tests/roxctl/bats-tests/cluster/scanner-generate.bats
+++ b/tests/roxctl/bats-tests/cluster/scanner-generate.bats
@@ -54,15 +54,6 @@ assert_number_of_k8s_resources() {
   assert_number_of_k8s_resources 14
 }
 
-@test "[openshift] roxctl scanner generate" {
-  run_scanner_generate_and_check openshift
-
-  assert_file_exist "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  run -0 grep -q 'ROX_OPENSHIFT_API' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  run -1 grep -q 'trusted-ca-volume' "${output_dir}/scanner/02-scanner-06-deployment.yaml"
-  assert_number_of_k8s_resources 14
-}
-
 @test "[k8s] roxctl scanner generate" {
   run_scanner_generate_and_check k8s
 

--- a/tests/roxctl/bats-tests/cluster/sensor-generate-bundle.bats
+++ b/tests/roxctl/bats-tests/cluster/sensor-generate-bundle.bats
@@ -41,10 +41,6 @@ run_generate_and_get_bundle_test() {
   run_generate_and_get_bundle_test k8s "k8s-test-cluster"
 }
 
-@test "[openshift3] roxctl sensor generate and get-bundle" {
-  run_generate_and_get_bundle_test openshift "oc3-test-cluster" --openshift-version 3
-}
-
 @test "[openshift4] roxctl sensor generate and get-bundle" {
   run_generate_and_get_bundle_test openshift "oc4-test-cluster" --openshift-version 4
 }

--- a/tests/roxctl/bats-tests/cluster/sensor-generate-bundle.bats
+++ b/tests/roxctl/bats-tests/cluster/sensor-generate-bundle.bats
@@ -49,3 +49,9 @@ run_generate_and_get_bundle_test() {
   generate_bundle k8s
   assert_failure
 }
+
+@test "[openshift3] roxctl sensor generate rejects unsupported openshift version" {
+  generate_bundle openshift --name oc3-test-cluster --openshift-version 3
+  assert_failure
+  assert_output --partial "only '4' is currently supported"
+}


### PR DESCRIPTION
## Description

This is a reduced version of https://github.com/stackrox/stackrox/pull/19937, which tries harder to focus on install methods only.

@porridge, I don't think it would be a good idea to slice the PR to have the auto-sensing improvement separate, because that change is heavily intertwined with the removal of the OCP3 support from the Helm charts (reason being that the API we want to probe for is OCP4-only). Hence, removing OCP3 from the Helm templating depends on the new auto-sensing in the sense that it will deny OCP3 configurations provided by the user and the new auto-sensing depends on the OCP3 removal because it can only detect OCP4 and hence it doesn't make sense to carry around Helm templates capable of producing OCP3 manifests.

But I did remove several commits from https://github.com/stackrox/stackrox/pull/19937 which are not directly related to the install changes: proto deprecation, cluster validation and related tests.

## User-facing documentation

- [x] CHANGELOG.md updated. (https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] documentation PR not needed, because it is already prominently documented that OCP3 is not a supported platform.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [x] modified existing tests

### How I validated my change

Automated tests.