### PR TITLE
ROX-34007: Fix pull request detection in create-custom-snapshot

### DIFF
--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -151,11 +151,10 @@ spec:
             }
 
             is_pull_request="true"
-            if [[ "{{ pull_request_number }}" == "" || "{{ pull_request_number }}" == *pull_request_number* ]]; then
-              # If it's an empty string or remains literally "{{ pull_request_number }}", it's not a pull request.
+            if [[ '{{ cel: target_branch }}' == '{{ cel: source_branch }}' ]]; then
               is_pull_request="false"
             fi
-            assert_boolean is_pull_request "pull_request_number: {{ pull_request_number }}"
+            assert_boolean is_pull_request
 
             is_matching_target_branch='{{ cel: target_branch.startsWith("release-") }}'
             assert_boolean is_matching_target_branch "target_branch: {{ target_branch }}"


### PR DESCRIPTION
## Description

In the merge commit https://github.com/stackrox/stackrox/commit/ced8ffd36efe2f06a72abe69602f5d8358541175 of https://github.com/stackrox/stackrox/pull/20016, `{{ pull_request_number }}` appeared with the value which is not what I expected. The logic wrongly decided it's a PR and did not run the rest of `create-custom-snapshot` pipeline. https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/create-custom-snapshot-tp48r/logs?task=determine-actual-build

It occurred to me that we can figure whether it's a PR by comparing source and target branches and so this is the implementation of that.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

None.

### How I validated my change

I looked through the test runs in https://github.com/stackrox/stackrox/pull/20016 to make sure that `{{ source_branch }}` and `{{ target_branch }}` are reported the way we expect.

I'd rely on just a CI run here https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/pipelineruns/create-custom-snapshot-8hrx9/logs?task=determine-actual-build

and one for tagged build: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/create-custom-snapshot-8phtn-determine-actual-build/logs