### PR TITLE
ROX-34432: Add telemetry for tailored profiles

### DIFF
--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -380,61 +380,39 @@ func withSACFilter(ctx context.Context, targetResource permissions.ResourceMetad
 	return search.FilterQueryByQuery(query, sacQueryFilter), nil
 }
 
-type profileCount struct {
-	Kind  storage.ComplianceOperatorProfileV2_OperatorKind
-	Name  string
-	Count int
-}
-
-// countProfileRefs loads all scan configurations and counts profile references
-// by name and kind. For legacy scan configs that lack profile_refs, all
-// profiles are counted as PROFILE kind since tailored profiles didn't exist
-// before that field was added.
-func countProfileRefs(ds DataStore, ctx context.Context) ([]profileCount, error) {
-	scanConfigs, err := ds.GetScanConfigurations(ctx, search.EmptyQuery())
-	if err != nil {
-		return nil, err
-	}
-	type key struct {
-		name string
-		kind storage.ComplianceOperatorProfileV2_OperatorKind
-	}
-	counts := make(map[key]int)
-	for _, sc := range scanConfigs {
-		refs := sc.GetProfileRefs()
-		if len(refs) == 0 {
-			for _, p := range sc.GetProfiles() {
-				counts[key{p.GetProfileName(), storage.ComplianceOperatorProfileV2_PROFILE}]++
-			}
-			continue
-		}
-		for _, ref := range refs {
-			counts[key{ref.GetName(), ref.GetKind()}]++
-		}
-	}
-	result := make([]profileCount, 0, len(counts))
-	for k, count := range counts {
-		result = append(result, profileCount{Kind: k.kind, Name: k.name, Count: count})
-	}
-	return result, nil
-}
-
 func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 	return func(ctx context.Context) (map[string]any, error) {
 		if ds == nil {
 			return map[string]any{}, nil
 		}
-		counts, err := countProfileRefs(ds, sac.WithAllAccess(ctx))
+		scanConfigs, err := ds.GetScanConfigurations(sac.WithAllAccess(ctx), search.EmptyQuery())
 		if err != nil {
 			return nil, errors.Wrap(err, "gathering compliance operator profiles for telemetry")
 		}
-		profiles := make(map[string]any)
-		for _, c := range counts {
-			if c.Kind != storage.ComplianceOperatorProfileV2_TAILORED_PROFILE {
-				profiles["Compliance Operator Profile "+c.Name] = c.Count
+
+		profiles := make(map[string]int)
+		for _, sc := range scanConfigs {
+			refs := sc.GetProfileRefs()
+			// If ProfileRefs is empty, this scan configuration was created before adding Tailored Profiles support.
+			// Therefore, profiles are stored in the legacy "profiles" field, and all of them are non-tailored profiles.
+			if len(refs) == 0 {
+				for _, p := range sc.GetProfiles() {
+					profiles[p.GetProfileName()]++
+				}
+				continue
+			}
+			for _, ref := range refs {
+				if ref.GetKind() == storage.ComplianceOperatorProfileV2_PROFILE {
+					profiles[ref.GetName()]++
+				}
 			}
 		}
-		return profiles, nil
+
+		r := make(map[string]any)
+		for name, count := range profiles {
+			r["Compliance Operator Profile "+name] = count
+		}
+		return r, nil
 	}
 }
 
@@ -447,18 +425,23 @@ func GatherTailoredProfiles(ds DataStore) phonehome.GatherFunc {
 		if ds == nil {
 			return map[string]any{}, nil
 		}
-		counts, err := countProfileRefs(ds, sac.WithAllAccess(ctx))
+		scanConfigs, err := ds.GetScanConfigurations(sac.WithAllAccess(ctx), search.EmptyQuery())
 		if err != nil {
-			return nil, errors.Wrap(err, "gathering tailored profile count for telemetry")
+			return nil, errors.Wrap(err, "gathering compliance operator tailored profiles for telemetry")
 		}
-		total := 0
-		for _, c := range counts {
-			if c.Kind == storage.ComplianceOperatorProfileV2_TAILORED_PROFILE {
-				total += c.Count
+
+		tpCount := 0
+		for _, sc := range scanConfigs {
+			for _, ref := range sc.GetProfileRefs() {
+				if ref.GetKind() == storage.ComplianceOperatorProfileV2_TAILORED_PROFILE {
+					tpCount++
+				}
 			}
 		}
+
 		return map[string]any{
-			"Compliance Operator Tailored Profile": total,
+			"Compliance Operator Tailored Profiles": tpCount,
 		}, nil
+
 	}
 }

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -383,7 +383,7 @@ func withSACFilter(ctx context.Context, targetResource permissions.ResourceMetad
 func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 	return func(ctx context.Context) (map[string]any, error) {
 		if ds == nil {
-			return nil, nil
+			return map[string]any{}, nil
 		}
 		telemetryCtx := sac.WithAllAccess(ctx)
 		counts, err := ds.DistinctProfiles(telemetryCtx, search.EmptyQuery())

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/logging"
 	pgPkg "github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/protocompat"
@@ -26,6 +27,7 @@ import (
 )
 
 var (
+	log           = logging.LoggerForModule()
 	complianceSAC = sac.ForResource(resources.Compliance)
 )
 
@@ -402,8 +404,13 @@ func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 				continue
 			}
 			for _, ref := range refs {
-				if ref.GetKind() == storage.ComplianceOperatorProfileV2_PROFILE {
+				switch ref.GetKind() {
+				case storage.ComplianceOperatorProfileV2_PROFILE:
 					profiles[ref.GetName()]++
+				case storage.ComplianceOperatorProfileV2_TAILORED_PROFILE:
+					// Tailored profiles are counted separately by GatherTailoredProfiles.
+				case storage.ComplianceOperatorProfileV2_OPERATOR_KIND_UNSPECIFIED:
+					log.Warnf("Scan config %q has profile ref %q with unspecified operator kind", sc.GetScanConfigName(), ref.GetName())
 				}
 			}
 		}
@@ -416,9 +423,9 @@ func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 	}
 }
 
-// GatherTailoredProfiles reports the aggregate count of tailored profiles referenced across all scan configurations.
-// Individual tailored profile names are not collected because they are user-defined (unlike standard Compliance Operator
-// profiles) and would expose customer data.
+// GatherTailoredProfiles reports the total number of tailored profile references across all scan configurations
+// (not the number of distinct tailored profiles). Individual tailored profile names are not collected because
+// they are user-defined (unlike standard Compliance Operator profiles) and would expose customer data.
 func GatherTailoredProfiles(ds DataStore) phonehome.GatherFunc {
 	return func(ctx context.Context) (map[string]any, error) {
 		if ds == nil {
@@ -432,8 +439,11 @@ func GatherTailoredProfiles(ds DataStore) phonehome.GatherFunc {
 		tpCount := 0
 		for _, sc := range scanConfigs {
 			for _, ref := range sc.GetProfileRefs() {
-				if ref.GetKind() == storage.ComplianceOperatorProfileV2_TAILORED_PROFILE {
+				switch ref.GetKind() {
+				case storage.ComplianceOperatorProfileV2_TAILORED_PROFILE:
 					tpCount++
+				case storage.ComplianceOperatorProfileV2_OPERATOR_KIND_UNSPECIFIED:
+					log.Warnf("Scan config %q has profile ref %q with unspecified operator kind", sc.GetScanConfigName(), ref.GetName())
 				}
 			}
 		}
@@ -441,6 +451,5 @@ func GatherTailoredProfiles(ds DataStore) phonehome.GatherFunc {
 		return map[string]any{
 			"Compliance Operator Tailored Profiles": tpCount,
 		}, nil
-
 	}
 }

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/concurrency"
-	"github.com/stackrox/rox/pkg/logging"
 	pgPkg "github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/schema"
 	"github.com/stackrox/rox/pkg/protocompat"
@@ -27,7 +26,6 @@ import (
 )
 
 var (
-	log           = logging.LoggerForModule()
 	complianceSAC = sac.ForResource(resources.Compliance)
 )
 
@@ -404,11 +402,8 @@ func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 				continue
 			}
 			for _, ref := range refs {
-				switch ref.GetKind() {
-				case storage.ComplianceOperatorProfileV2_PROFILE:
+				if ref.GetKind() == storage.ComplianceOperatorProfileV2_PROFILE {
 					profiles[ref.GetName()]++
-				case storage.ComplianceOperatorProfileV2_OPERATOR_KIND_UNSPECIFIED:
-					log.Warnf("Scan config %q has profile ref %q with unspecified operator kind", sc.GetScanConfigName(), ref.GetName())
 				}
 			}
 		}
@@ -437,11 +432,8 @@ func GatherTailoredProfiles(ds DataStore) phonehome.GatherFunc {
 		tpCount := 0
 		for _, sc := range scanConfigs {
 			for _, ref := range sc.GetProfileRefs() {
-				switch ref.GetKind() {
-				case storage.ComplianceOperatorProfileV2_TAILORED_PROFILE:
+				if ref.GetKind() == storage.ComplianceOperatorProfileV2_TAILORED_PROFILE {
 					tpCount++
-				case storage.ComplianceOperatorProfileV2_OPERATOR_KIND_UNSPECIFIED:
-					log.Warnf("Scan config %q has profile ref %q with unspecified operator kind", sc.GetScanConfigName(), ref.GetName())
 				}
 			}
 		}

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -417,8 +417,9 @@ func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 }
 
 // GatherTailoredProfiles reports the total number of tailored profile references across all scan configurations
-// (not the number of distinct tailored profiles). Individual tailored profile names are not collected because
-// they are user-defined (unlike standard Compliance Operator profiles) and would expose customer data.
+// (not the number of distinct tailored profiles - this mimics GatherProfiles where we count the same profile being
+// present in several scan configs). Individual tailored profile names are not collected because they are user-defined
+// (unlike standard Compliance Operator profiles) and would expose customer data.
 func GatherTailoredProfiles(ds DataStore) phonehome.GatherFunc {
 	return func(ctx context.Context) (map[string]any, error) {
 		if ds == nil {

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -407,8 +407,6 @@ func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 				switch ref.GetKind() {
 				case storage.ComplianceOperatorProfileV2_PROFILE:
 					profiles[ref.GetName()]++
-				case storage.ComplianceOperatorProfileV2_TAILORED_PROFILE:
-					// Tailored profiles are counted separately by GatherTailoredProfiles.
 				case storage.ComplianceOperatorProfileV2_OPERATOR_KIND_UNSPECIFIED:
 					log.Warnf("Scan config %q has profile ref %q with unspecified operator kind", sc.GetScanConfigName(), ref.GetName())
 				}

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -382,15 +382,33 @@ func withSACFilter(ctx context.Context, targetResource permissions.ResourceMetad
 
 func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 	return func(ctx context.Context) (map[string]any, error) {
+		if ds == nil {
+			return nil, nil
+		}
 		telemetryCtx := sac.WithAllAccess(ctx)
 		counts, err := ds.DistinctProfiles(telemetryCtx, search.EmptyQuery())
 		if err != nil {
 			return nil, errors.Wrap(err, "gathering compliance operator profiles for telemetry")
 		}
-		profiles := make(map[string]any, len(counts))
+		props := make(map[string]any, len(counts)+1)
 		for profile, count := range counts {
-			profiles["Compliance Operator Profile "+profile] = count
+			props["Compliance Operator Profile "+profile] = count
 		}
-		return profiles, nil
+
+		scanConfigs, err := ds.GetScanConfigurations(telemetryCtx, search.EmptyQuery())
+		if err != nil {
+			return props, errors.Wrap(err, "gathering tailored profile count for telemetry")
+		}
+		tailoredCount := 0
+		for _, sc := range scanConfigs {
+			for _, ref := range sc.GetProfileRefs() {
+				if ref.GetKind() == storage.ComplianceOperatorProfileV2_TAILORED_PROFILE {
+					tailoredCount++
+				}
+			}
+		}
+		props["Compliance Operator Tailored Profile"] = tailoredCount
+
+		return props, nil
 	}
 }

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -390,14 +390,27 @@ func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 		if err != nil {
 			return nil, errors.Wrap(err, "gathering compliance operator profiles for telemetry")
 		}
-		props := make(map[string]any, len(counts)+1)
+		profiles := make(map[string]any, len(counts))
 		for profile, count := range counts {
-			props["Compliance Operator Profile "+profile] = count
+			profiles["Compliance Operator Profile "+profile] = count
 		}
+		return profiles, nil
+	}
+}
 
+// GatherTailoredProfiles returns the total number of tailored profiles
+// referenced across all scan configurations. Individual tailored profile
+// names are not collected because they are user-defined (unlike standard
+// Compliance Operator profiles) and would expose customer-specific data.
+func GatherTailoredProfiles(ds DataStore) phonehome.GatherFunc {
+	return func(ctx context.Context) (map[string]any, error) {
+		if ds == nil {
+			return map[string]any{}, nil
+		}
+		telemetryCtx := sac.WithAllAccess(ctx)
 		scanConfigs, err := ds.GetScanConfigurations(telemetryCtx, search.EmptyQuery())
 		if err != nil {
-			return props, errors.Wrap(err, "gathering tailored profile count for telemetry")
+			return nil, errors.Wrap(err, "gathering tailored profile count for telemetry")
 		}
 		tailoredCount := 0
 		for _, sc := range scanConfigs {
@@ -407,8 +420,8 @@ func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 				}
 			}
 		}
-		props["Compliance Operator Tailored Profile"] = tailoredCount
-
-		return props, nil
+		return map[string]any{
+			"Compliance Operator Tailored Profile": tailoredCount,
+		}, nil
 	}
 }

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -416,10 +416,9 @@ func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 	}
 }
 
-// GatherTailoredProfiles reports the aggregate count of tailored profiles
-// referenced across all scan configurations. Individual tailored profile
-// names are not collected because they are user-defined (unlike standard
-// Compliance Operator profiles) and would expose customer-specific data.
+// GatherTailoredProfiles reports the aggregate count of tailored profiles referenced across all scan configurations.
+// Individual tailored profile names are not collected because they are user-defined (unlike standard Compliance Operator
+// profiles) and would expose customer data.
 func GatherTailoredProfiles(ds DataStore) phonehome.GatherFunc {
 	return func(ctx context.Context) (map[string]any, error) {
 		if ds == nil {

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -380,25 +380,53 @@ func withSACFilter(ctx context.Context, targetResource permissions.ResourceMetad
 	return search.FilterQueryByQuery(query, sacQueryFilter), nil
 }
 
+// gatherProfileCounts loads all scan configurations and categorizes profile
+// references into regular (CO-defined) and tailored (user-defined) profiles.
+// For legacy scan configs that lack profile_refs, all profiles are counted as
+// regular since tailored profiles didn't exist before that field was added.
+func gatherProfileCounts(ds DataStore, ctx context.Context) (regular map[string]int, tailoredCount int, err error) {
+	scanConfigs, err := ds.GetScanConfigurations(ctx, search.EmptyQuery())
+	if err != nil {
+		return nil, 0, err
+	}
+	regular = make(map[string]int)
+	for _, sc := range scanConfigs {
+		refs := sc.GetProfileRefs()
+		if len(refs) == 0 {
+			for _, p := range sc.GetProfiles() {
+				regular[p.GetProfileName()]++
+			}
+			continue
+		}
+		for _, ref := range refs {
+			if ref.GetKind() == storage.ComplianceOperatorProfileV2_TAILORED_PROFILE {
+				tailoredCount++
+			} else {
+				regular[ref.GetName()]++
+			}
+		}
+	}
+	return regular, tailoredCount, nil
+}
+
 func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 	return func(ctx context.Context) (map[string]any, error) {
 		if ds == nil {
 			return map[string]any{}, nil
 		}
-		telemetryCtx := sac.WithAllAccess(ctx)
-		counts, err := ds.DistinctProfiles(telemetryCtx, search.EmptyQuery())
+		regular, _, err := gatherProfileCounts(ds, sac.WithAllAccess(ctx))
 		if err != nil {
 			return nil, errors.Wrap(err, "gathering compliance operator profiles for telemetry")
 		}
-		profiles := make(map[string]any, len(counts))
-		for profile, count := range counts {
+		profiles := make(map[string]any, len(regular))
+		for profile, count := range regular {
 			profiles["Compliance Operator Profile "+profile] = count
 		}
 		return profiles, nil
 	}
 }
 
-// GatherTailoredProfiles returns the total number of tailored profiles
+// GatherTailoredProfiles reports the aggregate count of tailored profiles
 // referenced across all scan configurations. Individual tailored profile
 // names are not collected because they are user-defined (unlike standard
 // Compliance Operator profiles) and would expose customer-specific data.
@@ -407,18 +435,9 @@ func GatherTailoredProfiles(ds DataStore) phonehome.GatherFunc {
 		if ds == nil {
 			return map[string]any{}, nil
 		}
-		telemetryCtx := sac.WithAllAccess(ctx)
-		scanConfigs, err := ds.GetScanConfigurations(telemetryCtx, search.EmptyQuery())
+		_, tailoredCount, err := gatherProfileCounts(ds, sac.WithAllAccess(ctx))
 		if err != nil {
 			return nil, errors.Wrap(err, "gathering tailored profile count for telemetry")
-		}
-		tailoredCount := 0
-		for _, sc := range scanConfigs {
-			for _, ref := range sc.GetProfileRefs() {
-				if ref.GetKind() == storage.ComplianceOperatorProfileV2_TAILORED_PROFILE {
-					tailoredCount++
-				}
-			}
 		}
 		return map[string]any{
 			"Compliance Operator Tailored Profile": tailoredCount,

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl.go
@@ -380,33 +380,43 @@ func withSACFilter(ctx context.Context, targetResource permissions.ResourceMetad
 	return search.FilterQueryByQuery(query, sacQueryFilter), nil
 }
 
-// gatherProfileCounts loads all scan configurations and categorizes profile
-// references into regular (CO-defined) and tailored (user-defined) profiles.
-// For legacy scan configs that lack profile_refs, all profiles are counted as
-// regular since tailored profiles didn't exist before that field was added.
-func gatherProfileCounts(ds DataStore, ctx context.Context) (regular map[string]int, tailoredCount int, err error) {
+type profileCount struct {
+	Kind  storage.ComplianceOperatorProfileV2_OperatorKind
+	Name  string
+	Count int
+}
+
+// countProfileRefs loads all scan configurations and counts profile references
+// by name and kind. For legacy scan configs that lack profile_refs, all
+// profiles are counted as PROFILE kind since tailored profiles didn't exist
+// before that field was added.
+func countProfileRefs(ds DataStore, ctx context.Context) ([]profileCount, error) {
 	scanConfigs, err := ds.GetScanConfigurations(ctx, search.EmptyQuery())
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
-	regular = make(map[string]int)
+	type key struct {
+		name string
+		kind storage.ComplianceOperatorProfileV2_OperatorKind
+	}
+	counts := make(map[key]int)
 	for _, sc := range scanConfigs {
 		refs := sc.GetProfileRefs()
 		if len(refs) == 0 {
 			for _, p := range sc.GetProfiles() {
-				regular[p.GetProfileName()]++
+				counts[key{p.GetProfileName(), storage.ComplianceOperatorProfileV2_PROFILE}]++
 			}
 			continue
 		}
 		for _, ref := range refs {
-			if ref.GetKind() == storage.ComplianceOperatorProfileV2_TAILORED_PROFILE {
-				tailoredCount++
-			} else {
-				regular[ref.GetName()]++
-			}
+			counts[key{ref.GetName(), ref.GetKind()}]++
 		}
 	}
-	return regular, tailoredCount, nil
+	result := make([]profileCount, 0, len(counts))
+	for k, count := range counts {
+		result = append(result, profileCount{Kind: k.kind, Name: k.name, Count: count})
+	}
+	return result, nil
 }
 
 func GatherProfiles(ds DataStore) phonehome.GatherFunc {
@@ -414,13 +424,15 @@ func GatherProfiles(ds DataStore) phonehome.GatherFunc {
 		if ds == nil {
 			return map[string]any{}, nil
 		}
-		regular, _, err := gatherProfileCounts(ds, sac.WithAllAccess(ctx))
+		counts, err := countProfileRefs(ds, sac.WithAllAccess(ctx))
 		if err != nil {
 			return nil, errors.Wrap(err, "gathering compliance operator profiles for telemetry")
 		}
-		profiles := make(map[string]any, len(regular))
-		for profile, count := range regular {
-			profiles["Compliance Operator Profile "+profile] = count
+		profiles := make(map[string]any)
+		for _, c := range counts {
+			if c.Kind != storage.ComplianceOperatorProfileV2_TAILORED_PROFILE {
+				profiles["Compliance Operator Profile "+c.Name] = c.Count
+			}
 		}
 		return profiles, nil
 	}
@@ -435,12 +447,18 @@ func GatherTailoredProfiles(ds DataStore) phonehome.GatherFunc {
 		if ds == nil {
 			return map[string]any{}, nil
 		}
-		_, tailoredCount, err := gatherProfileCounts(ds, sac.WithAllAccess(ctx))
+		counts, err := countProfileRefs(ds, sac.WithAllAccess(ctx))
 		if err != nil {
 			return nil, errors.Wrap(err, "gathering tailored profile count for telemetry")
 		}
+		total := 0
+		for _, c := range counts {
+			if c.Kind == storage.ComplianceOperatorProfileV2_TAILORED_PROFILE {
+				total += c.Count
+			}
+		}
 		return map[string]any{
-			"Compliance Operator Tailored Profile": tailoredCount,
+			"Compliance Operator Tailored Profile": total,
 		}, nil
 	}
 }

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
-	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/sac"
@@ -41,10 +40,6 @@ const (
 	noAccessCtx                 = "noAccessCtx"
 
 	maxPaginationLimit = 1000
-)
-
-var (
-	log = logging.LoggerForModule()
 )
 
 func TestComplianceScanConfigDataStore(t *testing.T) {

--- a/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/datastore_impl_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/sac"
@@ -40,6 +41,10 @@ const (
 	noAccessCtx                 = "noAccessCtx"
 
 	maxPaginationLimit = 1000
+)
+
+var (
+	log = logging.LoggerForModule()
 )
 
 func TestComplianceScanConfigDataStore(t *testing.T) {

--- a/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
@@ -17,7 +17,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGatherProfiles(t *testing.T) {
+func TestGatherProfilesNilDatastore(t *testing.T) {
+	props, err := GatherProfiles(nil)(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, props)
+}
+
+func TestGatherTailoredProfilesNilDatastore(t *testing.T) {
+	props, err := GatherTailoredProfiles(nil)(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, props)
+}
+
+func TestGatherTailoredProfiles(t *testing.T) {
 	t.Setenv(features.ComplianceEnhancements.EnvVar(), "true")
 
 	pool := pgtest.ForT(t)
@@ -31,14 +43,12 @@ func TestGatherProfiles(t *testing.T) {
 	)
 
 	testCases := map[string]struct {
-		scanConfigs         []*storage.ComplianceOperatorScanConfigurationV2
-		expectedTailored    int
-		expectedProfileKeys []string
+		scanConfigs      []*storage.ComplianceOperatorScanConfigurationV2
+		expectedTailored int
 	}{
 		"no scan configs": {
-			scanConfigs:         nil,
-			expectedTailored:    0,
-			expectedProfileKeys: nil,
+			scanConfigs:      nil,
+			expectedTailored: 0,
 		},
 		"scan config with only regular profiles": {
 			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
@@ -47,8 +57,7 @@ func TestGatherProfiles(t *testing.T) {
 					{"ocp4-nist", storage.ComplianceOperatorProfileV2_PROFILE},
 				}),
 			},
-			expectedTailored:    0,
-			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile ocp4-nist"},
+			expectedTailored: 0,
 		},
 		"scan config with tailored profiles": {
 			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
@@ -57,8 +66,7 @@ func TestGatherProfiles(t *testing.T) {
 					{"my-tailored-cis", storage.ComplianceOperatorProfileV2_TAILORED_PROFILE},
 				}),
 			},
-			expectedTailored:    1,
-			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile my-tailored-cis"},
+			expectedTailored: 1,
 		},
 		"multiple scan configs with multiple tailored profiles": {
 			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
@@ -71,15 +79,13 @@ func TestGatherProfiles(t *testing.T) {
 					{"tp-pci", storage.ComplianceOperatorProfileV2_TAILORED_PROFILE},
 				}),
 			},
-			expectedTailored:    3,
-			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile tp-cis", "Compliance Operator Profile tp-nist", "Compliance Operator Profile tp-pci"},
+			expectedTailored: 3,
 		},
 		"scan config without profile_refs populated": {
 			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
 				makeScanConfigNoRefs("scan-no-refs", []string{"ocp4-cis"}),
 			},
-			expectedTailored:    0,
-			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis"},
+			expectedTailored: 0,
 		},
 		"scan config with unspecified kind does not count as tailored": {
 			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
@@ -89,8 +95,7 @@ func TestGatherProfiles(t *testing.T) {
 					{"tp-custom", storage.ComplianceOperatorProfileV2_TAILORED_PROFILE},
 				}),
 			},
-			expectedTailored:    1,
-			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile ocp4-nist", "Compliance Operator Profile tp-custom"},
+			expectedTailored: 1,
 		},
 	}
 
@@ -105,22 +110,11 @@ func TestGatherProfiles(t *testing.T) {
 				}
 			})
 
-			props, err := GatherProfiles(ds)(context.Background())
+			props, err := GatherTailoredProfiles(ds)(context.Background())
 			require.NoError(t, err)
-
 			assert.Equal(t, tc.expectedTailored, props["Compliance Operator Tailored Profile"])
-
-			for _, key := range tc.expectedProfileKeys {
-				assert.Contains(t, props, key)
-			}
 		})
 	}
-}
-
-func TestGatherProfilesNilDatastore(t *testing.T) {
-	props, err := GatherProfiles(nil)(context.Background())
-	require.NoError(t, err)
-	assert.Empty(t, props)
 }
 
 type profileDef struct {

--- a/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
@@ -45,12 +45,13 @@ func TestGatherProfiles(t *testing.T) {
 	testCases := map[string]struct {
 		scanConfigs         []*storage.ComplianceOperatorScanConfigurationV2
 		expectedProfileKeys []string
+		excludedKeys        []string
 	}{
 		"no scan configs": {
 			scanConfigs:         nil,
 			expectedProfileKeys: nil,
 		},
-		"reports each profile name": {
+		"reports each regular profile name": {
 			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
 				makeScanConfig("scan-1", []profileDef{
 					{"ocp4-cis", storage.ComplianceOperatorProfileV2_PROFILE},
@@ -59,14 +60,21 @@ func TestGatherProfiles(t *testing.T) {
 			},
 			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile ocp4-nist"},
 		},
-		"includes tailored profile names in profile list": {
+		"excludes tailored profile names": {
 			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
 				makeScanConfig("scan-2", []profileDef{
 					{"ocp4-cis", storage.ComplianceOperatorProfileV2_PROFILE},
 					{"my-tp", storage.ComplianceOperatorProfileV2_TAILORED_PROFILE},
 				}),
 			},
-			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile my-tp"},
+			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis"},
+			excludedKeys:        []string{"Compliance Operator Profile my-tp"},
+		},
+		"legacy scan config without profile_refs": {
+			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
+				makeScanConfigNoRefs("scan-legacy", []string{"ocp4-cis"}),
+			},
+			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis"},
 		},
 	}
 
@@ -86,6 +94,9 @@ func TestGatherProfiles(t *testing.T) {
 
 			for _, key := range tc.expectedProfileKeys {
 				assert.Contains(t, props, key)
+			}
+			for _, key := range tc.excludedKeys {
+				assert.NotContains(t, props, key)
 			}
 		})
 	}

--- a/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
@@ -117,6 +117,12 @@ func TestGatherProfiles(t *testing.T) {
 	}
 }
 
+func TestGatherProfilesNilDatastore(t *testing.T) {
+	props, err := GatherProfiles(nil)(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, props)
+}
+
 type profileDef struct {
 	name string
 	kind storage.ComplianceOperatorProfileV2_OperatorKind

--- a/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
@@ -1,0 +1,163 @@
+//go:build sql_integration
+
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/sac/testconsts"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatherProfiles(t *testing.T) {
+	t.Setenv(features.ComplianceEnhancements.EnvVar(), "true")
+
+	pool := pgtest.ForT(t)
+	ds := GetTestPostgresDataStore(t, pool.DB)
+
+	writeCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Compliance, resources.Cluster),
+		),
+	)
+
+	testCases := map[string]struct {
+		scanConfigs         []*storage.ComplianceOperatorScanConfigurationV2
+		expectedTailored    int
+		expectedProfileKeys []string
+	}{
+		"no scan configs": {
+			scanConfigs:         nil,
+			expectedTailored:    0,
+			expectedProfileKeys: nil,
+		},
+		"scan config with only regular profiles": {
+			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
+				makeScanConfig("scan-regular", []profileDef{
+					{"ocp4-cis", storage.ComplianceOperatorProfileV2_PROFILE},
+					{"ocp4-nist", storage.ComplianceOperatorProfileV2_PROFILE},
+				}),
+			},
+			expectedTailored:    0,
+			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile ocp4-nist"},
+		},
+		"scan config with tailored profiles": {
+			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
+				makeScanConfig("scan-tailored", []profileDef{
+					{"ocp4-cis", storage.ComplianceOperatorProfileV2_PROFILE},
+					{"my-tailored-cis", storage.ComplianceOperatorProfileV2_TAILORED_PROFILE},
+				}),
+			},
+			expectedTailored:    1,
+			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile my-tailored-cis"},
+		},
+		"multiple scan configs with multiple tailored profiles": {
+			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
+				makeScanConfig("scan-1", []profileDef{
+					{"ocp4-cis", storage.ComplianceOperatorProfileV2_PROFILE},
+					{"tp-cis", storage.ComplianceOperatorProfileV2_TAILORED_PROFILE},
+				}),
+				makeScanConfig("scan-2", []profileDef{
+					{"tp-nist", storage.ComplianceOperatorProfileV2_TAILORED_PROFILE},
+					{"tp-pci", storage.ComplianceOperatorProfileV2_TAILORED_PROFILE},
+				}),
+			},
+			expectedTailored:    3,
+			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile tp-cis", "Compliance Operator Profile tp-nist", "Compliance Operator Profile tp-pci"},
+		},
+		"scan config without profile_refs populated": {
+			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
+				makeScanConfigNoRefs("scan-no-refs", []string{"ocp4-cis"}),
+			},
+			expectedTailored:    0,
+			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis"},
+		},
+		"scan config with unspecified kind does not count as tailored": {
+			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
+				makeScanConfig("scan-unspecified", []profileDef{
+					{"ocp4-cis", storage.ComplianceOperatorProfileV2_OPERATOR_KIND_UNSPECIFIED},
+					{"ocp4-nist", storage.ComplianceOperatorProfileV2_PROFILE},
+					{"tp-custom", storage.ComplianceOperatorProfileV2_TAILORED_PROFILE},
+				}),
+			},
+			expectedTailored:    1,
+			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile ocp4-nist", "Compliance Operator Profile tp-custom"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			for _, sc := range tc.scanConfigs {
+				require.NoError(t, ds.UpsertScanConfiguration(writeCtx, sc))
+			}
+			t.Cleanup(func() {
+				for _, sc := range tc.scanConfigs {
+					_, _ = ds.DeleteScanConfiguration(writeCtx, sc.GetId())
+				}
+			})
+
+			props, err := GatherProfiles(ds)(context.Background())
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedTailored, props["Compliance Operator Tailored Profile"])
+
+			for _, key := range tc.expectedProfileKeys {
+				assert.Contains(t, props, key)
+			}
+		})
+	}
+}
+
+type profileDef struct {
+	name string
+	kind storage.ComplianceOperatorProfileV2_OperatorKind
+}
+
+func makeScanConfig(scanName string, profiles []profileDef) *storage.ComplianceOperatorScanConfigurationV2 {
+	profileNames := make([]*storage.ComplianceOperatorScanConfigurationV2_ProfileName, 0, len(profiles))
+	profileRefs := make([]*storage.ComplianceOperatorScanConfigurationV2_ProfileReference, 0, len(profiles))
+	for _, p := range profiles {
+		profileNames = append(profileNames, &storage.ComplianceOperatorScanConfigurationV2_ProfileName{
+			ProfileName: p.name,
+		})
+		profileRefs = append(profileRefs, &storage.ComplianceOperatorScanConfigurationV2_ProfileReference{
+			Name: p.name,
+			Kind: p.kind,
+		})
+	}
+	return &storage.ComplianceOperatorScanConfigurationV2{
+		Id:             uuid.NewV4().String(),
+		ScanConfigName: scanName,
+		Profiles:       profileNames,
+		ProfileRefs:    profileRefs,
+		Clusters: []*storage.ComplianceOperatorScanConfigurationV2_Cluster{
+			{ClusterId: testconsts.Cluster1},
+		},
+	}
+}
+
+func makeScanConfigNoRefs(scanName string, profiles []string) *storage.ComplianceOperatorScanConfigurationV2 {
+	profileNames := make([]*storage.ComplianceOperatorScanConfigurationV2_ProfileName, 0, len(profiles))
+	for _, p := range profiles {
+		profileNames = append(profileNames, &storage.ComplianceOperatorScanConfigurationV2_ProfileName{
+			ProfileName: p,
+		})
+	}
+	return &storage.ComplianceOperatorScanConfigurationV2{
+		Id:             uuid.NewV4().String(),
+		ScanConfigName: scanName,
+		Profiles:       profileNames,
+		Clusters: []*storage.ComplianceOperatorScanConfigurationV2_Cluster{
+			{ClusterId: testconsts.Cluster1},
+		},
+	}
+}

--- a/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
@@ -29,6 +29,68 @@ func TestGatherTailoredProfilesNilDatastore(t *testing.T) {
 	assert.Empty(t, props)
 }
 
+func TestGatherProfiles(t *testing.T) {
+	t.Setenv(features.ComplianceEnhancements.EnvVar(), "true")
+
+	pool := pgtest.ForT(t)
+	ds := GetTestPostgresDataStore(t, pool.DB)
+
+	writeCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
+		sac.AllowFixedScopes(
+			sac.AccessModeScopeKeys(storage.Access_READ_ACCESS, storage.Access_READ_WRITE_ACCESS),
+			sac.ResourceScopeKeys(resources.Compliance, resources.Cluster),
+		),
+	)
+
+	testCases := map[string]struct {
+		scanConfigs         []*storage.ComplianceOperatorScanConfigurationV2
+		expectedProfileKeys []string
+	}{
+		"no scan configs": {
+			scanConfigs:         nil,
+			expectedProfileKeys: nil,
+		},
+		"reports each profile name": {
+			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
+				makeScanConfig("scan-1", []profileDef{
+					{"ocp4-cis", storage.ComplianceOperatorProfileV2_PROFILE},
+					{"ocp4-nist", storage.ComplianceOperatorProfileV2_PROFILE},
+				}),
+			},
+			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile ocp4-nist"},
+		},
+		"includes tailored profile names in profile list": {
+			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
+				makeScanConfig("scan-2", []profileDef{
+					{"ocp4-cis", storage.ComplianceOperatorProfileV2_PROFILE},
+					{"my-tp", storage.ComplianceOperatorProfileV2_TAILORED_PROFILE},
+				}),
+			},
+			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile my-tp"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			for _, sc := range tc.scanConfigs {
+				require.NoError(t, ds.UpsertScanConfiguration(writeCtx, sc))
+			}
+			t.Cleanup(func() {
+				for _, sc := range tc.scanConfigs {
+					_, _ = ds.DeleteScanConfiguration(writeCtx, sc.GetId())
+				}
+			})
+
+			props, err := GatherProfiles(ds)(context.Background())
+			require.NoError(t, err)
+
+			for _, key := range tc.expectedProfileKeys {
+				assert.Contains(t, props, key)
+			}
+		})
+	}
+}
+
 func TestGatherTailoredProfiles(t *testing.T) {
 	t.Setenv(features.ComplianceEnhancements.EnvVar(), "true")
 

--- a/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
@@ -185,7 +185,7 @@ func TestGatherTailoredProfiles(t *testing.T) {
 
 			props, err := GatherTailoredProfiles(ds)(context.Background())
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedTailored, props["Compliance Operator Tailored Profile"])
+			assert.Equal(t, tc.expectedTailored, props["Compliance Operator Tailored Profiles"])
 		})
 	}
 }

--- a/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/datastore/telemetry_postgres_test.go
@@ -43,13 +43,13 @@ func TestGatherProfiles(t *testing.T) {
 	)
 
 	testCases := map[string]struct {
-		scanConfigs         []*storage.ComplianceOperatorScanConfigurationV2
-		expectedProfileKeys []string
-		excludedKeys        []string
+		scanConfigs   []*storage.ComplianceOperatorScanConfigurationV2
+		expectedProps map[string]any
+		excludedKeys  []string
 	}{
 		"no scan configs": {
-			scanConfigs:         nil,
-			expectedProfileKeys: nil,
+			scanConfigs:   nil,
+			expectedProps: map[string]any{},
 		},
 		"reports each regular profile name": {
 			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
@@ -58,7 +58,23 @@ func TestGatherProfiles(t *testing.T) {
 					{"ocp4-nist", storage.ComplianceOperatorProfileV2_PROFILE},
 				}),
 			},
-			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis", "Compliance Operator Profile ocp4-nist"},
+			expectedProps: map[string]any{
+				"Compliance Operator Profile ocp4-cis":  1,
+				"Compliance Operator Profile ocp4-nist": 1,
+			},
+		},
+		"same profile in multiple scan configs counts each reference": {
+			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
+				makeScanConfig("scan-a", []profileDef{
+					{"ocp4-cis", storage.ComplianceOperatorProfileV2_PROFILE},
+				}),
+				makeScanConfig("scan-b", []profileDef{
+					{"ocp4-cis", storage.ComplianceOperatorProfileV2_PROFILE},
+				}),
+			},
+			expectedProps: map[string]any{
+				"Compliance Operator Profile ocp4-cis": 2,
+			},
 		},
 		"excludes tailored profile names": {
 			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
@@ -67,14 +83,30 @@ func TestGatherProfiles(t *testing.T) {
 					{"my-tp", storage.ComplianceOperatorProfileV2_TAILORED_PROFILE},
 				}),
 			},
-			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis"},
-			excludedKeys:        []string{"Compliance Operator Profile my-tp"},
+			expectedProps: map[string]any{
+				"Compliance Operator Profile ocp4-cis": 1,
+			},
+			excludedKeys: []string{"Compliance Operator Profile my-tp"},
+		},
+		"excludes unspecified kind profiles": {
+			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
+				makeScanConfig("scan-unspec", []profileDef{
+					{"ocp4-cis", storage.ComplianceOperatorProfileV2_PROFILE},
+					{"unknown-profile", storage.ComplianceOperatorProfileV2_OPERATOR_KIND_UNSPECIFIED},
+				}),
+			},
+			expectedProps: map[string]any{
+				"Compliance Operator Profile ocp4-cis": 1,
+			},
+			excludedKeys: []string{"Compliance Operator Profile unknown-profile"},
 		},
 		"legacy scan config without profile_refs": {
 			scanConfigs: []*storage.ComplianceOperatorScanConfigurationV2{
 				makeScanConfigNoRefs("scan-legacy", []string{"ocp4-cis"}),
 			},
-			expectedProfileKeys: []string{"Compliance Operator Profile ocp4-cis"},
+			expectedProps: map[string]any{
+				"Compliance Operator Profile ocp4-cis": 1,
+			},
 		},
 	}
 
@@ -92,8 +124,9 @@ func TestGatherProfiles(t *testing.T) {
 			props, err := GatherProfiles(ds)(context.Background())
 			require.NoError(t, err)
 
-			for _, key := range tc.expectedProfileKeys {
-				assert.Contains(t, props, key)
+			assert.Len(t, props, len(tc.expectedProps))
+			for key, val := range tc.expectedProps {
+				assert.Equal(t, val, props[key], "key: %s", key)
 			}
 			for _, key := range tc.excludedKeys {
 				assert.NotContains(t, props, key)

--- a/central/main.go
+++ b/central/main.go
@@ -687,7 +687,7 @@ func addCentralIdentityGatherers(c *phonehomeClient.CentralClient) {
 	add(authProviderTelemetry.Gather)
 	add(cloudSourcesDS.Gather(cloudSourcesDS.Singleton()))
 	add(clusterDataStore.Gather)
-	add(virtualMachineDS.Gather(virtualMachineDS.Singleton()))
+	add(complianceScanDS.GatherProfiles(complianceScanDS.Singleton()))
 	add(declarativeconfig.ManagerSingleton().Gather())
 	add(delegatedRegistryConfigDS.Gather(delegatedRegistryConfigDS.Singleton()))
 	add(externalbackupsDS.Gather)
@@ -695,10 +695,10 @@ func addCentralIdentityGatherers(c *phonehomeClient.CentralClient) {
 	add(globaldb.Gather)
 	add(imageintegrationsDS.Gather)
 	add(notifierDS.Gather)
+	add(policyDataStore.Gather)
 	add(roleDataStore.Gather)
 	add(signatureIntegrationDS.Gather)
-	add(complianceScanDS.GatherProfiles(complianceScanDS.Singleton()))
-	add(policyDataStore.Gather)
+	add(virtualMachineDS.Gather(virtualMachineDS.Singleton()))
 }
 
 func registerDelayedIntegrations(integrationsInput []iiStore.DelayedIntegration) {

--- a/central/main.go
+++ b/central/main.go
@@ -688,6 +688,7 @@ func addCentralIdentityGatherers(c *phonehomeClient.CentralClient) {
 	add(cloudSourcesDS.Gather(cloudSourcesDS.Singleton()))
 	add(clusterDataStore.Gather)
 	add(complianceScanDS.GatherProfiles(complianceScanDS.Singleton()))
+	add(complianceScanDS.GatherTailoredProfiles(complianceScanDS.Singleton()))
 	add(declarativeconfig.ManagerSingleton().Gather())
 	add(delegatedRegistryConfigDS.Gather(delegatedRegistryConfigDS.Singleton()))
 	add(externalbackupsDS.Gather)


### PR DESCRIPTION
## Description

Add phonehome telemetry to track tailored profiles (TP) adoption in compliance scan configurations, and fix `GatherProfiles` to stop leaking user-defined tailored profile names.

### Note to reviewers

TP telemetry has been implemented in `GatherTailoredProfiles` rather than extending `GatherProfiles`, because:
- Profiles and Tailored Profiles are different resources in Compliance Operator, and from user perspective. They are stored in the same table in stackrox but that's an implementation detail.
- The nature of what is gathered is different: for profiles, we gather how many times each individual profile is used in a scan setting. For tailored profiles, we gather how many times any tailored profile is used (we aggregate all, without exposing individual TP names).
- The legacy fallback (see the code) only makes sense for non-tailored profiles.

### Rest of AI generated description

**Problem:** No visibility into whether customers use tailored profiles in their scan configurations. Additionally, `GatherProfiles` reported all profile names individually — including tailored profiles, whose names are user-defined and should not be exposed.

**Solution:**

1. **New `GatherTailoredProfiles` gatherer** — reports a single aggregate count of tailored profile references across all scan configurations: `"Compliance Operator Tailored Profiles": N`. Individual names are not collected because tailored profile names are user-defined and would expose customer data. The count reflects total references (not distinct profiles) — if the same tailored profile appears in two scan configs, it counts as 2.

2. **Fix `GatherProfiles`** — now inspects `profile_refs` to filter by kind, only reporting CO-defined profiles (`PROFILE` kind). Previously used `DistinctProfiles` SQL query which couldn't distinguish kinds and leaked tailored profile names.

3. **Legacy fallback** — scan configs created before `profile_refs` was added have only the legacy `profiles` field populated. These are treated as all-regular profiles (tailored profiles didn't exist then).

Also adds nil-datastore guards (prevents panics when `ComplianceEnhancements` feature flag is disabled) and sorts the gatherer registration list alphabetically.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI, and I verified telemetry actually lands in Amplitude:
<img width="1226" height="799" alt="SCR-20260506-lzav" src="https://github.com/user-attachments/assets/3a7255f6-63fb-40e0-a9d6-8cb03d40e2d8" />
<img width="1059" height="751" alt="Screenshot 2026-05-06 at 13 13 00" src="https://github.com/user-attachments/assets/bea1d930-f460-4634-908c-206dd21c22b2" />
