### PR TITLE
ROX-34170: Add GH Action to build VM scanning ContainerDisk images

### DIFF
--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -114,7 +114,14 @@ jobs:
             # `passt` is used by libguestfs for user-mode networking in the
             # appliance on Ubuntu 24.04; pull it in explicitly in case
             # libguestfs-tools doesn't hard-depend on it.
-            pkgs+=(libguestfs-tools qemu-utils passt)
+            # isc-dhcp-client provides `dhclient`, which supermin bundles
+            # into the libguestfs appliance. Without a DHCP client in the
+            # appliance, eth0 is never brought up + configured by passt,
+            # so the guest has no network at all and subscription-manager
+            # fails with `Name or service not known`. The appliance's
+            # /init tries `dhclient` then falls through to `dhcpcd` (also
+            # missing on the runner), hence `dhcpcd: command not found`.
+            pkgs+=(libguestfs-tools qemu-utils passt isc-dhcp-client)
           fi
           sudo apt-get install -y --no-install-recommends "${pkgs[@]}"
           podman --version

--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -155,6 +155,18 @@ jobs:
             echo "==> AppArmor status after teardown:"
             sudo aa-status || true
             ls -l /dev/kvm
+
+            # Replace the host's /etc/resolv.conf (symlinked to
+            # 127.0.0.53 = systemd-resolved stub) with a real upstream
+            # DNS. passt reads the host's resolver to forward guest DNS
+            # queries, and can't reach 127.0.0.53 from inside the
+            # appliance. Leaves the runner in a working DNS state
+            # because the public resolvers work from the host too.
+            sudo rm -f /etc/resolv.conf
+            printf 'nameserver 8.8.8.8\nnameserver 1.1.1.1\n' | \
+              sudo tee /etc/resolv.conf >/dev/null
+            echo "==> Host /etc/resolv.conf after override:"
+            cat /etc/resolv.conf
           fi
 
       - name: Check required secrets

--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -111,7 +111,10 @@ jobs:
           # idempotent so listing them keeps the step self-contained.
           pkgs=(podman skopeo jq)
           if [[ "$SCRIPT_VARIANT" == "virt-customize" ]]; then
-            pkgs+=(libguestfs-tools qemu-utils)
+            # `passt` is used by libguestfs for user-mode networking in the
+            # appliance on Ubuntu 24.04; pull it in explicitly in case
+            # libguestfs-tools doesn't hard-depend on it.
+            pkgs+=(libguestfs-tools qemu-utils passt)
           fi
           sudo apt-get install -y --no-install-recommends "${pkgs[@]}"
           podman --version

--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -56,7 +56,9 @@ permissions:
 
 jobs:
   build:
-    if: ${{ github.repository_owner == 'stackrox' }}
+    # FORK-ONLY: flipped from 'stackrox' to 'vikin91' for fork-based iteration
+    # testing. MUST BE REVERTED before the upstream PR merges.
+    if: ${{ github.repository_owner == 'vikin91' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -136,6 +136,21 @@ jobs:
             sudo chmod 0666 /dev/kvm || true
             sudo chmod 0644 /boot/vmlinuz-* || true
             echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns >/dev/null || true
+            # Ubuntu 24.04 ships an AppArmor profile for /usr/bin/passt that
+            # confines passt's writable paths to its own tmpdir. libguestfs
+            # launches passt with --pid under its own /run/user/*/libguestfs*/
+            # dir, which the profile doesn't permit, causing
+            # "PID file open: Permission denied" and `passt exited with
+            # status 1`. Unload the profile (keep AppArmor on for everything
+            # else).
+            if [[ -f /etc/apparmor.d/usr.bin.passt ]]; then
+              sudo apparmor_parser -R /etc/apparmor.d/usr.bin.passt || true
+              sudo ln -sf /etc/apparmor.d/usr.bin.passt /etc/apparmor.d/disable/ || true
+            fi
+            if [[ -f /etc/apparmor.d/passt ]]; then
+              sudo apparmor_parser -R /etc/apparmor.d/passt || true
+              sudo ln -sf /etc/apparmor.d/passt /etc/apparmor.d/disable/ || true
+            fi
             ls -l /dev/kvm
           fi
 

--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -143,14 +143,25 @@ jobs:
             # "PID file open: Permission denied" and `passt exited with
             # status 1`. Unload the profile (keep AppArmor on for everything
             # else).
-            if [[ -f /etc/apparmor.d/usr.bin.passt ]]; then
-              sudo apparmor_parser -R /etc/apparmor.d/usr.bin.passt || true
-              sudo ln -sf /etc/apparmor.d/usr.bin.passt /etc/apparmor.d/disable/ || true
-            fi
-            if [[ -f /etc/apparmor.d/passt ]]; then
-              sudo apparmor_parser -R /etc/apparmor.d/passt || true
-              sudo ln -sf /etc/apparmor.d/passt /etc/apparmor.d/disable/ || true
-            fi
+            # Unload AppArmor profiles that would otherwise block passt
+            # and qemu. passt: writes --pid under /run/user/*/libguestfs*/
+            # which its profile doesn't permit. qemu-system-x86_64: can't
+            # read disk images out of /tmp under the distro profile used
+            # by libvirt. libguestfs's `direct` backend invokes both from
+            # our runner user, so both profiles must be unloaded. We
+            # leave AppArmor on for everything else.
+            for profile in \
+                /etc/apparmor.d/usr.bin.passt \
+                /etc/apparmor.d/passt \
+                /etc/apparmor.d/usr.sbin.libvirtd \
+                /etc/apparmor.d/libvirt-* \
+                /etc/apparmor.d/usr.bin.qemu-system-x86_64; do
+              for p in $profile; do
+                [[ -f "$p" ]] || continue
+                sudo apparmor_parser -R "$p" 2>/dev/null || true
+                sudo ln -sf "$p" /etc/apparmor.d/disable/ || true
+              done
+            done
             ls -l /dev/kvm
           fi
 

--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -19,10 +19,10 @@ name: Build VM scanning images
 # One will eventually be kept and the other removed.
 
 on:
-  # TEMPORARY: fires on every push to the feature branch that touches the
-  # workflow or the build scripts so we can iterate before merging. The
-  # default branch doesn't know this workflow yet, so workflow_dispatch is
-  # not usable from a branch until this PR merges. REMOVE BEFORE MERGE.
+  # TODO(ROX-34170): Remove the `push` trigger before merging. It fires on
+  # every push to the feature branch so we can iterate without waiting for
+  # workflow_dispatch to become available (which requires the default branch
+  # to know this workflow).
   push:
     branches:
       - piotr/ROX-34170-vm-image-automation
@@ -56,9 +56,7 @@ permissions:
 
 jobs:
   build:
-    # FORK-ONLY: flipped from 'stackrox' to 'vikin91' for fork-based iteration
-    # testing. MUST BE REVERTED before the upstream PR merges.
-    if: ${{ github.repository_owner == 'vikin91' }}
+    if: ${{ github.repository_owner == 'stackrox' || github.repository_owner == 'vikin91' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -73,8 +71,8 @@ jobs:
             target_tag: rhel10-dnf-primed:latest
             platform: linux/amd64
     env:
-      # Temporary target while the workflow is being stabilized; will move to
-      # quay.io/rhacs-eng/ once repos and robot credentials are provisioned.
+      # TODO(ROX-34170): Change to quay.io/rhacs-eng once repos and robot
+      # credentials are provisioned on the upstream repo.
       TARGET_REGISTRY: quay.io/prygiels
       SRC_IMAGE_TAGGED: ${{ matrix.src_image }}
       TARGET_TAG: ${{ matrix.target_tag }}
@@ -258,9 +256,8 @@ jobs:
           fi
           echo "Last-built source-digest: ${last:-<none>}"
           echo "last_digest=${last}" >> "$GITHUB_OUTPUT"
-          # TEMPORARY: push events on the iteration branch always rebuild so
-          # script/workflow changes can actually be tested. Remove together
-          # with the `push:` trigger before merging.
+          # TODO(ROX-34170): Remove the push-event shortcut together with
+          # the `push:` trigger before merging.
           if [[ "$FORCE_REBUILD" == "true" ]]; then
             echo "rebuild=true (force)" && echo "rebuild=true" >> "$GITHUB_OUTPUT"
           elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then

--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -99,8 +99,11 @@ jobs:
         if: steps.filter.outputs.skip != 'true'
         env:
           # Schedule triggers pass empty strings for inputs; default to
-          # chroot for cron runs so scheduled builds keep working.
-          SCRIPT_VARIANT: ${{ github.event.inputs.script_variant || 'chroot' }}
+          # virt-customize for cron/push runs. TEMPORARY: while iterating,
+          # the chroot path hits "losetup: Permission denied" inside
+          # rootless --privileged podman on ubuntu-latest; evaluate
+          # virt-customize first.
+          SCRIPT_VARIANT: ${{ github.event.inputs.script_variant || 'virt-customize' }}
         run: |
           set -euo pipefail
           sudo apt-get update
@@ -219,7 +222,7 @@ jobs:
           RHEL_ACTIVATION_KEY: ${{ secrets.RHEL_ACTIVATION_KEY }}
           SRC_IMAGE: ${{ steps.upstream.outputs.src_pinned }}
           SOURCE_DIGEST: ${{ steps.upstream.outputs.digest }}
-          SCRIPT_VARIANT: ${{ github.event.inputs.script_variant || 'chroot' }}
+          SCRIPT_VARIANT: ${{ github.event.inputs.script_variant || 'virt-customize' }}
         run: |
           set -euo pipefail
           script="./vm-image-${SCRIPT_VARIANT}.sh"
@@ -232,7 +235,7 @@ jobs:
       - name: Summary
         if: steps.filter.outputs.skip != 'true'
         env:
-          SCRIPT_VARIANT: ${{ github.event.inputs.script_variant || 'chroot' }}
+          SCRIPT_VARIANT: ${{ github.event.inputs.script_variant || 'virt-customize' }}
         run: |
           {
             echo "### ${{ matrix.variant }}"

--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -1,0 +1,191 @@
+name: Build VM scanning images
+
+# Builds customized RHEL ContainerDisk images used by the VM scanning E2E
+# tests. Each run:
+#   1. Inspects the current upstream RHEL guest image digest on
+#      registry.redhat.io.
+#   2. Inspects the last-built image on quay.io/rhacs-eng and reads the
+#      recorded `org.opencontainers.image.source-digest` annotation.
+#   3. Skips the build when the digests match (unless force-rebuild is set).
+#   4. Otherwise runs vm-image.sh to build and push a dnf-primed image
+#      annotated with the new upstream digest.
+#
+# This workflow is repo-independent: it does not consume any stackrox source
+# code and only needs one of the `vm-image-*.sh` build scripts plus registry
+# credentials. Two image-building approaches live side-by-side for
+# evaluation:
+#   - chroot:          privileged UBI9 container + losetup + chroot
+#   - virt-customize:  libguestfs appliance (native Linux, needs /dev/kvm)
+# One will eventually be kept and the other removed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      force_rebuild:
+        description: "Rebuild and push even when upstream digest is unchanged"
+        type: boolean
+        default: false
+      matrix_filter:
+        description: "Optional variant filter (rhel9|rhel10). Empty = all."
+        type: string
+        default: ""
+      script_variant:
+        description: "Which image-building script to use"
+        type: choice
+        default: chroot
+        options:
+          - chroot
+          - virt-customize
+  schedule:
+    # Weekly on Mondays at 06:00 UTC. Red Hat publishes guest image updates
+    # infrequently (roughly quarterly) so weekly is more than enough.
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: ${{ github.repository_owner == 'stackrox' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: rhel9
+            src_image: registry.redhat.io/rhel9/rhel-guest-image:latest
+            target_tag: rhel9-dnf-primed:latest
+            platform: linux/amd64
+          - variant: rhel10
+            src_image: registry.redhat.io/rhel10/rhel-guest-image:latest
+            target_tag: rhel10-dnf-primed:latest
+            platform: linux/amd64
+    env:
+      # Temporary target while the workflow is being stabilized; will move to
+      # quay.io/rhacs-eng/ once repos and robot credentials are provisioned.
+      TARGET_REGISTRY: quay.io/prygiels
+      SRC_IMAGE_TAGGED: ${{ matrix.src_image }}
+      TARGET_TAG: ${{ matrix.target_tag }}
+      PLATFORM: ${{ matrix.platform }}
+    steps:
+      - name: Skip variants not matching filter
+        id: filter
+        run: |
+          filter='${{ github.event.inputs.matrix_filter }}'
+          if [[ -n "$filter" && "$filter" != "${{ matrix.variant }}" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping ${{ matrix.variant }} (filter=$filter)"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.filter.outputs.skip != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      - name: Install build tooling
+        if: steps.filter.outputs.skip != 'true'
+        env:
+          # Schedule triggers pass empty strings for inputs; default to
+          # chroot for cron runs so scheduled builds keep working.
+          SCRIPT_VARIANT: ${{ github.event.inputs.script_variant || 'chroot' }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          # podman + jq are preinstalled on ubuntu-latest, but apt-get is
+          # idempotent so listing them keeps the step self-contained.
+          pkgs=(podman skopeo jq)
+          if [[ "$SCRIPT_VARIANT" == "virt-customize" ]]; then
+            pkgs+=(libguestfs-tools qemu-utils)
+          fi
+          sudo apt-get install -y --no-install-recommends "${pkgs[@]}"
+          podman --version
+          skopeo --version
+
+      - name: Log in to registry.redhat.io
+        if: steps.filter.outputs.skip != 'true'
+        env:
+          REDHAT_REGISTRY_USER: ${{ secrets.REDHAT_REGISTRY_USER }}
+          REDHAT_REGISTRY_TOKEN: ${{ secrets.REDHAT_REGISTRY_TOKEN }}
+        run: |
+          echo "$REDHAT_REGISTRY_TOKEN" | \
+            podman login --username "$REDHAT_REGISTRY_USER" --password-stdin \
+            registry.redhat.io
+          # skopeo uses the same auth file as podman by default.
+
+      - name: Resolve upstream digest
+        if: steps.filter.outputs.skip != 'true'
+        id: upstream
+        run: |
+          set -euo pipefail
+          digest=$(skopeo inspect --format '{{.Digest}}' \
+            "docker://${SRC_IMAGE_TAGGED}")
+          echo "Upstream digest: $digest"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "src_pinned=${SRC_IMAGE_TAGGED%%:*}@${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to quay.io
+        if: steps.filter.outputs.skip != 'true'
+        env:
+          QUAY_USER: ${{ secrets.QUAY_RHACS_ENG_ROBOT_USER }}
+          QUAY_TOKEN: ${{ secrets.QUAY_RHACS_ENG_ROBOT_TOKEN }}
+        run: |
+          echo "$QUAY_TOKEN" | \
+            podman login --username "$QUAY_USER" --password-stdin quay.io
+
+      - name: Check existing target image
+        if: steps.filter.outputs.skip != 'true'
+        id: existing
+        env:
+          FORCE_REBUILD: ${{ github.event.inputs.force_rebuild }}
+          UPSTREAM_DIGEST: ${{ steps.upstream.outputs.digest }}
+        run: |
+          set -euo pipefail
+          target="docker://${TARGET_REGISTRY}/${TARGET_TAG}"
+          last=""
+          if raw=$(skopeo inspect "$target" 2>/dev/null); then
+            last=$(echo "$raw" | jq -r \
+              '.Labels["org.opencontainers.image.source-digest"] // empty')
+          fi
+          echo "Last-built source-digest: ${last:-<none>}"
+          echo "last_digest=${last}" >> "$GITHUB_OUTPUT"
+          if [[ "$FORCE_REBUILD" == "true" ]]; then
+            echo "rebuild=true (force)" && echo "rebuild=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$last" == "$UPSTREAM_DIGEST" ]]; then
+            echo "rebuild=false (up-to-date)"
+            echo "rebuild=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "rebuild=true (digest changed or no prior image)"
+            echo "rebuild=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push image
+        if: steps.filter.outputs.skip != 'true' && steps.existing.outputs.rebuild == 'true'
+        env:
+          RHEL_ACTIVATION_ORG: ${{ secrets.RHEL_ACTIVATION_ORG }}
+          RHEL_ACTIVATION_KEY: ${{ secrets.RHEL_ACTIVATION_KEY }}
+          SRC_IMAGE: ${{ steps.upstream.outputs.src_pinned }}
+          SOURCE_DIGEST: ${{ steps.upstream.outputs.digest }}
+          SCRIPT_VARIANT: ${{ github.event.inputs.script_variant || 'chroot' }}
+        run: |
+          set -euo pipefail
+          script="./vm-image-${SCRIPT_VARIANT}.sh"
+          if [[ ! -x "$script" ]]; then
+            chmod +x "$script"
+          fi
+          echo "==> Using $script"
+          "$script"
+
+      - name: Summary
+        if: steps.filter.outputs.skip != 'true'
+        env:
+          SCRIPT_VARIANT: ${{ github.event.inputs.script_variant || 'chroot' }}
+        run: |
+          {
+            echo "### ${{ matrix.variant }}"
+            echo "- Upstream: \`${SRC_IMAGE_TAGGED}\`"
+            echo "- Digest:   \`${{ steps.upstream.outputs.digest }}\`"
+            echo "- Rebuilt:  \`${{ steps.existing.outputs.rebuild }}\`"
+            echo "- Script:   \`vm-image-${SCRIPT_VARIANT}.sh\`"
+            echo "- Target:   \`${TARGET_REGISTRY}/${TARGET_TAG}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -19,6 +19,16 @@ name: Build VM scanning images
 # One will eventually be kept and the other removed.
 
 on:
+  # TEMPORARY: fires on every push to the feature branch that touches the
+  # workflow or the build scripts so we can iterate before merging. The
+  # default branch doesn't know this workflow yet, so workflow_dispatch is
+  # not usable from a branch until this PR merges. REMOVE BEFORE MERGE.
+  push:
+    branches:
+      - piotr/ROX-34170-vm-image-automation
+    paths:
+      - '.github/workflows/build-vm-images.yaml'
+      - 'vm-image-*.sh'
   workflow_dispatch:
     inputs:
       force_rebuild:
@@ -149,8 +159,14 @@ jobs:
           fi
           echo "Last-built source-digest: ${last:-<none>}"
           echo "last_digest=${last}" >> "$GITHUB_OUTPUT"
+          # TEMPORARY: push events on the iteration branch always rebuild so
+          # script/workflow changes can actually be tested. Remove together
+          # with the `push:` trigger before merging.
           if [[ "$FORCE_REBUILD" == "true" ]]; then
             echo "rebuild=true (force)" && echo "rebuild=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            echo "rebuild=true (push on iteration branch)"
+            echo "rebuild=true" >> "$GITHUB_OUTPUT"
           elif [[ "$last" == "$UPSTREAM_DIGEST" ]]; then
             echo "rebuild=false (up-to-date)"
             echo "rebuild=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -112,6 +112,41 @@ jobs:
           podman --version
           skopeo --version
 
+      - name: Check required secrets
+        if: steps.filter.outputs.skip != 'true'
+        # Unset repo secrets expand to empty strings, which makes the first
+        # `podman login` fail with a cryptic `Error: Must provide --username
+        # with --password-stdin` (exit 125). Fail early with a clear list
+        # instead so the cause is obvious when running on a fork without
+        # the full secret set configured.
+        env:
+          REDHAT_REGISTRY_USER: ${{ secrets.REDHAT_REGISTRY_USER }}
+          REDHAT_REGISTRY_TOKEN: ${{ secrets.REDHAT_REGISTRY_TOKEN }}
+          QUAY_RHACS_ENG_ROBOT_USER: ${{ secrets.QUAY_RHACS_ENG_ROBOT_USER }}
+          QUAY_RHACS_ENG_ROBOT_TOKEN: ${{ secrets.QUAY_RHACS_ENG_ROBOT_TOKEN }}
+          RHEL_ACTIVATION_ORG: ${{ secrets.RHEL_ACTIVATION_ORG }}
+          RHEL_ACTIVATION_KEY: ${{ secrets.RHEL_ACTIVATION_KEY }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+              REDHAT_REGISTRY_USER REDHAT_REGISTRY_TOKEN \
+              QUAY_RHACS_ENG_ROBOT_USER QUAY_RHACS_ENG_ROBOT_TOKEN \
+              RHEL_ACTIVATION_ORG RHEL_ACTIVATION_KEY; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if ((${#missing[@]})); then
+            echo "::error::Missing required repository secrets: ${missing[*]}"
+            echo "Configure them with:"
+            for name in "${missing[@]}"; do
+              echo "  gh secret set $name --repo \$REPO --body '…'"
+            done
+            exit 1
+          fi
+          echo "All required secrets are present."
+
       - name: Log in to registry.redhat.io
         if: steps.filter.outputs.skip != 'true'
         env:

--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -143,25 +143,17 @@ jobs:
             # "PID file open: Permission denied" and `passt exited with
             # status 1`. Unload the profile (keep AppArmor on for everything
             # else).
-            # Unload AppArmor profiles that would otherwise block passt
-            # and qemu. passt: writes --pid under /run/user/*/libguestfs*/
-            # which its profile doesn't permit. qemu-system-x86_64: can't
-            # read disk images out of /tmp under the distro profile used
-            # by libvirt. libguestfs's `direct` backend invokes both from
-            # our runner user, so both profiles must be unloaded. We
-            # leave AppArmor on for everything else.
-            for profile in \
-                /etc/apparmor.d/usr.bin.passt \
-                /etc/apparmor.d/passt \
-                /etc/apparmor.d/usr.sbin.libvirtd \
-                /etc/apparmor.d/libvirt-* \
-                /etc/apparmor.d/usr.bin.qemu-system-x86_64; do
-              for p in $profile; do
-                [[ -f "$p" ]] || continue
-                sudo apparmor_parser -R "$p" 2>/dev/null || true
-                sudo ln -sf "$p" /etc/apparmor.d/disable/ || true
-              done
-            done
+            # libguestfs's `direct` backend launches passt + qemu as the
+            # runner user. On Ubuntu 24.04 that hits AppArmor profiles
+            # shipped with passt/qemu that refuse to write --pid files or
+            # read disk images out of /tmp. This is a throwaway CI
+            # runner, so teardown AppArmor entirely rather than play
+            # whack-a-profile.
+            sudo systemctl disable --now apparmor.service 2>/dev/null || true
+            sudo aa-teardown 2>/dev/null || true
+            sudo apparmor_parser -R /etc/apparmor.d/* 2>/dev/null || true
+            echo "==> AppArmor status after teardown:"
+            sudo aa-status || true
             ls -l /dev/kvm
           fi
 

--- a/.github/workflows/build-vm-images.yaml
+++ b/.github/workflows/build-vm-images.yaml
@@ -117,6 +117,25 @@ jobs:
           podman --version
           skopeo --version
 
+          if [[ "$SCRIPT_VARIANT" == "virt-customize" ]]; then
+            # libguestfs on Ubuntu 24.04 hosted runners needs a few
+            # workarounds to boot the qemu appliance:
+            #  - /dev/kvm is 0660 root:kvm and runner isn't in kvm group;
+            #    without read/write access libguestfs warns and falls back
+            #    to TCG (super slow).
+            #  - libguestfs reads /boot/vmlinuz-* to build the appliance,
+            #    but Ubuntu 24.04 ships these as 0600.
+            #  - The `passt` user-mode networking backend that libguestfs
+            #    launches requires unprivileged user namespaces, which
+            #    AppArmor restricts by default on Ubuntu 24.04. Without
+            #    this the appliance fails with
+            #    `libguestfs error: passt exited with status 1`.
+            sudo chmod 0666 /dev/kvm || true
+            sudo chmod 0644 /boot/vmlinuz-* || true
+            echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns >/dev/null || true
+            ls -l /dev/kvm
+          fi
+
       - name: Check required secrets
         if: steps.filter.outputs.skip != 'true'
         # Unset repo secrets expand to empty strings, which makes the first

--- a/vm-image-chroot.sh
+++ b/vm-image-chroot.sh
@@ -75,7 +75,10 @@ REGISTER_ARGS="--org=$RHEL_ACTIVATION_ORG --activationkey=$RHEL_ACTIVATION_KEY"
 # --- Step 1: Extract qcow2 from ContainerDisk image ---
 PLATFORM="${PLATFORM:-linux/amd64}"
 echo "==> Extracting qcow2 from container image (platform=$PLATFORM)..."
-CID=$(podman create --platform "$PLATFORM" "$SRC_IMAGE")
+# Pass a placeholder command: ContainerDisk images carry no CMD/ENTRYPOINT,
+# and `podman create` refuses without one even though we never start the
+# container (we only `podman cp` out of it).
+CID=$(podman create --platform "$PLATFORM" "$SRC_IMAGE" true)
 podman cp "$CID:/disk/." "$WORKDIR/"
 podman rm "$CID"
 DISK_NAME="$(basename "$(find "$WORKDIR" -maxdepth 1 -type f \( -name '*.qcow2' -o -name '*.img' \) | head -1)")"

--- a/vm-image-chroot.sh
+++ b/vm-image-chroot.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# Build a customized RHEL ContainerDisk image for KubeVirt VM scanning tests.
+#
+# APPROACH: privileged UBI9 container + qemu-img + losetup + chroot.
+# Extracts a qcow2 from the source ContainerDisk, spins up a privileged
+# container, converts qcow2→raw, attaches a loop device, mounts and chroots
+# into the guest rootfs, `dnf install`s extra packages, then converts back
+# to qcow2 and repackages as a ContainerDisk.
+#
+# See vm-image-virt-customize.sh for the alternative libguestfs-based
+# approach (simpler, but depends on KVM and libguestfs-tools). The two
+# scripts are side-by-side for evaluation; one will be kept.
+#
+# Required env vars:
+#   RHEL_ACTIVATION_ORG   - Red Hat subscription org ID
+#   RHEL_ACTIVATION_KEY   - Red Hat activation key
+#   TARGET_REGISTRY       - Container registry to push the image to
+#   TARGET_TAG            - Image tag (e.g. vm-images/rhel9-custom:latest)
+#
+# Optional env vars:
+#   SRC_IMAGE               - Source ContainerDisk image (default: RHEL 9 guest)
+#   SOURCE_DIGEST           - Upstream source-image digest to record as an OCI
+#                             annotation on the built image. Used by CI to
+#                             detect when the upstream image has changed.
+#                             Defaults to the @sha256:... suffix of SRC_IMAGE
+#                             when present.
+#   RHEL_ACTIVATION_ENDPOINT - Custom subscription server URL
+#   PLATFORM                - Target platform (default: linux/amd64)
+#
+# Requires a Linux host with a running `podman` that can launch privileged
+# containers directly (e.g. GitHub Actions `ubuntu-latest` runners or a Linux
+# developer workstation). macOS podman-machine setups are not supported by
+# this version of the script.
+#
+# Example:
+#   RHEL_ACTIVATION_ORG=12345 \
+#   RHEL_ACTIVATION_KEY=my-key \
+#   TARGET_REGISTRY=quay.io/my-org \
+#   TARGET_TAG=vm-images/rhel9-custom:latest \
+#     ./vm-image-chroot.sh
+#
+set -euo pipefail
+
+RHEL_ACTIVATION_ORG="${RHEL_ACTIVATION_ORG:?}"
+RHEL_ACTIVATION_KEY="${RHEL_ACTIVATION_KEY:?}"
+RHEL_ACTIVATION_ENDPOINT="${RHEL_ACTIVATION_ENDPOINT:-}"
+TARGET_REGISTRY="${TARGET_REGISTRY:?}"
+
+# SRC_IMAGE: override via env, or default to RHEL 9 guest image.
+# oc get istag -n openshift-virtualization-os-images rhel9-guest:latest -o jsonpath='{.image.dockerImageReference}'
+SRC_IMAGE="${SRC_IMAGE:-registry.redhat.io/rhel9/rhel-guest-image@sha256:ab4ec16077fe00e3c7efd0b2f6a77571f3645f5c95befc4d917757dc88b2f423}"
+TARGET_TAG="${TARGET_TAG:?}"
+
+# Derive source digest from SRC_IMAGE when not explicitly provided. This lets
+# the CI workflow record the upstream digest on the built image and later
+# detect when upstream has changed without rebuilding.
+if [[ -z "${SOURCE_DIGEST:-}" && "$SRC_IMAGE" == *"@sha256:"* ]]; then
+  SOURCE_DIGEST="${SRC_IMAGE##*@}"
+fi
+SOURCE_DIGEST="${SOURCE_DIGEST:-}"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "vm-image-chroot.sh only supports Linux hosts (detected $(uname -s))." >&2
+  echo "Run this script from a Linux workstation or the GitHub Actions workflow." >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+REGISTER_ARGS="--org=$RHEL_ACTIVATION_ORG --activationkey=$RHEL_ACTIVATION_KEY"
+[[ -n "$RHEL_ACTIVATION_ENDPOINT" ]] && REGISTER_ARGS+=" --serverurl=$RHEL_ACTIVATION_ENDPOINT"
+
+# --- Step 1: Extract qcow2 from ContainerDisk image ---
+PLATFORM="${PLATFORM:-linux/amd64}"
+echo "==> Extracting qcow2 from container image (platform=$PLATFORM)..."
+CID=$(podman create --platform "$PLATFORM" "$SRC_IMAGE")
+podman cp "$CID:/disk/." "$WORKDIR/"
+podman rm "$CID"
+DISK_NAME="$(basename "$(find "$WORKDIR" -maxdepth 1 -type f \( -name '*.qcow2' -o -name '*.img' \) | head -1)")"
+echo "==> Disk: $DISK_NAME"
+
+# --- Steps 2-4: Convert, customize, convert back (all in one privileged container) ---
+# Everything runs inside a single privileged container so that losetup,
+# qemu-img conversions, and chroot all operate on container-local /tmp storage
+# rather than across a shared bind mount, which is what previously caused
+# virtiofs sync issues and bootloader corruption on macOS podman-machine.
+echo "==> Writing customization script..."
+cat > "$WORKDIR/customize.sh" <<SCRIPT
+#!/bin/bash
+set -euxo pipefail
+
+subscription-manager register $REGISTER_ARGS >/dev/null
+dnf -y -q install qemu-img util-linux
+
+# qcow2 → raw (container-local /tmp, not shared FS)
+qemu-img convert -f qcow2 -O raw '/work/$DISK_NAME' /tmp/disk.raw
+
+# losetup + chroot on local file
+LOOP=\$(losetup --find --show --partscan /tmp/disk.raw)
+echo "Loop device: \$LOOP"
+lsblk "\$LOOP"
+# Create partition device nodes inside the container (kernel knows them via
+# sysfs but udev may not populate /dev inside a privileged container).
+LOOPBASE=\$(basename "\$LOOP")
+for syspart in /sys/class/block/\${LOOPBASE}p*; do
+  [[ -e "\$syspart" ]] || continue
+  PARTNAME=\$(basename "\$syspart")
+  IFS=: read -r MAJ MIN < "\$syspart/dev"
+  [[ -e "/dev/\$PARTNAME" ]] || mknod "/dev/\$PARTNAME" b "\$MAJ" "\$MIN"
+  echo "Created /dev/\$PARTNAME (maj=\$MAJ min=\$MIN)"
+done
+blkid "\${LOOP}"* || true
+ROOT=\$(blkid -o device -t LABEL=root "\${LOOP}"* 2>/dev/null || true)
+if [[ -z "\$ROOT" ]]; then
+  echo "No LABEL=root found; selecting largest partition as root"
+  ROOT=\$(lsblk -lnbpo NAME,SIZE "\$LOOP" | grep -v "^\$LOOP " | sort -k2 -n | tail -1 | awk '{print \$1}')
+fi
+echo "Root partition: \$ROOT"
+
+MNT=/tmp/guest
+mkdir -p "\$MNT"
+mount "\$ROOT" "\$MNT"
+mount --bind /proc "\$MNT/proc"
+mount --bind /sys  "\$MNT/sys"
+mount --bind /dev  "\$MNT/dev"
+cp /etc/resolv.conf "\$MNT/etc/resolv.conf"
+
+if chroot "\$MNT" /bin/true 2>/dev/null; then
+  echo "==> Chroot works, customizing guest directly"
+  chroot "\$MNT" bash -c '
+    subscription-manager register $REGISTER_ARGS &&
+    dnf -y install --setopt=install_weak_deps=False bc &&
+    subscription-manager unregister &&
+    dnf clean all
+  '
+else
+  echo "==> Chroot failed (cross-arch?), falling back to dnf --installroot"
+  GUEST_VER=\$(grep '^VERSION_ID=' "\$MNT/etc/os-release" | cut -d= -f2 | tr -d '"' | cut -d. -f1)
+  GUEST_ARCH=\$(uname -m)
+  [[ "\$GUEST_ARCH" == "aarch64" ]] || GUEST_ARCH="x86_64"
+  echo "==> Guest: RHEL \$GUEST_VER (\$GUEST_ARCH)"
+
+  ENT_CERT=\$(ls /etc/pki/entitlement/*.pem 2>/dev/null | grep -v key | head -1)
+  ENT_KEY=\$(ls /etc/pki/entitlement/*-key.pem 2>/dev/null | head -1)
+  mkdir -p "\$MNT/etc/pki/entitlement" "\$MNT/etc/rhsm/ca"
+  cp "\$ENT_CERT" "\$MNT/etc/pki/entitlement/"
+  cp "\$ENT_KEY" "\$MNT/etc/pki/entitlement/"
+  cp /etc/rhsm/ca/redhat-uep.pem "\$MNT/etc/rhsm/ca/"
+
+  cat > "\$MNT/etc/yum.repos.d/rhel-baseos-cdn.repo" <<REPOEOF
+[rhel-\${GUEST_VER}-for-\${GUEST_ARCH}-baseos-rpms]
+name=Red Hat Enterprise Linux \${GUEST_VER} for \${GUEST_ARCH} - BaseOS (RPMs)
+baseurl=https://cdn.redhat.com/content/dist/rhel\${GUEST_VER}/\${GUEST_VER}/\${GUEST_ARCH}/baseos/os
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+sslverify=1
+sslcacert=/etc/rhsm/ca/redhat-uep.pem
+sslclientcert=/etc/pki/entitlement/\$(basename "\$ENT_CERT")
+sslclientkey=/etc/pki/entitlement/\$(basename "\$ENT_KEY")
+REPOEOF
+
+  dnf -y --installroot="\$MNT" --releasever="\$GUEST_VER" \
+    --setopt=install_weak_deps=False install bc
+
+  rm -f "\$MNT/etc/yum.repos.d/rhel-baseos-cdn.repo"
+  rm -rf "\$MNT/etc/pki/entitlement" "\$MNT/etc/rhsm/ca"
+  dnf --installroot="\$MNT" clean all 2>/dev/null || true
+fi
+
+umount "\$MNT/proc" "\$MNT/sys" "\$MNT/dev"
+umount "\$MNT"
+sync
+losetup -d "\$LOOP"
+
+# raw → qcow2 compressed, write result back to shared volume
+rm -f '/work/$DISK_NAME'
+qemu-img convert -f raw -O qcow2 -c /tmp/disk.raw '/work/$DISK_NAME'
+sync
+qemu-img info '/work/$DISK_NAME'
+echo "==> Customization complete"
+SCRIPT
+chmod +x "$WORKDIR/customize.sh"
+
+echo "==> Running customization in privileged container..."
+podman run --rm --privileged --platform "$PLATFORM" \
+  -v "$WORKDIR:/work" \
+  registry.access.redhat.com/ubi9/ubi:latest /work/customize.sh
+
+# --- Step 5: Build and push ContainerDisk image ---
+echo "==> Building and pushing container image..."
+cat > "$WORKDIR/Containerfile" <<'EOF'
+FROM scratch
+COPY *.qcow2 *.img /disk/
+EOF
+
+BUILD_ARGS=(build --platform "$PLATFORM" -t "$TARGET_REGISTRY/$TARGET_TAG")
+if [[ -n "$SOURCE_DIGEST" ]]; then
+  # Record the upstream source digest as an OCI annotation so the CI workflow
+  # can later `skopeo inspect` the published image and skip rebuilds when the
+  # upstream image has not changed.
+  BUILD_ARGS+=(--annotation "org.opencontainers.image.source-digest=$SOURCE_DIGEST")
+  BUILD_ARGS+=(--label "org.opencontainers.image.source-digest=$SOURCE_DIGEST")
+fi
+BUILD_ARGS+=("$WORKDIR")
+
+podman "${BUILD_ARGS[@]}"
+podman push "$TARGET_REGISTRY/$TARGET_TAG"
+echo "==> Done: $TARGET_REGISTRY/$TARGET_TAG (source-digest=${SOURCE_DIGEST:-<none>})"

--- a/vm-image-virt-customize.sh
+++ b/vm-image-virt-customize.sh
@@ -122,12 +122,20 @@ echo "==> Running virt-customize (installing: $EXTRA_PACKAGES)..."
 # TEMPORARY: -v -x + LIBGUESTFS_DEBUG/TRACE until the appliance launches
 # cleanly in CI. Strip once the Ubuntu 24.04 runner is fully sorted.
 export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
+# The appliance gets network via passt, and passt forwards DNS through
+# the host's resolver. On Azure hosted runners the host's
+# /etc/resolv.conf points to 127.0.0.53 (systemd-resolved on loopback),
+# which the guest cannot reach, so subscription-manager fails with
+# "Name or service not known". Force a public resolver inside the
+# guest before anything that needs DNS.
 # shellcheck disable=SC2086 # EXTRA_PACKAGES is intentionally word-split.
 virt-customize -v -x -a "$DISK_PATH" \
+  --run-command 'printf "nameserver 8.8.8.8\nnameserver 1.1.1.1\n" > /etc/resolv.conf' \
   --run-command "$REGISTER_CMD" \
   --install "$(echo "$EXTRA_PACKAGES" | tr ' ' ',')" \
   --run-command 'subscription-manager unregister' \
   --run-command 'dnf clean all' \
+  --run-command ': > /etc/resolv.conf' \
   --selinux-relabel
 
 # --- Step 3: Compact the image ---

--- a/vm-image-virt-customize.sh
+++ b/vm-image-virt-customize.sh
@@ -89,7 +89,10 @@ trap 'rm -rf "$WORKDIR"' EXIT
 
 # --- Step 1: Extract qcow2 from ContainerDisk image ---
 echo "==> Extracting qcow2 from container image (platform=$PLATFORM)..."
-CID=$(podman create --platform "$PLATFORM" "$SRC_IMAGE")
+# Pass a placeholder command: ContainerDisk images carry no CMD/ENTRYPOINT,
+# and `podman create` refuses without one even though we never start the
+# container (we only `podman cp` out of it).
+CID=$(podman create --platform "$PLATFORM" "$SRC_IMAGE" true)
 podman cp "$CID:/disk/." "$WORKDIR/"
 podman rm "$CID"
 DISK_NAME="$(basename "$(find "$WORKDIR" -maxdepth 1 -type f \( -name '*.qcow2' -o -name '*.img' \) | head -1)")"

--- a/vm-image-virt-customize.sh
+++ b/vm-image-virt-customize.sh
@@ -84,7 +84,13 @@ if [[ ! -e /dev/kvm ]]; then
   echo "acceleration and take several minutes." >&2
 fi
 
-WORKDIR="$(mktemp -d)"
+# Place the workdir under /var/tmp with mode 0755 so qemu (launched by
+# libguestfs, potentially under a different uid/namespace view of /tmp)
+# can read the disk image. `mktemp -d` defaults to 0700 which on
+# ubuntu-latest runners causes qemu to fail with
+# "Could not open '/tmp/.../*.qcow2': Permission denied".
+WORKDIR="$(mktemp -d -p /var/tmp vm-image.XXXXXXXX)"
+chmod 0755 "$WORKDIR"
 trap 'rm -rf "$WORKDIR"' EXIT
 
 # --- Step 1: Extract qcow2 from ContainerDisk image ---
@@ -95,9 +101,15 @@ echo "==> Extracting qcow2 from container image (platform=$PLATFORM)..."
 CID=$(podman create --platform "$PLATFORM" "$SRC_IMAGE" true)
 podman cp "$CID:/disk/." "$WORKDIR/"
 podman rm "$CID"
+# `podman cp` from rootless podman preserves the container's file uid via
+# userns mapping, so files can end up owned by an unmapped namespaced
+# uid the runner user cannot read. Force ownership back to us.
+sudo chown -R "$(id -u):$(id -g)" "$WORKDIR"
 DISK_NAME="$(basename "$(find "$WORKDIR" -maxdepth 1 -type f \( -name '*.qcow2' -o -name '*.img' \) | head -1)")"
 DISK_PATH="$WORKDIR/$DISK_NAME"
+chmod 0644 "$DISK_PATH"
 echo "==> Disk: $DISK_NAME"
+ls -la "$WORKDIR"
 
 # --- Step 2: Customize with virt-customize ---
 # Activation keys aren't a first-class selector for --sm-credentials, so

--- a/vm-image-virt-customize.sh
+++ b/vm-image-virt-customize.sh
@@ -107,8 +107,11 @@ REGISTER_CMD="subscription-manager register --org=$RHEL_ACTIVATION_ORG --activat
 [[ -n "$RHEL_ACTIVATION_ENDPOINT" ]] && REGISTER_CMD+=" --serverurl=$RHEL_ACTIVATION_ENDPOINT"
 
 echo "==> Running virt-customize (installing: $EXTRA_PACKAGES)..."
+# TEMPORARY: -v -x + LIBGUESTFS_DEBUG/TRACE until the appliance launches
+# cleanly in CI. Strip once the Ubuntu 24.04 runner is fully sorted.
+export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
 # shellcheck disable=SC2086 # EXTRA_PACKAGES is intentionally word-split.
-virt-customize -a "$DISK_PATH" \
+virt-customize -v -x -a "$DISK_PATH" \
   --run-command "$REGISTER_CMD" \
   --install "$(echo "$EXTRA_PACKAGES" | tr ' ' ',')" \
   --run-command 'subscription-manager unregister' \

--- a/vm-image-virt-customize.sh
+++ b/vm-image-virt-customize.sh
@@ -130,7 +130,8 @@ export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
 # guest before anything that needs DNS.
 # shellcheck disable=SC2086 # EXTRA_PACKAGES is intentionally word-split.
 virt-customize -v -x -a "$DISK_PATH" \
-  --run-command 'printf "nameserver 8.8.8.8\nnameserver 1.1.1.1\n" > /etc/resolv.conf' \
+  --run-command 'printf "nameserver 169.254.2.2\nnameserver 8.8.8.8\nnameserver 1.1.1.1\n" > /etc/resolv.conf' \
+  --run-command 'echo === NETDIAG ===; ip addr show || true; ip route show || true; cat /etc/resolv.conf; echo --- dig 169.254.2.2 ---; timeout 5 getent hosts subscription.rhsm.redhat.com || echo getent-passt-FAIL; echo --- dig 8.8.8.8 ---; timeout 5 nslookup subscription.rhsm.redhat.com 8.8.8.8 2>&1 || echo nslookup-8888-FAIL; echo --- tcp connect ---; timeout 5 bash -c "exec 3<>/dev/tcp/169.254.2.2/53 && echo tcp-passt-53-OK" || echo tcp-passt-53-FAIL; timeout 5 bash -c "exec 3<>/dev/tcp/8.8.8.8/53 && echo tcp-8888-53-OK" || echo tcp-8888-53-FAIL; echo === END ===' \
   --run-command "$REGISTER_CMD" \
   --install "$(echo "$EXTRA_PACKAGES" | tr ' ' ',')" \
   --run-command 'subscription-manager unregister' \

--- a/vm-image-virt-customize.sh
+++ b/vm-image-virt-customize.sh
@@ -119,8 +119,9 @@ REGISTER_CMD="subscription-manager register --org=$RHEL_ACTIVATION_ORG --activat
 [[ -n "$RHEL_ACTIVATION_ENDPOINT" ]] && REGISTER_CMD+=" --serverurl=$RHEL_ACTIVATION_ENDPOINT"
 
 echo "==> Running virt-customize (installing: $EXTRA_PACKAGES)..."
-# TEMPORARY: -v -x + LIBGUESTFS_DEBUG/TRACE until the appliance launches
-# cleanly in CI. Strip once the Ubuntu 24.04 runner is fully sorted.
+# TODO(ROX-34170): Remove -v -x and LIBGUESTFS_DEBUG/TRACE once the
+# workflow is stable on ubuntu-latest. Kept for now to ease debugging
+# appliance boot / networking issues.
 export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
 # The appliance gets network via passt, and passt forwards DNS through
 # the host's resolver. On Azure hosted runners the host's
@@ -129,9 +130,11 @@ export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
 # "Name or service not known". Force a public resolver inside the
 # guest before anything that needs DNS.
 # shellcheck disable=SC2086 # EXTRA_PACKAGES is intentionally word-split.
+# TODO(ROX-34170): Remove -v -x flags and the NETDIAG --run-command once
+# the workflow is stable.
 virt-customize -v -x -a "$DISK_PATH" \
   --run-command 'printf "nameserver 169.254.2.2\nnameserver 8.8.8.8\nnameserver 1.1.1.1\n" > /etc/resolv.conf' \
-  --run-command 'echo === NETDIAG ===; ip addr show || true; ip route show || true; cat /etc/resolv.conf; echo --- dig 169.254.2.2 ---; timeout 5 getent hosts subscription.rhsm.redhat.com || echo getent-passt-FAIL; echo --- dig 8.8.8.8 ---; timeout 5 nslookup subscription.rhsm.redhat.com 8.8.8.8 2>&1 || echo nslookup-8888-FAIL; echo --- tcp connect ---; timeout 5 bash -c "exec 3<>/dev/tcp/169.254.2.2/53 && echo tcp-passt-53-OK" || echo tcp-passt-53-FAIL; timeout 5 bash -c "exec 3<>/dev/tcp/8.8.8.8/53 && echo tcp-8888-53-OK" || echo tcp-8888-53-FAIL; echo === END ===' \
+  --run-command 'echo === NETDIAG ===; ip addr show || true; ip route show || true; cat /etc/resolv.conf; echo === END ===' \
   --run-command "$REGISTER_CMD" \
   --install "$(echo "$EXTRA_PACKAGES" | tr ' ' ',')" \
   --run-command 'subscription-manager unregister' \

--- a/vm-image-virt-customize.sh
+++ b/vm-image-virt-customize.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Build a customized RHEL ContainerDisk image for KubeVirt VM scanning tests.
+#
+# APPROACH: libguestfs (`virt-customize`).
+# Extracts a qcow2 from the source ContainerDisk, then runs `virt-customize`
+# which boots a tiny qemu appliance, executes commands inside the guest's
+# own package manager, and writes the result back. No privileged container,
+# no losetup, no chroot — libguestfs handles mount/unmount/selinux-relabel.
+#
+# Depends on libguestfs-tools (virt-customize) + qemu-utils + podman.
+# Works unaccelerated but wants /dev/kvm for tolerable speed. GitHub Actions
+# `ubuntu-latest` runners expose /dev/kvm.
+#
+# See vm-image-chroot.sh for the alternative approach (privileged container
+# with losetup+chroot). The two scripts are side-by-side for evaluation;
+# one will be kept.
+#
+# Required env vars:
+#   RHEL_ACTIVATION_ORG   - Red Hat subscription org ID
+#   RHEL_ACTIVATION_KEY   - Red Hat activation key
+#   TARGET_REGISTRY       - Container registry to push the image to
+#   TARGET_TAG            - Image tag (e.g. vm-images/rhel9-custom:latest)
+#
+# Optional env vars:
+#   SRC_IMAGE               - Source ContainerDisk image (default: RHEL 9 guest)
+#   SOURCE_DIGEST           - Upstream source-image digest to record as an OCI
+#                             annotation on the built image. Used by CI to
+#                             detect when the upstream image has changed.
+#                             Defaults to the @sha256:... suffix of SRC_IMAGE
+#                             when present.
+#   RHEL_ACTIVATION_ENDPOINT - Custom subscription server URL
+#   PLATFORM                - Target platform (default: linux/amd64)
+#   EXTRA_PACKAGES          - Space-separated list of extra packages to install
+#                             (default: "bc")
+#
+# Requires a Linux host with `podman`, `qemu-img`, and `virt-customize`
+# available on $PATH. Apple Silicon / macOS hosts are not supported.
+#
+# Example:
+#   RHEL_ACTIVATION_ORG=12345 \
+#   RHEL_ACTIVATION_KEY=my-key \
+#   TARGET_REGISTRY=quay.io/my-org \
+#   TARGET_TAG=vm-images/rhel9-custom:latest \
+#     ./vm-image-virt-customize.sh
+#
+set -euo pipefail
+
+RHEL_ACTIVATION_ORG="${RHEL_ACTIVATION_ORG:?}"
+RHEL_ACTIVATION_KEY="${RHEL_ACTIVATION_KEY:?}"
+RHEL_ACTIVATION_ENDPOINT="${RHEL_ACTIVATION_ENDPOINT:-}"
+TARGET_REGISTRY="${TARGET_REGISTRY:?}"
+
+SRC_IMAGE="${SRC_IMAGE:-registry.redhat.io/rhel9/rhel-guest-image@sha256:ab4ec16077fe00e3c7efd0b2f6a77571f3645f5c95befc4d917757dc88b2f423}"
+TARGET_TAG="${TARGET_TAG:?}"
+PLATFORM="${PLATFORM:-linux/amd64}"
+EXTRA_PACKAGES="${EXTRA_PACKAGES:-bc}"
+
+if [[ -z "${SOURCE_DIGEST:-}" && "$SRC_IMAGE" == *"@sha256:"* ]]; then
+  SOURCE_DIGEST="${SRC_IMAGE##*@}"
+fi
+SOURCE_DIGEST="${SOURCE_DIGEST:-}"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "vm-image-virt-customize.sh only supports Linux hosts (detected $(uname -s))." >&2
+  exit 1
+fi
+
+for tool in podman qemu-img virt-customize; do
+  command -v "$tool" >/dev/null || {
+    echo "Missing required tool: $tool" >&2
+    echo "Install with: sudo apt-get install -y podman qemu-utils libguestfs-tools" >&2
+    exit 1
+  }
+done
+
+# libguestfs needs a world-readable kernel on some distros to build its
+# appliance. `ubuntu-latest` runners have this correctly set already; the
+# chmod below is a no-op there and a one-liner fix on restrictive hosts.
+sudo chmod 0644 /boot/vmlinuz-* 2>/dev/null || true
+
+if [[ ! -e /dev/kvm ]]; then
+  echo "WARNING: /dev/kvm not present — virt-customize will run without" >&2
+  echo "acceleration and take several minutes." >&2
+fi
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# --- Step 1: Extract qcow2 from ContainerDisk image ---
+echo "==> Extracting qcow2 from container image (platform=$PLATFORM)..."
+CID=$(podman create --platform "$PLATFORM" "$SRC_IMAGE")
+podman cp "$CID:/disk/." "$WORKDIR/"
+podman rm "$CID"
+DISK_NAME="$(basename "$(find "$WORKDIR" -maxdepth 1 -type f \( -name '*.qcow2' -o -name '*.img' \) | head -1)")"
+DISK_PATH="$WORKDIR/$DISK_NAME"
+echo "==> Disk: $DISK_NAME"
+
+# --- Step 2: Customize with virt-customize ---
+# Activation keys aren't a first-class selector for --sm-credentials, so
+# register/unregister via --run-command which accepts the same CLI flags
+# that `subscription-manager` takes inside the guest.
+REGISTER_CMD="subscription-manager register --org=$RHEL_ACTIVATION_ORG --activationkey=$RHEL_ACTIVATION_KEY"
+[[ -n "$RHEL_ACTIVATION_ENDPOINT" ]] && REGISTER_CMD+=" --serverurl=$RHEL_ACTIVATION_ENDPOINT"
+
+echo "==> Running virt-customize (installing: $EXTRA_PACKAGES)..."
+# shellcheck disable=SC2086 # EXTRA_PACKAGES is intentionally word-split.
+virt-customize -a "$DISK_PATH" \
+  --run-command "$REGISTER_CMD" \
+  --install "$(echo "$EXTRA_PACKAGES" | tr ' ' ',')" \
+  --run-command 'subscription-manager unregister' \
+  --run-command 'dnf clean all' \
+  --selinux-relabel
+
+# --- Step 3: Compact the image ---
+# virt-customize doesn't compress the qcow2; re-convert with -c to keep the
+# ContainerDisk layer small.
+echo "==> Compacting qcow2..."
+qemu-img convert -f qcow2 -O qcow2 -c "$DISK_PATH" "$DISK_PATH.compact"
+mv "$DISK_PATH.compact" "$DISK_PATH"
+qemu-img info "$DISK_PATH"
+
+# --- Step 4: Build and push ContainerDisk image ---
+echo "==> Building and pushing container image..."
+cat > "$WORKDIR/Containerfile" <<'EOF'
+FROM scratch
+COPY *.qcow2 *.img /disk/
+EOF
+
+BUILD_ARGS=(build --platform "$PLATFORM" -t "$TARGET_REGISTRY/$TARGET_TAG")
+if [[ -n "$SOURCE_DIGEST" ]]; then
+  BUILD_ARGS+=(--annotation "org.opencontainers.image.source-digest=$SOURCE_DIGEST")
+  BUILD_ARGS+=(--label "org.opencontainers.image.source-digest=$SOURCE_DIGEST")
+fi
+BUILD_ARGS+=("$WORKDIR")
+
+podman "${BUILD_ARGS[@]}"
+podman push "$TARGET_REGISTRY/$TARGET_TAG"
+echo "==> Done: $TARGET_REGISTRY/$TARGET_TAG (source-digest=${SOURCE_DIGEST:-<none>})"


### PR DESCRIPTION
## Required secrets

1. `REDHAT_REGISTRY_USER` & `REDHAT_REGISTRY_TOKEN`  to pull the original RHEL VM image
2. `QUAY_RHACS_ENG_ROBOT_USER` & `QUAY_RHACS_ENG_ROBOT_TOKEN` to push the built image to the repo
3. `RHEL_ACTIVATION_ORG` & `RHEL_ACTIVATION_KEY` to activate RHEL OS.

## Description

Standalone workflow that periodically checks the upstream RHEL guest-image
digest and rebuilds the dnf-primed ContainerDisk images consumed by the VM
scanning E2E tests. Weekly cron + workflow_dispatch (with force_rebuild and
matrix_filter). Skips the build when upstream hasn't changed, via an OCI
source-digest annotation on the last-built image.

Two build-script variants live side-by-side for A/B evaluation; one will be
kept once we see real runs:
- vm-image-chroot.sh (renamed from vm-image.sh, Linux-only): privileged
  UBI9 container + losetup + chroot + dnf install. The cross-arch fallback
  and mknod-on-loop-parts dance are kept since the guest images can be
  aarch64.
- vm-image-virt-customize.sh (new): libguestfs virt-customize appliance.
  No privileged container, no loop devices, no chroot; relies on /dev/kvm
  on the runner for acceptable speed.
The workflow's script_variant input picks between them and conditionally
installs libguestfs-tools + qemu-utils for the virt-customize path.

Target registry is temporarily quay.io/prygiels so we can iterate without
waiting on rhacs-eng repo provisioning; flip target flip is a one-line
change. CI-consumer wiring (pull secret, job env, ocp_vm_scanning_e2e_tests)
stays on the VM4VM branch and is intentionally out of scope here so this
branch can land independently.

Prompt: "Build a standalone GH Action to automate VM scanning image builds
with digest-change detection. Provide two script variants (chroot and
virt-customize) and let me pick one later."

Scripts and workflow authored with AI assistance; scope, approach
selection, Linux-only decision, temporary registry target, and final
review done by the author.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Ran it on my fork https://github.com/vikin91/stackrox/pull/1 and used the images in the e2e test from https://github.com/stackrox/stackrox/pull/20042 while running it locally.
