### PR TITLE
ROX-32420: Add retries to Relay's VSOCK connection

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -180,8 +180,7 @@ func (c *Compliance) runVMRelayWithRetry(ctx context.Context, sensorClient senso
 		}
 		return err
 	}
-
-	return backoff.RetryNotify(operation, backoff.WithContext(c.newVMRelayBackOff(), ctx), func(err error, _ time.Duration) {
+	notification := func(err error, _ time.Duration) {
 		if ctx.Err() != nil {
 			return
 		}
@@ -190,7 +189,8 @@ func (c *Compliance) runVMRelayWithRetry(ctx context.Context, sensorClient senso
 			"VM relay failed: %v",
 			err,
 		)
-	})
+	}
+	return backoff.RetryNotify(operation, backoff.WithContext(c.newVMRelayBackOff(), ctx), notification)
 }
 
 func (c *Compliance) newVMRelayOperation() vmRelayOperation {

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -15,6 +15,7 @@ import (
 	cmetrics "github.com/stackrox/rox/compliance/collection/metrics"
 	"github.com/stackrox/rox/compliance/node"
 	"github.com/stackrox/rox/compliance/virtualmachines/relay"
+	relaymetrics "github.com/stackrox/rox/compliance/virtualmachines/relay/metrics"
 	"github.com/stackrox/rox/compliance/virtualmachines/relay/sender"
 	"github.com/stackrox/rox/compliance/virtualmachines/relay/stream"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
@@ -64,15 +65,13 @@ type vmRelayOperation func(ctx context.Context, sensorClient sensor.VirtualMachi
 func NewComplianceApp(nnp node.NodeNameProvider, scanner node.NodeScanner, nodeIndexer node.NodeIndexer,
 	umhNodeInv, umhNodeIndex node.UnconfirmedMessageHandler) *Compliance {
 	return &Compliance{
-		nodeNameProvider: nnp,
-		nodeScanner:      scanner,
-		nodeIndexer:      nodeIndexer,
-		umhNodeInventory: umhNodeInv,
-		umhNodeIndex:     umhNodeIndex,
-		vmRelayOperation: defaultVMRelayOperation,
-		vmRelayBackOffFactory: func() backoff.BackOff {
-			return defaultVMRelayBackOff()
-		},
+		nodeNameProvider:      nnp,
+		nodeScanner:           scanner,
+		nodeIndexer:           nodeIndexer,
+		umhNodeInventory:      umhNodeInv,
+		umhNodeIndex:          umhNodeIndex,
+		vmRelayOperation:      defaultVMRelayOperation,
+		vmRelayBackOffFactory: defaultVMRelayBackOff,
 	}
 }
 
@@ -172,6 +171,10 @@ func (c *Compliance) Start() {
 	log.Info("Successfully closed Sensor communication")
 }
 
+// runVMRelayWithRetry retries the VM relay operation with exponential backoff.
+// The primary retry target is vsock listener bind failures (e.g. KubeVirt not yet installed).
+// Once the listener is up and relay.Run enters its long-lived accept/send loop, that loop only
+// exits on context cancellation, which is treated as a permanent (non-retryable) error.
 func (c *Compliance) runVMRelayWithRetry(ctx context.Context, sensorClient sensor.VirtualMachineIndexReportServiceClient) error {
 	operation := func() error {
 		err := c.newVMRelayOperation()(ctx, sensorClient)
@@ -181,6 +184,7 @@ func (c *Compliance) runVMRelayWithRetry(ctx context.Context, sensorClient senso
 		return err
 	}
 	notification := func(err error, _ time.Duration) {
+		relaymetrics.RetryAttempts.Inc()
 		if ctx.Err() != nil {
 			return
 		}
@@ -207,6 +211,8 @@ func (c *Compliance) newVMRelayBackOff() backoff.BackOff {
 	return defaultVMRelayBackOff()
 }
 
+// defaultVMRelayBackOff returns an exponential backoff that retries indefinitely (MaxElapsedTime=0)
+// until the parent context is cancelled at shutdown. The interval is capped at 5 minutes.
 func defaultVMRelayBackOff() backoff.BackOff {
 	eb := backoff.NewExponentialBackOff()
 	eb.MaxInterval = 5 * time.Minute
@@ -215,6 +221,9 @@ func defaultVMRelayBackOff() backoff.BackOff {
 }
 
 func defaultVMRelayOperation(ctx context.Context, sensorClient sensor.VirtualMachineIndexReportServiceClient) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	reportStream, err := stream.New()
 	if err != nil {
 		return err

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -209,7 +209,7 @@ func (c *Compliance) newVMRelayBackOff() backoff.BackOff {
 
 func defaultVMRelayBackOff() backoff.BackOff {
 	eb := backoff.NewExponentialBackOff()
-	eb.MaxInterval = 30 * time.Second
+	eb.MaxInterval = 5 * time.Minute
 	eb.MaxElapsedTime = 0
 	return eb
 }

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -181,15 +181,14 @@ func (c *Compliance) runVMRelayWithRetry(ctx context.Context, sensorClient senso
 		return err
 	}
 
-	return backoff.RetryNotify(operation, backoff.WithContext(c.newVMRelayBackOff(), ctx), func(err error, t time.Duration) {
+	return backoff.RetryNotify(operation, backoff.WithContext(c.newVMRelayBackOff(), ctx), func(err error, _ time.Duration) {
 		if ctx.Err() != nil {
 			return
 		}
 		logging.GetRateLimitedLogger().WarnL(
 			vmRelayRetryRateLimitKey,
-			"Virtual machine relay failed: %v; will retry in %0.2f seconds",
+			"Virtual machine relay failed: %v",
 			err,
-			t.Seconds(),
 		)
 	})
 }

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -52,15 +52,11 @@ type Compliance struct {
 	nodeInventoryCache atomic.Pointer[sensor.MsgFromCompliance]
 	nodeIndexCache     atomic.Pointer[sensor.MsgFromCompliance]
 
-	vmRelayStreamFactory  func() (relay.IndexReportStream, error)
-	vmRelaySenderFactory  func(sensor.VirtualMachineIndexReportServiceClient) sender.IndexReportSender
-	vmRelayFactory        func(relay.IndexReportStream, sender.IndexReportSender) vmRelayRunner
+	vmRelayOperation      vmRelayOperation
 	vmRelayBackOffFactory func() backoff.BackOff
 }
 
-type vmRelayRunner interface {
-	Run(ctx context.Context) error
-}
+type vmRelayOperation func(ctx context.Context, sensorClient sensor.VirtualMachineIndexReportServiceClient) error
 
 // NewComplianceApp constructs the Compliance app object
 func NewComplianceApp(nnp node.NodeNameProvider, scanner node.NodeScanner, nodeIndexer node.NodeIndexer,
@@ -71,6 +67,10 @@ func NewComplianceApp(nnp node.NodeNameProvider, scanner node.NodeScanner, nodeI
 		nodeIndexer:      nodeIndexer,
 		umhNodeInventory: umhNodeInv,
 		umhNodeIndex:     umhNodeIndex,
+		vmRelayOperation: defaultVMRelayOperation,
+		vmRelayBackOffFactory: func() backoff.BackOff {
+			return defaultVMRelayBackOff()
+		},
 	}
 }
 
@@ -143,14 +143,15 @@ func (c *Compliance) Start() {
 	// sensor and accelerates initial development.
 	go func(ctx context.Context) {
 		defer wg.Add(-1)
-		if features.VirtualMachines.Enabled() {
-			log.Infof("Virtual machine relay enabled")
+		if !features.VirtualMachines.Enabled() {
+			return
+		}
+		log.Infof("Virtual machine relay enabled")
 
-			sensorClient := sensor.NewVirtualMachineIndexReportServiceClient(conn)
-			err := c.runVMRelayWithRetry(ctx, sensorClient)
-			if err != nil && ctx.Err() == nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-				log.Errorf("Error running virtual machine relay: %v", err)
-			}
+		sensorClient := sensor.NewVirtualMachineIndexReportServiceClient(conn)
+		err := c.runVMRelayWithRetry(ctx, sensorClient)
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			log.Errorf("Error running virtual machine relay: %v", err)
 		}
 	}(ctx)
 
@@ -171,21 +172,11 @@ func (c *Compliance) Start() {
 
 func (c *Compliance) runVMRelayWithRetry(ctx context.Context, sensorClient sensor.VirtualMachineIndexReportServiceClient) error {
 	operation := func() error {
-		reportStream, err := c.newVMRelayStream()
-		if err != nil {
-			return err
+		err := c.newVMRelayOperation()(ctx, sensorClient)
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return backoff.Permanent(err)
 		}
-
-		reportSender := c.newVMRelaySender(sensorClient)
-		vmRelay := c.newVMRelay(reportStream, reportSender)
-		if err := vmRelay.Run(ctx); err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return backoff.Permanent(err)
-			}
-			return err
-		}
-
-		return nil
+		return err
 	}
 
 	return backoff.RetryNotify(operation, backoff.WithContext(c.newVMRelayBackOff(), ctx), func(err error, t time.Duration) {
@@ -196,35 +187,36 @@ func (c *Compliance) runVMRelayWithRetry(ctx context.Context, sensorClient senso
 	})
 }
 
-func (c *Compliance) newVMRelayStream() (relay.IndexReportStream, error) {
-	if c.vmRelayStreamFactory != nil {
-		return c.vmRelayStreamFactory()
+func (c *Compliance) newVMRelayOperation() vmRelayOperation {
+	if c.vmRelayOperation != nil {
+		return c.vmRelayOperation
 	}
-	return stream.New()
-}
-
-func (c *Compliance) newVMRelaySender(sensorClient sensor.VirtualMachineIndexReportServiceClient) sender.IndexReportSender {
-	if c.vmRelaySenderFactory != nil {
-		return c.vmRelaySenderFactory(sensorClient)
-	}
-	return sender.New(sensorClient)
-}
-
-func (c *Compliance) newVMRelay(reportStream relay.IndexReportStream, reportSender sender.IndexReportSender) vmRelayRunner {
-	if c.vmRelayFactory != nil {
-		return c.vmRelayFactory(reportStream, reportSender)
-	}
-	return relay.New(reportStream, reportSender)
+	return defaultVMRelayOperation
 }
 
 func (c *Compliance) newVMRelayBackOff() backoff.BackOff {
 	if c.vmRelayBackOffFactory != nil {
 		return c.vmRelayBackOffFactory()
 	}
+	return defaultVMRelayBackOff()
+}
 
+func defaultVMRelayBackOff() backoff.BackOff {
 	eb := backoff.NewExponentialBackOff()
+	eb.MaxInterval = 30 * time.Second
 	eb.MaxElapsedTime = 0
 	return eb
+}
+
+func defaultVMRelayOperation(ctx context.Context, sensorClient sensor.VirtualMachineIndexReportServiceClient) error {
+	reportStream, err := stream.New()
+	if err != nil {
+		return err
+	}
+
+	reportSender := sender.New(sensorClient)
+	vmRelay := relay.New(reportStream, reportSender)
+	return vmRelay.Run(ctx)
 }
 
 func (c *Compliance) createIndexMsg(report *v4.IndexReport, nodeName string) *sensor.MsgFromCompliance {

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -187,7 +187,7 @@ func (c *Compliance) runVMRelayWithRetry(ctx context.Context, sensorClient senso
 		}
 		logging.GetRateLimitedLogger().WarnL(
 			vmRelayRetryRateLimitKey,
-			"Virtual machine relay failed: %v",
+			"VM relay failed: %v",
 			err,
 		)
 	})

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -51,6 +51,15 @@ type Compliance struct {
 	umhNodeIndex       node.UnconfirmedMessageHandler
 	nodeInventoryCache atomic.Pointer[sensor.MsgFromCompliance]
 	nodeIndexCache     atomic.Pointer[sensor.MsgFromCompliance]
+
+	vmRelayStreamFactory  func() (relay.IndexReportStream, error)
+	vmRelaySenderFactory  func(sensor.VirtualMachineIndexReportServiceClient) sender.IndexReportSender
+	vmRelayFactory        func(relay.IndexReportStream, sender.IndexReportSender) vmRelayRunner
+	vmRelayBackOffFactory func() backoff.BackOff
+}
+
+type vmRelayRunner interface {
+	Run(ctx context.Context) error
 }
 
 // NewComplianceApp constructs the Compliance app object
@@ -138,33 +147,7 @@ func (c *Compliance) Start() {
 			log.Infof("Virtual machine relay enabled")
 
 			sensorClient := sensor.NewVirtualMachineIndexReportServiceClient(conn)
-			eb := backoff.NewExponentialBackOff()
-			eb.MaxElapsedTime = 0
-
-			operation := func() error {
-				reportStream, err := stream.New()
-				if err != nil {
-					return err
-				}
-
-				reportSender := sender.New(sensorClient)
-				vmRelay := relay.New(reportStream, reportSender)
-				if err := vmRelay.Run(ctx); err != nil {
-					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-						return backoff.Permanent(err)
-					}
-					return err
-				}
-
-				return nil
-			}
-
-			err := backoff.RetryNotify(operation, backoff.WithContext(eb, ctx), func(err error, t time.Duration) {
-				if ctx.Err() != nil {
-					return
-				}
-				log.Errorf("Virtual machine relay failed: %v; will retry in %0.2f seconds", err, t.Seconds())
-			})
+			err := c.runVMRelayWithRetry(ctx, sensorClient)
 			if err != nil && ctx.Err() == nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 				log.Errorf("Error running virtual machine relay: %v", err)
 			}
@@ -184,6 +167,64 @@ func (c *Compliance) Start() {
 
 	stoppedSig.Wait()
 	log.Info("Successfully closed Sensor communication")
+}
+
+func (c *Compliance) runVMRelayWithRetry(ctx context.Context, sensorClient sensor.VirtualMachineIndexReportServiceClient) error {
+	operation := func() error {
+		reportStream, err := c.newVMRelayStream()
+		if err != nil {
+			return err
+		}
+
+		reportSender := c.newVMRelaySender(sensorClient)
+		vmRelay := c.newVMRelay(reportStream, reportSender)
+		if err := vmRelay.Run(ctx); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return backoff.Permanent(err)
+			}
+			return err
+		}
+
+		return nil
+	}
+
+	return backoff.RetryNotify(operation, backoff.WithContext(c.newVMRelayBackOff(), ctx), func(err error, t time.Duration) {
+		if ctx.Err() != nil {
+			return
+		}
+		log.Errorf("Virtual machine relay failed: %v; will retry in %0.2f seconds", err, t.Seconds())
+	})
+}
+
+func (c *Compliance) newVMRelayStream() (relay.IndexReportStream, error) {
+	if c.vmRelayStreamFactory != nil {
+		return c.vmRelayStreamFactory()
+	}
+	return stream.New()
+}
+
+func (c *Compliance) newVMRelaySender(sensorClient sensor.VirtualMachineIndexReportServiceClient) sender.IndexReportSender {
+	if c.vmRelaySenderFactory != nil {
+		return c.vmRelaySenderFactory(sensorClient)
+	}
+	return sender.New(sensorClient)
+}
+
+func (c *Compliance) newVMRelay(reportStream relay.IndexReportStream, reportSender sender.IndexReportSender) vmRelayRunner {
+	if c.vmRelayFactory != nil {
+		return c.vmRelayFactory(reportStream, reportSender)
+	}
+	return relay.New(reportStream, reportSender)
+}
+
+func (c *Compliance) newVMRelayBackOff() backoff.BackOff {
+	if c.vmRelayBackOffFactory != nil {
+		return c.vmRelayBackOffFactory()
+	}
+
+	eb := backoff.NewExponentialBackOff()
+	eb.MaxElapsedTime = 0
+	return eb
 }
 
 func (c *Compliance) createIndexMsg(report *v4.IndexReport, nodeName string) *sensor.MsgFromCompliance {

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -40,6 +40,8 @@ const (
 	// nodeResourceID is the resource ID used for node scanning UMH.
 	// Compliance handles exactly one node, so a single constant suffices.
 	nodeResourceID = "this-node"
+
+	vmRelayRetryRateLimitKey = "vm-relay-retry"
 )
 
 // Compliance represents the Compliance app
@@ -183,7 +185,12 @@ func (c *Compliance) runVMRelayWithRetry(ctx context.Context, sensorClient senso
 		if ctx.Err() != nil {
 			return
 		}
-		log.Errorf("Virtual machine relay failed: %v; will retry in %0.2f seconds", err, t.Seconds())
+		logging.GetRateLimitedLogger().WarnL(
+			vmRelayRetryRateLimitKey,
+			"Virtual machine relay failed: %v; will retry in %0.2f seconds",
+			err,
+			t.Seconds(),
+		)
 	})
 }
 

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -15,9 +15,6 @@ import (
 	cmetrics "github.com/stackrox/rox/compliance/collection/metrics"
 	"github.com/stackrox/rox/compliance/node"
 	"github.com/stackrox/rox/compliance/virtualmachines/relay"
-	relaymetrics "github.com/stackrox/rox/compliance/virtualmachines/relay/metrics"
-	"github.com/stackrox/rox/compliance/virtualmachines/relay/sender"
-	"github.com/stackrox/rox/compliance/virtualmachines/relay/stream"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
@@ -41,8 +38,6 @@ const (
 	// nodeResourceID is the resource ID used for node scanning UMH.
 	// Compliance handles exactly one node, so a single constant suffices.
 	nodeResourceID = "this-node"
-
-	vmRelayRetryRateLimitKey = "vm-relay-retry"
 )
 
 // Compliance represents the Compliance app
@@ -54,24 +49,17 @@ type Compliance struct {
 	umhNodeIndex       node.UnconfirmedMessageHandler
 	nodeInventoryCache atomic.Pointer[sensor.MsgFromCompliance]
 	nodeIndexCache     atomic.Pointer[sensor.MsgFromCompliance]
-
-	vmRelayOperation      vmRelayOperation
-	vmRelayBackOffFactory func() backoff.BackOff
 }
-
-type vmRelayOperation func(ctx context.Context, sensorClient sensor.VirtualMachineIndexReportServiceClient) error
 
 // NewComplianceApp constructs the Compliance app object
 func NewComplianceApp(nnp node.NodeNameProvider, scanner node.NodeScanner, nodeIndexer node.NodeIndexer,
 	umhNodeInv, umhNodeIndex node.UnconfirmedMessageHandler) *Compliance {
 	return &Compliance{
-		nodeNameProvider:      nnp,
-		nodeScanner:           scanner,
-		nodeIndexer:           nodeIndexer,
-		umhNodeInventory:      umhNodeInv,
-		umhNodeIndex:          umhNodeIndex,
-		vmRelayOperation:      defaultVMRelayOperation,
-		vmRelayBackOffFactory: defaultVMRelayBackOff,
+		nodeNameProvider: nnp,
+		nodeScanner:      scanner,
+		nodeIndexer:      nodeIndexer,
+		umhNodeInventory: umhNodeInv,
+		umhNodeIndex:     umhNodeIndex,
 	}
 }
 
@@ -150,7 +138,7 @@ func (c *Compliance) Start() {
 		log.Infof("Virtual machine relay enabled")
 
 		sensorClient := sensor.NewVirtualMachineIndexReportServiceClient(conn)
-		err := c.runVMRelayWithRetry(ctx, sensorClient)
+		err := relay.RunWithRetry(ctx, sensorClient)
 		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 			log.Errorf("Error running virtual machine relay: %v", err)
 		}
@@ -169,69 +157,6 @@ func (c *Compliance) Start() {
 
 	stoppedSig.Wait()
 	log.Info("Successfully closed Sensor communication")
-}
-
-// runVMRelayWithRetry retries the VM relay operation with exponential backoff.
-// The primary retry target is vsock listener bind failures (e.g. KubeVirt not yet installed).
-// Once the listener is up and relay.Run enters its long-lived accept/send loop, that loop only
-// exits on context cancellation, which is treated as a permanent (non-retryable) error.
-func (c *Compliance) runVMRelayWithRetry(ctx context.Context, sensorClient sensor.VirtualMachineIndexReportServiceClient) error {
-	operation := func() error {
-		err := c.newVMRelayOperation()(ctx, sensorClient)
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return backoff.Permanent(err)
-		}
-		return err
-	}
-	notification := func(err error, _ time.Duration) {
-		relaymetrics.RetryAttempts.Inc()
-		if ctx.Err() != nil {
-			return
-		}
-		logging.GetRateLimitedLogger().WarnL(
-			vmRelayRetryRateLimitKey,
-			"VM relay failed: %v",
-			err,
-		)
-	}
-	return backoff.RetryNotify(operation, backoff.WithContext(c.newVMRelayBackOff(), ctx), notification)
-}
-
-func (c *Compliance) newVMRelayOperation() vmRelayOperation {
-	if c.vmRelayOperation != nil {
-		return c.vmRelayOperation
-	}
-	return defaultVMRelayOperation
-}
-
-func (c *Compliance) newVMRelayBackOff() backoff.BackOff {
-	if c.vmRelayBackOffFactory != nil {
-		return c.vmRelayBackOffFactory()
-	}
-	return defaultVMRelayBackOff()
-}
-
-// defaultVMRelayBackOff returns an exponential backoff that retries indefinitely (MaxElapsedTime=0)
-// until the parent context is cancelled at shutdown. The interval is capped at 5 minutes.
-func defaultVMRelayBackOff() backoff.BackOff {
-	eb := backoff.NewExponentialBackOff()
-	eb.MaxInterval = 5 * time.Minute
-	eb.MaxElapsedTime = 0
-	return eb
-}
-
-func defaultVMRelayOperation(ctx context.Context, sensorClient sensor.VirtualMachineIndexReportServiceClient) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	reportStream, err := stream.New()
-	if err != nil {
-		return err
-	}
-
-	reportSender := sender.New(sensorClient)
-	vmRelay := relay.New(reportStream, reportSender)
-	return vmRelay.Run(ctx)
 }
 
 func (c *Compliance) createIndexMsg(report *v4.IndexReport, nodeName string) *sensor.MsgFromCompliance {

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -137,17 +137,35 @@ func (c *Compliance) Start() {
 		if features.VirtualMachines.Enabled() {
 			log.Infof("Virtual machine relay enabled")
 
-			reportStream, err := stream.New()
-			if err != nil {
-				log.Errorf("Error creating report stream: %v", err)
-				return
+			sensorClient := sensor.NewVirtualMachineIndexReportServiceClient(conn)
+			eb := backoff.NewExponentialBackOff()
+			eb.MaxElapsedTime = 0
+
+			operation := func() error {
+				reportStream, err := stream.New()
+				if err != nil {
+					return err
+				}
+
+				reportSender := sender.New(sensorClient)
+				vmRelay := relay.New(reportStream, reportSender)
+				if err := vmRelay.Run(ctx); err != nil {
+					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+						return backoff.Permanent(err)
+					}
+					return err
+				}
+
+				return nil
 			}
 
-			sensorClient := sensor.NewVirtualMachineIndexReportServiceClient(conn)
-			reportSender := sender.New(sensorClient)
-
-			vmRelay := relay.New(reportStream, reportSender)
-			if err := vmRelay.Run(ctx); err != nil {
+			err := backoff.RetryNotify(operation, backoff.WithContext(eb, ctx), func(err error, t time.Duration) {
+				if ctx.Err() != nil {
+					return
+				}
+				log.Errorf("Virtual machine relay failed: %v; will retry in %0.2f seconds", err, t.Seconds())
+			})
+			if err != nil && ctx.Err() == nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 				log.Errorf("Error running virtual machine relay: %v", err)
 			}
 		}

--- a/compliance/virtualmachines/relay/metrics/metrics.go
+++ b/compliance/virtualmachines/relay/metrics/metrics.go
@@ -61,15 +61,15 @@ var SemaphoreAcquisitionFailures = prometheus.NewCounterVec(
 	[]string{"reason"},
 )
 
-// RetryAttempts counts how many times the VM relay operation was retried
-// after a failure (e.g. vsock bind unavailable). A sustained non-zero rate
-// indicates the relay cannot start and is waiting for vsock to become available.
+// RetryAttempts counts how many times the VM relay operation was retried after
+// a retriable failure. A sustained non-zero rate indicates the relay is
+// repeatedly failing and being restarted by the retry loop.
 var RetryAttempts = prometheus.NewCounter(
 	prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.ComplianceSubsystem.String(),
 		Name:      "virtual_machine_relay_retry_attempts_total",
-		Help:      "Total number of VM relay retry attempts after failure of listening to vsock",
+		Help:      "Total number of VM relay retry attempts after retriable relay failures",
 	},
 )
 

--- a/compliance/virtualmachines/relay/metrics/metrics.go
+++ b/compliance/virtualmachines/relay/metrics/metrics.go
@@ -61,6 +61,18 @@ var SemaphoreAcquisitionFailures = prometheus.NewCounterVec(
 	[]string{"reason"},
 )
 
+// RetryAttempts counts how many times the VM relay operation was retried
+// after a failure (e.g. vsock bind unavailable). A sustained non-zero rate
+// indicates the relay cannot start and is waiting for vsock to become available.
+var RetryAttempts = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.ComplianceSubsystem.String(),
+		Name:      "virtual_machine_relay_retry_attempts_total",
+		Help:      "Total number of VM relay retry attempts after failure of listening to vsock",
+	},
+)
+
 var SemaphoreHoldingSize = prometheus.NewGauge(
 	prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
@@ -86,5 +98,6 @@ func init() {
 		SemaphoreAcquisitionFailures,
 		SemaphoreHoldingSize,
 		SemaphoreQueueSize,
+		RetryAttempts,
 	)
 }

--- a/compliance/virtualmachines/relay/retry.go
+++ b/compliance/virtualmachines/relay/retry.go
@@ -1,0 +1,100 @@
+package relay
+
+import (
+	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/compliance/virtualmachines/relay/metrics"
+	"github.com/stackrox/rox/compliance/virtualmachines/relay/sender"
+	"github.com/stackrox/rox/compliance/virtualmachines/relay/stream"
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/pkg/logging"
+)
+
+const retryRateLimitKey = "vm-relay-retry"
+
+// Operation creates and runs the VM relay pipeline (stream + sender + relay).
+type Operation func(ctx context.Context, sensorClient sensor.VirtualMachineIndexReportServiceClient) error
+
+type retryConfig struct {
+	operation      Operation
+	backOffFactory func() backoff.BackOff
+}
+
+// RetryOption configures RunWithRetry behavior.
+type RetryOption func(*retryConfig)
+
+// WithOperation overrides the default relay operation (primarily for testing).
+func WithOperation(op Operation) RetryOption {
+	return func(c *retryConfig) {
+		c.operation = op
+	}
+}
+
+// WithBackoff overrides the default backoff factory (primarily for testing).
+func WithBackoff(factory func() backoff.BackOff) RetryOption {
+	return func(c *retryConfig) {
+		c.backOffFactory = factory
+	}
+}
+
+// RunWithRetry runs the VM relay operation with exponential backoff.
+// The primary retry target is vsock listener bind failures (e.g. KubeVirt not yet installed).
+// Once the listener is up and Relay.Run enters its long-lived accept/send loop, that loop only
+// exits on context cancellation, which is treated as a permanent (non-retryable) error.
+//
+// Retries continue indefinitely until the parent context is cancelled at shutdown.
+func RunWithRetry(ctx context.Context, sensorClient sensor.VirtualMachineIndexReportServiceClient, opts ...RetryOption) error {
+	cfg := retryConfig{
+		operation:      defaultOperation,
+		backOffFactory: defaultBackOff,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	operation := func() error {
+		err := cfg.operation(ctx, sensorClient)
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}
+	notification := func(err error, _ time.Duration) {
+		metrics.RetryAttempts.Inc()
+		if ctx.Err() != nil {
+			return
+		}
+		logging.GetRateLimitedLogger().WarnL(
+			retryRateLimitKey,
+			"VM relay failed: %v",
+			err,
+		)
+	}
+	return backoff.RetryNotify(operation, backoff.WithContext(cfg.backOffFactory(), ctx), notification)
+}
+
+// defaultBackOff returns an exponential backoff that retries indefinitely (MaxElapsedTime=0)
+// until the parent context is cancelled at shutdown. The interval is capped at 5 minutes.
+func defaultBackOff() backoff.BackOff {
+	eb := backoff.NewExponentialBackOff()
+	eb.MaxInterval = 5 * time.Minute
+	eb.MaxElapsedTime = 0
+	return eb
+}
+
+func defaultOperation(ctx context.Context, sensorClient sensor.VirtualMachineIndexReportServiceClient) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	reportStream, err := stream.New()
+	if err != nil {
+		return err
+	}
+
+	reportSender := sender.New(sensorClient)
+	vmRelay := New(reportStream, reportSender)
+	return vmRelay.Run(ctx)
+}

--- a/compliance/virtualmachines/relay/retry_test.go
+++ b/compliance/virtualmachines/relay/retry_test.go
@@ -1,18 +1,22 @@
-package compliance
+package relay
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRunVMRelayWithRetry(t *testing.T) {
+var errTestPermanent = errors.New("permanent failure")
+
+func TestRunWithRetry(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
@@ -22,6 +26,13 @@ func TestRunVMRelayWithRetry(t *testing.T) {
 		expectedErr                error
 		expectedOperationAttempts  int32
 	}{
+		"should succeed on first try without retrying": {
+			operationErrors: []error{nil},
+			backOffFactory: func() backoff.BackOff {
+				return backoff.NewConstantBackOff(0)
+			},
+			expectedOperationAttempts: 1,
+		},
 		"should retry once then succeed": {
 			operationErrors: []error{errors.New("vsock not available"), nil},
 			backOffFactory: func() backoff.BackOff {
@@ -41,7 +52,7 @@ func TestRunVMRelayWithRetry(t *testing.T) {
 			},
 			expectedOperationAttempts: 4,
 		},
-		"should stop without retrying when relay run returns context canceled": {
+		"should stop without retrying when operation returns context canceled": {
 			operationErrors: []error{context.Canceled},
 			backOffFactory: func() backoff.BackOff {
 				return backoff.NewConstantBackOff(0)
@@ -49,7 +60,7 @@ func TestRunVMRelayWithRetry(t *testing.T) {
 			expectedErr:               context.Canceled,
 			expectedOperationAttempts: 1,
 		},
-		"should stop without retrying when relay run returns context deadline exceeded": {
+		"should stop without retrying when operation returns context deadline exceeded": {
 			operationErrors: []error{context.DeadlineExceeded},
 			backOffFactory: func() backoff.BackOff {
 				return backoff.NewConstantBackOff(0)
@@ -57,13 +68,33 @@ func TestRunVMRelayWithRetry(t *testing.T) {
 			expectedErr:               context.DeadlineExceeded,
 			expectedOperationAttempts: 1,
 		},
-		"should stop retries when context is canceled during stream creation failures": {
+		"should stop without retrying when operation returns wrapped context canceled": {
+			operationErrors: []error{fmt.Errorf("relay shut down: %w", context.Canceled)},
+			backOffFactory: func() backoff.BackOff {
+				return backoff.NewConstantBackOff(0)
+			},
+			expectedErr:               context.Canceled,
+			expectedOperationAttempts: 1,
+		},
+		// This test cancels the context inside the operation, then relies on
+		// backoff.WithContext to detect the cancelled context and return Stop
+		// from NextBackOff — skipping the 1-hour configured sleep. The backoff
+		// library's RetryNotify then returns ctx.Err() from the wrapped backoff.
+		"should stop retries when context is canceled during backoff sleep": {
 			operationErrors:            []error{errors.New("vsock not available")},
 			cancelOnFirstStreamAttempt: true,
 			backOffFactory: func() backoff.BackOff {
 				return backoff.NewConstantBackOff(time.Hour)
 			},
 			expectedErr:               context.Canceled,
+			expectedOperationAttempts: 1,
+		},
+		"should stop when backoff is exhausted": {
+			operationErrors: []error{errTestPermanent},
+			backOffFactory: func() backoff.BackOff {
+				return &backoff.StopBackOff{}
+			},
+			expectedErr:               errTestPermanent,
 			expectedOperationAttempts: 1,
 		},
 	}
@@ -75,28 +106,28 @@ func TestRunVMRelayWithRetry(t *testing.T) {
 
 			attempts := atomic.Int32{}
 
-			c := &Compliance{
-				vmRelayOperation: func(context.Context, sensor.VirtualMachineIndexReportServiceClient) error {
-					attempt := attempts.Add(1)
-					if tc.cancelOnFirstStreamAttempt && attempt == 1 {
-						cancel()
-					}
-					if int(attempt) <= len(tc.operationErrors) {
-						return tc.operationErrors[int(attempt)-1]
-					}
-					return nil
-				},
-				vmRelayBackOffFactory: tc.backOffFactory,
+			op := func(_ context.Context, _ sensor.VirtualMachineIndexReportServiceClient) error {
+				attempt := attempts.Add(1)
+				if tc.cancelOnFirstStreamAttempt && attempt == 1 {
+					cancel()
+				}
+				if int(attempt) <= len(tc.operationErrors) {
+					return tc.operationErrors[int(attempt)-1]
+				}
+				return nil
 			}
 
-			err := c.runVMRelayWithRetry(ctx, nil)
+			err := RunWithRetry(ctx, nil,
+				WithOperation(op),
+				WithBackoff(tc.backOffFactory),
+			)
 			if tc.expectedErr == nil {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				require.ErrorIs(t, err, tc.expectedErr)
+				assert.ErrorIs(t, err, tc.expectedErr)
 			}
-			require.Equal(t, tc.expectedOperationAttempts, attempts.Load())
+			assert.Equal(t, tc.expectedOperationAttempts, attempts.Load())
 		})
 	}
 }

--- a/compliance/virtualmachines/relay/stream/vsock_index_report_stream.go
+++ b/compliance/virtualmachines/relay/stream/vsock_index_report_stream.go
@@ -38,12 +38,28 @@ type VsockIndexReportStream struct {
 // New creates a VsockIndexReportStream with a vsock listener.
 // Concurrency limits are read from env vars VirtualMachinesMaxConcurrentVsockConnections
 // and VirtualMachinesConcurrencyTimeout.
+//
+// Bind-failure return path: vsock.NewListener() performs a one-shot bind. If vsock support is unavailable
+// (e.g. KubeVirt not yet installed), the error propagates to the caller. There is no retry here; the caller
+// (compliance) is responsible for retrying if desired.
 func New() (*VsockIndexReportStream, error) {
 	listener, err := vsock.NewListener()
 	if err != nil {
 		return nil, errors.Wrap(err, "creating vsock listener")
 	}
+	return newWithListener(listener), nil
+}
 
+// NewWithListener creates a VsockIndexReportStream with the given listener.
+// For testing only; use New() in production.
+func NewWithListener(listener net.Listener) (*VsockIndexReportStream, error) {
+	if listener == nil {
+		return nil, errors.New("listener is nil")
+	}
+	return newWithListener(listener), nil
+}
+
+func newWithListener(listener net.Listener) *VsockIndexReportStream {
 	maxConcurrentConnections := env.VirtualMachinesMaxConcurrentVsockConnections.IntegerSetting()
 	semaphoreTimeout := env.VirtualMachinesConcurrencyTimeout.DurationSetting()
 	maxSizeBytes := env.VirtualMachinesVsockConnMaxSizeKB.IntegerSetting() * 1024
@@ -56,7 +72,7 @@ func New() (*VsockIndexReportStream, error) {
 		connectionReadTimeout:    10 * time.Second,
 		waitAfterFailedAccept:    time.Second,
 		maxSizeBytes:             maxSizeBytes,
-	}, nil
+	}
 }
 
 // Start begins accepting vsock connections and returns a channel of validated reports.

--- a/compliance/virtualmachines/relay/stream/vsock_index_report_stream.go
+++ b/compliance/virtualmachines/relay/stream/vsock_index_report_stream.go
@@ -50,15 +50,6 @@ func New() (*VsockIndexReportStream, error) {
 	return newWithListener(listener), nil
 }
 
-// NewWithListener creates a VsockIndexReportStream with the given listener.
-// For testing only; use New() in production.
-func NewWithListener(listener net.Listener) (*VsockIndexReportStream, error) {
-	if listener == nil {
-		return nil, errors.New("listener is nil")
-	}
-	return newWithListener(listener), nil
-}
-
 func newWithListener(listener net.Listener) *VsockIndexReportStream {
 	maxConcurrentConnections := env.VirtualMachinesMaxConcurrentVsockConnections.IntegerSetting()
 	semaphoreTimeout := env.VirtualMachinesConcurrencyTimeout.DurationSetting()

--- a/compliance/virtualmachines/relay/stream/vsock_index_report_stream.go
+++ b/compliance/virtualmachines/relay/stream/vsock_index_report_stream.go
@@ -50,6 +50,9 @@ func New() (*VsockIndexReportStream, error) {
 	return newWithListener(listener), nil
 }
 
+// newWithListener constructs a VsockIndexReportStream from a pre-existing listener,
+// reading concurrency and size limits from env vars. Separated from New to allow
+// tests to inject a custom listener without requiring vsock kernel support.
 func newWithListener(listener net.Listener) *VsockIndexReportStream {
 	maxConcurrentConnections := env.VirtualMachinesMaxConcurrentVsockConnections.IntegerSetting()
 	semaphoreTimeout := env.VirtualMachinesConcurrencyTimeout.DurationSetting()

--- a/compliance/virtualmachines/relay/stream/vsock_index_report_stream.go
+++ b/compliance/virtualmachines/relay/stream/vsock_index_report_stream.go
@@ -226,19 +226,28 @@ func validateReportedVsockCID(vmReport *v1.VMReport, connVsockCID uint32) error 
 	return nil
 }
 
-func (p *VsockIndexReportStream) stop() {
+// Close stops the listener and releases associated resources. It is safe to
+// call multiple times. Normal shutdown goes through context cancellation (which
+// calls Close internally); this method exists for explicit cleanup when context
+// plumbing is unavailable, e.g. between retries.
+func (p *VsockIndexReportStream) Close() error {
 	p.listenerMu.Lock()
 	defer p.listenerMu.Unlock()
 
 	if p.listener == nil {
-		return
+		return nil
 	}
 
+	err := p.listener.Close()
+	p.listener = nil
+	return err
+}
+
+func (p *VsockIndexReportStream) stop() {
 	log.Info("Stopping index report stream")
-	if err := p.listener.Close(); err != nil {
+	if err := p.Close(); err != nil {
 		log.Errorf("Error closing listener: %v", err)
 	}
-	p.listener = nil
 }
 
 func (p *VsockIndexReportStream) acquireSemaphore(parentCtx context.Context) error {

--- a/compliance/virtualmachines/relay/stream/vsock_index_report_stream.go
+++ b/compliance/virtualmachines/relay/stream/vsock_index_report_stream.go
@@ -40,8 +40,8 @@ type VsockIndexReportStream struct {
 // and VirtualMachinesConcurrencyTimeout.
 //
 // Bind-failure return path: vsock.NewListener() performs a one-shot bind. If vsock support is unavailable
-// (e.g. KubeVirt not yet installed), the error propagates to the caller. There is no retry here; the caller
-// (compliance) is responsible for retrying if desired.
+// (e.g. KubeVirt not yet installed), the error propagates to the caller. Retry policy lives above this
+// constructor; relay.RunWithRetry wraps the relay operation and retries retriable startup failures.
 func New() (*VsockIndexReportStream, error) {
 	listener, err := vsock.NewListener()
 	if err != nil {
@@ -75,7 +75,7 @@ func newWithListener(listener net.Listener) *VsockIndexReportStream {
 func (p *VsockIndexReportStream) Start(ctx context.Context) (<-chan *v1.VMReport, error) {
 	log.Info("Starting report stream")
 
-	if p.listener == nil {
+	if p.currentListener() == nil {
 		return nil, errors.New("listener is nil")
 	}
 
@@ -98,10 +98,17 @@ func (p *VsockIndexReportStream) Start(ctx context.Context) (<-chan *v1.VMReport
 
 func (p *VsockIndexReportStream) acceptLoop(ctx context.Context, reportChan chan<- *v1.VMReport) {
 	for {
-		// Accept() is blocking, but it will return when ctx is cancelled and the goroutine in Start() calls p.stop()
-		conn, err := p.listener.Accept()
+		listener := p.currentListener()
+		if listener == nil {
+			log.Info("Stopping report stream")
+			return
+		}
+
+		// Accept() is blocking, but it will return when ctx is cancelled and the goroutine in Start() calls p.stop().
+		// Explicit Close() also shuts down the listener and causes the loop to exit cleanly.
+		conn, err := listener.Accept()
 		if err != nil {
-			if ctx.Err() != nil {
+			if ctx.Err() != nil || p.currentListener() == nil {
 				log.Info("Stopping report stream")
 				return
 			}
@@ -227,9 +234,10 @@ func validateReportedVsockCID(vmReport *v1.VMReport, connVsockCID uint32) error 
 }
 
 // Close stops the listener and releases associated resources. It is safe to
-// call multiple times. Normal shutdown goes through context cancellation (which
-// calls Close internally); this method exists for explicit cleanup when context
-// plumbing is unavailable, e.g. between retries.
+// call multiple times, including while the accept loop is blocked in Accept.
+// Normal shutdown goes through context cancellation (which calls Close
+// internally); this method also supports explicit cleanup when context plumbing
+// is unavailable, e.g. between retries.
 func (p *VsockIndexReportStream) Close() error {
 	p.listenerMu.Lock()
 	defer p.listenerMu.Unlock()
@@ -248,6 +256,13 @@ func (p *VsockIndexReportStream) stop() {
 	if err := p.Close(); err != nil {
 		log.Errorf("Error closing listener: %v", err)
 	}
+}
+
+func (p *VsockIndexReportStream) currentListener() net.Listener {
+	p.listenerMu.Lock()
+	defer p.listenerMu.Unlock()
+
+	return p.listener
 }
 
 func (p *VsockIndexReportStream) acquireSemaphore(parentCtx context.Context) error {

--- a/compliance/virtualmachines/relay/stream/vsock_index_report_stream_test.go
+++ b/compliance/virtualmachines/relay/stream/vsock_index_report_stream_test.go
@@ -1,15 +1,44 @@
 package stream
 
 import (
+	"context"
+	"net"
+	"sync"
 	"testing"
+	"time"
 
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/proto"
 )
 
 func TestStream(t *testing.T) {
 	suite.Run(t, new(streamTestSuite))
+}
+
+func TestVsockIndexReportStream_CloseStopsActiveAcceptLoop(t *testing.T) {
+	t.Parallel()
+
+	listener := newBlockingListener()
+	reportStream := newWithListener(listener)
+	reportStream.waitAfterFailedAccept = 0
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		reportStream.acceptLoop(context.Background(), nil)
+	}()
+
+	<-listener.acceptStarted
+
+	require.NoError(t, reportStream.Close())
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("accept loop did not stop after Close")
+	}
 }
 
 type streamTestSuite struct {
@@ -75,4 +104,37 @@ func (s *streamTestSuite) TestValidateVsockCID() {
 	connVsockCID = uint32(42)
 	err = validateReportedVsockCID(vmReport, connVsockCID)
 	s.Require().NoError(err)
+}
+
+type blockingListener struct {
+	acceptStarted chan struct{}
+	closeCh       chan struct{}
+	startOnce     sync.Once
+	closeOnce     sync.Once
+}
+
+func newBlockingListener() *blockingListener {
+	return &blockingListener{
+		acceptStarted: make(chan struct{}),
+		closeCh:       make(chan struct{}),
+	}
+}
+
+func (l *blockingListener) Accept() (net.Conn, error) {
+	l.startOnce.Do(func() {
+		close(l.acceptStarted)
+	})
+	<-l.closeCh
+	return nil, net.ErrClosed
+}
+
+func (l *blockingListener) Close() error {
+	l.closeOnce.Do(func() {
+		close(l.closeCh)
+	})
+	return nil
+}
+
+func (l *blockingListener) Addr() net.Addr {
+	return &net.UnixAddr{Name: "test", Net: "unix"}
 }

--- a/compliance/virtualmachines/relay/stream/vsock_index_report_stream_test.go
+++ b/compliance/virtualmachines/relay/stream/vsock_index_report_stream_test.go
@@ -3,11 +3,11 @@ package stream
 import (
 	"context"
 	"net"
-	"sync"
 	"testing"
 	"time"
 
 	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/proto"

--- a/compliance/virtualmachines/relay/vsock/vsock.go
+++ b/compliance/virtualmachines/relay/vsock/vsock.go
@@ -30,6 +30,9 @@ func ExtractVsockCIDFromConnection(conn net.Conn) (uint32, error) {
 
 // NewListener creates a vsock listener on the host context ID (vsock.Host) using the port
 // from VirtualMachinesVsockPort env var. Caller must close the returned listener.
+//
+// One-shot bind: ListenContextID fails immediately if vsock is unsupported (e.g. kernel module not loaded,
+// KubeVirt not installed). The caller receives the error; there is no retry at this layer.
 func NewListener() (net.Listener, error) {
 	port := env.VirtualMachinesVsockPort.IntegerSetting()
 	listener, err := vsock.ListenContextID(vsock.Host, uint32(port), nil)

--- a/compliance/virtualmachines/relay/vsock/vsock.go
+++ b/compliance/virtualmachines/relay/vsock/vsock.go
@@ -7,7 +7,6 @@ import (
 	"net"
 
 	"github.com/mdlayher/vsock"
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/env"
 )
 
@@ -35,9 +34,6 @@ func ExtractVsockCIDFromConnection(conn net.Conn) (uint32, error) {
 // KubeVirt not installed). The caller receives the error; there is no retry at this layer.
 func NewListener() (net.Listener, error) {
 	port := env.VirtualMachinesVsockPort.IntegerSetting()
-	listener, err := vsock.ListenContextID(vsock.Host, uint32(port), nil)
-	if err != nil {
-		return nil, errors.Wrapf(err, "listening on vsock port %d", port)
-	}
-	return listener, nil
+	//nolint:wrapcheck // The returned error is already pretty detailed: "listen vsock host(2):818: <reason>"
+	return vsock.ListenContextID(vsock.Host, uint32(port), nil)
 }

--- a/compliance/virtualmachines/relay/vsock/vsock.go
+++ b/compliance/virtualmachines/relay/vsock/vsock.go
@@ -34,6 +34,6 @@ func ExtractVsockCIDFromConnection(conn net.Conn) (uint32, error) {
 // KubeVirt not installed). The caller receives the error; there is no retry at this layer.
 func NewListener() (net.Listener, error) {
 	port := env.VirtualMachinesVsockPort.IntegerSetting()
-	//nolint:wrapcheck // The returned error is already pretty detailed: "listen vsock host(2):818: <reason>"
+	// Not wrapping as the returned error is already pretty detailed: "listen vsock host(2):818: <reason>"
 	return vsock.ListenContextID(vsock.Host, uint32(port), nil)
 }

--- a/compliance/vm_relay_retry_test.go
+++ b/compliance/vm_relay_retry_test.go
@@ -29,7 +29,7 @@ func TestRunVMRelayWithRetry(t *testing.T) {
 			},
 			expectedOperationAttempts: 2,
 		},
-		"should retry when relay run fails": {
+		"should retry when injected operation returns non-context error": {
 			operationErrors: []error{errors.New("relay failed"), nil},
 			backOffFactory: func() backoff.BackOff {
 				return backoff.NewConstantBackOff(0)

--- a/compliance/vm_relay_retry_test.go
+++ b/compliance/vm_relay_retry_test.go
@@ -22,19 +22,24 @@ func TestRunVMRelayWithRetry(t *testing.T) {
 		expectedErr                error
 		expectedOperationAttempts  int32
 	}{
-		"should retry when operation initially fails": {
+		"should retry once then succeed": {
 			operationErrors: []error{errors.New("vsock not available"), nil},
 			backOffFactory: func() backoff.BackOff {
 				return backoff.NewConstantBackOff(0)
 			},
 			expectedOperationAttempts: 2,
 		},
-		"should retry when injected operation returns non-context error": {
-			operationErrors: []error{errors.New("relay failed"), nil},
+		"should retry through multiple consecutive failures": {
+			operationErrors: []error{
+				errors.New("vsock not available"),
+				errors.New("vsock not available"),
+				errors.New("vsock not available"),
+				nil,
+			},
 			backOffFactory: func() backoff.BackOff {
 				return backoff.NewConstantBackOff(0)
 			},
-			expectedOperationAttempts: 2,
+			expectedOperationAttempts: 4,
 		},
 		"should stop without retrying when relay run returns context canceled": {
 			operationErrors: []error{context.Canceled},

--- a/compliance/vm_relay_retry_test.go
+++ b/compliance/vm_relay_retry_test.go
@@ -3,82 +3,63 @@ package compliance
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/stackrox/rox/compliance/virtualmachines/relay"
-	"github.com/stackrox/rox/compliance/virtualmachines/relay/sender"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
-	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
 	"github.com/stretchr/testify/require"
 )
-
-type vmRelayRunnerFunc func(ctx context.Context) error
-
-func (f vmRelayRunnerFunc) Run(ctx context.Context) error {
-	return f(ctx)
-}
-
-type fakeIndexReportStream struct{}
-
-func (fakeIndexReportStream) Start(context.Context) (<-chan *v1.VMReport, error) {
-	return nil, nil
-}
-
-type fakeIndexReportSender struct{}
-
-func (fakeIndexReportSender) Send(context.Context, *v1.VMReport) error {
-	return nil
-}
 
 func TestRunVMRelayWithRetry(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		streamErrors               []error
-		runErrors                  []error
+		operationErrors            []error
 		cancelOnFirstStreamAttempt bool
 		backOffFactory             func() backoff.BackOff
 		expectedErr                error
-		expectedStreamAttempts     int
-		expectedRunAttempts        int
+		expectedOperationAttempts  int32
 	}{
-		"should retry when stream creation initially fails": {
-			streamErrors: []error{errors.New("vsock not available")},
-			runErrors:    []error{nil},
+		"should retry when operation initially fails": {
+			operationErrors: []error{errors.New("vsock not available"), nil},
 			backOffFactory: func() backoff.BackOff {
 				return backoff.NewConstantBackOff(0)
 			},
-			expectedStreamAttempts: 2,
-			expectedRunAttempts:    1,
+			expectedOperationAttempts: 2,
 		},
-		"should retry from stream creation when relay run fails": {
-			runErrors: []error{errors.New("relay failed"), nil},
+		"should retry when relay run fails": {
+			operationErrors: []error{errors.New("relay failed"), nil},
 			backOffFactory: func() backoff.BackOff {
 				return backoff.NewConstantBackOff(0)
 			},
-			expectedStreamAttempts: 2,
-			expectedRunAttempts:    2,
+			expectedOperationAttempts: 2,
 		},
 		"should stop without retrying when relay run returns context canceled": {
-			runErrors: []error{context.Canceled},
+			operationErrors: []error{context.Canceled},
 			backOffFactory: func() backoff.BackOff {
 				return backoff.NewConstantBackOff(0)
 			},
-			expectedErr:            context.Canceled,
-			expectedStreamAttempts: 1,
-			expectedRunAttempts:    1,
+			expectedErr:               context.Canceled,
+			expectedOperationAttempts: 1,
+		},
+		"should stop without retrying when relay run returns context deadline exceeded": {
+			operationErrors: []error{context.DeadlineExceeded},
+			backOffFactory: func() backoff.BackOff {
+				return backoff.NewConstantBackOff(0)
+			},
+			expectedErr:               context.DeadlineExceeded,
+			expectedOperationAttempts: 1,
 		},
 		"should stop retries when context is canceled during stream creation failures": {
-			streamErrors:               []error{errors.New("vsock not available")},
+			operationErrors:            []error{errors.New("vsock not available")},
 			cancelOnFirstStreamAttempt: true,
 			backOffFactory: func() backoff.BackOff {
 				return backoff.NewConstantBackOff(time.Hour)
 			},
-			expectedErr:            context.Canceled,
-			expectedStreamAttempts: 1,
-			expectedRunAttempts:    0,
+			expectedErr:               context.Canceled,
+			expectedOperationAttempts: 1,
 		},
 	}
 
@@ -87,33 +68,18 @@ func TestRunVMRelayWithRetry(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			streamAttempts := 0
-			runAttempts := 0
+			attempts := atomic.Int32{}
 
 			c := &Compliance{
-				vmRelayStreamFactory: func() (relay.IndexReportStream, error) {
-					streamAttempts++
-					if tc.cancelOnFirstStreamAttempt && streamAttempts == 1 {
+				vmRelayOperation: func(context.Context, sensor.VirtualMachineIndexReportServiceClient) error {
+					attempt := attempts.Add(1)
+					if tc.cancelOnFirstStreamAttempt && attempt == 1 {
 						cancel()
 					}
-					if streamAttempts <= len(tc.streamErrors) {
-						if err := tc.streamErrors[streamAttempts-1]; err != nil {
-							return nil, err
-						}
+					if int(attempt) <= len(tc.operationErrors) {
+						return tc.operationErrors[int(attempt)-1]
 					}
-					return fakeIndexReportStream{}, nil
-				},
-				vmRelaySenderFactory: func(sensor.VirtualMachineIndexReportServiceClient) sender.IndexReportSender {
-					return fakeIndexReportSender{}
-				},
-				vmRelayFactory: func(relay.IndexReportStream, sender.IndexReportSender) vmRelayRunner {
-					return vmRelayRunnerFunc(func(context.Context) error {
-						runAttempts++
-						if runAttempts <= len(tc.runErrors) {
-							return tc.runErrors[runAttempts-1]
-						}
-						return nil
-					})
+					return nil
 				},
 				vmRelayBackOffFactory: tc.backOffFactory,
 			}
@@ -125,8 +91,7 @@ func TestRunVMRelayWithRetry(t *testing.T) {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tc.expectedErr)
 			}
-			require.Equal(t, tc.expectedStreamAttempts, streamAttempts)
-			require.Equal(t, tc.expectedRunAttempts, runAttempts)
+			require.Equal(t, tc.expectedOperationAttempts, attempts.Load())
 		})
 	}
 }

--- a/compliance/vm_relay_retry_test.go
+++ b/compliance/vm_relay_retry_test.go
@@ -1,0 +1,132 @@
+package compliance
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/stackrox/rox/compliance/virtualmachines/relay"
+	"github.com/stackrox/rox/compliance/virtualmachines/relay/sender"
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	v1 "github.com/stackrox/rox/generated/internalapi/virtualmachine/v1"
+	"github.com/stretchr/testify/require"
+)
+
+type vmRelayRunnerFunc func(ctx context.Context) error
+
+func (f vmRelayRunnerFunc) Run(ctx context.Context) error {
+	return f(ctx)
+}
+
+type fakeIndexReportStream struct{}
+
+func (fakeIndexReportStream) Start(context.Context) (<-chan *v1.VMReport, error) {
+	return nil, nil
+}
+
+type fakeIndexReportSender struct{}
+
+func (fakeIndexReportSender) Send(context.Context, *v1.VMReport) error {
+	return nil
+}
+
+func TestRunVMRelayWithRetry(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		streamErrors               []error
+		runErrors                  []error
+		cancelOnFirstStreamAttempt bool
+		backOffFactory             func() backoff.BackOff
+		expectedErr                error
+		expectedStreamAttempts     int
+		expectedRunAttempts        int
+	}{
+		"should retry when stream creation initially fails": {
+			streamErrors: []error{errors.New("vsock not available")},
+			runErrors:    []error{nil},
+			backOffFactory: func() backoff.BackOff {
+				return backoff.NewConstantBackOff(0)
+			},
+			expectedStreamAttempts: 2,
+			expectedRunAttempts:    1,
+		},
+		"should retry from stream creation when relay run fails": {
+			runErrors: []error{errors.New("relay failed"), nil},
+			backOffFactory: func() backoff.BackOff {
+				return backoff.NewConstantBackOff(0)
+			},
+			expectedStreamAttempts: 2,
+			expectedRunAttempts:    2,
+		},
+		"should stop without retrying when relay run returns context canceled": {
+			runErrors: []error{context.Canceled},
+			backOffFactory: func() backoff.BackOff {
+				return backoff.NewConstantBackOff(0)
+			},
+			expectedErr:            context.Canceled,
+			expectedStreamAttempts: 1,
+			expectedRunAttempts:    1,
+		},
+		"should stop retries when context is canceled during stream creation failures": {
+			streamErrors:               []error{errors.New("vsock not available")},
+			cancelOnFirstStreamAttempt: true,
+			backOffFactory: func() backoff.BackOff {
+				return backoff.NewConstantBackOff(time.Hour)
+			},
+			expectedErr:            context.Canceled,
+			expectedStreamAttempts: 1,
+			expectedRunAttempts:    0,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			streamAttempts := 0
+			runAttempts := 0
+
+			c := &Compliance{
+				vmRelayStreamFactory: func() (relay.IndexReportStream, error) {
+					streamAttempts++
+					if tc.cancelOnFirstStreamAttempt && streamAttempts == 1 {
+						cancel()
+					}
+					if streamAttempts <= len(tc.streamErrors) {
+						if err := tc.streamErrors[streamAttempts-1]; err != nil {
+							return nil, err
+						}
+					}
+					return fakeIndexReportStream{}, nil
+				},
+				vmRelaySenderFactory: func(sensor.VirtualMachineIndexReportServiceClient) sender.IndexReportSender {
+					return fakeIndexReportSender{}
+				},
+				vmRelayFactory: func(relay.IndexReportStream, sender.IndexReportSender) vmRelayRunner {
+					return vmRelayRunnerFunc(func(context.Context) error {
+						runAttempts++
+						if runAttempts <= len(tc.runErrors) {
+							return tc.runErrors[runAttempts-1]
+						}
+						return nil
+					})
+				},
+				vmRelayBackOffFactory: tc.backOffFactory,
+			}
+
+			err := c.runVMRelayWithRetry(ctx, nil)
+			if tc.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.expectedErr)
+			}
+			require.Equal(t, tc.expectedStreamAttempts, streamAttempts)
+			require.Equal(t, tc.expectedRunAttempts, runAttempts)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes `ROX-32420` by making VM relay startup in `compliance` resilient to delayed vsock availability.

Before this change, the relay attempted `stream.New()` once and exited the goroutine on failure, which could leave VM relay permanently down until pod restart.

After this change:
- VM relay startup and run are wrapped in exponential-backoff retry with `MaxElapsedTime = 0` (retry indefinitely).
- `stream.New()` failures are retried until success or context cancellation.
- non-context errors from `vmRelay.Run(ctx)` retry the full stream/sender/relay setup.
- context-cancellation outcomes exit cleanly without further retries.

To make this behavior unit-testable, the retry flow was extracted into `runVMRelayWithRetry(...)` with minimal injected factories for stream/sender/relay/backoff used by tests.


⚠️ This makes one issue more visible now: on master nodes, the log:
```
VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
```
will be repeated forever every 10 minutes (at the beginning a bit more frequently due to exp backoff). 
We are not detecting that the given node is master will never host any VMs. **I plan to tackle this issue in a follow-up.**

AI-generated portion: the retry/backoff implementation and the extracted helper/testing seam in `compliance/compliance.go`, plus the new `compliance/vm_relay_retry_test.go`.
User-written/corrected/checked portion: the requirements and acceptance criteria for retry semantics, scope constraints, and review/validation of the resulting behavior.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Newly added unit test
- Manual scenario:
    1. Start ACS  on a cluster without any virt resources
    2. See that the vsock connection DOES NOT STOP retrying after a single attempt
    3. Start virtualisation with VSOCK enabled
    4. Confirm that Agent and Compliance connect successfully.


Logs from compliance running on master node:

```
Setting up CA trust store in container
Looking for certificates in '/usr/local/share/ca-certificates'
No certificates found in /usr/local/share/ca-certificates
Looking for certificates in '/etc/pki/injected-ca-trust'
No certificates found in /etc/pki/injected-ca-trust
Updating CA trust
Done setting up CA trust store in container

pkg/memlimit: 2026/04/23 07:39:00.441591 memlimit.go:43: Info: ROX_MEMLIMIT set to 1.90Gi
node/inventory: 2026/04/23 07:39:00.442255 node_scanner.go:50: Info: Initialized gRPC connection to node-inventory container
main: 2026/04/23 07:39:00.442346 compliance.go:80: Info: Running StackRox Version: 4.11.x-750-g90ae79b1c4
pkg/metrics: 2026/04/23 07:39:00.442408 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2026/04/23 07:39:00.442542 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2026/04/23 07:39:00.442633 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2026/04/23 07:39:00.444801 throttle.go:90: Info: gathering CPU throttle metrics from sys/fs/cgroup/cpu.stat
main: 2026/04/23 07:39:00.444952 compliance.go:92: Info: Initialized gRPC stream connection to Sensor
main: 2026/04/23 07:39:00.448933 compliance.go:121: Info: Node Inventory v2 enabled
utils: 2026/04/23 07:39:00.449015 intervals.go:64: Info: Scanning intervals: base interval: 4h0m0s, maximum absolute deviation from base: 24m0s, first scan starts not later than in: 5m0s
utils: 2026/04/23 07:39:00.449046 intervals.go:72: Info: Initial scanning in 4m26.38922632s
main: 2026/04/23 07:39:00.449073 compliance.go:133: Info: Node Index v4 enabled
utils: 2026/04/23 07:39:00.449118 intervals.go:64: Info: Scanning intervals: base interval: 4h0m0s, maximum absolute deviation from base: 24m0s, first scan starts not later than in: 5m0s
utils: 2026/04/23 07:39:00.449149 intervals.go:72: Info: Initial scanning in 45.150687007s
main: 2026/04/23 07:39:00.449160 compliance.go:150: Info: Virtual machine relay enabled
root logger: 2026/04/23 07:39:00.449640 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
main: 2026/04/23 07:39:00.478690 compliance.go:531: Info: Successfully connected to Sensor at sensor.stackrox.svc:443
main: 2026/04/23 07:39:00.478916 compliance.go:480: Info: Starting audit log reader on node pr-04-20-vm2-kpwxc-master-1.c.acs-team-temp-dev.internal in cluster 274d52dd-ccfa-412c-8651-b203f443e566 using previously saved state: {
  "collectLogsSince":  "2026-04-23T07:38:30.587362Z",
  "lastAuditId":  "b78fb9dd-a36d-4334-bbb5-7a1e0e1fd2c6"
})
root logger: 2026/04/23 07:39:10.451084 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address - 5 log suppressed for limiter "vm-relay-retry"
root logger: 2026/04/23 07:39:12.568516 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
root logger: 2026/04/23 07:39:22.569297 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
root logger: 2026/04/23 07:39:24.727627 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
root logger: 2026/04/23 07:39:42.867752 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
main: 2026/04/23 07:39:45.600944 compliance.go:342: Info: Creating v4 Node Index report for node pr-04-20-vm2-kpwxc-master-1.c.acs-team-temp-dev.internal
2026/04/23 07:39:46 WARN rpm source packages always record 0 epoch; this may cause incorrect matching see-also="https://github.com/rpm-software-management/rpm/issues/2796 https://github.com/rpm-software-management/rpm/discussions/3703 https://github.com/rpm-software-management/rpm/pull/3755"
utils: 2026/04/23 07:39:46.918049 intervals.go:82: Info: Next node scan in 4h22m41.677222762s
main: 2026/04/23 07:39:47.962475 compliance.go:446: Debug: Received ComplianceACK: type=NODE_INDEX_REPORT, action=ACK, resource_id=pr-04-20-vm2-kpwxc-master-1.c.acs-team-temp-dev.internal, reason=
main: 2026/04/23 07:39:47.962757 compliance.go:446: Debug: Received ComplianceACK: type=NODE_INDEX_REPORT, action=ACK, resource_id=pr-04-20-vm2-kpwxc-master-1.c.acs-team-temp-dev.internal, reason=
root logger: 2026/04/23 07:39:53.301335 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
root logger: 2026/04/23 07:40:32.352040 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
root logger: 2026/04/23 07:41:24.853084 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
root logger: 2026/04/23 07:42:08.998082 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
main: 2026/04/23 07:43:26.907956 compliance.go:330: Error: Error running node scan: rpc error: code = Unknown desc = Node scanning is unsupported for this node
utils: 2026/04/23 07:43:26.908061 intervals.go:82: Info: Next node scan in 4h4m57.453113154s
root logger: 2026/04/23 07:43:37.568621 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
root logger: 2026/04/23 07:45:13.513281 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
root logger: 2026/04/23 07:50:23.374881 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
root logger: 2026/04/23 07:57:08.285961 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
root logger: 2026/04/23 08:02:15.278082 logger.go:77: Warn: compliance/compliance.go:191 - VM relay failed: creating vsock listener: listen vsock host(2):818: bind: cannot assign requested address
```

Logs from compliance running on worker node:

``` 
Setting up CA trust store in container
Looking for certificates in '/usr/local/share/ca-certificates'
No certificates found in /usr/local/share/ca-certificates
Looking for certificates in '/etc/pki/injected-ca-trust'
No certificates found in /etc/pki/injected-ca-trust
Updating CA trust
Done setting up CA trust store in container

pkg/memlimit: 2026/04/23 07:37:30.503595 memlimit.go:43: Info: ROX_MEMLIMIT set to 1.90Gi
node/inventory: 2026/04/23 07:37:30.504553 node_scanner.go:50: Info: Initialized gRPC connection to node-inventory container
main: 2026/04/23 07:37:30.504590 compliance.go:80: Info: Running StackRox Version: 4.11.x-750-g90ae79b1c4
pkg/metrics: 2026/04/23 07:37:30.504609 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2026/04/23 07:37:30.504663 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2026/04/23 07:37:30.504693 server.go:142: Warn: Secure metrics server is disabled
pkg/metrics: 2026/04/23 07:37:30.505672 throttle.go:90: Info: gathering CPU throttle metrics from sys/fs/cgroup/cpu.stat
main: 2026/04/23 07:37:30.505789 compliance.go:92: Info: Initialized gRPC stream connection to Sensor
main: 2026/04/23 07:37:30.507178 compliance.go:121: Info: Node Inventory v2 enabled
utils: 2026/04/23 07:37:30.507217 intervals.go:64: Info: Scanning intervals: base interval: 4h0m0s, maximum absolute deviation from base: 24m0s, first scan starts not later than in: 5m0s
utils: 2026/04/23 07:37:30.507229 intervals.go:72: Info: Initial scanning in 2m56.761836621s
main: 2026/04/23 07:37:30.507239 compliance.go:133: Info: Node Index v4 enabled
utils: 2026/04/23 07:37:30.507263 intervals.go:64: Info: Scanning intervals: base interval: 4h0m0s, maximum absolute deviation from base: 24m0s, first scan starts not later than in: 5m0s
utils: 2026/04/23 07:37:30.507293 intervals.go:72: Info: Initial scanning in 1m6.459017371s
main: 2026/04/23 07:37:30.507302 compliance.go:150: Info: Virtual machine relay enabled

# The important line:
virtualmachines/relay: 2026/04/23 07:37:30.507479 relay.go:36: Info: Starting virtual machine relay
virtualmachines/relay/stream: 2026/04/23 07:37:30.507499 vsock_index_report_stream.go:76: Info: Starting report 
stream


main: 2026/04/23 07:37:30.522575 compliance.go:531: Info: Successfully connected to Sensor at sensor.stackrox.svc:443
main: 2026/04/23 07:38:36.966844 compliance.go:342: Info: Creating v4 Node Index report for node pr-04-20-vm2-kpwxc-worker-d-5nzvd.c.acs-team-temp-dev.internal
2026/04/23 07:38:37 WARN rpm source packages always record 0 epoch; this may cause incorrect matching see-also="https://github.com/rpm-software-management/rpm/issues/2796 https://github.com/rpm-software-management/rpm/discussions/3703 https://github.com/rpm-software-management/rpm/pull/3755"
utils: 2026/04/23 07:38:37.438559 intervals.go:82: Info: Next node scan in 3h58m48.502645065s
main: 2026/04/23 07:38:38.655284 compliance.go:446: Debug: Received ComplianceACK: type=NODE_INDEX_REPORT, action=ACK, resource_id=pr-04-20-vm2-kpwxc-worker-d-5nzvd.c.acs-team-temp-dev.internal, reason=
main: 2026/04/23 07:38:38.655332 compliance.go:446: Debug: Received ComplianceACK: type=NODE_INDEX_REPORT, action=ACK, resource_id=pr-04-20-vm2-kpwxc-worker-d-5nzvd.c.acs-team-temp-dev.internal, reason=
main: 2026/04/23 07:40:27.283005 compliance.go:330: Error: Error running node scan: rpc error: code = Unknown desc = Node scanning is unsupported for this node
utils: 2026/04/23 07:40:27.283061 intervals.go:82: Info: Next node scan in 3h37m43.198531358s

```
