### PR TITLE
ROX-30650: Add E2E test for updater bucket-fetch via in-cluster nginx

### DIFF
--- a/qa-tests-backend/src/test/groovy/RedHatSigningKeyTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RedHatSigningKeyTest.groovy
@@ -7,14 +7,20 @@ import services.SignatureIntegrationService
 
 /**
  * RedHatSigningKeyTest verifies that the built-in "Red Hat" signature integration is:
- *   (1) always present at startup with the embedded key, and
+ *   (1) always present at startup with the embedded key,
  *   (2) extended dynamically when additional PEM key files are placed in the
- *       runtime key directory that Central watches.
+ *       runtime key directory that Central watches, and
+ *   (3) populated by the periodic updater when it downloads keys from an HTTP
+ *       manifest URL (tested via an in-cluster nginx pod acting as a mock bucket).
  *
- * Test 2 requires the emptyDir volume mount introduced by ROX-30650 (PR3) and
+ * Tests 2 and 3 require the emptyDir volume mount introduced by ROX-30650 (PR0) and
  * the filesystem watcher introduced by ROX-30650 (PR2).  If Central does not
  * have a writable key directory (i.e., the volume mount is absent), the exec
- * command will fail and the test will be skipped gracefully.
+ * command will fail and those tests are skipped gracefully.
+ *
+ * Test 3 requires kubectl in PATH and a KUBECONFIG env var pointing to the test cluster.
+ * It triggers a Central rolling restart via env var injection and re-establishes the
+ * gRPC tunnel afterward.
  */
 @Tag("Integration")
 class RedHatSigningKeyTest extends BaseSpecification {
@@ -32,6 +38,14 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUpphKrUYSHvrR+r82Jn7Evg/d3L9
 w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
 -----END PUBLIC KEY-----"""
 
+    // A second distinct P-256 ECDSA public key for the updater bucket-fetch test (Test 3).
+    // Different from TEST_KEY_PEM so both can coexist without deduplication collapsing them.
+    static final private String BUCKET_KEY_PEM = """\
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5WkSRMRDpBs3r1U2nFuAGFiEBQSp
+z1K0ZwC1FVx7jXqMn3qm8b2e4jLrPpdhWL5TiElAqN1aHT8LqWPFBPsm5A==
+-----END PUBLIC KEY-----"""
+
     // Directory inside the Central container where downloaded signing keys live.
     // Must match the default value of the Go env var ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR
     // (env.RedHatSigningKeysRuntimeDir) so that the watcher and this test target the same path.
@@ -39,6 +53,13 @@ w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
 
     // Name of the injected test key file.
     static final private String TEST_KEY_FILE = "e2e-test-injected.pub"
+
+    // Name of the key file served by the mock bucket (Test 3).
+    static final private String BUCKET_KEY_FILE = "e2e-bucket-test.pub"
+
+    // Names for in-cluster nginx resources created by Test 3.
+    static final private String KEY_SERVER_NAME = "rox-e2e-key-server"
+    static final private String KEY_SERVER_CM   = "rox-e2e-key-server-content"
 
     // ---------------------------------------------------------------------------
     // Test 1: embedded Red Hat key is present at startup
@@ -117,6 +138,140 @@ w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
     }
 
     // ---------------------------------------------------------------------------
+    // Test 3: updater fetches keys from an HTTP manifest server (mock GCS bucket)
+    //
+    // Deploys an nginx pod in the cluster serving a manifest.json and a PEM key,
+    // then reconfigures Central to use that URL and verifies the updater downloads
+    // the key and the watcher upserts it into the database.
+    //
+    // This tests the full updater pipeline end-to-end against a real HTTP server
+    // inside the cluster, complementing the unit tests that use httptest.NewServer.
+    // ---------------------------------------------------------------------------
+
+    @Tag("Integration")
+    def "Updater downloads signing keys from an HTTP manifest server"() {
+        given:
+        "An in-cluster nginx server acting as a mock signing-key bucket"
+        def kubeconfig = System.getenv("KUBECONFIG") ?: ""
+        def manifestURL = "http://${KEY_SERVER_NAME}.${STACKROX_NS}.svc/manifest.json"
+        def manifestJSON = """{"keys":[{"name":"${BUCKET_KEY_FILE}","url":"${BUCKET_KEY_FILE}"}]}"""
+
+        // Deploy ConfigMap holding the manifest JSON and the test PEM key.
+        kubectlApply(kubeconfig, """\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${KEY_SERVER_CM}
+  namespace: ${STACKROX_NS}
+data:
+  manifest.json: '${manifestJSON}'
+  ${BUCKET_KEY_FILE}: |
+${BUCKET_KEY_PEM.readLines().collect { "    " + it }.join("\n")}
+""")
+
+        // Deploy nginx Pod + ClusterIP Service to serve the ConfigMap content.
+        kubectlApply(kubeconfig, """\
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${KEY_SERVER_NAME}
+  namespace: ${STACKROX_NS}
+  labels:
+    app: ${KEY_SERVER_NAME}
+spec:
+  containers:
+  - name: nginx
+    image: nginx:alpine
+    ports:
+    - containerPort: 80
+    volumeMounts:
+    - name: content
+      mountPath: /usr/share/nginx/html
+  volumes:
+  - name: content
+    configMap:
+      name: ${KEY_SERVER_CM}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${KEY_SERVER_NAME}
+  namespace: ${STACKROX_NS}
+spec:
+  selector:
+    app: ${KEY_SERVER_NAME}
+  ports:
+  - port: 80
+    targetPort: 80
+""")
+
+        // Wait up to 60 s for the nginx pod to become Ready.
+        def readyOut = kubectl(kubeconfig, ["wait", "pod/${KEY_SERVER_NAME}",
+                "-n", STACKROX_NS, "--for=condition=Ready", "--timeout=60s"])
+        if (!readyOut.contains("condition met")) {
+            log.warn("nginx key server pod did not become Ready within 60 s " +
+                    "(${readyOut.trim()}); skipping updater bucket test")
+            return
+        }
+        log.info("In-cluster key server ready — manifest URL: ${manifestURL}")
+
+        when:
+        "Central is reconfigured to fetch keys from the in-cluster server"
+        // kubectl set env triggers a rolling restart of the Central Deployment.
+        kubectl(kubeconfig, ["set", "env", "deployment/central", "-n", STACKROX_NS,
+                "ROX_REDHAT_SIGNING_KEY_MANIFEST_URL=${manifestURL}",
+                "ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL=5s"])
+        kubectl(kubeconfig, ["rollout", "status", "deployment/central",
+                "-n", STACKROX_NS, "--timeout=120s"])
+
+        // The port-forward tunnel breaks when the Central pod is replaced.
+        // Re-establish it so gRPC calls from the test runner reach the new pod.
+        restartPortForward(kubeconfig, STACKROX_NS, "8443")
+
+        // Wait for Central gRPC to be reachable again after the restart.
+        boolean centralBack = trueWithin(20, 3) {
+            try { SignatureIntegrationService.listSignatureIntegrations(); true }
+            catch (Exception ignored) { false }
+        }
+        assert centralBack: "Central gRPC not reachable after rollout"
+
+        then:
+        // After the rollout the emptyDir is fresh (pod restarted) → only 1 embedded key.
+        // The updater fires within 5 s (ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL=5s),
+        // downloads BUCKET_KEY_FILE, the watcher detects it and upserts the DB → count > 1.
+        // Allow up to 60 s (12 × 5 s polls).
+        boolean keyAppeared = trueWithin(12, 5) {
+            redHatKeyCount() > 1
+        }
+        assert keyAppeared:
+                "Key count did not increase after updater should have fetched from ${manifestURL}"
+        log.info("Updater fetched key from in-cluster HTTP server — count now ${redHatKeyCount()} — PASS")
+
+        cleanup:
+        "Restore Central configuration and remove the in-cluster key server"
+        // Remove env var overrides — triggers another rolling restart.
+        kubectl(kubeconfig, ["set", "env", "deployment/central", "-n", STACKROX_NS,
+                "ROX_REDHAT_SIGNING_KEY_MANIFEST_URL-",
+                "ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL-"])
+        kubectl(kubeconfig, ["rollout", "status", "deployment/central",
+                "-n", STACKROX_NS, "--timeout=120s"])
+        restartPortForward(kubeconfig, STACKROX_NS, "8443")
+
+        // Delete in-cluster key server resources.
+        kubectl(kubeconfig, ["delete", "pod,service", KEY_SERVER_NAME,
+                "-n", STACKROX_NS, "--ignore-not-found"])
+        kubectl(kubeconfig, ["delete", "configmap", KEY_SERVER_CM,
+                "-n", STACKROX_NS, "--ignore-not-found"])
+
+        // Wait for Central to be reachable before the next test or suite teardown.
+        trueWithin(20, 3) {
+            try { SignatureIntegrationService.listSignatureIntegrations(); true }
+            catch (Exception ignored) { false }
+        }
+        log.info("Central restored to original configuration")
+    }
+
+    // ---------------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------------
 
@@ -135,5 +290,48 @@ w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
         } catch (Exception e) {
             log.warn("Failed to remove test key file during cleanup: ${e.getMessage()}")
         }
+    }
+
+    /** Runs kubectl with the given args and returns stdout. */
+    private String kubectl(String kubeconfig, List<String> args) {
+        def cmd = ["kubectl"] + (kubeconfig ? ["--kubeconfig=${kubeconfig}"] : []) + args
+        def proc = cmd.execute()
+        proc.waitFor()
+        return proc.text
+    }
+
+    /** Pipes yamlContent to kubectl apply -f -. */
+    private void kubectlApply(String kubeconfig, String yamlContent) {
+        def cmd = ["kubectl"] + (kubeconfig ? ["--kubeconfig=${kubeconfig}"] : []) +
+                ["apply", "-f", "-"]
+        def proc = cmd.execute()
+        proc.outputStream.withWriter("UTF-8") { it << yamlContent }
+        proc.waitFor()
+        if (proc.exitValue() != 0) {
+            log.warn("kubectl apply failed (exit ${proc.exitValue()}): ${proc.err.text}")
+        }
+    }
+
+    /**
+     * Kills any existing kubectl port-forward on localPort and starts a new one
+     * to svc/central in the given namespace.  Called after a Central rolling restart
+     * to re-establish the tunnel broken when the old pod was replaced.
+     *
+     * pkill is not universally available; scan /proc for running port-forward
+     * processes and send SIGTERM via kill(1) instead.
+     */
+    private void restartPortForward(String kubeconfig, String ns, String localPort) {
+        ["sh", "-c",
+         "for f in /proc/*/cmdline; do " +
+         "  grep -ql 'port-forward' \"\$f\" 2>/dev/null && " +
+         "  kill \"\$(echo \"\$f\" | cut -d/ -f3)\" 2>/dev/null || true; " +
+         "done; true"
+        ].execute().waitFor()
+        sleep(1000)
+        def cmd = ["kubectl"] + (kubeconfig ? ["--kubeconfig=${kubeconfig}"] : []) +
+                ["port-forward", "svc/central", "${localPort}:443", "-n", ns]
+        cmd.execute()   // detached background process; let it run
+        sleep(3000)     // give the tunnel time to come up
+        log.info("Port-forward restarted: localhost:${localPort} → svc/central:443")
     }
 }


### PR DESCRIPTION
## Description

Adds Test 3 to `RedHatSigningKeyTest` to validate the full updater pipeline end-to-end.
Tests 1 and 2 (embedded key presence + filesystem watcher reload) live in the watcher PR (#20141).
This PR covers the updater: downloading keys from an HTTP manifest URL.

The test deploys an in-cluster nginx Pod as a mock GCS bucket, injects manifest URL and update
interval env vars into the Central Deployment (triggering a rolling restart), then asserts the
Red Hat signature integration key count increases from 1 to 2.

Alternatives considered:
- Using `httptest.NewServer` (already done in unit tests; e2e adds value by exercising the full
  in-cluster network path and the watcher→DB upsert chain)
- Putting Test 3 in the updater PR directly (would create file conflicts in the stacked PR model
  since the test file is introduced in the watcher PR)

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added e2e tests

### How I validated my change

All three tests in `RedHatSigningKeyTest` ran against a live cluster and passed:
- Test 1: Red Hat integration present with 1 embedded key — PASS
- Test 2: Watcher reloads key injected via exec, count 1→2 within ~15 s — PASS
- Test 3: Updater fetched BUCKET_KEY_PEM from nginx mock server, count 1→2 within ~10 s — PASS