### PR TITLE
fix(ci): only create CLI stub files when not building real CLI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -195,6 +195,11 @@ jobs:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
       - name: Create CLI stub files
+        if: |
+          !(needs.define-job-matrix.outputs.gotags == 'release'
+            || github.ref_name == 'master'
+            || github.event_name == 'workflow_call'
+            || contains(github.event.pull_request.labels.*.name, 'ci-build-cli'))
         run: |
           cat > stub.txt << 'EOF'
           This is a placeholder file. CLI binaries were not built for this PR build.


### PR DESCRIPTION
## Description

The "Create CLI stub files" step ran unconditionally, including on master builds. This created text files in bin/linux_amd64/roxctl etc. When "Build CLI" then ran (which does run on master), Go found the text files and errored with "already exists and is not an object file".

Fix by adding an if condition to only create stubs when we're NOT building real CLI binaries (inverse of the Build CLI condition).

- https://github.com/golang/go/issues/57039
- https://github.com/stackrox/stackrox/actions/runs/24730906310/job/72344826119#step:8:220

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI
- https://github.com/stackrox/stackrox/actions/runs/24732274270/job/72349790837?pr=20134
- https://github.com/stackrox/stackrox/actions/runs/24732726836/job/72351395373?pr=20134#step:8:24
