### PR TITLE
chore: typo `occured` -> `occurred` in delegated scanning test log

### DIFF
--- a/tests/delegated_scanning_test_utils.go
+++ b/tests/delegated_scanning_test_utils.go
@@ -669,7 +669,7 @@ func (d *deleScanTestUtils) waitForBuildComplete(ctx context.Context, c buildv1c
 func (d *deleScanTestUtils) DisableMCONodeDrain(t *testing.T, ctx context.Context) error {
 	crFound, err := d.applyMachineConfiguration(t, ctx)
 	if err != nil {
-		logf(t, "Error occured disabling node drain via machineconfigurations: %v", err)
+		logf(t, "Error occurred disabling node drain via machineconfigurations: %v", err)
 	}
 	if crFound && err == nil {
 		// The machine configuration was successfully applied, short-circuit.


### PR DESCRIPTION
One-character typo fix inside `tests/delegated_scanning_test_utils.go:672`. User-visible log message in e2e test helper; no functional change.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>