### PR TITLE
fix(ui): Only enable the ConsolePlugin if it exists on the cluster

### DIFF
--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -69,8 +69,8 @@ test_ui_e2e() {
     deploy_optional_e2e_components
     deploy_stackrox
 
-    # Enable the console plugin for OpenShift
-    if [[ "${ORCHESTRATOR_FLAVOR}" == "openshift" ]]; then
+    # Enable the console plugin for OpenShift if the ConsolePlugin resource exists
+    if [[ "${ORCHESTRATOR_FLAVOR}" == "openshift" ]] && kubectl get consoleplugin advanced-cluster-security &>/dev/null; then
         enable_console_plugin
     fi
 


### PR DESCRIPTION
## Description

The recent change to enable ConsolePlugin tests requires that we enable the plugin before the e2e tests begin. However, in older versions of OpenShift the plugin is not present. To prevent errors in CI, we only enable the plugin if the CR is detected on the cluster.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI
