### PR TITLE
ROX-34411: Add DeliveryView and render query in report configuration

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups.tsx
@@ -19,7 +19,7 @@ export type CompoundSearchFilterDescriptionListGroupsProps = {
 
 // For maximum composability and reusability:
 // Render description list groups instead of description list.
-// If rules array is empty, caller is reponsible for conditional rendering, like a warning alert.
+// If rules array is empty, caller is responsible for conditional rendering, like a warning alert.
 function CompoundSearchFilterDescriptionListGroups({
     attributes,
     searchFilter,

--- a/ui/apps/platform/src/Components/EntityScope/EntityScopeDescriptionListGroups.tsx
+++ b/ui/apps/platform/src/Components/EntityScope/EntityScopeDescriptionListGroups.tsx
@@ -17,7 +17,7 @@ export type EntityScopeDescriptionListGroupsProps = {
 
 // For maximum composability and reusability:
 // Render description list groups instead of description list.
-// If rules array is empty, caller is reponsible for conditional rendering, like a warning alert.
+// If rules array is empty, caller is responsible for conditional rendering, like a warning alert.
 function EntityScopeDescriptionListGroups({
     entityScope,
 }: EntityScopeDescriptionListGroupsProps): ReactElement {

--- a/ui/apps/platform/src/Components/Reports/View/DeliveryView.tsx
+++ b/ui/apps/platform/src/Components/Reports/View/DeliveryView.tsx
@@ -27,6 +27,7 @@ function DeliveryView({
     horizontalTermWidthModifier,
     values,
 }: DeliveryViewProps): ReactElement {
+    /* eslint-disable react/no-array-index-key */
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
             <FlexItem>
@@ -48,8 +49,11 @@ function DeliveryView({
                                     direction={{ default: 'column' }}
                                     spaceItems={{ default: 'spaceItemsLg' }}
                                 >
-                                    {values.notifiers.map((notifier) => (
-                                        <NotifierConfigurationDescriptionList notifier={notifier} />
+                                    {values.notifiers.map((notifier, index) => (
+                                        <NotifierConfigurationDescriptionList
+                                            key={index}
+                                            notifier={notifier}
+                                        />
                                     ))}
                                 </Flex>
                             )}
@@ -65,6 +69,7 @@ function DeliveryView({
             </FlexItem>
         </Flex>
     );
+    /* eslint-enable react/no-array-index-key */
 }
 
 export default DeliveryView;

--- a/ui/apps/platform/src/Components/Reports/View/DeliveryView.tsx
+++ b/ui/apps/platform/src/Components/Reports/View/DeliveryView.tsx
@@ -1,0 +1,70 @@
+import type { ReactElement } from 'react';
+import {
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Flex,
+    FlexItem,
+    Title,
+} from '@patternfly/react-core';
+import type { BreakpointModifiers } from '@patternfly/react-core';
+
+import { formatRecurringSchedule } from 'utils/dateUtils';
+
+import type { DeliveryType } from '../reports.types';
+
+import NotifierConfigurationDescriptionList from './NotifierConfigurationDescriptionList';
+
+export type DeliveryViewProps = {
+    headingLevel: 'h2' | 'h3';
+    horizontalTermWidthModifier: BreakpointModifiers;
+    values: DeliveryType;
+};
+
+function DeliveryView({
+    headingLevel,
+    horizontalTermWidthModifier,
+    values,
+}: DeliveryViewProps): ReactElement {
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+            <FlexItem>
+                <Title headingLevel={headingLevel}>Delivery</Title>
+            </FlexItem>
+            <FlexItem>
+                <DescriptionList
+                    isCompact
+                    isHorizontal
+                    horizontalTermWidthModifier={horizontalTermWidthModifier}
+                >
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Destinations</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {values.notifiers.length === 0 ? (
+                                '-'
+                            ) : (
+                                <Flex
+                                    direction={{ default: 'column' }}
+                                    spaceItems={{ default: 'spaceItemsLg' }}
+                                >
+                                    {values.notifiers.map((notifier) => (
+                                        <NotifierConfigurationDescriptionList notifier={notifier} />
+                                    ))}
+                                </Flex>
+                            )}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                        <DescriptionListTerm>Schedule</DescriptionListTerm>
+                        <DescriptionListDescription>
+                            {values.schedule ? formatRecurringSchedule(values.schedule) : '-'}
+                        </DescriptionListDescription>
+                    </DescriptionListGroup>
+                </DescriptionList>
+            </FlexItem>
+        </Flex>
+    );
+}
+
+export default DeliveryView;

--- a/ui/apps/platform/src/Components/Reports/View/NotifierConfigurationDescriptionList.tsx
+++ b/ui/apps/platform/src/Components/Reports/View/NotifierConfigurationDescriptionList.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement } from 'react';
+import {
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+} from '@patternfly/react-core';
+
+import { isDefaultEmailTemplate } from 'Components/EmailTemplate/EmailTemplate.utils';
+import type { NotifierConfiguration } from 'services/ReportsService.types';
+
+export type NotifierConfigurationDescriptionListProps = {
+    notifier: NotifierConfiguration;
+};
+
+function NotifierConfigurationDescriptionList({
+    notifier,
+}: NotifierConfigurationDescriptionListProps): ReactElement {
+    const { emailConfig, notifierName } = notifier;
+    const { customBody, customSubject, mailingLists } = emailConfig;
+    const hasDefaultEmailTemplate = isDefaultEmailTemplate({
+        customBody,
+        customSubject,
+    });
+
+    return (
+        <DescriptionList isCompact isHorizontal>
+            <DescriptionListGroup>
+                <DescriptionListTerm>Email notifier</DescriptionListTerm>
+                <DescriptionListDescription>{notifierName}</DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+                <DescriptionListTerm>Distribution list</DescriptionListTerm>
+                <DescriptionListDescription>{mailingLists.join(', ')}</DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+                <DescriptionListTerm>Email template</DescriptionListTerm>
+                <DescriptionListDescription>
+                    {hasDefaultEmailTemplate ? 'Default template' : 'Custom template'}
+                </DescriptionListDescription>
+            </DescriptionListGroup>
+        </DescriptionList>
+    );
+}
+
+export default NotifierConfigurationDescriptionList;

--- a/ui/apps/platform/src/Components/Reports/reports.types.ts
+++ b/ui/apps/platform/src/Components/Reports/reports.types.ts
@@ -1,3 +1,11 @@
+import type { NotifierConfiguration } from 'services/ReportsService.types';
+import type { Schedule } from 'types/schedule.proto';
+
+export type DeliveryType = {
+    notifiers: NotifierConfiguration[];
+    schedule: Schedule | null;
+};
+
 export type DetailsType = {
     name: string;
     description: string;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersView.tsx
@@ -10,21 +10,38 @@ import {
 } from '@patternfly/react-core';
 import type { BreakpointModifiers } from '@patternfly/react-core';
 
+import CompoundSearchFilterDescriptionListGroups from 'Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups';
+import type {
+    CompoundSearchFilterAttribute,
+    CompoundSearchFilterConfig,
+} from 'Components/CompoundSearchFilter/types';
+import { getSearchFilterFromSearchString } from 'utils/searchUtils';
+
 import type { ImageVulnerabilityFiltersConfiguration } from '../imageVulnerabilityReports.types';
 import { getTextForCvesSince } from '../imageVulnerabilityReports.utils';
 
 export type ImageVulnerabilityFiltersViewProps = {
+    attributesSeparateFromConfig: CompoundSearchFilterAttribute[];
     headingLevel: 'h2' | 'h3';
     horizontalTermWidthModifier: BreakpointModifiers;
+    searchFilterConfig: CompoundSearchFilterConfig;
     values: ImageVulnerabilityFiltersConfiguration;
 };
 
 function ImageVulnerabilityFiltersView({
+    attributesSeparateFromConfig,
     headingLevel,
     horizontalTermWidthModifier,
+    searchFilterConfig,
     values,
 }: ImageVulnerabilityFiltersViewProps): ReactElement {
+    // Render separate attributes (more likely to be specified) preceding config.
+    const attributesFromConfig = searchFilterConfig.flatMap(({ attributes }) => attributes);
+    const attributes = [...attributesSeparateFromConfig, ...attributesFromConfig];
+
     const { vulnReportFilters } = values;
+    const { query } = vulnReportFilters;
+    const searchFilter = getSearchFilterFromSearchString(query);
 
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
@@ -37,7 +54,10 @@ function ImageVulnerabilityFiltersView({
                     isHorizontal
                     horizontalTermWidthModifier={horizontalTermWidthModifier}
                 >
-                    {/* TODO render labels for query string */}
+                    <CompoundSearchFilterDescriptionListGroups
+                        attributes={attributes}
+                        searchFilter={searchFilter}
+                    />
                     <DescriptionListGroup>
                         <DescriptionListTerm>CVEs discovered in image since</DescriptionListTerm>
                         <DescriptionListDescription>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityReportView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityReportView.tsx
@@ -2,6 +2,11 @@ import type { ReactElement } from 'react';
 import { Flex } from '@patternfly/react-core';
 import type { BreakpointModifiers } from '@patternfly/react-core';
 
+import type {
+    CompoundSearchFilterAttribute,
+    CompoundSearchFilterConfig,
+} from 'Components/CompoundSearchFilter/types';
+import DeliveryView from 'Components/Reports/View/DeliveryView';
 import DetailsView from 'Components/Reports/View/DetailsView';
 
 import type { ImageVulnerabilityReportConfiguration } from '../imageVulnerabilityReports.types';
@@ -12,14 +17,18 @@ import ImageVulnerabilityFiltersViewForCollection from './ImageVulnerabilityFilt
 import ImageVulnerabilityResourcesView from './ImageVulnerabilityResourcesView';
 
 export type ImageVulnerabilityReportViewProps = {
+    attributesSeparateFromConfig: CompoundSearchFilterAttribute[];
     headingLevel: 'h2' | 'h3';
     horizontalTermWidthModifier: BreakpointModifiers;
+    searchFilterConfig: CompoundSearchFilterConfig;
     values: ImageVulnerabilityReportConfiguration;
 };
 
 function ImageVulnerabilityReportView({
+    attributesSeparateFromConfig,
     headingLevel,
     horizontalTermWidthModifier,
+    searchFilterConfig,
     values,
 }: ImageVulnerabilityReportViewProps): ReactElement {
     return (
@@ -36,8 +45,10 @@ function ImageVulnerabilityReportView({
             />
             {hasConfigurationForEntity(values) ? (
                 <ImageVulnerabilityFiltersView
+                    attributesSeparateFromConfig={attributesSeparateFromConfig}
                     headingLevel={headingLevel}
                     horizontalTermWidthModifier={horizontalTermWidthModifier}
+                    searchFilterConfig={searchFilterConfig}
                     values={values}
                 />
             ) : (
@@ -47,7 +58,11 @@ function ImageVulnerabilityReportView({
                     values={values}
                 />
             )}
-            {/* TODO render delivery or destinations view after name have been decided */}
+            <DeliveryView
+                headingLevel={headingLevel}
+                horizontalTermWidthModifier={horizontalTermWidthModifier}
+                values={values}
+            />
         </Flex>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportJobDetails.tsx
@@ -11,8 +11,8 @@ import type { ViewBasedReportSnapshot } from 'services/ReportsService.types';
 import CompoundSearchFilterDescriptionListGroups from 'Components/CompoundSearchFilter/components/CompoundSearchFilterDescriptionListGroups';
 import { getSearchFilterFromSearchString } from 'utils/searchUtils';
 import {
-    attributesSeparateFromConfigForViewBasedReport,
-    configForViewBasedReport,
+    attributesSeparateFromConfigForImageVulnerabilityReport,
+    searchFilterConfigForWorkloadVulnerabilityResultsAndViewBasedReport,
 } from '../../searchFilterConfig';
 
 export type ViewBasedReportJobDetailsProps = {
@@ -26,8 +26,14 @@ function ViewBasedReportJobDetails({ reportSnapshot }: ViewBasedReportJobDetails
     const searchFilter = getSearchFilterFromSearchString(query);
 
     // Render separate attributes (more likely to be specified) preceding config.
-    const attributesFromConfig = configForViewBasedReport.flatMap(({ attributes }) => attributes);
-    const attributes = [...attributesSeparateFromConfigForViewBasedReport, ...attributesFromConfig];
+    const attributesFromConfig =
+        searchFilterConfigForWorkloadVulnerabilityResultsAndViewBasedReport.flatMap(
+            ({ attributes }) => attributes
+        );
+    const attributes = [
+        ...attributesSeparateFromConfigForImageVulnerabilityReport,
+        ...attributesFromConfig,
+    ];
 
     return (
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -36,14 +36,7 @@ import { hideColumnIf } from 'hooks/useManagedColumns';
 import useURLSort from 'hooks/useURLSort';
 import type { VulnerabilityState } from 'types/cve.proto';
 
-import {
-    clusterSearchFilterConfig,
-    deploymentSearchFilterConfig,
-    imageCVESearchFilterConfig,
-    imageComponentSearchFilterConfig,
-    imageSearchFilterConfig,
-    namespaceSearchFilterConfig,
-} from '../../searchFilterConfig';
+import { searchFilterConfigForWorkloadVulnerabilityResultsAndViewBasedReport } from '../../searchFilterConfig';
 import { isVulnMgmtLocalStorage, workloadEntityTabValues } from '../../types';
 import type { DefaultFilters, VulnMgmtLocalStorage, WorkloadEntityTab } from '../../types';
 import {
@@ -284,19 +277,10 @@ function WorkloadCvesOverviewPage() {
         return apolloClient.refetchQueries({ include: [imageListQuery] });
     }
 
-    // Keep searchFilterConfigWithFeatureFlagDependency for ROX_SCANNER_V4.
-    const searchFilterConfigWithFeatureFlagDependency = [
-        clusterSearchFilterConfig,
-        imageCVESearchFilterConfig,
-        deploymentSearchFilterConfig,
-        imageSearchFilterConfig,
-        imageComponentSearchFilterConfig,
-        namespaceSearchFilterConfig,
-    ];
-
+    // Keep getSearchFilterConfigWithFeatureFlagDependency for ROX_SCANNER_V4.
     const searchFilterConfig = getSearchFilterConfigWithFeatureFlagDependency(
         isFeatureFlagEnabled,
-        searchFilterConfigWithFeatureFlagDependency
+        searchFilterConfigForWorkloadVulnerabilityResultsAndViewBasedReport
     );
 
     // Report-specific state management

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -1,8 +1,11 @@
 /*
  * Search filter configurations for vulnerability views.
  *
- * If you add a new filter config that should be available in view-based reports,
- * add it to the configForViewBasedReport array at the bottom of this file.
+ * If you add a new filter config that should be available in any of the following
+ * scheduled reports
+ * view-based reports
+ * workload vulnerability results
+ * add it to either searchFilterConfigForWhatever array near the end of this file.
  */
 
 import type {
@@ -225,15 +228,20 @@ export const attributeForSeverityInBackendAndViewBasedReport: SelectSearchFilter
     },
 };
 
-// This array includes filter configs that are relevant to view-based reports.
-// Only add configs here if they should be available as filters in vulnerability reports.
-export const configForViewBasedReport = [
+// Scheduled report has resources instead of cluster, deployment, namespace.
+export const searchFilterConfigForImageVulnerabilityReport = [
     imageCVESearchFilterConfig,
     imageSearchFilterConfig,
     imageComponentSearchFilterConfig,
-    deploymentSearchFilterConfig,
-    namespaceSearchFilterConfig,
+];
+
+export const searchFilterConfigForWorkloadVulnerabilityResultsAndViewBasedReport = [
     clusterSearchFilterConfig,
+    imageCVESearchFilterConfig,
+    deploymentSearchFilterConfig,
+    imageSearchFilterConfig,
+    imageComponentSearchFilterConfig,
+    namespaceSearchFilterConfig,
 ];
 
 export const attributeForPlatformComponent: SelectSearchFilterAttribute = {
@@ -264,7 +272,8 @@ export const attributeForVulnerabilityState: SelectSearchFilterAttribute = {
     },
 };
 
-export const attributesSeparateFromConfigForViewBasedReport = [
+// For scheduled and view-based report.
+export const attributesSeparateFromConfigForImageVulnerabilityReport = [
     attributeForPlatformComponent,
     attributeForVulnerabilityState,
     attributeForSeverityInBackendAndViewBasedReport, // Formerly under Vulnerability parameters


### PR DESCRIPTION
## Description

TL;DR finish report view except
* Conditionally render warning `Alert` element if `entityScope.rules` is empty in **Resources**
* Conditionally render warning `Alert` element if `query` is empty in **Filters**
* **Custom template** in **Delivery**

### Objective

Provide equivalent filter for scheduled reports as view-based reports

### Analysis

1. Find in files **destination** without Match Whole Word includes:

    NotifierConfigurationView.tsx file which the following files render:

    Compliance

    * ConfigDetails.tsx relevant for this contribution
    * ReviewConfig.tsx

    Vulnerability Reports

    * ReportReviewForm.tsx
    * ReportJobs.tsx
    * ViewVulnReportPage.tsx relevant for this contribution

2. Find in Files **Schedule** with Match Whole Word includes:

    * ScanConfigParametersView.tsx file calls `formatRecurringSchedule` function from dateUtils.ts file.
    * ScheduleDetails.tsx file has its own business logic.

3. Investigate search filter config in searchFilterConfig.ts and  files.

### Solution

1. Add DeliveryView.tsx file in src/Components/Reports/View folder plus

    * Edit reports.types.ts file to add `DeliveryType`
    * Add NotifierConfigurationDescriptionList.tsx file to encapsulate each item of **Destinations**
        By the way, nested description list required `Flex` column layout with `spaceItems` prop.
    * TODO **Email template**

2. Edit ImageVulnerabilityFiltersView.tsx file.

    * Render `CompoundSearchFilterDescriptionListGroups` recently added in #19993
    * Add `attributesSeparateFromConfig` and `searchFilterConfig` as props for the above.

3. Edit ImageVulnerabilityReportView.tsx file.

    * Add `attributesSeparateFromConfig` and `searchFilterConfig` as props for the above.

4. Edit searchFilterConfig.ts file to rename:

    * `searchFilterConfigForImageVulnerabilityReport`
    * `searchFilterConfigForWorkloadVulnerabilityResultsAndViewBasedReport`
    * `attributesSeparateFromConfigForImageVulnerabilityReport`

### Residue

1. Add ImageVulnerabilityReportPage.tsx file.

    * Read report configuration, if relevant.
    * Conditionally render view or wizard.
    * Imitate feature flag filter from WorkloadCvesOverviewPage.tsx files so results and reports have similar source of truth.
        However, results include cluster, deployment, namespace, but scheduled report has resource instead.

2. Confirm that `Schedule` from schedule.proto.ts supersedes `Schedule` in ReportsService.types,ts file.

3. Investigate pro and con of modal for **Custom template** versus text.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

### Manual testing

Temporary edit ViewVulnReportPage.tsx file to simulate `'ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING'` enabled.

1. Visit /main/vulnerabilities/reports/configuration and then click a link.

    Before changes
    <img width="1440" height="892" alt="Vulnerability_reporting_baseline" src="https://github.com/user-attachments/assets/4ed540f7-ef15-452a-95f7-592b16d0a993" />

    After changes to render `ImageVulnerabilityReportView` element for collection scope
    <img width="1440" height="892" alt="Vulnerability_reporting_improved" src="https://github.com/user-attachments/assets/52265dce-ea53-444f-94bc-ae766404d183" />

    After changes for entity scope and `query` filters
    <img width="1440" height="892" alt="CompoundSearchFilterDescriptionListGroups" src="https://github.com/user-attachments/assets/48b0f7ad-a287-4379-8d64-a6f8fbf768bc" />

2. Visit /main/compliance/schedules and then click a link for comparison.
    <img width="1439" height="892" alt="Compliance_OpenShift_Schedules" src="https://github.com/user-attachments/assets/aa3b9830-8860-4ebe-a7eb-9148eb10942e" />
