### PR TITLE
fix(tests): ensure splunk configuration only happens once

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -46,6 +46,9 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
 
         splunkDeployment = SplunkUtil.createSplunk(orchestrator, TEST_NAMESPACE)
         waitForSplunkReady(splunkDeployment.splunkPortForward.getLocalPort())
+
+        String centralHost = orchestrator.getServiceIP("central", "stackrox")
+        configureSplunkTA(splunkDeployment, centralHost)
     }
 
     def cleanupSpec() {
@@ -73,10 +76,8 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
     @Tag("Integration")
     def "Verify Splunk violations: StackRox violations reach Splunk TA"() {
         given:
-        "Splunk TA is installed and configured, network and process violations triggered"
+        "network and process violations are triggered"
         String centralHost = orchestrator.getServiceIP("central", "stackrox")
-
-        configureSplunkTA(splunkDeployment, centralHost)
         triggerProcessViolation(splunkDeployment)
         triggerNetworkFlowViolation(splunkDeployment, centralHost)
 
@@ -143,11 +144,6 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         and:
         "FACT is configured to monitor /tmp paths"
         patchFactEnv()
-
-        and:
-        "Splunk TA is installed and configured"
-        String centralHost = orchestrator.getServiceIP("central", "stackrox")
-        configureSplunkTA(splunkDeployment, centralHost)
 
         and:
         "a file activity policy targeting a unique path"


### PR DESCRIPTION
## Description

Ensures the Splunk instance is only configured once. Tests may not have run on the original PR, despite correct label. #19496 

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI should be enough.
