### PR TITLE
ROX-34023: Implement init container extraction in Sensor

### DIFF
--- a/pkg/containers/filter.go
+++ b/pkg/containers/filter.go
@@ -1,0 +1,15 @@
+package containers
+
+import "github.com/stackrox/rox/generated/storage"
+
+// FilterRegularContainers returns only the containers with type REGULAR,
+// filtering out init and ephemeral containers.
+func FilterRegularContainers(containers []*storage.Container) []*storage.Container {
+	regular := make([]*storage.Container, 0, len(containers))
+	for _, c := range containers {
+		if c.GetType() == storage.ContainerType_REGULAR {
+			regular = append(regular, c)
+		}
+	}
+	return regular
+}

--- a/pkg/protoconv/resources/resources.go
+++ b/pkg/protoconv/resources/resources.go
@@ -8,6 +8,7 @@ import (
 	openshiftAppsV1 "github.com/openshift/api/apps/v1"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	imageUtils "github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/logging"
@@ -293,21 +294,39 @@ func (w *DeploymentWrap) populateTolerations(podSpec v1.PodSpec) {
 }
 
 func (w *DeploymentWrap) populateContainers(podSpec v1.PodSpec) {
-	w.Deployment.Containers = make([]*storage.Container, 0, len(podSpec.Containers))
+	allK8sContainers := make([]v1.Container, 0, len(podSpec.InitContainers)+len(podSpec.Containers))
+	w.Deployment.Containers = make([]*storage.Container, 0, len(podSpec.InitContainers)+len(podSpec.Containers))
+
+	if features.InitContainerSupport.Enabled() {
+		for _, c := range podSpec.InitContainers {
+			w.Deployment.Containers = append(w.Deployment.Containers, &storage.Container{
+				Id:   fmt.Sprintf("%s:%s", w.Deployment.GetId(), c.Name),
+				Name: c.Name,
+				Type: storage.ContainerType_INIT,
+			})
+			allK8sContainers = append(allK8sContainers, c)
+		}
+	}
+
 	for _, c := range podSpec.Containers {
 		w.Deployment.Containers = append(w.Deployment.Containers, &storage.Container{
 			Id:   fmt.Sprintf("%s:%s", w.Deployment.GetId(), c.Name),
 			Name: c.Name,
+			Type: storage.ContainerType_REGULAR,
 		})
+		allK8sContainers = append(allK8sContainers, c)
 	}
 
-	w.populateContainerConfigs(podSpec)
-	w.populateImages(podSpec)
-	w.populateSecurityContext(podSpec)
-	w.populateVolumesAndSecrets(podSpec)
-	w.populatePorts(podSpec)
-	w.populateResources(podSpec)
-	w.populateProbes(podSpec)
+	// combinedSpec aligns podSpec.Containers with w.Deployment.Containers for the index-based helpers.
+	combinedSpec := podSpec
+	combinedSpec.Containers = allK8sContainers
+	w.populateContainerConfigs(combinedSpec)
+	w.populateImages(combinedSpec)
+	w.populateSecurityContext(combinedSpec)
+	w.populateVolumesAndSecrets(combinedSpec)
+	w.populatePorts(combinedSpec)
+	w.populateResources(combinedSpec)
+	w.populateProbes(combinedSpec)
 }
 
 func (w *DeploymentWrap) populateServiceAccount(podSpec v1.PodSpec) {

--- a/pkg/protoconv/resources/resources.go
+++ b/pkg/protoconv/resources/resources.go
@@ -294,8 +294,12 @@ func (w *DeploymentWrap) populateTolerations(podSpec v1.PodSpec) {
 }
 
 func (w *DeploymentWrap) populateContainers(podSpec v1.PodSpec) {
-	allK8sContainers := make([]v1.Container, 0, len(podSpec.InitContainers)+len(podSpec.Containers))
-	w.Deployment.Containers = make([]*storage.Container, 0, len(podSpec.InitContainers)+len(podSpec.Containers))
+	containerCount := len(podSpec.Containers)
+	if features.InitContainerSupport.Enabled() {
+		containerCount += len(podSpec.InitContainers)
+	}
+	allK8sContainers := make([]v1.Container, 0, containerCount)
+	w.Deployment.Containers = make([]*storage.Container, 0, containerCount)
 
 	if features.InitContainerSupport.Enabled() {
 		for _, c := range podSpec.InitContainers {

--- a/pkg/protoconv/resources/resources_test.go
+++ b/pkg/protoconv/resources/resources_test.go
@@ -7,9 +7,12 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/kubernetes"
 	"github.com/stackrox/rox/pkg/protoconv/resources/volumes"
+	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsV1 "k8s.io/api/apps/v1"
 	appsV1beta2 "k8s.io/api/apps/v1beta2"
 	batchV1 "k8s.io/api/batch/v1"
@@ -393,4 +396,106 @@ func TestSecurityContext(t *testing.T) {
 			assert.Equal(t, testCase.result, actualAllowPrivilegeEscalationValue)
 		})
 	}
+}
+
+func TestPopulateContainersInitContainerExtraction(t *testing.T) {
+	type expectedContainer struct {
+		name          string
+		containerType storage.ContainerType
+		imageSubstr   string
+	}
+
+	cases := map[string]struct {
+		flagEnabled bool
+		expected    []expectedContainer
+	}{
+		"flag enabled extracts init and regular containers": {
+			flagEnabled: true,
+			expected: []expectedContainer{
+				{name: "init-setup", containerType: storage.ContainerType_INIT, imageSubstr: "busybox"},
+				{name: "nginx", containerType: storage.ContainerType_REGULAR, imageSubstr: "nginx"},
+				{name: "redis", containerType: storage.ContainerType_REGULAR, imageSubstr: "redis"},
+			},
+		},
+		"flag disabled ignores init containers": {
+			flagEnabled: false,
+			expected: []expectedContainer{
+				{name: "nginx", containerType: storage.ContainerType_REGULAR, imageSubstr: "nginx"},
+				{name: "redis", containerType: storage.ContainerType_REGULAR, imageSubstr: "redis"},
+			},
+		},
+	}
+
+	podSpec := v1.PodSpec{
+		InitContainers: []v1.Container{
+			{Name: "init-setup", Image: "busybox:latest", Command: []string{"sh", "-c", "echo init"}},
+		},
+		Containers: []v1.Container{
+			{Name: "nginx", Image: "nginx:latest"},
+			{Name: "redis", Image: "redis:latest"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			testutils.MustUpdateFeature(t, features.InitContainerSupport, tc.flagEnabled)
+
+			wrap := &DeploymentWrap{
+				Deployment: &storage.Deployment{Id: "test-deploy"},
+			}
+			wrap.populateContainers(podSpec)
+
+			require.Len(t, wrap.GetContainers(), len(tc.expected))
+			for i, exp := range tc.expected {
+				assert.Equal(t, exp.name, wrap.GetContainers()[i].GetName())
+				assert.Equal(t, exp.containerType, wrap.GetContainers()[i].GetType())
+				assert.Contains(t, wrap.GetContainers()[i].GetImage().GetName().GetFullName(), exp.imageSubstr)
+			}
+		})
+	}
+}
+
+func TestPopulateContainersInitContainerFieldsPopulated(t *testing.T) {
+	testutils.MustUpdateFeature(t, features.InitContainerSupport, true)
+
+	wrap := &DeploymentWrap{
+		Deployment: &storage.Deployment{Id: "test-deploy"},
+	}
+
+	podSpec := v1.PodSpec{
+		InitContainers: []v1.Container{
+			{
+				Name:    "init-setup",
+				Image:   "busybox:latest",
+				Command: []string{"sh", "-c", "echo init"},
+				Args:    []string{"arg1"},
+				SecurityContext: &v1.SecurityContext{
+					Privileged: boolPtr(true),
+				},
+				LivenessProbe: &v1.Probe{TimeoutSeconds: 5},
+			},
+		},
+		Containers: []v1.Container{
+			{
+				Name:  "nginx",
+				Image: "nginx:latest",
+			},
+		},
+	}
+
+	wrap.populateContainers(podSpec)
+
+	require.Len(t, wrap.GetContainers(), 2)
+
+	initContainer := wrap.GetContainers()[0]
+	assert.Equal(t, "init-setup", initContainer.GetName())
+	assert.Equal(t, storage.ContainerType_INIT, initContainer.GetType())
+	assert.Equal(t, []string{"sh", "-c", "echo init"}, initContainer.GetConfig().GetCommand())
+	assert.Equal(t, []string{"arg1"}, initContainer.GetConfig().GetArgs())
+	assert.True(t, initContainer.GetSecurityContext().GetPrivileged())
+	assert.True(t, initContainer.GetLivenessProbe().GetDefined())
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/containers"
 	"github.com/stackrox/rox/pkg/dedupingqueue"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
@@ -243,7 +244,7 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 func toEvent(action central.ResourceAction, deployment *storage.Deployment, timing *central.Timing) *central.SensorEvent {
 	dep := deployment.CloneVT()
 	if !centralcaps.Has(centralsensor.InitContainerSupport) {
-		dep.Containers = filterRegularContainers(dep.GetContainers())
+		dep.Containers = containers.FilterRegularContainers(dep.GetContainers())
 	}
 	return &central.SensorEvent{
 		Id:     dep.GetId(),
@@ -253,16 +254,6 @@ func toEvent(action central.ResourceAction, deployment *storage.Deployment, timi
 			Deployment: dep,
 		},
 	}
-}
-
-func filterRegularContainers(containers []*storage.Container) []*storage.Container {
-	regular := make([]*storage.Container, 0, len(containers))
-	for _, c := range containers {
-		if c.GetType() == storage.ContainerType_REGULAR {
-			regular = append(regular, c)
-		}
-	}
-	return regular
 }
 
 var _ component.Resolver = (*resolverImpl)(nil)

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -7,11 +7,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/dedupingqueue"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/metrics"
 	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/store"
@@ -239,14 +241,28 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 }
 
 func toEvent(action central.ResourceAction, deployment *storage.Deployment, timing *central.Timing) *central.SensorEvent {
+	dep := deployment.CloneVT()
+	if !centralcaps.Has(centralsensor.InitContainerSupport) {
+		dep.Containers = filterRegularContainers(dep.GetContainers())
+	}
 	return &central.SensorEvent{
-		Id:     deployment.GetId(),
+		Id:     dep.GetId(),
 		Action: action,
 		Timing: timing,
 		Resource: &central.SensorEvent_Deployment{
-			Deployment: deployment.CloneVT(),
+			Deployment: dep,
 		},
 	}
+}
+
+func filterRegularContainers(containers []*storage.Container) []*storage.Container {
+	regular := make([]*storage.Container, 0, len(containers))
+	for _, c := range containers {
+		if c.GetType() == storage.ContainerType_REGULAR {
+			regular = append(regular, c)
+		}
+	}
+	return regular
 }
 
 var _ component.Resolver = (*resolverImpl)(nil)

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -7,10 +7,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/clusterentities"
 	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/registry"
@@ -483,6 +485,44 @@ func (s *resolverSuite) Test_Send_ForwardedMessagesAreSent() {
 				messageReceived.Wait()
 			})
 		}
+	}
+}
+
+func (s *resolverSuite) Test_ToEvent_InitContainerFiltering() {
+	cases := map[string]struct {
+		caps               []centralsensor.CentralCapability
+		expectedContainers []string
+	}{
+		"filters init containers when Central lacks capability": {
+			caps:               []centralsensor.CentralCapability{},
+			expectedContainers: []string{"main-app"},
+		},
+		"includes init containers when Central has capability": {
+			caps:               []centralsensor.CentralCapability{centralsensor.InitContainerSupport},
+			expectedContainers: []string{"init-setup", "main-app"},
+		},
+	}
+
+	for name, tc := range cases {
+		s.Run(name, func() {
+			centralcaps.Set(tc.caps)
+			s.T().Cleanup(func() { centralcaps.Set(nil) })
+
+			deployment := &storage.Deployment{
+				Id: "test-deploy",
+				Containers: []*storage.Container{
+					{Name: "init-setup", Type: storage.ContainerType_INIT},
+					{Name: "main-app", Type: storage.ContainerType_REGULAR},
+				},
+			}
+
+			event := toEvent(central.ResourceAction_CREATE_RESOURCE, deployment, nil)
+			dep := event.GetDeployment()
+			s.Require().Len(dep.GetContainers(), len(tc.expectedContainers))
+			for i, name := range tc.expectedContainers {
+				s.Assert().Equal(name, dep.GetContainers()[i].GetName())
+			}
+		})
 	}
 }
 

--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -328,18 +328,29 @@ func (w *deploymentWrap) populateImageMetadata(localImages set.StringSet, pods .
 	// Determine each image's ID, if not already populated, as well as if the image is pullable and/or cluster-local.
 	for _, p := range pods {
 		// Build a map from container name to pod spec container for name-based lookup.
-		specContainersByName := make(map[string]v1.Container, len(p.Spec.Containers)+len(p.Spec.InitContainers))
+		mapSize := len(p.Spec.Containers)
+		statusCount := len(p.Status.ContainerStatuses)
+		if features.InitContainerSupport.Enabled() {
+			mapSize += len(p.Spec.InitContainers)
+			statusCount += len(p.Status.InitContainerStatuses)
+		}
+
+		specContainersByName := make(map[string]v1.Container, mapSize)
 		for _, sc := range p.Spec.Containers {
 			specContainersByName[sc.Name] = sc
 		}
-		for _, sc := range p.Spec.InitContainers {
-			specContainersByName[sc.Name] = sc
+		if features.InitContainerSupport.Enabled() {
+			for _, sc := range p.Spec.InitContainers {
+				specContainersByName[sc.Name] = sc
+			}
 		}
 
 		// Process both regular and init container statuses.
-		allStatuses := make([]v1.ContainerStatus, 0, len(p.Status.ContainerStatuses)+len(p.Status.InitContainerStatuses))
+		allStatuses := make([]v1.ContainerStatus, 0, statusCount)
 		allStatuses = append(allStatuses, p.Status.ContainerStatuses...)
-		allStatuses = append(allStatuses, p.Status.InitContainerStatuses...)
+		if features.InitContainerSupport.Enabled() {
+			allStatuses = append(allStatuses, p.Status.InitContainerStatuses...)
+		}
 
 		for _, c := range allStatuses {
 			deployContainer, found := containersByName[c.Name]

--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackrox/hashstructure"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/containers"
 	"github.com/stackrox/rox/pkg/features"
 	imageUtils "github.com/stackrox/rox/pkg/images/utils"
@@ -20,6 +21,7 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/common/service"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/references"
 	"github.com/stackrox/rox/sensor/kubernetes/orchestratornamespaces"
@@ -326,12 +328,20 @@ func (w *deploymentWrap) populateImageMetadata(localImages set.StringSet, pods .
 	// Determine each image's ID, if not already populated, as well as if the image is pullable and/or cluster-local.
 	for _, p := range pods {
 		// Build a map from container name to pod spec container for name-based lookup.
-		specContainersByName := make(map[string]v1.Container, len(p.Spec.Containers))
+		specContainersByName := make(map[string]v1.Container, len(p.Spec.Containers)+len(p.Spec.InitContainers))
 		for _, sc := range p.Spec.Containers {
 			specContainersByName[sc.Name] = sc
 		}
+		for _, sc := range p.Spec.InitContainers {
+			specContainersByName[sc.Name] = sc
+		}
 
-		for _, c := range p.Status.ContainerStatuses {
+		// Process both regular and init container statuses.
+		allStatuses := make([]v1.ContainerStatus, 0, len(p.Status.ContainerStatuses)+len(p.Status.InitContainerStatuses))
+		allStatuses = append(allStatuses, p.Status.ContainerStatuses...)
+		allStatuses = append(allStatuses, p.Status.InitContainerStatuses...)
+
+		for _, c := range allStatuses {
 			deployContainer, found := containersByName[c.Name]
 			if !found {
 				log.Debugf("Skipping container status %q with no matching deployment container for deploy %q, pod %q", c.Name, w.GetDeployment().GetName(), p.GetName())
@@ -481,13 +491,28 @@ func (w *deploymentWrap) toEvent(action central.ResourceAction) *central.SensorE
 	w.mutex.RLock()
 	defer w.mutex.RUnlock()
 
+	dep := w.GetDeployment().CloneVT()
+	if !centralcaps.Has(centralsensor.InitContainerSupport) {
+		dep.Containers = filterRegularContainers(dep.GetContainers())
+	}
+
 	return &central.SensorEvent{
 		Id:     w.GetId(),
 		Action: action,
 		Resource: &central.SensorEvent_Deployment{
-			Deployment: w.GetDeployment().CloneVT(),
+			Deployment: dep,
 		},
 	}
+}
+
+func filterRegularContainers(containers []*storage.Container) []*storage.Container {
+	regular := make([]*storage.Container, 0, len(containers))
+	for _, c := range containers {
+		if c.GetType() == storage.ContainerType_REGULAR {
+			regular = append(regular, c)
+		}
+	}
+	return regular
 }
 
 // anyNonHostPort is derived from `filterHostExposure(...)`. Therefore, if `filterHostExposure(...)` is updated,

--- a/sensor/kubernetes/listener/resources/convert.go
+++ b/sensor/kubernetes/listener/resources/convert.go
@@ -504,7 +504,7 @@ func (w *deploymentWrap) toEvent(action central.ResourceAction) *central.SensorE
 
 	dep := w.GetDeployment().CloneVT()
 	if !centralcaps.Has(centralsensor.InitContainerSupport) {
-		dep.Containers = filterRegularContainers(dep.GetContainers())
+		dep.Containers = containers.FilterRegularContainers(dep.GetContainers())
 	}
 
 	return &central.SensorEvent{
@@ -514,16 +514,6 @@ func (w *deploymentWrap) toEvent(action central.ResourceAction) *central.SensorE
 			Deployment: dep,
 		},
 	}
-}
-
-func filterRegularContainers(containers []*storage.Container) []*storage.Container {
-	regular := make([]*storage.Container, 0, len(containers))
-	for _, c := range containers {
-		if c.GetType() == storage.ContainerType_REGULAR {
-			regular = append(regular, c)
-		}
-	}
-	return regular
 }
 
 // anyNonHostPort is derived from `filterHostExposure(...)`. Therefore, if `filterHostExposure(...)` is updated,

--- a/sensor/kubernetes/listener/resources/convert_test.go
+++ b/sensor/kubernetes/listener/resources/convert_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/utils"
 	imageUtils "github.com/stackrox/rox/pkg/images/utils"
@@ -15,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
 	"github.com/stackrox/rox/sensor/kubernetes/listener/resources/references"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1457,6 +1459,47 @@ func TestConvert(t *testing.T) {
 				actual.StateTimestamp = 0
 			}
 			protoassert.Equal(t, c.expectedDeployment, actual)
+		})
+	}
+}
+
+func TestToEventInitContainerCompatibility(t *testing.T) {
+	cases := map[string]struct {
+		caps               []centralsensor.CentralCapability
+		expectedContainers []string
+	}{
+		"filters init containers when Central lacks capability": {
+			caps:               []centralsensor.CentralCapability{},
+			expectedContainers: []string{"main-app"},
+		},
+		"includes init containers when Central has capability": {
+			caps:               []centralsensor.CentralCapability{centralsensor.InitContainerSupport},
+			expectedContainers: []string{"init-setup", "main-app"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(features.InitContainerSupport.EnvVar(), "true")
+			centralcaps.Set(tc.caps)
+			t.Cleanup(func() { centralcaps.Set(nil) })
+
+			wrap := &deploymentWrap{
+				Deployment: &storage.Deployment{
+					Id: "test-deploy",
+					Containers: []*storage.Container{
+						{Name: "init-setup", Type: storage.ContainerType_INIT},
+						{Name: "main-app", Type: storage.ContainerType_REGULAR},
+					},
+				},
+			}
+
+			event := wrap.toEvent(central.ResourceAction_CREATE_RESOURCE)
+			dep := event.GetDeployment()
+			require.Len(t, dep.GetContainers(), len(tc.expectedContainers))
+			for i, name := range tc.expectedContainers {
+				assert.Equal(t, name, dep.GetContainers()[i].GetName())
+			}
 		})
 	}
 }

--- a/sensor/kubernetes/listener/resources/convert_test.go
+++ b/sensor/kubernetes/listener/resources/convert_test.go
@@ -482,6 +482,7 @@ func TestPopulateImageMetadataWithInitContainers(t *testing.T) {
 }
 
 func TestPopulateImageMetadataWithInitContainerStatuses(t *testing.T) {
+	t.Setenv(features.InitContainerSupport.EnvVar(), "true")
 	// Verifies that init container image digests are populated from
 	// pod.Status.InitContainerStatuses.
 	wrap := deploymentWrap{

--- a/sensor/kubernetes/listener/resources/convert_test.go
+++ b/sensor/kubernetes/listener/resources/convert_test.go
@@ -479,6 +479,54 @@ func TestPopulateImageMetadataWithInitContainers(t *testing.T) {
 	assert.Equal(t, "sha256:def456", wrap.GetDeployment().GetContainers()[2].GetImage().GetId())
 }
 
+func TestPopulateImageMetadataWithInitContainerStatuses(t *testing.T) {
+	// Verifies that init container image digests are populated from
+	// pod.Status.InitContainerStatuses.
+	wrap := deploymentWrap{
+		Deployment: &storage.Deployment{},
+	}
+
+	initImg, err := imageUtils.GenerateImageFromString("docker.io/library/busybox:latest")
+	require.NoError(t, err)
+	nginxImg, err := imageUtils.GenerateImageFromString("docker.io/library/nginx:latest")
+	require.NoError(t, err)
+
+	wrap.Containers = []*storage.Container{
+		{Name: "init-setup", Image: initImg, Type: storage.ContainerType_INIT},
+		{Name: "nginx", Image: nginxImg},
+	}
+
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{Name: "init-setup", Image: "docker.io/library/busybox:latest"},
+			},
+			Containers: []v1.Container{
+				{Name: "nginx", Image: "docker.io/library/nginx:latest"},
+			},
+		},
+		Status: v1.PodStatus{
+			InitContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:    "init-setup",
+					ImageID: "docker-pullable://docker.io/library/busybox@sha256:initdigest123",
+				},
+			},
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:    "nginx",
+					ImageID: "docker-pullable://docker.io/library/nginx@sha256:abc123",
+				},
+			},
+		},
+	}
+
+	wrap.populateImageMetadata(nil, pod)
+
+	assert.Equal(t, "sha256:initdigest123", wrap.GetDeployment().GetContainers()[0].GetImage().GetId())
+	assert.Equal(t, "sha256:abc123", wrap.GetDeployment().GetContainers()[1].GetImage().GetId())
+}
+
 func TestPopulateImageMetadataWithUnqualified(t *testing.T) {
 	testutils.MustUpdateFeature(t, features.UnqualifiedSearchRegistries, true)
 	type wrapContainer struct {


### PR DESCRIPTION
## Description

When the `ROX_INIT_CONTAINER_SUPPORT` feature flag is enabled, Sensor now extracts init containers from pod specs alongside regular containers. Init containers are assigned `ContainerType_INIT` and regular containers are assigned `ContainerType_REGULAR`. The extracted init containers go through the same field-population pipeline (configs, images, security context, volumes, ports, resources, probes) as regular containers by constructing a combined container list that keeps the index-based helper functions aligned.

In `sensor/kubernetes/listener/resources/convert.go`, the image metadata population logic is extended to look up init container specs and statuses from pods, so that image digests for init containers are correctly resolved. A capability-gated filter in `toEvent` ensures that init containers are stripped from deployment events sent to Central when Central does not advertise `InitContainerSupport`, preserving backward compatibility during rollout.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Deployed image `4.11.x-762-gc7fc1e452f` to a GKE cluster using roxie with `ROX_INIT_CONTAINER_SUPPORT` enabled. Ran 6 manual test cases against the Central API.

### Test 1: Init container extraction

Deployed a workload with a busybox init container and an nginx regular container:

```
curl -sk -u admin:$PASSWORD ".../v1/deployments/$DEPLOY_ID" \
  | jq '.containers[] | {name: .name, type: .type, image: .image.name.fullName}'
```

```json
{
  "name": "init-setup",
  "type": "INIT",
  "image": "docker.io/library/busybox:1.36"
}
{
  "name": "main-app",
  "type": "REGULAR",
  "image": "docker.io/library/nginx:1.25"
}
```

### Test 2: Init container field population

Deployed a workload with a fully-specified init container (env vars, resources, security context, volume mounts):

```
curl -sk -u admin:$PASSWORD ".../v1/deployments/$DEPLOY_ID" \
  | jq '.containers[] | select(.name == "init-full") | {type, securityContext, resources, volumes, config: {command: .config.command, env: .config.env}}'
```

```json
{
  "type": "INIT",
  "securityContext": {
    "privileged": false,
    "readOnlyRootFilesystem": true,
    "allowPrivilegeEscalation": true
  },
  "resources": {
    "cpuCoresRequest": 0.05,
    "cpuCoresLimit": 0.1,
    "memoryMbRequest": 32,
    "memoryMbLimit": 64
  },
  "volumes": [
    {
      "name": "shared-data",
      "destination": "/work",
      "type": "EmptyDir"
    }
  ],
  "config": {
    "command": ["sh", "-c", "echo hello > /work/init-output.txt"],
    "env": [
      { "key": "INIT_VAR", "value": "init-value", "envVarSource": "RAW" }
    ]
  }
}
```

### Test 3: Regular-only workloads unaffected (flag ON)

Deployed a workload with two regular containers (nginx + busybox sidecar), no init containers:

```
curl -sk -u admin:$PASSWORD ".../v1/deployments/$DEPLOY_ID" \
  | jq '{containers: [.containers[] | {name, type}], total: (.containers | length), init: ([.containers[] | select(.type == "INIT")] | length), regular: ([.containers[] | select(.type == "REGULAR")] | length)}'
```

```json
{
  "containers": [
    { "name": "web", "type": "REGULAR" },
    { "name": "sidecar", "type": "REGULAR" }
  ],
  "total": 2,
  "init": 0,
  "regular": 2
}
```

### Test 4: Feature flag OFF

Tore down and redeployed the same image without `ROX_INIT_CONTAINER_SUPPORT`. Deployed the same init-container workload from Test 1:

```
curl -sk -u admin:$PASSWORD ".../v1/deployments/$DEPLOY_ID" \
  | jq '{containers: [.containers[] | {name, type}], total: (.containers | length), init: ([.containers[] | select(.type == "INIT")] | length)}'
```

```json
{
  "containers": [
    { "name": "main-app", "type": "REGULAR" }
  ],
  "total": 1,
  "init": 0
}
```

Init containers correctly excluded when the flag is off.

### Test 5: Compatibility — old Central (flag OFF) + new Sensor (flag ON)

Patched the Central CR to set `ROX_INIT_CONTAINER_SUPPORT=false` while Sensor kept the flag ON. Sensor re-handshaked with Central after Central cycled. Deployed the same init-container workload:

```
curl -sk -u admin:$PASSWORD ".../v1/deployments/$DEPLOY_ID" \
  | jq '.containers[] | {name: .name, type: .type}'
```

```json
{
  "name": "main-app",
  "type": "REGULAR"
}
```

Sensor extracts init containers internally, but since Central didn't advertise `InitContainerSupport`, the resolver's `toEvent` filters them out before sending to Central.

### Test 6: Compatibility — new Central (flag ON) + old Sensor (flag OFF)

Patched Central CR back to `true` and SecuredCluster CR to `false`. Deployed the same workload:

```
curl -sk -u admin:$PASSWORD ".../v1/deployments/$DEPLOY_ID" \
  | jq '.containers[] | {name: .name, type: .type}'
```

```json
{
  "name": "main-app",
  "type": "REGULAR"
}
```

Sensor doesn't extract init containers when its flag is OFF, so Central never receives them even though it supports the feature.
