### PR TITLE
ROX-34007: Make `create-custom-snapshot` always run

### DIFF
--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -132,8 +132,11 @@ spec:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
           script: |
-            echo "Event is {{ event }}"
             echo "CEL event is {{ cel: event }}"
+            echo "CEL pac.event is {{ cel: pac.event }}"
+            echo "target_branch is {{ target_branch }}"
+            echo "CEL target_branch is {{ cel: target_branch }}"
+            echo "CEL pac.target_branch is {{ cel: pac.target_branch }}"
             echo '{{ cel: (event == "push") || (event == "pull_request") }}' | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -9,6 +9,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "500"
     pipelinesascode.tekton.dev/on-comment: "/konflux-retest create-custom-snapshot"
+    # Unlike other pipelines, this one is enabled for all PRs. See the description of determine-actual-build task.
+    # The condition for a label is to make sure the konflux-build label addition activates this pipeline, same as others.
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*|refs/tags/.*)$")) ||
@@ -119,28 +121,32 @@ spec:
       taskRef: *post-bigquery-metrics-ref
 
     # TODO: event_type=on-comment and the rest
-    - name: should-do-the-rest
+    - name: determine-actual-build
       taskSpec:
         description: |
-          Determines whether the actual tasks in the pipeline should be skipped or actually be executed.
+          Determines whether the actual tasks in the pipeline should be skipped or executed.
           Tasks will be skipped on PRs where Konflux builds aren't enabled (TODO: ROX-21073), see
           `pipelinesascode.tekton.dev/on-cel-expression` annotation in `*-build.yaml` files.
           This all is needed because we want to always run this `create-custom-snapshot` pipeline and make it part of
           required GitHub checks in branch protection rules.
         results:
-        - name: SHOULD_PROCEED
+        - name: SHOULD_REALLY_WORK
         steps:
-        - name: figure-out
+        - name: determine
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
+          # The script expresses the same condition as pipelinesascode.tekton.dev/on-cel-expression in other pipelines
+          # but in a more verbose way because, as it turns out, both syntax and fields of CEL expressions are slightly
+          # different.
           script: |
             set -euo pipefail
+
             function assert_boolean() {
               if [[ "${2:-}" != "" ]]; then
                 echo "${2}"
               fi
               echo "${1}: ${!1}"
               if [[ "${!1}" != "true" && "${!1}" != "false" ]]; then
-                >&2 echo "Error: not a boolean value: $1"
+                >&2 echo "Error: not a boolean value: ${!1}"
                 exit 2
               fi
             }
@@ -166,7 +172,7 @@ spec:
               result="true"
             fi
             echo -n "The result is: "
-            echo -n "${result}" | tee "$(results.SHOULD_PROCEED.path)"
+            echo -n "${result}" | tee "$(results.SHOULD_REALLY_WORK.path)"
             echo
 
             echo '-----------'
@@ -202,7 +208,7 @@ spec:
       - name: basic-auth
         workspace: git-auth
       when:
-      - input: $(tasks.should-do-the-rest.results.SHOULD_PROCEED)
+      - input: $(tasks.determine-actual-build.results.SHOULD_REALLY_WORK)
         operator: in
         values: [ "true" ]
 
@@ -222,7 +228,7 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(tasks.should-do-the-rest.results.SHOULD_PROCEED)
+      - input: $(tasks.determine-actual-build.results.SHOULD_REALLY_WORK)
         operator: in
         values: [ "true" ]
 
@@ -242,7 +248,7 @@ spec:
       # The timemout should be kept in sync with the pipeline timeout in the operator-bundle-build.yaml
       timeout: 3h25m
       when:
-      - input: $(tasks.should-do-the-rest.results.SHOULD_PROCEED)
+      - input: $(tasks.determine-actual-build.results.SHOULD_REALLY_WORK)
         operator: in
         values: [ "true" ]
 
@@ -333,6 +339,6 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(tasks.should-do-the-rest.results.SHOULD_PROCEED)
+      - input: $(tasks.determine-actual-build.results.SHOULD_REALLY_WORK)
         operator: in
         values: [ "true" ]

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -117,6 +117,13 @@ spec:
     - name: post-metric-start
       taskRef: *post-bigquery-metrics-ref
 
+
+    #      (event == "push") ||
+    #              (event == "pull_request" && (
+    #                  target_branch.startsWith("release-") ||
+    #                  source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+    #                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
+    #                ))
     - name: should-do-the-rest
       taskSpec:
         results:
@@ -124,13 +131,8 @@ spec:
         steps:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
-          #      (event == "push") ||
-          #              (event == "pull_request" && (
-          #                  target_branch.startsWith("release-") ||
-          #                  source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
-          #                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
-          #                ))
-          script: echo '{{ (event == "push") || (event == "pull_request") }}' | tee "$(results.SHOULD_PROCEED.path)"
+          script: |
+            echo '{{ cel: (event == "push") || (event == "pull_request") }}' | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -132,14 +132,9 @@ spec:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
           script: |
-            echo "CEL event is {{ cel: event }}"
-            echo "CEL pac.event is {{ cel: pac.event }}"
-            echo "target_branch is {{ target_branch }}"
-            echo "CEL target_branch is {{ cel: target_branch }}"
-            echo "CEL pac.target_branch is {{ cel: pac.target_branch }}"
-            echo "event_type is {{ event_type }}"
-            echo "CEL event_type is {{ event_type }}"
-            echo '{{ cel: (event_type == "push") || (event_type == "pull_request") }}' | tee "$(results.SHOULD_PROCEED.path)"
+            echo "event_type: {{ event_type }}"
+            echo "target_branch: {{ target_branch }}"
+            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && target_branch.startsWith("release-")) }}' | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -134,10 +134,11 @@ spec:
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
           script: |
             echo 'has body.pull_request: {{ cel: has(body.pull_request) }}'
+            echo 'has konflux-build label: {{ cel: has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") }}'
             echo "event_type: {{ event_type }}"
             echo "target_branch: {{ target_branch }}"
             echo "source_branch: {{ source_branch }}"
-            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)") || ( has(body.pull_request) )) }}' | tee "$(results.SHOULD_PROCEED.path)"
+            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)") || ( has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") )) }}' | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -163,9 +163,11 @@ spec:
             is_matching_source_branch='{{ cel: source_branch.matches("(konflux|renovate|appstudio|rhtap)") }}'
             assert_boolean is_matching_source_branch "source_branch: {{ source_branch }}"
 
+            # The label will be findable this way for pull request events.
             has_konflux_build_label_as_pr='{{ cel: has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") }}'
             assert_boolean has_konflux_build_label_as_pr
 
+            # The label will be findable this way for /test comments and alike.
             has_konflux_build_label_as_issue='{{ cel: has(body.issue) && has(body.issue.labels) && body.issue.labels.exists(l, l.name == "konflux-build") }}'
             assert_boolean has_konflux_build_label_as_issue
 

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -120,7 +120,6 @@ spec:
     - name: post-metric-start
       taskRef: *post-bigquery-metrics-ref
 
-    # TODO: event_type=on-comment and the rest
     - name: determine-actual-build
       taskSpec:
         description: |

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -133,6 +133,10 @@ spec:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
           script: |
+            echo 'body:'
+            cat <<EOF
+              {{ cel: body }}
+            EOF
             echo 'has body.pull_request: {{ cel: has(body.pull_request) }}'
             echo 'has konflux-build label: {{ cel: has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") }}'
             echo "event_type: {{ event_type }}"

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -138,6 +138,8 @@ spec:
             echo "event_type: {{ event_type }}"
             echo "target_branch: {{ target_branch }}"
             echo "source_branch: {{ source_branch }}"
+            echo "pull_request_number: {{ pull_request_number }}"
+            echo "CEL pull_request_number: {{ cel: pull_request_number }}"
             echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)") || ( has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") )) }}' | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -133,12 +133,11 @@ spec:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
           script: |
-            echo 'has body.pull_request: {{ has(body.pull_request) }}'
-            echo 'CEL has body.pull_request: {{ cel: has(body.pull_request) }}'
+            echo 'has body.pull_request: {{ cel: has(body.pull_request) }}'
             echo "event_type: {{ event_type }}"
             echo "target_branch: {{ target_branch }}"
             echo "source_branch: {{ source_branch }}"
-            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)")) }}' | tee "$(results.SHOULD_PROCEED.path)"
+            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)") || ( has(body.pull_request) )) }}' | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -124,6 +124,7 @@ spec:
     #                  source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
     #                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
     #                ))
+    # TODO: event_type=on-comment and the rest
     - name: should-do-the-rest
       taskSpec:
         results:
@@ -134,7 +135,8 @@ spec:
           script: |
             echo "event_type: {{ event_type }}"
             echo "target_branch: {{ target_branch }}"
-            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && target_branch.startsWith("release-")) }}' | tee "$(results.SHOULD_PROCEED.path)"
+            echo "source_branch: {{ source_branch }}"
+            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)")) }}' | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -124,16 +124,13 @@ spec:
         steps:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
-          params:
           #      (event == "push") ||
           #              (event == "pull_request" && (
           #                  target_branch.startsWith("release-") ||
           #                  source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
           #                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
           #                ))
-          - name: SHOULD_PROCEED
-            value: '{{ cel: pac.target_branch }}'
-          script: echo "$(params.SHOULD_PROCEED)" | tee "$(results.SHOULD_PROCEED.path)"
+          script: echo "{{ pac.target_branch }}" | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -11,15 +11,8 @@ metadata:
     pipelinesascode.tekton.dev/on-comment: "/konflux-retest create-custom-snapshot"
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
-      (
-        event == "push" && target_branch.matches("^(master|release-.*|refs/tags/.*)$")
-      ) || (
-        event == "pull_request" && (
-          target_branch.startsWith("release-") ||
-          source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
-          (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
-        ) && body.action != "ready_for_review"
-      )
+      (event == "push" && target_branch.matches("^(master|release-.*|refs/tags/.*)$")) ||
+      (event == "pull_request" && body.action != "ready_for_review")
     # The empty `on-label` annotation is a workaround to make sure the pipeline gets triggered when the label gets first
     # added to the PR. See the Slack tread linked from ROX-30580.
     pipelinesascode.tekton.dev/on-label: "[]"
@@ -123,6 +116,22 @@ spec:
 
     - name: post-metric-start
       taskRef: *post-bigquery-metrics-ref
+
+    - name: should-do-the-rest
+      taskSpec:
+        results:
+        - name: SHOULD_PROCEED
+        steps:
+        - name: blah
+          image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
+          script: echo "{{
+              (event == "push") ||
+              (event == "pull_request" && (
+                  target_branch.startsWith("release-") ||
+                  source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
+                ))
+            }}" | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -130,21 +130,30 @@ spec:
         results:
         - name: SHOULD_PROCEED
         steps:
-        - name: blah
+        - name: figure-out
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
           script: |
             set -euo pipefail
             function assert_boolean() {
+              if [[ "${2:-}" != "" ]]; then
+                echo "${2}"
+              fi
               echo "${1}: ${!1}"
               if [[ "${!1}" != "true" && "${!1}" != "false" ]]; then
                 >&2 echo "Error: not a boolean value: $1"
                 exit 2
               fi
             }
-            echo 'body:'
-            cat <<EOF
-              {{ cel: body }}
-            EOF
+
+            is_pull_request="false"
+            [[ "{{ pull_request_number }}" == "" ]] || is_pull_request="true"
+            assert_boolean is_pull_request "pull_request_number: {{ pull_request_number }}"
+
+            is_matching_target_branch='{{ cel: target_branch.startsWith("release-") }}'
+            assert_boolean is_matching_target_branch "target_branch: {{ target_branch }}"
+
+            is_matching_source_branch='{{ cel: source_branch.matches("(konflux|renovate|appstudio|rhtap)") }}'
+            assert_boolean is_matching_source_branch "source_branch: {{ source_branch }}"
 
             has_konflux_build_label_as_pr='{{ cel: has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") }}'
             assert_boolean has_konflux_build_label_as_pr
@@ -152,29 +161,18 @@ spec:
             has_konflux_build_label_as_issue='{{ cel: has(body.issue) && has(body.issue.labels) && body.issue.labels.exists(l, l.name == "konflux-build") }}'
             assert_boolean has_konflux_build_label_as_issue
 
-            echo "pull_request_number: {{ pull_request_number }}"
-            if [[ "{{ pull_request_number }}" != "" ]]; then
-              is_pull_request="true"
-            else
-              is_pull_request="false"
-            fi
-            assert_boolean is_pull_request
-
-            echo "target_branch: {{ target_branch }}"
-            is_matching_target_branch='{{ cel: target_branch.startsWith("release-") }}'
-            assert_boolean is_matching_target_branch
-
-            echo "source_branch: {{ source_branch }}"
-            is_matching_source_branch='{{ cel: source_branch.matches("(konflux|renovate|appstudio|rhtap)") }}'
-            assert_boolean is_matching_source_branch
-
             echo -n "The result is: "
             if [[ "${is_pull_request}" == "false" || "${is_matching_target_branch}" == "true" || "${is_matching_source_branch}" == "true" || "${has_konflux_build_label_as_pr}" == "true" || "${has_konflux_build_label_as_issue}" == "true" ]]; then
               echo "true" | tee "$(results.SHOULD_PROCEED.path)"
             else
               echo "false" | tee "$(results.SHOULD_PROCEED.path)"
             fi
-            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)") || ( has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") )) }}'
+
+            echo '-----------'
+            echo 'full body for diagnostics:'
+            cat <<EOF
+              {{ cel: body }}
+            EOF
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -130,7 +130,7 @@ spec:
           #                  source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
           #                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
           #                ))
-          script: echo "{{ (event == "push") || (event == "pull_request") }}" | tee "$(results.SHOULD_PROCEED.path)"
+          script: echo '{{ (event == "push") || (event == "pull_request") }}' | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -153,7 +153,7 @@ spec:
             assert_boolean has_konflux_build_label_as_issue
 
             echo "pull_request_number: {{ pull_request_number }}"
-            is_pull_request='{{ cel: pull_request_number != null & pull_request_number != "" }}'
+            is_pull_request='{{ cel: pull_request_number != null && pull_request_number != "" }}'
             assert_boolean is_pull_request
 
             echo "target_branch: {{ target_branch }}"

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -130,7 +130,7 @@ spec:
           #                  source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
           #                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
           #                ))
-          script: echo "{{ target_branch }}" | tee "$(results.SHOULD_PROCEED.path)"
+          script: echo "{{ (event == "push") || (event == "pull_request") }}" | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -150,8 +150,11 @@ spec:
               fi
             }
 
-            is_pull_request="false"
-            [[ "{{ pull_request_number }}" == "" ]] || is_pull_request="true"
+            is_pull_request="true"
+            if [[ "{{ pull_request_number }}" == "" || "{{ pull_request_number }}" == *pull_request_number* ]]; then
+              # If it's an empty string or remains literally "{{ pull_request_number }}", it's not a pull request.
+              is_pull_request="false"
+            fi
             assert_boolean is_pull_request "pull_request_number: {{ pull_request_number }}"
 
             is_matching_target_branch='{{ cel: target_branch.startsWith("release-") }}'

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -181,13 +181,6 @@ spec:
             fi
             echo -n "The result is: "
             echo -n "${result}" | tee "$(results.SHOULD_REALLY_WORK.path)"
-            echo
-
-            echo '-----------'
-            echo 'full body, for diagnostics if anything fails:'
-            cat <<EOF
-              {{ cel: body }}
-            EOF
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -124,7 +124,7 @@ spec:
         steps:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
-          env:
+          params:
           #      (event == "push") ||
           #              (event == "pull_request" && (
           #                  target_branch.startsWith("release-") ||
@@ -133,7 +133,7 @@ spec:
           #                ))
           - name: SHOULD_PROCEED
             value: {{ pac.event == "push" || (pac.event == "pull_request") }}
-          script: echo "${SHOULD_PROCEED}" | tee "$(results.SHOULD_PROCEED.path)"
+          script: echo "$(params.SHOULD_PROCEED)" | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -120,13 +120,13 @@ spec:
 
     # TODO: event_type=on-comment and the rest
     - name: should-do-the-rest
-      description: |
-        Determines whether the rest of actual tasks in the pipeline should be skipped or be actually executed.
-        Tasks will be skipped on PRs where konflux-builds aren't enabled (TODO: ROX-21073), see
-        `pipelinesascode.tekton.dev/on-cel-expression` in `*-build.yaml` files.
-        This all is needed because we want to always run this `create-custom-snapshot` pipeline and make it part of
-        required GitHub checks in branch protection rules.
       taskSpec:
+        description: |
+          Determines whether the actual tasks in the pipeline should be skipped or actually be executed.
+          Tasks will be skipped on PRs where Konflux builds aren't enabled (TODO: ROX-21073), see
+          `pipelinesascode.tekton.dev/on-cel-expression` annotation in `*-build.yaml` files.
+          This all is needed because we want to always run this `create-custom-snapshot` pipeline and make it part of
+          required GitHub checks in branch protection rules.
         results:
         - name: SHOULD_PROCEED
         steps:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -139,7 +139,7 @@ spec:
             EOF
             echo 'has body.pull_request: {{ cel: has(body.pull_request) }}'
             echo 'has pull_request konflux-build label: {{ cel: has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") }}'
-            echo 'has issue konflux-build label: {{ cel: has(body.pull_request) && has(body.issue.labels) && body.issue.labels.exists(l, l.name == "konflux-build") }}'
+            echo 'has issue konflux-build label: {{ cel: has(body.issue) && has(body.issue.labels) && body.issue.labels.exists(l, l.name == "konflux-build") }}'
             echo "event_type: {{ event_type }}"
             echo "target_branch: {{ target_branch }}"
             echo "source_branch: {{ source_branch }}"

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -132,6 +132,8 @@ spec:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
           script: |
+            echo "Event is {{ event }}"
+            echo "CEL event is {{ cel: event }}"
             echo '{{ cel: (event == "push") || (event == "pull_request") }}' | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -161,15 +161,15 @@ spec:
             has_konflux_build_label_as_issue='{{ cel: has(body.issue) && has(body.issue.labels) && body.issue.labels.exists(l, l.name == "konflux-build") }}'
             assert_boolean has_konflux_build_label_as_issue
 
-            echo -n "The result is: "
-            if [[ "${is_pull_request}" == "false" || "${is_matching_target_branch}" == "true" || "${is_matching_source_branch}" == "true" || "${has_konflux_build_label_as_pr}" == "true" || "${has_konflux_build_label_as_issue}" == "true" ]]; then
-              echo "true" | tee "$(results.SHOULD_PROCEED.path)"
-            else
-              echo "false" | tee "$(results.SHOULD_PROCEED.path)"
+            result="false"
+            if [[ "${is_pull_request}" != "true" || "${is_matching_target_branch}" == "true" || "${is_matching_source_branch}" == "true" || "${has_konflux_build_label_as_pr}" == "true" || "${has_konflux_build_label_as_issue}" == "true" ]]; then
+              result="true"
             fi
+            echo -n "The result is: "
+            echo "${result}" | tee "$(results.SHOULD_PROCEED.path)"
 
             echo '-----------'
-            echo 'full body for diagnostics:'
+            echo 'full body, for diagnostics:'
             cat <<EOF
               {{ cel: body }}
             EOF
@@ -200,6 +200,10 @@ spec:
       workspaces:
       - name: basic-auth
         workspace: git-auth
+      when:
+      - input: $(tasks.should-do-the-rest.results.SHOULD_PROCEED)
+        operator: in
+        values: ["true"]
 
     - name: determine-image-tag
       params:
@@ -216,6 +220,10 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+      when:
+      - input: $(tasks.should-do-the-rest.results.SHOULD_PROCEED)
+        operator: in
+        values: ["true"]
 
     - name: wait-for-bundle-image
       params:
@@ -232,6 +240,10 @@ spec:
         resolver: bundles
       # The timemout should be kept in sync with the pipeline timeout in the operator-bundle-build.yaml
       timeout: 3h25m
+      when:
+      - input: $(tasks.should-do-the-rest.results.SHOULD_PROCEED)
+        operator: in
+        values: ["true"]
 
     - name: create-acs-style-snapshot
       params:
@@ -319,3 +331,7 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+      when:
+      - input: $(tasks.should-do-the-rest.results.SHOULD_PROCEED)
+        operator: in
+        values: ["true"]

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -167,7 +167,7 @@ spec:
             has_konflux_build_label_as_pr='{{ cel: has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") }}'
             assert_boolean has_konflux_build_label_as_pr
 
-            # The label will be findable this way for /test comments and alike.
+            # The label will be findable this way on PRs for /test comments and alike.
             has_konflux_build_label_as_issue='{{ cel: has(body.issue) && has(body.issue.labels) && body.issue.labels.exists(l, l.name == "konflux-build") }}'
             assert_boolean has_konflux_build_label_as_issue
 

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -138,7 +138,8 @@ spec:
               {{ cel: body }}
             EOF
             echo 'has body.pull_request: {{ cel: has(body.pull_request) }}'
-            echo 'has konflux-build label: {{ cel: has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") }}'
+            echo 'has pull_request konflux-build label: {{ cel: has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") }}'
+            echo 'has issue konflux-build label: {{ cel: has(body.pull_request) && has(body.issue.labels) && body.issue.labels.exists(l, l.name == "konflux-build") }}'
             echo "event_type: {{ event_type }}"
             echo "target_branch: {{ target_branch }}"
             echo "source_branch: {{ source_branch }}"

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -133,19 +133,44 @@ spec:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
           script: |
+            set -euo pipefail
+            function assert_boolean() {
+              echo "${1}: ${!1}"
+              if [[ "${!1}" != "true" && "${!1}" != "false" ]]; then
+                >&2 echo "Error: not a boolean value: $1"
+                exit 2
+              fi
+            }
             echo 'body:'
             cat <<EOF
               {{ cel: body }}
             EOF
-            echo 'has body.pull_request: {{ cel: has(body.pull_request) }}'
-            echo 'has pull_request konflux-build label: {{ cel: has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") }}'
-            echo 'has issue konflux-build label: {{ cel: has(body.issue) && has(body.issue.labels) && body.issue.labels.exists(l, l.name == "konflux-build") }}'
-            echo "event_type: {{ event_type }}"
-            echo "target_branch: {{ target_branch }}"
-            echo "source_branch: {{ source_branch }}"
+
+            has_konflux_build_label_as_pr='{{ cel: has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") }}'
+            assert_boolean has_konflux_build_label_as_pr
+
+            has_konflux_build_label_as_issue='{{ cel: has(body.issue) && has(body.issue.labels) && body.issue.labels.exists(l, l.name == "konflux-build") }}'
+            assert_boolean has_konflux_build_label_as_issue
+
             echo "pull_request_number: {{ pull_request_number }}"
-            echo "CEL pull_request_number: {{ cel: pull_request_number }}"
-            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)") || ( has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") )) }}' | tee "$(results.SHOULD_PROCEED.path)"
+            is_pull_request='{{ cel: pull_request_number != null & pull_request_number != "" }}'
+            assert_boolean is_pull_request
+
+            echo "target_branch: {{ target_branch }}"
+            is_matching_target_branch='{{ cel: target_branch.startsWith("release-") }}'
+            assert_boolean is_matching_target_branch
+
+            echo "source_branch: {{ source_branch }}"
+            is_matching_source_branch='{{ cel: source_branch.matches("(konflux|renovate|appstudio|rhtap)") }}'
+            assert_boolean is_matching_source_branch
+
+            echo -n "The result is: "
+            if [[ "${is_pull_request}" == "false" || "${is_matching_target_branch}" == "true" || "${is_matching_source_branch}" == "true" || "${has_konflux_build_label_as_pr}" == "true" || "${has_konflux_build_label_as_issue}" == "true" ]]; then
+              echo "true" | tee "$(results.SHOULD_PROCEED.path)"
+            else
+              echo "false" | tee "$(results.SHOULD_PROCEED.path)"
+            fi
+            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)") || ( has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build") )) }}'
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -166,7 +166,8 @@ spec:
               result="true"
             fi
             echo -n "The result is: "
-            echo "${result}" | tee "$(results.SHOULD_PROCEED.path)"
+            echo -n "${result}" | tee "$(results.SHOULD_PROCEED.path)"
+            echo
 
             echo '-----------'
             echo 'full body, for diagnostics:'
@@ -203,7 +204,7 @@ spec:
       when:
       - input: $(tasks.should-do-the-rest.results.SHOULD_PROCEED)
         operator: in
-        values: ["true"]
+        values: [ "true" ]
 
     - name: determine-image-tag
       params:
@@ -223,7 +224,7 @@ spec:
       when:
       - input: $(tasks.should-do-the-rest.results.SHOULD_PROCEED)
         operator: in
-        values: ["true"]
+        values: [ "true" ]
 
     - name: wait-for-bundle-image
       params:
@@ -243,7 +244,7 @@ spec:
       when:
       - input: $(tasks.should-do-the-rest.results.SHOULD_PROCEED)
         operator: in
-        values: ["true"]
+        values: [ "true" ]
 
     - name: create-acs-style-snapshot
       params:
@@ -334,4 +335,4 @@ spec:
       when:
       - input: $(tasks.should-do-the-rest.results.SHOULD_PROCEED)
         operator: in
-        values: ["true"]
+        values: [ "true" ]

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -133,13 +133,10 @@ spec:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
           script: |
-            echo 'body.pull_request: {{ body.pull_request }}'
-            echo 'has body.pull_request: {{ has(body.pull_request) }}'
-            echo 'CEL has body.pull_request: {{ cel: has(body.pull_request) }}'
             echo "event_type: {{ event_type }}"
             echo "target_branch: {{ target_branch }}"
             echo "source_branch: {{ source_branch }}"
-            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)") || (has(body.pull_request))) }}' | tee "$(results.SHOULD_PROCEED.path)"
+            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)")) }}' | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -133,6 +133,8 @@ spec:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
           script: |
+            echo 'has body.pull_request: {{ has(body.pull_request) }}'
+            echo 'CEL has body.pull_request: {{ cel: has(body.pull_request) }}'
             echo "event_type: {{ event_type }}"
             echo "target_branch: {{ target_branch }}"
             echo "source_branch: {{ source_branch }}"

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -153,7 +153,11 @@ spec:
             assert_boolean has_konflux_build_label_as_issue
 
             echo "pull_request_number: {{ pull_request_number }}"
-            is_pull_request='{{ cel: pull_request_number != null && pull_request_number != "" }}'
+            if [[ "{{ pull_request_number }}" != "" ]]; then
+              is_pull_request="true"
+            else
+              is_pull_request="false"
+            fi
             assert_boolean is_pull_request
 
             echo "target_branch: {{ target_branch }}"

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -12,7 +12,8 @@ metadata:
     # TODO(ROX-21073): re-enable for all PR branches
     pipelinesascode.tekton.dev/on-cel-expression: |
       (event == "push" && target_branch.matches("^(master|release-.*|refs/tags/.*)$")) ||
-      (event == "pull_request" && body.action != "ready_for_review")
+      (event == "pull_request" && body.action != "ready_for_review") ||
+      (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
     # The empty `on-label` annotation is a workaround to make sure the pipeline gets triggered when the label gets first
     # added to the PR. See the Slack tread linked from ROX-30580.
     pipelinesascode.tekton.dev/on-label: "[]"
@@ -117,15 +118,14 @@ spec:
     - name: post-metric-start
       taskRef: *post-bigquery-metrics-ref
 
-
-    #      (event == "push") ||
-    #              (event == "pull_request" && (
-    #                  target_branch.startsWith("release-") ||
-    #                  source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
-    #                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
-    #                ))
     # TODO: event_type=on-comment and the rest
     - name: should-do-the-rest
+      description: |
+        Determines whether the rest of actual tasks in the pipeline should be skipped or be actually executed.
+        Tasks will be skipped on PRs where konflux-builds aren't enabled (TODO: ROX-21073), see
+        `pipelinesascode.tekton.dev/on-cel-expression` in `*-build.yaml` files.
+        This all is needed because we want to always run this `create-custom-snapshot` pipeline and make it part of
+        required GitHub checks in branch protection rules.
       taskSpec:
         results:
         - name: SHOULD_PROCEED
@@ -170,7 +170,7 @@ spec:
             echo
 
             echo '-----------'
-            echo 'full body, for diagnostics:'
+            echo 'full body, for diagnostics if anything fails:'
             cat <<EOF
               {{ cel: body }}
             EOF

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -132,7 +132,7 @@ spec:
           #                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
           #                ))
           - name: SHOULD_PROCEED
-            value: '{{ cel: pac.event == "push" || (pac.event == "pull_request") }}'
+            value: '{{ cel: pac.target_branch }}'
           script: echo "$(params.SHOULD_PROCEED)" | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -137,7 +137,9 @@ spec:
             echo "target_branch is {{ target_branch }}"
             echo "CEL target_branch is {{ cel: target_branch }}"
             echo "CEL pac.target_branch is {{ cel: pac.target_branch }}"
-            echo '{{ cel: (event == "push") || (event == "pull_request") }}' | tee "$(results.SHOULD_PROCEED.path)"
+            echo "event_type is {{ event_type }}"
+            echo "CEL event_type is {{ event_type }}"
+            echo '{{ cel: (event_type == "push") || (event_type == "pull_request") }}' | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -170,7 +170,11 @@ spec:
             assert_boolean has_konflux_build_label_as_issue
 
             result="false"
-            if [[ "${is_pull_request}" != "true" || "${is_matching_target_branch}" == "true" || "${is_matching_source_branch}" == "true" || "${has_konflux_build_label_as_pr}" == "true" || "${has_konflux_build_label_as_issue}" == "true" ]]; then
+            if [[ "${is_pull_request}" != "true" || \
+                "${is_matching_target_branch}" == "true" || \
+                "${is_matching_source_branch}" == "true" || \
+                "${has_konflux_build_label_as_pr}" == "true" || \
+                "${has_konflux_build_label_as_issue}" == "true" ]]; then
               result="true"
             fi
             echo -n "The result is: "

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -133,10 +133,13 @@ spec:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
           script: |
+            echo 'body.pull_request: {{ body.pull_request }}'
+            echo 'has body.pull_request: {{ has(body.pull_request) }}'
+            echo 'CEL has body.pull_request: {{ cel: has(body.pull_request) }}'
             echo "event_type: {{ event_type }}"
             echo "target_branch: {{ target_branch }}"
             echo "source_branch: {{ source_branch }}"
-            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)")) }}' | tee "$(results.SHOULD_PROCEED.path)"
+            echo '{{ cel: (event_type == "push") || (event_type == "pull_request" && (target_branch.startsWith("release-")) || source_branch.matches("(konflux|renovate|appstudio|rhtap)") || (has(body.pull_request))) }}' | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -132,7 +132,7 @@ spec:
           #                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
           #                ))
           - name: SHOULD_PROCEED
-            value: {{ pac.event == "push" || (pac.event == "pull_request") }}
+            value: '{{ cel: pac.event == "push" || (pac.event == "pull_request") }}'
           script: echo "$(params.SHOULD_PROCEED)" | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -130,7 +130,7 @@ spec:
           #                  source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
           #                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
           #                ))
-          script: echo "{{ pac.target_branch }}" | tee "$(results.SHOULD_PROCEED.path)"
+          script: echo "{{ target_branch }}" | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -124,14 +124,16 @@ spec:
         steps:
         - name: blah
           image: registry.redhat.io/ubi9-minimal:latest@sha256:fe688da81a696387ca53a4c19231e99289591f990c904ef913c51b6e87d4e4df
-          script: echo "{{
-              (event == "push") ||
-              (event == "pull_request" && (
-                  target_branch.startsWith("release-") ||
-                  source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
-                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
-                ))
-            }}" | tee "$(results.SHOULD_PROCEED.path)"
+          env:
+          #      (event == "push") ||
+          #              (event == "pull_request" && (
+          #                  target_branch.startsWith("release-") ||
+          #                  source_branch.matches("(konflux|renovate|appstudio|rhtap)") ||
+          #                  (has(body.pull_request) && has(body.pull_request.labels) && body.pull_request.labels.exists(l, l.name == "konflux-build"))
+          #                ))
+          - name: SHOULD_PROCEED
+            value: {{ pac.event == "push" || (pac.event == "pull_request") }}
+          script: echo "${SHOULD_PROCEED}" | tee "$(results.SHOULD_PROCEED.path)"
 
     - name: clone-repository
       params:


### PR DESCRIPTION
## Description

but skip real tasks if in PRs where Konflux is not enabled. This is alternative way to do <https://github.com/stackrox/stackrox/pull/19892>.

With the help of <https://pipelinesascode.com/docs/guides/creating-pipelines/cel-expressions/>.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

What I haven't tested is how it works with tags but I'm sure it should work as expected given that testing with branches went fine.

#### PR without activation

https://github.com/stackrox/stackrox/pull/20026 - everything gets quickly skipped and the pipeline succeeds.

1. Push https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-chsbx-determine-actual-build/logs
2. `/test ...` comment https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-jjxdb-determine-actual-build/logs
3. `/konflux-retest ...` comment https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-nnjzv-determine-actual-build/logs
4. Label change (not `konflux-build`) https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-9p5f2-determine-actual-build/logs

#### PR with `konflux` in the branch name

https://github.com/stackrox/stackrox/pull/20027 - the tasks get really executed after `determine-actual-build` gives a green light.
Though I cancel Konflux builds after I see that happening to save on resources.

1. Push https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-z4wv2-determine-actual-build/logs
2. `/retest ...` comment https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-55mrs-determine-actual-build/logs
3. `/konflux-retest ...` comment https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-rc882-determine-actual-build/logs
4. Label change (not `konflux-build`) https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-5xwz6-determine-actual-build/logs

#### PR with `konflux-build` label

https://github.com/stackrox/stackrox/pull/20122 - initially no activation without a label ([run](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-w4mwx-determine-actual-build/logs)), then tasks get really executed after the label is placed.
Though I cancelled pipelines to save resources.

1. `konflux-build` label added https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-mmg5j-determine-actual-build/logs
2. `/test ...` comment https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-42q8z-determine-actual-build/logs
3. `/konflux-retest ...` comment https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-zgs6q-determine-actual-build/logs
4. Commit push - https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-dr8hk-determine-actual-build/logs
5. Label change (not `konflux-build`) https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-vf7gt-determine-actual-build/logs

Then, upon removal of `konflux-build`, the pipeline does not start at all. It would be nice if it activated but one can anyway push a commit or do something else to trigger the pipeline.

#### Branch pushes (no PRs)

1. No pipeline at all on pushing to non-matching branch https://github.com/stackrox/stackrox/commits/misha-test-ccs-no-activation
2. Activated on pushing to `release-*` branch (https://github.com/stackrox/stackrox/commits/release-misha-test-cel/) - https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/create-custom-snapshot-nbx4h/logs?task=determine-actual-build
3. Activated on `/test` comment in `release-*` branch (https://github.com/stackrox/stackrox/commit/35c634a3c54b99fd13db09d4c4a23409d03dea22#commitcomment-183018739) https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-2j2ft-determine-actual-build

