### PR TITLE
ROX-33360: Add E2E test for namespace filtering

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -929,6 +929,10 @@ function launch_sensor {
         kubectl -n "${sensor_namespace}" get secret stackrox &>/dev/null || kubectl -n "${sensor_namespace}" create -f - < <("${common_dir}/pull-secret.sh" stackrox docker.io)
       fi
 
+      if [[ -n "${ROX_PROCESS_INDICATORS_PER_NAMESPACE}" ]]; then
+        extra_helm_config+=(--set "processIndicators.excludeNamespaceFilter=namespace-without-persistence")
+      fi
+
       echo "Deploying sensor using Helm..."
       helm upgrade --install -n "${sensor_namespace}" --create-namespace stackrox-secured-cluster-services "${sensor_helm_chart}" \
           "${helm_args[@]}" "${extra_helm_config[@]}"
@@ -952,6 +956,15 @@ function launch_sensor {
             echo >&2 "Please make sure to have a roxctl version ${MAIN_IMAGE_TAG} in PATH."
             exit 1
         fi
+
+        if [[ -n "${ROX_PROCESS_INDICATORS_PER_NAMESPACE}" ]]; then
+          if [[ -n "$extra_json_dynamic_config" ]]; then
+              extra_json_dynamic_config+=", "
+          fi
+
+          extra_json_dynamic_config+='"processIndicators": {"excludeNamespaceFilter": "namespace-without-persistence"}'
+        fi
+
         extra_json_config="${extra_json_config}, "'"dynamicConfig"'": {${extra_json_dynamic_config}}"
         get_cluster_zip "$API_ENDPOINT" "$CLUSTER" "${CLUSTER_TYPE}" "${MAIN_IMAGE}" "$CLUSTER_API_ENDPOINT" "$k8s_dir" "$COLLECTION_METHOD" "$extra_json_config"
         unzip "$k8s_dir/sensor-deploy.zip" -d "$k8s_dir/sensor-deploy"

--- a/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
+++ b/qa-tests-backend/src/test/groovy/ProcessVisualizationTest.groovy
@@ -23,6 +23,9 @@ class ProcessVisualizationTest extends BaseSpecification {
     // ldconfig process
     static final private String LDCONFIG = "/sbin/ldconfig"
 
+    // processes, originating from this namespace, will not be persisted
+    static final private String NO_PERSISTENCE_NS = "namespace-without-persistence"
+
     static final private List<Deployment> DEPLOYMENTS = [
             new Deployment()
                 .setName (NGINXDEPLOYMENT)
@@ -66,6 +69,11 @@ class ProcessVisualizationTest extends BaseSpecification {
                 .setImagePrefetcherAffinity()
                 .setImage ("quay.io/rhacs-eng/qa-multi-arch:ROX4979")
                 .addLabel ("app", "test" ),
+            new Deployment()
+                .setName (NGINXDEPLOYMENT)
+                .setNamespace (NO_PERSISTENCE_NS)
+                .setImage (TEST_IMAGE)
+                .addLabel ( "app", "test" ),
      ]
 
     static final private MAX_SLEEP_TIME = 240000
@@ -333,6 +341,34 @@ class ProcessVisualizationTest extends BaseSpecification {
             ["/usr/bin/grep", "^- /etc/elasticsearch/jvm.options"],
             ["/sbin/ldconfig", "-p"],
         ] | ELASTICDEPLOYMENT
+    }
+
+    @Tag("BAT")
+    @Tag("RUNTIME")
+    def "Verify process visualization on the excluded namespace"()  {
+        when:
+        "Get Process IDs running on deployment without persistence"
+        String uid = DEPLOYMENTS.find { it.namespace == NO_PERSISTENCE_NS }.deploymentUid
+        assert uid != null
+
+        // It's hard to prove we didn't receive a process on purpose, it may
+        // just not arrived yet. Instead wait for maximum allowed time, and
+        // verify afterwards.
+        Set<String> receivedProcessPaths
+        int retries = MAX_SLEEP_TIME / SLEEP_INCREMENT
+        int delaySeconds = SLEEP_INCREMENT / 1000
+        Timer t = new Timer(retries, delaySeconds)
+        while (t.IsValid()) {
+            receivedProcessPaths = ProcessService.getUniqueProcessPaths(uid)
+            if (receivedProcessPaths.size() > 0) {
+                break
+            }
+            log.info "Didn't find all the expected processes, retrying..."
+        }
+
+        then:
+        "Verify no processes in the deployment without persistence"
+        assert receivedProcessPaths.size() == 0
     }
 
     // Returns true if received contains all the (path,UIDGIDSet) pairs found in expected

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -417,6 +417,10 @@ deploy_sensor() {
     ci_export ROX_AFTERGLOW_PERIOD "15"
     ci_export ROX_COLLECTOR_INTROSPECTION_ENABLE "true"
 
+    # Per-namespace filtering tests expect to have one namespace configured
+    # without persistence.
+    ci_export ROX_PROCESS_INDICATORS_PER_NAMESPACE "true"
+
     if [[ "${DEPLOY_STACKROX_VIA_OPERATOR}" == "true" ]]; then
         deploy_sensor_via_operator "${sensor_namespace}" "${central_namespace}" "${validate}"
     else

--- a/tests/e2e/yaml/secured-cluster-cr.envsubst.yaml
+++ b/tests/e2e/yaml/secured-cluster-cr.envsubst.yaml
@@ -8,6 +8,8 @@ spec:
   perNode:
     fileActivityMonitoring:
       mode: $fam_mode_setting
+  processIndicators:
+    excludeNamespaceRegex: namespace-without-persistence
   scanner:
     scannerComponent: $scanner_component_setting
     analyzer:


### PR DESCRIPTION
## Description

NOTE: It's been split from https://github.com/stackrox/stackrox/pull/19455, for the purposes of simplifying the review. The PR contains only the third commit, adding the E2E test. The implementation is exactly the same as in the original PR.

Commits:
    405c8cf ("ROX-33361: Per-namespace persistence for process indicators (#199 57)")
    a666751d94 ("ROX-33361: Per-namespace persistence in SecuredCluster CR (#20102)")

have introduced a possibility to configure per-namespace persistence for process indicators, configurable via SecuredClusterCR. It relies on the fact that every single change in SecuredClusterCR changes it's fingerprints and causes Sensor to restart, propagating the new configuration to Central. This mechanism is suboptimal, and could be changed in the future. To prevent a silent failures in this case, implement an E2E test, verifying that the per-namespace filtering and configuration propagation works as expected. In this test we cover only the initial config propagation (no Sensor restarts are done), but since the mechanism is the same, it should be enough.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Manual validation (creating an operator-managed cluster and modifying the configuration), as well as E2E tests. Split from https://github.com/stackrox/stackrox/pull/19455 to simplify the review.