### PR TITLE
Batch populateImage in WalkByQuery to reduce query count during image export

### DIFF
--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -659,6 +659,99 @@ func getAllImageComponentCVEs(ctx context.Context, tx *postgres.Tx, imageID stri
 	return result, nil
 }
 
+const walkBatchSize = 100
+
+func (s *storeImpl) populateImages(ctx context.Context, tx *postgres.Tx, images []*storage.Image) error {
+	ids := make([]string, 0, len(images))
+	for _, img := range images {
+		ids = append(ids, img.GetId())
+	}
+
+	componentsByImage, err := getImageComponentsBatch(ctx, tx, ids)
+	if err != nil {
+		return err
+	}
+
+	cvesByImage, err := getAllImageComponentCVEsBatch(ctx, tx, ids)
+	if err != nil {
+		return err
+	}
+
+	for _, image := range images {
+		imageID := image.GetId()
+		components := componentsByImage[imageID]
+		cvesByComponent := cvesByImage[imageID]
+
+		imageParts := common.ImageParts{
+			Image:    image,
+			Children: make([]common.ComponentParts, 0, len(components)),
+		}
+		for _, component := range components {
+			cves := cvesByComponent[component.GetId()]
+			cveParts := make([]common.CVEParts, 0, len(cves))
+			for _, cve := range cves {
+				cveParts = append(cveParts, common.CVEParts{CVEV2: cve})
+			}
+			imageParts.Children = append(imageParts.Children, common.ComponentParts{
+				ComponentV2: component,
+				Children:    cveParts,
+			})
+		}
+		common.MergeV2(imageParts)
+	}
+	return nil
+}
+
+func getImageComponentsBatch(ctx context.Context, tx *postgres.Tx, imageIDs []string) (map[string][]*storage.ImageComponentV2, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ImageComponentsV2")
+
+	rows, err := tx.Query(ctx,
+		"SELECT serialized FROM "+imageComponentsV2Table+" WHERE imageid = ANY($1::text[])",
+		imageIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	components, err := pgutils.ScanRows[storage.ImageComponentV2, *storage.ImageComponentV2](rows)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string][]*storage.ImageComponentV2, len(imageIDs))
+	for _, comp := range components {
+		imgID := comp.GetImageId()
+		result[imgID] = append(result[imgID], comp)
+	}
+	return result, nil
+}
+
+func getAllImageComponentCVEsBatch(ctx context.Context, tx *postgres.Tx, imageIDs []string) (map[string]map[string][]*storage.ImageCVEV2, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ImageCVEsV2")
+
+	rows, err := tx.Query(ctx,
+		"SELECT serialized FROM "+imageComponentsV2CVEsTable+" WHERE imageid = ANY($1::text[])",
+		imageIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	cves, err := pgutils.ScanRows[storage.ImageCVEV2, *storage.ImageCVEV2](rows)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]map[string][]*storage.ImageCVEV2, len(imageIDs))
+	for _, cve := range cves {
+		imgID := cve.GetImageId()
+		compID := cve.GetComponentId()
+		if result[imgID] == nil {
+			result[imgID] = make(map[string][]*storage.ImageCVEV2)
+		}
+		result[imgID][compID] = append(result[imgID][compID], cve)
+	}
+	return result, nil
+}
+
 func getImageCVEs(ctx context.Context, tx *postgres.Tx, imageID string) ([]*storage.EmbeddedVulnerability, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ImageCVEsV2")
 
@@ -846,21 +939,37 @@ func (s *storeImpl) WalkByQuery(ctx context.Context, q *v1.Query, fn func(image 
 		}
 	}()
 
-	callback := func(image *storage.Image) error {
-		err := s.populateImage(ctx, tx, image)
-		if err != nil {
-			return errors.Wrap(err, "populate image")
+	batch := make([]*storage.Image, 0, walkBatchSize)
+
+	processBatch := func() error {
+		if len(batch) == 0 {
+			return nil
 		}
-		if err := fn(image); err != nil {
-			return errors.Wrap(err, "failed to process image")
+		if err := s.populateImages(ctx, tx, batch); err != nil {
+			return errors.Wrap(err, "populate images")
+		}
+		for _, image := range batch {
+			if err := fn(image); err != nil {
+				return errors.Wrap(err, "failed to process image")
+			}
+		}
+		batch = batch[:0]
+		return nil
+	}
+
+	callback := func(image *storage.Image) error {
+		batch = append(batch, image)
+		if len(batch) >= walkBatchSize {
+			return processBatch()
 		}
 		return nil
 	}
+
 	err = pgSearch.RunCursorQueryForSchemaFn(ctx, pkgSchema.ImagesSchema, q, s.db, callback)
 	if err != nil {
 		return errors.Wrap(err, "cursor by query")
 	}
-	return nil
+	return processBatch()
 }
 
 func (s *storeImpl) WalkMetadataByQuery(ctx context.Context, q *v1.Query, fn func(img *storage.Image) error) error {

--- a/central/image/datastore/store/v2/postgres/store_bench_test.go
+++ b/central/image/datastore/store/v2/postgres/store_bench_test.go
@@ -82,6 +82,67 @@ func BenchmarkRealisticPopulateImage(b *testing.B) {
 	})
 }
 
+// BenchmarkLargeScalePopulateImage benchmarks image retrieval at customer-representative scale.
+// Based on Amadeus profile: ~5,000 images x ~400 components x ~0.4 CVEs per component.
+func BenchmarkLargeScalePopulateImage(b *testing.B) {
+	if features.FlattenImageData.Enabled() {
+		b.Skip("Skipping benchmark - FlattenImageData is enabled.")
+	}
+	ctx := sac.WithAllAccess(context.Background())
+	testDB := pgtest.ForT(b)
+
+	store := New(testDB.DB, false, concurrency.NewKeyFence())
+
+	numImages := 5000
+	numComponents := 400
+	images := make([]*storage.Image, 0, numImages)
+	for i := 0; i < numImages; i++ {
+		components := make([]*storage.EmbeddedImageScanComponent, 0, numComponents)
+		for j := 0; j < numComponents; j++ {
+			var vulns []*storage.EmbeddedVulnerability
+			// ~40% of components have 1 CVE to approximate 0.4 CVEs/component ratio.
+			if j%5 < 2 {
+				vulns = []*storage.EmbeddedVulnerability{
+					{
+						Cve:               fmt.Sprintf("CVE-2025-%04d-%04d", i%500, j),
+						Cvss:              6.5,
+						VulnerabilityType: storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
+						Severity:          storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+						SetFixedBy:        &storage.EmbeddedVulnerability_FixedBy{FixedBy: "2.0.0"},
+					},
+				}
+			}
+			components = append(components, &storage.EmbeddedImageScanComponent{
+				Name:    fmt.Sprintf("pkg-%d-%d", i, j),
+				Version: fmt.Sprintf("%d.0.0", j),
+				Vulns:   vulns,
+			})
+		}
+		img := fixtures.GetImageWithUniqueComponents(0)
+		img.Id = fmt.Sprintf("sha256:largescale-%05d", i)
+		img.Scan = &storage.ImageScan{
+			Components: components,
+		}
+		images = append(images, img)
+	}
+
+	b.Log("Inserting", numImages, "images with", numComponents, "components each...")
+	for _, image := range images {
+		require.NoError(b, store.Upsert(ctx, image))
+	}
+
+	b.Run("WalkByQuery", func(b *testing.B) {
+		for b.Loop() {
+			count := 0
+			err := store.WalkByQuery(ctx, search.EmptyQuery(), func(image *storage.Image) error {
+				count++
+				return nil
+			})
+			require.NoError(b, err)
+		}
+	})
+}
+
 // TODO(ROX-30117): Remove this benchmark when FlattenImageData feature flag is removed.
 // BenchmarkWalkComparison benchmarks both Walk functions for comparison
 func BenchmarkWalkComparison(b *testing.B) {

--- a/central/imagev2/datastore/store/postgres/store.go
+++ b/central/imagev2/datastore/store/postgres/store.go
@@ -683,6 +683,99 @@ func getAllImageComponentCVEs(ctx context.Context, tx *postgres.Tx, imageID stri
 	return result, nil
 }
 
+const walkBatchSize = 100
+
+func (s *storeImpl) populateImages(ctx context.Context, tx *postgres.Tx, images []*storage.ImageV2) error {
+	ids := make([]string, 0, len(images))
+	for _, img := range images {
+		ids = append(ids, img.GetId())
+	}
+
+	componentsByImage, err := getImageComponentsBatchV2(ctx, tx, ids)
+	if err != nil {
+		return err
+	}
+
+	cvesByImage, err := getAllImageComponentCVEsBatchV2(ctx, tx, ids)
+	if err != nil {
+		return err
+	}
+
+	for _, image := range images {
+		imageID := image.GetId()
+		components := componentsByImage[imageID]
+		cvesByComponent := cvesByImage[imageID]
+
+		imageParts := common.ImagePartsV2{
+			Image:    image,
+			Children: make([]common.ComponentPartsV2, 0, len(components)),
+		}
+		for _, component := range components {
+			cves := cvesByComponent[component.GetId()]
+			cveParts := make([]common.CVEPartsV2, 0, len(cves))
+			for _, cve := range cves {
+				cveParts = append(cveParts, common.CVEPartsV2{CVEV2: cve})
+			}
+			imageParts.Children = append(imageParts.Children, common.ComponentPartsV2{
+				ComponentV2: component,
+				Children:    cveParts,
+			})
+		}
+		common.Merge(imageParts)
+	}
+	return nil
+}
+
+func getImageComponentsBatchV2(ctx context.Context, tx *postgres.Tx, imageIDs []string) (map[string][]*storage.ImageComponentV2, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ImageComponentsV2")
+
+	rows, err := tx.Query(ctx,
+		"SELECT serialized FROM "+imageComponentsV2Table+" WHERE imageidv2 = ANY($1::text[])",
+		imageIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	components, err := pgutils.ScanRows[storage.ImageComponentV2, *storage.ImageComponentV2](rows)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string][]*storage.ImageComponentV2, len(imageIDs))
+	for _, comp := range components {
+		imgID := comp.GetImageIdV2()
+		result[imgID] = append(result[imgID], comp)
+	}
+	return result, nil
+}
+
+func getAllImageComponentCVEsBatchV2(ctx context.Context, tx *postgres.Tx, imageIDs []string) (map[string]map[string][]*storage.ImageCVEV2, error) {
+	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ImageCVEsV2")
+
+	rows, err := tx.Query(ctx,
+		"SELECT serialized FROM "+imageComponentsV2CVEsTable+" WHERE imageidv2 = ANY($1::text[])",
+		imageIDs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	cves, err := pgutils.ScanRows[storage.ImageCVEV2, *storage.ImageCVEV2](rows)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]map[string][]*storage.ImageCVEV2, len(imageIDs))
+	for _, cve := range cves {
+		imgID := cve.GetImageIdV2()
+		compID := cve.GetComponentId()
+		if result[imgID] == nil {
+			result[imgID] = make(map[string][]*storage.ImageCVEV2)
+		}
+		result[imgID][compID] = append(result[imgID][compID], cve)
+	}
+	return result, nil
+}
+
 func getImageCVEs(ctx context.Context, tx *postgres.Tx, imageID string, imageIDField string) ([]*storage.EmbeddedVulnerability, error) {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Get, "ImageCVEsV2")
 
@@ -864,21 +957,37 @@ func (s *storeImpl) WalkByQuery(ctx context.Context, q *v1.Query, fn func(image 
 	}
 	defer postgres.FinishReadOnlyTransaction(tx)
 
-	callback := func(image *storage.ImageV2) error {
-		err := s.populateImage(ctx, tx, image)
-		if err != nil {
-			return errors.Wrap(err, "populate image")
+	batch := make([]*storage.ImageV2, 0, walkBatchSize)
+
+	processBatch := func() error {
+		if len(batch) == 0 {
+			return nil
 		}
-		if err := fn(image); err != nil {
-			return errors.Wrap(err, "failed to process image")
+		if err := s.populateImages(ctx, tx, batch); err != nil {
+			return errors.Wrap(err, "populate images")
+		}
+		for _, image := range batch {
+			if err := fn(image); err != nil {
+				return errors.Wrap(err, "failed to process image")
+			}
+		}
+		batch = batch[:0]
+		return nil
+	}
+
+	callback := func(image *storage.ImageV2) error {
+		batch = append(batch, image)
+		if len(batch) >= walkBatchSize {
+			return processBatch()
 		}
 		return nil
 	}
+
 	err = pgSearch.RunCursorQueryForSchemaFn(ctx, pkgSchema.ImagesV2Schema, q, s.db, callback)
 	if err != nil {
 		return errors.Wrap(err, "cursor by query")
 	}
-	return nil
+	return processBatch()
 }
 
 func (s *storeImpl) WalkMetadataByQuery(ctx context.Context, q *v1.Query, fn func(image *storage.ImageV2) error) error {

--- a/central/imagev2/datastore/store/postgres/store_bench_test.go
+++ b/central/imagev2/datastore/store/postgres/store_bench_test.go
@@ -82,6 +82,67 @@ func BenchmarkRealisticPopulateImage(b *testing.B) {
 	})
 }
 
+// BenchmarkLargeScalePopulateImage benchmarks image retrieval at customer-representative scale.
+// Based on Amadeus profile: ~5,000 images x ~400 components x ~0.4 CVEs per component.
+func BenchmarkLargeScalePopulateImage(b *testing.B) {
+	if !features.FlattenImageData.Enabled() {
+		b.Skip("Skipping benchmark - FlattenImageData is disabled.")
+	}
+	ctx := sac.WithAllAccess(context.Background())
+	testDB := pgtest.ForT(b)
+
+	store := New(testDB.DB, false, concurrency.NewKeyFence())
+
+	numImages := 5000
+	numComponents := 400
+	images := make([]*storage.ImageV2, 0, numImages)
+	for i := 0; i < numImages; i++ {
+		components := make([]*storage.EmbeddedImageScanComponent, 0, numComponents)
+		for j := 0; j < numComponents; j++ {
+			var vulns []*storage.EmbeddedVulnerability
+			// ~40% of components have 1 CVE to approximate 0.4 CVEs/component ratio.
+			if j%5 < 2 {
+				vulns = []*storage.EmbeddedVulnerability{
+					{
+						Cve:               fmt.Sprintf("CVE-2025-%04d-%04d", i%500, j),
+						Cvss:              6.5,
+						VulnerabilityType: storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
+						Severity:          storage.VulnerabilitySeverity_MODERATE_VULNERABILITY_SEVERITY,
+						SetFixedBy:        &storage.EmbeddedVulnerability_FixedBy{FixedBy: "2.0.0"},
+					},
+				}
+			}
+			components = append(components, &storage.EmbeddedImageScanComponent{
+				Name:    fmt.Sprintf("pkg-%d-%d", i, j),
+				Version: fmt.Sprintf("%d.0.0", j),
+				Vulns:   vulns,
+			})
+		}
+		img := fixtures.GetImageV2WithUniqueComponents(0)
+		img.Id = fmt.Sprintf("sha256:largescale-%05d", i)
+		img.Scan = &storage.ImageScan{
+			Components: components,
+		}
+		images = append(images, img)
+	}
+
+	b.Log("Inserting", numImages, "images with", numComponents, "components each...")
+	for _, image := range images {
+		require.NoError(b, store.Upsert(ctx, image))
+	}
+
+	b.Run("WalkByQuery", func(b *testing.B) {
+		for b.Loop() {
+			count := 0
+			err := store.WalkByQuery(ctx, search.EmptyQuery(), func(image *storage.ImageV2) error {
+				count++
+				return nil
+			})
+			require.NoError(b, err)
+		}
+	})
+}
+
 // BenchmarkWalkComparison benchmarks both Walk functions for comparison
 func BenchmarkWalkComparison(b *testing.B) {
 	if !features.FlattenImageData.Enabled() {


### PR DESCRIPTION
Customer reported 25-30 minute image exports with ~5,600 images. WalkByQuery
was issuing 2 queries per image (components + CVEs) sequentially. This batches
images in groups of 100 and uses ANY($1::text[]) to fetch all children in
2 queries per batch, reducing total queries from O(2N) to O(2N/batchSize).

Benchmarks at customer-representative scale (5,000 images x 400 components)
show ~24% improvement on localhost; real-world improvement over network will
be higher due to eliminated round-trips.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
