### PR TITLE
fix(ui): Fix nightly failures due to console tests

### DIFF
--- a/tests/e2e/run-ui-e2e.sh
+++ b/tests/e2e/run-ui-e2e.sh
@@ -101,6 +101,10 @@ run_ui_e2e_tests() {
     make -C ui test-e2e || touch FAIL
 
     store_test_results "ui/test-results/reports/cypress/integration/." "cy-reps"
+    # OCP console plugin tests write to a separate directory; only present on OpenShift runs
+    if [[ -d "ui/test-results/reports/cypress/integration-ocp" ]]; then
+        store_test_results "ui/test-results/reports/cypress/integration-ocp/." "cy-reps/consolePlugin"
+    fi
 
     if is_OPENSHIFT_CI; then
         cp -a ui/test-results/artifacts/* "${ARTIFACT_DIR}/" || true

--- a/ui/apps/platform/cypress/helpers/ocpConsole.ts
+++ b/ui/apps/platform/cypress/helpers/ocpConsole.ts
@@ -9,10 +9,19 @@ export function selectProject(project: string) {
 }
 
 export function filterByField(field: string, value: string) {
-    cy.get(`[data-ouia-component-id="DataViewFilters"] ${pf6.menuToggle}`).first().click();
-    cy.get(pf6.menuItem).contains(field).click();
-    // case insensitive search for the field + "filter" handles both 'Name filter' and 'Filter by name' forms
-    // that are used across console versions
-    cy.get(`input[aria-label*="${field}" i][aria-label*="filter" i]`).should('not.be.disabled');
-    cy.get(`input[aria-label*="${field}" i][aria-label*="filter" i]`).type(value);
+    // OCP 4.19 uses a PF6 Dropdown (data-test-id), 4.21+ uses a DataViewFilters MenuToggle (OUIA)
+    cy.get(
+        `[data-test-id="dropdown-button"], [data-ouia-component-id="DataViewFilters"] ${pf6.menuToggle}`
+    )
+        .first()
+        .click();
+    cy.contains('[data-test-id="dropdown-menu"], [role="menuitem"]', field).first().click();
+
+    // OCP 4.19 uses "Search by"  + field name, 4.21+ uses "Filter by" + field name
+    cy.get(`input[aria-label*="Search by ${field}" i], input[aria-label*="Filter by ${field}" i]`)
+        .first()
+        .should('not.be.disabled');
+    cy.get(`input[aria-label*="Search by ${field}" i], input[aria-label*="Filter by ${field}" i]`)
+        .first()
+        .type(value, { delay: 0 });
 }

--- a/ui/apps/platform/cypress/integration-ocp/projects/projectSecurityTab.test.ts
+++ b/ui/apps/platform/cypress/integration-ocp/projects/projectSecurityTab.test.ts
@@ -120,7 +120,7 @@ describe('Project Security Tabs', () => {
             }, 'Namespace');
         });
 
-        it.only('should display only the expected table columns for each entity type', () => {
+        it('should display only the expected table columns for each entity type', () => {
             visitProjectSecurityTabAndCheckColumns(() => {
                 visitFromConsoleLeftNavExpandable('Administration', 'Namespaces');
             }, 'Namespace');


### PR DESCRIPTION
## Description

Fixes two issues with ConsolePlugin test on nightly builds:

1. Updates selectors to support both OCP 4.19 and OCP 4.21
2. Gathers JUNIT results files to aid in debugging and recognizing console plugin test failures

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Local runs against two separate infra clusters.

<img width="837" height="376" alt="image" src="https://github.com/user-attachments/assets/a8425f8a-e0f4-4135-89fa-1149a38dff24" />


CI.

Nightly CI (next week).
