### PR TITLE
ROX-34084: replace in-memory severity aggregation with SQL GROUP BY

### DIFF
--- a/central/views/vmcve/db_response.go
+++ b/central/views/vmcve/db_response.go
@@ -145,3 +145,33 @@ func (c *cveComponentResponse) GetComponentSource() int32   { return c.Component
 func (c *cveComponentResponse) GetFixedBy() string          { return c.FixedBy }
 func (c *cveComponentResponse) GetAdvisoryName() string     { return c.AdvisoryName }
 func (c *cveComponentResponse) GetAdvisoryLink() string     { return c.AdvisoryLink }
+
+type vmSeverityCountsResponse struct {
+	VMID                          string `db:"virtual_machine_id"`
+	CriticalSeverityCount         int    `db:"critical_severity_count"`
+	FixableCriticalSeverityCount  int    `db:"fixable_critical_severity_count"`
+	ImportantSeverityCount        int    `db:"important_severity_count"`
+	FixableImportantSeverityCount int    `db:"fixable_important_severity_count"`
+	ModerateSeverityCount         int    `db:"moderate_severity_count"`
+	FixableModerateSeverityCount  int    `db:"fixable_moderate_severity_count"`
+	LowSeverityCount              int    `db:"low_severity_count"`
+	FixableLowSeverityCount       int    `db:"fixable_low_severity_count"`
+	UnknownSeverityCount          int    `db:"unknown_severity_count"`
+	FixableUnknownSeverityCount   int    `db:"fixable_unknown_severity_count"`
+}
+
+func (r *vmSeverityCountsResponse) GetVMID() string { return r.VMID }
+func (r *vmSeverityCountsResponse) GetSeverityCounts() common.ResourceCountByCVESeverity {
+	return &resourceCountByVMCVESeverity{
+		CriticalSeverityCount:         r.CriticalSeverityCount,
+		FixableCriticalSeverityCount:  r.FixableCriticalSeverityCount,
+		ImportantSeverityCount:        r.ImportantSeverityCount,
+		FixableImportantSeverityCount: r.FixableImportantSeverityCount,
+		ModerateSeverityCount:         r.ModerateSeverityCount,
+		FixableModerateSeverityCount:  r.FixableModerateSeverityCount,
+		LowSeverityCount:              r.LowSeverityCount,
+		FixableLowSeverityCount:       r.FixableLowSeverityCount,
+		UnknownSeverityCount:          r.UnknownSeverityCount,
+		FixableUnknownSeverityCount:   r.FixableUnknownSeverityCount,
+	}
+}

--- a/central/views/vmcve/mocks/types.go
+++ b/central/views/vmcve/mocks/types.go
@@ -318,6 +318,21 @@ func (mr *MockCveViewMockRecorder) CountBySeverity(ctx, q any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountBySeverity", reflect.TypeOf((*MockCveView)(nil).CountBySeverity), ctx, q)
 }
 
+// CountBySeverityPerVM mocks base method.
+func (m *MockCveView) CountBySeverityPerVM(ctx context.Context, q *v1.Query) ([]vmcve.VMSeverityCounts, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountBySeverityPerVM", ctx, q)
+	ret0, _ := ret[0].([]vmcve.VMSeverityCounts)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountBySeverityPerVM indicates an expected call of CountBySeverityPerVM.
+func (mr *MockCveViewMockRecorder) CountBySeverityPerVM(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountBySeverityPerVM", reflect.TypeOf((*MockCveView)(nil).CountBySeverityPerVM), ctx, q)
+}
+
 // Get mocks base method.
 func (m *MockCveView) Get(ctx context.Context, q *v1.Query) ([]vmcve.CveCore, error) {
 	m.ctrl.T.Helper()
@@ -361,4 +376,56 @@ func (m *MockCveView) GetVMIDs(ctx context.Context, q *v1.Query) ([]string, erro
 func (mr *MockCveViewMockRecorder) GetVMIDs(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMIDs", reflect.TypeOf((*MockCveView)(nil).GetVMIDs), ctx, q)
+}
+
+// MockVMSeverityCounts is a mock of VMSeverityCounts interface.
+type MockVMSeverityCounts struct {
+	ctrl     *gomock.Controller
+	recorder *MockVMSeverityCountsMockRecorder
+	isgomock struct{}
+}
+
+// MockVMSeverityCountsMockRecorder is the mock recorder for MockVMSeverityCounts.
+type MockVMSeverityCountsMockRecorder struct {
+	mock *MockVMSeverityCounts
+}
+
+// NewMockVMSeverityCounts creates a new mock instance.
+func NewMockVMSeverityCounts(ctrl *gomock.Controller) *MockVMSeverityCounts {
+	mock := &MockVMSeverityCounts{ctrl: ctrl}
+	mock.recorder = &MockVMSeverityCountsMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockVMSeverityCounts) EXPECT() *MockVMSeverityCountsMockRecorder {
+	return m.recorder
+}
+
+// GetSeverityCounts mocks base method.
+func (m *MockVMSeverityCounts) GetSeverityCounts() common.ResourceCountByCVESeverity {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSeverityCounts")
+	ret0, _ := ret[0].(common.ResourceCountByCVESeverity)
+	return ret0
+}
+
+// GetSeverityCounts indicates an expected call of GetSeverityCounts.
+func (mr *MockVMSeverityCountsMockRecorder) GetSeverityCounts() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeverityCounts", reflect.TypeOf((*MockVMSeverityCounts)(nil).GetSeverityCounts))
+}
+
+// GetVMID mocks base method.
+func (m *MockVMSeverityCounts) GetVMID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVMID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetVMID indicates an expected call of GetVMID.
+func (mr *MockVMSeverityCountsMockRecorder) GetVMID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMID", reflect.TypeOf((*MockVMSeverityCounts)(nil).GetVMID))
 }

--- a/central/views/vmcve/types.go
+++ b/central/views/vmcve/types.go
@@ -45,4 +45,11 @@ type CveView interface {
 	Get(ctx context.Context, q *v1.Query) ([]CveCore, error)
 	GetVMIDs(ctx context.Context, q *v1.Query) ([]string, error)
 	GetCVEComponents(ctx context.Context, q *v1.Query) ([]CVEComponentCore, error)
+	CountBySeverityPerVM(ctx context.Context, q *v1.Query) ([]VMSeverityCounts, error)
+}
+
+// VMSeverityCounts provides per-VM severity counts.
+type VMSeverityCounts interface {
+	GetVMID() string
+	GetSeverityCounts() common.ResourceCountByCVESeverity
 }

--- a/central/views/vmcve/view_impl.go
+++ b/central/views/vmcve/view_impl.go
@@ -122,6 +122,33 @@ func (v *vmCVECoreViewImpl) GetVMIDs(ctx context.Context, q *v1.Query) ([]string
 	return ret, nil
 }
 
+func (v *vmCVECoreViewImpl) CountBySeverityPerVM(ctx context.Context, q *v1.Query) ([]VMSeverityCounts, error) {
+	if err := common.ValidateQuery(q); err != nil {
+		return nil, err
+	}
+
+	cloned := common.WithCountBySeverityAndFixabilityQuery(q, search.VirtualMachineID)
+	cloned.Selects = append([]*v1.QuerySelect{
+		search.NewQuerySelect(search.VirtualMachineID).Proto(),
+	}, cloned.GetSelects()...)
+	cloned.GroupBy = &v1.QueryGroupBy{
+		Fields: []string{search.VirtualMachineID.String()},
+	}
+
+	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
+	defer cancel()
+
+	var ret []VMSeverityCounts
+	err := pgSearch.RunSelectRequestForSchemaFn[vmSeverityCountsResponse](queryCtx, v.db, v.schema, cloned, func(r *vmSeverityCountsResponse) error {
+		ret = append(ret, r)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 	cloned := q.CloneVT()
 	cloned.Selects = []*v1.QuerySelect{

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -93,18 +93,24 @@ func (s *serviceImpl) ListVMs(ctx context.Context, request *v2.ListVMsRequest) (
 		return nil, err
 	}
 
-	// Batch fetch CVE severity counts and component scan counts for all VMs
-	// in two queries instead of 2*N queries.
 	vmIDs := make([]string, 0, len(vms))
 	for _, vm := range vms {
 		vmIDs = append(vmIDs, vm.GetId())
 	}
 
-	severityByVM, err := s.batchCVESeverityByVM(ctx, vmIDs)
+	// Fetch per-VM CVE severity counts via SQL GROUP BY.
+	vmFilter := search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, vmIDs...).ProtoQuery()
+	severityRows, err := s.cveView.CountBySeverityPerVM(ctx, vmFilter)
 	if err != nil {
 		return nil, err
 	}
+	severityByVM := make(map[string]*v2.VulnCountBySeverity, len(severityRows))
+	for _, row := range severityRows {
+		severityByVM[row.GetVMID()] = storagetov2.SeverityCountsToProto(row.GetSeverityCounts())
+	}
 
+	// Batch fetch component scan counts (Notes field is not search-indexed,
+	// so in-memory aggregation is used).
 	componentCountsByVM, err := s.batchComponentScanCounts(ctx, vmIDs)
 	if err != nil {
 		return nil, err
@@ -114,6 +120,9 @@ func (s *serviceImpl) ListVMs(ctx context.Context, request *v2.ListVMsRequest) (
 	for _, vm := range vms {
 		item := storagetov2.VirtualMachineV2ToListItem(vm)
 		item.CveSeverityCounts = severityByVM[vm.GetId()]
+		if item.CveSeverityCounts == nil {
+			item.CveSeverityCounts = &v2.VulnCountBySeverity{}
+		}
 		item.ComponentScanCount = componentCountsByVM[vm.GetId()]
 		items = append(items, item)
 	}
@@ -191,58 +200,6 @@ func (s *serviceImpl) GetVMDashboardCounts(ctx context.Context, request *v2.VMDa
 		VmCount:  int32(vmCount),
 		CveCount: int32(cveCount),
 	}, nil
-}
-
-// batchCVESeverityByVM fetches all CVEs for the given VM IDs in one query
-// and aggregates severity counts per VM in memory.
-// TODO(ROX-34084): Evaluate whether a SQL view with GROUP BY vm_v2_id would
-// be more efficient than in-memory aggregation for large result sets.
-func (s *serviceImpl) batchCVESeverityByVM(ctx context.Context, vmIDs []string) (map[string]*v2.VulnCountBySeverity, error) {
-	result := make(map[string]*v2.VulnCountBySeverity, len(vmIDs))
-	for _, id := range vmIDs {
-		result[id] = &v2.VulnCountBySeverity{
-			Critical:  &v2.VulnFixableCount{},
-			Important: &v2.VulnFixableCount{},
-			Moderate:  &v2.VulnFixableCount{},
-			Low:       &v2.VulnFixableCount{},
-			Unknown:   &v2.VulnFixableCount{},
-		}
-	}
-	if len(vmIDs) == 0 {
-		return result, nil
-	}
-
-	q := search.NewQueryBuilder().AddExactMatches(search.VirtualMachineID, vmIDs...).ProtoQuery()
-	cves, err := s.cveDS.SearchRawVMCVEs(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, cve := range cves {
-		counts, ok := result[cve.GetVmV2Id()]
-		if !ok {
-			continue
-		}
-		var bucket *v2.VulnFixableCount
-		switch cve.GetSeverity() {
-		case storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY:
-			bucket = counts.GetCritical()
-		case storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY:
-			bucket = counts.GetImportant()
-		case storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY:
-			bucket = counts.GetModerate()
-		case storage.VulnerabilitySeverity_LOW_VULNERABILITY_SEVERITY:
-			bucket = counts.GetLow()
-		default:
-			bucket = counts.GetUnknown()
-		}
-		bucket.Total++
-		if cve.GetIsFixable() {
-			bucket.Fixable++
-		}
-	}
-
-	return result, nil
 }
 
 // batchComponentScanCounts fetches all components for the given VM IDs in one query

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -88,24 +88,17 @@ func (s *serviceImpl) ListVMs(ctx context.Context, request *v2.ListVMsRequest) (
 		return nil, err
 	}
 
-	searchResults, err := s.vmDS.Search(ctx, searchQuery)
+	vms, err := s.vmDS.SearchRawVirtualMachines(ctx, searchQuery)
 	if err != nil {
 		return nil, err
 	}
-
-	vmIDs := make([]string, 0, len(searchResults))
-	for _, r := range searchResults {
-		vmIDs = append(vmIDs, r.ID)
-	}
-
-	if len(vmIDs) == 0 {
+	if len(vms) == 0 {
 		return &v2.ListVMsResponse{TotalCount: int32(totalCount)}, nil
 	}
 
-	// Fetch full VM objects for the page.
-	vms, _, err := s.vmDS.GetManyVirtualMachines(ctx, vmIDs)
-	if err != nil {
-		return nil, err
+	vmIDs := make([]string, 0, len(vms))
+	for _, vm := range vms {
+		vmIDs = append(vmIDs, vm.GetId())
 	}
 
 	// Fetch per-VM CVE severity counts via SQL GROUP BY.

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -119,8 +119,9 @@ func (s *serviceImpl) ListVMs(ctx context.Context, request *v2.ListVMsRequest) (
 	items := make([]*v2.VMListItem, 0, len(vms))
 	for _, vm := range vms {
 		item := storagetov2.VirtualMachineV2ToListItem(vm)
-		item.CveSeverityCounts = severityByVM[vm.GetId()]
-		if item.CveSeverityCounts == nil {
+		if counts, ok := severityByVM[vm.GetId()]; ok {
+			item.CveSeverityCounts = counts
+		} else {
 			item.CveSeverityCounts = &v2.VulnCountBySeverity{}
 		}
 		item.ComponentScanCount = componentCountsByVM[vm.GetId()]
@@ -203,9 +204,8 @@ func (s *serviceImpl) GetVMDashboardCounts(ctx context.Context, request *v2.VMDa
 }
 
 // batchComponentScanCounts fetches all components for the given VM IDs in one query
-// and counts total vs scanned per VM in memory.
-// TODO(ROX-34084): Evaluate whether a SQL view with GROUP BY vm_v2_id would
-// be more efficient than in-memory aggregation for large result sets.
+// and counts total vs scanned per VM in memory. The component Notes field is not
+// search-indexed, so SQL-level aggregation of scanned vs unscanned is not possible.
 func (s *serviceImpl) batchComponentScanCounts(ctx context.Context, vmIDs []string) (map[string]*v2.ComponentScanCount, error) {
 	result := make(map[string]*v2.ComponentScanCount, len(vmIDs))
 	for _, id := range vmIDs {

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -88,14 +88,24 @@ func (s *serviceImpl) ListVMs(ctx context.Context, request *v2.ListVMsRequest) (
 		return nil, err
 	}
 
-	vms, err := s.vmDS.SearchRawVirtualMachines(ctx, searchQuery)
+	searchResults, err := s.vmDS.Search(ctx, searchQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	vmIDs := make([]string, 0, len(vms))
-	for _, vm := range vms {
-		vmIDs = append(vmIDs, vm.GetId())
+	vmIDs := make([]string, 0, len(searchResults))
+	for _, r := range searchResults {
+		vmIDs = append(vmIDs, r.ID)
+	}
+
+	if len(vmIDs) == 0 {
+		return &v2.ListVMsResponse{TotalCount: int32(totalCount)}, nil
+	}
+
+	// Fetch full VM objects for the page.
+	vms, _, err := s.vmDS.GetManyVirtualMachines(ctx, vmIDs)
+	if err != nil {
+		return nil, err
 	}
 
 	// Fetch per-VM CVE severity counts via SQL GROUP BY.
@@ -109,8 +119,9 @@ func (s *serviceImpl) ListVMs(ctx context.Context, request *v2.ListVMsRequest) (
 		severityByVM[row.GetVMID()] = storagetov2.SeverityCountsToProto(row.GetSeverityCounts())
 	}
 
-	// Batch fetch component scan counts (Notes field is not search-indexed,
-	// so in-memory aggregation is used).
+	// Batch fetch component scan counts. The component Notes field has no dedicated
+	// column (no search tag), so SQL-level filtering of scanned vs unscanned is not
+	// possible and in-memory aggregation is used.
 	componentCountsByVM, err := s.batchComponentScanCounts(ctx, vmIDs)
 	if err != nil {
 		return nil, err

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/grpc/testutils"
 	"github.com/stackrox/rox/pkg/protoassert"
-	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -713,8 +712,7 @@ func TestListVMs(t *testing.T) {
 		"successful list with severity and component counts": {
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(1, nil)
-				mockVM.EXPECT().Search(ctx, gomock.Any()).Return([]search.Result{{ID: "vm-1"}}, nil)
-				mockVM.EXPECT().GetManyVirtualMachines(ctx, []string{"vm-1"}).Return([]*storage.VirtualMachineV2{vm1}, nil, nil)
+				mockVM.EXPECT().SearchRawVirtualMachines(ctx, gomock.Any()).Return([]*storage.VirtualMachineV2{vm1}, nil)
 				sevCounts := cveViewMocks.NewMockVMSeverityCounts(gomock.NewController(t))
 				sevCounts.EXPECT().GetVMID().Return("vm-1").AnyTimes()
 				sevCounts.EXPECT().GetSeverityCounts().Return(&commonViews.ResourceCountByImageCVESeverity{
@@ -737,7 +735,7 @@ func TestListVMs(t *testing.T) {
 		"empty list": {
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(0, nil)
-				mockVM.EXPECT().Search(ctx, gomock.Any()).Return(nil, nil)
+				mockVM.EXPECT().SearchRawVirtualMachines(ctx, gomock.Any()).Return(nil, nil)
 			},
 			expectedCount: 0,
 		},

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -691,12 +691,6 @@ func TestListVMs(t *testing.T) {
 		State: storage.VirtualMachineV2_RUNNING,
 	}
 
-	cve1 := &storage.VirtualMachineCVEV2{
-		Id: "cve-uuid-1", VmV2Id: "vm-1",
-		Severity:  storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
-		IsFixable: true,
-	}
-
 	comp1 := &storage.VirtualMachineComponentV2{
 		Id: "comp-1", VmScanId: "scan-1", Name: "openssl", Version: "1.1.1",
 	}
@@ -719,7 +713,9 @@ func TestListVMs(t *testing.T) {
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(1, nil)
 				mockVM.EXPECT().SearchRawVirtualMachines(ctx, gomock.Any()).Return([]*storage.VirtualMachineV2{vm1}, nil)
-				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
+				mockView.EXPECT().CountBySeverityPerVM(ctx, gomock.Any()).Return([]vmcve.VMSeverityCounts{
+					&vmSeverityCountsMock{vmID: "vm-1", critical: 1, fixableCritical: 1},
+				}, nil)
 				mockComp.EXPECT().SearchRawVMComponents(ctx, gomock.Any()).Return([]*storage.VirtualMachineComponentV2{comp1, compUnscanned}, nil)
 				mockScan.EXPECT().GetBatch(ctx, gomock.Any()).Return([]*storage.VirtualMachineScanV2{scan1}, nil)
 			},
@@ -737,6 +733,7 @@ func TestListVMs(t *testing.T) {
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(0, nil)
 				mockVM.EXPECT().SearchRawVirtualMachines(ctx, gomock.Any()).Return([]*storage.VirtualMachineV2{}, nil)
+				mockView.EXPECT().CountBySeverityPerVM(ctx, gomock.Any()).Return(nil, nil)
 			},
 			expectedCount: 0,
 		},
@@ -793,7 +790,32 @@ type mockCveCore struct {
 	discovered *time.Time
 }
 
-func (m *mockCveCore) GetCVE() string      { return m.cve }
+func (m *mockCveCore) GetCVE() string { return m.cve }
+
+type vmSeverityCountsMock struct {
+	vmID                        string
+	critical, fixableCritical   int
+	important, fixableImportant int
+	moderate, fixableModerate   int
+	low, fixableLow             int
+	unknown, fixableUnknown     int
+}
+
+func (m *vmSeverityCountsMock) GetVMID() string { return m.vmID }
+func (m *vmSeverityCountsMock) GetSeverityCounts() commonViews.ResourceCountByCVESeverity {
+	return &commonViews.ResourceCountByImageCVESeverity{
+		CriticalSeverityCount:         m.critical,
+		FixableCriticalSeverityCount:  m.fixableCritical,
+		ImportantSeverityCount:        m.important,
+		FixableImportantSeverityCount: m.fixableImportant,
+		ModerateSeverityCount:         m.moderate,
+		FixableModerateSeverityCount:  m.fixableModerate,
+		LowSeverityCount:              m.low,
+		FixableLowSeverityCount:       m.fixableLow,
+		UnknownSeverityCount:          m.unknown,
+		FixableUnknownSeverityCount:   m.fixableUnknown,
+	}
+}
 func (m *mockCveCore) GetCVEIDs() []string { return m.cveIDs }
 func (m *mockCveCore) GetVMsBySeverity() commonViews.ResourceCountByCVESeverity {
 	return &commonViews.ResourceCountByImageCVESeverity{}

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/stackrox/rox/central/convert/storagetov2"
 	commonViews "github.com/stackrox/rox/central/views/common"
@@ -781,29 +780,6 @@ func TestListVMs(t *testing.T) {
 	}
 }
 
-// mockCveCore implements vmcve.CveCore for testing ListVMCVEs.
-type mockCveCore struct {
-	cve        string
-	cveIDs     []string
-	topCVSS    float32
-	affected   int
-	epss       float32
-	published  *time.Time
-	discovered *time.Time
-}
-
-func (m *mockCveCore) GetCVE() string { return m.cve }
-
-func (m *mockCveCore) GetCVEIDs() []string { return m.cveIDs }
-func (m *mockCveCore) GetVMsBySeverity() commonViews.ResourceCountByCVESeverity {
-	return &commonViews.ResourceCountByImageCVESeverity{}
-}
-func (m *mockCveCore) GetTopCVSS() float32                    { return m.topCVSS }
-func (m *mockCveCore) GetAffectedVMCount() int                { return m.affected }
-func (m *mockCveCore) GetFirstDiscoveredInSystem() *time.Time { return m.discovered }
-func (m *mockCveCore) GetPublishDate() *time.Time             { return m.published }
-func (m *mockCveCore) GetEPSSProbability() float32            { return m.epss }
-
 func TestListVMCVEs(t *testing.T) {
 	ctx := context.Background()
 
@@ -815,9 +791,14 @@ func TestListVMCVEs(t *testing.T) {
 		"successful list": {
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockView.EXPECT().Count(ctx, gomock.Any()).Return(1, nil)
-				mockView.EXPECT().Get(ctx, gomock.Any()).Return([]vmcve.CveCore{
-					&mockCveCore{cve: "CVE-2024-1234", topCVSS: 7.5, affected: 3, epss: 0.5},
-				}, nil)
+				cveCore := cveViewMocks.NewMockCveCore(gomock.NewController(t))
+				cveCore.EXPECT().GetCVE().Return("CVE-2024-1234").AnyTimes()
+				cveCore.EXPECT().GetVMsBySeverity().Return(&commonViews.ResourceCountByImageCVESeverity{}).AnyTimes()
+				cveCore.EXPECT().GetTopCVSS().Return(float32(7.5)).AnyTimes()
+				cveCore.EXPECT().GetAffectedVMCount().Return(3).AnyTimes()
+				cveCore.EXPECT().GetEPSSProbability().Return(float32(0.5)).AnyTimes()
+				cveCore.EXPECT().GetPublishDate().Return(nil).AnyTimes()
+				mockView.EXPECT().Get(ctx, gomock.Any()).Return([]vmcve.CveCore{cveCore}, nil)
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(10, nil)
 			},
 			expectedCount: 1,

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/grpc/testutils"
 	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -712,10 +713,14 @@ func TestListVMs(t *testing.T) {
 		"successful list with severity and component counts": {
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(1, nil)
-				mockVM.EXPECT().SearchRawVirtualMachines(ctx, gomock.Any()).Return([]*storage.VirtualMachineV2{vm1}, nil)
-				mockView.EXPECT().CountBySeverityPerVM(ctx, gomock.Any()).Return([]vmcve.VMSeverityCounts{
-					&vmSeverityCountsMock{vmID: "vm-1", critical: 1, fixableCritical: 1},
-				}, nil)
+				mockVM.EXPECT().Search(ctx, gomock.Any()).Return([]search.Result{{ID: "vm-1"}}, nil)
+				mockVM.EXPECT().GetManyVirtualMachines(ctx, []string{"vm-1"}).Return([]*storage.VirtualMachineV2{vm1}, nil, nil)
+				sevCounts := cveViewMocks.NewMockVMSeverityCounts(gomock.NewController(t))
+				sevCounts.EXPECT().GetVMID().Return("vm-1").AnyTimes()
+				sevCounts.EXPECT().GetSeverityCounts().Return(&commonViews.ResourceCountByImageCVESeverity{
+					CriticalSeverityCount: 1, FixableCriticalSeverityCount: 1,
+				}).AnyTimes()
+				mockView.EXPECT().CountBySeverityPerVM(ctx, gomock.Any()).Return([]vmcve.VMSeverityCounts{sevCounts}, nil)
 				mockComp.EXPECT().SearchRawVMComponents(ctx, gomock.Any()).Return([]*storage.VirtualMachineComponentV2{comp1, compUnscanned}, nil)
 				mockScan.EXPECT().GetBatch(ctx, gomock.Any()).Return([]*storage.VirtualMachineScanV2{scan1}, nil)
 			},
@@ -732,8 +737,7 @@ func TestListVMs(t *testing.T) {
 		"empty list": {
 			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, mockComp *componentDSMocks.MockDataStore, mockScan *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
 				mockVM.EXPECT().CountVirtualMachines(ctx, gomock.Any()).Return(0, nil)
-				mockVM.EXPECT().SearchRawVirtualMachines(ctx, gomock.Any()).Return([]*storage.VirtualMachineV2{}, nil)
-				mockView.EXPECT().CountBySeverityPerVM(ctx, gomock.Any()).Return(nil, nil)
+				mockVM.EXPECT().Search(ctx, gomock.Any()).Return(nil, nil)
 			},
 			expectedCount: 0,
 		},
@@ -792,30 +796,6 @@ type mockCveCore struct {
 
 func (m *mockCveCore) GetCVE() string { return m.cve }
 
-type vmSeverityCountsMock struct {
-	vmID                        string
-	critical, fixableCritical   int
-	important, fixableImportant int
-	moderate, fixableModerate   int
-	low, fixableLow             int
-	unknown, fixableUnknown     int
-}
-
-func (m *vmSeverityCountsMock) GetVMID() string { return m.vmID }
-func (m *vmSeverityCountsMock) GetSeverityCounts() commonViews.ResourceCountByCVESeverity {
-	return &commonViews.ResourceCountByImageCVESeverity{
-		CriticalSeverityCount:         m.critical,
-		FixableCriticalSeverityCount:  m.fixableCritical,
-		ImportantSeverityCount:        m.important,
-		FixableImportantSeverityCount: m.fixableImportant,
-		ModerateSeverityCount:         m.moderate,
-		FixableModerateSeverityCount:  m.fixableModerate,
-		LowSeverityCount:              m.low,
-		FixableLowSeverityCount:       m.fixableLow,
-		UnknownSeverityCount:          m.unknown,
-		FixableUnknownSeverityCount:   m.fixableUnknown,
-	}
-}
 func (m *mockCveCore) GetCVEIDs() []string { return m.cveIDs }
 func (m *mockCveCore) GetVMsBySeverity() commonViews.ResourceCountByCVESeverity {
 	return &commonViews.ResourceCountByImageCVESeverity{}


### PR DESCRIPTION
## Description

Add CountBySeverityPerVM to vmcve.CveView which does severity/fixability aggregation with GROUP BY vm_v2_id in SQL, returning per-VM counts. Replaces batchCVESeverityByVM which fetched all CVEs into memory.

Component scan counts remain in-memory since the Notes field is not search-indexed.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Unit tests updated. batchCVESeverityByVM removed.
