### PR TITLE
ci: prefetch images for compatibility tests in release-4.10

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -931,6 +931,12 @@ populate_prefetcher_image_list() {
     qa-nongroovy-e2e)
         cp "$SCRIPTS_ROOT/tests/images-to-prefetch.txt" "$image_list"
         ;;
+    nongroovy-compatibility)
+        cp "$SCRIPTS_ROOT/tests/images-to-prefetch.txt" "$image_list"
+        ;;
+    compatibility)
+        cp "$SCRIPTS_ROOT/qa-tests-backend/scripts/images-to-prefetch.txt" "$image_list"
+        ;;
     *)
         die "ERROR: An unsupported image prefetcher target was requested: $name"
         ;;

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -640,6 +640,14 @@ _image_prefetcher_prebuilt_start() {
         # prefect list stays up to date with additions.
         ci_export "IMAGE_PULL_POLICY_FOR_QUAY_IO" "Never"
         ;;
+    *nongroovy-compatibility-tests)
+        image_prefetcher_start_set nongroovy-compatibility
+        ci_export "IMAGE_PULL_POLICY_FOR_QUAY_IO" "Never"
+        ;;
+    *compatibility-tests)
+        image_prefetcher_start_set compatibility
+        ci_export "IMAGE_PULL_POLICY_FOR_QUAY_IO" "Never"
+        ;;
     *-operator-e2e-tests)
         image_prefetcher_start_set operator-e2e
         # TODO(ROX-20508): pre-fetch images of the release from which operator upgrade test starts as well.
@@ -762,6 +770,9 @@ _image_prefetcher_prebuilt_await() {
         ;;
     *nongroovy-e2e-tests)
         image_prefetcher_await_set qa-nongroovy-e2e
+        ;;
+    *compatibility-tests)
+        image_prefetcher_await_set compatibility
         ;;
     *-operator-e2e-tests)
         image_prefetcher_await_set operator-e2e

--- a/tests/yamls/multi-container-pod.yaml
+++ b/tests/yamls/multi-container-pod.yaml
@@ -14,13 +14,13 @@ spec:
   containers:
     - name: 1st
       image: quay.io/rhacs-eng/qa-multi-arch:nginx-1.21.1
-      imagePullPolicy: IfNotPresent
+      imagePullPolicy: Never
       volumeMounts:
         - name: html
           mountPath: /usr/share/nginx/html
     - name: 2nd
       image: quay.io/rhacs-eng/qa-multi-arch:ubuntu-latest@sha256:64483f3496c1373bfd55348e88694d1c4d0c9b660dee6bfef5e12f43b9933b30
-      imagePullPolicy: IfNotPresent
+      imagePullPolicy: Never
       volumeMounts:
         - name: html
           mountPath: /html


### PR DESCRIPTION
## Description

Compatibility tests (`gke-nongroovy-compatibility-tests`, `gke-compatibility-tests`) on release-4.10 have been consistently failing with `ImagePullBackOff` in `TestPod`. Root cause: `tests/yamls/multi-container-pod.yaml` uses `imagePullPolicy: IfNotPresent` with private `quay.io/rhacs-eng/qa-multi-arch` images, and `scripts/ci/lib.sh` has no prefetcher cases for `*compatibility-tests` jobs so GKE nodes never receive credentials to pull those images.

This is a manual backport of PR #19306 (fix on `main` by @janisz, 2026-03-05). The automatic backport via label failed due to cherry-pick conflict (lib.sh differs structurally between branches).

Changes:
- Add `*nongroovy-compatibility-tests` and `*compatibility-tests` cases to `_image_prefetcher_prebuilt_start()` in `scripts/ci/lib.sh`.
- Add `*compatibility-tests` case to `_image_prefetcher_prebuilt_await()`.
- Change `imagePullPolicy: IfNotPresent` → `Never` in `tests/yamls/multi-container-pod.yaml`.

The required images are already listed in `tests/images-to-prefetch.txt` on release-4.10.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new tests added — the fix enables existing tests (`TestPod` in `tests/pods_test.go`) to pass by fixing CI infrastructure.

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Verified the same fix exists on `main` (PR #19306) and that `tests/images-to-prefetch.txt` already contains both required images on release-4.10.
- Monitoring `gke-nongroovy-compatibility-tests` on this PR to confirm it passes.