### PR TITLE
ROX-29577: VM4VM e2e tests

### DIFF
--- a/.openshift-ci/begin.sh
+++ b/.openshift-ci/begin.sh
@@ -26,7 +26,11 @@ fi
 if [[ "${JOB_NAME:-}" =~ -ocp- ]]; then
     info "Setting worker node type and count for OCP 4 jobs"
     set_ci_shared_export WORKER_NODE_COUNT 2
-    set_ci_shared_export WORKER_NODE_TYPE e2-standard-8
+    if [[ "${JOB_NAME:-}" =~ vm-scanning ]]; then
+        set_ci_shared_export WORKER_NODE_TYPE n2-standard-8
+    else
+        set_ci_shared_export WORKER_NODE_TYPE e2-standard-8
+    fi
 fi
 
 if [[ "${JOB_NAME:-}" =~ -eks- ]]; then

--- a/.openshift-ci/ci_tests.py
+++ b/.openshift-ci/ci_tests.py
@@ -235,6 +235,20 @@ class NonGroovyE2e(BaseTest):
         )
 
 
+class VMScanningE2e(BaseTest):
+    TEST_TIMEOUT = 2 * 60 * 60
+    TEST_OUTPUT_DIR = "/tmp/vm-scanning-test-logs"
+
+    def run(self):
+        print("Executing VM scanning e2e tests")
+
+        self.run_with_graceful_kill(
+            ["tests/e2e/run-vm-scanning.sh", self.TEST_OUTPUT_DIR],
+            self.TEST_TIMEOUT,
+            output_dir=self.TEST_OUTPUT_DIR,
+        )
+
+
 class SensorIntegration(BaseTest):
     TEST_TIMEOUT = 90 * 60
     TEST_OUTPUT_DIR = "/tmp/sensor-integration-test-logs"

--- a/.openshift-ci/dispatch.sh
+++ b/.openshift-ci/dispatch.sh
@@ -31,7 +31,8 @@ ci_export CI_JOB_NAME "$ci_job"
 
 case "$ci_job" in
     gke*qa-e2e-tests|gke*nongroovy-e2e-tests|gke*upgrade-tests|gke-ui-e2e-tests|\
-    eks-qa-e2e-tests|osd*qa-e2e-tests|gke*sensor-integration-tests)
+    eks-qa-e2e-tests|osd*qa-e2e-tests|gke*sensor-integration-tests|\
+    ocp*vm-scanning-e2e-tests)
         openshift_ci_e2e_mods
         ;;
     *-operator-e2e-tests)
@@ -40,7 +41,8 @@ case "$ci_job" in
 esac
 
 case "$ci_job" in
-    eks-qa-e2e-tests|osd*qa-e2e-tests|ocp*ui-e2e-tests)
+    eks-qa-e2e-tests|osd*qa-e2e-tests|ocp*ui-e2e-tests|\
+    ocp*vm-scanning-e2e-tests)
         setup_automation_flavor_e2e_cluster "$ci_job"
         ;;
 esac

--- a/scripts/ci/jobs/ocp_vm_scanning_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_vm_scanning_e2e_tests.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env -S python3 -u
+
+"""
+Run VM scanning E2E tests on an OpenShift cluster with CNV / KubeVirt and VSOCK enabled.
+
+The CNV operator is installed automatically when INSTALL_CNV_OPERATOR=true (set below).
+If already present on the cluster, the existing installation is reused.
+VSOCK prerequisites are verified at Go test startup (mustVerifyClusterVSOCKReady) and the
+suite fails fast with actionable diagnostics if they are not met.
+"""
+import os
+
+from runners import ClusterTestRunner
+from clusters import AutomationFlavorsCluster
+from pre_tests import PreSystemTests
+from ci_tests import VMScanningE2e
+from post_tests import PostClusterTest, FinalPost
+
+os.environ["DEPLOY_STACKROX_VIA_OPERATOR"] = "true"
+os.environ["ORCHESTRATOR_FLAVOR"] = "openshift"
+os.environ["SENSOR_SCANNER_SUPPORT"] = "true"
+os.environ["ROX_DEPLOY_SENSOR_WITH_CRS"] = "true"
+os.environ["SENSOR_HELM_MANAGED"] = "true"
+os.environ["INSTALL_CNV_OPERATOR"] = "true"
+os.environ["ROX_VIRTUAL_MACHINES"] = "true"
+os.environ["ROX_SCANNER_V4"] = "true"
+# TODO: Move images to quay.io/rhacs-eng/ before merging to main.
+os.environ["VM_IMAGE_RHEL9"] = "quay.io/prygiels/rhel9-dnf-primed:latest"
+os.environ["VM_IMAGE_RHEL10"] = "quay.io/prygiels/rhel10-dnf-primed:latest"
+
+
+class VMScanningPostTest(PostClusterTest):
+    """Extends standard post-test with CNV namespace logs and VM artifacts."""
+
+    VM_ARTIFACTS_DIR = "/tmp/vm-scanning-artifacts"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.k8s_namespaces.extend([
+            "openshift-cnv",
+        ])
+
+    def run(self, test_outputs=None):
+        self.collect_vm_artifacts()
+        super().run(test_outputs=test_outputs)
+
+    def collect_vm_artifacts(self):
+        """Collect VM/VMI descriptions and events from test namespaces."""
+        artifacts_dir = self.VM_ARTIFACTS_DIR
+        os.makedirs(artifacts_dir, exist_ok=True)
+        for resource in [
+            "vm", "vmi", "datavolume",
+        ]:
+            self.run_with_best_effort(
+                [
+                    "bash", "-c",
+                    f"kubectl get {resource} --all-namespaces -o wide "
+                    f"> {artifacts_dir}/{resource}-list.txt 2>&1 || true; "
+                    f"kubectl describe {resource} --all-namespaces "
+                    f"> {artifacts_dir}/{resource}-describe.txt 2>&1 || true",
+                ],
+                timeout=self.COLLECT_TIMEOUT,
+            )
+        self.run_with_best_effort(
+            [
+                "bash", "-c",
+                f"kubectl get events --all-namespaces "
+                f"--field-selector involvedObject.kind=VirtualMachineInstance "
+                f"> {artifacts_dir}/vmi-events.txt 2>&1 || true",
+            ],
+            timeout=self.COLLECT_TIMEOUT,
+        )
+        self.data_to_store.append(artifacts_dir)
+
+
+ClusterTestRunner(
+    cluster=AutomationFlavorsCluster(),
+    pre_test=PreSystemTests(),
+    test=VMScanningE2e(),
+    post_test=VMScanningPostTest(
+        check_stackrox_logs=False,
+    ),
+    final_post=FinalPost(),
+).run()

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Required to start:
+# - Create a new OCP cluster
+# - install virtualization operator
+# - set KUBECONFIG
+# - Deploy ACS
+# - Enable ROX_VIRTUAL_MACHINES
+
+# Deployment behavior (matches CI lane intent)
+export ORCHESTRATOR_FLAVOR=openshift
+export DEPLOY_STACKROX_VIA_OPERATOR=true
+export SENSOR_SCANNER_SUPPORT=true
+export ROX_DEPLOY_SENSOR_WITH_CRS=true
+export SENSOR_HELM_MANAGED=true
+export ROX_VIRTUAL_MACHINES=true
+
+# VM-scanning required inputs
+export VIRTCTL_PATH="$(command -v virtctl)"
+export ROXAGENT_BINARY_PATH="$PWD/bin/linux_amd64/roxagent"
+
+# From your cluster's virtualization boot sources:
+# export VM_IMAGE_RHEL9="$(oc get istag -n openshift-virtualization-os-images rhel9-guest:latest -o jsonpath='{.image.dockerImageReference}')"
+export VM_IMAGE_RHEL9="quay.io/prygiels/rhel9-dnf-primed:latest"
+# export VM_IMAGE_RHEL10="$(oc get istag -n openshift-virtualization-os-images rhel10-guest:latest -o jsonpath='{.image.dockerImageReference}')"
+export VM_IMAGE_RHEL10="quay.io/prygiels/rhel10-dnf-primed:latest"
+export VM_IMAGE_PULL_SECRET_PATH="$HOME/.config/containers/auth.json"
+
+# Guest users for RHEL cloud images:
+export VM_GUEST_USER_RHEL9="cloud-user"
+export VM_GUEST_USER_RHEL10="cloud-user"
+
+export API_ENDPOINT="$(oc -n stackrox get route central -o jsonpath='{.spec.host}'):443"
+export ROX_USERNAME="admin"
+export ROX_ADMIN_PASSWORD="admin"
+
+# Persistent, dedicated SSH keypair for VM scanning E2E.
+# Reused across runs so manual troubleshooting can reuse the same key path.
+vm_scan_ssh_key="$HOME/.ssh/id_stackrox_vm_scan_e2e_rsa"
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+if [[ ! -f "$vm_scan_ssh_key" ]]; then
+    ssh-keygen -q -t rsa -b 4096 -N "" -f "$vm_scan_ssh_key" -C "stackrox-vm-scan-e2e" >/dev/null
+fi
+if [[ ! -f "${vm_scan_ssh_key}.pub" ]]; then
+    ssh-keygen -y -f "$vm_scan_ssh_key" > "${vm_scan_ssh_key}.pub"
+fi
+chmod 600 "$vm_scan_ssh_key"
+chmod 644 "${vm_scan_ssh_key}.pub"
+
+export VM_SSH_PRIVATE_KEY="$(cat "$vm_scan_ssh_key")"          # PEM content of the private key
+export VM_SSH_PUBLIC_KEY="$(cat "${vm_scan_ssh_key}.pub")"    # authorized_keys line for cloud-init
+
+
+export ROXAGENT_REPO2CPE_PRIMARY_URL="https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
+export ROXAGENT_REPO2CPE_FALLBACK_URL="https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
+export ROXAGENT_REPO2CPE_PRIMARY_ATTEMPTS=3
+
+export VM_SCAN_NAMESPACE_PREFIX="vm-scan-e2e"
+# TEMPORARY local-dev override: force one namespace across manual runs.
+export VM_SCAN_NAMESPACE="vm-scan-e2e-manual"
+export VM_SCAN_TIMEOUT=20m
+export VM_SCAN_POLL_INTERVAL=10s
+export VM_SCAN_ESCALATION_ATTEMPT=5
+export VM_DELETE_TIMEOUT=5m
+export VM_SCAN_SKIP_CLEANUP=true   # keep VMs and namespace after test run for faster iteration
+
+echo "Manual SSH (rhel9):"
+echo "${VIRTCTL_PATH} ssh -n ${VM_SCAN_NAMESPACE} --identity-file \"${vm_scan_ssh_key}\" --username \"${VM_GUEST_USER_RHEL9}\" vmi/vm-rhel9"
+echo
+echo "Manual SSH command check (sudo):"
+echo "${VIRTCTL_PATH} ssh -n ${VM_SCAN_NAMESPACE} --identity-file \"${vm_scan_ssh_key}\" --username \"${VM_GUEST_USER_RHEL9}\" vmi/vm-rhel9 --command '\"sudo\" \"-n\" \"true\"'"
+echo
+echo "Building roxagent..."
+make roxagent_linux-amd64
+echo
+echo "Running vmhelpers tests..."
+go test -race -p 1 -timeout 90m ./tests/vmhelpers -v
+echo
+echo "Running unit tests..."
+go test -tags test -race -count=1 -v ./tests/testmetrics
+go test -tags test_e2e ./tests -run TestLoadVMScanConfig -v
+echo
+echo "Running vmscanning tests..."
+go test -tags test_e2e -run TestVMScanning -v -count=1 -p 1 -timeout 120m ./tests
+
+echo "Done!"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -33,4 +33,16 @@ compliance-v2-tests:
 	@GOTAGS=$(GOTAGS),test,compliance ../scripts/go-test.sh -timeout 30m -cover -v -run TestComplianceV2 2>&1 | tee test.log
 	@$(MAKE) report JUNIT_OUT=compliance-v2-tests-results
 
+.PHONY: vm-scanning-unit-tests
+vm-scanning-unit-tests:
+	@echo "+ $@"
+	@GOTAGS=$(GOTAGS),test $(TOPLEVEL)/scripts/go-test.sh -cover $(TESTFLAGS) -v ./vmhelpers ./testmetrics 2>&1 | tee test.log
+	@$(MAKE) report JUNIT_OUT=vm-scanning-unit-tests-results
+
+.PHONY: vm-scanning-tests
+vm-scanning-tests:
+	@echo "+ $@"
+	@GOTAGS=$(GOTAGS),test,test_e2e $(TOPLEVEL)/scripts/go-test.sh -cover $(TESTFLAGS) -v -run 'TestVMScanning|TestLoadVMScanConfig' $(shell go list -e ./... | grep -v generated | grep -v vendor | grep -v vmhelpers) 2>&1 | tee test.log
+	@$(MAKE) report JUNIT_OUT=vm-scanning-tests-results
+
 include ../make/stackrox.mk

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -374,6 +374,10 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_INIT_CONTAINER_SUPPORT'
     customize_envVars+=$'\n        value: "true"'
+    if [[ "${ROX_VIRTUAL_MACHINES:-}" == "true" ]]; then
+        customize_envVars+=$'\n      - name: ROX_VIRTUAL_MACHINES'
+        customize_envVars+=$'\n        value: "true"'
+    fi
 
     local scannerV4ScannerComponent="Default"
     case "${ROX_SCANNER_V4:-}" in
@@ -486,6 +490,10 @@ deploy_sensor_via_operator() {
     fi
 
     customize_envVars=""
+    if [[ "${ROX_VIRTUAL_MACHINES:-}" == "true" ]]; then
+        customize_envVars+=$'\n    - name: ROX_VIRTUAL_MACHINES'
+        customize_envVars+=$'\n      value: "true"'
+    fi
     if [[ -n "${ROX_NETFLOW_BATCHING:-}" ]]; then
         customize_envVars+=$'\n    - name: ROX_NETFLOW_BATCHING'
         customize_envVars+=$'\n      value: "'"${ROX_NETFLOW_BATCHING}"'"'
@@ -572,6 +580,12 @@ deploy_optional_e2e_components() {
     else
         info "Skipping the compliance operator install"
     fi
+
+    if [[ "${INSTALL_CNV_OPERATOR:-false}" == "true" ]]; then
+        install_the_cnv_operator
+    else
+        info "Skipping the CNV operator install"
+    fi
 }
 
 install_the_compliance_operator() {
@@ -592,6 +606,63 @@ install_the_compliance_operator() {
 
     wait_for_profile_bundles_to_be_ready
     oc get csv -n openshift-compliance
+}
+
+install_the_cnv_operator() {
+    local csv
+    csv=$(oc get csv -n openshift-cnv -o json 2>/dev/null | jq -r '.items[] | select(.metadata.name | test("kubevirt-hyperconverged")).metadata.name // empty')
+    if [[ -z "$csv" ]]; then
+        info "Installing the OpenShift Virtualization (CNV) operator"
+        oc apply -f "${ROOT}/tests/e2e/yaml/cnv-operator/namespace.yaml"
+        oc apply -f "${ROOT}/tests/e2e/yaml/cnv-operator/operator-group.yaml"
+        oc apply -f "${ROOT}/tests/e2e/yaml/cnv-operator/subscription.yaml"
+        info "Waiting for CNV operator deployment (this may take several minutes)..."
+        wait_for_object_to_appear openshift-cnv deploy/hco-operator 900
+        oc rollout status deploy/hco-operator -n openshift-cnv --timeout=300s
+        info "Creating HyperConverged CR..."
+        oc apply -f "${ROOT}/tests/e2e/yaml/cnv-operator/hyperconverged.yaml"
+        info "Waiting for virt-operator deployment..."
+        wait_for_object_to_appear openshift-cnv deploy/virt-operator 600
+        oc rollout status deploy/virt-operator -n openshift-cnv --timeout=300s
+        info "Waiting for virt-handler daemonset..."
+        wait_for_object_to_appear openshift-cnv ds/virt-handler 600
+        oc rollout status ds/virt-handler -n openshift-cnv --timeout=600s
+    else
+        info "Reusing existing CNV operator deployment from $csv subscription"
+    fi
+
+    # Ensure VSOCK feature gate via annotation on the HyperConverged CR.
+    # The HC operator reconciles the KubeVirt CR, so patching KubeVirt
+    # directly is ephemeral. The jsonpatch annotation is the supported way
+    # to inject custom feature gates into the managed KubeVirt CR.
+    local vsock_patch='[{"op":"add","path":"/spec/configuration/developerConfiguration/featureGates/-","value":"VSOCK"}]'
+    local kv_gates
+    kv_gates=$(oc get kubevirt -n openshift-cnv \
+        -o jsonpath='{.items[0].spec.configuration.developerConfiguration.featureGates}' 2>/dev/null || true)
+    if [[ "$kv_gates" != *"VSOCK"* ]]; then
+        info "Annotating HyperConverged CR to add VSOCK feature gate..."
+        oc annotate hyperconverged kubevirt-hyperconverged -n openshift-cnv --overwrite \
+            "kubevirt.kubevirt.io/jsonpatch=${vsock_patch}"
+        info "Waiting for VSOCK to appear in KubeVirt CR feature gates..."
+        local attempts=0
+        while (( attempts < 60 )); do
+            kv_gates=$(oc get kubevirt -n openshift-cnv \
+                -o jsonpath='{.items[0].spec.configuration.developerConfiguration.featureGates}' 2>/dev/null || true)
+            if [[ "$kv_gates" == *"VSOCK"* ]]; then
+                break
+            fi
+            (( attempts++ ))
+            sleep 5
+        done
+        if [[ "$kv_gates" != *"VSOCK"* ]]; then
+            die "KubeVirt CR still missing VSOCK after 5 minutes"
+        fi
+        info "Waiting for virt-handler rollout after VSOCK enablement..."
+        oc rollout status ds/virt-handler -n openshift-cnv --timeout=600s
+    else
+        info "KubeVirt CR already has VSOCK feature gate"
+    fi
+    oc get csv -n openshift-cnv
 }
 
 setup_client_CA_auth_provider() {

--- a/tests/e2e/run-vm-scanning.sh
+++ b/tests/e2e/run-vm-scanning.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/lib.sh
+source "$ROOT/scripts/lib.sh"
+# shellcheck source=../../scripts/ci/sensor-wait.sh
+source "$ROOT/scripts/ci/sensor-wait.sh"
+# shellcheck source=../../tests/scripts/setup-certs.sh
+source "$ROOT/tests/scripts/setup-certs.sh"
+# shellcheck source=../../tests/e2e/lib.sh
+source "$ROOT/tests/e2e/lib.sh"
+# shellcheck source=../../tests/e2e/vm-scanning-lib.sh
+source "$ROOT/tests/e2e/vm-scanning-lib.sh"
+
+test_vm_scanning_e2e() {
+    local output_dir="${1:-vm-scanning-tests-results}"
+
+    info "Starting VM scanning e2e tests"
+
+    export_test_environment
+    setup_deployment_env true false
+    ensure_vm_scanning_cluster_prereqs
+    remove_existing_stackrox_resources
+    setup_default_TLS_certs
+
+    deploy_optional_e2e_components
+
+    verify_kvm_available
+    ensure_virtctl
+
+    deploy_stackrox
+
+    ensure_roxagent
+
+    cd "$ROOT"
+    rm -f FAIL
+    make -C tests TESTFLAGS="-race -p 1 -timeout 90m" vm-scanning-unit-tests || touch FAIL
+    store_test_results "tests/vm-scanning-unit-tests-results" "vm-scanning-unit-tests-results"
+    make -C tests TESTFLAGS="-race -p 1 -timeout 90m" vm-scanning-tests || touch FAIL
+    store_test_results "tests/vm-scanning-tests-results" "$output_dir"
+    [[ ! -f FAIL ]] || die "VM scanning e2e tests failed"
+}
+
+test_vm_scanning_e2e "${1:-vm-scanning-tests-results}"

--- a/tests/e2e/vm-scanning-lib.sh
+++ b/tests/e2e/vm-scanning-lib.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# VM scanning E2E cluster preflight helpers.
+# shellcheck disable=SC1091
+
+_VM_SCANNING_LIB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/lib.sh
+source "$_VM_SCANNING_LIB_ROOT/scripts/lib.sh"
+
+# Ensures VM-scanning E2E required environment variables are set before deploy/tests.
+# Variables with sensible defaults in the Go suite are optional here;
+# only truly external inputs that cannot be self-discovered are required.
+ensure_vm_scanning_cluster_prereqs() {
+    require_environment "KUBECONFIG"
+    require_environment "VM_IMAGE_RHEL9"
+    require_environment "VM_IMAGE_RHEL10"
+
+    # Self-discoverable: virtctl on $PATH, roxagent in build output, SSH keys generated on the fly.
+    # Override via env if the defaults are not suitable for the CI cluster.
+    # VIRTCTL_PATH          - defaults to $(command -v virtctl)
+    # ROXAGENT_BINARY_PATH  - defaults to bin/linux_amd64/roxagent
+    # VM_SSH_PRIVATE_KEY    - PEM content (not a path); ephemeral ed25519 key generated if unset
+    # VM_SSH_PUBLIC_KEY     - authorized_keys line (not a path); generated with private key if unset
+
+}
+
+# Verifies that at least one worker node advertises devices.kubevirt.io/kvm > 0.
+# Must be called after CNV is installed (the device plugin registers the resource).
+verify_kvm_available() {
+    local kvm_capacity
+    kvm_capacity="$(kubectl get nodes -o jsonpath='{.items[*].status.capacity.devices\.kubevirt\.io/kvm}' 2>/dev/null || true)"
+    if [[ -z "$kvm_capacity" ]] || [[ "$kvm_capacity" =~ ^[[:space:]]*0*[[:space:]]*$ ]]; then
+        die "No worker nodes with devices.kubevirt.io/kvm > 0. Nested virtualization may not be enabled on this cluster."
+    fi
+    info "KVM device capacity on nodes: ${kvm_capacity}"
+}
+
+# Downloads virtctl from the cluster's ConsoleCLIDownload if not already on PATH.
+ensure_virtctl() {
+    if command -v virtctl &>/dev/null; then
+        info "virtctl already on PATH: $(command -v virtctl)"
+        return
+    fi
+    local download_url
+    download_url="$(oc get consoleclidownload virtctl-clidownloads-kubevirt-hyperconverged \
+        -o jsonpath='{.spec.links[?(@.text=="Download virtctl for Linux for x86_64")].href}' 2>/dev/null || true)"
+    if [[ -z "$download_url" ]]; then
+        die "virtctl not found on PATH and ConsoleCLIDownload resource not available"
+    fi
+    info "Downloading virtctl from ${download_url}"
+    local dest="/usr/local/bin"
+    if [[ ! -w "$dest" ]]; then
+        dest="$(mktemp -d)"
+        export PATH="${dest}:${PATH}"
+    fi
+    local ca_bundle
+    ca_bundle="$(mktemp)"
+    if oc get configmap -n openshift-config-managed default-ingress-cert \
+            -o jsonpath='{.data.ca-bundle\.crt}' > "$ca_bundle" 2>/dev/null \
+       && [[ -s "$ca_bundle" ]]; then
+        info "Using ingress CA from default-ingress-cert configmap"
+    elif oc get secret -n openshift-ingress-operator router-ca \
+            -o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d > "$ca_bundle" \
+         && [[ -s "$ca_bundle" ]]; then
+        info "Using ingress CA from router-ca secret"
+    else
+        ca_bundle=""
+    fi
+    if [[ -n "$ca_bundle" ]]; then
+        if ! curl -sSL --cacert "$ca_bundle" "$download_url" | tar xz -C "$dest" virtctl; then
+            info "Download with cluster CA failed, retrying without TLS verification"
+            curl -sSLk "$download_url" | tar xz -C "$dest" virtctl
+        fi
+        rm -f "$ca_bundle"
+    else
+        info "Cluster ingress CA not available, skipping TLS verification"
+        curl -sSLk "$download_url" | tar xz -C "$dest" virtctl
+    fi
+    chmod +x "${dest}/virtctl"
+    info "virtctl installed at ${dest}/virtctl"
+}
+
+# Ensures roxagent binary is available. Checks, in order:
+# 1. ROXAGENT_BINARY_PATH already set and executable
+# 2. Default build output at bin/linux_amd64/roxagent
+# 3. Extract from the main container image (built by CI)
+# 4. Build from source as last resort
+# Sets ROXAGENT_BINARY_PATH for the Go test suite.
+ensure_roxagent() {
+    if [[ -n "${ROXAGENT_BINARY_PATH:-}" ]] && [[ -x "${ROXAGENT_BINARY_PATH}" ]]; then
+        info "roxagent already available at ${ROXAGENT_BINARY_PATH}"
+        return
+    fi
+
+    local default_path="${_VM_SCANNING_LIB_ROOT}/bin/linux_amd64/roxagent"
+    if [[ -x "$default_path" ]]; then
+        info "roxagent found at default build path: ${default_path}"
+        export ROXAGENT_BINARY_PATH="$default_path"
+        return
+    fi
+
+    local main_image="${MAIN_IMAGE:-}"
+    if [[ -z "$main_image" ]] && [[ -n "${MAIN_IMAGE_TAG:-}" ]]; then
+        local repo="${MAIN_IMAGE_REPO:-$(make --quiet --no-print-directory -C "$_VM_SCANNING_LIB_ROOT" default-image-registry)/main}"
+        main_image="${repo}:${MAIN_IMAGE_TAG}"
+    fi
+
+    if [[ -n "$main_image" ]]; then
+        local roxagent_dir
+        roxagent_dir="$(mktemp -d)"
+        info "Extracting roxagent from ${main_image}"
+        if oc image extract "${main_image}" --path="/stackrox/bin/roxagent:${roxagent_dir}" --confirm 2>/dev/null; then
+            chmod +x "${roxagent_dir}/roxagent"
+            export ROXAGENT_BINARY_PATH="${roxagent_dir}/roxagent"
+            info "roxagent extracted to ${ROXAGENT_BINARY_PATH}"
+            return
+        fi
+        info "oc image extract failed, falling back to build from source"
+    fi
+
+    info "Building roxagent from source"
+    make -C "$_VM_SCANNING_LIB_ROOT" roxagent_linux-amd64
+    export ROXAGENT_BINARY_PATH="$default_path"
+    info "roxagent built at ${ROXAGENT_BINARY_PATH}"
+}

--- a/tests/e2e/yaml/cnv-operator/hyperconverged.yaml
+++ b/tests/e2e/yaml/cnv-operator/hyperconverged.yaml
@@ -1,0 +1,8 @@
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+  annotations:
+    kubevirt.kubevirt.io/jsonpatch: '[{"op":"add","path":"/spec/configuration/developerConfiguration/featureGates/-","value":"VSOCK"}]'
+spec: {}

--- a/tests/e2e/yaml/cnv-operator/namespace.yaml
+++ b/tests/e2e/yaml/cnv-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cnv

--- a/tests/e2e/yaml/cnv-operator/operator-group.yaml
+++ b/tests/e2e/yaml/cnv-operator/operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kubevirt-hyperconverged-group
+  namespace: openshift-cnv
+spec:
+  targetNamespaces:
+  - openshift-cnv

--- a/tests/e2e/yaml/cnv-operator/subscription.yaml
+++ b/tests/e2e/yaml/cnv-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: hco-operatorhub
+  namespace: openshift-cnv
+spec:
+  channel: stable
+  name: kubevirt-hyperconverged
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/tests/testdata/vm-scanning/cloud-init.yaml.tmpl
+++ b/tests/testdata/vm-scanning/cloud-init.yaml.tmpl
@@ -1,0 +1,6 @@
+#cloud-config
+users:
+  - name: {{ yamlQuote .GuestUser }}
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    ssh_authorized_keys:
+      - {{ yamlQuote .SSHPublicKey }}

--- a/tests/testdata/vm-scanning/vmscanning.go
+++ b/tests/testdata/vm-scanning/vmscanning.go
@@ -1,0 +1,7 @@
+// Package vmscanning holds VM-scanning E2E static assets (templates) for test helpers.
+package vmscanning
+
+import _ "embed"
+
+//go:embed cloud-init.yaml.tmpl
+var CloudInitUserDataTemplate []byte

--- a/tests/testmetrics/parse.go
+++ b/tests/testmetrics/parse.go
@@ -1,0 +1,168 @@
+package testmetrics
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// Query identifies a single Prometheus counter to extract from scrape text.
+// When LabelFilter is empty, the first line matching Name is used.
+// When set, only lines containing both Name and LabelFilter are matched.
+type Query struct {
+	Name        string
+	LabelFilter string
+}
+
+// Value is a single scraped Prometheus counter value.
+type Value struct {
+	Val   float64
+	Found bool
+}
+
+// Key returns a stable map key for a Query.
+func Key(q Query) string {
+	if q.LabelFilter == "" {
+		return q.Name
+	}
+	return q.Name + "{" + q.LabelFilter + "}"
+}
+
+// Parse extracts the requested counters from raw Prometheus exposition text.
+// The returned map is keyed by Key(query).
+func Parse(text string, queries []Query) map[string]Value {
+	out := make(map[string]Value, len(queries))
+	for _, q := range queries {
+		k := Key(q)
+		if q.LabelFilter == "" {
+			v, ok := parseCounter(text, q.Name)
+			out[k] = Value{Val: v, Found: ok}
+		} else {
+			v, ok := parseCounterWithLabel(text, q.Name, q.LabelFilter)
+			out[k] = Value{Val: v, Found: ok}
+		}
+	}
+	return out
+}
+
+// ValuesEqual returns true when both maps have the same keys with identical Found/Val.
+func ValuesEqual(a, b map[string]Value) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		vb, ok := b[k]
+		if !ok || va != vb {
+			return false
+		}
+	}
+	return true
+}
+
+// StableConfig configures PollUntilStable.
+type StableConfig struct {
+	PollInterval time.Duration
+	StableRounds int
+	Logf         func(string, ...any)
+}
+
+// ScrapeFunc fetches metrics for one poll iteration. Returning an error signals a
+// retryable failure (e.g. pod not ready); the poll continues until the context expires.
+type ScrapeFunc func(ctx context.Context) (map[string]Value, error)
+
+// PollUntilStable polls scrapeFn until the returned values are identical across
+// stableRounds consecutive successful scrapes, or the context expires.
+// On timeout it returns the last successful result (assertions should catch the real issue).
+func PollUntilStable(ctx context.Context, cfg StableConfig, scrapeFn ScrapeFunc) map[string]Value {
+	interval := cfg.PollInterval
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	stableRounds := cfg.StableRounds
+	if stableRounds <= 0 {
+		stableRounds = 3
+	}
+	logf := cfg.Logf
+
+	var prev map[string]Value
+	consecutiveStable := 0
+
+	_ = wait.PollUntilContextCancel(ctx, interval, true, func(ctx context.Context) (bool, error) {
+		cur, err := scrapeFn(ctx)
+		if err != nil {
+			consecutiveStable = 0
+			prev = nil
+			if logf != nil {
+				logf("metrics poll: scrape error (will retry): %v", err)
+			}
+			return false, nil
+		}
+
+		if prev != nil && ValuesEqual(prev, cur) {
+			consecutiveStable++
+		} else {
+			consecutiveStable = 1
+		}
+
+		if logf != nil && (consecutiveStable == 1 || consecutiveStable == stableRounds) {
+			logf("metrics poll: stable=%d/%d values=%v", consecutiveStable, stableRounds, cur)
+		}
+		prev = cur
+		return consecutiveStable >= stableRounds, nil
+	})
+
+	if prev == nil {
+		return map[string]Value{}
+	}
+	return prev
+}
+
+func parseCounter(body, metricPrefix string) (float64, bool) {
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, metricPrefix) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		val, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err != nil {
+			continue
+		}
+		return val, true
+	}
+	return 0, false
+}
+
+func parseCounterWithLabel(body, metricName, labelSubstring string) (float64, bool) {
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, metricName) {
+			continue
+		}
+		if !strings.Contains(line, labelSubstring) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		val, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err != nil {
+			continue
+		}
+		return val, true
+	}
+	return 0, false
+}

--- a/tests/testmetrics/parse_test.go
+++ b/tests/testmetrics/parse_test.go
@@ -1,0 +1,76 @@
+//go:build test
+
+package testmetrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse_FoundAndMissing(t *testing.T) {
+	text := strings.Join([]string{
+		"some_counter_total 2",
+		"other_counter_total 1",
+		`labeled_total{status="ok"} 7`,
+	}, "\n")
+
+	queries := []Query{
+		{Name: "some_counter_total"},
+		{Name: "other_counter_total"},
+		{Name: "labeled_total", LabelFilter: `status="ok"`},
+		{Name: "labeled_total", LabelFilter: `status="err"`},
+		{Name: "absent_total"},
+	}
+	m := Parse(text, queries)
+
+	assertFound := func(q Query, expected float64) {
+		t.Helper()
+		v := m[Key(q)]
+		require.True(t, v.Found, "expected %s to be found", Key(q))
+		require.Equal(t, expected, v.Val, "wrong value for %s", Key(q))
+	}
+	assertMissing := func(q Query) {
+		t.Helper()
+		v := m[Key(q)]
+		require.False(t, v.Found, "expected %s to be absent", Key(q))
+	}
+
+	assertFound(queries[0], 2)
+	assertFound(queries[1], 1)
+	assertFound(queries[2], 7)
+	assertMissing(queries[3])
+	assertMissing(queries[4])
+}
+
+func TestParse_EmptyInput(t *testing.T) {
+	queries := []Query{
+		{Name: "foo_total"},
+		{Name: "bar_total"},
+	}
+	m := Parse("", queries)
+
+	for _, q := range queries {
+		v := m[Key(q)]
+		require.False(t, v.Found, "expected %s absent on empty input", Key(q))
+		require.Equal(t, float64(0), v.Val)
+	}
+}
+
+func TestKey(t *testing.T) {
+	require.Equal(t, "foo_total", Key(Query{Name: "foo_total"}))
+	require.Equal(t, `foo_total{status="ok"}`, Key(Query{Name: "foo_total", LabelFilter: `status="ok"`}))
+}
+
+func TestValuesEqual(t *testing.T) {
+	a := map[string]Value{"x": {Val: 1, Found: true}}
+	b := map[string]Value{"x": {Val: 1, Found: true}}
+	require.True(t, ValuesEqual(a, b))
+
+	c := map[string]Value{"x": {Val: 2, Found: true}}
+	require.False(t, ValuesEqual(a, c))
+
+	d := map[string]Value{"y": {Val: 1, Found: true}}
+	require.False(t, ValuesEqual(a, d))
+}

--- a/tests/testmetrics/scrape.go
+++ b/tests/testmetrics/scrape.go
@@ -1,0 +1,294 @@
+package testmetrics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// Transport selects how pod metrics are scraped.
+type Transport string
+
+const (
+	TransportProxy       Transport = "proxy"
+	TransportPortForward Transport = "portforward"
+)
+
+// PodSnapshot is a single /metrics (or custom path) scrape from one pod.
+type PodSnapshot struct {
+	PodName string
+	Body    string
+	Err     error
+}
+
+// PodScrapeOptions configures ScrapePodViaProxy (Kubernetes pods/proxy subresource).
+type PodScrapeOptions struct {
+	Namespace   string
+	PodName     string
+	Port        int
+	MetricsPath string
+}
+
+// PodCollectOptions scrapes metrics from every pod matching LabelSelector.
+type PodCollectOptions struct {
+	Namespace     string
+	LabelSelector string
+	FieldSelector string
+	Port          int
+	MetricsPath   string
+	Transport     Transport
+	RestConfig    *rest.Config
+}
+
+// ScrapeTarget describes how to collect metrics for one Kubernetes component.
+type ScrapeTarget struct {
+	ComponentName string
+	Namespace     string
+	LabelSelector string
+	FieldSelector string
+	MetricsPort   int
+	MetricsPath   string
+}
+
+// ScrapePodViaProxy scrapes Prometheus text from a pod via GET .../pods/{name}[:port]/proxy/{path}.
+func ScrapePodViaProxy(ctx context.Context, clientset kubernetes.Interface, opts PodScrapeOptions) ([]byte, error) {
+	if opts.Namespace == "" || opts.PodName == "" {
+		return nil, errors.New("testmetrics: ScrapePodViaProxy: namespace and pod name are required")
+	}
+	path := strings.Trim(opts.MetricsPath, "/")
+	if path == "" {
+		path = "metrics"
+	}
+	segments := strings.Split(path, "/")
+	podSubresourceName := opts.PodName
+	if opts.Port > 0 {
+		podSubresourceName = fmt.Sprintf("%s:%d", opts.PodName, opts.Port)
+	}
+	req := clientset.CoreV1().RESTClient().Get().
+		Namespace(opts.Namespace).
+		Resource("pods").
+		Name(podSubresourceName).
+		SubResource("proxy")
+	for _, seg := range segments {
+		if seg != "" {
+			req = req.Suffix(seg)
+		}
+	}
+	return req.Do(ctx).Raw()
+}
+
+// ScrapePodViaPortForward opens an ephemeral port-forward to remotePort on the pod
+// and GETs metricsPath on localhost.
+func ScrapePodViaPortForward(ctx context.Context, clientset kubernetes.Interface, restCfg *rest.Config, namespace, podName string, remotePort int, metricsPath string) ([]byte, error) {
+	if restCfg == nil {
+		return nil, errors.New("testmetrics: ScrapePodViaPortForward: rest.Config is required")
+	}
+	if namespace == "" || podName == "" {
+		return nil, errors.New("testmetrics: ScrapePodViaPortForward: namespace and pod name are required")
+	}
+	if remotePort <= 0 {
+		return nil, errors.New("testmetrics: ScrapePodViaPortForward: remote metrics port must be positive")
+	}
+	path := metricsPath
+	if path == "" {
+		path = "/metrics"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").Namespace(namespace).Name(podName).SubResource("portforward")
+	transport, upgrader, err := spdy.RoundTripperFor(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("testmetrics: port-forward transport: %w", err)
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, req.URL())
+
+	stopCh := make(chan struct{})
+	readyCh := make(chan struct{})
+	forwarder, err := portforward.New(dialer, []string{fmt.Sprintf("0:%d", remotePort)}, stopCh, readyCh, io.Discard, io.Discard)
+	if err != nil {
+		return nil, fmt.Errorf("testmetrics: port-forward: %w", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- forwarder.ForwardPorts() }()
+
+	select {
+	case <-ctx.Done():
+		close(stopCh)
+		<-errCh
+		return nil, ctx.Err()
+	case err = <-errCh:
+		return nil, fmt.Errorf("testmetrics: port-forward to %s/%s:%d failed: %w", namespace, podName, remotePort, err)
+	case <-readyCh:
+	}
+
+	ports, err := forwarder.GetPorts()
+	if err != nil || len(ports) == 0 {
+		close(stopCh)
+		<-errCh
+		return nil, fmt.Errorf("testmetrics: port-forward: no local ports: %w", err)
+	}
+	localPort := int(ports[0].Local)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d%s", localPort, path), nil)
+	if err != nil {
+		close(stopCh)
+		<-errCh
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		close(stopCh)
+		<-errCh
+		return nil, fmt.Errorf("testmetrics: port-forward metrics GET: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, readErr := io.ReadAll(resp.Body)
+	close(stopCh)
+	<-errCh
+	if readErr != nil {
+		return nil, readErr
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("testmetrics: port-forward metrics HTTP %s", resp.Status)
+	}
+	return body, nil
+}
+
+func scrapePod(ctx context.Context, clientset kubernetes.Interface, opts PodCollectOptions, podName string) ([]byte, error) {
+	transport := opts.Transport
+	if transport == "" {
+		transport = TransportProxy
+	}
+	path := opts.MetricsPath
+	if path == "" {
+		path = "metrics"
+	}
+	switch transport {
+	case TransportPortForward:
+		if opts.RestConfig == nil {
+			return nil, errors.New("testmetrics: PodCollectOptions.RestConfig is required for port-forward transport")
+		}
+		if opts.Port <= 0 {
+			return nil, errors.New("testmetrics: PodCollectOptions.Port must be set for port-forward transport")
+		}
+		return ScrapePodViaPortForward(ctx, clientset, opts.RestConfig, opts.Namespace, podName, opts.Port, path)
+	case TransportProxy:
+		return ScrapePodViaProxy(ctx, clientset, PodScrapeOptions{
+			Namespace:   opts.Namespace,
+			PodName:     podName,
+			Port:        opts.Port,
+			MetricsPath: path,
+		})
+	default:
+		return nil, fmt.Errorf("testmetrics: unsupported metrics transport %q", transport)
+	}
+}
+
+// CollectFromPods lists pods matching LabelSelector/FieldSelector and scrapes metrics
+// from each (same port/path/transport).
+func CollectFromPods(ctx context.Context, clientset kubernetes.Interface, opts PodCollectOptions) ([]PodSnapshot, error) {
+	if opts.Namespace == "" {
+		return nil, errors.New("testmetrics: CollectFromPods: namespace is required")
+	}
+	if opts.Transport == TransportPortForward && opts.RestConfig == nil {
+		return nil, errors.New("testmetrics: CollectFromPods: RestConfig required for port-forward")
+	}
+	list, err := clientset.CoreV1().Pods(opts.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: opts.LabelSelector,
+		FieldSelector: opts.FieldSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PodSnapshot, 0, len(list.Items))
+	for i := range list.Items {
+		name := list.Items[i].Name
+		body, err := scrapePod(ctx, clientset, opts, name)
+		snap := PodSnapshot{PodName: name}
+		if err != nil {
+			snap.Err = err
+		} else {
+			snap.Body = string(body)
+		}
+		out = append(out, snap)
+	}
+	return out, nil
+}
+
+// ScrapeComponent scrapes pods of a single component and parses the requested counters.
+// Pods that fail to serve metrics are skipped; an error is returned only when no pod yields valid data.
+// restCfg is required when transport is TransportPortForward; it may be nil for TransportProxy.
+func ScrapeComponent(ctx context.Context, clientset kubernetes.Interface, target ScrapeTarget, transport Transport, restCfg *rest.Config, queries []Query) (map[string]Value, error) {
+	snaps, err := CollectFromPods(ctx, clientset, PodCollectOptions{
+		Namespace:     target.Namespace,
+		LabelSelector: target.LabelSelector,
+		FieldSelector: target.FieldSelector,
+		Port:          target.MetricsPort,
+		MetricsPath:   target.MetricsPath,
+		Transport:     transport,
+		RestConfig:    restCfg,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scrape %s: %w", target.ComponentName, err)
+	}
+	if len(snaps) == 0 {
+		return nil, fmt.Errorf("scrape %s: no pods found (selector=%q field=%q)",
+			target.ComponentName, target.LabelSelector, target.FieldSelector)
+	}
+	var b strings.Builder
+	okPods := 0
+	var podErrors []string
+	for _, s := range snaps {
+		if s.Err != nil {
+			podErrors = append(podErrors, fmt.Sprintf("pod %s: %v", s.PodName, s.Err))
+			continue
+		}
+		okPods++
+		fmt.Fprintf(&b, "%s\n", s.Body)
+	}
+	if okPods == 0 {
+		return nil, fmt.Errorf("scrape %s: all %d pod(s) failed to serve metrics; errors: %s",
+			target.ComponentName, len(snaps), strings.Join(podErrors, "; "))
+	}
+	return Parse(b.String(), queries), nil
+}
+
+// FindServicePort checks whether any Service in the given namespace whose selector
+// contains appLabel=appValue exposes the specified targetPort (as either .spec.ports[].port
+// or .spec.ports[].targetPort). Returns nil if found, or a descriptive error.
+func FindServicePort(ctx context.Context, clientset kubernetes.Interface, namespace, appLabel, appValue string, targetPort int) error {
+	services, err := clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing services in %s: %w", namespace, err)
+	}
+	for _, svc := range services.Items {
+		if svc.Spec.Selector[appLabel] != appValue {
+			continue
+		}
+		for _, p := range svc.Spec.Ports {
+			if int(p.Port) == targetPort || p.TargetPort.IntValue() == targetPort {
+				return nil
+			}
+		}
+		var ports []string
+		for _, p := range svc.Spec.Ports {
+			ports = append(ports, fmt.Sprintf("%s:%d->%s", p.Name, p.Port, p.TargetPort.String()))
+		}
+		return fmt.Errorf("service %s/%s selects %s=%s pods but does not expose port %d; declared ports: %v",
+			namespace, svc.Name, appLabel, appValue, targetPort, ports)
+	}
+	return fmt.Errorf("no service in namespace %s selects %s=%s pods", namespace, appLabel, appValue)
+}

--- a/tests/testmetrics/scrape_test.go
+++ b/tests/testmetrics/scrape_test.go
@@ -1,0 +1,45 @@
+//go:build test
+
+package testmetrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestScrapePodViaProxy_Validation(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewSimpleClientset()
+	_, err := ScrapePodViaProxy(ctx, cs, PodScrapeOptions{Namespace: "ns"})
+	require.Error(t, err)
+	_, err = ScrapePodViaProxy(ctx, cs, PodScrapeOptions{PodName: "p"})
+	require.Error(t, err)
+}
+
+func TestCollectFromPods_Validation(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewSimpleClientset()
+	_, err := CollectFromPods(ctx, cs, PodCollectOptions{})
+	require.Error(t, err)
+	_, err = CollectFromPods(ctx, cs, PodCollectOptions{
+		Namespace:     "ns",
+		Transport:     TransportPortForward,
+		LabelSelector: "app=x",
+	})
+	require.Error(t, err)
+}
+
+func TestScrapePodViaPortForward_Validation(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewSimpleClientset()
+	_, err := ScrapePodViaPortForward(ctx, cs, nil, "ns", "pod", 9090, "/metrics")
+	require.Error(t, err)
+	_, err = ScrapePodViaPortForward(ctx, cs, &rest.Config{}, "", "pod", 9090, "")
+	require.Error(t, err)
+	_, err = ScrapePodViaPortForward(ctx, cs, &rest.Config{}, "ns", "pod", 0, "")
+	require.Error(t, err)
+}

--- a/tests/vm_scanning_compliance_setup_test.go
+++ b/tests/vm_scanning_compliance_setup_test.go
@@ -1,0 +1,239 @@
+//go:build test_e2e
+
+package tests
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackrox/rox/pkg/namespaces"
+	"github.com/stretchr/testify/require"
+	coreV1 "k8s.io/api/core/v1"
+	networkingV1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// ensureComplianceMetricsExposed guarantees that the collector compliance container
+// serves Prometheus metrics on port 9091, that a headless Service routes to it, and
+// that NetworkPolicies allow ingress to both collector and sensor metrics ports.
+//
+// The StackRox Helm chart sets ROX_METRICS_PORT=disabled and deploys a
+// "collector-no-ingress" NetworkPolicy (deny-all) when exposeMonitoring is false
+// (the operator default). There is no SecuredCluster CR field to set
+// exposeMonitoring for collector/sensor, so the test creates the equivalent
+// resources: env patch, Service, and permissive NetworkPolicies matching what
+// the chart would produce with exposeMonitoring=true.
+func (s *VMScanningSuite) ensureComplianceMetricsExposed() {
+	ns := namespaces.StackRox
+	const (
+		svcName       = "compliance-metrics"
+		dsName        = "collector"
+		containerName = "compliance"
+		metricsEnv    = "ROX_METRICS_PORT"
+		metricsValue  = ":9091"
+	)
+	metricsPort := int32(9091)
+
+	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Minute)
+	defer cancel()
+
+	s.ensureComplianceMetricsEnv(ctx, ns, dsName, containerName, metricsEnv, metricsValue)
+	s.ensureComplianceMetricsService(ctx, ns, svcName, metricsPort)
+	s.ensureMonitoringNetworkPolicy(ctx, ns, "collector-monitoring", "collector", []int32{9090, 9091})
+	s.ensureMonitoringNetworkPolicy(ctx, ns, "sensor-monitoring", "sensor", []int32{9090})
+}
+
+func (s *VMScanningSuite) ensureComplianceMetricsEnv(ctx context.Context, ns, dsName, containerName, envName, envValue string) {
+	t := s.T()
+	ds, err := s.k8sClient.AppsV1().DaemonSets(ns).Get(ctx, dsName, metaV1.GetOptions{})
+	require.NoError(t, err, "getting DaemonSet %s/%s", ns, dsName)
+
+	var container *coreV1.Container
+	for i := range ds.Spec.Template.Spec.Containers {
+		if ds.Spec.Template.Spec.Containers[i].Name == containerName {
+			container = &ds.Spec.Template.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, container, "container %q not found in DaemonSet %s/%s", containerName, ns, dsName)
+
+	for _, e := range container.Env {
+		if e.Name == envName && e.Value == envValue {
+			s.logf("VM scanning setup: DaemonSet %s/%s container %q already has %s=%s", ns, dsName, containerName, envName, envValue)
+			return
+		}
+	}
+
+	s.logf("VM scanning setup: patching DaemonSet %s/%s container %q: setting %s=%s", ns, dsName, containerName, envName, envValue)
+	updated := false
+	for i, e := range container.Env {
+		if e.Name == envName {
+			container.Env[i].Value = envValue
+			container.Env[i].ValueFrom = nil
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		container.Env = append(container.Env, coreV1.EnvVar{Name: envName, Value: envValue})
+	}
+
+	_, err = s.k8sClient.AppsV1().DaemonSets(ns).Update(ctx, ds, metaV1.UpdateOptions{})
+	require.NoError(t, err, "updating DaemonSet %s/%s to set %s=%s", ns, dsName, envName, envValue)
+
+	s.logf("VM scanning setup: waiting for DaemonSet %s/%s rollout", ns, dsName)
+	err = wait.PollUntilContextCancel(ctx, 10*time.Second, false, func(pollCtx context.Context) (bool, error) {
+		current, getErr := s.k8sClient.AppsV1().DaemonSets(ns).Get(pollCtx, dsName, metaV1.GetOptions{})
+		if getErr != nil {
+			s.logf("VM scanning setup: transient error checking DaemonSet rollout: %v", getErr)
+			return false, nil
+		}
+		ready := current.Status.DesiredNumberScheduled > 0 &&
+			current.Status.UpdatedNumberScheduled == current.Status.DesiredNumberScheduled &&
+			current.Status.NumberReady == current.Status.DesiredNumberScheduled &&
+			current.Status.ObservedGeneration >= current.Generation
+		if !ready {
+			s.logf("VM scanning setup: DaemonSet %s/%s rollout in progress (desired=%d updated=%d ready=%d)",
+				ns, dsName, current.Status.DesiredNumberScheduled, current.Status.UpdatedNumberScheduled, current.Status.NumberReady)
+		}
+		return ready, nil
+	})
+	require.NoError(t, err, "waiting for DaemonSet %s/%s rollout after setting %s=%s", ns, dsName, envName, envValue)
+	s.logf("VM scanning setup: DaemonSet %s/%s rollout complete", ns, dsName)
+}
+
+func (s *VMScanningSuite) ensureComplianceMetricsService(ctx context.Context, ns, svcName string, metricsPort int32) {
+	t := s.T()
+	desired := &coreV1.Service{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      svcName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "vm-scanning-e2e",
+			},
+		},
+		Spec: coreV1.ServiceSpec{
+			ClusterIP: "None",
+			Selector:  map[string]string{"app": "collector"},
+			Ports: []coreV1.ServicePort{{
+				Name:       "monitoring",
+				Port:       metricsPort,
+				TargetPort: intstr.FromInt32(metricsPort),
+				Protocol:   coreV1.ProtocolTCP,
+			}},
+		},
+	}
+
+	err := wait.PollUntilContextCancel(ctx, 5*time.Second, true, func(pollCtx context.Context) (bool, error) {
+		existing, getErr := s.k8sClient.CoreV1().Services(ns).Get(pollCtx, svcName, metaV1.GetOptions{})
+		if getErr == nil {
+			if serviceExposesPort(existing, metricsPort) {
+				s.logf("VM scanning setup: service %s/%s verified (port %d)", ns, svcName, metricsPort)
+				return true, nil
+			}
+			s.logf("VM scanning setup: service %s/%s exists but missing port %d, deleting and re-creating", ns, svcName, metricsPort)
+			_ = s.k8sClient.CoreV1().Services(ns).Delete(pollCtx, svcName, metaV1.DeleteOptions{})
+			return false, nil
+		}
+		if !apierrors.IsNotFound(getErr) {
+			s.logf("VM scanning setup: transient error checking service %s/%s: %v (retrying)", ns, svcName, getErr)
+			return false, nil
+		}
+
+		s.logf("VM scanning setup: creating service %s/%s (compliance metrics port %d)", ns, svcName, metricsPort)
+		_, createErr := s.k8sClient.CoreV1().Services(ns).Create(pollCtx, desired, metaV1.CreateOptions{})
+		if createErr != nil {
+			if apierrors.IsAlreadyExists(createErr) {
+				return false, nil
+			}
+			s.logf("VM scanning setup: create service %s/%s failed: %v (retrying)", ns, svcName, createErr)
+			return false, nil
+		}
+		return false, nil
+	})
+	require.NoError(t, err, "ensuring compliance-metrics service %s/%s with port %d", ns, svcName, metricsPort)
+}
+
+func serviceExposesPort(svc *coreV1.Service, port int32) bool {
+	for _, p := range svc.Spec.Ports {
+		if p.Port == port || p.TargetPort.IntValue() == int(port) {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureMonitoringNetworkPolicy creates an ingress-allow NetworkPolicy for the
+// given app label and TCP ports. This mirrors what the Helm chart creates when
+// exposeMonitoring is true (e.g. "collector-monitoring" or "sensor-monitoring").
+func (s *VMScanningSuite) ensureMonitoringNetworkPolicy(ctx context.Context, ns, name, appLabel string, ports []int32) {
+	t := s.T()
+	tcp := coreV1.ProtocolTCP
+	var ingressPorts []networkingV1.NetworkPolicyPort
+	for _, p := range ports {
+		ingressPorts = append(ingressPorts, networkingV1.NetworkPolicyPort{
+			Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: p},
+			Protocol: &tcp,
+		})
+	}
+
+	desired := &networkingV1.NetworkPolicy{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "vm-scanning-e2e",
+			},
+		},
+		Spec: networkingV1.NetworkPolicySpec{
+			PodSelector: metaV1.LabelSelector{
+				MatchLabels: map[string]string{"app": appLabel},
+			},
+			Ingress: []networkingV1.NetworkPolicyIngressRule{{
+				Ports: ingressPorts,
+			}},
+			PolicyTypes: []networkingV1.PolicyType{networkingV1.PolicyTypeIngress},
+		},
+	}
+
+	existing, err := s.k8sClient.NetworkingV1().NetworkPolicies(ns).Get(ctx, name, metaV1.GetOptions{})
+	if err == nil {
+		if networkPolicyMatchesPorts(existing, ports) {
+			s.logf("VM scanning setup: NetworkPolicy %s/%s already allows ports %v", ns, name, ports)
+			return
+		}
+		s.logf("VM scanning setup: NetworkPolicy %s/%s exists but ports differ, updating", ns, name)
+		desired.ResourceVersion = existing.ResourceVersion
+		_, err = s.k8sClient.NetworkingV1().NetworkPolicies(ns).Update(ctx, desired, metaV1.UpdateOptions{})
+		require.NoError(t, err, "updating NetworkPolicy %s/%s", ns, name)
+		return
+	}
+	if !apierrors.IsNotFound(err) {
+		require.NoError(t, err, "getting NetworkPolicy %s/%s", ns, name)
+	}
+
+	s.logf("VM scanning setup: creating NetworkPolicy %s/%s (app=%s, ports=%v)", ns, name, appLabel, ports)
+	_, err = s.k8sClient.NetworkingV1().NetworkPolicies(ns).Create(ctx, desired, metaV1.CreateOptions{})
+	require.NoError(t, err, "creating NetworkPolicy %s/%s", ns, name)
+}
+
+func networkPolicyMatchesPorts(np *networkingV1.NetworkPolicy, wantPorts []int32) bool {
+	if len(np.Spec.Ingress) != 1 {
+		return false
+	}
+	have := make(map[int32]bool)
+	for _, p := range np.Spec.Ingress[0].Ports {
+		if p.Port != nil {
+			have[p.Port.IntVal] = true
+		}
+	}
+	for _, p := range wantPorts {
+		if !have[p] {
+			return false
+		}
+	}
+	return len(have) == len(wantPorts)
+}

--- a/tests/vm_scanning_e2e_utils_preflight_test.go
+++ b/tests/vm_scanning_e2e_utils_preflight_test.go
@@ -1,0 +1,59 @@
+//go:build test_e2e
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	coreV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func makeVirtHandlerPod(namespace, name string, phase coreV1.PodPhase, hostPaths ...string) *coreV1.Pod {
+	volumes := make([]coreV1.Volume, 0, len(hostPaths))
+	for i, p := range hostPaths {
+		volumes = append(volumes, coreV1.Volume{
+			Name: fmt.Sprintf("hostpath-%d", i),
+			VolumeSource: coreV1.VolumeSource{
+				HostPath: &coreV1.HostPathVolumeSource{Path: p},
+			},
+		})
+	}
+	return &coreV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				"kubevirt.io": "virt-handler",
+			},
+		},
+		Spec: coreV1.PodSpec{
+			Volumes: volumes,
+		},
+		Status: coreV1.PodStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func TestVirtHandlerHostVsockVolumesLookUsable_AcceptsExplicitVsockHostPath(t *testing.T) {
+	t.Parallel()
+	client := kubefake.NewSimpleClientset(
+		makeVirtHandlerPod("openshift-cnv", "virt-handler-1", coreV1.PodRunning, "/dev/vhost-vsock"),
+	)
+	ok, diag := virtHandlerHostVsockVolumesLookUsable(context.Background(), t, client)
+	require.Truef(t, ok, "expected explicit vsock hostPath to pass preflight; diagnostics: %s", diag)
+}
+
+func TestVirtHandlerHostVsockVolumesLookUsable_AcceptsCNVLibvirtRuntimesHostPath(t *testing.T) {
+	t.Parallel()
+	client := kubefake.NewSimpleClientset(
+		makeVirtHandlerPod("openshift-cnv", "virt-handler-1", coreV1.PodRunning, "/var/run/kubevirt-libvirt-runtimes"),
+	)
+	ok, diag := virtHandlerHostVsockVolumesLookUsable(context.Background(), t, client)
+	require.Truef(t, ok, "expected CNV libvirt-runtimes hostPath to pass preflight; diagnostics: %s", diag)
+}

--- a/tests/vm_scanning_e2e_utils_test.go
+++ b/tests/vm_scanning_e2e_utils_test.go
@@ -1,0 +1,231 @@
+//go:build test_e2e
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	coreV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func mustLoadVMScanConfig(t *testing.T) *vmScanConfig {
+	t.Helper()
+	cfg, err := loadVMScanConfig()
+	require.NoError(t, err, "loadVMScanConfig")
+	return cfg
+}
+
+func mustCreateDynamicClient(t *testing.T, restCfg *rest.Config) dynamic.Interface {
+	t.Helper()
+	c, err := dynamic.NewForConfig(restCfg)
+	require.NoError(t, err, "dynamic.NewForConfig")
+	return c
+}
+
+// mustResolveSSHIdentityFile writes the PEM-encoded private key content to a temporary file
+// with 0600 permissions and returns the path, suitable for virtctl --identity-file.
+func mustResolveSSHIdentityFile(t *testing.T, cfg *vmScanConfig) string {
+	t.Helper()
+	content := cfg.SSHPrivateKey
+	require.NotEmpty(t, strings.TrimSpace(content), "SSH private key content is empty")
+	require.True(t, strings.HasPrefix(strings.TrimSpace(content), "-----BEGIN"),
+		"VM_SSH_PRIVATE_KEY must contain PEM-encoded key content, not a file path")
+
+	// OpenSSH requires a trailing newline after the END marker.
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), "vm-scan-ssh-*")
+	require.NoError(t, err)
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	require.NoError(t, os.Chmod(f.Name(), 0o600))
+	return f.Name()
+}
+
+var kubevirtCRGVR = schema.GroupVersionResource{
+	Group:    "kubevirt.io",
+	Version:  "v1",
+	Resource: "kubevirts",
+}
+
+// mustVerifyClusterVSOCKReady checks KubeVirt VSOCK enablement and host vsock plumbing used by the virt stack.
+// It fails with explicit diagnostics suitable for CI triage when either check cannot be satisfied.
+func mustVerifyClusterVSOCKReady(t *testing.T, ctx context.Context, k8s kubernetes.Interface, dyn dynamic.Interface) {
+	t.Helper()
+	checkCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+
+	kubevirtNS, kvObj, _, err := findKubeVirtWithVSOCKFeatureGate(checkCtx, dyn)
+	if err != nil {
+		t.Fatalf("VSOCK preflight: no KubeVirt CR with VSOCK feature gate found.\n"+
+			"Tried namespaces %s.\n"+
+			"%v\n"+
+			"Remediation: install/configure KubeVirt/CNV and add \"VSOCK\" to spec.configuration.developerConfiguration.featureGates on a KubeVirt CR (see KubeVirt docs for vsock).",
+			strings.Join(kubeVirtInstallNamespaces(), ", "), err)
+	}
+
+	if ok, diag := virtHandlerHostVsockVolumesLookUsable(checkCtx, t, k8s); !ok {
+		t.Fatalf("VSOCK preflight: virt-handler does not show usable vsock plumbing evidence.\n"+
+			"KubeVirt CR %q/%q has VSOCK feature gate enabled, but virt-handler pod evidence checks failed.\n"+
+			"%s\n"+
+			"Remediation: ensure worker nodes provide /dev/vhost-vsock (or equivalent) and virt-handler pods expose either "+
+			"an explicit vsock hostPath or the CNV libvirt runtime hostPath (/var/run/kubevirt-libvirt-runtimes); "+
+			"guest roxagent requires a working virtio-vsock channel (/dev/vsock in the guest once the VMI is created).",
+			kubevirtNS, kvObj.GetName(), diag)
+	}
+}
+
+func kubeVirtInstallNamespaces() []string {
+	return []string{"openshift-cnv", "kubevirt", "openshift-kubevirt"}
+}
+
+// findKubeVirtWithVSOCKFeatureGate scans every KubeVirt CR in candidate install namespaces and returns
+// the first whose developerConfiguration.featureGates lists VSOCK (case-insensitive). If none qualify,
+// the error message aggregates per-CR diagnostics for CI triage.
+func findKubeVirtWithVSOCKFeatureGate(ctx context.Context, dyn dynamic.Interface) (ns string, obj unstructured.Unstructured, fg []string, err error) {
+	var diag strings.Builder
+	var lastListErr error
+	for _, candidate := range kubeVirtInstallNamespaces() {
+		list, lerr := dyn.Resource(kubevirtCRGVR).Namespace(candidate).List(ctx, metaV1.ListOptions{})
+		if lerr != nil {
+			lastListErr = lerr
+			fmt.Fprintf(&diag, "namespace %q: list KubeVirt CRs failed: %v\n", candidate, lerr)
+			continue
+		}
+		if len(list.Items) == 0 {
+			fmt.Fprintf(&diag, "namespace %q: no KubeVirt custom resources\n", candidate)
+			continue
+		}
+		for _, item := range list.Items {
+			key := fmt.Sprintf("%s/%s", item.GetNamespace(), item.GetName())
+			fgList, found, nerr := unstructured.NestedStringSlice(item.Object, "spec", "configuration", "developerConfiguration", "featureGates")
+			if nerr != nil {
+				fmt.Fprintf(&diag, "KubeVirt %s: could not read featureGates: %v\n", key, nerr)
+				continue
+			}
+			if !found {
+				fmt.Fprintf(&diag, "KubeVirt %s: spec.configuration.developerConfiguration.featureGates missing\n", key)
+				continue
+			}
+			hasVsock := false
+			for _, g := range fgList {
+				if strings.EqualFold(strings.TrimSpace(g), "VSOCK") {
+					hasVsock = true
+					break
+				}
+			}
+			if hasVsock {
+				return item.GetNamespace(), item, fgList, nil
+			}
+			phase, _, _ := unstructured.NestedString(item.Object, "status", "phase")
+			fmt.Fprintf(&diag, "KubeVirt %s: VSOCK not in featureGates (status.phase=%q featureGates=%v)\n", key, phase, fgList)
+		}
+	}
+	summary := strings.TrimSpace(diag.String())
+	if summary == "" {
+		summary = "no KubeVirt CRs discovered in candidate namespaces"
+	}
+	if lastListErr != nil {
+		return "", unstructured.Unstructured{}, nil, fmt.Errorf("last list error: %w\n%s", lastListErr, summary)
+	}
+	return "", unstructured.Unstructured{}, nil, fmt.Errorf("%s", summary)
+}
+
+func virtHandlerHostVsockVolumesLookUsable(ctx context.Context, t *testing.T, k8s kubernetes.Interface) (bool, string) {
+	t.Helper()
+	var diag strings.Builder
+	selectors := []string{
+		"kubevirt.io=virt-handler",
+		"app.kubernetes.io/component=virt-handler",
+	}
+	for _, ns := range kubeVirtInstallNamespaces() {
+		var pods *coreV1.PodList
+		foundPods := false
+		for _, sel := range selectors {
+			list, lerr := k8s.CoreV1().Pods(ns).List(ctx, metaV1.ListOptions{LabelSelector: sel})
+			if lerr != nil {
+				fmt.Fprintf(&diag, "namespace %q: list pods (%q): %v\n", ns, sel, lerr)
+				continue
+			}
+			if len(list.Items) > 0 {
+				pods = list
+				foundPods = true
+				break
+			}
+		}
+		if !foundPods {
+			fmt.Fprintf(&diag, "namespace %q: no virt-handler pods for selectors %v\n", ns, selectors)
+			continue
+		}
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			phaseReady := pod.Status.Phase == coreV1.PodRunning || pod.Status.Phase == coreV1.PodPending
+			if !phaseReady {
+				fmt.Fprintf(&diag, "namespace %q pod %q: phase=%q\n", ns, pod.Name, pod.Status.Phase)
+			}
+			hasExplicitVsockPath := false
+			hasCNVLibvirtRuntimePath := false
+			for _, vol := range pod.Spec.Volumes {
+				if vol.HostPath == nil {
+					continue
+				}
+				p := strings.ToLower(vol.HostPath.Path)
+				if strings.Contains(p, "vhost_vsock") || strings.Contains(p, "vsock") {
+					hasExplicitVsockPath = true
+					break
+				}
+				if strings.Contains(p, "kubevirt-libvirt-runtimes") {
+					hasCNVLibvirtRuntimePath = true
+				}
+			}
+			if phaseReady {
+				if hasExplicitVsockPath {
+					return true, diag.String()
+				}
+				// OCP Virtualization commonly exposes vsock plumbing through libvirt runtime mounts
+				// without an explicit "/dev/vhost-vsock" hostPath in the pod spec.
+				if hasCNVLibvirtRuntimePath {
+					fmt.Fprintf(&diag, "namespace %q pod %q: accepting CNV libvirt runtime hostPath as vsock evidence\n", ns, pod.Name)
+					return true, diag.String()
+				}
+			}
+			fmt.Fprintf(&diag, "namespace %q pod %q: hostPath volumes (no vsock-like path): %s\n",
+				ns, pod.Name, summarizePodHostPathVolumes(pod))
+		}
+	}
+	return false, diag.String()
+}
+
+func summarizePodHostPathVolumes(pod *coreV1.Pod) string {
+	var b strings.Builder
+	n := 0
+	for _, vol := range pod.Spec.Volumes {
+		if vol.HostPath == nil {
+			continue
+		}
+		if n > 0 {
+			b.WriteString("; ")
+		}
+		fmt.Fprintf(&b, "%s->%q", vol.Name, vol.HostPath.Path)
+		n++
+	}
+	if n == 0 {
+		return "<none>"
+	}
+	return b.String()
+}

--- a/tests/vm_scanning_metrics_test.go
+++ b/tests/vm_scanning_metrics_test.go
@@ -1,0 +1,163 @@
+//go:build test_e2e
+
+package tests
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackrox/rox/pkg/namespaces"
+	"github.com/stackrox/rox/tests/testmetrics"
+	"github.com/stackrox/rox/tests/vmhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+// complianceTarget returns the ScrapeTarget for the compliance container on the VM's node.
+func (s *VMScanningSuite) complianceTarget(vmNodeName string) testmetrics.ScrapeTarget {
+	t := testmetrics.ScrapeTarget{
+		ComponentName: "compliance",
+		Namespace:     namespaces.StackRox,
+		LabelSelector: "app=collector",
+		MetricsPort:   9091,
+		MetricsPath:   "metrics",
+	}
+	if vmNodeName != "" {
+		t.FieldSelector = "spec.nodeName=" + vmNodeName
+	}
+	return t
+}
+
+// sensorTarget returns the ScrapeTarget for the sensor deployment.
+func (s *VMScanningSuite) sensorTarget() testmetrics.ScrapeTarget {
+	return testmetrics.ScrapeTarget{
+		ComponentName: "sensor",
+		Namespace:     namespaces.StackRox,
+		LabelSelector: "app=sensor",
+		MetricsPort:   9090,
+		MetricsPath:   "metrics",
+	}
+}
+
+// complianceQueries returns the Query set for the compliance relay.
+func complianceQueries() []testmetrics.Query {
+	return []testmetrics.Query{
+		{Name: vmhelpers.MetricComplianceRelayConnectionsAcceptedTotal},
+		{Name: vmhelpers.MetricComplianceRelayIndexReportsReceivedTotal},
+		{Name: vmhelpers.MetricComplianceRelayIndexReportsSentTotal, LabelFilter: `failed="false"`},
+		{Name: vmhelpers.MetricComplianceRelayIndexReportsSentTotal, LabelFilter: `failed="true"`},
+		{Name: vmhelpers.MetricComplianceRelayIndexReportsMismatchingVsockTotal},
+		{Name: vmhelpers.MetricComplianceRelayIndexReportAcksReceivedTotal},
+	}
+}
+
+// sensorQueries returns the Query set for the sensor VM index pipeline.
+func sensorQueries() []testmetrics.Query {
+	return []testmetrics.Query{
+		{Name: vmhelpers.MetricSensorVMIndexReportsReceivedTotal},
+		{Name: vmhelpers.MetricSensorVMIndexReportsSentTotal, LabelFilter: `status="` + vmhelpers.SensorIndexReportStatusSuccess + `"`},
+		{Name: vmhelpers.MetricSensorVMIndexReportsSentTotal, LabelFilter: `status="` + vmhelpers.SensorIndexReportStatusError + `"`},
+		{Name: vmhelpers.MetricSensorVMIndexReportsSentTotal, LabelFilter: `status="` + vmhelpers.SensorIndexReportStatusCentralNotReady + `"`},
+		{Name: vmhelpers.MetricSensorVMIndexReportAcksReceivedTotal, LabelFilter: `action="ACK"`},
+		{Name: vmhelpers.MetricSensorVMIndexReportEnqueueBlockedTotal},
+	}
+}
+
+// collectStableMetrics scrapes compliance and sensor metrics until values stabilize.
+// It returns two maps keyed by testmetrics.Key.
+//
+// We use TransportPortForward instead of TransportProxy because the StackRox Helm
+// chart deploys a "collector-no-ingress" NetworkPolicy that denies ALL ingress to
+// collector pods when exposeMonitoring is false (the operator default). The test
+// creates a permissive "collector-monitoring" NetworkPolicy, but port-forward
+// provides an additional safety net: it tunnels through the kubelet CRI directly
+// into the container's network namespace, bypassing NetworkPolicies entirely.
+// The same applies to sensor, whose NetworkPolicy restricts ingress to specific
+// StackRox components and does not include the metrics port (9090) by default.
+func (s *VMScanningSuite) collectStableMetrics(ctx context.Context, vmNodeName string) (compliance, sensor map[string]testmetrics.Value) {
+	const (
+		metricsTimeout  = 2 * time.Minute
+		metricsPollWait = 10 * time.Second
+		stableRounds    = 3
+	)
+
+	compTarget := s.complianceTarget(vmNodeName)
+	senTarget := s.sensorTarget()
+	compQ := complianceQueries()
+	senQ := sensorQueries()
+	transport := testmetrics.TransportPortForward
+
+	stableCfg := testmetrics.StableConfig{
+		PollInterval: metricsPollWait,
+		StableRounds: stableRounds,
+		Logf:         s.logf,
+	}
+
+	compCtx, compCancel := context.WithTimeout(ctx, metricsTimeout)
+	defer compCancel()
+	compliance = testmetrics.PollUntilStable(compCtx, stableCfg, func(ctx context.Context) (map[string]testmetrics.Value, error) {
+		return testmetrics.ScrapeComponent(ctx, s.k8sClient, compTarget, transport, s.restCfg, compQ)
+	})
+
+	senCtx, senCancel := context.WithTimeout(ctx, metricsTimeout)
+	defer senCancel()
+	sensor = testmetrics.PollUntilStable(senCtx, stableCfg, func(ctx context.Context) (map[string]testmetrics.Value, error) {
+		return testmetrics.ScrapeComponent(ctx, s.k8sClient, senTarget, transport, s.restCfg, senQ)
+	})
+
+	return compliance, sensor
+}
+
+// assertPipelineMetrics collects stable metrics and asserts their values.
+// vmNodeName must be non-empty so compliance metrics are scoped to the VM's local collector pod.
+func (s *VMScanningSuite) assertPipelineMetrics(ctx context.Context, t require.TestingT, vmNodeName string) {
+	require.NotEmpty(t, vmNodeName,
+		"VM node name must be known before asserting pipeline metrics; "+
+			"cluster-wide collector scraping is not supported because it conflates metrics from unrelated VMs")
+
+	compTarget := s.complianceTarget(vmNodeName)
+	s.logf("pipeline metrics: VM node=%q, compliance selector=%q field=%q",
+		vmNodeName, compTarget.LabelSelector, compTarget.FieldSelector)
+
+	err := testmetrics.FindServicePort(ctx, s.k8sClient, compTarget.Namespace, "app", "collector", compTarget.MetricsPort)
+	require.NoError(t, err,
+		"collector Service should expose compliance metrics port %d; the deployment may be missing the metrics port definition",
+		compTarget.MetricsPort)
+
+	comp, sen := s.collectStableMetrics(ctx, vmNodeName)
+
+	get := func(src map[string]testmetrics.Value, q testmetrics.Query) testmetrics.Value {
+		return src[testmetrics.Key(q)]
+	}
+
+	requirePositive := func(src map[string]testmetrics.Value, q testmetrics.Query, label string) {
+		v := get(src, q)
+		require.Truef(t, v.Found, "%s should be present in scraped metrics, but was not found", label)
+		require.Greaterf(t, v.Val, float64(0), "%s should be > 0, but got %.0f", label, v.Val)
+	}
+
+	requireZero := func(src map[string]testmetrics.Value, q testmetrics.Query, label string) {
+		v := get(src, q)
+		if !v.Found {
+			return
+		}
+		require.Equalf(t, float64(0), v.Val, "%s should be 0, but got %.0f", label, v.Val)
+	}
+
+	// Compliance relay assertions.
+	cq := complianceQueries()
+	requirePositive(comp, cq[0], "compliance relay connections_accepted")
+	requirePositive(comp, cq[1], "compliance relay index_reports_received")
+	requirePositive(comp, cq[2], "compliance relay index_reports_sent (failed=false)")
+	requireZero(comp, cq[3], "compliance relay index_reports_sent (failed=true)")
+	requireZero(comp, cq[4], "compliance relay vsock CID mismatches")
+	requirePositive(comp, cq[5], "compliance relay acks_received")
+
+	// Sensor assertions.
+	sq := sensorQueries()
+	requirePositive(sen, sq[0], "sensor index_reports_received")
+	requirePositive(sen, sq[1], "sensor index_reports_sent (success)")
+	requireZero(sen, sq[2], "sensor index_reports_sent (error)")
+	requireZero(sen, sq[3], "sensor index_reports_sent (central not ready)")
+	requirePositive(sen, sq[4], "sensor index_report_acks_received (ACK)")
+	requireZero(sen, sq[5], "sensor enqueue_blocked")
+}

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -1,0 +1,1042 @@
+//go:build test_e2e
+
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/namespaces"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/tests/vmhelpers"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	coreV1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+// VMHandle tracks a KubeVirt VM used by the suite (persistent or transient).
+type VMHandle struct {
+	Name      string
+	Namespace string
+	GuestUser string
+	// ID is the Central VirtualMachine id once known (populated in later tasks).
+	ID string
+	// NodeName is the Kubernetes node hosting the VirtualMachineInstance (populated after VMI is Running).
+	NodeName string
+}
+
+// VMScanningSuite exercises OpenShift VM scanning end-to-end (KubeVirt guests, roxagent, Central).
+type VMScanningSuite struct {
+	KubernetesSuite
+
+	ctx        context.Context
+	cleanupCtx context.Context
+	cancel     func()
+
+	cfg           *vmScanConfig
+	restCfg       *rest.Config
+	k8sClient     kubernetes.Interface
+	dynamicClient dynamic.Interface
+	namespace     string
+
+	conn     *grpc.ClientConn
+	vmClient v2.VirtualMachineServiceClient
+
+	virtctl vmhelpers.Virtctl
+
+	// persistentVMs are the two long-lived RHEL 9 / RHEL 10 guests provisioned in SetupSuite.
+	persistentVMs []VMHandle
+	// allVMs tracks every VM provisioned by the suite; TearDownSuite deletes each.
+	allVMs []VMHandle
+	// vmCreatedAt tracks when this suite created/recreated a VM (by namespace/name key).
+	vmCreatedAt map[string]time.Time
+	// terminalVSOCKFailure captures a hard vsock/device failure; subsequent tests are skipped.
+	terminalVSOCKFailure string
+	// scannerV4Checked is set after the one-time Scanner V4 matcher initialization check.
+	scannerV4Checked bool
+}
+
+// TestVMScanning is the suite entrypoint for VM scanning E2E tests.
+func TestVMScanning(t *testing.T) {
+	suite.Run(t, new(VMScanningSuite))
+}
+
+func (s *VMScanningSuite) SetupSuite() {
+	s.KubernetesSuite.SetupSuite()
+	t := s.T()
+
+	s.logf("VM scanning setup: initialize test contexts")
+	s.ctx, s.cleanupCtx, s.cancel = testContexts(t, "TestVMScanning", 90*time.Minute)
+
+	s.logf("VM scanning setup: load suite configuration from environment")
+	s.cfg = mustLoadVMScanConfig(t)
+	s.logf("VM scanning setup: create Kubernetes clients")
+	s.restCfg = getConfig(t)
+	s.k8sClient = createK8sClientWithConfig(t, s.restCfg)
+	s.dynamicClient = mustCreateDynamicClient(t, s.restCfg)
+
+	s.logf("VM scanning setup: ensure compliance metrics are exposed")
+	s.ensureComplianceMetricsExposed()
+
+	if fixedNamespace := strings.TrimSpace(os.Getenv("VM_SCAN_NAMESPACE")); fixedNamespace != "" {
+		s.namespace = fixedNamespace
+		s.logf("VM scanning setup: using fixed namespace from VM_SCAN_NAMESPACE=%q", s.namespace)
+	} else {
+		s.namespace = fmt.Sprintf("%s-%s", s.cfg.NamespacePrefix, uuid.NewV4().String()[:8])
+	}
+
+	s.logf("VM scanning setup: connect to Central gRPC")
+	s.conn = centralgrpc.GRPCConnectionToCentral(t)
+	s.vmClient = v2.NewVirtualMachineServiceClient(s.conn)
+
+	s.logf("VM scanning setup: verify central/sensor connectivity and feature gates")
+	s.mustWaitForHealthyCentralSensorConnection()
+	s.mustVerifyVirtualMachinesFeatureEnabled()
+	s.logf("VM scanning setup: verify cluster VSOCK readiness")
+	mustVerifyClusterVSOCKReady(t, s.ctx, s.k8sClient, s.dynamicClient)
+
+	s.logf("VM scanning setup: resolve SSH identity and configure virtctl")
+	identity := mustResolveSSHIdentityFile(t, s.cfg)
+	s.logf("VM_SSH_PRIVATE_KEY_PATH=%q", identity)
+	cmdTimeout := 30 * time.Minute
+	if s.cfg.ScanTimeout > 0 && s.cfg.ScanTimeout < cmdTimeout {
+		cmdTimeout = s.cfg.ScanTimeout
+	}
+	s.virtctl = vmhelpers.Virtctl{
+		Path:              s.cfg.VirtctlPath,
+		IdentityFile:      identity,
+		CommandTimeout:    cmdTimeout,
+		Logf:              s.logf,
+		HeartbeatInterval: 20 * time.Second,
+	}
+
+	s.logf("VM scanning setup: provision persistent VMs")
+	s.provisionPersistentVMs()
+	s.logf("VM scanning setup: prepare guests (ssh/cloud-init/roxagent/activation)")
+	s.preparePersistentGuests()
+	s.logf("VM scanning setup: complete")
+}
+
+func (s *VMScanningSuite) BeforeTest(_, testName string) {
+	if s.terminalVSOCKFailure == "" {
+		return
+	}
+	s.T().Skipf("skipping %s due to prior terminal vsock failure: %s", testName, s.terminalVSOCKFailure)
+}
+
+func (s *VMScanningSuite) TearDownSuite() {
+	if s.cancel != nil {
+		defer s.cancel()
+	}
+
+	if s.cfg != nil && s.cfg.SkipCleanup {
+		s.logf("teardown: VM_SCAN_SKIP_CLEANUP is set — skipping VM and namespace deletion (VMs and namespace left intact for debugging)")
+		s.closeConn()
+		return
+	}
+
+	deleteTimeout := s.teardownDeleteTimeout()
+	if s.dynamicClient != nil {
+		for _, vm := range s.allVMs {
+			vmCtx, vmCancel := context.WithTimeout(s.cleanupCtx, deleteTimeout)
+			if err := vmhelpers.DeleteVirtualMachine(vmCtx, s.dynamicClient, vm.Namespace, vm.Name); err != nil {
+				if vmhelpers.IsAuthenticationExpired(err) {
+					s.logf("teardown: STOPPING — %v", vmhelpers.ErrAuthenticationExpired)
+					vmCancel()
+					s.closeConn()
+					return
+				}
+				s.logf("teardown: DeleteVirtualMachine %s/%s failed: %v", vm.Namespace, vm.Name, err)
+			}
+			if err := vmhelpers.WaitForVirtualMachineDeleted(s.T(), vmCtx, s.dynamicClient, vm.Namespace, vm.Name); err != nil {
+				if vmhelpers.IsAuthenticationExpired(err) {
+					s.logf("teardown: STOPPING — %v", vmhelpers.ErrAuthenticationExpired)
+					vmCancel()
+					s.closeConn()
+					return
+				}
+				s.logf("teardown: WaitForVirtualMachineDeleted %s/%s timed out or failed: %v", vm.Namespace, vm.Name, err)
+			}
+			vmCancel()
+		}
+	} else if len(s.allVMs) > 0 {
+		s.logf("teardown: skipping VM cleanup (%d handle(s)): dynamic client is nil", len(s.allVMs))
+	}
+
+	if s.k8sClient != nil && s.namespace != "" {
+		nsCtx, nsCancel := context.WithTimeout(s.cleanupCtx, deleteTimeout)
+		err := s.k8sClient.CoreV1().Namespaces().Delete(nsCtx, s.namespace, metaV1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			if vmhelpers.IsAuthenticationExpired(err) {
+				s.logf("teardown: STOPPING — %v", vmhelpers.ErrAuthenticationExpired)
+				nsCancel()
+				s.closeConn()
+				return
+			}
+			s.logf("teardown: Namespace.Delete %q failed: %v", s.namespace, err)
+		}
+		if waitErr := waitForNamespaceDeleted(nsCtx, s.k8sClient, s.namespace); waitErr != nil {
+			s.logf("teardown: wait for namespace %q to be removed failed: %v", s.namespace, waitErr)
+		}
+		nsCancel()
+	}
+
+	s.closeConn()
+}
+
+func (s *VMScanningSuite) closeConn() {
+	if s.conn != nil {
+		if err := s.conn.Close(); err != nil {
+			s.logf("teardown: gRPC conn.Close failed: %v", err)
+		}
+	}
+}
+
+func (s *VMScanningSuite) teardownDeleteTimeout() time.Duration {
+	if s.cfg != nil && s.cfg.DeleteTimeout > 0 {
+		return s.cfg.DeleteTimeout
+	}
+	return 5 * time.Minute
+}
+
+func (s *VMScanningSuite) vmProvisionTimeout() time.Duration {
+	if s.cfg != nil && s.cfg.ScanTimeout > 0 {
+		return s.cfg.ScanTimeout
+	}
+	return 20 * time.Minute
+}
+
+func (s *VMScanningSuite) virtctlForVM(vm VMHandle) vmhelpers.Virtctl {
+	virt := s.virtctl
+	if u := strings.TrimSpace(vm.GuestUser); u != "" {
+		virt.Username = u
+	}
+	return virt
+}
+
+func (s *VMScanningSuite) guestStepTimeout() time.Duration {
+	// Keep guest prep bounded even when suite-level timeout is large.
+	const defaultTimeout = 20 * time.Minute
+	if s.cfg == nil || s.cfg.ScanTimeout <= 0 {
+		return defaultTimeout
+	}
+	if s.cfg.ScanTimeout < defaultTimeout {
+		return s.cfg.ScanTimeout
+	}
+	return defaultTimeout
+}
+
+func (s *VMScanningSuite) guestBootGracePeriod() time.Duration {
+	// New/recreated guests may report VMI Running before sshd/network are ready.
+	const defaultGrace = 20 * time.Minute
+	if s.cfg == nil || s.cfg.ScanTimeout <= 0 {
+		return defaultGrace
+	}
+	if s.cfg.ScanTimeout < defaultGrace {
+		return s.cfg.ScanTimeout
+	}
+	return defaultGrace
+}
+
+func stepElapsedSince(start time.Time) time.Duration {
+	elapsed := time.Since(start).Round(time.Second)
+	if elapsed <= 0 {
+		return time.Second
+	}
+	return elapsed
+}
+
+func vmHandleKey(vm VMHandle) string {
+	return vm.Namespace + "/" + vm.Name
+}
+
+func (s *VMScanningSuite) recordVMCreatedNow(vm VMHandle) {
+	if s.vmCreatedAt == nil {
+		s.vmCreatedAt = make(map[string]time.Time)
+	}
+	s.vmCreatedAt[vmHandleKey(vm)] = time.Now()
+}
+
+func (s *VMScanningSuite) recordVMCreationFromCluster(ctx context.Context, vm VMHandle) {
+	if s.dynamicClient == nil {
+		return
+	}
+	vmGVR := schema.GroupVersionResource{
+		Group:    kubevirtv1.GroupVersion.Group,
+		Version:  kubevirtv1.GroupVersion.Version,
+		Resource: "virtualmachines",
+	}
+	obj, err := s.dynamicClient.Resource(vmGVR).Namespace(vm.Namespace).Get(ctx, vm.Name, metaV1.GetOptions{})
+	if err != nil {
+		s.logf("could not read creation timestamp for %s/%s; SSH broken-claim grace will use suite-local timestamps only: %v",
+			vm.Namespace, vm.Name, err)
+		return
+	}
+	createdAt := obj.GetCreationTimestamp().Time
+	if createdAt.IsZero() {
+		s.logf("creation timestamp missing for %s/%s; SSH broken-claim grace will use suite-local timestamps only",
+			vm.Namespace, vm.Name)
+		return
+	}
+	if s.vmCreatedAt == nil {
+		s.vmCreatedAt = make(map[string]time.Time)
+	}
+	s.vmCreatedAt[vmHandleKey(vm)] = createdAt
+}
+
+func (s *VMScanningSuite) vmCreationAge(vm VMHandle) (time.Duration, bool) {
+	if s.vmCreatedAt == nil {
+		return 0, false
+	}
+	createdAt, ok := s.vmCreatedAt[vmHandleKey(vm)]
+	if !ok {
+		return 0, false
+	}
+	age := time.Since(createdAt)
+	if age < 0 {
+		return 0, true
+	}
+	return age, true
+}
+
+func (s *VMScanningSuite) maybeDelaySSHBrokenClaim(vm VMHandle, err error) (bool, error) {
+	const progressLogEvery = 30 * time.Second
+	recoverableSSHErr := errors.Is(err, vmhelpers.ErrSSHAuthenticationFailed) || errors.Is(err, vmhelpers.ErrSSHConnectivityStalled)
+	if !recoverableSSHErr {
+		return false, nil
+	}
+	age, known := s.vmCreationAge(vm)
+	if !known {
+		return false, nil
+	}
+
+	minAge := s.guestBootGracePeriod()
+	if minAge <= 0 || age >= minAge {
+		return false, nil
+	}
+
+	remaining := minAge - age
+	s.logf("Delaying SSH-broken classification for %s/%s by %s (VM age %s < required %s); last error: %v",
+		vm.Namespace, vm.Name, remaining.Round(time.Second), age.Round(time.Second), minAge, err)
+
+	delayDeadline := time.Now().Add(remaining)
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+	progressTicker := time.NewTicker(progressLogEvery)
+	defer progressTicker.Stop()
+	for {
+		select {
+		case <-timer.C:
+			s.logf("SSH-broken classification delay elapsed for %s/%s; continuing with strict checks", vm.Namespace, vm.Name)
+			return true, nil
+		case <-progressTicker.C:
+			left := time.Until(delayDeadline)
+			if left < 0 {
+				left = 0
+			}
+			s.logf("SSH-broken classification delay still active for %s/%s (%s remaining); last error: %v",
+				vm.Namespace, vm.Name, left.Round(time.Second), err)
+		case <-s.ctx.Done():
+			return false, fmt.Errorf("wait SSH broken-claim delay for %s/%s: %w", vm.Namespace, vm.Name, s.ctx.Err())
+		}
+	}
+}
+
+func (s *VMScanningSuite) prepareGuestRespectingSSHBrokenGrace(vm VMHandle) error {
+	for {
+		err := s.prepareGuest(vm)
+		if err == nil {
+			return nil
+		}
+		delayed, delayErr := s.maybeDelaySSHBrokenClaim(vm, err)
+		if delayErr != nil {
+			return delayErr
+		}
+		if !delayed {
+			return err
+		}
+		s.logf("Retrying guest preparation for %s/%s after SSH broken-claim delay", vm.Namespace, vm.Name)
+	}
+}
+
+func waitForNamespaceDeleted(ctx context.Context, k8s kubernetes.Interface, name string) error {
+	return wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		_, err := k8s.CoreV1().Namespaces().Get(ctx, name, metaV1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	})
+}
+
+func (s *VMScanningSuite) mustWaitForHealthyCentralSensorConnection() {
+	s.waitUntilK8sDeploymentReady(s.ctx, namespaces.StackRox, sensorDeployment)
+	waitUntilCentralSensorConnectionIs(s.T(), s.ctx, storage.ClusterHealthStatus_HEALTHY)
+}
+
+func (s *VMScanningSuite) mustVerifyVirtualMachinesFeatureEnabled() {
+	ctx, cancel := context.WithTimeout(s.ctx, 2*time.Minute)
+	defer cancel()
+
+	wantEnv := features.VirtualMachines.EnvVar()
+	ns := namespaces.StackRox
+
+	// Verify the feature flag env var is set on all components that need it.
+	s.mustVerifyContainerEnvVar(ctx, "deployment", "central", "central", ns, wantEnv)
+	s.mustVerifyContainerEnvVar(ctx, "deployment", sensorDeployment, sensorContainer, ns, wantEnv)
+	s.mustVerifyContainerEnvVar(ctx, "daemonset", "collector", "compliance", ns, wantEnv)
+}
+
+// mustVerifyContainerEnvVar asserts that the named container within a Deployment or DaemonSet
+// has the given environment variable set to a truthy value ("true", "1", etc.).
+// This catches deployment misconfigurations where a feature flag reaches Central but not
+// the workload containers that also need it.
+func (s *VMScanningSuite) mustVerifyContainerEnvVar(ctx context.Context, kind, name, containerName, ns, envName string) {
+	t := s.T()
+	t.Helper()
+
+	var containers []coreV1.Container
+	switch kind {
+	case "deployment":
+		obj, err := s.k8sClient.AppsV1().Deployments(ns).Get(ctx, name, metaV1.GetOptions{})
+		require.NoError(t, err, "get Deployment %s/%s", ns, name)
+		containers = obj.Spec.Template.Spec.Containers
+	case "daemonset":
+		obj, err := s.k8sClient.AppsV1().DaemonSets(ns).Get(ctx, name, metaV1.GetOptions{})
+		require.NoError(t, err, "get DaemonSet %s/%s", ns, name)
+		containers = obj.Spec.Template.Spec.Containers
+	default:
+		require.Failf(t, "unsupported kind", "%q", kind)
+	}
+
+	for _, c := range containers {
+		if c.Name != containerName {
+			continue
+		}
+		for _, e := range c.Env {
+			if e.Name == envName {
+				val := strings.ToLower(strings.TrimSpace(e.Value))
+				require.Truef(t, val == "true" || val == "1",
+					"%s %s/%s container %q has %s=%q which is not truthy; "+
+						"the VSOCK relay will not start without this flag",
+					kind, ns, name, containerName, envName, e.Value)
+				return
+			}
+		}
+		require.Failf(t, fmt.Sprintf("%s %s/%s container %q is missing env var %s", kind, ns, name, containerName, envName),
+			"the feature flag must be set on all components that need it (Central, Sensor, compliance); "+
+				"present env vars: %s", formatContainerEnvNames(c.Env))
+	}
+	require.Failf(t, fmt.Sprintf("container %q not found in %s %s/%s", containerName, kind, ns, name),
+		"available containers: %s", formatContainerNames(containers))
+}
+
+func formatContainerEnvNames(envs []coreV1.EnvVar) string {
+	names := make([]string, len(envs))
+	for i, e := range envs {
+		names[i] = e.Name
+	}
+	return strings.Join(names, ", ")
+}
+
+func formatContainerNames(containers []coreV1.Container) string {
+	names := make([]string, len(containers))
+	for i, c := range containers {
+		names[i] = c.Name
+	}
+	return strings.Join(names, ", ")
+}
+
+func (s *VMScanningSuite) provisionPersistentVMs() {
+	ctx := s.ctx
+	createdNow := make(map[string]bool)
+
+	s.logf("provision persistent VMs: creating namespace %q", s.namespace)
+	_, err := s.k8sClient.CoreV1().Namespaces().Create(ctx, &coreV1.Namespace{
+		ObjectMeta: metaV1.ObjectMeta{Name: s.namespace},
+	}, metaV1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		require.NoError(s.T(), err, "create test namespace %q", s.namespace)
+	}
+	if apierrors.IsAlreadyExists(err) {
+		s.logf("provision persistent VMs: namespace %q already exists; reusing it", s.namespace)
+	}
+
+	s.ensureImagePullSecret(ctx)
+
+	specs := []struct {
+		name      string
+		image     string
+		guestUser string
+	}{
+		{name: "vm-rhel9", image: s.cfg.ImageRHEL9, guestUser: s.cfg.GuestUserRHEL9},
+		{name: "vm-rhel10", image: s.cfg.ImageRHEL10, guestUser: s.cfg.GuestUserRHEL10},
+	}
+	for _, sp := range specs {
+		req := vmhelpers.VMRequest{
+			Name:         sp.name,
+			Namespace:    s.namespace,
+			Image:        sp.image,
+			GuestUser:    sp.guestUser,
+			SSHPublicKey: s.cfg.SSHPublicKey,
+		}
+		s.logf("provision persistent VMs: ensuring VM exists %s/%s with image %q", s.namespace, sp.name, sp.image)
+		createErr := vmhelpers.CreateVirtualMachine(ctx, s.dynamicClient, req)
+		if createErr == nil {
+			s.logf("provision persistent VMs: created VM %s/%s", s.namespace, sp.name)
+			createdNow[sp.name] = true
+		} else if apierrors.IsAlreadyExists(createErr) {
+			currentImage, imgErr := vmhelpers.GetVMContainerDiskImage(ctx, s.dynamicClient, s.namespace, sp.name)
+			if imgErr != nil {
+				s.logf("provision persistent VMs: could not read image for existing VM %s/%s: %v; recreating", s.namespace, sp.name, imgErr)
+			}
+			if imgErr != nil || currentImage != sp.image {
+				if imgErr == nil {
+					s.logf("provision persistent VMs: VM %s/%s has image %q but want %q; deleting and recreating",
+						s.namespace, sp.name, currentImage, sp.image)
+				}
+				delCtx, delCancel := context.WithTimeout(ctx, s.vmDeleteTimeout())
+				require.NoError(s.T(), vmhelpers.DeleteVirtualMachine(delCtx, s.dynamicClient, s.namespace, sp.name),
+					"DeleteVirtualMachine %s/%s for image mismatch", s.namespace, sp.name)
+				require.NoError(s.T(), vmhelpers.WaitForVirtualMachineDeleted(s.T(), delCtx, s.dynamicClient, s.namespace, sp.name),
+					"WaitForVirtualMachineDeleted %s/%s for image mismatch", s.namespace, sp.name)
+				delCancel()
+				require.NoError(s.T(), vmhelpers.CreateVirtualMachine(ctx, s.dynamicClient, req),
+					"CreateVirtualMachine %s/%s after image mismatch delete", s.namespace, sp.name)
+				s.logf("provision persistent VMs: recreated VM %s/%s with correct image", s.namespace, sp.name)
+				createdNow[sp.name] = true
+			} else {
+				s.logf("provision persistent VMs: VM %s/%s already exists with correct image; reusing it", s.namespace, sp.name)
+				createdNow[sp.name] = false
+			}
+		} else {
+			require.NoError(s.T(), createErr, "EnsureVirtualMachineExists %s/%s", s.namespace, sp.name)
+		}
+		h := VMHandle{Name: sp.name, Namespace: s.namespace, GuestUser: sp.guestUser}
+		if createdNow[sp.name] {
+			s.recordVMCreatedNow(h)
+		} else {
+			s.recordVMCreationFromCluster(ctx, h)
+		}
+		s.persistentVMs = append(s.persistentVMs, h)
+		s.allVMs = append(s.allVMs, h)
+	}
+	for i := range s.persistentVMs {
+		vm := &s.persistentVMs[i]
+		vmCtx, vmCancel := context.WithTimeout(ctx, s.vmProvisionTimeout())
+		s.logf("provision persistent VMs: waiting for VMI object %s/%s (timeout=%v)", vm.Namespace, vm.Name, s.vmProvisionTimeout())
+		require.NoError(s.T(), vmhelpers.WaitForVirtualMachineInstanceExists(s.T(), vmCtx, s.dynamicClient, vm.Namespace, vm.Name),
+			"WaitForVirtualMachineInstanceExists %s/%s", vm.Namespace, vm.Name)
+		s.logf("provision persistent VMs: waiting for VMI Running %s/%s (timeout=%v)", vm.Namespace, vm.Name, s.vmProvisionTimeout())
+		require.NoError(s.T(), vmhelpers.WaitForVirtualMachineInstanceRunning(s.T(), vmCtx, s.dynamicClient, vm.Namespace, vm.Name),
+			"WaitForVirtualMachineInstanceRunning %s/%s", vm.Namespace, vm.Name)
+		vmCancel()
+
+		nodeName, err := vmhelpers.GetVMINodeName(ctx, s.dynamicClient, vm.Namespace, vm.Name)
+		if err != nil {
+			s.logf("provision persistent VMs: could not determine node for %s/%s: %v", vm.Namespace, vm.Name, err)
+		} else {
+			vm.NodeName = nodeName
+			s.allVMs[i].NodeName = nodeName
+		}
+
+	}
+
+	s.logVMPlacement(ctx)
+}
+
+const vmImagePullSecretName = "vm-image-pull-secret" //nolint:gosec // G101: not a credential, just the k8s Secret resource name
+
+func (s *VMScanningSuite) ensureImagePullSecret(ctx context.Context) {
+	if s.cfg.ImagePullSecretPath == "" {
+		return
+	}
+	s.logf("provision persistent VMs: creating image pull secret from %q", s.cfg.ImagePullSecretPath)
+	dockerCfg, err := os.ReadFile(s.cfg.ImagePullSecretPath)
+	require.NoError(s.T(), err, "read image pull secret file %q", s.cfg.ImagePullSecretPath)
+
+	secret := &coreV1.Secret{
+		ObjectMeta: metaV1.ObjectMeta{Name: vmImagePullSecretName},
+		Type:       coreV1.SecretTypeDockerConfigJson,
+		Data:       map[string][]byte{coreV1.DockerConfigJsonKey: dockerCfg},
+	}
+	_, err = s.k8sClient.CoreV1().Secrets(s.namespace).Create(ctx, secret, metaV1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		_, err = s.k8sClient.CoreV1().Secrets(s.namespace).Update(ctx, secret, metaV1.UpdateOptions{})
+	}
+	require.NoError(s.T(), err, "ensure image pull secret %q in namespace %q", vmImagePullSecretName, s.namespace)
+
+	sa, err := s.k8sClient.CoreV1().ServiceAccounts(s.namespace).Get(ctx, "default", metaV1.GetOptions{})
+	require.NoError(s.T(), err, "get default service account in namespace %q", s.namespace)
+	hasRef := false
+	for _, ref := range sa.ImagePullSecrets {
+		if ref.Name == vmImagePullSecretName {
+			hasRef = true
+			break
+		}
+	}
+	if !hasRef {
+		sa.ImagePullSecrets = append(sa.ImagePullSecrets, coreV1.LocalObjectReference{Name: vmImagePullSecretName})
+		_, err = s.k8sClient.CoreV1().ServiceAccounts(s.namespace).Update(ctx, sa, metaV1.UpdateOptions{})
+		require.NoError(s.T(), err, "link image pull secret to default service account in namespace %q", s.namespace)
+	}
+	s.logf("provision persistent VMs: image pull secret %q ready in namespace %q", vmImagePullSecretName, s.namespace)
+}
+
+func (s *VMScanningSuite) logVMPlacement(ctx context.Context) {
+	lookupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	nodeToCollector := make(map[string]string)
+	pods, err := s.k8sClient.CoreV1().Pods(namespaces.StackRox).List(lookupCtx, metaV1.ListOptions{
+		LabelSelector: "app=collector",
+	})
+	if err != nil {
+		s.logf("VM placement: could not list collector pods: %v", err)
+	} else {
+		for _, p := range pods.Items {
+			nodeToCollector[p.Spec.NodeName] = p.Name
+		}
+	}
+
+	for _, vm := range s.persistentVMs {
+		node := vm.NodeName
+		if node == "" {
+			node = "<unknown>"
+		}
+		collector := nodeToCollector[vm.NodeName]
+		if collector == "" {
+			collector = "<none>"
+		}
+		s.logf("- VM: %s, Node: %s, Collector pod: %s", vm.Name, node, collector)
+	}
+}
+
+func (s *VMScanningSuite) preparePersistentGuests() {
+	t := s.T()
+	for i := range s.persistentVMs {
+		require.NoError(t, s.preparePersistentGuestWithRecovery(&s.persistentVMs[i]))
+	}
+}
+
+func (s *VMScanningSuite) preparePersistentGuestWithRecovery(vm *VMHandle) error {
+	const maxRecoveries = 2
+	for recoveryAttempt := 0; recoveryAttempt <= maxRecoveries; recoveryAttempt++ {
+		err := s.prepareGuestRespectingSSHBrokenGrace(*vm)
+		if err == nil {
+			return nil
+		}
+		recoverableSSHErr := errors.Is(err, vmhelpers.ErrSSHAuthenticationFailed) || errors.Is(err, vmhelpers.ErrSSHConnectivityStalled)
+		if !recoverableSSHErr {
+			return err
+		}
+		if recoveryAttempt == maxRecoveries {
+			return fmt.Errorf("prepare guest %s/%s failed after %d recovery attempt(s): %w",
+				vm.Namespace, vm.Name, maxRecoveries, err)
+		}
+		s.logf("SSH became unhealthy for %s/%s, recreating VM and retrying guest preparation (%d/%d): %v",
+			vm.Namespace, vm.Name, recoveryAttempt+1, maxRecoveries, err)
+		if recreateErr := s.recreatePersistentVM(vm); recreateErr != nil {
+			return fmt.Errorf("recreate persistent VM %s/%s after recoverable SSH failure: %w", vm.Namespace, vm.Name, recreateErr)
+		}
+	}
+	return nil
+}
+
+func (s *VMScanningSuite) recreatePersistentVM(vm *VMHandle) error {
+	req, err := s.vmRequestForExistingPersistentVM(*vm)
+	if err != nil {
+		return err
+	}
+
+	delCtx, delCancel := context.WithTimeout(s.ctx, s.vmDeleteTimeout())
+	defer delCancel()
+	if err := vmhelpers.DeleteVirtualMachine(delCtx, s.dynamicClient, vm.Namespace, vm.Name); err != nil {
+		return fmt.Errorf("DeleteVirtualMachine: %w", err)
+	}
+	if err := vmhelpers.WaitForVirtualMachineDeleted(s.T(), delCtx, s.dynamicClient, vm.Namespace, vm.Name); err != nil {
+		return fmt.Errorf("WaitForVirtualMachineDeleted: %w", err)
+	}
+
+	createCtx, createCancel := context.WithTimeout(s.ctx, s.vmProvisionTimeout())
+	defer createCancel()
+	if err := vmhelpers.CreateVirtualMachine(createCtx, s.dynamicClient, req); err != nil {
+		return fmt.Errorf("CreateVirtualMachine: %w", err)
+	}
+	s.recordVMCreatedNow(*vm)
+	if err := vmhelpers.WaitForVirtualMachineInstanceExists(s.T(), createCtx, s.dynamicClient, vm.Namespace, vm.Name); err != nil {
+		return fmt.Errorf("WaitForVirtualMachineInstanceExists: %w", err)
+	}
+	if err := vmhelpers.WaitForVirtualMachineInstanceRunning(s.T(), createCtx, s.dynamicClient, vm.Namespace, vm.Name); err != nil {
+		return fmt.Errorf("WaitForVirtualMachineInstanceRunning: %w", err)
+	}
+
+	nodeName, nodeErr := vmhelpers.GetVMINodeName(s.ctx, s.dynamicClient, vm.Namespace, vm.Name)
+	if nodeErr != nil {
+		s.logf("recreate VM: could not determine node for %s/%s: %v", vm.Namespace, vm.Name, nodeErr)
+		vm.NodeName = ""
+	} else {
+		s.logf("recreate VM: %s/%s now on node %s (was %s)", vm.Namespace, vm.Name, nodeName, vm.NodeName)
+		vm.NodeName = nodeName
+	}
+	s.syncVMHandleToAllVMs(*vm)
+	return nil
+}
+
+// syncVMHandleToAllVMs propagates field updates from a VMHandle to the matching entry in allVMs.
+func (s *VMScanningSuite) syncVMHandleToAllVMs(vm VMHandle) {
+	for i := range s.allVMs {
+		if s.allVMs[i].Name == vm.Name && s.allVMs[i].Namespace == vm.Namespace {
+			s.allVMs[i] = vm
+			return
+		}
+	}
+}
+
+func (s *VMScanningSuite) vmRequestForExistingPersistentVM(vm VMHandle) (vmhelpers.VMRequest, error) {
+	guestUser := strings.TrimSpace(vm.GuestUser)
+	if guestUser == "" {
+		switch vm.Name {
+		case "vm-rhel9":
+			guestUser = s.cfg.GuestUserRHEL9
+		case "vm-rhel10":
+			guestUser = s.cfg.GuestUserRHEL10
+		}
+	}
+
+	var image string
+	switch vm.Name {
+	case "vm-rhel9":
+		image = s.cfg.ImageRHEL9
+	case "vm-rhel10":
+		image = s.cfg.ImageRHEL10
+	default:
+		return vmhelpers.VMRequest{}, fmt.Errorf("unsupported persistent VM %s/%s for recreation", vm.Namespace, vm.Name)
+	}
+	if image == "" {
+		return vmhelpers.VMRequest{}, fmt.Errorf("missing image for persistent VM %s/%s recreation", vm.Namespace, vm.Name)
+	}
+	if guestUser == "" {
+		return vmhelpers.VMRequest{}, fmt.Errorf("missing guest user for persistent VM %s/%s recreation", vm.Namespace, vm.Name)
+	}
+
+	return vmhelpers.VMRequest{
+		Name:         vm.Name,
+		Namespace:    vm.Namespace,
+		Image:        image,
+		GuestUser:    guestUser,
+		SSHPublicKey: s.cfg.SSHPublicKey,
+	}, nil
+}
+
+func (s *VMScanningSuite) mustListVMByNamespaceAndName(namespace, name string) *v2.VirtualMachine {
+	t := s.T()
+	t.Helper()
+	vm, err := vmhelpers.ListVMByNamespaceName(s.ctx, s.vmClient, namespace, name)
+	require.NoError(t, err)
+	require.NotNil(t, vm, "ListVirtualMachines: no VM for namespace=%q name=%q", namespace, name)
+	return vm
+}
+
+func (s *VMScanningSuite) mustGetVM(id string) *v2.VirtualMachine {
+	t := s.T()
+	t.Helper()
+	resp, err := s.vmClient.GetVirtualMachine(s.ctx, &v2.GetVirtualMachineRequest{Id: id})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	return resp
+}
+
+const maxRoxagentStderrInError = 4096
+
+func formatRoxagentStderrForError(stderr string) string {
+	s := strings.TrimSpace(stderr)
+	if len(s) > maxRoxagentStderrInError {
+		return s[:maxRoxagentStderrInError] + fmt.Sprintf(" ... (truncated from %d bytes)", len(s))
+	}
+	return s
+}
+
+// roxagentStderrCrashLinePrefixes are lowercase; each stderr line is trimmed and lowercased before HasPrefix.
+var roxagentStderrCrashLinePrefixes = []string{
+	"panic:",
+	"fatal error:",
+	"runtime error:",
+}
+
+// validateRoxagentSuccessStderr allows empty or benign stderr but fails only on lines that start with
+// unambiguous Go/runtime crash signatures (after trim + lowercase), avoiding substring false positives.
+func validateRoxagentSuccessStderr(stderr string) error {
+	if strings.TrimSpace(stderr) == "" {
+		return nil
+	}
+	for _, line := range strings.Split(stderr, "\n") {
+		ln := strings.TrimSpace(strings.ToLower(line))
+		for _, prefix := range roxagentStderrCrashLinePrefixes {
+			if strings.HasPrefix(ln, prefix) {
+				return fmt.Errorf("ensureCanonicalScan: roxagent stderr indicates process/runtime failure (matched line prefix %q): %s", prefix, formatRoxagentStderrForError(stderr))
+			}
+		}
+	}
+	return nil
+}
+
+func (s *VMScanningSuite) persistRoxagentStdout(vm *VMHandle, stdout string) string {
+	if vm == nil || strings.TrimSpace(stdout) == "" {
+		return ""
+	}
+	f, err := os.CreateTemp(s.T().TempDir(), fmt.Sprintf("roxagent-%s-%s-*.stdout", vm.Namespace, vm.Name))
+	if err != nil {
+		s.logf("ensureCanonicalScan: could not persist roxagent stdout for %s/%s: %v", vm.Namespace, vm.Name, err)
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(stdout); err != nil {
+		s.logf("ensureCanonicalScan: could not write roxagent stdout file %q: %v", f.Name(), err)
+		return ""
+	}
+	return f.Name()
+}
+
+// waitForScannerV4Initialized blocks until the Scanner V4 matcher has finished
+// loading its vulnerability database. It polls Central's GetVulnDefinitionsInfo API
+// (which internally calls GetMatcherMetadata on the matcher) until a non-zero
+// last-updated timestamp is returned, meaning the vuln store is ready.
+//
+// Called once (guarded by scannerV4Checked) right before the first roxagent invocation
+// so that the matcher initialization happens in parallel with VM boot and SSH readiness.
+func (s *VMScanningSuite) waitForScannerV4Initialized() error {
+	s.logf("Scanner V4: waiting for matcher deployment to be K8s-ready")
+	s.waitUntilK8sDeploymentReady(s.ctx, namespaces.StackRox, "scanner-v4-matcher")
+
+	s.logf("Scanner V4: polling Central for matcher vuln DB initialization")
+	healthClient := v1.NewIntegrationHealthServiceClient(s.conn)
+
+	ctx, cancel := context.WithTimeout(s.ctx, 20*time.Minute)
+	defer cancel()
+
+	return wait.PollUntilContextCancel(ctx, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+		info, err := healthClient.GetVulnDefinitionsInfo(ctx, &v1.VulnDefinitionsInfoRequest{
+			Component: v1.VulnDefinitionsInfoRequest_SCANNER_V4,
+		})
+		if err != nil {
+			s.logf("Scanner V4: matcher not yet initialized: %v", err)
+			return false, nil
+		}
+		ts := info.GetLastUpdatedTimestamp().AsTime()
+		if ts.IsZero() {
+			s.logf("Scanner V4: vuln definitions timestamp is zero, still loading")
+			return false, nil
+		}
+		s.logf("Scanner V4: matcher initialized (vuln defs last updated: %v)", ts)
+		return true, nil
+	})
+}
+
+// ensureCanonicalScan runs a single guest-side roxagent invocation and validates failure signals.
+// It verifies the ROX_VIRTUAL_MACHINES feature flag is enabled before triggering the scan.
+func (s *VMScanningSuite) ensureCanonicalScan(ctx context.Context, vm *VMHandle) (*vmhelpers.RoxagentRunResult, error) {
+	if vm == nil {
+		return nil, errors.New("ensureCanonicalScan: nil VM handle")
+	}
+	s.mustVerifyVirtualMachinesFeatureEnabled()
+	if !s.scannerV4Checked {
+		if err := s.waitForScannerV4Initialized(); err != nil {
+			return nil, fmt.Errorf("Scanner V4 matcher did not initialize within timeout: %w", err)
+		}
+		s.scannerV4Checked = true
+	}
+	virt := s.virtctlForVM(*vm)
+	cfg := vmhelpers.RoxagentRunConfig{
+		Repo2CPEPrimaryURL:      s.cfg.Repo2CPEPrimaryURL,
+		Repo2CPEFallbackURL:     s.cfg.Repo2CPEFallbackURL,
+		Repo2CPEPrimaryAttempts: s.cfg.Repo2CPEPrimaryAttempts,
+	}
+	res, err := vmhelpers.RunRoxagentOnce(ctx, virt, vm.Namespace, vm.Name, cfg)
+	if err != nil {
+		if vmhelpers.IsTerminalVSOCKUnavailableError(err) {
+			s.terminalVSOCKFailure = fmt.Sprintf("%s/%s: %v", vm.Namespace, vm.Name, err)
+			s.logf("terminal vsock failure detected; skipping remaining suite tests: %s", s.terminalVSOCKFailure)
+			return nil, fmt.Errorf("ensureCanonicalScan: terminal vsock failure for %s/%s; subsequent suite tests will be skipped: %w",
+				vm.Namespace, vm.Name, err)
+		}
+		return nil, err
+	}
+	if res == nil {
+		return nil, errors.New("ensureCanonicalScan: nil result from RunRoxagentOnce")
+	}
+	stdoutPath := s.persistRoxagentStdout(vm, res.Stdout)
+	if stdoutPath != "" {
+		s.logf("ensureCanonicalScan: roxagent stdout saved to %q (%d bytes)", stdoutPath, len(res.Stdout))
+		if !vmhelpers.VerboseOutputLooksLikeReport(res.Stdout) {
+			s.logf("ensureCanonicalScan: roxagent stdout on %s/%s does not match known report shapes; continuing (stdout_file=%q)",
+				vm.Namespace, vm.Name, stdoutPath)
+		}
+	} else {
+		s.logf("ensureCanonicalScan: roxagent stdout empty on %s/%s (non-verbose mode)", vm.Namespace, vm.Name)
+	}
+	if err := validateRoxagentSuccessStderr(res.Stderr); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// waitForScan polls Central in order until scan data is visible.
+func (s *VMScanningSuite) waitForScan(ctx context.Context, vm *VMHandle) (*v2.VirtualMachine, error) {
+	if vm == nil {
+		return nil, errors.New("waitForScan: nil VM handle")
+	}
+	s.logf("scan wait %s/%s: start (timeout=%v poll=%v)", vm.Namespace, vm.Name, s.cfg.ScanTimeout, s.cfg.ScanPollInterval)
+	waitCtx, cancel := context.WithTimeout(ctx, s.cfg.ScanTimeout)
+	defer cancel()
+
+	baseOpts := vmhelpers.WaitOptions{
+		Timeout:      s.cfg.ScanTimeout,
+		PollInterval: s.cfg.ScanPollInterval,
+		Logf:         s.logf,
+	}
+
+	s.logf("scan wait %s/%s step 1/6: wait VM present in Central", vm.Namespace, vm.Name)
+	present, err := vmhelpers.WaitForVMPresentInCentral(waitCtx, s.vmClient, baseOpts, vm.Namespace, vm.Name)
+	if err != nil {
+		return nil, err
+	}
+	vm.ID = present.GetId()
+	s.logf("scan wait %s/%s step 1/6 complete: id=%q", vm.Namespace, vm.Name, vm.ID)
+
+	s.logf("scan wait %s/%s step 2/6: wait VM identity fields", vm.Namespace, vm.Name)
+	if _, err := vmhelpers.WaitForVMIdentityFields(waitCtx, s.vmClient, baseOpts, present.GetId(), vm.Namespace, vm.Name); err != nil {
+		return nil, err
+	}
+	s.logf("scan wait %s/%s step 2/6 complete", vm.Namespace, vm.Name)
+	s.logf("scan wait %s/%s step 3/6: wait VM running in Central", vm.Namespace, vm.Name)
+	if _, err := vmhelpers.WaitForVMRunningInCentral(waitCtx, s.vmClient, baseOpts, present.GetId()); err != nil {
+		return nil, err
+	}
+	s.logf("scan wait %s/%s step 3/6 complete", vm.Namespace, vm.Name)
+	s.logf("scan wait %s/%s step 4/6: wait non-nil scan", vm.Namespace, vm.Name)
+	if _, err := vmhelpers.WaitForVMScanNonNil(waitCtx, s.vmClient, baseOpts, present.GetId()); err != nil {
+		return nil, err
+	}
+	s.logf("scan wait %s/%s step 4/6 complete", vm.Namespace, vm.Name)
+	s.logf("scan wait %s/%s step 5/6: wait scan timestamp", vm.Namespace, vm.Name)
+	if _, err := vmhelpers.WaitForVMScanTimestamp(waitCtx, s.vmClient, baseOpts, present.GetId()); err != nil {
+		return nil, err
+	}
+	s.logf("scan wait %s/%s step 5/6 complete", vm.Namespace, vm.Name)
+
+	conds := vmhelpers.ScanReadiness{Components: true, AllScanned: true}
+	s.logf("scan wait %s/%s step 6/6: wait scan ready (components=%v all-scanned=%v)",
+		vm.Namespace, vm.Name, conds.Components, conds.AllScanned)
+	return vmhelpers.WaitForScanReady(waitCtx, s.vmClient, baseOpts, present.GetId(), conds)
+}
+
+func (s *VMScanningSuite) vmDeleteTimeout() time.Duration {
+	if s.cfg != nil && s.cfg.DeleteTimeout > 0 {
+		return s.cfg.DeleteTimeout
+	}
+	return 5 * time.Minute
+}
+
+func (s *VMScanningSuite) mustGetScanTimestamp(id string) *timestamppb.Timestamp {
+	t := s.T()
+	t.Helper()
+	vm := s.mustGetVM(id)
+	require.NotNil(t, vm.GetScan(), "mustGetScanTimestamp: GetVirtualMachine id=%q returned nil scan", id)
+	ts := vm.GetScan().GetScanTime()
+	require.NotNil(t, ts, "mustGetScanTimestamp: GetVirtualMachine id=%q scan_time is nil", id)
+	return ts
+}
+
+func (s *VMScanningSuite) prepareGuest(vm VMHandle) error {
+	virt := s.virtctlForVM(vm)
+	stepTimeout := s.guestStepTimeout()
+	stepNum := 0
+	withStepTimeout := func(fn func(stepCtx context.Context) error) error {
+		stepCtx, cancel := context.WithTimeout(s.ctx, stepTimeout)
+		defer cancel()
+		return fn(stepCtx)
+	}
+	runStep := func(stepName, errContext string, fn func(stepCtx context.Context) error) error {
+		stepNum++
+		s.logf("[guest preparation step %02d]: %s on %s/%s (timeout=%v)",
+			stepNum, stepName, vm.Namespace, vm.Name, stepTimeout)
+		if err := withStepTimeout(fn); err != nil {
+			return fmt.Errorf("prepare guest %s/%s: %s: %w", vm.Namespace, vm.Name, errContext, err)
+		}
+		return nil
+	}
+
+	if err := runStep("Wait for SSH to become reachable", "WaitForSSHReachable", func(stepCtx context.Context) error {
+		return vmhelpers.WaitForSSHReachable(s.T(), stepCtx, virt, vm.Namespace, vm.Name)
+	}); err != nil {
+		return err
+	}
+	if err := runStep("Wait for cloud-init to finish", "WaitForCloudInitFinished", func(stepCtx context.Context) error {
+		return vmhelpers.WaitForCloudInitFinished(stepCtx, virt, vm.Namespace, vm.Name)
+	}); err != nil {
+		return err
+	}
+	if err := runStep("Verify sudo", "VerifySudoWorks", func(stepCtx context.Context) error {
+		return vmhelpers.VerifySudoWorks(stepCtx, virt, vm.Namespace, vm.Name)
+	}); err != nil {
+		return err
+	}
+	if err := runStep("Copy roxagent binary", "CopyRoxagentBinary", func(stepCtx context.Context) error {
+		return vmhelpers.CopyRoxagentBinary(stepCtx, virt, vm.Namespace, vm.Name, s.cfg.RoxagentBinaryPath)
+	}); err != nil {
+		return err
+	}
+	if err := runStep("Verify roxagent binary presence", "VerifyRoxagentBinaryPresent", func(stepCtx context.Context) error {
+		return vmhelpers.VerifyRoxagentBinaryPresent(stepCtx, virt, vm.Namespace, vm.Name)
+	}); err != nil {
+		return err
+	}
+	if err := runStep("Verify roxagent executable mode", "VerifyRoxagentExecutable", func(stepCtx context.Context) error {
+		return vmhelpers.VerifyRoxagentExecutable(stepCtx, virt, vm.Namespace, vm.Name)
+	}); err != nil {
+		return err
+	}
+	if err := runStep("Verify roxagent install path", "VerifyRoxagentInstallPath", func(stepCtx context.Context) error {
+		return vmhelpers.VerifyRoxagentInstallPath(stepCtx, virt, vm.Namespace, vm.Name)
+	}); err != nil {
+		return err
+	}
+	var (
+		activated   bool
+		activStatus string
+	)
+	if err := runStep("Check activation status", "GetActivationStatus", func(stepCtx context.Context) error {
+		var innerErr error
+		activated, activStatus, innerErr = vmhelpers.GetActivationStatus(stepCtx, virt, vm.Namespace, vm.Name)
+		return innerErr
+	}); err != nil {
+		return err
+	}
+	s.logf("[guest prep] activation status for %s/%s: activated=%v detail=%q", vm.Namespace, vm.Name, activated, activStatus)
+	s.logf("[guest prep] COMPLETED for %s/%s in %d step(s)", vm.Namespace, vm.Name, stepNum)
+	return nil
+}

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -1,0 +1,106 @@
+//go:build test_e2e
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/tests/vmhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+func (s *VMScanningSuite) TestScanPipeline() {
+	for i := range s.persistentVMs {
+		vm := &s.persistentVMs[i]
+		s.T().Run(vm.Name, func(t *testing.T) {
+			var result *vmhelpers.RoxagentRunResult
+			var first *v2.VirtualMachine
+
+			t.Run("RunRoxagent", func(t *testing.T) {
+				t.Logf("running roxagent: sudo env ROXAGENT_REPO2CPE_URL=%s %s --verbose",
+					s.cfg.Repo2CPEPrimaryURL, vmhelpers.DefaultRoxagentInstallPath)
+				var err error
+				result, err = s.ensureCanonicalScan(s.ctx, vm)
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				if result.UsedFallback {
+					t.Logf("repo2cpe fallback was used")
+				}
+			})
+			if result == nil {
+				return
+			}
+
+			t.Run("WaitForScan", func(t *testing.T) {
+				var err error
+				first, err = s.waitForScan(s.ctx, vm)
+				require.NoError(t, err)
+				vm.ID = first.GetId()
+			})
+			if first == nil {
+				return
+			}
+
+			t.Run("CentralVMMetadata", func(t *testing.T) {
+				listed := s.mustListVMByNamespaceAndName(vm.Namespace, vm.Name)
+				require.Equal(t, listed.GetId(), first.GetId())
+				require.Equal(t, vm.Name, first.GetName())
+				require.Equal(t, vm.Namespace, first.GetNamespace())
+				require.NotEmpty(t, first.GetClusterId())
+				require.NotEmpty(t, first.GetClusterName())
+				require.Equal(t, v2.VirtualMachine_RUNNING, first.GetState())
+				require.NotNil(t, first.GetScan())
+				require.NotNil(t, first.GetScan().GetScanTime())
+			})
+
+			t.Run("CentralScanComponents", func(t *testing.T) {
+				for _, component := range first.GetScan().GetComponents() {
+					require.NotContains(t, component.GetNotes(), v2.ScanComponent_UNSCANNED)
+				}
+				require.NotEmpty(t, first.GetScan().GetComponents())
+			})
+
+			t.Run("CentralScanOperatingSystem", func(t *testing.T) {
+				os := first.GetScan().GetOperatingSystem()
+				require.NotEmpty(t, os,
+					"scan.operating_system should be populated via Sensor DiscoveredData")
+			})
+
+			beforeTime := s.mustGetScanTimestamp(first.GetId())
+			var rescan *v2.VirtualMachine
+
+			t.Run("Rescan", func(t *testing.T) {
+				_, err := s.ensureCanonicalScan(s.ctx, vm)
+				require.NoError(t, err)
+
+				waitCtx, cancel := context.WithTimeout(s.ctx, s.cfg.ScanTimeout)
+				defer cancel()
+				rescan, err = vmhelpers.WaitForScanTimestampAfter(
+					waitCtx, s.vmClient,
+					vmhelpers.WaitOptions{
+						Timeout:      s.cfg.ScanTimeout,
+						PollInterval: s.cfg.ScanPollInterval,
+						Logf:         s.logf,
+					},
+					vm.ID, beforeTime.AsTime(),
+				)
+				require.NoError(t, err, "rescan should produce a newer scan_time than %v", beforeTime.AsTime())
+			})
+			if rescan == nil {
+				return
+			}
+
+			t.Run("PipelineMetrics", func(t *testing.T) {
+				s.assertPipelineMetrics(s.ctx, t, vm.NodeName)
+			})
+
+			t.Run("ConsistencyCheck", func(t *testing.T) {
+				fetched := s.mustGetVM(rescan.GetId())
+				require.Equal(t, first.GetId(), fetched.GetId(),
+					"VM ID should remain stable across rescans")
+			})
+		})
+	}
+}

--- a/tests/vm_scanning_utils_test.go
+++ b/tests/vm_scanning_utils_test.go
@@ -1,0 +1,246 @@
+//go:build test_e2e
+
+package tests
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+// Defaults for environment variables that can be self-discovered or have sensible values.
+const (
+	defaultRepo2CPEPrimaryURL  = "https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
+	defaultRepo2CPEFallbackURL = "https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
+	defaultRepo2CPEAttempts    = 3
+	defaultNamespacePrefix     = "vm-scan-e2e"
+	defaultScanTimeout         = 20 * time.Minute
+	defaultScanPollInterval    = 10 * time.Second
+	defaultDeleteTimeout       = 5 * time.Minute
+	defaultGuestUser           = "cloud-user"
+)
+
+type vmScanConfig struct {
+	ImageRHEL9              string
+	ImageRHEL10             string
+	GuestUserRHEL9          string
+	GuestUserRHEL10         string
+	VirtctlPath             string
+	RoxagentBinaryPath      string
+	Repo2CPEPrimaryURL      string
+	Repo2CPEFallbackURL     string
+	Repo2CPEPrimaryAttempts int
+	SSHPrivateKey           string // PEM-encoded private key content (not a file path)
+	SSHPublicKey            string // OpenSSH authorized_keys line (not a file path)
+	NamespacePrefix         string
+	ScanTimeout             time.Duration
+	ScanPollInterval        time.Duration
+	DeleteTimeout           time.Duration
+	SkipCleanup             bool
+	ImagePullSecretPath     string // Path to docker config JSON for private registries
+}
+
+func loadVMScanConfig() (*vmScanConfig, error) {
+	cfg := &vmScanConfig{}
+
+	var err error
+	if cfg.ImageRHEL9, err = requireEnv("VM_IMAGE_RHEL9"); err != nil {
+		return nil, err
+	}
+	if cfg.ImageRHEL10, err = requireEnv("VM_IMAGE_RHEL10"); err != nil {
+		return nil, err
+	}
+
+	cfg.GuestUserRHEL9 = envOrDefault("VM_GUEST_USER_RHEL9", defaultGuestUser)
+	cfg.GuestUserRHEL10 = envOrDefault("VM_GUEST_USER_RHEL10", defaultGuestUser)
+
+	if cfg.VirtctlPath, err = discoverVirtctlPath(); err != nil {
+		return nil, err
+	}
+	if cfg.RoxagentBinaryPath, err = discoverRoxagentBinaryPath(); err != nil {
+		return nil, err
+	}
+
+	cfg.Repo2CPEPrimaryURL = envOrDefault("ROXAGENT_REPO2CPE_PRIMARY_URL", defaultRepo2CPEPrimaryURL)
+	cfg.Repo2CPEFallbackURL = envOrDefault("ROXAGENT_REPO2CPE_FALLBACK_URL", defaultRepo2CPEFallbackURL)
+	cfg.Repo2CPEPrimaryAttempts = envIntOrDefault("ROXAGENT_REPO2CPE_PRIMARY_ATTEMPTS", defaultRepo2CPEAttempts)
+
+	cfg.SSHPrivateKey = os.Getenv("VM_SSH_PRIVATE_KEY")
+	cfg.SSHPublicKey = strings.TrimSpace(os.Getenv("VM_SSH_PUBLIC_KEY"))
+	switch {
+	case strings.TrimSpace(cfg.SSHPrivateKey) == "" && cfg.SSHPublicKey == "":
+		priv, pub, genErr := generateEphemeralSSHKeypair()
+		if genErr != nil {
+			return nil, fmt.Errorf("VM_SSH_PRIVATE_KEY/VM_SSH_PUBLIC_KEY not set and ephemeral key generation failed: %w", genErr)
+		}
+		cfg.SSHPrivateKey = priv
+		cfg.SSHPublicKey = pub
+	case strings.TrimSpace(cfg.SSHPrivateKey) == "":
+		return nil, errors.New("VM_SSH_PUBLIC_KEY is set but VM_SSH_PRIVATE_KEY is missing; provide both or neither")
+	case cfg.SSHPublicKey == "":
+		return nil, errors.New("VM_SSH_PRIVATE_KEY is set but VM_SSH_PUBLIC_KEY is missing; provide both or neither")
+	}
+
+	cfg.NamespacePrefix = envOrDefault("VM_SCAN_NAMESPACE_PREFIX", defaultNamespacePrefix)
+	cfg.ScanTimeout = envDurationOrDefault("VM_SCAN_TIMEOUT", defaultScanTimeout)
+	cfg.ScanPollInterval = envDurationOrDefault("VM_SCAN_POLL_INTERVAL", defaultScanPollInterval)
+	cfg.DeleteTimeout = envDurationOrDefault("VM_DELETE_TIMEOUT", defaultDeleteTimeout)
+
+	cfg.SkipCleanup = envTruthy("VM_SCAN_SKIP_CLEANUP")
+	cfg.ImagePullSecretPath = strings.TrimSpace(os.Getenv("VM_IMAGE_PULL_SECRET_PATH"))
+
+	return cfg, nil
+}
+
+// discoverVirtctlPath returns the VIRTCTL_PATH env var if set, otherwise searches $PATH.
+func discoverVirtctlPath() (string, error) {
+	if v := strings.TrimSpace(os.Getenv("VIRTCTL_PATH")); v != "" {
+		return v, nil
+	}
+	p, err := exec.LookPath("virtctl")
+	if err != nil {
+		return "", fmt.Errorf("VIRTCTL_PATH not set and virtctl not found on $PATH: %w", err)
+	}
+	return p, nil
+}
+
+// discoverRoxagentBinaryPath returns the ROXAGENT_BINARY_PATH env var if set,
+// otherwise probes the standard build output path relative to the repository root.
+func discoverRoxagentBinaryPath() (string, error) {
+	if v := strings.TrimSpace(os.Getenv("ROXAGENT_BINARY_PATH")); v != "" {
+		return v, nil
+	}
+	root := repoRoot()
+	candidate := filepath.Join(root, "bin", "linux_amd64", "roxagent")
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate, nil
+	}
+	return "", fmt.Errorf("ROXAGENT_BINARY_PATH not set and %s does not exist; run 'make roxagent_linux-amd64'", candidate)
+}
+
+// repoRoot returns the repository root by walking up from this source file.
+func repoRoot() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "."
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), ".."))
+}
+
+// generateEphemeralSSHKeypair creates a one-time ed25519 keypair and returns
+// the PEM-encoded private key and the OpenSSH authorized_keys public key line.
+func generateEphemeralSSHKeypair() (privateKeyPEM string, publicKeyAuthorized string, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", "", fmt.Errorf("generate ed25519 key: %w", err)
+	}
+	privBytes, err := ssh.MarshalPrivateKey(priv, "stackrox-vm-scan-e2e-ephemeral")
+	if err != nil {
+		return "", "", fmt.Errorf("marshal private key: %w", err)
+	}
+	pemData := pem.EncodeToMemory(privBytes)
+
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return "", "", fmt.Errorf("convert public key: %w", err)
+	}
+	authorizedKey := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub)))
+
+	return string(pemData), authorizedKey, nil
+}
+
+func envTruthy(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "true", "1", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func envOrDefault(key, defaultVal string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return defaultVal
+}
+
+func envIntOrDefault(key string, defaultVal int) int {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return defaultVal
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return defaultVal
+	}
+	return n
+}
+
+func envDurationOrDefault(key string, defaultVal time.Duration) time.Duration {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return defaultVal
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return defaultVal
+	}
+	return d
+}
+
+func requireEnv(key string) (string, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return "", fmt.Errorf("required environment variable %s is not set", key)
+	}
+	return v, nil
+}
+
+func TestLoadVMScanConfig_MissingRequired(t *testing.T) {
+	t.Setenv("VM_IMAGE_RHEL9", "")
+	_, err := loadVMScanConfig()
+	require.ErrorContains(t, err, "VM_IMAGE_RHEL9")
+}
+
+func TestLoadVMScanConfig_Defaults(t *testing.T) {
+	t.Setenv("VM_IMAGE_RHEL9", "registry.example.com/rhel9:latest")
+	t.Setenv("VM_IMAGE_RHEL10", "registry.example.com/rhel10:latest")
+	// Clear all optional vars to exercise defaults.
+	for _, key := range []string{
+		"VM_GUEST_USER_RHEL9", "VM_GUEST_USER_RHEL10",
+		"VM_SCAN_NAMESPACE_PREFIX", "VM_SCAN_TIMEOUT", "VM_SCAN_POLL_INTERVAL", "VM_DELETE_TIMEOUT",
+		"ROXAGENT_REPO2CPE_PRIMARY_URL", "ROXAGENT_REPO2CPE_FALLBACK_URL", "ROXAGENT_REPO2CPE_PRIMARY_ATTEMPTS",
+	} {
+		t.Setenv(key, "")
+	}
+	cfg, err := loadVMScanConfig()
+	require.NoError(t, err)
+	require.Equal(t, defaultGuestUser, cfg.GuestUserRHEL9)
+	require.Equal(t, defaultGuestUser, cfg.GuestUserRHEL10)
+	require.Equal(t, defaultNamespacePrefix, cfg.NamespacePrefix)
+	require.Equal(t, defaultScanTimeout, cfg.ScanTimeout)
+	require.Equal(t, defaultScanPollInterval, cfg.ScanPollInterval)
+	require.Equal(t, defaultDeleteTimeout, cfg.DeleteTimeout)
+	require.Equal(t, defaultRepo2CPEAttempts, cfg.Repo2CPEPrimaryAttempts)
+}
+
+func TestGenerateEphemeralSSHKeypair(t *testing.T) {
+	priv, pub, err := generateEphemeralSSHKeypair()
+	require.NoError(t, err)
+	require.Contains(t, priv, "-----BEGIN OPENSSH PRIVATE KEY-----") // notsecret
+	require.Contains(t, pub, "ssh-ed25519 ")                         // notsecret
+}

--- a/tests/vmhelpers/central.go
+++ b/tests/vmhelpers/central.go
@@ -1,0 +1,249 @@
+package vmhelpers
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/pkg/search"
+)
+
+// ScanReadiness configures which scan fields must be present before
+// WaitForScanReady considers the scan complete.
+type ScanReadiness struct {
+	Components bool // at least one component reported
+	AllScanned bool // no UNSCANNED notes on any component
+}
+
+// WaitForVMPresentInCentral polls ListVirtualMachines until a VM matches namespace and name.
+func WaitForVMPresentInCentral(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, namespace, name string) (*v2.VirtualMachine, error) {
+	var found *v2.VirtualMachine
+	err := pollUntil(ctx, opts, fmt.Sprintf("VM present in Central (namespace=%q name=%q)", namespace, name), func(ctx context.Context) (bool, string, error) {
+		vm, err := ListVMByNamespaceName(ctx, client, namespace, name)
+		if err != nil {
+			return false, "", err
+		}
+		if vm == nil {
+			return false, "list returned no matching virtual machine", nil
+		}
+		found = vm
+		return true, fmt.Sprintf("id=%s", vm.GetId()), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return found, nil
+}
+
+// vmConditionCheck inspects a freshly-fetched VirtualMachine and reports whether
+// the desired condition is met. detail is included in poll logs and timeout errors.
+type vmConditionCheck func(vm *v2.VirtualMachine) (done bool, detail string)
+
+// waitForVMCondition polls GetVirtualMachine until check returns done==true.
+func waitForVMCondition(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id, desc string, check vmConditionCheck) (*v2.VirtualMachine, error) {
+	var vm *v2.VirtualMachine
+	err := pollUntil(ctx, opts, desc, func(ctx context.Context) (bool, string, error) {
+		cur, err := client.GetVirtualMachine(ctx, &v2.GetVirtualMachineRequest{Id: id})
+		if err != nil {
+			return false, "", err
+		}
+		done, detail := check(cur)
+		if done {
+			vm = cur
+		}
+		return done, detail, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return vm, nil
+}
+
+// WaitForVMIdentityFields polls GetVirtualMachine until id maps to the expected namespace and name.
+func WaitForVMIdentityFields(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id, expectedNamespace, expectedName string) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("VM identity fields (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		detail := fmt.Sprintf("namespace=%q name=%q", vm.GetNamespace(), vm.GetName())
+		return vm.GetNamespace() == expectedNamespace && vm.GetName() == expectedName, detail
+	})
+}
+
+// WaitForVMRunningInCentral polls until the VM state is RUNNING.
+func WaitForVMRunningInCentral(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("VM RUNNING (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		st := vm.GetState()
+		return st == v2.VirtualMachine_RUNNING, fmt.Sprintf("state=%s", st)
+	})
+}
+
+// WaitForVMScanNonNil polls until VirtualMachine.scan is non-nil.
+func WaitForVMScanNonNil(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("VM scan non-nil (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		if vm.GetScan() == nil {
+			return false, "scan is nil"
+		}
+		return true, "scan present"
+	})
+}
+
+// WaitForVMScanTimestamp polls until scan_time is set.
+func WaitForVMScanTimestamp(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("VM scan timestamp (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		sc := vm.GetScan()
+		if sc == nil {
+			return false, "scan is nil"
+		}
+		if sc.GetScanTime() == nil {
+			return false, "scan_time is nil"
+		}
+		return true, "scan_time set"
+	})
+}
+
+// WaitForScanTimestampAfter polls until the VM's scan_time is strictly after the given
+// threshold. Use this to wait for a rescan to be reflected in Central.
+func WaitForScanTimestampAfter(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string, after time.Time) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("scan timestamp after %v (id=%q)", after.Format(time.RFC3339), id), func(vm *v2.VirtualMachine) (bool, string) {
+		sc := vm.GetScan()
+		if sc == nil || sc.GetScanTime() == nil {
+			return false, "scan_time not set yet"
+		}
+		ts := sc.GetScanTime().AsTime()
+		if !ts.After(after) {
+			return false, fmt.Sprintf("scan_time=%v not yet after %v", ts.Format(time.RFC3339Nano), after.Format(time.RFC3339Nano))
+		}
+		return true, fmt.Sprintf("scan_time=%v", ts.Format(time.RFC3339Nano))
+	})
+}
+
+// WaitForVMComponentsReported polls until at least one scan component exists.
+func WaitForVMComponentsReported(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("VM components reported (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		if hasReportedComponents(vm) {
+			return true, "components present"
+		}
+		n := 0
+		if vm.GetScan() != nil {
+			n = len(vm.GetScan().GetComponents())
+		}
+		return false, fmt.Sprintf("component count=%d", n)
+	})
+}
+
+// WaitForAllVMComponentsScanned polls until every scan component lacks the UNSCANNED note.
+func WaitForAllVMComponentsScanned(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("all VM components scanned (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		if allComponentsScanned(vm) {
+			return true, "all components scanned"
+		}
+		return false, "pending UNSCANNED components or empty component list"
+	})
+}
+
+// WaitForScanReady polls GetVirtualMachine in a single loop until every field
+// requested in conds is populated. Each poll iteration logs which conditions
+// are already met and which are still pending, so partial progress is visible.
+func WaitForScanReady(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string, conds ScanReadiness) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("scan ready (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		scan := vm.GetScan()
+		if scan == nil {
+			return false, "scan is nil"
+		}
+
+		var ready, pending []string
+		comps := scan.GetComponents()
+
+		if conds.Components {
+			if n := len(comps); n > 0 {
+				ready = append(ready, fmt.Sprintf("components=%d", n))
+			} else {
+				pending = append(pending, "components")
+			}
+		}
+		if conds.AllScanned {
+			if len(comps) > 0 && !slices.ContainsFunc(comps, func(c *v2.ScanComponent) bool {
+				return slices.Contains(c.GetNotes(), v2.ScanComponent_UNSCANNED)
+			}) {
+				ready = append(ready, "all-scanned")
+			} else {
+				pending = append(pending, "all-scanned")
+			}
+		}
+
+		// OS is informational: it arrives in the same message as components,
+		// so if components are present and fully scanned, the OS won't appear
+		// in a later update. Report it but never block on it.
+		if os := scan.GetOperatingSystem(); os != "" {
+			ready = append(ready, fmt.Sprintf("os=%q", os))
+		} else if len(pending) == 0 {
+			ready = append(ready, "os=<not reported>")
+		}
+
+		detail := fmt.Sprintf("ready:[%s] waiting:[%s]", strings.Join(ready, ","), strings.Join(pending, ","))
+		return len(pending) == 0, detail
+	})
+}
+
+// listVMPageSize is the page size used when iterating ListVirtualMachines pages.
+const listVMPageSize = int32(1000)
+
+// rawListQueryNamespaceAndName builds a Central raw search query matching namespace and VM name.
+func rawListQueryNamespaceAndName(namespace, name string) string {
+	return fmt.Sprintf("%s:%s+%s:%s", search.Namespace, namespace, search.VirtualMachineName, name)
+}
+
+// ListVMByNamespaceName returns the first VirtualMachine in Central whose namespace and name
+// exactly match the given values, paging through all results. Returns (nil, nil) when no
+// match is found.
+func ListVMByNamespaceName(ctx context.Context, client v2.VirtualMachineServiceClient, namespace, name string) (*v2.VirtualMachine, error) {
+	baseQuery := rawListQueryNamespaceAndName(namespace, name)
+	for offset := int32(0); ; offset += listVMPageSize {
+		resp, err := client.ListVirtualMachines(ctx, &v2.ListVirtualMachinesRequest{
+			Query: &v2.RawQuery{
+				Query: baseQuery,
+				Pagination: &v2.Pagination{
+					Limit:  listVMPageSize,
+					Offset: offset,
+				},
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, vm := range resp.GetVirtualMachines() {
+			if vm.GetNamespace() == namespace && vm.GetName() == name {
+				return vm, nil
+			}
+		}
+		if int32(len(resp.GetVirtualMachines())) < listVMPageSize {
+			return nil, nil
+		}
+	}
+}
+
+// hasReportedComponents reports whether the VM scan lists at least one component.
+func hasReportedComponents(vm *v2.VirtualMachine) bool {
+	if vm == nil || vm.GetScan() == nil {
+		return false
+	}
+	return len(vm.GetScan().GetComponents()) > 0
+}
+
+// allComponentsScanned reports whether every scan component lacks the UNSCANNED note.
+func allComponentsScanned(vm *v2.VirtualMachine) bool {
+	if vm == nil || vm.GetScan() == nil {
+		return false
+	}
+	comps := vm.GetScan().GetComponents()
+	if len(comps) == 0 {
+		return false
+	}
+	for _, c := range comps {
+		if slices.Contains(c.GetNotes(), v2.ScanComponent_UNSCANNED) {
+			return false
+		}
+	}
+	return true
+}

--- a/tests/vmhelpers/central_test.go
+++ b/tests/vmhelpers/central_test.go
@@ -1,0 +1,260 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestHasReportedComponents_TrueForNComponents(t *testing.T) {
+	vm := &v2.VirtualMachine{
+		Scan: &v2.VirtualMachineScan{
+			Components: []*v2.ScanComponent{{Name: "pkg-a"}},
+		},
+	}
+	require.True(t, hasReportedComponents(vm))
+}
+
+func TestHasReportedComponents_FalseWhenNilScan(t *testing.T) {
+	require.False(t, hasReportedComponents(&v2.VirtualMachine{}))
+	require.False(t, hasReportedComponents(nil))
+}
+
+func TestAllComponentsScanned(t *testing.T) {
+	t.Run("true when no UNSCANNED notes", func(t *testing.T) {
+		vm := &v2.VirtualMachine{
+			Scan: &v2.VirtualMachineScan{
+				Components: []*v2.ScanComponent{
+					{Name: "a", Notes: []v2.ScanComponent_Note{v2.ScanComponent_UNSPECIFIED}},
+				},
+			},
+		}
+		require.True(t, allComponentsScanned(vm))
+	})
+	t.Run("false when UNSCANNED present", func(t *testing.T) {
+		vm := &v2.VirtualMachine{
+			Scan: &v2.VirtualMachineScan{
+				Components: []*v2.ScanComponent{
+					{Name: "a", Notes: []v2.ScanComponent_Note{v2.ScanComponent_UNSCANNED}},
+				},
+			},
+		}
+		require.False(t, allComponentsScanned(vm))
+	})
+	t.Run("false when empty components", func(t *testing.T) {
+		vm := &v2.VirtualMachine{Scan: &v2.VirtualMachineScan{}}
+		require.False(t, allComponentsScanned(vm))
+	})
+}
+
+func TestRawListQueryNamespaceAndName(t *testing.T) {
+	q := rawListQueryNamespaceAndName("stackrox", "vm-rhel9")
+	require.Contains(t, q, "Namespace:stackrox")
+	require.Contains(t, q, "Virtual Machine Name:vm-rhel9")
+}
+
+type stubVirtualMachineClient struct {
+	listFn func(ctx context.Context, req *v2.ListVirtualMachinesRequest) (*v2.ListVirtualMachinesResponse, error)
+	getFn  func(ctx context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error)
+}
+
+func (s *stubVirtualMachineClient) ListVirtualMachines(ctx context.Context, in *v2.ListVirtualMachinesRequest, _ ...grpc.CallOption) (*v2.ListVirtualMachinesResponse, error) {
+	if s.listFn == nil {
+		return &v2.ListVirtualMachinesResponse{}, nil
+	}
+	return s.listFn(ctx, in)
+}
+
+func (s *stubVirtualMachineClient) GetVirtualMachine(ctx context.Context, in *v2.GetVirtualMachineRequest, _ ...grpc.CallOption) (*v2.VirtualMachine, error) {
+	if s.getFn == nil {
+		return nil, errors.New("get not stubbed")
+	}
+	return s.getFn(ctx, in)
+}
+
+func TestWaitForVMPresentInCentral_UsesListVirtualMachines(t *testing.T) {
+	ctx := context.Background()
+	opts := WaitOptions{Timeout: 200 * time.Millisecond, PollInterval: 5 * time.Millisecond}
+	var sawQuery string
+	client := &stubVirtualMachineClient{
+		listFn: func(ctx context.Context, req *v2.ListVirtualMachinesRequest) (*v2.ListVirtualMachinesResponse, error) {
+			sawQuery = req.GetQuery().GetQuery()
+			return &v2.ListVirtualMachinesResponse{
+				VirtualMachines: []*v2.VirtualMachine{
+					{Id: "id-1", Namespace: "ns1", Name: "vm1"},
+				},
+			}, nil
+		},
+	}
+	vm, err := WaitForVMPresentInCentral(ctx, client, opts, "ns1", "vm1")
+	require.NoError(t, err)
+	require.Equal(t, "id-1", vm.GetId())
+	require.NotEmpty(t, sawQuery)
+	require.Contains(t, sawQuery, "Namespace:ns1")
+}
+
+func TestWaitForVMScanTimestamp(t *testing.T) {
+	ctx := context.Background()
+	opts := WaitOptions{Timeout: 150 * time.Millisecond, PollInterval: 5 * time.Millisecond}
+	var calls int
+	client := &stubVirtualMachineClient{
+		getFn: func(ctx context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
+			calls++
+			if calls < 3 {
+				return &v2.VirtualMachine{
+					Id:   req.GetId(),
+					Scan: &v2.VirtualMachineScan{},
+				}, nil
+			}
+			return &v2.VirtualMachine{
+				Id: req.GetId(),
+				Scan: &v2.VirtualMachineScan{
+					ScanTime: timestamppb.Now(),
+				},
+			}, nil
+		},
+	}
+	vm, err := WaitForVMScanTimestamp(ctx, client, opts, "vid")
+	require.NoError(t, err)
+	require.NotNil(t, vm.GetScan().GetScanTime())
+	require.GreaterOrEqual(t, calls, 3)
+}
+
+func TestCentralWaitStubClients(t *testing.T) {
+	ctx := context.Background()
+	opts := WaitOptions{Timeout: 150 * time.Millisecond, PollInterval: 5 * time.Millisecond}
+
+	for _, tc := range []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "WaitForVMIdentityFields",
+			run: func(t *testing.T) {
+				var calls int
+				client := &stubVirtualMachineClient{
+					getFn: func(_ context.Context, _ *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
+						calls++
+						if calls == 1 {
+							return &v2.VirtualMachine{Id: "vid", Namespace: "a", Name: "b"}, nil
+						}
+						return &v2.VirtualMachine{Id: "vid", Namespace: "ns-x", Name: "vm-x"}, nil
+					},
+				}
+				vm, err := WaitForVMIdentityFields(ctx, client, opts, "vid", "ns-x", "vm-x")
+				require.NoError(t, err)
+				require.Equal(t, "ns-x", vm.GetNamespace())
+				require.Equal(t, "vm-x", vm.GetName())
+				require.GreaterOrEqual(t, calls, 2)
+			},
+		},
+		{
+			name: "WaitForVMRunningInCentral",
+			run: func(t *testing.T) {
+				var calls int
+				client := &stubVirtualMachineClient{
+					getFn: func(_ context.Context, _ *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
+						calls++
+						if calls < 2 {
+							return &v2.VirtualMachine{Id: "r1", State: v2.VirtualMachine_STOPPED}, nil
+						}
+						return &v2.VirtualMachine{Id: "r1", State: v2.VirtualMachine_RUNNING}, nil
+					},
+				}
+				vm, err := WaitForVMRunningInCentral(ctx, client, opts, "r1")
+				require.NoError(t, err)
+				require.Equal(t, v2.VirtualMachine_RUNNING, vm.GetState())
+				require.GreaterOrEqual(t, calls, 2)
+			},
+		},
+		{
+			name: "WaitForVMScanNonNil",
+			run: func(t *testing.T) {
+				var calls int
+				client := &stubVirtualMachineClient{
+					getFn: func(_ context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
+						calls++
+						if calls == 1 {
+							return &v2.VirtualMachine{Id: req.GetId(), Scan: nil}, nil
+						}
+						return &v2.VirtualMachine{Id: req.GetId(), Scan: &v2.VirtualMachineScan{}}, nil
+					},
+				}
+				vm, err := WaitForVMScanNonNil(ctx, client, opts, "s1")
+				require.NoError(t, err)
+				require.NotNil(t, vm.GetScan())
+				require.GreaterOrEqual(t, calls, 2)
+			},
+		},
+		{
+			name: "WaitForVMComponentsReported",
+			run: func(t *testing.T) {
+				var calls int
+				client := &stubVirtualMachineClient{
+					getFn: func(_ context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
+						calls++
+						if calls == 1 {
+							return &v2.VirtualMachine{
+								Id:   req.GetId(),
+								Scan: &v2.VirtualMachineScan{Components: nil},
+							}, nil
+						}
+						return &v2.VirtualMachine{
+							Id: req.GetId(),
+							Scan: &v2.VirtualMachineScan{
+								Components: []*v2.ScanComponent{{Name: "c1"}},
+							},
+						}, nil
+					},
+				}
+				vm, err := WaitForVMComponentsReported(ctx, client, opts, "cvm")
+				require.NoError(t, err)
+				require.Len(t, vm.GetScan().GetComponents(), 1)
+				require.GreaterOrEqual(t, calls, 2)
+			},
+		},
+		{
+			name: "WaitForAllVMComponentsScanned",
+			run: func(t *testing.T) {
+				var calls int
+				client := &stubVirtualMachineClient{
+					getFn: func(_ context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
+						calls++
+						if calls == 1 {
+							return &v2.VirtualMachine{
+								Id: req.GetId(),
+								Scan: &v2.VirtualMachineScan{
+									Components: []*v2.ScanComponent{
+										{Name: "p", Notes: []v2.ScanComponent_Note{v2.ScanComponent_UNSCANNED}},
+									},
+								},
+							}, nil
+						}
+						return &v2.VirtualMachine{
+							Id: req.GetId(),
+							Scan: &v2.VirtualMachineScan{
+								Components: []*v2.ScanComponent{
+									{Name: "p", Notes: []v2.ScanComponent_Note{v2.ScanComponent_UNSPECIFIED}},
+								},
+							},
+						}, nil
+					},
+				}
+				vm, err := WaitForAllVMComponentsScanned(ctx, client, opts, "all1")
+				require.NoError(t, err)
+				require.True(t, allComponentsScanned(vm))
+				require.GreaterOrEqual(t, calls, 2)
+			},
+		},
+	} {
+		t.Run(tc.name, tc.run)
+	}
+}

--- a/tests/vmhelpers/guest.go
+++ b/tests/vmhelpers/guest.go
@@ -1,0 +1,162 @@
+package vmhelpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	guestCommandErrorMaxLen       = 4096
+	vsockReadinessMarker          = "VSOCK_READY"
+	rhsmPrecheckSSHRetryThreshold = 5
+)
+
+// checkVsockReadiness tests /dev/vsock presence and gathers diagnostics when absent.
+func checkVsockReadiness(ctx context.Context, virt Virtctl, namespace, vm string) (ready bool, detail string, err error) {
+	_, _, testErr := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+		description:            "vsock device check",
+		transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+	}, "test", "-e", "/dev/vsock")
+	if testErr == nil {
+		return true, vsockReadinessMarker + " /dev/vsock present", nil
+	}
+	if errors.Is(testErr, errSSHTransport) {
+		return false, "", testErr
+	}
+	// /dev/vsock absent — gather diagnostics via separate calls.
+	diagStr := collectVsockDiagnostics(ctx, virt, namespace, vm)
+	return false, fmt.Sprintf("VSOCK_MISSING /dev/vsock absent (%s)", diagStr), nil
+}
+
+// collectVsockDiagnostics gathers /dev/vsock and kernel module info from the guest for troubleshooting.
+func collectVsockDiagnostics(ctx context.Context, virt Virtctl, namespace, vm string) string {
+	var diag []string
+	lsOut, _, _ := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+		description: "vsock diagnostic ls", transportRetryAttempts: 1,
+	}, "ls", "-l", "/dev/vsock")
+	if s := strings.TrimSpace(lsOut); s != "" {
+		diag = append(diag, "ls: "+s)
+	}
+	lsmodOut, _, _ := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+		description: "vsock diagnostic lsmod", transportRetryAttempts: 1,
+	}, "lsmod")
+	for _, line := range strings.Split(lsmodOut, "\n") {
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "vsock") || strings.Contains(lower, "vhost") {
+			diag = append(diag, "module: "+strings.TrimSpace(line))
+		}
+	}
+	if len(diag) == 0 {
+		return "no diagnostic info available"
+	}
+	return strings.Join(diag, "; ")
+}
+
+// dnfHistoryHasTransactionsOutput returns true if dnf history list output contains at least one numeric transaction ID line.
+func dnfHistoryHasTransactionsOutput(output string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) == 0 {
+			continue
+		}
+		if _, err := strconv.Atoi(fields[0]); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// IsDnfHistoryPopulated runs dnf history list on the guest and reports whether any transactions exist yet.
+func IsDnfHistoryPopulated(ctx context.Context, virt Virtctl, namespace, vm string) (bool, error) {
+	stdout, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+		description:            "dnf history check",
+		transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+	}, "sudo", "dnf", "-q", "history", "list", "--reverse")
+	combined := strings.TrimSpace(stdout + "\n" + stderr)
+	if err != nil {
+		return false, fmt.Errorf("dnf history check: %w: %s", err, formatGuestCommandOutputForError(combined))
+	}
+	return dnfHistoryHasTransactionsOutput(combined), nil
+}
+
+// ensureVsockReady retries the virtio-vsock device check until /dev/vsock exists or SSH transport errors are exhausted.
+func ensureVsockReady(ctx context.Context, virt Virtctl, namespace, vm, stage string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, fmt.Sprintf("vsock precheck before %s", stage), func(ctx context.Context) error {
+		ready, detail, err := checkVsockReadiness(ctx, virt, namespace, vm)
+		if err != nil {
+			return err
+		}
+		if !ready {
+			return fmt.Errorf("vsock precheck before %s on %s/%s: %s", stage, namespace, vm, detail)
+		}
+		if virt.Logf != nil {
+			virt.Logf("vsock precheck before %s on %s/%s: ready", stage, namespace, vm)
+		}
+		return nil
+	})
+}
+
+// formatGuestCommandOutputForError trims guest command output and truncates it for error message inclusion.
+func formatGuestCommandOutputForError(output string) string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return "<no guest stdout/stderr>"
+	}
+	if len(output) <= guestCommandErrorMaxLen {
+		return output
+	}
+	return output[:guestCommandErrorMaxLen] + fmt.Sprintf(" ... (truncated from %d bytes)", len(output))
+}
+
+// overallStatusFromSubscriptionManagerOutput parses the "Overall Status:" line from subscription-manager combined output.
+func overallStatusFromSubscriptionManagerOutput(output string) (status string, found bool) {
+	const prefix = "overall status:"
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(strings.ToLower(line), prefix) {
+			continue
+		}
+		return strings.TrimSpace(line[len(prefix):]), true
+	}
+	return "", false
+}
+
+// isActivatedOverallStatus reports whether subscription-manager overall status text means the system is subscribed/registered.
+func isActivatedOverallStatus(status string) bool {
+	status = strings.TrimSpace(status)
+	return strings.EqualFold(status, "Current") || strings.EqualFold(status, "Registered")
+}
+
+// activationStatusFromCommandOutput interprets subscription-manager status stdout/stderr into activated vs error vs fallback identity parsing.
+func activationStatusFromCommandOutput(stdout, stderr string, cmdErr error) (activated bool, details string, err error) {
+	combined := strings.TrimSpace(stdout + "\n" + stderr)
+	if status, found := overallStatusFromSubscriptionManagerOutput(combined); found {
+		return isActivatedOverallStatus(status), combined, nil
+	}
+	if cmdErr != nil {
+		return false, combined, fmt.Errorf("subscription-manager status: %w (output: %s)", cmdErr, formatGuestCommandOutputForError(combined))
+	}
+	return activationFromSubscriptionManagerOutput(stdout), strings.TrimSpace(stdout), nil
+}
+
+// GetActivationStatus runs subscription-manager status and reports whether the guest looks activated.
+func GetActivationStatus(ctx context.Context, virt Virtctl, namespace, vm string) (activated bool, details string, err error) {
+	stdout, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+		description:            "subscription-manager status",
+		transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+	}, "sudo", "subscription-manager", "status")
+	activated, details, statusErr := activationStatusFromCommandOutput(stdout, stderr, err)
+	if statusErr != nil {
+		return false, details, fmt.Errorf("subscription-manager status on %s/%s: %w", namespace, vm, statusErr)
+	}
+	return activated, details, nil
+}
+
+// activationFromSubscriptionManagerOutput returns true when subscription-manager stdout contains an activated overall status.
+func activationFromSubscriptionManagerOutput(stdout string) bool {
+	status, found := overallStatusFromSubscriptionManagerOutput(stdout)
+	return found && isActivatedOverallStatus(status)
+}

--- a/tests/vmhelpers/guest_ssh_internal.go
+++ b/tests/vmhelpers/guest_ssh_internal.go
@@ -1,0 +1,176 @@
+package vmhelpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// SSH reachability and guest wait tuning: probe cadence, per-category stall thresholds,
+// single-probe timeout, and wait-loop logging/truncation for cloud-init and similar polls.
+const (
+	// sshReachablePollInterval is the sleep between consecutive SSH probe attempts.
+	sshReachablePollInterval = 10 * time.Second
+	// sshAuthFailureThreshold is the number of consecutive "permission denied" probe
+	// failures required to classify credentials as stale/missing before recovery kicks in.
+	sshAuthFailureThreshold = 3
+	// sshBannerTimeoutThreshold is the number of consecutive "banner exchange timeout"
+	// probe failures required to classify SSH connectivity as stalled.
+	sshBannerTimeoutThreshold = 6
+	// sshNetworkUnreachableThreshold is the number of consecutive network failures
+	// ("no route to host"/"connection refused") required to classify connectivity as stalled.
+	sshNetworkUnreachableThreshold = 36
+	// sshProbeTimeoutThreshold is the number of consecutive per-probe timeout failures
+	// required to classify SSH connectivity as stalled.
+	sshProbeTimeoutThreshold = 6
+	// sshProbeAttemptTimeout bounds one SSH probe attempt so wait-loop diagnostics
+	// continue even when a single virtctl invocation gets stuck.
+	sshProbeAttemptTimeout = 20 * time.Second
+)
+
+// passwordlessSudoRequirementHint is appended to errors when cloud-init/sudo checks need NOPASSWD sudo for the SSH user.
+const passwordlessSudoRequirementHint = `configure guest cloud-init with sudo: "ALL=(ALL) NOPASSWD:ALL"`
+
+// ErrSSHAuthenticationFailed indicates repeated SSH permission-denied failures.
+// Callers may recreate/reconfigure a VM and retry once this error is returned.
+var ErrSSHAuthenticationFailed = errors.New("ssh authentication failed")
+
+// ErrSSHConnectivityStalled indicates repeated SSH banner timeout failures.
+// Callers may recreate/reconfigure a VM and retry once this error is returned.
+var ErrSSHConnectivityStalled = errors.New("ssh connectivity stalled")
+
+// isSudoPasswordPromptError reports stderr patterns indicating sudo needs a TTY or password (non-passwordless sudo).
+func isSudoPasswordPromptError(stderr string) bool {
+	stderr = strings.ToLower(strings.TrimSpace(stderr))
+	return strings.Contains(stderr, "sudo: a terminal is required to read the password") ||
+		strings.Contains(stderr, "sudo: a password is required")
+}
+
+// isSSHAuthenticationFailure detects permission denied / too many auth failures in SSH client stderr.
+func isSSHAuthenticationFailure(stderr string) bool {
+	stderr = strings.ToLower(strings.TrimSpace(stderr))
+	return strings.Contains(stderr, "permission denied (publickey") ||
+		strings.Contains(stderr, "too many authentication failures")
+}
+
+// isSSHBannerTimeoutFailure detects SSH banner exchange timeouts typical of a slow or wedged sshd path.
+func isSSHBannerTimeoutFailure(stderr string) bool {
+	stderr = strings.ToLower(strings.TrimSpace(stderr))
+	return strings.Contains(stderr, "connection timed out during banner exchange") ||
+		strings.Contains(stderr, "connection to unknown port 65535 timed out")
+}
+
+// isSSHNetworkUnreachableFailure detects immediate connect failures (no route / connection refused) from the SSH client.
+func isSSHNetworkUnreachableFailure(stderr string) bool {
+	stderr = strings.ToLower(strings.TrimSpace(stderr))
+	return strings.Contains(stderr, "connect: no route to host") ||
+		strings.Contains(stderr, "connect: connection refused")
+}
+
+// sshUserForDiagnostic returns the configured virtctl SSH username or a placeholder for log and error text.
+func sshUserForDiagnostic(virt Virtctl) string {
+	if user := strings.TrimSpace(virt.Username); user != "" {
+		return user
+	}
+	return "<default ssh user>"
+}
+
+// isSSHProbeTimeoutFailure is true when the probe failed because its context deadline was exceeded.
+func isSSHProbeTimeoutFailure(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded)
+}
+
+// sshProbeFailureDetail combines stderr and error into a single diagnostic string for logging and stall decisions.
+func sshProbeFailureDetail(err error, stderr string) string {
+	stderr = strings.TrimSpace(stderr)
+	switch {
+	case stderr == "" && err == nil:
+		return "<no stderr>"
+	case stderr == "":
+		return err.Error()
+	case err == nil:
+		return stderr
+	case strings.Contains(stderr, err.Error()):
+		return stderr
+	default:
+		return fmt.Sprintf("%s (err: %v)", stderr, err)
+	}
+}
+
+// WaitForSSHReachable polls SSH until `true` succeeds or policy classifies a terminal auth/connectivity failure.
+func WaitForSSHReachable(t testing.TB, ctx context.Context, virt Virtctl, namespace, vm string) error {
+	t.Helper()
+	policy := defaultSSHReachabilityPolicy
+	attempts := 0
+	counters := &sshProbeCounters{}
+	lastDetail := ""
+	desc := fmt.Sprintf("wait SSH %s/%s reachable", namespace, vm)
+	maxAttempts, maxKnown := estimateMaxPollAttempts(ctx, policy.pollInterval)
+	err := wait.PollUntilContextCancel(ctx, policy.pollInterval, true, func(ctx context.Context) (bool, error) {
+		attempts++
+		stderr, err := runSSHReachabilityProbe(ctx, policy, virt, namespace, vm)
+		if err == nil {
+			counters.resetAll()
+			lastDetail = "ssh command succeeded"
+			logWaitAttempt(t, desc, attempts, maxAttempts, maxKnown, lastDetail)
+			return true, nil
+		}
+		decision := policy.classifyFailure(counters, virt, err, stderr)
+		lastDetail = decision.detail
+		logWaitAttempt(t, desc, attempts, maxAttempts, maxKnown, lastDetail)
+		if decision.terminalErr != nil {
+			return false, decision.terminalErr
+		}
+		return false, nil
+	})
+	if err == nil {
+		return nil
+	}
+	if lastDetail != "" {
+		return fmt.Errorf("wait SSH reachable for %s/%s failed after %d poll(s): %w (last detail: %s)", namespace, vm, attempts, err, truncateWaitDetail(lastDetail))
+	}
+	return fmt.Errorf("wait SSH reachable for %s/%s failed after %d poll(s): %w", namespace, vm, attempts, err)
+}
+
+// WaitForCloudInitFinished runs `sudo cloud-init status --wait` on the guest with SSH transport retries.
+func WaitForCloudInitFinished(ctx context.Context, virt Virtctl, namespace, vm string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, "cloud-init status --wait", func(ctx context.Context) error {
+		_, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "cloud-init status --wait",
+			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+		}, "sudo", "cloud-init", "status", "--wait")
+		if err != nil {
+			stderr = strings.TrimSpace(stderr)
+			if isSudoPasswordPromptError(stderr) {
+				return fmt.Errorf("cloud-init status --wait on %s/%s requires passwordless sudo for ssh user %q (%s): %w: %s",
+					namespace, vm, sshUserForDiagnostic(virt), passwordlessSudoRequirementHint, err, stderr)
+			}
+			return fmt.Errorf("cloud-init status --wait: %w: %s", err, stderr)
+		}
+		return nil
+	})
+}
+
+// VerifySudoWorks checks passwordless sudo via `sudo -n true` with SSH transport retries.
+func VerifySudoWorks(ctx context.Context, virt Virtctl, namespace, vm string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, "passwordless sudo check", func(ctx context.Context) error {
+		_, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "passwordless sudo check",
+			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+		}, "sudo", "-n", "true")
+		if err != nil {
+			stderr = strings.TrimSpace(stderr)
+			if isSudoPasswordPromptError(stderr) {
+				return fmt.Errorf("passwordless sudo check failed for %s/%s ssh user %q (%s): %w: %s",
+					namespace, vm, sshUserForDiagnostic(virt), passwordlessSudoRequirementHint, err, stderr)
+			}
+			return fmt.Errorf("sudo -n true: %w: %s", err, stderr)
+		}
+		return nil
+	})
+}

--- a/tests/vmhelpers/guest_ssh_policy.go
+++ b/tests/vmhelpers/guest_ssh_policy.go
@@ -1,0 +1,142 @@
+package vmhelpers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// sshReachabilityPolicy defines poll cadence, per-probe timeout, and consecutive-failure thresholds for SSH classification.
+type sshReachabilityPolicy struct {
+	pollInterval                time.Duration
+	probeTimeout                time.Duration
+	authFailureThreshold        int
+	bannerTimeoutThreshold      int
+	networkUnreachableThreshold int
+	probeTimeoutThreshold       int
+}
+
+// defaultSSHReachabilityPolicy is the production policy used by waitForSSHReachableImpl to detect stuck or broken SSH.
+var defaultSSHReachabilityPolicy = sshReachabilityPolicy{
+	pollInterval:                sshReachablePollInterval,
+	probeTimeout:                sshProbeAttemptTimeout,
+	authFailureThreshold:        sshAuthFailureThreshold,
+	bannerTimeoutThreshold:      sshBannerTimeoutThreshold,
+	networkUnreachableThreshold: sshNetworkUnreachableThreshold,
+	probeTimeoutThreshold:       sshProbeTimeoutThreshold,
+}
+
+// sshProbeCounters holds consecutive failure counts for each SSH failure category between successful probes.
+type sshProbeCounters struct {
+	authFailures               int
+	bannerTimeoutFailures      int
+	networkUnreachableFailures int
+	probeTimeoutFailures       int
+}
+
+// resetAll clears all category counters after a successful SSH probe.
+func (c *sshProbeCounters) resetAll() {
+	c.authFailures = 0
+	c.bannerTimeoutFailures = 0
+	c.networkUnreachableFailures = 0
+	c.probeTimeoutFailures = 0
+}
+
+// sshFailureCategory describes one class of SSH probe failure with its
+// matching predicate, associated counter, threshold, and terminal error.
+type sshFailureCategory struct {
+	label       string
+	matches     func(stderr string, err error) bool
+	counter     func(c *sshProbeCounters) *int
+	threshold   func(p sshReachabilityPolicy) int
+	sentinelErr error
+	terminalMsg func(virt Virtctl, count int, detail string) string
+}
+
+var sshFailureCategories = []sshFailureCategory{
+	{
+		label:       "ssh authentication failed",
+		matches:     func(stderr string, _ error) bool { return isSSHAuthenticationFailure(stderr) },
+		counter:     func(c *sshProbeCounters) *int { return &c.authFailures },
+		threshold:   func(p sshReachabilityPolicy) int { return p.authFailureThreshold },
+		sentinelErr: ErrSSHAuthenticationFailed,
+		terminalMsg: func(virt Virtctl, count int, detail string) string {
+			return fmt.Sprintf("for ssh user %q after %d consecutive attempts (likely stale/missing authorized key): %s",
+				sshUserForDiagnostic(virt), count, detail)
+		},
+	},
+	{
+		label:       "ssh banner timeout",
+		matches:     func(stderr string, _ error) bool { return isSSHBannerTimeoutFailure(stderr) },
+		counter:     func(c *sshProbeCounters) *int { return &c.bannerTimeoutFailures },
+		threshold:   func(p sshReachabilityPolicy) int { return p.bannerTimeoutThreshold },
+		sentinelErr: ErrSSHConnectivityStalled,
+		terminalMsg: func(_ Virtctl, count int, detail string) string {
+			return fmt.Sprintf("after %d consecutive attempts (guest may be unhealthy and need recreation): %s", count, detail)
+		},
+	},
+	{
+		label:       "ssh network unavailable",
+		matches:     func(stderr string, _ error) bool { return isSSHNetworkUnreachableFailure(stderr) },
+		counter:     func(c *sshProbeCounters) *int { return &c.networkUnreachableFailures },
+		threshold:   func(p sshReachabilityPolicy) int { return p.networkUnreachableThreshold },
+		sentinelErr: ErrSSHConnectivityStalled,
+		terminalMsg: func(_ Virtctl, count int, detail string) string {
+			return fmt.Sprintf("after %d consecutive attempts (guest network/sshd may be unhealthy and need recreation): %s", count, detail)
+		},
+	},
+	{
+		label:       "ssh probe timed out",
+		matches:     func(_ string, err error) bool { return isSSHProbeTimeoutFailure(err) },
+		counter:     func(c *sshProbeCounters) *int { return &c.probeTimeoutFailures },
+		threshold:   func(p sshReachabilityPolicy) int { return p.probeTimeoutThreshold },
+		sentinelErr: ErrSSHConnectivityStalled,
+		terminalMsg: func(_ Virtctl, count int, detail string) string {
+			return fmt.Sprintf("after %d consecutive probe timeouts (ssh command appears stuck): %s", count, detail)
+		},
+	},
+}
+
+// sshProbeDecision is the result of one classifyFailure evaluation: human detail and optional terminal error.
+type sshProbeDecision struct {
+	detail      string
+	terminalErr error
+}
+
+// runSSHReachabilityProbe runs a minimal SSH command (`true`) under the policy's per-attempt timeout and returns stderr.
+func runSSHReachabilityProbe(ctx context.Context, policy sshReachabilityPolicy, virt Virtctl, namespace, vm string) (stderr string, err error) {
+	probeCtx, cancel := context.WithTimeout(ctx, policy.probeTimeout)
+	defer cancel()
+	_, stderr, err = runSSHCommandWithFramework(probeCtx, virt, namespace, vm, sshCommandRunOptions{
+		description:            "ssh reachability probe",
+		transportRetryAttempts: 1,
+	}, "true")
+	return strings.TrimSpace(stderr), err
+}
+
+// classifyFailure decides whether to keep retrying while the VM is likely still booting
+// or to stop early when repeated failures strongly indicate a broken guest.
+func (p sshReachabilityPolicy) classifyFailure(counters *sshProbeCounters, virt Virtctl, err error, stderr string) sshProbeDecision {
+	detail := sshProbeFailureDetail(err, stderr)
+	for _, cat := range sshFailureCategories {
+		if !cat.matches(stderr, err) {
+			continue
+		}
+		ctr := cat.counter(counters)
+		prev := *ctr
+		counters.resetAll()
+		*ctr = prev + 1
+		thresh := cat.threshold(p)
+		msg := fmt.Sprintf("%s (%d/%d consecutive): %s", cat.label, *ctr, thresh, detail)
+		if *ctr >= thresh {
+			return sshProbeDecision{
+				detail:      msg,
+				terminalErr: fmt.Errorf("%w %s", cat.sentinelErr, cat.terminalMsg(virt, *ctr, truncateWaitDetail(detail))),
+			}
+		}
+		return sshProbeDecision{detail: msg}
+	}
+	counters.resetAll()
+	return sshProbeDecision{detail: fmt.Sprintf("ssh not reachable yet: %s", detail)}
+}

--- a/tests/vmhelpers/guest_test.go
+++ b/tests/vmhelpers/guest_test.go
@@ -1,0 +1,468 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// exitError returns an *exec.ExitError with the given exit code.
+func exitError(t *testing.T, code int) *exec.ExitError {
+	t.Helper()
+	err := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, code, exitErr.ExitCode())
+	return exitErr
+}
+
+func TestActivationFromSubscriptionManagerOutput_Current(t *testing.T) {
+	t.Parallel()
+	out := `+-------------------------------------------+
+   Overall Status: Current`
+	require.True(t, activationFromSubscriptionManagerOutput(out))
+}
+
+func TestActivationFromSubscriptionManagerOutput_NotCurrent(t *testing.T) {
+	t.Parallel()
+	out := `Overall Status: Unknown`
+	require.False(t, activationFromSubscriptionManagerOutput(out))
+}
+
+func TestActivationFromSubscriptionManagerOutput_Empty(t *testing.T) {
+	t.Parallel()
+	require.False(t, activationFromSubscriptionManagerOutput(""))
+}
+
+func TestActivationFromSubscriptionManagerOutput_CurrentCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	// activationFromSubscriptionManagerOutput uses EqualFold on the status token.
+	for _, out := range []string{
+		"Overall Status: current",
+		"Overall Status: CURRENT",
+		"Overall Status: registered",
+		"Overall Status: REGISTERED",
+	} {
+		require.True(t, activationFromSubscriptionManagerOutput(out), out)
+	}
+}
+
+func TestOverallStatusFromSubscriptionManagerOutput(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		output string
+		status string
+		found  bool
+	}{
+		"current status": {
+			output: "Overall Status: Current",
+			status: "Current",
+			found:  true,
+		},
+		"not registered status with leading spaces": {
+			output: "   Overall Status: Not registered",
+			status: "Not registered",
+			found:  true,
+		},
+		"case insensitive prefix": {
+			output: "overall status: Unknown",
+			status: "Unknown",
+			found:  true,
+		},
+		"missing status line": {
+			output: "subscription-manager output without marker",
+			status: "",
+			found:  false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			status, found := overallStatusFromSubscriptionManagerOutput(tc.output)
+			require.Equal(t, tc.status, status)
+			require.Equal(t, tc.found, found)
+		})
+	}
+}
+
+func TestActivationStatusFromCommandOutput(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		stdout    string
+		stderr    string
+		cmdErr    error
+		activated bool
+		wantErr   bool
+	}{
+		"current status and nil error": {
+			stdout:    "Overall Status: Current",
+			activated: true,
+			wantErr:   false,
+		},
+		"not registered with exit status is non fatal": {
+			stdout:    "Overall Status: Not registered",
+			stderr:    "exit status 1",
+			cmdErr:    errors.New("exit status 1"),
+			activated: false,
+			wantErr:   false,
+		},
+		"unknown status with exit status is non fatal": {
+			stdout:    "Overall Status: Unknown",
+			stderr:    "exit status 1",
+			cmdErr:    errors.New("exit status 1"),
+			activated: false,
+			wantErr:   false,
+		},
+		"registered status with exit status is non fatal and activated": {
+			stdout:    "Overall Status: Registered",
+			stderr:    "exit status 1",
+			cmdErr:    errors.New("exit status 1"),
+			activated: true,
+			wantErr:   false,
+		},
+		"missing status line with exit status is fatal": {
+			stdout:    "some other output",
+			stderr:    "rpc failure",
+			cmdErr:    errors.New("exit status 1"),
+			activated: false,
+			wantErr:   true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			activated, details, err := activationStatusFromCommandOutput(tc.stdout, tc.stderr, tc.cmdErr)
+			require.Equal(t, tc.activated, activated)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.NotEmpty(t, details)
+				return
+			}
+			require.NoError(t, err)
+			require.NotEmpty(t, details)
+		})
+	}
+}
+
+func TestDnfHistoryHasTransactionsOutput(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		output string
+		want   bool
+	}{
+		"has transaction row": {
+			output: `ID     | Command line             | Date and time    | Action(s)      | Altered
+-------------------------------------------------------------------------------
+23     | install bc               | 2026-04-08 09:00 | Install         | 1`,
+			want: true,
+		},
+		"empty history with headers only": {
+			output: `ID     | Command line             | Date and time    | Action(s)      | Altered
+-------------------------------------------------------------------------------`,
+			want: false,
+		},
+		"no transactions message": {
+			output: "No transactions.",
+			want:   false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, dnfHistoryHasTransactionsOutput(tc.output))
+		})
+	}
+}
+
+func TestClassifySSHFailure(t *testing.T) {
+	t.Parallel()
+	exit255 := exitError(t, 255)
+	exit1 := exitError(t, 1)
+	exit42 := exitError(t, 42)
+
+	tests := map[string]struct {
+		stderr    string
+		err       error
+		wantSSH   bool
+		wantRetry bool
+		wantCat   string
+	}{
+		"banner timeout with exit 255": {
+			stderr: "Connection timed out during banner exchange", err: exit255,
+			wantSSH: true, wantRetry: true, wantCat: "banner-timeout",
+		},
+		"websocket eof": {
+			stderr: "websocket: close 1006 (abnormal closure): unexpected EOF", err: exit255,
+			wantSSH: true, wantRetry: true, wantCat: "websocket-eof",
+		},
+		"broken pipe": {
+			stderr: "client_loop: send disconnect: Broken pipe", err: exit255,
+			wantSSH: true, wantRetry: true, wantCat: "broken-pipe",
+		},
+		"network unreachable via stderr": {
+			stderr: "Internal error occurred: dialing VM: dial tcp :22: connect: connection refused", err: exit255,
+			wantSSH: true, wantRetry: true, wantCat: "network",
+		},
+		"context deadline": {
+			stderr: "", err: context.DeadlineExceeded,
+			wantSSH: true, wantRetry: true, wantCat: "timeout",
+		},
+		"auth failure is terminal": {
+			stderr: "Permission denied (publickey)", err: exit255,
+			wantSSH: true, wantRetry: false, wantCat: "authentication",
+		},
+		"connection reset by peer": {
+			stderr: "read tcp 1.2.3.4:1234->5.6.7.8:6443: read: connection reset by peer\nexit status 255", err: exit255,
+			wantSSH: true, wantRetry: true, wantCat: "connection-reset",
+		},
+		"connection closed by UNKNOWN": {
+			stderr: "Connection closed by UNKNOWN port 65535", err: exit255,
+			wantSSH: true, wantRetry: true, wantCat: "remote-host-closed",
+		},
+		"exit 255 with unknown stderr falls back to exit code classification": {
+			stderr: "some totally unknown SSH failure message", err: exit255,
+			wantSSH: true, wantRetry: true, wantCat: "transport-exit-255",
+		},
+		"remote command exit 1 is not SSH": {
+			stderr: "metadata already locked by 3814", err: exit1,
+			wantSSH: false, wantRetry: false, wantCat: "",
+		},
+		"remote command exit 42 is not SSH": {
+			stderr: "ROXAGENT_VERBOSE_ASSERT_FAILED", err: exit42,
+			wantSSH: false, wantRetry: false, wantCat: "",
+		},
+		"plain error without ExitError is not SSH": {
+			stderr: "something went wrong", err: errors.New("generic failure"),
+			wantSSH: false, wantRetry: false, wantCat: "",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			gotSSH, gotRetry, gotCat := classifySSHFailure(tc.stderr, tc.err)
+			require.Equal(t, tc.wantSSH, gotSSH, "isSSH")
+			require.Equal(t, tc.wantRetry, gotRetry, "retryable")
+			require.Equal(t, tc.wantCat, gotCat, "category")
+		})
+	}
+}
+
+func TestIsSudoPasswordPromptError(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		stderr string
+		want   bool
+	}{
+		"terminal required": {
+			stderr: "sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper",
+			want:   true,
+		},
+		"password required": {
+			stderr: "sudo: a password is required",
+			want:   true,
+		},
+		"other sudo failure": {
+			stderr: "sudo: command not found",
+			want:   false,
+		},
+		"unrelated error": {
+			stderr: "Internal error occurred: dialing VM: dial tcp :22: connect: connection refused",
+			want:   false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isSudoPasswordPromptError(tc.stderr))
+		})
+	}
+}
+
+func TestIsSSHAuthenticationFailure(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		stderr string
+		want   bool
+	}{
+		"permission denied publickey": {
+			stderr: "cloud-user@vmi.vm-rhel9.vm-scan-e2e-manual: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).",
+			want:   true,
+		},
+		"warning plus denied": {
+			stderr: "Warning: Permanently added 'vmi.vm' (ED25519) to the list of known hosts.\ncloud-user@vmi.vm: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).",
+			want:   true,
+		},
+		"too many authentication failures": {
+			stderr: "Received disconnect from UNKNOWN port 65535:2: Too many authentication failures\nDisconnected from UNKNOWN port 65535",
+			want:   true,
+		},
+		"connection refused": {
+			stderr: "Internal error occurred: dialing VM: dial tcp :22: connect: connection refused",
+			want:   false,
+		},
+		"no route to host": {
+			stderr: "Internal error occurred: dialing VM: dial tcp 10.131.0.48:22: connect: no route to host",
+			want:   false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isSSHAuthenticationFailure(tc.stderr))
+		})
+	}
+}
+
+func TestIsSSHBannerTimeoutFailure(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		stderr string
+		want   bool
+	}{
+		"banner exchange timeout": {
+			stderr: "Connection timed out during banner exchange",
+			want:   true,
+		},
+		"unknown port timeout": {
+			stderr: "Connection to UNKNOWN port 65535 timed out",
+			want:   true,
+		},
+		"permission denied": {
+			stderr: "Permission denied (publickey,gssapi-keyex,gssapi-with-mic).",
+			want:   false,
+		},
+		"connection refused": {
+			stderr: "Internal error occurred: dialing VM: dial tcp :22: connect: connection refused",
+			want:   false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isSSHBannerTimeoutFailure(tc.stderr))
+		})
+	}
+}
+
+func TestIsSSHNetworkUnreachableFailure(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		stderr string
+		want   bool
+	}{
+		"no route to host": {
+			stderr: "Internal error occurred: dialing VM: dial tcp 10.129.2.42:22: connect: no route to host",
+			want:   true,
+		},
+		"connection refused": {
+			stderr: "Internal error occurred: dialing VM: dial tcp :22: connect: connection refused",
+			want:   true,
+		},
+		"permission denied": {
+			stderr: "Permission denied (publickey,gssapi-keyex,gssapi-with-mic).",
+			want:   false,
+		},
+		"banner timeout": {
+			stderr: "Connection timed out during banner exchange",
+			want:   false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isSSHNetworkUnreachableFailure(tc.stderr))
+		})
+	}
+}
+
+func TestIsSSHProbeTimeoutFailure(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isSSHProbeTimeoutFailure(context.DeadlineExceeded))
+	require.True(t, isSSHProbeTimeoutFailure(fmt.Errorf("wrap: %w", context.DeadlineExceeded)))
+	require.False(t, isSSHProbeTimeoutFailure(context.Canceled))
+	require.False(t, isSSHProbeTimeoutFailure(errors.New("other")))
+}
+
+func TestSSHProbeFailureDetail(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		err    error
+		stderr string
+		want   string
+	}{
+		"stderr only": {
+			stderr: "permission denied",
+			want:   "permission denied",
+		},
+		"err only": {
+			err:  context.DeadlineExceeded,
+			want: context.DeadlineExceeded.Error(),
+		},
+		"stderr and err": {
+			err:    context.DeadlineExceeded,
+			stderr: "connection timed out",
+			want:   "connection timed out (err: context deadline exceeded)",
+		},
+		"stderr already contains err": {
+			err:    errors.New("exit status 255"),
+			stderr: "permission denied; exit status 255",
+			want:   "permission denied; exit status 255",
+		},
+		"neither": {
+			want: "<no stderr>",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, sshProbeFailureDetail(tc.err, tc.stderr))
+		})
+	}
+}
+
+func TestSSHReachabilityPolicy_ClassifyFailureStopsEarlyOnAuthThreshold(t *testing.T) {
+	t.Parallel()
+
+	policy := defaultSSHReachabilityPolicy
+	counters := &sshProbeCounters{authFailures: policy.authFailureThreshold - 1}
+	decision := policy.classifyFailure(
+		counters,
+		Virtctl{Username: "cloud-user"},
+		errors.New("exit status 255"),
+		"Permission denied (publickey,gssapi-keyex,gssapi-with-mic).",
+	)
+
+	require.Error(t, decision.terminalErr)
+	require.ErrorIs(t, decision.terminalErr, ErrSSHAuthenticationFailed)
+	require.Contains(t, decision.detail, "ssh authentication failed")
+}
+
+func TestSSHReachabilityPolicy_ClassifyFailureKeepsRetryingOnProbeTimeout(t *testing.T) {
+	t.Parallel()
+
+	policy := defaultSSHReachabilityPolicy
+	counters := &sshProbeCounters{}
+	decision := policy.classifyFailure(counters, Virtctl{}, context.DeadlineExceeded, "")
+
+	require.NoError(t, decision.terminalErr)
+	require.Contains(t, decision.detail, "ssh probe timed out")
+}
+
+func TestFormatGuestCommandOutputForError(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "<no guest stdout/stderr>", formatGuestCommandOutputForError(" \n\t "))
+	require.Equal(t, "status output", formatGuestCommandOutputForError("status output"))
+
+	long := strings.Repeat("x", guestCommandErrorMaxLen+50)
+	got := formatGuestCommandOutputForError(long)
+	require.Contains(t, got, "(truncated from")
+	require.True(t, strings.HasPrefix(got, strings.Repeat("x", guestCommandErrorMaxLen)))
+}

--- a/tests/vmhelpers/observability.go
+++ b/tests/vmhelpers/observability.go
@@ -1,0 +1,44 @@
+package vmhelpers
+
+// Prometheus metric names and label keys must stay aligned with product code:
+//   - compliance/virtualmachines/relay/metrics/metrics.go
+//   - sensor/common/virtualmachine/metrics/metrics.go
+
+// prometheusNamespace is the metric name prefix shared by StackRox VM-related Prometheus series in tests.
+const prometheusNamespace = "rox"
+
+// Compliance relay series (subsystem "compliance" in product metrics).
+const (
+	MetricComplianceRelayConnectionsAcceptedTotal          = prometheusNamespace + "_compliance_virtual_machine_relay_connections_accepted_total"
+	MetricComplianceRelayIndexReportsReceivedTotal         = prometheusNamespace + "_compliance_virtual_machine_relay_index_reports_received_total"
+	MetricComplianceRelayIndexReportsSentTotal             = prometheusNamespace + "_compliance_virtual_machine_relay_index_reports_sent_total"
+	MetricComplianceRelayIndexReportsMismatchingVsockTotal = prometheusNamespace + "_compliance_virtual_machine_relay_index_reports_mismatching_vsock_cid_total"
+	MetricComplianceRelaySemaphoreAcquisitionFailuresTotal = prometheusNamespace + "_compliance_virtual_machine_relay_sem_acquisition_failures_total"
+
+	MetricComplianceRelayIndexReportAcksReceivedTotal = prometheusNamespace + "_compliance_virtual_machine_relay_index_report_acks_received_total"
+)
+
+// Sensor VM index series (subsystem "sensor").
+const (
+	MetricSensorVMIndexReportsReceivedTotal          = prometheusNamespace + "_sensor_virtual_machine_index_reports_received_total"
+	MetricSensorVMIndexReportsSentTotal              = prometheusNamespace + "_sensor_virtual_machine_index_reports_sent_total"
+	MetricSensorVMIndexReportAcksReceivedTotal       = prometheusNamespace + "_sensor_virtual_machine_index_report_acks_received_total"
+	MetricSensorVMIndexReportEnqueueBlockedTotal     = prometheusNamespace + "_sensor_virtual_machine_index_report_enqueue_blocked_total"
+	MetricSensorVMIndexReportBlockingEnqueueDuration = prometheusNamespace + "_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds"
+	MetricSensorVMIndexReportHandlingDuration        = prometheusNamespace + "_sensor_virtual_machine_index_report_handling_duration_milliseconds"
+	MetricSensorVMIndexReportProcessingDuration      = prometheusNamespace + "_sensor_virtual_machine_index_report_processing_duration_milliseconds"
+)
+
+// Prometheus label keys used in scrape text for the above vectors (must match registration).
+const (
+	LabelFailed = "failed"
+	LabelStatus = "status"
+	LabelAction = "action"
+)
+
+// Sensor IndexReportsSent status label values from sensor/common/virtualmachine/metrics/metrics.go
+const (
+	SensorIndexReportStatusCentralNotReady = "central not ready"
+	SensorIndexReportStatusError           = "error"
+	SensorIndexReportStatusSuccess         = "success"
+)

--- a/tests/vmhelpers/observability_test.go
+++ b/tests/vmhelpers/observability_test.go
@@ -1,0 +1,73 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVMIndexMetricSeriesMirrorProductDefinitions(t *testing.T) {
+	require.Equal(t, "rox_compliance_virtual_machine_relay_connections_accepted_total", MetricComplianceRelayConnectionsAcceptedTotal)
+	require.Equal(t, "rox_compliance_virtual_machine_relay_index_reports_received_total", MetricComplianceRelayIndexReportsReceivedTotal)
+	require.Equal(t, "rox_compliance_virtual_machine_relay_index_reports_sent_total", MetricComplianceRelayIndexReportsSentTotal)
+	require.Equal(t, "rox_compliance_virtual_machine_relay_index_reports_mismatching_vsock_cid_total", MetricComplianceRelayIndexReportsMismatchingVsockTotal)
+	require.Equal(t, "rox_compliance_virtual_machine_relay_sem_acquisition_failures_total", MetricComplianceRelaySemaphoreAcquisitionFailuresTotal)
+
+	require.Equal(t, "rox_sensor_virtual_machine_index_reports_received_total", MetricSensorVMIndexReportsReceivedTotal)
+	require.Equal(t, "rox_sensor_virtual_machine_index_reports_sent_total", MetricSensorVMIndexReportsSentTotal)
+	require.Equal(t, "rox_sensor_virtual_machine_index_report_acks_received_total", MetricSensorVMIndexReportAcksReceivedTotal)
+	require.Equal(t, "rox_sensor_virtual_machine_index_report_enqueue_blocked_total", MetricSensorVMIndexReportEnqueueBlockedTotal)
+}
+
+func moduleRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+// TestCanonicalMetricGoSourceFilesDriftGuard reads product metric definitions and fails when
+// required names/labels disappear from source (compliance relay, sensor VM index).
+func TestCanonicalMetricGoSourceFilesDriftGuard(t *testing.T) {
+	root := moduleRepoRoot(t)
+	compliancePath := filepath.Join(root, "compliance/virtualmachines/relay/metrics/metrics.go")
+	sensorPath := filepath.Join(root, "sensor/common/virtualmachine/metrics/metrics.go")
+
+	cb, err := os.ReadFile(compliancePath)
+	require.NoError(t, err, "read %s", compliancePath)
+	compliance := string(cb)
+	for _, sub := range []string{
+		"virtual_machine_relay_connections_accepted_total",
+		"virtual_machine_relay_index_reports_received_total",
+		"virtual_machine_relay_index_reports_sent_total",
+		"virtual_machine_relay_index_reports_mismatching_vsock_cid_total",
+		"virtual_machine_relay_sem_acquisition_failures_total",
+		`[]string{"failed"}`,
+	} {
+		require.Contains(t, compliance, sub, "compliance/virtualmachines/relay/metrics/metrics.go drift: missing %q", sub)
+	}
+
+	sb, err := os.ReadFile(sensorPath)
+	require.NoError(t, err, "read %s", sensorPath)
+	sensor := string(sb)
+	for _, sub := range []string{
+		"virtual_machine_index_reports_received_total",
+		"virtual_machine_index_reports_sent_total",
+		`[]string{"status"}`,
+		`"central not ready"`,
+		"virtual_machine_index_report_acks_received_total",
+		`[]string{"action"}`,
+		"virtual_machine_index_report_enqueue_blocked_total",
+		"virtual_machine_index_report_blocking_enqueue_duration_milliseconds",
+	} {
+		require.Contains(t, sensor, sub, "sensor/common/virtualmachine/metrics/metrics.go drift: missing %q", sub)
+	}
+
+	require.Contains(t, MetricComplianceRelayConnectionsAcceptedTotal, "virtual_machine_relay_connections_accepted_total")
+	require.Contains(t, MetricSensorVMIndexReportsReceivedTotal, "virtual_machine_index_reports_received_total")
+}

--- a/tests/vmhelpers/roxagent.go
+++ b/tests/vmhelpers/roxagent.go
@@ -1,0 +1,229 @@
+package vmhelpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Guest paths for staging and installing the roxagent binary during VM tests.
+const (
+	// DefaultRoxagentInstallPath is the path used when copying and running roxagent on the guest.
+	DefaultRoxagentInstallPath = "/usr/local/bin/roxagent"
+	roxagentStagingPath        = "/tmp/roxagent"
+)
+
+// ErrTerminalVSOCKUnavailable is returned when vsock is permanently unavailable on the guest (no retry).
+var ErrTerminalVSOCKUnavailable = errors.New("terminal vsock unavailable")
+
+// RoxagentRunConfig configures a single roxagent invocation (repo2cpe URL selection and binary path).
+type RoxagentRunConfig struct {
+	Repo2CPEPrimaryURL      string
+	Repo2CPEFallbackURL     string
+	Repo2CPEPrimaryAttempts int
+	// RoxagentInstallPath may only be empty or DefaultRoxagentInstallPath. CopyRoxagentBinary and the
+	// VerifyRoxagent* helpers always use DefaultRoxagentInstallPath; RunRoxagentOnce rejects any other
+	// value so the run cannot target a path the suite never populated.
+	RoxagentInstallPath string
+	// Repo2CPEEnvVar is the environment variable name passed to roxagent (default ROXAGENT_REPO2CPE_URL).
+	Repo2CPEEnvVar string
+}
+
+// RoxagentRunResult captures stdout/stderr and whether the fallback repo2cpe URL was used.
+type RoxagentRunResult struct {
+	Stdout       string
+	Stderr       string
+	UsedFallback bool
+}
+
+// roxagentPath returns RoxagentInstallPath when set, otherwise DefaultRoxagentInstallPath.
+func roxagentPath(cfg RoxagentRunConfig) string {
+	if cfg.RoxagentInstallPath != "" {
+		return cfg.RoxagentInstallPath
+	}
+	return DefaultRoxagentInstallPath
+}
+
+// repo2cpeEnvName returns Repo2CPEEnvVar if set, otherwise ROXAGENT_REPO2CPE_URL.
+func repo2cpeEnvName(cfg RoxagentRunConfig) string {
+	if cfg.Repo2CPEEnvVar != "" {
+		return cfg.Repo2CPEEnvVar
+	}
+	return "ROXAGENT_REPO2CPE_URL"
+}
+
+// chooseRepo2CPESource returns primaryURL until attemptsMade reaches maxPrimaryAttempts, then fallbackURL.
+func chooseRepo2CPESource(attemptsMade, maxPrimaryAttempts int, primaryURL, fallbackURL string) string {
+	if attemptsMade < maxPrimaryAttempts {
+		return primaryURL
+	}
+	return fallbackURL
+}
+
+// isVsockUnavailableOutput detects terminal vsock device errors in roxagent combined output.
+func isVsockUnavailableOutput(output string) bool {
+	lower := strings.ToLower(strings.TrimSpace(output))
+	if !strings.Contains(lower, "vsock") {
+		return false
+	}
+	return strings.Contains(lower, "no such device") ||
+		strings.Contains(lower, "no such file or directory")
+}
+
+// IsTerminalVSOCKUnavailableError reports whether err wraps ErrTerminalVSOCKUnavailable.
+func IsTerminalVSOCKUnavailableError(err error) bool {
+	return errors.Is(err, ErrTerminalVSOCKUnavailable)
+}
+
+// verboseOutputHasOSFields reports whether a roxagent --verbose stdout
+// contains at least one recognised OS-detection field.
+func verboseOutputHasOSFields(stdout string) bool {
+	return strings.Contains(stdout, `"detectedOs"`) ||
+		strings.Contains(stdout, `"operatingSystem"`) ||
+		strings.Contains(stdout, `"operating_system"`)
+}
+
+// buildRoxagentInstallArgs is the remote argv for `sudo install` to place the staged binary at dst.
+func buildRoxagentInstallArgs(src, dst string) []string {
+	return []string{"sudo", "install", "-m", "0755", src, dst}
+}
+
+// VerboseOutputLooksLikeReport returns true when stdout appears to contain a known
+// structured roxagent report shape (legacy scan-shaped or indexReport-shaped JSON).
+func VerboseOutputLooksLikeReport(stdout string) bool {
+	s := strings.TrimSpace(stdout)
+	if s == "" {
+		return false
+	}
+	if strings.Contains(s, `"indexReport"`) || strings.Contains(s, `"discoveredData"`) {
+		return true
+	}
+	return strings.Contains(s, `"components"`) &&
+		(strings.Contains(s, `"scan"`) || strings.Contains(s, `"operatingSystem"`) || strings.Contains(s, `"operating_system"`))
+}
+
+// CopyRoxagentBinary copies a local roxagent binary into the guest install path.
+func CopyRoxagentBinary(ctx context.Context, virt Virtctl, namespace, vm, hostBinaryPath string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, "copy roxagent binary", func(ctx context.Context) error {
+		stderr, err := virt.SCPTo(ctx, namespace, vm, hostBinaryPath, roxagentStagingPath)
+		if err != nil {
+			return fmt.Errorf("virtctl scp roxagent: %w: %s", err, strings.TrimSpace(stderr))
+		}
+		_, stderr, err = runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "install roxagent binary",
+			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+		}, buildRoxagentInstallArgs(roxagentStagingPath, DefaultRoxagentInstallPath)...)
+		if err != nil {
+			return fmt.Errorf("install roxagent binary on guest: %w: %s", err, strings.TrimSpace(stderr))
+		}
+		_, _, _ = runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "cleanup staged roxagent binary",
+			transportRetryAttempts: 1,
+		}, "rm", "-f", roxagentStagingPath)
+		return nil
+	})
+}
+
+// VerifyRoxagentBinaryPresent checks that the roxagent file exists on the guest.
+func VerifyRoxagentBinaryPresent(ctx context.Context, virt Virtctl, namespace, vm string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, "verify roxagent presence", func(ctx context.Context) error {
+		_, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "verify roxagent presence",
+			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+		}, "test", "-f", DefaultRoxagentInstallPath)
+		if err != nil {
+			return fmt.Errorf("roxagent presence: %w: %s", err, strings.TrimSpace(stderr))
+		}
+		return nil
+	})
+}
+
+// VerifyRoxagentExecutable checks that the roxagent binary is executable.
+func VerifyRoxagentExecutable(ctx context.Context, virt Virtctl, namespace, vm string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, "verify roxagent executable", func(ctx context.Context) error {
+		_, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "verify roxagent executable",
+			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+		}, "test", "-x", DefaultRoxagentInstallPath)
+		if err != nil {
+			return fmt.Errorf("roxagent executable: %w: %s", err, strings.TrimSpace(stderr))
+		}
+		return nil
+	})
+}
+
+// VerifyRoxagentInstallPath checks that `command -v roxagent` resolves to the canonical install path.
+func VerifyRoxagentInstallPath(ctx context.Context, virt Virtctl, namespace, vm string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, "verify roxagent install path", func(ctx context.Context) error {
+		stdout, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "verify roxagent install path",
+			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+		}, "command", "-v", "roxagent")
+		if err != nil {
+			return fmt.Errorf("roxagent install path: %w: %s", err, strings.TrimSpace(stderr))
+		}
+		if got := strings.TrimSpace(stdout); got != DefaultRoxagentInstallPath {
+			return fmt.Errorf("roxagent install path: got %q, want %q", got, DefaultRoxagentInstallPath)
+		}
+		return nil
+	})
+}
+
+// RunRoxagentOnce runs roxagent on the guest. It uses Repo2CPEPrimaryURL for each attempt
+// index in [0, Repo2CPEPrimaryAttempts) (i.e. up to Repo2CPEPrimaryAttempts primary runs when that
+// count is positive), stopping as soon as one run succeeds. If all primary runs fail, it performs
+// exactly one further run using Repo2CPEFallbackURL. When Repo2CPEPrimaryAttempts is zero, the
+// first run uses the fallback URL only.
+func RunRoxagentOnce(ctx context.Context, virt Virtctl, namespace, vm string, cfg RoxagentRunConfig) (*RoxagentRunResult, error) {
+	if cfg.RoxagentInstallPath != "" && cfg.RoxagentInstallPath != DefaultRoxagentInstallPath {
+		return nil, fmt.Errorf(
+			"vmhelpers RunRoxagentOnce: RoxagentInstallPath %q is not supported (CopyRoxagentBinary and VerifyRoxagent* only use %q); omit RoxagentInstallPath or set it to DefaultRoxagentInstallPath",
+			cfg.RoxagentInstallPath, DefaultRoxagentInstallPath,
+		)
+	}
+	maxPrimary := cfg.Repo2CPEPrimaryAttempts
+	if maxPrimary < 0 {
+		maxPrimary = 0
+	}
+	bin := roxagentPath(cfg)
+	envName := repo2cpeEnvName(cfg)
+	if err := ensureVsockReady(ctx, virt, namespace, vm, "roxagent run"); err != nil {
+		return nil, err
+	}
+
+	var lastStderr string
+
+	for attempt := 0; ; attempt++ {
+		url := chooseRepo2CPESource(attempt, maxPrimary, cfg.Repo2CPEPrimaryURL, cfg.Repo2CPEFallbackURL)
+		usedFallback := url == cfg.Repo2CPEFallbackURL && cfg.Repo2CPEFallbackURL != ""
+		envAssignment := fmt.Sprintf("%s=%s", envName, url)
+
+		stdout, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "run roxagent --verbose",
+			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+		}, "sudo", "env", envAssignment, bin, "--verbose")
+		lastStderr = stderr
+
+		if err == nil {
+			if !verboseOutputHasOSFields(stdout) {
+				return nil, fmt.Errorf("roxagent: verbose output OS assertion failed: no OS detection fields in output (stdout: %.200s)", strings.TrimSpace(stdout))
+			}
+			return &RoxagentRunResult{
+				Stdout:       stdout,
+				Stderr:       stderr,
+				UsedFallback: usedFallback,
+			}, nil
+		}
+		combined := strings.TrimSpace(stdout + "\n" + stderr)
+		if isVsockUnavailableOutput(combined) {
+			return nil, fmt.Errorf("%w: roxagent: no retry for vsock device error: %w (stderr: %s)",
+				ErrTerminalVSOCKUnavailable, err, strings.TrimSpace(stderr))
+		}
+
+		// attempt indices 0..maxPrimary-1 use primary; attempt maxPrimary uses fallback. Stop after fallback fails.
+		if attempt >= maxPrimary {
+			return nil, fmt.Errorf("roxagent: %w (stderr: %s)", err, strings.TrimSpace(lastStderr))
+		}
+	}
+}

--- a/tests/vmhelpers/roxagent_test.go
+++ b/tests/vmhelpers/roxagent_test.go
@@ -1,0 +1,131 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChooseRepo2CPESource(t *testing.T) {
+	t.Parallel()
+	primary := "https://remote/repo2cpe.json"
+	fallback := "file:///var/lib/rox/repo2cpe.json"
+	cases := map[string]struct {
+		attemptsMade, maxPrimary int
+		want                     string
+	}{
+		"zero attempts uses primary when budget positive":  {0, 5, primary},
+		"mid range still primary":                          {2, 5, primary},
+		"last primary slot before boundary":                {4, 5, primary},
+		"boundary falls back when attemptsMade equals max": {5, 5, fallback},
+		"plan boundary three of three":                     {3, 3, fallback},
+		"zero max immediate fallback on first index":       {0, 0, fallback},
+		"after boundary stays fallback":                    {10, 3, fallback},
+		"single primary slot then fallback":                {1, 1, fallback},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := chooseRepo2CPESource(tc.attemptsMade, tc.maxPrimary, primary, fallback)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRunRoxagentOnce_RejectsUnsupportedInstallPath(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	_, err := RunRoxagentOnce(ctx, Virtctl{}, "ns", "vm", RoxagentRunConfig{
+		RoxagentInstallPath: "/opt/roxagent",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not supported")
+	require.Contains(t, err.Error(), "/opt/roxagent")
+}
+
+func TestVerboseOutputHasOSFields(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		stdout string
+		want   bool
+	}{
+		"detectedOs key":       {`{"detectedOs":"rhel:9"}`, true},
+		"operatingSystem key":  {`{"operatingSystem":"rhel"}`, true},
+		"operating_system key": {`{"operating_system":"rhel"}`, true},
+		"no OS keys":           {`{"components":["rpm"]}`, false},
+		"empty":                {``, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, verboseOutputHasOSFields(tc.stdout))
+		})
+	}
+}
+
+func TestVerboseOutputLooksLikeReport_FalseForQuietOutput(t *testing.T) {
+	t.Parallel()
+	require.False(t, VerboseOutputLooksLikeReport("done"))
+}
+
+func TestVerboseOutputLooksLikeReport_TrueForSampleReportJSON(t *testing.T) {
+	t.Parallel()
+	sample := `{"scan":{"operatingSystem":"rhel"},"components":[{"name":"a"}]}`
+	require.True(t, VerboseOutputLooksLikeReport(sample))
+}
+
+func TestVerboseOutputLooksLikeReport_TrueForIndexReportJSON(t *testing.T) {
+	t.Parallel()
+	sample := `{"indexReport":{"state":"IndexFinished"},"discoveredData":{"operatingSystem":{"name":"rhel"}}}`
+	require.True(t, VerboseOutputLooksLikeReport(sample))
+}
+
+func TestBuildRoxagentInstallArgs_UsesSudoInstallModeAndPaths(t *testing.T) {
+	t.Parallel()
+	require.Equal(t,
+		[]string{"sudo", "install", "-m", "0755", "/tmp/roxagent", "/usr/local/bin/roxagent"},
+		buildRoxagentInstallArgs("/tmp/roxagent", "/usr/local/bin/roxagent"),
+	)
+}
+
+func TestIsVsockUnavailableOutput(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		output string
+		want   bool
+	}{
+		"vsock no such device": {
+			output: "dial vsock host(2):818: connect: no such device",
+			want:   true,
+		},
+		"dev vsock missing": {
+			output: "open /dev/vsock: no such file or directory",
+			want:   true,
+		},
+		"non-vsock no such device": {
+			output: "open /dev/does-not-exist: no such device",
+			want:   false,
+		},
+		"other vsock error is retryable": {
+			output: "dial vsock host(2):818: connection refused",
+			want:   false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isVsockUnavailableOutput(tc.output))
+		})
+	}
+}
+
+func TestIsTerminalVSOCKUnavailableError(t *testing.T) {
+	t.Parallel()
+
+	terminalErr := errors.Join(ErrTerminalVSOCKUnavailable, errors.New("exit status 1"))
+	require.True(t, IsTerminalVSOCKUnavailableError(terminalErr))
+	require.False(t, IsTerminalVSOCKUnavailableError(errors.New("other error")))
+}

--- a/tests/vmhelpers/ssh_command_framework.go
+++ b/tests/vmhelpers/ssh_command_framework.go
@@ -1,0 +1,182 @@
+package vmhelpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Default retry count and backoff between SSH transport retries inside runSSHCommandWithFramework.
+const (
+	defaultSSHTransportRetryAttempts = 3
+	defaultSSHTransportRetryInterval = 2 * time.Second
+)
+
+// errSSHTransport is a sentinel that wraps errors originating from the SSH
+// transport layer (banner timeout, network unreachable, authentication failure)
+// as opposed to errors returned by the remote command itself.
+// Callers can use errors.Is(err, errSSHTransport) to distinguish transport
+// failures from remote-command failures and apply different retry strategies.
+var errSSHTransport = errors.New("SSH transport error")
+
+// sshCommandRunOptions configures logging, transport retries, and backoff for runSSHCommandWithFramework.
+type sshCommandRunOptions struct {
+	description            string
+	transportRetryAttempts int
+	retryInterval          time.Duration
+	// suppressLog disables command-level logging for this call (use when the
+	// command contains secrets such as activation keys).
+	suppressLog bool
+}
+
+// isExitCode255 reports whether err wraps an *exec.ExitError with exit code 255.
+// OpenSSH (and virtctl, which wraps it) uses exit code 255 exclusively for
+// SSH transport failures; remote commands return 0–254.
+func isExitCode255(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && exitErr.ExitCode() == 255
+}
+
+// classifySSHStderrCategory returns a descriptive category for known SSH
+// transport stderr patterns so that logging stays specific. If no known
+// pattern matches, it returns "".
+func classifySSHStderrCategory(stderr string) (category string, retryable bool) {
+	if isSSHAuthenticationFailure(stderr) {
+		return "authentication", false
+	}
+	if isSSHBannerTimeoutFailure(stderr) {
+		return "banner-timeout", true
+	}
+	if isSSHNetworkUnreachableFailure(stderr) {
+		return "network", true
+	}
+	lower := strings.ToLower(strings.TrimSpace(stderr))
+	switch {
+	case strings.Contains(lower, "websocket: close 1006"):
+		return "websocket-eof", true
+	case strings.Contains(lower, "unexpected eof"):
+		return "unexpected-eof", true
+	case strings.Contains(lower, "broken pipe"):
+		return "broken-pipe", true
+	case strings.Contains(lower, "closed by remote host"),
+		strings.Contains(lower, "connection closed by"):
+		return "remote-host-closed", true
+	case strings.Contains(lower, "internal error occurred: dialing vm"):
+		return "dialing-vm", true
+	case strings.Contains(lower, "connection reset by peer"):
+		return "connection-reset", true
+	default:
+		return "", true
+	}
+}
+
+// classifySSHFailure decides whether a failure is SSH transport-level (vs remote command) and if retrying helps.
+func classifySSHFailure(stderr string, err error) (isSSH bool, retryable bool, category string) {
+	if err == nil {
+		return false, false, ""
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true, true, "timeout"
+	}
+
+	// Check stderr for a known pattern first — gives us the most specific
+	// category for logging regardless of exit code.
+	cat, catRetryable := classifySSHStderrCategory(stderr)
+
+	// Two independent signals: either a known stderr pattern OR exit code
+	// 255 is sufficient to classify this as an SSH transport error.
+	if cat != "" {
+		return true, catRetryable, cat
+	}
+	if isExitCode255(err) {
+		return true, true, "transport-exit-255"
+	}
+
+	return false, false, ""
+}
+
+// sshTransportRetryInterval is the pause between retries in retryOnSSHTransport after transport errors.
+const sshTransportRetryInterval = 10 * time.Second
+
+// retryOnSSHTransport retries fn whenever it returns an errSSHTransport error.
+// Non-transport errors and nil are returned immediately. The retry loop is
+// bounded by ctx — callers should set an appropriate deadline/timeout.
+func retryOnSSHTransport(ctx context.Context, logf func(string, ...any), desc string, fn func(ctx context.Context) error) error {
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		lastErr = fn(ctx)
+		if lastErr == nil || !errors.Is(lastErr, errSSHTransport) {
+			return lastErr
+		}
+		if logf != nil {
+			logf("%s: SSH transport error (attempt %d), retrying in %s: %v",
+				desc, attempt, sshTransportRetryInterval, lastErr)
+		}
+		timer := time.NewTimer(sshTransportRetryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("%s: context expired while retrying SSH transport error: %w (last: %v)",
+				desc, ctx.Err(), lastErr)
+		case <-timer.C:
+		}
+	}
+}
+
+// runSSHCommandWithFramework runs virt.SSH with transport classification, bounded retries, and optional logging.
+func runSSHCommandWithFramework(ctx context.Context, virt Virtctl, namespace, vm string, opts sshCommandRunOptions, command ...string) (stdout, stderr string, err error) {
+	if opts.suppressLog {
+		virt.Logf = nil
+	}
+	attempts := opts.transportRetryAttempts
+	if attempts <= 0 {
+		attempts = defaultSSHTransportRetryAttempts
+	}
+	interval := opts.retryInterval
+	if interval <= 0 {
+		interval = defaultSSHTransportRetryInterval
+	}
+	description := strings.TrimSpace(opts.description)
+	if description == "" {
+		description = "ssh command"
+	}
+
+	for attempt := 1; attempt <= attempts; attempt++ {
+		stdout, stderr, err = virt.SSH(ctx, namespace, vm, command...)
+		if err == nil {
+			return stdout, stderr, nil
+		}
+
+		isSSH, retryable, category := classifySSHFailure(stderr, err)
+		if !isSSH {
+			return stdout, stderr, err
+		}
+		if !retryable {
+			return stdout, stderr, fmt.Errorf("%w: %s on %s/%s: terminal SSH %s failure: %w",
+				errSSHTransport, description, namespace, vm, category, err)
+		}
+		if attempt >= attempts {
+			return stdout, stderr, fmt.Errorf("%w: %s on %s/%s: retryable SSH %s failure persisted after %d attempt(s): %w",
+				errSSHTransport, description, namespace, vm, category, attempts, err)
+		}
+
+		if virt.Logf != nil {
+			virt.Logf("%s on %s/%s: retryable SSH %s failure (attempt %d/%d): %s",
+				description, namespace, vm, category, attempt, attempts, formatGuestCommandOutputForError(stderr))
+		}
+
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return stdout, stderr, fmt.Errorf("%w: %s on %s/%s: context done during SSH retry backoff: %w",
+				errSSHTransport, description, namespace, vm, ctx.Err())
+		case <-timer.C:
+		}
+	}
+
+	return stdout, stderr, err
+}

--- a/tests/vmhelpers/virtctl.go
+++ b/tests/vmhelpers/virtctl.go
@@ -1,0 +1,295 @@
+package vmhelpers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// defaultLocalSSHOpts are SSH client options passed on every virtctl ssh/scp invocation via --local-ssh-opts.
+var defaultLocalSSHOpts = []string{
+	"-o StrictHostKeyChecking=no",
+	"-o UserKnownHostsFile=/dev/null",
+	"-o IdentitiesOnly=yes",
+	"-o ConnectTimeout=5",
+}
+
+// Constants for virtctl remote logging: heartbeat interval and max length for inlined command output.
+const (
+	defaultVirtctlHeartbeatInterval = 30 * time.Second
+)
+
+// normalizeVirtctlTarget returns vm unchanged if it already includes a resource prefix; otherwise prefixes with "vmi/".
+func normalizeVirtctlTarget(vm string) string {
+	vm = strings.TrimSpace(vm)
+	if strings.Contains(vm, "/") {
+		return vm
+	}
+	return "vmi/" + vm
+}
+
+// appendDefaultLocalSSHOpts appends defaultLocalSSHOpts to args as repeated --local-ssh-opts pairs.
+func appendDefaultLocalSSHOpts(args []string) []string {
+	for _, opt := range defaultLocalSSHOpts {
+		args = append(args, "--local-ssh-opts", opt)
+	}
+	return args
+}
+
+// buildVirtctlSCPToArgs builds the full argument list for `virtctl scp` uploading src to dst on the guest.
+func buildVirtctlSCPToArgs(virtctlPath, namespace, vm, identityFile, username, src, dst string) []string {
+	args := []string{
+		virtctlPath, "scp",
+		"--namespace", namespace,
+		"--identity-file", identityFile,
+		"--known-hosts", "/dev/null",
+	}
+	args = appendDefaultLocalSSHOpts(args)
+	if username != "" {
+		args = append(args, "--username", username)
+	}
+	args = append(args, src, fmt.Sprintf("%s:%s", normalizeVirtctlTarget(vm), dst))
+	return args
+}
+
+// virtctlFlagConsumesValue reports whether flag expects a separate value argument on the virtctl command line.
+func virtctlFlagConsumesValue(flag string) bool {
+	switch flag {
+	case "--namespace", "--identity-file", "--known-hosts", "--local-ssh-opts", "--username", "--command":
+		return true
+	default:
+		return false
+	}
+}
+
+// virtctlPositionalArgs returns non-flag arguments from a virtctl argv (skipping the binary and subcommand).
+func virtctlPositionalArgs(args []string) []string {
+	if len(args) <= 2 {
+		return nil
+	}
+	var positionals []string
+	for i := 2; i < len(args); i++ {
+		arg := args[i]
+		if strings.HasPrefix(arg, "--") {
+			if virtctlFlagConsumesValue(arg) && i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+		positionals = append(positionals, arg)
+	}
+	return positionals
+}
+
+// summarizeVirtctlCommand returns a short, log-safe description of args (subcommand-specific for ssh/scp).
+func summarizeVirtctlCommand(args []string) string {
+	if len(args) < 2 {
+		return "virtctl <unknown>"
+	}
+	subcommand := args[1]
+	switch subcommand {
+	case "ssh":
+		return summarizeVirtctlSSHCommand(args)
+	case "scp":
+		target := "<unknown target>"
+		if pos := virtctlPositionalArgs(args); len(pos) >= 2 {
+			target = pos[len(pos)-1]
+		}
+		return fmt.Sprintf("virtctl scp %s", target)
+	default:
+		return fmt.Sprintf("virtctl %s", subcommand)
+	}
+}
+
+// virtctlSSHVMTarget returns the vmi/vm target from virtctl ssh positionals, if present.
+func virtctlSSHVMTarget(args []string) (string, bool) {
+	if len(args) < 2 || args[1] != "ssh" {
+		return "", false
+	}
+	pos := virtctlPositionalArgs(args)
+	if len(pos) == 0 {
+		return "", false
+	}
+	return pos[0], true
+}
+
+// formatDeadlineRemaining formats the time left until ctx's deadline, or "none" if there is no deadline.
+func formatDeadlineRemaining(ctx context.Context) string {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return "none"
+	}
+	remaining := time.Until(deadline).Round(time.Second)
+	if remaining < 0 {
+		remaining = 0
+	}
+	return remaining.String()
+}
+
+const inlineLogMaxHeadTailLines = 100
+
+// formatRemoteCommandStreamsForInlineLog formats stdout and stderr for multi-line completion logs.
+// Large outputs are truncated to the first and last inlineLogMaxHeadTailLines lines.
+func formatRemoteCommandStreamsForInlineLog(stdout, stderr string) string {
+	var b strings.Builder
+	stderr = strings.TrimSpace(stderr)
+	stdout = strings.TrimSpace(stdout)
+	if stderr != "" {
+		b.WriteString("stderr:\n")
+		b.WriteString(stderr)
+	}
+	if stdout != "" {
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString("stdout:\n")
+		b.WriteString(truncateMiddleLines(stdout, inlineLogMaxHeadTailLines))
+	}
+	if b.Len() == 0 {
+		return "output: <empty stdout/stderr>"
+	}
+	return b.String()
+}
+
+// truncateMiddleLines keeps the first and last n lines, replacing the middle with a marker.
+func truncateMiddleLines(s string, n int) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) <= 2*n {
+		return s
+	}
+	head := lines[:n]
+	tail := lines[len(lines)-n:]
+	omitted := len(lines) - 2*n
+	return strings.Join(head, "\n") +
+		fmt.Sprintf("\n\n... (%d lines truncated) ...\n\n", omitted) +
+		strings.Join(tail, "\n")
+}
+
+// Virtctl runs virtctl subcommands with optional per-call timeout.
+type Virtctl struct {
+	Path           string
+	IdentityFile   string
+	Username       string
+	CommandTimeout time.Duration
+	// Logf is optional. When provided, each remote command logs start/heartbeat/completion.
+	Logf func(format string, args ...any)
+	// HeartbeatInterval controls "still running" log cadence for long commands.
+	// Zero uses defaultVirtctlHeartbeatInterval.
+	HeartbeatInterval time.Duration
+}
+
+// waitForProcessExitAfterKill waits for cmd.Wait after a kill, bounded by killWait, or returns ctx.Err().
+func waitForProcessExitAfterKill(ctx context.Context, waitErrCh <-chan error) error {
+	const killWait = 5 * time.Second
+	select {
+	case waitErr := <-waitErrCh:
+		if waitErr != nil {
+			return fmt.Errorf("%w (process terminated: %v)", ctx.Err(), waitErr)
+		}
+		return ctx.Err()
+	case <-time.After(killWait):
+		return fmt.Errorf("%w (process did not exit within %s after kill)", ctx.Err(), killWait)
+	}
+}
+
+// waitForCommandWithContext waits for cmd to finish; on ctx cancellation it kills the process and waits for exit.
+func waitForCommandWithContext(ctx context.Context, cmd *exec.Cmd) error {
+	waitErrCh := make(chan error, 1)
+	go func() {
+		waitErrCh <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-waitErrCh:
+		return err
+	case <-ctx.Done():
+		killVirtctlCmd(cmd)
+		return waitForProcessExitAfterKill(ctx, waitErrCh)
+	}
+}
+
+// run starts a virtctl (or argv[0]) subprocess, captures stdout/stderr, and honors optional logging and heartbeats.
+func (v Virtctl) run(ctx context.Context, args []string) (stdout string, stderr string, err error) {
+	if v.CommandTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, v.CommandTimeout)
+		defer cancel()
+	}
+	if len(args) == 0 {
+		return "", "", errors.New("virtctl: empty args")
+	}
+	cmd := exec.Command(args[0], args[1:]...)
+	configureVirtctlCmdForCancellation(cmd)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	start := time.Now()
+	summary := summarizeVirtctlCommand(args)
+	var (
+		stopHeartbeat chan struct{}
+		hbWG          sync.WaitGroup
+	)
+	if v.Logf != nil {
+		v.Logf("remote command start: %s (deadline in %s)", summary, formatDeadlineRemaining(ctx))
+		stopHeartbeat = make(chan struct{})
+		interval := v.HeartbeatInterval
+		if interval <= 0 {
+			interval = defaultVirtctlHeartbeatInterval
+		}
+		hbWG.Go(func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stopHeartbeat:
+					return
+				case <-ticker.C:
+					if vmTarget, ok := virtctlSSHVMTarget(args); ok {
+						v.Logf("remote command still running (%s elapsed) on VM %s", time.Since(start).Round(time.Second), vmTarget)
+					} else {
+						v.Logf("remote command still running (%s elapsed): %s", time.Since(start).Round(time.Second), summary)
+					}
+				}
+			}
+		})
+	}
+	if err = cmd.Start(); err != nil {
+		if stopHeartbeat != nil {
+			close(stopHeartbeat)
+			hbWG.Wait()
+		}
+		if v.Logf != nil {
+			v.Logf("remote command failed to start: %s (err=%v)", summary, err)
+		}
+		return outBuf.String(), errBuf.String(), err
+	}
+	err = waitForCommandWithContext(ctx, cmd)
+
+	if stopHeartbeat != nil {
+		close(stopHeartbeat)
+		hbWG.Wait()
+	}
+	if v.Logf != nil {
+		elapsed := time.Since(start).Round(time.Second)
+		if err != nil {
+			v.Logf("remote command failed in %s: %s (outcome=%v stdout=%dB stderr=%dB)\n%s",
+				elapsed, summary, err, outBuf.Len(), errBuf.Len(), formatRemoteCommandStreamsForInlineLog(outBuf.String(), errBuf.String()))
+		} else {
+			v.Logf("remote command complete in %s: %s (stdout=%dB stderr=%dB)\n%s",
+				elapsed, summary, outBuf.Len(), errBuf.Len(), formatRemoteCommandStreamsForInlineLog(outBuf.String(), errBuf.String()))
+		}
+	}
+	return outBuf.String(), errBuf.String(), err
+}
+
+// SCPTo copies a local file to the guest using `virtctl scp`.
+func (v Virtctl) SCPTo(ctx context.Context, namespace, vm, src, dst string) (stderr string, err error) {
+	args := buildVirtctlSCPToArgs(v.Path, namespace, vm, v.IdentityFile, v.Username, src, dst)
+	_, stderrStr, err := v.run(ctx, args)
+	return stderrStr, err
+}

--- a/tests/vmhelpers/virtctl_process_nonunix.go
+++ b/tests/vmhelpers/virtctl_process_nonunix.go
@@ -1,0 +1,16 @@
+//go:build !unix
+
+package vmhelpers
+
+import "os/exec"
+
+// configureVirtctlCmdForCancellation is a no-op on non-Unix platforms (no separate process group).
+func configureVirtctlCmdForCancellation(cmd *exec.Cmd) {}
+
+// killVirtctlCmd terminates the virtctl process on non-Unix platforms.
+func killVirtctlCmd(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+}

--- a/tests/vmhelpers/virtctl_process_unix.go
+++ b/tests/vmhelpers/virtctl_process_unix.go
@@ -1,0 +1,25 @@
+//go:build unix
+
+package vmhelpers
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureVirtctlCmdForCancellation puts the child in its own process group so signals target the whole tree.
+func configureVirtctlCmdForCancellation(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killVirtctlCmd sends SIGKILL to the virtctl process group, then kills the main process.
+func killVirtctlCmd(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	if pid := cmd.Process.Pid; pid > 0 {
+		// Kill the whole process group so child ssh/scp processes cannot outlive virtctl.
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	}
+	_ = cmd.Process.Kill()
+}

--- a/tests/vmhelpers/virtctl_ssh.go
+++ b/tests/vmhelpers/virtctl_ssh.go
@@ -1,0 +1,69 @@
+package vmhelpers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// buildVirtctlSSHArgs builds the full argv for `virtctl ssh`, optionally with a quoted remote --command.
+func buildVirtctlSSHArgs(virtctlPath, namespace, vm, identityFile, username string, command ...string) []string {
+	args := []string{
+		virtctlPath, "ssh",
+		"--namespace", namespace,
+		"--identity-file", identityFile,
+		"--known-hosts", "/dev/null",
+	}
+	args = appendDefaultLocalSSHOpts(args)
+	if username != "" {
+		args = append(args, "--username", username)
+	}
+	args = append(args, normalizeVirtctlTarget(vm))
+	if len(command) > 0 {
+		args = append(args, "--command", buildVirtctlSSHCommand(command...))
+	}
+	return args
+}
+
+// buildVirtctlSSHCommand joins shell command parts into one string with per-argument strconv.Quote quoting.
+func buildVirtctlSSHCommand(command ...string) string {
+	if len(command) == 0 {
+		return ""
+	}
+	quoted := make([]string, 0, len(command))
+	for _, arg := range command {
+		quoted = append(quoted, strconv.Quote(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+// summarizeVirtctlSSHCommand returns a short log line for a virtctl ssh argv (target and remote command summary).
+func summarizeVirtctlSSHCommand(args []string) string {
+	target := "<unknown target>"
+	if pos := virtctlPositionalArgs(args); len(pos) > 0 {
+		target = pos[0]
+	}
+	for i := range len(args) {
+		if args[i] != "--command" || i+1 >= len(args) {
+			continue
+		}
+		return fmt.Sprintf("virtctl ssh %s command=%s", target, summarizeRemoteSSHCommand(args[i+1]))
+	}
+	return fmt.Sprintf("virtctl ssh %s", target)
+}
+
+// summarizeRemoteSSHCommand returns the remote command string for the "start" log line (full --command value).
+func summarizeRemoteSSHCommand(cmd string) string {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return "<empty>"
+	}
+	return cmd
+}
+
+// SSH runs `virtctl ssh` against the VM and returns captured streams.
+func (v Virtctl) SSH(ctx context.Context, namespace, vm string, command ...string) (stdout string, stderr string, err error) {
+	args := buildVirtctlSSHArgs(v.Path, namespace, vm, v.IdentityFile, v.Username, command...)
+	return v.run(ctx, args)
+}

--- a/tests/vmhelpers/virtctl_test.go
+++ b/tests/vmhelpers/virtctl_test.go
@@ -1,0 +1,86 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSHCommandArgs_UsesIdentityAndNamespace(t *testing.T) {
+	args := buildVirtctlSSHArgs("/usr/bin/virtctl", "stackrox", "vm-rhel9", "/tmp/id_rsa", "cloud-user", "sudo", "true")
+	require.Equal(t, []string{
+		"/usr/bin/virtctl", "ssh",
+		"--namespace", "stackrox",
+		"--identity-file", "/tmp/id_rsa",
+		"--known-hosts", "/dev/null",
+		"--local-ssh-opts", "-o StrictHostKeyChecking=no",
+		"--local-ssh-opts", "-o UserKnownHostsFile=/dev/null",
+		"--local-ssh-opts", "-o IdentitiesOnly=yes",
+		"--local-ssh-opts", "-o ConnectTimeout=5",
+		"--username", "cloud-user",
+		"vmi/vm-rhel9",
+		"--command", `"sudo" "true"`,
+	}, args)
+}
+
+func TestBuildVirtctlSSHCommand_QuotesArguments(t *testing.T) {
+	got := buildVirtctlSSHCommand("sh", "-c", `echo "hello world" && true`)
+	require.Equal(t, `"sh" "-c" "echo \"hello world\" && true"`, got)
+}
+
+func TestSCPToArgs_RemoteTargetShape(t *testing.T) {
+	args := buildVirtctlSCPToArgs("/usr/bin/virtctl", "stackrox", "vm-rhel9", "/tmp/id_rsa", "cloud-user", "/local/roxagent", "/usr/local/bin/roxagent")
+	require.Equal(t, []string{
+		"/usr/bin/virtctl", "scp",
+		"--namespace", "stackrox",
+		"--identity-file", "/tmp/id_rsa",
+		"--known-hosts", "/dev/null",
+		"--local-ssh-opts", "-o StrictHostKeyChecking=no",
+		"--local-ssh-opts", "-o UserKnownHostsFile=/dev/null",
+		"--local-ssh-opts", "-o IdentitiesOnly=yes",
+		"--local-ssh-opts", "-o ConnectTimeout=5",
+		"--username", "cloud-user",
+		"/local/roxagent", "vmi/vm-rhel9:/usr/local/bin/roxagent",
+	}, args)
+}
+
+func TestSummarizeVirtctlCommand_SSHWithRemoteCommand(t *testing.T) {
+	args := buildVirtctlSSHArgs("/usr/bin/virtctl", "stackrox", "vm-rhel9", "/tmp/id_rsa", "cloud-user", "sudo", "true")
+	require.Equal(t, `virtctl ssh vmi/vm-rhel9 command="sudo" "true"`, summarizeVirtctlCommand(args))
+}
+
+func TestSummarizeVirtctlCommand_SCP(t *testing.T) {
+	args := buildVirtctlSCPToArgs("/usr/bin/virtctl", "stackrox", "vm-rhel9", "/tmp/id_rsa", "cloud-user", "/local/roxagent", "/usr/local/bin/roxagent")
+	require.Equal(t, "virtctl scp vmi/vm-rhel9:/usr/local/bin/roxagent", summarizeVirtctlCommand(args))
+}
+
+func TestVirtctlRun_RespectsContextDeadline(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, _, err := (Virtctl{}).run(ctx, []string{"sh", "-c", "sleep 5"})
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(start), 3*time.Second, "virtctl run should terminate promptly on context deadline")
+}
+
+func TestSummarizeRemoteSSHCommand(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "<empty>", summarizeRemoteSSHCommand(" \n\t "))
+	require.Equal(t, `"sudo" "true"`, summarizeRemoteSSHCommand(`"sudo" "true"`))
+
+	long := strings.Repeat("x", 300)
+	require.Equal(t, long, summarizeRemoteSSHCommand(long))
+}

--- a/tests/vmhelpers/vm.go
+++ b/tests/vmhelpers/vm.go
@@ -1,0 +1,458 @@
+package vmhelpers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	vmscanning "github.com/stackrox/rox/tests/testdata/vm-scanning"
+	coreV1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+// Defaults for VM resource requests and polling/logging during KubeVirt VM/VMI wait helpers.
+const (
+	defaultVMMemoryRequest = "2Gi"
+	defaultVMCPUCores      = int64(3)
+	vmPollInterval         = 2 * time.Second
+)
+
+// vmGVR and vmiGVR are dynamic client resources for KubeVirt VirtualMachine and VirtualMachineInstance objects.
+var (
+	vmGVR = schema.GroupVersionResource{
+		Group:    kubevirtv1.GroupVersion.Group,
+		Version:  kubevirtv1.GroupVersion.Version,
+		Resource: "virtualmachines",
+	}
+	vmiGVR = schema.GroupVersionResource{
+		Group:    kubevirtv1.GroupVersion.Group,
+		Version:  kubevirtv1.GroupVersion.Version,
+		Resource: "virtualmachineinstances",
+	}
+)
+
+// VMRequest describes inputs for cloud-init rendering and VirtualMachine creation.
+type VMRequest struct {
+	Name         string
+	Namespace    string
+	Image        string
+	GuestUser    string
+	SSHPublicKey string
+}
+
+// RenderCloudInit expands the embedded cloud-init template using req.
+func RenderCloudInit(req VMRequest) ([]byte, error) {
+	if err := validateCloudInitRequest(req); err != nil {
+		return nil, err
+	}
+	tmpl, err := template.New("cloud-init").Funcs(template.FuncMap{
+		"yamlQuote": strconv.Quote,
+	}).Parse(string(vmscanning.CloudInitUserDataTemplate))
+	if err != nil {
+		return nil, fmt.Errorf("parse cloud-init template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, req); err != nil {
+		return nil, fmt.Errorf("execute cloud-init template: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// validateCloudInitRequest ensures GuestUser and SSHPublicKey are set for cloud-init rendering.
+func validateCloudInitRequest(req VMRequest) error {
+	if req.GuestUser == "" {
+		return errors.New("VMRequest GuestUser is required")
+	}
+	if req.SSHPublicKey == "" {
+		return errors.New("VMRequest SSHPublicKey is required")
+	}
+	return nil
+}
+
+// CreateVirtualMachine submits a KubeVirt VirtualMachine with a container disk and NoCloud user-data.
+func CreateVirtualMachine(ctx context.Context, client dynamic.Interface, req VMRequest) error {
+	if req.Name == "" || req.Namespace == "" || req.Image == "" {
+		return errors.New("VMRequest Name, Namespace, and Image are required")
+	}
+	userData, err := RenderCloudInit(req)
+	if err != nil {
+		return err
+	}
+	runStrategy := kubevirtv1.RunStrategyAlways
+	autoattachVSOCK := true
+	vm := &kubevirtv1.VirtualMachine{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubevirt.io/v1",
+			Kind:       "VirtualMachine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.Name,
+			Namespace: req.Namespace,
+		},
+		Spec: kubevirtv1.VirtualMachineSpec{
+			RunStrategy: &runStrategy,
+			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
+				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					Domain: kubevirtv1.DomainSpec{
+						Devices: kubevirtv1.Devices{
+							AutoattachVSOCK: &autoattachVSOCK,
+							Disks: []kubevirtv1.Disk{
+								{
+									Name: "containerdisk",
+									DiskDevice: kubevirtv1.DiskDevice{
+										Disk: &kubevirtv1.DiskTarget{Bus: kubevirtv1.DiskBusVirtio},
+									},
+								},
+								{
+									Name: "cloudinitdisk",
+									DiskDevice: kubevirtv1.DiskDevice{
+										Disk: &kubevirtv1.DiskTarget{Bus: kubevirtv1.DiskBusVirtio},
+									},
+								},
+							},
+						},
+					},
+					Volumes: []kubevirtv1.Volume{
+						{
+							Name: "containerdisk",
+							VolumeSource: kubevirtv1.VolumeSource{
+								ContainerDisk: &kubevirtv1.ContainerDiskSource{Image: req.Image},
+							},
+						},
+						{
+							Name: "cloudinitdisk",
+							VolumeSource: kubevirtv1.VolumeSource{
+								CloudInitNoCloud: &kubevirtv1.CloudInitNoCloudSource{
+									UserData: string(userData),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	vm.Spec.Template.Spec.Domain.Resources.Requests = coreV1.ResourceList{
+		coreV1.ResourceMemory: resource.MustParse(defaultVMMemoryRequest),
+	}
+	u, err := k8sruntime.DefaultUnstructuredConverter.ToUnstructured(vm)
+	if err != nil {
+		return fmt.Errorf("convert VirtualMachine to unstructured: %w", err)
+	}
+	if err := unstructured.SetNestedField(u, defaultVMCPUCores, "spec", "template", "spec", "domain", "cpu", "cores"); err != nil {
+		return fmt.Errorf("set vm cpu cores in manifest: %w", err)
+	}
+	_, err = client.Resource(vmGVR).Namespace(req.Namespace).Create(ctx, &unstructured.Unstructured{Object: u}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("create VirtualMachine: %w", err)
+	}
+	return nil
+}
+
+// GetVMContainerDiskImage reads the container disk image from an existing VirtualMachine.
+func GetVMContainerDiskImage(ctx context.Context, client dynamic.Interface, namespace, name string) (string, error) {
+	vm, err := client.Resource(vmGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get VirtualMachine %s/%s: %w", namespace, name, err)
+	}
+	volumes, found, err := unstructured.NestedSlice(vm.Object, "spec", "template", "spec", "volumes")
+	if err != nil || !found {
+		return "", fmt.Errorf("VirtualMachine %s/%s has no spec.template.spec.volumes", namespace, name)
+	}
+	for _, raw := range volumes {
+		vol, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		n, _ := vol["name"].(string)
+		if n != "containerdisk" {
+			continue
+		}
+		image, _, _ := unstructured.NestedString(vol, "containerDisk", "image")
+		if image != "" {
+			return image, nil
+		}
+	}
+	return "", fmt.Errorf("VirtualMachine %s/%s has no containerdisk volume", namespace, name)
+}
+
+// DeleteVirtualMachine removes a KubeVirt VirtualMachine by name.
+func DeleteVirtualMachine(ctx context.Context, client dynamic.Interface, namespace, name string) error {
+	err := client.Resource(vmGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete VirtualMachine: %w", err)
+	}
+	return nil
+}
+
+// vmFailureConditionDetail returns a printable detail if the VM status has a True Failure condition.
+func vmFailureConditionDetail(vm *unstructured.Unstructured) (string, bool) {
+	conds, found, err := unstructured.NestedSlice(vm.Object, "status", "conditions")
+	if err != nil || !found {
+		return "", false
+	}
+	for _, raw := range conds {
+		cond, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		typ, _ := cond["type"].(string)
+		if !strings.EqualFold(strings.TrimSpace(typ), "Failure") {
+			continue
+		}
+		status, _ := cond["status"].(string)
+		if !strings.EqualFold(strings.TrimSpace(status), "True") {
+			continue
+		}
+		reason, _ := cond["reason"].(string)
+		msg, _ := cond["message"].(string)
+		reason = strings.TrimSpace(reason)
+		msg = strings.TrimSpace(msg)
+		switch {
+		case reason != "" && msg != "":
+			return fmt.Sprintf("failure condition reason=%q message=%q", reason, msg), true
+		case reason != "":
+			return fmt.Sprintf("failure condition reason=%q", reason), true
+		case msg != "":
+			return fmt.Sprintf("failure condition message=%q", msg), true
+		default:
+			return "failure condition present", true
+		}
+	}
+	return "", false
+}
+
+// virtualMachineStatusDetail loads the VM and returns status text for wait-loop logging; terminalFailure stops polling.
+func virtualMachineStatusDetail(ctx context.Context, client dynamic.Interface, namespace, name string) (detail string, terminalFailure bool, err error) {
+	vm, err := client.Resource(vmGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "virtual machine object not found", false, nil
+		}
+		return "", false, err
+	}
+	if detail, terminal := vmFailureConditionDetail(vm); terminal {
+		return detail, true, nil
+	}
+	printableStatus, found, nestedErr := unstructured.NestedString(vm.Object, "status", "printableStatus")
+	if nestedErr != nil {
+		return "", false, nestedErr
+	}
+	if found && strings.TrimSpace(printableStatus) != "" {
+		return fmt.Sprintf("vm printableStatus=%q", printableStatus), false, nil
+	}
+	return "vm status unavailable", false, nil
+}
+
+// terminalPrintableStatuses contains VM printableStatus values that indicate
+// unrecoverable errors where further polling is pointless.
+var terminalPrintableStatuses = []string{
+	"ImagePullBackOff",
+	"ErrImagePull",
+	"InvalidImageName",
+	"RegistryUnavailable",
+	"ImageInspectError",
+	"ErrImageNeverPull",
+	"CrashLoopBackOff",
+	"ErrorUnschedulable",
+}
+
+// vmPrintableStatusTerminal reads the VM printableStatus and returns it along
+// with whether the status indicates a terminal (unrecoverable) failure.
+func vmPrintableStatusTerminal(ctx context.Context, client dynamic.Interface, namespace, name string) (string, bool) {
+	vm, err := client.Resource(vmGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", false
+	}
+	ps, found, _ := unstructured.NestedString(vm.Object, "status", "printableStatus")
+	if !found || strings.TrimSpace(ps) == "" {
+		return "", false
+	}
+	for _, terminal := range terminalPrintableStatuses {
+		if strings.Contains(ps, terminal) {
+			return fmt.Sprintf("vm printableStatus=%q (terminal)", ps), true
+		}
+	}
+	return fmt.Sprintf("vm printableStatus=%q", ps), false
+}
+
+// vmiPhaseDetail summarizes VMI phase and Ready condition fields for poll attempt logs.
+func vmiPhaseDetail(vmi *unstructured.Unstructured) string {
+	parts := make([]string, 0, 2)
+	phase, found, _ := unstructured.NestedString(vmi.Object, "status", "phase")
+	if found && strings.TrimSpace(phase) != "" {
+		parts = append(parts, fmt.Sprintf("phase=%q", phase))
+	}
+	conds, found, _ := unstructured.NestedSlice(vmi.Object, "status", "conditions")
+	if found {
+		for _, raw := range conds {
+			cond, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			typ, _ := cond["type"].(string)
+			if !strings.EqualFold(strings.TrimSpace(typ), "Ready") {
+				continue
+			}
+			status, _ := cond["status"].(string)
+			reason, _ := cond["reason"].(string)
+			message, _ := cond["message"].(string)
+			part := fmt.Sprintf("ready.status=%q", strings.TrimSpace(status))
+			if strings.TrimSpace(reason) != "" {
+				part += fmt.Sprintf(" ready.reason=%q", strings.TrimSpace(reason))
+			}
+			if strings.TrimSpace(message) != "" {
+				part += fmt.Sprintf(" ready.message=%q", strings.TrimSpace(message))
+			}
+			parts = append(parts, part)
+			break
+		}
+	}
+	if len(parts) == 0 {
+		return "vmi status unavailable"
+	}
+	return strings.Join(parts, " ")
+}
+
+// pollKubeVirtCondition runs a poll loop with attempt counting, periodic logging, and
+// consistent timeout error wrapping. check receives the current attempt number and
+// returns (done, detail-for-logging, error). desc is used in log lines and errors.
+func pollKubeVirtCondition(t testing.TB, ctx context.Context, interval time.Duration, desc string,
+	check func(ctx context.Context, attempt int) (done bool, detail string, err error),
+) error {
+	t.Helper()
+	attempts := 0
+	lastDetail := ""
+	maxAttempts, maxKnown := estimateMaxPollAttempts(ctx, interval)
+	err := wait.PollUntilContextCancel(ctx, interval, true, func(ctx context.Context) (bool, error) {
+		attempts++
+		done, detail, err := check(ctx, attempts)
+		if detail != "" {
+			lastDetail = detail
+		}
+		logWaitAttempt(t, desc, attempts, maxAttempts, maxKnown, detail)
+		return done, err
+	})
+	if err == nil {
+		return nil
+	}
+	if lastDetail != "" {
+		return fmt.Errorf("%s failed after %d poll(s): %w (last detail: %s)", desc, attempts, err, lastDetail)
+	}
+	return fmt.Errorf("%s failed after %d poll(s): %w", desc, attempts, err)
+}
+
+// handleVMINotFound is used inside poll callbacks when the VMI doesn't exist yet.
+// It reads the parent VM status for diagnostics and returns a terminal error if the
+// VM itself is in a failure state (e.g. image pull error).
+func handleVMINotFound(ctx context.Context, client dynamic.Interface, namespace, name string, attempt int, terminalPrefix string) (detail string, err error) {
+	vmDetail, terminalFailure, detailErr := virtualMachineStatusDetail(ctx, client, namespace, name)
+	if detailErr != nil {
+		return "", fmt.Errorf("attempt %d: read VM status: %w", attempt, detailErr)
+	}
+	detail = fmt.Sprintf("vmi not found (%s)", vmDetail)
+	if terminalFailure {
+		return detail, fmt.Errorf("attempt %d: %s: %s", attempt, terminalPrefix, vmDetail)
+	}
+	return detail, nil
+}
+
+// WaitForVirtualMachineInstanceExists polls until the VMI object is present (same name as the VM).
+func WaitForVirtualMachineInstanceExists(t testing.TB, ctx context.Context, client dynamic.Interface, namespace, name string) error {
+	t.Helper()
+	return pollKubeVirtCondition(t, ctx, vmPollInterval, fmt.Sprintf("wait VMI %s/%s exists", namespace, name),
+		func(ctx context.Context, attempt int) (bool, string, error) {
+			_, err := client.Resource(vmiGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err == nil {
+				return true, "vmi now exists", nil
+			}
+			if apierrors.IsNotFound(err) {
+				detail, termErr := handleVMINotFound(ctx, client, namespace, name, attempt, "VMI was not created")
+				return false, detail, termErr
+			}
+			return false, "", fmt.Errorf("attempt %d: get VMI: %w", attempt, err)
+		},
+	)
+}
+
+// WaitForVirtualMachineInstanceRunning polls until the VMI reports Running phase.
+func WaitForVirtualMachineInstanceRunning(t testing.TB, ctx context.Context, client dynamic.Interface, namespace, name string) error {
+	t.Helper()
+	return pollKubeVirtCondition(t, ctx, vmPollInterval, fmt.Sprintf("wait VMI %s/%s running", namespace, name),
+		func(ctx context.Context, attempt int) (bool, string, error) {
+			vmi, err := client.Resource(vmiGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					detail, termErr := handleVMINotFound(ctx, client, namespace, name, attempt, "VMI failed before becoming Running")
+					return false, detail, termErr
+				}
+				return false, "", fmt.Errorf("attempt %d: get VMI: %w", attempt, err)
+			}
+			phase, found, err := unstructured.NestedString(vmi.Object, "status", "phase")
+			if err != nil {
+				return false, "", fmt.Errorf("attempt %d: read VMI phase: %w", attempt, err)
+			}
+			if !found {
+				return false, vmiPhaseDetail(vmi), nil
+			}
+			detail := vmiPhaseDetail(vmi)
+			if phase != string(kubevirtv1.Running) {
+				vmDetail, terminal := vmPrintableStatusTerminal(ctx, client, namespace, name)
+				if terminal {
+					return false, detail + " " + vmDetail, fmt.Errorf("attempt %d: unrecoverable VM error: %s", attempt, vmDetail)
+				}
+				if vmDetail != "" {
+					detail += " " + vmDetail
+				}
+			}
+			return phase == string(kubevirtv1.Running), detail, nil
+		},
+	)
+}
+
+// GetVMINodeName returns the Kubernetes node name that hosts the given VirtualMachineInstance.
+func GetVMINodeName(ctx context.Context, client dynamic.Interface, namespace, name string) (string, error) {
+	vmi, err := client.Resource(vmiGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get VMI %s/%s: %w", namespace, name, err)
+	}
+	nodeName, found, err := unstructured.NestedString(vmi.Object, "status", "nodeName")
+	if err != nil {
+		return "", fmt.Errorf("read VMI %s/%s status.nodeName: %w", namespace, name, err)
+	}
+	if !found || nodeName == "" {
+		return "", fmt.Errorf("VMI %s/%s has no status.nodeName (phase=%s)", namespace, name, vmiPhaseDetail(vmi))
+	}
+	return nodeName, nil
+}
+
+// WaitForVirtualMachineDeleted polls until the VirtualMachine object is gone.
+func WaitForVirtualMachineDeleted(t testing.TB, ctx context.Context, client dynamic.Interface, namespace, name string) error {
+	t.Helper()
+	return pollKubeVirtCondition(t, ctx, vmPollInterval, fmt.Sprintf("wait VM %s/%s deleted", namespace, name),
+		func(ctx context.Context, attempt int) (bool, string, error) {
+			_, err := client.Resource(vmGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return true, "vm no longer found", nil
+			}
+			if err != nil {
+				return false, "", fmt.Errorf("attempt %d: get VM: %w", attempt, err)
+			}
+			return false, "vm still exists", nil
+		},
+	)
+}

--- a/tests/vmhelpers/vm_test.go
+++ b/tests/vmhelpers/vm_test.go
@@ -1,0 +1,129 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestRenderCloudInit_InjectsAuthorizedKey(t *testing.T) {
+	data, err := RenderCloudInit(VMRequest{
+		GuestUser:    "cloud-user",
+		SSHPublicKey: "ssh-rsa AAAATEST",
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(data), "ssh_authorized_keys:")
+	require.Contains(t, string(data), "ssh-rsa AAAATEST")
+}
+
+func TestRenderCloudInit_IncludesGuestUser(t *testing.T) {
+	data, err := RenderCloudInit(VMRequest{
+		GuestUser:    "cloud-user",
+		SSHPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA",
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(data), "cloud-user")
+	require.Contains(t, string(data), "name:")
+}
+
+func TestRenderCloudInit_GrantsPasswordlessSudo(t *testing.T) {
+	data, err := RenderCloudInit(VMRequest{
+		GuestUser:    "cloud-user",
+		SSHPublicKey: "ssh-rsa AAAATEST",
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(data), "NOPASSWD:ALL")
+}
+
+func TestRenderCloudInit_MissingGuestUser(t *testing.T) {
+	_, err := RenderCloudInit(VMRequest{
+		GuestUser:    "",
+		SSHPublicKey: "ssh-rsa AAAA",
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "GuestUser")
+}
+
+func TestRenderCloudInit_MissingSSHPublicKey(t *testing.T) {
+	_, err := RenderCloudInit(VMRequest{
+		GuestUser:    "cloud-user",
+		SSHPublicKey: "",
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "SSHPublicKey")
+}
+
+func TestCreateVirtualMachine_RequiresCloudInitFields(t *testing.T) {
+	err := CreateVirtualMachine(context.Background(), nil, VMRequest{
+		Name: "vm", Namespace: "ns", Image: "quay.io/example/rhel9:latest",
+		GuestUser: "", SSHPublicKey: "ssh-rsa AAAA",
+	})
+	require.ErrorContains(t, err, "GuestUser")
+
+	err = CreateVirtualMachine(context.Background(), nil, VMRequest{
+		Name: "vm", Namespace: "ns", Image: "quay.io/example/rhel9:latest",
+		GuestUser: "cloud-user", SSHPublicKey: "",
+	})
+	require.ErrorContains(t, err, "SSHPublicKey")
+}
+
+func TestCreateVirtualMachine_SetsDefaultMemoryRequest(t *testing.T) {
+	t.Parallel()
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	req := VMRequest{
+		Name:         "vm-rhel9",
+		Namespace:    "ns",
+		Image:        "registry.redhat.io/rhel9/rhel-guest-image",
+		GuestUser:    "cloud-user",
+		SSHPublicKey: "ssh-rsa AAAA",
+	}
+
+	err := CreateVirtualMachine(context.Background(), client, req)
+	require.NoError(t, err)
+
+	obj, err := client.Resource(vmGVR).Namespace(req.Namespace).Get(context.Background(), req.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	got, found, err := unstructured.NestedString(obj.Object, "spec", "template", "spec", "domain", "resources", "requests", "memory")
+	require.NoError(t, err)
+	require.True(t, found, "expected memory request in VM manifest")
+	require.Equal(t, defaultVMMemoryRequest, got)
+
+	vsockEnabled, found, err := unstructured.NestedBool(obj.Object, "spec", "template", "spec", "domain", "devices", "autoattachVSOCK")
+	require.NoError(t, err)
+	require.True(t, found, "expected autoattachVSOCK in VM manifest")
+	require.True(t, vsockEnabled, "expected autoattachVSOCK=true in VM manifest")
+
+	cores, found, err := unstructured.NestedInt64(obj.Object, "spec", "template", "spec", "domain", "cpu", "cores")
+	require.NoError(t, err)
+	require.True(t, found, "expected domain.cpu.cores in VM manifest")
+	require.EqualValues(t, 3, cores, "expected VM cpu cores to be 3")
+}
+
+func TestVMFailureConditionDetail(t *testing.T) {
+	t.Parallel()
+	vm := &unstructured.Unstructured{
+		Object: map[string]any{
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":    "Failure",
+						"status":  "True",
+						"reason":  "FailedCreate",
+						"message": "no memory requested",
+					},
+				},
+			},
+		},
+	}
+	detail, terminal := vmFailureConditionDetail(vm)
+	require.True(t, terminal)
+	require.Contains(t, detail, "FailedCreate")
+	require.Contains(t, detail, "no memory requested")
+}

--- a/tests/vmhelpers/wait.go
+++ b/tests/vmhelpers/wait.go
@@ -1,0 +1,151 @@
+package vmhelpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Shared poll-loop logging constants used by both VM and guest SSH wait helpers.
+const (
+	waitLogEveryAttempts = 5
+	waitDetailMaxLen     = 300
+)
+
+// estimateMaxPollAttempts estimates how many poll iterations fit before ctx's deadline given interval.
+func estimateMaxPollAttempts(ctx context.Context, interval time.Duration) (max int, known bool) {
+	deadline, ok := ctx.Deadline()
+	if !ok || interval <= 0 {
+		return 0, false
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return 1, true
+	}
+	return int(remaining/interval) + 1, true
+}
+
+// shouldLogWaitAttempt limits poll-loop log noise: first attempt plus every Nth.
+func shouldLogWaitAttempt(attempt int) bool {
+	return attempt <= 1 || attempt%waitLogEveryAttempts == 0
+}
+
+// truncateWaitDetail shortens per-attempt detail strings for log lines.
+func truncateWaitDetail(detail string) string {
+	detail = strings.TrimSpace(detail)
+	if len(detail) <= waitDetailMaxLen {
+		return detail
+	}
+	return detail[:waitDetailMaxLen] + fmt.Sprintf(" ... (truncated from %d bytes)", len(detail))
+}
+
+// logWaitAttempt emits one structured poll line when shouldLogWaitAttempt allows it.
+func logWaitAttempt(t testing.TB, desc string, attempt, max int, maxKnown bool, detail string) {
+	t.Helper()
+	if !shouldLogWaitAttempt(attempt) {
+		return
+	}
+	if maxKnown {
+		left := max - attempt
+		if left < 0 {
+			left = 0
+		}
+		t.Logf("%s: attempt %d/%d (retries left: %d): %s", desc, attempt, max, left, detail)
+		return
+	}
+	t.Logf("%s: attempt %d: %s", desc, attempt, detail)
+}
+
+// ErrAuthenticationExpired is returned when an API call fails with an
+// authentication/authorization error that typically indicates an expired
+// kubeconfig token or revoked credentials. Tests should stop immediately
+// when this is encountered rather than retrying.
+var ErrAuthenticationExpired = errors.New("authentication expired — kubeconfig token or API credentials may have expired; remaining operations will fail")
+
+// IsAuthenticationExpired reports whether err looks like an expired or revoked
+// credential. It checks gRPC Unauthenticated status codes and Kubernetes
+// "Unauthorized" API errors.
+func IsAuthenticationExpired(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrAuthenticationExpired) {
+		return true
+	}
+	if s, ok := status.FromError(err); ok && s.Code() == codes.Unauthenticated {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Unauthorized") || strings.Contains(msg, "the server has asked for the client to provide credentials")
+}
+
+// WaitOptions configures a single-condition poll loop used by Central wait helpers.
+type WaitOptions struct {
+	Timeout      time.Duration
+	PollInterval time.Duration
+	// Logf, when set, is called on each unsuccessful poll with the condition
+	// description and current detail so operators can follow progress in real time.
+	Logf func(string, ...any)
+}
+
+// validateWaitOptions returns an error if Timeout or PollInterval are non-positive.
+func validateWaitOptions(desc string, opts WaitOptions) error {
+	if opts.Timeout <= 0 {
+		return fmt.Errorf("vmhelpers: %s: WaitOptions.Timeout must be positive", desc)
+	}
+	if opts.PollInterval <= 0 {
+		return fmt.Errorf("vmhelpers: %s: WaitOptions.PollInterval must be positive", desc)
+	}
+	return nil
+}
+
+// pollUntil runs poll until it returns done==true or ctx deadline/opts.Timeout elapses.
+// detail is included in timeout errors for targeted diagnostics.
+func pollUntil(ctx context.Context, opts WaitOptions, desc string, poll func(ctx context.Context) (done bool, detail string, err error)) error {
+	if err := validateWaitOptions(desc, opts); err != nil {
+		return err
+	}
+	deadline := time.Now().Add(opts.Timeout)
+	var lastDetail string
+	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("vmhelpers: %s: %w", desc, err)
+		}
+		done, detail, err := poll(ctx)
+		if detail != "" {
+			lastDetail = detail
+		}
+		if err != nil {
+			if IsAuthenticationExpired(err) {
+				return fmt.Errorf("vmhelpers: %s: %w: %v", desc, ErrAuthenticationExpired, err)
+			}
+			return fmt.Errorf("vmhelpers: %s: %w", desc, err)
+		}
+		if done {
+			if opts.Logf != nil && detail != "" {
+				opts.Logf("poll %s: done (%s)", desc, detail)
+			}
+			return nil
+		}
+		if opts.Logf != nil && detail != "" {
+			opts.Logf("poll %s: waiting (%s)", desc, detail)
+		}
+		if time.Now().After(deadline) {
+			if lastDetail != "" {
+				return fmt.Errorf("vmhelpers: timeout waiting for %s after %v (last detail: %s)", desc, opts.Timeout, lastDetail)
+			}
+			return fmt.Errorf("vmhelpers: timeout waiting for %s after %v", desc, opts.Timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("vmhelpers: %s: %w", desc, ctx.Err())
+		case <-time.After(opts.PollInterval):
+		}
+	}
+}

--- a/tests/vmhelpers/wait_test.go
+++ b/tests/vmhelpers/wait_test.go
@@ -1,0 +1,56 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPollUntil_ImmediateSuccess(t *testing.T) {
+	ctx := context.Background()
+	err := pollUntil(ctx, WaitOptions{
+		Timeout:      100 * time.Millisecond,
+		PollInterval: 1 * time.Millisecond,
+	}, "immediate", func(context.Context) (bool, string, error) {
+		return true, "ok", nil
+	})
+	require.NoError(t, err)
+}
+
+func TestPollUntil_SucceedsAfterRetries(t *testing.T) {
+	ctx := context.Background()
+	var polls int
+	err := pollUntil(ctx, WaitOptions{
+		Timeout:      300 * time.Millisecond,
+		PollInterval: 5 * time.Millisecond,
+	}, "retry-test", func(context.Context) (bool, string, error) {
+		polls++
+		return polls >= 3, "stepping", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, polls)
+}
+
+func TestPollUntil_TimesOutWithDetail(t *testing.T) {
+	ctx := context.Background()
+	err := pollUntil(ctx, WaitOptions{
+		Timeout:      30 * time.Millisecond,
+		PollInterval: 5 * time.Millisecond,
+	}, "timeout-test", func(context.Context) (bool, string, error) {
+		return false, "still waiting", nil
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timeout")
+	require.Contains(t, err.Error(), "still waiting")
+}
+
+func TestPollUntil_RejectsInvalidOptions(t *testing.T) {
+	ctx := context.Background()
+	err := pollUntil(ctx, WaitOptions{Timeout: -1, PollInterval: 1 * time.Millisecond}, "bad", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Timeout must be positive")
+}

--- a/vm-image.sh
+++ b/vm-image.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# Build a customized RHEL ContainerDisk image for KubeVirt VM scanning tests.
+#
+# Extracts a qcow2 guest disk from a source ContainerDisk image, injects
+# additional packages (e.g. bc) via chroot inside a privileged container,
+# then rebuilds and pushes a new ContainerDisk to the target registry.
+#
+# Required env vars:
+#   RHEL_ACTIVATION_ORG   - Red Hat subscription org ID
+#   RHEL_ACTIVATION_KEY   - Red Hat activation key
+#   TARGET_REGISTRY       - Container registry to push the image to
+#   TARGET_TAG            - Image tag (e.g. vm-images/rhel9-custom:latest)
+#
+# Optional env vars:
+#   SRC_IMAGE               - Source ContainerDisk image (default: RHEL 9 guest)
+#   RHEL_ACTIVATION_ENDPOINT - Custom subscription server URL
+#   PLATFORM                - Target platform (default: linux/amd64)
+#
+# Example:
+#   RHEL_ACTIVATION_ORG=12345 \
+#   RHEL_ACTIVATION_KEY=my-key \
+#   TARGET_REGISTRY=quay.io/my-org \
+#   TARGET_TAG=vm-images/rhel9-custom:latest \
+#     ./vm-image.sh
+#
+set -euo pipefail
+
+RHEL_ACTIVATION_ORG="${RHEL_ACTIVATION_ORG:?}"
+RHEL_ACTIVATION_KEY="${RHEL_ACTIVATION_KEY:?}"
+RHEL_ACTIVATION_ENDPOINT="${RHEL_ACTIVATION_ENDPOINT:-}"
+TARGET_REGISTRY="${TARGET_REGISTRY:?}"
+
+# SRC_IMAGE: override via env, or default to RHEL 9 guest image.
+# oc get istag -n openshift-virtualization-os-images rhel9-guest:latest -o jsonpath='{.image.dockerImageReference}'
+SRC_IMAGE="${SRC_IMAGE:-registry.redhat.io/rhel9/rhel-guest-image@sha256:ab4ec16077fe00e3c7efd0b2f6a77571f3645f5c95befc4d917757dc88b2f423}"
+TARGET_TAG="${TARGET_TAG:?}"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+REGISTER_ARGS="--org=$RHEL_ACTIVATION_ORG --activationkey=$RHEL_ACTIVATION_KEY"
+[[ -n "$RHEL_ACTIVATION_ENDPOINT" ]] && REGISTER_ARGS+=" --serverurl=$RHEL_ACTIVATION_ENDPOINT"
+
+# --- Step 1: Extract qcow2 from ContainerDisk image ---
+PLATFORM="${PLATFORM:-linux/amd64}"
+echo "==> Extracting qcow2 from container image (platform=$PLATFORM)..."
+CID=$(podman create --platform "$PLATFORM" "$SRC_IMAGE")
+podman cp "$CID:/disk/." "$WORKDIR/"
+podman rm "$CID"
+DISK_NAME="$(basename "$(find "$WORKDIR" -maxdepth 1 -type f \( -name '*.qcow2' -o -name '*.img' \) | head -1)")"
+echo "==> Disk: $DISK_NAME"
+
+# --- Steps 2-4: Convert, customize, convert back (all in one privileged container) ---
+# Everything runs inside a single privileged container on the podman machine VM
+# so that losetup, qemu-img conversions, and chroot all operate on local
+# storage (/tmp inside the container) — avoiding virtiofs sync issues that
+# corrupted the bootloader when these steps ran in separate contexts.
+echo "==> Writing customization script..."
+cat > "$WORKDIR/customize.sh" <<SCRIPT
+#!/bin/bash
+set -euxo pipefail
+
+subscription-manager register $REGISTER_ARGS >/dev/null
+dnf -y -q install qemu-img util-linux
+
+# qcow2 → raw (container-local /tmp, not shared FS)
+qemu-img convert -f qcow2 -O raw '/work/$DISK_NAME' /tmp/disk.raw
+
+# losetup + chroot on local file
+LOOP=\$(losetup --find --show --partscan /tmp/disk.raw)
+echo "Loop device: \$LOOP"
+lsblk "\$LOOP"
+# Create partition device nodes inside the container (kernel knows them via
+# sysfs but udev may not populate /dev inside a privileged container).
+LOOPBASE=\$(basename "\$LOOP")
+for syspart in /sys/class/block/\${LOOPBASE}p*; do
+  [[ -e "\$syspart" ]] || continue
+  PARTNAME=\$(basename "\$syspart")
+  IFS=: read -r MAJ MIN < "\$syspart/dev"
+  [[ -e "/dev/\$PARTNAME" ]] || mknod "/dev/\$PARTNAME" b "\$MAJ" "\$MIN"
+  echo "Created /dev/\$PARTNAME (maj=\$MAJ min=\$MIN)"
+done
+blkid "\${LOOP}"* || true
+ROOT=\$(blkid -o device -t LABEL=root "\${LOOP}"* 2>/dev/null || true)
+if [[ -z "\$ROOT" ]]; then
+  echo "No LABEL=root found; selecting largest partition as root"
+  ROOT=\$(lsblk -lnbpo NAME,SIZE "\$LOOP" | grep -v "^\$LOOP " | sort -k2 -n | tail -1 | awk '{print \$1}')
+fi
+echo "Root partition: \$ROOT"
+
+MNT=/tmp/guest
+mkdir -p "\$MNT"
+mount "\$ROOT" "\$MNT"
+mount --bind /proc "\$MNT/proc"
+mount --bind /sys  "\$MNT/sys"
+mount --bind /dev  "\$MNT/dev"
+cp /etc/resolv.conf "\$MNT/etc/resolv.conf"
+
+if chroot "\$MNT" /bin/true 2>/dev/null; then
+  echo "==> Chroot works, customizing guest directly"
+  chroot "\$MNT" bash -c '
+    subscription-manager register $REGISTER_ARGS &&
+    dnf -y install --setopt=install_weak_deps=False bc &&
+    subscription-manager unregister &&
+    dnf clean all
+  '
+else
+  echo "==> Chroot failed (cross-arch?), falling back to dnf --installroot"
+  GUEST_VER=\$(grep '^VERSION_ID=' "\$MNT/etc/os-release" | cut -d= -f2 | tr -d '"' | cut -d. -f1)
+  GUEST_ARCH=\$(uname -m)
+  [[ "\$GUEST_ARCH" == "aarch64" ]] || GUEST_ARCH="x86_64"
+  echo "==> Guest: RHEL \$GUEST_VER (\$GUEST_ARCH)"
+
+  ENT_CERT=\$(ls /etc/pki/entitlement/*.pem 2>/dev/null | grep -v key | head -1)
+  ENT_KEY=\$(ls /etc/pki/entitlement/*-key.pem 2>/dev/null | head -1)
+  mkdir -p "\$MNT/etc/pki/entitlement" "\$MNT/etc/rhsm/ca"
+  cp "\$ENT_CERT" "\$MNT/etc/pki/entitlement/"
+  cp "\$ENT_KEY" "\$MNT/etc/pki/entitlement/"
+  cp /etc/rhsm/ca/redhat-uep.pem "\$MNT/etc/rhsm/ca/"
+
+  cat > "\$MNT/etc/yum.repos.d/rhel-baseos-cdn.repo" <<REPOEOF
+[rhel-\${GUEST_VER}-for-\${GUEST_ARCH}-baseos-rpms]
+name=Red Hat Enterprise Linux \${GUEST_VER} for \${GUEST_ARCH} - BaseOS (RPMs)
+baseurl=https://cdn.redhat.com/content/dist/rhel\${GUEST_VER}/\${GUEST_VER}/\${GUEST_ARCH}/baseos/os
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify=1
+sslcacert=/etc/rhsm/ca/redhat-uep.pem
+sslclientcert=/etc/pki/entitlement/\$(basename "\$ENT_CERT")
+sslclientkey=/etc/pki/entitlement/\$(basename "\$ENT_KEY")
+REPOEOF
+
+  dnf -y --installroot="\$MNT" --releasever="\$GUEST_VER" \
+    --setopt=install_weak_deps=False install bc
+
+  rm -f "\$MNT/etc/yum.repos.d/rhel-baseos-cdn.repo"
+  rm -rf "\$MNT/etc/pki/entitlement" "\$MNT/etc/rhsm/ca"
+  dnf --installroot="\$MNT" clean all 2>/dev/null || true
+fi
+
+umount "\$MNT/proc" "\$MNT/sys" "\$MNT/dev"
+umount "\$MNT"
+sync
+losetup -d "\$LOOP"
+
+# raw → qcow2 compressed, write result back to shared volume
+rm -f '/work/$DISK_NAME'
+qemu-img convert -f raw -O qcow2 -c /tmp/disk.raw '/work/$DISK_NAME'
+sync
+qemu-img info '/work/$DISK_NAME'
+echo "==> Customization complete"
+SCRIPT
+chmod +x "$WORKDIR/customize.sh"
+
+echo "==> Running customization in privileged container on podman machine..."
+podman machine ssh sudo podman run --rm --privileged --platform "$PLATFORM" \
+  -v "$WORKDIR:/work" \
+  registry.access.redhat.com/ubi9/ubi:latest /work/customize.sh
+
+# --- Step 5: Build and push ContainerDisk image ---
+echo "==> Building and pushing container image..."
+cat > "$WORKDIR/Containerfile" <<'EOF'
+FROM scratch
+COPY *.qcow2 *.img /disk/
+EOF
+
+podman build --platform "$PLATFORM" -t "$TARGET_REGISTRY/$TARGET_TAG" "$WORKDIR"
+podman push "$TARGET_REGISTRY/$TARGET_TAG"
+echo "==> Done: $TARGET_REGISTRY/$TARGET_TAG"


### PR DESCRIPTION
## Description

User request (feature): "Design the end-to-end tests for the VM scanning feature."

Add a Go test_e2e VM-scanning suite that provisions RHEL 9 and RHEL 10 KubeVirt VMs, installs and runs roxagent, validates Central scan visibility, and captures progressive diagnostics for flaky-path triage.
Wire a dedicated OpenShift CI job and e2e scripts with CNV/VSOCK prerequisite checks and activation/repo2cpe guardrails.

AI-assisted: this commit was partially generated with AI assistance.
Made-with: Cursor

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

