### PR TITLE
ROX-33963: Remove Orchestrator Components code from NetGraph

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Header/MastheadToolbar.tsx
@@ -23,8 +23,7 @@ function MastheadToolbar(): ReactElement {
     const location = useLocation();
     const workflowState = parseURL(location);
     const useCase = workflowState.getUseCase();
-    const showOrchestratorComponentsToggle =
-        useCase === useCases.RISK || location.pathname === searchPath;
+    const showOrchestratorComponentsToggle = useCase === useCases.RISK;
 
     // TODO: (PatternFly) need more robust mobile experience than just hiding tools
     // <PageHeaderToolsGroup visibility={{ default: 'hidden', md: 'visible' }}>

--- a/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/NetworkGraphPage.tsx
@@ -73,9 +73,6 @@ const emptyModelState = {
 // TODO: get real includePorts flag from user input
 const includePorts = true;
 
-// for MVP, always show Orchestrator Components
-const ALWAYS_SHOW_ORCHESTRATOR_COMPONENTS = true;
-
 // This is a query param used to add policy data in the response for the network graph data
 const INCLUDE_POLICIES = true;
 
@@ -190,8 +187,7 @@ function NetworkGraphPageContent() {
                     deploymentsFromUrl,
                     queryToUse,
                     sinceTimestamp,
-                    includePorts,
-                    ALWAYS_SHOW_ORCHESTRATOR_COMPONENTS
+                    includePorts
                 ),
                 // fetch the network graph data, including policies, for the inactive graph
                 fetchNetworkFlowGraph(
@@ -201,7 +197,6 @@ function NetworkGraphPageContent() {
                     queryToUse,
                     undefined,
                     includePorts,
-                    ALWAYS_SHOW_ORCHESTRATOR_COMPONENTS,
                     INCLUDE_POLICIES
                 ),
             ])

--- a/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/components/NetworkSearch.tsx
@@ -1,22 +1,14 @@
 import { useEffect, useState } from 'react';
 
 import SearchFilterInput from 'Components/SearchFilterInput';
-import searchOptionsToQuery from 'services/searchOptionsToQuery';
 import { getSearchOptionsForCategory } from 'services/SearchService';
-import { orchestratorComponentsOption } from 'utils/orchestratorComponents';
 
 import { useSearchFilter } from '../NetworkGraphURLStateContext';
 
 import './NetworkSearch.css';
 
 const searchCategory = 'DEPLOYMENTS';
-const searchOptionExclusions = [
-    'Cluster',
-    'Deployment',
-    'Namespace',
-    'Namespace ID',
-    'Orchestrator Component',
-];
+const searchOptionExclusions = ['Cluster', 'Deployment', 'Namespace', 'Namespace ID'];
 
 type NetworkSearchProps = {
     selectedCluster: string;
@@ -57,8 +49,6 @@ function NetworkSearch({
         setSearchFilter(newOptions);
     }
 
-    const prependAutocompleteQuery = [...orchestratorComponentsOption];
-
     return (
         <SearchFilterInput
             className="pf-v6-u-w-100 pf-search-shim"
@@ -66,7 +56,6 @@ function NetworkSearch({
             searchFilter={searchFilter}
             searchCategory="DEPLOYMENTS"
             searchOptions={searchOptions}
-            autocompleteQueryPrefix={searchOptionsToQuery(prependAutocompleteQuery)}
             handleChangeSearchFilter={onSearch}
             isDisabled={isDisabled}
         />

--- a/ui/apps/platform/src/Containers/Search/SearchPage.tsx
+++ b/ui/apps/platform/src/Containers/Search/SearchPage.tsx
@@ -16,7 +16,6 @@ import SearchFilterInput from 'Components/SearchFilterInput';
 import { fetchGlobalSearchResults, getSearchOptionsForCategory } from 'services/SearchService';
 import type { SearchResponse } from 'services/SearchService';
 import type { SearchFilter } from 'types/search';
-import { ORCHESTRATOR_COMPONENTS_KEY } from 'utils/orchestratorComponents';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import { searchPath } from 'routePaths';
@@ -79,11 +78,7 @@ function SearchPage(): ReactElement {
             setSeachResponseErrorMessage(null);
 
             const parsedSearchFilter = parseSearchFilter(stringifiedSearchFilter);
-            const query = getRequestQueryStringForSearchFilter(
-                localStorage.getItem(ORCHESTRATOR_COMPONENTS_KEY) !== 'true'
-                    ? { ...parsedSearchFilter, 'Orchestrator Component': 'false' }
-                    : parsedSearchFilter
-            );
+            const query = getRequestQueryStringForSearchFilter(parsedSearchFilter);
 
             fetchGlobalSearchResults({ query })
                 .then(setSearchResponse)

--- a/ui/apps/platform/src/services/NetworkService.js
+++ b/ui/apps/platform/src/services/NetworkService.js
@@ -1,6 +1,5 @@
 import queryString from 'qs';
 
-import { ORCHESTRATOR_COMPONENTS_KEY } from 'utils/orchestratorComponents';
 import { convertToExactMatch, getListQueryParams } from 'utils/searchUtils';
 
 import axios from './instance';
@@ -160,8 +159,7 @@ export function fetchNetworkPolicyGraph(
     deployments,
     query,
     modification,
-    includePorts,
-    includeOrchestratorComponents = false
+    includePorts
 ) {
     const urlParams = query ? { query } : {};
     const namespaceQuery = namespaces.length > 0 ? `Namespace:${namespaces.join(',')}` : '';
@@ -173,15 +171,6 @@ export function fetchNetworkPolicyGraph(
         urlParams.includePorts = true;
     }
 
-    // for openshift filtering toggle
-    if (
-        !includeOrchestratorComponents &&
-        localStorage.getItem(ORCHESTRATOR_COMPONENTS_KEY) !== 'true'
-    ) {
-        urlParams.scope = {
-            query: 'Orchestrator Component:false',
-        };
-    }
     const params = queryString.stringify(urlParams, { arrayFormat: 'repeat', allowDots: true });
 
     let options;
@@ -218,7 +207,7 @@ export function fetchNetworkPolicyGraph(
  * @param {String} query
  * @param {String} sinceTimestamp
  * @param {boolean} includePorts
- * @param {boolean} includeOrchestratorComponents
+ * @param {boolean} includePolicies
  *
  * @returns {Promise<Object, Error>}
  */
@@ -229,7 +218,6 @@ export function fetchNetworkFlowGraph(
     query = '',
     sinceTimestamp = '',
     includePorts = false,
-    includeOrchestratorComponents = false,
     includePolicies = false
 ) {
     const urlParams = query ? { query } : {};
@@ -249,15 +237,6 @@ export function fetchNetworkFlowGraph(
     }
     if (includePolicies) {
         urlParams.include_policies = true;
-    }
-    // for openshift filtering toggle
-    if (
-        !includeOrchestratorComponents &&
-        localStorage.getItem(ORCHESTRATOR_COMPONENTS_KEY) !== 'true'
-    ) {
-        urlParams.scope = {
-            query: 'Orchestrator Component:false',
-        };
     }
     const params = queryString.stringify(urlParams, { arrayFormat: 'repeat', allowDots: true });
     const options = {


### PR DESCRIPTION
## Description

As titled - this is effectively a no-op as the Network Graph was hardcoded to always include Orchestrator Components, but now the dead code is removed.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

See requests do not include `Orchestrator Components` filter:
<img width="1665" height="1103" alt="image" src="https://github.com/user-attachments/assets/1728840b-ae4b-4da5-8751-c5ff6b73b8c2" />

See that the option for "Platform Components" is available in the search filter:
<img width="1665" height="1103" alt="image" src="https://github.com/user-attachments/assets/e4eb37df-0bc9-4037-b097-cba708552b9b" />
