### PR TITLE
ROX-34423: Hot reload TLS certificates in Go servers

### DIFF
--- a/pkg/mtls/README.md
+++ b/pkg/mtls/README.md
@@ -40,34 +40,23 @@
 - Sensor cert init (one-time copy at startup): `sensor/kubernetes/certinit/init_tls_certs.go`
 - Sensor cert refresh (TLS challenge + CA bundle): `sensor/kubernetes/certrefresh/`
 
-## Caching behavior
-
-### Read once per process (sync.Once in pkg/mtls/crypto.go)
-
-- `CACert()`, `CACertPEM()`, `SecondaryCACert()` — CA cert public bytes
-- `CAForSigning()`, `SecondaryCAForSigning()` — CA signing objects
-- CA key bytes
-- These NEVER refresh without a pod restart.
-
-### Hot-reloaded via certwatch (Central)
-
-- Default/ingress TLS cert — `certwatch.WatchCertDir` in `central/tlsconfig/manager_impl.go`
-- Internal service leaf cert — `certwatch.WatchCertDir` on `CertsPrefix` in `central/tlsconfig/manager_impl.go`, verified against internal CA on each reload
-- Primary leaf for TLS challenge — `certwatch.WatchCertDir` with atomic pointer in `central/metadata/service/service_impl.go`
-- Secure metrics TLS cert — `certwatch.WatchCertDir` in `pkg/metrics/tls.go`
-
-### Loaded once at startup, never refreshed
-
-- Scanner V4 (indexer/matcher): server cert via `verifier.NonCA{}`, client cert via `clientconn.TLSConfig`
-- Admission controller: webhook server cert via `verifier.NonCA{}`
-- Sensor: client cert loaded in `centralclient.NewClient`, proxy cert in `StartProxyServer`
-- Config controller: CA pool via `verifier.SystemCertPool()`
-
-## Central has three independent cert-handling paths
+### Central has three independent cert-handling paths
 
 1. **TLS manager** (`TLSConfigHolder`) — incoming connections. Composes default cert (watched) + internal cert (watched) + sync.Once trust roots.
 2. **Outbound client connections** (`clientconn.TLSConfig`) — reads leaf from disk per connection, trust pool from `mtls.CACert()`.
 3. **TLS challenge endpoint** (`central/metadata/service`) — reads primary leaf via certwatch, issues secondary leaf with short validity and auto-renewal, reads CA via `mtls.CACert()`.
+
+## Certificate caching
+
+The following certificates are currently known to be cached at start-up and not reloaded:
+
+- CA material (`CACert()`, `SecondaryCACert()`, `CAForSigning()`, etc.) in `pkg/mtls/crypto.go`: `sync.Once`, never refreshed. Intentional — the Operator restarts all pods on CA change.
+
+- Sensor: all certs are effectively cached because `certinit` copies them to an emptyDir at startup. Client certs are also cached at construction (`centralclient.NewClient`, `StartProxyServer`, scanner client).
+- Scanner V4 (indexer/matcher) client certs: cached at dial time via `clientconn.TLSConfig`
+- Admission controller client cert for Sensor connection: `clientconn.AuthenticatedGRPCConnection` at startup
+- Compliance client cert for Sensor connection: `clientconn.AuthenticatedGRPCConnection` at startup
+- Postgres (Central DB, Scanner DB, Scanner V4 DB): need SIGHUP to reload SSL certs
 
 ## Certificate management — who manages what
 
@@ -105,11 +94,3 @@
 - Response includes: primary cert chain, secondary cert chain (if present), additional CAs, default TLS leaf cert.
 - Signed with both primary and secondary leaf certs. Sensor verifies one signature and trusts all certs in the response (trust delegation).
 - Secondary leaf cert: issued in memory from secondary CA with ~3-hour validity, auto-renewed before expiry.
-
-## Sensor certinit — blocks hot reload
-
-`sensor/kubernetes/certinit/init_tls_certs.go` copies certs from source mounts
-(`certs-new` or `certs-legacy`) to `CertsPrefix` at startup. This is a ONE-TIME
-COPY to an emptyDir. After startup, Secret updates to the source volume do NOT
-propagate to the files the process reads. This blocks any hot-reload for Sensor
-until certinit is made continuous or removed.

--- a/pkg/mtls/verifier/verify.go
+++ b/pkg/mtls/verifier/verify.go
@@ -3,9 +3,14 @@ package verifier
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"path/filepath"
+	"sync/atomic"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stackrox/rox/pkg/mtls/certwatch"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/tlsprofile"
 )
 
@@ -27,6 +32,38 @@ func (f TLSConfigurerFunc) TLSConfig() (*tls.Config, error) {
 // A NonCA verifier picks up a certificate from the file system, rather than
 // issuing one to itself, and serves it.
 type NonCA struct{}
+
+var (
+	nonCALeafCert     atomic.Pointer[tls.Certificate]
+	nonCALeafCertOnce sync.Once
+)
+
+func startNonCALeafCertWatcher() {
+	nonCALeafCertOnce.Do(func() {
+		certwatch.WatchCertDir("service", mtls.CertsPrefix,
+			loadLeafCertFromDirectory, func(cert *tls.Certificate) {
+				if cert != nil {
+					nonCALeafCert.Store(cert)
+				}
+			}, certwatch.WithVerify(false))
+	})
+}
+
+func loadLeafCertFromDirectory(dir string) (*tls.Certificate, error) {
+	certFile := filepath.Join(dir, mtls.ServiceCertFileName)
+	keyFile := filepath.Join(dir, mtls.ServiceKeyFileName)
+
+	if filesExist, err := fileutils.AllExist(certFile, keyFile); err != nil || !filesExist {
+		return nil, err
+	}
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading service certificate")
+	}
+
+	return &cert, nil
+}
 
 // TrustedCertPool creates a CertPool that contains the CA certificate.
 func TrustedCertPool() (*x509.CertPool, error) {
@@ -64,20 +101,34 @@ func addSecondaryCACertIfExists(certPool *x509.CertPool) {
 
 // TLSConfig initializes a server configuration that requires client TLS
 // authentication based on a single certificate in the filesystem.
+// The returned config uses GetConfigForClient to serve the latest cert
+// from a file watcher, enabling hot reload when cert files change on disk.
 func (NonCA) TLSConfig() (*tls.Config, error) {
+	startNonCALeafCertWatcher()
+
 	serverTLSCert, err := mtls.LeafCertificateFromFile()
 	if err != nil {
 		return nil, errors.Wrap(err, "tls conversion")
 	}
+	nonCALeafCert.Store(&serverTLSCert)
 
-	conf, err := config(serverTLSCert)
+	rootConf, err := config(serverTLSCert)
 	if err != nil {
 		return nil, err
 	}
 	// TODO(cg): Sensors should also issue creds to, and verify, their clients.
 	// For the time being, we only verify that the client cert is from the central CA.
-	conf.ClientAuth = tls.VerifyClientCertIfGiven
-	return conf, nil
+	rootConf.ClientAuth = tls.VerifyClientCertIfGiven
+
+	rootConf.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		cert := nonCALeafCert.Load()
+		if cert == nil {
+			return nil, errors.New("no leaf certificate available")
+		}
+		return cert, nil
+	}
+
+	return rootConf, nil
 }
 
 // DefaultTLSServerConfig returns the default TLS config for servers in StackRox.

--- a/pkg/mtls/verifier/verify.go
+++ b/pkg/mtls/verifier/verify.go
@@ -101,19 +101,12 @@ func addSecondaryCACertIfExists(certPool *x509.CertPool) {
 func (NonCA) TLSConfig() (*tls.Config, error) {
 	loadAndWatchLeafCert()
 
-	cert := leafCert.Load()
-	if cert == nil {
-		return nil, errors.New("no leaf certificate available")
-	}
-
-	rootConf, err := config(*cert)
+	rootConf, err := serverTLSConfig()
 	if err != nil {
 		return nil, err
 	}
-	// TODO(cg): Sensors should also issue creds to, and verify, their clients.
-	// For the time being, we only verify that the client cert is from the central CA.
-	rootConf.ClientAuth = tls.VerifyClientCertIfGiven
 
+	rootConf.ClientAuth = tls.VerifyClientCertIfGiven
 	rootConf.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 		cert := leafCert.Load()
 		if cert == nil {
@@ -144,14 +137,10 @@ func DefaultTLSServerConfig(certPool *x509.CertPool, certs []tls.Certificate) *t
 	return cfg
 }
 
-func config(serverBundle tls.Certificate) (*tls.Config, error) {
+func serverTLSConfig() (*tls.Config, error) {
 	certPool, err := TrustedCertPool()
 	if err != nil {
 		return nil, errors.Wrap(err, "CA cert")
 	}
-
-	// This is based on TLSClientAuthServerConfig from cfssl/transport.
-	// However, we don't use enough of their ecosystem to fully use it yet.
-	cfg := DefaultTLSServerConfig(certPool, []tls.Certificate{serverBundle})
-	return cfg, nil
+	return DefaultTLSServerConfig(certPool, nil), nil
 }

--- a/pkg/mtls/verifier/verify.go
+++ b/pkg/mtls/verifier/verify.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 
 	"github.com/pkg/errors"
-	"github.com/stackrox/rox/pkg/fileutils"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/mtls/certwatch"
 	"github.com/stackrox/rox/pkg/sync"
@@ -34,16 +33,16 @@ func (f TLSConfigurerFunc) TLSConfig() (*tls.Config, error) {
 type NonCA struct{}
 
 var (
-	nonCALeafCert     atomic.Pointer[tls.Certificate]
-	nonCALeafCertOnce sync.Once
+	leafCert     atomic.Pointer[tls.Certificate]
+	leafCertOnce sync.Once
 )
 
-func startNonCALeafCertWatcher() {
-	nonCALeafCertOnce.Do(func() {
-		certwatch.WatchCertDir("service", mtls.CertsPrefix,
+func loadAndWatchLeafCert() {
+	leafCertOnce.Do(func() {
+		certwatch.WatchCertDir("service", filepath.Dir(mtls.CertFilePath()),
 			loadLeafCertFromDirectory, func(cert *tls.Certificate) {
 				if cert != nil {
-					nonCALeafCert.Store(cert)
+					leafCert.Store(cert)
 				}
 			}, certwatch.WithVerify(false))
 	})
@@ -53,13 +52,9 @@ func loadLeafCertFromDirectory(dir string) (*tls.Certificate, error) {
 	certFile := filepath.Join(dir, mtls.ServiceCertFileName)
 	keyFile := filepath.Join(dir, mtls.ServiceKeyFileName)
 
-	if filesExist, err := fileutils.AllExist(certFile, keyFile); err != nil || !filesExist {
-		return nil, err
-	}
-
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return nil, errors.Wrap(err, "loading service certificate")
+		return nil, errors.Wrapf(err, "loading service certificate from %q", dir)
 	}
 
 	return &cert, nil
@@ -104,15 +99,14 @@ func addSecondaryCACertIfExists(certPool *x509.CertPool) {
 // The returned config uses GetConfigForClient to serve the latest cert
 // from a file watcher, enabling hot reload when cert files change on disk.
 func (NonCA) TLSConfig() (*tls.Config, error) {
-	startNonCALeafCertWatcher()
+	loadAndWatchLeafCert()
 
-	serverTLSCert, err := mtls.LeafCertificateFromFile()
-	if err != nil {
-		return nil, errors.Wrap(err, "tls conversion")
+	cert := leafCert.Load()
+	if cert == nil {
+		return nil, errors.New("no leaf certificate available")
 	}
-	nonCALeafCert.Store(&serverTLSCert)
 
-	rootConf, err := config(serverTLSCert)
+	rootConf, err := config(*cert)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +115,7 @@ func (NonCA) TLSConfig() (*tls.Config, error) {
 	rootConf.ClientAuth = tls.VerifyClientCertIfGiven
 
 	rootConf.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-		cert := nonCALeafCert.Load()
+		cert := leafCert.Load()
 		if cert == nil {
 			return nil, errors.New("no leaf certificate available")
 		}

--- a/pkg/mtls/verifier/verify.go
+++ b/pkg/mtls/verifier/verify.go
@@ -100,13 +100,15 @@ func addSecondaryCACertIfExists(certPool *x509.CertPool) {
 // from a file watcher, enabling hot reload when cert files change on disk.
 func (NonCA) TLSConfig() (*tls.Config, error) {
 	loadAndWatchLeafCert()
+	if leafCert.Load() == nil {
+		return nil, errors.New("no leaf certificate available")
+	}
 
 	rootConf, err := serverTLSConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	rootConf.ClientAuth = tls.VerifyClientCertIfGiven
 	rootConf.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 		cert := leafCert.Load()
 		if cert == nil {

--- a/pkg/mtls/verifier/verify_test.go
+++ b/pkg/mtls/verifier/verify_test.go
@@ -1,8 +1,6 @@
 package verifier
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,46 +30,19 @@ func TestLoadLeafCertFromDirectory(t *testing.T) {
 		assert.Contains(t, cert.Leaf.DNSNames, "central.stackrox.svc")
 	})
 
-	t.Run("missing files returns nil", func(t *testing.T) {
+	t.Run("missing files returns error", func(t *testing.T) {
 		dir := t.TempDir()
 		cert, err := loadLeafCertFromDirectory(dir)
-		assert.NoError(t, err)
+		assert.Error(t, err)
 		assert.Nil(t, cert)
 	})
 
-	t.Run("cert only, no key", func(t *testing.T) {
+	t.Run("cert only, no key returns error", func(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, mtls.ServiceCertFileName), issuedCert.CertPEM, 0644))
 
 		cert, err := loadLeafCertFromDirectory(dir)
-		assert.NoError(t, err)
+		assert.Error(t, err)
 		assert.Nil(t, cert)
-	})
-}
-
-func TestNonCALeafCertUpdateCallback(t *testing.T) {
-	originalCert := &tls.Certificate{
-		Leaf: &x509.Certificate{},
-	}
-	nonCALeafCert.Store(originalCert)
-	defer nonCALeafCert.Store(nil)
-
-	updateFn := func(c *tls.Certificate) {
-		if c != nil {
-			nonCALeafCert.Store(c)
-		}
-	}
-
-	t.Run("nil does not overwrite existing cert", func(t *testing.T) {
-		updateFn(nil)
-		assert.Equal(t, originalCert, nonCALeafCert.Load())
-	})
-
-	t.Run("non-nil replaces cert", func(t *testing.T) {
-		newCert := &tls.Certificate{
-			Leaf: &x509.Certificate{},
-		}
-		updateFn(newCert)
-		assert.Equal(t, newCert, nonCALeafCert.Load())
 	})
 }

--- a/pkg/mtls/verifier/verify_test.go
+++ b/pkg/mtls/verifier/verify_test.go
@@ -1,0 +1,77 @@
+package verifier
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/certgen"
+	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadLeafCertFromDirectory(t *testing.T) {
+	ca, err := certgen.GenerateCA()
+	require.NoError(t, err)
+
+	issuedCert, err := ca.IssueCertForSubject(mtls.CentralSubject)
+	require.NoError(t, err)
+
+	t.Run("valid cert and key", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, mtls.ServiceCertFileName), issuedCert.CertPEM, 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, mtls.ServiceKeyFileName), issuedCert.KeyPEM, 0600))
+
+		cert, err := loadLeafCertFromDirectory(dir)
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+		require.NotNil(t, cert.Leaf)
+		assert.Contains(t, cert.Leaf.DNSNames, "central.stackrox.svc")
+	})
+
+	t.Run("missing files returns nil", func(t *testing.T) {
+		dir := t.TempDir()
+		cert, err := loadLeafCertFromDirectory(dir)
+		assert.NoError(t, err)
+		assert.Nil(t, cert)
+	})
+
+	t.Run("cert only, no key", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, mtls.ServiceCertFileName), issuedCert.CertPEM, 0644))
+
+		cert, err := loadLeafCertFromDirectory(dir)
+		assert.NoError(t, err)
+		assert.Nil(t, cert)
+	})
+}
+
+func TestNonCALeafCertUpdateCallback(t *testing.T) {
+	originalCert := &tls.Certificate{
+		Leaf: &x509.Certificate{},
+	}
+	nonCALeafCert.Store(originalCert)
+	defer nonCALeafCert.Store(nil)
+
+	updateFn := func(c *tls.Certificate) {
+		if c != nil {
+			nonCALeafCert.Store(c)
+		}
+	}
+
+	t.Run("nil does not overwrite existing cert", func(t *testing.T) {
+		updateFn(nil)
+		assert.Equal(t, originalCert, nonCALeafCert.Load())
+	})
+
+	t.Run("non-nil replaces cert", func(t *testing.T) {
+		newCert := &tls.Certificate{
+			Leaf: &x509.Certificate{},
+		}
+		updateFn(newCert)
+		assert.Equal(t, newCert, nonCALeafCert.Load())
+	})
+}


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Following-up https://github.com/stackrox/stackrox/pull/20075, this PR implements hot reloading of leaf certificates in other Go services. This single change affects `scanner-v4-indexer`, `scanner-v4-matcher`, and `admission-controller` **servers**.

**Note** that only servers are addressed in this PR. Client connections that still cache certificates will be handled in a follow-up PR.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

1. Issued new leaf certs for `scanner-v4-indexer`, `scanner-v4-matcher`, and `admission-control`, signed by the internal CA.
2. Patched the TLS secrets (`scanner-v4-indexer-tls`, `scanner-v4-matcher-tls` in `acs-central`; `tls-cert-admission-control` in `acs-sensor`).
3. All three components logged the cert reload without restart:
```
  pkg/mtls/certwatch: Info: service certificate loaded (SerialNumber: 8756446353882917470, ..., OU=SCANNER_V4_INDEXER_SERVICE, ...), watch dir: "/run/secrets/stackrox.io/certs/"
  pkg/mtls/certwatch: Info: service certificate loaded (SerialNumber: 15048387543479923847, ..., OU=SCANNER_V4_MATCHER_SERVICE, ...), watch dir: "/run/secrets/stackrox.io/certs/"
  pkg/mtls/certwatch: Info: service certificate loaded (SerialNumber: 3482647217515339622, ..., OU=ADMISSION_CONTROL_SERVICE, ...), watch dir: "/run/secrets/stackrox.io/certs/"
```
4. Verified via openssl s_client that each service serves the new cert:
  `scanner-v4-indexer`:  serial=79852590B1F4AA5E  ✓
  `scanner-v4-matcher`:  serial=D0D69CBDB388B487  ✓
  `admission-control`:   serial=3054D93146011F66  ✓