### PR TITLE
ROX-32848: Ack-based retry for VM

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -167,6 +167,8 @@ func (c *Compliance) Start() {
 				c.umhVMIndex,
 				maxPerMinute,
 				env.VMRelayStaleAckThreshold.DurationSetting(),
+				env.VMIndexReportRelayCacheSlots.IntegerSetting(),
+				env.VMIndexReportRelayCacheTTL.DurationSetting(),
 			)
 			if err := vmRelay.Run(ctx); err != nil {
 				log.Errorf("Running virtual machine relay: %v", err)

--- a/compliance/virtualmachines/relay/metrics/metrics.go
+++ b/compliance/virtualmachines/relay/metrics/metrics.go
@@ -137,6 +137,61 @@ var VMIndexACKsFromSensor = prometheus.NewCounterVec(
 	[]string{"action"}, // "ACK", "NACK"
 )
 
+// IndexReportCacheSlotsUsed is the current number of entries held in the VM index report payload cache.
+var IndexReportCacheSlotsUsed = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.ComplianceSubsystem.String(),
+		Name:      "virtual_machine_relay_index_report_cache_slots_used",
+		Help:      "Number of VM index report payloads currently stored in the Relay payload cache",
+	},
+)
+
+// IndexReportCacheSlotsCapacity is the maximum number of entries the VM index report payload cache can hold.
+var IndexReportCacheSlotsCapacity = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.ComplianceSubsystem.String(),
+		Name:      "virtual_machine_relay_index_report_cache_slots_capacity",
+		Help:      "Maximum number of VM index report payloads the Relay payload cache can store",
+	},
+)
+
+// IndexReportCacheResidencySeconds observes elapsed time from the most recent payload update
+// (updatedAt) to cache removal for VM index report payloads.
+var IndexReportCacheResidencySeconds = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.ComplianceSubsystem.String(),
+		Name:      "virtual_machine_relay_index_report_cache_residency_seconds",
+		Help:      "For each VM index report payload removed from cache, elapsed time between its most recent update and removal",
+		Buckets:   prometheus.ExponentialBuckets(0.1, 2, 10),
+	},
+)
+
+// IndexReportCacheLifetimeSeconds observes elapsed time from the first payload insert
+// for the current cache entry (firstUpdatedAt) to cache removal.
+var IndexReportCacheLifetimeSeconds = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.ComplianceSubsystem.String(),
+		Name:      "virtual_machine_relay_index_report_cache_lifetime_seconds",
+		Help:      "For each VM index report payload removed from cache, elapsed time between first insert and removal",
+		Buckets:   prometheus.ExponentialBuckets(0.1, 2, 10),
+	},
+)
+
+// IndexReportCacheLookupsTotal counts payload cache lookups by hit or miss.
+var IndexReportCacheLookupsTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.ComplianceSubsystem.String(),
+		Name:      "virtual_machine_relay_index_report_cache_lookups_total",
+		Help:      "Lookups against the VM index report payload cache partitioned by result",
+	},
+	[]string{"result"}, // hit|miss
+)
+
 func init() {
 	prometheus.MustRegister(
 		IndexReportsMismatchingVsockCID,
@@ -151,5 +206,10 @@ func init() {
 		ReportsRateLimited,
 		AcksReceived,
 		VMIndexACKsFromSensor,
+		IndexReportCacheSlotsUsed,
+		IndexReportCacheSlotsCapacity,
+		IndexReportCacheResidencySeconds,
+		IndexReportCacheLifetimeSeconds,
+		IndexReportCacheLookupsTotal,
 	)
 }

--- a/compliance/virtualmachines/relay/relay.go
+++ b/compliance/virtualmachines/relay/relay.go
@@ -50,6 +50,9 @@ type Relay struct {
 	// Rate limiting config
 	maxReportsPerMinute float64
 	staleAckThreshold   time.Duration
+	// payloadCacheTTL is the configured TTL for the payload cache; when positive,
+	// New installs a periodic payload sweep ticker independent of staleAckThreshold.
+	payloadCacheTTL time.Duration
 
 	// cacheEvictTicker owns the metadata eviction ticker in production so it can be
 	// stopped when the relay shuts down, avoiding ticker goroutine leaks.
@@ -60,12 +63,23 @@ type Relay struct {
 	// their own channel for deterministic control.
 	cacheEvictTickCh <-chan time.Time
 
+	// payloadSweepTicker drives periodic TTL sweeps of the payload cache when
+	// payloadCacheTTL > 0. It is independent of staleAckThreshold and cacheEvictTicker.
+	payloadSweepTicker *time.Ticker
+	// payloadSweepTickCh signals when expired payload cache entries should be swept.
+	// In production this is fed by payloadSweepTicker.C; tests may supply their own channel.
+	payloadSweepTickCh <-chan time.Time
+
 	// cache stores metadata (including the per-VSOCK rate limiter) for each VSOCK ID.
 	cache map[string]*cachedReportMetadata
 	// mu guards cache. A plain Mutex is preferred over RWMutex
 	// because nearly every incoming report writes to the map, so there is no
 	// read-heavy workload that would benefit from concurrent readers.
 	mu sync.Mutex
+
+	// payloadCache stores full VM reports for UMH-driven retransmission; it uses its own mutex
+	// (see reportPayloadCache) and is keyed by the same resource ID as UMH (vsock CID).
+	payloadCache *reportPayloadCache
 }
 
 // evictStaleEntries removes metadata entries for VMs that have
@@ -75,6 +89,7 @@ func (r *Relay) evictStaleEntries(now time.Time, threshold time.Duration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Remove cache entries for VMs that have not sent a report within the given threshold.
 	for vsockID, metadata := range r.cache {
 		if now.Sub(metadata.updatedAt) > threshold {
 			delete(r.cache, vsockID)
@@ -89,6 +104,8 @@ func New(
 	umh UnconfirmedMessageHandler,
 	maxReportsPerMinute float64,
 	staleAckThreshold time.Duration,
+	payloadCacheMaxSlots int,
+	payloadCacheTTL time.Duration,
 ) *Relay {
 	r := &Relay{
 		reportStream:        reportStream,
@@ -96,8 +113,12 @@ func New(
 		umh:                 umh,
 		maxReportsPerMinute: maxReportsPerMinute,
 		staleAckThreshold:   staleAckThreshold,
+		payloadCacheTTL:     payloadCacheTTL,
 		cache:               make(map[string]*cachedReportMetadata),
+		payloadCache:        newReportPayloadCache(payloadCacheMaxSlots, payloadCacheTTL),
 	}
+	metrics.IndexReportCacheSlotsCapacity.Set(float64(payloadCacheMaxSlots))
+	metrics.IndexReportCacheSlotsUsed.Set(float64(r.payloadCache.Len()))
 	if staleAckThreshold <= 0 {
 		log.Warnf("VM relay stale ACK threshold is non-positive (%s); disabling stale cache eviction", staleAckThreshold)
 	} else {
@@ -109,6 +130,15 @@ func New(
 		r.cacheEvictTicker = ticker
 		r.cacheEvictTickCh = ticker.C
 	}
+	if payloadCacheTTL > 0 {
+		payloadSweepInterval := payloadCacheTTL / 2
+		if payloadSweepInterval <= 0 {
+			payloadSweepInterval = payloadCacheTTL
+		}
+		pt := time.NewTicker(payloadSweepInterval)
+		r.payloadSweepTicker = pt
+		r.payloadSweepTickCh = pt.C
+	}
 	r.umh.OnACK(r.markAcked)
 	return r
 }
@@ -118,6 +148,9 @@ func (r *Relay) Run(ctx context.Context) error {
 	log.Info("Starting virtual machine relay")
 	if r.cacheEvictTicker != nil {
 		defer r.cacheEvictTicker.Stop()
+	}
+	if r.payloadSweepTicker != nil {
+		defer r.payloadSweepTicker.Stop()
 	}
 
 	reportChan, err := r.reportStream.Start(ctx)
@@ -139,9 +172,11 @@ func (r *Relay) Run(ctx context.Context) error {
 			if !ok {
 				return errors.New("UMH retry command channel closed")
 			}
-			log.Infof("UMH retry for resource %s; no payload cache available, skipping resend", resourceID)
+			r.handleRetryCommand(ctx, resourceID)
 		case tick := <-r.cacheEvictTickCh:
 			r.evictStaleEntries(tick, r.staleAckThreshold)
+		case tick := <-r.payloadSweepTickCh:
+			r.sweepPayloadCache(tick)
 		}
 	}
 }
@@ -161,12 +196,23 @@ func (r *Relay) markAcked(resourceID string) {
 			}
 		}
 	})
+
+	ev, removed := r.payloadCache.Remove(resourceID, now)
+	if removed {
+		observePayloadEvictionMetrics(ev)
+	}
+	metrics.IndexReportCacheSlotsUsed.Set(float64(r.payloadCache.Len()))
 }
 
 // handleIncomingReport processes an incoming report with rate limiting.
 func (r *Relay) handleIncomingReport(ctx context.Context, vmReport *v1.VMReport) {
 	vsockID := vmReport.GetIndexReport().GetVsockCid()
 	now := time.Now()
+
+	for _, ev := range r.payloadCache.Upsert(vsockID, vmReport, now) {
+		observePayloadEvictionMetrics(ev)
+	}
+	metrics.IndexReportCacheSlotsUsed.Set(float64(r.payloadCache.Len()))
 
 	r.cacheReport(vsockID, now)
 
@@ -231,4 +277,35 @@ func (r *Relay) tryConsume(vsockID string) bool {
 		metadata.limiter = rate.NewLimiter(rate.Limit(ratePerSecond), 1)
 	}
 	return metadata.limiter.Allow()
+}
+
+// sweepPayloadCache removes expired payload cache entries and updates cache metrics.
+func (r *Relay) sweepPayloadCache(now time.Time) {
+	for _, ev := range r.payloadCache.SweepExpired(now) {
+		observePayloadEvictionMetrics(ev)
+	}
+	metrics.IndexReportCacheSlotsUsed.Set(float64(r.payloadCache.Len()))
+}
+
+// handleRetryCommand attempts to resend a cached payload for the given resource ID.
+func (r *Relay) handleRetryCommand(ctx context.Context, resourceID string) {
+	now := time.Now()
+	cached, ok := r.payloadCache.Get(resourceID, now)
+	if ok {
+		metrics.IndexReportCacheLookupsTotal.WithLabelValues("hit").Inc()
+		if err := r.reportSender.Send(ctx, cached); err != nil {
+			r.umh.HandleNACK(resourceID)
+			log.Errorf("Failed to resend cached VM index report (resourceID=%s): %v", resourceID, err)
+			return
+		}
+		r.umh.ObserveSending(resourceID)
+		return
+	}
+	metrics.IndexReportCacheLookupsTotal.WithLabelValues("miss").Inc()
+	log.Infof("VM index report payload cache miss on retry for resource %s; not resending", resourceID)
+}
+
+func observePayloadEvictionMetrics(ev payloadEviction) {
+	metrics.IndexReportCacheResidencySeconds.Observe(ev.residency.Seconds())
+	metrics.IndexReportCacheLifetimeSeconds.Observe(ev.lifetime.Seconds())
 }

--- a/compliance/virtualmachines/relay/relay_test.go
+++ b/compliance/virtualmachines/relay/relay_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stackrox/rox/compliance/virtualmachines/relay/metrics"
 	relaytest "github.com/stackrox/rox/compliance/virtualmachines/relay/testutils"
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -55,7 +58,7 @@ func (s *relayTestSuite) TestRelay_StartFailure() {
 	}
 
 	// Construct the relay under test.
-	relay := New(stream, sender, &mockUMH{}, 0, 4*time.Hour)
+	relay := New(stream, sender, &mockUMH{}, 0, 4*time.Hour, 0, 0)
 
 	// Run the relay in a goroutine so we can assert it returns promptly and
 	// does not block in its select loop.
@@ -112,7 +115,7 @@ func (s *relayTestSuite) TestRelay_Integration() {
 
 	// Create relay with mock dependencies using the public constructor
 	// Rate limiting disabled (0)
-	relay := New(mockIndexReportStream, mockIndexReportSender, &mockUMH{}, 0, 4*time.Hour)
+	relay := New(mockIndexReportStream, mockIndexReportSender, &mockUMH{}, 0, 4*time.Hour, 0, 0)
 
 	// Run relay in background
 	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
@@ -182,7 +185,7 @@ func (s *relayTestSuite) TestRelay_SenderErrorsDoNotStopProcessing() {
 	}
 
 	umh := &mockUMH{}
-	relay := New(mockIndexReportStream, mockIndexReportSender, umh, 0, 4*time.Hour)
+	relay := New(mockIndexReportStream, mockIndexReportSender, umh, 0, 4*time.Hour, 0, 0)
 
 	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
 	defer cancel()
@@ -233,7 +236,7 @@ func (s *relayTestSuite) TestRelay_ContextCancellation() {
 		failOnIndex: -1, // never fail
 	}
 
-	relay := New(mockIndexReportStream, mockIndexReportSender, &mockUMH{}, 0, 4*time.Hour)
+	relay := New(mockIndexReportStream, mockIndexReportSender, &mockUMH{}, 0, 4*time.Hour, 0, 0)
 
 	ctx, cancel := context.WithCancel(s.ctx)
 
@@ -277,7 +280,7 @@ func (s *relayTestSuite) TestRelay_RateLimiting() {
 	}
 
 	// Rate limit: 1 per minute (effectively blocks after first)
-	relay := New(mockIndexReportStream, mockIndexReportSender, &mockUMH{}, 1, 4*time.Hour)
+	relay := New(mockIndexReportStream, mockIndexReportSender, &mockUMH{}, 1, 4*time.Hour, 0, 0)
 
 	ctx, cancel := context.WithTimeout(s.ctx, 1*time.Second)
 	defer cancel()
@@ -330,7 +333,7 @@ func (s *relayTestSuite) TestRelay_UMHInteraction() {
 		retryCh: make(chan string, 1),
 	}
 
-	relay := New(mockIndexReportStream, mockIndexReportSender, umh, 0, 4*time.Hour)
+	relay := New(mockIndexReportStream, mockIndexReportSender, umh, 0, 4*time.Hour, 0, 0)
 
 	ctx, cancel := context.WithTimeout(s.ctx, 2*time.Second)
 	defer cancel()
@@ -389,6 +392,7 @@ func (s *relayTestSuite) TestRelay_StaleCacheEntriesAreEvicted() {
 		staleAckThreshold: threshold,
 		cacheEvictTickCh:  evictCh,
 		cache:             make(map[string]*cachedReportMetadata),
+		payloadCache:      newReportPayloadCache(0, time.Hour),
 	}
 	r.umh.OnACK(r.markAcked)
 
@@ -500,25 +504,36 @@ func (s *relayTestSuite) TestRelay_EvictStaleEntries() {
 	}
 }
 
-func (s *relayTestSuite) TestRelay_StaleAckTicker() {
+func (s *relayTestSuite) TestRelay_StaleAckAndPayloadSweepTickers() {
 	cases := map[string]struct {
-		staleAck time.Duration
-		wantMeta bool
+		staleAck    time.Duration
+		payloadTTL  time.Duration
+		wantMeta    bool
+		wantPayload bool
 	}{
-		"non-positive stale ACK disables ticker": {
-			staleAck: 0, wantMeta: false,
+		"non-positive stale ACK and zero payload TTL disable both tickers": {
+			staleAck: 0, payloadTTL: 0, wantMeta: false, wantPayload: false,
 		},
-		"negative stale ACK disables ticker": {
-			staleAck: -time.Second, wantMeta: false,
+		"negative stale ACK and zero payload TTL disable both tickers": {
+			staleAck: -time.Second, payloadTTL: 0, wantMeta: false, wantPayload: false,
 		},
-		"positive stale ACK enables ticker": {
-			staleAck: time.Hour, wantMeta: true,
+		"non-positive stale ACK but positive payload TTL disables metadata ticker only": {
+			staleAck: 0, payloadTTL: time.Hour, wantMeta: false, wantPayload: true,
+		},
+		"negative stale ACK but positive payload TTL disables metadata ticker only": {
+			staleAck: -time.Second, payloadTTL: time.Hour, wantMeta: false, wantPayload: true,
+		},
+		"positive stale ACK and zero payload TTL enables metadata ticker only": {
+			staleAck: time.Hour, payloadTTL: 0, wantMeta: true, wantPayload: false,
+		},
+		"positive stale ACK and positive payload TTL enables both tickers": {
+			staleAck: time.Hour, payloadTTL: time.Hour, wantMeta: true, wantPayload: true,
 		},
 	}
 
 	for name, tc := range cases {
 		s.Run(name, func() {
-			r := New(&mockIndexReportStream{}, &mockIndexReportSender{failOnIndex: -1}, &mockUMH{}, 0, tc.staleAck)
+			r := New(&mockIndexReportStream{}, &mockIndexReportSender{failOnIndex: -1}, &mockUMH{}, 0, tc.staleAck, 0, tc.payloadTTL)
 			if tc.wantMeta {
 				s.NotNil(r.cacheEvictTicker, "metadata eviction ticker should exist")
 				s.NotNil(r.cacheEvictTickCh, "metadata eviction channel should be set")
@@ -526,8 +541,60 @@ func (s *relayTestSuite) TestRelay_StaleAckTicker() {
 				s.Nil(r.cacheEvictTicker, "metadata eviction ticker should not exist")
 				s.Nil(r.cacheEvictTickCh, "metadata eviction channel should be disabled")
 			}
+			if tc.wantPayload {
+				s.NotNil(r.payloadSweepTicker, "payload sweep ticker should exist when payload TTL is positive")
+				s.NotNil(r.payloadSweepTickCh, "payload sweep channel should be set when payload TTL is positive")
+			} else {
+				s.Nil(r.payloadSweepTicker, "payload sweep ticker should not exist when payload TTL is non-positive")
+				s.Nil(r.payloadSweepTickCh, "payload sweep channel should be disabled when payload TTL is non-positive")
+			}
 		})
 	}
+}
+
+func (s *relayTestSuite) TestRelay_Run_InvokesPayloadSweepWhenStaleAckEvictionDisabled() {
+	sweepCh := make(chan time.Time, 1)
+	now := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	ttl := 10 * time.Millisecond
+
+	r := &Relay{
+		reportStream:       &mockIndexReportStream{},
+		reportSender:       &mockIndexReportSender{failOnIndex: -1},
+		umh:                &mockUMH{},
+		staleAckThreshold:  0,
+		payloadCacheTTL:    ttl,
+		cacheEvictTickCh:   nil,
+		payloadSweepTickCh: sweepCh,
+		cache:              make(map[string]*cachedReportMetadata),
+		payloadCache:       newReportPayloadCache(4, ttl),
+	}
+	r.umh.OnACK(r.markAcked)
+
+	vmr := relaytest.NewTestVMReport("100")
+	s.Require().Empty(r.payloadCache.Upsert("100", vmr, now.Add(-2*ttl)))
+	s.Require().Equal(1, r.payloadCache.Len(), "precondition: one cached payload entry")
+
+	ctx, cancel := context.WithTimeout(s.ctx, 2*time.Second)
+	defer cancel()
+
+	sweepCh <- now
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- r.Run(ctx)
+	}()
+
+	s.Eventually(
+		func() bool {
+			return r.payloadCache.Len() == 0
+		},
+		time.Second,
+		10*time.Millisecond,
+		"expired payload entry should be removed on payload sweep tick",
+	)
+
+	cancel()
+	s.ErrorIs(<-errCh, context.Canceled)
 }
 
 func (s *relayTestSuite) TestRelay_RunReturnsErrorWhenRetryChannelCloses() {
@@ -536,7 +603,7 @@ func (s *relayTestSuite) TestRelay_RunReturnsErrorWhenRetryChannelCloses() {
 	umh := &mockUMH{
 		retryCh: retryCh,
 	}
-	r := New(&mockIndexReportStream{}, &mockIndexReportSender{failOnIndex: -1}, umh, 0, 4*time.Hour)
+	r := New(&mockIndexReportStream{}, &mockIndexReportSender{failOnIndex: -1}, umh, 0, 4*time.Hour, 0, 0)
 	s.Require().NotNil(r.cacheEvictTicker)
 
 	ctx, cancel := context.WithTimeout(s.ctx, time.Second)
@@ -545,6 +612,300 @@ func (s *relayTestSuite) TestRelay_RunReturnsErrorWhenRetryChannelCloses() {
 	err := r.Run(ctx)
 	s.Require().Error(err)
 	s.ErrorContains(err, "UMH retry command channel closed")
+}
+
+func (s *relayTestSuite) TestRelay_RetryCommand_CacheHit_Resends() {
+	done := concurrency.NewSignal()
+	mockSender := &mockIndexReportSender{
+		failOnIndex:   -1,
+		done:          &done,
+		expectedCount: 1,
+	}
+	umh := &mockUMH{
+		retryCh: make(chan string, 1),
+	}
+	stream := &mockIndexReportStream{
+		reports: []*v1.VMReport{
+			relaytest.NewTestVMReport("100"),
+		},
+	}
+	relay := New(stream, mockSender, umh, 0, 4*time.Hour, 4, 24*time.Hour)
+
+	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- relay.Run(ctx)
+	}()
+
+	select {
+	case <-done.Done():
+	case <-time.After(2 * time.Second):
+		s.Fail("timeout waiting for initial send")
+	}
+
+	hitBefore := testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("hit"))
+
+	umh.retryCh <- "100"
+	time.Sleep(300 * time.Millisecond)
+
+	var sentMessages []*v1.VMReport
+	concurrency.WithLock(&mockSender.mu, func() {
+		sentMessages = append(sentMessages, mockSender.sentMessages...)
+	})
+	s.Len(sentMessages, 2)
+	s.Equal("100", sentMessages[0].GetIndexReport().GetVsockCid())
+	s.Equal("100", sentMessages[1].GetIndexReport().GetVsockCid())
+
+	var sends []string
+	concurrency.WithLock(&umh.mu, func() {
+		sends = append(sends, umh.sends...)
+	})
+	s.Len(sends, 2)
+	s.Equal([]string{"100", "100"}, sends)
+
+	hitDelta := testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("hit")) - hitBefore
+	s.Equal(1.0, hitDelta)
+
+	cancel()
+	<-errCh
+}
+
+func (s *relayTestSuite) TestRelay_RetryCommand_CacheMiss_IncrementsMissAndDoesNotSend() {
+	mockSender := &mockIndexReportSender{
+		failOnIndex: -1,
+	}
+	umh := &mockUMH{
+		retryCh: make(chan string, 1),
+	}
+	stream := &mockIndexReportStream{
+		reports: nil,
+	}
+	relay := New(stream, mockSender, umh, 0, 4*time.Hour, 4, 24*time.Hour)
+
+	ctx, cancel := context.WithTimeout(s.ctx, 3*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- relay.Run(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	missBefore := testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("miss"))
+
+	umh.retryCh <- "not-cached"
+	time.Sleep(200 * time.Millisecond)
+
+	missDelta := testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("miss")) - missBefore
+	s.Equal(1.0, missDelta)
+
+	var sentCount int
+	concurrency.WithLock(&mockSender.mu, func() {
+		sentCount = len(mockSender.sentMessages)
+	})
+	s.Zero(sentCount)
+
+	cancel()
+	<-errCh
+}
+
+func (s *relayTestSuite) TestRelay_RetryCommand_CacheDisabled_DoesNotResend() {
+	done := concurrency.NewSignal()
+	mockSender := &mockIndexReportSender{
+		failOnIndex:   -1,
+		done:          &done,
+		expectedCount: 1,
+	}
+	umh := &mockUMH{
+		retryCh: make(chan string, 1),
+	}
+	stream := &mockIndexReportStream{
+		reports: []*v1.VMReport{
+			relaytest.NewTestVMReport("100"),
+		},
+	}
+	relay := New(stream, mockSender, umh, 0, 4*time.Hour, 0, 24*time.Hour)
+	s.Equal(0.0, testutil.ToFloat64(metrics.IndexReportCacheSlotsCapacity), "expected cache slots capacity 0 when cache is disabled")
+	slotsBase := testutil.ToFloat64(metrics.IndexReportCacheSlotsUsed)
+
+	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- relay.Run(ctx)
+	}()
+
+	select {
+	case <-done.Done():
+	case <-time.After(2 * time.Second):
+		s.Fail("timeout waiting for initial send")
+	}
+
+	s.Equal(0, relay.payloadCache.Len(), "expected payload cache to stay empty when disabled")
+	s.Equal(slotsBase, testutil.ToFloat64(metrics.IndexReportCacheSlotsUsed), "expected slots used to remain unchanged when cache is disabled")
+
+	missBefore := testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("miss"))
+	umh.retryCh <- "100"
+
+	s.Eventually(
+		func() bool {
+			return testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("miss")) > missBefore
+		},
+		2*time.Second,
+		10*time.Millisecond,
+		"expected retry lookup to be processed as cache miss",
+	)
+	s.Equal(1.0, testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("miss"))-missBefore)
+
+	var sentCount int
+	concurrency.WithLock(&mockSender.mu, func() {
+		sentCount = len(mockSender.sentMessages)
+	})
+	s.Equal(1, sentCount)
+
+	var sends []string
+	concurrency.WithLock(&umh.mu, func() {
+		sends = append(sends, umh.sends...)
+	})
+	s.Equal([]string{"100"}, sends)
+
+	cancel()
+	s.ErrorIs(<-errCh, context.Canceled)
+}
+
+func (s *relayTestSuite) TestRelay_ACK_RemovesPayloadCacheEntry() {
+	done := concurrency.NewSignal()
+	mockSender := &mockIndexReportSender{
+		failOnIndex:   -1,
+		done:          &done,
+		expectedCount: 1,
+	}
+	umh := &mockUMH{
+		retryCh: make(chan string, 1),
+	}
+	stream := &mockIndexReportStream{
+		reports: []*v1.VMReport{
+			relaytest.NewTestVMReport("100"),
+		},
+	}
+	relay := New(stream, mockSender, umh, 0, 4*time.Hour, 4, 24*time.Hour)
+	slotsBase := testutil.ToFloat64(metrics.IndexReportCacheSlotsUsed)
+
+	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- relay.Run(ctx)
+	}()
+
+	select {
+	case <-done.Done():
+	case <-time.After(2 * time.Second):
+		s.Fail("timeout waiting for send")
+	}
+
+	s.Equal(slotsBase+1.0, testutil.ToFloat64(metrics.IndexReportCacheSlotsUsed))
+
+	missBefore := testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("miss"))
+
+	umh.HandleACK("100")
+	time.Sleep(100 * time.Millisecond)
+	s.Equal(slotsBase+0.0, testutil.ToFloat64(metrics.IndexReportCacheSlotsUsed))
+
+	umh.retryCh <- "100"
+	time.Sleep(200 * time.Millisecond)
+
+	missDelta := testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("miss")) - missBefore
+	s.Equal(1.0, missDelta)
+
+	var sentCount int
+	concurrency.WithLock(&mockSender.mu, func() {
+		sentCount = len(mockSender.sentMessages)
+	})
+	s.Equal(1, sentCount)
+
+	cancel()
+	<-errCh
+}
+
+func (s *relayTestSuite) TestRelay_RetryCommand_ExpiredPayloadResendsUntilSweepEvicts() {
+	ttl := 50 * time.Millisecond
+	mockSender := &mockIndexReportSender{
+		failOnIndex: -1,
+	}
+	umh := &mockUMH{}
+	relay := &Relay{
+		reportSender: mockSender,
+		umh:          umh,
+		payloadCache: newReportPayloadCache(4, ttl),
+	}
+
+	now := time.Now()
+	s.Require().Empty(relay.payloadCache.Upsert("100", relaytest.NewTestVMReport("100"), now.Add(-3*ttl)))
+	metrics.IndexReportCacheSlotsUsed.Set(float64(relay.payloadCache.Len()))
+	s.Equal(1, relay.payloadCache.Len(), "precondition: expired payload should still be present before sweep")
+
+	missBefore := testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("miss"))
+	hitBefore := testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("hit"))
+	resCountBefore := residencyHistogramSampleCount(s.T())
+	lifeCountBefore := lifetimeHistogramSampleCount(s.T())
+
+	relay.handleRetryCommand(s.ctx, "100")
+
+	s.Equal(0.0, testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("miss"))-missBefore)
+	s.Equal(1.0, testutil.ToFloat64(metrics.IndexReportCacheLookupsTotal.WithLabelValues("hit"))-hitBefore)
+	s.Equal(1, relay.payloadCache.Len(), "expired payload should remain in cache until sweep")
+	s.Equal(1.0, testutil.ToFloat64(metrics.IndexReportCacheSlotsUsed))
+	var sentCount int
+	concurrency.WithLock(&mockSender.mu, func() {
+		sentCount = len(mockSender.sentMessages)
+	})
+	s.Equal(1, sentCount)
+	s.Equal(resCountBefore, residencyHistogramSampleCount(s.T()))
+	s.Equal(lifeCountBefore, lifetimeHistogramSampleCount(s.T()))
+
+	relay.sweepPayloadCache(now)
+	s.Equal(0, relay.payloadCache.Len(), "sweep should evict expired payload")
+	s.Equal(0.0, testutil.ToFloat64(metrics.IndexReportCacheSlotsUsed))
+	s.Equal(resCountBefore+1, residencyHistogramSampleCount(s.T()))
+	s.Equal(lifeCountBefore+1, lifetimeHistogramSampleCount(s.T()))
+}
+
+func lifetimeHistogramSampleCount(t *testing.T) uint64 {
+	t.Helper()
+	return histogramSampleCount(t, "rox_compliance_virtual_machine_relay_index_report_cache_lifetime_seconds")
+}
+
+// residencyHistogramSampleCount returns Histogram sample_count for the VM index report payload residency metric.
+func residencyHistogramSampleCount(t *testing.T) uint64 {
+	t.Helper()
+	return histogramSampleCount(t, "rox_compliance_virtual_machine_relay_index_report_cache_residency_seconds")
+}
+
+func histogramSampleCount(t *testing.T, wantName string) uint64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gathering prometheus metrics should succeed, but failed with: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != wantName {
+			continue
+		}
+		var n uint64
+		for _, m := range mf.GetMetric() {
+			if h := m.GetHistogram(); h != nil {
+				n += h.GetSampleCount()
+			}
+		}
+		return n
+	}
+	t.Fatalf("metric family %q should exist in default gatherer, but was not found", wantName)
+	return 0
 }
 
 // Mock implementations

--- a/compliance/virtualmachines/relay/report_payload_cache.go
+++ b/compliance/virtualmachines/relay/report_payload_cache.go
@@ -1,0 +1,203 @@
+package relay
+
+import (
+	"container/list"
+	"time"
+
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/sync"
+)
+
+const upsertExpiredEvictionPerInsert = 16
+
+// reportPayloadCache stores VM reports keyed by resource ID with bounded capacity.
+// Eviction removes the entry whose updatedAt is oldest (least recently updated), independent of read access.
+//
+// TTL behavior is enforced only by cleanup paths: Upsert performs a bounded front sweep of
+// expired entries before insert/update, and SweepExpired removes expired entries on demand.
+// Get does not enforce TTL and returns any entry that is currently present. This type does not
+// start any background sweeper; callers may invoke SweepExpired periodically (for example the VM
+// relay) to remove expired entries proactively. Remove deletes an entry on demand and does not
+// consult TTL.
+//
+// Capacity: when maxSlots is non-positive, new keys are never cached (Upsert for an unknown resourceID
+// is a no-op). Existing entries for that resource ID are unchanged by this constructor parameter alone;
+// use maxSlots > 0 to store new keys.
+type reportPayloadCache struct {
+	maxSlots int
+	ttl      time.Duration
+
+	mu      sync.Mutex
+	byID    map[string]*list.Element // resourceID -> LRU (least recently updated) list element (Value is *reportPayloadEntry)
+	lruList *list.List               // front = LRU (oldest updatedAt), back = MRU (newest updatedAt)
+}
+
+type reportPayloadEntry struct {
+	resourceID     string
+	report         *v1.VMReport
+	updatedAt      time.Time
+	firstUpdatedAt time.Time
+}
+
+// payloadEviction records a cache entry removal event and the entry residency at removal time.
+type payloadEviction struct {
+	resourceID string
+	residency  time.Duration // duration since the most recent payload update (now.Sub(updatedAt))
+	lifetime   time.Duration // duration since the first payload insert for this entry (now.Sub(firstUpdatedAt))
+}
+
+// newReportPayloadCache creates a cache with the given slot limit and TTL duration. See reportPayloadCache
+// for lazy TTL semantics and maxSlots <= 0 behavior.
+func newReportPayloadCache(maxSlots int, ttl time.Duration) *reportPayloadCache {
+	return &reportPayloadCache{
+		maxSlots: maxSlots,
+		ttl:      ttl,
+		byID:     make(map[string]*list.Element),
+		lruList:  list.New(),
+	}
+}
+
+// Upsert inserts or updates a report. Identical payloads (EqualVT) are a no-op and do not refresh updatedAt or recency.
+// When a new key is inserted at capacity, the LRU entry is evicted first; that eviction is returned for metrics (residency
+// is measured at eviction time relative to the evicted entry's updatedAt).
+func (c *reportPayloadCache) Upsert(resourceID string, report *v1.VMReport, now time.Time) []payloadEviction {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	evictions := c.evictExpiredFromFrontNoLock(now, upsertExpiredEvictionPerInsert)
+
+	if elem, ok := c.byID[resourceID]; ok {
+		ent := elem.Value.(*reportPayloadEntry)
+		if ent.report.EqualVT(report) {
+			return evictions
+		}
+		ent.report = report.CloneVT()
+		ent.updatedAt = now
+		c.lruList.MoveToBack(elem)
+		return evictions
+	}
+
+	if c.maxSlots <= 0 {
+		return evictions
+	}
+	if len(c.byID) >= c.maxSlots {
+		if ev, ok := c.evictLRUNoLock(now); ok {
+			evictions = append(evictions, ev)
+		}
+	}
+
+	ent := &reportPayloadEntry{
+		resourceID:     resourceID,
+		report:         report.CloneVT(),
+		updatedAt:      now,
+		firstUpdatedAt: now,
+	}
+	elem := c.lruList.PushBack(ent)
+	c.byID[resourceID] = elem
+	return evictions
+}
+
+// evictLRUNoLock removes the least-recently-updated entry and returns its eviction metadata.
+// The caller must hold c.mu.
+func (c *reportPayloadCache) evictLRUNoLock(now time.Time) (payloadEviction, bool) {
+	front := c.lruList.Front()
+	if front == nil {
+		return payloadEviction{}, false
+	}
+	ent := front.Value.(*reportPayloadEntry)
+	ev := evictionForEntry(ent, now)
+	c.removeElementNoLock(front)
+	return ev, true
+}
+
+// evictExpiredFromFrontNoLock removes up to budget expired entries from the LRU front.
+// A non-positive budget disables this opportunistic sweep. Because the list is ordered by
+// updatedAt (oldest first), eviction stops at the first non-expired entry.
+// The caller must hold c.mu.
+func (c *reportPayloadCache) evictExpiredFromFrontNoLock(now time.Time, budget int) []payloadEviction {
+	if budget <= 0 {
+		return nil
+	}
+	out := make([]payloadEviction, 0, min(budget, len(c.byID)))
+	for range budget {
+		front := c.lruList.Front()
+		if front == nil {
+			break
+		}
+		ent := front.Value.(*reportPayloadEntry)
+		if now.Before(ent.updatedAt.Add(c.ttl)) {
+			break
+		}
+		out = append(out, evictionForEntry(ent, now))
+		c.removeElementNoLock(front)
+	}
+	return out
+}
+
+// removeElementNoLock removes the given list element and its byID index entry.
+// The caller must hold c.mu.
+func (c *reportPayloadCache) removeElementNoLock(elem *list.Element) {
+	ent := elem.Value.(*reportPayloadEntry)
+	delete(c.byID, ent.resourceID)
+	c.lruList.Remove(elem)
+}
+
+// Get returns the cached report reference if present. Get does not enforce TTL and does not
+// modify cache contents. Reads do not affect eviction order by updatedAt. Callers must treat
+// returned reports as read-only.
+func (c *reportPayloadCache) Get(resourceID string, _ time.Time) (report *v1.VMReport, ok bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	elem, exists := c.byID[resourceID]
+	if !exists {
+		return nil, false
+	}
+	ent := elem.Value.(*reportPayloadEntry)
+	return ent.report, true
+}
+
+// Remove deletes the entry for resourceID if present, regardless of TTL. now is used only to compute
+// removal durations. The bool reports whether an entry was removed.
+func (c *reportPayloadCache) Remove(resourceID string, now time.Time) (payloadEviction, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	elem, ok := c.byID[resourceID]
+	if !ok {
+		return payloadEviction{}, false
+	}
+	ent := elem.Value.(*reportPayloadEntry)
+	ev := evictionForEntry(ent, now)
+	c.removeElementNoLock(elem)
+	return ev, true
+}
+
+// SweepExpired removes every entry whose updatedAt is older than TTL relative to now.
+// It returns eviction records in LRU order (oldest updatedAt first among those removed).
+func (c *reportPayloadCache) SweepExpired(now time.Time) []payloadEviction {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.evictExpiredFromFrontNoLock(now, len(c.byID))
+}
+
+// Len returns the number of entries currently stored.
+func (c *reportPayloadCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.byID)
+}
+
+// Capacity returns the configured maxSlots (see newReportPayloadCache).
+func (c *reportPayloadCache) Capacity() int {
+	return c.maxSlots
+}
+
+func evictionForEntry(ent *reportPayloadEntry, now time.Time) payloadEviction {
+	return payloadEviction{
+		resourceID: ent.resourceID,
+		residency:  now.Sub(ent.updatedAt),
+		lifetime:   now.Sub(ent.firstUpdatedAt),
+	}
+}

--- a/compliance/virtualmachines/relay/report_payload_cache_test.go
+++ b/compliance/virtualmachines/relay/report_payload_cache_test.go
@@ -1,0 +1,507 @@
+package relay
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	relaytest "github.com/stackrox/rox/compliance/virtualmachines/relay/testutils"
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	key1 = "k"
+	key2 = "a"
+	key3 = "b"
+)
+
+func TestReportPayloadCache_LRUByUpdatedAt_EvictionScenario(t *testing.T) {
+	t.Parallel()
+
+	const maxSlots = 2
+	ttl := 24 * time.Hour
+	c := newReportPayloadCache(maxSlots, ttl)
+
+	vm0, vm1, vm2 := "vm0", "vm1", "vm2"
+
+	t0 := time.Unix(100, 0)
+	t1 := time.Unix(200, 0)
+	t2 := time.Unix(300, 0)
+	t3 := time.Unix(400, 0)
+	t4 := time.Unix(500, 0)
+
+	payload0 := relaytest.NewTestVMReport("cid0")
+	payload1 := relaytest.NewTestVMReport("cid1")
+	payload2 := cloneVMReport(t, payload0)
+	payload2.DiscoveredData.OsVersion = "changed"
+	payload3 := relaytest.NewTestVMReport("cid3")
+
+	c.Upsert(vm0, payload0, t0)
+	c.Upsert(vm1, payload1, t1)
+
+	// Identical payload for vm0 — no recency / updatedAt change.
+	c.Upsert(vm0, cloneVMReport(t, payload0), t2)
+
+	c.Upsert(vm0, payload2, t3)
+
+	c.Upsert(vm2, payload3, t4)
+
+	got0, ok0 := c.Get(vm0, t4)
+	require.Truef(t, ok0, "expected vm0 cache lookup to be a hit, but got a miss")
+	require.Truef(t, got0.EqualVT(payload2), "expected vm0 cached payload to match payload2, but it did not")
+
+	got1, ok1 := c.Get(vm1, t4)
+	require.Falsef(t, ok1, "expected vm1 cache lookup to be a miss, but got a hit")
+	require.Nilf(t, got1, "expected vm1 cached payload to be nil, got %v", got1)
+
+	got2, ok2 := c.Get(vm2, t4)
+	require.Truef(t, ok2, "expected vm2 cache lookup to be a hit, but got a miss")
+	require.Truef(t, got2.EqualVT(payload3), "expected vm2 cached payload to match payload3, but it did not")
+}
+
+func TestReportPayloadCache_Upsert_StoresClone(t *testing.T) {
+	t.Parallel()
+
+	c := newReportPayloadCache(4, time.Hour)
+	now := time.Unix(20, 0)
+	r := relaytest.NewTestVMReport("upsert-clone")
+	expected := r.CloneVT()
+
+	c.Upsert(key1, r, now)
+	r.DiscoveredData.OsVersion = "mutated-after-upsert"
+
+	got, ok := c.Get(key1, now)
+	require.Truef(t, ok, "expected a cache hit, but got a miss")
+	require.Truef(t, got.EqualVT(expected), "expected cached payload to match the pre-mutation clone, but it did not")
+}
+
+func TestReportPayloadCache_Get_ReturnsCachedReference(t *testing.T) {
+	t.Parallel()
+
+	c := newReportPayloadCache(4, time.Hour)
+	now := time.Unix(10, 0)
+	r := relaytest.NewTestVMReport("x")
+	c.Upsert(key1, r, now)
+
+	out, ok := c.Get(key1, now)
+	require.Truef(t, ok, "expected initial cache lookup to be a hit, but got a miss")
+	require.Truef(t, out.EqualVT(r), "expected initial cached payload to match inserted payload, but it did not")
+	changedOsVersion := "mutated"
+	out.DiscoveredData.OsVersion = changedOsVersion
+
+	out2, ok2 := c.Get(key1, now)
+	require.Truef(t, ok2, "expected second cache lookup to be a hit, but got a miss")
+	got := out2.GetDiscoveredData().GetOsVersion()
+	require.Equalf(t, changedOsVersion, got, "expected second cached OS version %q, got %q", changedOsVersion, got)
+}
+
+func TestReportPayloadCache_Get_TTLExpiry_DoesNotEvict(t *testing.T) {
+	t.Parallel()
+
+	c := newReportPayloadCache(4, 10*time.Minute)
+	base := time.Unix(1000, 0)
+	r := relaytest.NewTestVMReport("x")
+	c.Upsert(key1, r, base)
+
+	_, ok := c.Get(key1, base.Add(10*time.Minute).Add(-time.Nanosecond))
+	require.Truef(t, ok, "expected pre-expiry lookup to be a hit, but got a miss")
+
+	got, ok := c.Get(key1, base.Add(10*time.Minute))
+	require.Truef(t, ok, "expected expiry-boundary lookup to still be a hit, but got a miss")
+	require.Truef(t, got.EqualVT(r), "expected cached payload at ttl boundary to match inserted payload, but it did not")
+	require.Equalf(t, 1, c.Len(), "expected expired entry to remain cached until sweep/upsert, got len=%d", c.Len())
+
+	evictions := c.SweepExpired(base.Add(10 * time.Minute))
+	require.Lenf(t, evictions, 1, "expected sweep eviction count %d, got %d", 1, len(evictions))
+	require.Equalf(
+		t,
+		key1,
+		evictions[0].resourceID,
+		"expected ttl eviction resourceID %q, got %q",
+		key1,
+		evictions[0].resourceID,
+	)
+	require.Equalf(
+		t,
+		10*time.Minute,
+		evictions[0].residency,
+		"expected ttl eviction residency %s, got %s",
+		10*time.Minute,
+		evictions[0].residency,
+	)
+	require.Equalf(
+		t,
+		10*time.Minute,
+		evictions[0].lifetime,
+		"expected ttl eviction lifetime %s, got %s",
+		10*time.Minute,
+		evictions[0].lifetime,
+	)
+	require.Equalf(t, 0, c.Len(), "expected cache length after sweep %d, got %d", 0, c.Len())
+}
+
+func TestReportPayloadCache_Upsert_ExpiresAtMostBudgetPerInsert(t *testing.T) {
+	t.Parallel()
+
+	const staleEntries = 20
+	ttl := 10 * time.Minute
+	c := newReportPayloadCache(64, ttl)
+	base := time.Unix(5000, 0)
+	for i := range staleEntries {
+		c.Upsert(fmt.Sprintf("k-%02d", i), relaytest.NewTestVMReport(fmt.Sprintf("%02d", i)), base.Add(time.Duration(i)*time.Second))
+	}
+	require.Equalf(t, staleEntries, c.Len(), "expected stale entries count %d, got %d", staleEntries, c.Len())
+
+	now := base.Add(ttl + time.Minute)
+	evictions := c.Upsert("fresh", relaytest.NewTestVMReport("fresh"), now)
+
+	require.Lenf(
+		t,
+		evictions,
+		upsertExpiredEvictionPerInsert,
+		"expected per-insert eviction cap %d, got %d",
+		upsertExpiredEvictionPerInsert,
+		len(evictions),
+	)
+	require.Equalf(
+		t,
+		staleEntries-upsertExpiredEvictionPerInsert+1,
+		c.Len(),
+		"expected cache length after bounded upsert sweep %d, got %d",
+		staleEntries-upsertExpiredEvictionPerInsert+1,
+		c.Len(),
+	)
+
+	remaining := c.SweepExpired(now)
+	require.Lenf(
+		t,
+		remaining,
+		staleEntries-upsertExpiredEvictionPerInsert,
+		"expected remaining stale evictions %d, got %d",
+		staleEntries-upsertExpiredEvictionPerInsert,
+		len(remaining),
+	)
+	require.Equalf(t, 1, c.Len(), "expected cache to retain only fresh entry, got len=%d", c.Len())
+	_, ok := c.Get("fresh", now)
+	require.Truef(t, ok, "expected fresh entry lookup to be a hit, but got a miss")
+}
+
+func TestReportPayloadCache_LenAndCapacity(t *testing.T) {
+	t.Parallel()
+
+	c := newReportPayloadCache(5, time.Hour)
+	require.Equalf(t, 5, c.Capacity(), "expected cache capacity %d, got %d", 5, c.Capacity())
+	require.Equalf(t, 0, c.Len(), "expected initial cache length %d, got %d", 0, c.Len())
+
+	now := time.Unix(10, 0)
+	c.Upsert("x", relaytest.NewTestVMReport("x"), now)
+	require.Equalf(t, 1, c.Len(), "expected cache length after one insert %d, got %d", 1, c.Len())
+}
+
+func TestReportPayloadCache_MaxSlotsNonPositive_NewKeyUpsertNoOps(t *testing.T) {
+	t.Parallel()
+
+	c := newReportPayloadCache(0, time.Hour)
+	now := time.Unix(50, 0)
+	c.Upsert("new", relaytest.NewTestVMReport("new"), now)
+	require.Equalf(
+		t,
+		0,
+		c.Len(),
+		"expected zero-capacity cache length after insert %d, got %d",
+		0,
+		c.Len(),
+	)
+	_, ok := c.Get("new", now)
+	require.Falsef(t, ok, "expected zero-capacity cache lookup to be a miss, but got a hit")
+
+	cNeg := newReportPayloadCache(-3, time.Hour)
+	cNeg.Upsert("other", relaytest.NewTestVMReport("other"), now)
+	require.Equalf(
+		t,
+		0,
+		cNeg.Len(),
+		"expected negative-capacity cache length after insert %d, got %d",
+		0,
+		cNeg.Len(),
+	)
+}
+
+func TestReportPayloadCache_SweepExpired_NoWork_UnchangedLen(t *testing.T) {
+	t.Parallel()
+
+	ttl := time.Hour
+	now := time.Unix(5000, 0)
+
+	t.Run("empty cache", func(t *testing.T) {
+		t.Parallel()
+		c := newReportPayloadCache(4, ttl)
+		require.Equalf(t, 0, c.Len(), "expected empty-cache initial length %d, got %d", 0, c.Len())
+		ev := c.SweepExpired(now)
+		require.Emptyf(t, ev, "expected no empty-cache sweep evictions, got %v", ev)
+		require.Equalf(t, 0, c.Len(), "expected empty-cache post-sweep length %d, got %d", 0, c.Len())
+	})
+
+	t.Run("all entries still within TTL", func(t *testing.T) {
+		t.Parallel()
+		c := newReportPayloadCache(4, ttl)
+		base := time.Unix(6000, 0)
+		c.Upsert(key2, relaytest.NewTestVMReport(key2), base)
+		c.Upsert(key3, relaytest.NewTestVMReport(key3), base.Add(30*time.Minute))
+		require.Equalf(
+			t,
+			2,
+			c.Len(),
+			"expected within-ttl cache length after inserts %d, got %d",
+			2,
+			c.Len(),
+		)
+
+		sweepAt := base.Add(20 * time.Minute)
+		ev := c.SweepExpired(sweepAt)
+		require.Emptyf(t, ev, "expected no within-ttl sweep evictions, got %v", ev)
+		require.Equalf(
+			t,
+			2,
+			c.Len(),
+			"expected within-ttl cache length after sweep %d, got %d",
+			2,
+			c.Len(),
+		)
+		_, okA := c.Get(key2, sweepAt)
+		require.Truef(t, okA, "expected within-ttl lookup for a to be a hit, but got a miss")
+		_, okB := c.Get(key3, sweepAt)
+		require.Truef(t, okB, "expected within-ttl lookup for b to be a hit, but got a miss")
+	})
+}
+
+func TestReportPayloadCache_SweepExpired_MultipleExpired_OrderedOldestUpdatedFirst(t *testing.T) {
+	t.Parallel()
+
+	ttl := time.Hour
+	c := newReportPayloadCache(4, ttl)
+	base := time.Unix(8000, 0)
+	rOld := relaytest.NewTestVMReport("older")
+	rNew := relaytest.NewTestVMReport("newer")
+	c.Upsert("older", rOld, base)
+	c.Upsert("newer", rNew, base.Add(20*time.Minute))
+
+	sweepAt := base.Add(90 * time.Minute)
+	evictions := c.SweepExpired(sweepAt)
+	require.Lenf(t, evictions, 2, "expected sweep eviction count %d, got %d", 2, len(evictions))
+	require.Equalf(
+		t,
+		"older",
+		evictions[0].resourceID,
+		"expected first eviction resourceID %q, got %q",
+		"older",
+		evictions[0].resourceID,
+	)
+	require.Equalf(
+		t,
+		90*time.Minute,
+		evictions[0].residency,
+		"expected first eviction residency %s, got %s",
+		90*time.Minute,
+		evictions[0].residency,
+	)
+	require.Equalf(
+		t,
+		90*time.Minute,
+		evictions[0].lifetime,
+		"expected first eviction lifetime %s, got %s",
+		90*time.Minute,
+		evictions[0].lifetime,
+	)
+	require.Equalf(
+		t,
+		"newer",
+		evictions[1].resourceID,
+		"expected second eviction resourceID %q, got %q",
+		"newer",
+		evictions[1].resourceID,
+	)
+	require.Equalf(
+		t,
+		70*time.Minute,
+		evictions[1].residency,
+		"expected second eviction residency %s, got %s",
+		70*time.Minute,
+		evictions[1].residency,
+	)
+	require.Equalf(
+		t,
+		70*time.Minute,
+		evictions[1].lifetime,
+		"expected second eviction lifetime %s, got %s",
+		70*time.Minute,
+		evictions[1].lifetime,
+	)
+	require.Equalf(t, 0, c.Len(), "expected cache length after sweep %d, got %d", 0, c.Len())
+}
+
+func TestReportPayloadCache_Remove_ReturnsEvictionDurations(t *testing.T) {
+	t.Parallel()
+
+	c := newReportPayloadCache(4, time.Hour)
+	base := time.Unix(1000, 0)
+	r := relaytest.NewTestVMReport("r")
+	c.Upsert(key1, r, base)
+
+	ev, removed := c.Remove(key1, base.Add(7*time.Minute+3*time.Second))
+	require.Truef(t, removed, "expected remove(existing key) to return true, but got false")
+	require.Equalf(
+		t,
+		7*time.Minute+3*time.Second,
+		ev.residency,
+		"expected remove(existing key) residency %s, got %s",
+		7*time.Minute+3*time.Second,
+		ev.residency,
+	)
+	require.Equalf(
+		t,
+		7*time.Minute+3*time.Second,
+		ev.lifetime,
+		"expected remove(existing key) lifetime %s, got %s",
+		7*time.Minute+3*time.Second,
+		ev.lifetime,
+	)
+	require.Equalf(
+		t,
+		0,
+		c.Len(),
+		"expected cache length after remove(existing key) %d, got %d",
+		0,
+		c.Len(),
+	)
+
+	ev2, removed2 := c.Remove(key1, base)
+	require.Falsef(t, removed2, "expected remove(missing key) to return false, but got true")
+	require.Equalf(t, payloadEviction{}, ev2, "expected zero eviction for missing remove, got %+v", ev2)
+}
+
+func TestReportPayloadCache_SweepExpired_KeepsFreshRemovesExpired(t *testing.T) {
+	t.Parallel()
+
+	ttl := time.Hour
+	c := newReportPayloadCache(4, ttl)
+	base := time.Unix(2000, 0)
+
+	oldReport := relaytest.NewTestVMReport("old")
+	freshReport := relaytest.NewTestVMReport("fresh")
+	c.Upsert("old", oldReport, base)
+	c.Upsert("fresh", freshReport, base.Add(30*time.Minute))
+
+	sweepAt := base.Add(80 * time.Minute)
+	evictions := c.SweepExpired(sweepAt)
+
+	require.Lenf(t, evictions, 1, "expected sweep eviction count %d, got %d", 1, len(evictions))
+	require.Equalf(
+		t,
+		"old",
+		evictions[0].resourceID,
+		"expected evicted resourceID %q, got %q",
+		"old",
+		evictions[0].resourceID,
+	)
+	require.Equalf(
+		t,
+		80*time.Minute,
+		evictions[0].residency,
+		"expected evicted residency %s, got %s",
+		80*time.Minute,
+		evictions[0].residency,
+	)
+	require.Equalf(
+		t,
+		80*time.Minute,
+		evictions[0].lifetime,
+		"expected evicted lifetime %s, got %s",
+		80*time.Minute,
+		evictions[0].lifetime,
+	)
+
+	require.Equalf(t, 1, c.Len(), "expected cache length after sweep %d, got %d", 1, c.Len())
+	gotFresh, ok := c.Get("fresh", sweepAt)
+	require.Truef(t, ok, "expected fresh entry lookup to be a hit, but got a miss")
+	require.Truef(t, gotFresh.EqualVT(freshReport), "expected fresh payload to match freshReport, but it did not")
+
+	_, okOld := c.Get("old", sweepAt)
+	require.Falsef(t, okOld, "expected old entry lookup to be a miss, but got a hit")
+}
+
+func TestReportPayloadCache_SweepExpired_ThenUpsert_EvictsLRUByUpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	const maxSlots = 2
+	ttl := time.Hour
+	c := newReportPayloadCache(maxSlots, ttl)
+
+	base := time.Unix(100, 0)
+	payloadA := relaytest.NewTestVMReport(key2)
+	payloadB := relaytest.NewTestVMReport(key3)
+	payloadC := relaytest.NewTestVMReport("c")
+	payloadD := relaytest.NewTestVMReport("d")
+
+	c.Upsert(key2, payloadA, base)
+	c.Upsert(key3, payloadB, base.Add(30*time.Minute))
+
+	evictions := c.SweepExpired(base.Add(80 * time.Minute))
+	require.Lenf(t, evictions, 1, "expected post-sweep eviction count %d, got %d", 1, len(evictions))
+	require.Equalf(
+		t,
+		key2,
+		evictions[0].resourceID,
+		"expected post-sweep evicted resourceID %q, got %q",
+		key2,
+		evictions[0].resourceID,
+	)
+
+	// Fill slots again; inserting "d" evicts "b" by least-recently-updated (not TTL — "b" is still valid).
+	c.Upsert("c", payloadC, base.Add(85*time.Minute))
+	now := base.Add(86 * time.Minute)
+	c.Upsert("d", payloadD, now)
+
+	_, okA := c.Get(key2, now)
+	require.Falsef(t, okA, "expected lookup for a to be a miss, but got a hit")
+	_, okB := c.Get(key3, now)
+	require.Falsef(t, okB, "expected lookup for b to be a miss, but got a hit")
+	gotC, okC := c.Get("c", now)
+	require.Truef(t, okC, "expected lookup for c to be a hit, but got a miss")
+	require.Truef(t, gotC.EqualVT(payloadC), "expected payload for c to match payloadC, but it did not")
+	gotD, okD := c.Get("d", now)
+	require.Truef(t, okD, "expected lookup for d to be a hit, but got a miss")
+	require.Truef(t, gotD.EqualVT(payloadD), "expected payload for d to match payloadD, but it did not")
+}
+
+func TestReportPayloadCache_Get_DoesNotPromoteRecency(t *testing.T) {
+	t.Parallel()
+
+	c := newReportPayloadCache(2, time.Hour)
+	t0 := time.Unix(1, 0)
+	t1 := time.Unix(2, 0)
+	t2 := time.Unix(3, 0)
+
+	c.Upsert(key2, relaytest.NewTestVMReport(key2), t0)
+	c.Upsert(key3, relaytest.NewTestVMReport(key3), t1)
+
+	// Read "a" (oldest by updatedAt) — must not move it to MRU.
+	_, ok := c.Get(key2, t1)
+	require.Truef(t, ok, "expected lookup for a before eviction to be a hit, but got a miss")
+
+	// Adding "c" should evict LRU by updatedAt ("a"), not "b".
+	c.Upsert("c", relaytest.NewTestVMReport("c"), t2)
+
+	_, okA := c.Get(key2, t2)
+	require.Falsef(t, okA, "expected lookup for a after eviction to be a miss, but got a hit")
+	_, okB := c.Get(key3, t2)
+	require.Truef(t, okB, "expected lookup for b after eviction to be a hit, but got a miss")
+	_, okC := c.Get("c", t2)
+	require.Truef(t, okC, "expected lookup for c after insert to be a hit, but got a miss")
+}
+
+func cloneVMReport(t *testing.T, r *v1.VMReport) *v1.VMReport {
+	t.Helper()
+	return r.CloneVT()
+}

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -58,4 +58,13 @@ var (
 	// If rate limited and ACK is recent, the report is silently dropped to protect Sensor/Central.
 	// Default: 4 hours
 	VMRelayStaleAckThreshold = registerDurationSetting("ROX_VM_RELAY_STALE_ACK_THRESHOLD", 4*time.Hour)
+
+	// VMIndexReportRelayCacheSlots is the maximum number of VM index report payloads the compliance-side relay
+	// retains in memory for UMH-driven retransmission (one slot per distinct VSOCK ID with a cached report).
+	// Set to 0 to disable the cache.
+	VMIndexReportRelayCacheSlots = RegisterIntegerSetting("ROX_VM_INDEX_REPORT_RELAY_CACHE_SLOTS", 100).WithMinimum(0)
+
+	// VMIndexReportRelayCacheTTL is how long a cached VM index report payload may be kept before it is evicted
+	// from the relay's retransmission cache.
+	VMIndexReportRelayCacheTTL = registerDurationSetting("ROX_VM_INDEX_REPORT_RELAY_CACHE_TTL", 4*time.Hour)
 )


### PR DESCRIPTION
## Description

Add a bounded, TTL-aware payload cache to the VM relay so that UMH-driven retransmissions can resend the last known report without waiting for the VM agent to push a new one.

### What

- `reportPayloadCache` — LRU cache (by `updatedAt`) with configurable max slots and TTL. Backed by `container/list` + map for O(1) insert/lookup/evict. Uses its own mutex, independent of the metadata cache.
- Relay integration:
  - **Upsert** on every incoming report (deduplicates identical payloads via `EqualVT`).
  - **Remove** on ACK (confirmed delivery — no reason to keep the payload).
  - **Get** on UMH retry command → resend cached payload or log a miss.
  - **SweepExpired** on a periodic ticker (`payloadCacheTTL / 2` interval).
- Prometheus metrics: `cache_slots_used`, `cache_slots_capacity`, `cache_residency_seconds`, `cache_lifetime_seconds`, `cache_lookups_total{hit|miss}`.
- Env vars: `ROX_VM_INDEX_REPORT_RELAY_CACHE_SLOTS` (default 100), `ROX_VM_INDEX_REPORT_RELAY_CACHE_TTL` (default 4h).

### Why

Without the cache, a UMH retry for a report whose initial send failed (or was not ACKed in time) has no payload to resend. The relay would have to wait for the next VM agent push, which may take minutes. Caching the last payload per VSOCK ID closes this gap.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

###ated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Ran the full compliance test suite and the relay package tests locally:

```bash
go test ./compliance/... ./compliance/virtualmachines/relay/... -count=1 -timeout 120s
```

All 25 packages pass (including 507 new lines of `report_payload_cache_test.go` covering LRU eviction order, TTL expiry, bounded sweep budget, capacity=0 disabled mode, `Get` not promoting recency, `Remove` duration reporting, and sweep-then-upsert interaction; plus 395 new/modified lines in `relay_test.go` covering cache-hit resend, cache-miss metric, cache-disabled mode, ACK removes payload entry, and expired-payload-resends-until-sweep-evicts).

### AI disclosure

The initial implementation and tests were generated with AI assistance. All code was reviewed, corrected, and validated by the author.

