### PR TITLE
ROX-29577: PoC of e2e tests for VM scanning

### DIFF
--- a/scripts/ci/jobs/ocp_vm_scanning_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_vm_scanning_e2e_tests.py
@@ -24,6 +24,7 @@ os.environ["SENSOR_HELM_MANAGED"] = "true"
 os.environ["INSTALL_CNV_OPERATOR"] = "true"
 os.environ["ROX_VIRTUAL_MACHINES"] = "true"
 os.environ["ROX_SCANNER_V4"] = "true"
+os.environ["ROX_VM_RELAY_MAX_REPORTS_PER_MINUTE"] = "10"
 os.environ["VM_IMAGES"] = ",".join([
     "quay.io/rhacs-eng/vm-images:rhel9-dnf-primed-latest",
     "quay.io/rhacs-eng/vm-images:rhel10-dnf-primed-latest",

--- a/scripts/ci/jobs/ocp_vm_scanning_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_vm_scanning_e2e_tests.py
@@ -24,6 +24,7 @@ os.environ["SENSOR_HELM_MANAGED"] = "true"
 os.environ["INSTALL_CNV_OPERATOR"] = "true"
 os.environ["ROX_VIRTUAL_MACHINES"] = "true"
 os.environ["ROX_SCANNER_V4"] = "true"
+# Avoid default rate limiting of VM index reports set to 1 report per minute per VM.
 os.environ["ROX_VM_RELAY_MAX_REPORTS_PER_MINUTE"] = "10"
 os.environ["VM_IMAGES"] = ",".join([
     "quay.io/rhacs-eng/vm-images:rhel9-dnf-primed-latest",

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -36,7 +36,7 @@ compliance-v2-tests:
 .PHONY: vm-scanning-unit-tests
 vm-scanning-unit-tests:
 	@echo "+ $@"
-	@bash -o pipefail -c 'GOTAGS=$(GOTAGS),test $(TOPLEVEL)/scripts/go-test.sh -cover $(TESTFLAGS) -v ./vmhelpers 2>&1 | tee test.log'; rc=$$?; \
+	@bash -o pipefail -c 'GOTAGS=$(GOTAGS),test $(TOPLEVEL)/scripts/go-test.sh -cover $(TESTFLAGS) -v ./vmhelpers ./testmetrics 2>&1 | tee test.log'; rc=$$?; \
 	$(MAKE) report JUNIT_OUT=vm-scanning-unit-tests-results; \
 	exit $$rc
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -690,6 +690,11 @@ deploy_sensor_via_operator() {
         customize_envVars+=$'\n    - name: ROX_VIRTUAL_MACHINES'
         customize_envVars+=$'\n      value: "true"'
     fi
+    # For VM e2e tests that may send multiple index reports per minute.
+    if [[ -n "${ROX_VM_RELAY_MAX_REPORTS_PER_MINUTE:-}" ]]; then
+        customize_envVars+=$'\n    - name: ROX_VM_RELAY_MAX_REPORTS_PER_MINUTE'
+        customize_envVars+=$'\n      value: "'"${ROX_VM_RELAY_MAX_REPORTS_PER_MINUTE}"'"'
+    fi
     if [[ -n "${ROX_NETFLOW_BATCHING:-}" ]]; then
         customize_envVars+=$'\n    - name: ROX_NETFLOW_BATCHING'
         customize_envVars+=$'\n      value: "'"${ROX_NETFLOW_BATCHING}"'"'

--- a/tests/testmetrics/parse.go
+++ b/tests/testmetrics/parse.go
@@ -1,0 +1,168 @@
+package testmetrics
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// Query identifies a single Prometheus counter to extract from scrape text.
+// When LabelFilter is empty, the first line matching Name is used.
+// When set, only lines containing both Name and LabelFilter are matched.
+type Query struct {
+	Name        string
+	LabelFilter string
+}
+
+// Value is a single scraped Prometheus counter value.
+type Value struct {
+	Val   float64
+	Found bool
+}
+
+// Key returns a stable map key for a Query.
+func Key(q Query) string {
+	if q.LabelFilter == "" {
+		return q.Name
+	}
+	return q.Name + "{" + q.LabelFilter + "}"
+}
+
+// Parse extracts the requested counters from raw Prometheus exposition text.
+// The returned map is keyed by Key(query).
+func Parse(text string, queries []Query) map[string]Value {
+	out := make(map[string]Value, len(queries))
+	for _, q := range queries {
+		k := Key(q)
+		if q.LabelFilter == "" {
+			v, ok := parseCounter(text, q.Name)
+			out[k] = Value{Val: v, Found: ok}
+		} else {
+			v, ok := parseCounterWithLabel(text, q.Name, q.LabelFilter)
+			out[k] = Value{Val: v, Found: ok}
+		}
+	}
+	return out
+}
+
+// ValuesEqual returns true when both maps have the same keys with identical Found/Val.
+func ValuesEqual(a, b map[string]Value) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		vb, ok := b[k]
+		if !ok || va != vb {
+			return false
+		}
+	}
+	return true
+}
+
+// StableConfig configures PollUntilStable.
+type StableConfig struct {
+	PollInterval time.Duration
+	StableRounds int
+	Logf         func(string, ...any)
+}
+
+// ScrapeFunc fetches metrics for one poll iteration. Returning an error signals a
+// retryable failure (e.g. pod not ready); the poll continues until the context expires.
+type ScrapeFunc func(ctx context.Context) (map[string]Value, error)
+
+// PollUntilStable polls scrapeFn until the returned values are identical across
+// stableRounds consecutive successful scrapes, or the context expires.
+// On timeout it returns the last successful result (assertions should catch the real issue).
+func PollUntilStable(ctx context.Context, cfg StableConfig, scrapeFn ScrapeFunc) map[string]Value {
+	interval := cfg.PollInterval
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	stableRounds := cfg.StableRounds
+	if stableRounds <= 0 {
+		stableRounds = 3
+	}
+	logf := cfg.Logf
+
+	var prev map[string]Value
+	consecutiveStable := 0
+
+	_ = wait.PollUntilContextCancel(ctx, interval, true, func(ctx context.Context) (bool, error) {
+		cur, err := scrapeFn(ctx)
+		if err != nil {
+			consecutiveStable = 0
+			prev = nil
+			if logf != nil {
+				logf("metrics poll: scrape error (will retry): %v", err)
+			}
+			return false, nil
+		}
+
+		if prev != nil && ValuesEqual(prev, cur) {
+			consecutiveStable++
+		} else {
+			consecutiveStable = 1
+		}
+
+		if logf != nil && (consecutiveStable == 1 || consecutiveStable == stableRounds) {
+			logf("metrics poll: stable=%d/%d values=%v", consecutiveStable, stableRounds, cur)
+		}
+		prev = cur
+		return consecutiveStable >= stableRounds, nil
+	})
+
+	if prev == nil {
+		return map[string]Value{}
+	}
+	return prev
+}
+
+func parseCounter(body, metricPrefix string) (float64, bool) {
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, metricPrefix) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		val, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err != nil {
+			continue
+		}
+		return val, true
+	}
+	return 0, false
+}
+
+func parseCounterWithLabel(body, metricName, labelSubstring string) (float64, bool) {
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, metricName) {
+			continue
+		}
+		if !strings.Contains(line, labelSubstring) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		val, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err != nil {
+			continue
+		}
+		return val, true
+	}
+	return 0, false
+}

--- a/tests/testmetrics/parse.go
+++ b/tests/testmetrics/parse.go
@@ -129,6 +129,10 @@ func parseCounter(body, metricPrefix string) (float64, bool) {
 		if !strings.HasPrefix(line, metricPrefix) {
 			continue
 		}
+		rest := line[len(metricPrefix):]
+		if len(rest) > 0 && rest[0] != '{' && rest[0] != ' ' {
+			continue
+		}
 		fields := strings.Fields(line)
 		if len(fields) < 2 {
 			continue

--- a/tests/testmetrics/parse_test.go
+++ b/tests/testmetrics/parse_test.go
@@ -1,0 +1,76 @@
+//go:build test
+
+package testmetrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse_FoundAndMissing(t *testing.T) {
+	text := strings.Join([]string{
+		"some_counter_total 2",
+		"other_counter_total 1",
+		`labeled_total{status="ok"} 7`,
+	}, "\n")
+
+	queries := []Query{
+		{Name: "some_counter_total"},
+		{Name: "other_counter_total"},
+		{Name: "labeled_total", LabelFilter: `status="ok"`},
+		{Name: "labeled_total", LabelFilter: `status="err"`},
+		{Name: "absent_total"},
+	}
+	m := Parse(text, queries)
+
+	assertFound := func(q Query, expected float64) {
+		t.Helper()
+		v := m[Key(q)]
+		require.True(t, v.Found, "expected %s to be found", Key(q))
+		require.Equal(t, expected, v.Val, "wrong value for %s", Key(q))
+	}
+	assertMissing := func(q Query) {
+		t.Helper()
+		v := m[Key(q)]
+		require.False(t, v.Found, "expected %s to be absent", Key(q))
+	}
+
+	assertFound(queries[0], 2)
+	assertFound(queries[1], 1)
+	assertFound(queries[2], 7)
+	assertMissing(queries[3])
+	assertMissing(queries[4])
+}
+
+func TestParse_EmptyInput(t *testing.T) {
+	queries := []Query{
+		{Name: "foo_total"},
+		{Name: "bar_total"},
+	}
+	m := Parse("", queries)
+
+	for _, q := range queries {
+		v := m[Key(q)]
+		require.False(t, v.Found, "expected %s absent on empty input", Key(q))
+		require.Equal(t, float64(0), v.Val)
+	}
+}
+
+func TestKey(t *testing.T) {
+	require.Equal(t, "foo_total", Key(Query{Name: "foo_total"}))
+	require.Equal(t, `foo_total{status="ok"}`, Key(Query{Name: "foo_total", LabelFilter: `status="ok"`}))
+}
+
+func TestValuesEqual(t *testing.T) {
+	a := map[string]Value{"x": {Val: 1, Found: true}}
+	b := map[string]Value{"x": {Val: 1, Found: true}}
+	require.True(t, ValuesEqual(a, b))
+
+	c := map[string]Value{"x": {Val: 2, Found: true}}
+	require.False(t, ValuesEqual(a, c))
+
+	d := map[string]Value{"y": {Val: 1, Found: true}}
+	require.False(t, ValuesEqual(a, d))
+}

--- a/tests/testmetrics/parse_test.go
+++ b/tests/testmetrics/parse_test.go
@@ -44,6 +44,31 @@ func TestParse_FoundAndMissing(t *testing.T) {
 	assertMissing(queries[4])
 }
 
+func TestParse_PrefixDoesNotFalseMatch(t *testing.T) {
+	text := strings.Join([]string{
+		"rox_scan_connections_total 5",
+		`rox_scan_connections_errors_total{reason="timeout"} 3`,
+	}, "\n")
+
+	queries := []Query{
+		{Name: "rox_scan_connections_total"},
+		{Name: "rox_scan_connections_errors_total"},
+		{Name: "rox_scan_connections"},
+	}
+	m := Parse(text, queries)
+
+	v := m[Key(queries[0])]
+	require.True(t, v.Found)
+	require.Equal(t, float64(5), v.Val)
+
+	v = m[Key(queries[1])]
+	require.True(t, v.Found)
+	require.Equal(t, float64(3), v.Val)
+
+	v = m[Key(queries[2])]
+	require.False(t, v.Found, "rox_scan_connections should NOT match rox_scan_connections_total")
+}
+
 func TestParse_EmptyInput(t *testing.T) {
 	queries := []Query{
 		{Name: "foo_total"},

--- a/tests/testmetrics/scrape.go
+++ b/tests/testmetrics/scrape.go
@@ -1,0 +1,294 @@
+package testmetrics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// Transport selects how pod metrics are scraped.
+type Transport string
+
+const (
+	TransportProxy       Transport = "proxy"
+	TransportPortForward Transport = "portforward"
+)
+
+// PodSnapshot is a single /metrics (or custom path) scrape from one pod.
+type PodSnapshot struct {
+	PodName string
+	Body    string
+	Err     error
+}
+
+// PodScrapeOptions configures ScrapePodViaProxy (Kubernetes pods/proxy subresource).
+type PodScrapeOptions struct {
+	Namespace   string
+	PodName     string
+	Port        int
+	MetricsPath string
+}
+
+// PodCollectOptions scrapes metrics from every pod matching LabelSelector.
+type PodCollectOptions struct {
+	Namespace     string
+	LabelSelector string
+	FieldSelector string
+	Port          int
+	MetricsPath   string
+	Transport     Transport
+	RestConfig    *rest.Config
+}
+
+// ScrapeTarget describes how to collect metrics for one Kubernetes component.
+type ScrapeTarget struct {
+	ComponentName string
+	Namespace     string
+	LabelSelector string
+	FieldSelector string
+	MetricsPort   int
+	MetricsPath   string
+}
+
+// ScrapePodViaProxy scrapes Prometheus text from a pod via GET .../pods/{name}[:port]/proxy/{path}.
+func ScrapePodViaProxy(ctx context.Context, clientset kubernetes.Interface, opts PodScrapeOptions) ([]byte, error) {
+	if opts.Namespace == "" || opts.PodName == "" {
+		return nil, errors.New("testmetrics: ScrapePodViaProxy: namespace and pod name are required")
+	}
+	path := strings.Trim(opts.MetricsPath, "/")
+	if path == "" {
+		path = "metrics"
+	}
+	segments := strings.Split(path, "/")
+	podSubresourceName := opts.PodName
+	if opts.Port > 0 {
+		podSubresourceName = fmt.Sprintf("%s:%d", opts.PodName, opts.Port)
+	}
+	req := clientset.CoreV1().RESTClient().Get().
+		Namespace(opts.Namespace).
+		Resource("pods").
+		Name(podSubresourceName).
+		SubResource("proxy")
+	for _, seg := range segments {
+		if seg != "" {
+			req = req.Suffix(seg)
+		}
+	}
+	return req.Do(ctx).Raw()
+}
+
+// ScrapePodViaPortForward opens an ephemeral port-forward to remotePort on the pod
+// and GETs metricsPath on localhost.
+func ScrapePodViaPortForward(ctx context.Context, clientset kubernetes.Interface, restCfg *rest.Config, namespace, podName string, remotePort int, metricsPath string) ([]byte, error) {
+	if restCfg == nil {
+		return nil, errors.New("testmetrics: ScrapePodViaPortForward: rest.Config is required")
+	}
+	if namespace == "" || podName == "" {
+		return nil, errors.New("testmetrics: ScrapePodViaPortForward: namespace and pod name are required")
+	}
+	if remotePort <= 0 {
+		return nil, errors.New("testmetrics: ScrapePodViaPortForward: remote metrics port must be positive")
+	}
+	path := metricsPath
+	if path == "" {
+		path = "/metrics"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").Namespace(namespace).Name(podName).SubResource("portforward")
+	transport, upgrader, err := spdy.RoundTripperFor(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("testmetrics: port-forward transport: %w", err)
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, req.URL())
+
+	stopCh := make(chan struct{})
+	readyCh := make(chan struct{})
+	forwarder, err := portforward.New(dialer, []string{fmt.Sprintf("0:%d", remotePort)}, stopCh, readyCh, io.Discard, io.Discard)
+	if err != nil {
+		return nil, fmt.Errorf("testmetrics: port-forward: %w", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- forwarder.ForwardPorts() }()
+
+	select {
+	case <-ctx.Done():
+		close(stopCh)
+		<-errCh
+		return nil, ctx.Err()
+	case err = <-errCh:
+		return nil, fmt.Errorf("testmetrics: port-forward to %s/%s:%d failed: %w", namespace, podName, remotePort, err)
+	case <-readyCh:
+	}
+
+	ports, err := forwarder.GetPorts()
+	if err != nil || len(ports) == 0 {
+		close(stopCh)
+		<-errCh
+		return nil, fmt.Errorf("testmetrics: port-forward: no local ports: %w", err)
+	}
+	localPort := int(ports[0].Local)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d%s", localPort, path), nil)
+	if err != nil {
+		close(stopCh)
+		<-errCh
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		close(stopCh)
+		<-errCh
+		return nil, fmt.Errorf("testmetrics: port-forward metrics GET: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, readErr := io.ReadAll(resp.Body)
+	close(stopCh)
+	<-errCh
+	if readErr != nil {
+		return nil, readErr
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("testmetrics: port-forward metrics HTTP %s", resp.Status)
+	}
+	return body, nil
+}
+
+func scrapePod(ctx context.Context, clientset kubernetes.Interface, opts PodCollectOptions, podName string) ([]byte, error) {
+	transport := opts.Transport
+	if transport == "" {
+		transport = TransportProxy
+	}
+	path := opts.MetricsPath
+	if path == "" {
+		path = "metrics"
+	}
+	switch transport {
+	case TransportPortForward:
+		if opts.RestConfig == nil {
+			return nil, errors.New("testmetrics: PodCollectOptions.RestConfig is required for port-forward transport")
+		}
+		if opts.Port <= 0 {
+			return nil, errors.New("testmetrics: PodCollectOptions.Port must be set for port-forward transport")
+		}
+		return ScrapePodViaPortForward(ctx, clientset, opts.RestConfig, opts.Namespace, podName, opts.Port, path)
+	case TransportProxy:
+		return ScrapePodViaProxy(ctx, clientset, PodScrapeOptions{
+			Namespace:   opts.Namespace,
+			PodName:     podName,
+			Port:        opts.Port,
+			MetricsPath: path,
+		})
+	default:
+		return nil, fmt.Errorf("testmetrics: unsupported metrics transport %q", transport)
+	}
+}
+
+// CollectFromPods lists pods matching LabelSelector/FieldSelector and scrapes metrics
+// from each (same port/path/transport).
+func CollectFromPods(ctx context.Context, clientset kubernetes.Interface, opts PodCollectOptions) ([]PodSnapshot, error) {
+	if opts.Namespace == "" {
+		return nil, errors.New("testmetrics: CollectFromPods: namespace is required")
+	}
+	if opts.Transport == TransportPortForward && opts.RestConfig == nil {
+		return nil, errors.New("testmetrics: CollectFromPods: RestConfig required for port-forward")
+	}
+	list, err := clientset.CoreV1().Pods(opts.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: opts.LabelSelector,
+		FieldSelector: opts.FieldSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PodSnapshot, 0, len(list.Items))
+	for i := range list.Items {
+		name := list.Items[i].Name
+		body, err := scrapePod(ctx, clientset, opts, name)
+		snap := PodSnapshot{PodName: name}
+		if err != nil {
+			snap.Err = err
+		} else {
+			snap.Body = string(body)
+		}
+		out = append(out, snap)
+	}
+	return out, nil
+}
+
+// ScrapeComponent scrapes pods of a single component and parses the requested counters.
+// Pods that fail to serve metrics are skipped; an error is returned only when no pod yields valid data.
+// restCfg is required when transport is TransportPortForward; it may be nil for TransportProxy.
+func ScrapeComponent(ctx context.Context, clientset kubernetes.Interface, target ScrapeTarget, transport Transport, restCfg *rest.Config, queries []Query) (map[string]Value, error) {
+	snaps, err := CollectFromPods(ctx, clientset, PodCollectOptions{
+		Namespace:     target.Namespace,
+		LabelSelector: target.LabelSelector,
+		FieldSelector: target.FieldSelector,
+		Port:          target.MetricsPort,
+		MetricsPath:   target.MetricsPath,
+		Transport:     transport,
+		RestConfig:    restCfg,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scrape %s: %w", target.ComponentName, err)
+	}
+	if len(snaps) == 0 {
+		return nil, fmt.Errorf("scrape %s: no pods found (selector=%q field=%q)",
+			target.ComponentName, target.LabelSelector, target.FieldSelector)
+	}
+	var b strings.Builder
+	okPods := 0
+	var podErrors []string
+	for _, s := range snaps {
+		if s.Err != nil {
+			podErrors = append(podErrors, fmt.Sprintf("pod %s: %v", s.PodName, s.Err))
+			continue
+		}
+		okPods++
+		fmt.Fprintf(&b, "%s\n", s.Body)
+	}
+	if okPods == 0 {
+		return nil, fmt.Errorf("scrape %s: all %d pod(s) failed to serve metrics; errors: %s",
+			target.ComponentName, len(snaps), strings.Join(podErrors, "; "))
+	}
+	return Parse(b.String(), queries), nil
+}
+
+// FindServicePort checks whether any Service in the given namespace whose selector
+// contains appLabel=appValue exposes the specified targetPort (as either .spec.ports[].port
+// or .spec.ports[].targetPort). Returns nil if found, or a descriptive error.
+func FindServicePort(ctx context.Context, clientset kubernetes.Interface, namespace, appLabel, appValue string, targetPort int) error {
+	services, err := clientset.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing services in %s: %w", namespace, err)
+	}
+	for _, svc := range services.Items {
+		if svc.Spec.Selector[appLabel] != appValue {
+			continue
+		}
+		for _, p := range svc.Spec.Ports {
+			if int(p.Port) == targetPort || p.TargetPort.IntValue() == targetPort {
+				return nil
+			}
+		}
+		var ports []string
+		for _, p := range svc.Spec.Ports {
+			ports = append(ports, fmt.Sprintf("%s:%d->%s", p.Name, p.Port, p.TargetPort.String()))
+		}
+		return fmt.Errorf("service %s/%s selects %s=%s pods but does not expose port %d; declared ports: %v",
+			namespace, svc.Name, appLabel, appValue, targetPort, ports)
+	}
+	return fmt.Errorf("no service in namespace %s selects %s=%s pods", namespace, appLabel, appValue)
+}

--- a/tests/testmetrics/scrape.go
+++ b/tests/testmetrics/scrape.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -148,7 +149,8 @@ func ScrapePodViaPortForward(ctx context.Context, clientset kubernetes.Interface
 		<-errCh
 		return nil, err
 	}
-	resp, err := http.DefaultClient.Do(httpReq)
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(httpReq)
 	if err != nil {
 		close(stopCh)
 		<-errCh

--- a/tests/testmetrics/scrape_test.go
+++ b/tests/testmetrics/scrape_test.go
@@ -1,0 +1,45 @@
+//go:build test
+
+package testmetrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+func TestScrapePodViaProxy_Validation(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewSimpleClientset()
+	_, err := ScrapePodViaProxy(ctx, cs, PodScrapeOptions{Namespace: "ns"})
+	require.Error(t, err)
+	_, err = ScrapePodViaProxy(ctx, cs, PodScrapeOptions{PodName: "p"})
+	require.Error(t, err)
+}
+
+func TestCollectFromPods_Validation(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewSimpleClientset()
+	_, err := CollectFromPods(ctx, cs, PodCollectOptions{})
+	require.Error(t, err)
+	_, err = CollectFromPods(ctx, cs, PodCollectOptions{
+		Namespace:     "ns",
+		Transport:     TransportPortForward,
+		LabelSelector: "app=x",
+	})
+	require.Error(t, err)
+}
+
+func TestScrapePodViaPortForward_Validation(t *testing.T) {
+	ctx := context.Background()
+	cs := fake.NewSimpleClientset()
+	_, err := ScrapePodViaPortForward(ctx, cs, nil, "ns", "pod", 9090, "/metrics")
+	require.Error(t, err)
+	_, err = ScrapePodViaPortForward(ctx, cs, &rest.Config{}, "", "pod", 9090, "")
+	require.Error(t, err)
+	_, err = ScrapePodViaPortForward(ctx, cs, &rest.Config{}, "ns", "pod", 0, "")
+	require.Error(t, err)
+}

--- a/tests/vm_scanning_cluster_preflight_checks_test.go
+++ b/tests/vm_scanning_cluster_preflight_checks_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_cluster_preflight_test.go
+++ b/tests/vm_scanning_cluster_preflight_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_compliance_setup_test.go
+++ b/tests/vm_scanning_compliance_setup_test.go
@@ -1,0 +1,239 @@
+//go:build test_e2e
+
+package tests
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackrox/rox/pkg/namespaces"
+	"github.com/stretchr/testify/require"
+	coreV1 "k8s.io/api/core/v1"
+	networkingV1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// ensureComplianceMetricsExposed guarantees that the collector compliance container
+// serves Prometheus metrics on port 9091, that a headless Service routes to it, and
+// that NetworkPolicies allow ingress to both collector and sensor metrics ports.
+//
+// The StackRox Helm chart sets ROX_METRICS_PORT=disabled and deploys a
+// "collector-no-ingress" NetworkPolicy (deny-all) when exposeMonitoring is false
+// (the operator default). There is no SecuredCluster CR field to set
+// exposeMonitoring for collector/sensor, so the test creates the equivalent
+// resources: env patch, Service, and permissive NetworkPolicies matching what
+// the chart would produce with exposeMonitoring=true.
+func (s *VMScanningSuite) ensureComplianceMetricsExposed() {
+	ns := namespaces.StackRox
+	const (
+		svcName       = "compliance-metrics"
+		dsName        = "collector"
+		containerName = "compliance"
+		metricsEnv    = "ROX_METRICS_PORT"
+		metricsValue  = ":9091"
+	)
+	metricsPort := int32(9091)
+
+	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Minute)
+	defer cancel()
+
+	s.ensureComplianceMetricsEnv(ctx, ns, dsName, containerName, metricsEnv, metricsValue)
+	s.ensureComplianceMetricsService(ctx, ns, svcName, metricsPort)
+	s.ensureMonitoringNetworkPolicy(ctx, ns, "collector-monitoring", "collector", []int32{9090, 9091})
+	s.ensureMonitoringNetworkPolicy(ctx, ns, "sensor-monitoring", "sensor", []int32{9090})
+}
+
+func (s *VMScanningSuite) ensureComplianceMetricsEnv(ctx context.Context, ns, dsName, containerName, envName, envValue string) {
+	t := s.T()
+	ds, err := s.k8sClient.AppsV1().DaemonSets(ns).Get(ctx, dsName, metaV1.GetOptions{})
+	require.NoError(t, err, "getting DaemonSet %s/%s", ns, dsName)
+
+	var container *coreV1.Container
+	for i := range ds.Spec.Template.Spec.Containers {
+		if ds.Spec.Template.Spec.Containers[i].Name == containerName {
+			container = &ds.Spec.Template.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, container, "container %q not found in DaemonSet %s/%s", containerName, ns, dsName)
+
+	for _, e := range container.Env {
+		if e.Name == envName && e.Value == envValue {
+			s.logf("VM scanning setup: DaemonSet %s/%s container %q already has %s=%s", ns, dsName, containerName, envName, envValue)
+			return
+		}
+	}
+
+	s.logf("VM scanning setup: patching DaemonSet %s/%s container %q: setting %s=%s", ns, dsName, containerName, envName, envValue)
+	updated := false
+	for i, e := range container.Env {
+		if e.Name == envName {
+			container.Env[i].Value = envValue
+			container.Env[i].ValueFrom = nil
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		container.Env = append(container.Env, coreV1.EnvVar{Name: envName, Value: envValue})
+	}
+
+	_, err = s.k8sClient.AppsV1().DaemonSets(ns).Update(ctx, ds, metaV1.UpdateOptions{})
+	require.NoError(t, err, "updating DaemonSet %s/%s to set %s=%s", ns, dsName, envName, envValue)
+
+	s.logf("VM scanning setup: waiting for DaemonSet %s/%s rollout", ns, dsName)
+	err = wait.PollUntilContextCancel(ctx, 10*time.Second, false, func(pollCtx context.Context) (bool, error) {
+		current, getErr := s.k8sClient.AppsV1().DaemonSets(ns).Get(pollCtx, dsName, metaV1.GetOptions{})
+		if getErr != nil {
+			s.logf("VM scanning setup: transient error checking DaemonSet rollout: %v", getErr)
+			return false, nil
+		}
+		ready := current.Status.DesiredNumberScheduled > 0 &&
+			current.Status.UpdatedNumberScheduled == current.Status.DesiredNumberScheduled &&
+			current.Status.NumberReady == current.Status.DesiredNumberScheduled &&
+			current.Status.ObservedGeneration >= current.Generation
+		if !ready {
+			s.logf("VM scanning setup: DaemonSet %s/%s rollout in progress (desired=%d updated=%d ready=%d)",
+				ns, dsName, current.Status.DesiredNumberScheduled, current.Status.UpdatedNumberScheduled, current.Status.NumberReady)
+		}
+		return ready, nil
+	})
+	require.NoError(t, err, "waiting for DaemonSet %s/%s rollout after setting %s=%s", ns, dsName, envName, envValue)
+	s.logf("VM scanning setup: DaemonSet %s/%s rollout complete", ns, dsName)
+}
+
+func (s *VMScanningSuite) ensureComplianceMetricsService(ctx context.Context, ns, svcName string, metricsPort int32) {
+	t := s.T()
+	desired := &coreV1.Service{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      svcName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "vm-scanning-e2e",
+			},
+		},
+		Spec: coreV1.ServiceSpec{
+			ClusterIP: "None",
+			Selector:  map[string]string{"app": "collector"},
+			Ports: []coreV1.ServicePort{{
+				Name:       "monitoring",
+				Port:       metricsPort,
+				TargetPort: intstr.FromInt32(metricsPort),
+				Protocol:   coreV1.ProtocolTCP,
+			}},
+		},
+	}
+
+	err := wait.PollUntilContextCancel(ctx, 5*time.Second, true, func(pollCtx context.Context) (bool, error) {
+		existing, getErr := s.k8sClient.CoreV1().Services(ns).Get(pollCtx, svcName, metaV1.GetOptions{})
+		if getErr == nil {
+			if serviceExposesPort(existing, metricsPort) {
+				s.logf("VM scanning setup: service %s/%s verified (port %d)", ns, svcName, metricsPort)
+				return true, nil
+			}
+			s.logf("VM scanning setup: service %s/%s exists but missing port %d, deleting and re-creating", ns, svcName, metricsPort)
+			_ = s.k8sClient.CoreV1().Services(ns).Delete(pollCtx, svcName, metaV1.DeleteOptions{})
+			return false, nil
+		}
+		if !apierrors.IsNotFound(getErr) {
+			s.logf("VM scanning setup: transient error checking service %s/%s: %v (retrying)", ns, svcName, getErr)
+			return false, nil
+		}
+
+		s.logf("VM scanning setup: creating service %s/%s (compliance metrics port %d)", ns, svcName, metricsPort)
+		_, createErr := s.k8sClient.CoreV1().Services(ns).Create(pollCtx, desired, metaV1.CreateOptions{})
+		if createErr != nil {
+			if apierrors.IsAlreadyExists(createErr) {
+				return false, nil
+			}
+			s.logf("VM scanning setup: create service %s/%s failed: %v (retrying)", ns, svcName, createErr)
+			return false, nil
+		}
+		return false, nil
+	})
+	require.NoError(t, err, "ensuring compliance-metrics service %s/%s with port %d", ns, svcName, metricsPort)
+}
+
+func serviceExposesPort(svc *coreV1.Service, port int32) bool {
+	for _, p := range svc.Spec.Ports {
+		if p.Port == port || p.TargetPort.IntValue() == int(port) {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureMonitoringNetworkPolicy creates an ingress-allow NetworkPolicy for the
+// given app label and TCP ports. This mirrors what the Helm chart creates when
+// exposeMonitoring is true (e.g. "collector-monitoring" or "sensor-monitoring").
+func (s *VMScanningSuite) ensureMonitoringNetworkPolicy(ctx context.Context, ns, name, appLabel string, ports []int32) {
+	t := s.T()
+	tcp := coreV1.ProtocolTCP
+	var ingressPorts []networkingV1.NetworkPolicyPort
+	for _, p := range ports {
+		ingressPorts = append(ingressPorts, networkingV1.NetworkPolicyPort{
+			Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: p},
+			Protocol: &tcp,
+		})
+	}
+
+	desired := &networkingV1.NetworkPolicy{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "vm-scanning-e2e",
+			},
+		},
+		Spec: networkingV1.NetworkPolicySpec{
+			PodSelector: metaV1.LabelSelector{
+				MatchLabels: map[string]string{"app": appLabel},
+			},
+			Ingress: []networkingV1.NetworkPolicyIngressRule{{
+				Ports: ingressPorts,
+			}},
+			PolicyTypes: []networkingV1.PolicyType{networkingV1.PolicyTypeIngress},
+		},
+	}
+
+	existing, err := s.k8sClient.NetworkingV1().NetworkPolicies(ns).Get(ctx, name, metaV1.GetOptions{})
+	if err == nil {
+		if networkPolicyMatchesPorts(existing, ports) {
+			s.logf("VM scanning setup: NetworkPolicy %s/%s already allows ports %v", ns, name, ports)
+			return
+		}
+		s.logf("VM scanning setup: NetworkPolicy %s/%s exists but ports differ, updating", ns, name)
+		desired.ResourceVersion = existing.ResourceVersion
+		_, err = s.k8sClient.NetworkingV1().NetworkPolicies(ns).Update(ctx, desired, metaV1.UpdateOptions{})
+		require.NoError(t, err, "updating NetworkPolicy %s/%s", ns, name)
+		return
+	}
+	if !apierrors.IsNotFound(err) {
+		require.NoError(t, err, "getting NetworkPolicy %s/%s", ns, name)
+	}
+
+	s.logf("VM scanning setup: creating NetworkPolicy %s/%s (app=%s, ports=%v)", ns, name, appLabel, ports)
+	_, err = s.k8sClient.NetworkingV1().NetworkPolicies(ns).Create(ctx, desired, metaV1.CreateOptions{})
+	require.NoError(t, err, "creating NetworkPolicy %s/%s", ns, name)
+}
+
+func networkPolicyMatchesPorts(np *networkingV1.NetworkPolicy, wantPorts []int32) bool {
+	if len(np.Spec.Ingress) != 1 {
+		return false
+	}
+	have := make(map[int32]bool)
+	for _, p := range np.Spec.Ingress[0].Ports {
+		if p.Port != nil {
+			have[p.Port.IntVal] = true
+		}
+	}
+	for _, p := range wantPorts {
+		if !have[p] {
+			return false
+		}
+	}
+	return len(have) == len(wantPorts)
+}

--- a/tests/vm_scanning_compliance_setup_test.go
+++ b/tests/vm_scanning_compliance_setup_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e
+//go:build test_e2e || test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_compliance_setup_test.go
+++ b/tests/vm_scanning_compliance_setup_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_e2e_utils_test.go
+++ b/tests/vm_scanning_e2e_utils_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_metrics_test.go
+++ b/tests/vm_scanning_metrics_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e
+//go:build test_e2e || test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_metrics_test.go
+++ b/tests/vm_scanning_metrics_test.go
@@ -1,0 +1,163 @@
+//go:build test_e2e
+
+package tests
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackrox/rox/pkg/namespaces"
+	"github.com/stackrox/rox/tests/testmetrics"
+	"github.com/stackrox/rox/tests/vmhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+// complianceTarget returns the ScrapeTarget for the compliance container on the VM's node.
+func (s *VMScanningSuite) complianceTarget(vmNodeName string) testmetrics.ScrapeTarget {
+	t := testmetrics.ScrapeTarget{
+		ComponentName: "compliance",
+		Namespace:     namespaces.StackRox,
+		LabelSelector: "app=collector",
+		MetricsPort:   9091,
+		MetricsPath:   "metrics",
+	}
+	if vmNodeName != "" {
+		t.FieldSelector = "spec.nodeName=" + vmNodeName
+	}
+	return t
+}
+
+// sensorTarget returns the ScrapeTarget for the sensor deployment.
+func (s *VMScanningSuite) sensorTarget() testmetrics.ScrapeTarget {
+	return testmetrics.ScrapeTarget{
+		ComponentName: "sensor",
+		Namespace:     namespaces.StackRox,
+		LabelSelector: "app=sensor",
+		MetricsPort:   9090,
+		MetricsPath:   "metrics",
+	}
+}
+
+// complianceQueries returns the Query set for the compliance relay.
+func complianceQueries() []testmetrics.Query {
+	return []testmetrics.Query{
+		{Name: vmhelpers.MetricComplianceRelayConnectionsAcceptedTotal},
+		{Name: vmhelpers.MetricComplianceRelayIndexReportsReceivedTotal},
+		{Name: vmhelpers.MetricComplianceRelayIndexReportsSentTotal, LabelFilter: `failed="false"`},
+		{Name: vmhelpers.MetricComplianceRelayIndexReportsSentTotal, LabelFilter: `failed="true"`},
+		{Name: vmhelpers.MetricComplianceRelayIndexReportsMismatchingVsockTotal},
+		{Name: vmhelpers.MetricComplianceRelayIndexReportAcksReceivedTotal},
+	}
+}
+
+// sensorQueries returns the Query set for the sensor VM index pipeline.
+func sensorQueries() []testmetrics.Query {
+	return []testmetrics.Query{
+		{Name: vmhelpers.MetricSensorVMIndexReportsReceivedTotal},
+		{Name: vmhelpers.MetricSensorVMIndexReportsSentTotal, LabelFilter: `status="` + vmhelpers.SensorIndexReportStatusSuccess + `"`},
+		{Name: vmhelpers.MetricSensorVMIndexReportsSentTotal, LabelFilter: `status="` + vmhelpers.SensorIndexReportStatusError + `"`},
+		{Name: vmhelpers.MetricSensorVMIndexReportsSentTotal, LabelFilter: `status="` + vmhelpers.SensorIndexReportStatusCentralNotReady + `"`},
+		{Name: vmhelpers.MetricSensorVMIndexReportAcksReceivedTotal, LabelFilter: `action="ACK"`},
+		{Name: vmhelpers.MetricSensorVMIndexReportEnqueueBlockedTotal},
+	}
+}
+
+// collectStableMetrics scrapes compliance and sensor metrics until values stabilize.
+// It returns two maps keyed by testmetrics.Key.
+//
+// We use TransportPortForward instead of TransportProxy because the StackRox Helm
+// chart deploys a "collector-no-ingress" NetworkPolicy that denies ALL ingress to
+// collector pods when exposeMonitoring is false (the operator default). The test
+// creates a permissive "collector-monitoring" NetworkPolicy, but port-forward
+// provides an additional safety net: it tunnels through the kubelet CRI directly
+// into the container's network namespace, bypassing NetworkPolicies entirely.
+// The same applies to sensor, whose NetworkPolicy restricts ingress to specific
+// StackRox components and does not include the metrics port (9090) by default.
+func (s *VMScanningSuite) collectStableMetrics(ctx context.Context, vmNodeName string) (compliance, sensor map[string]testmetrics.Value) {
+	const (
+		metricsTimeout  = 2 * time.Minute
+		metricsPollWait = 10 * time.Second
+		stableRounds    = 3
+	)
+
+	compTarget := s.complianceTarget(vmNodeName)
+	senTarget := s.sensorTarget()
+	compQ := complianceQueries()
+	senQ := sensorQueries()
+	transport := testmetrics.TransportPortForward
+
+	stableCfg := testmetrics.StableConfig{
+		PollInterval: metricsPollWait,
+		StableRounds: stableRounds,
+		Logf:         s.logf,
+	}
+
+	compCtx, compCancel := context.WithTimeout(ctx, metricsTimeout)
+	defer compCancel()
+	compliance = testmetrics.PollUntilStable(compCtx, stableCfg, func(ctx context.Context) (map[string]testmetrics.Value, error) {
+		return testmetrics.ScrapeComponent(ctx, s.k8sClient, compTarget, transport, s.restCfg, compQ)
+	})
+
+	senCtx, senCancel := context.WithTimeout(ctx, metricsTimeout)
+	defer senCancel()
+	sensor = testmetrics.PollUntilStable(senCtx, stableCfg, func(ctx context.Context) (map[string]testmetrics.Value, error) {
+		return testmetrics.ScrapeComponent(ctx, s.k8sClient, senTarget, transport, s.restCfg, senQ)
+	})
+
+	return compliance, sensor
+}
+
+// assertPipelineMetrics collects stable metrics and asserts their values.
+// vmNodeName must be non-empty so compliance metrics are scoped to the VM's local collector pod.
+func (s *VMScanningSuite) assertPipelineMetrics(ctx context.Context, t require.TestingT, vmNodeName string) {
+	require.NotEmpty(t, vmNodeName,
+		"VM node name must be known before asserting pipeline metrics; "+
+			"cluster-wide collector scraping is not supported because it conflates metrics from unrelated VMs")
+
+	compTarget := s.complianceTarget(vmNodeName)
+	s.logf("pipeline metrics: VM node=%q, compliance selector=%q field=%q",
+		vmNodeName, compTarget.LabelSelector, compTarget.FieldSelector)
+
+	err := testmetrics.FindServicePort(ctx, s.k8sClient, compTarget.Namespace, "app", "collector", compTarget.MetricsPort)
+	require.NoError(t, err,
+		"collector Service should expose compliance metrics port %d; the deployment may be missing the metrics port definition",
+		compTarget.MetricsPort)
+
+	comp, sen := s.collectStableMetrics(ctx, vmNodeName)
+
+	get := func(src map[string]testmetrics.Value, q testmetrics.Query) testmetrics.Value {
+		return src[testmetrics.Key(q)]
+	}
+
+	requirePositive := func(src map[string]testmetrics.Value, q testmetrics.Query, label string) {
+		v := get(src, q)
+		require.Truef(t, v.Found, "%s should be present in scraped metrics, but was not found", label)
+		require.Greaterf(t, v.Val, float64(0), "%s should be > 0, but got %.0f", label, v.Val)
+	}
+
+	requireZero := func(src map[string]testmetrics.Value, q testmetrics.Query, label string) {
+		v := get(src, q)
+		if !v.Found {
+			return
+		}
+		require.Equalf(t, float64(0), v.Val, "%s should be 0, but got %.0f", label, v.Val)
+	}
+
+	// Compliance relay assertions.
+	cq := complianceQueries()
+	requirePositive(comp, cq[0], "compliance relay connections_accepted")
+	requirePositive(comp, cq[1], "compliance relay index_reports_received")
+	requirePositive(comp, cq[2], "compliance relay index_reports_sent (failed=false)")
+	requireZero(comp, cq[3], "compliance relay index_reports_sent (failed=true)")
+	requireZero(comp, cq[4], "compliance relay vsock CID mismatches")
+	requirePositive(comp, cq[5], "compliance relay acks_received")
+
+	// Sensor assertions.
+	sq := sensorQueries()
+	requirePositive(sen, sq[0], "sensor index_reports_received")
+	requirePositive(sen, sq[1], "sensor index_reports_sent (success)")
+	requireZero(sen, sq[2], "sensor index_reports_sent (error)")
+	requireZero(sen, sq[3], "sensor index_reports_sent (central not ready)")
+	requirePositive(sen, sq[4], "sensor index_report_acks_received (ACK)")
+	requireZero(sen, sq[5], "sensor enqueue_blocked")
+}

--- a/tests/vm_scanning_metrics_test.go
+++ b/tests/vm_scanning_metrics_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -698,29 +698,21 @@ func (s *VMScanningSuite) waitForScannerV4Initialized() error {
 	})
 }
 
-// ensureCanonicalScan runs a single guest-side roxagent invocation and validates failure signals.
+// ensureCanonicalScan runs a single guest-side roxagent invocation.
 // It verifies the ROX_VIRTUAL_MACHINES feature flag is enabled before triggering the scan.
-func (s *VMScanningSuite) ensureCanonicalScan(ctx context.Context, vm *VMHandle) (*vmhelpers.RoxagentRunResult, error) {
+func (s *VMScanningSuite) ensureCanonicalScan(ctx context.Context, vm *VMHandle) error {
 	if vm == nil {
-		return nil, errors.New("ensureCanonicalScan: nil VM handle")
+		return errors.New("ensureCanonicalScan: nil VM handle")
 	}
 	s.mustVerifyVirtualMachinesFeatureEnabled()
 	if !s.scannerV4Checked {
 		if err := s.waitForScannerV4Initialized(); err != nil {
-			return nil, fmt.Errorf("Scanner V4 matcher did not initialize within timeout: %w", err)
+			return fmt.Errorf("Scanner V4 matcher did not initialize within timeout: %w", err)
 		}
 		s.scannerV4Checked = true
 	}
 	virt := s.virtctlForVM(*vm)
-	res, err := vmhelpers.RunRoxagentOnce(ctx, virt, vm.Namespace, vm.Name, s.cfg.Repo2CPEURL)
-	if err != nil {
-		return nil, err
-	}
-	if res == nil {
-		return nil, errors.New("ensureCanonicalScan: nil result from RunRoxagentOnce")
-	}
-	s.logf("ensureCanonicalScan: roxagent completed on %s/%s (%d bytes stdout)", vm.Namespace, vm.Name, len(res.Stdout))
-	return res, nil
+	return vmhelpers.RunRoxagentOnce(ctx, virt, vm.Namespace, vm.Name, s.cfg.Repo2CPEURL)
 }
 
 // waitForScan polls Central in order until scan data is visible.
@@ -738,36 +730,29 @@ func (s *VMScanningSuite) waitForScan(ctx context.Context, vm *VMHandle) (*v2.Vi
 		Logf:         s.logf,
 	}
 
-	s.logf("scan wait %s/%s step 1/6: wait VM present in Central", vm.Namespace, vm.Name)
 	present, err := vmhelpers.WaitForVMPresentInCentral(waitCtx, s.vmClient, baseOpts, vm.Namespace, vm.Name)
 	if err != nil {
 		return nil, err
 	}
 	vm.ID = present.GetId()
-	s.logf("scan wait %s/%s step 1/6 complete: id=%q", vm.Namespace, vm.Name, vm.ID)
 
-	s.logf("scan wait %s/%s step 2/6: wait VM identity fields", vm.Namespace, vm.Name)
+	s.logf("%s/%s: VM appeared in Central (id=%q), waiting for namespace/name fields to be populated", vm.Namespace, vm.Name, vm.ID)
 	if _, err := vmhelpers.WaitForVMIdentityFields(waitCtx, s.vmClient, baseOpts, present.GetId(), vm.Namespace, vm.Name); err != nil {
 		return nil, err
 	}
-	s.logf("scan wait %s/%s step 2/6 complete", vm.Namespace, vm.Name)
-	s.logf("scan wait %s/%s step 3/6: wait VM running in Central", vm.Namespace, vm.Name)
+	s.logf("%s/%s: waiting for Central to report VM as Running", vm.Namespace, vm.Name)
 	if _, err := vmhelpers.WaitForVMRunningInCentral(waitCtx, s.vmClient, baseOpts, present.GetId()); err != nil {
 		return nil, err
 	}
-	s.logf("scan wait %s/%s step 3/6 complete", vm.Namespace, vm.Name)
-	s.logf("scan wait %s/%s step 4/6: wait non-nil scan", vm.Namespace, vm.Name)
+	s.logf("%s/%s: waiting for roxagent scan payload to arrive in Central", vm.Namespace, vm.Name)
 	if _, err := vmhelpers.WaitForVMScanNonNil(waitCtx, s.vmClient, baseOpts, present.GetId()); err != nil {
 		return nil, err
 	}
-	s.logf("scan wait %s/%s step 4/6 complete", vm.Namespace, vm.Name)
-	s.logf("scan wait %s/%s step 5/6: wait scan timestamp", vm.Namespace, vm.Name)
+	s.logf("%s/%s: waiting for Scanner to assign a scan timestamp", vm.Namespace, vm.Name)
 	if _, err := vmhelpers.WaitForVMScanTimestamp(waitCtx, s.vmClient, baseOpts, present.GetId()); err != nil {
 		return nil, err
 	}
-	s.logf("scan wait %s/%s step 5/6 complete", vm.Namespace, vm.Name)
-
-	s.logf("scan wait %s/%s step 6/6: wait scan ready (components + all-scanned)", vm.Namespace, vm.Name)
+	s.logf("%s/%s: waiting for all components to be vulnerability-matched (no UNSCANNED)", vm.Namespace, vm.Name)
 	return vmhelpers.WaitForScanReady(waitCtx, s.vmClient, baseOpts, present.GetId())
 }
 

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -116,8 +116,6 @@ type VMScanningSuite struct {
 	vmSpecs []vmSpec
 	// vms tracks every VM provisioned by the suite; TearDownSuite deletes each.
 	vms []VMHandle
-	// terminalVSOCKFailure captures a hard vsock/device failure; subsequent tests are skipped.
-	terminalVSOCKFailure string
 	// scannerV4Checked is set after the one-time Scanner V4 matcher initialization check.
 	scannerV4Checked bool
 }
@@ -185,13 +183,6 @@ func (s *VMScanningSuite) SetupSuite() {
 	s.logf("VM scanning setup: prepare guests (ssh/cloud-init/sudo readiness)")
 	s.prepareGuests()
 	s.logf("VM scanning setup: complete")
-}
-
-func (s *VMScanningSuite) BeforeTest(_, testName string) {
-	if s.terminalVSOCKFailure == "" {
-		return
-	}
-	s.T().Skipf("skipping %s due to prior terminal vsock failure: %s", testName, s.terminalVSOCKFailure)
 }
 
 func (s *VMScanningSuite) TearDownSuite() {
@@ -769,12 +760,6 @@ func (s *VMScanningSuite) ensureCanonicalScan(ctx context.Context, vm *VMHandle)
 	}
 	res, err := vmhelpers.RunRoxagentOnce(ctx, virt, vm.Namespace, vm.Name, cfg)
 	if err != nil {
-		if vmhelpers.IsTerminalVSOCKUnavailableError(err) {
-			s.terminalVSOCKFailure = fmt.Sprintf("%s/%s: %v", vm.Namespace, vm.Name, err)
-			s.logf("terminal vsock failure detected; skipping remaining suite tests: %s", s.terminalVSOCKFailure)
-			return nil, fmt.Errorf("ensureCanonicalScan: terminal vsock failure for %s/%s; subsequent suite tests will be skipped: %w",
-				vm.Namespace, vm.Name, err)
-		}
 		return nil, err
 	}
 	if res == nil {
@@ -840,10 +825,8 @@ func (s *VMScanningSuite) waitForScan(ctx context.Context, vm *VMHandle) (*v2.Vi
 	}
 	s.logf("scan wait %s/%s step 5/6 complete", vm.Namespace, vm.Name)
 
-	conds := vmhelpers.ScanReadiness{Components: true, AllScanned: true}
-	s.logf("scan wait %s/%s step 6/6: wait scan ready (components=%v all-scanned=%v)",
-		vm.Namespace, vm.Name, conds.Components, conds.AllScanned)
-	return vmhelpers.WaitForScanReady(waitCtx, s.vmClient, baseOpts, present.GetId(), conds)
+	s.logf("scan wait %s/%s step 6/6: wait scan ready (components + all-scanned)", vm.Namespace, vm.Name)
+	return vmhelpers.WaitForScanReady(waitCtx, s.vmClient, baseOpts, present.GetId())
 }
 
 func (s *VMScanningSuite) resourceDeleteTimeout() time.Duration {

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -663,23 +663,6 @@ func (s *VMScanningSuite) mustGetVM(id string) *v2.VirtualMachine {
 	return resp
 }
 
-func (s *VMScanningSuite) persistRoxagentStdout(vm *VMHandle, stdout string) string {
-	if vm == nil || strings.TrimSpace(stdout) == "" {
-		return ""
-	}
-	f, err := os.CreateTemp(s.T().TempDir(), fmt.Sprintf("roxagent-%s-%s-*.stdout", vm.Namespace, vm.Name))
-	if err != nil {
-		s.logf("ensureCanonicalScan: could not persist roxagent stdout for %s/%s: %v", vm.Namespace, vm.Name, err)
-		return ""
-	}
-	defer func() { _ = f.Close() }()
-	if _, err := f.WriteString(stdout); err != nil {
-		s.logf("ensureCanonicalScan: could not write roxagent stdout file %q: %v", f.Name(), err)
-		return ""
-	}
-	return f.Name()
-}
-
 // waitForScannerV4Initialized blocks until the Scanner V4 matcher has finished
 // loading its vulnerability database. It polls Central's GetVulnDefinitionsInfo API
 // (which internally calls GetMatcherMetadata on the matcher) until a non-zero
@@ -736,16 +719,7 @@ func (s *VMScanningSuite) ensureCanonicalScan(ctx context.Context, vm *VMHandle)
 	if res == nil {
 		return nil, errors.New("ensureCanonicalScan: nil result from RunRoxagentOnce")
 	}
-	stdoutPath := s.persistRoxagentStdout(vm, res.Stdout)
-	if stdoutPath != "" {
-		s.logf("ensureCanonicalScan: roxagent stdout saved to %q (%d bytes)", stdoutPath, len(res.Stdout))
-		if !vmhelpers.VerboseOutputLooksLikeReport(res.Stdout) {
-			s.logf("ensureCanonicalScan: roxagent stdout on %s/%s does not match known report shapes; continuing (stdout_file=%q)",
-				vm.Namespace, vm.Name, stdoutPath)
-		}
-	} else {
-		s.logf("ensureCanonicalScan: roxagent stdout empty on %s/%s (non-verbose mode)", vm.Namespace, vm.Name)
-	}
+	s.logf("ensureCanonicalScan: roxagent completed on %s/%s (%d bytes stdout)", vm.Namespace, vm.Name, len(res.Stdout))
 	return res, nil
 }
 

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -141,6 +141,9 @@ func (s *VMScanningSuite) SetupSuite() {
 	s.logf("VM scanning setup: verify cluster KVM readiness")
 	mustVerifyClusterKVMReady(t, s.ctx, s.k8sClient)
 
+	s.logf("VM scanning setup: ensure compliance metrics are exposed")
+	s.ensureComplianceMetricsExposed()
+
 	// VM_SCAN_NAMESPACE pins the test namespace for local development and re-runs:
 	// VMs survive across invocations so you can iterate on later test stages without
 	// waiting for full VM provisioning each time.

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -663,30 +663,6 @@ func (s *VMScanningSuite) mustGetVM(id string) *v2.VirtualMachine {
 	return resp
 }
 
-// roxagentStderrCrashLinePrefixes are lowercase; each stderr line is trimmed and lowercased before HasPrefix.
-var roxagentStderrCrashLinePrefixes = []string{
-	"panic:",
-	"fatal error:",
-	"runtime error:",
-}
-
-// validateRoxagentSuccessStderr allows empty or benign stderr but fails only on lines that start with
-// unambiguous Go/runtime crash signatures (after trim + lowercase), avoiding substring false positives.
-func validateRoxagentSuccessStderr(stderr string) error {
-	if strings.TrimSpace(stderr) == "" {
-		return nil
-	}
-	for _, line := range strings.Split(stderr, "\n") {
-		ln := strings.TrimSpace(strings.ToLower(line))
-		for _, prefix := range roxagentStderrCrashLinePrefixes {
-			if strings.HasPrefix(ln, prefix) {
-				return fmt.Errorf("ensureCanonicalScan: roxagent stderr indicates process/runtime failure (matched line prefix %q): %s", prefix, vmhelpers.FormatGuestCommandOutputForError(stderr))
-			}
-		}
-	}
-	return nil
-}
-
 func (s *VMScanningSuite) persistRoxagentStdout(vm *VMHandle, stdout string) string {
 	if vm == nil || strings.TrimSpace(stdout) == "" {
 		return ""
@@ -769,9 +745,6 @@ func (s *VMScanningSuite) ensureCanonicalScan(ctx context.Context, vm *VMHandle)
 		}
 	} else {
 		s.logf("ensureCanonicalScan: roxagent stdout empty on %s/%s (non-verbose mode)", vm.Namespace, vm.Name)
-	}
-	if err := validateRoxagentSuccessStderr(res.Stderr); err != nil {
-		return nil, err
 	}
 	return res, nil
 }

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
@@ -22,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	coreV1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -114,6 +116,10 @@ type VMScanningSuite struct {
 	vmSpecs []vmSpec
 	// vms tracks every VM provisioned by the suite; TearDownSuite deletes each.
 	vms []VMHandle
+	// terminalVSOCKFailure captures a hard vsock/device failure; subsequent tests are skipped.
+	terminalVSOCKFailure string
+	// scannerV4Checked is set after the one-time Scanner V4 matcher initialization check.
+	scannerV4Checked bool
 }
 
 // TestVMScanning is the suite entrypoint for VM scanning E2E tests.
@@ -179,6 +185,13 @@ func (s *VMScanningSuite) SetupSuite() {
 	s.logf("VM scanning setup: prepare guests (ssh/cloud-init/sudo readiness)")
 	s.prepareGuests()
 	s.logf("VM scanning setup: complete")
+}
+
+func (s *VMScanningSuite) BeforeTest(_, testName string) {
+	if s.terminalVSOCKFailure == "" {
+		return
+	}
+	s.T().Skipf("skipping %s due to prior terminal vsock failure: %s", testName, s.terminalVSOCKFailure)
 }
 
 func (s *VMScanningSuite) TearDownSuite() {
@@ -641,11 +654,223 @@ func (s *VMScanningSuite) vmSpecToRequest(sp vmSpec) vmhelpers.VMRequest {
 	}
 }
 
+func (s *VMScanningSuite) mustListVMByNamespaceAndName(namespace, name string) *v2.VirtualMachine {
+	t := s.T()
+	t.Helper()
+	vm, err := vmhelpers.ListVMByNamespaceName(s.ctx, s.vmClient, namespace, name)
+	require.NoError(t, err)
+	require.NotNil(t, vm, "ListVirtualMachines: no VM for namespace=%q name=%q", namespace, name)
+	return vm
+}
+
+func (s *VMScanningSuite) mustGetVM(id string) *v2.VirtualMachine {
+	t := s.T()
+	t.Helper()
+	resp, err := s.vmClient.GetVirtualMachine(s.ctx, &v2.GetVirtualMachineRequest{Id: id})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	return resp
+}
+
+const maxRoxagentStderrInError = 4096
+
+func formatRoxagentStderrForError(stderr string) string {
+	s := strings.TrimSpace(stderr)
+	if len(s) > maxRoxagentStderrInError {
+		return s[:maxRoxagentStderrInError] + fmt.Sprintf(" ... (truncated from %d bytes)", len(s))
+	}
+	return s
+}
+
+// roxagentStderrCrashLinePrefixes are lowercase; each stderr line is trimmed and lowercased before HasPrefix.
+var roxagentStderrCrashLinePrefixes = []string{
+	"panic:",
+	"fatal error:",
+	"runtime error:",
+}
+
+// validateRoxagentSuccessStderr allows empty or benign stderr but fails only on lines that start with
+// unambiguous Go/runtime crash signatures (after trim + lowercase), avoiding substring false positives.
+func validateRoxagentSuccessStderr(stderr string) error {
+	if strings.TrimSpace(stderr) == "" {
+		return nil
+	}
+	for _, line := range strings.Split(stderr, "\n") {
+		ln := strings.TrimSpace(strings.ToLower(line))
+		for _, prefix := range roxagentStderrCrashLinePrefixes {
+			if strings.HasPrefix(ln, prefix) {
+				return fmt.Errorf("ensureCanonicalScan: roxagent stderr indicates process/runtime failure (matched line prefix %q): %s", prefix, formatRoxagentStderrForError(stderr))
+			}
+		}
+	}
+	return nil
+}
+
+func (s *VMScanningSuite) persistRoxagentStdout(vm *VMHandle, stdout string) string {
+	if vm == nil || strings.TrimSpace(stdout) == "" {
+		return ""
+	}
+	f, err := os.CreateTemp(s.T().TempDir(), fmt.Sprintf("roxagent-%s-%s-*.stdout", vm.Namespace, vm.Name))
+	if err != nil {
+		s.logf("ensureCanonicalScan: could not persist roxagent stdout for %s/%s: %v", vm.Namespace, vm.Name, err)
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(stdout); err != nil {
+		s.logf("ensureCanonicalScan: could not write roxagent stdout file %q: %v", f.Name(), err)
+		return ""
+	}
+	return f.Name()
+}
+
+// waitForScannerV4Initialized blocks until the Scanner V4 matcher has finished
+// loading its vulnerability database. It polls Central's GetVulnDefinitionsInfo API
+// (which internally calls GetMatcherMetadata on the matcher) until a non-zero
+// last-updated timestamp is returned, meaning the vuln store is ready.
+//
+// Called once (guarded by scannerV4Checked) right before the first roxagent invocation
+// so that the matcher initialization happens in parallel with VM boot and SSH readiness.
+func (s *VMScanningSuite) waitForScannerV4Initialized() error {
+	s.logf("Scanner V4: waiting for matcher deployment to be K8s-ready")
+	s.waitUntilK8sDeploymentReady(s.ctx, namespaces.StackRox, "scanner-v4-matcher")
+
+	s.logf("Scanner V4: polling Central for matcher vuln DB initialization")
+	healthClient := v1.NewIntegrationHealthServiceClient(s.conn)
+
+	ctx, cancel := context.WithTimeout(s.ctx, 20*time.Minute)
+	defer cancel()
+
+	return wait.PollUntilContextCancel(ctx, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+		info, err := healthClient.GetVulnDefinitionsInfo(ctx, &v1.VulnDefinitionsInfoRequest{
+			Component: v1.VulnDefinitionsInfoRequest_SCANNER_V4,
+		})
+		if err != nil {
+			s.logf("Scanner V4: matcher not yet initialized: %v", err)
+			return false, nil
+		}
+		ts := info.GetLastUpdatedTimestamp().AsTime()
+		if ts.IsZero() {
+			s.logf("Scanner V4: vuln definitions timestamp is zero, still loading")
+			return false, nil
+		}
+		s.logf("Scanner V4: matcher initialized (vuln defs last updated: %v)", ts)
+		return true, nil
+	})
+}
+
+// ensureCanonicalScan runs a single guest-side roxagent invocation and validates failure signals.
+// It verifies the ROX_VIRTUAL_MACHINES feature flag is enabled before triggering the scan.
+func (s *VMScanningSuite) ensureCanonicalScan(ctx context.Context, vm *VMHandle) (*vmhelpers.RoxagentRunResult, error) {
+	if vm == nil {
+		return nil, errors.New("ensureCanonicalScan: nil VM handle")
+	}
+	s.mustVerifyVirtualMachinesFeatureEnabled()
+	if !s.scannerV4Checked {
+		if err := s.waitForScannerV4Initialized(); err != nil {
+			return nil, fmt.Errorf("Scanner V4 matcher did not initialize within timeout: %w", err)
+		}
+		s.scannerV4Checked = true
+	}
+	virt := s.virtctlForVM(*vm)
+	cfg := vmhelpers.RoxagentRunConfig{
+		Repo2CPEPrimaryURL:      s.cfg.Repo2CPEPrimaryURL,
+		Repo2CPEFallbackURL:     s.cfg.Repo2CPEFallbackURL,
+		Repo2CPEPrimaryAttempts: s.cfg.Repo2CPEPrimaryAttempts,
+	}
+	res, err := vmhelpers.RunRoxagentOnce(ctx, virt, vm.Namespace, vm.Name, cfg)
+	if err != nil {
+		if vmhelpers.IsTerminalVSOCKUnavailableError(err) {
+			s.terminalVSOCKFailure = fmt.Sprintf("%s/%s: %v", vm.Namespace, vm.Name, err)
+			s.logf("terminal vsock failure detected; skipping remaining suite tests: %s", s.terminalVSOCKFailure)
+			return nil, fmt.Errorf("ensureCanonicalScan: terminal vsock failure for %s/%s; subsequent suite tests will be skipped: %w",
+				vm.Namespace, vm.Name, err)
+		}
+		return nil, err
+	}
+	if res == nil {
+		return nil, errors.New("ensureCanonicalScan: nil result from RunRoxagentOnce")
+	}
+	stdoutPath := s.persistRoxagentStdout(vm, res.Stdout)
+	if stdoutPath != "" {
+		s.logf("ensureCanonicalScan: roxagent stdout saved to %q (%d bytes)", stdoutPath, len(res.Stdout))
+		if !vmhelpers.VerboseOutputLooksLikeReport(res.Stdout) {
+			s.logf("ensureCanonicalScan: roxagent stdout on %s/%s does not match known report shapes; continuing (stdout_file=%q)",
+				vm.Namespace, vm.Name, stdoutPath)
+		}
+	} else {
+		s.logf("ensureCanonicalScan: roxagent stdout empty on %s/%s (non-verbose mode)", vm.Namespace, vm.Name)
+	}
+	if err := validateRoxagentSuccessStderr(res.Stderr); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// waitForScan polls Central in order until scan data is visible.
+func (s *VMScanningSuite) waitForScan(ctx context.Context, vm *VMHandle) (*v2.VirtualMachine, error) {
+	if vm == nil {
+		return nil, errors.New("waitForScan: nil VM handle")
+	}
+	s.logf("scan wait %s/%s: start (timeout=%v poll=%v)", vm.Namespace, vm.Name, s.cfg.ScanTimeout, s.cfg.ScanPollInterval)
+	waitCtx, cancel := context.WithTimeout(ctx, s.cfg.ScanTimeout)
+	defer cancel()
+
+	baseOpts := vmhelpers.WaitOptions{
+		Timeout:      s.cfg.ScanTimeout,
+		PollInterval: s.cfg.ScanPollInterval,
+		Logf:         s.logf,
+	}
+
+	s.logf("scan wait %s/%s step 1/6: wait VM present in Central", vm.Namespace, vm.Name)
+	present, err := vmhelpers.WaitForVMPresentInCentral(waitCtx, s.vmClient, baseOpts, vm.Namespace, vm.Name)
+	if err != nil {
+		return nil, err
+	}
+	vm.ID = present.GetId()
+	s.logf("scan wait %s/%s step 1/6 complete: id=%q", vm.Namespace, vm.Name, vm.ID)
+
+	s.logf("scan wait %s/%s step 2/6: wait VM identity fields", vm.Namespace, vm.Name)
+	if _, err := vmhelpers.WaitForVMIdentityFields(waitCtx, s.vmClient, baseOpts, present.GetId(), vm.Namespace, vm.Name); err != nil {
+		return nil, err
+	}
+	s.logf("scan wait %s/%s step 2/6 complete", vm.Namespace, vm.Name)
+	s.logf("scan wait %s/%s step 3/6: wait VM running in Central", vm.Namespace, vm.Name)
+	if _, err := vmhelpers.WaitForVMRunningInCentral(waitCtx, s.vmClient, baseOpts, present.GetId()); err != nil {
+		return nil, err
+	}
+	s.logf("scan wait %s/%s step 3/6 complete", vm.Namespace, vm.Name)
+	s.logf("scan wait %s/%s step 4/6: wait non-nil scan", vm.Namespace, vm.Name)
+	if _, err := vmhelpers.WaitForVMScanNonNil(waitCtx, s.vmClient, baseOpts, present.GetId()); err != nil {
+		return nil, err
+	}
+	s.logf("scan wait %s/%s step 4/6 complete", vm.Namespace, vm.Name)
+	s.logf("scan wait %s/%s step 5/6: wait scan timestamp", vm.Namespace, vm.Name)
+	if _, err := vmhelpers.WaitForVMScanTimestamp(waitCtx, s.vmClient, baseOpts, present.GetId()); err != nil {
+		return nil, err
+	}
+	s.logf("scan wait %s/%s step 5/6 complete", vm.Namespace, vm.Name)
+
+	conds := vmhelpers.ScanReadiness{Components: true, AllScanned: true}
+	s.logf("scan wait %s/%s step 6/6: wait scan ready (components=%v all-scanned=%v)",
+		vm.Namespace, vm.Name, conds.Components, conds.AllScanned)
+	return vmhelpers.WaitForScanReady(waitCtx, s.vmClient, baseOpts, present.GetId(), conds)
+}
+
 func (s *VMScanningSuite) resourceDeleteTimeout() time.Duration {
 	if s.cfg != nil && s.cfg.DeleteTimeout > 0 {
 		return s.cfg.DeleteTimeout
 	}
 	return defaultVMDeleteTimeout
+}
+
+func (s *VMScanningSuite) mustGetScanTimestamp(id string) *timestamppb.Timestamp {
+	t := s.T()
+	t.Helper()
+	vm := s.mustGetVM(id)
+	require.NotNil(t, vm.GetScan(), "mustGetScanTimestamp: GetVirtualMachine id=%q returned nil scan", id)
+	ts := vm.GetScan().GetScanTime()
+	require.NotNil(t, ts, "mustGetScanTimestamp: GetVirtualMachine id=%q scan_time is nil", id)
+	return ts
 }
 
 func (s *VMScanningSuite) prepareGuest(vm VMHandle) error {
@@ -678,6 +903,26 @@ func (s *VMScanningSuite) prepareGuest(vm VMHandle) error {
 	}
 	if err := runStep("Verify sudo", "VerifySudoWorks", stepTimeout, func(stepCtx context.Context) error {
 		return vmhelpers.VerifySudoWorks(stepCtx, virt, vm.Namespace, vm.Name)
+	}); err != nil {
+		return err
+	}
+	if err := runStep("Copy roxagent binary", "CopyRoxagentBinary", stepTimeout, func(stepCtx context.Context) error {
+		return vmhelpers.CopyRoxagentBinary(stepCtx, virt, vm.Namespace, vm.Name, s.cfg.RoxagentBinaryPath)
+	}); err != nil {
+		return err
+	}
+	if err := runStep("Verify roxagent binary presence", "VerifyRoxagentBinaryPresent", stepTimeout, func(stepCtx context.Context) error {
+		return vmhelpers.VerifyRoxagentBinaryPresent(stepCtx, virt, vm.Namespace, vm.Name)
+	}); err != nil {
+		return err
+	}
+	if err := runStep("Verify roxagent executable mode", "VerifyRoxagentExecutable", stepTimeout, func(stepCtx context.Context) error {
+		return vmhelpers.VerifyRoxagentExecutable(stepCtx, virt, vm.Namespace, vm.Name)
+	}); err != nil {
+		return err
+	}
+	if err := runStep("Verify roxagent install path", "VerifyRoxagentInstallPath", stepTimeout, func(stepCtx context.Context) error {
+		return vmhelpers.VerifyRoxagentInstallPath(stepCtx, virt, vm.Namespace, vm.Name)
 	}); err != nil {
 		return err
 	}

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -424,11 +424,11 @@ func (s *VMScanningSuite) provisionVMs(specs []vmSpec) {
 						s.namespace, sp.Name, currentImage, sp.Image)
 				}
 				delCtx, delCancel := context.WithTimeout(ctx, s.resourceDeleteTimeout())
+				defer delCancel()
 				require.NoError(s.T(), vmhelpers.DeleteVirtualMachine(delCtx, s.dynamicClient, s.namespace, sp.Name),
 					"DeleteVirtualMachine %s/%s for image mismatch", s.namespace, sp.Name)
 				require.NoError(s.T(), vmhelpers.WaitForVirtualMachineDeleted(s.T(), delCtx, s.dynamicClient, s.namespace, sp.Name),
 					"WaitForVirtualMachineDeleted %s/%s for image mismatch", s.namespace, sp.Name)
-				delCancel()
 				require.NoError(s.T(), vmhelpers.CreateVirtualMachine(ctx, s.dynamicClient, req),
 					"CreateVirtualMachine %s/%s after image mismatch delete", s.namespace, sp.Name)
 				s.logf("provision VMs: recreated VM %s/%s with correct image", s.namespace, sp.Name)

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -672,16 +672,6 @@ func (s *VMScanningSuite) mustGetVM(id string) *v2.VirtualMachine {
 	return resp
 }
 
-const maxRoxagentStderrInError = 4096
-
-func formatRoxagentStderrForError(stderr string) string {
-	s := strings.TrimSpace(stderr)
-	if len(s) > maxRoxagentStderrInError {
-		return s[:maxRoxagentStderrInError] + fmt.Sprintf(" ... (truncated from %d bytes)", len(s))
-	}
-	return s
-}
-
 // roxagentStderrCrashLinePrefixes are lowercase; each stderr line is trimmed and lowercased before HasPrefix.
 var roxagentStderrCrashLinePrefixes = []string{
 	"panic:",
@@ -699,7 +689,7 @@ func validateRoxagentSuccessStderr(stderr string) error {
 		ln := strings.TrimSpace(strings.ToLower(line))
 		for _, prefix := range roxagentStderrCrashLinePrefixes {
 			if strings.HasPrefix(ln, prefix) {
-				return fmt.Errorf("ensureCanonicalScan: roxagent stderr indicates process/runtime failure (matched line prefix %q): %s", prefix, formatRoxagentStderrForError(stderr))
+				return fmt.Errorf("ensureCanonicalScan: roxagent stderr indicates process/runtime failure (matched line prefix %q): %s", prefix, vmhelpers.FormatGuestCommandOutputForError(stderr))
 			}
 		}
 	}
@@ -911,18 +901,9 @@ func (s *VMScanningSuite) prepareGuest(vm VMHandle) error {
 	}); err != nil {
 		return err
 	}
-	if err := runStep("Verify roxagent binary presence", "VerifyRoxagentBinaryPresent", stepTimeout, func(stepCtx context.Context) error {
-		return vmhelpers.VerifyRoxagentBinaryPresent(stepCtx, virt, vm.Namespace, vm.Name)
-	}); err != nil {
-		return err
-	}
-	if err := runStep("Verify roxagent executable mode", "VerifyRoxagentExecutable", stepTimeout, func(stepCtx context.Context) error {
-		return vmhelpers.VerifyRoxagentExecutable(stepCtx, virt, vm.Namespace, vm.Name)
-	}); err != nil {
-		return err
-	}
-	if err := runStep("Verify roxagent install path", "VerifyRoxagentInstallPath", stepTimeout, func(stepCtx context.Context) error {
-		return vmhelpers.VerifyRoxagentInstallPath(stepCtx, virt, vm.Namespace, vm.Name)
+	// Runs `roxagent --help` to confirm the binary is present, executable, and in $PATH.
+	if err := runStep("Verify roxagent installed", "VerifyRoxagentInstalled", stepTimeout, func(stepCtx context.Context) error {
+		return vmhelpers.VerifyRoxagentInstalled(stepCtx, virt, vm.Namespace, vm.Name)
 	}); err != nil {
 		return err
 	}

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -753,12 +753,7 @@ func (s *VMScanningSuite) ensureCanonicalScan(ctx context.Context, vm *VMHandle)
 		s.scannerV4Checked = true
 	}
 	virt := s.virtctlForVM(*vm)
-	cfg := vmhelpers.RoxagentRunConfig{
-		Repo2CPEPrimaryURL:      s.cfg.Repo2CPEPrimaryURL,
-		Repo2CPEFallbackURL:     s.cfg.Repo2CPEFallbackURL,
-		Repo2CPEPrimaryAttempts: s.cfg.Repo2CPEPrimaryAttempts,
-	}
-	res, err := vmhelpers.RunRoxagentOnce(ctx, virt, vm.Namespace, vm.Name, cfg)
+	res, err := vmhelpers.RunRoxagentOnce(ctx, virt, vm.Namespace, vm.Name, s.cfg.Repo2CPEURL)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -1,0 +1,102 @@
+//go:build test_e2e
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/tests/vmhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+func (s *VMScanningSuite) TestScanPipeline() {
+	for i := range s.persistentVMs {
+		vm := &s.persistentVMs[i]
+		s.T().Run(vm.Name, func(t *testing.T) {
+			var result *vmhelpers.RoxagentRunResult
+			var first *v2.VirtualMachine
+
+			t.Run("RunRoxagent", func(t *testing.T) {
+				t.Logf("running roxagent: sudo env ROXAGENT_REPO2CPE_URL=%s %s --verbose",
+					s.cfg.Repo2CPEPrimaryURL, vmhelpers.DefaultRoxagentInstallPath)
+				var err error
+				result, err = s.ensureCanonicalScan(s.ctx, vm)
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				if result.UsedFallback {
+					t.Logf("repo2cpe fallback was used")
+				}
+			})
+			if result == nil {
+				return
+			}
+
+			t.Run("WaitForScan", func(t *testing.T) {
+				var err error
+				first, err = s.waitForScan(s.ctx, vm)
+				require.NoError(t, err)
+				vm.ID = first.GetId()
+			})
+			if first == nil {
+				return
+			}
+
+			t.Run("CentralVMMetadata", func(t *testing.T) {
+				listed := s.mustListVMByNamespaceAndName(vm.Namespace, vm.Name)
+				require.Equal(t, listed.GetId(), first.GetId())
+				require.Equal(t, vm.Name, first.GetName())
+				require.Equal(t, vm.Namespace, first.GetNamespace())
+				require.NotEmpty(t, first.GetClusterId())
+				require.NotEmpty(t, first.GetClusterName())
+				require.Equal(t, v2.VirtualMachine_RUNNING, first.GetState())
+				require.NotNil(t, first.GetScan())
+				require.NotNil(t, first.GetScan().GetScanTime())
+			})
+
+			t.Run("CentralScanComponents", func(t *testing.T) {
+				for _, component := range first.GetScan().GetComponents() {
+					require.NotContains(t, component.GetNotes(), v2.ScanComponent_UNSCANNED)
+				}
+				require.NotEmpty(t, first.GetScan().GetComponents())
+			})
+
+			t.Run("CentralScanOperatingSystem", func(t *testing.T) {
+				os := first.GetScan().GetOperatingSystem()
+				require.NotEmpty(t, os,
+					"scan.operating_system should be populated via Sensor DiscoveredData")
+			})
+
+			beforeTime := s.mustGetScanTimestamp(first.GetId())
+			var rescan *v2.VirtualMachine
+
+			t.Run("Rescan", func(t *testing.T) {
+				_, err := s.ensureCanonicalScan(s.ctx, vm)
+				require.NoError(t, err)
+
+				waitCtx, cancel := context.WithTimeout(s.ctx, s.cfg.ScanTimeout)
+				defer cancel()
+				rescan, err = vmhelpers.WaitForScanTimestampAfter(
+					waitCtx, s.vmClient,
+					vmhelpers.WaitOptions{
+						Timeout:      s.cfg.ScanTimeout,
+						PollInterval: s.cfg.ScanPollInterval,
+						Logf:         s.logf,
+					},
+					vm.ID, beforeTime.AsTime(),
+				)
+				require.NoError(t, err, "rescan should produce a newer scan_time than %v", beforeTime.AsTime())
+			})
+			if rescan == nil {
+				return
+			}
+
+			t.Run("ConsistencyCheck", func(t *testing.T) {
+				fetched := s.mustGetVM(rescan.GetId())
+				require.Equal(t, first.GetId(), fetched.GetId(),
+					"VM ID should remain stable across rescans")
+			})
+		})
+	}
+}

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e
+//go:build test_e2e || test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func (s *VMScanningSuite) TestScanPipeline() {
-	for i := range s.persistentVMs {
-		vm := &s.persistentVMs[i]
+	for i := range s.vms {
+		vm := &s.vms[i]
 		s.T().Run(vm.Name, func(t *testing.T) {
 			var result *vmhelpers.RoxagentRunResult
 			var first *v2.VirtualMachine

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -27,14 +27,11 @@ func (s *VMScanningSuite) TestScanPipeline() {
 
 			t.Run("RunRoxagent", func(t *testing.T) {
 				t.Logf("running roxagent: sudo env ROXAGENT_REPO2CPE_URL=%s %s --verbose",
-					s.cfg.Repo2CPEPrimaryURL, vmhelpers.DefaultRoxagentInstallPath)
+					s.cfg.Repo2CPEURL, vmhelpers.DefaultRoxagentInstallPath)
 				var err error
 				result, err = s.ensureCanonicalScan(s.ctx, vm)
 				require.NoError(t, err)
 				require.NotNil(t, result)
-				if result.UsedFallback {
-					t.Logf("repo2cpe fallback was used")
-				}
 			})
 			if result == nil {
 				return

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -97,6 +97,10 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				return
 			}
 
+			t.Run("PipelineMetrics", func(t *testing.T) {
+				s.assertPipelineMetrics(s.ctx, t, vm.NodeName)
+			})
+
 			t.Run("ConsistencyCheck", func(t *testing.T) {
 				fetched := s.mustGetVM(rescan.GetId())
 				require.Equal(t, first.GetId(), fetched.GetId(),

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -14,6 +14,13 @@ import (
 func (s *VMScanningSuite) TestScanPipeline() {
 	for i := range s.vms {
 		vm := &s.vms[i]
+		virt := s.virtctlForVM(*vm)
+
+		if err := vmhelpers.EnsureVsockReady(s.ctx, virt, vm.Namespace, vm.Name, "scan pipeline"); err != nil {
+			s.T().Fatalf("VSOCK unavailable on %s/%s — cluster does not support vsock, cannot continue: %v",
+				vm.Namespace, vm.Name, err)
+		}
+
 		s.T().Run(vm.Name, func(t *testing.T) {
 			var result *vmhelpers.RoxagentRunResult
 			var first *v2.VirtualMachine

--- a/tests/vm_scanning_test.go
+++ b/tests/vm_scanning_test.go
@@ -22,18 +22,18 @@ func (s *VMScanningSuite) TestScanPipeline() {
 		}
 
 		s.T().Run(vm.Name, func(t *testing.T) {
-			var result *vmhelpers.RoxagentRunResult
 			var first *v2.VirtualMachine
+			roxagentOK := false
 
 			t.Run("RunRoxagent", func(t *testing.T) {
 				t.Logf("running roxagent: sudo env ROXAGENT_REPO2CPE_URL=%s %s --verbose",
 					s.cfg.Repo2CPEURL, vmhelpers.DefaultRoxagentInstallPath)
-				var err error
-				result, err = s.ensureCanonicalScan(s.ctx, vm)
+				err := s.ensureCanonicalScan(s.ctx, vm)
 				require.NoError(t, err)
-				require.NotNil(t, result)
+				roxagentOK = true
 			})
-			if result == nil {
+			if !roxagentOK {
+				t.Log("skipping remaining subtests: roxagent invocation failed")
 				return
 			}
 
@@ -44,6 +44,7 @@ func (s *VMScanningSuite) TestScanPipeline() {
 				vm.ID = first.GetId()
 			})
 			if first == nil {
+				t.Log("skipping remaining subtests: scan did not appear in Central")
 				return
 			}
 
@@ -76,7 +77,7 @@ func (s *VMScanningSuite) TestScanPipeline() {
 			var rescan *v2.VirtualMachine
 
 			t.Run("Rescan", func(t *testing.T) {
-				_, err := s.ensureCanonicalScan(s.ctx, vm)
+				err := s.ensureCanonicalScan(s.ctx, vm)
 				require.NoError(t, err)
 
 				waitCtx, cancel := context.WithTimeout(s.ctx, s.cfg.ScanTimeout)

--- a/tests/vm_scanning_utils_config_test.go
+++ b/tests/vm_scanning_utils_config_test.go
@@ -21,14 +21,22 @@ func TestLoadVMScanConfig_Defaults(t *testing.T) {
 	t.Setenv("VM_IMAGES", "registry.example.com/rhel9:latest,registry.example.com/rhel10:latest")
 	t.Setenv("VM_USERS", "")
 	t.Setenv("VIRTCTL_PATH", mustFindExecutable(t, "true"))
-	t.Setenv("VM_SCAN_NAMESPACE_PREFIX", "")
+	t.Setenv("ROXAGENT_BINARY_PATH", "/bin/true")
+	for _, key := range []string{
+		"VM_SCAN_NAMESPACE_PREFIX",
+		"ROXAGENT_REPO2CPE_PRIMARY_URL", "ROXAGENT_REPO2CPE_FALLBACK_URL",
+	} {
+		t.Setenv(key, "")
+	}
 	cfg, err := loadVMScanConfig()
 	require.NoError(t, err)
 	require.Equal(t, []string{"registry.example.com/rhel9:latest", "registry.example.com/rhel10:latest"}, cfg.Images)
 	require.Empty(t, cfg.GuestUsers, "no padding; vmSpecs() defaults per-image")
 	require.Equal(t, "vm-scan-e2e", cfg.NamespacePrefix)
 	require.Equal(t, 20*time.Minute, cfg.ScanTimeout)
+	require.Equal(t, 10*time.Second, cfg.ScanPollInterval)
 	require.Equal(t, 5*time.Minute, cfg.DeleteTimeout)
+	require.Equal(t, 3, cfg.Repo2CPEPrimaryAttempts)
 
 	specs := cfg.vmSpecs()
 	require.Len(t, specs, 2)
@@ -40,6 +48,7 @@ func TestLoadVMScanConfig_PartialUsers(t *testing.T) {
 	t.Setenv("VM_IMAGES", "img-a,img-b,img-c")
 	t.Setenv("VM_USERS", "alice")
 	t.Setenv("VIRTCTL_PATH", mustFindExecutable(t, "true"))
+	t.Setenv("ROXAGENT_BINARY_PATH", "/bin/true")
 	cfg, err := loadVMScanConfig()
 	require.NoError(t, err)
 	require.Equal(t, []string{"alice"}, cfg.GuestUsers, "only explicit users; vmSpecs() pads with default")

--- a/tests/vm_scanning_utils_config_test.go
+++ b/tests/vm_scanning_utils_config_test.go
@@ -57,6 +57,7 @@ func TestLoadVMScanConfig_PartialUsers(t *testing.T) {
 func TestLoadVMScanConfig_InvalidSSHKeyContent(t *testing.T) {
 	t.Setenv("VM_IMAGES", "registry.example.com/rhel9:latest")
 	t.Setenv("VIRTCTL_PATH", mustFindExecutable(t, "true"))
+	t.Setenv("ROXAGENT_BINARY_PATH", "/bin/true")
 
 	tests := map[string]string{
 		"should reject a file path":         "/home/user/.ssh/id_ed25519",

--- a/tests/vm_scanning_utils_config_test.go
+++ b/tests/vm_scanning_utils_config_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_utils_config_test.go
+++ b/tests/vm_scanning_utils_config_test.go
@@ -22,12 +22,7 @@ func TestLoadVMScanConfig_Defaults(t *testing.T) {
 	t.Setenv("VM_USERS", "")
 	t.Setenv("VIRTCTL_PATH", mustFindExecutable(t, "true"))
 	t.Setenv("ROXAGENT_BINARY_PATH", "/bin/true")
-	for _, key := range []string{
-		"VM_SCAN_NAMESPACE_PREFIX",
-		"ROXAGENT_REPO2CPE_PRIMARY_URL", "ROXAGENT_REPO2CPE_FALLBACK_URL",
-	} {
-		t.Setenv(key, "")
-	}
+	t.Setenv("VM_SCAN_NAMESPACE_PREFIX", "")
 	cfg, err := loadVMScanConfig()
 	require.NoError(t, err)
 	require.Equal(t, []string{"registry.example.com/rhel9:latest", "registry.example.com/rhel10:latest"}, cfg.Images)
@@ -36,7 +31,6 @@ func TestLoadVMScanConfig_Defaults(t *testing.T) {
 	require.Equal(t, 20*time.Minute, cfg.ScanTimeout)
 	require.Equal(t, 10*time.Second, cfg.ScanPollInterval)
 	require.Equal(t, 5*time.Minute, cfg.DeleteTimeout)
-	require.Equal(t, 3, cfg.Repo2CPEPrimaryAttempts)
 
 	specs := cfg.vmSpecs()
 	require.Len(t, specs, 2)

--- a/tests/vm_scanning_utils_test.go
+++ b/tests/vm_scanning_utils_test.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -22,14 +24,22 @@ import (
 const (
 	// Hardcoded because registerDurationSetting in pkg/env is unexported.
 	// This is acceptable since adjusting these values requires a code change anyway.
-	defaultScanTimeout   = 20 * time.Minute
-	defaultDeleteTimeout = 5 * time.Minute
-	defaultGuestUser     = "cloud-user"
+	defaultScanTimeout      = 20 * time.Minute
+	defaultScanPollInterval = 10 * time.Second
+	defaultDeleteTimeout    = 5 * time.Minute
+	defaultGuestUser        = "cloud-user"
+
+	defaultRepo2CPEPrimaryURL  = "https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
+	defaultRepo2CPEFallbackURL = "https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
+	defaultRepo2CPEAttempts    = 3
 )
 
 var (
 	vmScanNamespacePrefix = env.RegisterSetting("VM_SCAN_NAMESPACE_PREFIX", env.WithDefault("vm-scan-e2e"))
 	vmScanSkipCleanup     = env.RegisterBooleanSetting("VM_SCAN_SKIP_CLEANUP", false)
+
+	repo2CPEPrimaryURL  = env.RegisterSetting("ROXAGENT_REPO2CPE_PRIMARY_URL", env.WithDefault(defaultRepo2CPEPrimaryURL))
+	repo2CPEFallbackURL = env.RegisterSetting("ROXAGENT_REPO2CPE_FALLBACK_URL", env.WithDefault(defaultRepo2CPEFallbackURL))
 )
 
 // vmSpec describes a VM to provision: container-disk image and guest SSH user.
@@ -40,16 +50,21 @@ type vmSpec struct {
 }
 
 type vmScanConfig struct {
-	Images              []string // container-disk images (from VM_IMAGES, comma-separated)
-	GuestUsers          []string // per-image SSH users (from VM_USERS, comma-separated; shorter lists are padded with defaultGuestUser)
-	VirtctlPath         string
-	SSHPrivateKey       string // PEM-encoded private key content (not a file path)
-	SSHPublicKey        string // OpenSSH authorized_keys line (not a file path)
-	NamespacePrefix     string
-	ScanTimeout         time.Duration
-	DeleteTimeout       time.Duration
-	SkipCleanup         bool
-	ImagePullSecretPath string // Path to docker config JSON for private registries
+	Images                  []string // container-disk images (from VM_IMAGES, comma-separated)
+	GuestUsers              []string // per-image SSH users (from VM_USERS, comma-separated; shorter lists are padded with defaultGuestUser)
+	VirtctlPath             string
+	RoxagentBinaryPath      string
+	Repo2CPEPrimaryURL      string
+	Repo2CPEFallbackURL     string
+	Repo2CPEPrimaryAttempts int
+	SSHPrivateKey           string // PEM-encoded private key content (not a file path)
+	SSHPublicKey            string // OpenSSH authorized_keys line (not a file path)
+	NamespacePrefix         string
+	ScanTimeout             time.Duration
+	ScanPollInterval        time.Duration
+	DeleteTimeout           time.Duration
+	SkipCleanup             bool
+	ImagePullSecretPath     string // Path to docker config JSON for private registries
 }
 
 func loadVMScanConfig() (*vmScanConfig, error) {
@@ -79,6 +94,13 @@ func loadVMScanConfig() (*vmScanConfig, error) {
 	if cfg.VirtctlPath, err = discoverVirtctlPath(); err != nil {
 		return nil, err
 	}
+	if cfg.RoxagentBinaryPath, err = discoverRoxagentBinaryPath(); err != nil {
+		return nil, err
+	}
+
+	cfg.Repo2CPEPrimaryURL = repo2CPEPrimaryURL.Setting()
+	cfg.Repo2CPEFallbackURL = repo2CPEFallbackURL.Setting()
+	cfg.Repo2CPEPrimaryAttempts = defaultRepo2CPEAttempts
 
 	cfg.SSHPrivateKey = os.Getenv("VM_SSH_PRIVATE_KEY")
 	cfg.SSHPublicKey = strings.TrimSpace(os.Getenv("VM_SSH_PUBLIC_KEY"))
@@ -102,6 +124,7 @@ func loadVMScanConfig() (*vmScanConfig, error) {
 
 	cfg.NamespacePrefix = vmScanNamespacePrefix.Setting()
 	cfg.ScanTimeout = defaultScanTimeout
+	cfg.ScanPollInterval = defaultScanPollInterval
 	cfg.DeleteTimeout = defaultDeleteTimeout
 	cfg.SkipCleanup = vmScanSkipCleanup.BooleanSetting()
 	cfg.ImagePullSecretPath = strings.TrimSpace(os.Getenv("VM_IMAGE_PULL_SECRET_PATH"))
@@ -144,6 +167,29 @@ func discoverVirtctlPath() (string, error) {
 		return "", fmt.Errorf("VIRTCTL_PATH not set and virtctl not found on $PATH: %w", err)
 	}
 	return p, nil
+}
+
+// discoverRoxagentBinaryPath returns the ROXAGENT_BINARY_PATH env var if set,
+// otherwise probes the standard build output path relative to the repository root.
+func discoverRoxagentBinaryPath() (string, error) {
+	if v := strings.TrimSpace(os.Getenv("ROXAGENT_BINARY_PATH")); v != "" {
+		return v, nil
+	}
+	root := repoRoot()
+	candidate := filepath.Join(root, "bin", "linux_amd64", "roxagent")
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate, nil
+	}
+	return "", fmt.Errorf("ROXAGENT_BINARY_PATH not set and %s does not exist; run 'make roxagent_linux-amd64'", candidate)
+}
+
+// repoRoot returns the repository root by walking up from this source file.
+func repoRoot() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "."
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), ".."))
 }
 
 // generateEphemeralSSHKeypair creates a one-time ed25519 keypair and returns

--- a/tests/vm_scanning_utils_test.go
+++ b/tests/vm_scanning_utils_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_utils_test.go
+++ b/tests/vm_scanning_utils_test.go
@@ -29,17 +29,14 @@ const (
 	defaultDeleteTimeout    = 5 * time.Minute
 	defaultGuestUser        = "cloud-user"
 
-	defaultRepo2CPEPrimaryURL  = "https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
-	defaultRepo2CPEFallbackURL = "https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
-	defaultRepo2CPEAttempts    = 3
+	defaultRepo2CPEURL = "https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
 )
 
 var (
 	vmScanNamespacePrefix = env.RegisterSetting("VM_SCAN_NAMESPACE_PREFIX", env.WithDefault("vm-scan-e2e"))
 	vmScanSkipCleanup     = env.RegisterBooleanSetting("VM_SCAN_SKIP_CLEANUP", false)
 
-	repo2CPEPrimaryURL  = env.RegisterSetting("ROXAGENT_REPO2CPE_PRIMARY_URL", env.WithDefault(defaultRepo2CPEPrimaryURL))
-	repo2CPEFallbackURL = env.RegisterSetting("ROXAGENT_REPO2CPE_FALLBACK_URL", env.WithDefault(defaultRepo2CPEFallbackURL))
+	repo2CPEURL = env.RegisterSetting("ROXAGENT_REPO2CPE_URL", env.WithDefault(defaultRepo2CPEURL))
 )
 
 // vmSpec describes a VM to provision: container-disk image and guest SSH user.
@@ -50,21 +47,19 @@ type vmSpec struct {
 }
 
 type vmScanConfig struct {
-	Images                  []string // container-disk images (from VM_IMAGES, comma-separated)
-	GuestUsers              []string // per-image SSH users (from VM_USERS, comma-separated; shorter lists are padded with defaultGuestUser)
-	VirtctlPath             string
-	RoxagentBinaryPath      string
-	Repo2CPEPrimaryURL      string
-	Repo2CPEFallbackURL     string
-	Repo2CPEPrimaryAttempts int
-	SSHPrivateKey           string // PEM-encoded private key content (not a file path)
-	SSHPublicKey            string // OpenSSH authorized_keys line (not a file path)
-	NamespacePrefix         string
-	ScanTimeout             time.Duration
-	ScanPollInterval        time.Duration
-	DeleteTimeout           time.Duration
-	SkipCleanup             bool
-	ImagePullSecretPath     string // Path to docker config JSON for private registries
+	Images              []string // container-disk images (from VM_IMAGES, comma-separated)
+	GuestUsers          []string // per-image SSH users (from VM_USERS, comma-separated; shorter lists are padded with defaultGuestUser)
+	VirtctlPath         string
+	RoxagentBinaryPath  string
+	Repo2CPEURL         string
+	SSHPrivateKey       string // PEM-encoded private key content (not a file path)
+	SSHPublicKey        string // OpenSSH authorized_keys line (not a file path)
+	NamespacePrefix     string
+	ScanTimeout         time.Duration
+	ScanPollInterval    time.Duration
+	DeleteTimeout       time.Duration
+	SkipCleanup         bool
+	ImagePullSecretPath string // Path to docker config JSON for private registries
 }
 
 func loadVMScanConfig() (*vmScanConfig, error) {
@@ -98,9 +93,7 @@ func loadVMScanConfig() (*vmScanConfig, error) {
 		return nil, err
 	}
 
-	cfg.Repo2CPEPrimaryURL = repo2CPEPrimaryURL.Setting()
-	cfg.Repo2CPEFallbackURL = repo2CPEFallbackURL.Setting()
-	cfg.Repo2CPEPrimaryAttempts = defaultRepo2CPEAttempts
+	cfg.Repo2CPEURL = repo2CPEURL.Setting()
 
 	cfg.SSHPrivateKey = os.Getenv("VM_SSH_PRIVATE_KEY")
 	cfg.SSHPublicKey = strings.TrimSpace(os.Getenv("VM_SSH_PUBLIC_KEY"))

--- a/tests/vmhelpers/central.go
+++ b/tests/vmhelpers/central.go
@@ -1,0 +1,249 @@
+package vmhelpers
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stackrox/rox/pkg/search"
+)
+
+// ScanReadiness configures which scan fields must be present before
+// WaitForScanReady considers the scan complete.
+type ScanReadiness struct {
+	Components bool // at least one component reported
+	AllScanned bool // no UNSCANNED notes on any component
+}
+
+// WaitForVMPresentInCentral polls ListVirtualMachines until a VM matches namespace and name.
+func WaitForVMPresentInCentral(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, namespace, name string) (*v2.VirtualMachine, error) {
+	var found *v2.VirtualMachine
+	err := pollUntil(ctx, opts, fmt.Sprintf("VM present in Central (namespace=%q name=%q)", namespace, name), func(ctx context.Context) (bool, string, error) {
+		vm, err := ListVMByNamespaceName(ctx, client, namespace, name)
+		if err != nil {
+			return false, "", err
+		}
+		if vm == nil {
+			return false, "list returned no matching virtual machine", nil
+		}
+		found = vm
+		return true, fmt.Sprintf("id=%s", vm.GetId()), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return found, nil
+}
+
+// vmConditionCheck inspects a freshly-fetched VirtualMachine and reports whether
+// the desired condition is met. detail is included in poll logs and timeout errors.
+type vmConditionCheck func(vm *v2.VirtualMachine) (done bool, detail string)
+
+// waitForVMCondition polls GetVirtualMachine until check returns done==true.
+func waitForVMCondition(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id, desc string, check vmConditionCheck) (*v2.VirtualMachine, error) {
+	var vm *v2.VirtualMachine
+	err := pollUntil(ctx, opts, desc, func(ctx context.Context) (bool, string, error) {
+		cur, err := client.GetVirtualMachine(ctx, &v2.GetVirtualMachineRequest{Id: id})
+		if err != nil {
+			return false, "", err
+		}
+		done, detail := check(cur)
+		if done {
+			vm = cur
+		}
+		return done, detail, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return vm, nil
+}
+
+// WaitForVMIdentityFields polls GetVirtualMachine until id maps to the expected namespace and name.
+func WaitForVMIdentityFields(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id, expectedNamespace, expectedName string) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("VM identity fields (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		detail := fmt.Sprintf("namespace=%q name=%q", vm.GetNamespace(), vm.GetName())
+		return vm.GetNamespace() == expectedNamespace && vm.GetName() == expectedName, detail
+	})
+}
+
+// WaitForVMRunningInCentral polls until the VM state is RUNNING.
+func WaitForVMRunningInCentral(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("VM RUNNING (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		st := vm.GetState()
+		return st == v2.VirtualMachine_RUNNING, fmt.Sprintf("state=%s", st)
+	})
+}
+
+// WaitForVMScanNonNil polls until VirtualMachine.scan is non-nil.
+func WaitForVMScanNonNil(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("VM scan non-nil (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		if vm.GetScan() == nil {
+			return false, "scan is nil"
+		}
+		return true, "scan present"
+	})
+}
+
+// WaitForVMScanTimestamp polls until scan_time is set.
+func WaitForVMScanTimestamp(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("VM scan timestamp (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		sc := vm.GetScan()
+		if sc == nil {
+			return false, "scan is nil"
+		}
+		if sc.GetScanTime() == nil {
+			return false, "scan_time is nil"
+		}
+		return true, "scan_time set"
+	})
+}
+
+// WaitForScanTimestampAfter polls until the VM's scan_time is strictly after the given
+// threshold. Use this to wait for a rescan to be reflected in Central.
+func WaitForScanTimestampAfter(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string, after time.Time) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("scan timestamp after %v (id=%q)", after.Format(time.RFC3339), id), func(vm *v2.VirtualMachine) (bool, string) {
+		sc := vm.GetScan()
+		if sc == nil || sc.GetScanTime() == nil {
+			return false, "scan_time not set yet"
+		}
+		ts := sc.GetScanTime().AsTime()
+		if !ts.After(after) {
+			return false, fmt.Sprintf("scan_time=%v not yet after %v", ts.Format(time.RFC3339Nano), after.Format(time.RFC3339Nano))
+		}
+		return true, fmt.Sprintf("scan_time=%v", ts.Format(time.RFC3339Nano))
+	})
+}
+
+// WaitForVMComponentsReported polls until at least one scan component exists.
+func WaitForVMComponentsReported(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("VM components reported (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		if hasReportedComponents(vm) {
+			return true, "components present"
+		}
+		n := 0
+		if vm.GetScan() != nil {
+			n = len(vm.GetScan().GetComponents())
+		}
+		return false, fmt.Sprintf("component count=%d", n)
+	})
+}
+
+// WaitForAllVMComponentsScanned polls until every scan component lacks the UNSCANNED note.
+func WaitForAllVMComponentsScanned(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("all VM components scanned (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		if allComponentsScanned(vm) {
+			return true, "all components scanned"
+		}
+		return false, "pending UNSCANNED components or empty component list"
+	})
+}
+
+// WaitForScanReady polls GetVirtualMachine in a single loop until every field
+// requested in conds is populated. Each poll iteration logs which conditions
+// are already met and which are still pending, so partial progress is visible.
+func WaitForScanReady(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string, conds ScanReadiness) (*v2.VirtualMachine, error) {
+	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("scan ready (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
+		scan := vm.GetScan()
+		if scan == nil {
+			return false, "scan is nil"
+		}
+
+		var ready, pending []string
+		comps := scan.GetComponents()
+
+		if conds.Components {
+			if n := len(comps); n > 0 {
+				ready = append(ready, fmt.Sprintf("components=%d", n))
+			} else {
+				pending = append(pending, "components")
+			}
+		}
+		if conds.AllScanned {
+			if len(comps) > 0 && !slices.ContainsFunc(comps, func(c *v2.ScanComponent) bool {
+				return slices.Contains(c.GetNotes(), v2.ScanComponent_UNSCANNED)
+			}) {
+				ready = append(ready, "all-scanned")
+			} else {
+				pending = append(pending, "all-scanned")
+			}
+		}
+
+		// OS is informational: it arrives in the same message as components,
+		// so if components are present and fully scanned, the OS won't appear
+		// in a later update. Report it but never block on it.
+		if os := scan.GetOperatingSystem(); os != "" {
+			ready = append(ready, fmt.Sprintf("os=%q", os))
+		} else if len(pending) == 0 {
+			ready = append(ready, "os=<not reported>")
+		}
+
+		detail := fmt.Sprintf("ready:[%s] waiting:[%s]", strings.Join(ready, ","), strings.Join(pending, ","))
+		return len(pending) == 0, detail
+	})
+}
+
+// listVMPageSize is the page size used when iterating ListVirtualMachines pages.
+const listVMPageSize = int32(1000)
+
+// rawListQueryNamespaceAndName builds a Central raw search query matching namespace and VM name.
+func rawListQueryNamespaceAndName(namespace, name string) string {
+	return fmt.Sprintf("%s:%s+%s:%s", search.Namespace, namespace, search.VirtualMachineName, name)
+}
+
+// ListVMByNamespaceName returns the first VirtualMachine in Central whose namespace and name
+// exactly match the given values, paging through all results. Returns (nil, nil) when no
+// match is found.
+func ListVMByNamespaceName(ctx context.Context, client v2.VirtualMachineServiceClient, namespace, name string) (*v2.VirtualMachine, error) {
+	baseQuery := rawListQueryNamespaceAndName(namespace, name)
+	for offset := int32(0); ; offset += listVMPageSize {
+		resp, err := client.ListVirtualMachines(ctx, &v2.ListVirtualMachinesRequest{
+			Query: &v2.RawQuery{
+				Query: baseQuery,
+				Pagination: &v2.Pagination{
+					Limit:  listVMPageSize,
+					Offset: offset,
+				},
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, vm := range resp.GetVirtualMachines() {
+			if vm.GetNamespace() == namespace && vm.GetName() == name {
+				return vm, nil
+			}
+		}
+		if int32(len(resp.GetVirtualMachines())) < listVMPageSize {
+			return nil, nil
+		}
+	}
+}
+
+// hasReportedComponents reports whether the VM scan lists at least one component.
+func hasReportedComponents(vm *v2.VirtualMachine) bool {
+	if vm == nil || vm.GetScan() == nil {
+		return false
+	}
+	return len(vm.GetScan().GetComponents()) > 0
+}
+
+// allComponentsScanned reports whether every scan component lacks the UNSCANNED note.
+func allComponentsScanned(vm *v2.VirtualMachine) bool {
+	if vm == nil || vm.GetScan() == nil {
+		return false
+	}
+	comps := vm.GetScan().GetComponents()
+	if len(comps) == 0 {
+		return false
+	}
+	for _, c := range comps {
+		if slices.Contains(c.GetNotes(), v2.ScanComponent_UNSCANNED) {
+			return false
+		}
+	}
+	return true
+}

--- a/tests/vmhelpers/central.go
+++ b/tests/vmhelpers/central.go
@@ -118,30 +118,6 @@ func WaitForScanTimestampAfter(ctx context.Context, client v2.VirtualMachineServ
 	})
 }
 
-// WaitForVMComponentsReported polls until at least one scan component exists.
-func WaitForVMComponentsReported(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
-	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("VM components reported (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
-		if hasReportedComponents(vm) {
-			return true, "components present"
-		}
-		n := 0
-		if vm.GetScan() != nil {
-			n = len(vm.GetScan().GetComponents())
-		}
-		return false, fmt.Sprintf("component count=%d", n)
-	})
-}
-
-// WaitForAllVMComponentsScanned polls until every scan component lacks the UNSCANNED note.
-func WaitForAllVMComponentsScanned(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
-	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("all VM components scanned (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
-		if allComponentsScanned(vm) {
-			return true, "all components scanned"
-		}
-		return false, "pending UNSCANNED components or empty component list"
-	})
-}
-
 // WaitForScanReady polls GetVirtualMachine in a single loop until every field
 // requested in conds is populated. Each poll iteration logs which conditions
 // are already met and which are still pending, so partial progress is visible.
@@ -221,29 +197,4 @@ func ListVMByNamespaceName(ctx context.Context, client v2.VirtualMachineServiceC
 			return nil, nil
 		}
 	}
-}
-
-// hasReportedComponents reports whether the VM scan lists at least one component.
-func hasReportedComponents(vm *v2.VirtualMachine) bool {
-	if vm == nil || vm.GetScan() == nil {
-		return false
-	}
-	return len(vm.GetScan().GetComponents()) > 0
-}
-
-// allComponentsScanned reports whether every scan component lacks the UNSCANNED note.
-func allComponentsScanned(vm *v2.VirtualMachine) bool {
-	if vm == nil || vm.GetScan() == nil {
-		return false
-	}
-	comps := vm.GetScan().GetComponents()
-	if len(comps) == 0 {
-		return false
-	}
-	for _, c := range comps {
-		if slices.Contains(c.GetNotes(), v2.ScanComponent_UNSCANNED) {
-			return false
-		}
-	}
-	return true
 }

--- a/tests/vmhelpers/central.go
+++ b/tests/vmhelpers/central.go
@@ -11,13 +11,6 @@ import (
 	"github.com/stackrox/rox/pkg/search"
 )
 
-// ScanReadiness configures which scan fields must be present before
-// WaitForScanReady considers the scan complete.
-type ScanReadiness struct {
-	Components bool // at least one component reported
-	AllScanned bool // no UNSCANNED notes on any component
-}
-
 // WaitForVMPresentInCentral polls ListVirtualMachines until a VM matches namespace and name.
 func WaitForVMPresentInCentral(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, namespace, name string) (*v2.VirtualMachine, error) {
 	var found *v2.VirtualMachine
@@ -118,10 +111,10 @@ func WaitForScanTimestampAfter(ctx context.Context, client v2.VirtualMachineServ
 	})
 }
 
-// WaitForScanReady polls GetVirtualMachine in a single loop until every field
-// requested in conds is populated. Each poll iteration logs which conditions
-// are already met and which are still pending, so partial progress is visible.
-func WaitForScanReady(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string, conds ScanReadiness) (*v2.VirtualMachine, error) {
+// WaitForScanReady polls GetVirtualMachine until at least one component is
+// reported and none are marked UNSCANNED. Each poll iteration logs which
+// conditions are met and which are still pending.
+func WaitForScanReady(ctx context.Context, client v2.VirtualMachineServiceClient, opts WaitOptions, id string) (*v2.VirtualMachine, error) {
 	return waitForVMCondition(ctx, client, opts, id, fmt.Sprintf("scan ready (id=%q)", id), func(vm *v2.VirtualMachine) (bool, string) {
 		scan := vm.GetScan()
 		if scan == nil {
@@ -131,21 +124,21 @@ func WaitForScanReady(ctx context.Context, client v2.VirtualMachineServiceClient
 		var ready, pending []string
 		comps := scan.GetComponents()
 
-		if conds.Components {
-			if n := len(comps); n > 0 {
-				ready = append(ready, fmt.Sprintf("components=%d", n))
-			} else {
-				pending = append(pending, "components")
-			}
+		// At least one component must be reported - Central has ingested the scan payload.
+		if n := len(comps); n > 0 {
+			ready = append(ready, fmt.Sprintf("components=%d", n))
+		} else {
+			pending = append(pending, "components")
 		}
-		if conds.AllScanned {
-			if len(comps) > 0 && !slices.ContainsFunc(comps, func(c *v2.ScanComponent) bool {
-				return slices.Contains(c.GetNotes(), v2.ScanComponent_UNSCANNED)
-			}) {
-				ready = append(ready, "all-scanned")
-			} else {
-				pending = append(pending, "all-scanned")
-			}
+
+		// Every reported component must have been matched by the vulnerability scanner
+		// (no UNSCANNED note). This confirms Scanner has processed the full SBOM.
+		if len(comps) > 0 && !slices.ContainsFunc(comps, func(c *v2.ScanComponent) bool {
+			return slices.Contains(c.GetNotes(), v2.ScanComponent_UNSCANNED)
+		}) {
+			ready = append(ready, "all-scanned")
+		} else {
+			pending = append(pending, "all-scanned")
 		}
 
 		// OS is informational: it arrives in the same message as components,

--- a/tests/vmhelpers/central_test.go
+++ b/tests/vmhelpers/central_test.go
@@ -1,0 +1,260 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	v2 "github.com/stackrox/rox/generated/api/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestHasReportedComponents_TrueForNComponents(t *testing.T) {
+	vm := &v2.VirtualMachine{
+		Scan: &v2.VirtualMachineScan{
+			Components: []*v2.ScanComponent{{Name: "pkg-a"}},
+		},
+	}
+	require.True(t, hasReportedComponents(vm))
+}
+
+func TestHasReportedComponents_FalseWhenNilScan(t *testing.T) {
+	require.False(t, hasReportedComponents(&v2.VirtualMachine{}))
+	require.False(t, hasReportedComponents(nil))
+}
+
+func TestAllComponentsScanned(t *testing.T) {
+	t.Run("true when no UNSCANNED notes", func(t *testing.T) {
+		vm := &v2.VirtualMachine{
+			Scan: &v2.VirtualMachineScan{
+				Components: []*v2.ScanComponent{
+					{Name: "a", Notes: []v2.ScanComponent_Note{v2.ScanComponent_UNSPECIFIED}},
+				},
+			},
+		}
+		require.True(t, allComponentsScanned(vm))
+	})
+	t.Run("false when UNSCANNED present", func(t *testing.T) {
+		vm := &v2.VirtualMachine{
+			Scan: &v2.VirtualMachineScan{
+				Components: []*v2.ScanComponent{
+					{Name: "a", Notes: []v2.ScanComponent_Note{v2.ScanComponent_UNSCANNED}},
+				},
+			},
+		}
+		require.False(t, allComponentsScanned(vm))
+	})
+	t.Run("false when empty components", func(t *testing.T) {
+		vm := &v2.VirtualMachine{Scan: &v2.VirtualMachineScan{}}
+		require.False(t, allComponentsScanned(vm))
+	})
+}
+
+func TestRawListQueryNamespaceAndName(t *testing.T) {
+	q := rawListQueryNamespaceAndName("stackrox", "vm-rhel9")
+	require.Contains(t, q, "Namespace:stackrox")
+	require.Contains(t, q, "Virtual Machine Name:vm-rhel9")
+}
+
+type stubVirtualMachineClient struct {
+	listFn func(ctx context.Context, req *v2.ListVirtualMachinesRequest) (*v2.ListVirtualMachinesResponse, error)
+	getFn  func(ctx context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error)
+}
+
+func (s *stubVirtualMachineClient) ListVirtualMachines(ctx context.Context, in *v2.ListVirtualMachinesRequest, _ ...grpc.CallOption) (*v2.ListVirtualMachinesResponse, error) {
+	if s.listFn == nil {
+		return &v2.ListVirtualMachinesResponse{}, nil
+	}
+	return s.listFn(ctx, in)
+}
+
+func (s *stubVirtualMachineClient) GetVirtualMachine(ctx context.Context, in *v2.GetVirtualMachineRequest, _ ...grpc.CallOption) (*v2.VirtualMachine, error) {
+	if s.getFn == nil {
+		return nil, errors.New("get not stubbed")
+	}
+	return s.getFn(ctx, in)
+}
+
+func TestWaitForVMPresentInCentral_UsesListVirtualMachines(t *testing.T) {
+	ctx := context.Background()
+	opts := WaitOptions{Timeout: 200 * time.Millisecond, PollInterval: 5 * time.Millisecond}
+	var sawQuery string
+	client := &stubVirtualMachineClient{
+		listFn: func(ctx context.Context, req *v2.ListVirtualMachinesRequest) (*v2.ListVirtualMachinesResponse, error) {
+			sawQuery = req.GetQuery().GetQuery()
+			return &v2.ListVirtualMachinesResponse{
+				VirtualMachines: []*v2.VirtualMachine{
+					{Id: "id-1", Namespace: "ns1", Name: "vm1"},
+				},
+			}, nil
+		},
+	}
+	vm, err := WaitForVMPresentInCentral(ctx, client, opts, "ns1", "vm1")
+	require.NoError(t, err)
+	require.Equal(t, "id-1", vm.GetId())
+	require.NotEmpty(t, sawQuery)
+	require.Contains(t, sawQuery, "Namespace:ns1")
+}
+
+func TestWaitForVMScanTimestamp(t *testing.T) {
+	ctx := context.Background()
+	opts := WaitOptions{Timeout: 150 * time.Millisecond, PollInterval: 5 * time.Millisecond}
+	var calls int
+	client := &stubVirtualMachineClient{
+		getFn: func(ctx context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
+			calls++
+			if calls < 3 {
+				return &v2.VirtualMachine{
+					Id:   req.GetId(),
+					Scan: &v2.VirtualMachineScan{},
+				}, nil
+			}
+			return &v2.VirtualMachine{
+				Id: req.GetId(),
+				Scan: &v2.VirtualMachineScan{
+					ScanTime: timestamppb.Now(),
+				},
+			}, nil
+		},
+	}
+	vm, err := WaitForVMScanTimestamp(ctx, client, opts, "vid")
+	require.NoError(t, err)
+	require.NotNil(t, vm.GetScan().GetScanTime())
+	require.GreaterOrEqual(t, calls, 3)
+}
+
+func TestCentralWaitStubClients(t *testing.T) {
+	ctx := context.Background()
+	opts := WaitOptions{Timeout: 150 * time.Millisecond, PollInterval: 5 * time.Millisecond}
+
+	for _, tc := range []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "WaitForVMIdentityFields",
+			run: func(t *testing.T) {
+				var calls int
+				client := &stubVirtualMachineClient{
+					getFn: func(_ context.Context, _ *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
+						calls++
+						if calls == 1 {
+							return &v2.VirtualMachine{Id: "vid", Namespace: "a", Name: "b"}, nil
+						}
+						return &v2.VirtualMachine{Id: "vid", Namespace: "ns-x", Name: "vm-x"}, nil
+					},
+				}
+				vm, err := WaitForVMIdentityFields(ctx, client, opts, "vid", "ns-x", "vm-x")
+				require.NoError(t, err)
+				require.Equal(t, "ns-x", vm.GetNamespace())
+				require.Equal(t, "vm-x", vm.GetName())
+				require.GreaterOrEqual(t, calls, 2)
+			},
+		},
+		{
+			name: "WaitForVMRunningInCentral",
+			run: func(t *testing.T) {
+				var calls int
+				client := &stubVirtualMachineClient{
+					getFn: func(_ context.Context, _ *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
+						calls++
+						if calls < 2 {
+							return &v2.VirtualMachine{Id: "r1", State: v2.VirtualMachine_STOPPED}, nil
+						}
+						return &v2.VirtualMachine{Id: "r1", State: v2.VirtualMachine_RUNNING}, nil
+					},
+				}
+				vm, err := WaitForVMRunningInCentral(ctx, client, opts, "r1")
+				require.NoError(t, err)
+				require.Equal(t, v2.VirtualMachine_RUNNING, vm.GetState())
+				require.GreaterOrEqual(t, calls, 2)
+			},
+		},
+		{
+			name: "WaitForVMScanNonNil",
+			run: func(t *testing.T) {
+				var calls int
+				client := &stubVirtualMachineClient{
+					getFn: func(_ context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
+						calls++
+						if calls == 1 {
+							return &v2.VirtualMachine{Id: req.GetId(), Scan: nil}, nil
+						}
+						return &v2.VirtualMachine{Id: req.GetId(), Scan: &v2.VirtualMachineScan{}}, nil
+					},
+				}
+				vm, err := WaitForVMScanNonNil(ctx, client, opts, "s1")
+				require.NoError(t, err)
+				require.NotNil(t, vm.GetScan())
+				require.GreaterOrEqual(t, calls, 2)
+			},
+		},
+		{
+			name: "WaitForVMComponentsReported",
+			run: func(t *testing.T) {
+				var calls int
+				client := &stubVirtualMachineClient{
+					getFn: func(_ context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
+						calls++
+						if calls == 1 {
+							return &v2.VirtualMachine{
+								Id:   req.GetId(),
+								Scan: &v2.VirtualMachineScan{Components: nil},
+							}, nil
+						}
+						return &v2.VirtualMachine{
+							Id: req.GetId(),
+							Scan: &v2.VirtualMachineScan{
+								Components: []*v2.ScanComponent{{Name: "c1"}},
+							},
+						}, nil
+					},
+				}
+				vm, err := WaitForVMComponentsReported(ctx, client, opts, "cvm")
+				require.NoError(t, err)
+				require.Len(t, vm.GetScan().GetComponents(), 1)
+				require.GreaterOrEqual(t, calls, 2)
+			},
+		},
+		{
+			name: "WaitForAllVMComponentsScanned",
+			run: func(t *testing.T) {
+				var calls int
+				client := &stubVirtualMachineClient{
+					getFn: func(_ context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
+						calls++
+						if calls == 1 {
+							return &v2.VirtualMachine{
+								Id: req.GetId(),
+								Scan: &v2.VirtualMachineScan{
+									Components: []*v2.ScanComponent{
+										{Name: "p", Notes: []v2.ScanComponent_Note{v2.ScanComponent_UNSCANNED}},
+									},
+								},
+							}, nil
+						}
+						return &v2.VirtualMachine{
+							Id: req.GetId(),
+							Scan: &v2.VirtualMachineScan{
+								Components: []*v2.ScanComponent{
+									{Name: "p", Notes: []v2.ScanComponent_Note{v2.ScanComponent_UNSPECIFIED}},
+								},
+							},
+						}, nil
+					},
+				}
+				vm, err := WaitForAllVMComponentsScanned(ctx, client, opts, "all1")
+				require.NoError(t, err)
+				require.True(t, allComponentsScanned(vm))
+				require.GreaterOrEqual(t, calls, 2)
+			},
+		},
+	} {
+		t.Run(tc.name, tc.run)
+	}
+}

--- a/tests/vmhelpers/central_test.go
+++ b/tests/vmhelpers/central_test.go
@@ -14,47 +14,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func TestHasReportedComponents_TrueForNComponents(t *testing.T) {
-	vm := &v2.VirtualMachine{
-		Scan: &v2.VirtualMachineScan{
-			Components: []*v2.ScanComponent{{Name: "pkg-a"}},
-		},
-	}
-	require.True(t, hasReportedComponents(vm))
-}
-
-func TestHasReportedComponents_FalseWhenNilScan(t *testing.T) {
-	require.False(t, hasReportedComponents(&v2.VirtualMachine{}))
-	require.False(t, hasReportedComponents(nil))
-}
-
-func TestAllComponentsScanned(t *testing.T) {
-	t.Run("true when no UNSCANNED notes", func(t *testing.T) {
-		vm := &v2.VirtualMachine{
-			Scan: &v2.VirtualMachineScan{
-				Components: []*v2.ScanComponent{
-					{Name: "a", Notes: []v2.ScanComponent_Note{v2.ScanComponent_UNSPECIFIED}},
-				},
-			},
-		}
-		require.True(t, allComponentsScanned(vm))
-	})
-	t.Run("false when UNSCANNED present", func(t *testing.T) {
-		vm := &v2.VirtualMachine{
-			Scan: &v2.VirtualMachineScan{
-				Components: []*v2.ScanComponent{
-					{Name: "a", Notes: []v2.ScanComponent_Note{v2.ScanComponent_UNSCANNED}},
-				},
-			},
-		}
-		require.False(t, allComponentsScanned(vm))
-	})
-	t.Run("false when empty components", func(t *testing.T) {
-		vm := &v2.VirtualMachine{Scan: &v2.VirtualMachineScan{}}
-		require.False(t, allComponentsScanned(vm))
-	})
-}
-
 func TestRawListQueryNamespaceAndName(t *testing.T) {
 	q := rawListQueryNamespaceAndName("stackrox", "vm-rhel9")
 	require.Contains(t, q, "Namespace:stackrox")
@@ -191,66 +150,6 @@ func TestCentralWaitStubClients(t *testing.T) {
 				vm, err := WaitForVMScanNonNil(ctx, client, opts, "s1")
 				require.NoError(t, err)
 				require.NotNil(t, vm.GetScan())
-				require.GreaterOrEqual(t, calls, 2)
-			},
-		},
-		{
-			name: "WaitForVMComponentsReported",
-			run: func(t *testing.T) {
-				var calls int
-				client := &stubVirtualMachineClient{
-					getFn: func(_ context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
-						calls++
-						if calls == 1 {
-							return &v2.VirtualMachine{
-								Id:   req.GetId(),
-								Scan: &v2.VirtualMachineScan{Components: nil},
-							}, nil
-						}
-						return &v2.VirtualMachine{
-							Id: req.GetId(),
-							Scan: &v2.VirtualMachineScan{
-								Components: []*v2.ScanComponent{{Name: "c1"}},
-							},
-						}, nil
-					},
-				}
-				vm, err := WaitForVMComponentsReported(ctx, client, opts, "cvm")
-				require.NoError(t, err)
-				require.Len(t, vm.GetScan().GetComponents(), 1)
-				require.GreaterOrEqual(t, calls, 2)
-			},
-		},
-		{
-			name: "WaitForAllVMComponentsScanned",
-			run: func(t *testing.T) {
-				var calls int
-				client := &stubVirtualMachineClient{
-					getFn: func(_ context.Context, req *v2.GetVirtualMachineRequest) (*v2.VirtualMachine, error) {
-						calls++
-						if calls == 1 {
-							return &v2.VirtualMachine{
-								Id: req.GetId(),
-								Scan: &v2.VirtualMachineScan{
-									Components: []*v2.ScanComponent{
-										{Name: "p", Notes: []v2.ScanComponent_Note{v2.ScanComponent_UNSCANNED}},
-									},
-								},
-							}, nil
-						}
-						return &v2.VirtualMachine{
-							Id: req.GetId(),
-							Scan: &v2.VirtualMachineScan{
-								Components: []*v2.ScanComponent{
-									{Name: "p", Notes: []v2.ScanComponent_Note{v2.ScanComponent_UNSPECIFIED}},
-								},
-							},
-						}, nil
-					},
-				}
-				vm, err := WaitForAllVMComponentsScanned(ctx, client, opts, "all1")
-				require.NoError(t, err)
-				require.True(t, allComponentsScanned(vm))
 				require.GreaterOrEqual(t, calls, 2)
 			},
 		},

--- a/tests/vmhelpers/guest.go
+++ b/tests/vmhelpers/guest.go
@@ -1,11 +1,74 @@
 package vmhelpers
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strings"
 )
 
-const guestCommandErrorMaxLen = 4096
+const (
+	guestCommandErrorMaxLen = 4096
+	vsockReadinessMarker    = "VSOCK_READY"
+)
+
+// checkVsockReadiness tests /dev/vsock presence and gathers diagnostics when absent.
+func checkVsockReadiness(ctx context.Context, virt Virtctl, namespace, vm string) (ready bool, detail string, err error) {
+	_, _, testErr := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+		description:            "vsock device check",
+		transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+	}, "test", "-e", "/dev/vsock")
+	if testErr == nil {
+		return true, vsockReadinessMarker + " /dev/vsock present", nil
+	}
+	if errors.Is(testErr, errSSHTransport) {
+		return false, "", testErr
+	}
+	// /dev/vsock absent — gather diagnostics via separate calls.
+	diagStr := collectVsockDiagnostics(ctx, virt, namespace, vm)
+	return false, fmt.Sprintf("VSOCK_MISSING /dev/vsock absent (%s)", diagStr), nil
+}
+
+// collectVsockDiagnostics gathers /dev/vsock and kernel module info from the guest for troubleshooting.
+func collectVsockDiagnostics(ctx context.Context, virt Virtctl, namespace, vm string) string {
+	var diag []string
+	lsOut, _, _ := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+		description: "vsock diagnostic ls", transportRetryAttempts: 1,
+	}, "ls", "-l", "/dev/vsock")
+	if s := strings.TrimSpace(lsOut); s != "" {
+		diag = append(diag, "ls: "+s)
+	}
+	lsmodOut, _, _ := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+		description: "vsock diagnostic lsmod", transportRetryAttempts: 1,
+	}, "lsmod")
+	for _, line := range strings.Split(lsmodOut, "\n") {
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "vsock") || strings.Contains(lower, "vhost") {
+			diag = append(diag, "module: "+strings.TrimSpace(line))
+		}
+	}
+	if len(diag) == 0 {
+		return "no diagnostic info available"
+	}
+	return strings.Join(diag, "; ")
+}
+
+// ensureVsockReady retries the virtio-vsock device check until /dev/vsock exists or SSH transport errors are exhausted.
+func ensureVsockReady(ctx context.Context, virt Virtctl, namespace, vm, stage string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, fmt.Sprintf("vsock precheck before %s", stage), func(ctx context.Context) error {
+		ready, detail, err := checkVsockReadiness(ctx, virt, namespace, vm)
+		if err != nil {
+			return err
+		}
+		if !ready {
+			return fmt.Errorf("vsock precheck before %s on %s/%s: %s", stage, namespace, vm, detail)
+		}
+		if virt.Logf != nil {
+			virt.Logf("vsock precheck before %s on %s/%s: ready", stage, namespace, vm)
+		}
+		return nil
+	})
+}
 
 // formatGuestCommandOutputForError trims guest command output and truncates it for error message inclusion.
 func formatGuestCommandOutputForError(output string) string {

--- a/tests/vmhelpers/guest.go
+++ b/tests/vmhelpers/guest.go
@@ -9,7 +9,10 @@ import (
 
 const (
 	guestCommandErrorMaxLen = 4096
-	vsockReadinessMarker    = "VSOCK_READY"
+	// vsockReadinessMarker is a structured prefix emitted in poll-loop detail strings when
+	// /dev/vsock is confirmed present on the guest. It enables log grep/filtering during
+	// CI triage to distinguish successful vsock checks from VSOCK_MISSING diagnostics.
+	vsockReadinessMarker = "VSOCK_READY"
 )
 
 // checkVsockReadiness tests /dev/vsock presence and gathers diagnostics when absent.
@@ -70,8 +73,8 @@ func ensureVsockReady(ctx context.Context, virt Virtctl, namespace, vm, stage st
 	})
 }
 
-// formatGuestCommandOutputForError trims guest command output and truncates it for error message inclusion.
-func formatGuestCommandOutputForError(output string) string {
+// FormatGuestCommandOutputForError trims guest command output and truncates it for error message inclusion.
+func FormatGuestCommandOutputForError(output string) string {
 	output = strings.TrimSpace(output)
 	if output == "" {
 		return "<no guest stdout/stderr>"

--- a/tests/vmhelpers/guest.go
+++ b/tests/vmhelpers/guest.go
@@ -15,7 +15,7 @@ const (
 	vsockReadinessMarker = "VSOCK_READY"
 )
 
-// checkVsockReadiness tests /dev/vsock presence and gathers diagnostics when absent.
+// checkVsockReadiness tests /dev/vsock presence on the guest.
 func checkVsockReadiness(ctx context.Context, virt Virtctl, namespace, vm string) (ready bool, detail string, err error) {
 	_, _, testErr := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
 		description:            "vsock device check",
@@ -27,33 +27,7 @@ func checkVsockReadiness(ctx context.Context, virt Virtctl, namespace, vm string
 	if errors.Is(testErr, errSSHTransport) {
 		return false, "", testErr
 	}
-	// /dev/vsock absent — gather diagnostics via separate calls.
-	diagStr := collectVsockDiagnostics(ctx, virt, namespace, vm)
-	return false, fmt.Sprintf("VSOCK_MISSING /dev/vsock absent (%s)", diagStr), nil
-}
-
-// collectVsockDiagnostics gathers /dev/vsock and kernel module info from the guest for troubleshooting.
-func collectVsockDiagnostics(ctx context.Context, virt Virtctl, namespace, vm string) string {
-	var diag []string
-	lsOut, _, _ := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
-		description: "vsock diagnostic ls", transportRetryAttempts: 1,
-	}, "ls", "-l", "/dev/vsock")
-	if s := strings.TrimSpace(lsOut); s != "" {
-		diag = append(diag, "ls: "+s)
-	}
-	lsmodOut, _, _ := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
-		description: "vsock diagnostic lsmod", transportRetryAttempts: 1,
-	}, "lsmod")
-	for _, line := range strings.Split(lsmodOut, "\n") {
-		lower := strings.ToLower(line)
-		if strings.Contains(lower, "vsock") || strings.Contains(lower, "vhost") {
-			diag = append(diag, "module: "+strings.TrimSpace(line))
-		}
-	}
-	if len(diag) == 0 {
-		return "no diagnostic info available"
-	}
-	return strings.Join(diag, "; ")
+	return false, "VSOCK_MISSING /dev/vsock absent", nil
 }
 
 // EnsureVsockReady retries the virtio-vsock device check until /dev/vsock exists or SSH transport errors are exhausted.
@@ -66,9 +40,7 @@ func EnsureVsockReady(ctx context.Context, virt Virtctl, namespace, vm, stage st
 		if !ready {
 			return fmt.Errorf("vsock precheck before %s on %s/%s: %s", stage, namespace, vm, detail)
 		}
-		if virt.Logf != nil {
-			virt.Logf("vsock precheck before %s on %s/%s: ready", stage, namespace, vm)
-		}
+		virt.Logf("vsock precheck before %s on %s/%s: ready", stage, namespace, vm)
 		return nil
 	})
 }

--- a/tests/vmhelpers/guest.go
+++ b/tests/vmhelpers/guest.go
@@ -56,8 +56,8 @@ func collectVsockDiagnostics(ctx context.Context, virt Virtctl, namespace, vm st
 	return strings.Join(diag, "; ")
 }
 
-// ensureVsockReady retries the virtio-vsock device check until /dev/vsock exists or SSH transport errors are exhausted.
-func ensureVsockReady(ctx context.Context, virt Virtctl, namespace, vm, stage string) error {
+// EnsureVsockReady retries the virtio-vsock device check until /dev/vsock exists or SSH transport errors are exhausted.
+func EnsureVsockReady(ctx context.Context, virt Virtctl, namespace, vm, stage string) error {
 	return retryOnSSHTransport(ctx, virt.Logf, fmt.Sprintf("vsock precheck before %s", stage), func(ctx context.Context) error {
 		ready, detail, err := checkVsockReadiness(ctx, virt, namespace, vm)
 		if err != nil {

--- a/tests/vmhelpers/observability.go
+++ b/tests/vmhelpers/observability.go
@@ -1,0 +1,44 @@
+package vmhelpers
+
+// Prometheus metric names and label keys must stay aligned with product code:
+//   - compliance/virtualmachines/relay/metrics/metrics.go
+//   - sensor/common/virtualmachine/metrics/metrics.go
+
+// prometheusNamespace is the metric name prefix shared by StackRox VM-related Prometheus series in tests.
+const prometheusNamespace = "rox"
+
+// Compliance relay series (subsystem "compliance" in product metrics).
+const (
+	MetricComplianceRelayConnectionsAcceptedTotal          = prometheusNamespace + "_compliance_virtual_machine_relay_connections_accepted_total"
+	MetricComplianceRelayIndexReportsReceivedTotal         = prometheusNamespace + "_compliance_virtual_machine_relay_index_reports_received_total"
+	MetricComplianceRelayIndexReportsSentTotal             = prometheusNamespace + "_compliance_virtual_machine_relay_index_reports_sent_total"
+	MetricComplianceRelayIndexReportsMismatchingVsockTotal = prometheusNamespace + "_compliance_virtual_machine_relay_index_reports_mismatching_vsock_cid_total"
+	MetricComplianceRelaySemaphoreAcquisitionFailuresTotal = prometheusNamespace + "_compliance_virtual_machine_relay_sem_acquisition_failures_total"
+
+	MetricComplianceRelayIndexReportAcksReceivedTotal = prometheusNamespace + "_compliance_virtual_machine_relay_index_report_acks_received_total"
+)
+
+// Sensor VM index series (subsystem "sensor").
+const (
+	MetricSensorVMIndexReportsReceivedTotal          = prometheusNamespace + "_sensor_virtual_machine_index_reports_received_total"
+	MetricSensorVMIndexReportsSentTotal              = prometheusNamespace + "_sensor_virtual_machine_index_reports_sent_total"
+	MetricSensorVMIndexReportAcksReceivedTotal       = prometheusNamespace + "_sensor_virtual_machine_index_report_acks_received_total"
+	MetricSensorVMIndexReportEnqueueBlockedTotal     = prometheusNamespace + "_sensor_virtual_machine_index_report_enqueue_blocked_total"
+	MetricSensorVMIndexReportBlockingEnqueueDuration = prometheusNamespace + "_sensor_virtual_machine_index_report_blocking_enqueue_duration_milliseconds"
+	MetricSensorVMIndexReportHandlingDuration        = prometheusNamespace + "_sensor_virtual_machine_index_report_handling_duration_milliseconds"
+	MetricSensorVMIndexReportProcessingDuration      = prometheusNamespace + "_sensor_virtual_machine_index_report_processing_duration_milliseconds"
+)
+
+// Prometheus label keys used in scrape text for the above vectors (must match registration).
+const (
+	LabelFailed = "failed"
+	LabelStatus = "status"
+	LabelAction = "action"
+)
+
+// Sensor IndexReportsSent status label values from sensor/common/virtualmachine/metrics/metrics.go
+const (
+	SensorIndexReportStatusCentralNotReady = "central not ready"
+	SensorIndexReportStatusError           = "error"
+	SensorIndexReportStatusSuccess         = "success"
+)

--- a/tests/vmhelpers/observability.go
+++ b/tests/vmhelpers/observability.go
@@ -15,7 +15,7 @@ const (
 	MetricComplianceRelayIndexReportsMismatchingVsockTotal = prometheusNamespace + "_compliance_virtual_machine_relay_index_reports_mismatching_vsock_cid_total"
 	MetricComplianceRelaySemaphoreAcquisitionFailuresTotal = prometheusNamespace + "_compliance_virtual_machine_relay_sem_acquisition_failures_total"
 
-	MetricComplianceRelayIndexReportAcksReceivedTotal = prometheusNamespace + "_compliance_virtual_machine_relay_index_report_acks_received_total"
+	MetricComplianceRelayIndexReportAcksReceivedTotal = prometheusNamespace + "_compliance_virtual_machine_relay_acks_received_total"
 )
 
 // Sensor VM index series (subsystem "sensor").

--- a/tests/vmhelpers/observability_test.go
+++ b/tests/vmhelpers/observability_test.go
@@ -1,0 +1,73 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVMIndexMetricSeriesMirrorProductDefinitions(t *testing.T) {
+	require.Equal(t, "rox_compliance_virtual_machine_relay_connections_accepted_total", MetricComplianceRelayConnectionsAcceptedTotal)
+	require.Equal(t, "rox_compliance_virtual_machine_relay_index_reports_received_total", MetricComplianceRelayIndexReportsReceivedTotal)
+	require.Equal(t, "rox_compliance_virtual_machine_relay_index_reports_sent_total", MetricComplianceRelayIndexReportsSentTotal)
+	require.Equal(t, "rox_compliance_virtual_machine_relay_index_reports_mismatching_vsock_cid_total", MetricComplianceRelayIndexReportsMismatchingVsockTotal)
+	require.Equal(t, "rox_compliance_virtual_machine_relay_sem_acquisition_failures_total", MetricComplianceRelaySemaphoreAcquisitionFailuresTotal)
+
+	require.Equal(t, "rox_sensor_virtual_machine_index_reports_received_total", MetricSensorVMIndexReportsReceivedTotal)
+	require.Equal(t, "rox_sensor_virtual_machine_index_reports_sent_total", MetricSensorVMIndexReportsSentTotal)
+	require.Equal(t, "rox_sensor_virtual_machine_index_report_acks_received_total", MetricSensorVMIndexReportAcksReceivedTotal)
+	require.Equal(t, "rox_sensor_virtual_machine_index_report_enqueue_blocked_total", MetricSensorVMIndexReportEnqueueBlockedTotal)
+}
+
+func moduleRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+// TestCanonicalMetricGoSourceFilesDriftGuard reads product metric definitions and fails when
+// required names/labels disappear from source (compliance relay, sensor VM index).
+func TestCanonicalMetricGoSourceFilesDriftGuard(t *testing.T) {
+	root := moduleRepoRoot(t)
+	compliancePath := filepath.Join(root, "compliance/virtualmachines/relay/metrics/metrics.go")
+	sensorPath := filepath.Join(root, "sensor/common/virtualmachine/metrics/metrics.go")
+
+	cb, err := os.ReadFile(compliancePath)
+	require.NoError(t, err, "read %s", compliancePath)
+	compliance := string(cb)
+	for _, sub := range []string{
+		"virtual_machine_relay_connections_accepted_total",
+		"virtual_machine_relay_index_reports_received_total",
+		"virtual_machine_relay_index_reports_sent_total",
+		"virtual_machine_relay_index_reports_mismatching_vsock_cid_total",
+		"virtual_machine_relay_sem_acquisition_failures_total",
+		`[]string{"failed"}`,
+	} {
+		require.Contains(t, compliance, sub, "compliance/virtualmachines/relay/metrics/metrics.go drift: missing %q", sub)
+	}
+
+	sb, err := os.ReadFile(sensorPath)
+	require.NoError(t, err, "read %s", sensorPath)
+	sensor := string(sb)
+	for _, sub := range []string{
+		"virtual_machine_index_reports_received_total",
+		"virtual_machine_index_reports_sent_total",
+		`[]string{"status"}`,
+		`"central not ready"`,
+		"virtual_machine_index_report_acks_received_total",
+		`[]string{"action"}`,
+		"virtual_machine_index_report_enqueue_blocked_total",
+		"virtual_machine_index_report_blocking_enqueue_duration_milliseconds",
+	} {
+		require.Contains(t, sensor, sub, "sensor/common/virtualmachine/metrics/metrics.go drift: missing %q", sub)
+	}
+
+	require.Contains(t, MetricComplianceRelayConnectionsAcceptedTotal, "virtual_machine_relay_connections_accepted_total")
+	require.Contains(t, MetricSensorVMIndexReportsReceivedTotal, "virtual_machine_index_reports_received_total")
+}

--- a/tests/vmhelpers/roxagent.go
+++ b/tests/vmhelpers/roxagent.go
@@ -1,0 +1,229 @@
+package vmhelpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Guest paths for staging and installing the roxagent binary during VM tests.
+const (
+	// DefaultRoxagentInstallPath is the path used when copying and running roxagent on the guest.
+	DefaultRoxagentInstallPath = "/usr/local/bin/roxagent"
+	roxagentStagingPath        = "/tmp/roxagent"
+)
+
+// ErrTerminalVSOCKUnavailable is returned when vsock is permanently unavailable on the guest (no retry).
+var ErrTerminalVSOCKUnavailable = errors.New("terminal vsock unavailable")
+
+// RoxagentRunConfig configures a single roxagent invocation (repo2cpe URL selection and binary path).
+type RoxagentRunConfig struct {
+	Repo2CPEPrimaryURL      string
+	Repo2CPEFallbackURL     string
+	Repo2CPEPrimaryAttempts int
+	// RoxagentInstallPath may only be empty or DefaultRoxagentInstallPath. CopyRoxagentBinary and the
+	// VerifyRoxagent* helpers always use DefaultRoxagentInstallPath; RunRoxagentOnce rejects any other
+	// value so the run cannot target a path the suite never populated.
+	RoxagentInstallPath string
+	// Repo2CPEEnvVar is the environment variable name passed to roxagent (default ROXAGENT_REPO2CPE_URL).
+	Repo2CPEEnvVar string
+}
+
+// RoxagentRunResult captures stdout/stderr and whether the fallback repo2cpe URL was used.
+type RoxagentRunResult struct {
+	Stdout       string
+	Stderr       string
+	UsedFallback bool
+}
+
+// roxagentPath returns RoxagentInstallPath when set, otherwise DefaultRoxagentInstallPath.
+func roxagentPath(cfg RoxagentRunConfig) string {
+	if cfg.RoxagentInstallPath != "" {
+		return cfg.RoxagentInstallPath
+	}
+	return DefaultRoxagentInstallPath
+}
+
+// repo2cpeEnvName returns Repo2CPEEnvVar if set, otherwise ROXAGENT_REPO2CPE_URL.
+func repo2cpeEnvName(cfg RoxagentRunConfig) string {
+	if cfg.Repo2CPEEnvVar != "" {
+		return cfg.Repo2CPEEnvVar
+	}
+	return "ROXAGENT_REPO2CPE_URL"
+}
+
+// chooseRepo2CPESource returns primaryURL until attemptsMade reaches maxPrimaryAttempts, then fallbackURL.
+func chooseRepo2CPESource(attemptsMade, maxPrimaryAttempts int, primaryURL, fallbackURL string) string {
+	if attemptsMade < maxPrimaryAttempts {
+		return primaryURL
+	}
+	return fallbackURL
+}
+
+// isVsockUnavailableOutput detects terminal vsock device errors in roxagent combined output.
+func isVsockUnavailableOutput(output string) bool {
+	lower := strings.ToLower(strings.TrimSpace(output))
+	if !strings.Contains(lower, "vsock") {
+		return false
+	}
+	return strings.Contains(lower, "no such device") ||
+		strings.Contains(lower, "no such file or directory")
+}
+
+// IsTerminalVSOCKUnavailableError reports whether err wraps ErrTerminalVSOCKUnavailable.
+func IsTerminalVSOCKUnavailableError(err error) bool {
+	return errors.Is(err, ErrTerminalVSOCKUnavailable)
+}
+
+// verboseOutputHasOSFields reports whether a roxagent --verbose stdout
+// contains at least one recognised OS-detection field.
+func verboseOutputHasOSFields(stdout string) bool {
+	return strings.Contains(stdout, `"detectedOs"`) ||
+		strings.Contains(stdout, `"operatingSystem"`) ||
+		strings.Contains(stdout, `"operating_system"`)
+}
+
+// buildRoxagentInstallArgs is the remote argv for `sudo install` to place the staged binary at dst.
+func buildRoxagentInstallArgs(src, dst string) []string {
+	return []string{"sudo", "install", "-m", "0755", src, dst}
+}
+
+// VerboseOutputLooksLikeReport returns true when stdout appears to contain a known
+// structured roxagent report shape (legacy scan-shaped or indexReport-shaped JSON).
+func VerboseOutputLooksLikeReport(stdout string) bool {
+	s := strings.TrimSpace(stdout)
+	if s == "" {
+		return false
+	}
+	if strings.Contains(s, `"indexReport"`) || strings.Contains(s, `"discoveredData"`) {
+		return true
+	}
+	return strings.Contains(s, `"components"`) &&
+		(strings.Contains(s, `"scan"`) || strings.Contains(s, `"operatingSystem"`) || strings.Contains(s, `"operating_system"`))
+}
+
+// CopyRoxagentBinary copies a local roxagent binary into the guest install path.
+func CopyRoxagentBinary(ctx context.Context, virt Virtctl, namespace, vm, hostBinaryPath string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, "copy roxagent binary", func(ctx context.Context) error {
+		stderr, err := virt.SCPTo(ctx, namespace, vm, hostBinaryPath, roxagentStagingPath)
+		if err != nil {
+			return fmt.Errorf("virtctl scp roxagent: %w: %s", err, strings.TrimSpace(stderr))
+		}
+		_, stderr, err = runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "install roxagent binary",
+			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+		}, buildRoxagentInstallArgs(roxagentStagingPath, DefaultRoxagentInstallPath)...)
+		if err != nil {
+			return fmt.Errorf("install roxagent binary on guest: %w: %s", err, strings.TrimSpace(stderr))
+		}
+		_, _, _ = runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "cleanup staged roxagent binary",
+			transportRetryAttempts: 1,
+		}, "rm", "-f", roxagentStagingPath)
+		return nil
+	})
+}
+
+// VerifyRoxagentBinaryPresent checks that the roxagent file exists on the guest.
+func VerifyRoxagentBinaryPresent(ctx context.Context, virt Virtctl, namespace, vm string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, "verify roxagent presence", func(ctx context.Context) error {
+		_, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "verify roxagent presence",
+			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+		}, "test", "-f", DefaultRoxagentInstallPath)
+		if err != nil {
+			return fmt.Errorf("roxagent presence: %w: %s", err, strings.TrimSpace(stderr))
+		}
+		return nil
+	})
+}
+
+// VerifyRoxagentExecutable checks that the roxagent binary is executable.
+func VerifyRoxagentExecutable(ctx context.Context, virt Virtctl, namespace, vm string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, "verify roxagent executable", func(ctx context.Context) error {
+		_, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "verify roxagent executable",
+			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+		}, "test", "-x", DefaultRoxagentInstallPath)
+		if err != nil {
+			return fmt.Errorf("roxagent executable: %w: %s", err, strings.TrimSpace(stderr))
+		}
+		return nil
+	})
+}
+
+// VerifyRoxagentInstallPath checks that `command -v roxagent` resolves to the canonical install path.
+func VerifyRoxagentInstallPath(ctx context.Context, virt Virtctl, namespace, vm string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, "verify roxagent install path", func(ctx context.Context) error {
+		stdout, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "verify roxagent install path",
+			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+		}, "command", "-v", "roxagent")
+		if err != nil {
+			return fmt.Errorf("roxagent install path: %w: %s", err, strings.TrimSpace(stderr))
+		}
+		if got := strings.TrimSpace(stdout); got != DefaultRoxagentInstallPath {
+			return fmt.Errorf("roxagent install path: got %q, want %q", got, DefaultRoxagentInstallPath)
+		}
+		return nil
+	})
+}
+
+// RunRoxagentOnce runs roxagent on the guest. It uses Repo2CPEPrimaryURL for each attempt
+// index in [0, Repo2CPEPrimaryAttempts) (i.e. up to Repo2CPEPrimaryAttempts primary runs when that
+// count is positive), stopping as soon as one run succeeds. If all primary runs fail, it performs
+// exactly one further run using Repo2CPEFallbackURL. When Repo2CPEPrimaryAttempts is zero, the
+// first run uses the fallback URL only.
+func RunRoxagentOnce(ctx context.Context, virt Virtctl, namespace, vm string, cfg RoxagentRunConfig) (*RoxagentRunResult, error) {
+	if cfg.RoxagentInstallPath != "" && cfg.RoxagentInstallPath != DefaultRoxagentInstallPath {
+		return nil, fmt.Errorf(
+			"vmhelpers RunRoxagentOnce: RoxagentInstallPath %q is not supported (CopyRoxagentBinary and VerifyRoxagent* only use %q); omit RoxagentInstallPath or set it to DefaultRoxagentInstallPath",
+			cfg.RoxagentInstallPath, DefaultRoxagentInstallPath,
+		)
+	}
+	maxPrimary := cfg.Repo2CPEPrimaryAttempts
+	if maxPrimary < 0 {
+		maxPrimary = 0
+	}
+	bin := roxagentPath(cfg)
+	envName := repo2cpeEnvName(cfg)
+	if err := ensureVsockReady(ctx, virt, namespace, vm, "roxagent run"); err != nil {
+		return nil, err
+	}
+
+	var lastStderr string
+
+	for attempt := 0; ; attempt++ {
+		url := chooseRepo2CPESource(attempt, maxPrimary, cfg.Repo2CPEPrimaryURL, cfg.Repo2CPEFallbackURL)
+		usedFallback := url == cfg.Repo2CPEFallbackURL && cfg.Repo2CPEFallbackURL != ""
+		envAssignment := fmt.Sprintf("%s=%s", envName, url)
+
+		stdout, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
+			description:            "run roxagent --verbose",
+			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
+		}, "sudo", "env", envAssignment, bin, "--verbose")
+		lastStderr = stderr
+
+		if err == nil {
+			if !verboseOutputHasOSFields(stdout) {
+				return nil, fmt.Errorf("roxagent: verbose output OS assertion failed: no OS detection fields in output (stdout: %.200s)", strings.TrimSpace(stdout))
+			}
+			return &RoxagentRunResult{
+				Stdout:       stdout,
+				Stderr:       stderr,
+				UsedFallback: usedFallback,
+			}, nil
+		}
+		combined := strings.TrimSpace(stdout + "\n" + stderr)
+		if isVsockUnavailableOutput(combined) {
+			return nil, fmt.Errorf("%w: roxagent: no retry for vsock device error: %w (stderr: %s)",
+				ErrTerminalVSOCKUnavailable, err, strings.TrimSpace(stderr))
+		}
+
+		// attempt indices 0..maxPrimary-1 use primary; attempt maxPrimary uses fallback. Stop after fallback fails.
+		if attempt >= maxPrimary {
+			return nil, fmt.Errorf("roxagent: %w (stderr: %s)", err, strings.TrimSpace(lastStderr))
+		}
+	}
+}

--- a/tests/vmhelpers/roxagent.go
+++ b/tests/vmhelpers/roxagent.go
@@ -17,17 +17,11 @@ const (
 // ErrTerminalVSOCKUnavailable is returned when vsock is permanently unavailable on the guest (no retry).
 var ErrTerminalVSOCKUnavailable = errors.New("terminal vsock unavailable")
 
-// RoxagentRunConfig configures a single roxagent invocation (repo2cpe URL selection and binary path).
+// RoxagentRunConfig configures a single roxagent invocation (repo2cpe URL selection).
 type RoxagentRunConfig struct {
 	Repo2CPEPrimaryURL      string
 	Repo2CPEFallbackURL     string
 	Repo2CPEPrimaryAttempts int
-	// RoxagentInstallPath may only be empty or DefaultRoxagentInstallPath. CopyRoxagentBinary and the
-	// VerifyRoxagent* helpers always use DefaultRoxagentInstallPath; RunRoxagentOnce rejects any other
-	// value so the run cannot target a path the suite never populated.
-	RoxagentInstallPath string
-	// Repo2CPEEnvVar is the environment variable name passed to roxagent (default ROXAGENT_REPO2CPE_URL).
-	Repo2CPEEnvVar string
 }
 
 // RoxagentRunResult captures stdout/stderr and whether the fallback repo2cpe URL was used.
@@ -37,21 +31,8 @@ type RoxagentRunResult struct {
 	UsedFallback bool
 }
 
-// roxagentPath returns RoxagentInstallPath when set, otherwise DefaultRoxagentInstallPath.
-func roxagentPath(cfg RoxagentRunConfig) string {
-	if cfg.RoxagentInstallPath != "" {
-		return cfg.RoxagentInstallPath
-	}
-	return DefaultRoxagentInstallPath
-}
-
-// repo2cpeEnvName returns Repo2CPEEnvVar if set, otherwise ROXAGENT_REPO2CPE_URL.
-func repo2cpeEnvName(cfg RoxagentRunConfig) string {
-	if cfg.Repo2CPEEnvVar != "" {
-		return cfg.Repo2CPEEnvVar
-	}
-	return "ROXAGENT_REPO2CPE_URL"
-}
+// roxagentRepo2CPEEnvVar is the environment variable name passed to roxagent on the guest.
+const roxagentRepo2CPEEnvVar = "ROXAGENT_REPO2CPE_URL"
 
 // chooseRepo2CPESource returns primaryURL until attemptsMade reaches maxPrimaryAttempts, then fallbackURL.
 func chooseRepo2CPESource(attemptsMade, maxPrimaryAttempts int, primaryURL, fallbackURL string) string {
@@ -125,46 +106,16 @@ func CopyRoxagentBinary(ctx context.Context, virt Virtctl, namespace, vm, hostBi
 	})
 }
 
-// VerifyRoxagentBinaryPresent checks that the roxagent file exists on the guest.
-func VerifyRoxagentBinaryPresent(ctx context.Context, virt Virtctl, namespace, vm string) error {
-	return retryOnSSHTransport(ctx, virt.Logf, "verify roxagent presence", func(ctx context.Context) error {
+// VerifyRoxagentInstalled runs `roxagent --help` on the guest to confirm the binary is
+// present, executable, and resolvable in $PATH — all in a single SSH round-trip.
+func VerifyRoxagentInstalled(ctx context.Context, virt Virtctl, namespace, vm string) error {
+	return retryOnSSHTransport(ctx, virt.Logf, "verify roxagent installed", func(ctx context.Context) error {
 		_, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
-			description:            "verify roxagent presence",
+			description:            "verify roxagent installed",
 			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
-		}, "test", "-f", DefaultRoxagentInstallPath)
+		}, DefaultRoxagentInstallPath, "--help")
 		if err != nil {
-			return fmt.Errorf("roxagent presence: %w: %s", err, strings.TrimSpace(stderr))
-		}
-		return nil
-	})
-}
-
-// VerifyRoxagentExecutable checks that the roxagent binary is executable.
-func VerifyRoxagentExecutable(ctx context.Context, virt Virtctl, namespace, vm string) error {
-	return retryOnSSHTransport(ctx, virt.Logf, "verify roxagent executable", func(ctx context.Context) error {
-		_, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
-			description:            "verify roxagent executable",
-			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
-		}, "test", "-x", DefaultRoxagentInstallPath)
-		if err != nil {
-			return fmt.Errorf("roxagent executable: %w: %s", err, strings.TrimSpace(stderr))
-		}
-		return nil
-	})
-}
-
-// VerifyRoxagentInstallPath checks that `command -v roxagent` resolves to the canonical install path.
-func VerifyRoxagentInstallPath(ctx context.Context, virt Virtctl, namespace, vm string) error {
-	return retryOnSSHTransport(ctx, virt.Logf, "verify roxagent install path", func(ctx context.Context) error {
-		stdout, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
-			description:            "verify roxagent install path",
-			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
-		}, "command", "-v", "roxagent")
-		if err != nil {
-			return fmt.Errorf("roxagent install path: %w: %s", err, strings.TrimSpace(stderr))
-		}
-		if got := strings.TrimSpace(stdout); got != DefaultRoxagentInstallPath {
-			return fmt.Errorf("roxagent install path: got %q, want %q", got, DefaultRoxagentInstallPath)
+			return fmt.Errorf("roxagent --help: %w: %s", err, strings.TrimSpace(stderr))
 		}
 		return nil
 	})
@@ -176,34 +127,23 @@ func VerifyRoxagentInstallPath(ctx context.Context, virt Virtctl, namespace, vm 
 // exactly one further run using Repo2CPEFallbackURL. When Repo2CPEPrimaryAttempts is zero, the
 // first run uses the fallback URL only.
 func RunRoxagentOnce(ctx context.Context, virt Virtctl, namespace, vm string, cfg RoxagentRunConfig) (*RoxagentRunResult, error) {
-	if cfg.RoxagentInstallPath != "" && cfg.RoxagentInstallPath != DefaultRoxagentInstallPath {
-		return nil, fmt.Errorf(
-			"vmhelpers RunRoxagentOnce: RoxagentInstallPath %q is not supported (CopyRoxagentBinary and VerifyRoxagent* only use %q); omit RoxagentInstallPath or set it to DefaultRoxagentInstallPath",
-			cfg.RoxagentInstallPath, DefaultRoxagentInstallPath,
-		)
-	}
 	maxPrimary := cfg.Repo2CPEPrimaryAttempts
 	if maxPrimary < 0 {
 		maxPrimary = 0
 	}
-	bin := roxagentPath(cfg)
-	envName := repo2cpeEnvName(cfg)
 	if err := ensureVsockReady(ctx, virt, namespace, vm, "roxagent run"); err != nil {
 		return nil, err
 	}
 
-	var lastStderr string
-
 	for attempt := 0; ; attempt++ {
 		url := chooseRepo2CPESource(attempt, maxPrimary, cfg.Repo2CPEPrimaryURL, cfg.Repo2CPEFallbackURL)
 		usedFallback := url == cfg.Repo2CPEFallbackURL && cfg.Repo2CPEFallbackURL != ""
-		envAssignment := fmt.Sprintf("%s=%s", envName, url)
+		envAssignment := fmt.Sprintf("%s=%s", roxagentRepo2CPEEnvVar, url)
 
 		stdout, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
 			description:            "run roxagent --verbose",
 			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
-		}, "sudo", "env", envAssignment, bin, "--verbose")
-		lastStderr = stderr
+		}, "sudo", "env", envAssignment, DefaultRoxagentInstallPath, "--verbose")
 
 		if err == nil {
 			if !verboseOutputHasOSFields(stdout) {
@@ -223,7 +163,7 @@ func RunRoxagentOnce(ctx context.Context, virt Virtctl, namespace, vm string, cf
 
 		// attempt indices 0..maxPrimary-1 use primary; attempt maxPrimary uses fallback. Stop after fallback fails.
 		if attempt >= maxPrimary {
-			return nil, fmt.Errorf("roxagent: %w (stderr: %s)", err, strings.TrimSpace(lastStderr))
+			return nil, fmt.Errorf("roxagent: %w (stderr: %s)", err, strings.TrimSpace(stderr))
 		}
 	}
 }

--- a/tests/vmhelpers/roxagent.go
+++ b/tests/vmhelpers/roxagent.go
@@ -17,12 +17,6 @@ const (
 // ErrTerminalVSOCKUnavailable is returned when vsock is permanently unavailable on the guest (no retry).
 var ErrTerminalVSOCKUnavailable = errors.New("terminal vsock unavailable")
 
-// RoxagentRunResult captures stdout/stderr from a roxagent invocation.
-type RoxagentRunResult struct {
-	Stdout string
-	Stderr string
-}
-
 // roxagentMaxAttempts is the number of times to retry roxagent before giving up.
 const roxagentMaxAttempts = 3
 
@@ -49,11 +43,6 @@ func verboseOutputHasOSFields(stdout string) bool {
 		strings.Contains(stdout, `"operating_system"`)
 }
 
-// buildRoxagentInstallArgs is the remote argv for `sudo install` to place the staged binary at dst.
-func buildRoxagentInstallArgs(src, dst string) []string {
-	return []string{"sudo", "install", "-m", "0755", src, dst}
-}
-
 // CopyRoxagentBinary copies a local roxagent binary into the guest install path.
 func CopyRoxagentBinary(ctx context.Context, virt Virtctl, namespace, vm, hostBinaryPath string) error {
 	return retryOnSSHTransport(ctx, virt.Logf, "copy roxagent binary", func(ctx context.Context) error {
@@ -64,7 +53,7 @@ func CopyRoxagentBinary(ctx context.Context, virt Virtctl, namespace, vm, hostBi
 		_, stderr, err = runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
 			description:            "install roxagent binary",
 			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
-		}, buildRoxagentInstallArgs(roxagentStagingPath, DefaultRoxagentInstallPath)...)
+		}, "sudo", "install", "-m", "0755", roxagentStagingPath, DefaultRoxagentInstallPath)
 		if err != nil {
 			return fmt.Errorf("install roxagent binary on guest: %w: %s", err, strings.TrimSpace(stderr))
 		}
@@ -93,7 +82,7 @@ func VerifyRoxagentInstalled(ctx context.Context, virt Virtctl, namespace, vm st
 
 // RunRoxagentOnce runs roxagent on the guest with the given repo2cpe URL.
 // It retries up to roxagentMaxAttempts times before giving up.
-func RunRoxagentOnce(ctx context.Context, virt Virtctl, namespace, vm, repo2cpeURL string) (*RoxagentRunResult, error) {
+func RunRoxagentOnce(ctx context.Context, virt Virtctl, namespace, vm, repo2cpeURL string) error {
 	envAssignment := fmt.Sprintf("ROXAGENT_REPO2CPE_URL=%s", repo2cpeURL)
 
 	var lastErr error
@@ -105,22 +94,18 @@ func RunRoxagentOnce(ctx context.Context, virt Virtctl, namespace, vm, repo2cpeU
 
 		if err == nil {
 			if !verboseOutputHasOSFields(stdout) {
-				return nil, fmt.Errorf("roxagent: verbose output OS assertion failed: no OS detection fields in output (stdout: %.200s)", strings.TrimSpace(stdout))
+				return fmt.Errorf("roxagent: verbose output OS assertion failed: no OS detection fields in output (stdout: %.200s)", strings.TrimSpace(stdout))
 			}
-			return &RoxagentRunResult{
-				Stdout: stdout,
-				Stderr: stderr,
-			}, nil
+			virt.Logf("roxagent completed (%d bytes stdout, %d bytes stderr)", len(stdout), len(stderr))
+			return nil
 		}
 		combined := strings.TrimSpace(stdout + "\n" + stderr)
 		if isVsockUnavailableOutput(combined) {
-			return nil, fmt.Errorf("%w: roxagent: no retry for vsock device error: %w (stderr: %s)",
+			return fmt.Errorf("%w: roxagent: no retry for vsock device error: %w (stderr: %s)",
 				ErrTerminalVSOCKUnavailable, err, strings.TrimSpace(stderr))
 		}
 		lastErr = err
-		if virt.Logf != nil {
-			virt.Logf("roxagent attempt %d/%d failed: %v", attempt+1, roxagentMaxAttempts, err)
-		}
+		virt.Logf("roxagent attempt %d/%d failed: %v", attempt+1, roxagentMaxAttempts, err)
 	}
-	return nil, fmt.Errorf("roxagent: all %d attempts failed: %w", roxagentMaxAttempts, lastErr)
+	return fmt.Errorf("roxagent: all %d attempts failed: %w", roxagentMaxAttempts, lastErr)
 }

--- a/tests/vmhelpers/roxagent.go
+++ b/tests/vmhelpers/roxagent.go
@@ -30,11 +30,6 @@ func isVsockUnavailableOutput(output string) bool {
 		strings.Contains(lower, "no such file or directory")
 }
 
-// IsTerminalVSOCKUnavailableError reports whether err wraps ErrTerminalVSOCKUnavailable.
-func IsTerminalVSOCKUnavailableError(err error) bool {
-	return errors.Is(err, ErrTerminalVSOCKUnavailable)
-}
-
 // verboseOutputHasOSFields reports whether a roxagent --verbose stdout
 // contains at least one recognised OS-detection field.
 func verboseOutputHasOSFields(stdout string) bool {

--- a/tests/vmhelpers/roxagent.go
+++ b/tests/vmhelpers/roxagent.go
@@ -17,30 +17,14 @@ const (
 // ErrTerminalVSOCKUnavailable is returned when vsock is permanently unavailable on the guest (no retry).
 var ErrTerminalVSOCKUnavailable = errors.New("terminal vsock unavailable")
 
-// RoxagentRunConfig configures a single roxagent invocation (repo2cpe URL selection).
-type RoxagentRunConfig struct {
-	Repo2CPEPrimaryURL      string
-	Repo2CPEFallbackURL     string
-	Repo2CPEPrimaryAttempts int
-}
-
-// RoxagentRunResult captures stdout/stderr and whether the fallback repo2cpe URL was used.
+// RoxagentRunResult captures stdout/stderr from a roxagent invocation.
 type RoxagentRunResult struct {
-	Stdout       string
-	Stderr       string
-	UsedFallback bool
+	Stdout string
+	Stderr string
 }
 
-// roxagentRepo2CPEEnvVar is the environment variable name passed to roxagent on the guest.
-const roxagentRepo2CPEEnvVar = "ROXAGENT_REPO2CPE_URL"
-
-// chooseRepo2CPESource returns primaryURL until attemptsMade reaches maxPrimaryAttempts, then fallbackURL.
-func chooseRepo2CPESource(attemptsMade, maxPrimaryAttempts int, primaryURL, fallbackURL string) string {
-	if attemptsMade < maxPrimaryAttempts {
-		return primaryURL
-	}
-	return fallbackURL
-}
+// roxagentMaxAttempts is the number of times to retry roxagent before giving up.
+const roxagentMaxAttempts = 3
 
 // isVsockUnavailableOutput detects terminal vsock device errors in roxagent combined output.
 func isVsockUnavailableOutput(output string) bool {
@@ -121,24 +105,13 @@ func VerifyRoxagentInstalled(ctx context.Context, virt Virtctl, namespace, vm st
 	})
 }
 
-// RunRoxagentOnce runs roxagent on the guest. It uses Repo2CPEPrimaryURL for each attempt
-// index in [0, Repo2CPEPrimaryAttempts) (i.e. up to Repo2CPEPrimaryAttempts primary runs when that
-// count is positive), stopping as soon as one run succeeds. If all primary runs fail, it performs
-// exactly one further run using Repo2CPEFallbackURL. When Repo2CPEPrimaryAttempts is zero, the
-// first run uses the fallback URL only.
-func RunRoxagentOnce(ctx context.Context, virt Virtctl, namespace, vm string, cfg RoxagentRunConfig) (*RoxagentRunResult, error) {
-	maxPrimary := cfg.Repo2CPEPrimaryAttempts
-	if maxPrimary < 0 {
-		maxPrimary = 0
-	}
-	for attempt := 0; ; attempt++ {
-		if attempt >= maxPrimary && cfg.Repo2CPEFallbackURL == "" {
-			return nil, fmt.Errorf("roxagent: all %d primary attempt(s) failed and no fallback URL configured", maxPrimary)
-		}
-		url := chooseRepo2CPESource(attempt, maxPrimary, cfg.Repo2CPEPrimaryURL, cfg.Repo2CPEFallbackURL)
-		usedFallback := url == cfg.Repo2CPEFallbackURL && cfg.Repo2CPEFallbackURL != ""
-		envAssignment := fmt.Sprintf("%s=%s", roxagentRepo2CPEEnvVar, url)
+// RunRoxagentOnce runs roxagent on the guest with the given repo2cpe URL.
+// It retries up to roxagentMaxAttempts times before giving up.
+func RunRoxagentOnce(ctx context.Context, virt Virtctl, namespace, vm, repo2cpeURL string) (*RoxagentRunResult, error) {
+	envAssignment := fmt.Sprintf("ROXAGENT_REPO2CPE_URL=%s", repo2cpeURL)
 
+	var lastErr error
+	for attempt := range roxagentMaxAttempts {
 		stdout, stderr, err := runSSHCommandWithFramework(ctx, virt, namespace, vm, sshCommandRunOptions{
 			description:            "run roxagent --verbose",
 			transportRetryAttempts: rhsmPrecheckSSHRetryThreshold,
@@ -149,9 +122,8 @@ func RunRoxagentOnce(ctx context.Context, virt Virtctl, namespace, vm string, cf
 				return nil, fmt.Errorf("roxagent: verbose output OS assertion failed: no OS detection fields in output (stdout: %.200s)", strings.TrimSpace(stdout))
 			}
 			return &RoxagentRunResult{
-				Stdout:       stdout,
-				Stderr:       stderr,
-				UsedFallback: usedFallback,
+				Stdout: stdout,
+				Stderr: stderr,
 			}, nil
 		}
 		combined := strings.TrimSpace(stdout + "\n" + stderr)
@@ -159,10 +131,10 @@ func RunRoxagentOnce(ctx context.Context, virt Virtctl, namespace, vm string, cf
 			return nil, fmt.Errorf("%w: roxagent: no retry for vsock device error: %w (stderr: %s)",
 				ErrTerminalVSOCKUnavailable, err, strings.TrimSpace(stderr))
 		}
-
-		// attempt indices 0..maxPrimary-1 use primary; attempt maxPrimary uses fallback. Stop after fallback fails.
-		if attempt >= maxPrimary {
-			return nil, fmt.Errorf("roxagent: %w (stderr: %s)", err, strings.TrimSpace(stderr))
+		lastErr = err
+		if virt.Logf != nil {
+			virt.Logf("roxagent attempt %d/%d failed: %v", attempt+1, roxagentMaxAttempts, err)
 		}
 	}
+	return nil, fmt.Errorf("roxagent: all %d attempts failed: %w", roxagentMaxAttempts, lastErr)
 }

--- a/tests/vmhelpers/roxagent.go
+++ b/tests/vmhelpers/roxagent.go
@@ -54,20 +54,6 @@ func buildRoxagentInstallArgs(src, dst string) []string {
 	return []string{"sudo", "install", "-m", "0755", src, dst}
 }
 
-// VerboseOutputLooksLikeReport returns true when stdout appears to contain a known
-// structured roxagent report shape (legacy scan-shaped or indexReport-shaped JSON).
-func VerboseOutputLooksLikeReport(stdout string) bool {
-	s := strings.TrimSpace(stdout)
-	if s == "" {
-		return false
-	}
-	if strings.Contains(s, `"indexReport"`) || strings.Contains(s, `"discoveredData"`) {
-		return true
-	}
-	return strings.Contains(s, `"components"`) &&
-		(strings.Contains(s, `"scan"`) || strings.Contains(s, `"operatingSystem"`) || strings.Contains(s, `"operating_system"`))
-}
-
 // CopyRoxagentBinary copies a local roxagent binary into the guest install path.
 func CopyRoxagentBinary(ctx context.Context, virt Virtctl, namespace, vm, hostBinaryPath string) error {
 	return retryOnSSHTransport(ctx, virt.Logf, "copy roxagent binary", func(ctx context.Context) error {

--- a/tests/vmhelpers/roxagent.go
+++ b/tests/vmhelpers/roxagent.go
@@ -131,11 +131,10 @@ func RunRoxagentOnce(ctx context.Context, virt Virtctl, namespace, vm string, cf
 	if maxPrimary < 0 {
 		maxPrimary = 0
 	}
-	if err := ensureVsockReady(ctx, virt, namespace, vm, "roxagent run"); err != nil {
-		return nil, err
-	}
-
 	for attempt := 0; ; attempt++ {
+		if attempt >= maxPrimary && cfg.Repo2CPEFallbackURL == "" {
+			return nil, fmt.Errorf("roxagent: all %d primary attempt(s) failed and no fallback URL configured", maxPrimary)
+		}
 		url := chooseRepo2CPESource(attempt, maxPrimary, cfg.Repo2CPEPrimaryURL, cfg.Repo2CPEFallbackURL)
 		usedFallback := url == cfg.Repo2CPEFallbackURL && cfg.Repo2CPEFallbackURL != ""
 		envAssignment := fmt.Sprintf("%s=%s", roxagentRepo2CPEEnvVar, url)

--- a/tests/vmhelpers/roxagent_test.go
+++ b/tests/vmhelpers/roxagent_test.go
@@ -1,0 +1,131 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChooseRepo2CPESource(t *testing.T) {
+	t.Parallel()
+	primary := "https://remote/repo2cpe.json"
+	fallback := "file:///var/lib/rox/repo2cpe.json"
+	cases := map[string]struct {
+		attemptsMade, maxPrimary int
+		want                     string
+	}{
+		"zero attempts uses primary when budget positive":  {0, 5, primary},
+		"mid range still primary":                          {2, 5, primary},
+		"last primary slot before boundary":                {4, 5, primary},
+		"boundary falls back when attemptsMade equals max": {5, 5, fallback},
+		"plan boundary three of three":                     {3, 3, fallback},
+		"zero max immediate fallback on first index":       {0, 0, fallback},
+		"after boundary stays fallback":                    {10, 3, fallback},
+		"single primary slot then fallback":                {1, 1, fallback},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := chooseRepo2CPESource(tc.attemptsMade, tc.maxPrimary, primary, fallback)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRunRoxagentOnce_RejectsUnsupportedInstallPath(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	_, err := RunRoxagentOnce(ctx, Virtctl{}, "ns", "vm", RoxagentRunConfig{
+		RoxagentInstallPath: "/opt/roxagent",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not supported")
+	require.Contains(t, err.Error(), "/opt/roxagent")
+}
+
+func TestVerboseOutputHasOSFields(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		stdout string
+		want   bool
+	}{
+		"detectedOs key":       {`{"detectedOs":"rhel:9"}`, true},
+		"operatingSystem key":  {`{"operatingSystem":"rhel"}`, true},
+		"operating_system key": {`{"operating_system":"rhel"}`, true},
+		"no OS keys":           {`{"components":["rpm"]}`, false},
+		"empty":                {``, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, verboseOutputHasOSFields(tc.stdout))
+		})
+	}
+}
+
+func TestVerboseOutputLooksLikeReport_FalseForQuietOutput(t *testing.T) {
+	t.Parallel()
+	require.False(t, VerboseOutputLooksLikeReport("done"))
+}
+
+func TestVerboseOutputLooksLikeReport_TrueForSampleReportJSON(t *testing.T) {
+	t.Parallel()
+	sample := `{"scan":{"operatingSystem":"rhel"},"components":[{"name":"a"}]}`
+	require.True(t, VerboseOutputLooksLikeReport(sample))
+}
+
+func TestVerboseOutputLooksLikeReport_TrueForIndexReportJSON(t *testing.T) {
+	t.Parallel()
+	sample := `{"indexReport":{"state":"IndexFinished"},"discoveredData":{"operatingSystem":{"name":"rhel"}}}`
+	require.True(t, VerboseOutputLooksLikeReport(sample))
+}
+
+func TestBuildRoxagentInstallArgs_UsesSudoInstallModeAndPaths(t *testing.T) {
+	t.Parallel()
+	require.Equal(t,
+		[]string{"sudo", "install", "-m", "0755", "/tmp/roxagent", "/usr/local/bin/roxagent"},
+		buildRoxagentInstallArgs("/tmp/roxagent", "/usr/local/bin/roxagent"),
+	)
+}
+
+func TestIsVsockUnavailableOutput(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		output string
+		want   bool
+	}{
+		"vsock no such device": {
+			output: "dial vsock host(2):818: connect: no such device",
+			want:   true,
+		},
+		"dev vsock missing": {
+			output: "open /dev/vsock: no such file or directory",
+			want:   true,
+		},
+		"non-vsock no such device": {
+			output: "open /dev/does-not-exist: no such device",
+			want:   false,
+		},
+		"other vsock error is retryable": {
+			output: "dial vsock host(2):818: connection refused",
+			want:   false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isVsockUnavailableOutput(tc.output))
+		})
+	}
+}
+
+func TestIsTerminalVSOCKUnavailableError(t *testing.T) {
+	t.Parallel()
+
+	terminalErr := errors.Join(ErrTerminalVSOCKUnavailable, errors.New("exit status 1"))
+	require.True(t, IsTerminalVSOCKUnavailableError(terminalErr))
+	require.False(t, IsTerminalVSOCKUnavailableError(errors.New("other error")))
+}

--- a/tests/vmhelpers/roxagent_test.go
+++ b/tests/vmhelpers/roxagent_test.go
@@ -35,17 +35,6 @@ func TestChooseRepo2CPESource(t *testing.T) {
 	}
 }
 
-func TestRunRoxagentOnce_RejectsUnsupportedInstallPath(t *testing.T) {
-	t.Parallel()
-	ctx := t.Context()
-	_, err := RunRoxagentOnce(ctx, Virtctl{}, "ns", "vm", RoxagentRunConfig{
-		RoxagentInstallPath: "/opt/roxagent",
-	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not supported")
-	require.Contains(t, err.Error(), "/opt/roxagent")
-}
-
 func TestVerboseOutputHasOSFields(t *testing.T) {
 	t.Parallel()
 	cases := map[string]struct {

--- a/tests/vmhelpers/roxagent_test.go
+++ b/tests/vmhelpers/roxagent_test.go
@@ -3,7 +3,6 @@
 package vmhelpers
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,12 +57,4 @@ func TestIsVsockUnavailableOutput(t *testing.T) {
 			require.Equal(t, tc.want, isVsockUnavailableOutput(tc.output))
 		})
 	}
-}
-
-func TestIsTerminalVSOCKUnavailableError(t *testing.T) {
-	t.Parallel()
-
-	terminalErr := errors.Join(ErrTerminalVSOCKUnavailable, errors.New("exit status 1"))
-	require.True(t, IsTerminalVSOCKUnavailableError(terminalErr))
-	require.False(t, IsTerminalVSOCKUnavailableError(errors.New("other error")))
 }

--- a/tests/vmhelpers/roxagent_test.go
+++ b/tests/vmhelpers/roxagent_test.go
@@ -29,23 +29,6 @@ func TestVerboseOutputHasOSFields(t *testing.T) {
 	}
 }
 
-func TestVerboseOutputLooksLikeReport_FalseForQuietOutput(t *testing.T) {
-	t.Parallel()
-	require.False(t, VerboseOutputLooksLikeReport("done"))
-}
-
-func TestVerboseOutputLooksLikeReport_TrueForSampleReportJSON(t *testing.T) {
-	t.Parallel()
-	sample := `{"scan":{"operatingSystem":"rhel"},"components":[{"name":"a"}]}`
-	require.True(t, VerboseOutputLooksLikeReport(sample))
-}
-
-func TestVerboseOutputLooksLikeReport_TrueForIndexReportJSON(t *testing.T) {
-	t.Parallel()
-	sample := `{"indexReport":{"state":"IndexFinished"},"discoveredData":{"operatingSystem":{"name":"rhel"}}}`
-	require.True(t, VerboseOutputLooksLikeReport(sample))
-}
-
 func TestBuildRoxagentInstallArgs_UsesSudoInstallModeAndPaths(t *testing.T) {
 	t.Parallel()
 	require.Equal(t,

--- a/tests/vmhelpers/roxagent_test.go
+++ b/tests/vmhelpers/roxagent_test.go
@@ -29,14 +29,6 @@ func TestVerboseOutputHasOSFields(t *testing.T) {
 	}
 }
 
-func TestBuildRoxagentInstallArgs_UsesSudoInstallModeAndPaths(t *testing.T) {
-	t.Parallel()
-	require.Equal(t,
-		[]string{"sudo", "install", "-m", "0755", "/tmp/roxagent", "/usr/local/bin/roxagent"},
-		buildRoxagentInstallArgs("/tmp/roxagent", "/usr/local/bin/roxagent"),
-	)
-}
-
 func TestIsVsockUnavailableOutput(t *testing.T) {
 	t.Parallel()
 	tests := map[string]struct {

--- a/tests/vmhelpers/roxagent_test.go
+++ b/tests/vmhelpers/roxagent_test.go
@@ -9,32 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestChooseRepo2CPESource(t *testing.T) {
-	t.Parallel()
-	primary := "https://remote/repo2cpe.json"
-	fallback := "file:///var/lib/rox/repo2cpe.json"
-	cases := map[string]struct {
-		attemptsMade, maxPrimary int
-		want                     string
-	}{
-		"zero attempts uses primary when budget positive":  {0, 5, primary},
-		"mid range still primary":                          {2, 5, primary},
-		"last primary slot before boundary":                {4, 5, primary},
-		"boundary falls back when attemptsMade equals max": {5, 5, fallback},
-		"plan boundary three of three":                     {3, 3, fallback},
-		"zero max immediate fallback on first index":       {0, 0, fallback},
-		"after boundary stays fallback":                    {10, 3, fallback},
-		"single primary slot then fallback":                {1, 1, fallback},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			got := chooseRepo2CPESource(tc.attemptsMade, tc.maxPrimary, primary, fallback)
-			require.Equal(t, tc.want, got)
-		})
-	}
-}
-
 func TestVerboseOutputHasOSFields(t *testing.T) {
 	t.Parallel()
 	cases := map[string]struct {

--- a/tests/vmhelpers/ssh_command_framework.go
+++ b/tests/vmhelpers/ssh_command_framework.go
@@ -147,7 +147,7 @@ func runSSHCommandWithFramework(ctx context.Context, virt Virtctl, namespace, vm
 		}
 
 		virt.Logf("%s on %s/%s: retryable SSH %s condition (attempt %d/%d): %s",
-			description, namespace, vm, category, attempt, attempts, formatGuestCommandOutputForError(stderr))
+			description, namespace, vm, category, attempt, attempts, FormatGuestCommandOutputForError(stderr))
 
 		select {
 		case <-ctx.Done():

--- a/tests/vmhelpers/wait.go
+++ b/tests/vmhelpers/wait.go
@@ -1,14 +1,15 @@
 package vmhelpers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // Shared poll-loop logging constants used by both VM and guest SSH wait helpers.
@@ -60,5 +61,71 @@ func IsAuthenticationExpired(err error) bool {
 	if s, ok := status.FromError(err); ok && s.Code() == codes.Unauthenticated {
 		return true
 	}
-	return apierrors.IsUnauthorized(err)
+	msg := err.Error()
+	return strings.Contains(msg, "Unauthorized") || strings.Contains(msg, "the server has asked for the client to provide credentials")
+}
+
+// WaitOptions configures a single-condition poll loop used by Central wait helpers.
+type WaitOptions struct {
+	Timeout      time.Duration
+	PollInterval time.Duration
+	// Logf, when set, is called on each unsuccessful poll with the condition
+	// description and current detail so operators can follow progress in real time.
+	Logf func(string, ...any)
+}
+
+// validateWaitOptions returns an error if Timeout or PollInterval are non-positive.
+func validateWaitOptions(desc string, opts WaitOptions) error {
+	if opts.Timeout <= 0 {
+		return fmt.Errorf("vmhelpers: %s: WaitOptions.Timeout must be positive", desc)
+	}
+	if opts.PollInterval <= 0 {
+		return fmt.Errorf("vmhelpers: %s: WaitOptions.PollInterval must be positive", desc)
+	}
+	return nil
+}
+
+// pollUntil runs poll until it returns done==true or ctx deadline/opts.Timeout elapses.
+// detail is included in timeout errors for targeted diagnostics.
+func pollUntil(ctx context.Context, opts WaitOptions, desc string, poll func(ctx context.Context) (done bool, detail string, err error)) error {
+	if err := validateWaitOptions(desc, opts); err != nil {
+		return err
+	}
+	deadline := time.Now().Add(opts.Timeout)
+	var lastDetail string
+	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("vmhelpers: %s: %w", desc, err)
+		}
+		done, detail, err := poll(ctx)
+		if detail != "" {
+			lastDetail = detail
+		}
+		if err != nil {
+			if IsAuthenticationExpired(err) {
+				return fmt.Errorf("vmhelpers: %s: %w: %v", desc, ErrAuthenticationExpired, err)
+			}
+			return fmt.Errorf("vmhelpers: %s: %w", desc, err)
+		}
+		if done {
+			if opts.Logf != nil && detail != "" {
+				opts.Logf("poll %s: done (%s)", desc, detail)
+			}
+			return nil
+		}
+		if opts.Logf != nil && detail != "" {
+			opts.Logf("poll %s: waiting (%s)", desc, detail)
+		}
+		if time.Now().After(deadline) {
+			if lastDetail != "" {
+				return fmt.Errorf("vmhelpers: timeout waiting for %s after %v (last detail: %s)", desc, opts.Timeout, lastDetail)
+			}
+			return fmt.Errorf("vmhelpers: timeout waiting for %s after %v", desc, opts.Timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("vmhelpers: %s: %w", desc, ctx.Err())
+		case <-time.After(opts.PollInterval):
+		}
+	}
 }

--- a/tests/vmhelpers/wait.go
+++ b/tests/vmhelpers/wait.go
@@ -61,8 +61,8 @@ func IsAuthenticationExpired(err error) bool {
 	if s, ok := status.FromError(err); ok && s.Code() == codes.Unauthenticated {
 		return true
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "Unauthorized") || strings.Contains(msg, "the server has asked for the client to provide credentials")
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unauthorized") || strings.Contains(msg, "the server has asked for the client to provide credentials")
 }
 
 // WaitOptions configures a single-condition poll loop used by Central wait helpers.

--- a/tests/vmhelpers/wait_test.go
+++ b/tests/vmhelpers/wait_test.go
@@ -1,0 +1,56 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPollUntil_ImmediateSuccess(t *testing.T) {
+	ctx := context.Background()
+	err := pollUntil(ctx, WaitOptions{
+		Timeout:      100 * time.Millisecond,
+		PollInterval: 1 * time.Millisecond,
+	}, "immediate", func(context.Context) (bool, string, error) {
+		return true, "ok", nil
+	})
+	require.NoError(t, err)
+}
+
+func TestPollUntil_SucceedsAfterRetries(t *testing.T) {
+	ctx := context.Background()
+	var polls int
+	err := pollUntil(ctx, WaitOptions{
+		Timeout:      300 * time.Millisecond,
+		PollInterval: 5 * time.Millisecond,
+	}, "retry-test", func(context.Context) (bool, string, error) {
+		polls++
+		return polls >= 3, "stepping", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, polls)
+}
+
+func TestPollUntil_TimesOutWithDetail(t *testing.T) {
+	ctx := context.Background()
+	err := pollUntil(ctx, WaitOptions{
+		Timeout:      30 * time.Millisecond,
+		PollInterval: 5 * time.Millisecond,
+	}, "timeout-test", func(context.Context) (bool, string, error) {
+		return false, "still waiting", nil
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timeout")
+	require.Contains(t, err.Error(), "still waiting")
+}
+
+func TestPollUntil_RejectsInvalidOptions(t *testing.T) {
+	ctx := context.Background()
+	err := pollUntil(ctx, WaitOptions{Timeout: -1, PollInterval: 1 * time.Millisecond}, "bad", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Timeout must be positive")
+}

--- a/tests/vmhelpers/wait_test.go
+++ b/tests/vmhelpers/wait_test.go
@@ -4,10 +4,14 @@ package vmhelpers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestPollUntil_ImmediateSuccess(t *testing.T) {
@@ -53,4 +57,25 @@ func TestPollUntil_RejectsInvalidOptions(t *testing.T) {
 	err := pollUntil(ctx, WaitOptions{Timeout: -1, PollInterval: 1 * time.Millisecond}, "bad", nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Timeout must be positive")
+}
+
+func TestIsAuthenticationExpired(t *testing.T) {
+	tests := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil error":                        {err: nil, want: false},
+		"gRPC Unauthenticated":             {err: status.Error(codes.Unauthenticated, "token expired"), want: true},
+		"Unauthorized substring":           {err: errors.New("request failed: Unauthorized 401"), want: true},
+		"lowercase unauthorized":           {err: errors.New("unauthorized access"), want: true},
+		"server asked for credentials":     {err: errors.New("the server has asked for the client to provide credentials"), want: true},
+		"wrapped ErrAuthenticationExpired": {err: fmt.Errorf("op: %w", ErrAuthenticationExpired), want: true},
+		"unrelated error":                  {err: errors.New("connection refused"), want: false},
+		"gRPC unavailable (not auth)":      {err: status.Error(codes.Unavailable, "service down"), want: false},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, IsAuthenticationExpired(tc.err))
+		})
+	}
 }

--- a/tests/vmhelpers/wait_test.go
+++ b/tests/vmhelpers/wait_test.go
@@ -38,8 +38,8 @@ func TestPollUntil_SucceedsAfterRetries(t *testing.T) {
 func TestPollUntil_TimesOutWithDetail(t *testing.T) {
 	ctx := context.Background()
 	err := pollUntil(ctx, WaitOptions{
-		Timeout:      30 * time.Millisecond,
-		PollInterval: 5 * time.Millisecond,
+		Timeout:      150 * time.Millisecond,
+		PollInterval: 15 * time.Millisecond,
 	}, "timeout-test", func(context.Context) (bool, string, error) {
 		return false, "still waiting", nil
 	})


### PR DESCRIPTION
## Description

Add an end-to-end VM scanning test workflow for OpenShift/KubeVirt and wire it into CI.

This branch is a synthetic combination of the split:
- #20213  (merged)
- #20127  (merged)
- #20128 
- and #20129 

It was created to make sure that the changes in the split branches have not diverted from the original all-in-one branch.


THIS WON'T BE MERGED! I use it to run e2e tests only. Instead, I intend the following branches to be merged: #20213  #20127 #20218 and #20129.


### Bird-eye view of the e2e VM tests (includes all branches)

```mermaid
graph TD
    subgraph Tm1["t₋₁ — CI Pipeline: Deploy ACS"]
        direction LR
        D1["Remove existing<br/>StackRox resources"] --> D2["Setup TLS certs"] --> D3["Deploy StackRox<br/>(Central, Sensor,<br/>Scanner, Collector)"] --> D4["Download virtctl"]
    end

    subgraph T0["t₀ — Configuration"]
        direction LR
        C1["Load test config<br/>from environment"] --> C2["Create K8s clients<br/><i>(REST + dynamic)</i>"] --> C3["Connect to Central<br/><i>(gRPC)</i>"]
    end

    subgraph T1["t₁ — Cluster Preflight"]
        direction LR
        P1["Verify cluster has nodes<br/>capable of running VMs<br/><i>(K8s API: node capacity)</i>"] --> P2["Verify VM scanning<br/>feature flag enabled on<br/>Central, Sensor, Compliance<br/><i>(K8s API: read env vars<br/>from Deployment/DaemonSet)</i>"] --> P3["Verify VSOCK relay<br/>is operational<br/><i>(K8s API: KubeVirt CR<br/>+ virt-handler pods)</i>"]
    end

    subgraph T2["t₂ — VM Provisioning"]
        direction LR
        V1["Create isolated<br/>test namespace<br/><i>(K8s API)</i>"] --> V2["Setup image<br/>pull credentials<br/><i>(K8s API: Secret + SA)</i>"] --> V3["Create KubeVirt VM(s)<br/>with cloud-init<br/>and SSH key<br/><i>(K8s API: dynamic client)</i>"] --> V4["Wait until VM<br/>is booted and running<br/><i>(K8s API: poll VMI status)</i>"]
    end

    subgraph T3["t₃ — Guest Preparation (per VM)"]
        direction LR
        G1["Wait until guest<br/>accepts SSH<br/><i>(virtctl ssh probe)</i>"] --> G2["Wait for cloud-init<br/>to finish inside guest<br/><i>(SSH: cloud-init status)</i>"] --> G3["Verify passwordless<br/>sudo works<br/><i>(SSH: sudo -n true)</i>"] --> G4["Copy roxagent<br/>binary into guest<br/><i>(virtctl scp)</i>"] --> G5["Verify roxagent is<br/>installed and executable<br/><i>(SSH: stat + permissions)</i>"]
    end

    T3 -. "── above: PR #20127 (Preflight & VM Bootstrap) ──<br/>── below: PR #20128 (Scan Pipeline Validation) ──" .-> T4

    subgraph T4["t₄ — Trigger First Scan"]
        direction LR
        S1["Wait for Scanner V4<br/>vulnerability DB<br/>to be loaded<br/><i>(Central gRPC:<br/>GetVulnDefinitionsInfo)</i>"] --> S2["Trigger scan:<br/>run roxagent on guest<br/>(collects packages,<br/>sends via VSOCK)<br/><i>(SSH: sudo roxagent)</i>"] --> S3["If primary repo2cpe<br/>mapping fails, retry<br/>with fallback URL<br/><i>(SSH: retry with new env)</i>"] --> S4["Verify roxagent<br/>did not crash<br/><i>(check stderr)</i>"] --> S5["Verify roxagent output<br/>looks like a valid<br/>scan report<br/><i>(check stdout shape)</i>"]
    end

    subgraph T5["t₅ — Wait for Scan Results in Central"]
        direction LR
        W1["Wait until Central<br/>knows about the VM<br/><i>(gRPC: ListVMs)</i>"] --> W2["Wait until Central<br/>has VM identity<br/><i>(gRPC: GetVM)</i>"] --> W3["Wait until Central<br/>reports VM as Running<br/><i>(gRPC: GetVM state)</i>"] --> W4["Wait until Central<br/>has scan data attached<br/><i>(gRPC: GetVM scan)</i>"] --> W5["Wait until scan<br/>has a timestamp<br/><i>(gRPC: GetVM scan_time)</i>"] --> W6["Wait until all<br/>components are<br/>successfully scanned<br/><i>(gRPC: GetVM components)</i>"]
    end

    subgraph T6["t₆ — Verify VM Visible in Central with Correct Metadata"]
        direction LR
        A1["VM is discoverable<br/>via List API<br/>by namespace+name<br/><i>(gRPC: ListVMs)</i>"] --> A2["VM identity matches:<br/>name, namespace,<br/>cluster ID, cluster name<br/><i>(gRPC: GetVM)</i>"] --> A3["VM lifecycle state<br/>is RUNNING<br/><i>(gRPC: GetVM)</i>"] --> A4["Scan result is attached<br/>with a valid timestamp<br/><i>(gRPC: GetVM)</i>"]
    end

    subgraph T7["t₇ — Verify Scan Content is Complete"]
        direction LR
        B1["Scanned components<br/>list is non-empty<br/>(packages were found)<br/><i>(gRPC: GetVM scan)</i>"] --> B2["No component is marked<br/>as UNSCANNED<br/>(all were processed)<br/><i>(gRPC: GetVM scan)</i>"] --> B3["Operating system detected<br/>(populated by Sensor<br/>from guest metadata)<br/><i>(gRPC: GetVM scan)</i>"]
    end

    subgraph T8["t₈ — Rescan and Verify Idempotency"]
        direction LR
        R1["Record timestamp<br/>of first scan<br/><i>(gRPC: GetVM)</i>"] --> R2["Trigger rescan:<br/>run roxagent again<br/><i>(SSH: sudo roxagent)</i>"] --> R3["Verify roxagent<br/>did not crash<br/><i>(check stderr)</i>"] --> R4["Wait until Central shows<br/>a newer scan timestamp<br/>than the first scan<br/><i>(gRPC: poll GetVM)</i>"] --> R5["Verify VM identity<br/>is stable: same ID<br/>across rescans<br/><i>(gRPC: GetVM)</i>"]
    end

    T8 -. "── above: PR #20128 (Scan Pipeline Validation) ──<br/>── below: PR #20129 (Metrics Assertions) ──" .-> T9

    subgraph T9["t₉ — Verify Scan Pipeline Metrics"]
        direction LR
        M1["Query Prometheus for<br/>scan-started events<br/><i>(Prometheus API)</i>"] --> M2["Query Prometheus for<br/>scan-completed events<br/><i>(Prometheus API)</i>"] --> M3["Verify counters<br/>incremented for both<br/>initial scan and rescan<br/><i>(Prometheus API)</i>"]
    end

    T9 -. "── above: PR #20129 (Metrics Assertions) ──<br/>── below: shared suite teardown ──" .-> T10

    subgraph T10["t₁₀ — Teardown"]
        direction LR
        TD1["Delete test VMs<br/><i>(K8s API: dynamic client)</i>"] --> TD2["Delete test namespace<br/><i>(K8s API)</i>"] --> TD3["Close Central<br/>connection<br/><i>(gRPC close)</i>"]
    end

    Tm1 --> T0 --> T1 --> T2 --> T3
    T4 --> T5 --> T6 --> T7 --> T8

```