### PR TITLE
ROX-30650: Watcher-based upsert of Red Hat signing keys

### DIFF
--- a/central/signatureintegration/datastore/datastore_decoration_test.go
+++ b/central/signatureintegration/datastore/datastore_decoration_test.go
@@ -1,0 +1,153 @@
+package datastore
+
+import (
+	"context"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	storeMocks "github.com/stackrox/rox/central/signatureintegration/store/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/signatures"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// allAccessCtx returns an all-access context suitable for unit tests.
+func allAccessCtx() context.Context {
+	return sac.WithAllAccess(context.Background())
+}
+
+// newUpsertTestStore creates a mock store for upsert tests.
+func newUpsertTestStore(t *testing.T) *storeMocks.MockSignatureIntegrationStore {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	return storeMocks.NewMockSignatureIntegrationStore(ctrl)
+}
+
+func TestUpsertRedHatSignatureIntegration_EmbeddedKeyOnly(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	mockStore := newUpsertTestStore(t)
+	mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, si *storage.SignatureIntegration) error {
+			require.Equal(t, signatures.DefaultRedHatSignatureIntegration.GetId(), si.GetId())
+			require.Len(t, si.GetCosign().GetPublicKeys(), 1,
+				"empty dir: only the embedded key should be present")
+			return nil
+		},
+	)
+
+	upsertRedHatSignatureIntegration(mockStore)
+}
+
+func TestUpsertRedHatSignatureIntegration_AddsKeysFromDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.pub"), []byte(anotherValidPublicKeyPEM), 0o600))
+
+	mockStore := newUpsertTestStore(t)
+	mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, si *storage.SignatureIntegration) error {
+			require.Equal(t, signatures.DefaultRedHatSignatureIntegration.GetId(), si.GetId())
+			require.Len(t, si.GetCosign().GetPublicKeys(), 2,
+				"embedded key + one dir key expected")
+			names := map[string]struct{}{}
+			for _, k := range si.GetCosign().GetPublicKeys() {
+				names[k.GetName()] = struct{}{}
+			}
+			require.Contains(t, names, "extra.pub")
+			return nil
+		},
+	)
+
+	upsertRedHatSignatureIntegration(mockStore)
+}
+
+func TestUpsertRedHatSignatureIntegration_DeduplicatesDirKey(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	// Write a file that contains the same key as the embedded key.
+	embeddedPEM := signatures.DefaultRedHatSignatureIntegration.GetCosign().GetPublicKeys()[0].GetPublicKeyPemEnc()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "duplicate.pub"), []byte(embeddedPEM), 0o600))
+
+	mockStore := newUpsertTestStore(t)
+	mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, si *storage.SignatureIntegration) error {
+			require.Len(t, si.GetCosign().GetPublicKeys(), 1,
+				"duplicate key from dir must be dropped")
+			return nil
+		},
+	)
+
+	upsertRedHatSignatureIntegration(mockStore)
+}
+
+func TestUpsertRedHatSignatureIntegration_DeduplicatesWithTrailingWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	// Write the embedded key with extra trailing newlines — must still be treated as duplicate.
+	embeddedPEM := signatures.DefaultRedHatSignatureIntegration.GetCosign().GetPublicKeys()[0].GetPublicKeyPemEnc()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "trailing.pub"), []byte(embeddedPEM+"\n\n"), 0o600))
+
+	mockStore := newUpsertTestStore(t)
+	mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, si *storage.SignatureIntegration) error {
+			require.Len(t, si.GetCosign().GetPublicKeys(), 1,
+				"key with trailing whitespace must be recognised as duplicate of embedded key")
+			return nil
+		},
+	)
+
+	upsertRedHatSignatureIntegration(mockStore)
+}
+
+func TestUpsertRedHatSignatureIntegration_PEMStoredInCanonicalForm(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.pub"), []byte(anotherValidPublicKeyPEM+"\n\n"), 0o600))
+
+	mockStore := newUpsertTestStore(t)
+	mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, si *storage.SignatureIntegration) error {
+			require.Len(t, si.GetCosign().GetPublicKeys(), 2)
+			for _, k := range si.GetCosign().GetPublicKeys() {
+				if k.GetName() == "extra.pub" {
+					// The stored PEM must be the canonical form (no trailing whitespace,
+					// produced by pem.EncodeToMemory).
+					block, _ := pem.Decode([]byte(k.GetPublicKeyPemEnc()))
+					require.NotNil(t, block, "stored PEM must be decodable")
+					require.Equal(t, string(pem.EncodeToMemory(block)), k.GetPublicKeyPemEnc(),
+						"stored PEM must be in canonical form")
+				}
+			}
+			return nil
+		},
+	)
+
+	upsertRedHatSignatureIntegration(mockStore)
+}
+
+func TestUpsertRedHatSignatureIntegration_DoesNotMutateDefaultIntegration(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR", dir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.pub"), []byte(anotherValidPublicKeyPEM), 0o600))
+
+	before := len(signatures.DefaultRedHatSignatureIntegration.GetCosign().GetPublicKeys())
+
+	mockStore := newUpsertTestStore(t)
+	mockStore.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil)
+
+	upsertRedHatSignatureIntegration(mockStore)
+
+	after := len(signatures.DefaultRedHatSignatureIntegration.GetCosign().GetPublicKeys())
+	require.Equal(t, before, after, "upsert must not modify the global DefaultRedHatSignatureIntegration")
+}

--- a/central/signatureintegration/datastore/datastore_impl.go
+++ b/central/signatureintegration/datastore/datastore_impl.go
@@ -40,7 +40,6 @@ func (d *datastoreImpl) GetSignatureIntegration(ctx context.Context, id string) 
 	if ok, err := integrationSAC.ReadAllowed(ctx); !ok || err != nil {
 		return nil, false, err
 	}
-
 	return d.storage.Get(ctx, id)
 }
 

--- a/central/signatureintegration/datastore/key_dir_watcher.go
+++ b/central/signatureintegration/datastore/key_dir_watcher.go
@@ -1,0 +1,51 @@
+package datastore
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/central/signatureintegration/store"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/k8scfgwatch"
+)
+
+// keyDirHandler implements k8scfgwatch.Handler to trigger a DB upsert of the
+// Red Hat signature integration whenever the runtime signing-key directory
+// changes on disk. The updater writes files there; this handler reacts to those
+// writes without any direct coupling to the updater.
+type keyDirHandler struct {
+	siStore store.SignatureIntegrationStore
+}
+
+// OnChange satisfies the k8scfgwatch.Handler interface. Side-effect-free as
+// required by the interface contract; the actual work is in OnStableUpdate.
+func (h *keyDirHandler) OnChange(_ string) (interface{}, error) {
+	return nil, nil
+}
+
+// OnStableUpdate is called after the watched directory has stabilised. It
+// re-reads the directory and upserts the merged key set into the DB.
+func (h *keyDirHandler) OnStableUpdate(_ interface{}, err error) {
+	if err != nil {
+		log.Warnf("Error reading Red Hat signing key directory: %v", err)
+		return
+	}
+	upsertRedHatSignatureIntegration(h.siStore)
+}
+
+// OnWatchError is called when the directory cannot be read (e.g. it does not
+// exist yet, before the first updater run). Errors are deduplicated by the
+// DeduplicateWatchErrors wrapper so each distinct message is logged once.
+func (h *keyDirHandler) OnWatchError(err error) {
+	log.Debugf("Cannot watch Red Hat signing key directory: %v", err)
+}
+
+func startRedHatSigningKeyDirWatcher(siStore store.SignatureIntegrationStore) {
+	targetDir := env.RedHatSigningKeysRuntimeDir.Setting()
+	handler := k8scfgwatch.DeduplicateWatchErrors(&keyDirHandler{siStore: siStore})
+	opts := k8scfgwatch.Options{
+		Interval: env.RedHatSigningKeyWatchInterval.DurationSetting(),
+		Force:    true, // start even before the updater creates the directory
+	}
+	// Errors are unreachable with Force=true, but discard defensively.
+	_ = k8scfgwatch.WatchConfigMountDir(context.Background(), targetDir, handler, opts)
+}

--- a/central/signatureintegration/datastore/key_dir_watcher.go
+++ b/central/signatureintegration/datastore/key_dir_watcher.go
@@ -46,6 +46,7 @@ func startRedHatSigningKeyDirWatcher(siStore store.SignatureIntegrationStore) {
 		Interval: env.RedHatSigningKeyWatchInterval.DurationSetting(),
 		Force:    true, // start even before the updater creates the directory
 	}
-	// Errors are unreachable with Force=true, but discard defensively.
-	_ = k8scfgwatch.WatchConfigMountDir(context.Background(), targetDir, handler, opts)
+	if err := k8scfgwatch.WatchConfigMountDir(context.Background(), targetDir, handler, opts); err != nil {
+		log.Errorf("Failed to start Red Hat signing key directory watcher for %q: %v", targetDir, err)
+	}
 }

--- a/central/signatureintegration/datastore/key_dir_watcher_test.go
+++ b/central/signatureintegration/datastore/key_dir_watcher_test.go
@@ -1,0 +1,53 @@
+package datastore
+
+import (
+	"testing"
+
+	storeMocks "github.com/stackrox/rox/central/signatureintegration/store/mocks"
+	"github.com/stackrox/rox/pkg/signatures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// TestKeyDirHandler_OnStableUpdate_TriggersUpsert verifies that OnStableUpdate
+// calls upsertRedHatSignatureIntegration when there is no error.
+func TestKeyDirHandler_OnStableUpdate_TriggersUpsert(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+	mockStore.EXPECT().
+		Upsert(gomock.Any(), gomock.Cond(func(si any) bool {
+			type idGetter interface{ GetId() string }
+			g, ok := si.(idGetter)
+			return ok && g.GetId() == signatures.DefaultRedHatSignatureIntegration.GetId()
+		})).
+		Return(nil).
+		Times(1)
+
+	h := &keyDirHandler{siStore: mockStore}
+	h.OnStableUpdate(nil, nil)
+}
+
+// TestKeyDirHandler_OnStableUpdate_SkipsOnError verifies that OnStableUpdate
+// does NOT call the store when invoked with a non-nil error.
+func TestKeyDirHandler_OnStableUpdate_SkipsOnError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+	// No Upsert call expected — gomock will fail the test if Upsert is called.
+
+	h := &keyDirHandler{siStore: mockStore}
+	h.OnStableUpdate(nil, assert.AnError)
+}
+
+// TestKeyDirHandler_OnChange_IsSideEffectFree verifies that OnChange is a
+// no-op (side-effect-free as required by k8scfgwatch.Handler).
+func TestKeyDirHandler_OnChange_IsSideEffectFree(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+	// No store calls expected.
+
+	h := &keyDirHandler{siStore: mockStore}
+	val, err := h.OnChange(t.TempDir())
+	require.NoError(t, err)
+	assert.Nil(t, val)
+}

--- a/central/signatureintegration/datastore/keyloader.go
+++ b/central/signatureintegration/datastore/keyloader.go
@@ -1,0 +1,68 @@
+package datastore
+
+import (
+	"bytes"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/signatures"
+)
+
+// loadKeysFromDir reads all files from the given directory and returns those that contain valid
+// PEM-encoded public keys. Files that are not valid public keys are skipped with a warning.
+// If the directory does not exist or is empty, an empty slice is returned without error.
+// Duplicate keys (same PEM content) are deduplicated — the first file encountered is kept.
+// This function is safe to call concurrently.
+func loadKeysFromDir(dir string) ([]*storage.CosignPublicKeyVerification_PublicKey, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errors.Wrapf(err, "reading Red Hat signing keys directory %q", dir)
+	}
+
+	seen := make(map[string]struct{})
+	var keys []*storage.CosignPublicKeyVerification_PublicKey
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		fullPath := filepath.Join(dir, name)
+
+		contents, err := os.ReadFile(fullPath)
+		if err != nil {
+			log.Warnf("Skipping Red Hat signing key file %q: %v", fullPath, err)
+			continue
+		}
+
+		// Trim trailing whitespace so files ending with \n\n are accepted.
+		trimmed := bytes.TrimRight(contents, " \t\r\n")
+		block, rest := pem.Decode(trimmed)
+		if !signatures.IsValidPublicKeyPEMBlock(block, rest) {
+			log.Warnf("Skipping Red Hat signing key file %q: not a valid PEM-encoded public key", fullPath)
+			continue
+		}
+
+		// Re-encode to canonical PEM form: normalises whitespace and strips any
+		// non-PEM content (e.g. GPG-style headers) that preceded the PEM block.
+		canonical := string(pem.EncodeToMemory(block))
+		if _, dup := seen[canonical]; dup {
+			log.Debugf("Skipping duplicate Red Hat signing key in file %q", fullPath)
+			continue
+		}
+		seen[canonical] = struct{}{}
+
+		keys = append(keys, &storage.CosignPublicKeyVerification_PublicKey{
+			Name:            name,
+			PublicKeyPemEnc: canonical,
+		})
+	}
+
+	return keys, nil
+}

--- a/central/signatureintegration/datastore/keyloader_test.go
+++ b/central/signatureintegration/datastore/keyloader_test.go
@@ -1,0 +1,158 @@
+package datastore
+
+import (
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// validPublicKeyPEM is a minimal RSA public key in PEM format used across keyloader tests.
+const validPublicKeyPEM = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAryQICCl6NZ5gDKrnSztO\n3Hy8PEUcuyvg/ikC+VcIo2SFFSf18a3IMYldIugqqqZCs4/4uVW3sbdLs/6PfgdX\n7O9D22ZiFWHPYA2k2N744MNiCD1UE+tJyllUhSblK48bn+v1oZHCM0nYQ2NqUkvS\nj+hwUU3RiWl7x3D2s9wSdNt7XUtW05a/FXehsPSiJfKvHJJnGOX0BgTvkLnkAOTd\nOrUZ/wK69Dzu4IvrN4vs9Nes8vbwPa/ddZEzGR0cQMt0JBkhk9kU/qwqUseP1QRJ\n5I1jR4g8aYPL/ke9K35PxZWuDp3U0UPAZ3PjFAh+5T+fc7gzCs9dPzSHloruU+gl\nFQIDAQAB\n-----END PUBLIC KEY-----"
+
+const anotherValidPublicKeyPEM = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkbBNiNdz/A5HRMVwmQpOgMqBQFNe\nCrZhzDO5cMWezEzKHwRFoKLUZl5U7k2c0SQHa2qAqFMgASlO6mMhXyZPjw==\n-----END PUBLIC KEY-----"
+
+func writePEMFile(t *testing.T, dir, name, contents string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o600))
+}
+
+func TestLoadKeysFromDir_DirectoryDoesNotExist(t *testing.T) {
+	keys, err := loadKeysFromDir("/nonexistent/path/that/does/not/exist")
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
+func TestLoadKeysFromDir_EmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
+func TestLoadKeysFromDir_SingleValidPEMFile(t *testing.T) {
+	dir := t.TempDir()
+	writePEMFile(t, dir, "key.pub", validPublicKeyPEM)
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, "key.pub", keys[0].GetName())
+	// pem.EncodeToMemory always appends a trailing newline.
+	require.Equal(t, validPublicKeyPEM+"\n", keys[0].GetPublicKeyPemEnc())
+}
+
+func TestLoadKeysFromDir_MultipleValidPEMFiles(t *testing.T) {
+	dir := t.TempDir()
+	writePEMFile(t, dir, "key-a.pub", validPublicKeyPEM)
+	writePEMFile(t, dir, "key-b.pub", anotherValidPublicKeyPEM)
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+
+	nameSet := map[string]struct{}{}
+	for _, k := range keys {
+		nameSet[k.GetName()] = struct{}{}
+	}
+	require.Contains(t, nameSet, "key-a.pub")
+	require.Contains(t, nameSet, "key-b.pub")
+}
+
+func TestLoadKeysFromDir_DuplicatePEMContent(t *testing.T) {
+	dir := t.TempDir()
+	// Two files with identical PEM — only one should be returned.
+	writePEMFile(t, dir, "key-a.pub", validPublicKeyPEM)
+	writePEMFile(t, dir, "key-b.pub", validPublicKeyPEM)
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	// pem.EncodeToMemory always appends a trailing newline.
+	require.Equal(t, validPublicKeyPEM+"\n", keys[0].GetPublicKeyPemEnc())
+}
+
+func TestLoadKeysFromDir_InvalidFileSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writePEMFile(t, dir, "not-a-key.pub", "this is not a PEM block at all")
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
+func TestLoadKeysFromDir_MixedValidAndInvalid(t *testing.T) {
+	dir := t.TempDir()
+	writePEMFile(t, dir, "good.pub", validPublicKeyPEM)
+	writePEMFile(t, dir, "bad.pub", "not a PEM block")
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, "good.pub", keys[0].GetName())
+}
+
+func TestLoadKeysFromDir_SubdirectoriesIgnored(t *testing.T) {
+	dir := t.TempDir()
+	// Create a subdirectory — it should be ignored.
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o755))
+	writePEMFile(t, dir, "key.pub", validPublicKeyPEM)
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, "key.pub", keys[0].GetName())
+}
+
+func TestLoadKeysFromDir_TrailingWhitespaceAccepted(t *testing.T) {
+	dir := t.TempDir()
+	// File ends with double newline — was previously rejected with misleading warning.
+	writePEMFile(t, dir, "key.pub", validPublicKeyPEM+"\n\n")
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1, "trailing whitespace must not cause the key to be rejected")
+}
+
+func TestLoadKeysFromDir_DuplicateWithTrailingWhitespaceDeduplicated(t *testing.T) {
+	dir := t.TempDir()
+	// Two files: one with and one without trailing newlines — same underlying key.
+	writePEMFile(t, dir, "key-a.pub", validPublicKeyPEM)
+	writePEMFile(t, dir, "key-b.pub", validPublicKeyPEM+"\n\n")
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1, "whitespace-differing duplicates must be deduplicated")
+}
+
+func TestLoadKeysFromDir_GPGStyleHeaderStripped(t *testing.T) {
+	dir := t.TempDir()
+	// Simulate a file with GPG-style metadata lines before the PEM block.
+	gpgStyleContent := "Red Hat Release Key (release-key-3)\nVersion: GnuPG v1\n\n" + validPublicKeyPEM
+	writePEMFile(t, dir, "key.pub", gpgStyleContent)
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1, "GPG-style header before PEM block must be accepted")
+
+	// The stored PEM must be canonical — no leading GPG header.
+	require.Equal(t, validPublicKeyPEM+"\n", keys[0].GetPublicKeyPemEnc(),
+		"stored PEM must be stripped of GPG-style headers")
+}
+
+func TestLoadKeysFromDir_StoredPEMIsCanonical(t *testing.T) {
+	dir := t.TempDir()
+	writePEMFile(t, dir, "key.pub", validPublicKeyPEM)
+
+	keys, err := loadKeysFromDir(dir)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	// The stored value must equal pem.EncodeToMemory of the decoded block.
+	block, _ := pem.Decode([]byte(validPublicKeyPEM))
+	require.NotNil(t, block)
+	require.Equal(t, string(pem.EncodeToMemory(block)), keys[0].GetPublicKeyPemEnc(),
+		"stored PEM must be in canonical pem.EncodeToMemory form")
+}

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -71,7 +71,7 @@ func upsertRedHatSignatureIntegration(siStore store.SignatureIntegrationStore) {
 	utils.Should(errors.Wrap(siStore.Upsert(ctx, integration), "upserting Red Hat signature integration"))
 }
 
-func startRedHatSigningKeyUpdater(siStore store.SignatureIntegrationStore) {
+func startRedHatSigningKeyUpdater() {
 	manifestURL := env.RedHatSigningKeyManifestURL.Setting()
 	if manifestURL == "" {
 		log.Info("Red Hat signing key manifest URL not configured, skipping key updater")
@@ -117,7 +117,7 @@ func Singleton() DataStore {
 		upsertRedHatSignatureIntegration(storage)
 		instance = New(storage, policyDataStore.Singleton())
 		startRedHatSigningKeyDirWatcher(storage)
-		startRedHatSigningKeyUpdater(storage)
+		startRedHatSigningKeyUpdater()
 	})
 	return instance
 }

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"context"
+	"encoding/pem"
 	"net/http"
 	"time"
 
@@ -25,18 +26,52 @@ var (
 	keyUpdaterLock sync.Mutex
 )
 
-func upsertDefaultRedHatSignatureIntegration(siStore store.SignatureIntegrationStore) {
+// upsertRedHatSignatureIntegration builds the Red Hat signature integration from
+// the embedded key plus any keys found in the runtime directory, then upserts it
+// to the datastore. Duplicate keys (by canonical PEM) are silently dropped.
+// It is called at startup and as the updater's onSuccess callback.
+func upsertRedHatSignatureIntegration(siStore store.SignatureIntegrationStore) {
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowAllAccessScopeChecker())
 
-	log.Debugf("Upserting default Red Hat signature integration %q (%s)",
-		signatures.DefaultRedHatSignatureIntegration.GetName(),
-		signatures.DefaultRedHatSignatureIntegration.GetId(),
+	// Start from a clone of the default integration so we never mutate the global.
+	integration := signatures.DefaultRedHatSignatureIntegration.CloneVT()
+
+	// Build a set of canonical PEM values from the embedded keys for deduplication.
+	seen := make(map[string]struct{})
+	for _, k := range integration.GetCosign().GetPublicKeys() {
+		// Normalise the embedded PEM so comparison with dir keys is consistent.
+		if block, _ := pem.Decode([]byte(k.GetPublicKeyPemEnc())); block != nil {
+			seen[string(pem.EncodeToMemory(block))] = struct{}{}
+		} else {
+			seen[k.GetPublicKeyPemEnc()] = struct{}{}
+		}
+	}
+
+	// Load additional keys from the runtime directory. The keyloader already
+	// returns canonical PEM (via pem.EncodeToMemory), so string comparison is safe.
+	runtimeDir := env.RedHatSigningKeysRuntimeDir.Setting()
+	additionalKeys, err := loadKeysFromDir(runtimeDir)
+	if err != nil {
+		log.Warnf("Failed to load Red Hat signing keys from %q: %v", runtimeDir, err)
+	}
+	for _, k := range additionalKeys {
+		if _, dup := seen[k.GetPublicKeyPemEnc()]; dup {
+			log.Debugf("Skipping duplicate Red Hat signing key %q from directory", k.GetName())
+			continue
+		}
+		seen[k.GetPublicKeyPemEnc()] = struct{}{}
+		integration.Cosign.PublicKeys = append(integration.Cosign.PublicKeys, k)
+	}
+
+	log.Debugf("Upserting Red Hat signature integration %q (%s) with %d key(s)",
+		integration.GetName(),
+		integration.GetId(),
+		len(integration.GetCosign().GetPublicKeys()),
 	)
-	err := siStore.Upsert(ctx, signatures.DefaultRedHatSignatureIntegration)
-	utils.Should(errors.Wrap(err, "upserting default Red Hat signature integration"))
+	utils.Should(errors.Wrap(siStore.Upsert(ctx, integration), "upserting Red Hat signature integration"))
 }
 
-func startRedHatSigningKeyUpdater() {
+func startRedHatSigningKeyUpdater(siStore store.SignatureIntegrationStore) {
 	manifestURL := env.RedHatSigningKeyManifestURL.Setting()
 	if manifestURL == "" {
 		log.Info("Red Hat signing key manifest URL not configured, skipping key updater")
@@ -79,9 +114,10 @@ func StopRedHatSigningKeyUpdater() {
 func Singleton() DataStore {
 	once.Do(func() {
 		storage := pgStore.New(globaldb.GetPostgres())
-		upsertDefaultRedHatSignatureIntegration(storage)
+		upsertRedHatSignatureIntegration(storage)
 		instance = New(storage, policyDataStore.Singleton())
-		startRedHatSigningKeyUpdater()
+		startRedHatSigningKeyDirWatcher(storage)
+		startRedHatSigningKeyUpdater(storage)
 	})
 	return instance
 }

--- a/central/signatureintegration/datastore/updater_test.go
+++ b/central/signatureintegration/datastore/updater_test.go
@@ -309,6 +309,7 @@ func TestNewUpdaterRejectsZeroInterval(t *testing.T) {
 	require.Contains(t, err.Error(), "interval must be positive")
 }
 
+
 func TestResolveKeyRefsRejectsEmptyName(t *testing.T) {
 	_, err := resolveKeyRefsFromManifest("https://example.com/manifest.json", manifest{
 		Keys: []manifestKey{{Name: "", URL: "key.pub"}},

--- a/pkg/env/signature.go
+++ b/pkg/env/signature.go
@@ -15,4 +15,10 @@ var (
 	// RedHatSigningKeysRuntimeDir is the writable directory where downloaded Red Hat signing keys are stored.
 	RedHatSigningKeysRuntimeDir = RegisterSetting("ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR",
 		WithDefault("/var/lib/stackrox/signature-keys/redhat"))
+
+	// RedHatSigningKeyWatchInterval controls how often the signing-key directory
+	// watcher polls for changes. Shorter values reduce the lag between the
+	// updater writing new keys and Central reloading them; set to a low value
+	// (e.g. 5s) in E2E tests to avoid long waits.
+	RedHatSigningKeyWatchInterval = registerDurationSetting("ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL", 30*time.Second)
 )

--- a/qa-tests-backend/src/main/groovy/services/SignatureIntegrationService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/SignatureIntegrationService.groovy
@@ -85,6 +85,10 @@ class SignatureIntegrationService extends BaseService {
         return ""
     }
 
+    static List<SignatureIntegrationOuterClass.SignatureIntegration> listSignatureIntegrations() {
+        return getSignatureIntegrationClient().listSignatureIntegrations(EMPTY).getIntegrationsList()
+    }
+
     static Boolean deleteSignatureIntegration(String integrationId) {
         try {
             getSignatureIntegrationClient().deleteSignatureIntegration(getResourceByID(integrationId))

--- a/qa-tests-backend/src/test/groovy/RedHatSigningKeyTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RedHatSigningKeyTest.groovy
@@ -1,0 +1,137 @@
+import static util.Helpers.trueWithin
+
+import spock.lang.Tag
+
+import common.Constants
+import services.SignatureIntegrationService
+
+/**
+ * RedHatSigningKeyTest verifies that the built-in "Red Hat" signature integration is:
+ *   (1) always present at startup with the embedded key, and
+ *   (2) extended dynamically when additional PEM key files are placed in the
+ *       runtime key directory that Central watches.
+ *
+ * Test 2 requires the emptyDir volume mount introduced by ROX-30650 (PR3) and
+ * the filesystem watcher introduced by ROX-30650 (PR2).  If Central does not
+ * have a writable key directory (i.e., the volume mount is absent), the exec
+ * command will fail and the test will be skipped gracefully.
+ */
+@Tag("Integration")
+class RedHatSigningKeyTest extends BaseSpecification {
+
+    static final private String REDHAT_INTEGRATION_ID =
+            "io.stackrox.signatureintegration.12a37a37-760e-4388-9e79-d62726c075b2"
+
+    static final private String STACKROX_NS = Constants.STACKROX_NAMESPACE
+
+    // A valid P-256 ECDSA public key that is NOT any real Red Hat signing key.
+    // Generated via `cosign generate-key-pair`; used only for test injection.
+    static final private String TEST_KEY_PEM = """\
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUpphKrUYSHvrR+r82Jn7Evg/d3L9
+w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
+-----END PUBLIC KEY-----"""
+
+    // Directory inside the Central container where downloaded signing keys live.
+    static final private String KEY_DIR = "/var/lib/stackrox/signature-keys/redhat"
+
+    // Name of the injected test key file.
+    static final private String TEST_KEY_FILE = "e2e-test-injected.pub"
+
+    // ---------------------------------------------------------------------------
+    // Test 1: embedded Red Hat key is present at startup
+    // ---------------------------------------------------------------------------
+
+    @Tag("BAT")
+    def "Red Hat signature integration exists with embedded key"() {
+        when:
+        "Listing all signature integrations"
+        def integrations = SignatureIntegrationService.listSignatureIntegrations()
+
+        then:
+        "The built-in Red Hat integration should be present with at least one public key"
+        def redHat = integrations.find { it.getId() == REDHAT_INTEGRATION_ID }
+        assert redHat != null: "Red Hat signature integration not found (expected ID: ${REDHAT_INTEGRATION_ID})"
+        assert redHat.getCosign().getPublicKeysList().size() >= 1:
+                "Expected at least one embedded Red Hat public key, got 0"
+        log.info("Red Hat integration '${redHat.getName()}' has " +
+                "${redHat.getCosign().getPublicKeysList().size()} key(s) — PASS")
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test 2: dynamic key injection via filesystem watcher
+    // ---------------------------------------------------------------------------
+
+    @Tag("Integration")
+    def "Red Hat signing keys are reloaded dynamically from the key directory"() {
+        given:
+        "A running Central pod in the stackrox namespace"
+        def pods = orchestrator.getPods(STACKROX_NS, "central")
+        if (pods.isEmpty()) {
+            log.warn("No central pod found, skipping dynamic key reload test")
+            return
+        }
+        def centralPod = pods[0].getMetadata().getName()
+        log.info("Using Central pod: ${centralPod}")
+
+        def initialCount = redHatKeyCount()
+        log.info("Initial Red Hat key count: ${initialCount}")
+
+        when:
+        "A new PEM key file is placed in the Central key directory via kubectl exec"
+        // Escape single quotes in the PEM for shell safety — use a here-doc approach.
+        // The key contains no single quotes, so direct single-quote quoting is fine.
+        def pemEscaped = TEST_KEY_PEM.replace("'", "'\\''")
+        def writeCmd = "mkdir -p '${KEY_DIR}' && printf '%s\\n' '${pemEscaped}' > '${KEY_DIR}/${TEST_KEY_FILE}'"
+        boolean wrote = orchestrator.execInContainerByPodName(
+                centralPod, STACKROX_NS, (["sh", "-c", writeCmd] as String[]), 5)
+
+        then:
+        "The exec command should succeed (volume is writable)"
+        if (!wrote) {
+            log.warn("Could not write to '${KEY_DIR}' in Central pod '${centralPod}'. " +
+                    "The emptyDir volume mount (ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR) may be absent. " +
+                    "Skipping dynamic key reload assertion.")
+            // Clean attempt just in case
+            cleanupTestKey(centralPod)
+            return
+        }
+
+        and:
+        "The filesystem watcher detects the new file and upserts the integration"
+        // The default watch interval is 30 s; allow up to 90 s total (3 polls).
+        // In CI set ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL=5s to reduce wait.
+        boolean keyAppeared = trueWithin(18, 5) {
+            redHatKeyCount() > initialCount
+        }
+        assert keyAppeared: "Red Hat integration key count did not increase within 90 s of injecting ${TEST_KEY_FILE}"
+
+        def finalCount = redHatKeyCount()
+        log.info("Red Hat key count after injection: ${finalCount} (was ${initialCount}) — PASS")
+
+        cleanup:
+        "Remove the injected test key file from the Central pod"
+        cleanupTestKey(centralPod)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private int redHatKeyCount() {
+        def integrations = SignatureIntegrationService.listSignatureIntegrations()
+        def redHat = integrations.find { it.getId() == REDHAT_INTEGRATION_ID }
+        return redHat?.getCosign()?.getPublicKeysList()?.size() ?: 0
+    }
+
+    private void cleanupTestKey(String centralPod) {
+        try {
+            def rmCmd = "rm -f '${KEY_DIR}/${TEST_KEY_FILE}'"
+            orchestrator.execInContainerByPodName(
+                    centralPod, STACKROX_NS, (["sh", "-c", rmCmd] as String[]), 3)
+            log.info("Removed test key file ${KEY_DIR}/${TEST_KEY_FILE} from Central pod")
+        } catch (Exception e) {
+            log.warn("Failed to remove test key file during cleanup: ${e.getMessage()}")
+        }
+    }
+}

--- a/qa-tests-backend/src/test/groovy/RedHatSigningKeyTest.groovy
+++ b/qa-tests-backend/src/test/groovy/RedHatSigningKeyTest.groovy
@@ -33,6 +33,8 @@ w9e2Azq1OYIh/pbeBMHARDrBaqqmuMR9+BfAaPAYdkNTU6f58M2zBbuL0A==
 -----END PUBLIC KEY-----"""
 
     // Directory inside the Central container where downloaded signing keys live.
+    // Must match the default value of the Go env var ROX_REDHAT_SIGNING_KEYS_RUNTIME_DIR
+    // (env.RedHatSigningKeysRuntimeDir) so that the watcher and this test target the same path.
     static final private String KEY_DIR = "/var/lib/stackrox/signature-keys/redhat"
 
     // Name of the injected test key file.


### PR DESCRIPTION
## Description

Decouples the DB upsert layer from the key updater (PR1) by introducing a
filesystem watcher that reacts to key files written by the updater.

**key_dir_watcher.go**: `keyDirHandler` implements `k8scfgwatch.Handler`
(same interface used for TLS cert reloading). `OnStableUpdate` calls
`upsertRedHatSignatureIntegration`; `OnWatchError` logs at Debug level with
deduplication. Started with `Force:true` so it begins watching before the
updater creates the key directory.

**singleton.go**: calls `startRedHatSigningKeyDirWatcher(storage)` after the
initial startup upsert.

**updater.go**: removes the `onSuccess func()` callback — the watcher replaces
that coupling.

**pkg/env/signature.go**: adds `ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL` (30s
default) so the poll cadence can be shortened in E2E tests.

Alternative considered: passing upsert as a callback to the updater. Rejected
because it couples the DB layer to the I/O layer; the watcher pattern is already
the codebase standard for reacting to filesystem changes.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Unit tests pass: `go test ./central/signatureintegration/datastore/...`
- E2E test (`RedHatSigningKeyTest.groovy`) verifies:
  - Embedded key is present in the Red Hat integration at startup
  - Injecting a PEM file into the running pod causes key count to increase on
    the next watcher poll