### PR TITLE
ROX-34405: Fix label filtering on clusters page

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClustersTablePanel.tsx
@@ -40,7 +40,11 @@ import type { Cluster } from 'types/cluster.proto';
 import type { ClusterIdToRetentionInfo } from 'types/clusterService.proto';
 import { getTableUIState } from 'utils/getTableUIState';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
-import { convertToRestSearch, getHasSearchApplied } from 'utils/searchUtils';
+import {
+    applyRegexSearchModifiers,
+    convertToRestSearch,
+    getHasSearchApplied,
+} from 'utils/searchUtils';
 import {
     clustersBasePath,
     clustersClusterRegistrationSecretsPath,
@@ -100,7 +104,10 @@ function ClustersTablePanel({ selectedClusterId }: ClustersTablePanelProps) {
     const [hasFetchedClusters, setHasFetchedClusters] = useState(false);
     const [isLoadingVisible, setIsLoadingVisible] = useState(false);
 
-    const restSearch = useMemo(() => convertToRestSearch(searchFilter ?? {}), [searchFilter]);
+    const restSearch = useMemo(
+        () => convertToRestSearch(applyRegexSearchModifiers(searchFilter ?? {})),
+        [searchFilter]
+    );
 
     const [currentClusters, setCurrentClusters] = useState<Cluster[]>([]);
     const [clusterIdToRetentionInfo, setClusterIdToRetentionInfo] =


### PR DESCRIPTION
## Description

Fixes an issue where label filters on the Clusters page were wrapped in quotes, preventing proper filtering (e.g. `"key=value"` instead of `key=value` or `"key"="value"`).

The Clusters page still uses a legacy search path (`convertToRestSearch` -> `searchOptionsToQuery`) and doesn't apply `applyRegexSearchModifiers`. This change applies `applyRegexSearchModifiers` during `convertToRestSearch`, fixing the issue without refactoring `ClustersService`.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Before (filter not working)
Parsed query param: `Cluster Label:"key=value"`

After (filter working)
Parsed query param: `Cluster Label:"key"="value"`