### PR TITLE
ROX-34417: show N/A for unresolvable control refs

### DIFF
--- a/central/complianceoperator/v2/report/manager/results/results_aggregator.go
+++ b/central/complianceoperator/v2/report/manager/results/results_aggregator.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	DATA_NOT_AVAILABLE = "Data Not Available"
-	NO_REMEDIATION     = "No Remediation Available"
+	DATA_NOT_AVAILABLE    = "Data Not Available"
+	CONTROL_NOT_APPLICABLE = "N/A"
+	NO_REMEDIATION        = "No Remediation Available"
 )
 
 var (
@@ -196,20 +197,20 @@ func (g *Aggregator) getControlsInfo(ctx context.Context, checkResult *storage.C
 	rules, err := g.complianceRuleDS.SearchRules(ctx, search.NewQueryBuilder().AddExactMatches(search.ComplianceOperatorRuleRef, checkResult.GetRuleRefId()).ProtoQuery())
 	if err != nil {
 		log.Errorf("Unable to retrieve compliance rule for result %q", checkResult.GetCheckName())
-		return DATA_NOT_AVAILABLE, err
+		return CONTROL_NOT_APPLICABLE, err
 	}
 	if len(rules) != 1 {
 		// A check result of a cluster maps to a single rule of that same cluster so there should only be 1.
 		log.Errorf("Unable to process compliance rule for result %q", checkResult.GetCheckName())
-		return DATA_NOT_AVAILABLE, nil
+		return CONTROL_NOT_APPLICABLE, nil
 	}
 	controls, err := utils.GetControlsForScanResults(ctx, g.complianceRuleDS, []string{rules[0].GetName()}, profileName)
 	if err != nil {
 		log.Errorf("Unable to retrieve controls for result %q.Error %s", checkResult.GetCheckName(), err)
-		return DATA_NOT_AVAILABLE, err
+		return CONTROL_NOT_APPLICABLE, err
 	}
 	if len(controls) == 0 {
-		return DATA_NOT_AVAILABLE, nil
+		return CONTROL_NOT_APPLICABLE, nil
 	}
 	controlsList := make([]string, 0, len(controls))
 	for _, ctrl := range controls {

--- a/central/complianceoperator/v2/report/manager/results/results_aggregator.go
+++ b/central/complianceoperator/v2/report/manager/results/results_aggregator.go
@@ -19,7 +19,11 @@ import (
 )
 
 const (
-	DATA_NOT_AVAILABLE     = "Data Not Available"
+	DATA_NOT_AVAILABLE = "Data Not Available"
+	// CONTROL_NOT_APPLICABLE is used when a control reference cannot be resolved for structural reasons
+	// (e.g. tailored profiles with no benchmark mapping, or profiles like E8 whose benchmark short name
+	// has no matching standard in rule annotations). DATA_NOT_AVAILABLE is used instead when the lookup
+	// fails due to errors or data-integrity issues.
 	CONTROL_NOT_APPLICABLE = "N/A"
 	NO_REMEDIATION         = "No Remediation Available"
 )

--- a/central/complianceoperator/v2/report/manager/results/results_aggregator.go
+++ b/central/complianceoperator/v2/report/manager/results/results_aggregator.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	DATA_NOT_AVAILABLE    = "Data Not Available"
+	DATA_NOT_AVAILABLE     = "Data Not Available"
 	CONTROL_NOT_APPLICABLE = "N/A"
-	NO_REMEDIATION        = "No Remediation Available"
+	NO_REMEDIATION         = "No Remediation Available"
 )
 
 var (
@@ -197,17 +197,17 @@ func (g *Aggregator) getControlsInfo(ctx context.Context, checkResult *storage.C
 	rules, err := g.complianceRuleDS.SearchRules(ctx, search.NewQueryBuilder().AddExactMatches(search.ComplianceOperatorRuleRef, checkResult.GetRuleRefId()).ProtoQuery())
 	if err != nil {
 		log.Errorf("Unable to retrieve compliance rule for result %q", checkResult.GetCheckName())
-		return CONTROL_NOT_APPLICABLE, err
+		return DATA_NOT_AVAILABLE, err
 	}
 	if len(rules) != 1 {
 		// A check result of a cluster maps to a single rule of that same cluster so there should only be 1.
 		log.Errorf("Unable to process compliance rule for result %q", checkResult.GetCheckName())
-		return CONTROL_NOT_APPLICABLE, nil
+		return DATA_NOT_AVAILABLE, nil
 	}
 	controls, err := utils.GetControlsForScanResults(ctx, g.complianceRuleDS, []string{rules[0].GetName()}, profileName)
 	if err != nil {
 		log.Errorf("Unable to retrieve controls for result %q.Error %s", checkResult.GetCheckName(), err)
-		return CONTROL_NOT_APPLICABLE, err
+		return DATA_NOT_AVAILABLE, err
 	}
 	if len(controls) == 0 {
 		return CONTROL_NOT_APPLICABLE, nil

--- a/central/complianceoperator/v2/report/manager/results/results_aggregator_test.go
+++ b/central/complianceoperator/v2/report/manager/results/results_aggregator_test.go
@@ -365,7 +365,7 @@ func (s *ComplianceResultsAggregatorSuite) Test_WalkByQuery() {
 				return []*datastore.ControlResult{}, nil
 			},
 		},
-		"tailored profile has no control reference": {
+		"profile without benchmark mapping has no control reference": {
 			check: getCheckResult(storage.ComplianceOperatorCheckResultV2_PASS),
 			expectedProfiles: func() ([]*storage.ComplianceOperatorProfileV2, error) {
 				return []*storage.ComplianceOperatorProfileV2{
@@ -386,7 +386,31 @@ func (s *ComplianceResultsAggregatorSuite) Test_WalkByQuery() {
 				return []*storage.ComplianceOperatorBenchmarkV2{}, nil
 			},
 		},
-		"tailored profile matching benchmark regex resolves controls": {
+		"profile with benchmark but no matching controls has no control reference": {
+			check: getCheckResult(storage.ComplianceOperatorCheckResultV2_PASS),
+			expectedProfiles: func() ([]*storage.ComplianceOperatorProfileV2, error) {
+				return []*storage.ComplianceOperatorProfileV2{
+					{
+						Name:           "ocp4-e8",
+						ProfileVersion: "1.0.0",
+						OperatorKind:   storage.ComplianceOperatorProfileV2_PROFILE,
+					},
+				}, nil
+			},
+			expectedRemediations: func() ([]*storage.ComplianceOperatorRemediationV2, error) {
+				return remediations, nil
+			},
+			expectedRules: func() ([]*storage.ComplianceOperatorRuleV2, error) {
+				return rules, nil
+			},
+			expectedBenchmarks: func() ([]*storage.ComplianceOperatorBenchmarkV2, error) {
+				return benchmarks, nil
+			},
+			expectedControls: func() ([]*datastore.ControlResult, error) {
+				return []*datastore.ControlResult{}, nil
+			},
+		},
+		"profile matching benchmark regex resolves controls": {
 			check: getCheckResult(storage.ComplianceOperatorCheckResultV2_PASS),
 			expectedProfiles: func() ([]*storage.ComplianceOperatorProfileV2, error) {
 				return []*storage.ComplianceOperatorProfileV2{

--- a/central/complianceoperator/v2/report/manager/results/results_aggregator_test.go
+++ b/central/complianceoperator/v2/report/manager/results/results_aggregator_test.go
@@ -365,6 +365,51 @@ func (s *ComplianceResultsAggregatorSuite) Test_WalkByQuery() {
 				return []*datastore.ControlResult{}, nil
 			},
 		},
+		"tailored profile has no control reference": {
+			check: getCheckResult(storage.ComplianceOperatorCheckResultV2_PASS),
+			expectedProfiles: func() ([]*storage.ComplianceOperatorProfileV2, error) {
+				return []*storage.ComplianceOperatorProfileV2{
+					{
+						Name:           "my-custom-tailored-profile",
+						ProfileVersion: "1.0.0",
+						OperatorKind:   storage.ComplianceOperatorProfileV2_TAILORED_PROFILE,
+					},
+				}, nil
+			},
+			expectedRemediations: func() ([]*storage.ComplianceOperatorRemediationV2, error) {
+				return remediations, nil
+			},
+			expectedRules: func() ([]*storage.ComplianceOperatorRuleV2, error) {
+				return rules, nil
+			},
+			expectedBenchmarks: func() ([]*storage.ComplianceOperatorBenchmarkV2, error) {
+				return []*storage.ComplianceOperatorBenchmarkV2{}, nil
+			},
+		},
+		"tailored profile matching benchmark regex resolves controls": {
+			check: getCheckResult(storage.ComplianceOperatorCheckResultV2_PASS),
+			expectedProfiles: func() ([]*storage.ComplianceOperatorProfileV2, error) {
+				return []*storage.ComplianceOperatorProfileV2{
+					{
+						Name:           "custom-stig",
+						ProfileVersion: "1.0.0",
+						OperatorKind:   storage.ComplianceOperatorProfileV2_TAILORED_PROFILE,
+					},
+				}, nil
+			},
+			expectedRemediations: func() ([]*storage.ComplianceOperatorRemediationV2, error) {
+				return remediations, nil
+			},
+			expectedRules: func() ([]*storage.ComplianceOperatorRuleV2, error) {
+				return rules, nil
+			},
+			expectedBenchmarks: func() ([]*storage.ComplianceOperatorBenchmarkV2, error) {
+				return benchmarks, nil
+			},
+			expectedControls: func() ([]*datastore.ControlResult, error) {
+				return controls, nil
+			},
+		},
 	}
 	for tname, tcase := range cases {
 		s.Run(tname, func() {
@@ -579,16 +624,16 @@ func assertResult(t *testing.T, tcase walkByQueryTestCase, row *report.ResultRow
 	}
 	expRules, _ := tcase.expectedRules()
 	if len(expRules) != 1 {
-		assert.Equal(t, DATA_NOT_AVAILABLE, row.ControlRef)
+		assert.Equal(t, CONTROL_NOT_APPLICABLE, row.ControlRef)
 		return
 	}
 	if tcase.expectedBenchmarks == nil {
-		assert.Equal(t, DATA_NOT_AVAILABLE, row.ControlRef)
+		assert.Equal(t, CONTROL_NOT_APPLICABLE, row.ControlRef)
 		return
 	}
 	expBench, _ := tcase.expectedBenchmarks()
 	if len(expBench) == 0 {
-		assert.Equal(t, DATA_NOT_AVAILABLE, row.ControlRef)
+		assert.Equal(t, CONTROL_NOT_APPLICABLE, row.ControlRef)
 		return
 	}
 	if tcase.expectedControls == nil {
@@ -596,7 +641,7 @@ func assertResult(t *testing.T, tcase walkByQueryTestCase, row *report.ResultRow
 	}
 	expControls, _ := tcase.expectedControls()
 	if len(expControls) == 0 {
-		assert.Equal(t, DATA_NOT_AVAILABLE, row.ControlRef)
+		assert.Equal(t, CONTROL_NOT_APPLICABLE, row.ControlRef)
 		return
 	}
 	expControlInfos := make([]string, 0, len(expControls))

--- a/central/complianceoperator/v2/report/manager/results/results_aggregator_test.go
+++ b/central/complianceoperator/v2/report/manager/results/results_aggregator_test.go
@@ -410,17 +410,14 @@ func (s *ComplianceResultsAggregatorSuite) Test_WalkByQuery() {
 				return []*datastore.ControlResult{}, nil
 			},
 		},
-		// Exercises the happy path where a profile name matches a benchmark regex and
-		// GetControlsByRulesAndBenchmarks (mocked) returns controls. In production, whether
-		// controls are actually found depends on rule annotations containing a matching standard.
 		"profile matching benchmark regex resolves controls": {
 			check: getCheckResult(storage.ComplianceOperatorCheckResultV2_PASS),
 			expectedProfiles: func() ([]*storage.ComplianceOperatorProfileV2, error) {
 				return []*storage.ComplianceOperatorProfileV2{
 					{
-						Name:           "custom-stig",
-						ProfileVersion: "1.0.0",
-						OperatorKind:   storage.ComplianceOperatorProfileV2_TAILORED_PROFILE,
+						Name:           "ocp4-cis",
+						ProfileVersion: "1.4.0",
+						OperatorKind:   storage.ComplianceOperatorProfileV2_PROFILE,
 					},
 				}, nil
 			},

--- a/central/complianceoperator/v2/report/manager/results/results_aggregator_test.go
+++ b/central/complianceoperator/v2/report/manager/results/results_aggregator_test.go
@@ -410,6 +410,9 @@ func (s *ComplianceResultsAggregatorSuite) Test_WalkByQuery() {
 				return []*datastore.ControlResult{}, nil
 			},
 		},
+		// Exercises the happy path where a profile name matches a benchmark regex and
+		// GetControlsByRulesAndBenchmarks (mocked) returns controls. In production, whether
+		// controls are actually found depends on rule annotations containing a matching standard.
 		"profile matching benchmark regex resolves controls": {
 			check: getCheckResult(storage.ComplianceOperatorCheckResultV2_PASS),
 			expectedProfiles: func() ([]*storage.ComplianceOperatorProfileV2, error) {

--- a/central/complianceoperator/v2/report/manager/results/results_aggregator_test.go
+++ b/central/complianceoperator/v2/report/manager/results/results_aggregator_test.go
@@ -365,7 +365,7 @@ func (s *ComplianceResultsAggregatorSuite) Test_WalkByQuery() {
 				return []*datastore.ControlResult{}, nil
 			},
 		},
-		"profile without benchmark mapping has no control reference": {
+		"profile without benchmark mapping renders control reference as N/A": {
 			check: getCheckResult(storage.ComplianceOperatorCheckResultV2_PASS),
 			expectedProfiles: func() ([]*storage.ComplianceOperatorProfileV2, error) {
 				return []*storage.ComplianceOperatorProfileV2{
@@ -386,7 +386,7 @@ func (s *ComplianceResultsAggregatorSuite) Test_WalkByQuery() {
 				return []*storage.ComplianceOperatorBenchmarkV2{}, nil
 			},
 		},
-		"profile with benchmark but no matching controls has no control reference": {
+		"profile with benchmark but no matching controls renders control reference as N/A": {
 			check: getCheckResult(storage.ComplianceOperatorCheckResultV2_PASS),
 			expectedProfiles: func() ([]*storage.ComplianceOperatorProfileV2, error) {
 				return []*storage.ComplianceOperatorProfileV2{
@@ -648,11 +648,11 @@ func assertResult(t *testing.T, tcase walkByQueryTestCase, row *report.ResultRow
 	}
 	expRules, _ := tcase.expectedRules()
 	if len(expRules) != 1 {
-		assert.Equal(t, CONTROL_NOT_APPLICABLE, row.ControlRef)
+		assert.Equal(t, DATA_NOT_AVAILABLE, row.ControlRef)
 		return
 	}
 	if tcase.expectedBenchmarks == nil {
-		assert.Equal(t, CONTROL_NOT_APPLICABLE, row.ControlRef)
+		assert.Equal(t, DATA_NOT_AVAILABLE, row.ControlRef)
 		return
 	}
 	expBench, _ := tcase.expectedBenchmarks()


### PR DESCRIPTION
## Description

The "Control Reference" column (first column) in compliance v2 CSV reports displayed "Data Not Available" when the control reference could not be resolved for a check result. This is the expected outcome for profiles where the control resolution chain fails:

- **Tailored profiles**: their names don't match any known benchmark regex in `benchmark.go`, so `GetBenchmarkShortNameFromProfileName` returns empty and `GetControlsForScanResults` short-circuits before querying.
- **E8/STIG profiles**: the benchmark short names "E8/STIG" are derived from the profile names, but no rules have those as a standard in their annotations (rules use framework names like `NIST-800-53`, `CIS-OCP` from the `control.compliance.openshift.io/` annotations). So `GetControlsByRulesAndBenchmarks` returns empty results (see "Why E8/STIG have no control annotations" below for details).

In both cases `getControlsInfo` sees `len(controls) == 0` and now returns "N/A" via a new `CONTROL_NOT_APPLICABLE` constant, distinct from `DATA_NOT_AVAILABLE` which continues to be used for profile info and remediation fields.

<img width="1094" height="431" alt="image" src="https://github.com/user-attachments/assets/2cbea436-5804-48db-b6cf-a2e460816b45" />

### Why N/A instead of Data Not Available

"N/A" communicates that the control reference is structurally not applicable for this profile type, rather than suggesting a transient data availability issue.

The control reference resolution is benchmark-based: profile name → benchmark short name (via regex) → DB query for controls matching that standard. When the profile doesn't map cleanly to a single benchmark (tailored profiles) or
the benchmark short name doesn't correspond to any actual standard in rule annotations (E8), there is no coherent control reference to display.

### Why E8/STIG have no control annotations

Because E8 (ACSC Essential Eight) and STIG don't define numbered control identifiers. E8 is a list of eight named strategies with maturity levels, which CO happens to verify using rules that also implement other benchmarks. Similar situation exists with STIG profiles.

Consequently rules included in E8/STIG profiles don't contain any control annotation related to them, and therefore filtering by E8/STIG yields nothing. We could instead show all the controls associated to the rule, but this would be inconsistent: for standards-based profiles we show only controls from that specific standard, so for E8/STIG, which have no standard-specific controls, the analogous result is nothing.

```console
$ kubectl -n openshift-compliance get rule ocp4-scc-limit-privileged-containers -ojson | jq .metadata.annotations
{
  "compliance.openshift.io/image-digest": "pb-ocp4hktv8",
  "compliance.openshift.io/profiles": "ocp4-cis,ocp4-cis-1-7,ocp4-cis-1-9,ocp4-bsi,ocp4-pci-dss,ocp4-high-rev-4,ocp4-high,ocp4-nerc-cip,ocp4-stig,ocp4-stig-v2r3,ocp4-moderate-rev-4,ocp4-pci-dss-4-0,ocp4-stig-v2r2,ocp4-moderate,ocp4-pci-dss-3-2,ocp4-bsi-2022,ocp4-e8",
  "compliance.openshift.io/rule": "scc-limit-privileged-containers",
  "control.compliance.openshift.io/BSI": "APP.4.4.A4;APP.4.4.A9;SYS.1.6.A16;SYS.1.6.A17;SYS.1.6.A18;SYS.1.6.A21",
  "control.compliance.openshift.io/CIS-OCP": "5.2.1;5.2;5",
  "control.compliance.openshift.io/NERC-CIP": "CIP-003-8 R6;CIP-004-6 R3;CIP-007-3 R6.1",
  "control.compliance.openshift.io/NIST-800-53": "CM-6;CM-6(1)",
  "control.compliance.openshift.io/PCI-DSS": "Req-2.2",
  "control.compliance.openshift.io/PCI-DSS-4-0": "2.2.1;2.2",
  "policies.open-cluster-management.io/controls": "CM-6,CM-6(1),Req-2.2,APP.4.4.A4,APP.4.4.A9,SYS.1.6.A16,SYS.1.6.A17,SYS.1.6.A18,SYS.1.6.A21,5.2.1,5.2,5,2.2.1,2.2",
  "policies.open-cluster-management.io/standards": "NIST-800-53,PCI-DSS,BSI,CIS-OCP,PCI-DSS-4-0"
}
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI, I also deployed this image, generated a report and verified it shows N/A for tailored profile and E8 checks (see screenshot in description). 