### PR TITLE
ROX-33555: Add matcher-not-ready NACK reason for VM enrichment

### DIFF
--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
@@ -2,6 +2,7 @@ package virtualmachineindex
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/convert/v1tov2storage"
@@ -18,12 +19,18 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
 	vmEnricher "github.com/stackrox/rox/pkg/virtualmachine/enricher"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
 	log = logging.LoggerForModule()
 
 	_ pipeline.Fragment = (*pipelineImpl)(nil)
+)
+
+const (
+	matcherNotReadyReasonText = "the matcher is not initialized"
 )
 
 // GetPipeline returns an instantiation of this particular pipeline
@@ -78,6 +85,26 @@ func sendVMIndexNACK(ctx context.Context, resourceID, reason string, injector co
 	common.SendSensorACK(ctx, central.SensorACK_NACK, central.SensorACK_VM_INDEX_REPORT, resourceID, reason, injector)
 }
 
+func reasonForEnrichmentFailure(err error) string {
+	if isMatcherNotReadyError(err) {
+		return centralsensor.SensorACKReasonMatcherNotReady
+	}
+	return centralsensor.SensorACKReasonEnrichmentFailed
+}
+
+func isMatcherNotReadyError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	grpcStatus, ok := status.FromError(err)
+	if !ok || grpcStatus.Code() != codes.FailedPrecondition {
+		return false
+	}
+
+	return strings.Contains(grpcStatus.Message(), matcherNotReadyReasonText)
+}
+
 func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.MsgFromSensor, injector common.MessageInjector) error {
 	defer countMetrics.IncrementResourceProcessedCounter(pipeline.ActionToOperation(msg.GetEvent().GetAction()), metrics.VirtualMachineIndex)
 
@@ -121,7 +148,7 @@ func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 	// Enrich VM with vulnerabilities
 	err := p.enricher.EnrichVirtualMachineWithVulnerabilities(vm, indexV4)
 	if err != nil {
-		sendVMIndexNACK(ctx, index.GetId(), centralsensor.SensorACKReasonEnrichmentFailed, injector)
+		sendVMIndexNACK(ctx, index.GetId(), reasonForEnrichmentFailure(err), injector)
 		return errors.Wrapf(err, "failed to enrich VM %s with vulnerabilities", index.GetId())
 	}
 

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -459,6 +461,37 @@ func (suite *PipelineTestSuite) TestRun_NACKOnEnrichmentError() {
 	suite.Equal(central.SensorACK_VM_INDEX_REPORT, ack.GetMessageType())
 	suite.Equal(vmID, ack.GetResourceId())
 	suite.Equal(centralsensor.SensorACKReasonEnrichmentFailed, ack.GetReason())
+}
+
+func (suite *PipelineTestSuite) TestRun_NACKOnMatcherNotInitializedError() {
+	suite.T().Setenv(features.VirtualMachines.EnvVar(), "true")
+	suite.T().Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), "false")
+	vmID := "vm-matcher-not-initialized"
+	msg := createVMIndexMessage(vmID, central.ResourceAction_SYNC_RESOURCE)
+
+	suite.enricher.EXPECT().
+		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
+		Return(errors.Wrap(
+			status.Errorf(codes.FailedPrecondition, "the matcher is not initialized: initial load for the vulnerability store is in progress"),
+			"getting scan for VM",
+		))
+
+	injector := &mockInjector{
+		capabilities: map[centralsensor.SensorCapability]bool{
+			centralsensor.SensorACKSupport: true,
+		},
+	}
+
+	err := suite.pipeline.Run(ctx, testClusterID, msg, injector)
+	suite.Error(err)
+
+	suite.Require().Len(injector.messages, 1)
+	ack := injector.messages[0].GetSensorAck()
+	suite.Require().NotNil(ack)
+	suite.Equal(central.SensorACK_NACK, ack.GetAction())
+	suite.Equal(central.SensorACK_VM_INDEX_REPORT, ack.GetMessageType())
+	suite.Equal(vmID, ack.GetResourceId())
+	suite.Equal(centralsensor.SensorACKReasonMatcherNotReady, ack.GetReason())
 }
 
 func (suite *PipelineTestSuite) TestRun_NACKOnMissingClusterID() {

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
@@ -472,7 +472,7 @@ func (suite *PipelineTestSuite) TestRun_NACKOnMatcherNotInitializedError() {
 	suite.enricher.EXPECT().
 		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 		Return(errors.Wrap(
-			status.Errorf(codes.FailedPrecondition, "the matcher is not initialized: initial load for the vulnerability store is in progress"),
+			status.Error(codes.FailedPrecondition, "the matcher is not initialized: initial load for the vulnerability store is in progress"),
 			"getting scan for VM",
 		))
 

--- a/pkg/centralsensor/sensor_ack.go
+++ b/pkg/centralsensor/sensor_ack.go
@@ -5,6 +5,7 @@ package centralsensor
 const (
 	SensorACKReasonRateLimited       = "central rate limit exceeded"
 	SensorACKReasonEnrichmentFailed  = "enrichment failed"
+	SensorACKReasonMatcherNotReady   = "enrichment failed: matcher not initialized"
 	SensorACKReasonStorageFailed     = "storage failed"
 	SensorACKReasonMissingScanData   = "missing scanner index data"
 	SensorACKReasonMissingClusterID  = "missing cluster ID"


### PR DESCRIPTION
## Description

Implements Improvement 2 from `TODO-scanner-v4-nack-improvements.md`: return a dedicated NACK reason when VM enrichment fails because Scanner V4 matcher is not initialized, so Sensor/compliance can distinguish transient matcher warm-up from generic enrichment failures.

- Adds `SensorACKReasonMatcherNotReady` (`"enrichment failed: matcher not initialized"`).
- In the VM index pipeline, maps enrichment errors to the new reason only when the wrapped gRPC error is `FailedPrecondition` and contains `the matcher is not initialized`.
- Keeps existing behavior for all other enrichment failures (`"enrichment failed"`).
- Keeps scope intentionally narrow: no retry changes, no `pgutils` changes, and no gRPC/proto changes.
- Adds a regression/unit test that validates the matcher-not-initialized path.

Example:
- Before: matcher-not-initialized and generic enrichment failures both produced `reason: "enrichment failed"`.
- After: matcher-not-initialized produces `reason: "enrichment failed: matcher not initialized"`; generic enrichment failures remain `reason: "enrichment failed"`.

AI-assisted: AI generated the NACK-reason classification helper, the new reason constant, and the regression test. The user defined scope/constraints, reviewed the behavior, and committed the final change.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- CI

