### PR TITLE
ROX-33040: check secondary NVD metrics

### DIFF
--- a/scanner/enricher/nvd/nvd.go
+++ b/scanner/enricher/nvd/nvd.go
@@ -320,7 +320,7 @@ func filterFields(cve *schema.CVEAPIJSON20CVEItem) *schema.CVEAPIJSON20CVEItem {
 		return item
 	}
 
-	mapV31 := func(m *schema.CvssMetricV31) *schema.CVEAPIJSON20CVSSV31 {
+	mapV31 := func(m *schema.CVEAPIJSON20CVSSV31) *schema.CVEAPIJSON20CVSSV31 {
 		return &schema.CVEAPIJSON20CVSSV31{
 			CvssData: &schema.CVSSV31{
 				Version:      m.CvssData.Version,
@@ -330,7 +330,7 @@ func filterFields(cve *schema.CVEAPIJSON20CVEItem) *schema.CVEAPIJSON20CVEItem {
 		}
 	}
 
-	mapV30 := func(m *schema.CvssMetricV30) *schema.CVEAPIJSON20CVSSV30 {
+	mapV30 := func(m *schema.CVEAPIJSON20CVSSV30) *schema.CVEAPIJSON20CVSSV30 {
 		return &schema.CVEAPIJSON20CVSSV30{
 			CvssData: &schema.CVSSV30{
 				Version:      m.CvssData.Version,
@@ -340,7 +340,7 @@ func filterFields(cve *schema.CVEAPIJSON20CVEItem) *schema.CVEAPIJSON20CVEItem {
 		}
 	}
 
-	mapV2 := func(m *schema.CvssMetricV2) *schema.CVEAPIJSON20CVSSV2 {
+	mapV2 := func(m *schema.CVEAPIJSON20CVSSV2) *schema.CVEAPIJSON20CVSSV2 {
 		return &schema.CVEAPIJSON20CVSSV2{
 			CvssData: &schema.CVSSV20{
 				Version:      m.CvssData.Version,

--- a/scanner/enricher/nvd/nvd.go
+++ b/scanner/enricher/nvd/nvd.go
@@ -319,41 +319,77 @@ func filterFields(cve *schema.CVEAPIJSON20CVEItem) *schema.CVEAPIJSON20CVEItem {
 	if cve.Metrics == nil {
 		return item
 	}
-	for _, cvss := range cve.Metrics.CvssMetricV31 {
-		if cvss.Type != "Primary" && cvss.Type != "" {
-			continue
-		}
-		item.Metrics.CvssMetricV31 = append(item.Metrics.CvssMetricV31, &schema.CVEAPIJSON20CVSSV31{
+
+	mapV31 := func(m *schema.CvssMetricV31) *schema.CVEAPIJSON20CVSSV31 {
+		return &schema.CVEAPIJSON20CVSSV31{
 			CvssData: &schema.CVSSV31{
-				Version:      cvss.CvssData.Version,
-				VectorString: cvss.CvssData.VectorString,
-				BaseScore:    cvss.CvssData.BaseScore,
+				Version:      m.CvssData.Version,
+				VectorString: m.CvssData.VectorString,
+				BaseScore:    m.CvssData.BaseScore,
 			},
-		})
-	}
-	for _, cvss := range cve.Metrics.CvssMetricV30 {
-		if cvss.Type != "Primary" && cvss.Type != "" {
-			continue
 		}
-		item.Metrics.CvssMetricV30 = append(item.Metrics.CvssMetricV30, &schema.CVEAPIJSON20CVSSV30{
+	}
+
+	mapV30 := func(m *schema.CvssMetricV30) *schema.CVEAPIJSON20CVSSV30 {
+		return &schema.CVEAPIJSON20CVSSV30{
 			CvssData: &schema.CVSSV30{
-				Version:      cvss.CvssData.Version,
-				VectorString: cvss.CvssData.VectorString,
-				BaseScore:    cvss.CvssData.BaseScore,
+				Version:      m.CvssData.Version,
+				VectorString: m.CvssData.VectorString,
+				BaseScore:    m.CvssData.BaseScore,
 			},
-		})
-	}
-	for _, cvss := range cve.Metrics.CvssMetricV2 {
-		if cvss.Type != "Primary" && cvss.Type != "" {
-			continue
 		}
-		item.Metrics.CvssMetricV2 = append(item.Metrics.CvssMetricV2, &schema.CVEAPIJSON20CVSSV2{
+	}
+
+	mapV2 := func(m *schema.CvssMetricV2) *schema.CVEAPIJSON20CVSSV2 {
+		return &schema.CVEAPIJSON20CVSSV2{
 			CvssData: &schema.CVSSV20{
-				Version:      cvss.CvssData.Version,
-				VectorString: cvss.CvssData.VectorString,
-				BaseScore:    cvss.CvssData.BaseScore,
+				Version:      m.CvssData.Version,
+				VectorString: m.CvssData.VectorString,
+				BaseScore:    m.CvssData.BaseScore,
 			},
-		})
+		}
+	}
+
+	hasPrimary := false
+
+	for _, cvss := range cve.Metrics.CvssMetricV31 {
+		if cvss.Type == "Primary" || cvss.Type == "" {
+			item.Metrics.CvssMetricV31 = append(item.Metrics.CvssMetricV31, mapV31(cvss))
+			hasPrimary = true
+		}
+	}
+
+	for _, cvss := range cve.Metrics.CvssMetricV30 {
+		if cvss.Type == "Primary" || cvss.Type == "" {
+			item.Metrics.CvssMetricV30 = append(item.Metrics.CvssMetricV30, mapV30(cvss))
+			hasPrimary = true
+		}
+	}
+
+	for _, cvss := range cve.Metrics.CvssMetricV2 {
+		if cvss.Type == "Primary" || cvss.Type == "" {
+			item.Metrics.CvssMetricV2 = append(item.Metrics.CvssMetricV2, mapV2(cvss))
+			hasPrimary = true
+		}
+	}
+
+	// Fallback only if NO primary was found in any version
+	if !hasPrimary {
+		for _, cvss := range cve.Metrics.CvssMetricV31 {
+			if cvss.Type == "Secondary" {
+				item.Metrics.CvssMetricV31 = append(item.Metrics.CvssMetricV31, mapV31(cvss))
+			}
+		}
+		for _, cvss := range cve.Metrics.CvssMetricV30 {
+			if cvss.Type == "Secondary" {
+				item.Metrics.CvssMetricV30 = append(item.Metrics.CvssMetricV30, mapV30(cvss))
+			}
+		}
+		for _, cvss := range cve.Metrics.CvssMetricV2 {
+			if cvss.Type == "Secondary" {
+				item.Metrics.CvssMetricV2 = append(item.Metrics.CvssMetricV2, mapV2(cvss))
+			}
+		}
 	}
 	return item
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->
There are some NVD enrichment CVEs in the v4 vuln bundle that are missing the "metrics" field, which is expected to include the CVSS score, severity, and related data.
such as
`{"Updater":"nvd","Fingerprint":"134f043f-db47-4d5e-aa6f-317dcf550256","Date":"2026-04-16T18:55:16.705270814Z","Ref":"97a10549-e247-47e2-8f68-fd275a7eeee2","Enrichment":{"Tags":["CVE-2026-33870"],"Enrichment":{"descriptions":[{"lang":"en","value":"Netty is an asynchronous, event-driven network application framework. In versions prior to 4.1.132.Final and 4.2.10.Final, Netty incorrectly parses quoted strings in HTTP/1.1 chunked transfer encoding extension values, enabling request smuggling attacks. Versions 4.1.132.Final and 4.2.10.Final fix the issue."}],"id":"CVE-2026-33870","lastModified":"2026-03-30T20:12:16.330","metrics":{},"published":"2026-03-27T20:16:34.663","references":null}},"Kind":"enrichment"}`

On the other hand, NVD feeds downloaded from NVD site (gs://definitions.stackrox.io/v4/nvd/nvd-feeds.zip) has "metrics" field for such as `CVE-2026-33870`

After checking gs://definitions.stackrox.io/v4/nvd/nvd-feeds.zip => `v4_nvd_nvd-feeds/2026.nvd.json`
Some CVEs has CVSS version 3.1 but it's listed as “**_Secondary_**” and it remains the **_only_** available CVSS score when _**no**_ “Primary” score exists.
`{"cve": {"id": "CVE-2026-33870", ..., "metrics": {"cvssMetricV31": [{"source": "security-advisories@github.com", "type": "Secondary", "cvssData": {"version": "3.1", "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N", "baseScore": 7.5, "baseSeverity": "HIGH", "attackVector": "NETWORK", "attackComplexity": "LOW", "privilegesRequired": "NONE", "userInteraction": "NONE", "scope": "UNCHANGED", "confidentialityImpact": "NONE", "integrityImpact": "HIGH", "availabilityImpact": "NONE"}, "exploitabilityScore": 3.9, "impactScore": 3.6}]}, "weaknesses": [{"source": "security-advisories@github.com", "type": "Primary", "description": [{"lang": "en", "value": "CWE-444"}]}], "configurations": [{"nodes": [{"operator": "OR", "negate": false, "cpeMatch": [{"vulnerable": true, "criteria": "cpe:2.3:a:netty:netty:*:*:*:*:*:*:*:*", "versionEndExcluding": "4.1.132", "matchCriteriaId": "8F551B7E-5E29-4062-8FDB-AA1377B3E8F5"}, {"vulnerable": true, "criteria": "cpe:2.3:a:netty:netty:*:*:*:*:*:*:*:*", "versionStartIncluding": "4.2.0", "versionEndExcluding": "4.2.10", "matchCriteriaId": "419E92FA-6271-4613-AF3D-CF09ADFF2E13"}]}]}], ..., "tags": ["Technical Description"]}]}}`

The NVD enricher currently ignores these "Secondary" metrics.
And no cvss can cause some vuln missing severity: https://github.com/stackrox/stackrox/blob/503713eb10ee85f492ba42cf0309f2eb6552906c/pkg/scanners/scannerv4/convert.go#L400


But we may need to get some customers' feedback on how they would like those secondary scores.
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

`gs://scanner-v4-test/vulnerability-bundles/yli3-nvdMetrics/vulnerabilities.zip`
Unzip and check the NVD json:
`
{"Updater":"nvd","Fingerprint":"038f5720-d206-495b-8619-6add389c6cf9","Date":"2026-04-17T19:45:01.479806662Z","Ref":"d836b47e-45b4-4628-8a25-8adcf08f6b23","Enrichment":{"Tags":["CVE-2026-33870"],"Enrichment":{"descriptions":[{"lang":"en","value":"Netty is an asynchronous, event-driven network application framework. In versions prior to 4.1.132.Final and 4.2.10.Final, Netty incorrectly parses quoted strings in HTTP/1.1 chunked transfer encoding extension values, enabling request smuggling attacks. Versions 4.1.132.Final and 4.2.10.Final fix the issue."}],"id":"CVE-2026-33870","lastModified":"2026-03-30T20:12:16.330","metrics":{"cvssMetricV31":[{"cvssData":{"baseScore":7.5,"baseSeverity":"","vectorString":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N","version":"3.1"},"source":"","type":""}]},"published":"2026-03-27T20:16:34.663","references":null}},"Kind":"enrichment"}
`
