### PR TITLE
fix(ui): Apply feature flag filtering to search configs

### DIFF
--- a/ui/apps/platform/src/ConsolePlugin/CveDetailPage/CveDetailPage.tsx
+++ b/ui/apps/platform/src/ConsolePlugin/CveDetailPage/CveDetailPage.tsx
@@ -2,6 +2,7 @@ import { NamespaceBar, useActiveNamespace } from '@openshift-console/dynamic-plu
 
 import useURLSearch from 'hooks/useURLSearch';
 import { hideColumnIf } from 'hooks/useManagedColumns';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import { ALL_NAMESPACES_KEY } from 'ConsolePlugin/constants';
 import { useDefaultWorkloadCveViewContext } from 'ConsolePlugin/hooks/useDefaultWorkloadCveViewContext';
 import { WorkloadCveViewContext } from 'Containers/Vulnerabilities/WorkloadCves/WorkloadCveViewContext';
@@ -11,6 +12,7 @@ import {
     imageSearchFilterConfig,
     namespaceSearchFilterConfig,
 } from 'Containers/Vulnerabilities/searchFilterConfig';
+import { getSearchFilterConfigWithFeatureFlagDependency } from 'Components/CompoundSearchFilter/utils/utils';
 import ImageCvePage from 'Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage';
 import { useAnalyticsPageView } from '../hooks/useAnalyticsPageView';
 
@@ -20,12 +22,16 @@ export function CveDetailPage() {
     const [activeNamespace] = useActiveNamespace();
     const { searchFilter, setSearchFilter } = useURLSearch();
     const context = useDefaultWorkloadCveViewContext();
-    const searchFilterConfig = [
-        imageSearchFilterConfig,
-        imageComponentSearchFilterConfig,
-        deploymentSearchFilterConfig,
-        ...(activeNamespace === ALL_NAMESPACES_KEY ? [namespaceSearchFilterConfig] : []),
-    ];
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const searchFilterConfig = getSearchFilterConfigWithFeatureFlagDependency(
+        isFeatureFlagEnabled,
+        [
+            imageSearchFilterConfig,
+            imageComponentSearchFilterConfig,
+            deploymentSearchFilterConfig,
+            ...(activeNamespace === ALL_NAMESPACES_KEY ? [namespaceSearchFilterConfig] : []),
+        ]
+    );
 
     return (
         <WorkloadCveViewContext.Provider value={context}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageRoute.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePageRoute.tsx
@@ -1,5 +1,6 @@
 import { hideColumnIf } from 'hooks/useManagedColumns';
 import useIsScannerV4Enabled from 'hooks/useIsScannerV4Enabled';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 
 import {
     clusterSearchFilterConfig,
@@ -8,17 +9,22 @@ import {
     imageSearchFilterConfig,
     namespaceSearchFilterConfig,
 } from '../../searchFilterConfig';
+import { getSearchFilterConfigWithFeatureFlagDependency } from 'Components/CompoundSearchFilter/utils/utils';
 import ImageCvePage from './ImageCvePage';
 import useVulnerabilityState from '../hooks/useVulnerabilityState';
 
 function ImageCvePageRoute() {
-    const searchFilterConfig = [
-        clusterSearchFilterConfig,
-        deploymentSearchFilterConfig,
-        imageSearchFilterConfig,
-        imageComponentSearchFilterConfig,
-        namespaceSearchFilterConfig,
-    ];
+    const { isFeatureFlagEnabled } = useFeatureFlags();
+    const searchFilterConfig = getSearchFilterConfigWithFeatureFlagDependency(
+        isFeatureFlagEnabled,
+        [
+            clusterSearchFilterConfig,
+            deploymentSearchFilterConfig,
+            imageSearchFilterConfig,
+            imageComponentSearchFilterConfig,
+            namespaceSearchFilterConfig,
+        ]
+    );
 
     const vulnerabilityState = useVulnerabilityState();
     const isScannerV4Enabled = useIsScannerV4Enabled();


### PR DESCRIPTION
Apply feature flag filtering to search configurations in ImageCvePageRoute and CveDetailPage to prevent displaying search filters that are gated behind disabled feature flags.