### PR TITLE
ROX-32433: Use 'ID' instead of 'SHA' for flat data

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -173,7 +173,7 @@ function ImagePage({
     // Create a scoped search filter that includes the image SHA filter plus any applied search filters.
     const imageScopedSearchFilterForReport = {
         ...baseSearchFilter,
-        'Image SHA': [imageId],
+        ...(isNewImageDataModelEnabled ? { 'Image ID': [imageId] } : { 'Image SHA': [imageId] }),
         ...querySearchFilter,
         'Vulnerability State': [vulnerabilityState],
     };

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePageVulnerabilities.tsx
@@ -325,7 +325,9 @@ function ImagePageVulnerabilities({
                         trackAppliedFilter(WORKLOAD_CVE_FILTER_APPLIED, searchPayload);
                     }}
                     additionalContextFilter={{
-                        'Image SHA': imageId,
+                        ...(isNewImageDataModelEnabled
+                            ? { 'Image ID': imageId }
+                            : { 'Image SHA': imageId }),
                         ...baseSearchFilter,
                     }}
                 >


### PR DESCRIPTION
## Description

When ROX_FLATTEN_IMAGE_DATA is `true`, API requests need to use `Image ID` instead of `Image SHA`. This fixes the inconsistency in:
1. Image page autocomplete results
2. Image page CSV report exports

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Manual test with flag disabled - no change.

Manual test with flag enabled:
<img width="1665" height="1103" alt="image" src="https://github.com/user-attachments/assets/2dcc47fe-18b6-400f-b440-763f1e780692" />

Verify correct parameter is sent when generating CSV report:
<img width="1665" height="1103" alt="image" src="https://github.com/user-attachments/assets/11657c6b-1fbe-400b-80a3-5128a85e568a" />

With the flag change, CVE results are sent in the report, without the change, an empty report is generated.
