### PR TITLE
ROX-34157: Allow label scopes on audit event policies

### DIFF
--- a/central/policy/service/validator.go
+++ b/central/policy/service/validator.go
@@ -196,7 +196,7 @@ func (s *policyValidator) validateEventSource(policy *storage.Policy) error {
 }
 
 func validateNoLabelsInScopeForAuditEvent(scope *storage.Scope, context string) error {
-	if scope.GetLabel() != nil || (features.LabelBasedPolicyScoping.Enabled() && (scope.GetClusterLabel() != nil || scope.GetNamespaceLabel() != nil)) {
+	if scope.GetLabel() != nil {
 		return errors.Errorf("labels in `%s` section are not permitted for audit log events based policies", context)
 	}
 	return nil

--- a/pkg/scopecomp/scope.go
+++ b/pkg/scopecomp/scope.go
@@ -95,8 +95,8 @@ func CompileScope(scope *storage.Scope, clusterLabelProvider ClusterLabelProvide
 	return cs, nil
 }
 
-// MatchesClusterLabels evaluates cluster label matchers against a deployment's cluster
-func (c *CompiledScope) MatchesClusterLabels(ctx context.Context, deployment *storage.Deployment) bool {
+// MatchesClusterLabels evaluates cluster label matchers against a cluster's labels
+func (c *CompiledScope) MatchesClusterLabels(ctx context.Context, clusterID string) bool {
 	if c.ClusterLabelKey == nil {
 		return true
 	}
@@ -104,16 +104,16 @@ func (c *CompiledScope) MatchesClusterLabels(ctx context.Context, deployment *st
 		log.Error("Cluster label matcher defined but provider is nil - failing closed")
 		return false
 	}
-	clusterLabels, err := c.clusterLabelProvider.GetClusterLabels(ctx, deployment.GetClusterId())
+	clusterLabels, err := c.clusterLabelProvider.GetClusterLabels(ctx, clusterID)
 	if err != nil {
-		log.Errorf("Failed to fetch cluster labels for cluster %s: %v", deployment.GetClusterId(), err)
+		log.Errorf("Failed to fetch cluster labels for cluster %s: %v", clusterID, err)
 		return false
 	}
 	return c.MatchesLabels(c.ClusterLabelKey, c.ClusterLabelValue, clusterLabels)
 }
 
-// MatchesNamespaceLabels evaluates namespace label matchers against a deployment's namespace
-func (c *CompiledScope) MatchesNamespaceLabels(ctx context.Context, deployment *storage.Deployment) bool {
+// MatchesNamespaceLabels evaluates namespace label matchers against a namespace's labels
+func (c *CompiledScope) MatchesNamespaceLabels(ctx context.Context, clusterID string, namespace string) bool {
 	if c.NamespaceLabelKey == nil {
 		return true
 	}
@@ -121,9 +121,9 @@ func (c *CompiledScope) MatchesNamespaceLabels(ctx context.Context, deployment *
 		log.Error("Namespace label matcher defined but provider is nil - failing closed")
 		return false
 	}
-	namespaceLabels, err := c.namespaceLabelProvider.GetNamespaceLabels(ctx, deployment.GetClusterId(), deployment.GetNamespace())
+	namespaceLabels, err := c.namespaceLabelProvider.GetNamespaceLabels(ctx, clusterID, namespace)
 	if err != nil {
-		log.Errorf("Failed to fetch namespace labels for namespace %s in cluster %s: %v", deployment.GetNamespace(), deployment.GetClusterId(), err)
+		log.Errorf("Failed to fetch namespace labels for namespace %s in cluster %s: %v", namespace, clusterID, err)
 		return false
 	}
 	return c.MatchesLabels(c.NamespaceLabelKey, c.NamespaceLabelValue, namespaceLabels)
@@ -137,13 +137,13 @@ func (c *CompiledScope) MatchesDeployment(ctx context.Context, deployment *stora
 	if !c.MatchesCluster(deployment.GetClusterId()) {
 		return false
 	}
-	if !c.MatchesClusterLabels(ctx, deployment) {
+	if !c.MatchesClusterLabels(ctx, deployment.GetClusterId()) {
 		return false
 	}
 	if !c.MatchesNamespace(deployment.GetNamespace()) {
 		return false
 	}
-	if !c.MatchesNamespaceLabels(ctx, deployment) {
+	if !c.MatchesNamespaceLabels(ctx, deployment.GetClusterId(), deployment.GetNamespace()) {
 		return false
 	}
 	if !c.MatchesLabels(c.LabelKey, c.LabelValue, deployment.GetLabels()) {
@@ -188,7 +188,13 @@ func (c *CompiledScope) MatchesAuditEvent(ctx context.Context, auditEvent *stora
 	if !c.MatchesCluster(auditEvent.GetObject().GetClusterId()) {
 		return false
 	}
+	if !c.MatchesClusterLabels(ctx, auditEvent.GetObject().GetClusterId()) {
+		return false
+	}
 	if !c.MatchesNamespace(auditEvent.GetObject().GetNamespace()) {
+		return false
+	}
+	if !c.MatchesNamespaceLabels(ctx, auditEvent.GetObject().GetClusterId(), auditEvent.GetObject().GetNamespace()) {
 		return false
 	}
 	return true

--- a/pkg/scopecomp/scope.go
+++ b/pkg/scopecomp/scope.go
@@ -191,11 +191,16 @@ func (c *CompiledScope) MatchesAuditEvent(ctx context.Context, auditEvent *stora
 	if !c.MatchesClusterLabels(ctx, auditEvent.GetObject().GetClusterId()) {
 		return false
 	}
-	if !c.MatchesNamespace(auditEvent.GetObject().GetNamespace()) {
-		return false
-	}
-	if !c.MatchesNamespaceLabels(ctx, auditEvent.GetObject().GetClusterId(), auditEvent.GetObject().GetNamespace()) {
-		return false
+	// Namespace matching is only applied for namespace-scoped resources.
+	// Cluster-scoped resources (e.g. clusterroles) have an empty namespace
+	// and should not be filtered out by namespace-based matchers.
+	if ns := auditEvent.GetObject().GetNamespace(); ns != "" {
+		if !c.MatchesNamespace(ns) {
+			return false
+		}
+		if !c.MatchesNamespaceLabels(ctx, auditEvent.GetObject().GetClusterId(), ns) {
+			return false
+		}
 	}
 	return true
 }

--- a/pkg/scopecomp/scope_test.go
+++ b/pkg/scopecomp/scope_test.go
@@ -355,3 +355,164 @@ func TestWithinScope(t *testing.T) {
 		assert.Equalf(t, test.result, cs.MatchesDeployment(context.Background(), test.deployment), "Failed test '%s'", test.name)
 	}
 }
+
+func TestMatchesAuditEventWithLabels(t *testing.T) {
+	testutils.MustUpdateFeature(t, features.LabelBasedPolicyScoping, true)
+
+	subtests := map[string]struct {
+		scope           *storage.Scope
+		auditEvent      *storage.KubernetesEvent
+		clusterLabels   map[string]string
+		namespaceLabels map[string]string
+		result          bool
+	}{
+		"cluster label match": {
+			scope: &storage.Scope{
+				ClusterLabel: &storage.Scope_Label{
+					Key:   "env",
+					Value: "prod",
+				},
+			},
+			auditEvent: &storage.KubernetesEvent{
+				Object: &storage.KubernetesEvent_Object{
+					ClusterId: "cluster1",
+					Namespace: "default",
+				},
+			},
+			clusterLabels: map[string]string{"env": "prod"},
+			result:        true,
+		},
+		"cluster label mismatch": {
+			scope: &storage.Scope{
+				ClusterLabel: &storage.Scope_Label{
+					Key:   "env",
+					Value: "prod",
+				},
+			},
+			auditEvent: &storage.KubernetesEvent{
+				Object: &storage.KubernetesEvent_Object{
+					ClusterId: "cluster1",
+					Namespace: "default",
+				},
+			},
+			clusterLabels: map[string]string{"env": "dev"},
+			result:        false,
+		},
+		"namespace label match": {
+			scope: &storage.Scope{
+				NamespaceLabel: &storage.Scope_Label{
+					Key:   "team",
+					Value: "backend",
+				},
+			},
+			auditEvent: &storage.KubernetesEvent{
+				Object: &storage.KubernetesEvent_Object{
+					ClusterId: "cluster1",
+					Namespace: "test-backend",
+				},
+			},
+			namespaceLabels: map[string]string{"team": "backend"},
+			result:          true,
+		},
+		"namespace label mismatch": {
+			scope: &storage.Scope{
+				NamespaceLabel: &storage.Scope_Label{
+					Key:   "team",
+					Value: "backend",
+				},
+			},
+			auditEvent: &storage.KubernetesEvent{
+				Object: &storage.KubernetesEvent_Object{
+					ClusterId: "cluster1",
+					Namespace: "test-frontend",
+				},
+			},
+			namespaceLabels: map[string]string{"team": "frontend"},
+			result:          false,
+		},
+		"combined cluster and namespace label match": {
+			scope: &storage.Scope{
+				ClusterLabel: &storage.Scope_Label{
+					Key:   "env",
+					Value: "prod",
+				},
+				NamespaceLabel: &storage.Scope_Label{
+					Key:   "team",
+					Value: "backend",
+				},
+			},
+			auditEvent: &storage.KubernetesEvent{
+				Object: &storage.KubernetesEvent_Object{
+					ClusterId: "cluster1",
+					Namespace: "test-backend",
+				},
+			},
+			clusterLabels:   map[string]string{"env": "prod"},
+			namespaceLabels: map[string]string{"team": "backend"},
+			result:          true,
+		},
+		"cluster matches but namespace does not": {
+			scope: &storage.Scope{
+				ClusterLabel: &storage.Scope_Label{
+					Key:   "env",
+					Value: "prod",
+				},
+				NamespaceLabel: &storage.Scope_Label{
+					Key:   "team",
+					Value: "backend",
+				},
+			},
+			auditEvent: &storage.KubernetesEvent{
+				Object: &storage.KubernetesEvent_Object{
+					ClusterId: "cluster1",
+					Namespace: "test-frontend",
+				},
+			},
+			clusterLabels:   map[string]string{"env": "prod"},
+			namespaceLabels: map[string]string{"team": "frontend"},
+			result:          false,
+		},
+		"no label scope matches any audit event": {
+			scope: &storage.Scope{
+				Cluster:   "cluster1",
+				Namespace: "default",
+			},
+			auditEvent: &storage.KubernetesEvent{
+				Object: &storage.KubernetesEvent_Object{
+					ClusterId: "cluster1",
+					Namespace: "default",
+				},
+			},
+			result: true,
+		},
+	}
+	for name, test := range subtests {
+		t.Run(name, func(_ *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			var clusterProvider ClusterLabelProvider
+			var namespaceProvider NamespaceLabelProvider
+			if test.clusterLabels != nil {
+				mockCluster := mocks.NewMockClusterLabelProvider(ctrl)
+				mockCluster.EXPECT().
+					GetClusterLabels(gomock.Any(), gomock.Eq(test.auditEvent.GetObject().GetClusterId())).
+					Return(test.clusterLabels, nil).
+					AnyTimes()
+				clusterProvider = mockCluster
+			}
+			if test.namespaceLabels != nil {
+				mockNamespace := mocks.NewMockNamespaceLabelProvider(ctrl)
+				mockNamespace.EXPECT().
+					GetNamespaceLabels(gomock.Any(), gomock.Eq(test.auditEvent.GetObject().GetClusterId()), gomock.Eq(test.auditEvent.GetObject().GetNamespace())).
+					Return(test.namespaceLabels, nil).
+					AnyTimes()
+				namespaceProvider = mockNamespace
+			}
+
+			cs, err := CompileScope(test.scope, clusterProvider, namespaceProvider)
+			require.NoError(t, err)
+			assert.Equalf(t, test.result, cs.MatchesAuditEvent(context.Background(), test.auditEvent), "Failed test '%s'", name)
+		})
+	}
+}

--- a/pkg/scopecomp/scope_test.go
+++ b/pkg/scopecomp/scope_test.go
@@ -485,6 +485,65 @@ func TestMatchesAuditEventWithLabels(t *testing.T) {
 			},
 			result: true,
 		},
+		"cluster-scoped resource with namespace_label scope still fires": {
+			scope: &storage.Scope{
+				NamespaceLabel: &storage.Scope_Label{
+					Key:   "team",
+					Value: "backend",
+				},
+			},
+			auditEvent: &storage.KubernetesEvent{
+				Object: &storage.KubernetesEvent_Object{
+					ClusterId: "cluster1",
+					Namespace: "",
+				},
+			},
+			result: true,
+		},
+		"cluster-scoped resource with namespace scope still fires": {
+			scope: &storage.Scope{
+				Namespace: "some-namespace",
+			},
+			auditEvent: &storage.KubernetesEvent{
+				Object: &storage.KubernetesEvent_Object{
+					ClusterId: "cluster1",
+					Namespace: "",
+				},
+			},
+			result: true,
+		},
+		"cluster-scoped resource with cluster_label scope respects labels": {
+			scope: &storage.Scope{
+				ClusterLabel: &storage.Scope_Label{
+					Key:   "env",
+					Value: "prod",
+				},
+			},
+			auditEvent: &storage.KubernetesEvent{
+				Object: &storage.KubernetesEvent_Object{
+					ClusterId: "cluster1",
+					Namespace: "",
+				},
+			},
+			clusterLabels: map[string]string{"env": "prod"},
+			result:        true,
+		},
+		"cluster-scoped resource with cluster_label mismatch does not fire": {
+			scope: &storage.Scope{
+				ClusterLabel: &storage.Scope_Label{
+					Key:   "env",
+					Value: "prod",
+				},
+			},
+			auditEvent: &storage.KubernetesEvent{
+				Object: &storage.KubernetesEvent_Object{
+					ClusterId: "cluster1",
+					Namespace: "",
+				},
+			},
+			clusterLabels: map[string]string{"env": "dev"},
+			result:        false,
+		},
 	}
 	for name, test := range subtests {
 		t.Run(name, func(_ *testing.T) {


### PR DESCRIPTION
## Description

Fixes a bug where cluster and namespace label scopes were incorrectly rejected on audit log event policies. In https://redhat.atlassian.net/browse/ROX-32149, the `validateNoLabelsInScopeForAuditEvent` guard was extended to reject `cluster_label` and `namespace_label` scopes, modeled after the existing rejection of deployment labels. However, unlike deployment labels, audit events carry cluster ID and namespace information that is sufficient to resolve cluster and namespace labels via providers.

This change removes `cluster_label`/`namespace_label` from the validation rejection (keeping the deployment `label` rejection, since audit events have no deployment context) and wires up MatchesClusterLabels and `MatchesNamespaceLabels` in `MatchesAuditEvent` so that label-based cluster/namespace scoping actually works for audit event policies.

Additionally, `MatchesClusterLabels` and `MatchesNamespaceLabels` signatures are refactored to accept primitive parameters (`clusterID string`, `namespace string`) instead of a full `*storage.Deployment`, making them usable from non-deployment contexts like audit events.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

#### Manual Validation (OCP cluster, image `4.11.x-674-gdd12183441`)

**Setup:** Two namespaces with different labels: `test-backend` (`team=backend`), `test-frontend` (`team=frontend`). `ROX_LABEL_BASED_POLICY_SCOPING=true` on Central and Sensor.

**1. Policy creation with `namespace_label` scope on audit log event policy succeeds:**

```
$ curl -sk -X POST "https://localhost:8000/v1/policies" -u admin:$PASSWORD \
  -H "Content-Type: application/json" -d '{
  "name": "Test - Audit Log Label Scoping",
  "lifecycleStages": ["RUNTIME"],
  "eventSource": "AUDIT_LOG_EVENT",
  "severity": "HIGH_SEVERITY",
  "categories": ["Kubernetes Events"],
  "policySections": [{"sectionName": "Audit Event", "policyGroups": [
    {"fieldName": "Kubernetes Resource", "values": [{"value": "SECRETS"}]},
    {"fieldName": "Kubernetes API Verb", "values": [{"value": "CREATE"}]}
  ]}],
  "scope": [{"namespace_label": {"key": "team", "value": "backend"}}]
}'

{"id":"997b61db-a6df-4fbe-82a8-92e64de0d636","name":"Test - Audit Log Label Scoping",...,"scope":[{"namespaceLabel":{"key":"team","value":"backend"}}],...}
```

Previously this returned `labels in 'scope' section are not permitted for audit log events based policies`.

**2. Namespace label scoping — matching namespace generates alert, non-matching does not:**

```
$ kubectl create secret generic test-secret-1 --from-literal=key=value -n test-backend
$ kubectl create secret generic test-secret-2 --from-literal=key=value -n test-frontend

# After ~90s for audit pipeline (compliance → sensor → central):
$ curl -sk "https://localhost:8000/v1/alerts?query=Policy:Test+-+Audit+Log+Label+Scoping" -u admin:$PASSWORD

{"alerts":[{"id":"861223f1-ce97-431a-9725-31481b2fb371","lifecycleStage":"RUNTIME",
  "policy":{"name":"Test - Audit Log Label Scoping"},
  "commonEntityInfo":{"namespace":"test-backend","resourceType":"SECRETS"},
  "resource":{"name":"test-secret-1"}}]}
```

Alert for `test-secret-1` in `test-backend` (label matches). No alert for `test-secret-2` in `test-frontend` (label doesn't match).

**3. Cluster label scoping — mismatched cluster label produces no alert:**

```
$ kubectl patch securedcluster stackrox-secured-cluster-services -n stackrox --type=merge \
  -p '{"spec":{"clusterLabels":{"env":"prod"}}}'

$ curl -sk -X POST "https://localhost:8000/v1/policies" -u admin:$PASSWORD \
  -H "Content-Type: application/json" -d '{
  "name": "Test - Audit Log Cluster Label Mismatch",
  "lifecycleStages": ["RUNTIME"],
  "eventSource": "AUDIT_LOG_EVENT",
  "severity": "HIGH_SEVERITY",
  "categories": ["Kubernetes Events"],
  "policySections": [{"sectionName": "Audit Event", "policyGroups": [
    {"fieldName": "Kubernetes Resource", "values": [{"value": "SECRETS"}]},
    {"fieldName": "Kubernetes API Verb", "values": [{"value": "CREATE"}]}
  ]}],
  "scope": [{"cluster_label": {"key": "env", "value": "staging"}}]
}'

$ kubectl create secret generic test-secret-3 --from-literal=key=value -n test-backend

$ curl -sk "https://localhost:8000/v1/alerts?query=Policy:Test+-+Audit+Log+Cluster+Label+Mismatch" -u admin:$PASSWORD

{"alerts":[]}
```

Cluster has `env=prod`, policy requires `env=staging` — no alert as expected.
