### PR TITLE
ROX-34356: add pg_stat_activity to diagnostic bundle

### DIFF
--- a/central/debug/service/db_diagnostics_test.go
+++ b/central/debug/service/db_diagnostics_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/postgres/stats"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stretchr/testify/suite"
 )
@@ -67,4 +68,19 @@ func (s *DBDiagnosticTestSuite) TestBuildDiagnosticData() {
 	// Drive some error cases
 	diagnosticData = buildDBDiagnosticData(s.ctx, nil, s.dbPool)
 	s.Equal(diagnosticData.DatabaseConnectString, "")
+}
+
+func (s *DBDiagnosticTestSuite) TestGetPGStatActivities() {
+	activities := stats.GetPGStatActivities(s.ctx, s.dbPool, 100)
+	s.Empty(activities.Error)
+	s.True(len(activities.Activities) > 0)
+
+	foundActive := false
+	for _, a := range activities.Activities {
+		if a.State != nil && *a.State == "active" {
+			foundActive = true
+			break
+		}
+	}
+	s.True(foundActive, "expected to find at least one active connection")
 }

--- a/central/debug/service/service.go
+++ b/central/debug/service/service.go
@@ -503,7 +503,16 @@ func getCentralDBData(ctx context.Context, zipWriter *zipWriter) error {
 	if tuples.Error != "" {
 		log.Errorw("error retrieving pg_stat_user_tables", logging.Err(errors.New(tuples.Error)))
 	}
-	return addJSONToZip(zipWriter, "central-db-pg-tuples.json", tuples)
+	if err := addJSONToZip(zipWriter, "central-db-pg-tuples.json", tuples); err != nil {
+		return err
+	}
+
+	// Get the active session stats
+	activities := stats.GetPGStatActivities(ctx, db, pgStatStatementsMax)
+	if activities.Error != "" {
+		log.Errorw("error retrieving pg_stat_activity", logging.Err(errors.New(activities.Error)))
+	}
+	return addJSONToZip(zipWriter, "central-db-pg-activity.json", activities)
 }
 
 func (s *serviceImpl) getLogImbue(ctx context.Context, zipWriter *zipWriter) error {

--- a/pkg/postgres/stats/stats.go
+++ b/pkg/postgres/stats/stats.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"context"
+	"regexp"
 	"time"
 
 	"github.com/pkg/errors"
@@ -133,6 +134,13 @@ func GetPGAnalyzeStats(ctx context.Context, db postgres.DB, limit int) *PGAnalyz
 	return &analyzeStats
 }
 
+var literalRedactor = regexp.MustCompile(`'(?:[^']|'')*'`)
+
+// redactQueryLiterals replaces SQL string literals with $? to avoid leaking sensitive values.
+func redactQueryLiterals(query string) string {
+	return literalRedactor.ReplaceAllString(query, "$?")
+}
+
 // PGStatActivity is the data model for a single row in pg_stat_activity
 type PGStatActivity struct {
 	DatabaseName    *string
@@ -184,6 +192,10 @@ func GetPGStatActivities(ctx context.Context, db postgres.DB, limit int) *PGStat
 		); err != nil {
 			activities.Error = errors.Wrap(err, "error scanning rows from pg_stat_activity").Error()
 			return &activities
+		}
+		if a.Query != nil {
+			redacted := redactQueryLiterals(*a.Query)
+			a.Query = &redacted
 		}
 		activities.Activities = append(activities.Activities, &a)
 	}

--- a/pkg/postgres/stats/stats.go
+++ b/pkg/postgres/stats/stats.go
@@ -107,6 +107,66 @@ type PGAnalyzeStats struct {
 	Error        string
 }
 
+// PGStatActivity is the data model for a single row in pg_stat_activity
+type PGStatActivity struct {
+	DatabaseName    *string    `json:"DatabaseName,omitempty"`
+	PID             int32      `json:"PID"`
+	UserName        *string    `json:"UserName,omitempty"`
+	ApplicationName *string    `json:"ApplicationName,omitempty"`
+	BackendStart    *time.Time `json:"BackendStart,omitempty"`
+	XactStart       *time.Time `json:"XactStart,omitempty"`
+	QueryStart      *time.Time `json:"QueryStart,omitempty"`
+	StateChange     *time.Time `json:"StateChange,omitempty"`
+	WaitEventType   *string    `json:"WaitEventType,omitempty"`
+	WaitEvent       *string    `json:"WaitEvent,omitempty"`
+	State           *string    `json:"State,omitempty"`
+	BackendType     *string    `json:"BackendType,omitempty"`
+	Query           *string    `json:"Query,omitempty"`
+}
+
+// PGStatActivities is a wrapper around PGStatActivity
+type PGStatActivities struct {
+	Activities []*PGStatActivity `json:"Activities"`
+	Error      string            `json:"Error,omitempty"`
+}
+
+// GetPGStatActivities returns an activities struct that wraps the results from the query to pg_stat_activity
+func GetPGStatActivities(ctx context.Context, db postgres.DB, limit int) *PGStatActivities {
+	var activities PGStatActivities
+	rows, err := db.Query(ctx,
+		`SELECT datname, pid, usename, application_name,
+			backend_start, xact_start, query_start, state_change,
+			wait_event_type, wait_event, state, backend_type,
+			substr(query, 1, 1000)
+		FROM pg_stat_activity
+		WHERE state IS NOT NULL
+		ORDER BY query_start ASC NULLS LAST
+		LIMIT $1`, limit)
+	if err != nil {
+		activities.Error = err.Error()
+		return &activities
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var a PGStatActivity
+		if err := rows.Scan(
+			&a.DatabaseName, &a.PID, &a.UserName, &a.ApplicationName,
+			&a.BackendStart, &a.XactStart, &a.QueryStart, &a.StateChange,
+			&a.WaitEventType, &a.WaitEvent, &a.State, &a.BackendType,
+			&a.Query,
+		); err != nil {
+			activities.Error = errors.Wrap(err, "error scanning rows from pg_stat_activity").Error()
+			return &activities
+		}
+		activities.Activities = append(activities.Activities, &a)
+	}
+	if err := rows.Err(); err != nil {
+		activities.Error = err.Error()
+	}
+	return &activities
+}
+
 // GetPGAnalyzeStats returns a tuple struct that wraps the results from the query to pg_stat_user_tables.
 // pg_stat_user_tables is used instead of pg_stat_all_tables because external database instances
 // may not grant access to pg_stat_all_tables.

--- a/pkg/postgres/stats/stats.go
+++ b/pkg/postgres/stats/stats.go
@@ -109,25 +109,25 @@ type PGAnalyzeStats struct {
 
 // PGStatActivity is the data model for a single row in pg_stat_activity
 type PGStatActivity struct {
-	DatabaseName    *string    `json:"DatabaseName,omitempty"`
-	PID             int32      `json:"PID"`
-	UserName        *string    `json:"UserName,omitempty"`
-	ApplicationName *string    `json:"ApplicationName,omitempty"`
-	BackendStart    *time.Time `json:"BackendStart,omitempty"`
-	XactStart       *time.Time `json:"XactStart,omitempty"`
-	QueryStart      *time.Time `json:"QueryStart,omitempty"`
-	StateChange     *time.Time `json:"StateChange,omitempty"`
-	WaitEventType   *string    `json:"WaitEventType,omitempty"`
-	WaitEvent       *string    `json:"WaitEvent,omitempty"`
-	State           *string    `json:"State,omitempty"`
-	BackendType     *string    `json:"BackendType,omitempty"`
-	Query           *string    `json:"Query,omitempty"`
+	DatabaseName    *string
+	PID             int32
+	UserName        *string
+	ApplicationName *string
+	BackendStart    *time.Time
+	XactStart       *time.Time
+	QueryStart      *time.Time
+	StateChange     *time.Time
+	WaitEventType   *string
+	WaitEvent       *string
+	State           *string
+	BackendType     *string
+	Query           *string
 }
 
 // PGStatActivities is a wrapper around PGStatActivity
 type PGStatActivities struct {
-	Activities []*PGStatActivity `json:"Activities"`
-	Error      string            `json:"Error,omitempty"`
+	Activities []*PGStatActivity
+	Error      string
 }
 
 // GetPGStatActivities returns an activities struct that wraps the results from the query to pg_stat_activity

--- a/pkg/postgres/stats/stats.go
+++ b/pkg/postgres/stats/stats.go
@@ -107,6 +107,32 @@ type PGAnalyzeStats struct {
 	Error        string
 }
 
+// GetPGAnalyzeStats returns a tuple struct that wraps the results from the query to pg_stat_user_tables.
+// pg_stat_user_tables is used instead of pg_stat_all_tables because external database instances
+// may not grant access to pg_stat_all_tables.
+func GetPGAnalyzeStats(ctx context.Context, db postgres.DB, limit int) *PGAnalyzeStats {
+	var analyzeStats PGAnalyzeStats
+	rows, err := db.Query(ctx, "SELECT relname, last_autoanalyze, last_analyze, last_autovacuum, last_vacuum FROM pg_stat_user_tables ORDER BY relname LIMIT $1", limit)
+	if err != nil {
+		analyzeStats.Error = err.Error()
+		return &analyzeStats
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var analyzeStat PGAnalyzeStat
+		if err := rows.Scan(&analyzeStat.TableName, &analyzeStat.LastAutoAnalyze, &analyzeStat.LastAnalyze, &analyzeStat.LastAutoVacuum, &analyzeStat.LastVacuum); err != nil {
+			analyzeStats.Error = errors.Wrap(err, "error scanning rows from pg_stat_user_tables").Error()
+			return &analyzeStats
+		}
+		analyzeStats.AnalyzeStats = append(analyzeStats.AnalyzeStats, &analyzeStat)
+	}
+	if err := rows.Err(); err != nil {
+		analyzeStats.Error = err.Error()
+	}
+	return &analyzeStats
+}
+
 // PGStatActivity is the data model for a single row in pg_stat_activity
 type PGStatActivity struct {
 	DatabaseName    *string
@@ -165,30 +191,4 @@ func GetPGStatActivities(ctx context.Context, db postgres.DB, limit int) *PGStat
 		activities.Error = err.Error()
 	}
 	return &activities
-}
-
-// GetPGAnalyzeStats returns a tuple struct that wraps the results from the query to pg_stat_user_tables.
-// pg_stat_user_tables is used instead of pg_stat_all_tables because external database instances
-// may not grant access to pg_stat_all_tables.
-func GetPGAnalyzeStats(ctx context.Context, db postgres.DB, limit int) *PGAnalyzeStats {
-	var analyzeStats PGAnalyzeStats
-	rows, err := db.Query(ctx, "SELECT relname, last_autoanalyze, last_analyze, last_autovacuum, last_vacuum FROM pg_stat_user_tables ORDER BY relname LIMIT $1", limit)
-	if err != nil {
-		analyzeStats.Error = err.Error()
-		return &analyzeStats
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var analyzeStat PGAnalyzeStat
-		if err := rows.Scan(&analyzeStat.TableName, &analyzeStat.LastAutoAnalyze, &analyzeStat.LastAnalyze, &analyzeStat.LastAutoVacuum, &analyzeStat.LastVacuum); err != nil {
-			analyzeStats.Error = errors.Wrap(err, "error scanning rows from pg_stat_user_tables").Error()
-			return &analyzeStats
-		}
-		analyzeStats.AnalyzeStats = append(analyzeStats.AnalyzeStats, &analyzeStat)
-	}
-	if err := rows.Err(); err != nil {
-		analyzeStats.Error = err.Error()
-	}
-	return &analyzeStats
 }

--- a/pkg/postgres/stats/stats_test.go
+++ b/pkg/postgres/stats/stats_test.go
@@ -1,0 +1,45 @@
+package stats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedactQueryLiterals(t *testing.T) {
+	cases := map[string]struct {
+		input    string
+		expected string
+	}{
+		"simple string literal": {
+			input:    "SELECT * FROM users WHERE name = 'alice'",
+			expected: "SELECT * FROM users WHERE name = $?",
+		},
+		"multiple literals": {
+			input:    "SELECT * FROM t WHERE a = 'foo' AND b = 'bar'",
+			expected: "SELECT * FROM t WHERE a = $? AND b = $?",
+		},
+		"escaped quote": {
+			input:    "SELECT * FROM t WHERE name = 'it''s fine'",
+			expected: "SELECT * FROM t WHERE name = $?",
+		},
+		"empty string literal": {
+			input:    "SELECT * FROM t WHERE name = ''",
+			expected: "SELECT * FROM t WHERE name = $?",
+		},
+		"parameterized query unchanged": {
+			input:    "SELECT * FROM t WHERE id = $1 AND name = $2",
+			expected: "SELECT * FROM t WHERE id = $1 AND name = $2",
+		},
+		"no literals": {
+			input:    "SELECT count(*) FROM pg_stat_activity",
+			expected: "SELECT count(*) FROM pg_stat_activity",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, redactQueryLiterals(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Support frequently needs pg_stat_activity data when triaging database performance issues (slow queries, connection exhaustion, lock contention) but has to ask customers to run  manual queries. This adds it to the diagnostic bundle automatically as central-db-pg-activity.json, following the existing pg_stat_statements/tuple stats pattern in pkg/postgres/stats.                                                                                                                                                               

Columns captured:                                                                                                                                                                
datname, pid, usename, application_name, backend_start, xact_start, query_start, state_change, wait_event_type, wait_event, state, backend_type, query (truncated to 1000 chars)  

External database handling:                                                                                                                                                        
No special-casing needed. On external databases with limited privileges, PostgreSQL returns only the application's own sessions — which is the right data for diagnosing StackRox issues. If the view is completely inaccessible, the error is captured in the JSON output and the file is still written to the bundle.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

  1. Verified both pkg/postgres/stats and central/debug/service compile cleanly                                                                                                     
  2. Ran the new integration test against a local PostgreSQL instance:
  go test -v -tags sql_integration ./central/debug/service/ \                                                                                                                       
    -run TestDBDiagnostic/TestGetPGStatActivities -count=1                                                                                                                          
  2. Test passes — confirms the query returns results, finds at least one active connection (the test's own session), and produces no errors                                        
  3. Verified the getCentralDBData code path is exercised in both the full diagnostic bundle (withCentral) and the database-only bundle (withDBOnly) modes                          
  4. Reviewed query behavior for external databases: pg_stat_activity is accessible to any user for their own sessions without requiring pg_read_all_stats or superuser, so no      
  permission errors are expected in the common case