### PR TITLE
ROX-33790: Fix inconsistent CRS and init bundle reusability text

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterModal.tsx
@@ -79,7 +79,7 @@ function SecureClusterModal({ isModalOpen, setIsModalOpen }): ReactElement {
                 <Alert
                     variant="info"
                     isInline
-                    title="You can use one registration secret to secure multiple clusters that have the same installation method."
+                    title="You can use one cluster registration secret to secure multiple clusters."
                     component="p"
                 />
             </Flex>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterModal.tsx
@@ -79,7 +79,7 @@ function SecureClusterModal({ isModalOpen, setIsModalOpen }): ReactElement {
                 <Alert
                     variant="info"
                     isInline
-                    title="You can use one cluster registration secret to secure multiple clusters."
+                    title="You can use a single cluster registration secret to register multiple clusters."
                     component="p"
                 />
             </Flex>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
@@ -74,7 +74,7 @@ function SecureClusterPage(): ReactElement {
                 <Alert
                     variant="info"
                     isInline
-                    title="You can use one cluster registration secret to secure at most one cluster."
+                    title="You can use one cluster registration secret to secure multiple clusters."
                     component="p"
                 />
             </PageSection>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
@@ -74,7 +74,7 @@ function SecureClusterPage(): ReactElement {
                 <Alert
                     variant="info"
                     isInline
-                    title="You can use one cluster registration secret to secure multiple clusters."
+                    title="You can use a single cluster registration secret to register multiple clusters."
                     component="p"
                 />
             </PageSection>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -188,7 +188,7 @@ function InitBundleForm(): ReactElement {
                             <FormHelperText>
                                 <HelperText>
                                     <HelperTextItem>
-                                        You can use one bundle to secure multiple clusters.
+                                        You can use a single init bundle to register multiple clusters.
                                     </HelperTextItem>
                                 </HelperText>
                             </FormHelperText>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -188,7 +188,8 @@ function InitBundleForm(): ReactElement {
                             <FormHelperText>
                                 <HelperText>
                                     <HelperTextItem>
-                                        You can use a single init bundle to register multiple clusters.
+                                        You can use a single init bundle to register multiple
+                                        clusters.
                                     </HelperTextItem>
                                 </HelperText>
                             </FormHelperText>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/InitBundleForm.tsx
@@ -188,8 +188,7 @@ function InitBundleForm(): ReactElement {
                             <FormHelperText>
                                 <HelperText>
                                     <HelperTextItem>
-                                        You can use one bundle to secure multiple clusters that have
-                                        the same installation method.
+                                        You can use one bundle to secure multiple clusters.
                                     </HelperTextItem>
                                 </HelperText>
                             </FormHelperText>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
@@ -74,7 +74,7 @@ function SecureClusterPage(): ReactElement {
                 <Alert
                     variant="info"
                     isInline
-                    title="You can use one bundle to secure multiple clusters that have the same installation method."
+                    title="You can use one bundle to secure multiple clusters."
                     component="p"
                 />
             </PageSection>

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
@@ -74,7 +74,7 @@ function SecureClusterPage(): ReactElement {
                 <Alert
                     variant="info"
                     isInline
-                    title="You can use one bundle to secure multiple clusters."
+                    title="You can use a single init bundle to register multiple clusters."
                     component="p"
                 />
             </PageSection>


### PR DESCRIPTION
## Description

**Jira:** [ROX-33790](https://issues.redhat.com/browse/ROX-33790)

The UI showed contradictory information about cluster registration secret (CRS) reusability: the SecureClusterModal said a CRS can secure "multiple clusters that have the same installation method," while the SecureClusterPage said "at most one cluster." Both statements are wrong. A CRS can secure multiple clusters across any installation method (Helm and Operator).

- Fixed CRS alert text in `SecureClusterModal.tsx` and `SecureClusterPage.tsx` to consistently say "You can use one cluster registration secret to secure multiple clusters."
- Removed misleading "that have the same installation method" qualifier from init bundle text in `InitBundles/SecureClusterPage.tsx` and `InitBundleForm.tsx`

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Verified ESLint passes on all 4 changed files
- Verified TypeScript type checking passes
- No existing tests assert on these string literals (the only related Cypress test is already skipped)
- String-only changes with no logic modifications

[ROX-33790]: https://redhat.atlassian.net/browse/ROX-33790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ