### PR TITLE
ROX-28732: Sync CRS secure-a-cluster page text with InitBundles structure

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingHelmChart.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingHelmChart.tsx
@@ -11,7 +11,11 @@ import {
     ListItem,
     Title,
 } from '@patternfly/react-core';
+
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
 import useClipboardCopy from 'hooks/useClipboardCopy';
+import useMetadata from 'hooks/useMetadata';
+import { getVersionedDocs } from 'utils/versioning';
 
 import InstallMethodDeprecationAlert from '../Components/InstallMethodDeprecationAlert';
 
@@ -32,6 +36,7 @@ export type SecureClusterUsingHelmChartProps = {
 function SecureClusterUsingHelmChart({
     headingLevel,
 }: SecureClusterUsingHelmChartProps): ReactElement {
+    const { version } = useMetadata();
     const subHeadingLevel = headingLevel === 'h2' ? 'h3' : 'h4';
     const { wasCopied, copyToClipboard } = useClipboardCopy();
 
@@ -60,6 +65,38 @@ function SecureClusterUsingHelmChart({
                     }
                 />
             </FlexItem>
+            <Title headingLevel={headingLevel}>
+                Secure a cluster using Helm chart installation method
+            </Title>
+            {version && (
+                <>
+                    <ExternalLink>
+                        <a
+                            href={getVersionedDocs(
+                                version,
+                                'installing/installing-rhacs-on-other-platforms#portal-generate-crs_init-bundle-other'
+                            )}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Generating and applying a cluster registration secret for RHACS on other
+                            platforms
+                        </a>
+                    </ExternalLink>
+                    <ExternalLink>
+                        <a
+                            href={getVersionedDocs(
+                                version,
+                                'installing/installing-rhacs-on-other-platforms#install-secured-cluster-other'
+                            )}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Installing secured cluster services for RHACS on other platforms
+                        </a>
+                    </ExternalLink>
+                </>
+            )}
             <Title headingLevel={subHeadingLevel}>Prerequisites</Title>
             <List component="ul">
                 <ListItem>
@@ -86,6 +123,9 @@ function SecureClusterUsingHelmChart({
                         Central service on.
                     </p>
                 </ListItem>
+            </List>
+            <Title headingLevel={subHeadingLevel}>Repeat for each secured cluster</Title>
+            <List component="ol">
                 <ListItem>
                     <Flex
                         direction={{ default: 'column' }}

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingOperator.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterUsingOperator.tsx
@@ -1,6 +1,10 @@
 import type { ReactElement } from 'react';
 import { ClipboardCopy, Flex, List, ListItem, Title } from '@patternfly/react-core';
 
+import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
+import useMetadata from 'hooks/useMetadata';
+import { getVersionedDocs } from 'utils/versioning';
+
 export type SecureClusterUsingOperatorProps = {
     headingLevel: 'h2' | 'h3';
 };
@@ -11,10 +15,68 @@ const kubectlApplyCommand = 'kubectl create -f <cluster-registration-secret-file
 function SecureClusterUsingOperator({
     headingLevel,
 }: SecureClusterUsingOperatorProps): ReactElement {
+    const { version } = useMetadata();
     const subHeadingLevel = headingLevel === 'h2' ? 'h3' : 'h4';
 
     return (
         <Flex direction={{ default: 'column' }}>
+            <Title headingLevel={headingLevel}>
+                Secure a cluster using the Operator installation method
+            </Title>
+            {version && (
+                <>
+                    <ExternalLink>
+                        <a
+                            href={getVersionedDocs(
+                                version,
+                                'installing/installing-rhacs-on-red-hat-openshift#generate-crs_init-bundle-ocp'
+                            )}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Generating and applying a cluster registration secret for RHACS on Red
+                            Hat OpenShift (OpenShift)
+                        </a>
+                    </ExternalLink>
+                    <ExternalLink>
+                        <a
+                            href={getVersionedDocs(
+                                version,
+                                'installing/installing-rhacs-on-red-hat-openshift#install-secured-cluster-ocp'
+                            )}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Installing RHACS on secured clusters by using the Operator (OpenShift)
+                        </a>
+                    </ExternalLink>
+                    <ExternalLink>
+                        <a
+                            href={getVersionedDocs(
+                                version,
+                                'installing/installing-rhacs-on-other-platforms#portal-generate-crs_init-bundle-other'
+                            )}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Generating and applying a cluster registration secret for RHACS on other
+                            platforms
+                        </a>
+                    </ExternalLink>
+                    <ExternalLink>
+                        <a
+                            href={getVersionedDocs(
+                                version,
+                                'installing/installing-rhacs-on-other-platforms#install-secured-cluster-other'
+                            )}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Installing secured cluster services for RHACS on other platforms
+                        </a>
+                    </ExternalLink>
+                </>
+            )}
             <p>
                 You can install secured cluster services on your clusters using the{' '}
                 <strong>SecuredCluster</strong> custom resource.
@@ -45,9 +107,31 @@ function SecureClusterUsingOperator({
                         </ListItem>
                     </List>
                 </ListItem>
+            </List>
+            <Title headingLevel={subHeadingLevel}>Repeat for each secured cluster</Title>
+            <List component="ol">
                 <ListItem>
                     <p>Apply the cluster registration secret on the secured cluster.</p>
-                    <p>Apply it using one of the following methods:</p>
+                    <p>
+                        Applying the cluster registration secret provides the credentials that the
+                        secured cluster uses to register with RHACS. During registration, RHACS
+                        provisions the certificates that secured cluster services need to
+                        communicate. Apply it using one of the following methods:
+                    </p>
+                    {version && (
+                        <ExternalLink>
+                            <a
+                                href={getVersionedDocs(
+                                    version,
+                                    'rhacs_cloud_service/setting-up-rhacs-cloud-service-with-red-hat-openshift-secured-clusters#crs-apply-secured-cluster_init-bundle-cloud-ocp-apply'
+                                )}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Applying the cluster registration secret on the secured cluster
+                            </a>
+                        </ExternalLink>
+                    )}
                     <List component="ul">
                         <ListItem>
                             <p>


### PR DESCRIPTION
## Description

**Jira:** [ROX-28732](https://issues.redhat.com/browse/ROX-28732)

The CRS (Cluster Registration Secrets) "Secure a cluster" pages were structurally simpler than their InitBundles counterparts, missing main headings, external documentation links, and proper separation between prerequisites and per-cluster action steps. This caused accessibility issues (heading levels skipped from h1 to h3) and made the CRS pages harder to follow compared to the InitBundles experience.

- Add main `<Title>` headings to both CRS Operator and Helm chart pages
- Import and use `useMetadata` and `getVersionedDocs` for versioned Red Hat doc links
- Add 4 external doc links to the Operator page and 2 to the Helm chart page using CRS-specific anchors
- Restructure both pages to separate Prerequisites from a "Repeat for each secured cluster" section with `<List component="ol">`
- Add CRS-specific explanatory text about the bootstrap credential/registration flow in the Operator Apply step
- Add an "Applying the CRS on the secured cluster" doc link in the Operator Apply step

**Note:** This change only updates the CRS pages. The InitBundles pages are intentionally left unchanged -- they are the source of truth for structure.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] modified existing tests

### How I validated my change

- TypeScript type checking passes (`npx tsc --noEmit`)
- ESLint/Prettier passes on both changed files (`npm run lint:fast-dev`)
- No logic changes -- this is a content/structure-only update adding headings, doc links, and restructuring existing content into proper sections
- Existing component behavior (clipboard copy, tab switching) is unchanged

[ROX-28732]: https://redhat.atlassian.net/browse/ROX-28732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ