### PR TITLE
ROX-34163: Show "No data available" when no scans are configured

### DIFF
--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -36,7 +36,7 @@ import (
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/paginated"
 	"google.golang.org/grpc"
-	"slices"
+	"k8s.io/utils/strings/slices"
 )
 
 const (

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -36,7 +36,7 @@ import (
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/paginated"
 	"google.golang.org/grpc"
-	"k8s.io/utils/strings/slices"
+	"slices"
 )
 
 const (
@@ -550,6 +550,9 @@ func (s *serviceImpl) getProfiles(ctx context.Context, query *v1.Query, countQue
 	profileNames, err := s.scanConfigDS.GetProfilesNames(ctx, query)
 	if err != nil {
 		return nil, 0, errors.Wrapf(errox.InvalidArgs, "Unable to retrieve scan configurations for query %v", query)
+	}
+	if len(profileNames) == 0 {
+		return nil, 0, nil
 	}
 
 	// Build query to get the filtered list by profile names

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
@@ -19,6 +19,7 @@ import (
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore/mocks"
 	"github.com/stackrox/rox/central/reports/common"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	apiV2 "github.com/stackrox/rox/generated/api/v2"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errox"
@@ -55,18 +56,18 @@ var (
 		},
 	}
 
-	defaultAPISchedule = &v2.Schedule{
+	defaultAPISchedule = &apiV2.Schedule{
 		IntervalType: 1,
 		Hour:         15,
 		Minute:       0,
-		Interval: &v2.Schedule_DaysOfWeek_{
-			DaysOfWeek: &v2.Schedule_DaysOfWeek{
+		Interval: &apiV2.Schedule_DaysOfWeek_{
+			DaysOfWeek: &apiV2.Schedule_DaysOfWeek{
 				Days: []int32{1, 2, 3, 4, 5, 6, 7},
 			},
 		},
 	}
 
-	apiRequester = &v2.SlimUser{
+	apiRequester = &apiV2.SlimUser{
 		Id:   "uid",
 		Name: "name",
 	}
@@ -300,28 +301,28 @@ func (s *ComplianceScanConfigServiceTestSuite) TestListComplianceScanConfigurati
 
 	testCases := []struct {
 		desc           string
-		query          *v2.RawQuery
+		query          *apiV2.RawQuery
 		expectedQ      *v1.Query
 		expectedCountQ *v1.Query
 	}{
 		{
 			desc:           "Empty query",
-			query:          &v2.RawQuery{Query: ""},
+			query:          &apiV2.RawQuery{Query: ""},
 			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
 			expectedCountQ: search.EmptyQuery(),
 		},
 		{
 			desc:  "Query with search field",
-			query: &v2.RawQuery{Query: "Cluster ID:id"},
+			query: &apiV2.RawQuery{Query: "Cluster ID:id"},
 			expectedQ: search.NewQueryBuilder().AddStrings(search.ClusterID, "id").
 				WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
 			expectedCountQ: search.NewQueryBuilder().AddStrings(search.ClusterID, "id").ProtoQuery(),
 		},
 		{
 			desc: "Query with custom pagination",
-			query: &v2.RawQuery{
+			query: &apiV2.RawQuery{
 				Query:      "",
-				Pagination: &v2.Pagination{Limit: 1},
+				Pagination: &apiV2.Pagination{Limit: 1},
 			},
 			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(1)).ProtoQuery(),
 			expectedCountQ: search.EmptyQuery(),
@@ -330,8 +331,8 @@ func (s *ComplianceScanConfigServiceTestSuite) TestListComplianceScanConfigurati
 
 	for _, tc := range testCases {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			expectedResp := &v2.ListComplianceScanConfigurationsResponse{
-				Configurations: []*v2.ComplianceScanConfigurationStatus{
+			expectedResp := &apiV2.ListComplianceScanConfigurationsResponse{
+				Configurations: []*apiV2.ComplianceScanConfigurationStatus{
 					getTestAPIStatusRec(createdTime, lastUpdatedTime),
 				},
 				TotalCount: 6,
@@ -425,7 +426,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestGetComplianceScanConfiguratio
 	testCases := []struct {
 		desc         string
 		scanID       string
-		expectedResp *v2.ComplianceScanConfigurationStatus
+		expectedResp *apiV2.ComplianceScanConfigurationStatus
 		expectedErr  error
 		found        bool
 	}{
@@ -522,7 +523,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestGetComplianceScanConfiguratio
 					Return(nil, false, errors.New("record not found")).Times(1)
 			}
 
-			config, err := s.service.GetComplianceScanConfiguration(allAccessContext, &v2.ResourceByID{Id: tc.scanID})
+			config, err := s.service.GetComplianceScanConfiguration(allAccessContext, &apiV2.ResourceByID{Id: tc.scanID})
 			if tc.expectedErr == nil {
 				s.Require().NoError(err)
 			} else {
@@ -538,28 +539,28 @@ func (s *ComplianceScanConfigServiceTestSuite) ListComplianceScanConfigProfiles(
 
 	testCases := []struct {
 		desc           string
-		query          *v2.RawQuery
+		query          *apiV2.RawQuery
 		expectedQ      *v1.Query
 		expectedCountQ *v1.Query
 	}{
 		{
 			desc:           "Empty query",
-			query:          &v2.RawQuery{Query: ""},
+			query:          &apiV2.RawQuery{Query: ""},
 			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
 			expectedCountQ: search.EmptyQuery(),
 		},
 		{
 			desc:  "Query with search field",
-			query: &v2.RawQuery{Query: "Cluster ID:id"},
+			query: &apiV2.RawQuery{Query: "Cluster ID:id"},
 			expectedQ: search.NewQueryBuilder().AddStrings(search.ClusterID, "id").
 				WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
 			expectedCountQ: search.NewQueryBuilder().AddStrings(search.ClusterID, "id").ProtoQuery(),
 		},
 		{
 			desc: "Query with custom pagination",
-			query: &v2.RawQuery{
+			query: &apiV2.RawQuery{
 				Query:      "",
-				Pagination: &v2.Pagination{Limit: 1},
+				Pagination: &apiV2.Pagination{Limit: 1},
 			},
 			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(1)).ProtoQuery(),
 			expectedCountQ: search.EmptyQuery(),
@@ -568,7 +569,7 @@ func (s *ComplianceScanConfigServiceTestSuite) ListComplianceScanConfigProfiles(
 
 	for _, tc := range testCases {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			expectedResp := &v2.ListComplianceScanConfigsProfileResponse{
+			expectedResp := &apiV2.ListComplianceScanConfigsProfileResponse{
 				Profiles:   nil,
 				TotalCount: 6,
 			}
@@ -1167,23 +1168,23 @@ func (s *ComplianceScanConfigServiceTestSuite) TestDeleteReport() {
 	})
 }
 
-func getTestAPIStatusRec(createdTime, lastUpdatedTime time.Time) *v2.ComplianceScanConfigurationStatus {
-	return &v2.ComplianceScanConfigurationStatus{
+func getTestAPIStatusRec(createdTime, lastUpdatedTime time.Time) *apiV2.ComplianceScanConfigurationStatus {
+	return &apiV2.ComplianceScanConfigurationStatus{
 		Id:       uuid.NewDummy().String(),
 		ScanName: "test-scan",
-		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
+		ScanConfig: &apiV2.BaseComplianceScanConfigurationSettings{
 			OneTimeScan:  false,
 			Profiles:     []string{"ocp4-cis"},
 			ScanSchedule: defaultAPISchedule,
 			Description:  "test-description",
 			Notifiers:    []*v2.NotifierConfiguration{},
 		},
-		ClusterStatus: []*v2.ClusterScanStatus{
+		ClusterStatus: []*apiV2.ClusterScanStatus{
 			{
 				ClusterId:   fixtureconsts.Cluster1,
 				ClusterName: mockClusterName,
 				Errors:      []string{"This binding is not ready", "Error 1", "Error 2", "Error 3"},
-				SuiteStatus: &v2.ClusterScanStatus_SuiteStatus{
+				SuiteStatus: &apiV2.ClusterScanStatus_SuiteStatus{
 					Phase:              "DONE",
 					Result:             "NON-COMPLIANT",
 					LastTransitionTime: protoconv.ConvertTimeToTimestamp(lastUpdatedTime),
@@ -1210,10 +1211,10 @@ func (s *ComplianceScanConfigServiceTestSuite) TestGetProfiles_NoMatch() {
 	s.Zero(count)
 }
 
-func getTestAPIRec() *v2.ComplianceScanConfiguration {
-	return &v2.ComplianceScanConfiguration{
+func getTestAPIRec() *apiV2.ComplianceScanConfiguration {
+	return &apiV2.ComplianceScanConfiguration{
 		ScanName: "test-scan",
-		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
+		ScanConfig: &apiV2.BaseComplianceScanConfigurationSettings{
 			OneTimeScan:  false,
 			Profiles:     []string{"ocp4-cis"},
 			ScanSchedule: defaultAPISchedule,

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
@@ -19,7 +19,6 @@ import (
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore/mocks"
 	"github.com/stackrox/rox/central/reports/common"
 	v1 "github.com/stackrox/rox/generated/api/v1"
-	apiV2 "github.com/stackrox/rox/generated/api/v2"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errox"
@@ -56,18 +55,18 @@ var (
 		},
 	}
 
-	defaultAPISchedule = &apiV2.Schedule{
+	defaultAPISchedule = &v2.Schedule{
 		IntervalType: 1,
 		Hour:         15,
 		Minute:       0,
-		Interval: &apiV2.Schedule_DaysOfWeek_{
-			DaysOfWeek: &apiV2.Schedule_DaysOfWeek{
+		Interval: &v2.Schedule_DaysOfWeek_{
+			DaysOfWeek: &v2.Schedule_DaysOfWeek{
 				Days: []int32{1, 2, 3, 4, 5, 6, 7},
 			},
 		},
 	}
 
-	apiRequester = &apiV2.SlimUser{
+	apiRequester = &v2.SlimUser{
 		Id:   "uid",
 		Name: "name",
 	}
@@ -301,28 +300,28 @@ func (s *ComplianceScanConfigServiceTestSuite) TestListComplianceScanConfigurati
 
 	testCases := []struct {
 		desc           string
-		query          *apiV2.RawQuery
+		query          *v2.RawQuery
 		expectedQ      *v1.Query
 		expectedCountQ *v1.Query
 	}{
 		{
 			desc:           "Empty query",
-			query:          &apiV2.RawQuery{Query: ""},
+			query:          &v2.RawQuery{Query: ""},
 			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
 			expectedCountQ: search.EmptyQuery(),
 		},
 		{
 			desc:  "Query with search field",
-			query: &apiV2.RawQuery{Query: "Cluster ID:id"},
+			query: &v2.RawQuery{Query: "Cluster ID:id"},
 			expectedQ: search.NewQueryBuilder().AddStrings(search.ClusterID, "id").
 				WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
 			expectedCountQ: search.NewQueryBuilder().AddStrings(search.ClusterID, "id").ProtoQuery(),
 		},
 		{
 			desc: "Query with custom pagination",
-			query: &apiV2.RawQuery{
+			query: &v2.RawQuery{
 				Query:      "",
-				Pagination: &apiV2.Pagination{Limit: 1},
+				Pagination: &v2.Pagination{Limit: 1},
 			},
 			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(1)).ProtoQuery(),
 			expectedCountQ: search.EmptyQuery(),
@@ -331,8 +330,8 @@ func (s *ComplianceScanConfigServiceTestSuite) TestListComplianceScanConfigurati
 
 	for _, tc := range testCases {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			expectedResp := &apiV2.ListComplianceScanConfigurationsResponse{
-				Configurations: []*apiV2.ComplianceScanConfigurationStatus{
+			expectedResp := &v2.ListComplianceScanConfigurationsResponse{
+				Configurations: []*v2.ComplianceScanConfigurationStatus{
 					getTestAPIStatusRec(createdTime, lastUpdatedTime),
 				},
 				TotalCount: 6,
@@ -426,7 +425,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestGetComplianceScanConfiguratio
 	testCases := []struct {
 		desc         string
 		scanID       string
-		expectedResp *apiV2.ComplianceScanConfigurationStatus
+		expectedResp *v2.ComplianceScanConfigurationStatus
 		expectedErr  error
 		found        bool
 	}{
@@ -523,7 +522,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestGetComplianceScanConfiguratio
 					Return(nil, false, errors.New("record not found")).Times(1)
 			}
 
-			config, err := s.service.GetComplianceScanConfiguration(allAccessContext, &apiV2.ResourceByID{Id: tc.scanID})
+			config, err := s.service.GetComplianceScanConfiguration(allAccessContext, &v2.ResourceByID{Id: tc.scanID})
 			if tc.expectedErr == nil {
 				s.Require().NoError(err)
 			} else {
@@ -539,28 +538,28 @@ func (s *ComplianceScanConfigServiceTestSuite) ListComplianceScanConfigProfiles(
 
 	testCases := []struct {
 		desc           string
-		query          *apiV2.RawQuery
+		query          *v2.RawQuery
 		expectedQ      *v1.Query
 		expectedCountQ *v1.Query
 	}{
 		{
 			desc:           "Empty query",
-			query:          &apiV2.RawQuery{Query: ""},
+			query:          &v2.RawQuery{Query: ""},
 			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
 			expectedCountQ: search.EmptyQuery(),
 		},
 		{
 			desc:  "Query with search field",
-			query: &apiV2.RawQuery{Query: "Cluster ID:id"},
+			query: &v2.RawQuery{Query: "Cluster ID:id"},
 			expectedQ: search.NewQueryBuilder().AddStrings(search.ClusterID, "id").
 				WithPagination(search.NewPagination().Limit(maxPaginationLimit)).ProtoQuery(),
 			expectedCountQ: search.NewQueryBuilder().AddStrings(search.ClusterID, "id").ProtoQuery(),
 		},
 		{
 			desc: "Query with custom pagination",
-			query: &apiV2.RawQuery{
+			query: &v2.RawQuery{
 				Query:      "",
-				Pagination: &apiV2.Pagination{Limit: 1},
+				Pagination: &v2.Pagination{Limit: 1},
 			},
 			expectedQ:      search.NewQueryBuilder().WithPagination(search.NewPagination().Limit(1)).ProtoQuery(),
 			expectedCountQ: search.EmptyQuery(),
@@ -569,7 +568,7 @@ func (s *ComplianceScanConfigServiceTestSuite) ListComplianceScanConfigProfiles(
 
 	for _, tc := range testCases {
 		s.T().Run(tc.desc, func(t *testing.T) {
-			expectedResp := &apiV2.ListComplianceScanConfigsProfileResponse{
+			expectedResp := &v2.ListComplianceScanConfigsProfileResponse{
 				Profiles:   nil,
 				TotalCount: 6,
 			}
@@ -1168,23 +1167,23 @@ func (s *ComplianceScanConfigServiceTestSuite) TestDeleteReport() {
 	})
 }
 
-func getTestAPIStatusRec(createdTime, lastUpdatedTime time.Time) *apiV2.ComplianceScanConfigurationStatus {
-	return &apiV2.ComplianceScanConfigurationStatus{
+func getTestAPIStatusRec(createdTime, lastUpdatedTime time.Time) *v2.ComplianceScanConfigurationStatus {
+	return &v2.ComplianceScanConfigurationStatus{
 		Id:       uuid.NewDummy().String(),
 		ScanName: "test-scan",
-		ScanConfig: &apiV2.BaseComplianceScanConfigurationSettings{
+		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			OneTimeScan:  false,
 			Profiles:     []string{"ocp4-cis"},
 			ScanSchedule: defaultAPISchedule,
 			Description:  "test-description",
 			Notifiers:    []*v2.NotifierConfiguration{},
 		},
-		ClusterStatus: []*apiV2.ClusterScanStatus{
+		ClusterStatus: []*v2.ClusterScanStatus{
 			{
 				ClusterId:   fixtureconsts.Cluster1,
 				ClusterName: mockClusterName,
 				Errors:      []string{"This binding is not ready", "Error 1", "Error 2", "Error 3"},
-				SuiteStatus: &apiV2.ClusterScanStatus_SuiteStatus{
+				SuiteStatus: &v2.ClusterScanStatus_SuiteStatus{
 					Phase:              "DONE",
 					Result:             "NON-COMPLIANT",
 					LastTransitionTime: protoconv.ConvertTimeToTimestamp(lastUpdatedTime),
@@ -1198,10 +1197,23 @@ func getTestAPIStatusRec(createdTime, lastUpdatedTime time.Time) *apiV2.Complian
 	}
 }
 
-func getTestAPIRec() *apiV2.ComplianceScanConfiguration {
-	return &apiV2.ComplianceScanConfiguration{
+// TestGetProfiles_NoMatch verifies that when GetProfilesNames returns nil (filter
+// matches no scan configs), getProfiles short-circuits and returns an empty list
+// rather than falling through to SearchProfiles with no WHERE clause (which would
+// return every profile in the database).
+func (s *ComplianceScanConfigServiceTestSuite) TestGetProfiles_NoMatch() {
+	s.scanConfigDatastore.EXPECT().GetProfilesNames(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+
+	profiles, count, err := s.service.(*serviceImpl).getProfiles(s.ctx, search.EmptyQuery(), search.EmptyQuery())
+	s.Require().NoError(err)
+	s.Empty(profiles)
+	s.Zero(count)
+}
+
+func getTestAPIRec() *v2.ComplianceScanConfiguration {
+	return &v2.ComplianceScanConfiguration{
 		ScanName: "test-scan",
-		ScanConfig: &apiV2.BaseComplianceScanConfigurationSettings{
+		ScanConfig: &v2.BaseComplianceScanConfigurationSettings{
 			OneTimeScan:  false,
 			Profiles:     []string{"ocp4-cis"},
 			ScanSchedule: defaultAPISchedule,


### PR DESCRIPTION
## Description

Before this PR, when no scan configurations existed at all `/v2/compliance/scan/configurations/profiles/collection` returned every profile in the database instead of none, which resulted in the "Openshift Coverage" page showing all profiles with no check results: 

<img width="1089" height="749" alt="Screenshot 2026-04-16 at 10 52 52" src="https://github.com/user-attachments/assets/f709255a-bb48-4dfe-9f5b-bb7470671492" />

That happened because when `GetProfilesNames` correctly returned an empty set of profiles associated to scan configurations (no configurations exist), further logic in `getProfiles` caused that empty slice to end up in a query with no `WHERE` clause, which then resulted in all profiles being returned.

Fix: early-return in `getProfiles` before building the second query when the first query returns no profiles. After that, the "Openshift Coverage" page correctly shows "No scan data available":

<img width="1718" height="1185" alt="Screenshot 2026-04-16 at 13 59 32" src="https://github.com/user-attachments/assets/27a1653d-9847-4739-920c-9d5bfb30ac4f" />

Affected endpoints:
- `GET /v2/compliance/scan/configurations/profiles/collection` (`ListComplianceScanConfigProfiles`)
- `GET /v2/compliance/scan/configurations/clusters/{cluster_id}/profiles/collection` (`ListComplianceScanConfigClusterProfiles`)

A similar issue exists in /v2/compliance/profiles/summary, addressed in https://github.com/stackrox/stackrox/pull/20048.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

By running in a live cluster and querying with an empty query against the profiles collection endpoint (no scan configurations defined):

```console
Verification in a live cluster (see screenshots in description).

```