### PR TITLE
fix(tests): make splunk tests more selective

### DIFF
--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -83,12 +83,15 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         when:
         "Search for violations in Splunk"
         // The TA polls Central every 5s (input interval). Violations may not be indexed yet.
+        // Filter by deployment name to avoid picking up violations from other tests.
+        def deployName = splunkDeployment.deployment.name
         List<Map<String, String>> results = Collections.emptyList()
         boolean hasNetworkViolation = false
         boolean hasProcessViolation = false
         def port = splunkDeployment.splunkPortForward.getLocalPort()
         withRetry(40, 15) {
-            def searchId = SplunkUtil.createSearch(port, "search sourcetype=stackrox-violations")
+            def searchId = SplunkUtil.createSearch(port,
+                    "search sourcetype=stackrox-violations \"${deployName}\"")
             Response response = SplunkUtil.getSearchResults(port, searchId)
             // We should have at least one violation in the response
             assert response != null
@@ -110,7 +113,7 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         withRetry(40, 15) {
             def vSearchId = SplunkUtil.createSearch(port,
                     "| datamodel Alerts Alerts search | rename Alerts.* AS *" +
-                    " | search sourcetype=stackrox-violations", "-30m")
+                    " | search sourcetype=stackrox-violations \"${deployName}\"", "-30m")
             Response vResponse = SplunkUtil.getSearchResults(port, vSearchId)
             assert vResponse != null
             alerts = vResponse.getBody().jsonPath().getList("results")


### PR DESCRIPTION
## Description

The splunk TA tests were picking up violations from other tests (notably node file activity violations) so this makes the tests more selective about which violations it validates.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Run locally on their own and alongside FileActivityTest specifically (on Openshift cluster.) CI should reflect this success.
