### PR TITLE
ci: Run backup/restore e2e test in GHA

### DIFF
--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -99,6 +99,7 @@ jobs:
     - uses: stackrox/actions/infra/install-infractl@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/infra/install-infractl@v1
 
     - name: Build roxctl
+      # The test uses roxctl for central backup/restore operations
       run: |
         make roxctl_linux-amd64
         echo "$(pwd)/bin/linux_amd64" >> "$GITHUB_PATH"

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -61,6 +61,7 @@ jobs:
       CLUSTER_NAME: e2e-dbbr-${{ github.run_id }}-${{ github.run_attempt }}
       CI_JOB_NAME: gke-db-backup-restore-test
       ARTIFACT_DIR: ./junit-reports/
+      LOAD_BALANCER: lb
     timeout-minutes: 60
     steps:
 
@@ -131,7 +132,6 @@ jobs:
         QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
         REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
         REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
-        LOAD_BALANCER: lb
         ORCHESTRATOR_FLAVOR: k8s
       run: |
         source tests/e2e/lib.sh
@@ -140,6 +140,8 @@ jobs:
         export_test_environment
         setup_deployment_env false false
         deploy_stackrox
+        # Persist API_ENDPOINT for post-test steps (ci_export only sets it in this shell)
+        echo "API_ENDPOINT=${API_ENDPOINT}" >> "$GITHUB_ENV"
         db_backup_and_restore_test /tmp/db-backup-restore-test
 
     - name: Run post-test

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -1,0 +1,194 @@
+name: e2e-db-backup-restore-test
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+    - '*'
+    branches:
+    - master
+    - release-*
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - labeled
+    - synchronize
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  wait-for-images:
+    if: >-
+      !github.event.pull_request.head.repo.fork && (
+        github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'e2e-db-backup-restore-test')
+      )
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+    - name: Get image tag
+      id: get-tag
+      run: echo "tag=${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}" | tee -a "$GITHUB_ENV"
+    - name: Wait for images
+      uses: stackrox/actions/release/wait-for-image@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/wait-for-image@v1
+      with:
+        token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
+        image: |
+          rhacs-eng/main:${{ env.tag }}
+          rhacs-eng/central-db:${{ env.tag }}
+          rhacs-eng/roxctl:${{ env.tag }}
+          rhacs-eng/scanner-v4:${{ env.tag }}
+          rhacs-eng/scanner-v4-db:${{ env.tag }}
+          rhacs-eng/collector:${{ env.tag }}
+
+  gke-db-backup-restore-test:
+    needs: [ wait-for-images ]
+    if: >-
+      !github.event.pull_request.head.repo.fork && (
+        github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'e2e-db-backup-restore-test')
+      )
+    runs-on: ubuntu-latest
+    env:
+      USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
+      INFRA_TOKEN: ${{ secrets.INFRA_TOKEN }}
+      CLUSTER_NAME: e2e-dbbr-${{ github.run_id }}-${{ github.run_attempt }}
+      CI_JOB_NAME: gke-db-backup-restore-test
+      ARTIFACT_DIR: ./junit-reports/
+    container:
+      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
+      volumes:
+      - /usr:/mnt/usr
+      - /opt:/mnt/opt
+    timeout-minutes: 60
+    steps:
+
+    - name: Checkout repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    - uses: ./.github/actions/job-preamble
+      with:
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
+    - name: Trigger test cluster creation
+      uses: stackrox/actions/infra/create-cluster@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/infra/create-cluster@v1
+      with:
+        token: ${{ secrets.INFRA_TOKEN }}
+        flavor: gke-default
+        name: ${{ env.CLUSTER_NAME }}
+        lifespan: 1h
+        args: nodes=3,machine-type=e2-standard-8
+        wait: false
+
+    - name: Docker login to Quay.io
+      env:
+        REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+        REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+      run: docker login -u "${REGISTRY_USERNAME}" --password-stdin quay.io <<<"${REGISTRY_PASSWORD}"
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
+      with:
+        install_components: "gke-gcloud-auth-plugin"
+
+    - name: Build roxctl
+      run: |
+        make roxctl_linux-amd64
+        echo "$(pwd)/bin/linux_amd64" >> "$GITHUB_PATH"
+
+    - name: Wait for the cluster and grab artifacts
+      timeout-minutes: 25
+      run: |
+        infractl wait "${CLUSTER_NAME}"
+        infractl artifacts "${CLUSTER_NAME}" --download-dir artifacts > /dev/null
+        echo "KUBECONFIG=$(pwd)/artifacts/kubeconfig" >> "$GITHUB_ENV"
+
+    - name: Verify kubectl access
+      run: |
+        kubectl cluster-info
+        kubectl get nodes
+
+    - name: Run pre-test
+      shell: python
+      env:
+        QUAY_RHACS_ENG_BEARER_TOKEN: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
+        PYTHONUNBUFFERED: "1"
+      run: |
+        import sys
+        sys.path.append('.openshift-ci')
+        from pre_tests import PreSystemTests
+        PreSystemTests().run()
+
+    - name: Deploy StackRox and run DB backup/restore test
+      env:
+        QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+        QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+        REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+        REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+        LOAD_BALANCER: lb
+        ORCHESTRATOR_FLAVOR: k8s
+      run: |
+        source tests/e2e/lib.sh
+        source tests/scripts/setup-certs.sh
+        source scripts/ci/sensor-wait.sh
+        export_test_environment
+        setup_deployment_env false false
+        deploy_stackrox
+        db_backup_and_restore_test /tmp/db-backup-restore-test
+
+    - name: Run post-test
+      if: always()
+      shell: python
+      env:
+        PYTHONUNBUFFERED: "1"
+      run: |
+        import sys
+        sys.path.append('.openshift-ci')
+        from post_tests import CheckStackroxLogs
+        CheckStackroxLogs(
+            check_for_errors_in_stackrox_logs=True,
+            artifact_destination_prefix="db-test",
+        ).run(['/tmp/db-backup-restore-test', '${{ env.ARTIFACT_DIR }}'])
+
+    - name: Run final-post
+      if: always()
+      shell: python
+      env:
+        PYTHONUNBUFFERED: "1"
+      run: |
+        import sys
+        sys.path.append('.openshift-ci')
+        from post_tests import FinalPost
+        FinalPost(store_qa_tests_data=False).run()
+
+    - name: Delete cluster
+      if: always()
+      run: infractl delete "${CLUSTER_NAME}" || echo "infractl delete failed or cluster not found; relying on lifespan expiry"
+
+    - name: Publish test summary
+      uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # ratchet:test-summary/action@v2
+      if: always()
+      with:
+        paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
+        show: all
+
+    - name: Report junit failures in jira
+      if: (!cancelled())
+      id: junit2jira
+      uses: ./.github/actions/junit2jira
+      with:
+        create-jiras: ${{ github.event_name == 'push' }}
+        jira-user: ${{ secrets.JIRA_USER }}
+        jira-token: ${{ secrets.JIRA_TOKEN }}
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+        directory: ${{ env.ARTIFACT_DIR }}

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -43,7 +43,6 @@ jobs:
         image: |
           rhacs-eng/main:${{ env.tag }}
           rhacs-eng/central-db:${{ env.tag }}
-          rhacs-eng/roxctl:${{ env.tag }}
           rhacs-eng/scanner-v4:${{ env.tag }}
           rhacs-eng/scanner-v4-db:${{ env.tag }}
           rhacs-eng/collector:${{ env.tag }}
@@ -62,11 +61,6 @@ jobs:
       CLUSTER_NAME: e2e-dbbr-${{ github.run_id }}-${{ github.run_attempt }}
       CI_JOB_NAME: gke-db-backup-restore-test
       ARTIFACT_DIR: ./junit-reports/
-    container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
-      volumes:
-      - /usr:/mnt/usr
-      - /opt:/mnt/opt
     timeout-minutes: 60
     steps:
 
@@ -100,6 +94,8 @@ jobs:
       uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
       with:
         install_components: "gke-gcloud-auth-plugin"
+
+    - uses: stackrox/actions/infra/install-infractl@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/infra/install-infractl@v1
 
     - name: Build roxctl
       run: |

--- a/qa-tests-backend/scripts/lib.sh
+++ b/qa-tests-backend/scripts/lib.sh
@@ -46,6 +46,11 @@ surface_spec_logs() {
         return
     fi
 
+    if ! is_OPENSHIFT_CI; then
+        info "This is not OpenShiftCI, no need to create HTML summary for spec logs."
+        return
+    fi
+
     if [[ ! -d "${ARTIFACT_DIR}/spec-logs" ]]; then
         info "No spec-logs stored"
         return

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1657,7 +1657,7 @@ store_test_results() {
         return
     fi
     if [[ -z "${ARTIFACT_DIR:-}" ]]; then
-        >&2 echo "WARNING: ARTIFACT_DIR is not set, skipping store_test_results"
+        warn "ARTIFACT_DIR is not set, skipping store_test_results"
         return
     fi
 

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -173,9 +173,11 @@ process_central_metrics() {
 
     local output_dir="$1"
 
+    local base_link
     local metrics_output
     local csv_output
     local debug_dump_zip
+    base_link="$(get_base_link)"
     metrics_output="$(mktemp --suffix=.prom)"
     csv_output="$(mktemp --suffix=.csv)"
     # shellcheck disable=SC2012
@@ -184,12 +186,7 @@ process_central_metrics() {
 
     get_prometheus_metrics_parser
 
-    # We need a link to repository. In case it's not part of job spec (e.g., periodic`s)
-    # we will fallback to short commit
-    base_link="$(echo "$JOB_SPEC" | jq ".refs.base_link | select( . != null )" -r)"
-    calculated_base_link="https://github.com/stackrox/stackrox/commit/$(make --quiet --no-print-directory shortcommit)"
-
-    local metadata="build_tag=${STACKROX_BUILD_TAG:-none},build_id=${BUILD_ID:-none},orchestrator_flavor=${ORCHESTRATOR_FLAVOR:-PROW},job_name=${JOB_NAME:-missing},base_link=${base_link:-$calculated_base_link}"
+    local metadata="build_tag=${STACKROX_BUILD_TAG:-none},build_id=${BUILD_ID:-none},orchestrator_flavor=${ORCHESTRATOR_FLAVOR:-PROW},job_name=${JOB_NAME:-missing},base_link=${base_link}"
     prometheus-metric-parser single \
         --format csv \
         --file "${metrics_output}" \
@@ -971,7 +968,7 @@ populate_stackrox_image_list() {
     local image_list="$1"
 
     local tag
-    tag="$(make --quiet --no-print-directory tag)"
+    tag="${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}"
     local operator_metadata_tag
     operator_metadata_tag="$(echo "v${tag}" | sed 's,x,0,')"
     local operator_controller_tag="${tag//x/0}"
@@ -1630,7 +1627,7 @@ handle_nightly_binary_version_mismatch() {
 }
 
 store_qa_test_results() {
-    if ! is_OPENSHIFT_CI; then
+    if ! is_CI; then
         return
     fi
 
@@ -1656,7 +1653,11 @@ store_test_results() {
         die "missing args. usage: store_test_results <from> <to>"
     fi
 
-    if ! is_OPENSHIFT_CI; then
+    if ! is_CI; then
+        return
+    fi
+    if [[ -z "${ARTIFACT_DIR:-}" ]]; then
+        >&2 echo "WARNING: ARTIFACT_DIR is not set, skipping store_test_results"
         return
     fi
 
@@ -1691,7 +1692,6 @@ post_process_test_results() {
     local csv_output
     local extra_args=()
     local base_link
-    local calculated_base_link
     local create_jiras
     local jira_project="ROX"
     local prow_job_link
@@ -1727,14 +1727,11 @@ post_process_test_results() {
         fi
 
         csv_output="$(mktemp --suffix=.csv)"
-        # We need a link to repository. In case it's not part of job spec (e.g., periodic`s)
-        # we will fallback to short commit
-        base_link="$(echo "$JOB_SPEC" | jq ".refs.base_link | select( . != null )" -r)"
-        calculated_base_link="https://github.com/stackrox/stackrox/commit/$(make --quiet --no-print-directory shortcommit)"
+        base_link="$(get_base_link)"
         curl --retry 5 --retry-connrefused -SsfL https://github.com/stackrox/junit2jira/releases/download/v0.0.27/junit2jira -o junit2jira && \
         chmod +x junit2jira && \
         ./junit2jira \
-            -base-link "${base_link:-$calculated_base_link}" \
+            -base-link "${base_link}" \
             -build-id "${BUILD_ID}" \
             -build-link "${prow_job_link}" \
             -build-tag "${STACKROX_BUILD_TAG}" \
@@ -1753,6 +1750,19 @@ post_process_test_results() {
         save_test_metrics "${csv_output}"
     } || true
     set -u
+}
+
+get_base_link() {
+    # We need a link to repository. In case it's not part of job spec (e.g., periodic`s)
+    # we will fallback to short commit
+    local base_link=""
+    if [[ "${JOB_SPEC:-}" ]]; then
+        base_link="$(echo "$JOB_SPEC" | jq ".refs.base_link | select( . != null )" -r)"
+    fi
+    if [[ -z "${base_link}" ]]; then
+        base_link="https://github.com/stackrox/stackrox/commit/$(make --quiet --no-print-directory shortcommit)"
+    fi
+    echo "${base_link}"
 }
 
 gate_flaky_tests() {

--- a/scripts/ci/store-artifacts.sh
+++ b/scripts/ci/store-artifacts.sh
@@ -105,6 +105,10 @@ set_gs_path_vars() {
         WORKFLOW_SUBDIR="${repo}/${workflow_id}"
         JOB_SUBDIR="${BUILD_ID}-${JOB_NAME}"
         GS_JOB_URL="${GS_URL}/${WORKFLOW_SUBDIR}/${JOB_SUBDIR}"
+    elif is_GITHUB_ACTIONS; then
+        WORKFLOW_SUBDIR="${GITHUB_REPOSITORY}/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        JOB_SUBDIR="${GITHUB_JOB}"
+        GS_JOB_URL="${GS_URL}/${WORKFLOW_SUBDIR}/${JOB_SUBDIR}"
     else
         die "Support is missing for this CI environment"
     fi
@@ -140,52 +144,92 @@ make_artifacts_help() {
     if is_OPENSHIFT_CI; then
         require_environment "ARTIFACT_DIR"
         help_file="$ARTIFACT_DIR/howto-locate-other-artifacts-summary.html"
+
+        cat > "$help_file" <<- EOH
+            <html>
+            <head>
+            <title>Additional StackRox e2e artifacts</title>
+            <style>
+              body { color: #e8e8e8; background-color: #424242; font-family: "Roboto", "Helvetica", "Arial", sans-serif }
+              a { color: #ff8caa }
+              a:visited { color: #ff8caa }
+            </style>
+            </head>
+            <body>
+
+            Additional StackRox e2e artifacts are stored in a GCS bucket (<code>$GS_URL</code>) by the
+            <code>store_artifacts</code> bash function.<br>
+
+            There are at least two options for access:
+
+            <h2>Option 1: gcloud storage cp</h2>
+
+            Copy all artifacts for the build/job:
+            <pre>gcloud storage cp -r $gs_job_url .</pre>
+
+            or copy all artifacts for the entire workflow:
+            <pre>gcloud storage cp -r $gs_workflow_url .</pre>
+
+            Then browse files locally.
+
+            <h2>Option 2: Browse using the Google cloud UI</h2>
+
+            <p>Make sure to use the URL where <code>authuser</code> corresponds to your @redhat.com account.<br>
+            You can check this by clicking on the user avatar in the top right corner of Google Cloud Console page
+            after following the link.</p>
+
+            <a target="_blank" href="$browser_job_url?authuser=0">authuser=0</a><br>
+            <a target="_blank" href="$browser_job_url?authuser=1">authuser=1</a><br>
+            <a target="_blank" href="$browser_job_url?authuser=2">authuser=2</a><br>
+
+            <br><br>
+
+            </body>
+            </html>
+EOH
+    elif is_GITHUB_ACTIONS; then
+        (
+            export GS_URL
+            export gs_job_url
+            export gs_workflow_url
+            export browser_job_url
+            echo '
+# Additional StackRox e2e artifacts
+
+Additional StackRox e2e artifacts are stored in a GCS bucket (`$GS_URL`) by the
+`store_artifacts` bash function.
+
+There are at least two options for access:
+
+## Option 1: gcloud storage cp
+
+Copy all artifacts for the build/job:
+```bash
+gcloud storage cp -r $gs_job_url .
+```
+
+or copy all artifacts for the entire workflow:
+```bash
+gcloud storage cp -r $gs_workflow_url .
+```
+
+Then browse files locally.
+
+## Option 2: Browse using the Google cloud UI
+
+Make sure to use the URL where `authuser` corresponds to your @redhat.com account.
+
+You can check this by clicking on the user avatar in the top right corner of Google Cloud Console page
+after following the link.
+
+* [authuser=0](${browser_job_url}?authuser=0)
+* [authuser=1](${browser_job_url}?authuser=1)
+* [authuser=2](${browser_job_url}?authuser=2)
+            ' | envsubst | tee -a "${GITHUB_STEP_SUMMARY}"
+        )
     else
         die "This is an unsupported environment"
     fi
-
-    cat > "$help_file" <<- EOH
-        <html>
-        <head>
-        <title>Additional StackRox e2e artifacts</title>
-        <style>
-          body { color: #e8e8e8; background-color: #424242; font-family: "Roboto", "Helvetica", "Arial", sans-serif }
-          a { color: #ff8caa }
-          a:visited { color: #ff8caa }
-        </style>
-        </head>
-        <body>
-
-        Additional StackRox e2e artifacts are stored in a GCS bucket (<code>$GS_URL</code>) by the
-        <code>store_artifacts</code> bash function.<br>
-
-        There are at least two options for access:
-
-        <h2>Option 1: gcloud storage cp</h2>
-
-        Copy all artifacts for the build/job:
-        <pre>gcloud storage cp -r $gs_job_url .</pre>
-
-        or copy all artifacts for the entire workflow:
-        <pre>gcloud storage cp -r $gs_workflow_url .</pre>
-
-        Then browse files locally.
-
-        <h2>Option 2: Browse using the Google cloud UI</h2>
-
-        <p>Make sure to use the URL where <code>authuser</code> corresponds to your @redhat.com account.<br>
-        You can check this by clicking on the user avatar in the top right corner of Google Cloud Console page
-        after following the link.</p>
-
-        <a target="_blank" href="$browser_job_url?authuser=0">authuser=0</a><br>
-        <a target="_blank" href="$browser_job_url?authuser=1">authuser=1</a><br>
-        <a target="_blank" href="$browser_job_url?authuser=2">authuser=2</a><br>
-
-        <br><br>
-
-        </body>
-        </html>
-EOH
 
     info "Artifacts are stored in a GCS bucket ($GS_URL)"
 }

--- a/tests/scripts/setup-certs.sh
+++ b/tests/scripts/setup-certs.sh
@@ -38,7 +38,7 @@ keyUsage = critical, digitalSignature, cRLSign, keyCertSign
   basicConstraints=CA:TRUE,pathlen:1
   "
     # Root CA
-    openssl req -quiet -nodes -config <(echo "$root_ca_exts") -new -x509 -keyout ca.key -out ca.crt -subj "/CN=Root ${ca_name}"
+    openssl req -nodes -config <(echo "$root_ca_exts") -new -x509 -keyout ca.key -out ca.crt -subj "/CN=Root ${ca_name}"
 
     # Intermediate CA
     openssl genrsa -out intermediate.key 4096


### PR DESCRIPTION
## Description

Adds a new GitHub Actions workflow for running the DB backup/restore E2E test on GKE, and fixes several CI helper scripts to work correctly in GitHub Actions environments (not just OpenShift CI/Prow).

The DB backup/restore E2E test currently runs across multiple cluster flavors (GKE, OCP, OSD, AKS, EKS, ARO, ROSA) via Prow/OpenShift CI. This PR adds a standalone GHA workflow for the GKE flavor as a first step toward migrating E2E tests to GHA. Existing Prow configurations are intentionally left in place. The workflow triggers on pushes to `master`/`release-*` branches, tags, and PRs (when labeled with `e2e-db-backup-restore-test`).

Key CI helper fixes for GHA compatibility:
- `scripts/ci/lib.sh`: Extracted `get_base_link()` helper to handle `JOB_SPEC` being absent in GHA. Changed `store_qa_test_results` and `store_test_results` guards from `is_OPENSHIFT_CI` to `is_CI` so they work in any CI environment. Used `MAIN_IMAGE_TAG` env var fallback in `populate_stackrox_image_list`.
- `scripts/ci/store-artifacts.sh`: Added GHA support to `set_gs_path_vars()` using `GITHUB_REPOSITORY`, `GITHUB_RUN_ID`, `GITHUB_RUN_ATTEMPT`, and `GITHUB_JOB`. Added GHA-specific markdown artifact summary output in `make_artifacts_help()` using `GITHUB_STEP_SUMMARY`.
- `qa-tests-backend/scripts/lib.sh`: Skip HTML spec-log summary generation when not running in OpenShift CI.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

The new GHA workflow will be validated by triggering it on this PR (add the `e2e-db-backup-restore-test` label).