### PR TITLE
ROX-34404: Fix NetworkBaselineTest external flows flake

### DIFF
--- a/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
+++ b/qa-tests-backend/src/test/groovy/NetworkBaselineTest.groovy
@@ -473,8 +473,9 @@ class NetworkBaselineTest extends BaseSpecification {
 
         def externalBaseline = evaluateWithRetry(30, 4) {
             def externalBaseline = NetworkBaselineService.getNetworkBaselineForExternalFlows(deploymentUid)
-            assert externalBaseline.totalAnomalous + externalBaseline.totalBaseline != 0 :
-                    "No peers in baseline for deployment ${deploymentUid} yet. Baseline is ${externalBaseline}"
+            assert externalBaseline.totalBaseline >= 3 :
+                    "Expected at least 3 baseline peers for deployment ${deploymentUid}, " +
+                    "got ${externalBaseline.totalBaseline}. Baseline is ${externalBaseline}"
             return externalBaseline
         }
 
@@ -534,8 +535,10 @@ class NetworkBaselineTest extends BaseSpecification {
 
         def externalBaselineAfter = evaluateWithRetry(30, 4) {
             def externalBaselineAfter = NetworkBaselineService.getNetworkBaselineForExternalFlows(deploymentUid)
-            assert externalBaselineAfter.totalAnomalous + externalBaselineAfter.totalBaseline != 0 :
-                    "No peers in baseline for deployment ${deploymentUid} yet. Baseline is ${externalBaselineAfter}"
+            assert externalBaselineAfter.totalAnomalous == 2 && externalBaselineAfter.totalBaseline == 1 :
+                    "Expected 2 anomalous + 1 baseline for deployment ${deploymentUid}, " +
+                    "got ${externalBaselineAfter.totalAnomalous} anomalous + " +
+                    "${externalBaselineAfter.totalBaseline} baseline. Baseline is ${externalBaselineAfter}"
             return externalBaselineAfter
         }
 


### PR DESCRIPTION
## Description

`NetworkBaselineTest."Verify network baseline functionality with multiple external entities"` flakes with NPE at line 500 ([CI run](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-ocp-4-21-merge-qa-e2e-tests/2046875138003046400)).

**Root cause:** The `evaluateWithRetry` for `getNetworkBaselineForExternalFlows` exits as soon as *any* peer is present (`totalAnomalous + totalBaseline != 0`), but the assertions that follow expect all 3 external IPs (`8.8.8.8:53`, `1.1.1.1:53`, `1.1.1.2:80`). When some flows arrive slower, `.find()` returns null and `.getPeer()` throws NPE.

**Fix:**
- Wait for `totalBaseline >= 3` before proceeding to per-IP assertions
- Tighten the post-modify retry to wait for the exact expected distribution (`2 anomalous + 1 baseline`) instead of just any peers

This is a follow-up to #20046 which fixed a different flake in the same test (unreachable IP).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

The fix is straightforward: the retry condition now matches what the subsequent assertions expect. Will validate via CI (`/test gke-qa-e2e-tests`).