### PR TITLE
ROX-34026: Filter init containers from policy evaluation

### DIFF
--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -273,9 +273,20 @@ func constructDeployment(deployment *storage.Deployment, images []*storage.Image
 }
 
 // filterInitContainers returns a filtered deployment and image slice with init containers removed.
-// TODO(ROX-33067): Remove this filter when policy evaluation supports init containers.
+// TODO(ROX-33067): Make this filter conditional on policy evaluation settings.
 func filterInitContainers(deployment *storage.Deployment, images []*storage.Image) (*storage.Deployment, []*storage.Image) {
 	if !features.InitContainerSupport.Enabled() {
+		return deployment, images
+	}
+
+	hasInit := false
+	for _, c := range deployment.GetContainers() {
+		if c.GetType() == storage.ContainerType_INIT {
+			hasInit = true
+			break
+		}
+	}
+	if !hasInit {
 		return deployment, images
 	}
 

--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/booleanpolicy/evaluator/pathutil"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -28,6 +29,9 @@ func findMatchingContainerIdxForProcess(deployment *storage.Deployment, process 
 
 // ConstructDeploymentWithProcess constructs an augmented deployment with process information.
 func ConstructDeploymentWithProcess(deployment *storage.Deployment, images []*storage.Image, applied *NetworkPoliciesApplied, process *storage.ProcessIndicator, processNotInBaseline bool) (*pathutil.AugmentedObj, error) {
+	// Filter before both ConstructDeployment and findMatchingContainerIdxForProcess
+	// so the index lookup matches the filtered container list.
+	deployment, images = filterInitContainers(deployment, images)
 	obj, err := ConstructDeployment(deployment, images, applied)
 	if err != nil {
 		return nil, err
@@ -217,6 +221,7 @@ func ConstructDeploymentWithNetworkFlowInfo(
 // It assumes that the given images are in the same order as the containers specified within the given deployment.
 // If there's a mismatch in the amount of containers on the deployment and the given images, an error will be returned.
 func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image, applied *NetworkPoliciesApplied) (*pathutil.AugmentedObj, error) {
+	deployment, images = filterInitContainers(deployment, images)
 	obj := pathutil.NewAugmentedObj(deployment)
 	if len(images) != len(deployment.GetContainers()) {
 		return nil, errors.Errorf("deployment %s/%s had %d containers, but got %d images",
@@ -261,6 +266,28 @@ func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image
 	}
 
 	return obj, nil
+}
+
+// filterInitContainers returns a filtered deployment and image slice with init containers removed.
+// Temporary for 4.11 tech preview — remove in 5.0 when policy UX supports init containers.
+func filterInitContainers(deployment *storage.Deployment, images []*storage.Image) (*storage.Deployment, []*storage.Image) {
+	if !features.InitContainerSupport.Enabled() {
+		return deployment, images
+	}
+
+	filtered := deployment.CloneVT()
+	filtered.Containers = nil
+	var filteredImages []*storage.Image
+	for i, c := range deployment.GetContainers() {
+		if c.GetType() == storage.ContainerType_INIT {
+			continue
+		}
+		filtered.Containers = append(filtered.Containers, c)
+		if i < len(images) {
+			filteredImages = append(filteredImages, images[i])
+		}
+	}
+	return filtered, filteredImages
 }
 
 // ConstructImage constructs the augmented image object.

--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -269,7 +269,7 @@ func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image
 }
 
 // filterInitContainers returns a filtered deployment and image slice with init containers removed.
-// Temporary for 4.11 tech preview — remove in 5.0 when policy UX supports init containers.
+// TODO(ROX-33067): Remove this filter when policy evaluation supports init containers.
 func filterInitContainers(deployment *storage.Deployment, images []*storage.Image) (*storage.Deployment, []*storage.Image) {
 	if !features.InitContainerSupport.Enabled() {
 		return deployment, images

--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -29,10 +29,7 @@ func findMatchingContainerIdxForProcess(deployment *storage.Deployment, process 
 
 // ConstructDeploymentWithProcess constructs an augmented deployment with process information.
 func ConstructDeploymentWithProcess(deployment *storage.Deployment, images []*storage.Image, applied *NetworkPoliciesApplied, process *storage.ProcessIndicator, processNotInBaseline bool) (*pathutil.AugmentedObj, error) {
-	// Filter before both ConstructDeployment and findMatchingContainerIdxForProcess
-	// so the index lookup matches the filtered container list.
-	deployment, images = filterInitContainers(deployment, images)
-	obj, err := ConstructDeployment(deployment, images, applied)
+	obj, filtered, err := constructDeployment(deployment, images, applied)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +38,7 @@ func ConstructDeploymentWithProcess(deployment *storage.Deployment, images []*st
 		return nil, err
 	}
 
-	matchingContainerIdx, err := findMatchingContainerIdxForProcess(deployment, process)
+	matchingContainerIdx, err := findMatchingContainerIdxForProcess(filtered, process)
 	if err != nil {
 		return nil, err
 	}
@@ -221,16 +218,23 @@ func ConstructDeploymentWithNetworkFlowInfo(
 // It assumes that the given images are in the same order as the containers specified within the given deployment.
 // If there's a mismatch in the amount of containers on the deployment and the given images, an error will be returned.
 func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image, applied *NetworkPoliciesApplied) (*pathutil.AugmentedObj, error) {
+	obj, _, err := constructDeployment(deployment, images, applied)
+	return obj, err
+}
+
+// constructDeployment is the internal implementation that also returns the filtered deployment,
+// allowing callers like ConstructDeploymentWithProcess to use it for index lookups.
+func constructDeployment(deployment *storage.Deployment, images []*storage.Image, applied *NetworkPoliciesApplied) (*pathutil.AugmentedObj, *storage.Deployment, error) {
 	deployment, images = filterInitContainers(deployment, images)
 	obj := pathutil.NewAugmentedObj(deployment)
 	if len(images) != len(deployment.GetContainers()) {
-		return nil, errors.Errorf("deployment %s/%s had %d containers, but got %d images",
+		return nil, nil, errors.Errorf("deployment %s/%s had %d containers, but got %d images",
 			deployment.GetNamespace(), deployment.GetName(), len(deployment.GetContainers()), len(images))
 	}
 
 	appliedPolicies := pathutil.NewAugmentedObj(applied)
 	if err := obj.AddAugmentedObjAt(appliedPolicies, pathutil.FieldStep(networkPoliciesAppliedKey)); err != nil {
-		return nil, utils.ShouldErr(err)
+		return nil, nil, utils.ShouldErr(err)
 	}
 
 	for i, image := range images {
@@ -239,14 +243,14 @@ func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image
 		containerImageFullName := deployment.GetContainers()[i].GetImage().GetName().GetFullName()
 		augmentedImg, err := ConstructImage(image, containerImageFullName)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		err = obj.AddAugmentedObjAt(
 			augmentedImg,
 			pathutil.FieldStep("Containers"), pathutil.IndexStep(i), pathutil.FieldStep(imageAugmentKey),
 		)
 		if err != nil {
-			return nil, utils.ShouldErr(err)
+			return nil, nil, utils.ShouldErr(err)
 		}
 	}
 
@@ -260,12 +264,12 @@ func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image
 			)
 
 			if err != nil {
-				return nil, utils.ShouldErr(err)
+				return nil, nil, utils.ShouldErr(err)
 			}
 		}
 	}
 
-	return obj, nil
+	return obj, deployment, nil
 }
 
 // filterInitContainers returns a filtered deployment and image slice with init containers removed.

--- a/pkg/booleanpolicy/augmentedobjs/construct_test.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct_test.go
@@ -104,7 +104,108 @@ func TestConstructDeploymentFiltersInitContainers(t *testing.T) {
 }
 
 func TestConstructDeploymentWithProcessFiltersInitContainers(t *testing.T) {
-	t.Setenv(features.InitContainerSupport.EnvVar(), "true")
+	cases := map[string]struct {
+		containers       []*storage.Container
+		images           []*storage.Image
+		processContainer string
+		expectError      bool
+	}{
+		"single init + single regular, process on regular": {
+			containers: []*storage.Container{
+				{Name: "init", Type: storage.ContainerType_INIT},
+				{Name: "main", Type: storage.ContainerType_REGULAR},
+			},
+			images:           []*storage.Image{{Id: "init-img"}, {Id: "main-img"}},
+			processContainer: "main",
+		},
+		"init between two regular containers, process on second regular": {
+			containers: []*storage.Container{
+				{Name: "app", Type: storage.ContainerType_REGULAR},
+				{Name: "init-setup", Type: storage.ContainerType_INIT},
+				{Name: "sidecar", Type: storage.ContainerType_REGULAR},
+			},
+			images:           []*storage.Image{{Id: "app-img"}, {Id: "init-img"}, {Id: "sidecar-img"}},
+			processContainer: "sidecar",
+		},
+		"init between two regular containers, process on first regular": {
+			containers: []*storage.Container{
+				{Name: "app", Type: storage.ContainerType_REGULAR},
+				{Name: "init-setup", Type: storage.ContainerType_INIT},
+				{Name: "sidecar", Type: storage.ContainerType_REGULAR},
+			},
+			images:           []*storage.Image{{Id: "app-img"}, {Id: "init-img"}, {Id: "sidecar-img"}},
+			processContainer: "app",
+		},
+		"multiple init containers before multiple regular containers": {
+			containers: []*storage.Container{
+				{Name: "init-db", Type: storage.ContainerType_INIT},
+				{Name: "init-config", Type: storage.ContainerType_INIT},
+				{Name: "api", Type: storage.ContainerType_REGULAR},
+				{Name: "worker", Type: storage.ContainerType_REGULAR},
+				{Name: "sidecar", Type: storage.ContainerType_REGULAR},
+			},
+			images:           []*storage.Image{{Id: "init-db-img"}, {Id: "init-config-img"}, {Id: "api-img"}, {Id: "worker-img"}, {Id: "sidecar-img"}},
+			processContainer: "sidecar",
+		},
+		"multiple init containers + single regular, process on regular": {
+			containers: []*storage.Container{
+				{Name: "init-db", Type: storage.ContainerType_INIT},
+				{Name: "init-config", Type: storage.ContainerType_INIT},
+				{Name: "main", Type: storage.ContainerType_REGULAR},
+			},
+			images:           []*storage.Image{{Id: "init-db-img"}, {Id: "init-config-img"}, {Id: "main-img"}},
+			processContainer: "main",
+		},
+		"process on filtered init container returns error": {
+			containers: []*storage.Container{
+				{Name: "init", Type: storage.ContainerType_INIT},
+				{Name: "main", Type: storage.ContainerType_REGULAR},
+			},
+			images:           []*storage.Image{{Id: "init-img"}, {Id: "main-img"}},
+			processContainer: "init",
+			expectError:      true,
+		},
+		"no init containers, multiple regular, process on last": {
+			containers: []*storage.Container{
+				{Name: "app", Type: storage.ContainerType_REGULAR},
+				{Name: "sidecar", Type: storage.ContainerType_REGULAR},
+				{Name: "proxy", Type: storage.ContainerType_REGULAR},
+			},
+			images:           []*storage.Image{{Id: "app-img"}, {Id: "sidecar-img"}, {Id: "proxy-img"}},
+			processContainer: "proxy",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(features.InitContainerSupport.EnvVar(), "true")
+
+			deployment := &storage.Deployment{
+				Id:         "deploy-1",
+				Name:       "test-deploy",
+				Namespace:  "default",
+				ClusterId:  "cluster-1",
+				Containers: tc.containers,
+			}
+			process := &storage.ProcessIndicator{
+				ContainerName: tc.processContainer,
+				Signal:        &storage.ProcessSignal{ExecFilePath: "/bin/sh"},
+			}
+
+			obj, err := ConstructDeploymentWithProcess(deployment, tc.images, &NetworkPoliciesApplied{}, process, false)
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "not found")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, obj)
+			}
+		})
+	}
+}
+
+func TestConstructDeploymentWithProcessFlagOff(t *testing.T) {
+	t.Setenv(features.InitContainerSupport.EnvVar(), "false")
 
 	deployment := &storage.Deployment{
 		Id:        "deploy-1",
@@ -112,51 +213,35 @@ func TestConstructDeploymentWithProcessFiltersInitContainers(t *testing.T) {
 		Namespace: "default",
 		ClusterId: "cluster-1",
 		Containers: []*storage.Container{
-			{Name: "init", Type: storage.ContainerType_INIT},
-			{Name: "main", Type: storage.ContainerType_REGULAR},
+			{Name: "init-db", Type: storage.ContainerType_INIT},
+			{Name: "init-config", Type: storage.ContainerType_INIT},
+			{Name: "api", Type: storage.ContainerType_REGULAR},
+			{Name: "sidecar", Type: storage.ContainerType_REGULAR},
 		},
 	}
 	images := []*storage.Image{
-		{Id: "init-image"},
-		{Id: "main-image"},
-	}
-	process := &storage.ProcessIndicator{
-		ContainerName: "main",
-		Signal: &storage.ProcessSignal{
-			ExecFilePath: "/bin/sh",
-		},
+		{Id: "init-db-img"},
+		{Id: "init-config-img"},
+		{Id: "api-img"},
+		{Id: "sidecar-img"},
 	}
 
+	// With flag off, init containers are NOT filtered. Process on a regular container
+	// should still resolve correctly against the full unfiltered list.
+	process := &storage.ProcessIndicator{
+		ContainerName: "sidecar",
+		Signal:        &storage.ProcessSignal{ExecFilePath: "/bin/sh"},
+	}
 	obj, err := ConstructDeploymentWithProcess(deployment, images, &NetworkPoliciesApplied{}, process, false)
 	require.NoError(t, err)
 	require.NotNil(t, obj)
-}
 
-func TestConstructDeploymentWithProcessForInitContainerReturnsError(t *testing.T) {
-	t.Setenv(features.InitContainerSupport.EnvVar(), "true")
-
-	deployment := &storage.Deployment{
-		Id:        "deploy-1",
-		Name:      "test-deploy",
-		Namespace: "default",
-		ClusterId: "cluster-1",
-		Containers: []*storage.Container{
-			{Name: "init", Type: storage.ContainerType_INIT},
-			{Name: "main", Type: storage.ContainerType_REGULAR},
-		},
+	// Process on an init container should also resolve when flag is off (no filtering).
+	processOnInit := &storage.ProcessIndicator{
+		ContainerName: "init-db",
+		Signal:        &storage.ProcessSignal{ExecFilePath: "/bin/sh"},
 	}
-	images := []*storage.Image{
-		{Id: "init-image"},
-		{Id: "main-image"},
-	}
-	process := &storage.ProcessIndicator{
-		ContainerName: "init",
-		Signal: &storage.ProcessSignal{
-			ExecFilePath: "/bin/sh",
-		},
-	}
-
-	_, err := ConstructDeploymentWithProcess(deployment, images, &NetworkPoliciesApplied{}, process, false)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	obj, err = ConstructDeploymentWithProcess(deployment, images, &NetworkPoliciesApplied{}, processOnInit, false)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
 }

--- a/pkg/booleanpolicy/augmentedobjs/construct_test.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct_test.go
@@ -1,0 +1,162 @@
+package augmentedobjs
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterInitContainers(t *testing.T) {
+	initContainer := &storage.Container{
+		Name: "init",
+		Type: storage.ContainerType_INIT,
+	}
+	regularContainer := &storage.Container{
+		Name: "main",
+		Type: storage.ContainerType_REGULAR,
+	}
+	initImage := &storage.Image{
+		Id: "init-image",
+	}
+	regularImage := &storage.Image{
+		Id: "main-image",
+	}
+
+	cases := map[string]struct {
+		flagEnabled        bool
+		containers         []*storage.Container
+		images             []*storage.Image
+		expectedContainers []*storage.Container
+		expectedImages     []*storage.Image
+	}{
+		"flag enabled, init containers filtered out": {
+			flagEnabled:        true,
+			containers:         []*storage.Container{initContainer, regularContainer},
+			images:             []*storage.Image{initImage, regularImage},
+			expectedContainers: []*storage.Container{regularContainer},
+			expectedImages:     []*storage.Image{regularImage},
+		},
+		"flag enabled, no init containers is a no-op": {
+			flagEnabled:        true,
+			containers:         []*storage.Container{regularContainer},
+			images:             []*storage.Image{regularImage},
+			expectedContainers: []*storage.Container{regularContainer},
+			expectedImages:     []*storage.Image{regularImage},
+		},
+		"flag disabled, init containers passed through": {
+			flagEnabled:        false,
+			containers:         []*storage.Container{initContainer, regularContainer},
+			images:             []*storage.Image{initImage, regularImage},
+			expectedContainers: []*storage.Container{initContainer, regularContainer},
+			expectedImages:     []*storage.Image{initImage, regularImage},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.flagEnabled {
+				t.Setenv(features.InitContainerSupport.EnvVar(), "true")
+			} else {
+				t.Setenv(features.InitContainerSupport.EnvVar(), "false")
+			}
+
+			deployment := &storage.Deployment{
+				Containers: tc.containers,
+			}
+
+			filtered, filteredImages := filterInitContainers(deployment, tc.images)
+
+			require.Len(t, filtered.GetContainers(), len(tc.expectedContainers))
+			for i, c := range filtered.GetContainers() {
+				assert.Equal(t, tc.expectedContainers[i].GetName(), c.GetName())
+				assert.Equal(t, tc.expectedContainers[i].GetType(), c.GetType())
+			}
+			require.Len(t, filteredImages, len(tc.expectedImages))
+			for i, img := range filteredImages {
+				assert.Equal(t, tc.expectedImages[i].GetId(), img.GetId())
+			}
+		})
+	}
+}
+
+func TestConstructDeploymentFiltersInitContainers(t *testing.T) {
+	t.Setenv(features.InitContainerSupport.EnvVar(), "true")
+
+	deployment := &storage.Deployment{
+		Name:      "test-deploy",
+		Namespace: "default",
+		Containers: []*storage.Container{
+			{Name: "init", Type: storage.ContainerType_INIT},
+			{Name: "main", Type: storage.ContainerType_REGULAR},
+		},
+	}
+	images := []*storage.Image{
+		{Id: "init-image"},
+		{Id: "main-image"},
+	}
+
+	obj, err := ConstructDeployment(deployment, images, &NetworkPoliciesApplied{})
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+}
+
+func TestConstructDeploymentWithProcessFiltersInitContainers(t *testing.T) {
+	t.Setenv(features.InitContainerSupport.EnvVar(), "true")
+
+	deployment := &storage.Deployment{
+		Id:        "deploy-1",
+		Name:      "test-deploy",
+		Namespace: "default",
+		ClusterId: "cluster-1",
+		Containers: []*storage.Container{
+			{Name: "init", Type: storage.ContainerType_INIT},
+			{Name: "main", Type: storage.ContainerType_REGULAR},
+		},
+	}
+	images := []*storage.Image{
+		{Id: "init-image"},
+		{Id: "main-image"},
+	}
+	process := &storage.ProcessIndicator{
+		ContainerName: "main",
+		Signal: &storage.ProcessSignal{
+			ExecFilePath: "/bin/sh",
+		},
+	}
+
+	obj, err := ConstructDeploymentWithProcess(deployment, images, &NetworkPoliciesApplied{}, process, false)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+}
+
+func TestConstructDeploymentWithProcessForInitContainerReturnsError(t *testing.T) {
+	t.Setenv(features.InitContainerSupport.EnvVar(), "true")
+
+	deployment := &storage.Deployment{
+		Id:        "deploy-1",
+		Name:      "test-deploy",
+		Namespace: "default",
+		ClusterId: "cluster-1",
+		Containers: []*storage.Container{
+			{Name: "init", Type: storage.ContainerType_INIT},
+			{Name: "main", Type: storage.ContainerType_REGULAR},
+		},
+	}
+	images := []*storage.Image{
+		{Id: "init-image"},
+		{Id: "main-image"},
+	}
+	process := &storage.ProcessIndicator{
+		ContainerName: "init",
+		Signal: &storage.ProcessSignal{
+			ExecFilePath: "/bin/sh",
+		},
+	}
+
+	_, err := ConstructDeploymentWithProcess(deployment, images, &NetworkPoliciesApplied{}, process, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}


### PR DESCRIPTION
## Description

Filters init containers from policy evaluation when the `InitContainerSupport` feature flag is enabled. This is a temporary measure for tech preview: init containers are now scanned and displayed in deployments, but the policy UX does not yet support selective init container evaluation. Without this filter, enabling the feature flag would cause unexpected policy violations for init containers (e.g., CVE violations, privileged mode checks, process baseline alerts).

The fix adds a `filterInitContainers` helper in `pkg/booleanpolicy/augmentedobjs/construct.go` that clones the deployment, strips containers with `ContainerType_INIT`, and returns the filtered deployment along with a correctly aligned image slice. This function is called at the top of the internal `constructDeployment` helper, which backs both `ConstructDeployment` and `ConstructDeploymentWithProcess`. Since `constructDeployment` is the single entry point for all policy evaluation paths (Central deploy-time, Sensor runtime, and Admission Controller), this one filter point protects all evaluation paths.

The filter is called before `findMatchingContainerIdxForProcess` so the process indicator index lookup matches the filtered container list, avoiding an index mismatch bug.

When the feature flag is disabled, the function is a no-op pass-through. When enabled but no init containers are present, an early exit avoids unnecessary cloning.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Deployed image `4.11.x-805-g6b4d4b0e7b` to a GKE cluster using roxie with `ROX_INIT_CONTAINER_SUPPORT` enabled. Ran 9 manual test cases covering deploy-time policy filtering, runtime process indicator index alignment across all init/regular container count combinations, process criteria policy validation, and split flag scenarios.

### Test 1: Privileged init container produces NO violation (flag ON)

Deployed a workload with a privileged init container (`busybox:1.36`, `privileged: true`) and a non-privileged regular container (`nginx:1.25`):

```
curl -sk -u admin:$PASSWORD ".../v1/deployments/$DEPLOY_ID" \
  | jq '.containers[] | {name: .name, type: .type, privileged: .securityContext.privileged}'
```

```json
{
  "name": "init-privileged",
  "type": "INIT",
  "privileged": true
}
{
  "name": "main-app",
  "type": "REGULAR",
  "privileged": false
}
```

Init container is extracted and visible in the deployment data, but produces no "Privileged Container" alert:

```
curl -sk -u admin:$PASSWORD '.../v1/alerts?query=Deployment%3Aprivileged-init-test%2BPolicy%3APrivileged+Container' \
  | jq '.alerts'
```

```json
[]
```

### Test 2: Privileged regular container still produces a violation (flag ON)

Deployed a workload with a non-privileged init container and a privileged regular container:

```
curl -sk -u admin:$PASSWORD '.../v1/alerts?query=Deployment%3Aprivileged-regular-test%2BPolicy%3APrivileged+Container' \
  | jq '.alerts[] | {policy: .policy.name, deployment: .deployment.name, state}'
```

```json
{
  "policy": "Privileged Container",
  "deployment": "privileged-regular-test",
  "state": "ACTIVE"
}
```

Filtering only removes init containers from policy evaluation — regular containers still trigger alerts as expected.

### Test 3: Feature flag OFF — no regression

Patched both CRs to set `ROX_INIT_CONTAINER_SUPPORT=false`. Deployed the same privileged-init workload:

```
curl -sk -u admin:$PASSWORD ".../v1/deployments/$DEPLOY_ID" \
  | jq '.containers[] | {name: .name, type: .type}'
```

```json
{
  "name": "main-app",
  "type": "REGULAR"
}
```

Init container not extracted (flag off), no "Privileged Container" alert. Privileged regular container still triggers correctly:

```json
{
  "policy": "Privileged Container",
  "deployment": "privileged-regular-test"
}
```

### Test 4: Runtime process path — all init/regular container combinations (flag ON)

Deployed 4 workloads covering every combination of init and regular container counts to exercise the `ConstructDeploymentWithProcess` code path and verify process indicator index alignment after init container filtering:

| Deployment | Init containers | Regular containers | Process exec target |
|---|---|---|---|
| `test-1r-1i` | 1 (`init-setup`) | 1 (`main-app`) | `main-app` |
| `test-1r-2i` | 2 (`init-db`, `init-config`) | 1 (`main-app`) | `main-app` |
| `test-2r-1i` | 1 (`init-setup`) | 2 (`api-server`, `sidecar`) | `sidecar` |
| `test-2r-2i` | 2 (`init-db`, `init-config`) | 2 (`api-server`, `sidecar`) | `sidecar` |

All 4 deployments showed correct container types in Central (INIT/REGULAR). After exec'ing into the target container in each deployment, "Kubernetes Actions: Exec into Pod" runtime alerts fired for all 4:

```
curl -sk -u admin:$PASSWORD ".../v1/alerts?query=Deployment%3Atest-2r-2i" \
  | jq '.alerts[] | select(.policy.name == "Kubernetes Actions: Exec into Pod")'
```

```json
{
  "policy": "Kubernetes Actions: Exec into Pod",
  "state": "ACTIVE"
}
```

No index mismatch errors in Central logs:

```
kubectl logs -n stackrox deploy/central --tail=500 \
  | grep -i "could not be matched\|index out of"
# (no output)
```

Note: "Kubernetes Actions: Exec into Pod" is a kube event-based policy (`ConstructKubeResourceWithEvent`), not a process indicator-based policy. See Test 5 for the `ConstructDeploymentWithProcess` path validation.

### Test 5: Process criteria policy with init container filtering (flag ON)

Enabled the OOTB "Process with UID 0" policy (disabled by default) to exercise the `ConstructDeploymentWithProcess` code path specifically. This policy uses process criteria (Process UID field), which goes through the process indicator evaluation path where index alignment matters.

Deployed a workload with 1 init container (`init-setup`) and 2 regular containers (`api-server`, `sidecar`). Exec'd `ls /` into `sidecar` (runs as UID 0 in busybox):

```
curl -sk -u admin:$PASSWORD ".../v1/alerts?query=Deployment%3Aprocess-path-test%2BPolicy%3AProcess+with+UID+0" \
  | jq '.alerts[] | {policy: .policy.name, deployment: .deployment.name, state}'
```

```json
{
  "policy": "Process with UID 0",
  "deployment": "process-path-test",
  "state": "ACTIVE"
}
```

No index mismatch errors in Central logs. This confirms `ConstructDeploymentWithProcess` correctly handles init container filtering — the process indicator for `sidecar` resolved to the right index in the filtered container list after `init-setup` was removed.

### Test 6: Split flag — Central OFF, Sensor ON

Patched the Central CR to set `ROX_INIT_CONTAINER_SUPPORT=false` while leaving Sensor at `true`. This tests the capability handshake path: Sensor extracts init containers locally but strips them in `toEvent` because Central does not advertise `InitContainerSupport`.

Deployed a workload with 1 init container (`init-setup`) and 2 regular containers (`api-server`, `sidecar`):

```
kubectl exec -n stackrox deploy/central -- printenv | grep ROX_INIT_CONTAINER_SUPPORT
# ROX_INIT_CONTAINER_SUPPORT=false

kubectl exec -n stackrox deploy/sensor -- printenv | grep ROX_INIT_CONTAINER_SUPPORT
# ROX_INIT_CONTAINER_SUPPORT=true
```

Central only sees regular containers — init container was stripped by Sensor before sending:

```
curl -sk -u admin:$PASSWORD ".../v1/deployments/$DEPLOY_ID" \
  | jq '.deployment.containers[] | {name: .name, type: .type}'
```

```json
{
  "name": "api-server",
  "type": "REGULAR"
}
{
  "name": "sidecar",
  "type": "REGULAR"
}
```

No `init-setup` present. After exec'ing into the sidecar, "Kubernetes Actions: Exec into Pod" alert fired correctly:

```json
{
  "policy": "Kubernetes Actions: Exec into Pod",
  "state": "ACTIVE"
}
```

No index mismatch errors in Central or Sensor logs. Restored Central flag to `true` after test.
