### PR TITLE
ROX-30650: Mount Red Hat signing keys volume in Central Helm chart

### DIFF
--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -206,6 +206,8 @@ spec:
           mountPath: /run/secrets/stackrox.io/monitoring-tls
           readOnly: true
         {{- end }}
+        - name: redhat-signing-keys
+          mountPath: /var/lib/stackrox/signature-keys
         {{- range $extraMount := (default list ._rox.central.extraMounts) }}
         - name: {{ $extraMount.name }}
           {{- $extraMount.mount | toYaml | nindent 10 }}
@@ -295,6 +297,12 @@ spec:
         secret:
           secretName: central-monitoring-tls
       {{- end }}
+      # Runtime directory for Red Hat signing keys downloaded by the updater.
+      # For disconnected deployments, replace this emptyDir with a ConfigMap or
+      # PVC containing your organisation's PEM key files; Central will load them
+      # at startup regardless of whether the manifest-URL updater is configured.
+      - name: redhat-signing-keys
+        emptyDir: {}
       {{- range $extraMount := (default list ._rox.central.extraMounts) }}
       - name: {{ $extraMount.name }}
         {{- $extraMount.source | toYaml | nindent 8 }}

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -206,7 +206,7 @@ spec:
           mountPath: /run/secrets/stackrox.io/monitoring-tls
           readOnly: true
         {{- end }}
-        - name: redhat-signing-keys
+        - name: central-signing-keys-volume
           mountPath: /var/lib/stackrox/signature-keys
         {{- range $extraMount := (default list ._rox.central.extraMounts) }}
         - name: {{ $extraMount.name }}
@@ -297,11 +297,7 @@ spec:
         secret:
           secretName: central-monitoring-tls
       {{- end }}
-      # Runtime directory for Red Hat signing keys downloaded by the updater.
-      # For disconnected deployments, replace this emptyDir with a ConfigMap or
-      # PVC containing your organisation's PEM key files; Central will load them
-      # at startup regardless of whether the manifest-URL updater is configured.
-      - name: redhat-signing-keys
+      - name: central-signing-keys-volume
         emptyDir: {}
       {{- range $extraMount := (default list ._rox.central.extraMounts) }}
       - name: {{ $extraMount.name }}


### PR DESCRIPTION
## Description

Adds an `emptyDir` volume (`central-signing-keys-volume`) and corresponding `volumeMount` at `/var/lib/stackrox/signature-keys` to the Central Helm deployment template. This is the bottom of a 3-PR stack for ROX-30650.

Without a writable mount at that path, the Red Hat signing key updater (PR #19353) cannot create its staging directory (via `os.MkdirTemp(filepath.Dir(targetDir), ...)`), causing it to fail on every run. The volume follows the `central-*-volume` naming convention used by all other Central `emptyDir` volumes.

For disconnected deployments, the `emptyDir` can be replaced by a `ConfigMap` or `PVC` containing pre-downloaded PEM key files; Central will pick them up via the filesystem watcher (PR #20141).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No automated tests added. This is a Helm chart template change (volume mount only) with no logic to unit-test; correctness is verified by the downstream PRs that depend on this volume being present.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Reviewed the rendered Helm template output to confirm the `emptyDir` volume and `volumeMount` are present with the correct names and mount path. Full functional validation is covered by the e2e tests in the dependent PRs (#19353, #20141).