### PR TITLE
ROX-34161: adds node resource type to ListAlert

### DIFF
--- a/central/alert/datastore/datastore_impl.go
+++ b/central/alert/datastore/datastore_impl.go
@@ -566,6 +566,8 @@ func (c *AlertSearchResultConverter) BuildLocation(result *search.Result) string
 	resourceName := fv[strings.ToLower(search.ResourceName.String())]
 	resourceType := fv[strings.ToLower(search.ResourceType.String())]
 
+	nodeName := fv[strings.ToLower(search.Node.String())]
+
 	var entityName string
 	switch entityType {
 	case "DEPLOYMENT":
@@ -573,6 +575,9 @@ func (c *AlertSearchResultConverter) BuildLocation(result *search.Result) string
 		resourceType = entityType
 	case "RESOURCE":
 		entityName = resourceName
+	case "NODE":
+		entityName = nodeName
+		resourceType = entityType
 	}
 
 	var location string

--- a/generated/api/v1/alert_service.swagger.json
+++ b/generated/api/v1/alert_service.swagger.json
@@ -1428,10 +1428,11 @@
         "CLUSTER_ROLE_BINDINGS",
         "NETWORK_POLICIES",
         "SECURITY_CONTEXT_CONSTRAINTS",
-        "EGRESS_FIREWALLS"
+        "EGRESS_FIREWALLS",
+        "NODE"
       ],
       "default": "DEPLOYMENT",
-      "title": "A special ListAlert-only enumeration of all resource types. Unlike Alert.Resource.ResourceType this also includes deployment as a type\nThis must be kept in sync with Alert.Resource.ResourceType (excluding the deployment value)"
+      "title": "A special ListAlert-only enumeration of all resource types. Unlike Alert.Resource.ResourceType this also includes deployment and node as types\nThis must be kept in sync with Alert.Resource.ResourceType (excluding the deployment and node values)"
     },
     "storageNetworkEntityInfoType": {
       "type": "string",

--- a/generated/storage/alert.pb.go
+++ b/generated/storage/alert.pb.go
@@ -245,8 +245,8 @@ func (Alert_Violation_Type) EnumDescriptor() ([]byte, []int) {
 	return file_storage_alert_proto_rawDescGZIP(), []int{0, 3, 0}
 }
 
-// A special ListAlert-only enumeration of all resource types. Unlike Alert.Resource.ResourceType this also includes deployment as a type
-// This must be kept in sync with Alert.Resource.ResourceType (excluding the deployment value)
+// A special ListAlert-only enumeration of all resource types. Unlike Alert.Resource.ResourceType this also includes deployment and node as types
+// This must be kept in sync with Alert.Resource.ResourceType (excluding the deployment and node values)
 type ListAlert_ResourceType int32
 
 const (
@@ -258,6 +258,7 @@ const (
 	ListAlert_NETWORK_POLICIES             ListAlert_ResourceType = 5
 	ListAlert_SECURITY_CONTEXT_CONSTRAINTS ListAlert_ResourceType = 6
 	ListAlert_EGRESS_FIREWALLS             ListAlert_ResourceType = 7
+	ListAlert_NODE                         ListAlert_ResourceType = 8
 )
 
 // Enum value maps for ListAlert_ResourceType.
@@ -271,6 +272,7 @@ var (
 		5: "NETWORK_POLICIES",
 		6: "SECURITY_CONTEXT_CONSTRAINTS",
 		7: "EGRESS_FIREWALLS",
+		8: "NODE",
 	}
 	ListAlert_ResourceType_value = map[string]int32{
 		"DEPLOYMENT":                   0,
@@ -281,6 +283,7 @@ var (
 		"NETWORK_POLICIES":             5,
 		"SECURITY_CONTEXT_CONSTRAINTS": 6,
 		"EGRESS_FIREWALLS":             7,
+		"NODE":                         8,
 	}
 )
 
@@ -2065,7 +2068,7 @@ const file_storage_alert_proto_rawDesc = "" +
 	"\x0fCONTAINER_IMAGE\x10\x02\x12\f\n" +
 	"\bRESOURCE\x10\x03\x12\b\n" +
 	"\x04NODE\x10\x04B\b\n" +
-	"\x06EntityJ\x04\b\f\x10\rJ\x04\b\x0e\x10\x0fR\vsnooze_till\"\xdf\b\n" +
+	"\x06EntityJ\x04\b\f\x10\rJ\x04\b\x0e\x10\x0fR\vsnooze_till\"\xe9\b\n" +
 	"\tListAlert\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12@\n" +
 	"\x0flifecycle_stage\x18\x02 \x01(\x0e2\x17.storage.LifecycleStageR\x0elifecycleStage\x12.\n" +
@@ -2092,7 +2095,7 @@ const file_storage_alert_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x1a \n" +
 	"\n" +
 	"NodeEntity\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"\xb7\x01\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"\xc1\x01\n" +
 	"\fResourceType\x12\x0e\n" +
 	"\n" +
 	"DEPLOYMENT\x10\x00\x12\v\n" +
@@ -2103,7 +2106,8 @@ const file_storage_alert_proto_rawDesc = "" +
 	"\x15CLUSTER_ROLE_BINDINGS\x10\x04\x12\x14\n" +
 	"\x10NETWORK_POLICIES\x10\x05\x12 \n" +
 	"\x1cSECURITY_CONTEXT_CONSTRAINTS\x10\x06\x12\x14\n" +
-	"\x10EGRESS_FIREWALLS\x10\aB\b\n" +
+	"\x10EGRESS_FIREWALLS\x10\a\x12\b\n" +
+	"\x04NODE\x10\bB\b\n" +
 	"\x06EntityJ\x04\b\b\x10\t\"\xb0\x02\n" +
 	"\x0fListAlertPolicy\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +

--- a/pkg/alert/convert/convert.go
+++ b/pkg/alert/convert/convert.go
@@ -84,8 +84,9 @@ func populateListAlertEntityInfoForNode(listAlert *storage.ListAlert, alert *sto
 		},
 	}
 	listAlert.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
-		ClusterName: alert.GetClusterName(),
-		ClusterId:   alert.GetClusterId(),
+		ClusterName:  alert.GetClusterName(),
+		ClusterId:    alert.GetClusterId(),
+		ResourceType: storage.ListAlert_NODE,
 	}
 }
 

--- a/pkg/alert/convert/convert_test.go
+++ b/pkg/alert/convert/convert_test.go
@@ -7,11 +7,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAlertToListAlertSetsNodeResourceType(t *testing.T) {
+	alert := &storage.Alert{
+		Id:          "alert-1",
+		ClusterId:   "cluster-1",
+		ClusterName: "test-cluster",
+		Entity: &storage.Alert_Node_{
+			Node: &storage.Alert_Node{
+				Id:   "node-1",
+				Name: "test-node",
+			},
+		},
+	}
+
+	listAlert := AlertToListAlert(alert)
+
+	assert.Equal(t, storage.ListAlert_NODE, listAlert.GetCommonEntityInfo().GetResourceType())
+	assert.Equal(t, "test-cluster", listAlert.GetCommonEntityInfo().GetClusterName())
+	assert.Equal(t, "cluster-1", listAlert.GetCommonEntityInfo().GetClusterId())
+	assert.Equal(t, "test-node", listAlert.GetNode().GetName())
+}
+
 func TestAlertAndListAlertResourceTypesAreInSync(t *testing.T) {
 	assert.Equal(t, storage.ListAlert_ResourceType_name[0], "DEPLOYMENT")
 	assert.Equal(t, storage.Alert_Resource_ResourceType_name[0], "UNKNOWN")
 
-	assert.Equal(t, len(storage.Alert_Resource_ResourceType_value), len(storage.ListAlert_ResourceType_value))
+	// ListAlert.ResourceType omits UNKNOWN but includes DEPLOYMENT and NODE,
+	// so it has one more entry than Alert.Resource.ResourceType.
+	listAlertOnlyTypes := 1
+	assert.Equal(t, len(storage.Alert_Resource_ResourceType_value)+listAlertOnlyTypes, len(storage.ListAlert_ResourceType_value))
 	for i, at := range storage.Alert_Resource_ResourceType_name {
 		if r := storage.Alert_Resource_ResourceType(i); r == storage.Alert_Resource_UNKNOWN {
 			continue

--- a/proto/storage/alert.proto
+++ b/proto/storage/alert.proto
@@ -179,8 +179,8 @@ message ListAlert {
     ResourceType resource_type = 5;
   }
 
-  // A special ListAlert-only enumeration of all resource types. Unlike Alert.Resource.ResourceType this also includes deployment as a type
-  // This must be kept in sync with Alert.Resource.ResourceType (excluding the deployment value)
+  // A special ListAlert-only enumeration of all resource types. Unlike Alert.Resource.ResourceType this also includes deployment and node as types
+  // This must be kept in sync with Alert.Resource.ResourceType (excluding the deployment and node values)
   enum ResourceType {
     DEPLOYMENT = 0;
     SECRETS = 1;
@@ -190,6 +190,7 @@ message ListAlert {
     NETWORK_POLICIES = 5;
     SECURITY_CONTEXT_CONSTRAINTS = 6;
     EGRESS_FIREWALLS = 7;
+    NODE = 8;
   }
 
   message ResourceEntity {

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -315,6 +315,10 @@
               {
                 "name": "EGRESS_FIREWALLS",
                 "integer": 7
+              },
+              {
+                "name": "NODE",
+                "integer": 8
               }
             ]
           },


### PR DESCRIPTION
## Description

Without the node resource type, the response to any UI request for node violations resulted in them being incorrectly marked as DEPLOYMENT type. The conversion to ListAlert did not handle Node alerts properly, and did not set the resource type for these alerts which means the default value was used (DEPLOYMENT.)

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

New tests & CI should be enough.
