### PR TITLE
ROX-34164: Validation checks in exclusion scope

### DIFF
--- a/central/policy/service/validator.go
+++ b/central/policy/service/validator.go
@@ -313,7 +313,16 @@ func (s *policyValidator) validateDeploymentExclusion(exclusion *storage.Exclusi
 		return errors.New("at least one field of deployment exclusion scope must be defined")
 	}
 	if deployment.GetScope() != nil {
-		if err := s.validateScope(deployment.GetScope()); err != nil {
+		// No feature flag check — exclusion scopes do not
+		// support cluster and namespace labels.
+		scope := deployment.GetScope()
+		if scope.GetClusterLabel() != nil {
+			return errors.New("exclusion scopes do not support cluster labels")
+		}
+		if scope.GetNamespaceLabel() != nil {
+			return errors.New("exclusion scopes do not support namespace labels")
+		}
+		if err := s.validateScope(scope); err != nil {
 			return errors.Wrap(err, "deployment exclusion scope is invalid")
 		}
 	}

--- a/central/policy/service/validator_test.go
+++ b/central/policy/service/validator_test.go
@@ -719,6 +719,70 @@ func (s *PolicyValidatorTestSuite) TestValidateExclusions() {
 	s.NoError(s.validator.validateExclusions(policy))
 }
 
+func (s *PolicyValidatorTestSuite) TestValidateExclusionRejectsLabels() {
+	for name, tc := range map[string]struct {
+		exclusion   *storage.Exclusion
+		errExpected bool
+		errContains string
+	}{
+		"cluster_label on exclusion scope is rejected": {
+			exclusion: &storage.Exclusion{
+				Deployment: &storage.Exclusion_Deployment{
+					Scope: &storage.Scope{
+						ClusterLabel: &storage.Scope_Label{Key: "env", Value: "prod"},
+					},
+				},
+			},
+			errExpected: true,
+			errContains: "cluster labels",
+		},
+		"namespace_label on exclusion scope is rejected": {
+			exclusion: &storage.Exclusion{
+				Deployment: &storage.Exclusion_Deployment{
+					Scope: &storage.Scope{
+						NamespaceLabel: &storage.Scope_Label{Key: "team", Value: "backend"},
+					},
+				},
+			},
+			errExpected: true,
+			errContains: "namespace labels",
+		},
+		"deployment label on exclusion scope is allowed": {
+			exclusion: &storage.Exclusion{
+				Deployment: &storage.Exclusion_Deployment{
+					Scope: &storage.Scope{
+						Label: &storage.Scope_Label{Key: "app", Value: "nginx"},
+					},
+				},
+			},
+			errExpected: false,
+		},
+		"cluster ID on exclusion scope is allowed": {
+			exclusion: &storage.Exclusion{
+				Deployment: &storage.Exclusion_Deployment{
+					Scope: &storage.Scope{
+						Cluster: "cluster-1",
+					},
+				},
+			},
+			errExpected: false,
+		},
+	} {
+		s.T().Run(name, func(t *testing.T) {
+			policy := &storage.Policy{
+				LifecycleStages: []storage.LifecycleStage{storage.LifecycleStage_DEPLOY},
+				Exclusions:      []*storage.Exclusion{tc.exclusion},
+			}
+			err := s.validator.validateExclusions(policy)
+			if tc.errExpected {
+				assert.ErrorContains(t, err, tc.errContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func (s *PolicyValidatorTestSuite) TestAllDefaultPoliciesValidate() {
 	defaultPolicies, err := policies.DefaultPolicies()
 	s.Require().NoError(err)

--- a/pkg/scopecomp/scope.go
+++ b/pkg/scopecomp/scope.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/regexutils"
+	"github.com/stackrox/rox/pkg/utils"
 )
 
 var (
@@ -100,8 +101,10 @@ func (c *CompiledScope) MatchesClusterLabels(ctx context.Context, deployment *st
 	if c.ClusterLabelKey == nil {
 		return true
 	}
+	// Unreachable: all CompileScope callers for inclusion scopes pass real
+	// providers, and exclusion scopes reject labels at validation time.
 	if c.clusterLabelProvider == nil {
-		log.Error("Cluster label matcher defined but provider is nil - failing closed")
+		utils.Should(errors.New("cluster label matcher defined but provider is nil"))
 		return false
 	}
 	clusterLabels, err := c.clusterLabelProvider.GetClusterLabels(ctx, deployment.GetClusterId())
@@ -117,8 +120,10 @@ func (c *CompiledScope) MatchesNamespaceLabels(ctx context.Context, deployment *
 	if c.NamespaceLabelKey == nil {
 		return true
 	}
+	// Unreachable: all CompileScope callers for inclusion scopes pass real
+	// providers, and exclusion scopes reject labels at validation time.
 	if c.namespaceLabelProvider == nil {
-		log.Error("Namespace label matcher defined but provider is nil - failing closed")
+		utils.Should(errors.New("namespace label matcher defined but provider is nil"))
 		return false
 	}
 	namespaceLabels, err := c.namespaceLabelProvider.GetNamespaceLabels(ctx, deployment.GetClusterId(), deployment.GetNamespace())


### PR DESCRIPTION
## Description

### Problem (before)

Policy exclusions accept a `Scope` which includes `cluster_label` and `namespace_label` fields, however label matchers are not supported in exclusions and do not resolve at runtime.

If a user sets `cluster_label` or `namespace_label` on an exclusion scope:
- Validation passes without error
- At match time, `MatchesClusterLabels`/`MatchesNamespaceLabels` detects the nil provider and returns `false`
- The policy applies more broadly than intended - deployments the user expected to be excluded still trigger violations, but there is no user visible error.

### Behavior (after)

- `validateDeploymentExclusion` rejects `cluster_label` and `namespace_label` on exclusion scopes with a clear user visible error message
- The nil-provider guard in `MatchesClusterLabels`/`MatchesNamespaceLabels` is upgraded from `log.Error` to `utils.Should` so that it panics in dev/test builds, logs in release. It is noted that this path is unreachable in production code.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
CI + Manual
```
ksanchet@ksanchet-mac:~/go/src/github.com/stackrox/stackrox$ curl -k -X POST 'https://localhost:8000/v1/policies' \
>   -u 'admin:<password>' \
>   -H 'Content-Type: application/json' \
>   -d '{
>     "name": "My Test Policy",
>     "description": "Policy with cluster label exclusion",
>     "severity": "LOW_SEVERITY",
>     "categories": ["DevOps Best Practices"],
>     "lifecycleStages": ["DEPLOY"],
>     "eventSource": "NOT_APPLICABLE",
>     "policyVersion": "1.1",
>     "policySections": [
>       {
>         "policyGroups": [
>           {
>             "fieldName": "Image Registry",
>             "values": [
>               { "value": "docker.io" }
>             ]
>           }
>         ]
>       }
>     ],
>     "exclusions": [
>       {
>         "name": "Exclude by cluster label",
>         "deployment": {
>           "scope": {
>             "clusterLabel": {
>               "key": "env",
>               "value": "staging"
>             }
>           }
>         }
>       }
>     ]
>   }'
{"code":3,"message":"policy invalid error: exclusion scopes do not support cluster labels: invalid arguments","details":[],"error":"policy invalid error: exclusion scopes do not support cluster labels: invalid arguments"
```
