### PR TITLE
ROX-34425: resolve file access violations

### DIFF
--- a/qa-tests-backend/src/test/groovy/FileActivityTest.groovy
+++ b/qa-tests-backend/src/test/groovy/FileActivityTest.groovy
@@ -83,6 +83,7 @@ class FileActivityTest extends BaseSpecification {
         assert alert.violationsList[0].message.contains(path)
 
         cleanup:
+        resolveAlertsByPolicy(policyName)
         if (policyID) {
             PolicyService.deletePolicy(policyID)
         }
@@ -127,6 +128,7 @@ class FileActivityTest extends BaseSpecification {
             orchestrator.execInContainer(hostDeployment, "chroot /host sudo rm -f ${path}")
             orchestrator.deleteDeployment(hostDeployment)
         }
+        resolveAlertsByPolicy(policyName)
         if (policyID) {
             PolicyService.deletePolicy(policyID)
         }
@@ -205,5 +207,15 @@ class FileActivityTest extends BaseSpecification {
                                 .build()
                 )
                 .build()
+    }
+
+    private static void resolveAlertsByPolicy(String policyName) {
+        def alerts = AlertService.getViolations(
+                ListAlertsRequest.newBuilder()
+                        .setQuery("Policy:${policyName}+Violation State:ACTIVE")
+                        .build())
+        for (alert in alerts) {
+            AlertService.resolveAlert(alert.id)
+        }
     }
 }

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -132,9 +132,10 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         // FILE_ACCESS violations may lack deploymentInfo (e.g. node-level events)
         // and have their own CIM structure validated in the file access test
         // (currently disabled pending ROX-31047).
-        def nonFileAccessAlerts = alerts.findAll { !isViolationOfType(it, "FILE_ACCESS") }
-        for (alert in nonFileAccessAlerts) {
-            validateCimMappings(alert)
+        alerts.findAll {
+            !isViolationOfType(it, "FILE_ACCESS")
+        }.each {
+            alert -> validateCimMappings(alert)
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/IntegrationsSplunkViolationsTest.groovy
@@ -129,7 +129,11 @@ class IntegrationsSplunkViolationsTest extends BaseSpecification {
         "StackRox violations are in Splunk with correct CIM field mappings"
         assert !alerts.isEmpty()
         log.info "Validating CIM mappings for alerts"
-        for (alert in alerts) {
+        // FILE_ACCESS violations may lack deploymentInfo (e.g. node-level events)
+        // and have their own CIM structure validated in the file access test
+        // (currently disabled pending ROX-31047).
+        def nonFileAccessAlerts = alerts.findAll { !isViolationOfType(it, "FILE_ACCESS") }
+        for (alert in nonFileAccessAlerts) {
             validateCimMappings(alert)
         }
     }


### PR DESCRIPTION
## Description

Further strictness for splunk TA tests, and ensure file access tests resolve violations to avoid contamination of other test suites.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI should be enough (with `ci-all-qa-tests` label) 