### PR TITLE
ROX-34165: simplify GetVMCVEComponents with SQL view

### DIFF
--- a/central/views/vmcve/db_response.go
+++ b/central/views/vmcve/db_response.go
@@ -129,3 +129,19 @@ func (r *resourceCountByFixability) GetTotal() int {
 func (r *resourceCountByFixability) GetFixable() int {
 	return r.fixable
 }
+
+type cveComponentResponse struct {
+	ComponentName    string `db:"component"`
+	ComponentVersion string `db:"component_version"`
+	ComponentSource  int32  `db:"component_source"`
+	FixedBy          string `db:"fixed_by"`
+	AdvisoryName     string `db:"advisory_name"`
+	AdvisoryLink     string `db:"advisory_link"`
+}
+
+func (c *cveComponentResponse) GetComponentName() string    { return c.ComponentName }
+func (c *cveComponentResponse) GetComponentVersion() string { return c.ComponentVersion }
+func (c *cveComponentResponse) GetComponentSource() int32   { return c.ComponentSource }
+func (c *cveComponentResponse) GetFixedBy() string          { return c.FixedBy }
+func (c *cveComponentResponse) GetAdvisoryName() string     { return c.AdvisoryName }
+func (c *cveComponentResponse) GetAdvisoryLink() string     { return c.AdvisoryLink }

--- a/central/views/vmcve/mocks/types.go
+++ b/central/views/vmcve/mocks/types.go
@@ -156,6 +156,114 @@ func (mr *MockCveCoreMockRecorder) GetVMsBySeverity() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMsBySeverity", reflect.TypeOf((*MockCveCore)(nil).GetVMsBySeverity))
 }
 
+// MockCVEComponentCore is a mock of CVEComponentCore interface.
+type MockCVEComponentCore struct {
+	ctrl     *gomock.Controller
+	recorder *MockCVEComponentCoreMockRecorder
+	isgomock struct{}
+}
+
+// MockCVEComponentCoreMockRecorder is the mock recorder for MockCVEComponentCore.
+type MockCVEComponentCoreMockRecorder struct {
+	mock *MockCVEComponentCore
+}
+
+// NewMockCVEComponentCore creates a new mock instance.
+func NewMockCVEComponentCore(ctrl *gomock.Controller) *MockCVEComponentCore {
+	mock := &MockCVEComponentCore{ctrl: ctrl}
+	mock.recorder = &MockCVEComponentCoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCVEComponentCore) EXPECT() *MockCVEComponentCoreMockRecorder {
+	return m.recorder
+}
+
+// GetAdvisoryLink mocks base method.
+func (m *MockCVEComponentCore) GetAdvisoryLink() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAdvisoryLink")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetAdvisoryLink indicates an expected call of GetAdvisoryLink.
+func (mr *MockCVEComponentCoreMockRecorder) GetAdvisoryLink() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdvisoryLink", reflect.TypeOf((*MockCVEComponentCore)(nil).GetAdvisoryLink))
+}
+
+// GetAdvisoryName mocks base method.
+func (m *MockCVEComponentCore) GetAdvisoryName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAdvisoryName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetAdvisoryName indicates an expected call of GetAdvisoryName.
+func (mr *MockCVEComponentCoreMockRecorder) GetAdvisoryName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdvisoryName", reflect.TypeOf((*MockCVEComponentCore)(nil).GetAdvisoryName))
+}
+
+// GetComponentName mocks base method.
+func (m *MockCVEComponentCore) GetComponentName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetComponentName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetComponentName indicates an expected call of GetComponentName.
+func (mr *MockCVEComponentCoreMockRecorder) GetComponentName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetComponentName", reflect.TypeOf((*MockCVEComponentCore)(nil).GetComponentName))
+}
+
+// GetComponentSource mocks base method.
+func (m *MockCVEComponentCore) GetComponentSource() int32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetComponentSource")
+	ret0, _ := ret[0].(int32)
+	return ret0
+}
+
+// GetComponentSource indicates an expected call of GetComponentSource.
+func (mr *MockCVEComponentCoreMockRecorder) GetComponentSource() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetComponentSource", reflect.TypeOf((*MockCVEComponentCore)(nil).GetComponentSource))
+}
+
+// GetComponentVersion mocks base method.
+func (m *MockCVEComponentCore) GetComponentVersion() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetComponentVersion")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetComponentVersion indicates an expected call of GetComponentVersion.
+func (mr *MockCVEComponentCoreMockRecorder) GetComponentVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetComponentVersion", reflect.TypeOf((*MockCVEComponentCore)(nil).GetComponentVersion))
+}
+
+// GetFixedBy mocks base method.
+func (m *MockCVEComponentCore) GetFixedBy() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFixedBy")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetFixedBy indicates an expected call of GetFixedBy.
+func (mr *MockCVEComponentCoreMockRecorder) GetFixedBy() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFixedBy", reflect.TypeOf((*MockCVEComponentCore)(nil).GetFixedBy))
+}
+
 // MockCveView is a mock of CveView interface.
 type MockCveView struct {
 	ctrl     *gomock.Controller
@@ -223,6 +331,21 @@ func (m *MockCveView) Get(ctx context.Context, q *v1.Query) ([]vmcve.CveCore, er
 func (mr *MockCveViewMockRecorder) Get(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCveView)(nil).Get), ctx, q)
+}
+
+// GetCVEComponents mocks base method.
+func (m *MockCveView) GetCVEComponents(ctx context.Context, q *v1.Query) ([]vmcve.CVEComponentCore, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCVEComponents", ctx, q)
+	ret0, _ := ret[0].([]vmcve.CVEComponentCore)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCVEComponents indicates an expected call of GetCVEComponents.
+func (mr *MockCveViewMockRecorder) GetCVEComponents(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCVEComponents", reflect.TypeOf((*MockCveView)(nil).GetCVEComponents), ctx, q)
 }
 
 // GetVMIDs mocks base method.

--- a/central/views/vmcve/types.go
+++ b/central/views/vmcve/types.go
@@ -22,6 +22,18 @@ type CveCore interface {
 	GetEPSSProbability() float32
 }
 
+// CVEComponentCore provides component details for a specific CVE.
+//
+//go:generate mockgen-wrapper
+type CVEComponentCore interface {
+	GetComponentName() string
+	GetComponentVersion() string
+	GetComponentSource() int32
+	GetFixedBy() string
+	GetAdvisoryName() string
+	GetAdvisoryLink() string
+}
+
 // CveView interface is like a SQL view that provides functionality to fetch VM CVE data
 // irrespective of the data model. One CVE can have multiple database entries if that CVE
 // impacts multiple VMs or components. However, the core information is the same.
@@ -32,4 +44,5 @@ type CveView interface {
 	CountBySeverity(ctx context.Context, q *v1.Query) (common.ResourceCountByCVESeverity, error)
 	Get(ctx context.Context, q *v1.Query) ([]CveCore, error)
 	GetVMIDs(ctx context.Context, q *v1.Query) ([]string, error)
+	GetCVEComponents(ctx context.Context, q *v1.Query) ([]CVEComponentCore, error)
 }

--- a/central/views/vmcve/view_impl.go
+++ b/central/views/vmcve/view_impl.go
@@ -168,6 +168,31 @@ func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string) *v1.Qu
 	return cloned
 }
 
+func (v *vmCVECoreViewImpl) GetCVEComponents(ctx context.Context, q *v1.Query) ([]CVEComponentCore, error) {
+	cloned := q.CloneVT()
+	cloned.Selects = []*v1.QuerySelect{
+		search.NewQuerySelect(search.Component).Proto(),
+		search.NewQuerySelect(search.ComponentVersion).Proto(),
+		search.NewQuerySelect(search.ComponentSource).Proto(),
+		search.NewQuerySelect(search.FixedBy).Proto(),
+		search.NewQuerySelect(search.AdvisoryName).Proto(),
+		search.NewQuerySelect(search.AdvisoryLink).Proto(),
+	}
+
+	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
+	defer cancel()
+
+	var ret []CVEComponentCore
+	err := pgSearch.RunSelectRequestForSchemaFn[cveComponentResponse](queryCtx, v.db, v.schema, cloned, func(r *cveComponentResponse) error {
+		ret = append(ret, r)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 func (v *vmCVECoreViewImpl) getFilteredCVEs(ctx context.Context, q *v1.Query) ([]string, error) {
 	var cveIDsToFilter []string
 

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -397,7 +397,6 @@ func (s *serviceImpl) ListVMCVEsByVM(ctx context.Context, request *v2.ListVMCVEs
 }
 
 // GetVMCVEComponents returns components affected by a specific CVE on a specific VM.
-// TODO(ROX-34165): Simplify with a SQL view joining CVEs and components.
 func (s *serviceImpl) GetVMCVEComponents(ctx context.Context, request *v2.GetVMCVEComponentsRequest) (*v2.GetVMCVEComponentsResponse, error) {
 	if request.GetVmId() == "" || request.GetCveId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "vm_id and cve_id must be specified")
@@ -408,43 +407,26 @@ func (s *serviceImpl) GetVMCVEComponents(ctx context.Context, request *v2.GetVMC
 		search.NewQueryBuilder().AddExactMatches(search.CVE, request.GetCveId()).ProtoQuery(),
 	)
 
-	// Get CVEs matching the CVE ID to find the associated component IDs.
-	cves, err := s.cveDS.SearchRawVMCVEs(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	componentIDSet := make(map[string]struct{}, len(cves))
-	cveByComponent := make(map[string]*v2.Advisory, len(cves))
-	fixedByComponent := make(map[string]string, len(cves))
-	for _, cve := range cves {
-		componentIDSet[cve.GetVmComponentId()] = struct{}{}
-		if cve.GetAdvisory() != nil {
-			cveByComponent[cve.GetVmComponentId()] = &v2.Advisory{
-				Name: cve.GetAdvisory().GetName(),
-				Link: cve.GetAdvisory().GetLink(),
-			}
-		}
-		fixedByComponent[cve.GetVmComponentId()] = cve.GetFixedBy()
-	}
-
-	componentIDs := make([]string, 0, len(componentIDSet))
-	for id := range componentIDSet {
-		componentIDs = append(componentIDs, id)
-	}
-	components, err := s.componentDS.GetBatch(ctx, componentIDs)
+	components, err := s.cveView.GetCVEComponents(ctx, q)
 	if err != nil {
 		return nil, err
 	}
 
 	rows := make([]*v2.VMCVEComponentRow, 0, len(components))
 	for _, comp := range components {
+		var advisory *v2.Advisory
+		if comp.GetAdvisoryName() != "" {
+			advisory = &v2.Advisory{
+				Name: comp.GetAdvisoryName(),
+				Link: comp.GetAdvisoryLink(),
+			}
+		}
 		rows = append(rows, &v2.VMCVEComponentRow{
-			ComponentName:    comp.GetName(),
-			ComponentVersion: comp.GetVersion(),
-			Source:           v2.SourceType(comp.GetSource()),
-			FixedBy:          fixedByComponent[comp.GetId()],
-			Advisory:         cveByComponent[comp.GetId()],
+			ComponentName:    comp.GetComponentName(),
+			ComponentVersion: comp.GetComponentVersion(),
+			Source:           v2.SourceType(comp.GetComponentSource()),
+			FixedBy:          comp.GetFixedBy(),
+			Advisory:         advisory,
 		})
 	}
 

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -267,27 +267,6 @@ func TestListVMCVEsByVM(t *testing.T) {
 func TestGetVMCVEComponents(t *testing.T) {
 	ctx := context.Background()
 
-	cve1 := &storage.VirtualMachineCVEV2{
-		Id:            "cve-uuid-1",
-		VmV2Id:        "vm-1",
-		VmComponentId: "comp-1",
-		CveBaseInfo: &storage.CVEInfo{
-			Cve: "CVE-2024-1234",
-		},
-		HasFixedBy: &storage.VirtualMachineCVEV2_FixedBy{FixedBy: "1.2.3"},
-		Advisory: &storage.Advisory{
-			Name: "RHSA-2024:1234",
-			Link: "https://access.redhat.com",
-		},
-	}
-
-	comp1 := &storage.VirtualMachineComponentV2{
-		Id:      "comp-1",
-		Name:    "openssl",
-		Version: "1.1.1",
-		Source:  storage.SourceType_OS,
-	}
-
 	tests := map[string]struct {
 		request       *v2.GetVMCVEComponentsRequest
 		setupMock     func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView)
@@ -317,8 +296,12 @@ func TestGetVMCVEComponents(t *testing.T) {
 				CveId: "CVE-2024-1234",
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
-				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
-				mockComp.EXPECT().GetBatch(ctx, []string{"comp-1"}).Return([]*storage.VirtualMachineComponentV2{comp1}, nil)
+				mockView.EXPECT().GetCVEComponents(ctx, gomock.Any()).Return([]vmcve.CVEComponentCore{
+					&cveComponentMock{
+						name: "openssl", version: "1.1.1", source: int32(storage.SourceType_OS),
+						fixedBy: "1.2.3", advisoryName: "RHSA-2024:1234", advisoryLink: "https://access.redhat.com",
+					},
+				}, nil)
 			},
 		},
 	}
@@ -759,6 +742,18 @@ func TestListVMs(t *testing.T) {
 		})
 	}
 }
+
+type cveComponentMock struct {
+	name, version, fixedBy, advisoryName, advisoryLink string
+	source                                             int32
+}
+
+func (c *cveComponentMock) GetComponentName() string    { return c.name }
+func (c *cveComponentMock) GetComponentVersion() string { return c.version }
+func (c *cveComponentMock) GetComponentSource() int32   { return c.source }
+func (c *cveComponentMock) GetFixedBy() string          { return c.fixedBy }
+func (c *cveComponentMock) GetAdvisoryName() string     { return c.advisoryName }
+func (c *cveComponentMock) GetAdvisoryLink() string     { return c.advisoryLink }
 
 // mockCveCore implements vmcve.CveCore for testing ListVMCVEs.
 type mockCveCore struct {

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -290,19 +290,15 @@ func TestGetVMCVEComponents(t *testing.T) {
 			},
 			expectedError: "vm_id and cve_id must be specified",
 		},
-		"successful with components": {
+		"view error": {
 			request: &v2.GetVMCVEComponentsRequest{
 				VmId:  "vm-1",
 				CveId: "CVE-2024-1234",
 			},
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
-				mockView.EXPECT().GetCVEComponents(ctx, gomock.Any()).Return([]vmcve.CVEComponentCore{
-					&cveComponentMock{
-						name: "openssl", version: "1.1.1", source: int32(storage.SourceType_OS),
-						fixedBy: "1.2.3", advisoryName: "RHSA-2024:1234", advisoryLink: "https://access.redhat.com",
-					},
-				}, nil)
+				mockView.EXPECT().GetCVEComponents(ctx, gomock.Any()).Return(nil, errors.New("view error"))
 			},
+			expectedError: "view error",
 		},
 	}
 
@@ -335,16 +331,59 @@ func TestGetVMCVEComponents(t *testing.T) {
 				assert.Nil(t, result)
 			} else {
 				require.NoError(t, err)
-				require.Len(t, result.GetComponents(), 1)
-				row := result.GetComponents()[0]
-				assert.Equal(t, "openssl", row.GetComponentName())
-				assert.Equal(t, "1.1.1", row.GetComponentVersion())
-				assert.Equal(t, v2.SourceType_OS, row.GetSource())
-				assert.Equal(t, "1.2.3", row.GetFixedBy())
-				assert.Equal(t, "RHSA-2024:1234", row.GetAdvisory().GetName())
+				require.NotEmpty(t, result.GetComponents())
 			}
 		})
 	}
+
+	// Verify specific field values for the success case.
+	t.Run("successful with components - field values", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockView := cveViewMocks.NewMockCveView(ctrl)
+		comp := cveViewMocks.NewMockCVEComponentCore(ctrl)
+		comp.EXPECT().GetComponentName().Return("openssl").AnyTimes()
+		comp.EXPECT().GetComponentVersion().Return("1.1.1").AnyTimes()
+		comp.EXPECT().GetComponentSource().Return(int32(storage.SourceType_OS)).AnyTimes()
+		comp.EXPECT().GetFixedBy().Return("1.2.3").AnyTimes()
+		comp.EXPECT().GetAdvisoryName().Return("RHSA-2024:1234").AnyTimes()
+		comp.EXPECT().GetAdvisoryLink().Return("https://access.redhat.com").AnyTimes()
+		mockView.EXPECT().GetCVEComponents(ctx, gomock.Any()).Return([]vmcve.CVEComponentCore{comp}, nil)
+
+		svc := &serviceImpl{cveView: mockView}
+		result, err := svc.GetVMCVEComponents(ctx, &v2.GetVMCVEComponentsRequest{VmId: "vm-1", CveId: "CVE-2024-1234"})
+		require.NoError(t, err)
+		require.Len(t, result.GetComponents(), 1)
+		row := result.GetComponents()[0]
+		assert.Equal(t, "openssl", row.GetComponentName())
+		assert.Equal(t, "1.1.1", row.GetComponentVersion())
+		assert.Equal(t, v2.SourceType_OS, row.GetSource())
+		assert.Equal(t, "1.2.3", row.GetFixedBy())
+		assert.Equal(t, "RHSA-2024:1234", row.GetAdvisory().GetName())
+	})
+
+	// Verify nil advisory when advisory name is empty.
+	t.Run("nil advisory when empty", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockView := cveViewMocks.NewMockCveView(ctrl)
+		comp := cveViewMocks.NewMockCVEComponentCore(ctrl)
+		comp.EXPECT().GetComponentName().Return("curl").AnyTimes()
+		comp.EXPECT().GetComponentVersion().Return("7.0").AnyTimes()
+		comp.EXPECT().GetComponentSource().Return(int32(storage.SourceType_OS)).AnyTimes()
+		comp.EXPECT().GetFixedBy().Return("").AnyTimes()
+		comp.EXPECT().GetAdvisoryName().Return("").AnyTimes()
+		comp.EXPECT().GetAdvisoryLink().Return("").AnyTimes()
+		mockView.EXPECT().GetCVEComponents(ctx, gomock.Any()).Return([]vmcve.CVEComponentCore{comp}, nil)
+
+		svc := &serviceImpl{cveView: mockView}
+		result, err := svc.GetVMCVEComponents(ctx, &v2.GetVMCVEComponentsRequest{VmId: "vm-1", CveId: "CVE-2024-5678"})
+		require.NoError(t, err)
+		require.Len(t, result.GetComponents(), 1)
+		assert.Nil(t, result.GetComponents()[0].GetAdvisory())
+	})
 }
 
 func TestListVMComponents(t *testing.T) {
@@ -742,18 +781,6 @@ func TestListVMs(t *testing.T) {
 		})
 	}
 }
-
-type cveComponentMock struct {
-	name, version, fixedBy, advisoryName, advisoryLink string
-	source                                             int32
-}
-
-func (c *cveComponentMock) GetComponentName() string    { return c.name }
-func (c *cveComponentMock) GetComponentVersion() string { return c.version }
-func (c *cveComponentMock) GetComponentSource() int32   { return c.source }
-func (c *cveComponentMock) GetFixedBy() string          { return c.fixedBy }
-func (c *cveComponentMock) GetAdvisoryName() string     { return c.advisoryName }
-func (c *cveComponentMock) GetAdvisoryLink() string     { return c.advisoryLink }
 
 // mockCveCore implements vmcve.CveCore for testing ListVMCVEs.
 type mockCveCore struct {


### PR DESCRIPTION
## Description

Add GetCVEComponents to vmcve.CveView which JOINs CVE and component tables in a single query, returning component name, version, source, fixedBy, and advisory data. Replaces the previous two-step fetch (SearchRawVMCVEs + GetBatch) and manual in-memory mapping in GetVMCVEComponents.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Unit tests updated to mock the new view method.
