### PR TITLE
ROX-30650: Mount Red Hat signing keys dir in central Helm chart

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -456,7 +456,8 @@ jobs:
           make -C operator/ docker-push-index | cat
 
   build-and-push-main:
-    runs-on: ubuntu-latest
+    # Use native arm64 runner to avoid QEMU emulation overhead (~2x slower).
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-latest' }}
     needs:
       - define-job-matrix
       - pre-build-cli
@@ -535,7 +536,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_CI_ACCOUNT_PASSWORD }}
 
       - name: Set up QEMU
-        if: matrix.arch != 'amd64'
+        if: matrix.arch != 'amd64' && matrix.arch != 'arm64'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
@@ -784,7 +785,7 @@ jobs:
         message-path: build-comment.md
 
   build-and-push-operator:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-latest' }}
     needs:
       - define-job-matrix
       - pre-build-go-binaries
@@ -862,7 +863,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_CI_ACCOUNT_PASSWORD }}
 
       - name: Set up QEMU
-        if: matrix.arch != 'amd64'
+        if: matrix.arch != 'amd64' && matrix.arch != 'arm64'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
       - name: Check that Operator image is runnable

--- a/central/signatureintegration/datastore/datastore_decoration_test.go
+++ b/central/signatureintegration/datastore/datastore_decoration_test.go
@@ -1,0 +1,162 @@
+package datastore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	storeMocks "github.com/stackrox/rox/central/signatureintegration/store/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/signatures"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// readCtx is an all-access read context suitable for unit tests.
+func allAccessCtx() context.Context {
+	return sac.WithAllAccess(context.Background())
+}
+
+// newDecorationTestDataStore creates a datastoreImpl backed by a mock store for decoration tests.
+func newDecorationTestDataStore(t *testing.T) (DataStore, *storeMocks.MockSignatureIntegrationStore) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+	ds := New(mockStore, nil)
+	return ds, mockStore
+}
+
+// rhIntegrationWithKeys returns a copy of the default Red Hat integration.
+func rhIntegrationWithKeys(extraKeys ...*storage.CosignPublicKeyVerification_PublicKey) *storage.SignatureIntegration {
+	cloned := signatures.DefaultRedHatSignatureIntegration.CloneVT()
+	cloned.Cosign.PublicKeys = append(cloned.Cosign.PublicKeys, extraKeys...)
+	return cloned
+}
+
+func TestGetSignatureIntegration_DecoratesRedHatIntegration(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.pub"), []byte(anotherValidPublicKeyPEM), 0o600))
+
+	ds, mockStore := newDecorationTestDataStore(t)
+	rhID := signatures.DefaultRedHatSignatureIntegration.GetId()
+	mockStore.EXPECT().Get(gomock.Any(), rhID).Return(rhIntegrationWithKeys(), true, nil)
+
+	result, found, err := ds.GetSignatureIntegration(allAccessCtx(), rhID)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	// Should now have the embedded key plus the extra one from the directory.
+	require.Len(t, result.GetCosign().GetPublicKeys(), 2)
+	names := map[string]struct{}{}
+	for _, k := range result.GetCosign().GetPublicKeys() {
+		names[k.GetName()] = struct{}{}
+	}
+	require.Contains(t, names, "extra.pub")
+}
+
+func TestGetSignatureIntegration_DoesNotDecorateNonRedHatIntegration(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.pub"), []byte(anotherValidPublicKeyPEM), 0o600))
+
+	ds, mockStore := newDecorationTestDataStore(t)
+
+	userIntegration := &storage.SignatureIntegration{
+		Id:   GenerateSignatureIntegrationID(),
+		Name: "user-created",
+		Cosign: &storage.CosignPublicKeyVerification{
+			PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
+				{Name: "my-key", PublicKeyPemEnc: validPublicKeyPEM},
+			},
+		},
+	}
+	mockStore.EXPECT().Get(gomock.Any(), userIntegration.GetId()).Return(userIntegration, true, nil)
+
+	result, found, err := ds.GetSignatureIntegration(allAccessCtx(), userIntegration.GetId())
+	require.NoError(t, err)
+	require.True(t, found)
+	// Should only have the original key — no decoration.
+	require.Len(t, result.GetCosign().GetPublicKeys(), 1)
+	require.Equal(t, "my-key", result.GetCosign().GetPublicKeys()[0].GetName())
+}
+
+func TestGetAllSignatureIntegrations_DecoratesOnlyRedHatIntegration(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.pub"), []byte(anotherValidPublicKeyPEM), 0o600))
+
+	ds, mockStore := newDecorationTestDataStore(t)
+
+	userIntegration := &storage.SignatureIntegration{
+		Id:   GenerateSignatureIntegrationID(),
+		Name: "user-created",
+		Cosign: &storage.CosignPublicKeyVerification{
+			PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
+				{Name: "my-key", PublicKeyPemEnc: validPublicKeyPEM},
+			},
+		},
+	}
+
+	mockStore.EXPECT().Walk(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, fn func(*storage.SignatureIntegration) error) error {
+			if err := fn(rhIntegrationWithKeys()); err != nil {
+				return err
+			}
+			return fn(userIntegration)
+		},
+	)
+
+	results, err := ds.GetAllSignatureIntegrations(allAccessCtx())
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	for _, r := range results {
+		if r.GetId() == signatures.DefaultRedHatSignatureIntegration.GetId() {
+			// Red Hat integration must be decorated.
+			require.Len(t, r.GetCosign().GetPublicKeys(), 2, "Red Hat integration should have 2 keys")
+		} else {
+			// User integration must be untouched.
+			require.Len(t, r.GetCosign().GetPublicKeys(), 1, "user integration should have 1 key")
+		}
+	}
+}
+
+func TestGetSignatureIntegration_EmptyRuntimeDir_ReturnsOnlyEmbeddedKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	ds, mockStore := newDecorationTestDataStore(t)
+	rhID := signatures.DefaultRedHatSignatureIntegration.GetId()
+	mockStore.EXPECT().Get(gomock.Any(), rhID).Return(rhIntegrationWithKeys(), true, nil)
+
+	result, found, err := ds.GetSignatureIntegration(allAccessCtx(), rhID)
+	require.NoError(t, err)
+	require.True(t, found)
+	// Only the embedded key from DefaultRedHatSignatureIntegration.
+	require.Len(t, result.GetCosign().GetPublicKeys(), 1)
+}
+
+func TestGetSignatureIntegration_DeduplicatesKeysFromDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	// Write a file whose PEM matches the embedded key — should not be added twice.
+	embeddedPEM := signatures.DefaultRedHatSignatureIntegration.GetCosign().GetPublicKeys()[0].GetPublicKeyPemEnc()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "duplicate.pub"), []byte(embeddedPEM), 0o600))
+
+	ds, mockStore := newDecorationTestDataStore(t)
+	rhID := signatures.DefaultRedHatSignatureIntegration.GetId()
+	mockStore.EXPECT().Get(gomock.Any(), rhID).Return(rhIntegrationWithKeys(), true, nil)
+
+	result, found, err := ds.GetSignatureIntegration(allAccessCtx(), rhID)
+	require.NoError(t, err)
+	require.True(t, found)
+	// Still only one key — the duplicate was filtered.
+	require.Len(t, result.GetCosign().GetPublicKeys(), 1)
+}

--- a/central/signatureintegration/datastore/datastore_decoration_test.go
+++ b/central/signatureintegration/datastore/datastore_decoration_test.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,149 +15,139 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-// readCtx is an all-access read context suitable for unit tests.
+// allAccessCtx returns an all-access context suitable for unit tests.
 func allAccessCtx() context.Context {
 	return sac.WithAllAccess(context.Background())
 }
 
-// newDecorationTestDataStore creates a datastoreImpl backed by a mock store for decoration tests.
-func newDecorationTestDataStore(t *testing.T) (DataStore, *storeMocks.MockSignatureIntegrationStore) {
+// newUpsertTestStore creates a mock store for upsert tests.
+func newUpsertTestStore(t *testing.T) *storeMocks.MockSignatureIntegrationStore {
 	t.Helper()
 	ctrl := gomock.NewController(t)
-	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
-	ds := New(mockStore, nil)
-	return ds, mockStore
+	return storeMocks.NewMockSignatureIntegrationStore(ctrl)
 }
 
-// rhIntegrationWithKeys returns a copy of the default Red Hat integration.
-func rhIntegrationWithKeys(extraKeys ...*storage.CosignPublicKeyVerification_PublicKey) *storage.SignatureIntegration {
-	cloned := signatures.DefaultRedHatSignatureIntegration.CloneVT()
-	cloned.Cosign.PublicKeys = append(cloned.Cosign.PublicKeys, extraKeys...)
-	return cloned
-}
-
-func TestGetSignatureIntegration_DecoratesRedHatIntegration(t *testing.T) {
+func TestUpsertRedHatSignatureIntegration_EmbeddedKeyOnly(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
 
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.pub"), []byte(anotherValidPublicKeyPEM), 0o600))
-
-	ds, mockStore := newDecorationTestDataStore(t)
-	rhID := signatures.DefaultRedHatSignatureIntegration.GetId()
-	mockStore.EXPECT().Get(gomock.Any(), rhID).Return(rhIntegrationWithKeys(), true, nil)
-
-	result, found, err := ds.GetSignatureIntegration(allAccessCtx(), rhID)
-	require.NoError(t, err)
-	require.True(t, found)
-
-	// Should now have the embedded key plus the extra one from the directory.
-	require.Len(t, result.GetCosign().GetPublicKeys(), 2)
-	names := map[string]struct{}{}
-	for _, k := range result.GetCosign().GetPublicKeys() {
-		names[k.GetName()] = struct{}{}
-	}
-	require.Contains(t, names, "extra.pub")
-}
-
-func TestGetSignatureIntegration_DoesNotDecorateNonRedHatIntegration(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
-
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.pub"), []byte(anotherValidPublicKeyPEM), 0o600))
-
-	ds, mockStore := newDecorationTestDataStore(t)
-
-	userIntegration := &storage.SignatureIntegration{
-		Id:   GenerateSignatureIntegrationID(),
-		Name: "user-created",
-		Cosign: &storage.CosignPublicKeyVerification{
-			PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
-				{Name: "my-key", PublicKeyPemEnc: validPublicKeyPEM},
-			},
-		},
-	}
-	mockStore.EXPECT().Get(gomock.Any(), userIntegration.GetId()).Return(userIntegration, true, nil)
-
-	result, found, err := ds.GetSignatureIntegration(allAccessCtx(), userIntegration.GetId())
-	require.NoError(t, err)
-	require.True(t, found)
-	// Should only have the original key — no decoration.
-	require.Len(t, result.GetCosign().GetPublicKeys(), 1)
-	require.Equal(t, "my-key", result.GetCosign().GetPublicKeys()[0].GetName())
-}
-
-func TestGetAllSignatureIntegrations_DecoratesOnlyRedHatIntegration(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
-
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.pub"), []byte(anotherValidPublicKeyPEM), 0o600))
-
-	ds, mockStore := newDecorationTestDataStore(t)
-
-	userIntegration := &storage.SignatureIntegration{
-		Id:   GenerateSignatureIntegrationID(),
-		Name: "user-created",
-		Cosign: &storage.CosignPublicKeyVerification{
-			PublicKeys: []*storage.CosignPublicKeyVerification_PublicKey{
-				{Name: "my-key", PublicKeyPemEnc: validPublicKeyPEM},
-			},
-		},
-	}
-
-	mockStore.EXPECT().Walk(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, fn func(*storage.SignatureIntegration) error) error {
-			if err := fn(rhIntegrationWithKeys()); err != nil {
-				return err
-			}
-			return fn(userIntegration)
+	mockStore := newUpsertTestStore(t)
+	mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, si *storage.SignatureIntegration) error {
+			require.Equal(t, signatures.DefaultRedHatSignatureIntegration.GetId(), si.GetId())
+			require.Len(t, si.GetCosign().GetPublicKeys(), 1,
+				"empty dir: only the embedded key should be present")
+			return nil
 		},
 	)
 
-	results, err := ds.GetAllSignatureIntegrations(allAccessCtx())
-	require.NoError(t, err)
-	require.Len(t, results, 2)
-
-	for _, r := range results {
-		if r.GetId() == signatures.DefaultRedHatSignatureIntegration.GetId() {
-			// Red Hat integration must be decorated.
-			require.Len(t, r.GetCosign().GetPublicKeys(), 2, "Red Hat integration should have 2 keys")
-		} else {
-			// User integration must be untouched.
-			require.Len(t, r.GetCosign().GetPublicKeys(), 1, "user integration should have 1 key")
-		}
-	}
+	upsertRedHatSignatureIntegration(mockStore)
 }
 
-func TestGetSignatureIntegration_EmptyRuntimeDir_ReturnsOnlyEmbeddedKey(t *testing.T) {
+func TestUpsertRedHatSignatureIntegration_AddsKeysFromDir(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
 
-	ds, mockStore := newDecorationTestDataStore(t)
-	rhID := signatures.DefaultRedHatSignatureIntegration.GetId()
-	mockStore.EXPECT().Get(gomock.Any(), rhID).Return(rhIntegrationWithKeys(), true, nil)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.pub"), []byte(anotherValidPublicKeyPEM), 0o600))
 
-	result, found, err := ds.GetSignatureIntegration(allAccessCtx(), rhID)
-	require.NoError(t, err)
-	require.True(t, found)
-	// Only the embedded key from DefaultRedHatSignatureIntegration.
-	require.Len(t, result.GetCosign().GetPublicKeys(), 1)
+	mockStore := newUpsertTestStore(t)
+	mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, si *storage.SignatureIntegration) error {
+			require.Equal(t, signatures.DefaultRedHatSignatureIntegration.GetId(), si.GetId())
+			require.Len(t, si.GetCosign().GetPublicKeys(), 2,
+				"embedded key + one dir key expected")
+			names := map[string]struct{}{}
+			for _, k := range si.GetCosign().GetPublicKeys() {
+				names[k.GetName()] = struct{}{}
+			}
+			require.Contains(t, names, "extra.pub")
+			return nil
+		},
+	)
+
+	upsertRedHatSignatureIntegration(mockStore)
 }
 
-func TestGetSignatureIntegration_DeduplicatesKeysFromDir(t *testing.T) {
+func TestUpsertRedHatSignatureIntegration_DeduplicatesDirKey(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
 
-	// Write a file whose PEM matches the embedded key — should not be added twice.
+	// Write a file that contains the same key as the embedded key.
 	embeddedPEM := signatures.DefaultRedHatSignatureIntegration.GetCosign().GetPublicKeys()[0].GetPublicKeyPemEnc()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "duplicate.pub"), []byte(embeddedPEM), 0o600))
 
-	ds, mockStore := newDecorationTestDataStore(t)
-	rhID := signatures.DefaultRedHatSignatureIntegration.GetId()
-	mockStore.EXPECT().Get(gomock.Any(), rhID).Return(rhIntegrationWithKeys(), true, nil)
+	mockStore := newUpsertTestStore(t)
+	mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, si *storage.SignatureIntegration) error {
+			require.Len(t, si.GetCosign().GetPublicKeys(), 1,
+				"duplicate key from dir must be dropped")
+			return nil
+		},
+	)
 
-	result, found, err := ds.GetSignatureIntegration(allAccessCtx(), rhID)
-	require.NoError(t, err)
-	require.True(t, found)
-	// Still only one key — the duplicate was filtered.
-	require.Len(t, result.GetCosign().GetPublicKeys(), 1)
+	upsertRedHatSignatureIntegration(mockStore)
+}
+
+func TestUpsertRedHatSignatureIntegration_DeduplicatesWithTrailingWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	// Write the embedded key with extra trailing newlines — must still be treated as duplicate.
+	embeddedPEM := signatures.DefaultRedHatSignatureIntegration.GetCosign().GetPublicKeys()[0].GetPublicKeyPemEnc()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "trailing.pub"), []byte(embeddedPEM+"\n\n"), 0o600))
+
+	mockStore := newUpsertTestStore(t)
+	mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, si *storage.SignatureIntegration) error {
+			require.Len(t, si.GetCosign().GetPublicKeys(), 1,
+				"key with trailing whitespace must be recognised as duplicate of embedded key")
+			return nil
+		},
+	)
+
+	upsertRedHatSignatureIntegration(mockStore)
+}
+
+func TestUpsertRedHatSignatureIntegration_PEMStoredInCanonicalForm(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.pub"), []byte(anotherValidPublicKeyPEM+"\n\n"), 0o600))
+
+	mockStore := newUpsertTestStore(t)
+	mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, si *storage.SignatureIntegration) error {
+			require.Len(t, si.GetCosign().GetPublicKeys(), 2)
+			for _, k := range si.GetCosign().GetPublicKeys() {
+				if k.GetName() == "extra.pub" {
+					// The stored PEM must be the canonical form (no trailing whitespace,
+					// produced by pem.EncodeToMemory).
+					block, _ := pem.Decode([]byte(k.GetPublicKeyPemEnc()))
+					require.NotNil(t, block, "stored PEM must be decodable")
+					require.Equal(t, string(pem.EncodeToMemory(block)), k.GetPublicKeyPemEnc(),
+						"stored PEM must be in canonical form")
+				}
+			}
+			return nil
+		},
+	)
+
+	upsertRedHatSignatureIntegration(mockStore)
+}
+
+func TestUpsertRedHatSignatureIntegration_DoesNotMutateDefaultIntegration(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.pub"), []byte(anotherValidPublicKeyPEM), 0o600))
+
+	before := len(signatures.DefaultRedHatSignatureIntegration.GetCosign().GetPublicKeys())
+
+	mockStore := newUpsertTestStore(t)
+	mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil)
+
+	upsertRedHatSignatureIntegration(mockStore)
+
+	after := len(signatures.DefaultRedHatSignatureIntegration.GetCosign().GetPublicKeys())
+	require.Equal(t, before, after, "upsert must not modify the global DefaultRedHatSignatureIntegration")
 }

--- a/central/signatureintegration/datastore/datastore_impl.go
+++ b/central/signatureintegration/datastore/datastore_impl.go
@@ -8,6 +8,7 @@ import (
 	policyDatastore "github.com/stackrox/rox/central/policy/datastore"
 	"github.com/stackrox/rox/central/signatureintegration/store"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protoutils"
@@ -15,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/pkg/signatures"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -41,7 +43,11 @@ func (d *datastoreImpl) GetSignatureIntegration(ctx context.Context, id string) 
 		return nil, false, err
 	}
 
-	return d.storage.Get(ctx, id)
+	integration, found, err := d.storage.Get(ctx, id)
+	if err != nil || !found {
+		return integration, found, err
+	}
+	return d.decorateRedHatIntegration(integration), true, nil
 }
 
 func (d *datastoreImpl) GetAllSignatureIntegrations(ctx context.Context) ([]*storage.SignatureIntegration, error) {
@@ -53,7 +59,7 @@ func (d *datastoreImpl) GetAllSignatureIntegrations(ctx context.Context) ([]*sto
 	walkFn := func() error {
 		integrations = integrations[:0]
 		return d.storage.Walk(ctx, func(integration *storage.SignatureIntegration) error {
-			integrations = append(integrations, integration)
+			integrations = append(integrations, d.decorateRedHatIntegration(integration))
 			return nil
 		})
 	}
@@ -61,6 +67,46 @@ func (d *datastoreImpl) GetAllSignatureIntegrations(ctx context.Context) ([]*sto
 		return nil, err
 	}
 	return integrations, nil
+}
+
+// decorateRedHatIntegration augments the default Red Hat signature integration with any additional
+// public keys found in the runtime directory. Non-Red Hat integrations are returned unchanged.
+// The integration proto is cloned before mutation so the stored copy is never modified.
+func (d *datastoreImpl) decorateRedHatIntegration(integration *storage.SignatureIntegration) *storage.SignatureIntegration {
+	if integration.GetId() != signatures.DefaultRedHatSignatureIntegration.GetId() {
+		return integration
+	}
+
+	runtimeDir := env.RedHatSigningKeysRuntimeDir.Setting()
+	additionalKeys, err := loadKeysFromDir(runtimeDir)
+	if err != nil {
+		log.Warnf("Failed to load Red Hat signing keys from %q: %v", runtimeDir, err)
+		return integration
+	}
+	if len(additionalKeys) == 0 {
+		return integration
+	}
+
+	// Build a set of PEM values already present so we can deduplicate.
+	existing := getPublicKeyPEMSet(integration)
+
+	var newKeys []*storage.CosignPublicKeyVerification_PublicKey
+	for _, k := range additionalKeys {
+		if !existing.Contains(k.GetPublicKeyPemEnc()) {
+			newKeys = append(newKeys, k)
+		}
+	}
+	if len(newKeys) == 0 {
+		return integration
+	}
+
+	// Clone before mutating to avoid touching the cached/stored proto.
+	cloned := integration.CloneVT()
+	if cloned.Cosign == nil {
+		cloned.Cosign = &storage.CosignPublicKeyVerification{}
+	}
+	cloned.Cosign.PublicKeys = append(cloned.Cosign.PublicKeys, newKeys...)
+	return cloned
 }
 
 func (d *datastoreImpl) CountSignatureIntegrations(ctx context.Context) (int, error) {

--- a/central/signatureintegration/datastore/datastore_impl.go
+++ b/central/signatureintegration/datastore/datastore_impl.go
@@ -8,7 +8,6 @@ import (
 	policyDatastore "github.com/stackrox/rox/central/policy/datastore"
 	"github.com/stackrox/rox/central/signatureintegration/store"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protoutils"
@@ -16,7 +15,6 @@ import (
 	"github.com/stackrox/rox/pkg/sac/resources"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
-	"github.com/stackrox/rox/pkg/signatures"
 	"github.com/stackrox/rox/pkg/sync"
 )
 
@@ -42,12 +40,7 @@ func (d *datastoreImpl) GetSignatureIntegration(ctx context.Context, id string) 
 	if ok, err := integrationSAC.ReadAllowed(ctx); !ok || err != nil {
 		return nil, false, err
 	}
-
-	integration, found, err := d.storage.Get(ctx, id)
-	if err != nil || !found {
-		return integration, found, err
-	}
-	return d.decorateRedHatIntegration(integration), true, nil
+	return d.storage.Get(ctx, id)
 }
 
 func (d *datastoreImpl) GetAllSignatureIntegrations(ctx context.Context) ([]*storage.SignatureIntegration, error) {
@@ -59,7 +52,7 @@ func (d *datastoreImpl) GetAllSignatureIntegrations(ctx context.Context) ([]*sto
 	walkFn := func() error {
 		integrations = integrations[:0]
 		return d.storage.Walk(ctx, func(integration *storage.SignatureIntegration) error {
-			integrations = append(integrations, d.decorateRedHatIntegration(integration))
+			integrations = append(integrations, integration)
 			return nil
 		})
 	}
@@ -67,46 +60,6 @@ func (d *datastoreImpl) GetAllSignatureIntegrations(ctx context.Context) ([]*sto
 		return nil, err
 	}
 	return integrations, nil
-}
-
-// decorateRedHatIntegration augments the default Red Hat signature integration with any additional
-// public keys found in the runtime directory. Non-Red Hat integrations are returned unchanged.
-// The integration proto is cloned before mutation so the stored copy is never modified.
-func (d *datastoreImpl) decorateRedHatIntegration(integration *storage.SignatureIntegration) *storage.SignatureIntegration {
-	if integration.GetId() != signatures.DefaultRedHatSignatureIntegration.GetId() {
-		return integration
-	}
-
-	runtimeDir := env.RedHatSigningKeysRuntimeDir.Setting()
-	additionalKeys, err := loadKeysFromDir(runtimeDir)
-	if err != nil {
-		log.Warnf("Failed to load Red Hat signing keys from %q: %v", runtimeDir, err)
-		return integration
-	}
-	if len(additionalKeys) == 0 {
-		return integration
-	}
-
-	// Build a set of PEM values already present so we can deduplicate.
-	existing := getPublicKeyPEMSet(integration)
-
-	var newKeys []*storage.CosignPublicKeyVerification_PublicKey
-	for _, k := range additionalKeys {
-		if !existing.Contains(k.GetPublicKeyPemEnc()) {
-			newKeys = append(newKeys, k)
-		}
-	}
-	if len(newKeys) == 0 {
-		return integration
-	}
-
-	// Clone before mutating to avoid touching the cached/stored proto.
-	cloned := integration.CloneVT()
-	if cloned.Cosign == nil {
-		cloned.Cosign = &storage.CosignPublicKeyVerification{}
-	}
-	cloned.Cosign.PublicKeys = append(cloned.Cosign.PublicKeys, newKeys...)
-	return cloned
 }
 
 func (d *datastoreImpl) CountSignatureIntegrations(ctx context.Context) (int, error) {

--- a/central/signatureintegration/datastore/keyloader.go
+++ b/central/signatureintegration/datastore/keyloader.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"bytes"
 	"encoding/pem"
 	"os"
 	"path/filepath"
@@ -40,22 +41,26 @@ func loadKeysFromDir(dir string) ([]*storage.CosignPublicKeyVerification_PublicK
 			continue
 		}
 
-		block, rest := pem.Decode(contents)
+		// Trim trailing whitespace so files ending with \n\n are accepted.
+		trimmed := bytes.TrimRight(contents, " \t\r\n")
+		block, rest := pem.Decode(trimmed)
 		if !signatures.IsValidPublicKeyPEMBlock(block, rest) {
 			log.Warnf("Skipping Red Hat signing key file %q: not a valid PEM-encoded public key", fullPath)
 			continue
 		}
 
-		pemStr := string(contents)
-		if _, dup := seen[pemStr]; dup {
+		// Re-encode to canonical PEM form: normalises whitespace and strips any
+		// non-PEM content (e.g. GPG-style headers) that preceded the PEM block.
+		canonical := string(pem.EncodeToMemory(block))
+		if _, dup := seen[canonical]; dup {
 			log.Debugf("Skipping duplicate Red Hat signing key in file %q", fullPath)
 			continue
 		}
-		seen[pemStr] = struct{}{}
+		seen[canonical] = struct{}{}
 
 		keys = append(keys, &storage.CosignPublicKeyVerification_PublicKey{
 			Name:            name,
-			PublicKeyPemEnc: pemStr,
+			PublicKeyPemEnc: canonical,
 		})
 	}
 

--- a/central/signatureintegration/datastore/keyloader.go
+++ b/central/signatureintegration/datastore/keyloader.go
@@ -1,0 +1,63 @@
+package datastore
+
+import (
+	"encoding/pem"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/signatures"
+)
+
+// loadKeysFromDir reads all files from the given directory and returns those that contain valid
+// PEM-encoded public keys. Files that are not valid public keys are skipped with a warning.
+// If the directory does not exist or is empty, an empty slice is returned without error.
+// Duplicate keys (same PEM content) are deduplicated — the first file encountered is kept.
+// This function is safe to call concurrently.
+func loadKeysFromDir(dir string) ([]*storage.CosignPublicKeyVerification_PublicKey, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errors.Wrapf(err, "reading Red Hat signing keys directory %q", dir)
+	}
+
+	seen := make(map[string]struct{})
+	var keys []*storage.CosignPublicKeyVerification_PublicKey
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		fullPath := filepath.Join(dir, name)
+
+		contents, err := os.ReadFile(fullPath)
+		if err != nil {
+			log.Warnf("Skipping Red Hat signing key file %q: %v", fullPath, err)
+			continue
+		}
+
+		block, rest := pem.Decode(contents)
+		if !signatures.IsValidPublicKeyPEMBlock(block, rest) {
+			log.Warnf("Skipping Red Hat signing key file %q: not a valid PEM-encoded public key", fullPath)
+			continue
+		}
+
+		pemStr := string(contents)
+		if _, dup := seen[pemStr]; dup {
+			log.Debugf("Skipping duplicate Red Hat signing key in file %q", fullPath)
+			continue
+		}
+		seen[pemStr] = struct{}{}
+
+		keys = append(keys, &storage.CosignPublicKeyVerification_PublicKey{
+			Name:            name,
+			PublicKeyPemEnc: pemStr,
+		})
+	}
+
+	return keys, nil
+}

--- a/central/signatureintegration/datastore/keyloader_test.go
+++ b/central/signatureintegration/datastore/keyloader_test.go
@@ -1,0 +1,104 @@
+package datastore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// validPublicKeyPEM is a minimal RSA public key in PEM format used across keyloader tests.
+const validPublicKeyPEM = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAryQICCl6NZ5gDKrnSztO\n3Hy8PEUcuyvg/ikC+VcIo2SFFSf18a3IMYldIugqqqZCs4/4uVW3sbdLs/6PfgdX\n7O9D22ZiFWHPYA2k2N744MNiCD1UE+tJyllUhSblK48bn+v1oZHCM0nYQ2NqUkvS\nj+hwUU3RiWl7x3D2s9wSdNt7XUtW05a/FXehsPSiJfKvHJJnGOX0BgTvkLnkAOTd\nOrUZ/wK69Dzu4IvrN4vs9Nes8vbwPa/ddZEzGR0cQMt0JBkhk9kU/qwqUseP1QRJ\n5I1jR4g8aYPL/ke9K35PxZWuDp3U0UPAZ3PjFAh+5T+fc7gzCs9dPzSHloruU+gl\nFQIDAQAB\n-----END PUBLIC KEY-----"
+
+const anotherValidPublicKeyPEM = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkbBNiNdz/A5HRMVwmQpOgMqBQFNe\nCrZhzDO5cMWezEzKHwRFoKLUZl5U7k2c0SQHa2qAqFMgASlO6mMhXyZPjw==\n-----END PUBLIC KEY-----"
+
+func writePEMFile(t *testing.T, dir, name, contents string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o600))
+}
+
+func TestLoadKeysFromDir_DirectoryDoesNotExist(t *testing.T) {
+	keys, err := loadKeysFromDir("/nonexistent/path/that/does/not/exist")
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
+func TestLoadKeysFromDir_EmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
+func TestLoadKeysFromDir_SingleValidPEMFile(t *testing.T) {
+	dir := t.TempDir()
+	writePEMFile(t, dir, "key.pub", validPublicKeyPEM)
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, "key.pub", keys[0].GetName())
+	require.Equal(t, validPublicKeyPEM, keys[0].GetPublicKeyPemEnc())
+}
+
+func TestLoadKeysFromDir_MultipleValidPEMFiles(t *testing.T) {
+	dir := t.TempDir()
+	writePEMFile(t, dir, "key-a.pub", validPublicKeyPEM)
+	writePEMFile(t, dir, "key-b.pub", anotherValidPublicKeyPEM)
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+
+	nameSet := map[string]struct{}{}
+	for _, k := range keys {
+		nameSet[k.GetName()] = struct{}{}
+	}
+	require.Contains(t, nameSet, "key-a.pub")
+	require.Contains(t, nameSet, "key-b.pub")
+}
+
+func TestLoadKeysFromDir_DuplicatePEMContent(t *testing.T) {
+	dir := t.TempDir()
+	// Two files with identical PEM — only one should be returned.
+	writePEMFile(t, dir, "key-a.pub", validPublicKeyPEM)
+	writePEMFile(t, dir, "key-b.pub", validPublicKeyPEM)
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, validPublicKeyPEM, keys[0].GetPublicKeyPemEnc())
+}
+
+func TestLoadKeysFromDir_InvalidFileSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writePEMFile(t, dir, "not-a-key.pub", "this is not a PEM block at all")
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
+func TestLoadKeysFromDir_MixedValidAndInvalid(t *testing.T) {
+	dir := t.TempDir()
+	writePEMFile(t, dir, "good.pub", validPublicKeyPEM)
+	writePEMFile(t, dir, "bad.pub", "not a PEM block")
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, "good.pub", keys[0].GetName())
+}
+
+func TestLoadKeysFromDir_SubdirectoriesIgnored(t *testing.T) {
+	dir := t.TempDir()
+	// Create a subdirectory — it should be ignored.
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o755))
+	writePEMFile(t, dir, "key.pub", validPublicKeyPEM)
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, "key.pub", keys[0].GetName())
+}

--- a/central/signatureintegration/datastore/keyloader_test.go
+++ b/central/signatureintegration/datastore/keyloader_test.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +40,8 @@ func TestLoadKeysFromDir_SingleValidPEMFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
 	require.Equal(t, "key.pub", keys[0].GetName())
-	require.Equal(t, validPublicKeyPEM, keys[0].GetPublicKeyPemEnc())
+	// pem.EncodeToMemory always appends a trailing newline.
+	require.Equal(t, validPublicKeyPEM+"\n", keys[0].GetPublicKeyPemEnc())
 }
 
 func TestLoadKeysFromDir_MultipleValidPEMFiles(t *testing.T) {
@@ -68,7 +70,8 @@ func TestLoadKeysFromDir_DuplicatePEMContent(t *testing.T) {
 	keys, err := loadKeysFromDir(dir)
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
-	require.Equal(t, validPublicKeyPEM, keys[0].GetPublicKeyPemEnc())
+	// pem.EncodeToMemory always appends a trailing newline.
+	require.Equal(t, validPublicKeyPEM+"\n", keys[0].GetPublicKeyPemEnc())
 }
 
 func TestLoadKeysFromDir_InvalidFileSkipped(t *testing.T) {
@@ -101,4 +104,55 @@ func TestLoadKeysFromDir_SubdirectoriesIgnored(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
 	require.Equal(t, "key.pub", keys[0].GetName())
+}
+
+func TestLoadKeysFromDir_TrailingWhitespaceAccepted(t *testing.T) {
+	dir := t.TempDir()
+	// File ends with double newline — was previously rejected with misleading warning.
+	writePEMFile(t, dir, "key.pub", validPublicKeyPEM+"\n\n")
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1, "trailing whitespace must not cause the key to be rejected")
+}
+
+func TestLoadKeysFromDir_DuplicateWithTrailingWhitespaceDeduplicated(t *testing.T) {
+	dir := t.TempDir()
+	// Two files: one with and one without trailing newlines — same underlying key.
+	writePEMFile(t, dir, "key-a.pub", validPublicKeyPEM)
+	writePEMFile(t, dir, "key-b.pub", validPublicKeyPEM+"\n\n")
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1, "whitespace-differing duplicates must be deduplicated")
+}
+
+func TestLoadKeysFromDir_GPGStyleHeaderStripped(t *testing.T) {
+	dir := t.TempDir()
+	// Simulate a file with GPG-style metadata lines before the PEM block.
+	gpgStyleContent := "Red Hat Release Key (release-key-3)\nVersion: GnuPG v1\n\n" + validPublicKeyPEM
+	writePEMFile(t, dir, "key.pub", gpgStyleContent)
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1, "GPG-style header before PEM block must be accepted")
+
+	// The stored PEM must be canonical — no leading GPG header.
+	require.Equal(t, validPublicKeyPEM+"\n", keys[0].GetPublicKeyPemEnc(),
+		"stored PEM must be stripped of GPG-style headers")
+}
+
+func TestLoadKeysFromDir_StoredPEMIsCanonical(t *testing.T) {
+	dir := t.TempDir()
+	writePEMFile(t, dir, "key.pub", validPublicKeyPEM)
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	// The stored value must equal pem.EncodeToMemory of the decoded block.
+	block, _ := pem.Decode([]byte(validPublicKeyPEM))
+	require.NotNil(t, block)
+	require.Equal(t, string(pem.EncodeToMemory(block)), keys[0].GetPublicKeyPemEnc(),
+		"stored PEM must be in canonical pem.EncodeToMemory form")
 }

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+	"encoding/pem"
 	"net/http"
 	"time"
 
@@ -25,23 +26,59 @@ var (
 	keyUpdaterLock sync.Mutex
 )
 
-func upsertDefaultRedHatSignatureIntegration(siStore store.SignatureIntegrationStore) {
+// upsertRedHatSignatureIntegration builds the Red Hat signature integration from
+// the embedded key plus any keys found in the runtime directory, then upserts it
+// to the datastore. Duplicate keys (by canonical PEM) are silently dropped.
+// It is called at startup and as the updater's onSuccess callback.
+func upsertRedHatSignatureIntegration(siStore store.SignatureIntegrationStore) {
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowAllAccessScopeChecker())
 
-	log.Debugf("Upserting default Red Hat signature integration %q (%s)",
-		signatures.DefaultRedHatSignatureIntegration.GetName(),
-		signatures.DefaultRedHatSignatureIntegration.GetId(),
+	// Start from a clone of the default integration so we never mutate the global.
+	integration := signatures.DefaultRedHatSignatureIntegration.CloneVT()
+
+	// Build a set of canonical PEM values from the embedded keys for deduplication.
+	seen := make(map[string]struct{})
+	for _, k := range integration.GetCosign().GetPublicKeys() {
+		// Normalise the embedded PEM so comparison with dir keys is consistent.
+		if block, _ := pem.Decode([]byte(k.GetPublicKeyPemEnc())); block != nil {
+			seen[string(pem.EncodeToMemory(block))] = struct{}{}
+		} else {
+			seen[k.GetPublicKeyPemEnc()] = struct{}{}
+		}
+	}
+
+	// Load additional keys from the runtime directory. The keyloader already
+	// returns canonical PEM (via pem.EncodeToMemory), so string comparison is safe.
+	runtimeDir := env.RedHatSigningKeysRuntimeDir.Setting()
+	additionalKeys, err := loadKeysFromDir(runtimeDir)
+	if err != nil {
+		log.Warnf("Failed to load Red Hat signing keys from %q: %v", runtimeDir, err)
+	}
+	for _, k := range additionalKeys {
+		if _, dup := seen[k.GetPublicKeyPemEnc()]; dup {
+			log.Debugf("Skipping duplicate Red Hat signing key %q from directory", k.GetName())
+			continue
+		}
+		seen[k.GetPublicKeyPemEnc()] = struct{}{}
+		integration.Cosign.PublicKeys = append(integration.Cosign.PublicKeys, k)
+	}
+
+	log.Debugf("Upserting Red Hat signature integration %q (%s) with %d key(s)",
+		integration.GetName(),
+		integration.GetId(),
+		len(integration.GetCosign().GetPublicKeys()),
 	)
-	err := siStore.Upsert(ctx, signatures.DefaultRedHatSignatureIntegration)
-	utils.Should(errors.Wrap(err, "upserting default Red Hat signature integration"))
+	utils.Should(errors.Wrap(siStore.Upsert(ctx, integration), "upserting Red Hat signature integration"))
 }
 
-func startRedHatSigningKeyUpdater() {
+func startRedHatSigningKeyUpdater(siStore store.SignatureIntegrationStore) {
 	manifestURL := env.RedHatSigningKeyManifestURL.Setting()
 	if manifestURL == "" {
 		log.Info("Red Hat signing key manifest URL not configured, skipping key updater")
 		return
 	}
+
+	onSuccess := func() { upsertRedHatSignatureIntegration(siStore) }
 
 	u, err := newUpdater(
 		&http.Client{
@@ -51,6 +88,7 @@ func startRedHatSigningKeyUpdater() {
 		manifestURL,
 		env.RedHatSigningKeysRuntimeDir.Setting(),
 		env.RedHatSigningKeyUpdateInterval.DurationSetting(),
+		onSuccess,
 	)
 	if err != nil {
 		utils.Should(errors.Wrap(err, "creating Red Hat signing key updater"))
@@ -79,9 +117,9 @@ func StopRedHatSigningKeyUpdater() {
 func Singleton() DataStore {
 	once.Do(func() {
 		storage := pgStore.New(globaldb.GetPostgres())
-		upsertDefaultRedHatSignatureIntegration(storage)
+		upsertRedHatSignatureIntegration(storage)
 		instance = New(storage, policyDataStore.Singleton())
-		startRedHatSigningKeyUpdater()
+		startRedHatSigningKeyUpdater(storage)
 	})
 	return instance
 }

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/globaldb"
@@ -10,6 +11,7 @@ import (
 	"github.com/stackrox/rox/central/signatureintegration/store"
 	pgStore "github.com/stackrox/rox/central/signatureintegration/store/postgres"
 	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/signatures"
 	"github.com/stackrox/rox/pkg/sync"
@@ -17,8 +19,10 @@ import (
 )
 
 var (
-	once     sync.Once
-	instance DataStore
+	once           sync.Once
+	instance       DataStore
+	keyUpdater     *updater
+	keyUpdaterLock sync.Mutex
 )
 
 func upsertDefaultRedHatSignatureIntegration(siStore store.SignatureIntegrationStore) {
@@ -40,7 +44,10 @@ func startRedHatSigningKeyUpdater() {
 	}
 
 	u, err := newUpdater(
-		&http.Client{},
+		&http.Client{
+			Timeout:   30 * time.Second,
+			Transport: proxy.RoundTripper(),
+		},
 		manifestURL,
 		env.RedHatSigningKeysRuntimeDir.Setting(),
 		env.RedHatSigningKeyUpdateInterval.DurationSetting(),
@@ -49,7 +56,23 @@ func startRedHatSigningKeyUpdater() {
 		utils.Should(errors.Wrap(err, "creating Red Hat signing key updater"))
 		return
 	}
+
+	keyUpdaterLock.Lock()
+	keyUpdater = u
+	keyUpdaterLock.Unlock()
+
 	u.Start()
+}
+
+// StopRedHatSigningKeyUpdater stops the background key updater if running.
+func StopRedHatSigningKeyUpdater() {
+	keyUpdaterLock.Lock()
+	u := keyUpdater
+	keyUpdaterLock.Unlock()
+
+	if u != nil {
+		u.Stop()
+	}
 }
 
 // Singleton returns the sole instance of the DataStore service.

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -2,12 +2,14 @@ package datastore
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/globaldb"
 	policyDataStore "github.com/stackrox/rox/central/policy/datastore"
 	"github.com/stackrox/rox/central/signatureintegration/store"
 	pgStore "github.com/stackrox/rox/central/signatureintegration/store/postgres"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/signatures"
 	"github.com/stackrox/rox/pkg/sync"
@@ -30,12 +32,33 @@ func upsertDefaultRedHatSignatureIntegration(siStore store.SignatureIntegrationS
 	utils.Should(errors.Wrap(err, "upserting default Red Hat signature integration"))
 }
 
+func startRedHatSigningKeyUpdater() {
+	manifestURL := env.RedHatSigningKeyManifestURL.Setting()
+	if manifestURL == "" {
+		log.Info("Red Hat signing key manifest URL not configured, skipping key updater")
+		return
+	}
+
+	u, err := newUpdater(
+		&http.Client{},
+		manifestURL,
+		env.RedHatSigningKeysRuntimeDir.Setting(),
+		env.RedHatSigningKeyUpdateInterval.DurationSetting(),
+	)
+	if err != nil {
+		utils.Should(errors.Wrap(err, "creating Red Hat signing key updater"))
+		return
+	}
+	u.Start()
+}
+
 // Singleton returns the sole instance of the DataStore service.
 func Singleton() DataStore {
 	once.Do(func() {
 		storage := pgStore.New(globaldb.GetPostgres())
 		upsertDefaultRedHatSignatureIntegration(storage)
 		instance = New(storage, policyDataStore.Singleton())
+		startRedHatSigningKeyUpdater()
 	})
 	return instance
 }

--- a/central/signatureintegration/datastore/updater.go
+++ b/central/signatureintegration/datastore/updater.go
@@ -1,0 +1,295 @@
+package datastore
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+const defaultUpdateInterval = 4 * time.Hour
+
+type manifest struct {
+	Keys []manifestKey `json:"keys"`
+}
+
+type manifestKey struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type keyRef struct {
+	name string
+	url  string
+}
+
+type updater struct {
+	client      *http.Client
+	interval    time.Duration
+	manifestURL string
+	targetDir   string
+	once        sync.Once
+	stopSig     concurrency.Signal
+}
+
+func newUpdater(client *http.Client, manifestURL, targetDir string, interval time.Duration) (*updater, error) {
+	if client == nil {
+		return nil, errors.New("http client must be provided")
+	}
+	if interval <= 0 {
+		interval = defaultUpdateInterval
+	}
+
+	return &updater{
+		client:      client,
+		interval:    interval,
+		manifestURL: manifestURL,
+		targetDir:   targetDir,
+		stopSig:     concurrency.NewSignal(),
+	}, nil
+}
+
+func (u *updater) Stop() {
+	u.stopSig.Signal()
+}
+
+func (u *updater) Start() {
+	u.once.Do(func() {
+		go u.runForever()
+	})
+}
+
+func (u *updater) runForever() {
+	log.Infof("Starting Red Hat key file updater every %v", u.interval)
+	u.doUpdate()
+
+	t := time.NewTimer(u.interval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			u.doUpdate()
+			t.Reset(u.interval)
+		case <-u.stopSig.Done():
+			return
+		}
+	}
+}
+
+func (u *updater) doUpdate() {
+	if err := u.update(); err != nil {
+		log.Errorf("Failed to download Red Hat key files from manifest %q into %q: %v", u.manifestURL, u.targetDir, err)
+	}
+}
+
+func (u *updater) update() error {
+	manifest, err := u.downloadManifest(u.manifestURL)
+	if err != nil {
+		return errors.Wrapf(err, "downloading manifest from URL %q", u.manifestURL)
+	}
+
+	keyRefs, err := resolveKeyRefsFromManifest(u.manifestURL, manifest)
+	if err != nil {
+		return errors.Wrap(err, "resolving key references from manifest")
+	}
+	if err := os.MkdirAll(u.targetDir, 0o755); err != nil {
+		return errors.Wrapf(err, "creating target directory %q", u.targetDir)
+	}
+	stagingDir, err := os.MkdirTemp(filepath.Dir(u.targetDir), ".redhat-keys-staging-*")
+	if err != nil {
+		return errors.Wrapf(err, "creating staging directory for target %q", u.targetDir)
+	}
+	defer func() {
+		_ = os.RemoveAll(stagingDir)
+	}()
+
+	if err := u.downloadKeys(keyRefs, stagingDir); err != nil {
+		return errors.Wrap(err, "downloading keys to staging")
+	}
+	if err := replaceDirectoryContents(u.targetDir, stagingDir); err != nil {
+		return errors.Wrapf(err, "replacing target directory %q contents", u.targetDir)
+	}
+
+	return nil
+}
+
+// resolveKeyRefsFromManifest resolves the key references from a manifest.
+func resolveKeyRefsFromManifest(manifestURL string, manifest manifest) ([]keyRef, error) {
+	if len(manifest.Keys) == 0 {
+		return nil, errors.Errorf("manifest at %q does not contain any files", manifestURL)
+	}
+
+	keyRefs := make([]keyRef, 0, len(manifest.Keys))
+	for _, key := range manifest.Keys {
+		resolvedURL, err := resolveKeyURL(manifestURL, key.URL)
+		if err != nil {
+			return nil, errors.Wrapf(err, "resolving URL %q", key.URL)
+		}
+		keyRefs = append(keyRefs, keyRef{
+			name: key.Name,
+			url:  resolvedURL,
+		})
+	}
+	return keyRefs, nil
+}
+
+func (u *updater) downloadKeys(keys []keyRef, stagingDir string) error {
+	successes := 0
+	failures := 0
+
+	for _, key := range keys {
+		destination := filepath.Join(stagingDir, key.name)
+		if err := u.downloadFile(key.url, destination); err != nil {
+			failures++
+			log.Warnf("Skipping manifest entry %q: %v", key.url, err)
+			continue
+		}
+		successes++
+	}
+
+	if successes == 0 {
+		return errors.New("failed to download any keys")
+	}
+	if failures > 0 {
+		log.Warnf("Downloaded %d keys to staging %q, skipped %d entries", successes, stagingDir, failures)
+	} else {
+		log.Debugf("Downloaded %d keys to staging %q", successes, stagingDir)
+	}
+
+	return nil
+}
+
+func (u *updater) downloadFile(url string, destination string) error {
+	contents, err := u.downloadBytes(url)
+	if err != nil {
+		return errors.Wrapf(err, "failed to download file from URL %q", url)
+	}
+
+	if err := os.WriteFile(destination, contents, 0o600); err != nil {
+		_ = os.Remove(destination)
+		return errors.Wrapf(err, "failed to write file %q", destination)
+	}
+
+	return nil
+}
+
+func replaceDirectoryContents(targetDir, sourceDir string) error {
+	if err := clearDirectory(targetDir); err != nil {
+		return errors.Wrap(err, "clearing target directory")
+	}
+
+	entries, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return errors.Wrap(err, "reading source directory")
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(sourceDir, entry.Name())
+		targetPath := filepath.Join(targetDir, entry.Name())
+		if err := os.Rename(sourcePath, targetPath); err != nil {
+			return errors.Wrapf(err, "moving %q to target directory", entry.Name())
+		}
+	}
+
+	return nil
+}
+
+func clearDirectory(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return errors.Wrap(err, "reading directory entries")
+	}
+	for _, entry := range entries {
+		entryPath := filepath.Join(dir, entry.Name())
+		if err := os.RemoveAll(entryPath); err != nil {
+			return errors.Wrapf(err, "removing %q", entryPath)
+		}
+	}
+
+	return nil
+}
+
+func (u *updater) downloadBytes(rawURL string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "constructing request")
+	}
+
+	resp, err := u.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "executing request")
+	}
+	defer utils.IgnoreError(resp.Body.Close)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("HTTP response code was %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading response body")
+	}
+
+	return body, nil
+}
+
+func (u *updater) downloadManifest(manifestURL string) (manifest, error) {
+	manifestBytes, err := u.downloadBytes(manifestURL)
+	if err != nil {
+		return manifest{}, err
+	}
+
+	var parsedManifest manifest
+	if err = json.Unmarshal(manifestBytes, &parsedManifest); err != nil {
+		return manifest{}, errors.Wrap(err, "unmarshalling manifest")
+	}
+
+	return parsedManifest, nil
+}
+
+// resolveKeyURL resolves a key URL relative to a manifest URL.
+// The key URL can be absolute or relative.
+// If it is relative, it is resolved relative to the manifest URL.
+// If it is absolute, it is returned as is.
+func resolveKeyURL(manifestURL, keyURL string) (string, error) {
+	keyURL = strings.TrimSpace(keyURL)
+
+	var resolved string
+	if strings.HasPrefix(keyURL, "http://") || strings.HasPrefix(keyURL, "https://") {
+		resolved = keyURL
+	} else {
+		base, err := url.Parse(manifestURL)
+		if err != nil {
+			return "", errors.Wrap(err, "parsing manifest URL")
+		}
+		base.Path = strings.TrimSuffix(base.Path, "/")
+		if idx := strings.LastIndex(base.Path, "/"); idx >= 0 {
+			base.Path = base.Path[:idx+1]
+		}
+
+		ref, err := url.Parse(keyURL)
+		if err != nil {
+			return "", errors.Wrap(err, "parsing key entry")
+		}
+		resolved = base.ResolveReference(ref).String()
+	}
+
+	parsed, err := url.Parse(resolved)
+	if err != nil {
+		return "", errors.Wrap(err, "parsing resolved URL")
+	}
+	if strings.HasSuffix(parsed.Path, "/") || parsed.Path == "" {
+		return "", errors.Errorf("URL must point to a file, not a directory: %s", resolved)
+	}
+
+	return resolved, nil
+}

--- a/central/signatureintegration/datastore/updater.go
+++ b/central/signatureintegration/datastore/updater.go
@@ -1,12 +1,14 @@
 package datastore
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -184,42 +186,29 @@ func (u *updater) downloadFile(url string, destination string) error {
 }
 
 func replaceDirectoryContents(targetDir, sourceDir string) error {
-	if err := clearDirectory(targetDir); err != nil {
-		return errors.Wrap(err, "clearing target directory")
+	backupDir := targetDir + ".backup-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	if err := os.Rename(targetDir, backupDir); err != nil {
+		return errors.Wrap(err, "moving current target directory to backup")
 	}
-
-	entries, err := os.ReadDir(sourceDir)
-	if err != nil {
-		return errors.Wrap(err, "reading source directory")
-	}
-	for _, entry := range entries {
-		sourcePath := filepath.Join(sourceDir, entry.Name())
-		targetPath := filepath.Join(targetDir, entry.Name())
-		if err := os.Rename(sourcePath, targetPath); err != nil {
-			return errors.Wrapf(err, "moving %q to target directory", entry.Name())
+	if err := os.Rename(sourceDir, targetDir); err != nil {
+		rollbackErr := os.Rename(backupDir, targetDir)
+		if rollbackErr != nil {
+			return errors.Wrapf(err, "moving staged directory into target failed and rollback failed: %v", rollbackErr)
 		}
+		return errors.Wrap(err, "moving staged directory into target")
 	}
-
-	return nil
-}
-
-func clearDirectory(dir string) error {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return errors.Wrap(err, "reading directory entries")
-	}
-	for _, entry := range entries {
-		entryPath := filepath.Join(dir, entry.Name())
-		if err := os.RemoveAll(entryPath); err != nil {
-			return errors.Wrapf(err, "removing %q", entryPath)
-		}
+	if err := os.RemoveAll(backupDir); err != nil {
+		return errors.Wrap(err, "removing backup directory")
 	}
 
 	return nil
 }
 
 func (u *updater) downloadBytes(rawURL string) ([]byte, error) {
-	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	reqCtx, cancel := u.newRequestContext()
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing request")
 	}
@@ -231,7 +220,7 @@ func (u *updater) downloadBytes(rawURL string) ([]byte, error) {
 	defer utils.IgnoreError(resp.Body.Close)
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("HTTP response code was %d", resp.StatusCode)
+		return nil, errors.Errorf("HTTP %d for %q", resp.StatusCode, rawURL)
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -240,6 +229,27 @@ func (u *updater) downloadBytes(rawURL string) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+func (u *updater) newRequestContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	select {
+	case <-u.stopSig.Done():
+		cancel()
+		return ctx, cancel
+	default:
+	}
+
+	go func() {
+		select {
+		case <-u.stopSig.Done():
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	return ctx, cancel
 }
 
 func (u *updater) downloadManifest(manifestURL string) (manifest, error) {

--- a/central/signatureintegration/datastore/updater.go
+++ b/central/signatureintegration/datastore/updater.go
@@ -37,11 +37,12 @@ type updater struct {
 	interval    time.Duration
 	manifestURL string
 	targetDir   string
+	onSuccess   func()
 	once        sync.Once
 	stopSig     concurrency.Signal
 }
 
-func newUpdater(client *http.Client, manifestURL, targetDir string, interval time.Duration) (*updater, error) {
+func newUpdater(client *http.Client, manifestURL, targetDir string, interval time.Duration, onSuccess func()) (*updater, error) {
 	if client == nil {
 		return nil, errors.New("http client must be provided")
 	}
@@ -54,6 +55,7 @@ func newUpdater(client *http.Client, manifestURL, targetDir string, interval tim
 		interval:    interval,
 		manifestURL: manifestURL,
 		targetDir:   targetDir,
+		onSuccess:   onSuccess,
 		stopSig:     concurrency.NewSignal(),
 	}, nil
 }
@@ -89,6 +91,10 @@ func (u *updater) runForever() {
 func (u *updater) doUpdate() {
 	if err := u.update(); err != nil {
 		log.Errorf("Failed to download Red Hat key files from manifest %q into %q: %v", u.manifestURL, u.targetDir, err)
+		return
+	}
+	if u.onSuccess != nil {
+		u.onSuccess()
 	}
 }
 

--- a/central/signatureintegration/datastore/updater.go
+++ b/central/signatureintegration/datastore/updater.go
@@ -18,8 +18,6 @@ import (
 	"github.com/stackrox/rox/pkg/utils"
 )
 
-const defaultUpdateInterval = 4 * time.Hour
-
 type manifest struct {
 	Keys []manifestKey `json:"keys"`
 }
@@ -48,7 +46,7 @@ func newUpdater(client *http.Client, manifestURL, targetDir string, interval tim
 		return nil, errors.New("http client must be provided")
 	}
 	if interval <= 0 {
-		interval = defaultUpdateInterval
+		return nil, errors.New("update interval must be positive")
 	}
 
 	return &updater{
@@ -95,12 +93,12 @@ func (u *updater) doUpdate() {
 }
 
 func (u *updater) update() error {
-	manifest, err := u.downloadManifest(u.manifestURL)
+	mf, err := u.downloadManifest(u.manifestURL)
 	if err != nil {
 		return errors.Wrapf(err, "downloading manifest from URL %q", u.manifestURL)
 	}
 
-	keyRefs, err := resolveKeyRefsFromManifest(u.manifestURL, manifest)
+	keyRefs, err := resolveKeyRefsFromManifest(u.manifestURL, mf)
 	if err != nil {
 		return errors.Wrap(err, "resolving key references from manifest")
 	}
@@ -115,60 +113,73 @@ func (u *updater) update() error {
 		_ = os.RemoveAll(stagingDir)
 	}()
 
-	if err := u.downloadKeys(keyRefs, stagingDir); err != nil {
+	n, err := u.downloadKeys(keyRefs, stagingDir)
+	if err != nil {
 		return errors.Wrap(err, "downloading keys to staging")
 	}
 	if err := replaceDirectoryContents(u.targetDir, stagingDir); err != nil {
 		return errors.Wrapf(err, "replacing target directory %q contents", u.targetDir)
 	}
 
+	log.Infof("Successfully updated Red Hat signing keys from %q: %d keys written to %q", u.manifestURL, n, u.targetDir)
 	return nil
 }
 
 // resolveKeyRefsFromManifest resolves the key references from a manifest.
-func resolveKeyRefsFromManifest(manifestURL string, manifest manifest) ([]keyRef, error) {
-	if len(manifest.Keys) == 0 {
+func resolveKeyRefsFromManifest(manifestURL string, mf manifest) ([]keyRef, error) {
+	if len(mf.Keys) == 0 {
 		return nil, errors.Errorf("manifest at %q does not contain any files", manifestURL)
 	}
 
-	keyRefs := make([]keyRef, 0, len(manifest.Keys))
-	for _, key := range manifest.Keys {
+	keyRefs := make([]keyRef, 0, len(mf.Keys))
+	for _, key := range mf.Keys {
+		name := strings.TrimSpace(key.Name)
+		if name == "" {
+			return nil, errors.New("manifest entry has empty name")
+		}
+		if strings.ContainsAny(name, "/\\") {
+			return nil, errors.Errorf("manifest entry name %q contains path separator", name)
+		}
 		resolvedURL, err := resolveKeyURL(manifestURL, key.URL)
 		if err != nil {
 			return nil, errors.Wrapf(err, "resolving URL %q", key.URL)
 		}
 		keyRefs = append(keyRefs, keyRef{
-			name: key.Name,
+			name: name,
 			url:  resolvedURL,
 		})
 	}
 	return keyRefs, nil
 }
 
-func (u *updater) downloadKeys(keys []keyRef, stagingDir string) error {
+func (u *updater) downloadKeys(keys []keyRef, stagingDir string) (int, error) {
 	successes := 0
 	failures := 0
 
+	cleanStagingDir := filepath.Clean(stagingDir) + string(os.PathSeparator)
 	for _, key := range keys {
 		destination := filepath.Join(stagingDir, key.name)
+		if !strings.HasPrefix(filepath.Clean(destination)+string(os.PathSeparator), cleanStagingDir) {
+			failures++
+			log.Warnf("Skipping manifest entry %q (URL %q): resolved path escapes staging directory", key.name, key.url)
+			continue
+		}
 		if err := u.downloadFile(key.url, destination); err != nil {
 			failures++
-			log.Warnf("Skipping manifest entry %q: %v", key.url, err)
+			log.Warnf("Skipping manifest entry %q (URL %q): %v", key.name, key.url, err)
 			continue
 		}
 		successes++
 	}
 
 	if successes == 0 {
-		return errors.New("failed to download any keys")
+		return 0, errors.New("failed to download any keys")
 	}
 	if failures > 0 {
-		log.Warnf("Downloaded %d keys to staging %q, skipped %d entries", successes, stagingDir, failures)
-	} else {
-		log.Debugf("Downloaded %d keys to staging %q", successes, stagingDir)
+		log.Warnf("Downloaded %d keys, skipped %d entries", successes, failures)
 	}
 
-	return nil
+	return successes, nil
 }
 
 func (u *updater) downloadFile(url string, destination string) error {
@@ -177,7 +188,7 @@ func (u *updater) downloadFile(url string, destination string) error {
 		return errors.Wrapf(err, "failed to download file from URL %q", url)
 	}
 
-	if err := os.WriteFile(destination, contents, 0o600); err != nil {
+	if err := os.WriteFile(destination, contents, 0o644); err != nil {
 		_ = os.Remove(destination)
 		return errors.Wrapf(err, "failed to write file %q", destination)
 	}
@@ -198,11 +209,14 @@ func replaceDirectoryContents(targetDir, sourceDir string) error {
 		return errors.Wrap(err, "moving staged directory into target")
 	}
 	if err := os.RemoveAll(backupDir); err != nil {
-		return errors.Wrap(err, "removing backup directory")
+		log.Warnf("Failed to remove backup directory %q: %v", backupDir, err)
 	}
 
 	return nil
 }
+
+// maxResponseBodySize is the maximum size of a response body (manifest or key file) we will read.
+const maxResponseBodySize = 5 * 1024 * 1024 // 5 MB
 
 func (u *updater) downloadBytes(rawURL string) ([]byte, error) {
 	reqCtx, cancel := u.newRequestContext()
@@ -223,32 +237,22 @@ func (u *updater) downloadBytes(rawURL string) ([]byte, error) {
 		return nil, errors.Errorf("HTTP %d for %q", resp.StatusCode, rawURL)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize+1))
 	if err != nil {
 		return nil, errors.Wrap(err, "reading response body")
+	}
+	if len(body) > maxResponseBodySize {
+		return nil, errors.Errorf("response body from %q exceeds maximum size of %d bytes", rawURL, maxResponseBodySize)
 	}
 
 	return body, nil
 }
 
+const requestTimeout = 60 * time.Second
+
 func (u *updater) newRequestContext() (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	select {
-	case <-u.stopSig.Done():
-		cancel()
-		return ctx, cancel
-	default:
-	}
-
-	go func() {
-		select {
-		case <-u.stopSig.Done():
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
-
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	concurrency.CancelContextOnSignal(ctx, cancel, &u.stopSig)
 	return ctx, cancel
 }
 
@@ -296,6 +300,9 @@ func resolveKeyURL(manifestURL, keyURL string) (string, error) {
 	parsed, err := url.Parse(resolved)
 	if err != nil {
 		return "", errors.Wrap(err, "parsing resolved URL")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", errors.Errorf("unsupported URL scheme %q in %s", parsed.Scheme, resolved)
 	}
 	if strings.HasSuffix(parsed.Path, "/") || parsed.Path == "" {
 		return "", errors.Errorf("URL must point to a file, not a directory: %s", resolved)

--- a/central/signatureintegration/datastore/updater_test.go
+++ b/central/signatureintegration/datastore/updater_test.go
@@ -1,0 +1,214 @@
+package datastore
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func validPEM(t *testing.T) string {
+	t.Helper()
+	return goodCosignConfig.GetPublicKeys()[0].GetPublicKeyPemEnc()
+}
+
+func newTestUpdater(t *testing.T, manifestURL, targetDir string) *updater {
+	t.Helper()
+	u, err := newUpdater(&http.Client{Timeout: 5 * time.Second}, manifestURL, targetDir, time.Second)
+	require.NoError(t, err)
+	return u
+}
+
+func TestResolveKeyURL(t *testing.T) {
+	tests := []struct {
+		manifestURL string
+		keyURL      string
+		want        string
+		wantErr     bool
+	}{
+		{"https://a.com/dir/manifest.json", "https://b.com/key.pub", "https://b.com/key.pub", false},
+		{"https://a.com/dir/manifest.json", "http://b.com/key.pub", "http://b.com/key.pub", false},
+		{"https://example.com/keys/manifest.json", "release-key.pub", "https://example.com/keys/release-key.pub", false},
+		{"https://example.com/keys/manifest.json", "sub/key.pub", "https://example.com/keys/sub/key.pub", false},
+		{"https://example.com/manifest.json", "key.pub", "https://example.com/key.pub", false},
+		{"https://example.com/keys/manifest.json", "https://example.com/keys/", "", true},
+		{"https://example.com/keys/manifest.json", "keys/", "", true},
+		{"://invalid", "key.pub", "", true},
+	}
+
+	for _, tt := range tests {
+		got, err := resolveKeyURL(tt.manifestURL, tt.keyURL)
+		if tt.wantErr {
+			require.Error(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+			continue
+		}
+		require.NoError(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+		require.Equal(t, tt.want, got, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+	}
+}
+
+func TestUpdateDownloadsAllFiles(t *testing.T) {
+	pem := validPEM(t)
+	targetDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "stale.pub"), []byte("stale"), 0o600))
+
+	manifest := manifest{
+		Keys: []manifestKey{
+			{Name: "key-a.pub", URL: "key-a.pub"},
+			{Name: "key-b.pub", URL: "nested/key-b.pub"},
+		},
+	}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(manifestBody)
+		case "/key-a.pub", "/nested/key-b.pub":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(pem))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.NoError(t, u.update())
+
+	entries, err := os.ReadDir(targetDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	a, err := os.ReadFile(filepath.Join(targetDir, "key-a.pub"))
+	require.NoError(t, err)
+	require.Equal(t, pem, string(a))
+
+	b, err := os.ReadFile(filepath.Join(targetDir, "key-b.pub"))
+	require.NoError(t, err)
+	require.Equal(t, pem, string(b))
+
+	_, err = os.Stat(filepath.Join(targetDir, "stale.pub"))
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestNewUpdaterRequiresClient(t *testing.T) {
+	_, err := newUpdater(nil, "https://example.com/manifest.json", t.TempDir(), time.Second)
+	require.Error(t, err)
+}
+
+func TestUpdateAllowsPartialDownloads(t *testing.T) {
+	pem := validPEM(t)
+	targetDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "stale.pub"), []byte("stale"), 0o600))
+
+	manifest := manifest{
+		Keys: []manifestKey{
+			{Name: "key-a.pub", URL: "key-a.pub"},
+			{Name: "missing.pub", URL: "missing.pub"},
+		},
+	}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(manifestBody)
+		case "/key-a.pub":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(pem))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.NoError(t, u.update())
+
+	entries, err := os.ReadDir(targetDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	a, err := os.ReadFile(filepath.Join(targetDir, "key-a.pub"))
+	require.NoError(t, err)
+	require.Equal(t, pem, string(a))
+
+	_, err = os.Stat(filepath.Join(targetDir, "stale.pub"))
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestUpdateAllowsDuplicateOutputFileNames_LastWriteWins(t *testing.T) {
+	pem := validPEM(t)
+	targetDir := t.TempDir()
+
+	manifest := manifest{
+		Keys: []manifestKey{
+			{Name: "key.pub", URL: "keys/key.pub"},
+			{Name: "key.pub", URL: "other/key.pub"},
+		},
+	}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(manifestBody)
+		case "/keys/key.pub", "/other/key.pub":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(pem))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.NoError(t, u.update())
+	content, err := os.ReadFile(filepath.Join(targetDir, "key.pub"))
+	require.NoError(t, err)
+	require.Equal(t, pem, string(content))
+}
+
+func TestUpdateFailsWhenNoFilesCanBeDownloaded(t *testing.T) {
+	targetDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "existing.pub"), []byte("existing"), 0o600))
+	manifest := manifest{
+		Keys: []manifestKey{
+			{Name: "Missing A", URL: "a.pub"},
+			{Name: "Missing B", URL: "b.pub"},
+		},
+	}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/manifest.json" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(manifestBody)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.Error(t, u.update())
+
+	existing, err := os.ReadFile(filepath.Join(targetDir, "existing.pub"))
+	require.NoError(t, err)
+	require.Equal(t, "existing", string(existing))
+}

--- a/central/signatureintegration/datastore/updater_test.go
+++ b/central/signatureintegration/datastore/updater_test.go
@@ -34,6 +34,7 @@ func TestResolveKeyURL(t *testing.T) {
 		{"https://a.com/dir/manifest.json", "https://b.com/key.pub", "https://b.com/key.pub", false},
 		{"https://a.com/dir/manifest.json", "http://b.com/key.pub", "http://b.com/key.pub", false},
 		{"https://example.com/keys/manifest.json", "release-key.pub", "https://example.com/keys/release-key.pub", false},
+		{"https://example.com/keys/manifest.json", "  key.pub \n", "https://example.com/keys/key.pub", false},
 		{"https://example.com/keys/manifest.json", "sub/key.pub", "https://example.com/keys/sub/key.pub", false},
 		{"https://example.com/manifest.json", "key.pub", "https://example.com/key.pub", false},
 		{"https://example.com/keys/manifest.json", "https://example.com/keys/", "", true},
@@ -44,11 +45,11 @@ func TestResolveKeyURL(t *testing.T) {
 	for _, tt := range tests {
 		got, err := resolveKeyURL(tt.manifestURL, tt.keyURL)
 		if tt.wantErr {
-			require.Error(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+			require.Errorf(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
 			continue
 		}
-		require.NoError(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
-		require.Equal(t, tt.want, got, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+		require.NoErrorf(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+		require.Equalf(t, tt.want, got, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
 	}
 }
 

--- a/central/signatureintegration/datastore/updater_test.go
+++ b/central/signatureintegration/datastore/updater_test.go
@@ -2,10 +2,12 @@ package datastore
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,16 +42,20 @@ func TestResolveKeyURL(t *testing.T) {
 		{"https://example.com/keys/manifest.json", "https://example.com/keys/", "", true},
 		{"https://example.com/keys/manifest.json", "keys/", "", true},
 		{"://invalid", "key.pub", "", true},
+		{"https://example.com/keys/manifest.json", "file:///etc/shadow", "", true},
+		{"https://example.com/keys/manifest.json", "gopher://evil.com/key", "", true},
 	}
 
 	for _, tt := range tests {
-		got, err := resolveKeyURL(tt.manifestURL, tt.keyURL)
-		if tt.wantErr {
-			require.Errorf(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
-			continue
-		}
-		require.NoErrorf(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
-		require.Equalf(t, tt.want, got, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+		t.Run(fmt.Sprintf("%s_%s", tt.manifestURL, tt.keyURL), func(t *testing.T) {
+			got, err := resolveKeyURL(tt.manifestURL, tt.keyURL)
+			if tt.wantErr {
+				require.Errorf(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+				return
+			}
+			require.NoErrorf(t, err, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+			require.Equalf(t, tt.want, got, "manifest=%q key=%q", tt.manifestURL, tt.keyURL)
+		})
 	}
 }
 
@@ -295,4 +301,41 @@ func TestUpdateFailsWhenNoFilesCanBeDownloaded(t *testing.T) {
 	existing, err := os.ReadFile(filepath.Join(targetDir, "existing.pub"))
 	require.NoError(t, err)
 	require.Equal(t, "existing", string(existing))
+}
+
+func TestNewUpdaterRejectsZeroInterval(t *testing.T) {
+	_, err := newUpdater(&http.Client{}, "https://example.com/manifest.json", t.TempDir(), 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "interval must be positive")
+}
+
+func TestResolveKeyRefsRejectsEmptyName(t *testing.T) {
+	_, err := resolveKeyRefsFromManifest("https://example.com/manifest.json", manifest{
+		Keys: []manifestKey{{Name: "", URL: "key.pub"}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty name")
+}
+
+func TestResolveKeyRefsRejectsPathSeparatorInName(t *testing.T) {
+	_, err := resolveKeyRefsFromManifest("https://example.com/manifest.json", manifest{
+		Keys: []manifestKey{{Name: "../etc/evil", URL: "key.pub"}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "path separator")
+}
+
+func TestDownloadBytesRejectsOversizedResponse(t *testing.T) {
+	// Serve a response that exceeds maxResponseBodySize.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Write maxResponseBodySize + 100 bytes.
+		_, _ = w.Write([]byte(strings.Repeat("x", maxResponseBodySize+100)))
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", t.TempDir())
+	_, err := u.downloadBytes(server.URL + "/big-file")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum size")
 }

--- a/central/signatureintegration/datastore/updater_test.go
+++ b/central/signatureintegration/datastore/updater_test.go
@@ -21,7 +21,7 @@ func validPEM(t *testing.T) string {
 
 func newTestUpdater(t *testing.T, manifestURL, targetDir string) *updater {
 	t.Helper()
-	u, err := newUpdater(&http.Client{Timeout: 5 * time.Second}, manifestURL, targetDir, time.Second)
+	u, err := newUpdater(&http.Client{Timeout: 5 * time.Second}, manifestURL, targetDir, time.Second, nil)
 	require.NoError(t, err)
 	return u
 }
@@ -108,7 +108,7 @@ func TestUpdateDownloadsAllFiles(t *testing.T) {
 }
 
 func TestNewUpdaterRequiresClient(t *testing.T) {
-	_, err := newUpdater(nil, "https://example.com/manifest.json", t.TempDir(), time.Second)
+	_, err := newUpdater(nil, "https://example.com/manifest.json", t.TempDir(), time.Second, nil)
 	require.Error(t, err)
 }
 
@@ -304,9 +304,72 @@ func TestUpdateFailsWhenNoFilesCanBeDownloaded(t *testing.T) {
 }
 
 func TestNewUpdaterRejectsZeroInterval(t *testing.T) {
-	_, err := newUpdater(&http.Client{}, "https://example.com/manifest.json", t.TempDir(), 0)
+	_, err := newUpdater(&http.Client{}, "https://example.com/manifest.json", t.TempDir(), 0, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "interval must be positive")
+}
+
+func TestDoUpdate_OnSuccessCalledOnSuccess(t *testing.T) {
+	pem := validPEM(t)
+	targetDir := t.TempDir()
+
+	manifest := manifest{
+		Keys: []manifestKey{{Name: "key.pub", URL: "key.pub"}},
+	}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			_, _ = w.Write(manifestBody)
+		case "/key.pub":
+			_, _ = w.Write([]byte(pem))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	called := make(chan struct{}, 1)
+	u, err := newUpdater(
+		&http.Client{Timeout: 5 * time.Second},
+		server.URL+"/manifest.json",
+		targetDir,
+		time.Second,
+		func() { called <- struct{}{} },
+	)
+	require.NoError(t, err)
+
+	u.doUpdate()
+
+	select {
+	case <-called:
+		// expected
+	default:
+		t.Fatal("onSuccess was not called after a successful update")
+	}
+}
+
+func TestDoUpdate_OnSuccessNotCalledOnFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	called := false
+	u, err := newUpdater(
+		&http.Client{Timeout: 5 * time.Second},
+		server.URL+"/manifest.json",
+		t.TempDir(),
+		time.Second,
+		func() { called = true },
+	)
+	require.NoError(t, err)
+
+	u.doUpdate()
+
+	require.False(t, called, "onSuccess must not be called when the update fails")
 }
 
 func TestResolveKeyRefsRejectsEmptyName(t *testing.T) {

--- a/central/signatureintegration/datastore/updater_test.go
+++ b/central/signatureintegration/datastore/updater_test.go
@@ -184,6 +184,89 @@ func TestUpdateAllowsDuplicateOutputFileNames_LastWriteWins(t *testing.T) {
 	require.Equal(t, pem, string(content))
 }
 
+func TestUpdateFailsOnEmptyManifest(t *testing.T) {
+	targetDir := t.TempDir()
+	manifest := manifest{Keys: []manifestKey{}}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(manifestBody)
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.Error(t, u.update())
+}
+
+func TestUpdateFailsOnInvalidManifestJSON(t *testing.T) {
+	targetDir := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.Error(t, u.update())
+}
+
+func TestUpdateFailsOnManifestHTTPError(t *testing.T) {
+	targetDir := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	require.Error(t, u.update())
+}
+
+func TestReplaceDirectoryContentsIsAtomic(t *testing.T) {
+	targetDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "old.txt"), []byte("old"), 0o600))
+
+	sourceDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "new.txt"), []byte("new"), 0o600))
+
+	require.NoError(t, replaceDirectoryContents(targetDir, sourceDir))
+
+	content, err := os.ReadFile(filepath.Join(targetDir, "new.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "new", string(content))
+
+	_, err = os.Stat(filepath.Join(targetDir, "old.txt"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestStartStopLifecycle(t *testing.T) {
+	pem := validPEM(t)
+	targetDir := t.TempDir()
+	manifest := manifest{
+		Keys: []manifestKey{{Name: "key.pub", URL: "key.pub"}},
+	}
+	manifestBody, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			_, _ = w.Write(manifestBody)
+		case "/key.pub":
+			_, _ = w.Write([]byte(pem))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	u := newTestUpdater(t, server.URL+"/manifest.json", targetDir)
+	u.Start()
+	u.Start() // second call should be no-op (sync.Once)
+	u.Stop()
+}
+
 func TestUpdateFailsWhenNoFilesCanBeDownloaded(t *testing.T) {
 	targetDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "existing.pub"), []byte("existing"), 0o600))

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -206,6 +206,8 @@ spec:
           mountPath: /run/secrets/stackrox.io/monitoring-tls
           readOnly: true
         {{- end }}
+        - name: redhat-signing-keys
+          mountPath: /var/lib/stackrox/signature-keys
         {{- range $extraMount := (default list ._rox.central.extraMounts) }}
         - name: {{ $extraMount.name }}
           {{- $extraMount.mount | toYaml | nindent 10 }}
@@ -295,6 +297,12 @@ spec:
         secret:
           secretName: central-monitoring-tls
       {{- end }}
+      # Runtime directory for Red Hat signing keys downloaded by the updater.
+      # For disconnected deployments, replace this emptyDir with a ConfigMap or
+      # PVC containing your organisation's PEM key files; Central will load them
+      # at startup regardless of whether the manifest-URL updater is configured.
+      - name: redhat-signing-keys
+        emptyDir: {}
       {{- range $extraMount := (default list ._rox.central.extraMounts) }}
       - name: {{ $extraMount.name }}
         {{- $extraMount.source | toYaml | nindent 8 }}

--- a/pkg/env/signature.go
+++ b/pkg/env/signature.go
@@ -1,6 +1,18 @@
 package env
 
+import "time"
+
 var (
 	// DisableSignatureFetching disables signature fetching within the reprocessing loop.
 	DisableSignatureFetching = RegisterBooleanSetting("ROX_DISABLE_SIGNATURE_FETCHING", false)
+
+	// RedHatSigningKeyManifestURL is the URL of the manifest listing trusted Red Hat signing keys.
+	RedHatSigningKeyManifestURL = RegisterSetting("ROX_REDHAT_SIGNING_KEY_MANIFEST_URL")
+
+	// RedHatSigningKeyUpdateInterval controls how often the signing key updater runs.
+	RedHatSigningKeyUpdateInterval = registerDurationSetting("ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL", 4*time.Hour)
+
+	// RedHatSigningKeysRuntimeDir is the writable directory where downloaded Red Hat signing keys are stored.
+	RedHatSigningKeysRuntimeDir = RegisterSetting("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR",
+		WithDefault("/var/lib/stackrox/signature-keys/redhat"))
 )


### PR DESCRIPTION
## What
Mounts a writable `emptyDir` volume at `/var/lib/stackrox/signature-keys` in the Central deployment, allowing the manifest-URL updater (PR #20141) to write downloaded PEM files to the `redhat/` subdirectory at runtime.

## Why
The updater calls `os.MkdirTemp(filepath.Dir(targetDir), ...)` to create a staging directory. Since `targetDir = /var/lib/stackrox/signature-keys/redhat`, the staging dir is created in the *parent* `/var/lib/stackrox/signature-keys/`. The base image has a read-only root filesystem, so the emptyDir must be mounted at the parent path to allow both the staging write and the final atomic rename.

## Alternatives considered
- Mount at `/var/lib/stackrox/signature-keys/redhat` (the target dir itself): fails because the staging dir is one level up in the parent.

## How
Added `volumeMount` at `mountPath: /var/lib/stackrox/signature-keys` and a matching `emptyDir` volume named `redhat-signing-keys` in `01-central-13-deployment.yaml.htpl`.

The volume is unconditional (no `if` guard). For disconnected deployments, replace `emptyDir` with a `ConfigMap` or `PVC` containing organisation-supplied PEM files; Central loads them at startup via `upsertRedHatSignatureIntegration` regardless of whether the manifest-URL updater is configured.

## Testing
- Deployed with `ROX_REDHAT_SIGNING_KEY_MANIFEST_URL=https://storage.googleapis.com/rox-public-key-test-20260203/manifest.json`
- Confirmed updater successfully downloads keys to `/var/lib/stackrox/signature-keys/redhat/`
- Confirmed `onSuccess` callback fires and triggers re-upsert
- Confirmed deduplication correctly skips keys already in the embedded integration

## Checklist
- [x] Follows [RHACS coding style](https://github.com/stackrox/stackrox/blob/master/.github/go-coding-style.md)
- [x] Tests provided or not applicable (Helm template change, covered by E2E)
- [x] Documentation updated or not needed
