### PR TITLE
docs(agents): direct AI agents to read Go style guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ When working on specific areas, refer to these detailed guides:
 
 ### Style and Conventions
 - Go code follows golangci-lint standards
-- Additional project specific style guide in `.github/go-coding-style.md`
+- When writing or reviewing Go code, read and follow the project-specific style guide in `.github/go-coding-style.md`
 - Protocol buffers have enforced style guidelines
 - Shell scripts are checked with shellcheck
 - UI code uses TypeScript with React conventions


### PR DESCRIPTION
## Description

Changes the existing informational bullet about the Go style guide in AGENTS.md into a conditional directive: AI agents should read and follow `.github/go-coding-style.md` **when writing or reviewing Go code**, not in every
conversation.

The previous wording (`Additional project specific style guide in ...`) merely stated the file exists. AI agents had no instruction to actually read it, which meant they could produce code that violates project conventions (e.g. naked
returns, non-deferred mutex unlocks, direct proto field access).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Recreated situation where AI generated non-compliant code before and verified it generates compliant code now.