### PR TITLE
ROX-34153: Don't return compliance profiles if filter matches nothing

### DIFF
--- a/central/complianceoperator/v2/profiles/service/service_impl.go
+++ b/central/complianceoperator/v2/profiles/service/service_impl.go
@@ -163,6 +163,9 @@ func (s *serviceImpl) ListProfileSummaries(ctx context.Context, request *v2.Clus
 	if err != nil {
 		return nil, errors.Wrapf(errox.InvalidArgs, "Unable to retrieve compliance profiles for %v", request)
 	}
+	if len(profileNames) == 0 {
+		return &v2.ListComplianceProfileSummaryResponse{}, nil
+	}
 
 	// Build query to get the filtered list by profile names
 	profileQuery := search.NewQueryBuilder().AddSelectFields().AddExactMatches(search.ComplianceOperatorProfileName, profileNames...).ProtoQuery()

--- a/central/complianceoperator/v2/profiles/service/service_impl_test.go
+++ b/central/complianceoperator/v2/profiles/service/service_impl_test.go
@@ -157,13 +157,16 @@ func (s *ComplianceProfilesServiceTestSuite) TestListProfileSummaries() {
 			},
 		},
 		{
-			desc:         "No profiles match filter",
-			query:        &apiV2.ClustersProfileSummaryRequest{ClusterIds: []string{fixtureconsts.Cluster1}},
+			desc: "No profiles match filter",
+			query: &apiV2.ClustersProfileSummaryRequest{
+				ClusterIds: []string{fixtureconsts.Cluster1},
+				Query:      &apiV2.RawQuery{Query: "Compliance Profile Name:nonexistent"},
+			},
 			expectedErr:  nil,
 			expectedResp: []*apiV2.ComplianceProfileSummary{},
 			found:        true,
 			setMocks: func() {
-				profileQuery := search.EmptyQuery()
+				profileQuery, _ := search.ParseQuery("Compliance Profile Name:nonexistent", search.MatchAllIfEmpty())
 				paginated.FillPaginationV2(profileQuery, nil, maxPaginationLimit)
 				profileQuery.Pagination.SortOptions = []*apiV1.QuerySortOption{
 					{

--- a/central/complianceoperator/v2/profiles/service/service_impl_test.go
+++ b/central/complianceoperator/v2/profiles/service/service_impl_test.go
@@ -157,6 +157,23 @@ func (s *ComplianceProfilesServiceTestSuite) TestListProfileSummaries() {
 			},
 		},
 		{
+			desc:         "No profiles match filter",
+			query:        &apiV2.ClustersProfileSummaryRequest{ClusterIds: []string{fixtureconsts.Cluster1}},
+			expectedErr:  nil,
+			expectedResp: []*apiV2.ComplianceProfileSummary{},
+			found:        true,
+			setMocks: func() {
+				profileQuery := search.EmptyQuery()
+				paginated.FillPaginationV2(profileQuery, nil, maxPaginationLimit)
+				profileQuery.Pagination.SortOptions = []*apiV1.QuerySortOption{
+					{
+						Field: search.ComplianceOperatorProfileName.String(),
+					},
+				}
+				s.profileDatastore.EXPECT().GetProfilesNames(gomock.Any(), profileQuery, []string{fixtureconsts.Cluster1}).Return(nil, nil).Times(1)
+			},
+		},
+		{
 			desc:        "Query with cluster 1",
 			query:       &apiV2.ClustersProfileSummaryRequest{ClusterIds: []string{fixtureconsts.Cluster1}},
 			expectedErr: nil,

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
+import { Alert } from '@patternfly/react-core';
 
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
@@ -11,14 +12,16 @@ import { addRegexPrefixToFilters } from 'utils/searchUtils';
 
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
-import { combineSearchFilterWithScanConfig } from './compliance.coverage.utils';
+import { combineSearchFilterWithScanConfig, getStatusCounts } from './compliance.coverage.utils';
+import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
 import ProfileChecksTable from './ProfileChecksTable';
 import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 
 function ProfileChecksPage() {
     const { profileName } = useParams() as { profileName: string };
 
-    const { selectedScanConfigName } = useContext(ScanConfigurationsContext);
+    const { selectedScanConfigName, scanConfigurationsQuery } = useContext(ScanConfigurationsContext);
+    const { scanConfigProfilesResponse } = useContext(ComplianceProfilesContext);
     const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
@@ -53,20 +56,64 @@ function ProfileChecksPage() {
         searchFilter,
     });
 
+    const selectedProfile = scanConfigProfilesResponse?.profiles.find(
+        (profile) => profile.name === profileName
+    );
+    const isTailoredProfile = selectedProfile?.operatorKind === 'TAILORED_PROFILE';
+
+    const clusterCount = useMemo(() => {
+        if (!selectedScanConfigName) return 0;
+        const selectedConfig = scanConfigurationsQuery.response.configurations.find(
+            (c) => c.scanName === selectedScanConfigName
+        );
+        return selectedConfig?.clusterStatus.length ?? 0;
+    }, [scanConfigurationsQuery.response.configurations, selectedScanConfigName]);
+
+    const hasInconsistentChecks = useMemo(() => {
+        const results = profileChecks?.profileResults;
+        if (!results || results.length === 0) {
+            return false;
+        }
+        const totalCounts = results.map((check) => getStatusCounts(check.checkStats).totalCount);
+        const maxCount = Math.max(...totalCounts);
+        // Some checks appear in fewer clusters than others (different check sets with overlap)
+        if (totalCounts.some((count) => count < maxCount)) return true;
+        // All checks share the same count, but it is less than the total cluster count:
+        // clusters have completely disjoint check sets
+        if (clusterCount > maxCount) return true;
+        return false;
+    }, [profileChecks, clusterCount]);
+
     function onClearFilters() {
         setSearchFilter({});
         setPage(1);
     }
 
     return (
-        <ProfileChecksTable
-            profileChecksResultsCount={profileChecks?.totalCount ?? 0}
-            profileName={profileName}
-            pagination={pagination}
-            tableState={tableState}
-            getSortParams={getSortParams}
-            onClearFilters={onClearFilters}
-        />
+        <>
+            {isTailoredProfile && hasInconsistentChecks && (
+                <Alert
+                    className="pf-v6-u-mb-md"
+                    variant="warning"
+                    isInline
+                    title="Inconsistent checks across clusters"
+                    component="p"
+                >
+                    The checks in this tailored profile differ across clusters. This may indicate
+                    that the tailored profile is defined differently in each cluster, for example
+                    due to differences in Compliance Operator versions or the underlying base
+                    profile.
+                </Alert>
+            )}
+            <ProfileChecksTable
+                profileChecksResultsCount={profileChecks?.totalCount ?? 0}
+                profileName={profileName}
+                pagination={pagination}
+                tableState={tableState}
+                getSortParams={getSortParams}
+                onClearFilters={onClearFilters}
+            />
+        </>
     );
 }
 

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Coverage/ProfileChecksPage.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useContext } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
-import { Alert } from '@patternfly/react-core';
 
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
@@ -12,16 +11,14 @@ import { addRegexPrefixToFilters } from 'utils/searchUtils';
 
 import { DEFAULT_COMPLIANCE_PAGE_SIZE } from '../compliance.constants';
 import { CHECK_NAME_QUERY, CLUSTER_QUERY } from './compliance.coverage.constants';
-import { combineSearchFilterWithScanConfig, getStatusCounts } from './compliance.coverage.utils';
-import { ComplianceProfilesContext } from './ComplianceProfilesProvider';
+import { combineSearchFilterWithScanConfig } from './compliance.coverage.utils';
 import ProfileChecksTable from './ProfileChecksTable';
 import { ScanConfigurationsContext } from './ScanConfigurationsProvider';
 
 function ProfileChecksPage() {
     const { profileName } = useParams() as { profileName: string };
 
-    const { selectedScanConfigName, scanConfigurationsQuery } = useContext(ScanConfigurationsContext);
-    const { scanConfigProfilesResponse } = useContext(ComplianceProfilesContext);
+    const { selectedScanConfigName } = useContext(ScanConfigurationsContext);
     const pagination = useURLPagination(DEFAULT_COMPLIANCE_PAGE_SIZE);
     const { page, perPage, setPage } = pagination;
     const { sortOption, getSortParams } = useURLSort({
@@ -56,64 +53,20 @@ function ProfileChecksPage() {
         searchFilter,
     });
 
-    const selectedProfile = scanConfigProfilesResponse?.profiles.find(
-        (profile) => profile.name === profileName
-    );
-    const isTailoredProfile = selectedProfile?.operatorKind === 'TAILORED_PROFILE';
-
-    const clusterCount = useMemo(() => {
-        if (!selectedScanConfigName) return 0;
-        const selectedConfig = scanConfigurationsQuery.response.configurations.find(
-            (c) => c.scanName === selectedScanConfigName
-        );
-        return selectedConfig?.clusterStatus.length ?? 0;
-    }, [scanConfigurationsQuery.response.configurations, selectedScanConfigName]);
-
-    const hasInconsistentChecks = useMemo(() => {
-        const results = profileChecks?.profileResults;
-        if (!results || results.length === 0) {
-            return false;
-        }
-        const totalCounts = results.map((check) => getStatusCounts(check.checkStats).totalCount);
-        const maxCount = Math.max(...totalCounts);
-        // Some checks appear in fewer clusters than others (different check sets with overlap)
-        if (totalCounts.some((count) => count < maxCount)) return true;
-        // All checks share the same count, but it is less than the total cluster count:
-        // clusters have completely disjoint check sets
-        if (clusterCount > maxCount) return true;
-        return false;
-    }, [profileChecks, clusterCount]);
-
     function onClearFilters() {
         setSearchFilter({});
         setPage(1);
     }
 
     return (
-        <>
-            {isTailoredProfile && hasInconsistentChecks && (
-                <Alert
-                    className="pf-v6-u-mb-md"
-                    variant="warning"
-                    isInline
-                    title="Inconsistent checks across clusters"
-                    component="p"
-                >
-                    The checks in this tailored profile differ across clusters. This may indicate
-                    that the tailored profile is defined differently in each cluster, for example
-                    due to differences in Compliance Operator versions or the underlying base
-                    profile.
-                </Alert>
-            )}
-            <ProfileChecksTable
-                profileChecksResultsCount={profileChecks?.totalCount ?? 0}
-                profileName={profileName}
-                pagination={pagination}
-                tableState={tableState}
-                getSortParams={getSortParams}
-                onClearFilters={onClearFilters}
-            />
-        </>
+        <ProfileChecksTable
+            profileChecksResultsCount={profileChecks?.totalCount ?? 0}
+            profileName={profileName}
+            pagination={pagination}
+            tableState={tableState}
+            getSortParams={getSortParams}
+            onClearFilters={onClearFilters}
+        />
     );
 }
 


### PR DESCRIPTION
## Description

Before this PR, a filter matching 0 profiles in `GET /v2/compliance/profiles/summary` resulted in querying the database without a `WHERE` clause, so the API returned every profile in the database instead of none. Meanwhile `totalCount` was computed correctly as 0, contradicting the returned data.

This PR fixes the logic by adding an early return when a filter does not match.

A similar issue exists in `/v2/compliance/scan/configurations/`, addressed in https://github.com/stackrox/stackrox/pull/20044.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

By running in a live cluster and querying with a filter that matches nothing:

```console
# Before (master)
$ curl -sku admin:admin "https://central/v2/compliance/profiles/summary?cluster_ids=$CLUSTER_1&query.query=Compliance+Profile+Name:nonexistent" | jq '.profiles[].name' | wc -l
52

# After
$ curl -sku admin:admin "https://central/v2/compliance/profiles/summary?cluster_ids=$CLUSTER_1&query.query=Compliance+Profile+Name:nonexistent" | jq '.profiles[].name' | wc -l
0
```