### PR TITLE
ROX-33490: Make cluster labels read only in UI

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterDeployment.tsx
@@ -30,23 +30,24 @@ function ClusterDeployment({
 }: ClusterDeploymentProps): ReactElement {
     const { analyticsTrack } = useAnalytics();
 
-    let managerTypeTitle = 'Dynamic configurations are automatically applied';
-    let managerTypeText =
-        'If you edited static configurations or you need to redeploy, download a new bundle.';
-    if (managerType === 'MANAGER_TYPE_KUBERNETES_OPERATOR') {
-        managerTypeTitle = 'Cluster labels have been saved';
-        managerTypeText = 'All other cluster settings are managed by the Kubernetes operator.';
-    }
-    if (managerType === 'MANAGER_TYPE_HELM_CHART') {
-        managerTypeTitle = 'Cluster labels have been saved';
-        managerTypeText = 'All other cluster settings are managed by the Helm chart.';
-    }
+    const isHelmOrOperatorManaged =
+        managerType === 'MANAGER_TYPE_KUBERNETES_OPERATOR' ||
+        managerType === 'MANAGER_TYPE_HELM_CHART';
+
+    const showPostCheckInSavedConfigAlert = editing && clusterCheckedIn && !isHelmOrOperatorManaged;
+
     // Without FlexItem element, Button stretches to column width.
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
-            {editing && clusterCheckedIn && (
-                <Alert variant="info" isInline title={managerTypeTitle} component="p">
-                    {managerTypeText}
+            {showPostCheckInSavedConfigAlert && (
+                <Alert
+                    variant="info"
+                    isInline
+                    title="Dynamic configurations are automatically applied"
+                    component="p"
+                >
+                    If you edited static configurations or you need to redeploy, download a new
+                    bundle.
                 </Alert>
             )}
             {managerType !== 'MANAGER_TYPE_KUBERNETES_OPERATOR' && (

--- a/ui/apps/platform/src/Containers/Clusters/ClusterLabelsConfigurationStatusSummary.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterLabelsConfigurationStatusSummary.tsx
@@ -1,16 +1,14 @@
 import type { ReactElement } from 'react';
-import { Alert, Flex, FlexItem, Title } from '@patternfly/react-core';
+import { Alert, Content, Flex, FlexItem, Title } from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import type { Cluster, ClusterManagerType, CompleteClusterConfig } from 'types/cluster.proto';
 import type { DecommissionedClusterRetentionInfo } from 'types/clusterService.proto';
-
-import ClusterLabelsTable from './ClusterLabelsTable';
 import ClusterStatusGrid from './ClusterStatusGrid';
 import ClusterSummaryGrid from './ClusterSummaryGrid';
 import DynamicConfigurationForm from './DynamicConfigurationForm';
 import StaticConfigurationForm from './StaticConfigurationForm';
-
 // Delete whenever deprecated properties are deleted.
 function getClusterHasDefaultsForAdmissionController(helmConfig: CompleteClusterConfig) {
     return (
@@ -30,7 +28,6 @@ type ClusterLabelsConfigurationStatusSummaryProps = {
     managerType: ClusterManagerType;
     handleChange: (path: string, value: boolean | number | string) => void;
     handleChangeAdmissionControllerEnforcementBehavior: (value: boolean) => void;
-    handleChangeLabels: (labels) => void;
 };
 
 function ClusterLabelsConfigurationStatusSummary({
@@ -40,7 +37,6 @@ function ClusterLabelsConfigurationStatusSummary({
     managerType,
     handleChange,
     handleChangeAdmissionControllerEnforcementBehavior,
-    handleChangeLabels,
 }: ClusterLabelsConfigurationStatusSummaryProps): ReactElement {
     const isManagerTypeNonConfigurable =
         managerType === 'MANAGER_TYPE_KUBERNETES_OPERATOR' ||
@@ -77,11 +73,30 @@ function ClusterLabelsConfigurationStatusSummary({
             {selectedCluster.id && (
                 <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
                     <Title headingLevel="h2">Cluster labels</Title>
-                    <ClusterLabelsTable
-                        labels={selectedCluster?.labels ?? {}}
-                        handleChangeLabels={handleChangeLabels}
-                        hasAction
-                    />
+                    {Object.keys(selectedCluster?.labels ?? {}).length === 0 ? (
+                        <Content component="p">No labels</Content>
+                    ) : (
+                        <Table variant="compact" aria-label="Cluster labels">
+                            <Thead>
+                                <Tr>
+                                    <Th>Key</Th>
+                                    <Th>Value</Th>
+                                </Tr>
+                            </Thead>
+                            <Tbody>
+                                {Object.entries(selectedCluster.labels).map(([key, value]) => (
+                                    <Tr key={key}>
+                                        <Td dataLabel="Key" modifier="breakWord">
+                                            {key}
+                                        </Td>
+                                        <Td dataLabel="Value" modifier="breakWord">
+                                            {value}
+                                        </Td>
+                                    </Tr>
+                                ))}
+                            </Tbody>
+                        </Table>
+                    )}
                 </Flex>
             )}
             {isManagerTypeNonConfigurable &&

--- a/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterLabelsTable.tsx
@@ -9,30 +9,19 @@ import { getIsValidLabelKey, getIsValidLabelValue } from 'utils/labels';
 
 export type ClusterLabelsTableProps = {
     labels: ClusterLabels;
-    hasAction: boolean;
     handleChangeLabels: (labels: ClusterLabels) => void;
-    isValueRequired?: boolean;
 };
 
 /*
- * Render table of cluster labels.
- *
- * If hasAction (always at the moment)
- * render delete buttons at the right of each label row
- * render a row to add a new label or replace an existing label
+ * Editable table of cluster labels: add, replace, and delete rows.
  */
-function ClusterLabelsTable({
-    labels,
-    hasAction,
-    handleChangeLabels,
-    isValueRequired,
-}: ClusterLabelsTableProps): ReactElement {
+function ClusterLabelsTable({ labels, handleChangeLabels }: ClusterLabelsTableProps): ReactElement {
     const refKeyInput = useRef<null | HTMLInputElement>(null); // for focus after adding a label
     const [keyInput, setKeyInput] = useState('');
     const [valueInput, setValueInput] = useState('');
 
     const isValidKey = getIsValidLabelKey(keyInput);
-    const isValidValue = getIsValidLabelValue(valueInput, isValueRequired);
+    const isValidValue = getIsValidLabelValue(valueInput, true);
     const isValid = isValidKey && isValidValue;
 
     const isReplace = Object.prototype.hasOwnProperty.call(labels, keyInput); // no-prototype-builtins
@@ -73,12 +62,12 @@ function ClusterLabelsTable({
     }
 
     return (
-        <Table variant="compact">
+        <Table variant="compact" aria-label="Cluster labels">
             <Thead>
                 <Tr>
                     <Th>Key</Th>
                     <Th>Value</Th>
-                    {hasAction && <Th>Action</Th>}
+                    <Th>Action</Th>
                 </Tr>
             </Thead>
             <Tbody>
@@ -98,84 +87,80 @@ function ClusterLabelsTable({
                         <Td dataLabel="Value" modifier="breakWord">
                             {value}
                         </Td>
-                        {hasAction && (
-                            <Td dataLabel="Action">
-                                <Tooltip content="Delete value">
-                                    <Button
-                                        icon={
-                                            <TimesCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />
-                                        }
-                                        aria-label="Delete value"
-                                        variant="plain"
-                                        style={{ padding: 0 }}
-                                        onClick={() => onDeleteLabel(key)}
-                                    />
-                                </Tooltip>
-                            </Td>
-                        )}
-                    </Tr>
-                ))}
-                {hasAction && (
-                    <Tr>
-                        <Td dataLabel="Key">
-                            <TextInput
-                                aria-label="Type a label key"
-                                value={keyInput}
-                                validated={validatedKey}
-                                onChange={(_event, val) => setKeyInput(val)}
-                                ref={refKeyInput}
-                            />
-                            {validatedKey === ValidatedOptions.error && (
-                                <p className="pf-v6-u-font-size-sm pf-v6-u-text-color-status-danger">
-                                    Invalid label key
-                                </p>
-                            )}
-                            {validatedKey === ValidatedOptions.warning && (
-                                <p className="pf-v6-u-font-size-sm pf-v6-u-text-color-status-warning">
-                                    You will replace an existing label which has the same key
-                                </p>
-                            )}
-                        </Td>
-                        <Td dataLabel="Value">
-                            <TextInput
-                                aria-label="Type a label value"
-                                value={valueInput}
-                                validated={validatedValue}
-                                onChange={(_event, val) => setValueInput(val)}
-                                onKeyPress={onKeyPressValue}
-                            />
-                            {validatedValue === ValidatedOptions.error && (
-                                <p className="pf-v6-u-font-size-sm pf-v6-u-text-color-status-danger">
-                                    {valueInput.length === 0
-                                        ? 'Label value is required'
-                                        : 'Invalid label value'}
-                                </p>
-                            )}
-                        </Td>
                         <Td dataLabel="Action">
-                            <Tooltip content={isReplace ? 'Replace label' : 'Add label'}>
+                            <Tooltip content="Delete value">
                                 <Button
                                     icon={
-                                        <Icon>
-                                            <PlusCircleIcon
-                                                color={
-                                                    isReplace
-                                                        ? 'var(--pf-t--global--icon--color--status--warning--default)'
-                                                        : 'var(--pf-t--global--icon--color--status--success--default)'
-                                                }
-                                            />
-                                        </Icon>
+                                        <TimesCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />
                                     }
-                                    aria-label={isReplace ? 'Replace label' : 'Add label'}
+                                    aria-label="Delete value"
                                     variant="plain"
                                     style={{ padding: 0 }}
-                                    isDisabled={!isValid}
-                                    onClick={() => onAddLabel()}
+                                    onClick={() => onDeleteLabel(key)}
                                 />
                             </Tooltip>
                         </Td>
                     </Tr>
-                )}
+                ))}
+                <Tr>
+                    <Td dataLabel="Key">
+                        <TextInput
+                            aria-label="Type a label key"
+                            value={keyInput}
+                            validated={validatedKey}
+                            onChange={(_event, val) => setKeyInput(val)}
+                            ref={refKeyInput}
+                        />
+                        {validatedKey === ValidatedOptions.error && (
+                            <p className="pf-v6-u-font-size-sm pf-v6-u-text-color-status-danger">
+                                Invalid label key
+                            </p>
+                        )}
+                        {validatedKey === ValidatedOptions.warning && (
+                            <p className="pf-v6-u-font-size-sm pf-v6-u-text-color-status-warning">
+                                You will replace an existing label which has the same key
+                            </p>
+                        )}
+                    </Td>
+                    <Td dataLabel="Value">
+                        <TextInput
+                            aria-label="Type a label value"
+                            value={valueInput}
+                            validated={validatedValue}
+                            onChange={(_event, val) => setValueInput(val)}
+                            onKeyPress={onKeyPressValue}
+                        />
+                        {validatedValue === ValidatedOptions.error && (
+                            <p className="pf-v6-u-font-size-sm pf-v6-u-text-color-status-danger">
+                                {valueInput.length === 0
+                                    ? 'Label value is required'
+                                    : 'Invalid label value'}
+                            </p>
+                        )}
+                    </Td>
+                    <Td dataLabel="Action">
+                        <Tooltip content={isReplace ? 'Replace label' : 'Add label'}>
+                            <Button
+                                icon={
+                                    <Icon>
+                                        <PlusCircleIcon
+                                            color={
+                                                isReplace
+                                                    ? 'var(--pf-t--global--icon--color--status--warning--default)'
+                                                    : 'var(--pf-t--global--icon--color--status--success--default)'
+                                            }
+                                        />
+                                    </Icon>
+                                }
+                                aria-label={isReplace ? 'Replace label' : 'Add label'}
+                                variant="plain"
+                                style={{ padding: 0 }}
+                                isDisabled={!isValid}
+                                onClick={() => onAddLabel()}
+                            />
+                        </Tooltip>
+                    </Td>
+                </Tr>
             </Tbody>
         </Table>
     );

--- a/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterPage.tsx
@@ -225,15 +225,6 @@ function ClusterPage({ clusterId }: ClusterPageProps): ReactElement {
         });
     }
 
-    /*
-     * Adapt preceding code for labels whose value is not from an input element.
-     */
-    function handleChangeLabels(labels) {
-        setSelectedCluster((oldClusterSettings) => {
-            return { ...oldClusterSettings, labels };
-        });
-    }
-
     function onNext() {
         if (wizardStep === 'FORM') {
             setMessageState(null);
@@ -354,7 +345,6 @@ function ClusterPage({ clusterId }: ClusterPageProps): ReactElement {
                                 handleChangeAdmissionControllerEnforcementBehavior={
                                     onChangeAdmissionControllerEnforcementBehavior
                                 }
-                                handleChangeLabels={handleChangeLabels}
                             />
                         ))}
                     {!isBlocked && wizardStep === 'DEPLOYMENT' && (

--- a/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Details/PrivateConfigDataRetentionDetails.tsx
@@ -14,8 +14,7 @@ import {
     Tooltip,
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
-
-import ClusterLabelsTable from 'Containers/Clusters/ClusterLabelsTable';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import type { PrivateConfig } from 'types/config.proto';
 import { clustersBasePath } from 'routePaths';
 
@@ -279,13 +278,29 @@ const PrivateConfigDataRetentionDetails = ({
                         ).length === 0 ? (
                             'No labels'
                         ) : (
-                            <ClusterLabelsTable
-                                labels={
-                                    privateConfig.decommissionedClusterRetention.ignoreClusterLabels
-                                }
-                                hasAction={false}
-                                handleChangeLabels={() => {}}
-                            />
+                            <Table variant="compact" aria-label="Cluster labels">
+                                <Thead>
+                                    <Tr>
+                                        <Th>Key</Th>
+                                        <Th>Value</Th>
+                                    </Tr>
+                                </Thead>
+                                <Tbody>
+                                    {Object.entries(
+                                        privateConfig.decommissionedClusterRetention
+                                            .ignoreClusterLabels
+                                    ).map(([key, value]) => (
+                                        <Tr key={key}>
+                                            <Td dataLabel="Key" modifier="breakWord">
+                                                {key}
+                                            </Td>
+                                            <Td dataLabel="Value" modifier="breakWord">
+                                                {value}
+                                            </Td>
+                                        </Tr>
+                                    ))}
+                                </Tbody>
+                            </Table>
                         )}
                     </CardBody>
                     {isClustersRoutePathRendered && (

--- a/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
+++ b/ui/apps/platform/src/Containers/SystemConfig/Form/SystemConfigForm.tsx
@@ -519,9 +519,7 @@ const SystemConfigForm = ({
                                         values.privateConfig.decommissionedClusterRetention
                                             .ignoreClusterLabels
                                     }
-                                    hasAction
                                     handleChangeLabels={handleChangeLabels}
-                                    isValueRequired
                                 />
                             </FormGroup>
                         </GridItem>


### PR DESCRIPTION
## Description

Remove cluster label editing from the UI

####  Notes:
- Split cluster label UI by intent
  - `ClusterLabelsTable` = edit-only (add / replace / delete, validation)
  - Read only views use a simple PatternFly table + “No labels” empty state
- Removed add/edit labels from cluster page
  - Those edits only lived in Central (acs database) and didn’t propagate to Sensor

#### Caveat
Removing this also removes a workaround some users relied on. UI labels could be used to differentiate clusters when Sensor wasn’t communicating with Central (to avoid auto deletion). However, users can still use the API to add a label and work around this edge-case.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Verified that cluster labels added using helm or through the SecuredCluster CR still show up as read only labels in the UI

#### Clusters Page

Cluster without labels:
<img width="1770" height="422" alt="Screenshot 2026-04-21 at 11 33 06 AM" src="https://github.com/user-attachments/assets/da6078b5-5142-4ef2-9acb-bce3f6826364" />

Cluster with labels:
<img width="1770" height="422" alt="Screenshot 2026-04-21 at 11 32 52 AM" src="https://github.com/user-attachments/assets/87bb97b9-10bc-4efc-9993-e455543c5ba2" />

---

#### System Config Page

View state:
<img width="896" height="368" alt="Screenshot 2026-04-21 at 11 33 25 AM" src="https://github.com/user-attachments/assets/c8998bc0-5d78-4de3-a809-1d5d4038d884" />


Edit state:
<img width="896" height="368" alt="Screenshot 2026-04-21 at 11 33 34 AM" src="https://github.com/user-attachments/assets/ebcc673d-6ce0-4025-bbf3-d6c795785487" />

