### PR TITLE
ROX-34172: Add ImageVulnerabilityReportView with entity scope

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportForm.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportForm.test.ts
@@ -125,7 +125,7 @@ describe('Vulnerability Reporting form', () => {
             ['CVE severity', 'Critical'],
             ['CVE severity', 'Important'],
             ['CVE severity', 'Moderate'],
-            ['CVE status', 'Unfixable'],
+            ['CVE status', 'Not fixable'],
             ['Collection included', testCollectionName],
             ['Image type', 'Deployed images'],
             ['Image type', 'Watched images'],
@@ -142,7 +142,7 @@ describe('Vulnerability Reporting form', () => {
         getInputByLabel('CVE severity').click();
 
         getInputByLabel('CVE status').click();
-        getSelectOption('Unfixable').click();
+        getSelectOption('Not fixable').click();
         getInputByLabel('CVE status').click();
 
         // Create a Collection via the modal

--- a/ui/apps/platform/src/Components/EntityScope/EntityScopeDescriptionListGroups.tsx
+++ b/ui/apps/platform/src/Components/EntityScope/EntityScopeDescriptionListGroups.tsx
@@ -1,0 +1,48 @@
+import type { ReactElement } from 'react';
+import {
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Flex,
+    FlexItem,
+} from '@patternfly/react-core';
+
+import type { EntityScope } from 'services/ReportsService.types';
+
+import { ruleEntityFieldText, ruleValueText } from './entityScopeText';
+
+export type EntityScopeDescriptionListGroupsProps = {
+    entityScope: EntityScope;
+};
+
+// For maximum composability and reusability:
+// Render description list groups instead of description list.
+// If rules array is empty, caller is reponsible for conditional rendering, like a warning alert.
+function EntityScopeDescriptionListGroups({
+    entityScope,
+}: EntityScopeDescriptionListGroupsProps): ReactElement {
+    /* eslint-disable react/no-array-index-key */
+    return (
+        <>
+            {entityScope.rules.map((rule, indexOfRule) => {
+                return (
+                    <DescriptionListGroup key={indexOfRule}>
+                        <DescriptionListTerm>{ruleEntityFieldText(rule)}</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            <Flex direction={{ default: 'column' }}>
+                                {rule.values.map((ruleValue, indexOfValue) => (
+                                    <FlexItem key={indexOfValue}>
+                                        {ruleValueText(ruleValue)}
+                                    </FlexItem>
+                                ))}
+                            </Flex>
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                );
+            })}
+        </>
+    );
+    /* eslint-enable react/no-array-index-key */
+}
+
+export default EntityScopeDescriptionListGroups;

--- a/ui/apps/platform/src/Components/EntityScope/entityScopeText.ts
+++ b/ui/apps/platform/src/Components/EntityScope/entityScopeText.ts
@@ -1,0 +1,38 @@
+import type {
+    EntityScopeRule,
+    MatchType,
+    RuleValue,
+    ScopeEntity,
+    ScopeField,
+} from 'services/ReportsService.types';
+
+const entityTextMap: Record<ScopeEntity, string> = {
+    SCOPE_ENTITY_UNSET: '',
+    SCOPE_ENTITY_DEPLOYMENT: 'Deployment',
+    SCOPE_ENTITY_NAMESPACE: 'Namespace',
+    SCOPE_ENTITY_CLUSTER: 'Cluster',
+} as const;
+
+const fieldTextMap: Record<ScopeField, string> = {
+    FIELD_UNSET: '',
+    FIELD_ID: 'ID',
+    FIELD_NAME: 'name',
+    FIELD_LABEL: 'label',
+    FIELD_ANNOTATION: 'annotation',
+} as const;
+
+export function ruleEntityFieldText({ entity, field }: EntityScopeRule) {
+    const entityText = entityTextMap[entity] ?? '';
+    const fieldText = fieldTextMap[field] ?? '';
+
+    return entityText && fieldText ? `${entityText} ${fieldText}` : 'Resource or field unset';
+}
+
+const matchTypeSuffixMap: Record<MatchType, string> = {
+    EXACT: ' (exact match)',
+    REGEX: ' (regex match)',
+} as const;
+
+export function ruleValueText({ value, matchType }: RuleValue) {
+    return `${value}${matchTypeSuffixMap[matchType] ?? ''}`;
+}

--- a/ui/apps/platform/src/Components/Reports/View/DetailsView.tsx
+++ b/ui/apps/platform/src/Components/Reports/View/DetailsView.tsx
@@ -8,22 +8,32 @@ import {
     FlexItem,
     Title,
 } from '@patternfly/react-core';
+import type { BreakpointModifiers } from '@patternfly/react-core';
 
 import type { DetailsType } from '../reports.types';
 
 export type DetailsViewProps = {
     headingLevel: 'h2' | 'h3';
+    horizontalTermWidthModifier: BreakpointModifiers;
     values: DetailsType;
 };
 
-function DetailsView({ headingLevel, values }: DetailsViewProps): ReactElement {
+function DetailsView({
+    headingLevel,
+    horizontalTermWidthModifier,
+    values,
+}: DetailsViewProps): ReactElement {
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
             <FlexItem>
                 <Title headingLevel={headingLevel}>Details</Title>
             </FlexItem>
             <FlexItem>
-                <DescriptionList isCompact isHorizontal>
+                <DescriptionList
+                    isCompact
+                    isHorizontal
+                    horizontalTermWidthModifier={horizontalTermWidthModifier}
+                >
                     <DescriptionListGroup>
                         <DescriptionListTerm>Name</DescriptionListTerm>
                         <DescriptionListDescription>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersView.tsx
@@ -8,17 +8,20 @@ import {
     FlexItem,
     Title,
 } from '@patternfly/react-core';
+import type { BreakpointModifiers } from '@patternfly/react-core';
 
 import type { ImageVulnerabilityFiltersConfiguration } from '../imageVulnerabilityReports.types';
 import { getTextForCvesSince } from '../imageVulnerabilityReports.utils';
 
 export type ImageVulnerabilityFiltersViewProps = {
     headingLevel: 'h2' | 'h3';
+    horizontalTermWidthModifier: BreakpointModifiers;
     values: ImageVulnerabilityFiltersConfiguration;
 };
 
 function ImageVulnerabilityFiltersView({
     headingLevel,
+    horizontalTermWidthModifier,
     values,
 }: ImageVulnerabilityFiltersViewProps): ReactElement {
     const { vulnReportFilters } = values;
@@ -29,7 +32,11 @@ function ImageVulnerabilityFiltersView({
                 <Title headingLevel={headingLevel}>Filters</Title>
             </FlexItem>
             <FlexItem>
-                <DescriptionList isCompact isHorizontal>
+                <DescriptionList
+                    isCompact
+                    isHorizontal
+                    horizontalTermWidthModifier={horizontalTermWidthModifier}
+                >
                     {/* TODO render labels for query string */}
                     <DescriptionListGroup>
                         <DescriptionListTerm>CVEs discovered in image since</DescriptionListTerm>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersViewForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersViewForCollection.tsx
@@ -6,9 +6,9 @@ import {
     DescriptionListTerm,
     Flex,
     FlexItem,
-    Label,
     Title,
 } from '@patternfly/react-core';
+import type { BreakpointModifiers } from '@patternfly/react-core';
 
 import { fixabilityLabels } from 'constants/reportConstants';
 import { vulnerabilitySeverityLabels } from 'messages/common';
@@ -18,11 +18,13 @@ import { getTextForCvesSince } from '../imageVulnerabilityReports.utils';
 
 export type ImageVulnerabilityFiltersViewForCollectionProps = {
     headingLevel: 'h2' | 'h3';
+    horizontalTermWidthModifier: BreakpointModifiers;
     values: ImageVulnerabilityFiltersConfigurationForCollection;
 };
 
 function ImageVulnerabilityFiltersViewForCollection({
     headingLevel,
+    horizontalTermWidthModifier,
     values,
 }: ImageVulnerabilityFiltersViewForCollectionProps): ReactElement {
     const { vulnReportFilters } = values;
@@ -34,17 +36,25 @@ function ImageVulnerabilityFiltersViewForCollection({
                 <Title headingLevel={headingLevel}>Filters</Title>
             </FlexItem>
             <FlexItem>
-                <DescriptionList isCompact isHorizontal>
+                <DescriptionList
+                    isCompact
+                    isHorizontal
+                    horizontalTermWidthModifier={horizontalTermWidthModifier}
+                >
                     <DescriptionListGroup>
                         <DescriptionListTerm>CVE severity</DescriptionListTerm>
                         <DescriptionListDescription>
-                            {severities.length === 0
-                                ? '-'
-                                : severities.map((severity) => (
-                                      <Label key={severity} variant="outline">
-                                          {vulnerabilitySeverityLabels[severity]}
-                                      </Label>
-                                  ))}
+                            {severities.length === 0 ? (
+                                '-'
+                            ) : (
+                                <Flex direction={{ default: 'column' }}>
+                                    {severities.map((severity) => (
+                                        <FlexItem key={severity}>
+                                            {vulnerabilitySeverityLabels[severity]}
+                                        </FlexItem>
+                                    ))}
+                                </Flex>
+                            )}
                         </DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityReportView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityReportView.tsx
@@ -1,0 +1,55 @@
+import type { ReactElement } from 'react';
+import { Flex } from '@patternfly/react-core';
+import type { BreakpointModifiers } from '@patternfly/react-core';
+
+import DetailsView from 'Components/Reports/View/DetailsView';
+
+import type { ImageVulnerabilityReportConfiguration } from '../imageVulnerabilityReports.types';
+import { hasConfigurationForEntity } from '../imageVulnerabilityReports.utils';
+
+import ImageVulnerabilityFiltersView from './ImageVulnerabilityFiltersView';
+import ImageVulnerabilityFiltersViewForCollection from './ImageVulnerabilityFiltersViewForCollection';
+import ImageVulnerabilityResourcesView from './ImageVulnerabilityResourcesView';
+
+export type ImageVulnerabilityReportViewProps = {
+    headingLevel: 'h2' | 'h3';
+    horizontalTermWidthModifier: BreakpointModifiers;
+    values: ImageVulnerabilityReportConfiguration;
+};
+
+function ImageVulnerabilityReportView({
+    headingLevel,
+    horizontalTermWidthModifier,
+    values,
+}: ImageVulnerabilityReportViewProps): ReactElement {
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+            <DetailsView
+                headingLevel={headingLevel}
+                horizontalTermWidthModifier={horizontalTermWidthModifier}
+                values={values}
+            />
+            <ImageVulnerabilityResourcesView
+                headingLevel={headingLevel}
+                horizontalTermWidthModifier={horizontalTermWidthModifier}
+                values={values}
+            />
+            {hasConfigurationForEntity(values) ? (
+                <ImageVulnerabilityFiltersView
+                    headingLevel={headingLevel}
+                    horizontalTermWidthModifier={horizontalTermWidthModifier}
+                    values={values}
+                />
+            ) : (
+                <ImageVulnerabilityFiltersViewForCollection
+                    headingLevel={headingLevel}
+                    horizontalTermWidthModifier={horizontalTermWidthModifier}
+                    values={values}
+                />
+            )}
+            {/* TODO render delivery or destinations view after name have been decided */}
+        </Flex>
+    );
+}
+
+export default ImageVulnerabilityReportView;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityResourcesView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityResourcesView.tsx
@@ -6,20 +6,24 @@ import {
     DescriptionListTerm,
     Flex,
     FlexItem,
-    Label,
     Title,
 } from '@patternfly/react-core';
+import type { BreakpointModifiers } from '@patternfly/react-core';
+
+import EntityScopeDescriptionListGroups from 'Components/EntityScope/EntityScopeDescriptionListGroups';
 
 import type { ImageVulnerabilityResourcesConfiguration } from '../imageVulnerabilityReports.types';
 import { imageTypeLabelMap } from '../imageVulnerabilityReports.utils';
 
 export type ImageVulnerabilityResourcesViewProps = {
     headingLevel: 'h2' | 'h3';
+    horizontalTermWidthModifier: BreakpointModifiers;
     values: ImageVulnerabilityResourcesConfiguration;
 };
 
 function ImageVulnerabilityResourcesView({
     headingLevel,
+    horizontalTermWidthModifier,
     values,
 }: ImageVulnerabilityResourcesViewProps): ReactElement {
     const { resourceScope, vulnReportFilters } = values;
@@ -31,17 +35,25 @@ function ImageVulnerabilityResourcesView({
                 <Title headingLevel={headingLevel}>Resources</Title>
             </FlexItem>
             <FlexItem>
-                <DescriptionList isCompact isHorizontal>
+                <DescriptionList
+                    isCompact
+                    isHorizontal
+                    horizontalTermWidthModifier={horizontalTermWidthModifier}
+                >
                     <DescriptionListGroup>
                         <DescriptionListTerm>Image type</DescriptionListTerm>
                         <DescriptionListDescription>
-                            {imageTypes.length === 0
-                                ? '-'
-                                : imageTypes.map((imageType) => (
-                                      <Label key={imageType} variant="outline">
-                                          {imageTypeLabelMap[imageType]}
-                                      </Label>
-                                  ))}
+                            {imageTypes.length === 0 ? (
+                                '-'
+                            ) : (
+                                <Flex direction={{ default: 'column' }}>
+                                    {imageTypes.map((imageType) => (
+                                        <FlexItem key={imageType}>
+                                            {imageTypeLabelMap[imageType]}
+                                        </FlexItem>
+                                    ))}
+                                </Flex>
+                            )}
                         </DescriptionListDescription>
                     </DescriptionListGroup>
                     {'collectionScope' in resourceScope && (
@@ -53,12 +65,7 @@ function ImageVulnerabilityResourcesView({
                         </DescriptionListGroup>
                     )}
                     {'entityScope' in resourceScope && (
-                        <DescriptionListGroup>
-                            <DescriptionListTerm>TODO</DescriptionListTerm>
-                            <DescriptionListDescription>
-                                <>TODO</>
-                            </DescriptionListDescription>
-                        </DescriptionListGroup>
+                        <EntityScopeDescriptionListGroups entityScope={resourceScope.entityScope} />
                     )}
                 </DescriptionList>
             </FlexItem>

--- a/ui/apps/platform/src/constants/reportConstants.ts
+++ b/ui/apps/platform/src/constants/reportConstants.ts
@@ -5,5 +5,5 @@ type FixabilityLabels = Record<FixabilityLabelKey, string>;
 
 export const fixabilityLabels: FixabilityLabels = {
     FIXABLE: 'Fixable',
-    NOT_FIXABLE: 'Unfixable',
+    NOT_FIXABLE: 'Not fixable',
 };


### PR DESCRIPTION
## Description

**Review**: Hide space because of indentation changes.

### Objective

Provide equivalent filter for scheduled reports as view-based reports

### Analysis

Entity scope is structured alternative to search filter fields.

In addition to other report types, it might become replacement for collections.

Unlike **node** vulnerability reports which have entity scope only (as far as we know) for resources, **image** vulnerability reports also have **Image types** for resources.

### Solution

1. Add src/Components/EntityScope folder with component and utils files.

    Render description list groups similar to compound search filter.
    * Render `entity` and `field` as term.
    * Render `value` and `matchType` as description with flex column layout.

2. Edit view files.

    * Add `horizontalTermWidthModifier` prop for consistent alignment of description lists, especially for search field labels.
    * Replace `LabelGroup` with `Flex` column layout for **Image type** and **CVE severity**

3. Edit ImageVulnerabilityFiltersView.tsx file. TODO rebase after contribution is merged.

    * Render `CompoundSearchFilterDescriptionListGroups` as for view-based reports in #19993

4. Add ImageVulnerabilityReportView.tsx file for view page and **Review** step of wizard.

### Residue

1. Defer **Destinations** or **Delivery** until name has been confirmed, or my backlog is empty, whichever comes first.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

### Manual testing

Tempoorarily edit ViewVulnReportPage.tsx file to render component with simulated response data.

1. Visit /main/vulnerabilities/reports/configuration and click a link.

    Before changes:
    <img width="1440" height="892" alt="dv-test-delete_baseline" src="https://github.com/user-attachments/assets/08d43e9f-df43-42f0-b45f-5ee4366a7d04" />

    After changes:
    <img width="1440" height="892" alt="dv-test-delete_improved" src="https://github.com/user-attachments/assets/4173d0ab-f40e-4a1e-9069-bf9e4deae911" />

2. Click another link:

    Before changes:
    <img width="1440" height="892" alt="kerry-test_baseline" src="https://github.com/user-attachments/assets/f0757be8-6083-4787-8617-422922dcee22" />

    After changes:
    <img width="1440" height="892" alt="kerry-test_improved" src="https://github.com/user-attachments/assets/fe7a6812-679f-4357-8fd8-5ea07457fe80" />

3. Temporarily edit to render a report configuration with entity scope. TODO rebase to render search filter
    <img width="1439" height="440" alt="entityScope" src="https://github.com/user-attachments/assets/360ffa5c-ce4a-492e-8f7b-7f3c7acdb4fa" />

```ts
const entityScopeConfiguration: ImageVulnerabilityReportConfigurationForEntity = {
    id: 'id',
    name: 'ROX-34172-ImageVulnerabilityReportView',
    description: 'ROX-34172: Add ImageVulnerabilityReportView with entity scope',
    type: 'VULNERABILITY',
    vulnReportFilters: {
        imageTypes: ['DEPLOYED'],
        query: 'TODO',
        sinceLastSentScheduledReport: true,
    },
    notifiers: [],
    schedule: null,
    resourceScope: {
        entityScope: {
            rules: [
                {
                    entity: 'SCOPE_ENTITY_CLUSTER',
                    field: 'FIELD_NAME',
                    values: [
                        {
                            matchType: 'EXACT',
                            value: 'staging-secured-cluster',
                        },
                    ],
                },
                {
                    entity: 'SCOPE_ENTITY_NAMESPACE',
                    field: 'FIELD_NAME',
                    values: [
                        {
                            matchType: 'EXACT',
                            value: 'stackrox',
                        }
                    ]
                },
                {
                    entity: 'SCOPE_ENTITY_DEPLOYMENT',
                    field: 'FIELD_NAME',
                    values: [
                        {
                            matchType: 'REGEX',
                            value: 'scanner',
                        },
                        {
                            matchType: 'EXACT',
                            value: 'collector',
                        },
                    ],
                },
            ],
        },
    },
} as const;
```