### PR TITLE
ci: skip GHA lint jobs when .github/ files unchanged

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -1,0 +1,64 @@
+name: Detect changed files
+
+# Outputs the list of files changed in a PR, one per line, wrapped
+# with ^ and $ anchors (e.g. ^ui/src/App.tsx$). Jobs match with
+# contains() using anchors for precise substring matching:
+#   '^scripts/'  — root directory (won't match nested scripts/)
+#   '.go$'       — file extension (won't match .gotmpl)
+#   '^go.mod$'   — exact root file
+#
+# Empty output (push events, API failure, 3000+ files) is falsy,
+# so jobs prefix with: !needs.detect-changes.outputs.files ||
+# to default to "run" when the file list is unavailable.
+
+on:
+  workflow_call:
+    outputs:
+      files:
+        description: >
+          Newline-separated list of changed filenames, or empty
+          string on push/failure (falsy, so jobs default to run).
+        value: ${{ jobs.detect.outputs.files }}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.list.outputs.files }}
+    steps:
+      - name: List changed files
+        id: list
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -eo pipefail
+
+          if [[ -z "${PR_NUMBER}" ]]; then
+            echo "Not a PR" >&2
+            exit 0
+          fi
+
+          if ! output="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')"; then
+            echo "::warning::GitHub API call failed" >&2
+            exit 0
+          fi
+
+          mapfile -t files < <(echo -n "${output}")
+          echo "Changed files (${#files[@]}):" >&2
+          printf '  %s\n' "${files[@]}" >&2
+
+          if [[ ${#files[@]} -ge 3000 ]]; then
+            echo "::warning::PR has 3000+ changed files" >&2
+            exit 0
+          fi
+
+          if [[ ${#files[@]} -gt 0 ]]; then
+            {
+              echo "files<<EOF"
+              printf '^%s$\n' "${files[@]}"
+              echo "EOF"
+            } >> "${GITHUB_OUTPUT}"
+          fi

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -3,7 +3,7 @@ name: Detect changed files
 # Outputs the list of files changed in a PR, one per line, wrapped
 # with ^ and $ anchors (e.g. ^ui/src/App.tsx$). Jobs match with
 # contains() using anchors for precise substring matching:
-#   '^scripts/'  — root directory (won't match nested scripts/)
+#   '^scripts/'  — full tree under a root directory
 #   '.go$'       — file extension (won't match .gotmpl)
 #   '^go.mod$'   — exact root file
 #

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -19,6 +19,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   check-generated-files:
     env:
       ARTIFACT_DIR: junit-reports/
@@ -281,6 +284,10 @@ jobs:
             rhacs-eng/release-scanner-db-slim:${{ env.scanner_tag }}-fast
 
   github-actions-lint:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      contains(needs.detect-changes.outputs.files, '^.github/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -296,6 +303,10 @@ jobs:
         shell: bash
 
   github-actions-shellcheck:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      contains(needs.detect-changes.outputs.files, '^.github/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -306,6 +317,10 @@ jobs:
         run: shellcheck -P SCRIPTDIR -x ./.github/workflows/scripts/*.sh
 
   openshift-ci-lint:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      contains(needs.detect-changes.outputs.files, '^.openshift-ci/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Add a reusable workflow (`detect-changes.yml`) that fetches the PR's changed file list via GitHub API and outputs it with `^`/`$` anchors for precise substring matching.

Gate 3 low-risk style jobs as initial validation:
- `github-actions-lint`: skipped unless `.github/` files changed
- `github-actions-shellcheck`: skipped unless `.github/` files changed
- `openshift-ci-lint`: skipped unless `.openshift-ci/` files changed

```yaml
if: >-
  !needs.detect-changes.outputs.files ||
  contains(needs.detect-changes.outputs.files, '^.github/')
```

## What about required jobs?
> "Required status checks must have a successful, **skipped**, or neutral status before collaborators can make changes to a protected branch." https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging

See #20171 for the full design exploration.

## Testing and quality

- [x] CI results are inspected

### How I validated my change

- `actionlint` passes on all modified workflows
- Validated on #20171 that detect-changes correctly identifies file changes and skips/runs jobs appropriately

- https://github.com/stackrox/stackrox/actions/runs/24857095270?pr=20195 :
<img width="983" height="590" alt="image" src="https://github.com/user-attachments/assets/514581cc-197f-4689-99a2-a5a83c1bef70" />

- Enables ui-only PRs to skip go tests&style: https://github.com/stackrox/stackrox/pull/20196
- Enables go-only PRs to skip ui tests&style: https://github.com/stackrox/stackrox/pull/20197


🤖 Generated with [Claude Code](https://claude.com/claude-code)