### PR TITLE
ROX-34179: Hot reload internal leaf certificates in Central

### DIFF
--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -83,7 +83,7 @@ type CertificateProvider interface {
 // defaultCertificateProvider implements CertificateProvider using global mtls functions
 type defaultCertificateProvider struct{}
 
-func startPrimaryLeafCertWatcher() {
+func loadAndWatchPrimaryLeafCert() {
 	primaryLeafCertOnce.Do(func() {
 		certwatch.WatchCertDir("internal service", mtls.CertsPrefix, tlsconfig.LoadInternalCertificateFromDirectory, func(cert *tls.Certificate) {
 			if cert != nil {
@@ -98,7 +98,7 @@ func (p *defaultCertificateProvider) GetPrimaryCACert() (*x509.Certificate, []by
 }
 
 func (p *defaultCertificateProvider) GetPrimaryLeafCert() (tls.Certificate, error) {
-	startPrimaryLeafCertWatcher()
+	loadAndWatchPrimaryLeafCert()
 	if cert := primaryLeafCert.Load(); cert != nil {
 		return *cert, nil
 	}

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"sync/atomic"
+	"time"
 
 	cTLS "github.com/google/certificate-transparency-go/tls"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -56,10 +57,12 @@ var (
 	watchedPrimaryLeafCert     atomic.Pointer[tls.Certificate]
 	primaryLeafCertWatcherOnce sync.Once
 
-	// Secondary CA leaf certificate caching
-	secondaryCALeafCertOnce sync.Once
-	secondaryCALeafCert     tls.Certificate
-	secondaryCALeafCertErr  error
+	// cachedSecondaryLeafCert holds a short-lived leaf cert signed by the secondary CA,
+	// used only to sign TLSChallenge responses for Sensors that trust the secondary CA.
+	// Re-issued automatically when it nears expiry.
+	cachedSecondaryLeafCert     atomic.Pointer[tls.Certificate]
+	secondaryLeafCertIssueMu    sync.Mutex
+	secondaryLeafCertRenewalBuf = 1 * time.Hour
 )
 
 // CertificateProvider provides certificates for TLS challenge operations
@@ -111,21 +114,36 @@ func (p *defaultCertificateProvider) GetSecondaryCACert() (*x509.Certificate, []
 	return mtls.SecondaryCACert()
 }
 
-func (p *defaultCertificateProvider) GetSecondaryLeafCert() (tls.Certificate, error) {
-	secondaryCALeafCertOnce.Do(func() {
-		leafCert, err := issueSecondaryCALeafCert(p)
-		if err != nil {
-			secondaryCALeafCertErr = err
-			return
-		}
-		secondaryCALeafCert = leafCert
-	})
+func loadSecondaryLeafCertIfValid() *tls.Certificate {
+	cert := cachedSecondaryLeafCert.Load()
+	if cert != nil && cert.Leaf != nil &&
+		time.Now().Add(secondaryLeafCertRenewalBuf).Before(cert.Leaf.NotAfter) {
+		return cert
+	}
+	return nil
+}
 
-	if secondaryCALeafCertErr != nil {
-		return tls.Certificate{}, secondaryCALeafCertErr
+func (p *defaultCertificateProvider) GetSecondaryLeafCert() (tls.Certificate, error) {
+	if cert := loadSecondaryLeafCertIfValid(); cert != nil {
+		return *cert, nil
+	}
+	return p.issueAndCacheSecondaryLeafCert()
+}
+
+func (p *defaultCertificateProvider) issueAndCacheSecondaryLeafCert() (tls.Certificate, error) {
+	secondaryLeafCertIssueMu.Lock()
+	defer secondaryLeafCertIssueMu.Unlock()
+
+	if cert := loadSecondaryLeafCertIfValid(); cert != nil {
+		return *cert, nil
 	}
 
-	return secondaryCALeafCert, nil
+	leafCert, err := issueSecondaryCALeafCert(p)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	cachedSecondaryLeafCert.Store(&leafCert)
+	return leafCert, nil
 }
 
 func issueSecondaryCALeafCert(certProvider CertificateProvider) (tls.Certificate, error) {
@@ -134,7 +152,7 @@ func issueSecondaryCALeafCert(certProvider CertificateProvider) (tls.Certificate
 		return tls.Certificate{}, errors.Wrap(err, "failed to load secondary CA for signing")
 	}
 
-	issuedCert, issueErr := secondaryCA.IssueCertForSubject(mtls.CentralSubject)
+	issuedCert, issueErr := secondaryCA.IssueCertForSubject(mtls.CentralSubject, mtls.WithValidityExpiringInDays())
 	if issueErr != nil {
 		return tls.Certificate{}, errors.Wrap(issueErr, "failed to issue leaf certificate from secondary CA")
 	}
@@ -142,6 +160,11 @@ func issueSecondaryCALeafCert(certProvider CertificateProvider) (tls.Certificate
 	leafCert, err := tls.X509KeyPair(issuedCert.CertPEM, issuedCert.KeyPEM)
 	if err != nil {
 		return tls.Certificate{}, errors.Wrap(err, "failed to load X509 key pair for temporary leaf cert from secondary CA")
+	}
+
+	leafCert.Leaf, err = x509.ParseCertificate(leafCert.Certificate[0])
+	if err != nil {
+		return tls.Certificate{}, errors.Wrap(err, "parsing secondary leaf certificate")
 	}
 
 	return leafCert, nil

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -152,7 +152,7 @@ func issueSecondaryCALeafCert(certProvider CertificateProvider) (tls.Certificate
 		return tls.Certificate{}, errors.Wrap(err, "failed to load secondary CA for signing")
 	}
 
-	issuedCert, issueErr := secondaryCA.IssueCertForSubject(mtls.CentralSubject, mtls.WithValidityExpiringInDays())
+	issuedCert, issueErr := secondaryCA.IssueCertForSubject(mtls.CentralSubject, mtls.WithValidityExpiringInHours())
 	if issueErr != nil {
 		return tls.Certificate{}, errors.Wrap(issueErr, "failed to issue leaf certificate from secondary CA")
 	}

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -86,7 +86,7 @@ type defaultCertificateProvider struct{}
 
 func startPrimaryLeafCertWatcher() {
 	primaryLeafCertWatcherOnce.Do(func() {
-		certwatch.WatchCertDir(mtls.CertsPrefix, tlsconfig.LoadInternalCertificateFromDirectory, func(cert *tls.Certificate) {
+		certwatch.WatchCertDir("internal service", mtls.CertsPrefix, tlsconfig.LoadInternalCertificateFromDirectory, func(cert *tls.Certificate) {
 			if cert != nil {
 				watchedPrimaryLeafCert.Store(cert)
 			}

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -53,15 +53,14 @@ var (
 		},
 	})
 
-	// watchedPrimaryLeafCert holds the latest primary leaf certificate, updated by a file watcher.
-	watchedPrimaryLeafCert     atomic.Pointer[tls.Certificate]
-	primaryLeafCertWatcherOnce sync.Once
+	primaryLeafCert     atomic.Pointer[tls.Certificate]
+	primaryLeafCertOnce sync.Once
 
-	// cachedSecondaryLeafCert holds a short-lived leaf cert signed by the secondary CA,
+	// secondaryCALeafCert holds a short-lived leaf cert signed by the secondary CA,
 	// used only to sign TLSChallenge responses for Sensors that trust the secondary CA.
 	// Re-issued automatically when it nears expiry.
-	cachedSecondaryLeafCert     atomic.Pointer[tls.Certificate]
-	secondaryLeafCertIssueMu    sync.Mutex
+	secondaryCALeafCert         atomic.Pointer[tls.Certificate]
+	secondaryCALeafCertIssueMu  sync.Mutex
 	secondaryLeafCertRenewalBuf = 1 * time.Hour
 )
 
@@ -85,10 +84,10 @@ type CertificateProvider interface {
 type defaultCertificateProvider struct{}
 
 func startPrimaryLeafCertWatcher() {
-	primaryLeafCertWatcherOnce.Do(func() {
+	primaryLeafCertOnce.Do(func() {
 		certwatch.WatchCertDir("internal service", mtls.CertsPrefix, tlsconfig.LoadInternalCertificateFromDirectory, func(cert *tls.Certificate) {
 			if cert != nil {
-				watchedPrimaryLeafCert.Store(cert)
+				primaryLeafCert.Store(cert)
 			}
 		}, certwatch.WithVerify(false))
 	})
@@ -100,7 +99,7 @@ func (p *defaultCertificateProvider) GetPrimaryCACert() (*x509.Certificate, []by
 
 func (p *defaultCertificateProvider) GetPrimaryLeafCert() (tls.Certificate, error) {
 	startPrimaryLeafCertWatcher()
-	if cert := watchedPrimaryLeafCert.Load(); cert != nil {
+	if cert := primaryLeafCert.Load(); cert != nil {
 		return *cert, nil
 	}
 	return mtls.LeafCertificateFromFile()
@@ -115,7 +114,7 @@ func (p *defaultCertificateProvider) GetSecondaryCACert() (*x509.Certificate, []
 }
 
 func loadSecondaryLeafCertIfValid() *tls.Certificate {
-	cert := cachedSecondaryLeafCert.Load()
+	cert := secondaryCALeafCert.Load()
 	if cert != nil && cert.Leaf != nil &&
 		time.Now().Add(secondaryLeafCertRenewalBuf).Before(cert.Leaf.NotAfter) {
 		return cert
@@ -131,8 +130,8 @@ func (p *defaultCertificateProvider) GetSecondaryLeafCert() (tls.Certificate, er
 }
 
 func (p *defaultCertificateProvider) issueAndCacheSecondaryLeafCert() (tls.Certificate, error) {
-	secondaryLeafCertIssueMu.Lock()
-	defer secondaryLeafCertIssueMu.Unlock()
+	secondaryCALeafCertIssueMu.Lock()
+	defer secondaryCALeafCertIssueMu.Unlock()
 
 	if cert := loadSecondaryLeafCertIfValid(); cert != nil {
 		return *cert, nil
@@ -142,7 +141,7 @@ func (p *defaultCertificateProvider) issueAndCacheSecondaryLeafCert() (tls.Certi
 	if err != nil {
 		return tls.Certificate{}, err
 	}
-	cachedSecondaryLeafCert.Store(&leafCert)
+	secondaryCALeafCert.Store(&leafCert)
 	return leafCert, nil
 }
 

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -115,8 +115,11 @@ func (p *defaultCertificateProvider) GetSecondaryCACert() (*x509.Certificate, []
 
 func loadSecondaryLeafCertIfValid() *tls.Certificate {
 	cert := secondaryCALeafCert.Load()
-	if cert != nil && cert.Leaf != nil &&
-		time.Now().Add(secondaryLeafCertRenewalBuf).Before(cert.Leaf.NotAfter) {
+	if cert == nil || cert.Leaf == nil {
+		return nil
+	}
+	stillInRenewalBuffer := time.Now().Add(secondaryLeafCertRenewalBuf).Before(cert.Leaf.NotAfter)
+	if stillInRenewalBuffer {
 		return cert
 	}
 	return nil
@@ -126,10 +129,10 @@ func (p *defaultCertificateProvider) GetSecondaryLeafCert() (tls.Certificate, er
 	if cert := loadSecondaryLeafCertIfValid(); cert != nil {
 		return *cert, nil
 	}
-	return p.issueAndCacheSecondaryLeafCert()
+	return p.ensureSecondaryLeafCert()
 }
 
-func (p *defaultCertificateProvider) issueAndCacheSecondaryLeafCert() (tls.Certificate, error) {
+func (p *defaultCertificateProvider) ensureSecondaryLeafCert() (tls.Certificate, error) {
 	secondaryCALeafCertIssueMu.Lock()
 	defer secondaryCALeafCertIssueMu.Unlock()
 

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"sync/atomic"
 
 	cTLS "github.com/google/certificate-transparency-go/tls"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -25,6 +26,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
 	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stackrox/rox/pkg/mtls/certwatch"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgconfig"
 	"github.com/stackrox/rox/pkg/sync"
@@ -50,10 +52,9 @@ var (
 		},
 	})
 
-	// Primary leaf certificate caching
-	primaryLeafCertOnce sync.Once
-	primaryLeafCert     tls.Certificate
-	primaryLeafCertErr  error
+	// watchedPrimaryLeafCert holds the latest primary leaf certificate, updated by a file watcher.
+	watchedPrimaryLeafCert     atomic.Pointer[tls.Certificate]
+	primaryLeafCertWatcherOnce sync.Once
 
 	// Secondary CA leaf certificate caching
 	secondaryCALeafCertOnce sync.Once
@@ -80,21 +81,26 @@ type CertificateProvider interface {
 // defaultCertificateProvider implements CertificateProvider using global mtls functions
 type defaultCertificateProvider struct{}
 
+func startPrimaryLeafCertWatcher() {
+	primaryLeafCertWatcherOnce.Do(func() {
+		certwatch.WatchCertDir(mtls.CertsPrefix, tlsconfig.LoadInternalCertificateFromDirectory, func(cert *tls.Certificate) {
+			if cert != nil {
+				watchedPrimaryLeafCert.Store(cert)
+			}
+		}, certwatch.WithVerify(false))
+	})
+}
+
 func (p *defaultCertificateProvider) GetPrimaryCACert() (*x509.Certificate, []byte, error) {
 	return mtls.CACert()
 }
 
 func (p *defaultCertificateProvider) GetPrimaryLeafCert() (tls.Certificate, error) {
-	primaryLeafCertOnce.Do(func() {
-		cert, err := mtls.LeafCertificateFromFile()
-		if err != nil {
-			primaryLeafCertErr = err
-			return
-		}
-		primaryLeafCert = cert
-	})
-
-	return primaryLeafCert, primaryLeafCertErr
+	startPrimaryLeafCertWatcher()
+	if cert := watchedPrimaryLeafCert.Load(); cert != nil {
+		return *cert, nil
+	}
+	return mtls.LeafCertificateFromFile()
 }
 
 func (p *defaultCertificateProvider) GetSecondaryCAForSigning() (mtls.CA, error) {

--- a/central/metadata/service/service_impl.go
+++ b/central/metadata/service/service_impl.go
@@ -58,7 +58,7 @@ var (
 
 	// secondaryCALeafCert holds a short-lived leaf cert signed by the secondary CA,
 	// used only to sign TLSChallenge responses for Sensors that trust the secondary CA.
-	// Re-issued automatically when it nears expiry.
+	// Re-issued automatically when closer than secondaryLeafCertRenewalBuf to expiry.
 	secondaryCALeafCert         atomic.Pointer[tls.Certificate]
 	secondaryCALeafCertIssueMu  sync.Mutex
 	secondaryLeafCertRenewalBuf = 1 * time.Hour

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/initca"
@@ -265,6 +266,63 @@ func (s *serviceImplTestSuite) TestIssueSecondaryCALeafCert() {
 		s.Require().Error(err)
 		s.Contains(err.Error(), "failed to load secondary CA for signing")
 		s.Contains(err.Error(), "secondary CA file not found")
+	})
+
+	s.Run("issued cert has short validity", func() {
+		mockProvider := &testCertificateProvider{
+			secondaryCA:         secondaryCA,
+			shouldFailSecondary: false,
+		}
+
+		cert, err := issueSecondaryCALeafCert(mockProvider)
+		s.Require().NoError(err)
+		s.Require().NotNil(cert.Leaf)
+
+		validity := cert.Leaf.NotAfter.Sub(cert.Leaf.NotBefore)
+		s.Less(validity, 3*24*time.Hour, "secondary leaf cert should have short validity (<=2 days)")
+	})
+}
+
+func (s *serviceImplTestSuite) TestLoadSecondaryLeafCertIfValid() {
+	s.Run("returns nil when no cert is cached", func() {
+		cachedSecondaryLeafCert.Store(nil)
+		s.Nil(loadSecondaryLeafCertIfValid())
+	})
+
+	s.Run("returns cert when valid", func() {
+		secondaryCA := s.createTestCA("Test Secondary CA", "17520h")
+		mockProvider := &testCertificateProvider{
+			secondaryCA:         secondaryCA,
+			shouldFailSecondary: false,
+		}
+		cert, err := issueSecondaryCALeafCert(mockProvider)
+		s.Require().NoError(err)
+
+		cachedSecondaryLeafCert.Store(&cert)
+		s.NotNil(loadSecondaryLeafCertIfValid())
+		cachedSecondaryLeafCert.Store(nil)
+	})
+
+	s.Run("returns nil when cert is expired", func() {
+		expiredCert := &tls.Certificate{
+			Leaf: &x509.Certificate{
+				NotAfter: time.Now().Add(-1 * time.Hour),
+			},
+		}
+		cachedSecondaryLeafCert.Store(expiredCert)
+		s.Nil(loadSecondaryLeafCertIfValid())
+		cachedSecondaryLeafCert.Store(nil)
+	})
+
+	s.Run("returns nil when cert is within renewal buffer", func() {
+		nearExpiryCert := &tls.Certificate{
+			Leaf: &x509.Certificate{
+				NotAfter: time.Now().Add(30 * time.Minute),
+			},
+		}
+		cachedSecondaryLeafCert.Store(nearExpiryCert)
+		s.Nil(loadSecondaryLeafCertIfValid(), "cert expiring within renewal buffer should trigger re-issue")
+		cachedSecondaryLeafCert.Store(nil)
 	})
 }
 

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -285,7 +285,7 @@ func (s *serviceImplTestSuite) TestIssueSecondaryCALeafCert() {
 
 func (s *serviceImplTestSuite) TestLoadSecondaryLeafCertIfValid() {
 	s.Run("returns nil when no cert is cached", func() {
-		cachedSecondaryLeafCert.Store(nil)
+		secondaryCALeafCert.Store(nil)
 		s.Nil(loadSecondaryLeafCertIfValid())
 	})
 
@@ -298,9 +298,9 @@ func (s *serviceImplTestSuite) TestLoadSecondaryLeafCertIfValid() {
 		cert, err := issueSecondaryCALeafCert(mockProvider)
 		s.Require().NoError(err)
 
-		cachedSecondaryLeafCert.Store(&cert)
+		secondaryCALeafCert.Store(&cert)
 		s.NotNil(loadSecondaryLeafCertIfValid())
-		cachedSecondaryLeafCert.Store(nil)
+		secondaryCALeafCert.Store(nil)
 	})
 
 	s.Run("returns nil when cert is expired", func() {
@@ -309,9 +309,9 @@ func (s *serviceImplTestSuite) TestLoadSecondaryLeafCertIfValid() {
 				NotAfter: time.Now().Add(-1 * time.Hour),
 			},
 		}
-		cachedSecondaryLeafCert.Store(expiredCert)
+		secondaryCALeafCert.Store(expiredCert)
 		s.Nil(loadSecondaryLeafCertIfValid())
-		cachedSecondaryLeafCert.Store(nil)
+		secondaryCALeafCert.Store(nil)
 	})
 
 	s.Run("returns nil when cert is within renewal buffer", func() {
@@ -320,9 +320,9 @@ func (s *serviceImplTestSuite) TestLoadSecondaryLeafCertIfValid() {
 				NotAfter: time.Now().Add(30 * time.Minute),
 			},
 		}
-		cachedSecondaryLeafCert.Store(nearExpiryCert)
+		secondaryCALeafCert.Store(nearExpiryCert)
 		s.Nil(loadSecondaryLeafCertIfValid(), "cert expiring within renewal buffer should trigger re-issue")
-		cachedSecondaryLeafCert.Store(nil)
+		secondaryCALeafCert.Store(nil)
 	})
 }
 

--- a/central/metadata/service/service_impl_test.go
+++ b/central/metadata/service/service_impl_test.go
@@ -279,7 +279,7 @@ func (s *serviceImplTestSuite) TestIssueSecondaryCALeafCert() {
 		s.Require().NotNil(cert.Leaf)
 
 		validity := cert.Leaf.NotAfter.Sub(cert.Leaf.NotBefore)
-		s.Less(validity, 3*24*time.Hour, "secondary leaf cert should have short validity (<=2 days)")
+		s.Less(validity, 4*time.Hour, "secondary leaf cert should have short validity (<=3 hours)")
 	})
 }
 

--- a/central/tlsconfig/manager_impl.go
+++ b/central/tlsconfig/manager_impl.go
@@ -26,6 +26,8 @@ type providerData struct {
 type managerImpl struct {
 	mutex sync.RWMutex
 
+	namespace string
+
 	internalTrustRoots []*x509.Certificate
 	userTrustRoots     []*x509.Certificate
 
@@ -57,11 +59,13 @@ func newManager(namespace string) (*managerImpl, error) {
 
 	mgr := &managerImpl{
 		providerIDToProviderData: make(map[string]providerData),
+		namespace:                namespace,
 		internalTrustRoots:       trustRoots,
 		internalCerts:            internalCerts,
 	}
 
 	certwatch.WatchCertDir(DefaultCertPath, MaybeGetDefaultTLSCertificateFromDirectory, mgr.UpdateDefaultTLSCertificate)
+	certwatch.WatchCertDir(mtls.CertsPrefix, LoadInternalCertificateFromDirectory, mgr.UpdateInternalCertificate, certwatch.WithVerify(false))
 
 	return mgr, nil
 }
@@ -76,6 +80,33 @@ func (m *managerImpl) UpdateDefaultTLSCertificate(defaultCert *tls.Certificate) 
 		m.defaultCerts = []tls.Certificate{*defaultCert}
 	}
 
+	m.updateConfigurersNoLock()
+}
+
+func (m *managerImpl) UpdateInternalCertificate(cert *tls.Certificate) {
+	if cert == nil {
+		return
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	internalCerts := []tls.Certificate{*cert}
+
+	if cert.Leaf != nil && !validForAllDNSNames(cert.Leaf, mtls.CentralSubject.AllHostnamesForNamespace(m.namespace)...) {
+		log.Warnw("Reloaded internal TLS certificate is not valid for all cluster-internal DNS names, "+
+			"issuing ephemeral certificate with adequate DNS names",
+			logging.String("namespace", m.namespace),
+			logging.Strings("internalDNSNames", mtls.CentralSubject.AllHostnamesForNamespace(m.namespace)))
+		ephemeralCert, err := issueInternalCertificate(m.namespace)
+		if err != nil {
+			log.Errorf("Failed to issue ephemeral internal certificate during reload: %v", err)
+		} else {
+			internalCerts = append(internalCerts, *ephemeralCert)
+		}
+	}
+
+	m.internalCerts = internalCerts
 	m.updateConfigurersNoLock()
 }
 

--- a/central/tlsconfig/manager_impl.go
+++ b/central/tlsconfig/manager_impl.go
@@ -90,7 +90,7 @@ func (m *managerImpl) UpdateInternalCertificate(cert *tls.Certificate) {
 
 	internalCerts, err := buildInternalCerts(cert, m.namespace)
 	if err != nil {
-		log.Errorf("Failed to issue ephemeral certificate for alternative namespace during reload, keeping previous certs: %v", err)
+		log.Errorf("Failed to build internal certificates (keeping previous certs): %v", err)
 		return
 	}
 

--- a/central/tlsconfig/manager_impl.go
+++ b/central/tlsconfig/manager_impl.go
@@ -88,24 +88,14 @@ func (m *managerImpl) UpdateInternalCertificate(cert *tls.Certificate) {
 		return
 	}
 
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
-	internalCerts := []tls.Certificate{*cert}
-
-	if cert.Leaf != nil && !validForAllDNSNames(cert.Leaf, mtls.CentralSubject.AllHostnamesForNamespace(m.namespace)...) {
-		log.Warnw("Reloaded internal TLS certificate is not valid for all cluster-internal DNS names, "+
-			"issuing ephemeral certificate with adequate DNS names",
-			logging.String("namespace", m.namespace),
-			logging.Strings("internalDNSNames", mtls.CentralSubject.AllHostnamesForNamespace(m.namespace)))
-		ephemeralCert, err := issueInternalCertificate(m.namespace)
-		if err != nil {
-			log.Errorf("Failed to issue ephemeral internal certificate during reload: %v", err)
-		} else {
-			internalCerts = append(internalCerts, *ephemeralCert)
-		}
+	internalCerts, err := buildInternalCerts(cert, m.namespace)
+	if err != nil {
+		log.Errorf("Failed to issue ephemeral certificate for alternative namespace during reload, keeping previous certs: %v", err)
+		return
 	}
 
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	m.internalCerts = internalCerts
 	m.updateConfigurersNoLock()
 }

--- a/central/tlsconfig/manager_impl.go
+++ b/central/tlsconfig/manager_impl.go
@@ -64,8 +64,8 @@ func newManager(namespace string) (*managerImpl, error) {
 		internalCerts:            internalCerts,
 	}
 
-	certwatch.WatchCertDir(DefaultCertPath, MaybeGetDefaultTLSCertificateFromDirectory, mgr.UpdateDefaultTLSCertificate)
-	certwatch.WatchCertDir(mtls.CertsPrefix, LoadInternalCertificateFromDirectory, mgr.UpdateInternalCertificate, certwatch.WithVerify(false))
+	certwatch.WatchCertDir("default TLS", DefaultCertPath, MaybeGetDefaultTLSCertificateFromDirectory, mgr.UpdateDefaultTLSCertificate)
+	certwatch.WatchCertDir("internal service", mtls.CertsPrefix, LoadInternalCertificateFromDirectory, mgr.UpdateInternalCertificate, certwatch.WithVerify(false))
 
 	return mgr, nil
 }

--- a/central/tlsconfig/manager_impl_test.go
+++ b/central/tlsconfig/manager_impl_test.go
@@ -180,29 +180,6 @@ func (s *managerTestSuite) TestUpdateInternalCertificateIssuesEphemeralForAltNam
 	s.Len(mgr.internalCerts, 2, "expected reloaded cert + ephemeral cert for alt namespace")
 }
 
-func (s *managerTestSuite) TestUpdateInternalCertificatePropagates() {
-	mgr, err := newManager(namespaces.StackRox)
-	s.Require().NoError(err)
-
-	configurer, err := mgr.TLSConfigurer(Options{
-		ServerCerts: []ServerCertSource{ServiceCertSource},
-	})
-	s.Require().NoError(err)
-
-	ca, err := certgen.GenerateCA()
-	s.Require().NoError(err)
-	issuedCert, err := ca.IssueCertForSubject(mtls.CentralSubject)
-	s.Require().NoError(err)
-	newCert, err := tls.X509KeyPair(issuedCert.CertPEM, issuedCert.KeyPEM)
-	s.Require().NoError(err)
-
-	mgr.UpdateInternalCertificate(&newCert)
-
-	tlsConf, err := configurer.TLSConfig()
-	s.Require().NoError(err)
-	s.Require().NotNil(tlsConf)
-}
-
 func (s *managerTestSuite) TestLoadInternalCertificateFromDirectory() {
 	ca, err := mtls.CAForSigning()
 	s.Require().NoError(err)

--- a/central/tlsconfig/manager_impl_test.go
+++ b/central/tlsconfig/manager_impl_test.go
@@ -177,7 +177,15 @@ func (s *managerTestSuite) TestUpdateInternalCertificateIssuesEphemeralForAltNam
 	newCert := testutils.IssueSelfSignedCert(s.T(), "central.stackrox", "central.stackrox.svc")
 	mgr.UpdateInternalCertificate(&newCert)
 
-	s.Len(mgr.internalCerts, 2, "expected reloaded cert + ephemeral cert for alt namespace")
+	s.Require().Len(mgr.internalCerts, 2, "expected reloaded cert + ephemeral cert for alt namespace")
+
+	// First cert is the one we passed in (no alt-ns DNS names)
+	s.Require().NotNil(mgr.internalCerts[0].Leaf)
+	s.Error(mgr.internalCerts[0].Leaf.VerifyHostname("central.alt-ns.svc"))
+
+	// Second cert is the ephemeral one covering the alt namespace
+	s.Require().NotNil(mgr.internalCerts[1].Leaf)
+	s.NoError(mgr.internalCerts[1].Leaf.VerifyHostname("central.alt-ns.svc"))
 }
 
 func (s *managerTestSuite) TestLoadInternalCertificateFromDirectory() {

--- a/central/tlsconfig/manager_impl_test.go
+++ b/central/tlsconfig/manager_impl_test.go
@@ -137,6 +137,97 @@ func (s *managerTestSuite) testConnectionWithManager(mgr *managerImpl, acceptedS
 	s.ErrorIs(err, net.ErrClosed)
 }
 
+func (s *managerTestSuite) TestUpdateInternalCertificateReplacesExisting() {
+	mgr, err := newManager(namespaces.StackRox)
+	s.Require().NoError(err)
+
+	s.Require().NotEmpty(mgr.internalCerts)
+	originalSerial := mgr.internalCerts[0].Leaf.SerialNumber
+
+	ca, err := certgen.GenerateCA()
+	s.Require().NoError(err)
+	issuedCert, err := ca.IssueCertForSubject(mtls.CentralSubject)
+	s.Require().NoError(err)
+	newCert, err := tls.X509KeyPair(issuedCert.CertPEM, issuedCert.KeyPEM)
+	s.Require().NoError(err)
+
+	mgr.UpdateInternalCertificate(&newCert)
+
+	s.Len(mgr.internalCerts, 1)
+	s.NotEqual(originalSerial, mgr.internalCerts[0].Leaf.SerialNumber)
+}
+
+func (s *managerTestSuite) TestUpdateInternalCertificateNilIsNoop() {
+	mgr, err := newManager(namespaces.StackRox)
+	s.Require().NoError(err)
+
+	s.Require().NotEmpty(mgr.internalCerts)
+	certCountBefore := len(mgr.internalCerts)
+
+	mgr.UpdateInternalCertificate(nil)
+
+	s.Len(mgr.internalCerts, certCountBefore)
+}
+
+func (s *managerTestSuite) TestUpdateInternalCertificateIssuesEphemeralForAltNamespace() {
+	mgr, err := newManager("alt-ns")
+	s.Require().NoError(err)
+
+	// Cert without alt-ns DNS names triggers ephemeral cert issuance
+	newCert := testutils.IssueSelfSignedCert(s.T(), "central.stackrox", "central.stackrox.svc")
+	mgr.UpdateInternalCertificate(&newCert)
+
+	s.Len(mgr.internalCerts, 2, "expected reloaded cert + ephemeral cert for alt namespace")
+}
+
+func (s *managerTestSuite) TestUpdateInternalCertificatePropagates() {
+	mgr, err := newManager(namespaces.StackRox)
+	s.Require().NoError(err)
+
+	configurer, err := mgr.TLSConfigurer(Options{
+		ServerCerts: []ServerCertSource{ServiceCertSource},
+	})
+	s.Require().NoError(err)
+
+	ca, err := certgen.GenerateCA()
+	s.Require().NoError(err)
+	issuedCert, err := ca.IssueCertForSubject(mtls.CentralSubject)
+	s.Require().NoError(err)
+	newCert, err := tls.X509KeyPair(issuedCert.CertPEM, issuedCert.KeyPEM)
+	s.Require().NoError(err)
+
+	mgr.UpdateInternalCertificate(&newCert)
+
+	tlsConf, err := configurer.TLSConfig()
+	s.Require().NoError(err)
+	s.Require().NotNil(tlsConf)
+}
+
+func (s *managerTestSuite) TestLoadInternalCertificateFromDirectory() {
+	ca, err := certgen.GenerateCA()
+	s.Require().NoError(err)
+
+	centralCert, err := ca.IssueCertForSubject(mtls.CentralSubject)
+	s.Require().NoError(err)
+
+	dir := s.T().TempDir()
+	s.Require().NoError(os.WriteFile(filepath.Join(dir, mtls.ServiceCertFileName), centralCert.CertPEM, 0644))
+	s.Require().NoError(os.WriteFile(filepath.Join(dir, mtls.ServiceKeyFileName), centralCert.KeyPEM, 0600))
+
+	cert, err := LoadInternalCertificateFromDirectory(dir)
+	s.Require().NoError(err)
+	s.Require().NotNil(cert)
+	s.Require().NotNil(cert.Leaf)
+	s.Contains(cert.Leaf.DNSNames, "central.stackrox.svc")
+}
+
+func (s *managerTestSuite) TestLoadInternalCertificateFromDirectoryMissingFiles() {
+	dir := s.T().TempDir()
+	cert, err := LoadInternalCertificateFromDirectory(dir)
+	s.NoError(err)
+	s.Nil(cert)
+}
+
 func getCertPool(certs []*x509.Certificate) *x509.CertPool {
 	pool := x509.NewCertPool()
 	for _, cert := range certs {

--- a/central/tlsconfig/manager_impl_test.go
+++ b/central/tlsconfig/manager_impl_test.go
@@ -204,7 +204,7 @@ func (s *managerTestSuite) TestUpdateInternalCertificatePropagates() {
 }
 
 func (s *managerTestSuite) TestLoadInternalCertificateFromDirectory() {
-	ca, err := certgen.GenerateCA()
+	ca, err := mtls.CAForSigning()
 	s.Require().NoError(err)
 
 	centralCert, err := ca.IssueCertForSubject(mtls.CentralSubject)

--- a/central/tlsconfig/tlsconfig.go
+++ b/central/tlsconfig/tlsconfig.go
@@ -270,7 +270,7 @@ func getInternalCertificates(namespace string) ([]tls.Certificate, error) {
 
 // buildInternalCerts returns a cert slice containing the given cert. If the cert
 // is not valid for all DNS names in the given namespace, an additional ephemeral
-// cert with the correct SANs is appended.
+// cert with the correct SANs is issued and appended.
 func buildInternalCerts(cert *tls.Certificate, namespace string) ([]tls.Certificate, error) {
 	if cert.Leaf != nil && validForAllDNSNames(cert.Leaf, mtls.CentralSubject.AllHostnamesForNamespace(namespace)...) {
 		return []tls.Certificate{*cert}, nil

--- a/central/tlsconfig/tlsconfig.go
+++ b/central/tlsconfig/tlsconfig.go
@@ -210,11 +210,6 @@ func LoadInternalCertificateFromDirectory(dir string) (*tls.Certificate, error) 
 		return nil, errors.Wrap(err, "loading internal certificate")
 	}
 
-	cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing internal leaf certificate")
-	}
-
 	trustPool, err := verifier.TrustedCertPool()
 	if err != nil {
 		return nil, errors.Wrap(err, "building trust pool for internal certificate verification")
@@ -251,19 +246,13 @@ func getInternalCertificates(namespace string) ([]tls.Certificate, error) {
 		return nil, err
 	}
 	if certFromFiles != nil {
-		if certFromFiles.Leaf == nil {
-			certFromFiles.Leaf, err = x509.ParseCertificate(certFromFiles.Certificate[0])
-			if err != nil {
-				return nil, errors.Wrap(err, "loaded internal certificate is invalid")
-			}
-		}
 		return buildInternalCerts(certFromFiles, namespace)
 	}
 
 	// No cert files on disk — issue an ephemeral cert from scratch.
 	ephemeralCert, err := issueInternalCertificate(namespace)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "issuing ephemeral internal certificate for namespace %s", namespace)
 	}
 	return []tls.Certificate{*ephemeralCert}, nil
 }

--- a/central/tlsconfig/tlsconfig.go
+++ b/central/tlsconfig/tlsconfig.go
@@ -193,6 +193,29 @@ func loadInternalCertificateFromFiles() (*tls.Certificate, error) {
 	return &cert, nil
 }
 
+// LoadInternalCertificateFromDirectory loads the internal service leaf certificate
+// (cert.pem + key.pem) from the given directory.
+func LoadInternalCertificateFromDirectory(dir string) (*tls.Certificate, error) {
+	certFile := filepath.Join(dir, mtls.ServiceCertFileName)
+	keyFile := filepath.Join(dir, mtls.ServiceKeyFileName)
+
+	if filesExist, err := fileutils.AllExist(certFile, keyFile); err != nil || !filesExist {
+		return nil, err
+	}
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading internal certificate")
+	}
+
+	cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing internal leaf certificate")
+	}
+
+	return &cert, nil
+}
+
 func issueInternalCertificate(namespace string) (*tls.Certificate, error) {
 	issuedCert, err := mtls.IssueNewCert(mtls.CentralSubject, mtls.WithNamespace(namespace))
 	if err != nil {

--- a/central/tlsconfig/tlsconfig.go
+++ b/central/tlsconfig/tlsconfig.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stackrox/rox/pkg/mtls/verifier"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/x509utils"
 )
@@ -194,7 +195,8 @@ func loadInternalCertificateFromFiles() (*tls.Certificate, error) {
 }
 
 // LoadInternalCertificateFromDirectory loads the internal service leaf certificate
-// (cert.pem + key.pem) from the given directory.
+// (cert.pem + key.pem) from the given directory and verifies it against the
+// internal CA trust roots.
 func LoadInternalCertificateFromDirectory(dir string) (*tls.Certificate, error) {
 	certFile := filepath.Join(dir, mtls.ServiceCertFileName)
 	keyFile := filepath.Join(dir, mtls.ServiceKeyFileName)
@@ -211,6 +213,14 @@ func LoadInternalCertificateFromDirectory(dir string) (*tls.Certificate, error) 
 	cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing internal leaf certificate")
+	}
+
+	trustPool, err := verifier.TrustedCertPool()
+	if err != nil {
+		return nil, errors.Wrap(err, "building trust pool for internal certificate verification")
+	}
+	if _, err := cert.Leaf.Verify(x509.VerifyOptions{Roots: trustPool}); err != nil {
+		return nil, errors.Wrap(err, "verifying internal certificate against trusted CAs")
 	}
 
 	return &cert, nil

--- a/central/tlsconfig/tlsconfig.go
+++ b/central/tlsconfig/tlsconfig.go
@@ -282,7 +282,7 @@ func buildInternalCerts(cert *tls.Certificate, namespace string) ([]tls.Certific
 		logging.Strings("internalDNSNames", mtls.CentralSubject.AllHostnamesForNamespace(namespace)))
 	ephemeralCert, err := issueInternalCertificate(namespace)
 	if err != nil {
-		return []tls.Certificate{*cert}, err
+		return []tls.Certificate{*cert}, errors.Wrap(err, "issuing ephemeral certificate for alternative namespace")
 	}
 	return []tls.Certificate{*cert, *ephemeralCert}, nil
 }

--- a/central/tlsconfig/tlsconfig.go
+++ b/central/tlsconfig/tlsconfig.go
@@ -236,34 +236,45 @@ func issueInternalCertificate(namespace string) (*tls.Certificate, error) {
 }
 
 func getInternalCertificates(namespace string) ([]tls.Certificate, error) {
-	var internalCerts []tls.Certificate
-	// First try to load the internal certificate from files. If the files don't exist, issue
-	// ourselves a cert.
-	if certFromFiles, err := loadInternalCertificateFromFiles(); err != nil {
-		return nil, err
-	} else if certFromFiles != nil {
-		internalCerts = append(internalCerts, *certFromFiles)
-	}
-
-	if len(internalCerts) > 0 {
-		serviceCert, err := x509.ParseCertificate(internalCerts[0].Certificate[0])
-		if err != nil {
-			return nil, errors.Wrap(err, "loaded internal certificate is invalid")
-		}
-		if validForAllDNSNames(serviceCert, mtls.CentralSubject.AllHostnamesForNamespace(namespace)...) {
-			return internalCerts, nil // cert loaded from secret is sufficient
-		}
-	}
-
-	log.Warnw("Internal TLS certificates are not valid for all cluster-internal DNS names due to deployment in "+
-		"alternative namespace, issuing ephemeral certificate with adequate DNS names",
-		logging.String("namespace", namespace), logging.Strings("internalDNSNames", mtls.CentralSubject.AllHostnamesForNamespace(namespace)))
-	newInternalCert, err := issueInternalCertificate(namespace)
+	certFromFiles, err := loadInternalCertificateFromFiles()
 	if err != nil {
-		return internalCerts, err
+		return nil, err
 	}
-	internalCerts = append(internalCerts, *newInternalCert)
-	return internalCerts, nil
+	if certFromFiles != nil {
+		if certFromFiles.Leaf == nil {
+			certFromFiles.Leaf, err = x509.ParseCertificate(certFromFiles.Certificate[0])
+			if err != nil {
+				return nil, errors.Wrap(err, "loaded internal certificate is invalid")
+			}
+		}
+		return buildInternalCerts(certFromFiles, namespace)
+	}
+
+	// No cert files on disk — issue an ephemeral cert from scratch.
+	ephemeralCert, err := issueInternalCertificate(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return []tls.Certificate{*ephemeralCert}, nil
+}
+
+// buildInternalCerts returns a cert slice containing the given cert. If the cert
+// is not valid for all DNS names in the given namespace, an additional ephemeral
+// cert with the correct SANs is appended.
+func buildInternalCerts(cert *tls.Certificate, namespace string) ([]tls.Certificate, error) {
+	if cert.Leaf != nil && validForAllDNSNames(cert.Leaf, mtls.CentralSubject.AllHostnamesForNamespace(namespace)...) {
+		return []tls.Certificate{*cert}, nil
+	}
+
+	log.Warnw("Internal TLS certificate is not valid for all cluster-internal DNS names, "+
+		"issuing ephemeral certificate with adequate DNS names",
+		logging.String("namespace", namespace),
+		logging.Strings("internalDNSNames", mtls.CentralSubject.AllHostnamesForNamespace(namespace)))
+	ephemeralCert, err := issueInternalCertificate(namespace)
+	if err != nil {
+		return []tls.Certificate{*cert}, err
+	}
+	return []tls.Certificate{*cert, *ephemeralCert}, nil
 }
 
 func validForAllDNSNames(cert *x509.Certificate, dnsNames ...string) bool {

--- a/pkg/metrics/tls.go
+++ b/pkg/metrics/tls.go
@@ -111,7 +111,7 @@ func NewTLSConfigurerFromEnv() verifier.TLSConfigurer {
 // watchForChanges watches for changes of the server TLS certificate files and the client CA config map.
 func (t *tlsConfigurerImpl) watchForChanges() {
 	// Watch for changes of server TLS certificate.
-	certwatch.WatchCertDir(t.certDir, t.getCertificateFromDirectory, t.updateCertificate, certwatch.WithVerify(false))
+	certwatch.WatchCertDir("secure metrics", t.certDir, t.getCertificateFromDirectory, t.updateCertificate, certwatch.WithVerify(false))
 
 	// Watch for changes of client CA.
 	t.k8sWatcher.Watch(context.Background(), t.clientCANamespace, t.clientCAConfigMap)

--- a/pkg/mtls/README.md
+++ b/pkg/mtls/README.md
@@ -30,7 +30,7 @@
 - TLS config composition: `pkg/mtls/certwatch/tls_config_holder.go` — `atomic.Pointer[tls.Config]`, rotates session ticket keys on every update to invalidate cached TLS sessions
 - Trust pool builders: `pkg/mtls/verifier/verify.go` — `TrustedCertPool()`, `NonCA.TLSConfig()`
 - Central TLS manager: `central/tlsconfig/manager_impl.go` — composes server certs + trust roots for incoming connections
-- Central TLS cert loaders: `central/tlsconfig/tlsconfig.go` — `loadInternalCertificateFromFiles()`, `MaybeGetDefaultTLSCertificateFromDirectory()`
+- Central TLS cert loaders: `central/tlsconfig/tlsconfig.go` — `LoadInternalCertificateFromDirectory()`, `MaybeGetDefaultTLSCertificateFromDirectory()`
 - TLS challenge endpoint: `central/metadata/service/service_impl.go`
 - Cert issuance for Secured Clusters: `central/securedclustercertgen/certificates.go`
 - CA rotation logic: `operator/internal/central/carotation/rotation.go`
@@ -47,16 +47,15 @@
 - CA key bytes
 - These NEVER refresh without a pod restart.
 
-### Hot-reloaded via certwatch
+### Hot-reloaded via certwatch (Central)
 
-- Default/ingress TLS cert — `certwatch.WatchCertDir(DefaultCertPath, ...)` in `central/tlsconfig/manager_impl.go`
+- Default/ingress TLS cert — `certwatch.WatchCertDir` in `central/tlsconfig/manager_impl.go`
+- Internal service leaf cert — `certwatch.WatchCertDir` on `CertsPrefix` in `central/tlsconfig/manager_impl.go`, verified against internal CA on each reload
+- Primary leaf for TLS challenge — `certwatch.WatchCertDir` with atomic pointer in `central/metadata/service/service_impl.go`
 - Secure metrics TLS cert — `certwatch.WatchCertDir` in `pkg/metrics/tls.go`
 
 ### Loaded once at startup, never refreshed
 
-- Central internal service leaf cert — loaded in `getInternalCertificates()` at TLS manager construction, stored in `internalCerts`
-- Central primary leaf for TLS challenge — `sync.Once` in `central/metadata/service/service_impl.go`
-- Central secondary leaf for TLS challenge — `sync.Once`, issued in memory from secondary CA
 - Scanner V4 (indexer/matcher): server cert via `verifier.NonCA{}`, client cert via `clientconn.TLSConfig`
 - Admission controller: webhook server cert via `verifier.NonCA{}`
 - Sensor: client cert loaded in `centralclient.NewClient`, proxy cert in `StartProxyServer`
@@ -64,9 +63,9 @@
 
 ## Central has three independent cert-handling paths
 
-1. **TLS manager** (`TLSConfigHolder`) — incoming connections. Composes default cert (watched) + internal cert (loaded once) + sync.Once trust roots.
+1. **TLS manager** (`TLSConfigHolder`) — incoming connections. Composes default cert (watched) + internal cert (watched) + sync.Once trust roots.
 2. **Outbound client connections** (`clientconn.TLSConfig`) — reads leaf from disk per connection, trust pool from `mtls.CACert()`.
-3. **TLS challenge endpoint** (`central/metadata/service`) — reads primary leaf via `sync.Once`, issues secondary leaf via `sync.Once`, reads CA via `mtls.CACert()`.
+3. **TLS challenge endpoint** (`central/metadata/service`) — reads primary leaf via certwatch, issues secondary leaf with short validity and auto-renewal, reads CA via `mtls.CACert()`.
 
 ## CA rotation
 
@@ -91,7 +90,7 @@
 - Unauthenticated endpoint. Sensor sends challenge token, Central returns signed TrustInfo.
 - Response includes: primary cert chain, secondary cert chain (if present), additional CAs, default TLS leaf cert.
 - Signed with both primary and secondary leaf certs. Sensor verifies one signature and trusts all certs in the response (trust delegation).
-- Secondary leaf cert: issued in memory from secondary CA with 1-year validity via sync.Once, never renewed.
+- Secondary leaf cert: issued in memory from secondary CA with ~3-hour validity, auto-renewed before expiry.
 
 ## Sensor certinit — blocks hot reload
 

--- a/pkg/mtls/certwatch/certwatch.go
+++ b/pkg/mtls/certwatch/certwatch.go
@@ -26,9 +26,11 @@ type (
 	updateCertificateFunc func(cert *tls.Certificate)
 )
 
-// WatchCertDir starts watching the directory containing certificates
-func WatchCertDir(dir string, loadCert loadCertificateFunc, updateCert updateCertificateFunc, options ...CertWatchOption) {
+// WatchCertDir starts watching the directory containing certificates.
+// The name parameter is used in log messages to identify which certificate is being watched.
+func WatchCertDir(name string, dir string, loadCert loadCertificateFunc, updateCert updateCertificateFunc, options ...CertWatchOption) {
 	wh := &handler{
+		name:       name,
 		dir:        dir,
 		loadCert:   loadCert,
 		updateCert: updateCert,
@@ -43,6 +45,7 @@ func WatchCertDir(dir string, loadCert loadCertificateFunc, updateCert updateCer
 }
 
 type handler struct {
+	name       string
 	dir        string
 	loadCert   loadCertificateFunc
 	updateCert updateCertificateFunc
@@ -56,14 +59,14 @@ func (h *handler) OnChange(dir string) (interface{}, error) {
 func (h *handler) OnStableUpdate(val interface{}, err error) {
 	var cert *tls.Certificate
 	if err != nil {
-		log.Errorf("Error reading TLS certificates: %v. Disabling TLS certificate. Watch dir: %q", err, h.dir)
+		log.Errorf("Error reading %s certificate: %v. Watch dir: %q", h.name, err, h.dir)
 	} else {
 		cert, _ = val.(*tls.Certificate)
 		if cert == nil {
-			log.Infof("No TLS certificate found. Using internal certificates for HTTPS. Watch dir: %q", h.dir)
+			log.Infof("No %s certificate found in %q", h.name, h.dir)
 		} else {
-			log.Infof("TLS certificate loaded, using the following cert for HTTPS: (SerialNumber: %s, Subject: %s, DNSNames: %s, Issuer: %s), watch dir: %q",
-				cert.Leaf.SerialNumber, cert.Leaf.Subject, cert.Leaf.DNSNames, cert.Leaf.Issuer, h.dir)
+			log.Infof("%s certificate loaded (SerialNumber: %s, Subject: %s, DNSNames: %s, Issuer: %s), watch dir: %q",
+				h.name, cert.Leaf.SerialNumber, cert.Leaf.Subject, cert.Leaf.DNSNames, cert.Leaf.Issuer, h.dir)
 
 			parsedChain, err := x509utils.ParseCertificateChain(cert.Certificate)
 			if err != nil {
@@ -83,5 +86,5 @@ func (h *handler) OnStableUpdate(val interface{}, err error) {
 }
 
 func (h *handler) OnWatchError(err error) {
-	log.Errorf("Error watching TLS certificate directory %q: %v. Not updating TLS certificates!", h.dir, err)
+	log.Errorf("Error watching %s certificate directory %q: %v", h.name, h.dir, err)
 }


### PR DESCRIPTION
## Description

Central currently loads its internal service TLS leaf certificate once at startup and never refreshes them.
This blocks shorter-lived certificates because even if the cert files change on disk (e.g. rotated by the Operator),
Central keeps serving stale material until the pod restarts. To workaround that, we currently use 1-year certs and refresh after 6 months, hoping that in those 6 months the pods will restart. This limitation is mentioned in the docs [here](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.10/html/configuring/reissue-internal-certificates#reissuing-internal-certificates-for-central-services_reissue-internal-certificates) and [here](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.10/html/configuring/reissue-internal-certificates#applying-the-latest-internal-certificates_reissue-internal-certificates).

This PR adds hot reload for Central's internal leaf certificate, using the same `certwatch.WatchCertDir`
pattern already in place for the default/custom TLS certificate. It does **not** touch CA trust roots.

### Why leaf-only, not CA?
Reloading only the leaf cert is safe to do incrementally per-service: the leaf is presented by the
server that owns it, and peers verify it against the CA which hasn't changed. And when the CA is rotated by the Operator, the Operator also makes sure to [restart all pods](https://github.com/stackrox/stackrox/pull/16419).

CA hot reloading is not really necessary because:
- Operator Centrals & Secured Clusters restart all pods on CA change detection
- Helm Centrals & Secured Clusters don't update their CA, and will be soon deprecated

### Secondary leaf cert for TLS challenge
Central's `TLSChallenge` endpoint signs responses with a leaf cert from the secondary CA (when present
during CA rotation), so that Sensors trusting only the secondary CA can verify the response.
Previously this cert was issued once via `sync.Once` with 365-day validity and never refreshed. A
Central running for over a year would silently serve an expired cert. That was acceptable before, because
the certificates loaded at startup had a remaining validity that was always lower than 1y.

This PR issues it with ~3-hour validity and automatically re-issues it when it nears expiry.

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->
## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

#### Leaf certificate hot reloading
1. Extracted the CA cert and key from the central-tls secret.
2. Issued a new leaf certificate signed by the same CA (using mtls.LoadCAForSigning + IssueCertForSubject), producing a cert with a different serial (A44E2A60F0BE0084 vs original AA0E5187F991F2A8).
3. Patched the central-tls secret with the new cert.pem and key.pem.
4. Central's logs confirmed the certwatch picked up the new cert:
```
  pkg/mtls/certwatch: Info: internal service certificate loaded (SerialNumber: 11839447066247823492, Subject: ...,CN=CENTRAL_SERVICE: Central,OU=CENTRAL_SERVICE, DNSNames: [central.stackrox central.stackrox.svc central.acs-central central.acs-central.svc], ...), watch dir: "/run/secrets/stackrox.io/certs/"
```
5. Verified Central serves the new cert via openssl s_client:
```
  $ echo | openssl s_client -connect localhost:18443 -servername central.stackrox 2>/dev/null | openssl x509 -noout -serial
  serial=A44E2A60F0BE0084
```
6. Deleted the Sensor pod, it reconnected successfully to Central with the new cert in place.

#### Secondary leaf cert auto-renewal
1. Scaled down the operator so that I can manually add a secondary CA to central-tls, restarted Central.
2. First TLS challenge request - secondary leaf cert issued with 3h validity:
  --- Secondary Leaf (short-lived) ---
    Serial:   3f411e1b897a443f
    Validity: 2026-04-22 19:14:00 -> 2026-04-22 22:14:00 (3h0m0s)
3. Second request immediately after — same serial 3f411e1b897a443f (cached).
4. Third request ~2h20m later (past the 2h renewal buffer, <1h remaining on cert) — new cert issued lazily on demand:
  --- Secondary Leaf (short-lived) ---
    Serial:   16905ee946445ac5
    Validity: 2026-04-22 21:30:00 -> 2026-04-23 00:30:00 (3h0m0s)
