### PR TITLE
ROX-33742: Add FiltersQuery for report configuration

### DIFF
--- a/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
@@ -1,0 +1,84 @@
+import type { ReactElement } from 'react';
+import { Alert, Flex, FormGroup } from '@patternfly/react-core';
+import type { FormikProps } from 'formik';
+
+import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
+import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
+import SearchFilterSelectInclusive from 'Components/CompoundSearchFilter/components/SearchFilterSelectInclusive';
+import type {
+    CompoundSearchFilterConfig,
+    OnSearchPayload,
+    SelectSearchFilterAttribute,
+} from 'Components/CompoundSearchFilter/types';
+import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
+import type { SearchFilter } from 'types/search';
+import {
+    getRequestQueryStringForSearchFilter,
+    getSearchFilterFromSearchString,
+} from 'utils/searchUtils';
+
+export type FiltersQueryConfiguration = {
+    vulnReportFilters: {
+        query: string;
+    };
+};
+
+export type FiltersQueryProps = {
+    attributesSeparateFromConfig: SelectSearchFilterAttribute[];
+    formik: FormikProps<FiltersQueryConfiguration>;
+    searchFilterConfig: CompoundSearchFilterConfig;
+};
+
+function FiltersQuery({
+    attributesSeparateFromConfig,
+    formik,
+    searchFilterConfig,
+}: FiltersQueryProps): ReactElement {
+    const searchFilter = getSearchFilterFromSearchString(formik.values.vulnReportFilters.query);
+
+    function onFilterChange(searchFilterChanged: SearchFilter) {
+        formik.setFieldValue(
+            'vulnReportFilters.query',
+            getRequestQueryStringForSearchFilter(searchFilterChanged)
+        );
+    }
+
+    function onSearch(payload: OnSearchPayload) {
+        onFilterChange(updateSearchFilter(searchFilter, payload));
+    }
+
+    return (
+        <>
+            {attributesSeparateFromConfig.map((attribute) => (
+                <FormGroup key={attribute.searchTerm} label={attribute.displayName} fieldId="TODO">
+                    <SearchFilterSelectInclusive
+                        attribute={attribute}
+                        onSearch={onSearch}
+                        searchFilter={searchFilter}
+                    />
+                </FormGroup>
+            ))}
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+                <CompoundSearchFilter
+                    config={searchFilterConfig}
+                    onSearch={onSearch}
+                    searchFilter={searchFilter}
+                />
+                {Object.keys(searchFilter).length !== 0 ? (
+                    <CompoundSearchFilterLabels
+                        attributesSeparateFromConfig={attributesSeparateFromConfig}
+                        config={searchFilterConfig}
+                        onFilterChange={onFilterChange}
+                        searchFilter={searchFilter}
+                    />
+                ) : (
+                    <Alert variant="warning" title="TODO" isInline component="p">
+                        To be determined
+                    </Alert>
+                )}
+            </Flex>
+        </>
+    );
+}
+
+export default FiltersQuery;


### PR DESCRIPTION
## Description

Add some components independent of step or view that will render them.

### Objective

Provide equivalent filter for schduled reports as view-based reports.

### Analysis

1. `CompoundSearchFilter` and `CompoundSearchFilterLabels` elements already have props:

    * `attributesSeparateFromConfig`
    * `config` that is short for `searchFilterConfig`

2. searchFilterConfig.ts file will become source of truth for vulnerabilities:

    * results
    * scheduled reports
    * view-based reports

### Solution

Similar to components that return description list groups, return form groups for maximum composability.

Just as groups do not know about `horizontalTermWidthModifier` prop of list, groups do not know about potential `isHorizontal` or `isWidthLimited` props of form.

1. Add FiltersQuery.tsx file in src/Components/Reports/Step folder because it is generic:

    * image vulnerability reports
    * node vulnerability reports
    * violation reports

### Residue

1. Make **Clear filters** link optional in CompoundSearchFilterLabels.tsx file, because absence of filters is a problem for scheduled report.

2. Get wording for warning `Alert` element (also for `FiltersView` element) and `entityScope` also needs.

3. Investigate case insensitive search field labels for SEVERITY and FIXABLE in `query` string.

    Although we will fix it in create from results scenario, create via API request might mix up the case.

    Apparently quotes and regex work with round-trip conversion, which is a pleasant surprise.

    I will pay closer attention when **Filters** step renders `FiltersQuery` element.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

### Manual testing

Temporary edit ViewVulnReportPage.tsx file to render `ImageVulnerabilityReportWizard` from branch that is still in review.

1. Visit /main/vulnerabilities/user-workloads and select search filters.

    Request has `query: "Platform Component:false+SEVERITY:CRITICAL_VULNERABILITY_SEVERITY,IMPORTANT_VULNERABILITY_SEVERITY,MODERATE_VULNERABILITY_SEVERITY+FIXABLE:true+EPSS Probability:>=0.9+Component Layer Type:APPLICATION+Image Registry:\"quay.io\"+Vulnerability State:OBSERVED"`
    <img width="1441" height="892" alt="Step_1_Results" src="https://github.com/user-attachments/assets/d79162ee-5dda-418b-9e45-5f46aec02bb6" />

2. Visit /main/vulnerabilities/reports/configuration and click a link

    With `query` above in simulated report configuration for entity (instead of collection) scope:
    <img width="1439" height="892" alt="Step_2_FiltersQuery" src="https://github.com/user-attachments/assets/77ec65ed-aa90-4ee9-b2c5-453a87bb2539" />

3. Clear **Moderate** from **CVE severity** select element.
    <img width="1440" height="892" alt="Step_3_clear_Moderate" src="https://github.com/user-attachments/assets/4054efe5-7617-42bf-99ff-355840643c71" />

4. Delete **CVE status** filter chip.
    <img width="1440" height="892" alt="Step_4_delete_Fixable" src="https://github.com/user-attachments/assets/6b777725-5083-4d65-aac6-83bb740112ff" />

5. Add **CVSS** greater than or equal to **9**
    <img width="1440" height="892" alt="Step_5_add_CVSS" src="https://github.com/user-attachments/assets/5e0ca5a1-f33d-4775-8985-2e42c1c723d3" />

    Haha, I advanced to see the query in **Review** step, but it is still in review.
