### PR TITLE
ROX-32721: Switch SearchListAlerts and WalkAll to column projection

### DIFF
--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -179,7 +179,10 @@ func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excl
 						Categories:  []string(categories),
 					},
 					EnforcementAction: storage.EnforcementAction(enforcementAction.Int32),
-					EnforcementCount:  enforcementCount.Int32,
+				}
+
+				if storage.ViolationState(state.Int32) == storage.ViolationState_ACTIVE {
+					la.EnforcementCount = enforcementCount.Int32
 				}
 
 				if violationTime.Valid {
@@ -718,7 +721,10 @@ func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(*storage.ListAlert
 						Categories:  []string(categories),
 					},
 					EnforcementAction: storage.EnforcementAction(enforcementAction.Int32),
-					EnforcementCount:  enforcementCount.Int32,
+				}
+
+				if storage.ViolationState(state.Int32) == storage.ViolationState_ACTIVE {
+					la.EnforcementCount = enforcementCount.Int32
 				}
 
 				if violationTime.Valid {

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -56,7 +56,7 @@ var (
 		search.NewQuerySelect(search.Severity).Proto(),
 		search.NewQuerySelect(search.Description).Proto(),
 		search.NewQuerySelect(search.Category).Proto(),
-		search.NewQuerySelect(search.Enforcement).Proto(),
+		search.NewQuerySelect(search.EnforcementAction).Proto(),
 		search.NewQuerySelect(search.EnforcementCount).Proto(),
 		search.NewQuerySelect(search.EntityType).Proto(),
 		search.NewQuerySelect(search.ClusterID).Proto(),

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -42,41 +42,6 @@ var (
 	log = logging.LoggerForModule()
 
 	alertSAC = sac.ForResource(resources.Alert)
-
-	// listAlertSelectProtos defines the column projections for SearchListAlerts.
-	// Order must match the scan destinations in listAlertScanner.dests.
-	listAlertSelectProtos = []*v1.QuerySelect{
-		search.NewQuerySelect(search.AlertID).Proto(),
-		search.NewQuerySelect(search.LifecycleStage).Proto(),
-		search.NewQuerySelect(search.ViolationTime).Proto(),
-		search.NewQuerySelect(search.ViolationState).Proto(),
-		search.NewQuerySelect(search.PolicyID).Proto(),
-		search.NewQuerySelect(search.PolicyName).Proto(),
-		search.NewQuerySelect(search.Severity).Proto(),
-		search.NewQuerySelect(search.Description).Proto(),
-		search.NewQuerySelect(search.Category).Proto(),
-		search.NewQuerySelect(search.EnforcementAction).Proto(),
-		search.NewQuerySelect(search.EnforcementCount).Proto(),
-		search.NewQuerySelect(search.EntityType).Proto(),
-		search.NewQuerySelect(search.ClusterID).Proto(),
-		search.NewQuerySelect(search.Cluster).Proto(),
-		search.NewQuerySelect(search.Namespace).Proto(),
-		search.NewQuerySelect(search.NamespaceID).Proto(),
-		search.NewQuerySelect(search.DeploymentID).Proto(),
-		search.NewQuerySelect(search.DeploymentName).Proto(),
-		search.NewQuerySelect(search.DeploymentType).Proto(),
-		search.NewQuerySelect(search.Inactive).Proto(),
-		search.NewQuerySelect(search.NodeID).Proto(),
-		search.NewQuerySelect(search.Node).Proto(),
-		search.NewQuerySelect(search.ResourceName).Proto(),
-		search.NewQuerySelect(search.ResourceType).Proto(),
-	}
-
-	// listAlertArrayFields tells the query builder that "category" is a
-	// parent-table array column, not a child table requiring a JOIN.
-	listAlertArrayFields = map[string]bool{
-		"category": true,
-	}
 )
 
 // datastoreImpl is a transaction script with methods that provide the domain logic for CRUD uses cases for Alert
@@ -122,11 +87,11 @@ func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excl
 	}
 
 	cloned := q.CloneVT()
-	cloned.Selects = listAlertSelectProtos
+	cloned.Selects = alertviews.ListAlertSelectProtos
 
 	var sc alertviews.ListAlertScanner
 	listAlerts := make([]*storage.ListAlert, 0, paginated.GetLimit(cloned.GetPagination().GetLimit(), whenUnlimited))
-	err := pgSearch.RunSelectDirectFn(ctx, ds.db, schema.AlertsSchema, cloned, listAlertArrayFields,
+	err := pgSearch.RunSelectDirectFn(ctx, ds.db, schema.AlertsSchema, cloned, alertviews.ListAlertArrayFields,
 		&pgSearch.DirectScanConfig{
 			ScanDests: sc.Dests,
 			OnRow: func() error {
@@ -560,10 +525,10 @@ func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(*storage.ListAlert
 	}
 
 	q := searchCommon.EmptyQuery()
-	q.Selects = listAlertSelectProtos
+	q.Selects = alertviews.ListAlertSelectProtos
 
 	var sc alertviews.ListAlertScanner
-	return pgSearch.RunSelectDirectFn(ctx, ds.db, schema.AlertsSchema, q, listAlertArrayFields,
+	return pgSearch.RunSelectDirectFn(ctx, ds.db, schema.AlertsSchema, q, alertviews.ListAlertArrayFields,
 		&pgSearch.DirectScanConfig{
 			ScanDests: sc.Dests,
 			OnRow: func() error {

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -105,6 +105,20 @@ func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excl
 	return listAlerts, nil
 }
 
+// searchListAlertsLegacy is the original SearchListAlerts implementation that
+// deserializes the full alert blob. Used as a fallback via ROX_LIST_ALERT_LEGACY_QUERY.
+func (ds *datastoreImpl) searchListAlertsLegacy(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, error) {
+	listAlerts := make([]*storage.ListAlert, 0, paginated.GetLimit(q.GetPagination().GetLimit(), whenUnlimited))
+	err := ds.storage.GetByQueryFn(ctx, q, func(alert *storage.Alert) error {
+		listAlerts = append(listAlerts, convert.AlertToListAlert(alert))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return listAlerts, nil
+}
+
 // SearchAlertPolicyNamesAndSeverities returns lightweight policy name and severity pairs
 // for matching alerts.
 func (ds *datastoreImpl) SearchAlertPolicyNamesAndSeverities(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*alertviews.PolicyNameAndSeverity, error) {
@@ -537,6 +551,17 @@ func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(*storage.ListAlert
 		})
 }
 
+// walkAllLegacy is the original WalkAll implementation that deserializes the
+// full alert blob. Used as a fallback via ROX_LIST_ALERT_LEGACY_QUERY.
+func (ds *datastoreImpl) walkAllLegacy(ctx context.Context, fn func(*storage.ListAlert) error) error {
+	walkFn := func() error {
+		return ds.storage.Walk(ctx, func(alert *storage.Alert) error {
+			return fn(convert.AlertToListAlert(alert))
+		})
+	}
+	return pgutils.RetryIfPostgres(ctx, walkFn)
+}
+
 // DefaultStateAlertDataStoreImpl will only return unresolved alerts unless Violation State=Resolved is explicitly provided by the query
 type DefaultStateAlertDataStoreImpl struct {
 	DataStore *DataStore
@@ -625,29 +650,4 @@ func (c *AlertSearchResultConverter) GetCategory() v1.SearchCategory {
 
 func (c *AlertSearchResultConverter) GetScore(result *search.Result) float64 {
 	return result.Score
-}
-
-// searchListAlertsLegacy is the original SearchListAlerts implementation that
-// deserializes the full alert blob. Used as a fallback via ROX_LIST_ALERT_LEGACY_QUERY.
-func (ds *datastoreImpl) searchListAlertsLegacy(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, error) {
-	listAlerts := make([]*storage.ListAlert, 0, paginated.GetLimit(q.GetPagination().GetLimit(), whenUnlimited))
-	err := ds.storage.GetByQueryFn(ctx, q, func(alert *storage.Alert) error {
-		listAlerts = append(listAlerts, convert.AlertToListAlert(alert))
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return listAlerts, nil
-}
-
-// walkAllLegacy is the original WalkAll implementation that deserializes the
-// full alert blob. Used as a fallback via ROX_LIST_ALERT_LEGACY_QUERY.
-func (ds *datastoreImpl) walkAllLegacy(ctx context.Context, fn func(*storage.ListAlert) error) error {
-	walkFn := func() error {
-		return ds.storage.Walk(ctx, func(alert *storage.Alert) error {
-			return fn(convert.AlertToListAlert(alert))
-		})
-	}
-	return pgutils.RetryIfPostgres(ctx, walkFn)
 }

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/alert/datastore/internal/store"
 	alertutils "github.com/stackrox/rox/central/alert/utils"
@@ -20,7 +21,6 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres"
-	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
@@ -41,6 +41,41 @@ var (
 	log = logging.LoggerForModule()
 
 	alertSAC = sac.ForResource(resources.Alert)
+
+	// listAlertSelectProtos defines the 22 column projections for SearchListAlerts.
+	// Order must match the scan destinations in scanListAlertRow.
+	listAlertSelectProtos = []*v1.QuerySelect{
+		search.NewQuerySelect(search.AlertID).Proto(),
+		search.NewQuerySelect(search.LifecycleStage).Proto(),
+		search.NewQuerySelect(search.ViolationTime).Proto(),
+		search.NewQuerySelect(search.ViolationState).Proto(),
+		search.NewQuerySelect(search.PolicyID).Proto(),
+		search.NewQuerySelect(search.PolicyName).Proto(),
+		search.NewQuerySelect(search.Severity).Proto(),
+		search.NewQuerySelect(search.Description).Proto(),
+		search.NewQuerySelect(search.Category).Proto(),
+		search.NewQuerySelect(search.EnforcementAction).Proto(),
+		search.NewQuerySelect(search.EnforcementCount).Proto(),
+		search.NewQuerySelect(search.EntityType).Proto(),
+		search.NewQuerySelect(search.ClusterID).Proto(),
+		search.NewQuerySelect(search.Cluster).Proto(),
+		search.NewQuerySelect(search.Namespace).Proto(),
+		search.NewQuerySelect(search.NamespaceID).Proto(),
+		search.NewQuerySelect(search.DeploymentID).Proto(),
+		search.NewQuerySelect(search.DeploymentName).Proto(),
+		search.NewQuerySelect(search.DeploymentType).Proto(),
+		search.NewQuerySelect(search.Inactive).Proto(),
+		search.NewQuerySelect(search.NodeID).Proto(),
+		search.NewQuerySelect(search.Node).Proto(),
+		search.NewQuerySelect(search.ResourceName).Proto(),
+		search.NewQuerySelect(search.ResourceType).Proto(),
+	}
+
+	// listAlertArrayFields tells the query builder that "category" is a
+	// parent-table array column, not a child table requiring a JOIN.
+	listAlertArrayFields = map[string]bool{
+		"category": true,
+	}
 )
 
 // datastoreImpl is a transaction script with methods that provide the domain logic for CRUD uses cases for Alert
@@ -80,11 +115,122 @@ func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excl
 	if excludeResolved {
 		q = applyDefaultState(q)
 	}
-	listAlerts := make([]*storage.ListAlert, 0, paginated.GetLimit(q.GetPagination().GetLimit(), whenUnlimited))
-	err := ds.storage.GetByQueryFn(ctx, q, func(alert *storage.Alert) error {
-		listAlerts = append(listAlerts, convert.AlertToListAlert(alert))
-		return nil
-	})
+
+	cloned := q.CloneVT()
+	cloned.Selects = listAlertSelectProtos
+
+	// Scan destinations — pgtype value types avoid per-field heap allocations.
+	var (
+		id                 pgtype.Text
+		lifecycleStage     pgtype.Int4
+		violationTime      pgtype.Timestamp
+		state              pgtype.Int4
+		policyID           pgtype.Text
+		policyName         pgtype.Text
+		severity           pgtype.Int4
+		description        pgtype.Text
+		categories         pgtype.FlatArray[string]
+		enforcementAction  pgtype.Int4
+		enforcementCount   pgtype.Int4
+		entityType         pgtype.Int4
+		clusterID          pgtype.Text
+		clusterName        pgtype.Text
+		namespace          pgtype.Text
+		namespaceID        pgtype.Text
+		deploymentID       pgtype.Text
+		deploymentName     pgtype.Text
+		deploymentType     pgtype.Text
+		deploymentInactive pgtype.Bool
+		nodeID             pgtype.Text
+		nodeName           pgtype.Text
+		resourceName       pgtype.Text
+		resourceType       pgtype.Int4
+	)
+
+	dests := []any{
+		&id, &lifecycleStage, &violationTime, &state,
+		&policyID, &policyName, &severity, &description, &categories,
+		&enforcementAction, &enforcementCount, &entityType,
+		&clusterID, &clusterName, &namespace, &namespaceID,
+		&deploymentID, &deploymentName, &deploymentType, &deploymentInactive,
+		&nodeID, &nodeName, &resourceName, &resourceType,
+	}
+
+	listAlerts := make([]*storage.ListAlert, 0, paginated.GetLimit(cloned.GetPagination().GetLimit(), whenUnlimited))
+	err := pgSearch.RunSelectDirectFn(ctx, ds.db, schema.AlertsSchema, cloned, listAlertArrayFields,
+		&pgSearch.DirectScanConfig{
+			ScanDests: func() []any { return dests },
+			OnRow: func() error {
+				la := &storage.ListAlert{
+					Id:             id.String,
+					LifecycleStage: storage.LifecycleStage(lifecycleStage.Int32),
+					State:          storage.ViolationState(state.Int32),
+					Policy: &storage.ListAlertPolicy{
+						Id:          policyID.String,
+						Name:        policyName.String,
+						Severity:    storage.Severity(severity.Int32),
+						Description: description.String,
+						Categories:  []string(categories),
+					},
+					EnforcementAction: storage.EnforcementAction(enforcementAction.Int32),
+					EnforcementCount:  enforcementCount.Int32,
+				}
+
+				if violationTime.Valid {
+					la.Time = protocompat.ConvertTimeToTimestampOrNil(&violationTime.Time)
+				}
+
+				et := storage.Alert_EntityType(entityType.Int32)
+				switch et {
+				case storage.Alert_DEPLOYMENT:
+					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
+						ClusterName:  clusterName.String,
+						ClusterId:    clusterID.String,
+						Namespace:    namespace.String,
+						NamespaceId:  namespaceID.String,
+						ResourceType: storage.ListAlert_DEPLOYMENT,
+					}
+					la.Entity = &storage.ListAlert_Deployment{
+						Deployment: &storage.ListAlertDeployment{
+							Id:             deploymentID.String,
+							Name:           deploymentName.String,
+							ClusterName:    clusterName.String,
+							ClusterId:      clusterID.String,
+							Namespace:      namespace.String,
+							NamespaceId:    namespaceID.String,
+							DeploymentType: deploymentType.String,
+							Inactive:       deploymentInactive.Bool,
+						},
+					}
+				case storage.Alert_RESOURCE:
+					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
+						ClusterName:  clusterName.String,
+						ClusterId:    clusterID.String,
+						Namespace:    namespace.String,
+						NamespaceId:  namespaceID.String,
+						ResourceType: storage.ListAlert_ResourceType(resourceType.Int32),
+					}
+					la.Entity = &storage.ListAlert_Resource{
+						Resource: &storage.ListAlert_ResourceEntity{
+							Name: resourceName.String,
+						},
+					}
+				case storage.Alert_NODE:
+					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
+						ClusterName: clusterName.String,
+						ClusterId:   clusterID.String,
+					}
+					la.Entity = &storage.ListAlert_Node{
+						Node: &storage.ListAlert_NodeEntity{
+							Name: nodeName.String,
+						},
+					}
+				}
+
+				listAlerts = append(listAlerts, la)
+				return nil
+			},
+		})
 	if err != nil {
 		return nil, err
 	}
@@ -506,13 +652,118 @@ func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(*storage.ListAlert
 		return sac.ErrResourceAccessDenied
 	}
 
-	walkFn := func() error {
-		return ds.storage.Walk(ctx, func(alert *storage.Alert) error {
-			listAlert := convert.AlertToListAlert(alert)
-			return fn(listAlert)
-		})
+	q := searchCommon.EmptyQuery()
+	q.Selects = listAlertSelectProtos
+
+	var (
+		id                 pgtype.Text
+		lifecycleStage     pgtype.Int4
+		violationTime      pgtype.Timestamp
+		state              pgtype.Int4
+		policyID           pgtype.Text
+		policyName         pgtype.Text
+		severity           pgtype.Int4
+		description        pgtype.Text
+		categories         pgtype.FlatArray[string]
+		enforcementAction  pgtype.Int4
+		enforcementCount   pgtype.Int4
+		entityType         pgtype.Int4
+		clusterID          pgtype.Text
+		clusterName        pgtype.Text
+		namespace          pgtype.Text
+		namespaceID        pgtype.Text
+		deploymentID       pgtype.Text
+		deploymentName     pgtype.Text
+		deploymentType     pgtype.Text
+		deploymentInactive pgtype.Bool
+		nodeID             pgtype.Text
+		nodeName           pgtype.Text
+		resourceName       pgtype.Text
+		resourceType       pgtype.Int4
+	)
+
+	dests := []any{
+		&id, &lifecycleStage, &violationTime, &state,
+		&policyID, &policyName, &severity, &description, &categories,
+		&enforcementAction, &enforcementCount, &entityType,
+		&clusterID, &clusterName, &namespace, &namespaceID,
+		&deploymentID, &deploymentName, &deploymentType, &deploymentInactive,
+		&nodeID, &nodeName, &resourceName, &resourceType,
 	}
-	return pgutils.RetryIfPostgres(ctx, walkFn)
+
+	return pgSearch.RunSelectDirectFn(ctx, ds.db, schema.AlertsSchema, q, listAlertArrayFields,
+		&pgSearch.DirectScanConfig{
+			ScanDests: func() []any { return dests },
+			OnRow: func() error {
+				la := &storage.ListAlert{
+					Id:             id.String,
+					LifecycleStage: storage.LifecycleStage(lifecycleStage.Int32),
+					State:          storage.ViolationState(state.Int32),
+					Policy: &storage.ListAlertPolicy{
+						Id:          policyID.String,
+						Name:        policyName.String,
+						Severity:    storage.Severity(severity.Int32),
+						Description: description.String,
+						Categories:  []string(categories),
+					},
+					EnforcementAction: storage.EnforcementAction(enforcementAction.Int32),
+					EnforcementCount:  enforcementCount.Int32,
+				}
+
+				if violationTime.Valid {
+					la.Time = protocompat.ConvertTimeToTimestampOrNil(&violationTime.Time)
+				}
+
+				et := storage.Alert_EntityType(entityType.Int32)
+				switch et {
+				case storage.Alert_DEPLOYMENT:
+					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
+						ClusterName:  clusterName.String,
+						ClusterId:    clusterID.String,
+						Namespace:    namespace.String,
+						NamespaceId:  namespaceID.String,
+						ResourceType: storage.ListAlert_DEPLOYMENT,
+					}
+					la.Entity = &storage.ListAlert_Deployment{
+						Deployment: &storage.ListAlertDeployment{
+							Id:             deploymentID.String,
+							Name:           deploymentName.String,
+							ClusterName:    clusterName.String,
+							ClusterId:      clusterID.String,
+							Namespace:      namespace.String,
+							NamespaceId:    namespaceID.String,
+							DeploymentType: deploymentType.String,
+							Inactive:       deploymentInactive.Bool,
+						},
+					}
+				case storage.Alert_RESOURCE:
+					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
+						ClusterName:  clusterName.String,
+						ClusterId:    clusterID.String,
+						Namespace:    namespace.String,
+						NamespaceId:  namespaceID.String,
+						ResourceType: storage.ListAlert_ResourceType(resourceType.Int32),
+					}
+					la.Entity = &storage.ListAlert_Resource{
+						Resource: &storage.ListAlert_ResourceEntity{
+							Name: resourceName.String,
+						},
+					}
+				case storage.Alert_NODE:
+					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
+						ClusterName: clusterName.String,
+						ClusterId:   clusterID.String,
+					}
+					la.Entity = &storage.ListAlert_Node{
+						Node: &storage.ListAlert_NodeEntity{
+							Name: nodeName.String,
+						},
+					}
+				}
+
+				return fn(la)
+			},
+		})
 }
 
 // DefaultStateAlertDataStoreImpl will only return unresolved alerts unless Violation State=Resolved is explicitly provided by the query

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -78,12 +78,12 @@ func (ds *datastoreImpl) Count(ctx context.Context, q *v1.Query, excludeResolved
 func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excludeResolved bool) ([]*storage.ListAlert, error) {
 	defer metrics.SetDatastoreFunctionDuration(time.Now(), "Alert", "SearchListAlerts")
 
-	if excludeResolved {
-		q = applyDefaultState(q)
-	}
-
 	if q == nil {
 		q = search.EmptyQuery()
+	}
+
+	if excludeResolved {
+		q = applyDefaultState(q)
 	}
 
 	if env.ListAlertUseLegacyQuery.BooleanSetting() {

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -223,8 +223,9 @@ func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excl
 					}
 				case storage.Alert_NODE:
 					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
-						ClusterName: clusterName.String,
-						ClusterId:   clusterID.String,
+						ClusterName:  clusterName.String,
+						ClusterId:    clusterID.String,
+						ResourceType: storage.ListAlert_NODE,
 					}
 					la.Entity = &storage.ListAlert_Node{
 						Node: &storage.ListAlert_NodeEntity{
@@ -761,8 +762,9 @@ func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(*storage.ListAlert
 					}
 				case storage.Alert_NODE:
 					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
-						ClusterName: clusterName.String,
-						ClusterId:   clusterID.String,
+						ClusterName:  clusterName.String,
+						ClusterId:    clusterID.String,
+						ResourceType: storage.ListAlert_NODE,
 					}
 					la.Entity = &storage.ListAlert_Node{
 						Node: &storage.ListAlert_NodeEntity{

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -17,10 +17,12 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/alert/convert"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
@@ -114,6 +116,10 @@ func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excl
 
 	if excludeResolved {
 		q = applyDefaultState(q)
+	}
+
+	if env.ListAlertUseLegacyQuery.BooleanSetting() {
+		return ds.searchListAlertsLegacy(ctx, q)
 	}
 
 	cloned := q.CloneVT()
@@ -652,6 +658,10 @@ func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(*storage.ListAlert
 		return sac.ErrResourceAccessDenied
 	}
 
+	if env.ListAlertUseLegacyQuery.BooleanSetting() {
+		return ds.walkAllLegacy(ctx, fn)
+	}
+
 	q := searchCommon.EmptyQuery()
 	q.Selects = listAlertSelectProtos
 
@@ -854,4 +864,29 @@ func (c *AlertSearchResultConverter) GetCategory() v1.SearchCategory {
 
 func (c *AlertSearchResultConverter) GetScore(result *search.Result) float64 {
 	return result.Score
+}
+
+// searchListAlertsLegacy is the original SearchListAlerts implementation that
+// deserializes the full alert blob. Used as a fallback via ROX_LIST_ALERT_LEGACY_QUERY.
+func (ds *datastoreImpl) searchListAlertsLegacy(ctx context.Context, q *v1.Query) ([]*storage.ListAlert, error) {
+	listAlerts := make([]*storage.ListAlert, 0, paginated.GetLimit(q.GetPagination().GetLimit(), whenUnlimited))
+	err := ds.storage.GetByQueryFn(ctx, q, func(alert *storage.Alert) error {
+		listAlerts = append(listAlerts, convert.AlertToListAlert(alert))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return listAlerts, nil
+}
+
+// walkAllLegacy is the original WalkAll implementation that deserializes the
+// full alert blob. Used as a fallback via ROX_LIST_ALERT_LEGACY_QUERY.
+func (ds *datastoreImpl) walkAllLegacy(ctx context.Context, fn func(*storage.ListAlert) error) error {
+	walkFn := func() error {
+		return ds.storage.Walk(ctx, func(alert *storage.Alert) error {
+			return fn(convert.AlertToListAlert(alert))
+		})
+	}
+	return pgutils.RetryIfPostgres(ctx, walkFn)
 }

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -82,6 +82,10 @@ func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excl
 		q = applyDefaultState(q)
 	}
 
+	if q == nil {
+		q = search.EmptyQuery()
+	}
+
 	if env.ListAlertUseLegacyQuery.BooleanSetting() {
 		return ds.searchListAlertsLegacy(ctx, q)
 	}

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -56,7 +56,7 @@ var (
 		search.NewQuerySelect(search.Severity).Proto(),
 		search.NewQuerySelect(search.Description).Proto(),
 		search.NewQuerySelect(search.Category).Proto(),
-		search.NewQuerySelect(search.EnforcementAction).Proto(),
+		search.NewQuerySelect(search.Enforcement).Proto(),
 		search.NewQuerySelect(search.EnforcementCount).Proto(),
 		search.NewQuerySelect(search.EntityType).Proto(),
 		search.NewQuerySelect(search.ClusterID).Proto(),

--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/alert/datastore/internal/store"
 	alertutils "github.com/stackrox/rox/central/alert/utils"
@@ -44,8 +43,8 @@ var (
 
 	alertSAC = sac.ForResource(resources.Alert)
 
-	// listAlertSelectProtos defines the 22 column projections for SearchListAlerts.
-	// Order must match the scan destinations in scanListAlertRow.
+	// listAlertSelectProtos defines the column projections for SearchListAlerts.
+	// Order must match the scan destinations in listAlertScanner.dests.
 	listAlertSelectProtos = []*v1.QuerySelect{
 		search.NewQuerySelect(search.AlertID).Proto(),
 		search.NewQuerySelect(search.LifecycleStage).Proto(),
@@ -125,119 +124,13 @@ func (ds *datastoreImpl) SearchListAlerts(ctx context.Context, q *v1.Query, excl
 	cloned := q.CloneVT()
 	cloned.Selects = listAlertSelectProtos
 
-	// Scan destinations — pgtype value types avoid per-field heap allocations.
-	var (
-		id                 pgtype.Text
-		lifecycleStage     pgtype.Int4
-		violationTime      pgtype.Timestamp
-		state              pgtype.Int4
-		policyID           pgtype.Text
-		policyName         pgtype.Text
-		severity           pgtype.Int4
-		description        pgtype.Text
-		categories         pgtype.FlatArray[string]
-		enforcementAction  pgtype.Int4
-		enforcementCount   pgtype.Int4
-		entityType         pgtype.Int4
-		clusterID          pgtype.Text
-		clusterName        pgtype.Text
-		namespace          pgtype.Text
-		namespaceID        pgtype.Text
-		deploymentID       pgtype.Text
-		deploymentName     pgtype.Text
-		deploymentType     pgtype.Text
-		deploymentInactive pgtype.Bool
-		nodeID             pgtype.Text
-		nodeName           pgtype.Text
-		resourceName       pgtype.Text
-		resourceType       pgtype.Int4
-	)
-
-	dests := []any{
-		&id, &lifecycleStage, &violationTime, &state,
-		&policyID, &policyName, &severity, &description, &categories,
-		&enforcementAction, &enforcementCount, &entityType,
-		&clusterID, &clusterName, &namespace, &namespaceID,
-		&deploymentID, &deploymentName, &deploymentType, &deploymentInactive,
-		&nodeID, &nodeName, &resourceName, &resourceType,
-	}
-
+	var sc alertviews.ListAlertScanner
 	listAlerts := make([]*storage.ListAlert, 0, paginated.GetLimit(cloned.GetPagination().GetLimit(), whenUnlimited))
 	err := pgSearch.RunSelectDirectFn(ctx, ds.db, schema.AlertsSchema, cloned, listAlertArrayFields,
 		&pgSearch.DirectScanConfig{
-			ScanDests: func() []any { return dests },
+			ScanDests: sc.Dests,
 			OnRow: func() error {
-				la := &storage.ListAlert{
-					Id:             id.String,
-					LifecycleStage: storage.LifecycleStage(lifecycleStage.Int32),
-					State:          storage.ViolationState(state.Int32),
-					Policy: &storage.ListAlertPolicy{
-						Id:          policyID.String,
-						Name:        policyName.String,
-						Severity:    storage.Severity(severity.Int32),
-						Description: description.String,
-						Categories:  []string(categories),
-					},
-					EnforcementAction: storage.EnforcementAction(enforcementAction.Int32),
-				}
-
-				if storage.ViolationState(state.Int32) == storage.ViolationState_ACTIVE {
-					la.EnforcementCount = enforcementCount.Int32
-				}
-
-				if violationTime.Valid {
-					la.Time = protocompat.ConvertTimeToTimestampOrNil(&violationTime.Time)
-				}
-
-				et := storage.Alert_EntityType(entityType.Int32)
-				switch et {
-				case storage.Alert_DEPLOYMENT:
-					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
-						ClusterName:  clusterName.String,
-						ClusterId:    clusterID.String,
-						Namespace:    namespace.String,
-						NamespaceId:  namespaceID.String,
-						ResourceType: storage.ListAlert_DEPLOYMENT,
-					}
-					la.Entity = &storage.ListAlert_Deployment{
-						Deployment: &storage.ListAlertDeployment{
-							Id:             deploymentID.String,
-							Name:           deploymentName.String,
-							ClusterName:    clusterName.String,
-							ClusterId:      clusterID.String,
-							Namespace:      namespace.String,
-							NamespaceId:    namespaceID.String,
-							DeploymentType: deploymentType.String,
-							Inactive:       deploymentInactive.Bool,
-						},
-					}
-				case storage.Alert_RESOURCE:
-					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
-						ClusterName:  clusterName.String,
-						ClusterId:    clusterID.String,
-						Namespace:    namespace.String,
-						NamespaceId:  namespaceID.String,
-						ResourceType: storage.ListAlert_ResourceType(resourceType.Int32),
-					}
-					la.Entity = &storage.ListAlert_Resource{
-						Resource: &storage.ListAlert_ResourceEntity{
-							Name: resourceName.String,
-						},
-					}
-				case storage.Alert_NODE:
-					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
-						ClusterName:  clusterName.String,
-						ClusterId:    clusterID.String,
-						ResourceType: storage.ListAlert_NODE,
-					}
-					la.Entity = &storage.ListAlert_Node{
-						Node: &storage.ListAlert_NodeEntity{
-							Name: nodeName.String,
-						},
-					}
-				}
-
-				listAlerts = append(listAlerts, la)
+				listAlerts = append(listAlerts, sc.Build())
 				return nil
 			},
 		})
@@ -669,117 +562,12 @@ func (ds *datastoreImpl) WalkAll(ctx context.Context, fn func(*storage.ListAlert
 	q := searchCommon.EmptyQuery()
 	q.Selects = listAlertSelectProtos
 
-	var (
-		id                 pgtype.Text
-		lifecycleStage     pgtype.Int4
-		violationTime      pgtype.Timestamp
-		state              pgtype.Int4
-		policyID           pgtype.Text
-		policyName         pgtype.Text
-		severity           pgtype.Int4
-		description        pgtype.Text
-		categories         pgtype.FlatArray[string]
-		enforcementAction  pgtype.Int4
-		enforcementCount   pgtype.Int4
-		entityType         pgtype.Int4
-		clusterID          pgtype.Text
-		clusterName        pgtype.Text
-		namespace          pgtype.Text
-		namespaceID        pgtype.Text
-		deploymentID       pgtype.Text
-		deploymentName     pgtype.Text
-		deploymentType     pgtype.Text
-		deploymentInactive pgtype.Bool
-		nodeID             pgtype.Text
-		nodeName           pgtype.Text
-		resourceName       pgtype.Text
-		resourceType       pgtype.Int4
-	)
-
-	dests := []any{
-		&id, &lifecycleStage, &violationTime, &state,
-		&policyID, &policyName, &severity, &description, &categories,
-		&enforcementAction, &enforcementCount, &entityType,
-		&clusterID, &clusterName, &namespace, &namespaceID,
-		&deploymentID, &deploymentName, &deploymentType, &deploymentInactive,
-		&nodeID, &nodeName, &resourceName, &resourceType,
-	}
-
+	var sc alertviews.ListAlertScanner
 	return pgSearch.RunSelectDirectFn(ctx, ds.db, schema.AlertsSchema, q, listAlertArrayFields,
 		&pgSearch.DirectScanConfig{
-			ScanDests: func() []any { return dests },
+			ScanDests: sc.Dests,
 			OnRow: func() error {
-				la := &storage.ListAlert{
-					Id:             id.String,
-					LifecycleStage: storage.LifecycleStage(lifecycleStage.Int32),
-					State:          storage.ViolationState(state.Int32),
-					Policy: &storage.ListAlertPolicy{
-						Id:          policyID.String,
-						Name:        policyName.String,
-						Severity:    storage.Severity(severity.Int32),
-						Description: description.String,
-						Categories:  []string(categories),
-					},
-					EnforcementAction: storage.EnforcementAction(enforcementAction.Int32),
-				}
-
-				if storage.ViolationState(state.Int32) == storage.ViolationState_ACTIVE {
-					la.EnforcementCount = enforcementCount.Int32
-				}
-
-				if violationTime.Valid {
-					la.Time = protocompat.ConvertTimeToTimestampOrNil(&violationTime.Time)
-				}
-
-				et := storage.Alert_EntityType(entityType.Int32)
-				switch et {
-				case storage.Alert_DEPLOYMENT:
-					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
-						ClusterName:  clusterName.String,
-						ClusterId:    clusterID.String,
-						Namespace:    namespace.String,
-						NamespaceId:  namespaceID.String,
-						ResourceType: storage.ListAlert_DEPLOYMENT,
-					}
-					la.Entity = &storage.ListAlert_Deployment{
-						Deployment: &storage.ListAlertDeployment{
-							Id:             deploymentID.String,
-							Name:           deploymentName.String,
-							ClusterName:    clusterName.String,
-							ClusterId:      clusterID.String,
-							Namespace:      namespace.String,
-							NamespaceId:    namespaceID.String,
-							DeploymentType: deploymentType.String,
-							Inactive:       deploymentInactive.Bool,
-						},
-					}
-				case storage.Alert_RESOURCE:
-					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
-						ClusterName:  clusterName.String,
-						ClusterId:    clusterID.String,
-						Namespace:    namespace.String,
-						NamespaceId:  namespaceID.String,
-						ResourceType: storage.ListAlert_ResourceType(resourceType.Int32),
-					}
-					la.Entity = &storage.ListAlert_Resource{
-						Resource: &storage.ListAlert_ResourceEntity{
-							Name: resourceName.String,
-						},
-					}
-				case storage.Alert_NODE:
-					la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
-						ClusterName:  clusterName.String,
-						ClusterId:    clusterID.String,
-						ResourceType: storage.ListAlert_NODE,
-					}
-					la.Entity = &storage.ListAlert_Node{
-						Node: &storage.ListAlert_NodeEntity{
-							Name: nodeName.String,
-						},
-					}
-				}
-
-				return fn(la)
+				return fn(sc.Build())
 			},
 		})
 }

--- a/central/alert/datastore/datastore_impl_test.go
+++ b/central/alert/datastore/datastore_impl_test.go
@@ -515,6 +515,71 @@ func (s *AlertDatastoreImplSuite) TestSearchListAlerts() {
 	protoassert.Equal(s.T(), expectedListAlert, returnedAlert)
 }
 
+// TestSearchListAlertsEntityTypes verifies that the projection-based SearchListAlerts
+// correctly handles deployment, resource, and node entity types, including
+// deployment_type, enforcement_count, and categories.
+func (s *AlertDatastoreImplSuite) TestSearchListAlertsEntityTypes() {
+	// 1. Deployment alert with deployment_type and enforcement.
+	deployAlert := fixtures.GetAlert()
+	deployAlert.Id = fixtureconsts.Deployment1
+	deployAlert.GetDeployment().Type = "DaemonSet"
+	deployAlert.EntityType = storage.Alert_DEPLOYMENT
+	deployAlert.PlatformComponent = false
+	deployAlert.Enforcement = &storage.Alert_Enforcement{
+		Action: storage.EnforcementAction_SCALE_TO_ZERO_ENFORCEMENT,
+	}
+	s.matcher.EXPECT().MatchAlert(gomock.Any()).Return(false, nil)
+	s.createAndTrackAlert(deployAlert)
+
+	// 2. Resource alert.
+	resourceAlert := fixtures.GetResourceAlert()
+	resourceAlert.Id = fixtureconsts.Deployment2
+	resourceAlert.EntityType = storage.Alert_RESOURCE
+	resourceAlert.PlatformComponent = false
+	s.matcher.EXPECT().MatchAlert(gomock.Any()).Return(false, nil)
+	s.createAndTrackAlert(resourceAlert)
+
+	// 3. Node alert.
+	nodeAlert := fixtures.GetScopedNodeAlert(fixtureconsts.Deployment3, fixtureconsts.Cluster1, fixtureconsts.Node1, "test-node")
+	nodeAlert.EntityType = storage.Alert_NODE
+	nodeAlert.PlatformComponent = false
+	s.matcher.EXPECT().MatchAlert(gomock.Any()).Return(false, nil)
+	s.createAndTrackAlert(nodeAlert)
+
+	// Search all.
+	listAlerts, err := s.datastore.SearchListAlerts(ctx, search.EmptyQuery(), false)
+	s.NoError(err)
+	s.Len(listAlerts, 3)
+
+	// Verify each entity type by comparing with convert.AlertToListAlert.
+	for _, la := range listAlerts {
+		switch la.GetId() {
+		case deployAlert.GetId():
+			expected := convert.AlertToListAlert(deployAlert)
+			s.Equal("DaemonSet", la.GetDeployment().GetDeploymentType())
+			s.Equal(expected.GetEnforcementCount(), la.GetEnforcementCount())
+			s.Equal(expected.GetPolicy().GetCategories(), la.GetPolicy().GetCategories())
+			s.NotNil(la.GetCommonEntityInfo())
+			s.Equal(storage.ListAlert_DEPLOYMENT, la.GetCommonEntityInfo().GetResourceType())
+
+		case resourceAlert.GetId():
+			s.NotNil(la.GetResource())
+			s.Equal(resourceAlert.GetResource().GetName(), la.GetResource().GetName())
+			s.NotNil(la.GetCommonEntityInfo())
+			s.Equal(storage.ListAlert_ResourceType(storage.Alert_Resource_SECRETS), la.GetCommonEntityInfo().GetResourceType())
+
+		case nodeAlert.GetId():
+			s.NotNil(la.GetNode())
+			s.Equal("test-node", la.GetNode().GetName())
+			s.NotNil(la.GetCommonEntityInfo())
+			s.Equal(nodeAlert.GetClusterName(), la.GetCommonEntityInfo().GetClusterName())
+
+		default:
+			s.Failf("unexpected alert ID", "got %s", la.GetId())
+		}
+	}
+}
+
 // TestCountAlerts tests the CountAlerts functionality
 func (s *AlertDatastoreImplSuite) TestCountAlerts() {
 	// Create some active alerts using Alert constants

--- a/central/alert/datastore/datastore_impl_test.go
+++ b/central/alert/datastore/datastore_impl_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stackrox/rox/central/alert/datastore/internal/store/postgres"
 	alertviews "github.com/stackrox/rox/central/alert/views"
@@ -18,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/suite"
@@ -512,6 +514,10 @@ func (s *AlertDatastoreImplSuite) TestSearchListAlerts() {
 	s.NotNil(matchingCreatedAlert, "Should find matching created alert")
 
 	expectedListAlert := convert.AlertToListAlert(matchingCreatedAlert)
+	// PostgreSQL timestamps have microsecond precision, so round both
+	// sides to microseconds before comparing.
+	expectedListAlert.Time = protoutils.RoundTimestamp(expectedListAlert.GetTime(), time.Microsecond)
+	returnedAlert.Time = protoutils.RoundTimestamp(returnedAlert.GetTime(), time.Microsecond)
 	protoassert.Equal(s.T(), expectedListAlert, returnedAlert)
 }
 

--- a/central/alert/views/list_alert_scanner.go
+++ b/central/alert/views/list_alert_scanner.go
@@ -1,0 +1,128 @@
+package views
+
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/protocompat"
+)
+
+var log = logging.LoggerForModule()
+
+// ListAlertScanner holds pgtype scan destinations for the column projection
+// query and converts scanned values into a *storage.ListAlert.
+type ListAlertScanner struct {
+	ID                 pgtype.Text
+	LifecycleStage     pgtype.Int4
+	ViolationTime      pgtype.Timestamp
+	State              pgtype.Int4
+	PolicyID           pgtype.Text
+	PolicyName         pgtype.Text
+	Severity           pgtype.Int4
+	Description        pgtype.Text
+	Categories         pgtype.FlatArray[string]
+	EnforcementAction  pgtype.Int4
+	EnforcementCount   pgtype.Int4
+	EntityType         pgtype.Int4
+	ClusterID          pgtype.Text
+	ClusterName        pgtype.Text
+	Namespace          pgtype.Text
+	NamespaceID        pgtype.Text
+	DeploymentID       pgtype.Text
+	DeploymentName     pgtype.Text
+	DeploymentType     pgtype.Text
+	DeploymentInactive pgtype.Bool
+	NodeID             pgtype.Text
+	NodeName           pgtype.Text
+	ResourceName       pgtype.Text
+	ResourceType       pgtype.Int4
+}
+
+// Dests returns scan destination pointers in the order matching listAlertSelectProtos.
+func (s *ListAlertScanner) Dests() []any {
+	return []any{
+		&s.ID, &s.LifecycleStage, &s.ViolationTime, &s.State,
+		&s.PolicyID, &s.PolicyName, &s.Severity, &s.Description, &s.Categories,
+		&s.EnforcementAction, &s.EnforcementCount, &s.EntityType,
+		&s.ClusterID, &s.ClusterName, &s.Namespace, &s.NamespaceID,
+		&s.DeploymentID, &s.DeploymentName, &s.DeploymentType, &s.DeploymentInactive,
+		&s.NodeID, &s.NodeName, &s.ResourceName, &s.ResourceType,
+	}
+}
+
+// Build converts the scanned column values into a *storage.ListAlert.
+func (s *ListAlertScanner) Build() *storage.ListAlert {
+	la := &storage.ListAlert{
+		Id:             s.ID.String,
+		LifecycleStage: storage.LifecycleStage(s.LifecycleStage.Int32),
+		State:          storage.ViolationState(s.State.Int32),
+		Policy: &storage.ListAlertPolicy{
+			Id:          s.PolicyID.String,
+			Name:        s.PolicyName.String,
+			Severity:    storage.Severity(s.Severity.Int32),
+			Description: s.Description.String,
+			Categories:  []string(s.Categories),
+		},
+		EnforcementAction: storage.EnforcementAction(s.EnforcementAction.Int32),
+	}
+
+	if storage.ViolationState(s.State.Int32) == storage.ViolationState_ACTIVE {
+		la.EnforcementCount = s.EnforcementCount.Int32
+	}
+
+	if s.ViolationTime.Valid {
+		la.Time = protocompat.ConvertTimeToTimestampOrNil(&s.ViolationTime.Time)
+	}
+
+	et := storage.Alert_EntityType(s.EntityType.Int32)
+	switch et {
+	case storage.Alert_DEPLOYMENT:
+		la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
+			ClusterName:  s.ClusterName.String,
+			ClusterId:    s.ClusterID.String,
+			Namespace:    s.Namespace.String,
+			NamespaceId:  s.NamespaceID.String,
+			ResourceType: storage.ListAlert_DEPLOYMENT,
+		}
+		la.Entity = &storage.ListAlert_Deployment{
+			Deployment: &storage.ListAlertDeployment{
+				Id:             s.DeploymentID.String,
+				Name:           s.DeploymentName.String,
+				ClusterName:    s.ClusterName.String,
+				ClusterId:      s.ClusterID.String,
+				Namespace:      s.Namespace.String,
+				NamespaceId:    s.NamespaceID.String,
+				DeploymentType: s.DeploymentType.String,
+				Inactive:       s.DeploymentInactive.Bool,
+			},
+		}
+	case storage.Alert_RESOURCE:
+		la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
+			ClusterName:  s.ClusterName.String,
+			ClusterId:    s.ClusterID.String,
+			Namespace:    s.Namespace.String,
+			NamespaceId:  s.NamespaceID.String,
+			ResourceType: storage.ListAlert_ResourceType(s.ResourceType.Int32),
+		}
+		la.Entity = &storage.ListAlert_Resource{
+			Resource: &storage.ListAlert_ResourceEntity{
+				Name: s.ResourceName.String,
+			},
+		}
+	case storage.Alert_NODE:
+		la.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
+			ClusterName:  s.ClusterName.String,
+			ClusterId:    s.ClusterID.String,
+			ResourceType: storage.ListAlert_NODE,
+		}
+		la.Entity = &storage.ListAlert_Node{
+			Node: &storage.ListAlert_NodeEntity{
+				Name: s.NodeName.String,
+			},
+		}
+	default:
+		log.Warnf("alert %s has unhandled entity type %d, skipping entity info", s.ID.String, s.EntityType.Int32)
+	}
+
+	return la
+}

--- a/central/alert/views/list_alert_scanner.go
+++ b/central/alert/views/list_alert_scanner.go
@@ -113,6 +113,11 @@ func (s *ListAlertScanner) Build() *storage.ListAlert {
 		la.Time = protocompat.ConvertTimeToTimestampOrNil(&s.ViolationTime.Time)
 	}
 
+	if !s.EntityType.Valid {
+		log.Warnf("alert %s has NULL entity type, skipping entity info", s.ID.String)
+		return la
+	}
+
 	et := storage.Alert_EntityType(s.EntityType.Int32)
 	switch et {
 	case storage.Alert_DEPLOYMENT:

--- a/central/alert/views/list_alert_scanner.go
+++ b/central/alert/views/list_alert_scanner.go
@@ -2,12 +2,51 @@ package views
 
 import (
 	"github.com/jackc/pgx/v5/pgtype"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/search"
 )
 
-var log = logging.LoggerForModule()
+var (
+	log = logging.LoggerForModule()
+
+	// ListAlertSelectProtos defines the column projections for ListAlert queries.
+	// Order must match the scan destinations in ListAlertScanner.Dests.
+	ListAlertSelectProtos = []*v1.QuerySelect{
+		search.NewQuerySelect(search.AlertID).Proto(),
+		search.NewQuerySelect(search.LifecycleStage).Proto(),
+		search.NewQuerySelect(search.ViolationTime).Proto(),
+		search.NewQuerySelect(search.ViolationState).Proto(),
+		search.NewQuerySelect(search.PolicyID).Proto(),
+		search.NewQuerySelect(search.PolicyName).Proto(),
+		search.NewQuerySelect(search.Severity).Proto(),
+		search.NewQuerySelect(search.Description).Proto(),
+		search.NewQuerySelect(search.Category).Proto(),
+		search.NewQuerySelect(search.EnforcementAction).Proto(),
+		search.NewQuerySelect(search.EnforcementCount).Proto(),
+		search.NewQuerySelect(search.EntityType).Proto(),
+		search.NewQuerySelect(search.ClusterID).Proto(),
+		search.NewQuerySelect(search.Cluster).Proto(),
+		search.NewQuerySelect(search.Namespace).Proto(),
+		search.NewQuerySelect(search.NamespaceID).Proto(),
+		search.NewQuerySelect(search.DeploymentID).Proto(),
+		search.NewQuerySelect(search.DeploymentName).Proto(),
+		search.NewQuerySelect(search.DeploymentType).Proto(),
+		search.NewQuerySelect(search.Inactive).Proto(),
+		search.NewQuerySelect(search.NodeID).Proto(),
+		search.NewQuerySelect(search.Node).Proto(),
+		search.NewQuerySelect(search.ResourceName).Proto(),
+		search.NewQuerySelect(search.ResourceType).Proto(),
+	}
+
+	// ListAlertArrayFields tells the query builder that "category" is a
+	// parent-table array column, not a child table requiring a JOIN.
+	ListAlertArrayFields = map[string]bool{
+		"category": true,
+	}
+)
 
 // ListAlertScanner holds pgtype scan destinations for the column projection
 // query and converts scanned values into a *storage.ListAlert.

--- a/central/alert/views/list_alert_scanner_test.go
+++ b/central/alert/views/list_alert_scanner_test.go
@@ -1,0 +1,52 @@
+package views
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListAlertSelectProtosMatchDests(t *testing.T) {
+	var sc ListAlertScanner
+	dests := sc.Dests()
+
+	require.Equal(t, len(ListAlertSelectProtos), len(dests),
+		"ListAlertSelectProtos and Dests() must have the same length")
+
+	expectedOrder := []search.FieldLabel{
+		search.AlertID,
+		search.LifecycleStage,
+		search.ViolationTime,
+		search.ViolationState,
+		search.PolicyID,
+		search.PolicyName,
+		search.Severity,
+		search.Description,
+		search.Category,
+		search.EnforcementAction,
+		search.EnforcementCount,
+		search.EntityType,
+		search.ClusterID,
+		search.Cluster,
+		search.Namespace,
+		search.NamespaceID,
+		search.DeploymentID,
+		search.DeploymentName,
+		search.DeploymentType,
+		search.Inactive,
+		search.NodeID,
+		search.Node,
+		search.ResourceName,
+		search.ResourceType,
+	}
+
+	require.Equal(t, len(expectedOrder), len(ListAlertSelectProtos),
+		"expectedOrder must match ListAlertSelectProtos length")
+
+	for i, sel := range ListAlertSelectProtos {
+		assert.Equal(t, expectedOrder[i].String(), sel.GetField().GetName(),
+			"ListAlertSelectProtos[%d] field name mismatch", i)
+	}
+}

--- a/generated/storage/alert.pb.go
+++ b/generated/storage/alert.pb.go
@@ -1406,7 +1406,7 @@ func (x *Alert_ProcessViolation) GetProcesses() []*ProcessIndicator {
 
 type Alert_Enforcement struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Action        EnforcementAction      `protobuf:"varint,1,opt,name=action,proto3,enum=storage.EnforcementAction" json:"action,omitempty" search:"Enforcement"` // @gotags: search:"Enforcement"
+	Action        EnforcementAction      `protobuf:"varint,1,opt,name=action,proto3,enum=storage.EnforcementAction" json:"action,omitempty" search:"Enforcement Action"` // @gotags: search:"Enforcement Action"
 	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/pkg/env/list_alert.go
+++ b/pkg/env/list_alert.go
@@ -1,0 +1,9 @@
+package env
+
+var (
+	// ListAlertUseLegacyQuery controls whether SearchListAlerts and WalkAll
+	// use the legacy blob deserialization path instead of the optimized column
+	// projection path. Set to true to revert to the old behavior if the
+	// projection path causes issues.
+	ListAlertUseLegacyQuery = RegisterBooleanSetting("ROX_LIST_ALERT_LEGACY_QUERY", false)
+)

--- a/pkg/env/list_alert.go
+++ b/pkg/env/list_alert.go
@@ -1,9 +1,6 @@
 package env
 
 var (
-	// ListAlertUseLegacyQuery controls whether SearchListAlerts and WalkAll
-	// use the legacy blob deserialization path instead of the optimized column
-	// projection path. Set to true to revert to the old behavior if the
-	// projection path causes issues.
+	// ListAlertUseLegacyQuery reverts SearchListAlerts and WalkAll to blob deserialization.
 	ListAlertUseLegacyQuery = RegisterBooleanSetting("ROX_LIST_ALERT_LEGACY_QUERY", false)
 )

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -40,6 +40,7 @@ var (
 
 	PolicyID           = newFieldLabel("Policy ID")
 	Enforcement        = newFieldLabel("Enforcement")
+	EnforcementAction  = newFieldLabel("Enforcement Action")
 	EnforcementCount   = newFieldLabel("Enforcement Count")
 	PolicyName         = newFieldLabel("Policy")
 	PolicyCategoryName = newFieldLabel("Policy Category")

--- a/proto/storage/alert.proto
+++ b/proto/storage/alert.proto
@@ -110,7 +110,7 @@ message Alert {
   }
 
   message Enforcement {
-    storage.EnforcementAction action = 1; // @gotags: search:"Enforcement"
+    storage.EnforcementAction action = 1; // @gotags: search:"Enforcement Action"
     string message = 2;
   }
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

ROX-32721: Switch SearchListAlerts and WalkAll to column projection

Replace the blob deserialization path (GetByQueryFn + AlertToListAlert)
with direct column projection via RunSelectDirectFn. All 24 ListAlert
fields are now read from indexed columns using pgtype value types,
avoiding both protobuf deserialization and scany reflection overhead.

Benchmarks show 2-3x latency improvement and ~8x memory reduction
compared to the blob-based approach.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


  1. End-to-end — the production SearchListAlerts path, legacy vs projection. The headline numbers at 5k alerts: 2.5x faster, 8.4x less memory.                                     
  2. PostgreSQL I/O — raw scan cost isolated from Go object construction. Shows the projection transfers 4.1x less data but has slightly higher scan latency due to more columns.
  3. EXPLAIN ANALYZE — the smoking gun: blob rows are too wide for work_mem, forcing a disk spill. Projection stays in-memory. 2.9x faster on the DB side alone.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

  End-to-End: Legacy Blob Deserialization vs 24-Column Projection                                                                                                               
                                                     
  | Alerts | Query | Metric | Legacy (blob) | Projection | Improvement |                                                                                                            
  |--------|-------|--------|---------------|------------|-------------|                                                                                                            
  | 100 | all | latency | 496µs | 226µs | **2.2x** |                                                                                                                                
  | | | memory | 902KB | 147KB | **6.1x** |                             
  | | | allocs | 10974 | 2560 | **4.3x** |
  | 100 | by deployment | latency | 139µs | 149µs | **0.9x** |                                                                                                                      
  | | | memory | 206KB | 80KB | **2.6x** |                                                                                                                                          
  | | | allocs | 2481 | 1217 | **2.0x** |                                                                                                                                           
  | 100 | by policy+state | latency | 149µs | 123µs | **1.2x** |                                                                                                                    
  | | | memory | 222KB | 61KB | **3.6x** |                                                                                                                                          
  | | | allocs | 2707 | 831 | **3.3x** |                                                                                                                                            
  | 1000 | all | latency | 4.6ms | 1.8ms | **2.6x** |                                                                                                                               
  | | | memory | 9.8MB | 1.2MB | **8.2x** |                             
  | | | allocs | 119247 | 23247 | **5.1x** |                                                                                                                                        
  | 1000 | by deployment | latency | 1.3ms | 720µs | **1.8x** |                                                                                                                     
  | | | memory | 2.6MB | 359KB | **7.2x** |                                                                                                                                         
  | | | allocs | 30867 | 6679 | **4.6x** |                                                                                                                                          
  | 1000 | by policy+state | latency | 1.0ms | 642µs | **1.6x** |                                                                                                                   
  | | | memory | 2.0MB | 265KB | **7.6x** |                                                                                                                                         
  | | | allocs | 24401 | 5001 | **4.9x** |                              
  | 5000 | all | latency | 24.4ms | 9.9ms | **2.5x** |                                                                                                                              
  | | | memory | 54.4MB | 6.5MB | **8.4x** |                                                                                                                                        
  | | | allocs | 660160 | 126788 | **5.2x** |                                                                                                                                       
  | 5000 | by deployment | latency | 6.8ms | 3.9ms | **1.8x** |                                                                                                                     
  | | | memory | 15.4MB | 1.8MB | **8.6x** |                                                                                                                                        
  | | | allocs | 184933 | 34802 | **5.3x** |                                                                                                                                        
  | 5000 | by policy+state | latency | 5.1ms | 3.3ms | **1.5x** |                                                                                                                   
  | | | memory | 11.1MB | 1.3MB | **8.5x** |                                                                                                                                        
  | | | allocs | 134959 | 26084 | **5.2x** |                                                                                                                                        
                                                                                                                                                                                    
  _Median of 5 runs, `-benchmem -count 5`, local PostgreSQL 15, 12-core Apple M2 Max._                                                                                              
                                                                                                                                                                                    
  ### PostgreSQL I/O: Blob vs 24-Column Projection (raw scan, no Go object construction)                                                                                            
                                                                        
  | Alerts | Strategy | Latency | Transfer | Allocs |                                                                                                                               
  |--------|----------|---------|----------|--------|                   
  | 1000 | SELECT id + serialized (legacy) | 1.7ms | 1.8MB | 5020 |                                                                                                                 
  | 1000 | SELECT 24 columns / pgtype (projection) | 1.9ms | 449KB | 14717 |                                                                                                        
  | | **delta** | **0.9x** | **4.1x** | |                                                                                                                                           
  | 5000 | SELECT id + serialized (legacy) | 6.0ms | 10.9MB | 30020 |                                                                                                               
  | 5000 | SELECT 24 columns / pgtype (projection) | 7.3ms | 2.7MB | 88248 |                                                                                                        
  | | **delta** | **0.8x** | **4.1x** | |                                                                                                                                           
                                                                                                                                                                                    
  _Median of 3 runs. Measures pure DB execution + wire transfer + row scanning — no protobuf deserialization or ListAlert construction._                                            
                                                                                                                                                                                    
  ### EXPLAIN ANALYZE (6,000 rows, ORDER BY time DESC)                                                                                                                              
                                                                        
  | Metric | SELECT serialized (legacy) | SELECT 24 columns (projection) |                                                                                                          
  |--------|---------------------------|-------------------------------|
  | Row width | 1,532 bytes | 453 bytes |                                                                                                                                           
  | Sort method | external merge (**Disk: 9,112 KB**) | quicksort (**Memory: 2,555 KB**) |
  | Execution time | 10.0ms | 3.5ms |                                                                                                                                               
   
  The blob's wide rows (1,532 B) force PostgreSQL to spill the sort to disk. The projection's narrower rows (453 B) fit in `work_mem`, enabling an in-memory quicksort — **2.9x     
  faster on the database side alone.**  