### PR TITLE
ROX-34166: Fix label autocomplete dropping all but first filter value

### DIFF
--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -597,6 +597,10 @@ func composePostTransforms(a, b func(interface{}) interface{}) func(interface{})
 	return func(v interface{}) interface{} {
 		aResult := a(v)
 		bResult := b(v)
+		// PostTransform returns interface{}, but for map fields (labels,
+		// annotations) the concrete type is []string. If either assertion
+		// fails we skip the merge and return aResult untouched — this is
+		// safe because only map fields produce duplicate SelectPath entries.
 		aSlice, aOk := aResult.([]string)
 		bSlice, bOk := bResult.([]string)
 		if aOk && bOk {

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -610,6 +611,30 @@ func combineQueryEntries(entries []*pgsearch.QueryEntry, separator string) *pgse
 		for _, selectedField := range entry.SelectedFields {
 			if seenSelectFields.Add(selectedField.SelectPath) {
 				newQE.SelectedFields = append(newQE.SelectedFields, selectedField)
+			} else if selectedField.PostTransform != nil {
+				// When multiple entries target the same column with different
+				// PostTransform functions (e.g., map/label queries with multiple
+				// filter values in a disjunction), compose the transforms so all
+				// matching values are included in the results.
+				for i, existing := range newQE.SelectedFields {
+					if existing.SelectPath == selectedField.SelectPath && existing.PostTransform != nil {
+						prevTransform := existing.PostTransform
+						newTransform := selectedField.PostTransform
+						newQE.SelectedFields[i].PostTransform = func(v interface{}) interface{} {
+							prevResult := prevTransform(v)
+							newResult := newTransform(v)
+							prevSlice, prevOk := prevResult.([]string)
+							newSlice, newOk := newResult.([]string)
+							if prevOk && newOk {
+								combined := append(prevSlice, newSlice...)
+								slices.Sort(combined)
+								return slices.Compact(combined)
+							}
+							return prevResult
+						}
+						break
+					}
+				}
 			}
 		}
 		if len(entry.GroupBy) > 0 {

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -597,10 +597,7 @@ func composePostTransforms(a, b func(interface{}) interface{}) func(interface{})
 	return func(v interface{}) interface{} {
 		aResult := a(v)
 		bResult := b(v)
-		// PostTransform returns interface{}, but for map fields (labels,
-		// annotations) the concrete type is []string. If either assertion
-		// fails we skip the merge and return aResult untouched — this is
-		// safe because only map fields produce duplicate SelectPath entries.
+		// Type-assert to []string; if either result isn't a string slice, skip the merge.
 		aSlice, aOk := aResult.([]string)
 		bSlice, bOk := bResult.([]string)
 		if aOk && bOk {

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -589,6 +589,27 @@ func combineDisjunction(entries []*pgsearch.QueryEntry) *pgsearch.QueryEntry {
 
 }
 
+// composePostTransforms returns a PostTransform that runs both a and b on the
+// same input and merges their deduplicated []string results. Both transforms
+// return interface{}, but for map fields (labels, annotations) the concrete
+// type is []string.
+func composePostTransforms(a, b func(interface{}) interface{}) func(interface{}) interface{} {
+	return func(v interface{}) interface{} {
+		aResult := a(v)
+		bResult := b(v)
+		aSlice, aOk := aResult.([]string)
+		bSlice, bOk := bResult.([]string)
+		if aOk && bOk {
+			combined := make([]string, 0, len(aSlice)+len(bSlice))
+			combined = append(combined, aSlice...)
+			combined = append(combined, bSlice...)
+			slices.Sort(combined)
+			return slices.Compact(combined)
+		}
+		return aResult
+	}
+}
+
 func combineQueryEntries(entries []*pgsearch.QueryEntry, separator string) *pgsearch.QueryEntry {
 	if len(entries) == 0 {
 		return nil
@@ -618,20 +639,9 @@ func combineQueryEntries(entries []*pgsearch.QueryEntry, separator string) *pgse
 				// matching values are included in the results.
 				for i, existing := range newQE.SelectedFields {
 					if existing.SelectPath == selectedField.SelectPath && existing.PostTransform != nil {
-						prevTransform := existing.PostTransform
-						newTransform := selectedField.PostTransform
-						newQE.SelectedFields[i].PostTransform = func(v interface{}) interface{} {
-							prevResult := prevTransform(v)
-							newResult := newTransform(v)
-							prevSlice, prevOk := prevResult.([]string)
-							newSlice, newOk := newResult.([]string)
-							if prevOk && newOk {
-								combined := append(prevSlice, newSlice...)
-								slices.Sort(combined)
-								return slices.Compact(combined)
-							}
-							return prevResult
-						}
+						newQE.SelectedFields[i].PostTransform = composePostTransforms(
+							existing.PostTransform, selectedField.PostTransform,
+						)
 						break
 					}
 				}

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -591,8 +591,8 @@ func combineDisjunction(entries []*pgsearch.QueryEntry) *pgsearch.QueryEntry {
 
 // composePostTransforms returns a PostTransform that runs both a and b on the
 // same input and merges their deduplicated []string results. Both transforms
-// return interface{}, but for map fields (labels, annotations) the concrete
-// type is []string.
+// return interface{}, but for map fields (labels, annotations) and array fields
+// the concrete type is []string.
 func composePostTransforms(a, b func(interface{}) interface{}) func(interface{}) interface{} {
 	return func(v interface{}) interface{} {
 		aResult := a(v)

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/postgres/aggregatefunc"
+	pgsearch "github.com/stackrox/rox/pkg/search/postgres/query"
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/assert"
@@ -1337,6 +1338,108 @@ func TestGetQueries(t *testing.T) {
 			assert.Equal(t, GET, actual.QueryType)
 			assert.Equal(t, c.expectedQuery, actual.AsSQL())
 			assert.Equal(t, c.expectedData, actual.Data)
+		})
+	}
+}
+
+func TestCombineQueryEntries_PostTransformComposition(t *testing.T) {
+	makeTransform := func(values []string) func(interface{}) interface{} {
+		return func(_ interface{}) interface{} { return values }
+	}
+
+	cases := map[string]struct {
+		entries           []*pgsearch.QueryEntry
+		expectedWhere     string
+		expectedValues    []interface{}
+		expectedTransform []string // nil means PostTransform should be nil
+	}{
+		"two label filters are composed": {
+			entries: []*pgsearch.QueryEntry{
+				{
+					Where: pgsearch.WhereClause{Query: "cond_a", Values: []interface{}{"a"}},
+					SelectedFields: []pgsearch.SelectQueryField{{
+						SelectPath:    "deployments.Labels",
+						FieldPath:     "deployment.labels",
+						PostTransform: makeTransform([]string{"app=visa"}),
+					}},
+				},
+				{
+					Where: pgsearch.WhereClause{Query: "cond_b", Values: []interface{}{"b"}},
+					SelectedFields: []pgsearch.SelectQueryField{{
+						SelectPath:    "deployments.Labels",
+						FieldPath:     "deployment.labels",
+						PostTransform: makeTransform([]string{"app=mastercard"}),
+					}},
+				},
+			},
+			expectedWhere:     "(cond_a or cond_b)",
+			expectedValues:    []interface{}{"a", "b"},
+			expectedTransform: []string{"app=visa", "app=mastercard"},
+		},
+		"three filters chain correctly": {
+			entries: []*pgsearch.QueryEntry{
+				{
+					Where:          pgsearch.WhereClause{Query: "a"},
+					SelectedFields: []pgsearch.SelectQueryField{{SelectPath: "col", PostTransform: makeTransform([]string{"x"})}},
+				},
+				{
+					Where:          pgsearch.WhereClause{Query: "b"},
+					SelectedFields: []pgsearch.SelectQueryField{{SelectPath: "col", PostTransform: makeTransform([]string{"y"})}},
+				},
+				{
+					Where:          pgsearch.WhereClause{Query: "c"},
+					SelectedFields: []pgsearch.SelectQueryField{{SelectPath: "col", PostTransform: makeTransform([]string{"z"})}},
+				},
+			},
+			expectedWhere:     "(a or b or c)",
+			expectedTransform: []string{"x", "y", "z"},
+		},
+		"overlapping filters are deduplicated": {
+			entries: []*pgsearch.QueryEntry{
+				{
+					Where:          pgsearch.WhereClause{Query: "a"},
+					SelectedFields: []pgsearch.SelectQueryField{{SelectPath: "col", PostTransform: makeTransform([]string{"app=visa"})}},
+				},
+				{
+					Where:          pgsearch.WhereClause{Query: "b"},
+					SelectedFields: []pgsearch.SelectQueryField{{SelectPath: "col", PostTransform: makeTransform([]string{"app=visa", "app=mastercard"})}},
+				},
+			},
+			expectedWhere:     "(a or b)",
+			expectedTransform: []string{"app=mastercard", "app=visa"},
+		},
+		"nil PostTransform duplicates are dropped without error": {
+			entries: []*pgsearch.QueryEntry{
+				{
+					Where:          pgsearch.WhereClause{Query: "a"},
+					SelectedFields: []pgsearch.SelectQueryField{{SelectPath: "col"}},
+				},
+				{
+					Where:          pgsearch.WhereClause{Query: "b"},
+					SelectedFields: []pgsearch.SelectQueryField{{SelectPath: "col"}},
+				},
+			},
+			expectedWhere:     "(a or b)",
+			expectedTransform: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			result := combineQueryEntries(tc.entries, " or ")
+
+			assert.Equal(t, tc.expectedWhere, result.Where.Query)
+			if tc.expectedValues != nil {
+				assert.Equal(t, tc.expectedValues, result.Where.Values)
+			}
+			assert.Len(t, result.SelectedFields, 1)
+
+			if tc.expectedTransform == nil {
+				assert.Nil(t, result.SelectedFields[0].PostTransform)
+			} else {
+				got := result.SelectedFields[0].PostTransform(nil).([]string)
+				assert.ElementsMatch(t, tc.expectedTransform, got)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description

When searching with multiple label filter values in a disjunction (e.g., `Deployment Label: app=visa,app=mastercard`), autocomplete results only returned matches for the first filter value. The root cause is in `combineQueryEntries` in `pkg/search/postgres/common.go`: when combining disjunction query entries that target the same column, the `seenSelectFields` deduplication dropped all but the first entry's `PostTransform` function. Since each label filter value has its own `PostTransform` to filter matching labels from the raw DB column, only the first transform survived, silently discarding results for all subsequent filter values.                                                                                                         
                                                                               
This fix composes the `PostTransform` functions when multiple entries target the same `SelectPath` with non-nil transforms. Instead of dropping duplicate selected fields outright, the new code finds the existing field for that path and wraps both the old and new transforms into a single function that concatenates their `[]string` results. This preserves the deduplication of the select column itself while ensuring all filter values contribute to the final output.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Added unit test `TestCombineQueryEntries_PostTransformComposition` in `pkg/search/postgres/common_test.go` covering:
    - Two label filters are composed (both results appear in output)
    - Three filters chain correctly
    - Nil PostTransform duplicates are dropped without error (no regression)
- Comprehensive manual testing
  - Deployed ACS from the branch build to a local cluster with four test workloads carrying distinct labels, then validated the fix against the autocomplete API — multi-filter queries return all results, filter order doesn't matter, single filters and non-label fields still work, and overlapping filters are deduplicated.