### PR TITLE
ROX-34174: Get initial entity scope rules from search filter

### DIFF
--- a/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
+++ b/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
@@ -6,7 +6,11 @@ import type {
 } from 'services/ReportsService.types';
 import type { SearchFilter } from 'types/search';
 import type { SearchFieldLabel } from 'types/searchOptions';
-import { isQuotedString, searchValueAsArray } from 'utils/searchUtils';
+import {
+    getValueByCaseInsensitiveKey,
+    isQuotedString,
+    searchValueAsArray,
+} from 'utils/searchUtils';
 
 type EntityScopeSearchFieldLabelForCluster = Extract<
     SearchFieldLabel,
@@ -107,7 +111,10 @@ function getEntityScopeRulesFromSearchFilter(
     const rules: EntityScopeRule[] = [];
 
     Object.entries(searchFilter).forEach(([searchFieldLabel, searchFieldValue]) => {
-        const ruleWithoutValues = searchFieldLabelMap[searchFieldLabel];
+        const ruleWithoutValues = getValueByCaseInsensitiveKey(
+            searchFieldLabelMap,
+            searchFieldLabel
+        );
         const searchFieldValues = searchValueAsArray(searchFieldValue);
 
         if (ruleWithoutValues && searchFieldValues.length !== 0) {

--- a/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
+++ b/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
@@ -1,0 +1,104 @@
+import type {
+    EntityScopeRule,
+    RuleValue,
+    ScopeEntity,
+    ScopeField,
+} from 'services/ReportsService.types';
+import type { SearchFilter } from 'types/search';
+import type { SearchFieldLabel } from 'types/searchOptions';
+import { isQuotedString, searchValueAsArray } from 'utils/searchUtils';
+
+type EntityScopeSearchFieldLabel = Extract<
+    SearchFieldLabel,
+    | 'Cluster ID'
+    | 'Cluster'
+    | 'Cluster Label'
+    | 'Namespace ID'
+    | 'Namespace'
+    | 'Namespace Label'
+    | 'Namespace Annotation'
+    | 'Deployment ID'
+    | 'Deployment'
+    | 'Deployment Label'
+    | 'Deployment Annotation'
+>;
+
+type EntityScopeRuleWithoutValues = {
+    entity: Exclude<ScopeEntity, 'SCOPE_ENTITY_UNSET'>;
+    field: Exclude<ScopeField, 'FIELD_UNSET'>;
+};
+
+const searchFieldLabelMap: Record<EntityScopeSearchFieldLabel, EntityScopeRuleWithoutValues> = {
+    'Cluster ID': {
+        entity: 'SCOPE_ENTITY_CLUSTER',
+        field: 'FIELD_ID',
+    },
+    Cluster: {
+        entity: 'SCOPE_ENTITY_CLUSTER',
+        field: 'FIELD_NAME',
+    },
+    'Cluster Label': {
+        entity: 'SCOPE_ENTITY_CLUSTER',
+        field: 'FIELD_LABEL',
+    },
+    // 'Cluster Annotation' is not a search filter
+    'Namespace ID': {
+        entity: 'SCOPE_ENTITY_NAMESPACE',
+        field: 'FIELD_ID',
+    },
+    Namespace: {
+        entity: 'SCOPE_ENTITY_NAMESPACE',
+        field: 'FIELD_NAME',
+    },
+    'Namespace Label': {
+        entity: 'SCOPE_ENTITY_NAMESPACE',
+        field: 'FIELD_LABEL',
+    },
+    'Namespace Annotation': {
+        entity: 'SCOPE_ENTITY_NAMESPACE',
+        field: 'FIELD_ANNOTATION',
+    },
+    'Deployment ID': {
+        entity: 'SCOPE_ENTITY_DEPLOYMENT',
+        field: 'FIELD_ID',
+    },
+    Deployment: {
+        entity: 'SCOPE_ENTITY_DEPLOYMENT',
+        field: 'FIELD_NAME',
+    },
+    'Deployment Label': {
+        entity: 'SCOPE_ENTITY_DEPLOYMENT',
+        field: 'FIELD_LABEL',
+    },
+    'Deployment Annotation': {
+        entity: 'SCOPE_ENTITY_DEPLOYMENT',
+        field: 'FIELD_ANNOTATION',
+    },
+} as const;
+
+export const searchFieldValueMapper = (value: string): RuleValue =>
+    isQuotedString(value)
+        ? { matchType: 'EXACT', value: value.slice(1, -1) }
+        : { matchType: 'REGEX', value };
+
+/**
+ * Return initial entity scope rules for corresponding search fields
+ * when user creates scheduled report configuration from results page.
+ */
+export function getEntityScopeRulesForSearchFilter(searchFilter: SearchFilter) {
+    const rules: EntityScopeRule[] = [];
+
+    Object.entries(searchFilter).forEach(([searchFieldLabel, searchFieldValue]) => {
+        const ruleWithoutValues = searchFieldLabelMap[searchFieldLabel];
+        const searchFieldValues = searchValueAsArray(searchFieldValue);
+
+        if (ruleWithoutValues && searchFieldValues.length !== 0) {
+            rules.push({
+                ...ruleWithoutValues,
+                values: searchFieldValues.map(searchFieldValueMapper),
+            });
+        }
+    });
+
+    return rules;
+}

--- a/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
+++ b/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
@@ -133,6 +133,6 @@ export function getEntityScopeRulesFromSearchFilterForCluster(searchFilter: Sear
  * Return initial entity scope rules for corresponding search fields
  * when user creates either violation or image vulnerability report configuration from results page.
  */
-export function getEntityScopeRulesFromSearchFilterForCWorkload(searchFilter: SearchFilter) {
+export function getEntityScopeRulesFromSearchFilterForWorkload(searchFilter: SearchFilter) {
     return getEntityScopeRulesFromSearchFilter(searchFilter, searchFieldLabelMapForWorkload);
 }

--- a/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
+++ b/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
@@ -8,7 +8,12 @@ import type { SearchFilter } from 'types/search';
 import type { SearchFieldLabel } from 'types/searchOptions';
 import { isQuotedString, searchValueAsArray } from 'utils/searchUtils';
 
-type EntityScopeSearchFieldLabel = Extract<
+type EntityScopeSearchFieldLabelForCluster = Extract<
+    SearchFieldLabel,
+    'Cluster ID' | 'Cluster' | 'Cluster Label'
+>;
+
+type EntityScopeSearchFieldLabelForWorkload = Extract<
     SearchFieldLabel,
     | 'Cluster ID'
     | 'Cluster'
@@ -28,7 +33,10 @@ type EntityScopeRuleWithoutValues = {
     field: Exclude<ScopeField, 'FIELD_UNSET'>;
 };
 
-const searchFieldLabelMap: Record<EntityScopeSearchFieldLabel, EntityScopeRuleWithoutValues> = {
+const searchFieldLabelMapForCluster: Record<
+    EntityScopeSearchFieldLabelForCluster,
+    EntityScopeRuleWithoutValues
+> = {
     'Cluster ID': {
         entity: 'SCOPE_ENTITY_CLUSTER',
         field: 'FIELD_ID',
@@ -42,6 +50,13 @@ const searchFieldLabelMap: Record<EntityScopeSearchFieldLabel, EntityScopeRuleWi
         field: 'FIELD_LABEL',
     },
     // 'Cluster Annotation' is not a search filter
+} as const;
+
+const searchFieldLabelMapForWorkload: Record<
+    EntityScopeSearchFieldLabelForWorkload,
+    EntityScopeRuleWithoutValues
+> = {
+    ...searchFieldLabelMapForCluster,
     'Namespace ID': {
         entity: 'SCOPE_ENTITY_NAMESPACE',
         field: 'FIELD_ID',
@@ -85,7 +100,10 @@ export const searchFieldValueMapper = (value: string): RuleValue =>
  * Return initial entity scope rules for corresponding search fields
  * when user creates scheduled report configuration from results page.
  */
-export function getEntityScopeRulesForSearchFilter(searchFilter: SearchFilter) {
+function getEntityScopeRulesFromSearchFilter(
+    searchFilter: SearchFilter,
+    searchFieldLabelMap: Record<string, EntityScopeRuleWithoutValues>
+) {
     const rules: EntityScopeRule[] = [];
 
     Object.entries(searchFilter).forEach(([searchFieldLabel, searchFieldValue]) => {
@@ -101,4 +119,20 @@ export function getEntityScopeRulesForSearchFilter(searchFilter: SearchFilter) {
     });
 
     return rules;
+}
+
+/**
+ * Return initial entity scope rules for corresponding search fields
+ * when user creates node vulnerability report configuration from results page.
+ */
+export function getEntityScopeRulesFromSearchFilterForCluster(searchFilter: SearchFilter) {
+    return getEntityScopeRulesFromSearchFilter(searchFilter, searchFieldLabelMapForCluster);
+}
+
+/**
+ * Return initial entity scope rules for corresponding search fields
+ * when user creates either violation or image vulnerability report configuration from results page.
+ */
+export function getEntityScopeRulesFromSearchFilterForCWorkload(searchFilter: SearchFilter) {
+    return getEntityScopeRulesFromSearchFilter(searchFilter, searchFieldLabelMapForWorkload);
 }

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -454,7 +454,7 @@ export function isKeyValueSearchTerm(searchTerm: string): boolean {
     return keyValueSearchOptions.has(searchTerm.toLowerCase());
 }
 
-function isQuotedString(value: string): boolean {
+export function isQuotedString(value: string): boolean {
     return value.startsWith('"') && value.endsWith('"') && value.length >= 2;
 }
 


### PR DESCRIPTION
## Description

### Objective

Provide equivalent filter for scheduled reports as view-based reports

### Analysis

Entity scope is structured alternative to search filter fields.

When user creates report configuration from results view:
* One side of coin: because `query` cannot include include the entity fields, filter them out (future contribution).
* Other side of coin: as a courtesy, get initial rules that correspond to entity fields.

In addition to other report types, it might become replacement for collections.

Delayed realization: Cluster is only relevant entity scope for (future) **node** vulnerability reports.
 
### Solution

1. Add src/Components/EntityScope folder with entityScopeRules.ts file (that is separate from from entityScopeDescriptions.ts file in a parallel contribution, both to prevent merge conflicts now and because this is for create and that is for view).

### Residue

1. Investigate values for labels (and annotations) given changes in #19902

    Write unit tests after I am sure that I understand expected results :)

2. Write much simpler function for reports.utils.ts file to get initial value of `sinceStartDate` from `'CVE Created Time'` with **after** value (with understanding that search filter means time in entire system versus report configuration means time in particular image).

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

### Manual testing

Temporary edit ConfigReportsTab.tsx file to add `console.log` statements for `searchFilter` and `getEntityScopeRulesForSearchFilter(searchFilter)` for `?action=createFromFilters` in simulation of that scenario.

1. Visit /main/vulnerabilities/platform select search filter, click **Create report**, and then click **Create scheduled report** to see **Vulnerability Reports**

    Cluster name: staging-secured-cluster (exact)
    Namespace: stackrox (exact)
    Deployment: scanner (regex)
    Deployment: collector (exact)

    Forgive me for forgetting to include an ID
    <img width="1440" height="420" alt="Platform" src="https://github.com/user-attachments/assets/61605ee1-02c6-4f91-8ff9-8d9917bfddd4" />

    See query string in request payload which is same as for view-based report
    `query: "Platform Component:true+SEVERITY:CRITICAL_VULNERABILITY_SEVERITY,IMPORTANT_VULNERABILITY_SEVERITY+FIXABLE:true+Cluster:\"staging-secured-cluster\"+Namespace:\"stackrox\"+Deployment:r/scanner,\"collector\"+Vulnerability State:OBSERVED""`

    See query string in address of **Vulnerability Reporting** page
    Forgive me for forgetting to copy it again after I added the second deployment
    `?action=createFromFilters&s[Platform%20Component]=true&s[SEVERITY]=CRITICAL_VULNERABILITY_SEVERITY&s[SEVERITY]=IMPORTANT_VULNERABILITY_SEVERITY&s[FIXABLE]=true&s[Cluster]="staging-secured-cluster"&s[Namespace]="stackrox"&s[Deployment]=scanner&s[Vulnerability%20State]=OBSERVED`

    `searchFilter`

    ```json
    {
        "Platform Component": "true",
        "SEVERITY": [
            "CRITICAL_VULNERABILITY_SEVERITY",
            "IMPORTANT_VULNERABILITY_SEVERITY"
        ],
        "FIXABLE": "true",
        "Cluster": "\"staging-secured-cluster\"",
        "Namespace": "\"stackrox\"",
        "Deployment": [
            "scanner",
            "\"collector\""
        ],
        "Vulnerability State": "OBSERVED"
    }    
    ```

    `getEntityScopeRulesForSearchFilter(searchFilter)` returns rules only for entity search fields

    ```json
    [
        {
            "entity": "SCOPE_ENTITY_CLUSTER",
            "field": "FIELD_NAME",
            "values": [
                {
                    "matchType": "EXACT",
                    "value": "staging-secured-cluster"
                }
            ]
        },
        {
            "entity": "SCOPE_ENTITY_NAMESPACE",
            "field": "FIELD_NAME",
            "values": [
                {
                    "matchType": "EXACT",
                    "value": "stackrox"
                }
            ]
        },
        {
            "entity": "SCOPE_ENTITY_DEPLOYMENT",
            "field": "FIELD_NAME",
            "values": [
                {
                    "matchType": "REGEX",
                    "value": "scanner"
                },
                {
                    "matchType": "EXACT",
                    "value": "collector"
                }
            ]
        }
    ]
    ```
