### PR TITLE
ROX-34024: Use name-based matching in populateImageMetadata

### DIFF
--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -310,11 +310,13 @@ func (w *deploymentWrap) populateImageMetadata(localImages set.StringSet, pods .
 	// The downside to this is that if different pods have different versions then we will miss that fact that pods are running
 	// different versions and clobber it. I've added a log to illustrate the clobbering so we can see how often it happens
 
-	// Sort the w.Deployment.Containers by name and p.Status.ContainerStatuses by name
-	// This is because the order is not guaranteed
-	sort.SliceStable(w.GetDeployment().GetContainers(), func(i, j int) bool {
-		return w.GetDeployment().GetContainers()[i].GetName() < w.GetDeployment().GetContainers()[j].GetName()
-	})
+	// Build a map from container name to deployment container for name-based matching.
+	// This avoids index-based alignment which breaks when other container types are
+	// present in deployment.Containers but not in pod container statuses.
+	containersByName := make(map[string]*storage.Container, len(w.GetDeployment().GetContainers()))
+	for _, c := range w.GetDeployment().GetContainers() {
+		containersByName[c.GetName()] = c
+	}
 
 	// Sort the pods by time created as that pod will be most likely to have the most updated spec
 	sort.SliceStable(pods, func(i, j int) bool {
@@ -323,19 +325,20 @@ func (w *deploymentWrap) populateImageMetadata(localImages set.StringSet, pods .
 
 	// Determine each image's ID, if not already populated, as well as if the image is pullable and/or cluster-local.
 	for _, p := range pods {
-		sort.SliceStable(p.Status.ContainerStatuses, func(i, j int) bool {
-			return p.Status.ContainerStatuses[i].Name < p.Status.ContainerStatuses[j].Name
-		})
-		sort.SliceStable(p.Spec.Containers, func(i, j int) bool {
-			return p.Spec.Containers[i].Name < p.Spec.Containers[j].Name
-		})
-		for i, c := range p.Status.ContainerStatuses {
-			if i >= len(w.GetDeployment().GetContainers()) || i >= len(p.Spec.Containers) {
-				// This should not happen, but could happen if w.Deployment.Containers and container status are out of sync
-				break
+		// Build a map from container name to pod spec container for name-based lookup.
+		specContainersByName := make(map[string]v1.Container, len(p.Spec.Containers))
+		for _, sc := range p.Spec.Containers {
+			specContainersByName[sc.Name] = sc
+		}
+
+		for _, c := range p.Status.ContainerStatuses {
+			deployContainer, found := containersByName[c.Name]
+			if !found {
+				log.Debugf("Skipping container status %q with no matching deployment container for deploy %q, pod %q", c.Name, w.GetDeployment().GetName(), p.GetName())
+				continue
 			}
 
-			image := w.GetDeployment().GetContainers()[i].GetImage()
+			image := deployContainer.GetImage()
 
 			var runtimeImageName *storage.ImageName
 			if features.UnqualifiedSearchRegistries.Enabled() && c.ImageID != "" {
@@ -365,7 +368,12 @@ func (w *deploymentWrap) populateImageMetadata(localImages set.StringSet, pods .
 				continue
 			}
 
-			parsedName, err := imageUtils.GenerateImageFromStringWithOverride(p.Spec.Containers[i].Image, w.registryOverride)
+			specContainer, found := specContainersByName[c.Name]
+			if !found {
+				continue
+			}
+
+			parsedName, err := imageUtils.GenerateImageFromStringWithOverride(specContainer.Image, w.registryOverride)
 			if err != nil {
 				// This error will only happen if we could not parse the image, this is possible if the image in kubernetes is malformed
 				// e.g. us.gcr.io/$PROJECT/xyz:latest is an example that we have seen

--- a/sensor/kubernetes/listener/resources/convert_test.go
+++ b/sensor/kubernetes/listener/resources/convert_test.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -390,23 +391,27 @@ func TestPopulateImageMetadata(t *testing.T) {
 			wrap := deploymentWrap{
 				Deployment: &storage.Deployment{},
 			}
-			for _, container := range c.wrap {
+			for i, container := range c.wrap {
+				name := fmt.Sprintf("container-%d", i)
 				img, err := imageUtils.GenerateImageFromString(container.image)
 				require.NoError(t, err)
 				wrap.Containers = append(wrap.Containers, &storage.Container{
+					Name:  name,
 					Image: img,
 				})
-
 			}
 
 			pods := make([]*v1.Pod, 0, len(c.pods))
 			for _, pod := range c.pods {
 				k8sPod := &v1.Pod{}
-				for _, img := range pod.images {
-					k8sPod.Spec.Containers = append(k8sPod.Spec.Containers, v1.Container{Image: img})
+				for i, img := range pod.images {
+					name := fmt.Sprintf("container-%d", i)
+					k8sPod.Spec.Containers = append(k8sPod.Spec.Containers, v1.Container{Name: name, Image: img})
 				}
-				for _, imageID := range pod.imageIDsInStatus {
+				for i, imageID := range pod.imageIDsInStatus {
+					name := fmt.Sprintf("container-%d", i)
 					k8sPod.Status.ContainerStatuses = append(k8sPod.Status.ContainerStatuses, v1.ContainerStatus{
+						Name:    name,
 						ImageID: imageID,
 					})
 				}
@@ -545,23 +550,27 @@ func TestPopulateImageMetadataWithUnqualified(t *testing.T) {
 			wrap := deploymentWrap{
 				Deployment: &storage.Deployment{},
 			}
-			for _, container := range c.wrap {
+			for i, container := range c.wrap {
+				name := fmt.Sprintf("container-%d", i)
 				img, err := imageUtils.GenerateImageFromString(container.image)
 				require.NoError(t, err)
 				wrap.Containers = append(wrap.Containers, &storage.Container{
+					Name:  name,
 					Image: img,
 				})
-
 			}
 
 			pods := make([]*v1.Pod, 0, len(c.pods))
 			for _, pod := range c.pods {
 				k8sPod := &v1.Pod{}
-				for _, img := range pod.images {
-					k8sPod.Spec.Containers = append(k8sPod.Spec.Containers, v1.Container{Image: img})
+				for i, img := range pod.images {
+					name := fmt.Sprintf("container-%d", i)
+					k8sPod.Spec.Containers = append(k8sPod.Spec.Containers, v1.Container{Name: name, Image: img})
 				}
-				for _, imageID := range pod.imageIDsInStatus {
+				for i, imageID := range pod.imageIDsInStatus {
+					name := fmt.Sprintf("container-%d", i)
 					k8sPod.Status.ContainerStatuses = append(k8sPod.Status.ContainerStatuses, v1.ContainerStatus{
+						Name:    name,
 						ImageID: imageID,
 					})
 				}

--- a/sensor/kubernetes/listener/resources/convert_test.go
+++ b/sensor/kubernetes/listener/resources/convert_test.go
@@ -428,6 +428,57 @@ func TestPopulateImageMetadata(t *testing.T) {
 	}
 }
 
+func TestPopulateImageMetadataWithInitContainers(t *testing.T) {
+	// Simulates a deployment with init containers in deployment.Containers that do not
+	// appear in pod.Status.ContainerStatuses. Name-based matching should skip the init
+	// containers and correctly assign digests to the regular containers.
+	wrap := deploymentWrap{
+		Deployment: &storage.Deployment{},
+	}
+
+	initImg, err := imageUtils.GenerateImageFromString("docker.io/library/busybox:latest")
+	require.NoError(t, err)
+	nginxImg, err := imageUtils.GenerateImageFromString("docker.io/library/nginx:latest")
+	require.NoError(t, err)
+	redisImg, err := imageUtils.GenerateImageFromString("docker.io/library/redis:latest")
+	require.NoError(t, err)
+
+	wrap.Containers = []*storage.Container{
+		{Name: "init-setup", Image: initImg},
+		{Name: "nginx", Image: nginxImg},
+		{Name: "redis", Image: redisImg},
+	}
+
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "nginx", Image: "docker.io/library/nginx:latest"},
+				{Name: "redis", Image: "docker.io/library/redis:latest"},
+			},
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:    "nginx",
+					ImageID: "docker-pullable://docker.io/library/nginx@sha256:abc123",
+				},
+				{
+					Name:    "redis",
+					ImageID: "docker-pullable://docker.io/library/redis@sha256:def456",
+				},
+			},
+		},
+	}
+
+	wrap.populateImageMetadata(nil, pod)
+
+	// Init container should have no digest (not in pod status).
+	assert.Empty(t, wrap.GetDeployment().GetContainers()[0].GetImage().GetId())
+	// Regular containers should have correct digests matched by name.
+	assert.Equal(t, "sha256:abc123", wrap.GetDeployment().GetContainers()[1].GetImage().GetId())
+	assert.Equal(t, "sha256:def456", wrap.GetDeployment().GetContainers()[2].GetImage().GetId())
+}
+
 func TestPopulateImageMetadataWithUnqualified(t *testing.T) {
 	testutils.MustUpdateFeature(t, features.UnqualifiedSearchRegistries, true)
 	type wrapContainer struct {


### PR DESCRIPTION
## Description

Changes `populateImageMetadata` in Sensor to use name-based container matching instead of index-based matching when correlating pod container statuses with deployment containers.

The current implementation sorts deployment containers and pod container statuses by name, then aligns them by index. This will break when init containers are present because `deployment.Containers` is a unified list containing both init and regular containers, while `pod.Status.ContainerStatuses` only contains regular containers. Index-based alignment then assigns the wrong image digests to the wrong containers.

The fix replaces index-based alignment with name-based map lookups: deployment containers and pod spec containers are indexed by name, and each pod container status is matched to its corresponding deployment container via `containersByName[c.Name]`. This correctly handles deployments with init containers, regular containers, or both. Existing unit tests are updated to include container names so name-based matching is exercised.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

**Unit tests**: Updated existing tests in `sensor/kubernetes/listener/resources/convert_test.go` to use named containers so name-based matching is exercised.

**Manual testing on infra cluster**:

Deployed ACS with the PR image (`4.11.x-659-g53713779a1`) on a GKE cluster. Created 6 workload types to verify name-based matching produces correct digests across the board. Used the Central REST API to verify:

```bash
ADMIN_PASS=$(kubectl get secret admin-password -n stackrox -o jsonpath='{.data.password}' | base64 -d)
DEP_ID=$(curl -sk -u "admin:${ADMIN_PASS}" "${CENTRAL_URL}/v1/deployments?query=Deployment%3A<name>" | python3 -c "import json,sys; print(json.load(sys.stdin)['deployments'][0]['id'])")
curl -sk -u "admin:${ADMIN_PASS}" "${CENTRAL_URL}/v1/deployments/${DEP_ID}"
```

**Results — all correct, no regressions:**

```
=== test-single (Deployment, 1 container) ===
[0] nginx: image=docker.io/library/nginx:latest, digest=sha256:7f0adca1fc6c...

=== test-multi (Deployment, 3 containers) ===
[0] nginx:   image=docker.io/library/nginx:latest,   digest=sha256:7f0adca1fc6c...
[1] redis:   image=docker.io/library/redis:latest,    digest=sha256:1f073813b641...
[2] busybox: image=docker.io/library/busybox:latest,  digest=sha256:1487d0af5f52...

=== test-daemonset (DaemonSet, 2 containers) ===
[0] nginx: image=docker.io/library/nginx:latest, digest=sha256:7f0adca1fc6c...
[1] redis: image=docker.io/library/redis:latest,  digest=sha256:1f073813b641...

=== test-statefulset (StatefulSet, 2 containers) ===
[0] nginx: image=docker.io/library/nginx:latest, digest=sha256:7f0adca1fc6c...
[1] redis: image=docker.io/library/redis:latest,  digest=sha256:1f073813b641...

=== test-cronjob (CronJob, 2 containers) ===
[0] nginx: image=docker.io/library/nginx:latest, digest=sha256:7f0adca1fc6c...
[1] redis: image=docker.io/library/redis:latest,  digest=sha256:1f073813b641...

=== test-digest (Deployment, tag + digest-pinned) ===
[0] by-tag:    image=docker.io/library/nginx:latest,       digest=sha256:7f0adca1fc6c...
[1] by-digest: image=docker.io/library/nginx@sha256:7f0..., digest=sha256:7f0adca1fc6c...
```

Every container across all workload types has the correct image digest assigned to the correct container name. No mismatched or missing digests.