### PR TITLE
ROX-33962: Remove Orchestrator Components from Global Search

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
@@ -23,8 +23,7 @@ function MastheadToolbar(): ReactElement {
     const location = useLocation();
     const workflowState = parseURL(location);
     const useCase = workflowState.getUseCase();
-    const showOrchestratorComponentsToggle =
-        useCase === useCases.RISK || location.pathname === searchPath;
+    const showOrchestratorComponentsToggle = useCase === useCases.RISK;
 
     // TODO: (PatternFly) need more robust mobile experience than just hiding tools
     // <PageHeaderToolsGroup visibility={{ default: 'hidden', md: 'visible' }}>

--- a/ui/apps/platform/src/Containers/Search/SearchPage.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchPage.tsx
@@ -16,7 +16,6 @@ import SearchFilterInput from 'Components/SearchFilterInput';
 import { fetchGlobalSearchResults, getSearchOptionsForCategory } from 'services/SearchService';
 import type { SearchResponse } from 'services/SearchService';
 import type { SearchFilter } from 'types/search';
-import { ORCHESTRATOR_COMPONENTS_KEY } from 'utils/orchestratorComponents';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { searchPath } from 'routePaths';
@@ -79,11 +78,7 @@ function SearchPage(): ReactElement {
             setSeachResponseErrorMessage(null);
 
             const parsedSearchFilter = parseSearchFilter(stringifiedSearchFilter);
-            const query = getRequestQueryStringForSearchFilter(
-                localStorage.getItem(ORCHESTRATOR_COMPONENTS_KEY) !== 'true'
-                    ? { ...parsedSearchFilter, 'Orchestrator Component': 'false' }
-                    : parsedSearchFilter
-            );
+            const query = getRequestQueryStringForSearchFilter(parsedSearchFilter);
 
             fetchGlobalSearchResults({ query })
                 .then(setSearchResponse)


### PR DESCRIPTION
## Description

As titled, this functionality has been replaced with "Platform Components" which can be used natively from the search bar.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Orchestrator Components toggle is no longer present on global search page:
<img width="1665" height="752" alt="image" src="https://github.com/user-attachments/assets/be2e18bb-320f-440f-9c80-13217bcbf282" />

Search queries do not include "Orchestrator Components"
<img width="1665" height="1103" alt="image" src="https://github.com/user-attachments/assets/38b671c8-05bd-488a-bd1f-304b533dd73f" />

Platform Components is available and functional in the search filter bar:
<img width="1665" height="1103" alt="image" src="https://github.com/user-attachments/assets/05177de8-e1bc-4460-a32c-914a5fbf6c09" />


