### PR TITLE
ROX-32420: Gate VM relay startup on master nodes by default

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -2,6 +2,7 @@ package compliance
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"sync/atomic"
@@ -32,7 +33,12 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-var log = logging.LoggerForModule()
+var (
+	log = logging.LoggerForModule()
+
+	errNilScrapeConfig           = errors.New("initial scrape config is unexpectedly nil")
+	errRelayDisabledOnMasterNode = errors.New("relay disabled on master node by default")
+)
 
 const (
 	// nodeResourceID is the resource ID used for node scanning UMH.
@@ -98,8 +104,7 @@ func (c *Compliance) Start() {
 
 	toSensorC := make(chan *sensor.MsgFromCompliance)
 	defer close(toSensorC)
-	c.scrapeConfig.Store(nil)
-	c.scrapeConfigReady.Reset()
+	// the anonymous go func will read from toSensorC and send it using the client
 	go func() {
 		c.manageStream(ctx, cli, &stoppedSig, toSensorC)
 	}()
@@ -139,14 +144,11 @@ func (c *Compliance) Start() {
 		if !features.VirtualMachines.Enabled() {
 			return
 		}
-		// Assumption: VM relay startup is gated by the first valid scrape config.
+		// Design choice: VM relay startup is gated by the first valid scrape config.
 		// We must not start relay until that config is available.
-		config, ok := c.waitForInitialScrapeConfig(ctx)
-		if !ok {
-			return
-		}
-		if !shouldRunVMRelay(config) {
-			log.Infof("Virtual machine relay disabled on master node by default; set %s=true to enable it", env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar())
+		config := c.waitForInitialScrapeConfig(ctx)
+		if err := shouldRunVMRelay(config); err != nil {
+			log.Infof("Virtual machine relay not started: %v", err)
 			return
 		}
 		log.Infof("Virtual machine relay enabled")
@@ -335,36 +337,37 @@ func (c *Compliance) manageStream(ctx context.Context, cli sensor.ComplianceServ
 }
 
 // waitForInitialScrapeConfig waits for the first scrape config observed by the
-// stream manager and returns it.
+// stream manager and returns it:
 //
-// Assumptions:
+// Design choices:
 //   - manageStream stores scrape config before signaling readiness.
 //   - the first scrape config is valid (non-nil) and must exist before VM relay
 //     startup is allowed; nil is treated as unexpected and startup is skipped.
 //   - waiting on scrapeConfigReady prevents races between scrape config
 //     publication and VM relay startup.
-func (c *Compliance) waitForInitialScrapeConfig(ctx context.Context) (*sensor.MsgToCompliance_ScrapeConfig, bool) {
+func (c *Compliance) waitForInitialScrapeConfig(ctx context.Context) *sensor.MsgToCompliance_ScrapeConfig {
 	select {
 	case <-ctx.Done():
-		return nil, false
+		return nil
 	case <-c.scrapeConfigReady.Done():
-		config := c.scrapeConfig.Load()
-		if config == nil {
-			log.Error("VM relay startup skipped because initial scrape config is unexpectedly nil")
-			return nil, false
-		}
-		return config, true
+		return c.scrapeConfig.Load()
 	}
 }
 
-func shouldRunVMRelay(config *sensor.MsgToCompliance_ScrapeConfig) bool {
+// shouldRunVMRelay decides whether the VM relay should start based on the
+// scrape config. Returns nil when the relay is allowed, or an error describing
+// why it was skipped.
+func shouldRunVMRelay(config *sensor.MsgToCompliance_ScrapeConfig) error {
 	if config == nil {
-		return false
+		return errNilScrapeConfig
 	}
 	if !config.GetIsMasterNode() {
-		return true
+		return nil
 	}
-	return env.VirtualMachinesRelayEnabledOnMasterNodes.BooleanSetting()
+	if env.VirtualMachinesRelayEnabledOnMasterNodes.BooleanSetting() {
+		return nil
+	}
+	return fmt.Errorf("%w; set %s=true to enable it", errRelayDisabledOnMasterNode, env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar())
 }
 
 func (c *Compliance) runRecv(ctx context.Context, client sensor.ComplianceService_CommunicateClient, config *sensor.MsgToCompliance_ScrapeConfig) error {

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -95,10 +95,7 @@ func (c *Compliance) Start() {
 
 	toSensorC := make(chan *sensor.MsgFromCompliance)
 	defer close(toSensorC)
-	// the anonymous go func will read from toSensorC and send it using the client
-	go func() {
-		c.manageStream(ctx, cli, &stoppedSig, toSensorC)
-	}()
+	vmRelayConfigC := c.manageStream(ctx, cli, &stoppedSig, toSensorC)
 
 	var wg concurrency.WaitGroup
 	wg.Add(3)
@@ -133,6 +130,9 @@ func (c *Compliance) Start() {
 	go func(ctx context.Context) {
 		defer wg.Add(-1)
 		if !features.VirtualMachines.Enabled() {
+			return
+		}
+		if !waitForVMRelayEligibility(ctx, vmRelayConfigC) {
 			return
 		}
 		log.Infof("Virtual machine relay enabled")
@@ -283,36 +283,98 @@ func (c *Compliance) runNodeIndex(ctx context.Context) *sensor.MsgFromCompliance
 	return msg
 }
 
-func (c *Compliance) manageStream(ctx context.Context, cli sensor.ComplianceServiceClient, sig *concurrency.Signal, toSensorC <-chan *sensor.MsgFromCompliance) {
+func (c *Compliance) manageStream(ctx context.Context, cli sensor.ComplianceServiceClient, sig *concurrency.Signal, toSensorC <-chan *sensor.MsgFromCompliance) <-chan *sensor.MsgToCompliance_ScrapeConfig {
+	vmRelayConfigC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)
+	go func() {
+		defer close(vmRelayConfigC)
+		for {
+			select {
+			case <-ctx.Done():
+				sig.Signal()
+				return
+			default:
+				// initializeStream must only be called once across all Compliance components,
+				// as multiple calls would overwrite associations on the Sensor side.
+				client, config, err := c.initializeStream(ctx, cli)
+				if err != nil {
+					if ctx.Err() != nil {
+						// continue and the <-ctx.Done() path should be taken next iteration
+						continue
+					}
+					log.Fatalf("Error initializing stream to sensor: %v", err)
+				}
+				// Best-effort publish of the latest config for relay startup without ever
+				// blocking stream management when no receiver is waiting.
+				publishLatestVMRelayConfig(vmRelayConfigC, config)
+				// A second Context is introduced for cancelling the goroutine if runRecv returns.
+				// runRecv only returns on errors, upon which the client will get reinitialized,
+				// orphaning manageSendToSensor in the process.
+				ctx2, cancelFn := context.WithCancel(ctx)
+				if toSensorC != nil {
+					go c.manageSendToSensor(ctx2, client, toSensorC)
+				}
+				if err := c.runRecv(ctx, client, config); err != nil {
+					log.Errorf("Error running recv: %v", err)
+				}
+				cancelFn() // runRecv is blocking, so the context is safely cancelled before the next call to initializeStream
+			}
+		}
+	}()
+	return vmRelayConfigC
+}
+
+// publishLatestVMRelayConfig publishes config without blocking and keeps at most
+// the latest scrape config in the channel buffer.
+func publishLatestVMRelayConfig(vmRelayConfigC chan *sensor.MsgToCompliance_ScrapeConfig, config *sensor.MsgToCompliance_ScrapeConfig) {
+	select {
+	case vmRelayConfigC <- config:
+		return
+	default:
+	}
+
+	// Channel is full: drop one stale item and try to publish the latest.
+	select {
+	case <-vmRelayConfigC:
+	default:
+	}
+	select {
+	case vmRelayConfigC <- config:
+	default:
+	}
+}
+
+// waitForVMRelayEligibility blocks until VM relay is eligible to start based on
+// scrape config updates. It returns false when the context is cancelled or when
+// the config channel closes before an eligible config is observed.
+func waitForVMRelayEligibility(ctx context.Context, vmRelayConfigC <-chan *sensor.MsgToCompliance_ScrapeConfig) bool {
 	for {
 		select {
 		case <-ctx.Done():
-			sig.Signal()
-			return
-		default:
-			// initializeStream must only be called once across all Compliance components,
-			// as multiple calls would overwrite associations on the Sensor side.
-			client, config, err := c.initializeStream(ctx, cli)
-			if err != nil {
-				if ctx.Err() != nil {
-					// continue and the <-ctx.Done() path should be taken next iteration
-					continue
-				}
-				log.Fatalf("Error initializing stream to sensor: %v", err)
+			return false
+		case config, ok := <-vmRelayConfigC:
+			if !ok {
+				return false
 			}
-			// A second Context is introduced for cancelling the goroutine if runRecv returns.
-			// runRecv only returns on errors, upon which the client will get reinitialized,
-			// orphaning manageSendToSensor in the process.
-			ctx2, cancelFn := context.WithCancel(ctx)
-			if toSensorC != nil {
-				go c.manageSendToSensor(ctx2, client, toSensorC)
+			if config == nil {
+				log.Info("Virtual machine relay starting without scrape config (safe fallback)")
+				return true
 			}
-			if err := c.runRecv(ctx, client, config); err != nil {
-				log.Errorf("Error running recv: %v", err)
+			if shouldRunVMRelay(config) {
+				return true
 			}
-			cancelFn() // runRecv is blocking, so the context is safely cancelled before the next call to initializeStream
+			log.Infof("Virtual machine relay disabled on master node by default; set %s=true to enable it", env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar())
 		}
 	}
+}
+
+func shouldRunVMRelay(config *sensor.MsgToCompliance_ScrapeConfig) bool {
+	if config == nil {
+		return true
+	}
+	if !config.GetIsMasterNode() {
+		return true
+	}
+	return env.VirtualMachinesRelayEnabledOnMasterNodes.BooleanSetting()
 }
 
 func (c *Compliance) runRecv(ctx context.Context, client sensor.ComplianceService_CommunicateClient, config *sensor.MsgToCompliance_ScrapeConfig) error {

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -149,6 +149,10 @@ func (c *Compliance) Start() {
 		// Design choice: VM relay startup is gated by the first valid scrape config.
 		// We must not start relay until that config is available.
 		config := c.waitForInitialScrapeConfig(ctx)
+		if err := ctx.Err(); err != nil {
+			log.Infof("Virtual machine relay start aborted: %v", err)
+			return
+		}
 		if err := shouldStartVMRelay(config); err != nil {
 			log.Infof("Virtual machine relay not started: %v", err)
 			return

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -145,7 +145,7 @@ func (c *Compliance) Start() {
 			log.Info("Virtual machine relay start aborted: context cancelled")
 			return
 		}
-		if !checkNodeRelayEligibility(config) {
+		if !shouldStartVMRelay(config) {
 			log.Infof("Virtual machine relay not started on master node; set %s=true to enable",
 				env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar())
 			return
@@ -350,9 +350,9 @@ func (c *Compliance) waitForInitialScrapeConfig(ctx context.Context) *sensor.Msg
 	}
 }
 
-// checkNodeRelayEligibility reports whether the VM relay should start based on
+// shouldStartVMRelay reports whether the VM relay should start based on
 // the scrape config and the master-node override env var.
-func checkNodeRelayEligibility(config *sensor.MsgToCompliance_ScrapeConfig) bool {
+func shouldStartVMRelay(config *sensor.MsgToCompliance_ScrapeConfig) bool {
 	return !config.GetIsMasterNode() || env.VirtualMachinesRelayEnabledOnMasterNodes.BooleanSetting()
 }
 

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -49,17 +49,20 @@ type Compliance struct {
 	umhNodeIndex       node.UnconfirmedMessageHandler
 	nodeInventoryCache atomic.Pointer[sensor.MsgFromCompliance]
 	nodeIndexCache     atomic.Pointer[sensor.MsgFromCompliance]
+	scrapeConfig       atomic.Pointer[sensor.MsgToCompliance_ScrapeConfig]
+	scrapeConfigReady  concurrency.Signal
 }
 
 // NewComplianceApp constructs the Compliance app object
 func NewComplianceApp(nnp node.NodeNameProvider, scanner node.NodeScanner, nodeIndexer node.NodeIndexer,
 	umhNodeInv, umhNodeIndex node.UnconfirmedMessageHandler) *Compliance {
 	return &Compliance{
-		nodeNameProvider: nnp,
-		nodeScanner:      scanner,
-		nodeIndexer:      nodeIndexer,
-		umhNodeInventory: umhNodeInv,
-		umhNodeIndex:     umhNodeIndex,
+		nodeNameProvider:  nnp,
+		nodeScanner:       scanner,
+		nodeIndexer:       nodeIndexer,
+		umhNodeInventory:  umhNodeInv,
+		umhNodeIndex:      umhNodeIndex,
+		scrapeConfigReady: concurrency.NewSignal(),
 	}
 }
 
@@ -95,7 +98,11 @@ func (c *Compliance) Start() {
 
 	toSensorC := make(chan *sensor.MsgFromCompliance)
 	defer close(toSensorC)
-	vmRelayConfigC := c.manageStream(ctx, cli, &stoppedSig, toSensorC)
+	c.scrapeConfig.Store(nil)
+	c.scrapeConfigReady.Reset()
+	go func() {
+		c.manageStream(ctx, cli, &stoppedSig, toSensorC)
+	}()
 
 	var wg concurrency.WaitGroup
 	wg.Add(3)
@@ -132,7 +139,14 @@ func (c *Compliance) Start() {
 		if !features.VirtualMachines.Enabled() {
 			return
 		}
-		if !waitForVMRelayEligibility(ctx, vmRelayConfigC) {
+		// Assumption: VM relay startup is gated by the first valid scrape config.
+		// We must not start relay until that config is available.
+		config, ok := c.waitForInitialScrapeConfig(ctx)
+		if !ok {
+			return
+		}
+		if !shouldRunVMRelay(config) {
+			log.Infof("Virtual machine relay disabled on master node by default; set %s=true to enable it", env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar())
 			return
 		}
 		log.Infof("Virtual machine relay enabled")
@@ -283,94 +297,69 @@ func (c *Compliance) runNodeIndex(ctx context.Context) *sensor.MsgFromCompliance
 	return msg
 }
 
-func (c *Compliance) manageStream(ctx context.Context, cli sensor.ComplianceServiceClient, sig *concurrency.Signal, toSensorC <-chan *sensor.MsgFromCompliance) <-chan *sensor.MsgToCompliance_ScrapeConfig {
-	vmRelayConfigC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)
-	go func() {
-		defer close(vmRelayConfigC)
-		for {
-			select {
-			case <-ctx.Done():
-				sig.Signal()
-				return
-			default:
-				// initializeStream must only be called once across all Compliance components,
-				// as multiple calls would overwrite associations on the Sensor side.
-				client, config, err := c.initializeStream(ctx, cli)
-				if err != nil {
-					if ctx.Err() != nil {
-						// continue and the <-ctx.Done() path should be taken next iteration
-						continue
-					}
-					log.Fatalf("Error initializing stream to sensor: %v", err)
-				}
-				// Best-effort publish of the latest config for relay startup without ever
-				// blocking stream management when no receiver is waiting.
-				publishLatestVMRelayConfig(vmRelayConfigC, config)
-				// A second Context is introduced for cancelling the goroutine if runRecv returns.
-				// runRecv only returns on errors, upon which the client will get reinitialized,
-				// orphaning manageSendToSensor in the process.
-				ctx2, cancelFn := context.WithCancel(ctx)
-				if toSensorC != nil {
-					go c.manageSendToSensor(ctx2, client, toSensorC)
-				}
-				if err := c.runRecv(ctx, client, config); err != nil {
-					log.Errorf("Error running recv: %v", err)
-				}
-				cancelFn() // runRecv is blocking, so the context is safely cancelled before the next call to initializeStream
-			}
-		}
-	}()
-	return vmRelayConfigC
-}
-
-// publishLatestVMRelayConfig publishes config without blocking and keeps at most
-// the latest scrape config in the channel buffer.
-// REQUIRES: single producer; concurrent calls are unsafe.
-func publishLatestVMRelayConfig(vmRelayConfigC chan *sensor.MsgToCompliance_ScrapeConfig, config *sensor.MsgToCompliance_ScrapeConfig) {
-	select {
-	case vmRelayConfigC <- config:
-		return
-	default:
-	}
-
-	// Channel is full: drop one stale item and try to publish the latest.
-	select {
-	case <-vmRelayConfigC:
-	default:
-	}
-	select {
-	case vmRelayConfigC <- config:
-	default:
-	}
-}
-
-// waitForVMRelayEligibility blocks until VM relay is eligible to start based on
-// scrape config updates. It returns false when the context is cancelled or when
-// the config channel closes before an eligible config is observed.
-func waitForVMRelayEligibility(ctx context.Context, vmRelayConfigC <-chan *sensor.MsgToCompliance_ScrapeConfig) bool {
+func (c *Compliance) manageStream(ctx context.Context, cli sensor.ComplianceServiceClient, sig *concurrency.Signal, toSensorC <-chan *sensor.MsgFromCompliance) {
 	for {
 		select {
 		case <-ctx.Done():
-			return false
-		case config, ok := <-vmRelayConfigC:
-			if !ok {
-				return false
+			sig.Signal()
+			return
+		default:
+			// initializeStream must only be called once across all Compliance components,
+			// as multiple calls would overwrite associations on the Sensor side.
+			client, config, err := c.initializeStream(ctx, cli)
+			if err != nil {
+				if ctx.Err() != nil {
+					// continue and the <-ctx.Done() path should be taken next iteration
+					continue
+				}
+				log.Fatalf("Error initializing stream to sensor: %v", err)
 			}
-			if config == nil {
-				log.Info("Virtual machine relay starting without scrape config (safe fallback)")
-				return true
+			// Record and signal the first valid scrape config for VM relay startup.
+			if !c.scrapeConfigReady.IsDone() {
+				c.scrapeConfig.Store(config)
+				c.scrapeConfigReady.Signal()
 			}
-			if shouldRunVMRelay(config) {
-				return true
+			// A second Context is introduced for cancelling the goroutine if runRecv returns.
+			// runRecv only returns on errors, upon which the client will get reinitialized,
+			// orphaning manageSendToSensor in the process.
+			ctx2, cancelFn := context.WithCancel(ctx)
+			if toSensorC != nil {
+				go c.manageSendToSensor(ctx2, client, toSensorC)
 			}
-			log.Infof("Virtual machine relay disabled on master node by default; set %s=true to enable it", env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar())
+			if err := c.runRecv(ctx, client, config); err != nil {
+				log.Errorf("Error running recv: %v", err)
+			}
+			cancelFn() // runRecv is blocking, so the context is safely cancelled before the next call to initializeStream
 		}
+	}
+}
+
+// waitForInitialScrapeConfig waits for the first scrape config observed by the
+// stream manager and returns it.
+//
+// Assumptions:
+//   - manageStream stores scrape config before signaling readiness.
+//   - the first scrape config is valid (non-nil) and must exist before VM relay
+//     startup is allowed; nil is treated as unexpected and startup is skipped.
+//   - waiting on scrapeConfigReady prevents races between scrape config
+//     publication and VM relay startup.
+func (c *Compliance) waitForInitialScrapeConfig(ctx context.Context) (*sensor.MsgToCompliance_ScrapeConfig, bool) {
+	select {
+	case <-ctx.Done():
+		return nil, false
+	case <-c.scrapeConfigReady.Done():
+		config := c.scrapeConfig.Load()
+		if config == nil {
+			log.Error("VM relay startup skipped because initial scrape config is unexpectedly nil")
+			return nil, false
+		}
+		return config, true
 	}
 }
 
 func shouldRunVMRelay(config *sensor.MsgToCompliance_ScrapeConfig) bool {
 	if config == nil {
-		return true
+		return false
 	}
 	if !config.GetIsMasterNode() {
 		return true

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -36,8 +37,9 @@ import (
 var (
 	log = logging.LoggerForModule()
 
-	errNilScrapeConfig           = errors.New("initial scrape config is unexpectedly nil")
-	errRelayDisabledOnMasterNode = errors.New("relay disabled on master node by default")
+	errNilScrapeConfig    = errors.New("initial scrape config is unexpectedly nil")
+	errRelayDisabledByEnv = errors.New("relay explicitly disabled via env var")
+	errRelayOnMasterNode  = errors.New("relay disabled on master node by default")
 )
 
 const (
@@ -147,7 +149,7 @@ func (c *Compliance) Start() {
 		// Design choice: VM relay startup is gated by the first valid scrape config.
 		// We must not start relay until that config is available.
 		config := c.waitForInitialScrapeConfig(ctx)
-		if err := shouldRunVMRelay(config); err != nil {
+		if err := shouldStartVMRelay(config); err != nil {
 			log.Infof("Virtual machine relay not started: %v", err)
 			return
 		}
@@ -354,20 +356,41 @@ func (c *Compliance) waitForInitialScrapeConfig(ctx context.Context) *sensor.Msg
 	}
 }
 
-// shouldRunVMRelay decides whether the VM relay should start based on the
+// shouldStartVMRelay decides whether the VM relay should start by checking the env
+// override first, then falling back to scrape-config-based logic. Returns nil
+// when the relay is allowed, or an error describing why it was skipped.
+//
+// Decision order:
+//  1. ROX_VIRTUAL_MACHINES_RELAY_ENABLED="true"  → always start
+//  2. ROX_VIRTUAL_MACHINES_RELAY_ENABLED="false" → never start
+//  3. unset → rely on scrape config (start on worker, skip on master)
+func shouldStartVMRelay(config *sensor.MsgToCompliance_ScrapeConfig) error {
+	override := strings.ToLower(env.VirtualMachinesRelayEnabled.Setting())
+	switch override {
+	case "true":
+		return nil
+	case "false":
+		return errRelayDisabledByEnv
+	case "":
+		// unset — fall through to config-based decision
+	default:
+		log.Warnf("Unexpected value %q for %s; falling back to default (scrape config based decision)",
+			override, env.VirtualMachinesRelayEnabled.EnvVar())
+	}
+	return checkNodeRelayEligibility(config)
+}
+
+// checkNodeRelayEligibility decides whether the VM relay should start based on the
 // scrape config. Returns nil when the relay is allowed, or an error describing
 // why it was skipped.
-func shouldRunVMRelay(config *sensor.MsgToCompliance_ScrapeConfig) error {
+func checkNodeRelayEligibility(config *sensor.MsgToCompliance_ScrapeConfig) error {
 	if config == nil {
 		return errNilScrapeConfig
 	}
 	if !config.GetIsMasterNode() {
 		return nil
 	}
-	if env.VirtualMachinesRelayEnabledOnMasterNodes.BooleanSetting() {
-		return nil
-	}
-	return fmt.Errorf("%w; set %s=true to enable it", errRelayDisabledOnMasterNode, env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar())
+	return fmt.Errorf("%w; set %s=true to override", errRelayOnMasterNode, env.VirtualMachinesRelayEnabled.EnvVar())
 }
 
 func (c *Compliance) runRecv(ctx context.Context, client sensor.ComplianceService_CommunicateClient, config *sensor.MsgToCompliance_ScrapeConfig) error {

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -32,9 +32,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-var (
-	log = logging.LoggerForModule()
-)
+var log = logging.LoggerForModule()
 
 const (
 	// nodeResourceID is the resource ID used for node scanning UMH.

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -325,6 +325,7 @@ func (c *Compliance) manageStream(ctx context.Context, cli sensor.ComplianceServ
 
 // publishLatestVMRelayConfig publishes config without blocking and keeps at most
 // the latest scrape config in the channel buffer.
+// REQUIRES: single producer; concurrent calls are unsafe.
 func publishLatestVMRelayConfig(vmRelayConfigC chan *sensor.MsgToCompliance_ScrapeConfig, config *sensor.MsgToCompliance_ScrapeConfig) {
 	select {
 	case vmRelayConfigC <- config:

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -2,10 +2,8 @@ package compliance
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -36,10 +34,6 @@ import (
 
 var (
 	log = logging.LoggerForModule()
-
-	errNilScrapeConfig    = errors.New("initial scrape config is unexpectedly nil")
-	errRelayDisabledByEnv = errors.New("relay explicitly disabled via env var")
-	errRelayOnMasterNode  = errors.New("relay disabled on master node by default")
 )
 
 const (
@@ -146,15 +140,16 @@ func (c *Compliance) Start() {
 		if !features.VirtualMachines.Enabled() {
 			return
 		}
-		// Design choice: VM relay startup is gated by the first valid scrape config.
+		// VM relay startup is gated by the first scrape config.
 		// We must not start relay until that config is available.
 		config := c.waitForInitialScrapeConfig(ctx)
-		if err := ctx.Err(); err != nil {
-			log.Infof("Virtual machine relay start aborted: %v", err)
+		if config == nil { // nil means ctx was cancelled
+			log.Info("Virtual machine relay start aborted: context cancelled")
 			return
 		}
-		if err := shouldStartVMRelay(config); err != nil {
-			log.Infof("Virtual machine relay not started: %v", err)
+		if !checkNodeRelayEligibility(config) {
+			log.Infof("Virtual machine relay not started on master node; set %s=true to enable",
+				env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar())
 			return
 		}
 		log.Infof("Virtual machine relay enabled")
@@ -343,14 +338,11 @@ func (c *Compliance) manageStream(ctx context.Context, cli sensor.ComplianceServ
 }
 
 // waitForInitialScrapeConfig waits for the first scrape config observed by the
-// stream manager and returns it:
+// stream manager and returns it. Returns nil only when ctx is cancelled.
 //
-// Design choices:
-//   - manageStream stores scrape config before signaling readiness.
-//   - the first scrape config is valid (non-nil) and must exist before VM relay
-//     startup is allowed; nil is treated as unexpected and startup is skipped.
-//   - waiting on scrapeConfigReady prevents races between scrape config
-//     publication and VM relay startup.
+// manageStream stores the scrape config before signaling readiness, and
+// initializeStream guarantees a non-nil config on success, so the returned
+// config is always valid when the context is not cancelled.
 func (c *Compliance) waitForInitialScrapeConfig(ctx context.Context) *sensor.MsgToCompliance_ScrapeConfig {
 	select {
 	case <-ctx.Done():
@@ -360,41 +352,10 @@ func (c *Compliance) waitForInitialScrapeConfig(ctx context.Context) *sensor.Msg
 	}
 }
 
-// shouldStartVMRelay decides whether the VM relay should start by checking the env
-// override first, then falling back to scrape-config-based logic. Returns nil
-// when the relay is allowed, or an error describing why it was skipped.
-//
-// Decision order:
-//  1. ROX_VIRTUAL_MACHINES_RELAY_ENABLED="true"  → always start
-//  2. ROX_VIRTUAL_MACHINES_RELAY_ENABLED="false" → never start
-//  3. unset → rely on scrape config (start on worker, skip on master)
-func shouldStartVMRelay(config *sensor.MsgToCompliance_ScrapeConfig) error {
-	override := strings.ToLower(env.VirtualMachinesRelayEnabled.Setting())
-	switch override {
-	case "true":
-		return nil
-	case "false":
-		return errRelayDisabledByEnv
-	case "":
-		// unset — fall through to config-based decision
-	default:
-		log.Warnf("Unexpected value %q for %s; falling back to default (scrape config based decision)",
-			override, env.VirtualMachinesRelayEnabled.EnvVar())
-	}
-	return checkNodeRelayEligibility(config)
-}
-
-// checkNodeRelayEligibility decides whether the VM relay should start based on the
-// scrape config. Returns nil when the relay is allowed, or an error describing
-// why it was skipped.
-func checkNodeRelayEligibility(config *sensor.MsgToCompliance_ScrapeConfig) error {
-	if config == nil {
-		return errNilScrapeConfig
-	}
-	if !config.GetIsMasterNode() {
-		return nil
-	}
-	return fmt.Errorf("%w; set %s=true to override", errRelayOnMasterNode, env.VirtualMachinesRelayEnabled.EnvVar())
+// checkNodeRelayEligibility reports whether the VM relay should start based on
+// the scrape config and the master-node override env var.
+func checkNodeRelayEligibility(config *sensor.MsgToCompliance_ScrapeConfig) bool {
+	return !config.GetIsMasterNode() || env.VirtualMachinesRelayEnabledOnMasterNodes.BooleanSetting()
 }
 
 func (c *Compliance) runRecv(ctx context.Context, client sensor.ComplianceService_CommunicateClient, config *sensor.MsgToCompliance_ScrapeConfig) error {

--- a/compliance/compliance_test.go
+++ b/compliance/compliance_test.go
@@ -106,40 +106,40 @@ func TestShouldRunVMRelay(t *testing.T) {
 	cases := map[string]struct {
 		config                   *sensor.MsgToCompliance_ScrapeConfig
 		enableRelayOnMasterNodes string
-		expectedShouldRunVMRelay bool
+		expectedErr              error
 	}{
 		"nil config should not run relay": {
-			config:                   nil,
-			enableRelayOnMasterNodes: "",
-			expectedShouldRunVMRelay: false,
+			config:      nil,
+			expectedErr: errNilScrapeConfig,
 		},
 		"worker node should run relay": {
 			config: &sensor.MsgToCompliance_ScrapeConfig{
 				IsMasterNode: false,
 			},
-			enableRelayOnMasterNodes: "",
-			expectedShouldRunVMRelay: true,
+			expectedErr: nil,
 		},
 		"master node should skip relay by default": {
 			config: &sensor.MsgToCompliance_ScrapeConfig{
 				IsMasterNode: true,
 			},
-			enableRelayOnMasterNodes: "",
-			expectedShouldRunVMRelay: false,
+			expectedErr: errRelayDisabledOnMasterNode,
 		},
 		"master node should run relay when override is enabled": {
 			config: &sensor.MsgToCompliance_ScrapeConfig{
 				IsMasterNode: true,
 			},
 			enableRelayOnMasterNodes: "true",
-			expectedShouldRunVMRelay: true,
+			expectedErr:              nil,
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), tc.enableRelayOnMasterNodes)
-			require.Equal(t, tc.expectedShouldRunVMRelay, shouldRunVMRelay(tc.config))
+			if tc.enableRelayOnMasterNodes != "" {
+				t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), tc.enableRelayOnMasterNodes)
+			}
+			err := shouldRunVMRelay(tc.config)
+			require.ErrorIs(t, err, tc.expectedErr)
 		})
 	}
 }
@@ -149,7 +149,6 @@ func TestWaitForInitialScrapeConfig(t *testing.T) {
 	cases := map[string]struct {
 		arrange        func(c *Compliance, cancel context.CancelFunc)
 		expectedConfig *sensor.MsgToCompliance_ScrapeConfig
-		expectedOK     bool
 	}{
 		"should return config after readiness signal": {
 			arrange: func(c *Compliance, _ context.CancelFunc) {
@@ -157,21 +156,18 @@ func TestWaitForInitialScrapeConfig(t *testing.T) {
 				c.scrapeConfigReady.Signal()
 			},
 			expectedConfig: workerConfig,
-			expectedOK:     true,
 		},
-		"should return false when context is cancelled": {
+		"should return nil when context is cancelled": {
 			arrange: func(_ *Compliance, cancel context.CancelFunc) {
 				cancel()
 			},
 			expectedConfig: nil,
-			expectedOK:     false,
 		},
-		"should return false when signal fires without config": {
+		"should return nil when signal fires without config": {
 			arrange: func(c *Compliance, _ context.CancelFunc) {
 				c.scrapeConfigReady.Signal()
 			},
 			expectedConfig: nil,
-			expectedOK:     false,
 		},
 	}
 
@@ -184,8 +180,7 @@ func TestWaitForInitialScrapeConfig(t *testing.T) {
 			defer cancel()
 
 			tc.arrange(c, cancel)
-			config, ok := c.waitForInitialScrapeConfig(ctx)
-			require.Equal(t, tc.expectedOK, ok)
+			config := c.waitForInitialScrapeConfig(ctx)
 			if tc.expectedConfig == nil {
 				require.Nil(t, config)
 			} else {

--- a/compliance/compliance_test.go
+++ b/compliance/compliance_test.go
@@ -128,7 +128,7 @@ func TestCheckNodeRelayEligibility(t *testing.T) {
 			if tc.enableRelayOnMasterNodes != "" {
 				t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), tc.enableRelayOnMasterNodes)
 			}
-			require.Equal(t, tc.expected, checkNodeRelayEligibility(tc.config))
+			require.Equal(t, tc.expected, shouldStartVMRelay(tc.config))
 		})
 	}
 }

--- a/compliance/compliance_test.go
+++ b/compliance/compliance_test.go
@@ -1,9 +1,13 @@
 package compliance
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/protoassert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -95,4 +99,108 @@ func (s *ComplianceTestSuite) TestHandleComplianceACK_NilACK() {
 	s.Equal(0, mockInventory.nackCount)
 	s.Equal(0, mockIndex.ackCount)
 	s.Equal(0, mockIndex.nackCount)
+}
+
+func TestShouldRunVMRelay(t *testing.T) {
+	cases := map[string]struct {
+		config                   *sensor.MsgToCompliance_ScrapeConfig
+		enableRelayOnMasterNodes string
+		expectedShouldRunVMRelay bool
+	}{
+		"nil config should run relay for safety": {
+			config:                   nil,
+			enableRelayOnMasterNodes: "",
+			expectedShouldRunVMRelay: true,
+		},
+		"worker node should run relay": {
+			config: &sensor.MsgToCompliance_ScrapeConfig{
+				IsMasterNode: false,
+			},
+			enableRelayOnMasterNodes: "",
+			expectedShouldRunVMRelay: true,
+		},
+		"master node should skip relay by default": {
+			config: &sensor.MsgToCompliance_ScrapeConfig{
+				IsMasterNode: true,
+			},
+			enableRelayOnMasterNodes: "",
+			expectedShouldRunVMRelay: false,
+		},
+		"master node should run relay when override is enabled": {
+			config: &sensor.MsgToCompliance_ScrapeConfig{
+				IsMasterNode: true,
+			},
+			enableRelayOnMasterNodes: "true",
+			expectedShouldRunVMRelay: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), tc.enableRelayOnMasterNodes)
+			require.Equal(t, tc.expectedShouldRunVMRelay, shouldRunVMRelay(tc.config))
+		})
+	}
+}
+
+func TestWaitForVMRelayEligibility(t *testing.T) {
+	t.Run("should start immediately for worker config", func(t *testing.T) {
+		t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), "")
+		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)
+		defer close(configC)
+		configC <- &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false}
+
+		require.True(t, waitForVMRelayEligibility(context.Background(), configC))
+	})
+
+	t.Run("should wait for later eligible config", func(t *testing.T) {
+		t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), "")
+		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 2)
+		defer close(configC)
+		configC <- &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true}
+		configC <- &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false}
+
+		require.True(t, waitForVMRelayEligibility(context.Background(), configC))
+	})
+
+	t.Run("should return false when channel closes before eligibility", func(t *testing.T) {
+		t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), "")
+		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)
+		configC <- &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true}
+		close(configC)
+
+		require.False(t, waitForVMRelayEligibility(context.Background(), configC))
+	})
+
+	t.Run("should return false when context is cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig)
+		defer close(configC)
+
+		require.False(t, waitForVMRelayEligibility(ctx, configC))
+	})
+}
+
+func TestPublishLatestVMRelayConfig(t *testing.T) {
+	t.Run("should publish when channel is empty", func(t *testing.T) {
+		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)
+		defer close(configC)
+		config := &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false}
+
+		publishLatestVMRelayConfig(configC, config)
+		protoassert.Equal(t, config, <-configC)
+	})
+
+	t.Run("should replace stale config when channel is full", func(t *testing.T) {
+		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)
+		defer close(configC)
+		staleConfig := &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true}
+		latestConfig := &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false}
+
+		configC <- staleConfig
+		publishLatestVMRelayConfig(configC, latestConfig)
+
+		protoassert.Equal(t, latestConfig, <-configC)
+	})
 }

--- a/compliance/compliance_test.go
+++ b/compliance/compliance_test.go
@@ -104,83 +104,31 @@ func (s *ComplianceTestSuite) TestHandleComplianceACK_NilACK() {
 
 func TestCheckNodeRelayEligibility(t *testing.T) {
 	cases := map[string]struct {
-		config      *sensor.MsgToCompliance_ScrapeConfig
-		expectedErr error
+		config                   *sensor.MsgToCompliance_ScrapeConfig
+		enableRelayOnMasterNodes string
+		expected                 bool
 	}{
-		"nil config should not run relay": {
-			config:      nil,
-			expectedErr: errNilScrapeConfig,
-		},
 		"worker node should run relay": {
-			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false},
-			expectedErr: nil,
+			config:   &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false},
+			expected: true,
 		},
-		"master node should skip relay": {
-			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true},
-			expectedErr: errRelayOnMasterNode,
+		"master node should skip relay by default": {
+			config:   &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true},
+			expected: false,
 		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			err := checkNodeRelayEligibility(tc.config)
-			require.ErrorIs(t, err, tc.expectedErr)
-		})
-	}
-}
-
-func TestShouldStartVMRelay(t *testing.T) {
-	cases := map[string]struct {
-		config      *sensor.MsgToCompliance_ScrapeConfig
-		envOverride string
-		expectedErr error
-	}{
-		"env=true overrides nil config": {
-			config:      nil,
-			envOverride: "true",
-			expectedErr: nil,
-		},
-		"env=true overrides master node": {
-			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true},
-			envOverride: "true",
-			expectedErr: nil,
-		},
-		"env=false disables relay on worker node": {
-			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false},
-			envOverride: "false",
-			expectedErr: errRelayDisabledByEnv,
-		},
-		"env=false disables relay on master node": {
-			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true},
-			envOverride: "false",
-			expectedErr: errRelayDisabledByEnv,
-		},
-		"invalid env value falls back to scrape config": {
-			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true},
-			envOverride: "maybe",
-			expectedErr: errRelayOnMasterNode,
-		},
-		"unset env with nil config should not run relay": {
-			config:      nil,
-			expectedErr: errNilScrapeConfig,
-		},
-		"unset env with worker node should run relay": {
-			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false},
-			expectedErr: nil,
-		},
-		"unset env with master node should skip relay": {
-			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true},
-			expectedErr: errRelayOnMasterNode,
+		"master node should run relay when override is enabled": {
+			config:                   &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true},
+			enableRelayOnMasterNodes: "true",
+			expected:                 true,
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if tc.envOverride != "" {
-				t.Setenv(env.VirtualMachinesRelayEnabled.EnvVar(), tc.envOverride)
+			if tc.enableRelayOnMasterNodes != "" {
+				t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), tc.enableRelayOnMasterNodes)
 			}
-			err := shouldStartVMRelay(tc.config)
-			require.ErrorIs(t, err, tc.expectedErr)
+			require.Equal(t, tc.expected, checkNodeRelayEligibility(tc.config))
 		})
 	}
 }

--- a/compliance/compliance_test.go
+++ b/compliance/compliance_test.go
@@ -102,43 +102,84 @@ func (s *ComplianceTestSuite) TestHandleComplianceACK_NilACK() {
 	s.Equal(0, mockIndex.nackCount)
 }
 
-func TestShouldRunVMRelay(t *testing.T) {
+func TestCheckNodeRelayEligibility(t *testing.T) {
 	cases := map[string]struct {
-		config                   *sensor.MsgToCompliance_ScrapeConfig
-		enableRelayOnMasterNodes string
-		expectedErr              error
+		config      *sensor.MsgToCompliance_ScrapeConfig
+		expectedErr error
 	}{
 		"nil config should not run relay": {
 			config:      nil,
 			expectedErr: errNilScrapeConfig,
 		},
 		"worker node should run relay": {
-			config: &sensor.MsgToCompliance_ScrapeConfig{
-				IsMasterNode: false,
-			},
+			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false},
 			expectedErr: nil,
 		},
-		"master node should skip relay by default": {
-			config: &sensor.MsgToCompliance_ScrapeConfig{
-				IsMasterNode: true,
-			},
-			expectedErr: errRelayDisabledOnMasterNode,
-		},
-		"master node should run relay when override is enabled": {
-			config: &sensor.MsgToCompliance_ScrapeConfig{
-				IsMasterNode: true,
-			},
-			enableRelayOnMasterNodes: "true",
-			expectedErr:              nil,
+		"master node should skip relay": {
+			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true},
+			expectedErr: errRelayOnMasterNode,
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if tc.enableRelayOnMasterNodes != "" {
-				t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), tc.enableRelayOnMasterNodes)
+			err := checkNodeRelayEligibility(tc.config)
+			require.ErrorIs(t, err, tc.expectedErr)
+		})
+	}
+}
+
+func TestShouldStartVMRelay(t *testing.T) {
+	cases := map[string]struct {
+		config      *sensor.MsgToCompliance_ScrapeConfig
+		envOverride string
+		expectedErr error
+	}{
+		"env=true overrides nil config": {
+			config:      nil,
+			envOverride: "true",
+			expectedErr: nil,
+		},
+		"env=true overrides master node": {
+			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true},
+			envOverride: "true",
+			expectedErr: nil,
+		},
+		"env=false disables relay on worker node": {
+			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false},
+			envOverride: "false",
+			expectedErr: errRelayDisabledByEnv,
+		},
+		"env=false disables relay on master node": {
+			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true},
+			envOverride: "false",
+			expectedErr: errRelayDisabledByEnv,
+		},
+		"invalid env value falls back to scrape config": {
+			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true},
+			envOverride: "maybe",
+			expectedErr: errRelayOnMasterNode,
+		},
+		"unset env with nil config should not run relay": {
+			config:      nil,
+			expectedErr: errNilScrapeConfig,
+		},
+		"unset env with worker node should run relay": {
+			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false},
+			expectedErr: nil,
+		},
+		"unset env with master node should skip relay": {
+			config:      &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true},
+			expectedErr: errRelayOnMasterNode,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.envOverride != "" {
+				t.Setenv(env.VirtualMachinesRelayEnabled.EnvVar(), tc.envOverride)
 			}
-			err := shouldRunVMRelay(tc.config)
+			err := shouldStartVMRelay(tc.config)
 			require.ErrorIs(t, err, tc.expectedErr)
 		})
 	}

--- a/compliance/compliance_test.go
+++ b/compliance/compliance_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stretchr/testify/require"
@@ -107,10 +108,10 @@ func TestShouldRunVMRelay(t *testing.T) {
 		enableRelayOnMasterNodes string
 		expectedShouldRunVMRelay bool
 	}{
-		"nil config should run relay for safety": {
+		"nil config should not run relay": {
 			config:                   nil,
 			enableRelayOnMasterNodes: "",
-			expectedShouldRunVMRelay: true,
+			expectedShouldRunVMRelay: false,
 		},
 		"worker node should run relay": {
 			config: &sensor.MsgToCompliance_ScrapeConfig{
@@ -143,72 +144,53 @@ func TestShouldRunVMRelay(t *testing.T) {
 	}
 }
 
-func TestWaitForVMRelayEligibility(t *testing.T) {
-	t.Run("should start for nil config as safe fallback", func(t *testing.T) {
-		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)
-		defer close(configC)
-		configC <- (*sensor.MsgToCompliance_ScrapeConfig)(nil)
+func TestWaitForInitialScrapeConfig(t *testing.T) {
+	workerConfig := &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false}
+	cases := map[string]struct {
+		arrange        func(c *Compliance, cancel context.CancelFunc)
+		expectedConfig *sensor.MsgToCompliance_ScrapeConfig
+		expectedOK     bool
+	}{
+		"should return config after readiness signal": {
+			arrange: func(c *Compliance, _ context.CancelFunc) {
+				c.scrapeConfig.Store(workerConfig)
+				c.scrapeConfigReady.Signal()
+			},
+			expectedConfig: workerConfig,
+			expectedOK:     true,
+		},
+		"should return false when context is cancelled": {
+			arrange: func(_ *Compliance, cancel context.CancelFunc) {
+				cancel()
+			},
+			expectedConfig: nil,
+			expectedOK:     false,
+		},
+		"should return false when signal fires without config": {
+			arrange: func(c *Compliance, _ context.CancelFunc) {
+				c.scrapeConfigReady.Signal()
+			},
+			expectedConfig: nil,
+			expectedOK:     false,
+		},
+	}
 
-		require.True(t, waitForVMRelayEligibility(context.Background(), configC))
-	})
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &Compliance{
+				scrapeConfigReady: concurrency.NewSignal(),
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-	t.Run("should start immediately for worker config", func(t *testing.T) {
-		t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), "")
-		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)
-		defer close(configC)
-		configC <- &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false}
-
-		require.True(t, waitForVMRelayEligibility(context.Background(), configC))
-	})
-
-	t.Run("should wait for later eligible config", func(t *testing.T) {
-		t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), "")
-		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 2)
-		defer close(configC)
-		configC <- &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true}
-		configC <- &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false}
-
-		require.True(t, waitForVMRelayEligibility(context.Background(), configC))
-	})
-
-	t.Run("should return false when channel closes before eligibility", func(t *testing.T) {
-		t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), "")
-		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)
-		configC <- &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true}
-		close(configC)
-
-		require.False(t, waitForVMRelayEligibility(context.Background(), configC))
-	})
-
-	t.Run("should return false when context is cancelled", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig)
-		defer close(configC)
-
-		require.False(t, waitForVMRelayEligibility(ctx, configC))
-	})
-}
-
-func TestPublishLatestVMRelayConfig(t *testing.T) {
-	t.Run("should publish when channel is empty", func(t *testing.T) {
-		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)
-		defer close(configC)
-		config := &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false}
-
-		publishLatestVMRelayConfig(configC, config)
-		protoassert.Equal(t, config, <-configC)
-	})
-
-	t.Run("should replace stale config when channel is full", func(t *testing.T) {
-		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)
-		defer close(configC)
-		staleConfig := &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: true}
-		latestConfig := &sensor.MsgToCompliance_ScrapeConfig{IsMasterNode: false}
-
-		configC <- staleConfig
-		publishLatestVMRelayConfig(configC, latestConfig)
-
-		protoassert.Equal(t, latestConfig, <-configC)
-	})
+			tc.arrange(c, cancel)
+			config, ok := c.waitForInitialScrapeConfig(ctx)
+			require.Equal(t, tc.expectedOK, ok)
+			if tc.expectedConfig == nil {
+				require.Nil(t, config)
+			} else {
+				protoassert.Equal(t, tc.expectedConfig, config)
+			}
+		})
+	}
 }

--- a/compliance/compliance_test.go
+++ b/compliance/compliance_test.go
@@ -144,6 +144,14 @@ func TestShouldRunVMRelay(t *testing.T) {
 }
 
 func TestWaitForVMRelayEligibility(t *testing.T) {
+	t.Run("should start for nil config as safe fallback", func(t *testing.T) {
+		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)
+		defer close(configC)
+		configC <- (*sensor.MsgToCompliance_ScrapeConfig)(nil)
+
+		require.True(t, waitForVMRelayEligibility(context.Background(), configC))
+	})
+
 	t.Run("should start immediately for worker config", func(t *testing.T) {
 		t.Setenv(env.VirtualMachinesRelayEnabledOnMasterNodes.EnvVar(), "")
 		configC := make(chan *sensor.MsgToCompliance_ScrapeConfig, 1)

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -26,11 +26,9 @@ var (
 	VirtualMachinesIndexReportsBufferSize = RegisterIntegerSetting("ROX_VIRTUAL_MACHINES_INDEX_REPORTS_BUFFER_SIZE", 100).
 						WithMinimum(0)
 
-	// VirtualMachinesRelayEnabled is a tri-state override for VM relay startup:
-	//   - "true":  always start the relay regardless of scrape config
-	//   - "false": never start the relay
-	//   - unset:   rely on the scrape config (start on worker nodes, skip on master nodes)
-	VirtualMachinesRelayEnabled = RegisterSetting("ROX_VIRTUAL_MACHINES_RELAY_ENABLED", AllowEmpty())
+	// VirtualMachinesRelayEnabledOnMasterNodes allows enabling the VM relay on master/control-plane nodes.
+	// The default is false because these nodes typically do not host VMs and would otherwise retry forever.
+	VirtualMachinesRelayEnabledOnMasterNodes = RegisterBooleanSetting("ROX_VIRTUAL_MACHINES_RELAY_ENABLED_ON_MASTER_NODES", false)
 
 	// VMIndexReportRateLimit defines the maximum number of VM index reports per second that Central will accept
 	// across all sensors that actually send VM index reports. Each such sensor gets an equal share (1/N) of this

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -26,9 +26,11 @@ var (
 	VirtualMachinesIndexReportsBufferSize = RegisterIntegerSetting("ROX_VIRTUAL_MACHINES_INDEX_REPORTS_BUFFER_SIZE", 100).
 						WithMinimum(0)
 
-	// VirtualMachinesRelayEnabledOnMasterNodes allows enabling the VM relay on master/control-plane nodes.
-	// The default is false because these nodes typically do not host VMs and would otherwise retry forever.
-	VirtualMachinesRelayEnabledOnMasterNodes = RegisterBooleanSetting("ROX_VIRTUAL_MACHINES_RELAY_ENABLED_ON_MASTER_NODES", false)
+	// VirtualMachinesRelayEnabled is a tri-state override for VM relay startup:
+	//   - "true":  always start the relay regardless of scrape config
+	//   - "false": never start the relay
+	//   - unset:   rely on the scrape config (start on worker nodes, skip on master nodes)
+	VirtualMachinesRelayEnabled = RegisterSetting("ROX_VIRTUAL_MACHINES_RELAY_ENABLED", AllowEmpty())
 
 	// VMIndexReportRateLimit defines the maximum number of VM index reports per second that Central will accept
 	// across all sensors that actually send VM index reports. Each such sensor gets an equal share (1/N) of this

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -26,6 +26,10 @@ var (
 	VirtualMachinesIndexReportsBufferSize = RegisterIntegerSetting("ROX_VIRTUAL_MACHINES_INDEX_REPORTS_BUFFER_SIZE", 100).
 						WithMinimum(0)
 
+	// VirtualMachinesRelayEnabledOnMasterNodes allows enabling the VM relay on master/control-plane nodes.
+	// The default is false because these nodes typically do not host VMs and would otherwise retry forever.
+	VirtualMachinesRelayEnabledOnMasterNodes = RegisterBooleanSetting("ROX_VIRTUAL_MACHINES_RELAY_ENABLED_ON_MASTER_NODES", false)
+
 	// VMIndexReportRateLimit defines the maximum number of VM index reports per second that Central will accept
 	// across all sensors that actually send VM index reports. Each such sensor gets an equal share (1/N) of this
 	// global capacity. The split happens when a new client ID registers in the VM index report pipeline; there is


### PR DESCRIPTION
## Description

Follow-up from #20124: compliance on master/control-plane nodes could retry
VM relay startup indefinitely, producing repeated vsock bind failures.

This PR gates VM relay startup based on the scrape config received from Sensor:
worker nodes start the relay, master nodes skip it by default.
`ROX_VIRTUAL_MACHINES_RELAY_ENABLED_ON_MASTER_NODES=true` overrides this for
master nodes that do host VMs.

Design:
- `waitForInitialScrapeConfig` blocks until the first scrape config is
  available (via `atomic.Pointer` + `concurrency.Signal`), returns nil only
  when the context is cancelled. `initializeStream` guarantees a non-nil
  config on success.
- `checkNodeRelayEligibility` is a pure one-liner: returns true for worker
  nodes, or for master nodes when the override env var is set.
- Logging is done by the caller, keeping decision functions side-effect-free.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- CI
- Tested it on a cluster manually by checking the logs on master and worker nodes

AI-Assisted: cursor, refactored relay startup gating and tests