### PR TITLE
perf(ci): Add ESLint caching to CI style checks

### DIFF
--- a/.github/actions/cache-eslint/action.yaml
+++ b/.github/actions/cache-eslint/action.yaml
@@ -8,13 +8,13 @@ runs:
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # ratchet:actions/cache@v5
       with:
         path: ui/apps/platform/.eslintcache
-        key: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json', 'ui/apps/platform/eslint-plugins/**') }}-${{ github.sha }}
-        restore-keys: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json', 'ui/apps/platform/eslint-plugins/**') }}-
+        key: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json', 'ui/apps/platform/eslint.config.js', 'ui/apps/platform/eslint-plugins/**') }}-${{ github.sha }}
+        restore-keys: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json', 'ui/apps/platform/eslint.config.js', 'ui/apps/platform/eslint-plugins/**') }}-
 
     - name: Cache ESLint (restore)
       if: ${{ !(github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) }}
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # ratchet:actions/cache/restore@v5
       with:
         path: ui/apps/platform/.eslintcache
-        key: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json', 'ui/apps/platform/eslint-plugins/**') }}-${{ github.sha }}
-        restore-keys: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json', 'ui/apps/platform/eslint-plugins/**') }}-
+        key: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json', 'ui/apps/platform/eslint.config.js', 'ui/apps/platform/eslint-plugins/**') }}-${{ github.sha }}
+        restore-keys: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json', 'ui/apps/platform/eslint.config.js', 'ui/apps/platform/eslint-plugins/**') }}-

--- a/.github/actions/cache-eslint/action.yaml
+++ b/.github/actions/cache-eslint/action.yaml
@@ -1,0 +1,20 @@
+name: Cache ESLint Results
+description: Cache ESLint results to speed up linting on subsequent runs
+runs:
+  using: composite
+  steps:
+    - name: Cache ESLint (save)
+      if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # ratchet:actions/cache@v5
+      with:
+        path: ui/apps/platform/.eslintcache
+        key: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json') }}-${{ github.sha }}
+        restore-keys: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json') }}-
+
+    - name: Cache ESLint (restore)
+      if: ${{ !(github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) }}
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # ratchet:actions/cache/restore@v5
+      with:
+        path: ui/apps/platform/.eslintcache
+        key: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json') }}-${{ github.sha }}
+        restore-keys: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json') }}-

--- a/.github/actions/cache-eslint/action.yaml
+++ b/.github/actions/cache-eslint/action.yaml
@@ -8,13 +8,13 @@ runs:
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # ratchet:actions/cache@v5
       with:
         path: ui/apps/platform/.eslintcache
-        key: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json') }}-${{ github.sha }}
-        restore-keys: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json') }}-
+        key: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json', 'ui/apps/platform/eslint-plugins/**') }}-${{ github.sha }}
+        restore-keys: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json', 'ui/apps/platform/eslint-plugins/**') }}-
 
     - name: Cache ESLint (restore)
       if: ${{ !(github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) }}
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # ratchet:actions/cache/restore@v5
       with:
         path: ui/apps/platform/.eslintcache
-        key: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json') }}-${{ github.sha }}
-        restore-keys: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json') }}-
+        key: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json', 'ui/apps/platform/eslint-plugins/**') }}-${{ github.sha }}
+        restore-keys: eslint-v1-${{ github.job }}-${{ hashFiles('ui/apps/platform/package-lock.json', 'ui/apps/platform/eslint-plugins/**') }}-

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -171,6 +171,9 @@ jobs:
       - name: Fetch UI deps
         run: make -C ui deps
 
+      - name: Cache ESLint results
+        uses: ./.github/actions/cache-eslint
+
       - name: make style-slim
         run: make style-slim
 

--- a/ui/apps/platform/README.md
+++ b/ui/apps/platform/README.md
@@ -50,6 +50,10 @@ the value of `UI_START_TARGET`: `https://8.8.8.8:443`.
 
 ### Linting
 
+The `npm run lint` command uses ESLint with `--cache --cache-strategy content`. This caches lint results per file based on content hashes, so subsequent runs only re-lint changed files. The cache file (`.eslintcache`) is gitignored. If you need a clean lint run (e.g. after modifying custom rules in `eslint-plugins/`), delete `.eslintcache` and re-run.
+
+In CI, the `.eslintcache` file is persisted between runs via the `cache-eslint` GitHub Action (`.github/actions/cache-eslint/`). The cache is saved on master merges and restored on PR runs. The cache key includes hashes of `package-lock.json` and `eslint-plugins/**`, so dependency upgrades or custom rule changes automatically bust the cache.
+
 If **stackrox/ui** is your workspace root folder, you can create or edit stackrox/ui/.vscode/settings.json file to add the following properties:
 
 ```json

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -103,7 +103,7 @@
         "build:ocp-plugin": "tsc && NODE_ENV=production webpack --config webpack.ocp-plugin.config.js",
         "test": "TZ=UTC vitest",
         "test-coverage": "TZ=UTC vitest run --coverage",
-        "lint": "eslint --quiet",
+        "lint": "eslint --quiet --cache --cache-strategy content",
         "lint:fast-dev": "eslint --rule 'import/namespace: off' --rule 'import/no-cycle: off'",
         "lint:fast-dev-fix": "eslint --fix --rule 'import/namespace: off' --rule 'import/no-cycle: off'",
         "lint:fix": "eslint --fix",


### PR DESCRIPTION
## Description

The ESLint lint command in CI (`eslint --quiet`) re-lints all ~1926 UI files from scratch on every PR, taking roughly 5 minutes. This change adds ESLint result caching to CI style checks, reducing warm lint times to seconds.

Three changes are made:                                                                                                                                                                   
1. A new `cache-eslint` composite GitHub Action that follows the same save/restore pattern as the existing `cache-go-dependencies` action. Cache is saved only on pushes to the default branch (master merges), and PR runs only restore from existing caches. The cache key includes `github.job` to prevent cross-job collisions.
2. The `style.yaml` workflow is updated to restore the ESLint cache before running `make style-slim`, which eventually calls `eslint --quiet --cache --cache-strategy content`. When the cache file is present, ESLint skips re-linting files whose content hash hasn't changed since the last master merge.
3. The `lint` script in `ui/apps/platform/package.json` is updated to pass `--cache --cache-strategy content`. The `content` strategy uses file content hashes instead of modification times, which is necessary because `git checkout` resets all mtimes.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Local benchmarking of `npm run lint` in `ui/apps/platform/`: 
  - Cold run (no cache): ~4:45
  - Warm run (with --cache --cache-strategy content): ~0:03