### PR TITLE
ROX-33638: resolver conditional send and dedup key

### DIFF
--- a/pkg/dedupingqueue/deduping_queue.go
+++ b/pkg/dedupingqueue/deduping_queue.go
@@ -14,6 +14,14 @@ type Item[K comparable] interface {
 	GetDedupeKey() K
 }
 
+// Mergeable is an optional interface that queue items can implement to merge
+// state from an existing item when a duplicate key is pushed. If the new item
+// implements Mergeable, MergeFrom is called with the old item before the old
+// item is removed from the queue.
+type Mergeable[K comparable] interface {
+	MergeFrom(old Item[K])
+}
+
 // OptionFunc provides options for the queue.
 type OptionFunc[K comparable] func(*DedupingQueue[K])
 
@@ -125,6 +133,9 @@ func (q *DedupingQueue[K]) Push(item Item[K]) {
 	if oldItem, ok := q.indexer[key]; ok {
 		if q.operationMetric != nil {
 			q.operationMetric(ops.Dedupe, q.name)
+		}
+		if m, ok := item.(Mergeable[K]); ok {
+			m.MergeFrom(oldItem.Value.(Item[K]))
 		}
 		msgInserted = q.queue.InsertBefore(item, oldItem)
 		q.queue.Remove(oldItem)

--- a/pkg/dedupingqueue/deduping_queue_test.go
+++ b/pkg/dedupingqueue/deduping_queue_test.go
@@ -18,8 +18,8 @@ func TestUniQueue(t *testing.T) {
 }
 
 func (s *uniQueueSuite) TestPushPull() {
-	items := []*testItem{{1}, {2}, {1}, {3}}
-	expectedItems := []*testItem{{1}, {2}, {3}}
+	items := []*testItem{{value: 1}, {value: 2}, {value: 1}, {value: 3}}
+	expectedItems := []*testItem{{value: 1}, {value: 2}, {value: 3}}
 	q := NewDedupingQueue[string]()
 	for _, i := range items {
 		q.Push(i)
@@ -103,8 +103,8 @@ func (s *uniQueueSuite) TestMergeableThreeWayMerge() {
 
 func (s *uniQueueSuite) TestNonMergeableItemsReplaceOnDuplicate() {
 	q := NewDedupingQueue[string]()
-	q.Push(&testItem{value: 1})
-	q.Push(&testItem{value: 1})
+	q.Push(&testItem{value: 1, payload: "first"})
+	q.Push(&testItem{value: 1, payload: "second"})
 
 	s.Assert().Equal(1, q.queue.Len(), "duplicate key should result in one item")
 
@@ -113,7 +113,7 @@ func (s *uniQueueSuite) TestNonMergeableItemsReplaceOnDuplicate() {
 	item := q.PullBlocking(&stopSignal)
 	pulled, ok := item.(*testItem)
 	s.Require().True(ok)
-	s.Assert().Equal(1, pulled.value, "non-mergeable item should be replaced, not merged")
+	s.Assert().Equal("second", pulled.payload, "new item should replace the old one")
 }
 
 func (s *uniQueueSuite) TestMergeablePreservesQueueOrder() {
@@ -137,7 +137,8 @@ func (s *uniQueueSuite) TestMergeablePreservesQueueOrder() {
 }
 
 type testItem struct {
-	value int
+	value   int
+	payload string
 }
 
 func (i *testItem) GetDedupeKey() string {

--- a/pkg/dedupingqueue/deduping_queue_test.go
+++ b/pkg/dedupingqueue/deduping_queue_test.go
@@ -127,12 +127,16 @@ func (s *uniQueueSuite) TestMergeablePreservesQueueOrder() {
 	stopSignal := concurrency.NewSignal()
 	defer stopSignal.Signal()
 
-	first := q.PullBlocking(&stopSignal).(*mergeableItem)
+	firstItem := q.PullBlocking(&stopSignal)
+	first, ok := firstItem.(*mergeableItem)
+	s.Require().True(ok)
 	s.Assert().Equal("a", first.id, "merged item should keep its original position")
 	s.Assert().True(first.flag1)
 	s.Assert().True(first.flag2)
 
-	second := q.PullBlocking(&stopSignal).(*mergeableItem)
+	secondItem := q.PullBlocking(&stopSignal)
+	second, ok := secondItem.(*mergeableItem)
+	s.Require().True(ok)
 	s.Assert().Equal("b", second.id)
 }
 

--- a/pkg/dedupingqueue/deduping_queue_test.go
+++ b/pkg/dedupingqueue/deduping_queue_test.go
@@ -68,12 +68,99 @@ func (s *uniQueueSuite) TestPullBlocking() {
 	}, time.Second, 100*time.Millisecond, "an nil value should be returned after the stop signal is triggered")
 }
 
+func (s *uniQueueSuite) TestMergeableItemsMergeOnDuplicate() {
+	q := NewDedupingQueue[string]()
+	q.Push(&mergeableItem{id: "a", flag1: false, flag2: true})
+	q.Push(&mergeableItem{id: "a", flag1: true, flag2: false})
+
+	s.Assert().Equal(1, q.queue.Len(), "duplicate key should result in one item")
+
+	stopSignal := concurrency.NewSignal()
+	defer stopSignal.Signal()
+	item := q.PullBlocking(&stopSignal)
+	merged, ok := item.(*mergeableItem)
+	s.Require().True(ok)
+	s.Assert().True(merged.flag1, "flag1 should be sticky-true after merge")
+	s.Assert().True(merged.flag2, "flag2 should be sticky-true after merge")
+}
+
+func (s *uniQueueSuite) TestMergeableThreeWayMerge() {
+	q := NewDedupingQueue[string]()
+	q.Push(&mergeableItem{id: "a", flag1: false, flag2: false})
+	q.Push(&mergeableItem{id: "a", flag1: true, flag2: false})
+	q.Push(&mergeableItem{id: "a", flag1: false, flag2: true})
+
+	s.Assert().Equal(1, q.queue.Len())
+
+	stopSignal := concurrency.NewSignal()
+	defer stopSignal.Signal()
+	item := q.PullBlocking(&stopSignal)
+	merged, ok := item.(*mergeableItem)
+	s.Require().True(ok)
+	s.Assert().True(merged.flag1, "flag1 should accumulate across three pushes")
+	s.Assert().True(merged.flag2, "flag2 should accumulate across three pushes")
+}
+
+func (s *uniQueueSuite) TestNonMergeableItemsReplaceOnDuplicate() {
+	q := NewDedupingQueue[string]()
+	q.Push(&testItem{value: 1})
+	q.Push(&testItem{value: 1})
+
+	s.Assert().Equal(1, q.queue.Len(), "duplicate key should result in one item")
+
+	stopSignal := concurrency.NewSignal()
+	defer stopSignal.Signal()
+	item := q.PullBlocking(&stopSignal)
+	pulled, ok := item.(*testItem)
+	s.Require().True(ok)
+	s.Assert().Equal(1, pulled.value, "non-mergeable item should be replaced, not merged")
+}
+
+func (s *uniQueueSuite) TestMergeablePreservesQueueOrder() {
+	q := NewDedupingQueue[string]()
+	q.Push(&mergeableItem{id: "a", flag1: true, flag2: false})
+	q.Push(&mergeableItem{id: "b", flag1: false, flag2: true})
+	q.Push(&mergeableItem{id: "a", flag1: false, flag2: true})
+
+	s.Assert().Equal(2, q.queue.Len(), "should have two items after merge")
+
+	stopSignal := concurrency.NewSignal()
+	defer stopSignal.Signal()
+
+	first := q.PullBlocking(&stopSignal).(*mergeableItem)
+	s.Assert().Equal("a", first.id, "merged item should keep its original position")
+	s.Assert().True(first.flag1)
+	s.Assert().True(first.flag2)
+
+	second := q.PullBlocking(&stopSignal).(*mergeableItem)
+	s.Assert().Equal("b", second.id)
+}
+
 type testItem struct {
 	value int
 }
 
 func (i *testItem) GetDedupeKey() string {
 	return fmt.Sprintf("%d", i.value)
+}
+
+type mergeableItem struct {
+	id    string
+	flag1 bool
+	flag2 bool
+}
+
+func (i *mergeableItem) GetDedupeKey() string {
+	return i.id
+}
+
+func (i *mergeableItem) MergeFrom(old Item[string]) {
+	oldItem, ok := old.(*mergeableItem)
+	if !ok {
+		return
+	}
+	i.flag1 = i.flag1 || oldItem.flag1
+	i.flag2 = i.flag2 || oldItem.flag2
 }
 
 type itemWithNoKeyFunction struct {

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -33,7 +33,19 @@ type deploymentRef struct {
 
 // GetDedupeKey returns the key to index the deploymentRef in the queue
 func (d *deploymentRef) GetDedupeKey() string {
-	return fmt.Sprintf("%s-%s-%t-%t", d.id, d.action.String(), d.skipResolving, d.forceDetection)
+	return fmt.Sprintf("%s-%s", d.id, d.action.String())
+}
+
+// MergeFrom merges flags from an existing queued ref when a duplicate key is pushed.
+// forceDetection is sticky-true: if either ref needs forced detection, keep it.
+// skipResolving is sticky-false: if either ref needs full resolution, do it.
+func (d *deploymentRef) MergeFrom(old dedupingqueue.Item[string]) {
+	oldRef, ok := old.(*deploymentRef)
+	if !ok {
+		return
+	}
+	d.forceDetection = d.forceDetection || oldRef.forceDetection
+	d.skipResolving = d.skipResolving && oldRef.skipResolving
 }
 
 type resolverImpl struct {
@@ -175,6 +187,18 @@ func (r *resolverImpl) resolveDeployment(msg *component.ResourceEvent, ref *depl
 	return false
 }
 
+// resolveAndSend resolves a single deployment ref and sends the resulting event
+// to the output queue if the deployment was resolved or if reprocess data was added.
+func (r *resolverImpl) resolveAndSend(ref *deploymentRef) {
+	msg := component.NewEvent()
+	msg.Context = ref.context
+	msg.DeploymentTiming = ref.deploymentTiming
+	resolved := r.resolveDeployment(msg, ref)
+	if resolved || len(msg.ReprocessDeployments) > 0 {
+		r.outputQueue.Send(msg)
+	}
+}
+
 // runPullAndResolve pull the next deployment reference to be resolved out of the queue
 func (r *resolverImpl) runPullAndResolve() {
 	defer r.pullAndResolveStopped.Signal()
@@ -194,12 +218,7 @@ func (r *resolverImpl) runPullAndResolve() {
 		if ref == nil {
 			continue
 		}
-		msg := component.NewEvent()
-		msg.Context = ref.context
-		msg.DeploymentTiming = ref.deploymentTiming
-		if r.resolveDeployment(msg, ref) {
-			r.outputQueue.Send(msg)
-		}
+		r.resolveAndSend(ref)
 	}
 }
 

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_race_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_race_test.go
@@ -94,11 +94,8 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// Central sends UpdatedImage while a K8s deployment update is in-flight.
 		// The K8s dispatcher already stored the new wrap (isBuilt=false) but the
 		// resolver hasn't processed the deployment's own ref yet. The Central ref
-		// reaches the resolver first.
-		// FF disabled: resolveDeployment returns false but msg is sent unconditionally
-		//   with ReprocessDeployments → PASSES.
-		// FF enabled: resolveDeployment returns false and the conditional send in
-		//   runPullAndResolve drops the msg → FAILS (bug).
+		// reaches the resolver first. resolveDeployment returns false, but the
+		// ReprocessDeployments data must still be sent.
 		"central UpdatedImage arrives while deployment is being rebuilt": {
 			testFFDisabled: true,
 			steps: []func(*raceTestEnv){
@@ -122,8 +119,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		},
 
 		// Full resolve path with forceDetection=true but BuildDeploymentWithDependencies
-		// fails. The reprocess data was already added to the event but the conditional
-		// send drops it.
+		// fails. The reprocess data must still be sent despite the build error.
 		"forceDetection ref with build error preserves reprocess data": {
 			testFFDisabled: true,
 			steps: []func(*raceTestEnv){
@@ -268,6 +264,20 @@ func TestResolverRaceScenarios(t *testing.T) {
 				givenDeploymentResolvable("deploy-1"),
 				pushFullResolveRef("deploy-1"),
 				pushSkipResolvingRef("deploy-1"),
+				resolveNextItem(),
+				expectDetectionSent("deploy-1"),
+				expectReprocessSent("deploy-1"),
+				expectQueueEmpty(),
+			},
+		},
+		// Same as "merge: both refs in queue bypass isBuilt guard" but the Central
+		// ref arrives first. The K8s ref merges into it, flipping skipResolving to
+		// false. Verifies the isBuilt guard is bypassed regardless of push order.
+		"merge: both refs in queue bypass isBuilt guard when k8s event comes after": {
+			steps: []func(*raceTestEnv){
+				givenDeploymentResolvable("deploy-1"),
+				pushSkipResolvingRef("deploy-1"),
+				pushFullResolveRef("deploy-1"),
 				resolveNextItem(),
 				expectDetectionSent("deploy-1"),
 				expectReprocessSent("deploy-1"),

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_race_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_race_test.go
@@ -1,0 +1,620 @@
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/dedupingqueue"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/sensor/common/service"
+	"github.com/stackrox/rox/sensor/common/store"
+	mocksStore "github.com/stackrox/rox/sensor/common/store/mocks"
+	resolverStore "github.com/stackrox/rox/sensor/common/store/resolver"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type raceTestEnv struct {
+	t        *testing.T
+	resolver *resolverImpl
+
+	mockDeploymentStore *mocksStore.MockDeploymentStore
+	mockRBACStore       *mocksStore.MockRBACStore
+	mockServiceStore    *mocksStore.MockServiceStore
+	mockEndpointManager *mocksStore.MockEndpointManager
+
+	sentEvents []*component.ResourceEvent
+}
+
+func newRaceTestEnv(t *testing.T) *raceTestEnv {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+
+	depStore := mocksStore.NewMockDeploymentStore(ctrl)
+	rbacStore := mocksStore.NewMockRBACStore(ctrl)
+	svcStore := mocksStore.NewMockServiceStore(ctrl)
+	endpointMgr := mocksStore.NewMockEndpointManager(ctrl)
+	mockOutput := mocks.NewMockOutputQueue(ctrl)
+
+	env := &raceTestEnv{
+		t:                   t,
+		mockDeploymentStore: depStore,
+		mockRBACStore:       rbacStore,
+		mockServiceStore:    svcStore,
+		mockEndpointManager: endpointMgr,
+	}
+
+	mockOutput.EXPECT().Send(gomock.Any()).AnyTimes().Do(func(event *component.ResourceEvent) {
+		env.sentEvents = append(env.sentEvents, event)
+	})
+
+	var queue *dedupingqueue.DedupingQueue[string]
+	if features.SensorAggregateDeploymentReferenceOptimization.Enabled() {
+		queue = dedupingqueue.NewDedupingQueue[string]()
+	}
+
+	env.resolver = &resolverImpl{
+		outputQueue: mockOutput,
+		storeProvider: &fakeProvider{
+			deploymentStore: depStore,
+			serviceStore:    svcStore,
+			rbacStore:       rbacStore,
+			endpointManager: endpointMgr,
+		},
+		stopper:               concurrency.NewStopper(),
+		pullAndResolveStopped: concurrency.NewSignal(),
+		deploymentRefQueue:    queue,
+	}
+
+	return env
+}
+
+type raceTestCase struct {
+	steps          []func(*raceTestEnv)
+	testFFDisabled bool
+}
+
+func TestResolverRaceScenarios(t *testing.T) {
+	cases := map[string]raceTestCase{
+		// Central sends UpdatedImage while a K8s deployment update is in-flight.
+		// The K8s dispatcher already stored the new wrap (isBuilt=false) but the
+		// resolver hasn't processed the deployment's own ref yet. The Central ref
+		// reaches the resolver first.
+		// FF disabled: resolveDeployment returns false but msg is sent unconditionally
+		//   with ReprocessDeployments → PASSES.
+		// FF enabled: resolveDeployment returns false and the conditional send in
+		//   runPullAndResolve drops the msg → FAILS (bug).
+		"central UpdatedImage arrives while deployment is being rebuilt": {
+			testFFDisabled: true,
+			steps: []func(*raceTestEnv){
+				givenDeploymentNotBuilt("deploy-1"),
+				dispatchCentralUpdatedImage("deploy-1"),
+				resolveNextItem(),
+				expectReprocessSent("deploy-1"),
+			},
+		},
+
+		// Same scenario but the deployment was completely removed from the store
+		// between the event being queued and resolved.
+		"forceDetection ref for a deleted deployment preserves reprocess data": {
+			testFFDisabled: true,
+			steps: []func(*raceTestEnv){
+				givenDeploymentNotFound("deploy-1"),
+				dispatchCentralUpdatedImage("deploy-1"),
+				resolveNextItem(),
+				expectReprocessSent("deploy-1"),
+			},
+		},
+
+		// Full resolve path with forceDetection=true but BuildDeploymentWithDependencies
+		// fails. The reprocess data was already added to the event but the conditional
+		// send drops it.
+		"forceDetection ref with build error preserves reprocess data": {
+			testFFDisabled: true,
+			steps: []func(*raceTestEnv){
+				givenDeploymentBuildError("deploy-1"),
+				dispatchForceDetectionEvent("deploy-1"),
+				resolveNextItem(),
+				expectReprocessSent("deploy-1"),
+			},
+		},
+
+		// Happy path: skipResolving when the deployment is fully built.
+		// GetBuiltDeployment returns (d, true), detection succeeds.
+		"skipResolving with isBuilt=true succeeds": {
+			testFFDisabled: true,
+			steps: []func(*raceTestEnv){
+				givenDeploymentBuilt("deploy-1"),
+				dispatchCentralUpdatedImage("deploy-1"),
+				resolveNextItem(),
+				expectReprocessSent("deploy-1"),
+				expectDetectionSent("deploy-1"),
+			},
+		},
+
+		// Happy path: full resolve for a new deployment.
+		// BuildDeploymentWithDependencies returns newObject=true.
+		"full resolve of new deployment triggers detection": {
+			testFFDisabled: true,
+			steps: []func(*raceTestEnv){
+				givenDeploymentResolvable("deploy-1"),
+				dispatchK8sDeploymentEvent("deploy-1"),
+				resolveNextItem(),
+				expectDetectionSent("deploy-1"),
+				expectForwardMessageSent("deploy-1"),
+			},
+		},
+
+		// Full resolve where the deployment hasn't changed (!forceDetection && !newObject).
+		// processMessage always sends the original msg (which has no deployment data).
+		// resolveNextItem does nothing because resolveDeployment returns false and
+		// ReprocessDeployments is empty.
+		"full resolve with no changes sends only original msg": {
+			testFFDisabled: true,
+			steps: []func(*raceTestEnv){
+				givenDeploymentUnchanged("deploy-1"),
+				dispatchK8sDeploymentEvent("deploy-1"),
+				resolveNextItem(),
+				expectNoDetectionSent(),
+				expectNoForwardMessageSent(),
+			},
+		},
+
+		// Normal ordering: K8s ref is resolved first (builds deployment, sets isBuilt=true).
+		// Then the Central ref arrives and the skipResolving path succeeds.
+		"K8s ref resolved before central ref — no race": {
+			testFFDisabled: true,
+			steps: []func(*raceTestEnv){
+				givenDeploymentResolvable("deploy-1"),
+				dispatchK8sDeploymentEvent("deploy-1"),
+				resolveNextItem(),
+				givenDeploymentBuilt("deploy-1"),
+				dispatchCentralUpdatedImage("deploy-1"),
+				resolveNextItem(),
+				expectDetectionSent("deploy-1"),
+				expectReprocessSent("deploy-1"),
+			},
+		},
+
+		// Full resolve with real dependency data flowing through.
+		// Verifies that RBAC permissions and service exposure are carried
+		// to the output in ForwardMessages and DetectorMessages.
+		"full resolve carries dependency data to output": {
+			testFFDisabled: true,
+			steps: []func(*raceTestEnv){
+				givenDeploymentWithDependencies("deploy-1",
+					storage.PermissionLevel_ELEVATED_IN_NAMESPACE,
+					[]map[service.PortRef][]*storage.PortConfig_ExposureInfo{
+						{
+							{Port: intstr.IntOrString{IntVal: 8080}, Protocol: "TCP"}: {
+								{Level: storage.PortConfig_EXTERNAL, ServiceName: "my.service", ServicePort: 80},
+							},
+						},
+					},
+				),
+				dispatchK8sDeploymentEvent("deploy-1"),
+				resolveNextItem(),
+				expectForwardMessageWithPermissionLevel("deploy-1", storage.PermissionLevel_ELEVATED_IN_NAMESPACE),
+			},
+		},
+
+		// Merge: Central ref (skipResolving=true, forceDetection=true) is pushed first,
+		// then K8s ref (skipResolving=false, forceDetection=false) merges into it.
+		// Merged result: skipResolving=false, forceDetection=true → full resolve
+		// with forced detection. Only one item in the queue.
+		"merge: central then K8s ref collapses to full resolve with forceDetection": {
+			steps: []func(*raceTestEnv){
+				givenDeploymentResolvable("deploy-1"),
+				pushSkipResolvingRef("deploy-1"),
+				pushFullResolveRef("deploy-1"),
+				resolveNextItem(),
+				expectDetectionSent("deploy-1"),
+				expectReprocessSent("deploy-1"),
+				expectForwardMessageSent("deploy-1"),
+				expectQueueEmpty(),
+			},
+		},
+
+		// Merge: same as above but K8s ref is pushed first.
+		// Verifies that push order doesn't affect the merged result.
+		"merge: K8s then central ref collapses to full resolve with forceDetection": {
+			steps: []func(*raceTestEnv){
+				givenDeploymentResolvable("deploy-1"),
+				pushFullResolveRef("deploy-1"),
+				pushSkipResolvingRef("deploy-1"),
+				resolveNextItem(),
+				expectDetectionSent("deploy-1"),
+				expectReprocessSent("deploy-1"),
+				expectForwardMessageSent("deploy-1"),
+				expectQueueEmpty(),
+			},
+		},
+
+		// Merge: two K8s refs for the same deployment. Flags don't change
+		// (both skipResolving=false, forceDetection=false). Only one resolve happens.
+		"merge: two K8s refs dedup to single resolve": {
+			steps: []func(*raceTestEnv){
+				givenDeploymentResolvable("deploy-1"),
+				pushFullResolveRef("deploy-1"),
+				pushFullResolveRef("deploy-1"),
+				resolveNextItem(),
+				expectDetectionSent("deploy-1"),
+				expectForwardMessageSent("deploy-1"),
+				expectQueueEmpty(),
+			},
+		},
+
+		// Merge eliminates the isBuilt race: K8s ref is already in the queue when
+		// the Central ref arrives. The merge produces skipResolving=false,
+		// forceDetection=true. The full resolve path bypasses the isBuilt guard
+		// entirely.
+		"merge: both refs in queue bypass isBuilt guard": {
+			steps: []func(*raceTestEnv){
+				givenDeploymentResolvable("deploy-1"),
+				pushFullResolveRef("deploy-1"),
+				pushSkipResolvingRef("deploy-1"),
+				resolveNextItem(),
+				expectDetectionSent("deploy-1"),
+				expectReprocessSent("deploy-1"),
+				expectQueueEmpty(),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		ffStates := []bool{true}
+		if tc.testFFDisabled {
+			ffStates = append(ffStates, false)
+		}
+		for _, ffEnabled := range ffStates {
+			t.Run(fmt.Sprintf("%s/ff=%t", name, ffEnabled), func(t *testing.T) {
+				t.Setenv(features.SensorAggregateDeploymentReferenceOptimization.EnvVar(),
+					fmt.Sprintf("%t", ffEnabled))
+				env := newRaceTestEnv(t)
+				for _, step := range tc.steps {
+					step(env)
+				}
+			})
+		}
+	}
+}
+
+// --- Step functions: mock setup ---
+
+func givenDeploymentNotBuilt(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		env.mockDeploymentStore.EXPECT().Get(gomock.Eq(id)).
+			Return(&storage.Deployment{Id: id}).Times(1)
+		env.mockDeploymentStore.EXPECT().GetBuiltDeployment(gomock.Eq(id)).
+			Return(&storage.Deployment{Id: id}, false).Times(1)
+	}
+}
+
+func givenDeploymentNotFound(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		env.mockDeploymentStore.EXPECT().Get(gomock.Eq(id)).
+			Return(nil).Times(1)
+		// GetBuiltDeployment is NOT called because Get returns nil → early return.
+	}
+}
+
+func givenDeploymentBuilt(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		env.mockDeploymentStore.EXPECT().Get(gomock.Eq(id)).
+			Return(&storage.Deployment{Id: id}).Times(1)
+		env.mockDeploymentStore.EXPECT().GetBuiltDeployment(gomock.Eq(id)).
+			Return(&storage.Deployment{Id: id}, true).Times(1)
+	}
+}
+
+func givenDeploymentResolvable(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		givenFullResolveMocks(env, id,
+			storage.PermissionLevel_NONE, nil,
+			&storage.Deployment{Id: id}, true, nil)
+	}
+}
+
+func givenDeploymentUnchanged(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		givenFullResolveMocks(env, id,
+			storage.PermissionLevel_NONE, nil,
+			&storage.Deployment{Id: id}, false, nil)
+	}
+}
+
+func givenDeploymentBuildError(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		givenFullResolveMocks(env, id,
+			storage.PermissionLevel_NONE, nil,
+			nil, false, errors.New("dependency error"))
+	}
+}
+
+func givenDeploymentWithDependencies(
+	id string,
+	permLevel storage.PermissionLevel,
+	exposures []map[service.PortRef][]*storage.PortConfig_ExposureInfo,
+) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		var flatExposures []*storage.PortConfig_ExposureInfo
+		for _, e := range exposures {
+			for _, list := range e {
+				flatExposures = append(flatExposures, list...)
+			}
+		}
+		builtDeployment := &storage.Deployment{
+			Id:                            id,
+			ServiceAccountPermissionLevel: permLevel,
+			Ports: []*storage.PortConfig{
+				{ExposureInfos: flatExposures},
+			},
+		}
+		givenFullResolveMocks(env, id, permLevel, exposures, builtDeployment, true, nil)
+	}
+}
+
+func givenFullResolveMocks(
+	env *raceTestEnv,
+	id string,
+	permLevel storage.PermissionLevel,
+	exposures []map[service.PortRef][]*storage.PortConfig_ExposureInfo,
+	builtDeployment *storage.Deployment,
+	newObject bool,
+	buildErr error,
+) {
+	env.mockDeploymentStore.EXPECT().Get(gomock.Eq(id)).
+		Return(&storage.Deployment{Id: id}).Times(1)
+	env.mockEndpointManager.EXPECT().OnDeploymentCreateOrUpdateByID(gomock.Eq(id)).Times(1)
+	env.mockRBACStore.EXPECT().GetPermissionLevelForDeployment(gomock.Any()).
+		Return(permLevel).Times(1)
+	env.mockServiceStore.EXPECT().GetExposureInfos(gomock.Any(), gomock.Any()).
+		Return(exposures).Times(1)
+	env.mockDeploymentStore.EXPECT().BuildDeploymentWithDependencies(
+		gomock.Eq(id), gomock.Eq(store.Dependencies{
+			PermissionLevel: permLevel,
+			Exposures:       exposures,
+			LocalImages:     set.NewStringSet(),
+		})).
+		Return(builtDeployment, newObject, buildErr).Times(1)
+}
+
+// --- Step functions: dispatch events ---
+
+// dispatchCentralUpdatedImage creates a ResourceEvent with skipResolving+forceDetection
+// and feeds it through processMessage.
+// Represents: Central sent UpdatedImage, ReprocessDeployment, or InvalidateImageCache.
+func dispatchCentralUpdatedImage(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		event := &component.ResourceEvent{
+			DeploymentReferences: []component.DeploymentReference{
+				{
+					Reference:            resolverStore.ResolveDeploymentIds(id),
+					ParentResourceAction: central.ResourceAction_UPDATE_RESOURCE,
+					ForceDetection:       true,
+					SkipResolving:        true,
+				},
+			},
+			Context: context.Background(),
+		}
+		env.resolver.processMessage(event)
+	}
+}
+
+// dispatchK8sDeploymentEvent creates a ResourceEvent with a full-resolve ref
+// and feeds it through processMessage.
+// Represents: K8s dispatcher event (deployment create/update, service, RBAC, secret).
+func dispatchK8sDeploymentEvent(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		event := &component.ResourceEvent{
+			DeploymentReferences: []component.DeploymentReference{
+				{
+					Reference:            resolverStore.ResolveDeploymentIds(id),
+					ParentResourceAction: central.ResourceAction_UPDATE_RESOURCE,
+				},
+			},
+			Context: context.Background(),
+		}
+		env.resolver.processMessage(event)
+	}
+}
+
+// dispatchForceDetectionEvent creates a ResourceEvent with forceDetection=true
+// (but skipResolving=false) and feeds it through processMessage.
+// Represents: network policy or service account event.
+func dispatchForceDetectionEvent(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		event := &component.ResourceEvent{
+			DeploymentReferences: []component.DeploymentReference{
+				{
+					Reference:            resolverStore.ResolveDeploymentIds(id),
+					ParentResourceAction: central.ResourceAction_UPDATE_RESOURCE,
+					ForceDetection:       true,
+				},
+			},
+			Context: context.Background(),
+		}
+		env.resolver.processMessage(event)
+	}
+}
+
+// --- Step functions: direct queue operations ---
+
+// pushSkipResolvingRef pushes a skipResolving+forceDetection ref directly to the queue.
+// Represents: Central sent UpdatedImage, ReprocessDeployment, or InvalidateImageCache.
+// Used in merge tests where we need two refs in the queue before resolving.
+func pushSkipResolvingRef(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		env.resolver.deploymentRefQueue.Push(&deploymentRef{
+			context:        context.Background(),
+			id:             id,
+			action:         central.ResourceAction_UPDATE_RESOURCE,
+			forceDetection: true,
+			skipResolving:  true,
+		})
+	}
+}
+
+// pushFullResolveRef pushes a full-resolve ref directly to the queue.
+// Represents: K8s dispatcher event (deployment create/update, service, RBAC, secret).
+// Used in merge tests where we need two refs in the queue before resolving.
+func pushFullResolveRef(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		env.resolver.deploymentRefQueue.Push(&deploymentRef{
+			context:        context.Background(),
+			id:             id,
+			action:         central.ResourceAction_UPDATE_RESOURCE,
+			forceDetection: false,
+			skipResolving:  false,
+		})
+	}
+}
+
+// --- Step functions: resolve ---
+
+// resolveNextItem pulls one item from the DedupingQueue and resolves it
+// via resolveAndSend — the same method used by runPullAndResolve.
+// When the FF is disabled (no queue), this is a no-op because processMessage
+// already resolved the ref inline.
+func resolveNextItem() func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		if env.resolver.deploymentRefQueue == nil {
+			return
+		}
+
+		stop := concurrency.NewSignal()
+		item := env.resolver.deploymentRefQueue.PullBlocking(&stop)
+		require.NotNil(env.t, item, "expected an item in the queue")
+
+		ref, ok := item.(*deploymentRef)
+		require.True(env.t, ok, "pulled item is not a *deploymentRef")
+
+		env.resolver.resolveAndSend(ref)
+	}
+}
+
+// --- Step functions: assertions ---
+
+func expectReprocessSent(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		env.t.Helper()
+		for _, event := range env.sentEvents {
+			if slices.Contains(event.ReprocessDeployments, id) {
+				return
+			}
+		}
+		assert.Failf(env.t, "missing reprocess",
+			"expected ReprocessDeployments containing %q, got events: %s",
+			id, formatSentEvents(env.sentEvents))
+	}
+}
+
+func expectDetectionSent(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		env.t.Helper()
+		for _, event := range env.sentEvents {
+			for _, det := range event.DetectorMessages {
+				if det.Object.GetId() == id {
+					return
+				}
+			}
+		}
+		assert.Failf(env.t, "missing detection",
+			"expected DetectorMessages for %q, got events: %s",
+			id, formatSentEvents(env.sentEvents))
+	}
+}
+
+func expectForwardMessageSent(id string) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		env.t.Helper()
+		for _, event := range env.sentEvents {
+			for _, msg := range event.ForwardMessages {
+				if msg.GetDeployment().GetId() == id {
+					return
+				}
+			}
+		}
+		assert.Failf(env.t, "missing forward message",
+			"expected ForwardMessages with deployment %q, got events: %s",
+			id, formatSentEvents(env.sentEvents))
+	}
+}
+
+func expectForwardMessageWithPermissionLevel(id string, level storage.PermissionLevel) func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		env.t.Helper()
+		for _, event := range env.sentEvents {
+			for _, msg := range event.ForwardMessages {
+				d := msg.GetDeployment()
+				if d.GetId() == id && d.GetServiceAccountPermissionLevel() == level {
+					return
+				}
+			}
+		}
+		assert.Failf(env.t, "missing forward message with permission level",
+			"expected ForwardMessages with deployment %q and permission level %s, got events: %s",
+			id, level, formatSentEvents(env.sentEvents))
+	}
+}
+
+func expectNoDetectionSent() func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		env.t.Helper()
+		for _, event := range env.sentEvents {
+			assert.Empty(env.t, event.DetectorMessages,
+				"expected no DetectorMessages, got events: %s", formatSentEvents(env.sentEvents))
+		}
+	}
+}
+
+func expectNoForwardMessageSent() func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		env.t.Helper()
+		for _, event := range env.sentEvents {
+			assert.Empty(env.t, event.ForwardMessages,
+				"expected no ForwardMessages, got events: %s", formatSentEvents(env.sentEvents))
+		}
+	}
+}
+
+// expectQueueEmpty asserts that the DedupingQueue has no remaining items.
+// Verifies that the merge collapsed multiple refs into one.
+func expectQueueEmpty() func(*raceTestEnv) {
+	return func(env *raceTestEnv) {
+		env.t.Helper()
+		if env.resolver.deploymentRefQueue == nil {
+			return
+		}
+		stop := concurrency.NewSignal()
+		stop.Signal()
+		item := env.resolver.deploymentRefQueue.PullBlocking(&stop)
+		assert.Nil(env.t, item, "expected queue to be empty after merge")
+	}
+}
+
+func formatSentEvents(events []*component.ResourceEvent) string {
+	if len(events) == 0 {
+		return "[]"
+	}
+	result := "["
+	for i, e := range events {
+		if i > 0 {
+			result += ", "
+		}
+		result += fmt.Sprintf("{Forward:%d, Detector:%d, Reprocess:%v}",
+			len(e.ForwardMessages), len(e.DetectorMessages), e.ReprocessDeployments)
+	}
+	return result + "]"
+}

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_race_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_race_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"testing"
+	"testing/synctest"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -13,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/dedupingqueue"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/testutils/goleak"
 	"github.com/stackrox/rox/sensor/common/service"
 	"github.com/stackrox/rox/sensor/common/store"
 	mocksStore "github.com/stackrox/rox/sensor/common/store/mocks"
@@ -86,6 +88,8 @@ type raceTestCase struct {
 }
 
 func TestResolverRaceScenarios(t *testing.T) {
+	defer goleak.AssertNoGoroutineLeaks(t)
+
 	cases := map[string]raceTestCase{
 		// Central sends UpdatedImage while a K8s deployment update is in-flight.
 		// The K8s dispatcher already stored the new wrap (isBuilt=false) but the
@@ -279,12 +283,14 @@ func TestResolverRaceScenarios(t *testing.T) {
 		}
 		for _, ffEnabled := range ffStates {
 			t.Run(fmt.Sprintf("%s/ff=%t", name, ffEnabled), func(t *testing.T) {
-				t.Setenv(features.SensorAggregateDeploymentReferenceOptimization.EnvVar(),
-					fmt.Sprintf("%t", ffEnabled))
-				env := newRaceTestEnv(t)
-				for _, step := range tc.steps {
-					step(env)
-				}
+				synctest.Test(t, func(t *testing.T) {
+					t.Setenv(features.SensorAggregateDeploymentReferenceOptimization.EnvVar(),
+						fmt.Sprintf("%t", ffEnabled))
+					env := newRaceTestEnv(t)
+					for _, step := range tc.steps {
+						step(env)
+					}
+				})
 			})
 		}
 	}
@@ -591,6 +597,7 @@ func expectNoForwardMessageSent() func(*raceTestEnv) {
 
 // expectQueueEmpty asserts that the DedupingQueue has no remaining items.
 // Verifies that the merge collapsed multiple refs into one.
+// Uses synctest.Wait to confirm PullBlocking is durably blocked (queue empty).
 func expectQueueEmpty() func(*raceTestEnv) {
 	return func(env *raceTestEnv) {
 		env.t.Helper()
@@ -598,9 +605,14 @@ func expectQueueEmpty() func(*raceTestEnv) {
 			return
 		}
 		stop := concurrency.NewSignal()
+		var pulled bool
+		go func() {
+			env.resolver.deploymentRefQueue.PullBlocking(&stop)
+			pulled = true
+		}()
+		synctest.Wait()
+		assert.False(env.t, pulled, "expected queue to be empty after merge, but an item was pulled")
 		stop.Signal()
-		item := env.resolver.deploymentRefQueue.PullBlocking(&stop)
-		assert.Nil(env.t, item, "expected queue to be empty after merge")
 	}
 }
 

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_race_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_race_test.go
@@ -83,8 +83,11 @@ func newRaceTestEnv(t *testing.T) *raceTestEnv {
 }
 
 type raceTestCase struct {
-	steps          []func(*raceTestEnv)
-	testFFDisabled bool
+	steps []func(*raceTestEnv)
+	// requiresDeduperQueue skips the FF-disabled run. Set this for tests that
+	// push refs directly to the DedupingQueue (e.g. merge scenarios), since
+	// the queue does not exist when the optimization FF is off.
+	requiresDeduperQueue bool
 }
 
 func TestResolverRaceScenarios(t *testing.T) {
@@ -97,7 +100,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// reaches the resolver first. resolveDeployment returns false, but the
 		// ReprocessDeployments data must still be sent.
 		"central UpdatedImage arrives while deployment is being rebuilt": {
-			testFFDisabled: true,
+
 			steps: []func(*raceTestEnv){
 				givenDeploymentNotBuilt("deploy-1"),
 				dispatchCentralUpdatedImage("deploy-1"),
@@ -109,7 +112,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// Same scenario but the deployment was completely removed from the store
 		// between the event being queued and resolved.
 		"forceDetection ref for a deleted deployment preserves reprocess data": {
-			testFFDisabled: true,
+
 			steps: []func(*raceTestEnv){
 				givenDeploymentNotFound("deploy-1"),
 				dispatchCentralUpdatedImage("deploy-1"),
@@ -121,7 +124,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// Full resolve path with forceDetection=true but BuildDeploymentWithDependencies
 		// fails. The reprocess data must still be sent despite the build error.
 		"forceDetection ref with build error preserves reprocess data": {
-			testFFDisabled: true,
+
 			steps: []func(*raceTestEnv){
 				givenDeploymentBuildError("deploy-1"),
 				dispatchForceDetectionEvent("deploy-1"),
@@ -133,7 +136,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// Happy path: skipResolving when the deployment is fully built.
 		// GetBuiltDeployment returns (d, true), detection succeeds.
 		"skipResolving with isBuilt=true succeeds": {
-			testFFDisabled: true,
+
 			steps: []func(*raceTestEnv){
 				givenDeploymentBuilt("deploy-1"),
 				dispatchCentralUpdatedImage("deploy-1"),
@@ -146,7 +149,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// Happy path: full resolve for a new deployment.
 		// BuildDeploymentWithDependencies returns newObject=true.
 		"full resolve of new deployment triggers detection": {
-			testFFDisabled: true,
+
 			steps: []func(*raceTestEnv){
 				givenDeploymentResolvable("deploy-1"),
 				dispatchK8sDeploymentEvent("deploy-1"),
@@ -161,7 +164,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// resolveNextItem does nothing because resolveDeployment returns false and
 		// ReprocessDeployments is empty.
 		"full resolve with no changes sends only original msg": {
-			testFFDisabled: true,
+
 			steps: []func(*raceTestEnv){
 				givenDeploymentUnchanged("deploy-1"),
 				dispatchK8sDeploymentEvent("deploy-1"),
@@ -174,7 +177,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// Normal ordering: K8s ref is resolved first (builds deployment, sets isBuilt=true).
 		// Then the Central ref arrives and the skipResolving path succeeds.
 		"K8s ref resolved before central ref — no race": {
-			testFFDisabled: true,
+
 			steps: []func(*raceTestEnv){
 				givenDeploymentResolvable("deploy-1"),
 				dispatchK8sDeploymentEvent("deploy-1"),
@@ -191,7 +194,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// Verifies that RBAC permissions and service exposure are carried
 		// to the output in ForwardMessages and DetectorMessages.
 		"full resolve carries dependency data to output": {
-			testFFDisabled: true,
+
 			steps: []func(*raceTestEnv){
 				givenDeploymentWithDependencies("deploy-1",
 					storage.PermissionLevel_ELEVATED_IN_NAMESPACE,
@@ -214,6 +217,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// Merged result: skipResolving=false, forceDetection=true → full resolve
 		// with forced detection. Only one item in the queue.
 		"merge: central then K8s ref collapses to full resolve with forceDetection": {
+			requiresDeduperQueue: true,
 			steps: []func(*raceTestEnv){
 				givenDeploymentResolvable("deploy-1"),
 				pushSkipResolvingRef("deploy-1"),
@@ -229,6 +233,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// Merge: same as above but K8s ref is pushed first.
 		// Verifies that push order doesn't affect the merged result.
 		"merge: K8s then central ref collapses to full resolve with forceDetection": {
+			requiresDeduperQueue: true,
 			steps: []func(*raceTestEnv){
 				givenDeploymentResolvable("deploy-1"),
 				pushFullResolveRef("deploy-1"),
@@ -244,6 +249,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// Merge: two K8s refs for the same deployment. Flags don't change
 		// (both skipResolving=false, forceDetection=false). Only one resolve happens.
 		"merge: two K8s refs dedup to single resolve": {
+			requiresDeduperQueue: true,
 			steps: []func(*raceTestEnv){
 				givenDeploymentResolvable("deploy-1"),
 				pushFullResolveRef("deploy-1"),
@@ -260,6 +266,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// forceDetection=true. The full resolve path bypasses the isBuilt guard
 		// entirely.
 		"merge: both refs in queue bypass isBuilt guard": {
+			requiresDeduperQueue: true,
 			steps: []func(*raceTestEnv){
 				givenDeploymentResolvable("deploy-1"),
 				pushFullResolveRef("deploy-1"),
@@ -274,6 +281,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 		// ref arrives first. The K8s ref merges into it, flipping skipResolving to
 		// false. Verifies the isBuilt guard is bypassed regardless of push order.
 		"merge: both refs in queue bypass isBuilt guard when k8s event comes after": {
+			requiresDeduperQueue: true,
 			steps: []func(*raceTestEnv){
 				givenDeploymentResolvable("deploy-1"),
 				pushSkipResolvingRef("deploy-1"),
@@ -288,7 +296,7 @@ func TestResolverRaceScenarios(t *testing.T) {
 
 	for name, tc := range cases {
 		ffStates := []bool{true}
-		if tc.testFFDisabled {
+		if !tc.requiresDeduperQueue {
 			ffStates = append(ffStates, false)
 		}
 		for _, ffEnabled := range ffStates {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The `ROX_AGGREGATE_DEPLOYMENT_REFERENCE_OPTIMIZATION` feature flag was disabled in May 2024 (PR #11097) because it caused SummaryTests e2e flakes. The optimization uses a `DedupingQueue` to deduplicate deployment references, reducing the O(secrets × deployments) amplification that causes OOM in large clusters. This PR fixes two correctness issues that likely caused those flakes.

**Problem 1 — conditional send drops ReprocessDeployments data.** When `resolveDeployment` returns false (deployment not yet built, not found, or build error), `runPullAndResolve` skips sending the event. But if `forceDetection` was true, `ReprocessDeployments` data (deduper reset) was already added to the event and gets silently dropped. In the FF-disabled path, `processMessage` sends unconditionally, so the data is preserved. The fix sends the event whenever `ReprocessDeployments` has data, regardless of the resolve result.

**Problem 2 — dedup key includes flags, preventing cross-type deduplication.** The old key `{id}-{action}-{skipResolving}-{forceDetection}` means a Central `UpdatedImage` ref and a K8s deployment update ref for the same deployment occupy separate queue slots. They're resolved independently, and the skip-resolve path can hit the `isBuilt=false` guard when the deployment is mid-update. The fix simplifies the key to `{id}-{action}` and merges flags on duplicate push (`forceDetection` sticky-true, `skipResolving` sticky-false). A merged ref takes the full resolve path with forced detection, bypassing the `isBuilt` guard entirely.

| Race scenario | Before fix | After fix |
|---|---|---|
| Central ref arrives while `isBuilt=false`, no K8s ref in queue | ReprocessDeployments dropped | Sent (reprocess data check) |
| Central ref and K8s ref both in queue for same deployment | Resolved independently, skip-resolve can hit `isBuilt=false` | Merged to single full-resolve with forceDetection |
| `forceDetection` ref but deployment not found or build error | ReprocessDeployments dropped | Sent (reprocess data check) |

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] Unit tests cover all race scenarios with both FF enabled and disabled (21 tests)
- [x] DedupingQueue merge tests verify the Mergeable interface (4 tests)
- [x] Existing resolver suite tests pass with no regressions (36 tests)
