### PR TITLE
feat(roxctl): central migrate-to-operator subcommand

### DIFF
--- a/roxctl/central/central.go
+++ b/roxctl/central/central.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/roxctl/central/initbundles"
 	"github.com/stackrox/rox/roxctl/central/login"
 	"github.com/stackrox/rox/roxctl/central/m2m"
+	"github.com/stackrox/rox/roxctl/central/migratetooperator"
 	"github.com/stackrox/rox/roxctl/central/userpki"
 	"github.com/stackrox/rox/roxctl/central/whoami"
 	"github.com/stackrox/rox/roxctl/common/environment"
@@ -37,6 +38,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		login.Command(cliEnvironment),
 		export.Command(cliEnvironment),
 		m2m.Command(cliEnvironment),
+		migratetooperator.Command(cliEnvironment),
 	)
 	if features.ClusterRegistrationSecrets.Enabled() {
 		c.AddCommand(crs.Command(cliEnvironment))

--- a/roxctl/central/migratetooperator/cluster_source.go
+++ b/roxctl/central/migratetooperator/cluster_source.go
@@ -1,0 +1,46 @@
+package migratetooperator
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	// Activate auth providers for client-go.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+type clusterSource struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+func newClusterSource(namespace string) (*clusterSource, error) {
+	config, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	if err != nil {
+		return nil, errors.Wrap(err, "loading kubeconfig")
+	}
+
+	restConfig, err := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "building REST config from kubeconfig")
+	}
+
+	client, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating Kubernetes client")
+	}
+
+	return &clusterSource{client: client, namespace: namespace}, nil
+}
+
+func (s *clusterSource) CentralDBDeployment() (*appsv1.Deployment, error) {
+	dep, err := s.client.AppsV1().Deployments(s.namespace).Get(context.Background(), "central-db", metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting central-db Deployment in namespace %q", s.namespace)
+	}
+	return dep, nil
+}

--- a/roxctl/central/migratetooperator/cluster_source.go
+++ b/roxctl/central/migratetooperator/cluster_source.go
@@ -2,6 +2,7 @@ package migratetooperator
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -38,7 +39,10 @@ func newClusterSource(namespace string) (*clusterSource, error) {
 }
 
 func (s *clusterSource) CentralDBDeployment() (*appsv1.Deployment, error) {
-	dep, err := s.client.AppsV1().Deployments(s.namespace).Get(context.Background(), "central-db", metav1.GetOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dep, err := s.client.AppsV1().Deployments(s.namespace).Get(ctx, "central-db", metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting central-db Deployment in namespace %q", s.namespace)
 	}

--- a/roxctl/central/migratetooperator/command.go
+++ b/roxctl/central/migratetooperator/command.go
@@ -31,9 +31,9 @@ seamlessly take over management of the deployment.`,
 			return cmd.run()
 		}),
 	}
-	c.Flags().StringVar(&cmd.fromDir, "from-dir", "", "Path to directory containing roxctl-generated manifests")
-	c.Flags().StringVarP(&cmd.namespace, "namespace", "n", "", "Kubernetes namespace of the running Central deployment")
-	c.Flags().StringVarP(&cmd.output, "output", "o", "", "Path to write the generated Central CR YAML (default: stdout)")
+	c.Flags().StringVar(&cmd.fromDir, "from-dir", "", "Path to directory containing roxctl-generated manifests.")
+	c.Flags().StringVarP(&cmd.namespace, "namespace", "n", "", "Kubernetes namespace of the running Central deployment.")
+	c.Flags().StringVarP(&cmd.output, "output", "o", "", "Path to write the generated Central CR YAML (default: stdout).")
 	c.MarkFlagsMutuallyExclusive("from-dir", "namespace")
 	return c
 }

--- a/roxctl/central/migratetooperator/command.go
+++ b/roxctl/central/migratetooperator/command.go
@@ -56,18 +56,26 @@ func (cmd *command) run() error {
 		return errors.Wrap(err, "marshalling Central CR")
 	}
 
-	var w io.Writer = os.Stdout
+	var w io.Writer = cmd.env.InputOutput().Out()
+	var f *os.File
 	if cmd.output != "" {
-		f, err := os.Create(cmd.output)
+		f, err = os.Create(cmd.output)
 		if err != nil {
 			return errors.Wrap(err, "creating output file")
 		}
-		defer f.Close()
 		w = f
 	}
 
 	if _, err := w.Write(out); err != nil {
+		if f != nil {
+			_ = f.Close()
+		}
 		return errors.Wrap(err, "writing output")
+	}
+	if f != nil {
+		if err := f.Close(); err != nil {
+			return errors.Wrap(err, "closing output file")
+		}
 	}
 	return nil
 }

--- a/roxctl/central/migratetooperator/command.go
+++ b/roxctl/central/migratetooperator/command.go
@@ -1,0 +1,84 @@
+package migratetooperator
+
+import (
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/roxctl/common/environment"
+	"github.com/stackrox/rox/roxctl/common/util"
+)
+
+type command struct {
+	env       environment.Environment
+	fromDir   string
+	namespace string
+	output    string
+}
+
+// Command defines the migrate-to-operator command.
+func Command(cliEnvironment environment.Environment) *cobra.Command {
+	cmd := &command{env: cliEnvironment}
+	c := &cobra.Command{
+		Use:   "migrate-to-operator",
+		Short: "Generate a Central custom resource from existing roxctl-generated manifests",
+		Long: `Inspects an existing StackRox Central deployment (from a directory of generated
+manifests or a live cluster) and produces a Central custom resource YAML that
+preserves the detected configuration, allowing the StackRox operator to
+seamlessly take over management of the deployment.`,
+		RunE: util.RunENoArgs(func(c *cobra.Command) error {
+			return cmd.run()
+		}),
+	}
+	c.Flags().StringVar(&cmd.fromDir, "from-dir", "", "Path to directory containing roxctl-generated manifests")
+	c.Flags().StringVarP(&cmd.namespace, "namespace", "n", "", "Kubernetes namespace of the running Central deployment")
+	c.Flags().StringVarP(&cmd.output, "output", "o", "", "Path to write the generated Central CR YAML (default: stdout)")
+	c.MarkFlagsMutuallyExclusive("from-dir", "namespace")
+	return c
+}
+
+func (cmd *command) run() error {
+	src, err := cmd.createSource()
+	if err != nil {
+		return err
+	}
+
+	config, err := detect(src)
+	if err != nil {
+		return errors.Wrap(err, "detecting configuration")
+	}
+
+	cr := generateCR(config)
+
+	out, err := marshalCR(cr)
+	if err != nil {
+		return errors.Wrap(err, "marshalling Central CR")
+	}
+
+	var w io.Writer = os.Stdout
+	if cmd.output != "" {
+		f, err := os.Create(cmd.output)
+		if err != nil {
+			return errors.Wrap(err, "creating output file")
+		}
+		defer f.Close()
+		w = f
+	}
+
+	if _, err := w.Write(out); err != nil {
+		return errors.Wrap(err, "writing output")
+	}
+	return nil
+}
+
+func (cmd *command) createSource() (source, error) {
+	switch {
+	case cmd.fromDir != "":
+		return newDirSource(cmd.fromDir)
+	case cmd.namespace != "":
+		return newClusterSource(cmd.namespace)
+	default:
+		return nil, errors.New("either --from-dir or --namespace must be specified")
+	}
+}

--- a/roxctl/central/migratetooperator/detect.go
+++ b/roxctl/central/migratetooperator/detect.go
@@ -34,7 +34,7 @@ func detect(src source) (*detectedConfig, error) {
 func detectStorage(src source) (*storageConfig, error) {
 	dep, err := src.CentralDBDeployment()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "retrieving central-db Deployment")
 	}
 
 	var diskVolume *corev1.Volume

--- a/roxctl/central/migratetooperator/detect.go
+++ b/roxctl/central/migratetooperator/detect.go
@@ -1,0 +1,70 @@
+package migratetooperator
+
+import (
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type storageType int
+
+const (
+	storagePVC storageType = iota
+	storageHostPath
+)
+
+type storageConfig struct {
+	Type         storageType
+	PVCName      string
+	HostPath     string
+	NodeSelector map[string]string
+}
+
+type detectedConfig struct {
+	Storage storageConfig
+}
+
+func detect(src source) (*detectedConfig, error) {
+	storage, err := detectStorage(src)
+	if err != nil {
+		return nil, err
+	}
+	return &detectedConfig{Storage: *storage}, nil
+}
+
+func detectStorage(src source) (*storageConfig, error) {
+	dep, err := src.CentralDBDeployment()
+	if err != nil {
+		return nil, err
+	}
+
+	var diskVolume *corev1.Volume
+	for i := range dep.Spec.Template.Spec.Volumes {
+		if dep.Spec.Template.Spec.Volumes[i].Name == "disk" {
+			diskVolume = &dep.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	if diskVolume == nil {
+		return nil, errors.New("central-db Deployment has no volume named \"disk\"")
+	}
+
+	if pvc := diskVolume.PersistentVolumeClaim; pvc != nil {
+		return &storageConfig{
+			Type:    storagePVC,
+			PVCName: pvc.ClaimName,
+		}, nil
+	}
+
+	if hp := diskVolume.HostPath; hp != nil {
+		cfg := &storageConfig{
+			Type:     storageHostPath,
+			HostPath: hp.Path,
+		}
+		if ns := dep.Spec.Template.Spec.NodeSelector; len(ns) > 0 {
+			cfg.NodeSelector = ns
+		}
+		return cfg, nil
+	}
+
+	return nil, errors.New("central-db Deployment \"disk\" volume is neither a PVC nor a hostPath")
+}

--- a/roxctl/central/migratetooperator/detect.go
+++ b/roxctl/central/migratetooperator/detect.go
@@ -48,23 +48,24 @@ func detectStorage(src source) (*storageConfig, error) {
 		return nil, errors.New("central-db Deployment has no volume named \"disk\"")
 	}
 
-	if pvc := diskVolume.PersistentVolumeClaim; pvc != nil {
-		return &storageConfig{
+	var cfg *storageConfig
+	switch {
+	case diskVolume.PersistentVolumeClaim != nil:
+		cfg = &storageConfig{
 			Type:    storagePVC,
-			PVCName: pvc.ClaimName,
-		}, nil
-	}
-
-	if hp := diskVolume.HostPath; hp != nil {
-		cfg := &storageConfig{
+			PVCName: diskVolume.PersistentVolumeClaim.ClaimName,
+		}
+	case diskVolume.HostPath != nil:
+		cfg = &storageConfig{
 			Type:     storageHostPath,
-			HostPath: hp.Path,
+			HostPath: diskVolume.HostPath.Path,
 		}
-		if ns := dep.Spec.Template.Spec.NodeSelector; len(ns) > 0 {
-			cfg.NodeSelector = ns
-		}
-		return cfg, nil
+	default:
+		return nil, errors.New("central-db Deployment \"disk\" volume is neither a PVC nor a hostPath")
 	}
 
-	return nil, errors.New("central-db Deployment \"disk\" volume is neither a PVC nor a hostPath")
+	if ns := dep.Spec.Template.Spec.NodeSelector; len(ns) > 0 {
+		cfg.NodeSelector = ns
+	}
+	return cfg, nil
 }

--- a/roxctl/central/migratetooperator/detect_test.go
+++ b/roxctl/central/migratetooperator/detect_test.go
@@ -1,0 +1,129 @@
+package migratetooperator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type fakeSource struct {
+	deployment *appsv1.Deployment
+	err        error
+}
+
+func (f *fakeSource) CentralDBDeployment() (*appsv1.Deployment, error) {
+	return f.deployment, f.err
+}
+
+func centralDBDeployment(volumes []corev1.Volume, nodeSelector map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "central-db"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Volumes:      volumes,
+					NodeSelector: nodeSelector,
+				},
+			},
+		},
+	}
+}
+
+func TestDetectStorage(t *testing.T) {
+	tests := map[string]struct {
+		volumes      []corev1.Volume
+		nodeSelector map[string]string
+		expected     storageConfig
+	}{
+		"PVC with default name": {
+			volumes: []corev1.Volume{{
+				Name: "disk",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "central-db",
+					},
+				},
+			}},
+			expected: storageConfig{Type: storagePVC, PVCName: "central-db"},
+		},
+		"PVC with custom name": {
+			volumes: []corev1.Volume{{
+				Name: "disk",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "my-custom-db",
+					},
+				},
+			}},
+			expected: storageConfig{Type: storagePVC, PVCName: "my-custom-db"},
+		},
+		"hostPath with default path": {
+			volumes: []corev1.Volume{{
+				Name: "disk",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/var/lib/stackrox-central",
+					},
+				},
+			}},
+			expected: storageConfig{Type: storageHostPath, HostPath: "/var/lib/stackrox-central"},
+		},
+		"hostPath with custom path and nodeSelector": {
+			volumes: []corev1.Volume{{
+				Name: "disk",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/data/stackrox",
+					},
+				},
+			}},
+			nodeSelector: map[string]string{"kubernetes.io/hostname": "worker-1"},
+			expected: storageConfig{
+				Type:         storageHostPath,
+				HostPath:     "/data/stackrox",
+				NodeSelector: map[string]string{"kubernetes.io/hostname": "worker-1"},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			src := &fakeSource{deployment: centralDBDeployment(tt.volumes, tt.nodeSelector)}
+			config, err := detect(src)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, config.Storage)
+		})
+	}
+}
+
+func TestDetectStorageErrors(t *testing.T) {
+	tests := map[string]struct {
+		volumes []corev1.Volume
+		errMsg  string
+	}{
+		"no disk volume": {
+			volumes: []corev1.Volume{{Name: "other"}},
+			errMsg:  "no volume named \"disk\"",
+		},
+		"disk volume with neither PVC nor hostPath": {
+			volumes: []corev1.Volume{{
+				Name:         "disk",
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			}},
+			errMsg: "neither a PVC nor a hostPath",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			src := &fakeSource{deployment: centralDBDeployment(tt.volumes, nil)}
+			_, err := detect(src)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}

--- a/roxctl/central/migratetooperator/dir_source.go
+++ b/roxctl/central/migratetooperator/dir_source.go
@@ -48,7 +48,7 @@ func (s *dirSource) CentralDBDeployment() (*appsv1.Deployment, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "walking directory tree")
 	}
 	if found == nil {
 		return nil, errors.Errorf("central-db Deployment not found in %q", s.dir)

--- a/roxctl/central/migratetooperator/dir_source.go
+++ b/roxctl/central/migratetooperator/dir_source.go
@@ -1,0 +1,66 @@
+package migratetooperator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type dirSource struct {
+	dir string
+}
+
+func newDirSource(dir string) (*dirSource, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "accessing directory %q", dir)
+	}
+	if !info.IsDir() {
+		return nil, errors.Errorf("%q is not a directory", dir)
+	}
+	return &dirSource{dir: dir}, nil
+}
+
+func (s *dirSource) CentralDBDeployment() (*appsv1.Deployment, error) {
+	centralDir := filepath.Join(s.dir, "central")
+	entries, err := os.ReadDir(centralDir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading directory %q", centralDir)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(centralDir, entry.Name()))
+		if err != nil {
+			return nil, errors.Wrapf(err, "reading file %q", entry.Name())
+		}
+
+		for _, doc := range splitYAMLDocuments(data) {
+			var dep appsv1.Deployment
+			if err := yaml.Unmarshal(doc, &dep); err != nil {
+				continue
+			}
+			if dep.Kind == "Deployment" && dep.Name == "central-db" {
+				return &dep, nil
+			}
+		}
+	}
+	return nil, errors.Errorf("central-db Deployment not found in %q", centralDir)
+}
+
+func splitYAMLDocuments(data []byte) [][]byte {
+	var docs [][]byte
+	for _, part := range strings.Split(string(data), "\n---") {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			docs = append(docs, []byte(trimmed))
+		}
+	}
+	return docs
+}

--- a/roxctl/central/migratetooperator/dir_source.go
+++ b/roxctl/central/migratetooperator/dir_source.go
@@ -26,32 +26,34 @@ func newDirSource(dir string) (*dirSource, error) {
 }
 
 func (s *dirSource) CentralDBDeployment() (*appsv1.Deployment, error) {
-	centralDir := filepath.Join(s.dir, "central")
-	entries, err := os.ReadDir(centralDir)
-	if err != nil {
-		return nil, errors.Wrapf(err, "reading directory %q", centralDir)
-	}
-
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
-			continue
+	var found *appsv1.Deployment
+	err := filepath.WalkDir(s.dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || (!strings.HasSuffix(d.Name(), ".yaml") && !strings.HasSuffix(d.Name(), ".yml")) {
+			return err
 		}
-		data, err := os.ReadFile(filepath.Join(centralDir, entry.Name()))
+		data, err := os.ReadFile(path)
 		if err != nil {
-			return nil, errors.Wrapf(err, "reading file %q", entry.Name())
+			return errors.Wrapf(err, "reading %q", path)
 		}
-
 		for _, doc := range splitYAMLDocuments(data) {
 			var dep appsv1.Deployment
 			if err := yaml.Unmarshal(doc, &dep); err != nil {
 				continue
 			}
 			if dep.Kind == "Deployment" && dep.Name == "central-db" {
-				return &dep, nil
+				found = &dep
+				return filepath.SkipAll
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return nil, errors.Errorf("central-db Deployment not found in %q", centralDir)
+	if found == nil {
+		return nil, errors.Errorf("central-db Deployment not found in %q", s.dir)
+	}
+	return found, nil
 }
 
 func splitYAMLDocuments(data []byte) [][]byte {

--- a/roxctl/central/migratetooperator/dir_source_test.go
+++ b/roxctl/central/migratetooperator/dir_source_test.go
@@ -9,12 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDirSource_PVC(t *testing.T) {
-	dir := t.TempDir()
-	centralDir := filepath.Join(dir, "central")
-	require.NoError(t, os.MkdirAll(centralDir, 0755))
-
-	deploymentYAML := `apiVersion: apps/v1
+const pvcDeploymentYAML = `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: central-db
@@ -26,26 +21,8 @@ spec:
         persistentVolumeClaim:
           claimName: my-pvc
 `
-	require.NoError(t, os.WriteFile(filepath.Join(centralDir, "01-central-12-central-db.yaml"), []byte(deploymentYAML), 0644))
 
-	src, err := newDirSource(dir)
-	require.NoError(t, err)
-
-	dep, err := src.CentralDBDeployment()
-	require.NoError(t, err)
-	assert.Equal(t, "central-db", dep.Name)
-
-	require.Len(t, dep.Spec.Template.Spec.Volumes, 1)
-	require.NotNil(t, dep.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim)
-	assert.Equal(t, "my-pvc", dep.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName)
-}
-
-func TestDirSource_HostPathWithNodeSelector(t *testing.T) {
-	dir := t.TempDir()
-	centralDir := filepath.Join(dir, "central")
-	require.NoError(t, os.MkdirAll(centralDir, 0755))
-
-	deploymentYAML := `apiVersion: apps/v1
+const hostPathDeploymentYAML = `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: central-db
@@ -59,7 +36,54 @@ spec:
         hostPath:
           path: /data/stackrox
 `
-	require.NoError(t, os.WriteFile(filepath.Join(centralDir, "01-central-12-central-db.yaml"), []byte(deploymentYAML), 0644))
+
+func TestDirSource_PVCInSubdir(t *testing.T) {
+	dir := t.TempDir()
+	centralDir := filepath.Join(dir, "central")
+	require.NoError(t, os.MkdirAll(centralDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(centralDir, "01-central-12-central-db.yaml"), []byte(pvcDeploymentYAML), 0644))
+
+	src, err := newDirSource(dir)
+	require.NoError(t, err)
+
+	dep, err := src.CentralDBDeployment()
+	require.NoError(t, err)
+	assert.Equal(t, "central-db", dep.Name)
+	require.Len(t, dep.Spec.Template.Spec.Volumes, 1)
+	require.NotNil(t, dep.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim)
+	assert.Equal(t, "my-pvc", dep.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName)
+}
+
+func TestDirSource_PVCInRoot(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "deployment.yaml"), []byte(pvcDeploymentYAML), 0644))
+
+	src, err := newDirSource(dir)
+	require.NoError(t, err)
+
+	dep, err := src.CentralDBDeployment()
+	require.NoError(t, err)
+	assert.Equal(t, "central-db", dep.Name)
+	assert.Equal(t, "my-pvc", dep.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName)
+}
+
+func TestDirSource_DeepNesting(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "a", "b", "c")
+	require.NoError(t, os.MkdirAll(nested, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(nested, "db.yaml"), []byte(pvcDeploymentYAML), 0644))
+
+	src, err := newDirSource(dir)
+	require.NoError(t, err)
+
+	dep, err := src.CentralDBDeployment()
+	require.NoError(t, err)
+	assert.Equal(t, "central-db", dep.Name)
+}
+
+func TestDirSource_HostPathWithNodeSelector(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "db.yaml"), []byte(hostPathDeploymentYAML), 0644))
 
 	src, err := newDirSource(dir)
 	require.NoError(t, err)
@@ -68,35 +92,19 @@ spec:
 	require.NoError(t, err)
 	assert.Equal(t, "central-db", dep.Name)
 	assert.Equal(t, map[string]string{"kubernetes.io/hostname": "worker-1"}, dep.Spec.Template.Spec.NodeSelector)
-
-	require.Len(t, dep.Spec.Template.Spec.Volumes, 1)
 	require.NotNil(t, dep.Spec.Template.Spec.Volumes[0].HostPath)
 	assert.Equal(t, "/data/stackrox", dep.Spec.Template.Spec.Volumes[0].HostPath.Path)
 }
 
 func TestDirSource_MultiDocYAML(t *testing.T) {
 	dir := t.TempDir()
-	centralDir := filepath.Join(dir, "central")
-	require.NoError(t, os.MkdirAll(centralDir, 0755))
-
 	multiDocYAML := `apiVersion: v1
 kind: Secret
 metadata:
   name: central-db-password
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: central-db
-spec:
-  template:
-    spec:
-      volumes:
-      - name: disk
-        persistentVolumeClaim:
-          claimName: central-db
-`
-	require.NoError(t, os.WriteFile(filepath.Join(centralDir, "01-central-12-central-db.yaml"), []byte(multiDocYAML), 0644))
+` + pvcDeploymentYAML
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bundle.yaml"), []byte(multiDocYAML), 0644))
 
 	src, err := newDirSource(dir)
 	require.NoError(t, err)
@@ -108,15 +116,35 @@ spec:
 
 func TestDirSource_NotFound(t *testing.T) {
 	dir := t.TempDir()
-	centralDir := filepath.Join(dir, "central")
-	require.NoError(t, os.MkdirAll(centralDir, 0755))
-
 	otherYAML := `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: central
 `
-	require.NoError(t, os.WriteFile(filepath.Join(centralDir, "deployment.yaml"), []byte(otherYAML), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "deployment.yaml"), []byte(otherYAML), 0644))
+
+	src, err := newDirSource(dir)
+	require.NoError(t, err)
+
+	_, err = src.CentralDBDeployment()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestDirSource_YmlExtension(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "deployment.yml"), []byte(pvcDeploymentYAML), 0644))
+
+	src, err := newDirSource(dir)
+	require.NoError(t, err)
+
+	dep, err := src.CentralDBDeployment()
+	require.NoError(t, err)
+	assert.Equal(t, "central-db", dep.Name)
+}
+
+func TestDirSource_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
 
 	src, err := newDirSource(dir)
 	require.NoError(t, err)

--- a/roxctl/central/migratetooperator/dir_source_test.go
+++ b/roxctl/central/migratetooperator/dir_source_test.go
@@ -143,6 +143,25 @@ func TestDirSource_YmlExtension(t *testing.T) {
 	assert.Equal(t, "central-db", dep.Name)
 }
 
+func TestNewDirSource_NonexistentPath(t *testing.T) {
+	base := t.TempDir()
+	src, err := newDirSource(filepath.Join(base, "does-not-exist"))
+	require.Error(t, err)
+	assert.Nil(t, src)
+	assert.Contains(t, err.Error(), "accessing directory")
+}
+
+func TestNewDirSource_NonDirectoryPath(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "not-a-directory")
+	require.NoError(t, os.WriteFile(filePath, []byte("not a directory"), 0644))
+
+	src, err := newDirSource(filePath)
+	require.Error(t, err)
+	assert.Nil(t, src)
+	assert.Contains(t, err.Error(), "is not a directory")
+}
+
 func TestDirSource_EmptyDir(t *testing.T) {
 	dir := t.TempDir()
 

--- a/roxctl/central/migratetooperator/dir_source_test.go
+++ b/roxctl/central/migratetooperator/dir_source_test.go
@@ -1,0 +1,127 @@
+package migratetooperator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirSource_PVC(t *testing.T) {
+	dir := t.TempDir()
+	centralDir := filepath.Join(dir, "central")
+	require.NoError(t, os.MkdirAll(centralDir, 0755))
+
+	deploymentYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central-db
+spec:
+  template:
+    spec:
+      volumes:
+      - name: disk
+        persistentVolumeClaim:
+          claimName: my-pvc
+`
+	require.NoError(t, os.WriteFile(filepath.Join(centralDir, "01-central-12-central-db.yaml"), []byte(deploymentYAML), 0644))
+
+	src, err := newDirSource(dir)
+	require.NoError(t, err)
+
+	dep, err := src.CentralDBDeployment()
+	require.NoError(t, err)
+	assert.Equal(t, "central-db", dep.Name)
+
+	require.Len(t, dep.Spec.Template.Spec.Volumes, 1)
+	require.NotNil(t, dep.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim)
+	assert.Equal(t, "my-pvc", dep.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName)
+}
+
+func TestDirSource_HostPathWithNodeSelector(t *testing.T) {
+	dir := t.TempDir()
+	centralDir := filepath.Join(dir, "central")
+	require.NoError(t, os.MkdirAll(centralDir, 0755))
+
+	deploymentYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central-db
+spec:
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: worker-1
+      volumes:
+      - name: disk
+        hostPath:
+          path: /data/stackrox
+`
+	require.NoError(t, os.WriteFile(filepath.Join(centralDir, "01-central-12-central-db.yaml"), []byte(deploymentYAML), 0644))
+
+	src, err := newDirSource(dir)
+	require.NoError(t, err)
+
+	dep, err := src.CentralDBDeployment()
+	require.NoError(t, err)
+	assert.Equal(t, "central-db", dep.Name)
+	assert.Equal(t, map[string]string{"kubernetes.io/hostname": "worker-1"}, dep.Spec.Template.Spec.NodeSelector)
+
+	require.Len(t, dep.Spec.Template.Spec.Volumes, 1)
+	require.NotNil(t, dep.Spec.Template.Spec.Volumes[0].HostPath)
+	assert.Equal(t, "/data/stackrox", dep.Spec.Template.Spec.Volumes[0].HostPath.Path)
+}
+
+func TestDirSource_MultiDocYAML(t *testing.T) {
+	dir := t.TempDir()
+	centralDir := filepath.Join(dir, "central")
+	require.NoError(t, os.MkdirAll(centralDir, 0755))
+
+	multiDocYAML := `apiVersion: v1
+kind: Secret
+metadata:
+  name: central-db-password
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central-db
+spec:
+  template:
+    spec:
+      volumes:
+      - name: disk
+        persistentVolumeClaim:
+          claimName: central-db
+`
+	require.NoError(t, os.WriteFile(filepath.Join(centralDir, "01-central-12-central-db.yaml"), []byte(multiDocYAML), 0644))
+
+	src, err := newDirSource(dir)
+	require.NoError(t, err)
+
+	dep, err := src.CentralDBDeployment()
+	require.NoError(t, err)
+	assert.Equal(t, "central-db", dep.Name)
+}
+
+func TestDirSource_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	centralDir := filepath.Join(dir, "central")
+	require.NoError(t, os.MkdirAll(centralDir, 0755))
+
+	otherYAML := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central
+`
+	require.NoError(t, os.WriteFile(filepath.Join(centralDir, "deployment.yaml"), []byte(otherYAML), 0644))
+
+	src, err := newDirSource(dir)
+	require.NoError(t, err)
+
+	_, err = src.CentralDBDeployment()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/roxctl/central/migratetooperator/generate.go
+++ b/roxctl/central/migratetooperator/generate.go
@@ -1,0 +1,64 @@
+package migratetooperator
+
+import (
+	platform "github.com/stackrox/rox/operator/api/v1alpha1"
+	"github.com/stackrox/rox/pkg/pointers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func generateCR(config *detectedConfig) *platform.Central {
+	cr := &platform.Central{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "platform.stackrox.io/v1alpha1",
+			Kind:       "Central",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stackrox-central-services",
+		},
+	}
+
+	switch config.Storage.Type {
+	case storagePVC:
+		cr.Spec.Central = &platform.CentralComponentSpec{
+			DB: &platform.CentralDBSpec{
+				Persistence: &platform.DBPersistence{
+					PersistentVolumeClaim: &platform.DBPersistentVolumeClaim{
+						ClaimName: pointers.String(config.Storage.PVCName),
+					},
+				},
+			},
+		}
+	case storageHostPath:
+		db := &platform.CentralDBSpec{
+			Persistence: &platform.DBPersistence{
+				HostPath: &platform.HostPathSpec{
+					Path: pointers.String(config.Storage.HostPath),
+				},
+			},
+		}
+		if len(config.Storage.NodeSelector) > 0 {
+			db.NodeSelector = config.Storage.NodeSelector
+		}
+		cr.Spec.Central = &platform.CentralComponentSpec{DB: db}
+	}
+
+	return cr
+}
+
+// marshalCR serializes only the spec portion of the Central CR, avoiding
+// empty status fields that the operator types include.
+func marshalCR(cr *platform.Central) ([]byte, error) {
+	obj := struct {
+		APIVersion string               `json:"apiVersion"`
+		Kind       string               `json:"kind"`
+		Metadata   map[string]string    `json:"metadata"`
+		Spec       platform.CentralSpec `json:"spec"`
+	}{
+		APIVersion: cr.APIVersion,
+		Kind:       cr.Kind,
+		Metadata:   map[string]string{"name": cr.Name},
+		Spec:       cr.Spec,
+	}
+	return yaml.Marshal(obj)
+}

--- a/roxctl/central/migratetooperator/generate.go
+++ b/roxctl/central/migratetooperator/generate.go
@@ -18,30 +18,28 @@ func generateCR(config *detectedConfig) *platform.Central {
 		},
 	}
 
+	db := &platform.CentralDBSpec{}
 	switch config.Storage.Type {
 	case storagePVC:
-		cr.Spec.Central = &platform.CentralComponentSpec{
-			DB: &platform.CentralDBSpec{
-				Persistence: &platform.DBPersistence{
-					PersistentVolumeClaim: &platform.DBPersistentVolumeClaim{
-						ClaimName: pointers.String(config.Storage.PVCName),
-					},
-				},
+		// Only claimName is set. Size and storageClassName are intentionally
+		// omitted: the PVC already exists on the cluster, and the operator
+		// rejects these fields for pre-existing ("BYO") PVCs.
+		db.Persistence = &platform.DBPersistence{
+			PersistentVolumeClaim: &platform.DBPersistentVolumeClaim{
+				ClaimName: pointers.String(config.Storage.PVCName),
 			},
 		}
 	case storageHostPath:
-		db := &platform.CentralDBSpec{
-			Persistence: &platform.DBPersistence{
-				HostPath: &platform.HostPathSpec{
-					Path: pointers.String(config.Storage.HostPath),
-				},
+		db.Persistence = &platform.DBPersistence{
+			HostPath: &platform.HostPathSpec{
+				Path: pointers.String(config.Storage.HostPath),
 			},
 		}
-		if len(config.Storage.NodeSelector) > 0 {
-			db.NodeSelector = config.Storage.NodeSelector
-		}
-		cr.Spec.Central = &platform.CentralComponentSpec{DB: db}
 	}
+	if len(config.Storage.NodeSelector) > 0 {
+		db.NodeSelector = config.Storage.NodeSelector
+	}
+	cr.Spec.Central = &platform.CentralComponentSpec{DB: db}
 
 	return cr
 }

--- a/roxctl/central/migratetooperator/generate.go
+++ b/roxctl/central/migratetooperator/generate.go
@@ -1,6 +1,7 @@
 package migratetooperator
 
 import (
+	"github.com/pkg/errors"
 	platform "github.com/stackrox/rox/operator/api/v1alpha1"
 	"github.com/stackrox/rox/pkg/pointers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,5 +59,9 @@ func marshalCR(cr *platform.Central) ([]byte, error) {
 		Metadata:   map[string]string{"name": cr.Name},
 		Spec:       cr.Spec,
 	}
-	return yaml.Marshal(obj)
+	out, err := yaml.Marshal(obj)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshalling to YAML")
+	}
+	return out, nil
 }

--- a/roxctl/central/migratetooperator/generate_test.go
+++ b/roxctl/central/migratetooperator/generate_test.go
@@ -1,0 +1,67 @@
+package migratetooperator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+func TestGenerateCR_PVC(t *testing.T) {
+	config := &detectedConfig{
+		Storage: storageConfig{
+			Type:    storagePVC,
+			PVCName: "my-db-pvc",
+		},
+	}
+
+	cr := generateCR(config)
+
+	assert.Equal(t, "platform.stackrox.io/v1alpha1", cr.APIVersion)
+	assert.Equal(t, "Central", cr.Kind)
+	assert.Equal(t, "stackrox-central-services", cr.Name)
+	require.NotNil(t, cr.Spec.Central)
+	require.NotNil(t, cr.Spec.Central.DB)
+	require.NotNil(t, cr.Spec.Central.DB.Persistence)
+	require.NotNil(t, cr.Spec.Central.DB.Persistence.PersistentVolumeClaim)
+	assert.Equal(t, "my-db-pvc", *cr.Spec.Central.DB.Persistence.PersistentVolumeClaim.ClaimName)
+	assert.Nil(t, cr.Spec.Central.DB.Persistence.HostPath)
+
+	out, err := yaml.Marshal(cr)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "hostPath")
+	assert.NotContains(t, string(out), "nodeSelector")
+}
+
+func TestGenerateCR_HostPath(t *testing.T) {
+	config := &detectedConfig{
+		Storage: storageConfig{
+			Type:         storageHostPath,
+			HostPath:     "/data/stackrox",
+			NodeSelector: map[string]string{"kubernetes.io/hostname": "worker-1"},
+		},
+	}
+
+	cr := generateCR(config)
+
+	require.NotNil(t, cr.Spec.Central.DB.Persistence.HostPath)
+	assert.Equal(t, "/data/stackrox", *cr.Spec.Central.DB.Persistence.HostPath.Path)
+	assert.Nil(t, cr.Spec.Central.DB.Persistence.PersistentVolumeClaim)
+	assert.Equal(t, "worker-1", cr.Spec.Central.DB.NodeSelector["kubernetes.io/hostname"])
+}
+
+func TestGenerateCR_HostPathWithoutNodeSelector(t *testing.T) {
+	config := &detectedConfig{
+		Storage: storageConfig{
+			Type:     storageHostPath,
+			HostPath: "/var/lib/stackrox-central",
+		},
+	}
+
+	cr := generateCR(config)
+
+	require.NotNil(t, cr.Spec.Central.DB.Persistence.HostPath)
+	assert.Equal(t, "/var/lib/stackrox-central", *cr.Spec.Central.DB.Persistence.HostPath.Path)
+	assert.Empty(t, cr.Spec.Central.DB.NodeSelector)
+}

--- a/roxctl/central/migratetooperator/source.go
+++ b/roxctl/central/migratetooperator/source.go
@@ -7,6 +7,7 @@ import (
 // source provides access to Kubernetes resources from either a directory
 // of YAML manifests or a live cluster.
 type source interface {
-	// CentralDBDeployment returns the central-db Deployment, or nil if not found.
+	// CentralDBDeployment returns the central-db Deployment.
+	// It returns a non-nil error if the deployment is not found or cannot be retrieved.
 	CentralDBDeployment() (*appsv1.Deployment, error)
 }

--- a/roxctl/central/migratetooperator/source.go
+++ b/roxctl/central/migratetooperator/source.go
@@ -1,0 +1,12 @@
+package migratetooperator
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// source provides access to Kubernetes resources from either a directory
+// of YAML manifests or a live cluster.
+type source interface {
+	// CentralDBDeployment returns the central-db Deployment, or nil if not found.
+	CentralDBDeployment() (*appsv1.Deployment, error)
+}

--- a/roxctl/maincommand/command_tree_debug.yaml
+++ b/roxctl/maincommand/command_tree_debug.yaml
@@ -990,6 +990,25 @@ central:
         - plaintext
         - server-name
         - use-current-k8s-context
+  migrate-to-operator:
+    LOCAL_FLAGS:
+      - from-dir
+      - namespace
+      - output
+    INHERITED_FLAGS:
+      - ca
+      - direct-grpc
+      - endpoint
+      - force-http1
+      - help
+      - insecure
+      - insecure-skip-tls-verify
+      - no-color
+      - password
+      - plaintext
+      - server-name
+      - token-file
+      - use-current-k8s-context
   userpki:
     INHERITED_FLAGS:
       - ca

--- a/roxctl/maincommand/command_tree_release.yaml
+++ b/roxctl/maincommand/command_tree_release.yaml
@@ -970,6 +970,25 @@ central:
         - plaintext
         - server-name
         - use-current-k8s-context
+  migrate-to-operator:
+    LOCAL_FLAGS:
+      - from-dir
+      - namespace
+      - output
+    INHERITED_FLAGS:
+      - ca
+      - direct-grpc
+      - endpoint
+      - force-http1
+      - help
+      - insecure
+      - insecure-skip-tls-verify
+      - no-color
+      - password
+      - plaintext
+      - server-name
+      - token-file
+      - use-current-k8s-context
   userpki:
     INHERITED_FLAGS:
       - ca

--- a/tests/roxctl/bats-tests/local/central-migrate-to-operator.bats
+++ b/tests/roxctl/bats-tests/local/central-migrate-to-operator.bats
@@ -31,56 +31,56 @@ generate_and_migrate() {
 
 @test "migrate-to-operator: k8s pvc default produces claimName central-db" {
   generate_and_migrate k8s pvc
-  run yq '.spec.central.db.persistence.persistentVolumeClaim.claimName' "$cr_out"
+  run yq e '.spec.central.db.persistence.persistentVolumeClaim.claimName' "$cr_out"
   assert_success
   assert_output "central-db"
 }
 
 @test "migrate-to-operator: k8s pvc --db-name=foo produces claimName foo" {
   generate_and_migrate k8s pvc --db-name=foo
-  run yq '.spec.central.db.persistence.persistentVolumeClaim.claimName' "$cr_out"
+  run yq e '.spec.central.db.persistence.persistentVolumeClaim.claimName' "$cr_out"
   assert_success
   assert_output "foo"
 }
 
 @test "migrate-to-operator: openshift pvc default produces claimName central-db" {
   generate_and_migrate openshift pvc
-  run yq '.spec.central.db.persistence.persistentVolumeClaim.claimName' "$cr_out"
+  run yq e '.spec.central.db.persistence.persistentVolumeClaim.claimName' "$cr_out"
   assert_success
   assert_output "central-db"
 }
 
 @test "migrate-to-operator: openshift pvc --db-name=custom-pvc produces claimName custom-pvc" {
   generate_and_migrate openshift pvc --db-name=custom-pvc
-  run yq '.spec.central.db.persistence.persistentVolumeClaim.claimName' "$cr_out"
+  run yq e '.spec.central.db.persistence.persistentVolumeClaim.claimName' "$cr_out"
   assert_success
   assert_output "custom-pvc"
 }
 
 @test "migrate-to-operator: pvc with --db-storage-class does not include storageClassName in CR" {
   generate_and_migrate k8s pvc --db-storage-class=fast-ssd
-  run yq '.spec.central.db.persistence.persistentVolumeClaim.storageClassName' "$cr_out"
+  run yq e '.spec.central.db.persistence.persistentVolumeClaim.storageClassName' "$cr_out"
   assert_success
   assert_output "null"
 }
 
 @test "migrate-to-operator: pvc with --db-size=200 does not include size in CR" {
   generate_and_migrate k8s pvc --db-size=200
-  run yq '.spec.central.db.persistence.persistentVolumeClaim.size' "$cr_out"
+  run yq e '.spec.central.db.persistence.persistentVolumeClaim.size' "$cr_out"
   assert_success
   assert_output "null"
 }
 
 @test "migrate-to-operator: pvc mode does not produce hostPath" {
   generate_and_migrate k8s pvc
-  run yq '.spec.central.db.persistence.hostPath' "$cr_out"
+  run yq e '.spec.central.db.persistence.hostPath' "$cr_out"
   assert_success
   assert_output "null"
 }
 
 @test "migrate-to-operator: pvc mode does not produce nodeSelector" {
   generate_and_migrate k8s pvc
-  run yq '.spec.central.db.nodeSelector' "$cr_out"
+  run yq e '.spec.central.db.nodeSelector' "$cr_out"
   assert_success
   assert_output "null"
 }
@@ -89,28 +89,28 @@ generate_and_migrate() {
 
 @test "migrate-to-operator: k8s hostpath default produces path /var/lib/stackrox-central" {
   generate_and_migrate k8s hostpath
-  run yq '.spec.central.db.persistence.hostPath.path' "$cr_out"
+  run yq e '.spec.central.db.persistence.hostPath.path' "$cr_out"
   assert_success
   assert_output "/var/lib/stackrox-central"
 }
 
 @test "migrate-to-operator: k8s hostpath --db-hostpath=/data/db produces path /data/db" {
   generate_and_migrate k8s hostpath --db-hostpath=/data/db
-  run yq '.spec.central.db.persistence.hostPath.path' "$cr_out"
+  run yq e '.spec.central.db.persistence.hostPath.path' "$cr_out"
   assert_success
   assert_output "/data/db"
 }
 
 @test "migrate-to-operator: openshift hostpath default produces path /var/lib/stackrox-central" {
   generate_and_migrate openshift hostpath
-  run yq '.spec.central.db.persistence.hostPath.path' "$cr_out"
+  run yq e '.spec.central.db.persistence.hostPath.path' "$cr_out"
   assert_success
   assert_output "/var/lib/stackrox-central"
 }
 
 @test "migrate-to-operator: hostpath mode does not produce persistentVolumeClaim" {
   generate_and_migrate k8s hostpath
-  run yq '.spec.central.db.persistence.persistentVolumeClaim' "$cr_out"
+  run yq e '.spec.central.db.persistence.persistentVolumeClaim' "$cr_out"
   assert_success
   assert_output "null"
 }
@@ -121,14 +121,14 @@ generate_and_migrate() {
   generate_and_migrate k8s hostpath \
     --db-node-selector-key=kubernetes.io/hostname \
     --db-node-selector-value=worker-1
-  run yq '.spec.central.db.nodeSelector["kubernetes.io/hostname"]' "$cr_out"
+  run yq e '.spec.central.db.nodeSelector["kubernetes.io/hostname"]' "$cr_out"
   assert_success
   assert_output "worker-1"
 }
 
 @test "migrate-to-operator: hostpath without nodeSelector produces no nodeSelector" {
   generate_and_migrate k8s hostpath
-  run yq '.spec.central.db.nodeSelector' "$cr_out"
+  run yq e '.spec.central.db.nodeSelector' "$cr_out"
   assert_success
   assert_output "null"
 }
@@ -137,17 +137,17 @@ generate_and_migrate() {
 
 @test "migrate-to-operator: produces correct apiVersion and kind" {
   generate_and_migrate k8s pvc
-  run yq '.apiVersion' "$cr_out"
+  run yq e '.apiVersion' "$cr_out"
   assert_success
   assert_output "platform.stackrox.io/v1alpha1"
-  run yq '.kind' "$cr_out"
+  run yq e '.kind' "$cr_out"
   assert_success
   assert_output "Central"
 }
 
 @test "migrate-to-operator: produces name stackrox-central-services" {
   generate_and_migrate k8s pvc
-  run yq '.metadata.name' "$cr_out"
+  run yq e '.metadata.name' "$cr_out"
   assert_success
   assert_output "stackrox-central-services"
 }

--- a/tests/roxctl/bats-tests/local/central-migrate-to-operator.bats
+++ b/tests/roxctl/bats-tests/local/central-migrate-to-operator.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+
+load "../helpers.bash"
+
+out_dir=""
+cr_out=""
+
+setup_file() {
+  delete-outdated-binaries "$(roxctl-development version)"
+  echo "Testing roxctl version: '$(roxctl-development version)'" >&3
+  command -v yq > /dev/null || skip "Tests in this file require yq"
+}
+
+setup() {
+  out_dir="$(mktemp -d -u)"
+  cr_out="$(mktemp -u).yaml"
+}
+
+teardown() {
+  rm -rf "$out_dir" "$cr_out"
+}
+
+generate_and_migrate() {
+  run roxctl-development central generate "$@" --output-dir "$out_dir"
+  assert_success
+  run roxctl-development central migrate-to-operator --from-dir "$out_dir" -o "$cr_out"
+  assert_success
+}
+
+# PVC storage
+
+@test "migrate-to-operator: k8s pvc default produces claimName central-db" {
+  generate_and_migrate k8s pvc
+  run yq '.spec.central.db.persistence.persistentVolumeClaim.claimName' "$cr_out"
+  assert_success
+  assert_output "central-db"
+}
+
+@test "migrate-to-operator: k8s pvc --db-name=foo produces claimName foo" {
+  generate_and_migrate k8s pvc --db-name=foo
+  run yq '.spec.central.db.persistence.persistentVolumeClaim.claimName' "$cr_out"
+  assert_success
+  assert_output "foo"
+}
+
+@test "migrate-to-operator: openshift pvc default produces claimName central-db" {
+  generate_and_migrate openshift pvc
+  run yq '.spec.central.db.persistence.persistentVolumeClaim.claimName' "$cr_out"
+  assert_success
+  assert_output "central-db"
+}
+
+@test "migrate-to-operator: openshift pvc --db-name=custom-pvc produces claimName custom-pvc" {
+  generate_and_migrate openshift pvc --db-name=custom-pvc
+  run yq '.spec.central.db.persistence.persistentVolumeClaim.claimName' "$cr_out"
+  assert_success
+  assert_output "custom-pvc"
+}
+
+@test "migrate-to-operator: pvc with --db-storage-class does not include storageClassName in CR" {
+  generate_and_migrate k8s pvc --db-storage-class=fast-ssd
+  run yq '.spec.central.db.persistence.persistentVolumeClaim.storageClassName' "$cr_out"
+  assert_success
+  assert_output "null"
+}
+
+@test "migrate-to-operator: pvc with --db-size=200 does not include size in CR" {
+  generate_and_migrate k8s pvc --db-size=200
+  run yq '.spec.central.db.persistence.persistentVolumeClaim.size' "$cr_out"
+  assert_success
+  assert_output "null"
+}
+
+@test "migrate-to-operator: pvc mode does not produce hostPath" {
+  generate_and_migrate k8s pvc
+  run yq '.spec.central.db.persistence.hostPath' "$cr_out"
+  assert_success
+  assert_output "null"
+}
+
+@test "migrate-to-operator: pvc mode does not produce nodeSelector" {
+  generate_and_migrate k8s pvc
+  run yq '.spec.central.db.nodeSelector' "$cr_out"
+  assert_success
+  assert_output "null"
+}
+
+# Hostpath storage
+
+@test "migrate-to-operator: k8s hostpath default produces path /var/lib/stackrox-central" {
+  generate_and_migrate k8s hostpath
+  run yq '.spec.central.db.persistence.hostPath.path' "$cr_out"
+  assert_success
+  assert_output "/var/lib/stackrox-central"
+}
+
+@test "migrate-to-operator: k8s hostpath --db-hostpath=/data/db produces path /data/db" {
+  generate_and_migrate k8s hostpath --db-hostpath=/data/db
+  run yq '.spec.central.db.persistence.hostPath.path' "$cr_out"
+  assert_success
+  assert_output "/data/db"
+}
+
+@test "migrate-to-operator: openshift hostpath default produces path /var/lib/stackrox-central" {
+  generate_and_migrate openshift hostpath
+  run yq '.spec.central.db.persistence.hostPath.path' "$cr_out"
+  assert_success
+  assert_output "/var/lib/stackrox-central"
+}
+
+@test "migrate-to-operator: hostpath mode does not produce persistentVolumeClaim" {
+  generate_and_migrate k8s hostpath
+  run yq '.spec.central.db.persistence.persistentVolumeClaim' "$cr_out"
+  assert_success
+  assert_output "null"
+}
+
+# Hostpath with nodeSelector
+
+@test "migrate-to-operator: hostpath with nodeSelector" {
+  generate_and_migrate k8s hostpath \
+    --db-node-selector-key=kubernetes.io/hostname \
+    --db-node-selector-value=worker-1
+  run yq '.spec.central.db.nodeSelector["kubernetes.io/hostname"]' "$cr_out"
+  assert_success
+  assert_output "worker-1"
+}
+
+@test "migrate-to-operator: hostpath without nodeSelector produces no nodeSelector" {
+  generate_and_migrate k8s hostpath
+  run yq '.spec.central.db.nodeSelector' "$cr_out"
+  assert_success
+  assert_output "null"
+}
+
+# CR metadata
+
+@test "migrate-to-operator: produces correct apiVersion and kind" {
+  generate_and_migrate k8s pvc
+  run yq '.apiVersion' "$cr_out"
+  assert_success
+  assert_output "platform.stackrox.io/v1alpha1"
+  run yq '.kind' "$cr_out"
+  assert_success
+  assert_output "Central"
+}
+
+@test "migrate-to-operator: produces name stackrox-central-services" {
+  generate_and_migrate k8s pvc
+  run yq '.metadata.name' "$cr_out"
+  assert_success
+  assert_output "stackrox-central-services"
+}
+
+# Error cases
+
+@test "migrate-to-operator: fails without --from-dir or --namespace" {
+  run roxctl-development central migrate-to-operator
+  assert_failure
+  assert_output --partial "either --from-dir or --namespace must be specified"
+}
+
+@test "migrate-to-operator: fails with --from-dir and --namespace" {
+  run roxctl-development central migrate-to-operator --from-dir /tmp --namespace stackrox
+  assert_failure
+  assert_output --partial "if any flags in the group"
+}
+
+@test "migrate-to-operator: fails with nonexistent directory" {
+  run roxctl-development central migrate-to-operator --from-dir /nonexistent/path
+  assert_failure
+  assert_output --partial "accessing directory"
+}

--- a/tools/roxvet/analyzers/validateimports/analyzer.go
+++ b/tools/roxvet/analyzers/validateimports/analyzer.go
@@ -375,7 +375,7 @@ func verifyImportsFromAllowedPackagesOnly(pass *analysis.Pass, imports []*ast.Im
 		allowedPackages = appendPackageWithChildren(allowedPackages, "tests/bad-ca")
 	}
 
-	if validImportRoot == "pkg" {
+	if validImportRoot == "roxctl" || validImportRoot == "pkg" {
 		allowedPackages = appendPackageWithChildren(allowedPackages, "operator/api")
 		if isTestFile {
 			allowedPackages = appendPackageWithChildren(allowedPackages, "tools/generate-helpers/pg-table-bindings")


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

* This is the scaffolding and partial implementation for https://redhat.atlassian.net/browse/ROX-33122 and https://redhat.atlassian.net/browse/ROX-33127
* Follow-up PR's will provide support for more tunables, and to support secured-cluster (https://redhat.atlassian.net/browse/ROX-33121) in a similar spirit.
* My hope it that the same code can also be used for migrating helm-based installations to the operator, but I haven't verified that yet.
* My initial plan was to only provide in 4.11 timeframe a simple description for humans to read and manually prepare a central custom resource for migrating from legacy methods. I had claude draft such document in https://github.com/stackrox/stackrox/blob/porridge/migraion/MIGRATION/options-master-list.md However, going through such instructions would be quite tedious and maintaining this documentation without making without a way of making sure it actually works would also be difficult and labour-intensive. Providing this as code seems like a better approach.

Draft plan:
* 4.11: this command is released; helm-based installations deprecated (manifest-based ones are already deprecated)
* 5.0: this command is deprecated, in time to allow removal in 5.2
* 5.1: legacy install methods removed, command still available such that users who upgrade their `roxctl` to 5.1 will still be able to migrate their 5.0 installations to operator-based 5.1
* 5.2: this command removed

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
