### PR TITLE
ROX-34027: Skip init container image scans in AC webhook

### DIFF
--- a/sensor/admission-control/manager/images.go
+++ b/sensor/admission-control/manager/images.go
@@ -9,6 +9,7 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/protoconv/resources"
@@ -221,8 +222,14 @@ func (m *manager) getAvailableImagesAndKickOffScans(ctx context.Context, shouldF
 	fetchCount := 0
 
 	scanInline := s.GetClusterConfig().GetAdmissionControllerConfig().GetScanInline()
+	initContainerSupportEnabled := features.InitContainerSupport.Enabled()
 
 	for idx, container := range deployment.GetContainers() {
+		// Init container images are filtered from policy evaluation (ROX-34026), skip scanning them.
+		if initContainerSupportEnabled && container.GetType() == storage.ContainerType_INIT {
+			images[idx] = types.ToImage(container.GetImage())
+			continue
+		}
 		image := container.GetImage()
 		if image.GetId() != "" || scanInline {
 			cachedImage := m.getCachedImage(image, s, true)

--- a/sensor/admission-control/manager/images_test.go
+++ b/sensor/admission-control/manager/images_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/coalescer"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/sizeboundedcache"
 	"github.com/stretchr/testify/require"
@@ -396,4 +398,86 @@ func (s *ImageCacheTestSuite) TestClearImageCacheGen() {
 	s.Equal(uint64(0), s.manager.imageCacheGen.Get(s.T(), "sha256:a"))
 	s.Equal(uint64(0), s.manager.imageCacheGen.Get(s.T(), "sha256:b"))
 	s.Equal("", s.manager.imageCacheGen.CacheVersion())
+}
+
+func (s *ImageCacheTestSuite) TestGetAvailableImagesInitContainerHandling() {
+	cases := map[string]struct {
+		flagEnabled    bool
+		containers     []*storage.Container
+		expectedImages []string
+		skippedIndexes []int // indexes where init containers should get placeholder (no scan)
+	}{
+		"flag on, single init + single regular": {
+			flagEnabled: true,
+			containers: []*storage.Container{
+				{Name: "init", Type: storage.ContainerType_INIT, Image: &storage.ContainerImage{Id: "sha256:init123", Name: &storage.ImageName{FullName: "docker.io/library/busybox:1.36"}}},
+				{Name: "main", Type: storage.ContainerType_REGULAR, Image: &storage.ContainerImage{Id: "sha256:main456", Name: &storage.ImageName{FullName: "docker.io/library/nginx:1.25"}}},
+			},
+			expectedImages: []string{"docker.io/library/busybox:1.36", "docker.io/library/nginx:1.25"},
+			skippedIndexes: []int{0},
+		},
+		"flag on, multiple init + multiple regular": {
+			flagEnabled: true,
+			containers: []*storage.Container{
+				{Name: "init-db", Type: storage.ContainerType_INIT, Image: &storage.ContainerImage{Id: "sha256:initdb123", Name: &storage.ImageName{FullName: "docker.io/library/busybox:1.36"}}},
+				{Name: "init-config", Type: storage.ContainerType_INIT, Image: &storage.ContainerImage{Id: "sha256:initcfg456", Name: &storage.ImageName{FullName: "docker.io/library/alpine:3.18"}}},
+				{Name: "api-server", Type: storage.ContainerType_REGULAR, Image: &storage.ContainerImage{Id: "sha256:api789", Name: &storage.ImageName{FullName: "docker.io/library/nginx:1.25"}}},
+				{Name: "sidecar", Type: storage.ContainerType_REGULAR, Image: &storage.ContainerImage{Id: "sha256:side012", Name: &storage.ImageName{FullName: "docker.io/library/redis:7.2"}}},
+			},
+			expectedImages: []string{"docker.io/library/busybox:1.36", "docker.io/library/alpine:3.18", "docker.io/library/nginx:1.25", "docker.io/library/redis:7.2"},
+			skippedIndexes: []int{0, 1},
+		},
+		"flag off, init containers not skipped": {
+			flagEnabled: false,
+			containers: []*storage.Container{
+				{Name: "init", Type: storage.ContainerType_INIT, Image: &storage.ContainerImage{Id: "sha256:init123", Name: &storage.ImageName{FullName: "docker.io/library/busybox:1.36"}}},
+				{Name: "main", Type: storage.ContainerType_REGULAR, Image: &storage.ContainerImage{Id: "sha256:main456", Name: &storage.ImageName{FullName: "docker.io/library/nginx:1.25"}}},
+			},
+			expectedImages: []string{"docker.io/library/busybox:1.36", "docker.io/library/nginx:1.25"},
+			skippedIndexes: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		s.Run(name, func() {
+			if tc.flagEnabled {
+				s.T().Setenv(features.InitContainerSupport.EnvVar(), "true")
+			} else {
+				s.T().Setenv(features.InitContainerSupport.EnvVar(), "false")
+			}
+
+			st := createTestState(false)
+			st.ClusterConfig = &storage.DynamicClusterConfig{
+				AdmissionControllerConfig: &storage.AdmissionControllerConfig{
+					ScanInline: true,
+				},
+			}
+			s.manager.state.Store(st)
+
+			deployment := &storage.Deployment{
+				Name:       "test",
+				Namespace:  "default",
+				Containers: tc.containers,
+			}
+
+			images, resultChan := s.manager.getAvailableImagesAndKickOffScans(context.Background(), false, st, deployment)
+			for range resultChan {
+			}
+
+			s.Require().Len(images, len(tc.expectedImages))
+			for i, expected := range tc.expectedImages {
+				s.Equal(expected, images[i].GetName().GetFullName())
+			}
+
+			skipped := make(map[int]bool)
+			for _, idx := range tc.skippedIndexes {
+				skipped[idx] = true
+			}
+			for i := range images {
+				if skipped[i] {
+					s.Empty(images[i].GetScan(), "init container at index %d should have no scan", i)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

Skip triggering vulnerability scans for init container images in the Admission Controller webhook when the `InitContainerSupport` feature flag is enabled. Policy evaluation ([ROX-34026](https://redhat.atlassian.net/browse/ROX-34026)) filters out init containers during policy matching, so scanning their images on the webhook hot path adds latency for results that are ultimately discarded. This is a performance optimization to help avoid webhook timeouts, which is an ongoing customer issue.

The change is in `sensor/admission-control/manager/images.go` in the `getAvailableImagesAndKickOffScans` function. When the feature flag is enabled and the container type is `INIT`, the loop skips spawning `fetchImage` goroutines and avoids `ScanImageInternal`/`GetImage` calls. Instead, a placeholder image is assigned so the images slice stays correctly indexed. Regular containers continue to be scanned normally, and with the flag off there is no behavior change.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

No user-facing documentation or CHANGELOG update needed. This is an internal performance optimization behind a feature flag with no change to external APIs or behavior.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Deployed image `4.11.x-804-g08580b7c14` to a GKE cluster using roxie with `ROX_INIT_CONTAINER_SUPPORT` enabled. Configured the admission controller with `scanInline: true`, `enabled: true`, and `enforceOnUpdates: true`. Ran 5 manual test cases exercising AC webhook behavior with init containers.

### Test 1: AC webhook admits deployment with init containers (flag ON)

Deployed a workload with a busybox init container and nginx regular container. The admission controller admitted the deployment without error. Both containers appeared in Central's API:

```
curl -sk -u admin:$PASSWORD ".../v1/deployments/$DEPLOY_ID" \
  | jq '.containers[] | {name: .name, type: .type, image: .image.name.fullName}'
```

```json
{
  "name": "init-setup",
  "type": "INIT",
  "image": "docker.io/library/busybox:1.36"
}
{
  "name": "main-app",
  "type": "REGULAR",
  "image": "docker.io/library/nginx:1.25"
}
```

No alerts related to the init container image:

```
curl -sk -u admin:$PASSWORD '.../v1/alerts?query=Deployment%3Atest-init-container-admit' \
  | jq '.alerts[] | {policy: .policy.name}'
```

Only standard informational policies fired (CIS 4.1, image age, etc.) — none referencing the init container.

### Test 2: AC enforcement still blocks privileged regular containers (flag ON)

Enabled `SCALE_TO_ZERO_ENFORCEMENT` on the "Privileged Container" policy. Attempted to deploy a workload with a privileged regular container (`nginx:1.25`, `privileged: true`). The admission controller denied the request:

```
$ kubectl apply -f ...
error: failed to create resource: admission webhook "policyeval.stackrox.io" denied the request: ...
```

Alert in Central confirms enforcement fired against the regular container:

```
curl -sk -u admin:$PASSWORD ".../v1/alerts/$ALERT_ID" \
  | jq '{policy: .policy.name, state: .state, enforcement: .enforcement, violations: [.violations[].message]}'
```

```json
{
  "policy": "Privileged Container",
  "state": "ATTEMPTED",
  "enforcement": {
    "action": "FAIL_DEPLOYMENT_CREATE_ENFORCEMENT",
    "message": "Failed deployment create in response to this policy violation."
  },
  "violations": [
    "Container 'privileged-main' is privileged"
  ]
}
```

### Test 3: Privileged init container is NOT blocked by AC (flag ON)

Deployed a workload with a privileged init container (`busybox:1.36`, `privileged: true`) and a non-privileged regular container (`nginx:1.25`). The AC admitted the deployment successfully and the pod reached Running state:

```
$ kubectl get pods -n default -l app=test-priv-init
NAME                                    READY   STATUS    RESTARTS   AGE
test-privileged-init-...                1/1     Running   0          30s
```

No "Privileged Container" alerts fired — the init container's privileged security context was not evaluated:

```
curl -sk -u admin:$PASSWORD '.../v1/alerts?query=Deployment%3Atest-privileged-init' \
  | jq '.alerts | length'
```

```json
0
```

This confirms that init container images are not being scanned/evaluated by the AC webhook, so a privileged init container does not trigger enforcement.

### Test 4: No regression with feature flag OFF

Patched both CRs (`centrals.platform.stackrox.io`, `securedclusters.platform.stackrox.io`) to set `ROX_INIT_CONTAINER_SUPPORT=false`. Verified all three components (Central, Sensor, AC) picked up the change. Deployed the same init+regular container workload. The AC admitted it normally. In Central, only the regular container appeared:

```
curl -sk -u admin:$PASSWORD ".../v1/deployments/$DEPLOY_ID" \
  | jq '.containers[] | {name: .name, type: .type}'
```

```json
{
  "name": "main-app",
  "type": "REGULAR"
}
```

No "Privileged Container" violations — init containers are not extracted by Sensor when the flag is off, so there is nothing for the AC to scan or skip.

### Test 5: Restore "Privileged Container" policy to default

Removed `SCALE_TO_ZERO_ENFORCEMENT` from the policy via API:

```
curl -sk -u admin:$PASSWORD ".../v1/policies/$POLICY_ID" \
  | jq '{name: .name, enforcementActions: .enforcementActions, disabled: .disabled}'
```

```json
{
  "name": "Privileged Container",
  "enforcementActions": [],
  "disabled": false
}
```

[ROX-34026]: https://redhat.atlassian.net/browse/ROX-34026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ