### PR TITLE
ROX-34184: Add ImageVulnerabilityReportWizard

### DIFF
--- a/ui/apps/platform/src/Components/Reports/Step/DetailsStep.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/DetailsStep.tsx
@@ -1,15 +1,59 @@
 import type { ReactElement } from 'react';
-import { Divider, Flex, PageSection, Title } from '@patternfly/react-core';
+import { Flex, Form, PageSection, TextArea, TextInput, Title } from '@patternfly/react-core';
+import type { FormikProps } from 'formik';
 
-// import type { DetailsType } from '../reports.types';
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 
-function DetailsStep(): ReactElement {
+import type { DetailsType, ReportPageAction } from '../reports.types';
+
+export type DetailsStepProps = {
+    formik: FormikProps<DetailsType>;
+    pageAction: ReportPageAction;
+};
+
+function DetailsStep({ formik, pageAction }: DetailsStepProps): ReactElement {
     return (
         <PageSection>
-            <Flex direction={{ default: 'column' }}>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Details</Title>
-                <Divider component="div" />
-                {/* TODO Form includes name and description */}
+                <Form>
+                    <FormLabelGroup
+                        label="Name"
+                        isRequired
+                        fieldId="name"
+                        errors={formik.errors}
+                        touched={formik.touched}
+                    >
+                        <TextInput
+                            type="text"
+                            id="name"
+                            name="name"
+                            value={formik.values.name}
+                            isDisabled={pageAction === 'edit'}
+                            isRequired
+                            validated={
+                                formik.errors?.name && formik.touched?.name ? 'error' : 'default'
+                            }
+                            onChange={formik.handleChange}
+                            onBlur={formik.handleBlur}
+                        />
+                    </FormLabelGroup>
+                    <FormLabelGroup
+                        label="Description"
+                        fieldId="description"
+                        errors={formik.errors}
+                        touched={formik.touched}
+                    >
+                        <TextArea
+                            type="text"
+                            id="description"
+                            name="description"
+                            value={formik.values.description}
+                            onChange={formik.handleChange}
+                            onBlur={formik.handleBlur}
+                        />
+                    </FormLabelGroup>
+                </Form>
             </Flex>
         </PageSection>
     );

--- a/ui/apps/platform/src/Components/Reports/Step/DetailsStep.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/DetailsStep.tsx
@@ -6,12 +6,15 @@ import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 
 import type { DetailsType, ReportPageAction } from '../reports.types';
 
-export type DetailsStepProps = {
-    formik: FormikProps<DetailsType>;
+export type DetailsStepProps<T extends DetailsType = DetailsType> = {
+    formik: FormikProps<T>;
     pageAction: ReportPageAction;
 };
 
-function DetailsStep({ formik, pageAction }: DetailsStepProps): ReactElement {
+function DetailsStep<T extends DetailsType = DetailsType>({
+    formik,
+    pageAction,
+}: DetailsStepProps<T>): ReactElement {
     return (
         <PageSection>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>

--- a/ui/apps/platform/src/Components/Reports/reports.types.ts
+++ b/ui/apps/platform/src/Components/Reports/reports.types.ts
@@ -1,12 +1,14 @@
 import type { NotifierConfiguration } from 'services/ReportsService.types';
 import type { Schedule } from 'types/schedule.proto';
 
-export type DeliveryType = {
-    notifiers: NotifierConfiguration[];
-    schedule: Schedule | null;
-};
+export type ReportPageAction = 'clone' | 'create' | 'edit' | 'createFromFilters';
 
 export type DetailsType = {
     name: string;
     description: string;
+};
+
+export type DeliveryType = {
+    notifiers: NotifierConfiguration[];
+    schedule: Schedule | null;
 };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import type { ComponentProps, ReactElement } from 'react';
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { Wizard, WizardStep } from '@patternfly/react-core';
+import { useFormik } from 'formik';
+
+import type {
+    CompoundSearchFilterAttribute,
+    CompoundSearchFilterConfig,
+} from 'Components/CompoundSearchFilter/types';
+import DetailsStep from 'Components/Reports/Step/DetailsStep';
+import type { ReportPageAction } from 'Components/Reports/reports.types';
+import { createReportConfiguration, updateReportConfiguration } from 'services/ReportsService';
+import type { ReportConfiguration } from 'services/ReportsService.types';
+import { vulnerabilityConfigurationReportsPath } from 'routePaths';
+
+import type { ImageVulnerabilityReportConfiguration } from '../imageVulnerabilityReports.types';
+import { hasConfigurationForEntity } from '../imageVulnerabilityReports.utils';
+
+import ImageVulnerabilityResourcesStep from './Step2/ImageVulnerabilityResourcesStep';
+import ImageVulnerabilityFiltersStep from './Step3/ImageVulnerabilityFiltersStep';
+import ImageVulnerabilityFiltersStepForCollection from './Step3/ImageVulnerabilityFiltersStepForCollection';
+import ImageVulnerabilityReviewStep from './Step5/ImageVulnerabilityReviewStep';
+
+export type ImageVulnerabilityReportWizardProps = {
+    attributesSeparateFromConfig: CompoundSearchFilterAttribute[];
+    initialValues: ImageVulnerabilityReportConfiguration;
+    pageAction: ReportPageAction;
+    searchFilterConfig: CompoundSearchFilterConfig;
+};
+
+function ImageVulnerabilityReportWizard({
+    attributesSeparateFromConfig,
+    initialValues,
+    pageAction,
+    searchFilterConfig,
+}: ImageVulnerabilityReportWizardProps): ReactElement {
+    const navigate = useNavigate();
+    const [error, setError] = useState<Error | null>(null);
+
+    const formik = useFormik({
+        initialValues,
+        onSubmit: (values: ImageVulnerabilityReportConfiguration, { setSubmitting }) => {
+            const request =
+                pageAction === 'edit'
+                    ? updateReportConfiguration(values.id, values as ReportConfiguration)
+                    : createReportConfiguration(values as ReportConfiguration);
+
+            request
+                .then((data) => {
+                    if (pageAction === 'edit') {
+                        // Go back either to reports table or page for existing report.
+                        navigate(-1);
+                    } else {
+                        // Go to page for new report.
+                        navigate(`${vulnerabilityConfigurationReportsPath}/${data.id}`);
+                    }
+                })
+                .catch((errorCaught) => {
+                    setError(errorCaught);
+                })
+                .finally(() => {
+                    setSubmitting(false);
+                });
+        },
+    });
+
+    // Too bad, so sad: formik types do not understand subsets of values.
+    return (
+        <Wizard>
+            <WizardStep id="Details" name="Details" body={{ hasNoPadding: true }}>
+                <DetailsStep
+                    formik={formik as unknown as ComponentProps<typeof DetailsStep>['formik']}
+                    pageAction={pageAction}
+                />
+            </WizardStep>
+            <WizardStep id="Resources" name="Resources" body={{ hasNoPadding: true }}>
+                <ImageVulnerabilityResourcesStep
+                    formik={
+                        formik as unknown as ComponentProps<
+                            typeof ImageVulnerabilityResourcesStep
+                        >['formik']
+                    }
+                />
+            </WizardStep>
+            <WizardStep id="Filters" name="Filters" body={{ hasNoPadding: true }}>
+                {hasConfigurationForEntity(formik.values) ? (
+                    <ImageVulnerabilityFiltersStep
+                        formik={
+                            formik as unknown as ComponentProps<
+                                typeof ImageVulnerabilityFiltersStep
+                            >['formik']
+                        }
+                    />
+                ) : (
+                    <ImageVulnerabilityFiltersStepForCollection
+                        formik={
+                            formik as unknown as ComponentProps<
+                                typeof ImageVulnerabilityFiltersStepForCollection
+                            >['formik']
+                        }
+                    />
+                )}
+            </WizardStep>
+            <WizardStep id="Delivery" name="Delivery" body={{ hasNoPadding: true }}>
+                <></>
+            </WizardStep>
+            <WizardStep id="Review" name="Review" body={{ hasNoPadding: true }}>
+                <ImageVulnerabilityReviewStep
+                    attributesSeparateFromConfig={attributesSeparateFromConfig}
+                    error={error}
+                    searchFilterConfig={searchFilterConfig}
+                    values={formik.values}
+                />
+            </WizardStep>
+        </Wizard>
+    );
+}
+
+export default ImageVulnerabilityReportWizard;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
@@ -5,8 +5,8 @@ import { Wizard, WizardStep } from '@patternfly/react-core';
 import { useFormik } from 'formik';
 
 import type {
-    CompoundSearchFilterAttribute,
     CompoundSearchFilterConfig,
+    SelectSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 import DetailsStep from 'Components/Reports/Step/DetailsStep';
 import type { ReportPageAction } from 'Components/Reports/reports.types';
@@ -23,7 +23,7 @@ import ImageVulnerabilityFiltersStepForCollection from './Step3/ImageVulnerabili
 import ImageVulnerabilityReviewStep from './Step5/ImageVulnerabilityReviewStep';
 
 export type ImageVulnerabilityReportWizardProps = {
-    attributesSeparateFromConfig: CompoundSearchFilterAttribute[];
+    attributesSeparateFromConfig: SelectSearchFilterAttribute[];
     initialValues: ImageVulnerabilityReportConfiguration;
     pageAction: ReportPageAction;
     searchFilterConfig: CompoundSearchFilterConfig;
@@ -86,11 +86,13 @@ function ImageVulnerabilityReportWizard({
             <WizardStep id="Filters" name="Filters" body={{ hasNoPadding: true }}>
                 {hasConfigurationForEntity(formik.values) ? (
                     <ImageVulnerabilityFiltersStep
+                        attributesSeparateFromConfig={attributesSeparateFromConfig}
                         formik={
                             formik as unknown as ComponentProps<
                                 typeof ImageVulnerabilityFiltersStep
                             >['formik']
                         }
+                        searchFilterConfig={searchFilterConfig}
                     />
                 ) : (
                     <ImageVulnerabilityFiltersStepForCollection

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
@@ -85,7 +85,6 @@ function ImageVulnerabilityReportWizard({
         },
     });
 
-    // Too bad, so sad: formik types do not understand subsets of values.
     return (
         <Wizard>
             <WizardStep id="Details" name="Details" body={{ hasNoPadding: true }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import type { ComponentProps, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { Wizard, WizardStep } from '@patternfly/react-core';
 import { useFormik } from 'formik';
+import type { FormikProps } from 'formik';
 
 import type {
     CompoundSearchFilterConfig,
@@ -14,13 +15,32 @@ import { createReportConfiguration, updateReportConfiguration } from 'services/R
 import type { ReportConfiguration } from 'services/ReportsService.types';
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 
-import type { ImageVulnerabilityReportConfiguration } from '../imageVulnerabilityReports.types';
-import { hasConfigurationForEntity } from '../imageVulnerabilityReports.utils';
+import type {
+    ImageVulnerabilityReportConfiguration,
+    ImageVulnerabilityReportConfigurationForCollection,
+    ImageVulnerabilityReportConfigurationForEntity,
+} from '../imageVulnerabilityReports.types';
 
 import ImageVulnerabilityResourcesStep from './Step2/ImageVulnerabilityResourcesStep';
 import ImageVulnerabilityFiltersStep from './Step3/ImageVulnerabilityFiltersStep';
 import ImageVulnerabilityFiltersStepForCollection from './Step3/ImageVulnerabilityFiltersStepForCollection';
 import ImageVulnerabilityReviewStep from './Step5/ImageVulnerabilityReviewStep';
+
+// TypeScript needs help because entityScope and vulnReportFilters have mutual dependencies.
+// entityScope implies query but not fixibility nore severities
+// collectionScope implies fixibility and severities but not query
+
+export function hasFormikPropsForEntity(
+    formik
+): formik is FormikProps<ImageVulnerabilityReportConfigurationForEntity> {
+    return 'entityScope' in formik.values.resourceScope;
+}
+
+export function hasFormikPropsForCollection(
+    formik
+): formik is FormikProps<ImageVulnerabilityReportConfigurationForCollection> {
+    return 'collectionScope' in formik.values.resourceScope;
+}
 
 export type ImageVulnerabilityReportWizardProps = {
     attributesSeparateFromConfig: SelectSearchFilterAttribute[];
@@ -69,39 +89,21 @@ function ImageVulnerabilityReportWizard({
     return (
         <Wizard>
             <WizardStep id="Details" name="Details" body={{ hasNoPadding: true }}>
-                <DetailsStep
-                    formik={formik as unknown as ComponentProps<typeof DetailsStep>['formik']}
-                    pageAction={pageAction}
-                />
+                <DetailsStep formik={formik} pageAction={pageAction} />
             </WizardStep>
             <WizardStep id="Resources" name="Resources" body={{ hasNoPadding: true }}>
-                <ImageVulnerabilityResourcesStep
-                    formik={
-                        formik as unknown as ComponentProps<
-                            typeof ImageVulnerabilityResourcesStep
-                        >['formik']
-                    }
-                />
+                <ImageVulnerabilityResourcesStep formik={formik} />
             </WizardStep>
             <WizardStep id="Filters" name="Filters" body={{ hasNoPadding: true }}>
-                {hasConfigurationForEntity(formik.values) ? (
+                {hasFormikPropsForEntity(formik) && (
                     <ImageVulnerabilityFiltersStep
                         attributesSeparateFromConfig={attributesSeparateFromConfig}
-                        formik={
-                            formik as unknown as ComponentProps<
-                                typeof ImageVulnerabilityFiltersStep
-                            >['formik']
-                        }
+                        formik={formik}
                         searchFilterConfig={searchFilterConfig}
                     />
-                ) : (
-                    <ImageVulnerabilityFiltersStepForCollection
-                        formik={
-                            formik as unknown as ComponentProps<
-                                typeof ImageVulnerabilityFiltersStepForCollection
-                            >['formik']
-                        }
-                    />
+                )}
+                {hasFormikPropsForCollection(formik) && (
+                    <ImageVulnerabilityFiltersStepForCollection formik={formik} />
                 )}
             </WizardStep>
             <WizardStep id="Delivery" name="Delivery" body={{ hasNoPadding: true }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
@@ -6,13 +6,15 @@ import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 
 import type { ImageVulnerabilityResourcesConfiguration } from '../../imageVulnerabilityReports.types';
 
-export type ImageVulnerabilityResourcesStepProps = {
-    formik: FormikProps<ImageVulnerabilityResourcesConfiguration>;
+export type ImageVulnerabilityResourcesStepProps<
+    T extends ImageVulnerabilityResourcesConfiguration = ImageVulnerabilityResourcesConfiguration,
+> = {
+    formik: FormikProps<T>;
 };
 
-function ImageVulnerabilityResourcesStep({
-    formik,
-}: ImageVulnerabilityResourcesStepProps): ReactElement {
+function ImageVulnerabilityResourcesStep<
+    T extends ImageVulnerabilityResourcesConfiguration = ImageVulnerabilityResourcesConfiguration,
+>({ formik }: ImageVulnerabilityResourcesStepProps<T>): ReactElement {
     return (
         <PageSection>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
@@ -1,15 +1,33 @@
 import type { ReactElement } from 'react';
-import { Divider, Flex, PageSection, Title } from '@patternfly/react-core';
+import { Flex, Form, PageSection, Title } from '@patternfly/react-core';
+import type { FormikProps } from 'formik';
 
-// import type { ImageVulnerabilityResourcesConfiguration } from '../../imageVulnerabilityReports.types';
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 
-function ImageVulnerabilityResourcesStep(): ReactElement {
+import type { ImageVulnerabilityResourcesConfiguration } from '../../imageVulnerabilityReports.types';
+
+export type ImageVulnerabilityResourcesStepProps = {
+    formik: FormikProps<ImageVulnerabilityResourcesConfiguration>;
+};
+
+function ImageVulnerabilityResourcesStep({
+    formik,
+}: ImageVulnerabilityResourcesStepProps): ReactElement {
     return (
         <PageSection>
-            <Flex direction={{ default: 'column' }}>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Resources</Title>
-                <Divider component="div" />
-                {/* TODO Form includes imageType and resourceScope */}
+                <Form>
+                    <FormLabelGroup
+                        label="Image type"
+                        isRequired
+                        fieldId="vulnReportFilters.imageTypes"
+                        errors={formik.errors}
+                    >
+                        <>{JSON.stringify(formik.values.vulnReportFilters.imageTypes, null, 0)}</>
+                    </FormLabelGroup>
+                </Form>
+                {/* TODO resourceScope */}
             </Flex>
         </PageSection>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
@@ -2,11 +2,20 @@ import type { ReactElement } from 'react';
 import { Flex, Form, PageSection, Title } from '@patternfly/react-core';
 import type { FormikProps } from 'formik';
 
+import type {
+    CompoundSearchFilterConfig,
+    SelectSearchFilterAttribute,
+} from 'Components/CompoundSearchFilter/types';
+
 import type { ImageVulnerabilityFiltersConfiguration } from '../../imageVulnerabilityReports.types';
 
+/* eslint-disable react/no-unused-prop-types */
 export type ImageVulnerabilityFiltersStepProps = {
+    attributesSeparateFromConfig: SelectSearchFilterAttribute[];
     formik: FormikProps<ImageVulnerabilityFiltersConfiguration>;
+    searchFilterConfig: CompoundSearchFilterConfig;
 };
+/* eslint-enable react/no-unused-prop-types */
 
 function ImageVulnerabilityFiltersStep({
     formik,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
@@ -7,19 +7,23 @@ import type {
     SelectSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 
-import type { ImageVulnerabilityFiltersConfiguration } from '../../imageVulnerabilityReports.types';
+import type { ImageVulnerabilityReportConfigurationForEntity } from '../../imageVulnerabilityReports.types';
 
 /* eslint-disable react/no-unused-prop-types */
-export type ImageVulnerabilityFiltersStepProps = {
+export type ImageVulnerabilityFiltersStepProps<
+    T extends ImageVulnerabilityReportConfigurationForEntity =
+        ImageVulnerabilityReportConfigurationForEntity,
+> = {
     attributesSeparateFromConfig: SelectSearchFilterAttribute[];
-    formik: FormikProps<ImageVulnerabilityFiltersConfiguration>;
+    formik: FormikProps<T>;
     searchFilterConfig: CompoundSearchFilterConfig;
 };
 /* eslint-enable react/no-unused-prop-types */
 
-function ImageVulnerabilityFiltersStep({
-    formik,
-}: ImageVulnerabilityFiltersStepProps): ReactElement {
+function ImageVulnerabilityFiltersStep<
+    T extends ImageVulnerabilityReportConfigurationForEntity =
+        ImageVulnerabilityReportConfigurationForEntity,
+>({ formik }: ImageVulnerabilityFiltersStepProps<T>): ReactElement {
     return (
         <PageSection>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
@@ -1,15 +1,24 @@
 import type { ReactElement } from 'react';
-import { Divider, Flex, PageSection, Title } from '@patternfly/react-core';
+import { Flex, Form, PageSection, Title } from '@patternfly/react-core';
+import type { FormikProps } from 'formik';
 
-// import type { ImageVulnerabilityFiltersConfiguration } from '../../imageVulnerabilityReports.types';
+import type { ImageVulnerabilityFiltersConfiguration } from '../../imageVulnerabilityReports.types';
 
-function ImageVulnerabilityFiltersStep(): ReactElement {
+export type ImageVulnerabilityFiltersStepProps = {
+    formik: FormikProps<ImageVulnerabilityFiltersConfiguration>;
+};
+
+function ImageVulnerabilityFiltersStep({
+    formik,
+}: ImageVulnerabilityFiltersStepProps): ReactElement {
     return (
         <PageSection>
-            <Flex direction={{ default: 'column' }}>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Filters</Title>
-                <Divider component="div" />
-                {/* TODO Form includes query and cvesSince */}
+                <Form>
+                    <>{formik.values.vulnReportFilters.query}</>
+                    {/* TODO cvesSince */}
+                </Form>
             </Flex>
         </PageSection>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
@@ -7,13 +7,17 @@ import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 
 import type { ImageVulnerabilityFiltersConfigurationForCollection } from '../../imageVulnerabilityReports.types';
 
-export type ImageVulnerabilityFiltersStepForCollectionProps = {
-    formik: FormikProps<ImageVulnerabilityFiltersConfigurationForCollection>;
+export type ImageVulnerabilityFiltersStepForCollectionProps<
+    T extends ImageVulnerabilityFiltersConfigurationForCollection =
+        ImageVulnerabilityFiltersConfigurationForCollection,
+> = {
+    formik: FormikProps<T>;
 };
 
-function ImageVulnerabilityFiltersStepForCollection({
-    formik,
-}: ImageVulnerabilityFiltersStepForCollectionProps): ReactElement {
+function ImageVulnerabilityFiltersStepForCollection<
+    T extends ImageVulnerabilityFiltersConfigurationForCollection =
+        ImageVulnerabilityFiltersConfigurationForCollection,
+>({ formik }: ImageVulnerabilityFiltersStepForCollectionProps<T>): ReactElement {
     return (
         <PageSection>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
@@ -1,15 +1,42 @@
 import type { ReactElement } from 'react';
-import { Divider, Flex, PageSection, Title } from '@patternfly/react-core';
+import { Flex, Form, PageSection, Title } from '@patternfly/react-core';
 
-// import type { ImageVulnerabilityFiltersConfigurationForCollection } from '../../imageVulnerabilityReports.types';
+import type { FormikProps } from 'formik';
 
-function ImageVulnerabilityFiltersStepForCollection(): ReactElement {
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+
+import type { ImageVulnerabilityFiltersConfigurationForCollection } from '../../imageVulnerabilityReports.types';
+
+export type ImageVulnerabilityFiltersStepForCollectionProps = {
+    formik: FormikProps<ImageVulnerabilityFiltersConfigurationForCollection>;
+};
+
+function ImageVulnerabilityFiltersStepForCollection({
+    formik,
+}: ImageVulnerabilityFiltersStepForCollectionProps): ReactElement {
     return (
         <PageSection>
-            <Flex direction={{ default: 'column' }}>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Filters</Title>
-                <Divider component="div" />
-                {/* TODO Form includes fixability, severities, and cvesSince */}
+                <Form>
+                    <FormLabelGroup
+                        label="CVE severity"
+                        isRequired
+                        fieldId="vulnReportFilters.cveSeverities"
+                        errors={formik.errors}
+                    >
+                        <>{JSON.stringify(formik.values.vulnReportFilters.severities)}</>
+                    </FormLabelGroup>
+                    <FormLabelGroup
+                        label="CVE status"
+                        isRequired
+                        fieldId="vulnReportFilters.cveStatus"
+                        errors={formik.errors}
+                    >
+                        <>{formik.values.vulnReportFilters.fixability}</>
+                    </FormLabelGroup>
+                    {/* TODO Form includes fixability, severities, and cvesSince */}
+                </Form>
             </Flex>
         </PageSection>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step5/ImageVulnerabilityReviewStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step5/ImageVulnerabilityReviewStep.tsx
@@ -2,8 +2,8 @@ import type { ReactElement } from 'react';
 import { Alert, Flex, PageSection, Title } from '@patternfly/react-core';
 
 import type {
-    CompoundSearchFilterAttribute,
     CompoundSearchFilterConfig,
+    SelectSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
@@ -11,7 +11,7 @@ import type { ImageVulnerabilityReportConfiguration } from '../../imageVulnerabi
 
 /* eslint-disable react/no-unused-prop-types */
 export type ImageVulnerabilityReviewStepProps = {
-    attributesSeparateFromConfig: CompoundSearchFilterAttribute[];
+    attributesSeparateFromConfig: SelectSearchFilterAttribute[];
     error: Error | null;
     searchFilterConfig: CompoundSearchFilterConfig;
     values: ImageVulnerabilityReportConfiguration;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step5/ImageVulnerabilityReviewStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step5/ImageVulnerabilityReviewStep.tsx
@@ -1,16 +1,39 @@
 import type { ReactElement } from 'react';
-import { Divider, Flex, PageSection, Title } from '@patternfly/react-core';
+import { Alert, Flex, PageSection, Title } from '@patternfly/react-core';
 
-function ImageVulnerabilityReviewStep(): ReactElement {
+import type {
+    CompoundSearchFilterAttribute,
+    CompoundSearchFilterConfig,
+} from 'Components/CompoundSearchFilter/types';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+import type { ImageVulnerabilityReportConfiguration } from '../../imageVulnerabilityReports.types';
+
+/* eslint-disable react/no-unused-prop-types */
+export type ImageVulnerabilityReviewStepProps = {
+    attributesSeparateFromConfig: CompoundSearchFilterAttribute[];
+    error: Error | null;
+    searchFilterConfig: CompoundSearchFilterConfig;
+    values: ImageVulnerabilityReportConfiguration;
+};
+/* eslint-enable react/no-unused-prop-types */
+
+function ImageVulnerabilityReviewStep({ error }: ImageVulnerabilityReviewStepProps): ReactElement {
     return (
         <PageSection>
-            <Flex direction={{ default: 'column' }}>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Review</Title>
-                <Divider component="div" />
-                {/* DetailsView */}
-                {/* ImageVulnerabilityResourcesView */}
-                {/* ImageVulnerabilityParametersView or ImageVulnerabilityParametersForCollectionView */}
-                {/* TODO DeliveryView or DestinationsView */}
+                {/* ImageVulnerabilityReportView */}
+                {error && (
+                    <Alert
+                        variant="danger"
+                        isInline
+                        title="Error saving report configuration"
+                        component="p"
+                    >
+                        {getAxiosErrorMessage(error)}
+                    </Alert>
+                )}
             </Flex>
         </PageSection>
     );


### PR DESCRIPTION
## Description

**Review**: Hide space because of indentation changes.

### Objective

Provide equivalent filter for scheduled reports as view-based reports

### Analysis

1. Compare wizards:

    * `ScanConfigWizardForm`
    * `PolicyWizard` is the example I adapted
    * `ReportFormWizard`

2. Find `FormikProps` is relevant generic type to declare subset of values for steps.

    Too bad, so sad: formik types do not understand subsets of values, therefore `as` type assertion in wuzard.

    Which is dangerous, because it hid bogus `formik={formik.values}` instead of `formik={formik}` which caused page crash in testing.

### Solution

1. Future ImageVulnerabilityReportPage.tsx file will adapt example of PolicyPage.tsx

    * Request data for **clone** and **edit** actions plus view
    * Initialize data for **create** action
    * Convert data for **createFronFilters** action
    * Filter relevant `seaerchFilterConfig` (pardon pun) for feature flags as source of truth for **Filters** of both view abd wizard.

2. Add ImageVulnerabilityReportWizard.tsx file.

3. Edit step files.

    * Delete `Divider` element, because not in PatternFly design guidelines:

        https://www.patternfly.org/components/wizard/design-guidelines
    
    * Add `FormLabelGroup` elements even if placeholder for some of their children, pending **Residue** stem 2.

### Residue

1. Add DeliveryStep.tsx and DeliveryView.tsx files in src/Components/Reports now that name has been confirmed.
2. Investigate pro and con to factor out components for some form elements.
3. Add validation.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Temporary edit CreateVulnReportPage.tsx and ViewVulnReportPage.tsx files to render wizard.

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

### Manual testing

1. Visit /main/vulnerabilities/reports/configuration and then click a link

    Edit **Name** and **Description** in **Details** step.
    <img width="1440" height="892" alt="edit_Step1_Details" src="https://github.com/user-attachments/assets/f4d3e073-5253-42d4-89b6-5897e6f22529" />

2. Click **Next** to verify that **Resources** and **Filters** can stringify relevant values.