### PR TITLE
ROX-29822: Use 1.1.1.2 to test port 80 in NetworkBaselineTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -33,7 +33,7 @@ class NetworkBaselineTest extends BaseSpecification {
     private static final String NGINX_IMAGE = "quay.io/rhacs-eng/qa-multi-arch:nginx-1-19-alpine"
     private static final String EXTERNAL_IP1 = "8.8.8.8" // Google Public DNS
     private static final String EXTERNAL_IP2 = "1.1.1.1" // Cloudflare Public DNS
-    private static final String EXTERNAL_IP3 = "142.250.72.238" // Google CDN
+    private static final String EXTERNAL_IP3 = InetAddress.getByName("example.org").getHostAddress()
 
     // The baseline generation duration must be changed from the default for this test to succeed.
     private static final int EXPECTED_BASELINE_DURATION_SECONDS = 240

--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -33,7 +33,7 @@ class NetworkBaselineTest extends BaseSpecification {
     private static final String NGINX_IMAGE = "quay.io/rhacs-eng/qa-multi-arch:nginx-1-19-alpine"
     private static final String EXTERNAL_IP1 = "8.8.8.8" // Google Public DNS
     private static final String EXTERNAL_IP2 = "1.1.1.1" // Cloudflare Public DNS
-    private static final String EXTERNAL_IP3 = InetAddress.getByName("example.org").getHostAddress()
+    private static final String EXTERNAL_IP3 = "1.1.1.2" // Cloudflare (this will be used to test port 80)
 
     // The baseline generation duration must be changed from the default for this test to succeed.
     private static final int EXPECTED_BASELINE_DURATION_SECONDS = 240


### PR DESCRIPTION
## Description

`NetworkBaselineTest."Verify network baseline functionality with multiple external entities"` fails consistently because `EXTERNAL_IP3` (`142.250.72.238`, a Google CDN anycast IP) no longer responds on port 80. The hardcoded IP stopped accepting connections (confirmed: no ping, no HTTP, no HTTPS), causing `nc -zv` to hang indefinitely and the flow to never be generated.

Fix: use `1.1.1.2` instead, which is a well-known IP unlikely to change.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

TBD