### PR TITLE
ROX-30650: add dynamic Red Hat signing key bundle

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -1046,6 +1046,13 @@ func waitForTerminationSignal() {
 			stoppableWithName{platformReprocessor.Singleton(), "platform components reprocessor"})
 	}
 
+	if w := signatureIntegrationDS.KeyBundleWatcher(); w != nil {
+		stoppables = append(stoppables, stoppableWithName{w, "Red Hat signing key bundle watcher"})
+	}
+	if u := signatureIntegrationDS.KeyBundleUpdater(); u != nil {
+		stoppables = append(stoppables, stoppableWithName{u, "Red Hat signing key bundle updater"})
+	}
+
 	var wg sync.WaitGroup
 	for _, stoppable := range stoppables {
 		wg.Add(1)

--- a/central/signatureintegration/datastore/key_bundle.go
+++ b/central/signatureintegration/datastore/key_bundle.go
@@ -30,6 +30,7 @@ func parseKeyBundle(data []byte) (*keyBundle, error) {
 	seenNames := make(map[string]struct{}, len(bundle.Keys))
 	for i := range bundle.Keys {
 		entry := &bundle.Keys[i]
+		entry.Name = strings.TrimSpace(entry.Name)
 		if entry.Name == "" {
 			return nil, errors.Errorf("key at index %d has empty name", i)
 		}

--- a/central/signatureintegration/datastore/key_bundle.go
+++ b/central/signatureintegration/datastore/key_bundle.go
@@ -1,0 +1,70 @@
+package datastore
+
+import (
+	"encoding/json"
+	"encoding/pem"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/signatures"
+)
+
+type keyBundle struct {
+	Keys []keyBundleEntry `json:"keys"`
+}
+
+type keyBundleEntry struct {
+	Name string `json:"name"`
+	PEM  string `json:"pem"`
+}
+
+func parseKeyBundle(data []byte) (*keyBundle, error) {
+	var bundle keyBundle
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling key bundle JSON")
+	}
+	if len(bundle.Keys) == 0 {
+		return nil, errors.New("key bundle must contain at least one key")
+	}
+	seenNames := make(map[string]struct{}, len(bundle.Keys))
+	for i := range bundle.Keys {
+		entry := &bundle.Keys[i]
+		if entry.Name == "" {
+			return nil, errors.Errorf("key at index %d has empty name", i)
+		}
+		if strings.ContainsAny(entry.Name, "/\\") {
+			return nil, errors.Errorf("key name %q must not contain path separators", entry.Name)
+		}
+		if _, exists := seenNames[entry.Name]; exists {
+			return nil, errors.Errorf("duplicate key name %q", entry.Name)
+		}
+		seenNames[entry.Name] = struct{}{}
+		keyBlock, rest := pem.Decode([]byte(strings.TrimSpace(entry.PEM)))
+		if !signatures.IsValidPublicKeyPEMBlock(keyBlock, rest) {
+			return nil, errors.Errorf("key %q has invalid PEM-encoded public key", entry.Name)
+		}
+		entry.PEM = string(pem.EncodeToMemory(keyBlock))
+	}
+	return &bundle, nil
+}
+
+func (kb *keyBundle) toSignatureIntegration() *storage.SignatureIntegration {
+	publicKeys := make([]*storage.CosignPublicKeyVerification_PublicKey, 0, len(kb.Keys))
+	for _, entry := range kb.Keys {
+		publicKeys = append(publicKeys, &storage.CosignPublicKeyVerification_PublicKey{
+			Name:            entry.Name,
+			PublicKeyPemEnc: entry.PEM,
+		})
+	}
+	return &storage.SignatureIntegration{
+		Id:   signatures.DefaultRedHatSignatureIntegration.GetId(),
+		Name: signatures.DefaultRedHatSignatureIntegration.GetName(),
+		Cosign: &storage.CosignPublicKeyVerification{
+			PublicKeys: publicKeys,
+		},
+		Traits: &storage.Traits{
+			Origin: storage.Traits_DEFAULT,
+		},
+	}
+}

--- a/central/signatureintegration/datastore/key_bundle_test.go
+++ b/central/signatureintegration/datastore/key_bundle_test.go
@@ -62,7 +62,7 @@ func TestParseKeyBundle(t *testing.T) {
 			wantErr: "invalid PEM-encoded public key",
 		},
 		"wrong PEM type": { //nolint:gosec // G101: test data, not real credentials
-			input: `{"keys": [{"name": "bad-key", "pem": "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJB\n-----END RSA PRIVATE KEY-----\n"}]}`,
+			input:   `{"keys": [{"name": "bad-key", "pem": "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJB\n-----END RSA PRIVATE KEY-----\n"}]}`,
 			wantErr: "invalid PEM-encoded public key",
 		},
 		"valid + invalid key rejects entire bundle": {

--- a/central/signatureintegration/datastore/key_bundle_test.go
+++ b/central/signatureintegration/datastore/key_bundle_test.go
@@ -61,8 +61,8 @@ func TestParseKeyBundle(t *testing.T) {
 			input:   `{"keys": [{"name": "bad-key", "pem": "not-a-pem"}]}`,
 			wantErr: "invalid PEM-encoded public key",
 		},
-		"wrong PEM type": {
-			input:   `{"keys": [{"name": "bad-key", "pem": "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJB\n-----END RSA PRIVATE KEY-----\n"}]}`, //nolint:gosec // G101: test data, not real credentials
+		"wrong PEM type": { //nolint:gosec // G101: test data, not real credentials
+			input: `{"keys": [{"name": "bad-key", "pem": "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJB\n-----END RSA PRIVATE KEY-----\n"}]}`,
 			wantErr: "invalid PEM-encoded public key",
 		},
 		"valid + invalid key rejects entire bundle": {

--- a/central/signatureintegration/datastore/key_bundle_test.go
+++ b/central/signatureintegration/datastore/key_bundle_test.go
@@ -62,7 +62,7 @@ func TestParseKeyBundle(t *testing.T) {
 			wantErr: "invalid PEM-encoded public key",
 		},
 		"wrong PEM type": {
-			input:   `{"keys": [{"name": "bad-key", "pem": "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJB\n-----END RSA PRIVATE KEY-----\n"}]}`,
+			input:   `{"keys": [{"name": "bad-key", "pem": "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJB\n-----END RSA PRIVATE KEY-----\n"}]}`, //nolint:gosec // G101: test data, not real credentials
 			wantErr: "invalid PEM-encoded public key",
 		},
 		"valid + invalid key rejects entire bundle": {

--- a/central/signatureintegration/datastore/key_bundle_test.go
+++ b/central/signatureintegration/datastore/key_bundle_test.go
@@ -1,0 +1,153 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/signatures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// Test-only ECDSA P-256 keys, not real Red Hat keys.
+	testPublicKeyPEM = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE16IoQbiiB5exTRLTkl2rn5FuyXys
+4TbDn4+GhQD1JmLZnAiA0cXktX+gFdxu/0JM9pcjjaqT7pdXztbBs78cXg==
+-----END PUBLIC KEY-----
+`
+	testPublicKeyPEM2 = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQq1X/6XxCA4s0++8Tvl8k+Z0G/GN
+LKpdYJEldXnyRE4ppY5d7vnRZHvdZQMSE3KoRSMvVnzZtc9LTKLB3DlS/w==
+-----END PUBLIC KEY-----
+`
+)
+
+func TestParseKeyBundle(t *testing.T) {
+	cases := map[string]struct {
+		input   string
+		wantErr string
+	}{
+		"valid single key": {
+			input: `{"keys": [{"name": "key-1", "pem": "` + jsonEscapePEM(testPublicKeyPEM) + `"}]}`,
+		},
+		"valid multiple keys": {
+			input: `{"keys": [
+				{"name": "key-1", "pem": "` + jsonEscapePEM(testPublicKeyPEM) + `"},
+				{"name": "key-2", "pem": "` + jsonEscapePEM(testPublicKeyPEM2) + `"}
+			]}`,
+		},
+		"empty keys array": {
+			input:   `{"keys": []}`,
+			wantErr: "at least one key",
+		},
+		"missing keys field": {
+			input:   `{}`,
+			wantErr: "at least one key",
+		},
+		"malformed JSON": {
+			input:   `{not json`,
+			wantErr: "unmarshalling key bundle JSON",
+		},
+		"empty name": {
+			input:   `{"keys": [{"name": "", "pem": "` + jsonEscapePEM(testPublicKeyPEM) + `"}]}`,
+			wantErr: "empty name",
+		},
+		"name with path separator": {
+			input:   `{"keys": [{"name": "foo/bar", "pem": "` + jsonEscapePEM(testPublicKeyPEM) + `"}]}`,
+			wantErr: "path separators",
+		},
+		"invalid PEM": {
+			input:   `{"keys": [{"name": "bad-key", "pem": "not-a-pem"}]}`,
+			wantErr: "invalid PEM-encoded public key",
+		},
+		"wrong PEM type": {
+			input:   `{"keys": [{"name": "bad-key", "pem": "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJB\n-----END RSA PRIVATE KEY-----\n"}]}`,
+			wantErr: "invalid PEM-encoded public key",
+		},
+		"valid + invalid key rejects entire bundle": {
+			input: `{"keys": [
+				{"name": "good", "pem": "` + jsonEscapePEM(testPublicKeyPEM) + `"},
+				{"name": "bad", "pem": "not-a-pem"}
+			]}`,
+			wantErr: "invalid PEM-encoded public key",
+		},
+		"trailing PEM data": {
+			input:   `{"keys": [{"name": "key-1", "pem": "` + jsonEscapePEM(testPublicKeyPEM+"extra") + `"}]}`,
+			wantErr: "invalid PEM-encoded public key",
+		},
+		"duplicate key names": {
+			input: `{"keys": [
+				{"name": "key-1", "pem": "` + jsonEscapePEM(testPublicKeyPEM) + `"},
+				{"name": "key-1", "pem": "` + jsonEscapePEM(testPublicKeyPEM2) + `"}
+			]}`,
+			wantErr: "duplicate key name",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			bundle, err := parseKeyBundle([]byte(tc.input))
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+				assert.Nil(t, bundle)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, bundle)
+			}
+		})
+	}
+}
+
+func TestParseKeyBundlePEMCanonicalization(t *testing.T) {
+	// PEM with extra trailing newlines should be canonicalized.
+	pemWithExtraNewlines := testPublicKeyPEM + "\n\n\n"
+	input := `{"keys": [{"name": "key-1", "pem": "` + jsonEscapePEM(pemWithExtraNewlines) + `"}]}`
+
+	bundle, err := parseKeyBundle([]byte(input))
+	require.NoError(t, err)
+	require.Len(t, bundle.Keys, 1)
+
+	// Canonicalized PEM ends with exactly one trailing newline.
+	assert.Regexp(t, `\n$`, bundle.Keys[0].PEM)
+	assert.NotRegexp(t, `\n\n$`, bundle.Keys[0].PEM)
+}
+
+func TestToSignatureIntegration(t *testing.T) {
+	bundle := &keyBundle{
+		Keys: []keyBundleEntry{
+			{Name: "key-1", PEM: testPublicKeyPEM},
+			{Name: "key-2", PEM: testPublicKeyPEM2},
+		},
+	}
+
+	si := bundle.toSignatureIntegration()
+
+	assert.Equal(t, signatures.DefaultRedHatSignatureIntegration.GetId(), si.GetId())
+	assert.Equal(t, "Red Hat", si.GetName())
+	assert.Equal(t, storage.Traits_DEFAULT, si.GetTraits().GetOrigin())
+
+	keys := si.GetCosign().GetPublicKeys()
+	require.Len(t, keys, 2)
+	assert.Equal(t, "key-1", keys[0].GetName())
+	assert.Equal(t, testPublicKeyPEM, keys[0].GetPublicKeyPemEnc())
+	assert.Equal(t, "key-2", keys[1].GetName())
+	assert.Equal(t, testPublicKeyPEM2, keys[1].GetPublicKeyPemEnc())
+}
+
+func jsonEscapePEM(s string) string {
+	var out []byte
+	for _, c := range []byte(s) {
+		switch c {
+		case '\n':
+			out = append(out, '\\', 'n')
+		case '"':
+			out = append(out, '\\', '"')
+		case '\\':
+			out = append(out, '\\', '\\')
+		default:
+			out = append(out, c)
+		}
+	}
+	return string(out)
+}

--- a/central/signatureintegration/datastore/key_bundle_test.go
+++ b/central/signatureintegration/datastore/key_bundle_test.go
@@ -53,6 +53,10 @@ func TestParseKeyBundle(t *testing.T) {
 			input:   `{"keys": [{"name": "", "pem": "` + jsonEscapePEM(testPublicKeyPEM) + `"}]}`,
 			wantErr: "empty name",
 		},
+		"whitespace-only name": {
+			input:   `{"keys": [{"name": "  \t ", "pem": "` + jsonEscapePEM(testPublicKeyPEM) + `"}]}`,
+			wantErr: "empty name",
+		},
 		"name with path separator": {
 			input:   `{"keys": [{"name": "foo/bar", "pem": "` + jsonEscapePEM(testPublicKeyPEM) + `"}]}`,
 			wantErr: "path separators",

--- a/central/signatureintegration/datastore/key_bundle_watcher.go
+++ b/central/signatureintegration/datastore/key_bundle_watcher.go
@@ -23,7 +23,13 @@ type keyBundleWatcher struct {
 	lastHash [sha256.Size]byte
 }
 
+const minWatchInterval = 5 * time.Second
+
 func newKeyBundleWatcher(filePath string, interval time.Duration, siStore store.SignatureIntegrationStore) *keyBundleWatcher {
+	if interval < minWatchInterval {
+		log.Warnf("Watch interval %v is below minimum %v, clamping", interval, minWatchInterval)
+		interval = minWatchInterval
+	}
 	return &keyBundleWatcher{
 		filePath: filePath,
 		interval: interval,

--- a/central/signatureintegration/datastore/key_bundle_watcher.go
+++ b/central/signatureintegration/datastore/key_bundle_watcher.go
@@ -1,0 +1,104 @@
+package datastore
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/stackrox/rox/central/signatureintegration/store"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/sac"
+)
+
+const maxBundleFileSize = 5 * 1024 * 1024 // 5 MB
+
+type keyBundleWatcher struct {
+	filePath string
+	interval time.Duration
+	siStore  store.SignatureIntegrationStore
+	stopSig  concurrency.Signal
+	lastHash [sha256.Size]byte
+}
+
+func newKeyBundleWatcher(filePath string, interval time.Duration, siStore store.SignatureIntegrationStore) *keyBundleWatcher {
+	return &keyBundleWatcher{
+		filePath: filePath,
+		interval: interval,
+		siStore:  siStore,
+		stopSig:  concurrency.NewSignal(),
+	}
+}
+
+func (w *keyBundleWatcher) Start() {
+	go w.run()
+}
+
+func (w *keyBundleWatcher) Stop() {
+	w.stopSig.Signal()
+}
+
+func (w *keyBundleWatcher) run() {
+	log.Info("Starting Red Hat signing key bundle watcher")
+	defer log.Info("Stopped Red Hat signing key bundle watcher")
+
+	w.checkAndUpsert()
+
+	t := time.NewTicker(w.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			w.checkAndUpsert()
+		case <-w.stopSig.Done():
+			return
+		}
+	}
+}
+
+func (w *keyBundleWatcher) checkAndUpsert() {
+	data, err := os.ReadFile(w.filePath)
+	if errors.Is(err, os.ErrNotExist) {
+		log.Debugf("Key bundle file %q does not exist, skipping", w.filePath)
+		w.lastHash = [sha256.Size]byte{}
+		return
+	}
+	if err != nil {
+		log.Warnf("Failed to read key bundle file %q: %v", w.filePath, err)
+		return
+	}
+	if len(data) > maxBundleFileSize {
+		log.Warnf("Key bundle file %q exceeds maximum size of %d bytes, skipping", w.filePath, maxBundleFileSize)
+		return
+	}
+
+	hash := sha256.Sum256(data)
+	if hash == w.lastHash {
+		log.Debug("Key bundle file unchanged, skipping")
+		return
+	}
+
+	bundle, err := parseKeyBundle(data)
+	if err != nil {
+		log.Warnf("Invalid key bundle file %q: %v", w.filePath, err)
+		w.lastHash = hash
+		return
+	}
+
+	si := bundle.toSignatureIntegration()
+	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowAllAccessScopeChecker())
+	if err := w.siStore.Upsert(ctx, si); err != nil {
+		log.Errorf("Failed to upsert Red Hat signature integration from key bundle: %v", err)
+		return
+	}
+
+	w.lastHash = hash
+	keyNames := make([]string, 0, len(bundle.Keys))
+	for _, k := range bundle.Keys {
+		keyNames = append(keyNames, k.Name)
+	}
+	log.Infof("Updated Red Hat signature integration with %d key(s) from bundle: [%s]",
+		len(bundle.Keys), strings.Join(keyNames, ", "))
+}

--- a/central/signatureintegration/datastore/key_bundle_watcher_test.go
+++ b/central/signatureintegration/datastore/key_bundle_watcher_test.go
@@ -1,0 +1,170 @@
+package datastore
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	storeMocks "github.com/stackrox/rox/central/signatureintegration/store/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/signatures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func redHatIntegrationMatcher() gomock.Matcher {
+	return gomock.Cond(func(x any) bool {
+		si, ok := x.(*storage.SignatureIntegration)
+		return ok && si.GetId() == signatures.DefaultRedHatSignatureIntegration.GetId()
+	})
+}
+
+func validBundleJSON() string {
+	return fmt.Sprintf(`{"keys": [{"name": "test-key-1", "pem": %q}]}`, testPublicKeyPEM)
+}
+
+func validBundleJSON2Keys() string {
+	return fmt.Sprintf(`{"keys": [{"name": "test-key-1", "pem": %q}, {"name": "test-key-2", "pem": %q}]}`,
+		testPublicKeyPEM, testPublicKeyPEM2)
+}
+
+func TestWatcherFileAppears(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+	mockStore.EXPECT().Upsert(gomock.Any(), redHatIntegrationMatcher()).Return(nil).Times(1)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bundle.json")
+
+	w := newKeyBundleWatcher(filePath, 50*time.Millisecond, mockStore)
+
+	// File does not exist yet — no upsert expected on first check.
+	w.checkAndUpsert()
+
+	// Write valid bundle file.
+	require.NoError(t, os.WriteFile(filePath, []byte(validBundleJSON()), 0600))
+
+	// Now the file exists — upsert should be called.
+	w.checkAndUpsert()
+}
+
+func TestWatcherInvalidFile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+	// Upsert must NOT be called for an invalid bundle.
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bundle.json")
+	require.NoError(t, os.WriteFile(filePath, []byte(`{"keys": []}`), 0600))
+
+	w := newKeyBundleWatcher(filePath, 50*time.Millisecond, mockStore)
+	w.checkAndUpsert()
+
+	// Hash is updated even on parse failure to avoid log spam from repeated attempts.
+	assert.NotEqual(t, [sha256.Size]byte{}, w.lastHash)
+}
+
+func TestWatcherFileDoesNotExist(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "nonexistent.json")
+
+	w := newKeyBundleWatcher(filePath, 50*time.Millisecond, mockStore)
+	w.checkAndUpsert()
+
+	assert.Equal(t, [sha256.Size]byte{}, w.lastHash)
+}
+
+func TestWatcherFileDeletedResetsHash(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+	mockStore.EXPECT().Upsert(gomock.Any(), redHatIntegrationMatcher()).Return(nil).Times(2)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bundle.json")
+
+	w := newKeyBundleWatcher(filePath, 50*time.Millisecond, mockStore)
+
+	// Write and process file.
+	require.NoError(t, os.WriteFile(filePath, []byte(validBundleJSON()), 0600))
+	w.checkAndUpsert()
+	assert.NotEqual(t, [sha256.Size]byte{}, w.lastHash)
+
+	// Delete file — hash should be reset.
+	require.NoError(t, os.Remove(filePath))
+	w.checkAndUpsert()
+	assert.Equal(t, [sha256.Size]byte{}, w.lastHash)
+
+	// Re-create with same content — should upsert again since hash was reset.
+	require.NoError(t, os.WriteFile(filePath, []byte(validBundleJSON()), 0600))
+	w.checkAndUpsert()
+}
+
+func TestWatcherFileChanges(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+	mockStore.EXPECT().Upsert(gomock.Any(), redHatIntegrationMatcher()).Return(nil).Times(2)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bundle.json")
+
+	w := newKeyBundleWatcher(filePath, 50*time.Millisecond, mockStore)
+
+	// First version.
+	require.NoError(t, os.WriteFile(filePath, []byte(validBundleJSON()), 0600))
+	w.checkAndUpsert()
+	firstHash := w.lastHash
+
+	// Updated version with two keys.
+	require.NoError(t, os.WriteFile(filePath, []byte(validBundleJSON2Keys()), 0600))
+	w.checkAndUpsert()
+	assert.NotEqual(t, firstHash, w.lastHash)
+}
+
+func TestWatcherFileUnchanged(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+	// Upsert should only be called once — the second check has the same hash.
+	mockStore.EXPECT().Upsert(gomock.Any(), redHatIntegrationMatcher()).Return(nil).Times(1)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bundle.json")
+	require.NoError(t, os.WriteFile(filePath, []byte(validBundleJSON()), 0600))
+
+	w := newKeyBundleWatcher(filePath, 50*time.Millisecond, mockStore)
+	w.checkAndUpsert()
+	w.checkAndUpsert()
+}
+
+func TestWatcherStartStop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+	mockStore.EXPECT().Upsert(gomock.Any(), redHatIntegrationMatcher()).Return(nil).AnyTimes()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bundle.json")
+	require.NoError(t, os.WriteFile(filePath, []byte(validBundleJSON()), 0600))
+
+	w := &keyBundleWatcher{
+		filePath: filePath,
+		interval: 50 * time.Millisecond,
+		siStore:  mockStore,
+		stopSig:  concurrency.NewSignal(),
+	}
+
+	w.Start()
+	time.Sleep(100 * time.Millisecond)
+	w.Stop()
+	select {
+	case <-w.stopSig.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not stop within timeout")
+	}
+}

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -46,11 +46,12 @@ func seedRedHatSignatureIntegration(siStore store.SignatureIntegrationStore) {
 
 	id := signatures.DefaultRedHatSignatureIntegration.GetId()
 	_, exists, err := siStore.Get(ctx, id)
-	utils.Should(errors.Wrap(err, "checking for default Red Hat signature integration"))
-	if err != nil || exists {
-		if exists {
-			log.Debugf("Default Red Hat signature integration %q already exists, skipping seed", id)
-		}
+	if err != nil {
+		utils.Should(errors.Wrap(err, "checking for default Red Hat signature integration"))
+		return
+	}
+	if exists {
+		log.Debugf("Default Red Hat signature integration %q already exists, skipping seed", id)
 		return
 	}
 

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -8,34 +8,89 @@ import (
 	policyDataStore "github.com/stackrox/rox/central/policy/datastore"
 	"github.com/stackrox/rox/central/signatureintegration/store"
 	pgStore "github.com/stackrox/rox/central/signatureintegration/store/postgres"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/signatures"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
+// Stoppable represents a background process that can be stopped.
+type Stoppable interface {
+	Stop()
+}
+
 var (
 	once     sync.Once
 	instance DataStore
+
+	bundleUpdater Stoppable
+	bundleWatcher Stoppable
 )
 
-func upsertDefaultRedHatSignatureIntegration(siStore store.SignatureIntegrationStore) {
+// KeyBundleUpdater returns the key bundle updater for shutdown registration.
+// Returns nil if the updater was not started (e.g. no URL configured).
+// Must only be called after Singleton().
+func KeyBundleUpdater() Stoppable {
+	return bundleUpdater
+}
+
+// KeyBundleWatcher returns the key bundle watcher for shutdown registration.
+// Must only be called after Singleton().
+func KeyBundleWatcher() Stoppable {
+	return bundleWatcher
+}
+
+func seedRedHatSignatureIntegration(siStore store.SignatureIntegrationStore) {
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowAllAccessScopeChecker())
 
-	log.Debugf("Upserting default Red Hat signature integration %q (%s)",
-		signatures.DefaultRedHatSignatureIntegration.GetName(),
-		signatures.DefaultRedHatSignatureIntegration.GetId(),
-	)
-	err := siStore.Upsert(ctx, signatures.DefaultRedHatSignatureIntegration)
-	utils.Should(errors.Wrap(err, "upserting default Red Hat signature integration"))
+	id := signatures.DefaultRedHatSignatureIntegration.GetId()
+	_, exists, err := siStore.Get(ctx, id)
+	utils.Should(errors.Wrap(err, "checking for default Red Hat signature integration"))
+	if err != nil || exists {
+		if exists {
+			log.Debugf("Default Red Hat signature integration %q already exists, skipping seed", id)
+		}
+		return
+	}
+
+	log.Infof("Seeding default Red Hat signature integration %q", id)
+	err = siStore.Upsert(ctx, signatures.DefaultRedHatSignatureIntegration)
+	utils.Should(errors.Wrap(err, "seeding default Red Hat signature integration"))
+}
+
+func startKeyBundleWatcher(siStore store.SignatureIntegrationStore) {
+	filePath := env.RedHatSigningKeyBundlePath.Setting()
+	interval := env.RedHatSigningKeyWatchInterval.DurationSetting()
+
+	w := newKeyBundleWatcher(filePath, interval, siStore)
+	w.Start()
+	bundleWatcher = w
+}
+
+func startKeyBundleUpdater() {
+	url := env.RedHatSigningKeyBundleURL.Setting()
+	if url == "" {
+		log.Info("ROX_REDHAT_SIGNING_KEY_BUNDLE_URL not set, key bundle updater will not start")
+		return
+	}
+
+	filePath := env.RedHatSigningKeyBundlePath.Setting()
+	interval := env.RedHatSigningKeyUpdateInterval.DurationSetting()
+
+	u := newKeyBundleUpdater(url, filePath, interval)
+	u.Start()
+	bundleUpdater = u
 }
 
 // Singleton returns the sole instance of the DataStore service.
 func Singleton() DataStore {
 	once.Do(func() {
 		storage := pgStore.New(globaldb.GetPostgres())
-		upsertDefaultRedHatSignatureIntegration(storage)
+		seedRedHatSignatureIntegration(storage)
 		instance = New(storage, policyDataStore.Singleton())
+		startKeyBundleWatcher(storage)
+		startKeyBundleUpdater()
 	})
 	return instance
 }

--- a/central/signatureintegration/datastore/singleton_test.go
+++ b/central/signatureintegration/datastore/singleton_test.go
@@ -1,0 +1,31 @@
+package datastore
+
+import (
+	"testing"
+
+	storeMocks "github.com/stackrox/rox/central/signatureintegration/store/mocks"
+	"github.com/stackrox/rox/pkg/signatures"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSeedFirstInstall(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+
+	id := signatures.DefaultRedHatSignatureIntegration.GetId()
+	mockStore.EXPECT().Get(gomock.Any(), id).Return(nil, false, nil).Times(1)
+	mockStore.EXPECT().Upsert(gomock.Any(), signatures.DefaultRedHatSignatureIntegration).Return(nil).Times(1)
+
+	seedRedHatSignatureIntegration(mockStore)
+}
+
+func TestSeedSubsequentStartup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := storeMocks.NewMockSignatureIntegrationStore(ctrl)
+
+	id := signatures.DefaultRedHatSignatureIntegration.GetId()
+	mockStore.EXPECT().Get(gomock.Any(), id).Return(signatures.DefaultRedHatSignatureIntegration, true, nil).Times(1)
+	// Upsert must NOT be called — integration already exists.
+
+	seedRedHatSignatureIntegration(mockStore)
+}

--- a/central/signatureintegration/datastore/updater.go
+++ b/central/signatureintegration/datastore/updater.go
@@ -27,7 +27,13 @@ type keyBundleUpdater struct {
 	stopSig  concurrency.Signal
 }
 
+const minUpdateInterval = 1 * time.Minute
+
 func newKeyBundleUpdater(url, filePath string, interval time.Duration) *keyBundleUpdater {
+	if interval < minUpdateInterval {
+		log.Warnf("Update interval %v is below minimum %v, clamping", interval, minUpdateInterval)
+		interval = minUpdateInterval
+	}
 	return &keyBundleUpdater{
 		client: &http.Client{
 			Transport: proxy.RoundTripper(),

--- a/central/signatureintegration/datastore/updater.go
+++ b/central/signatureintegration/datastore/updater.go
@@ -1,0 +1,153 @@
+package datastore
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/httputil/proxy"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+const (
+	maxResponseBodySize = 5 * 1024 * 1024 // 5 MB
+	requestTimeout      = 60 * time.Second
+)
+
+type keyBundleUpdater struct {
+	client   *http.Client
+	url      string
+	filePath string
+	interval time.Duration
+	stopSig  concurrency.Signal
+}
+
+func newKeyBundleUpdater(url, filePath string, interval time.Duration) *keyBundleUpdater {
+	return &keyBundleUpdater{
+		client: &http.Client{
+			Transport: proxy.RoundTripper(),
+		},
+		url:      url,
+		filePath: filePath,
+		interval: interval,
+		stopSig:  concurrency.NewSignal(),
+	}
+}
+
+func (u *keyBundleUpdater) Start() {
+	go u.run()
+}
+
+func (u *keyBundleUpdater) Stop() {
+	u.stopSig.Signal()
+}
+
+func (u *keyBundleUpdater) run() {
+	log.Info("Starting Red Hat signing key bundle updater")
+	defer log.Info("Stopped Red Hat signing key bundle updater")
+
+	if err := os.MkdirAll(filepath.Dir(u.filePath), 0700); err != nil {
+		log.Errorf("Failed to create directory for key bundle file: %v", err)
+		return
+	}
+
+	u.download()
+
+	t := time.NewTimer(u.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			u.download()
+			t.Reset(u.interval)
+		case <-u.stopSig.Done():
+			return
+		}
+	}
+}
+
+func (u *keyBundleUpdater) download() {
+	if err := u.doDownload(); err != nil {
+		log.Warnf("Failed to download Red Hat signing key bundle from %q: %v", u.url, err)
+	}
+}
+
+func (u *keyBundleUpdater) doDownload() error {
+	log.Debugf("Downloading Red Hat signing key bundle from %q", u.url)
+
+	ctx, cancel := concurrency.DependentContext(context.Background(), &u.stopSig)
+	defer cancel()
+	ctx, cancel = context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.url, nil)
+	if err != nil {
+		return errors.Wrap(err, "constructing request")
+	}
+
+	resp, err := u.client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "executing request")
+	}
+	defer utils.IgnoreError(resp.Body.Close)
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.Errorf("unexpected HTTP status %d", resp.StatusCode)
+	}
+
+	limitedReader := io.LimitReader(resp.Body, maxResponseBodySize+1)
+	body, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return errors.Wrap(err, "reading response body")
+	}
+	if len(body) > maxResponseBodySize {
+		return errors.Errorf("response body exceeds maximum size of %d bytes", maxResponseBodySize)
+	}
+
+	if err := atomicWriteFile(u.filePath, body); err != nil {
+		return errors.Wrap(err, "writing key bundle file")
+	}
+
+	log.Infof("Successfully downloaded Red Hat signing key bundle from %q", u.url)
+	return nil
+}
+
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".key-bundle-*.tmp")
+	if err != nil {
+		return errors.Wrap(err, "creating temp file")
+	}
+	tmpPath := tmp.Name()
+
+	if err := os.Chmod(tmpPath, 0600); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return errors.Wrap(err, "setting temp file permissions")
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return errors.Wrap(err, "writing temp file")
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return errors.Wrap(err, "syncing temp file")
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return errors.Wrap(err, "closing temp file")
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return errors.Wrap(err, "renaming temp file")
+	}
+	return nil
+}

--- a/central/signatureintegration/datastore/updater_test.go
+++ b/central/signatureintegration/datastore/updater_test.go
@@ -1,0 +1,162 @@
+package datastore
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdaterSuccessfulDownload(t *testing.T) {
+	bundleContent := `{"keys": [{"name": "test-key", "pem": "test"}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(bundleContent))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bundle.json")
+
+	u := &keyBundleUpdater{
+		client:   server.Client(),
+		url:      server.URL,
+		filePath: filePath,
+		interval: time.Hour,
+		stopSig:  newStopSignal(),
+	}
+
+	err := u.doDownload()
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, bundleContent, string(data))
+}
+
+func TestUpdaterHTTPErrorDoesNotModifyFile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bundle.json")
+	originalContent := "original"
+	require.NoError(t, os.WriteFile(filePath, []byte(originalContent), 0600))
+
+	u := &keyBundleUpdater{
+		client:   server.Client(),
+		url:      server.URL,
+		filePath: filePath,
+		interval: time.Hour,
+		stopSig:  newStopSignal(),
+	}
+
+	err := u.doDownload()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected HTTP status 500")
+
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, originalContent, string(data))
+}
+
+func TestUpdaterOversizedResponseRejected(t *testing.T) {
+	largeBody := strings.Repeat("x", maxResponseBodySize+100)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(largeBody))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bundle.json")
+
+	u := &keyBundleUpdater{
+		client:   server.Client(),
+		url:      server.URL,
+		filePath: filePath,
+		interval: time.Hour,
+		stopSig:  newStopSignal(),
+	}
+
+	err := u.doDownload()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size")
+	assert.NoFileExists(t, filePath)
+}
+
+func TestUpdaterSequentialDownloads(t *testing.T) {
+	content1 := `{"keys": [{"name": "key-v1", "pem": "test"}]}`
+	content2 := `{"keys": [{"name": "key-v2", "pem": "test"}]}`
+
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if callCount.Add(1) == 1 {
+			_, _ = w.Write([]byte(content1))
+		} else {
+			_, _ = w.Write([]byte(content2))
+		}
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bundle.json")
+
+	u := &keyBundleUpdater{
+		client:   server.Client(),
+		url:      server.URL,
+		filePath: filePath,
+		interval: time.Hour,
+		stopSig:  newStopSignal(),
+	}
+
+	require.NoError(t, u.doDownload())
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, content1, string(data))
+
+	require.NoError(t, u.doDownload())
+	data, err = os.ReadFile(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, content2, string(data))
+}
+
+func TestUpdaterStopSignal(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bundle.json")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("content"))
+	}))
+	defer server.Close()
+
+	u := &keyBundleUpdater{
+		client:   server.Client(),
+		url:      server.URL,
+		filePath: filePath,
+		interval: 50 * time.Millisecond,
+		stopSig:  newStopSignal(),
+	}
+
+	u.Start()
+
+	// Poll for file existence instead of fixed sleep.
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(filePath)
+		return err == nil
+	}, 2*time.Second, 10*time.Millisecond, "updater did not write the file")
+
+	u.Stop()
+}
+
+func newStopSignal() concurrency.Signal {
+	return concurrency.NewSignal()
+}

--- a/pkg/env/signature.go
+++ b/pkg/env/signature.go
@@ -1,6 +1,22 @@
 package env
 
+import "time"
+
 var (
 	// DisableSignatureFetching disables signature fetching within the reprocessing loop.
 	DisableSignatureFetching = RegisterBooleanSetting("ROX_DISABLE_SIGNATURE_FETCHING", false)
+
+	// RedHatSigningKeyBundleURL is the remote URL of the key bundle JSON.
+	// If empty, the key bundle updater does not start.
+	RedHatSigningKeyBundleURL = RegisterSetting("ROX_REDHAT_SIGNING_KEY_BUNDLE_URL", AllowEmpty())
+
+	// RedHatSigningKeyBundlePath is the local file path where the key bundle is read from.
+	RedHatSigningKeyBundlePath = RegisterSetting("ROX_REDHAT_SIGNING_KEY_BUNDLE_PATH",
+		WithDefault("/tmp/redhat-signing-keys/bundle.json"))
+
+	// RedHatSigningKeyUpdateInterval controls how often the updater re-downloads the bundle.
+	RedHatSigningKeyUpdateInterval = registerDurationSetting("ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL", 4*time.Hour)
+
+	// RedHatSigningKeyWatchInterval controls how often the watcher polls the file for changes.
+	RedHatSigningKeyWatchInterval = registerDurationSetting("ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL", 30*time.Second)
 )


### PR DESCRIPTION
## Description

Central automatically downloads a JSON key bundle from a configurable remote URL,
watches the local file for changes using SHA-256 content hashing, and upserts
validated keys into the database as the default Red Hat signature integration.

Three new components in `central/signatureintegration/datastore/`:

- **Updater** — periodic HTTP downloader, writes to disk atomically (temp file + fsync + rename)
- **Watcher** — file poller with SHA-256 hash-based change detection, validates and upserts
- **Seed logic** — only creates the default integration on first install (checks existence before upserting)

Key design decisions:
- All-or-nothing bundle validation: if any key fails, entire bundle is rejected
- Bundle replaces all keys (complete desired state, not merge)
- Updater is intentionally a dumb downloader — separation of concerns with watcher
- `lastHash` set on parse failure to prevent log spam; reset on file deletion so re-created files are detected

New env vars: `ROX_REDHAT_SIGNING_KEY_BUNDLE_URL`, `ROX_REDHAT_SIGNING_KEY_BUNDLE_PATH`,
`ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL`, `ROX_REDHAT_SIGNING_KEY_WATCH_INTERVAL`.

Shutdown hooks registered in `central/main.go` via the existing `stoppable` pattern.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- 30 unit tests pass including with `-race` (14 parsing, 8 watcher, 5 updater, 2 seed, plus pre-existing)
- Manual E2E on OpenShift cluster: seed logic, watcher picks up file, updater downloads from nginx, hash dedup confirmed
- Built custom Central image via crane, deployed to cluster, verified full updater → watcher → upsert flow

AI-assisted: code partially generated by Claude.