### PR TITLE
ROX-34344: sort by UUIDv7 scan ID instead of scan_time in GetVM

### DIFF
--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -664,14 +664,14 @@ func (s *serviceImpl) GetVM(ctx context.Context, request *v2.GetVMRequest) (*v2.
 
 	detail := storagetov2.VirtualMachineV2ToDetail(vm)
 
-	// Get the latest scan for this VM. Scan IDs are UUIDv7 (time-sortable) but the
-	// search framework has no field label for scan ID, so we sort by scan_time which
-	// has a btree index.
+	// Get the latest scan for this VM. Scan IDs are UUIDv7 (time-sortable),
+	// so sorting by the primary key is equivalent to sorting by time and avoids
+	// a separate index scan.
 	scanQuery := search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, request.GetId()).ProtoQuery()
 	scanQuery.Pagination = &v1.QueryPagination{
 		Limit: 1,
 		SortOptions: []*v1.QuerySortOption{
-			{Field: search.VirtualMachineScanTime.String(), Reversed: true},
+			{Field: search.VirtualMachineScanID.String(), Reversed: true},
 		},
 	}
 	scans, err := s.scanDS.SearchRawVMScans(ctx, scanQuery)

--- a/generated/storage/virtual_machine_scan_v2.pb.go
+++ b/generated/storage/virtual_machine_scan_v2.pb.go
@@ -79,7 +79,7 @@ type VirtualMachineScanV2 struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// UUIDv7 primary key -- time-sortable, encodes creation timestamp.
 	// Finding the latest scan is ORDER BY id DESC LIMIT 1 without a separate timestamp index.
-	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk,type(uuid)"` // @gotags: sql:"pk,type(uuid)"
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" search:"Virtual Machine Scan ID,hidden" sql:"pk,type(uuid)"` // @gotags: search:"Virtual Machine Scan ID,hidden" sql:"pk,type(uuid)"
 	// FK to VirtualMachineV2.id. CASCADE DELETE ensures scan cleanup when VM is removed.
 	VmV2Id string `protobuf:"bytes,2,opt,name=vm_v2_id,json=vmV2Id,proto3" json:"vm_v2_id,omitempty" sql:"fk(VirtualMachineV2:id),type(uuid),index=btree"` // @gotags: sql:"fk(VirtualMachineV2:id),type(uuid),index=btree"
 	// OS detected by the scanner during this scan.

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -496,6 +496,7 @@ var (
 	VirtualMachineName     = newFieldLabel("Virtual Machine Name")
 	GuestOS                = newFieldLabel("Guest OS")
 	VirtualMachineState    = newFieldLabel("Virtual Machine State")
+	VirtualMachineScanID   = newFieldLabel("Virtual Machine Scan ID")
 	VirtualMachineScanTime = newFieldLabel("Virtual Machine Scan Time")
 	VirtualMachineScanOS   = newFieldLabel("Virtual Machine Scan OS")
 	VirtualMachineTopCVSS  = newFieldLabel("Virtual Machine Top CVSS")

--- a/proto/storage/virtual_machine_scan_v2.proto
+++ b/proto/storage/virtual_machine_scan_v2.proto
@@ -14,7 +14,7 @@ option java_package = "io.stackrox.proto.storage";
 message VirtualMachineScanV2 {
   // UUIDv7 primary key -- time-sortable, encodes creation timestamp.
   // Finding the latest scan is ORDER BY id DESC LIMIT 1 without a separate timestamp index.
-  string id = 1; // @gotags: sql:"pk,type(uuid)"
+  string id = 1; // @gotags: search:"Virtual Machine Scan ID,hidden" sql:"pk,type(uuid)"
 
   // FK to VirtualMachineV2.id. CASCADE DELETE ensures scan cleanup when VM is removed.
   string vm_v2_id = 2; // @gotags: sql:"fk(VirtualMachineV2:id),type(uuid),index=btree"


### PR DESCRIPTION
## Description

Add a search label for the scan primary key (VirtualMachineScanID) and use it to sort scans in descending order when finding the latest scan. UUIDv7 IDs encode creation time, so ORDER BY id DESC is equivalent to ORDER BY scan_time DESC but uses the primary key index directly.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Existing tests pass. Sort field changed from scan_time to scan ID (PK).
