### PR TITLE
ROX-34390: Add file activity to berserker load in long running cluster

### DIFF
--- a/scripts/release-tools/kube-burner-configs/berserker-load/berserker-configmap-file-activity.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/berserker-configmap-file-activity.yml
@@ -5,10 +5,10 @@ metadata:
 data:
   workload.ber: |
     machine {
-      profile("bpf");
+      path("/tmp/data");
     }
 
-    main (workers = 2, duration = 10) {
+    main (workers = 2, duration = 0) {
       open(random_path("/tmp/data"));
     } : exp {
       rate = 10.0;  // 10 operations per second

--- a/scripts/release-tools/kube-burner-configs/berserker-load/berserker-configmap-file-activity.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/berserker-configmap-file-activity.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.JobName}}-berserker-file-activity-config
+data:
+  workload.ber: |
+    machine {
+      profile("bpf");
+    }
+
+    main (workers = 2, duration = 10) {
+      open(random_path("/tmp/data"));
+    } : exp {
+      rate = 10.0;  // 10 operations per second
+    }

--- a/scripts/release-tools/kube-burner-configs/berserker-load/berserker-configmap-file-activity.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/berserker-configmap-file-activity.yml
@@ -11,5 +11,5 @@ data:
     main (workers = 2, duration = 0) {
       open(random_path("/tmp/data"));
     } : exp {
-      rate = 1000.0;
+      rate = 100.0;
     }

--- a/scripts/release-tools/kube-burner-configs/berserker-load/berserker-configmap-file-activity.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/berserker-configmap-file-activity.yml
@@ -11,5 +11,5 @@ data:
     main (workers = 2, duration = 0) {
       open(random_path("/tmp/data"));
     } : exp {
-      rate = 10.0;  // 10 operations per second
+      rate = 1000.0;
     }

--- a/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
@@ -62,3 +62,6 @@ jobs:
 
       - objectTemplate: berserker-configmap-processes.yml
         replicas: 10
+
+      - objectTemplate: berserker-configmap-file-activity.yml
+        replicas: 10

--- a/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
@@ -32,17 +32,22 @@ jobs:
     objects:
 
       - objectTemplate: process-load-daemonset.yml
-        replicas: 6
+        replicas: 4
         inputVars:
           podReplicas: 2
 
       - objectTemplate: endpoint-load-daemonset.yml
-        replicas: 6
+        replicas: 4
         inputVars:
           podReplicas: 2
 
       - objectTemplate: connection-load-daemonset.yml
-        replicas: 6
+        replicas: 4
+        inputVars:
+          podReplicas: 2
+
+      - objectTemplate: file-activity-load-daemonset.yml
+        replicas: 4
         inputVars:
           podReplicas: 2
 

--- a/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
@@ -32,24 +32,24 @@ jobs:
     objects:
 
       - objectTemplate: process-load-daemonset.yml
-        replicas: 4
+        replicas: 6
         inputVars:
           podReplicas: 2
 
       - objectTemplate: endpoint-load-daemonset.yml
-        replicas: 4
+        replicas: 6
         inputVars:
           podReplicas: 2
 
       - objectTemplate: connection-load-daemonset.yml
-        replicas: 4
+        replicas: 6
         inputVars:
           podReplicas: 2
 
       - objectTemplate: file-activity-load-daemonset.yml
         replicas: 4
         inputVars:
-          podReplicas: 1
+          podReplicas: 2
 
       - objectTemplate: service.yml
         replicas: 10

--- a/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
@@ -49,7 +49,7 @@ jobs:
       - objectTemplate: file-activity-load-daemonset.yml
         replicas: 4
         inputVars:
-          podReplicas: 2
+          podReplicas: 1
 
       - objectTemplate: service.yml
         replicas: 10

--- a/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/config.yml
@@ -47,7 +47,7 @@ jobs:
           podReplicas: 2
 
       - objectTemplate: file-activity-load-daemonset.yml
-        replicas: 4
+        replicas: 1
         inputVars:
           podReplicas: 2
 

--- a/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
@@ -23,10 +23,10 @@ spec:
         image: quay.io/stackrox-io/berserker:1.0-88-gbc9a937d18
         resources:
           requests:
-            memory: "10Mi"
+            memory: "20Mi"
             cpu: "15m"
           limits:
-            memory: "10Mi"
+            memory: "20Mi"
             cpu: "15m"
         volumeMounts:
         - name: config

--- a/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
@@ -12,8 +12,6 @@ spec:
       labels:
         app: file-activity-load-{{.Replica}}
     spec:
-      imagePullSecrets:
-        - name: {{.JobName}}-{{.Replica}}
       containers:
       - command:
         - berserker

--- a/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
@@ -21,10 +21,10 @@ spec:
         image: quay.io/stackrox-io/berserker:1.0-88-gbc9a937d18
         resources:
           requests:
-            memory: "20Mi"
+            memory: "200Mi"
             cpu: "15m"
           limits:
-            memory: "20Mi"
+            memory: "200Mi"
             cpu: "15m"
         volumeMounts:
         - name: config

--- a/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
@@ -1,0 +1,60 @@
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: file-activity-load-{{.Replica}}
+spec:
+  selector:
+    matchLabels:
+      app: file-activity-load-{{.Replica}}
+  template:
+    metadata:
+      labels:
+        app: file-activity-load-{{.Replica}}
+    spec:
+      imagePullSecrets:
+        - name: {{.JobName}}-{{.Replica}}
+      containers:
+      - args:
+        - sleep
+        - infinity
+        image: quay.io/stackrox-io/berserker:1.0-88-gbc9a937d18
+        resources:
+          requests:
+            memory: "10Mi"
+            cpu: "15m"
+          limits:
+            memory: "10Mi"
+            cpu: "15m"
+        volumeMounts:
+        - name: config
+          mountPath: "/etc/berserker"
+          readOnly: true
+        imagePullPolicy: IfNotPresent
+        name: berserker
+        env:
+        - name: RUST_LOG
+          value: "error"
+        downwardAPI:
+          items:
+            - path: "labels"
+              fieldRef:
+                fieldPath: metadata.labels
+      volumes:
+      - name: config
+        configMap:
+          name: {{.JobName}}-berserker-file-activity-config
+          items:
+          - key: workload.ber
+            path: workload.ber
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900

--- a/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
@@ -15,7 +15,9 @@ spec:
       imagePullSecrets:
         - name: {{.JobName}}-{{.Replica}}
       containers:
-      - args:
+      - command:
+        - berserker
+        args:
         - -f
         - /etc/berserker/workload.ber
         image: quay.io/stackrox-io/berserker:1.0-88-gbc9a937d18

--- a/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
@@ -16,8 +16,8 @@ spec:
         - name: {{.JobName}}-{{.Replica}}
       containers:
       - args:
-        - sleep
-        - infinity
+        - -f
+        - /etc/berserker/workload.ber
         image: quay.io/stackrox-io/berserker:1.0-88-gbc9a937d18
         resources:
           requests:

--- a/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
@@ -18,7 +18,7 @@ spec:
         args:
         - -f
         - /etc/berserker/workload.ber
-        image: quay.io/stackrox-io/berserker:1.0-88-gbc9a937d18
+        image: quay.io/stackrox-io/berserker:1.0-92-g117c7679ac
         resources:
           requests:
             memory: "200Mi"

--- a/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
@@ -18,7 +18,7 @@ spec:
         args:
         - -f
         - /etc/berserker/workload.ber
-        image: quay.io/stackrox-io/berserker:1.0-92-g117c7679ac
+        image: quay.io/stackrox-io/berserker:1.0-93-gddd0aedc36
         resources:
           requests:
             memory: "200Mi"

--- a/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
@@ -18,7 +18,7 @@ spec:
         args:
         - -f
         - /etc/berserker/workload.ber
-        image: quay.io/stackrox-io/berserker:1.0-96-gc213cfd0c7
+        image: quay.io/stackrox-io/berserker:1.0-97-g64cfd0ee0b
         resources:
           requests:
             memory: "200Mi"

--- a/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
+++ b/scripts/release-tools/kube-burner-configs/berserker-load/file-activity-load-daemonset.yml
@@ -18,7 +18,7 @@ spec:
         args:
         - -f
         - /etc/berserker/workload.ber
-        image: quay.io/stackrox-io/berserker:1.0-93-gddd0aedc36
+        image: quay.io/stackrox-io/berserker:1.0-96-gc213cfd0c7
         resources:
           requests:
             memory: "200Mi"


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

We would like to know the impact of file activity monitoring on the various ACS components. For that reason this PR adds file activity load to the berserker load in the long running cluster.

There is a companion stackrox/actions PR at https://github.com/stackrox/actions/pull/92 which enables the fact agent in the long running cluster.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Went to https://github.com/stackrox/test-gh-actions/actions/workflows/create-clusters.yml
Clicked "Run workflow"
Set the branch to jv-ROX-34390-add-file-activity-to-berserker-load-in-long-running-clusters
Set the version to 4.11.x-741-g4cb2b05680
Selected "Create a long-running cluster on RC1"
Clicked "Run workflow"

Connected to the cluster running the berserker workload

Checked the status of the secured cluster

```
$ ks get pod
NAME                                                      READY   STATUS              RESTARTS   AGE
admission-control-dfcc8ff67-5ftcp                         1/1     Running             0          9m46s
admission-control-dfcc8ff67-cjzs8                         1/1     Running             0          9m46s
admission-control-dfcc8ff67-rmwvr                         1/1     Running             0          9m48s
collector-bgbjf                                           3/3     Running             0          9m1s
collector-h77c7                                           3/3     Running             0          8m51s
collector-mrvql                                           3/3     Running             0          8m55s
collector-mx2gm                                           3/3     Running             0          8m50s
collector-w4vxk                                           3/3     Running             0          8m56s
monitoring-7f658fbc74-m7sbf                               2/2     Running             0          9m33s
scanner-5cdd85cd54-gzs2j                                  0/1     ContainerCreating   0          9m32s
scanner-5cdd85cd54-hz2wz                                  0/1     ContainerCreating   0          9m48s
scanner-db-6b7b79bc46-rdh42                               0/1     Init:0/1            0          9m47s
scanner-v4-db-56f999b88f-9tpql                            0/1     Init:0/1            0          9m48s
scanner-v4-indexer-7b76fcdc75-4f5pv                       0/1     ContainerCreating   0          9m31s
scanner-v4-indexer-7b76fcdc75-ht5pp                       0/1     ContainerCreating   0          9m48s
sensor-85dffcf764-qshdn                                   1/1     Running             0          8m56s
stackrox-monitoring-alertmanager-0                        2/2     Running             0          9m32s
stackrox-monitoring-kube-state-metrics-7c77c7d988-jnkmn   1/1     Running             0          9m33s
```

Checked the fact logs

```
$ ks logs collector-bgbjf -c fact
[INFO  2026-04-25T17:02:54Z] (fact/src/config/mod.rs:41) FactConfig {
    paths: Some(
        [
            "/tmp/data/**/*",
        ],
    ),
    grpc: GrpcConfig {
        url: Some(
            "https://sensor.stackrox.svc:443",
        ),
        certs: Some(
            "/var/run/secrets/stackrox.io/certs/",
        ),
    },
    endpoint: EndpointConfig {
        address: None,
        expose_metrics: None,
        health_check: None,
    },
    skip_pre_flight: Some(
        true,
    ),
    json: None,
    ringbuf_size: None,
    hotreload: None,
    scan_interval: None,
}
[INFO  2026-04-25T17:02:54Z] (fact/src/lib.rs:53) fact version: 0.2.x-123-g34585d5a91
[DEBUG 2026-04-25T17:02:54Z] (fact/src/host_info.rs:165) Failed to open /host/etc/os-release
[DEBUG 2026-04-25T17:02:54Z] (fact/src/host_info.rs:165) Failed to open /host/usr/lib/os-release

...

[DEBUG 2026-04-25T17:08:24Z] (fact/src/host_scanner.rs:114) Host scan done
[DEBUG 2026-04-25T17:08:54Z] (fact/src/host_scanner.rs:90) Host scan started
[DEBUG 2026-04-25T17:08:54Z] (fact/src/host_scanner.rs:114) Host scan done
[DEBUG 2026-04-25T17:09:24Z] (fact/src/host_scanner.rs:90) Host scan started
[DEBUG 2026-04-25T17:09:24Z] (fact/src/host_scanner.rs:114) Host scan done
[DEBUG 2026-04-25T17:09:54Z] (fact/src/host_scanner.rs:90) Host scan started
[DEBUG 2026-04-25T17:09:54Z] (fact/src/host_scanner.rs:114) Host scan done
[DEBUG 2026-04-25T17:10:24Z] (fact/src/host_scanner.rs:90) Host scan started
[DEBUG 2026-04-25T17:10:24Z] (fact/src/host_scanner.rs:114) Host scan done
[DEBUG 2026-04-25T17:10:54Z] (fact/src/host_scanner.rs:90) Host scan started
[DEBUG 2026-04-25T17:10:54Z] (fact/src/host_scanner.rs:114) Host scan done
[DEBUG 2026-04-25T17:11:24Z] (fact/src/host_scanner.rs:90) Host scan started
[DEBUG 2026-04-25T17:11:24Z] (fact/src/host_scanner.rs:114) Host scan done
[DEBUG 2026-04-25T17:11:54Z] (fact/src/host_scanner.rs:90) Host scan started
[DEBUG 2026-04-25T17:11:54Z] (fact/src/host_scanner.rs:114) Host scan done
[DEBUG 2026-04-25T17:12:24Z] (fact/src/host_scanner.rs:90) Host scan started
[DEBUG 2026-04-25T17:12:24Z] (fact/src/host_scanner.rs:114) Host scan done
```

Checked the namespaces

```
$ kc get ns
NAME                          STATUS   AGE
berserker-1                   Active   5m15s
berserker-2                   Active   5m12s
berserker-3                   Active   5m7s
berserker-4                   Active   5m3s
berserker-5                   Active   9m28s
default                       Active   40m
gke-managed-cim               Active   38m
gke-managed-system            Active   38m
gke-managed-volumepopulator   Active   38m
gmp-public                    Active   37m
gmp-system                    Active   37m
kube-burner                   Active   11m
kube-node-lease               Active   40m
kube-public                   Active   40m
kube-system                   Active   40m
stackrox                      Active   12m
```

Checked the berserker pods in one of the namespaces

```
$ kc -n berserker-1 get pod
NAME                         READY   STATUS    RESTARTS        AGE
connection-load-1-2gc6j      1/1     Running   0               5m24s
connection-load-1-76d2r      1/1     Running   0               5m23s
connection-load-1-kqjnv      1/1     Running   0               5m25s
connection-load-1-l7j76      1/1     Running   0               5m22s
connection-load-1-ngzpb      1/1     Running   0               5m27s
connection-load-2-cqd5d      1/1     Running   0               5m22s
connection-load-2-kqv47      1/1     Running   0               5m24s
connection-load-2-lw7wc      1/1     Running   0               5m26s
connection-load-2-phwf4      1/1     Running   0               5m25s
connection-load-2-vqtvg      1/1     Running   0               5m21s
connection-load-3-jjqdf      1/1     Running   0               5m25s
connection-load-3-nbg7j      1/1     Running   0               5m27s
connection-load-3-q49d4      1/1     Running   0               5m25s
connection-load-3-v78cp      1/1     Running   0               5m24s
connection-load-3-zwncz      1/1     Running   0               5m24s
connection-load-4-6zps4      1/1     Running   0               5m33s
connection-load-4-bdxdp      1/1     Running   0               5m34s
connection-load-4-n6jd6      1/1     Running   0               5m34s
connection-load-4-qvps6      1/1     Running   0               5m35s
connection-load-4-v8gx6      1/1     Running   0               5m33s
endpoint-load-1-6bct2        1/1     Running   0               5m30s
endpoint-load-1-6ts7c        1/1     Running   0               5m31s
endpoint-load-1-jm54d        1/1     Running   0               5m32s
endpoint-load-1-scnv5        1/1     Running   0               5m30s
endpoint-load-1-sjxff        1/1     Running   0               5m31s
endpoint-load-2-hh7z2        1/1     Running   0               5m34s
endpoint-load-2-jfsqj        1/1     Running   0               5m35s
endpoint-load-2-nfwrf        1/1     Running   0               5m33s
endpoint-load-2-nk9lx        1/1     Running   0               5m33s
endpoint-load-2-qpt2h        1/1     Running   0               5m34s
endpoint-load-3-58jqd        1/1     Running   0               5m34s
endpoint-load-3-5jv8g        1/1     Running   0               5m35s
endpoint-load-3-dsjxg        1/1     Running   0               5m33s
endpoint-load-3-szpfl        1/1     Running   0               5m34s
endpoint-load-3-tg4tk        1/1     Running   0               5m33s
endpoint-load-4-7b24t        1/1     Running   0               5m34s
endpoint-load-4-8g79x        1/1     Running   0               5m34s
endpoint-load-4-gvc5k        1/1     Running   0               5m35s
endpoint-load-4-k4msb        1/1     Running   0               5m33s
endpoint-load-4-xpp8r        1/1     Running   0               5m33s
file-activity-load-1-2ff77   1/1     Running   0               5m30s
file-activity-load-1-4qmvj   1/1     Running   0               5m29s
file-activity-load-1-6fzln   1/1     Running   0               5m30s
file-activity-load-1-cdc8z   1/1     Running   0               5m29s
file-activity-load-1-kt2mw   1/1     Running   0               5m31s
file-activity-load-2-6pbnf   1/1     Running   0               5m32s
file-activity-load-2-8lj8z   1/1     Running   0               5m28s
file-activity-load-2-ffvhx   1/1     Running   0               5m31s
file-activity-load-2-mstpv   1/1     Running   0               5m31s
file-activity-load-2-qtfpj   1/1     Running   1 (2m47s ago)   5m27s
file-activity-load-3-5vfgv   1/1     Running   0               5m24s
file-activity-load-3-6djc8   1/1     Running   0               5m25s
file-activity-load-3-h9ngs   1/1     Running   0               5m24s
file-activity-load-3-vjll5   1/1     Running   0               5m22s
file-activity-load-3-vl8cd   1/1     Running   0               5m22s
file-activity-load-4-b4tcn   1/1     Running   0               5m32s
file-activity-load-4-d2ckd   1/1     Running   0               5m31s
file-activity-load-4-fwjmn   1/1     Running   0               5m29s
file-activity-load-4-g9tbl   1/1     Running   0               5m28s
file-activity-load-4-rkm87   1/1     Running   0               5m31s
process-load-1-4g4bl         1/1     Running   0               5m27s
process-load-1-mdpkv         1/1     Running   0               5m26s
process-load-1-ntktd         1/1     Running   0               5m25s
process-load-1-qk84k         1/1     Running   1               5m24s
process-load-1-vzmqc         1/1     Running   0               5m23s
process-load-2-ffr8t         1/1     Running   0               5m34s
process-load-2-p6z9r         1/1     Running   0               5m33s
process-load-2-t7mf8         1/1     Running   0               5m34s
process-load-2-w5n8d         1/1     Running   0               5m34s
process-load-2-xgkb4         1/1     Running   0               5m33s
process-load-3-7p9n7         1/1     Running   0               5m20s
process-load-3-97qvq         1/1     Running   0               5m21s
process-load-3-dhkgp         1/1     Running   0               5m20s
process-load-3-fcnm8         1/1     Running   0               5m20s
process-load-3-h5q52         1/1     Running   0               5m20s
process-load-4-7sjdv         1/1     Running   0               5m30s
process-load-4-9px7b         1/1     Running   0               5m32s
process-load-4-cn7bx         1/1     Running   0               5m30s
process-load-4-lgmvk         1/1     Running   0               5m29s
process-load-4-nxxpd         1/1     Running   0               5m29s
```

Created a FIM policy that would be triggered by the berserker load

<img width="1920" height="909" alt="Screenshot From 2026-04-25 10-24-03" src="https://github.com/user-attachments/assets/0f5eeb25-5862-458d-9671-b3b8729db98f" />

<img width="1920" height="909" alt="Screenshot From 2026-04-25 10-24-25" src="https://github.com/user-attachments/assets/19d0a86a-0e03-4e4c-9258-54660294f4e2" />

<img width="1920" height="909" alt="Screenshot From 2026-04-25 10-28-40" src="https://github.com/user-attachments/assets/743187f4-3910-4846-baad-bc70f5c660a3" />

<img width="1920" height="909" alt="Screenshot From 2026-04-25 10-29-07" src="https://github.com/user-attachments/assets/762b323a-09cd-4753-9dc6-5de8962b61de" />

<img width="1920" height="909" alt="Screenshot From 2026-04-25 10-29-20" src="https://github.com/user-attachments/assets/4f335026-297b-4f87-ae3c-d49704592257" />

<img width="1920" height="909" alt="Screenshot From 2026-04-25 10-29-32" src="https://github.com/user-attachments/assets/59d1b247-6e3a-4c44-ad2f-7258fe422c06" />

<img width="1920" height="909" alt="Screenshot From 2026-04-25 10-29-39" src="https://github.com/user-attachments/assets/2b3746ac-c26b-47fa-9a34-daf66f4395f4" />

<img width="1920" height="909" alt="Screenshot From 2026-04-25 10-32-12" src="https://github.com/user-attachments/assets/a1e8f6c0-d49b-4e57-b215-eb5cc8661c67" />

<img width="1920" height="909" alt="Screenshot From 2026-04-25 10-32-38" src="https://github.com/user-attachments/assets/6161d7c5-58d8-4b1a-a34a-bc9989fb2b58" />
