### PR TITLE
fix(tests): disable file activity splunk tests

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -14,6 +14,7 @@ import common.Constants
 import objects.Deployment
 import services.AlertService
 import services.ApiTokenService
+import services.FeatureFlagService
 import services.NetworkBaselineService
 import services.PolicyService
 import util.Env
@@ -135,14 +136,17 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
     @Tag("Integration")
     def "Verify Splunk violations: file access violations reach Splunk TA"() {
         given:
-        "FACT is enabled in the collector"
+        "Fact is enabled in the collector"
         Assume.assumeTrue(
-                "FACT container not found in collector DaemonSet — skipping file access test",
+                "Fact container not found in collector DaemonSet — skipping file access test",
                 orchestrator.containsDaemonSetContainer(
                         Constants.STACKROX_NAMESPACE, COLLECTOR_DS, FACT_CONTAINER))
+        Assume.assumeTrue(
+                "ROX_SENSITIVE_FILE_ACTIVITY is not enabled — skipping file access test",
+                FeatureFlagService.isFeatureFlagEnabled("ROX_SENSITIVE_FILE_ACTIVITY"))
 
         and:
-        "FACT is configured to monitor /tmp paths"
+        "Fact is configured to monitor /tmp paths"
         patchFactEnv()
 
         and:

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -50,6 +50,11 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
 
         String centralHost = orchestrator.getServiceIP("central", "stackrox")
         configureSplunkTA(splunkDeployment, centralHost)
+
+        if (orchestrator.containsDaemonSetContainer(
+                Constants.STACKROX_NAMESPACE, COLLECTOR_DS, FACT_CONTAINER)) {
+            patchFactEnv()
+        }
     }
 
     def cleanupSpec() {
@@ -144,10 +149,6 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         Assume.assumeTrue(
                 "ROX_SENSITIVE_FILE_ACTIVITY is not enabled — skipping file access test",
                 FeatureFlagService.isFeatureFlagEnabled("ROX_SENSITIVE_FILE_ACTIVITY"))
-
-        and:
-        "Fact is configured to monitor /tmp paths"
-        patchFactEnv()
 
         and:
         "a file activity policy targeting a unique path"

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -1,4 +1,3 @@
-import static util.Helpers.waitForTrue
 import static util.Helpers.withRetry
 import static util.SplunkUtil.postToSplunk
 import static util.SplunkUtil.tearDownSplunk
@@ -14,7 +13,6 @@ import common.Constants
 import objects.Deployment
 import services.AlertService
 import services.ApiTokenService
-import services.FeatureFlagService
 import services.NetworkBaselineService
 import services.PolicyService
 import util.Env
@@ -50,11 +48,6 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
 
         String centralHost = orchestrator.getServiceIP("central", "stackrox")
         configureSplunkTA(splunkDeployment, centralHost)
-
-        if (orchestrator.containsDaemonSetContainer(
-                Constants.STACKROX_NAMESPACE, COLLECTOR_DS, FACT_CONTAINER)) {
-            patchFactEnv()
-        }
     }
 
     def cleanupSpec() {
@@ -141,14 +134,8 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
     @Tag("Integration")
     def "Verify Splunk violations: file access violations reach Splunk TA"() {
         given:
-        "Fact is enabled in the collector"
-        Assume.assumeTrue(
-                "Fact container not found in collector DaemonSet — skipping file access test",
-                orchestrator.containsDaemonSetContainer(
-                        Constants.STACKROX_NAMESPACE, COLLECTOR_DS, FACT_CONTAINER))
-        Assume.assumeTrue(
-                "ROX_SENSITIVE_FILE_ACTIVITY is not enabled — skipping file access test",
-                FeatureFlagService.isFeatureFlagEnabled("ROX_SENSITIVE_FILE_ACTIVITY"))
+        "ROX-34178: skip until file access Splunk TA test is stabilised"
+        Assume.assumeTrue("ROX-34178: file access Splunk TA test is disabled pending stabilisation", false)
 
         and:
         "a file activity policy targeting a unique path"
@@ -201,19 +188,6 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         cleanup:
         if (policyID) {
             PolicyService.deletePolicy(policyID)
-        }
-    }
-
-    private void patchFactEnv() {
-        log.info "Setting FACT_PATHS on collector DaemonSet"
-        waitForTrue(20, 20) {
-            orchestrator.updateDaemonSetEnv(
-                    Constants.STACKROX_NAMESPACE, COLLECTOR_DS, FACT_CONTAINER,
-                    "FACT_PATHS", "/tmp/**/*")
-            orchestrator.daemonSetEnvVarUpdated(
-                    Constants.STACKROX_NAMESPACE, COLLECTOR_DS, FACT_CONTAINER,
-                    "FACT_PATHS", "/tmp/**/*")
-            orchestrator.daemonSetReady(Constants.STACKROX_NAMESPACE, COLLECTOR_DS)
         }
     }
 

--- a/scripts/ci/jobs/ocp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_qa_e2e_tests.py
@@ -26,7 +26,7 @@ try:
 
     m = re.match(EXPR, ocp_variant)
     if int(m.group("major")) >= 4 and int(m.group("minor")) >= 16:
-        os.environ["SFA_AGENT"] = "Enabled"
+        os.environ["SFA_AGENT"] = "true"
 except Exception as ex:
     print(f"Could not identify the OCP version, {ex}, SFA is disabled")
 

--- a/scripts/ci/jobs/ocp_scanner_v4_install_tests.py
+++ b/scripts/ci/jobs/ocp_scanner_v4_install_tests.py
@@ -28,7 +28,7 @@ try:
 
     m = re.match(EXPR, ocp_variant)
     if int(m.group("major")) >= 4 and int(m.group("minor")) >= 16:
-        os.environ["SFA_AGENT"] = "Enabled"
+        os.environ["SFA_AGENT"] = "true"
 except Exception as ex:
     print(f"Could not identify the OCP version, {ex}, SFA is disabled")
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -13,6 +13,7 @@ source "$TEST_ROOT/scripts/ci/lib.sh"
 # shellcheck source=../../scripts/ci/test_state.sh
 source "$TEST_ROOT/scripts/ci/test_state.sh"
 
+export SFA_AGENT="${SFA_AGENT:-false}"
 export QA_TEST_DEBUG_LOGS="/tmp/qa-tests-backend-logs"
 export QA_DEPLOY_WAIT_INFO="/tmp/wait-for-kubectl-object"
 
@@ -357,7 +358,7 @@ deploy_central_via_operator() {
     customize_envVars+=$'\n      - name: ROX_CISA_KEV'
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_SENSITIVE_FILE_ACTIVITY'
-    customize_envVars+=$'\n        value: "false"'
+    customize_envVars+=$'\n        value: "'"${SFA_AGENT}"'"'
     customize_envVars+=$'\n      - name: ROX_CVE_FIX_TIMESTAMP'
     customize_envVars+=$'\n        value: "true"'
     customize_envVars+=$'\n      - name: ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING'
@@ -476,8 +477,8 @@ deploy_sensor_via_operator() {
         secured_cluster_yaml_path="tests/e2e/yaml/secured-cluster-cr-with-scanner-v4.envsubst.yaml"
     fi
 
-    if [[ "${SFA_AGENT:-}" == "Enabled" ]]; then
-       echo "Enabling File Activity Monitoring due to SFA_AGENT variable: ${SFA_AGENT}"
+    if [[ "${SFA_AGENT:-}" == "true" ]]; then
+       echo "Enabling File Activity Monitoring"
        fam_mode_setting="Enabled"
     fi
 


### PR DESCRIPTION
## Description

Further Splunk TA e2e test fixes; correctly set the FIM feature flag when Fact is enabled, and skip the FIM tests in Splunk TA when it's not enabled.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI should be enough, but only with `ci-all-qa-tests` and `ci-release-build`
