### PR TITLE
ROX-33409: Increasing adm cntrl image cache TTL

### DIFF
--- a/pkg/env/admission_control.go
+++ b/pkg/env/admission_control.go
@@ -1,5 +1,7 @@
 package env
 
+import "time"
+
 var (
 	// AdmissionControlImageCacheMaxSizeMB AdmissionControlImageCacheSizeMB controls the maximum size (in megabytes) of
 	// the in-process image cache used by the admission controller for policy evaluation.
@@ -13,4 +15,9 @@ var (
 	// requiring to be re-fetched. Disable for workflows where image tags are frequently repointed
 	// to new digests without being re-tagged (mutable tags).
 	AdmissionControlImageNameCacheEnabled = RegisterBooleanSetting("ROX_ADMISSION_CONTROL_IMAGE_NAME_CACHE_ENABLED", true)
+
+	// AdmissionControlImageCacheTTL controls how long enriched image entries remain valid
+	// in the admission controller's in-process cache before being evicted and re-fetched.
+	// Aligned with the Central reprocessing interval by default.
+	AdmissionControlImageCacheTTL = registerDurationSetting("ROX_ADMISSION_CONTROL_IMAGE_CACHE_TTL", 4*time.Hour)
 )

--- a/sensor/admission-control/manager/images.go
+++ b/sensor/admission-control/manager/images.go
@@ -17,10 +17,6 @@ import (
 	admission "k8s.io/api/admission/v1"
 )
 
-const (
-	imageCacheTTL = 30 * time.Minute
-)
-
 type imageCacheEntry struct {
 	*storage.Image
 	timestamp time.Time
@@ -79,7 +75,7 @@ func (m *manager) getCachedImage(img *storage.ContainerImage, s *state, observe 
 		emit(observeCacheMiss)
 		return nil
 	}
-	if time.Since(cachedImg.timestamp) > imageCacheTTL {
+	if time.Since(cachedImg.timestamp) > m.imageCacheTTL {
 		m.imageCache.RemoveIf(id, func(entry imageCacheEntry) bool { return entry == cachedImg })
 		// imageCache entry TTL-expired. Same reasoning as above: only tag-only refs
 		// have a name→key mapping to invalidate.

--- a/sensor/admission-control/manager/images_test.go
+++ b/sensor/admission-control/manager/images_test.go
@@ -37,6 +37,7 @@ func (s *ImageCacheTestSuite) SetupSuite() {
 		imageCache:               cache,
 		imageNameToImageCacheKey: nameCache,
 		imageNameCacheEnabled:    true,
+		imageCacheTTL:            4 * time.Hour,
 		imageFetchGroup:          coalescer.New[*storage.Image](),
 		imageCacheGen:            newImageGenTracker(),
 	}

--- a/sensor/admission-control/manager/manager_impl.go
+++ b/sensor/admission-control/manager/manager_impl.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/detection"
 	"github.com/stackrox/rox/pkg/detection/deploytime"
 	"github.com/stackrox/rox/pkg/detection/runtime"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/protocompat"
@@ -172,6 +173,7 @@ type manager struct {
 	// Bounded by imageNameCacheSize to prevent unbounded growth during long-lived Sensor sessions.
 	imageNameToImageCacheKey *lru.Cache[string, string]
 	imageNameCacheEnabled    bool
+	imageCacheTTL            time.Duration
 	imageFetchGroup          *coalescer.Coalescer[*storage.Image]
 
 	depClient               sensor.DeploymentServiceClient
@@ -221,6 +223,7 @@ func NewManager(namespace string, maxImageCacheSize int64, imageNameCacheEnabled
 		imageCache:               cache,
 		imageNameToImageCacheKey: nameCache,
 		imageNameCacheEnabled:    imageNameCacheEnabled,
+		imageCacheTTL:            env.AdmissionControlImageCacheTTL.DurationSetting(),
 		imageFetchGroup:          coalescer.New[*storage.Image](),
 		imageCacheGen:            newImageGenTracker(),
 

--- a/sensor/admission-control/manager/manager_impl_test.go
+++ b/sensor/admission-control/manager/manager_impl_test.go
@@ -38,6 +38,7 @@ func (s *ManagerImplSuite) SetupSuite() {
 	s.mgr = &manager{
 		imageCache:               cache,
 		imageNameToImageCacheKey: nameCache,
+		imageCacheTTL:            4 * time.Hour,
 		imageFetchGroup:          coalescer.New[*storage.Image](),
 		imageCacheGen:            newImageGenTracker(),
 	}


### PR DESCRIPTION
## Description

Increases the admission controller image cache TTL from 30 minutes to 4 hours, aligned with Central's default reprocessing interval (`ROX_REPROCESSING_INTERVAL`).

The previous 30-minute TTL caused unnecessary re-fetches of image scan data from Sensor (central if Sensor is down) during the ~3.5-hour gap between TTL expiry and the next reprocessor cycle, adding latency to admission requests and generating redundant gRPC traffic _without getting fresh data_ since sensor image cache is updated only during periodic reprocessing. With the targeted invalidation and generation counter mechanisms now in place (PRs #19840, #19600), cache entries are proactively invalidated when scan data changes, making the TTL purely a safety net rather than the primary freshness mechanism.

Introduces a new configurable environment variable `ROX_ADMISSION_CONTROL_IMAGE_CACHE_TTL` (default: `4h`) so users can tune the TTL without code changes (and change back to 30m if so desired)

**Considered alternative:** Removing the TTL entirely. Rejected because reprocessor cycles can be skipped under certain conditions (Central restart, Sensor disconnect, `InjectMessage` timeout), which could leave the AC cache with indefinitely stale data. A long TTL provides a bounded staleness guarantee.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
CI only