### PR TITLE
ci(perf): buildah build with registry cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -560,7 +560,7 @@ jobs:
             echo "Building static buildah 1.43.0 from source (will be cached for next run)"
             docker run --rm -v /usr/local/bin:/out golang:1.24-alpine sh -c '
               apk add --no-cache git gcc musl-dev linux-headers \
-                gpgme-dev libseccomp-dev libassuan-dev lvm2-dev btrfs-progs-dev
+                gpgme-dev libseccomp-dev libseccomp-static libassuan-dev lvm2-dev btrfs-progs-dev
               git clone --depth 1 --branch v1.43.0 https://github.com/containers/buildah.git /buildah
               cd /buildah
               CGO_ENABLED=1 go build \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -585,45 +585,96 @@ jobs:
         if: matrix.name == 'race-condition-debug'
         run: echo "BUILD_TAG=$(make --quiet --no-print-directory tag)-rcd" >> "$GITHUB_ENV"
 
-      - name: Build main images
+      - name: Prepare build contexts
         run: |
-          GOOS=linux GOARCH=${{ matrix.arch }} scripts/lib.sh retry 6 true make docker-build-main-image
+          GOOS=linux GOARCH=${{ matrix.arch }} make copy-binaries-to-image-dir
+          cp -f bin/linux_${{ matrix.arch }}/roxctl image/roxctl/roxctl-linux
 
-      - name: Check debugger presence in the main image
-        run: make check-debugger
-
-      - name: Build roxctl image
+      - name: Compute image tags
         run: |
-          GOOS=linux GOARCH=${{ matrix.arch }} scripts/lib.sh retry 6 true make docker-build-roxctl-image
+          source ./scripts/ci/lib.sh
+          registry="$(registry_from_branding "${{ env.ROX_PRODUCT_BRANDING }}")"
+          tag="${{ env.BUILD_TAG }}"
+          arch="${{ matrix.arch }}"
+          NL=$'\n'
 
-      # needed for docs ensure_image.sh initial pull with RHACS_BRANDING
-      - name: Docker login
-        # Skip for external contributions.
-        if: |
-          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
-        env:
-          QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
-          QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
-        run: |
-          ./scripts/ci/lib.sh registry_ro_login "quay.io/rhacs-eng"
+          push_context=""
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "master" ]]; then
+            push_context="merge-to-master"
+          fi
 
-      - name: Push images
-        # Skip for external contributions.
-        if: |
-          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
-        env:
-          QUAY_RHACS_ENG_RW_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          QUAY_RHACS_ENG_RW_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-          QUAY_STACKROX_IO_RW_USERNAME: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
-          QUAY_STACKROX_IO_RW_PASSWORD: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
-        run: |
-            source ./scripts/ci/lib.sh
-            echo "Will determine context from: ${{ github.event_name }} & ${{ github.ref_name }}"
-            push_context=""
-            if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "master" ]]; then
-              push_context="merge-to-master"
+          for image in main roxctl central-db; do
+            TAGS="${registry}/${image}:${tag}-${arch}"
+            TAGS="${TAGS}${NL}${registry}/${image}:cache-${arch}"
+
+            if [[ "$push_context" == "merge-to-master" ]]; then
+              TAGS="${TAGS}${NL}${registry}/${image}:latest-${arch}"
             fi
-            push_main_image_set "$push_context" "${{ env.ROX_PRODUCT_BRANDING }}" "${{ matrix.arch }}"
+
+            TAG_VAR="$(echo "${image}" | tr '-' '_' | tr '[:lower:]' '[:upper:]')_TAGS"
+            {
+              echo "${TAG_VAR}<<EOF"
+              echo "$TAGS"
+              echo "EOF"
+            } >> "$GITHUB_ENV"
+          done
+
+          echo "QUAY_REGISTRY=${registry}" >> "$GITHUB_ENV"
+
+      - name: Login to quay.io
+        # Skip for external contributions.
+        if: |
+          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_USERNAME || secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          password: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_PASSWORD || secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+      - name: Build and push main image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
+        with:
+          context: image/rhel
+          file: image/rhel/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+          provenance: false
+          tags: ${{ env.MAIN_TAGS }}
+          build-args: |
+            DEBUG_BUILD=${{ env.DEBUG_BUILD || 'no' }}
+            ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }}
+            TARGET_ARCH=${{ matrix.arch }}
+            ROX_IMAGE_FLAVOR=development_build
+            LABEL_VERSION=${{ env.BUILD_TAG }}
+            LABEL_RELEASE=${{ env.SHORTCOMMIT }}
+          cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }},mode=max,compression=zstd
+
+      - name: Build and push roxctl image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
+        with:
+          context: image/roxctl
+          file: image/roxctl/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+          provenance: false
+          tags: ${{ env.ROXCTL_TAGS }}
+          cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }},mode=max,compression=zstd
+
+      - name: Build and push central-db image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
+        with:
+          context: image/postgres
+          file: image/postgres/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+          provenance: false
+          tags: ${{ env.CENTRAL_DB_TAGS }}
+          build-args: |
+            MAIN_IMAGE_TAG=${{ env.BUILD_TAG }}
+          cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }}
+          cache-to: type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }},mode=max,compression=zstd
 
   push-matching-collector-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -548,10 +548,10 @@ jobs:
           ver=$(buildah version | awk '/^Version:/{print $2}')
           echo "Installed: buildah $ver"
           if [[ "$ver" < "1.41" ]]; then
-            echo "Installing buildah from source..."
-            sudo apt-get install -y -qq libgpgme-dev libseccomp-dev
-            go install github.com/containers/buildah/cmd/buildah@v1.43.0
-            sudo cp "$(go env GOPATH)/bin/buildah" /usr/bin/buildah
+            echo "Extracting buildah from quay.io/buildah/stable..."
+            id=$(docker create quay.io/buildah/stable:latest)
+            sudo docker cp "$id:/usr/bin/buildah" /usr/bin/buildah
+            docker rm "$id" > /dev/null
             echo "Upgraded: $(buildah version | head -1)"
           fi
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -181,8 +181,11 @@ jobs:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
     env:
-      BUILD_TAG: ${{ needs.define-job-matrix.outputs.build-tag }}
-      SHORTCOMMIT: ${{ needs.define-job-matrix.outputs.short-commit }}
+      # Stable version for Go binaries — produces byte-identical output
+      # across commits that don't change Go source. Enables Docker
+      # COPY --link layer caching: unchanged binary = cached layer = skip push.
+      BUILD_TAG: 0.0.0
+      SHORTCOMMIT: "0000000"
       GOTAGS: ${{ needs.define-job-matrix.outputs.gotags }}
     steps:
       - name: Checkout
@@ -263,8 +266,9 @@ jobs:
         - /usr:/mnt/usr
         - /opt:/mnt/opt
     env:
-      BUILD_TAG: ${{ needs.define-job-matrix.outputs.build-tag }}
-      SHORTCOMMIT: ${{ needs.define-job-matrix.outputs.short-commit }}
+      # Stable version for byte-identical binaries (see pre-build-cli comment)
+      BUILD_TAG: 0.0.0
+      SHORTCOMMIT: "0000000"
       GOTAGS: ${{ needs.define-job-matrix.outputs.gotags }}
     steps:
       - name: Checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -543,12 +543,7 @@ jobs:
         if: matrix.arch != 'amd64' && matrix.arch != 'arm64'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
-        with:
-          # docker driver skips ~40s container boot for native builds.
-          # QEMU cross-builds (ppc64le/s390x) need the default docker-container driver.
-          driver: ${{ (matrix.arch == 'amd64' || matrix.arch == 'arm64') && 'docker' || 'docker-container' }}
+      # buildah is pre-installed on ubuntu runners — no container boot overhead
 
       - name: Checkout submodules
         run: |
@@ -635,62 +630,60 @@ jobs:
         # Skip for external contributions.
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
-        with:
-          registry: quay.io
-          username: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_USERNAME || secrets.QUAY_RHACS_ENG_RW_USERNAME }}
-          password: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_PASSWORD || secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-
-      - name: Build and push images
-        env:
-          BUILDKIT_PROGRESS: plain
         run: |
-          tag_flags() { echo "$1" | while read -r t; do [[ -n "$t" ]] && echo "--tag=$t"; done; }
-
-          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event.pull_request.head.repo.fork }}" != "true" ]]; then
-            OUTPUT="--push"
+          if [[ "${{ env.QUAY_REGISTRY }}" == "quay.io/stackrox-io" ]]; then
+            buildah login -u "${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}" -p "${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}" quay.io
           else
-            OUTPUT="--load"
+            buildah login -u "${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}" -p "${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}" quay.io
           fi
 
-          docker buildx build \
+      - name: Build and push images
+        run: |
+          tag_flags() { echo "$1" | while read -r t; do [[ -n "$t" ]] && echo "--tag=$t"; done; }
+          REGISTRY="${{ env.QUAY_REGISTRY }}"
+          ARCH="${{ matrix.arch }}"
+
+          buildah build --layers \
             --file image/rhel/Dockerfile \
-            --platform linux/${{ matrix.arch }} \
-            $OUTPUT --provenance=false \
+            --platform linux/${ARCH} \
             $(tag_flags "$MAIN_TAGS") \
             --build-arg DEBUG_BUILD=${{ env.DEBUG_BUILD || 'no' }} \
             --build-arg ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }} \
-            --build-arg TARGET_ARCH=${{ matrix.arch }} \
+            --build-arg TARGET_ARCH=${ARCH} \
             --build-arg ROX_IMAGE_FLAVOR=development_build \
             --build-arg LABEL_VERSION=${{ env.BUILD_TAG }} \
             --build-arg LABEL_RELEASE=${{ env.SHORTCOMMIT }} \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }} \
-            --cache-to type=inline \
+            --cache-from ${REGISTRY}/main:cache-${ARCH} \
+            --cache-to ${REGISTRY}/main:cache-${ARCH} \
             image/rhel &
           pid_main=$!
 
-          docker buildx build \
+          buildah build --layers \
             --file image/roxctl/Dockerfile \
-            --platform linux/${{ matrix.arch }} \
-            $OUTPUT --provenance=false \
+            --platform linux/${ARCH} \
             $(tag_flags "$ROXCTL_TAGS") \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }} \
-            --cache-to type=inline \
+            --cache-from ${REGISTRY}/roxctl:cache-${ARCH} \
+            --cache-to ${REGISTRY}/roxctl:cache-${ARCH} \
             image/roxctl &
           pid_roxctl=$!
 
-          docker buildx build \
+          buildah build --layers \
             --file image/postgres/Dockerfile \
-            --platform linux/${{ matrix.arch }} \
-            $OUTPUT --provenance=false \
+            --platform linux/${ARCH} \
             $(tag_flags "$CENTRAL_DB_TAGS") \
             --build-arg MAIN_IMAGE_TAG=${{ env.BUILD_TAG }} \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }} \
-            --cache-to type=inline \
+            --cache-from ${REGISTRY}/central-db:cache-${ARCH} \
+            --cache-to ${REGISTRY}/central-db:cache-${ARCH} \
             image/postgres &
           pid_centraldb=$!
 
           wait $pid_main $pid_roxctl $pid_centraldb
+
+          # Push all images (buildah build doesn't have --push)
+          echo "$MAIN_TAGS" | while read -r t; do [[ -n "$t" ]] && buildah push "$t"; done &
+          echo "$ROXCTL_TAGS" | while read -r t; do [[ -n "$t" ]] && buildah push "$t"; done &
+          echo "$CENTRAL_DB_TAGS" | while read -r t; do [[ -n "$t" ]] && buildah push "$t"; done &
+          wait
 
   push-matching-collector-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -544,22 +544,31 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
       # Need buildah >= 1.41 for COPY --link support.
-      - name: Upgrade buildah
-        if: matrix.arch == 'amd64'
-        uses: redhat-actions/podman-install@edf9cd67e118e45e295f27c6e3ef5f73ad6505d3 # ratchet:redhat-actions/podman-install@v1
+      # Ubuntu repos and kubic repos only ship 1.39.x.
+      # Build a static binary from source (cached across runs).
+      - name: Cache buildah
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # ratchet:actions/cache@v4
+        with:
+          path: /usr/local/bin/buildah
+          key: buildah-1.43.0-${{ runner.arch }}
 
-      # redhat-actions/podman-install hardcodes amd64 CRIU package
-      - name: Upgrade buildah (arm64)
-        if: matrix.arch == 'arm64'
+      - name: Upgrade buildah
         run: |
-          echo "redhat-actions/podman-install hardcodes amd64 CRIU, installing directly for arm64"
-          echo "Need >= 1.41 for COPY --link support"
-          . /etc/os-release
-          curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${VERSION_ID}/Release.key" \
-            | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/kubic.gpg
-          echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${VERSION_ID}/ /" \
-            | sudo tee /etc/apt/sources.list.d/kubic.list > /dev/null
-          sudo apt-get update -qq && sudo apt-get install -y -qq buildah
+          if [[ -x /usr/local/bin/buildah ]]; then
+            echo "Using cached buildah"
+          else
+            echo "Building static buildah 1.43.0 from source (will be cached for next run)"
+            docker run --rm -v /usr/local/bin:/out golang:1.24-alpine sh -c '
+              apk add --no-cache git gcc musl-dev linux-headers \
+                gpgme-dev libseccomp-dev libassuan-dev lvm2-dev btrfs-progs-dev
+              git clone --depth 1 --branch v1.43.0 https://github.com/containers/buildah.git /buildah
+              cd /buildah
+              CGO_ENABLED=1 go build \
+                -tags "seccomp exclude_graphdriver_devicemapper containers_image_openpgp" \
+                -ldflags "-s -w -linkmode external -extldflags -static" \
+                -o /out/buildah ./cmd/buildah
+            '
+          fi
           buildah version | head -1
 
       - name: Checkout submodules

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -664,7 +664,7 @@ jobs:
           REGISTRY_USERNAME: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_USERNAME || secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           REGISTRY_PASSWORD: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_PASSWORD || secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
         run: |
-          echo "$REGISTRY_PASSWORD" | buildah login -u "$REGISTRY_USERNAME" --password-stdin quay.io
+          echo "$REGISTRY_PASSWORD" | sudo buildah login -u "$REGISTRY_USERNAME" --password-stdin quay.io
 
       - name: Build and push images
         # Skip for external contributions.
@@ -672,11 +672,11 @@ jobs:
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
           tag_flags() { echo "$1" | while read -r t; do [[ -n "$t" ]] && echo "--tag=$t"; done; }
-          push_tags() { local root="$1"; while IFS= read -r t; do [[ -n "$t" ]] && buildah --root "$root" push "$t" || return 1; done; }
+          push_tags() { local root="$1"; while IFS= read -r t; do [[ -n "$t" ]] && sudo buildah --root "$root" push "$t" || return 1; done; }
           REGISTRY="${{ env.QUAY_REGISTRY }}"
           ARCH="${{ matrix.arch }}"
 
-          buildah build --layers \
+          sudo buildah build --layers \
             --root "$RUNNER_TEMP/store-main" --runroot "$RUNNER_TEMP/run-main" \
             --file image/rhel/Dockerfile \
             --platform linux/${ARCH} \
@@ -692,7 +692,7 @@ jobs:
             image/rhel &
           pid_main=$!
 
-          buildah build --layers \
+          sudo buildah build --layers \
             --root "$RUNNER_TEMP/store-roxctl" --runroot "$RUNNER_TEMP/run-roxctl" \
             --file image/roxctl/Dockerfile \
             --platform linux/${ARCH} \
@@ -702,7 +702,7 @@ jobs:
             image/roxctl &
           pid_roxctl=$!
 
-          buildah build --layers \
+          sudo buildah build --layers \
             --root "$RUNNER_TEMP/store-centraldb" --runroot "$RUNNER_TEMP/run-centraldb" \
             --file image/postgres/Dockerfile \
             --platform linux/${ARCH} \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -545,9 +545,17 @@ jobs:
 
       - name: Ensure buildah >= 1.41 (COPY --link support)
         run: |
-          buildah version
-          [[ "$(buildah version | awk '/^Version:/{print $2}')" > "1.40" ]] \
-            || { sudo apt-get update -qq && sudo apt-get install -y -qq buildah && buildah version; }
+          ver=$(buildah version | awk '/^Version:/{print $2}')
+          echo "Installed: buildah $ver"
+          if [[ "$ver" < "1.41" ]]; then
+            . /etc/os-release
+            curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_${VERSION_ID}/Release.key" \
+              | sudo gpg --dearmor -o /etc/apt/keyrings/kubic.gpg
+            echo "deb [signed-by=/etc/apt/keyrings/kubic.gpg] https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_${VERSION_ID}/ /" \
+              | sudo tee /etc/apt/sources.list.d/kubic.list > /dev/null
+            sudo apt-get update -qq && sudo apt-get install -y -qq buildah
+            echo "Upgraded: buildah $(buildah version | awk '/^Version:/{print $2}')"
+          fi
 
       - name: Checkout submodules
         run: |
@@ -596,8 +604,8 @@ jobs:
         run: |
           GOOS=linux GOARCH=${{ matrix.arch }} make copy-binaries-to-image-dir
           cp -f bin/linux_${{ matrix.arch }}/roxctl image/roxctl/roxctl-linux
-          echo "${{ env.BUILD_TAG }}" > image/rhel/VERSION
           cp -f *VERSION image/rhel/
+          echo "${{ env.BUILD_TAG }}" > image/rhel/VERSION
 
       - name: Compute image tags
         run: |
@@ -634,12 +642,10 @@ jobs:
         # Skip for external contributions.
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
-        run: |
-          if [[ "${{ env.QUAY_REGISTRY }}" == "quay.io/stackrox-io" ]]; then
-            buildah login -u "${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}" -p "${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}" quay.io
-          else
-            buildah login -u "${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}" -p "${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}" quay.io
-          fi
+        env:
+          REGISTRY_USERNAME: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_USERNAME || secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          REGISTRY_PASSWORD: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_PASSWORD || secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+        run: echo "$REGISTRY_PASSWORD" | buildah login -u "$REGISTRY_USERNAME" --password-stdin quay.io
 
       - name: Build and push images
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -544,9 +544,23 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
       # Need buildah >= 1.41 for COPY --link support.
-      # redhat-actions/podman-install handles kubic repo + dependency workarounds.
       - name: Upgrade buildah
+        if: matrix.arch == 'amd64'
         uses: redhat-actions/podman-install@edf9cd67e118e45e295f27c6e3ef5f73ad6505d3 # ratchet:redhat-actions/podman-install@v1
+
+      # redhat-actions/podman-install hardcodes amd64 CRIU package
+      - name: Upgrade buildah (arm64)
+        if: matrix.arch == 'arm64'
+        run: |
+          echo "redhat-actions/podman-install hardcodes amd64 CRIU, installing directly for arm64"
+          echo "Need >= 1.41 for COPY --link support"
+          . /etc/os-release
+          curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${VERSION_ID}/Release.key" \
+            | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/kubic.gpg
+          echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${VERSION_ID}/ /" \
+            | sudo tee /etc/apt/sources.list.d/kubic.list > /dev/null
+          sudo apt-get update -qq && sudo apt-get install -y -qq buildah
+          buildah version | head -1
 
       - name: Checkout submodules
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -653,8 +653,8 @@ jobs:
             --build-arg ROX_IMAGE_FLAVOR=development_build \
             --build-arg LABEL_VERSION=${{ env.BUILD_TAG }} \
             --build-arg LABEL_RELEASE=${{ env.SHORTCOMMIT }} \
-            --cache-from ${REGISTRY}/main:cache-${ARCH} \
-            --cache-to ${REGISTRY}/main:cache-${ARCH} \
+            --cache-from ${REGISTRY}/main \
+            --cache-to ${REGISTRY}/main \
             image/rhel &
           pid_main=$!
 
@@ -662,8 +662,8 @@ jobs:
             --file image/roxctl/Dockerfile \
             --platform linux/${ARCH} \
             $(tag_flags "$ROXCTL_TAGS") \
-            --cache-from ${REGISTRY}/roxctl:cache-${ARCH} \
-            --cache-to ${REGISTRY}/roxctl:cache-${ARCH} \
+            --cache-from ${REGISTRY}/roxctl \
+            --cache-to ${REGISTRY}/roxctl \
             image/roxctl &
           pid_roxctl=$!
 
@@ -672,8 +672,8 @@ jobs:
             --platform linux/${ARCH} \
             $(tag_flags "$CENTRAL_DB_TAGS") \
             --build-arg MAIN_IMAGE_TAG=${{ env.BUILD_TAG }} \
-            --cache-from ${REGISTRY}/central-db:cache-${ARCH} \
-            --cache-to ${REGISTRY}/central-db:cache-${ARCH} \
+            --cache-from ${REGISTRY}/central-db \
+            --cache-to ${REGISTRY}/central-db \
             image/postgres &
           pid_centraldb=$!
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -543,17 +543,26 @@ jobs:
         if: matrix.arch != 'amd64' && matrix.arch != 'arm64'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
-      - name: Ensure buildah >= 1.41 (COPY --link support)
+      - name: Cache buildah binary
+        id: cache-buildah
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # ratchet:actions/cache@v4
+        with:
+          path: /usr/local/bin/buildah
+          key: buildah-${{ runner.arch }}
+
+      - name: Upgrade buildah
         run: |
-          ver=$(buildah version | awk '/^Version:/{print $2}')
-          echo "Installed: buildah $ver"
-          if [[ "$ver" < "1.41" ]]; then
-            echo "Extracting buildah from quay.io/buildah/stable..."
+          echo "Need >= 1.41 for COPY --link support"
+          if [[ -x /usr/local/bin/buildah ]]; then
+            echo "Using cached binary"
+          else
+            echo "Extracting from quay.io/buildah/stable..."
             id=$(docker create quay.io/buildah/stable:latest)
-            sudo docker cp "$id:/usr/bin/buildah" /usr/bin/buildah
+            docker cp "$id:/usr/bin/buildah" /tmp/buildah
             docker rm "$id" > /dev/null
-            echo "Upgraded: $(buildah version | head -1)"
+            sudo install /tmp/buildah /usr/local/bin/buildah
           fi
+          buildah version | head -1
 
       - name: Checkout submodules
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -597,6 +597,8 @@ jobs:
         run: |
           GOOS=linux GOARCH=${{ matrix.arch }} make copy-binaries-to-image-dir
           cp -f bin/linux_${{ matrix.arch }}/roxctl image/roxctl/roxctl-linux
+          echo "${{ env.BUILD_TAG }}" > image/rhel/VERSION
+          cp -f *VERSION image/rhel/
 
       - name: Compute image tags
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -543,27 +543,30 @@ jobs:
         if: matrix.arch != 'amd64' && matrix.arch != 'arm64'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
-      - name: Cache buildah binary
-        id: cache-buildah
+      - name: Cache buildah
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # ratchet:actions/cache@v4
         with:
-          path: /usr/local/bin/buildah
+          path: /opt/buildah
           key: buildah-${{ runner.arch }}
 
       - name: Upgrade buildah
         run: |
           echo "Need >= 1.41 for COPY --link support"
-          if [[ -x /usr/local/bin/buildah ]]; then
-            echo "Using cached binary"
+          if [[ -x /opt/buildah/bin/buildah ]]; then
+            echo "Using cached buildah"
           else
             echo "Extracting from quay.io/buildah/stable..."
             id=$(docker create quay.io/buildah/stable:latest)
-            docker cp "$id:/usr/bin/buildah" /tmp/buildah
+            mkdir -p /opt/buildah/bin /opt/buildah/lib
+            docker cp "$id:/usr/bin/buildah" /opt/buildah/bin/buildah
+            for lib in $(docker run --rm quay.io/buildah/stable ldd /usr/bin/buildah | awk '/=>/{print $3}'); do
+              docker cp "$id:$lib" /opt/buildah/lib/ 2>/dev/null || true
+            done
             docker rm "$id" > /dev/null
-            sudo install /tmp/buildah /usr/local/bin/buildah
-            # Install shared libs the extracted binary needs
-            sudo apt-get install -y -qq libsubid5 2>/dev/null || true
           fi
+          export LD_LIBRARY_PATH="/opt/buildah/lib:${LD_LIBRARY_PATH:-}"
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "/opt/buildah/bin" >> "$GITHUB_PATH"
           buildah version | head -1
 
       - name: Checkout submodules

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -543,30 +543,21 @@ jobs:
         if: matrix.arch != 'amd64' && matrix.arch != 'arm64'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
-      - name: Cache buildah
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # ratchet:actions/cache@v4
-        with:
-          path: /opt/buildah
-          key: buildah-${{ runner.arch }}
-
       - name: Upgrade buildah
         run: |
           echo "Need >= 1.41 for COPY --link support"
-          if [[ -x /opt/buildah/bin/buildah ]]; then
-            echo "Using cached buildah"
+          ver=$(buildah version | awk '/^Version:/{print $2}')
+          if [[ "$ver" > "1.40" ]]; then
+            echo "buildah $ver is sufficient"
           else
-            echo "Extracting from quay.io/buildah/stable..."
-            id=$(docker create quay.io/buildah/stable:latest)
-            mkdir -p /opt/buildah/bin /opt/buildah/lib
-            docker cp "$id:/usr/bin/buildah" /opt/buildah/bin/buildah
-            for lib in $(docker run --rm quay.io/buildah/stable ldd /usr/bin/buildah | awk '/=>/{print $3}'); do
-              docker cp "$id:$lib" /opt/buildah/lib/ 2>/dev/null || true
-            done
-            docker rm "$id" > /dev/null
+            echo "Upgrading via kubic repo (per redhat-actions/podman-install)..."
+            . /etc/os-release
+            curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${VERSION_ID}/Release.key" \
+              | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/kubic.gpg
+            echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${VERSION_ID}/ /" \
+              | sudo tee /etc/apt/sources.list.d/kubic.list > /dev/null
+            sudo apt-get update -qq && sudo apt-get install -y -qq buildah
           fi
-          export LD_LIBRARY_PATH="/opt/buildah/lib:${LD_LIBRARY_PATH:-}"
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
-          echo "/opt/buildah/bin" >> "$GITHUB_PATH"
           buildah version | head -1
 
       - name: Checkout submodules

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -569,6 +569,10 @@ jobs:
                 -o /out/buildah ./cmd/buildah
             '
           fi
+          # Avoid "unshare: Operation not permitted" on GHA runners
+          mkdir -p /etc/containers
+          echo '[storage]' | sudo tee /etc/containers/storage.conf > /dev/null
+          echo 'driver = "vfs"' | sudo tee -a /etc/containers/storage.conf > /dev/null
           buildah version | head -1
 
       - name: Checkout submodules
@@ -660,14 +664,7 @@ jobs:
           REGISTRY_USERNAME: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_USERNAME || secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           REGISTRY_PASSWORD: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_PASSWORD || secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
         run: |
-          set -x
-          which buildah
-          buildah version | head -1
-          echo "$REGISTRY_PASSWORD" | buildah login -u "$REGISTRY_USERNAME" --password-stdin quay.io 2>&1 || {
-            echo "Retrying with explicit authfile..."
-            echo "$REGISTRY_PASSWORD" | buildah login --authfile /tmp/auth.json -u "$REGISTRY_USERNAME" --password-stdin quay.io
-            echo "REGISTRY_AUTH_FILE=/tmp/auth.json" >> "$GITHUB_ENV"
-          }
+          echo "$REGISTRY_PASSWORD" | buildah login -u "$REGISTRY_USERNAME" --password-stdin quay.io
 
       - name: Build and push images
         # Skip for external contributions.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -548,13 +548,11 @@ jobs:
           ver=$(buildah version | awk '/^Version:/{print $2}')
           echo "Installed: buildah $ver"
           if [[ "$ver" < "1.41" ]]; then
-            . /etc/os-release
-            curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_${VERSION_ID}/Release.key" \
-              | sudo gpg --dearmor -o /etc/apt/keyrings/kubic.gpg
-            echo "deb [signed-by=/etc/apt/keyrings/kubic.gpg] https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_${VERSION_ID}/ /" \
-              | sudo tee /etc/apt/sources.list.d/kubic.list > /dev/null
-            sudo apt-get update -qq && sudo apt-get install -y -qq buildah
-            echo "Upgraded: buildah $(buildah version | awk '/^Version:/{print $2}')"
+            echo "Installing buildah from source..."
+            sudo apt-get install -y -qq libgpgme-dev libseccomp-dev
+            go install github.com/containers/buildah/cmd/buildah@v1.43.0
+            sudo cp "$(go env GOPATH)/bin/buildah" /usr/bin/buildah
+            echo "Upgraded: $(buildah version | head -1)"
           fi
 
       - name: Checkout submodules

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -653,12 +653,17 @@ jobs:
         run: echo "$REGISTRY_PASSWORD" | buildah login -u "$REGISTRY_USERNAME" --password-stdin quay.io
 
       - name: Build and push images
+        # Skip for external contributions.
+        if: |
+          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         run: |
           tag_flags() { echo "$1" | while read -r t; do [[ -n "$t" ]] && echo "--tag=$t"; done; }
+          push_tags() { local root="$1"; while IFS= read -r t; do [[ -n "$t" ]] && buildah --root "$root" push "$t" || return 1; done; }
           REGISTRY="${{ env.QUAY_REGISTRY }}"
           ARCH="${{ matrix.arch }}"
 
           buildah build --layers \
+            --root "$RUNNER_TEMP/store-main" --runroot "$RUNNER_TEMP/run-main" \
             --file image/rhel/Dockerfile \
             --platform linux/${ARCH} \
             $(tag_flags "$MAIN_TAGS") \
@@ -674,6 +679,7 @@ jobs:
           pid_main=$!
 
           buildah build --layers \
+            --root "$RUNNER_TEMP/store-roxctl" --runroot "$RUNNER_TEMP/run-roxctl" \
             --file image/roxctl/Dockerfile \
             --platform linux/${ARCH} \
             $(tag_flags "$ROXCTL_TAGS") \
@@ -683,6 +689,7 @@ jobs:
           pid_roxctl=$!
 
           buildah build --layers \
+            --root "$RUNNER_TEMP/store-centraldb" --runroot "$RUNNER_TEMP/run-centraldb" \
             --file image/postgres/Dockerfile \
             --platform linux/${ARCH} \
             $(tag_flags "$CENTRAL_DB_TAGS") \
@@ -692,13 +699,21 @@ jobs:
             image/postgres &
           pid_centraldb=$!
 
-          wait $pid_main $pid_roxctl $pid_centraldb
+          rc=0
+          wait "$pid_main"      || { echo "::error::main build failed"; rc=1; }
+          wait "$pid_roxctl"    || { echo "::error::roxctl build failed"; rc=1; }
+          wait "$pid_centraldb" || { echo "::error::central-db build failed"; rc=1; }
+          [[ $rc -eq 0 ]] || exit $rc
 
-          # Push all images (buildah build doesn't have --push)
-          echo "$MAIN_TAGS" | while read -r t; do [[ -n "$t" ]] && buildah push "$t"; done &
-          echo "$ROXCTL_TAGS" | while read -r t; do [[ -n "$t" ]] && buildah push "$t"; done &
-          echo "$CENTRAL_DB_TAGS" | while read -r t; do [[ -n "$t" ]] && buildah push "$t"; done &
-          wait
+          # Push all images in parallel (buildah build doesn't have --push)
+          push_tags "$RUNNER_TEMP/store-main"      <<<"$MAIN_TAGS"       & pp_main=$!
+          push_tags "$RUNNER_TEMP/store-roxctl"    <<<"$ROXCTL_TAGS"     & pp_roxctl=$!
+          push_tags "$RUNNER_TEMP/store-centraldb" <<<"$CENTRAL_DB_TAGS" & pp_db=$!
+          rc=0
+          wait "$pp_main"   || { echo "::error::main push failed"; rc=1; }
+          wait "$pp_roxctl" || { echo "::error::roxctl push failed"; rc=1; }
+          wait "$pp_db"     || { echo "::error::central-db push failed"; rc=1; }
+          [[ $rc -eq 0 ]] || exit $rc
 
   push-matching-collector-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -659,7 +659,9 @@ jobs:
         env:
           REGISTRY_USERNAME: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_USERNAME || secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           REGISTRY_PASSWORD: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_PASSWORD || secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
-        run: echo "$REGISTRY_PASSWORD" | buildah login -u "$REGISTRY_USERNAME" --password-stdin quay.io
+        run: |
+          mkdir -p "${XDG_RUNTIME_DIR:-/tmp}/containers"
+          echo "$REGISTRY_PASSWORD" | buildah login -u "$REGISTRY_USERNAME" --password-stdin quay.io
 
       - name: Build and push images
         # Skip for external contributions.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -561,6 +561,8 @@ jobs:
             docker cp "$id:/usr/bin/buildah" /tmp/buildah
             docker rm "$id" > /dev/null
             sudo install /tmp/buildah /usr/local/bin/buildah
+            # Install shared libs the extracted binary needs
+            sudo apt-get install -y -qq libsubid5 2>/dev/null || true
           fi
           buildah version | head -1
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -550,13 +550,15 @@ jobs:
           if [[ "$ver" > "1.40" ]]; then
             echo "buildah $ver is sufficient"
           else
-            echo "Upgrading via kubic repo (per redhat-actions/podman-install)..."
-            . /etc/os-release
-            curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${VERSION_ID}/Release.key" \
+            # Same repo used by redhat-actions/podman-install:
+            # https://github.com/redhat-actions/podman-install/blob/main/action.yml#L50
+            echo "Upgrading via kubic repo..."
+            UBUNTU_VER=23.10
+            curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${UBUNTU_VER}/Release.key" \
               | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/kubic.gpg
-            echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${VERSION_ID}/ /" \
+            echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${UBUNTU_VER}/ /" \
               | sudo tee /etc/apt/sources.list.d/kubic.list > /dev/null
-            sudo apt-get update -qq && sudo apt-get install -y -qq buildah
+            sudo apt-get update -qq && sudo apt-get install -y -qq --allow-unauthenticated buildah
           fi
           buildah version | head -1
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -656,7 +656,7 @@ jobs:
             --build-arg ROX_IMAGE_FLAVOR=development_build \
             --build-arg LABEL_VERSION=${{ env.BUILD_TAG }} \
             --build-arg LABEL_RELEASE=${{ env.SHORTCOMMIT }} \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/main:nocache-${{ matrix.arch }} \
             --cache-to type=inline \
             image/rhel &
           pid_main=$!
@@ -666,7 +666,7 @@ jobs:
             --platform linux/${{ matrix.arch }} \
             $OUTPUT --provenance=false \
             $(tag_flags "$ROXCTL_TAGS") \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:nocache-${{ matrix.arch }} \
             --cache-to type=inline \
             image/roxctl &
           pid_roxctl=$!
@@ -677,7 +677,7 @@ jobs:
             $OUTPUT --provenance=false \
             $(tag_flags "$CENTRAL_DB_TAGS") \
             --build-arg MAIN_IMAGE_TAG=${{ env.BUILD_TAG }} \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:nocache-${{ matrix.arch }} \
             --cache-to type=inline \
             image/postgres &
           pid_centraldb=$!

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -660,8 +660,14 @@ jobs:
           REGISTRY_USERNAME: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_USERNAME || secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           REGISTRY_PASSWORD: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_PASSWORD || secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
         run: |
-          mkdir -p "${XDG_RUNTIME_DIR:-/tmp}/containers"
-          echo "$REGISTRY_PASSWORD" | buildah login -u "$REGISTRY_USERNAME" --password-stdin quay.io
+          set -x
+          which buildah
+          buildah version | head -1
+          echo "$REGISTRY_PASSWORD" | buildah login -u "$REGISTRY_USERNAME" --password-stdin quay.io 2>&1 || {
+            echo "Retrying with explicit authfile..."
+            echo "$REGISTRY_PASSWORD" | buildah login --authfile /tmp/auth.json -u "$REGISTRY_USERNAME" --password-stdin quay.io
+            echo "REGISTRY_AUTH_FILE=/tmp/auth.json" >> "$GITHUB_ENV"
+          }
 
       - name: Build and push images
         # Skip for external contributions.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -635,53 +635,54 @@ jobs:
           username: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_USERNAME || secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_PASSWORD || secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
-      - name: Build and push main image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
-        with:
-          context: image/rhel
-          file: image/rhel/Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
-          load: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}
-          provenance: false
-          tags: ${{ env.MAIN_TAGS }}
-          build-args: |
-            DEBUG_BUILD=${{ env.DEBUG_BUILD || 'no' }}
-            ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }}
-            TARGET_ARCH=${{ matrix.arch }}
-            ROX_IMAGE_FLAVOR=development_build
-            LABEL_VERSION=${{ env.BUILD_TAG }}
-            LABEL_RELEASE=${{ env.SHORTCOMMIT }}
-          cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }}
-          cache-to: type=inline
+      - name: Build and push images
+        run: |
+          tag_flags() { echo "$1" | while read -r t; do [[ -n "$t" ]] && echo "--tag=$t"; done; }
 
-      - name: Build and push roxctl image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
-        with:
-          context: image/roxctl
-          file: image/roxctl/Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
-          load: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}
-          provenance: false
-          tags: ${{ env.ROXCTL_TAGS }}
-          cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }}
-          cache-to: type=inline
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event.pull_request.head.repo.fork }}" != "true" ]]; then
+            OUTPUT="--push"
+          else
+            OUTPUT="--load"
+          fi
 
-      - name: Build and push central-db image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
-        with:
-          context: image/postgres
-          file: image/postgres/Dockerfile
-          platforms: linux/${{ matrix.arch }}
-          push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
-          load: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}
-          provenance: false
-          tags: ${{ env.CENTRAL_DB_TAGS }}
-          build-args: |
-            MAIN_IMAGE_TAG=${{ env.BUILD_TAG }}
-          cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }}
-          cache-to: type=inline
+          docker buildx build \
+            --file image/rhel/Dockerfile \
+            --platform linux/${{ matrix.arch }} \
+            $OUTPUT --provenance=false \
+            $(tag_flags "$MAIN_TAGS") \
+            --build-arg DEBUG_BUILD=${{ env.DEBUG_BUILD || 'no' }} \
+            --build-arg ROX_PRODUCT_BRANDING=${{ env.ROX_PRODUCT_BRANDING }} \
+            --build-arg TARGET_ARCH=${{ matrix.arch }} \
+            --build-arg ROX_IMAGE_FLAVOR=development_build \
+            --build-arg LABEL_VERSION=${{ env.BUILD_TAG }} \
+            --build-arg LABEL_RELEASE=${{ env.SHORTCOMMIT }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }} \
+            --cache-to type=inline \
+            image/rhel &
+          pid_main=$!
+
+          docker buildx build \
+            --file image/roxctl/Dockerfile \
+            --platform linux/${{ matrix.arch }} \
+            $OUTPUT --provenance=false \
+            $(tag_flags "$ROXCTL_TAGS") \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }} \
+            --cache-to type=inline \
+            image/roxctl &
+          pid_roxctl=$!
+
+          docker buildx build \
+            --file image/postgres/Dockerfile \
+            --platform linux/${{ matrix.arch }} \
+            $OUTPUT --provenance=false \
+            $(tag_flags "$CENTRAL_DB_TAGS") \
+            --build-arg MAIN_IMAGE_TAG=${{ env.BUILD_TAG }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }} \
+            --cache-to type=inline \
+            image/postgres &
+          pid_centraldb=$!
+
+          wait $pid_main $pid_roxctl $pid_centraldb
 
   push-matching-collector-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -543,24 +543,10 @@ jobs:
         if: matrix.arch != 'amd64' && matrix.arch != 'arm64'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
+      # Need buildah >= 1.41 for COPY --link support.
+      # redhat-actions/podman-install handles kubic repo + dependency workarounds.
       - name: Upgrade buildah
-        run: |
-          echo "Need >= 1.41 for COPY --link support"
-          ver=$(buildah version | awk '/^Version:/{print $2}')
-          if [[ "$ver" > "1.40" ]]; then
-            echo "buildah $ver is sufficient"
-          else
-            # Same repo used by redhat-actions/podman-install:
-            # https://github.com/redhat-actions/podman-install/blob/main/action.yml#L50
-            echo "Upgrading via kubic repo..."
-            UBUNTU_VER=23.10
-            curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${UBUNTU_VER}/Release.key" \
-              | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/kubic.gpg
-            echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${UBUNTU_VER}/ /" \
-              | sudo tee /etc/apt/sources.list.d/kubic.list > /dev/null
-            sudo apt-get update -qq && sudo apt-get install -y -qq --allow-unauthenticated buildah
-          fi
-          buildah version | head -1
+        uses: redhat-actions/podman-install@edf9cd67e118e45e295f27c6e3ef5f73ad6505d3 # ratchet:redhat-actions/podman-install@v1
 
       - name: Checkout submodules
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -636,6 +636,8 @@ jobs:
           password: ${{ env.QUAY_REGISTRY == 'quay.io/stackrox-io' && secrets.QUAY_STACKROX_IO_RW_PASSWORD || secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
       - name: Build and push images
+        env:
+          BUILDKIT_PROGRESS: plain
         run: |
           tag_flags() { echo "$1" | while read -r t; do [[ -n "$t" ]] && echo "--tag=$t"; done; }
 
@@ -656,7 +658,7 @@ jobs:
             --build-arg ROX_IMAGE_FLAVOR=development_build \
             --build-arg LABEL_VERSION=${{ env.BUILD_TAG }} \
             --build-arg LABEL_RELEASE=${{ env.SHORTCOMMIT }} \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/main:nocache-${{ matrix.arch }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }} \
             --cache-to type=inline \
             image/rhel &
           pid_main=$!
@@ -666,7 +668,7 @@ jobs:
             --platform linux/${{ matrix.arch }} \
             $OUTPUT --provenance=false \
             $(tag_flags "$ROXCTL_TAGS") \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:nocache-${{ matrix.arch }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }} \
             --cache-to type=inline \
             image/roxctl &
           pid_roxctl=$!
@@ -677,7 +679,7 @@ jobs:
             $OUTPUT --provenance=false \
             $(tag_flags "$CENTRAL_DB_TAGS") \
             --build-arg MAIN_IMAGE_TAG=${{ env.BUILD_TAG }} \
-            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:nocache-${{ matrix.arch }} \
+            --cache-from type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }} \
             --cache-to type=inline \
             image/postgres &
           pid_centraldb=$!

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -541,6 +541,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
+        with:
+          # docker driver skips ~40s container boot for native builds.
+          # QEMU cross-builds (ppc64le/s390x) need the default docker-container driver.
+          driver: ${{ (matrix.arch == 'amd64' || matrix.arch == 'arm64') && 'docker' || 'docker-container' }}
 
       - name: Checkout submodules
         run: |
@@ -638,6 +642,7 @@ jobs:
           file: image/rhel/Dockerfile
           platforms: linux/${{ matrix.arch }}
           push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+          load: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}
           provenance: false
           tags: ${{ env.MAIN_TAGS }}
           build-args: |
@@ -648,7 +653,7 @@ jobs:
             LABEL_VERSION=${{ env.BUILD_TAG }}
             LABEL_RELEASE=${{ env.SHORTCOMMIT }}
           cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }}
-          cache-to: type=registry,ref=${{ env.QUAY_REGISTRY }}/main:cache-${{ matrix.arch }},mode=max,compression=zstd
+          cache-to: type=inline
 
       - name: Build and push roxctl image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
@@ -657,10 +662,11 @@ jobs:
           file: image/roxctl/Dockerfile
           platforms: linux/${{ matrix.arch }}
           push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+          load: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}
           provenance: false
           tags: ${{ env.ROXCTL_TAGS }}
           cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }}
-          cache-to: type=registry,ref=${{ env.QUAY_REGISTRY }}/roxctl:cache-${{ matrix.arch }},mode=max,compression=zstd
+          cache-to: type=inline
 
       - name: Build and push central-db image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # ratchet:docker/build-push-action@v6
@@ -669,12 +675,13 @@ jobs:
           file: image/postgres/Dockerfile
           platforms: linux/${{ matrix.arch }}
           push: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+          load: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}
           provenance: false
           tags: ${{ env.CENTRAL_DB_TAGS }}
           build-args: |
             MAIN_IMAGE_TAG=${{ env.BUILD_TAG }}
           cache-from: type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }}
-          cache-to: type=registry,ref=${{ env.QUAY_REGISTRY }}/central-db:cache-${{ matrix.arch }},mode=max,compression=zstd
+          cache-to: type=inline
 
   push-matching-collector-scanner:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -543,7 +543,11 @@ jobs:
         if: matrix.arch != 'amd64' && matrix.arch != 'arm64'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
-      # buildah is pre-installed on ubuntu runners — no container boot overhead
+      - name: Ensure buildah >= 1.41 (COPY --link support)
+        run: |
+          buildah version
+          [[ "$(buildah version | awk '/^Version:/{print $2}')" > "1.40" ]] \
+            || { sudo apt-get update -qq && sudo apt-get install -y -qq buildah && buildah version; }
 
       - name: Checkout submodules
         run: |

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -95,6 +95,8 @@ COPY --link bin/config-controller  /stackrox/bin/config-controller
 COPY --link bin/roxagent           /stackrox/bin/roxagent
 COPY --link bin/roxctl*            /assets/downloads/cli/
 
+COPY --link *VERSION /
+
 RUN ln -s /assets/downloads/cli/roxctl-linux-${TARGET_ARCH} /stackrox/roxctl && \
     ln -s /assets/downloads/cli/roxctl-linux-amd64 /assets/downloads/cli/roxctl-linux
 

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -64,8 +64,8 @@ ENV PATH="/stackrox:$PATH" \
 
 COPY --from=package_installer /out/ /
 
-COPY static-bin /stackrox/
-COPY --from=downloads /output/go/ /go/
+COPY --link static-bin /stackrox/
+COPY --link --from=downloads /output/go/ /go/
 
 RUN \
     # The contents of paths mounted as emptyDir volumes in Kubernetes are saved
@@ -78,22 +78,22 @@ RUN \
     mkdir -p /var/cache/stackrox && chown -R 4000:4000 /var/cache/stackrox && \
     chown -R 4000:4000 /tmp
 
-COPY --from=stackrox_data /stackrox-data /stackrox/static-data
-COPY ./docs/api/v1/swagger.json /stackrox/static-data/docs/api/v1/swagger.json
-COPY ./docs/api/v2/swagger.json /stackrox/static-data/docs/api/v2/swagger.json
-COPY THIRD_PARTY_NOTICES /THIRD_PARTY_NOTICES/
+COPY --link --from=stackrox_data /stackrox-data /stackrox/static-data
+COPY --link ./docs/api/v1/swagger.json /stackrox/static-data/docs/api/v1/swagger.json
+COPY --link ./docs/api/v2/swagger.json /stackrox/static-data/docs/api/v2/swagger.json
+COPY --link THIRD_PARTY_NOTICES /THIRD_PARTY_NOTICES/
 
-COPY ui /ui
+COPY --link ui /ui
 
-COPY bin/central            /stackrox/central
-COPY bin/migrator           /stackrox/bin/migrator
-COPY bin/compliance         /stackrox/bin/compliance
-COPY bin/kubernetes-sensor  /stackrox/bin/kubernetes-sensor
-COPY bin/sensor-upgrader    /stackrox/bin/sensor-upgrader
-COPY bin/admission-control  /stackrox/bin/admission-control
-COPY bin/config-controller  /stackrox/bin/config-controller
-COPY bin/roxagent           /stackrox/bin/roxagent
-COPY bin/roxctl*            /assets/downloads/cli/
+COPY --link bin/central            /stackrox/central
+COPY --link bin/migrator           /stackrox/bin/migrator
+COPY --link bin/compliance         /stackrox/bin/compliance
+COPY --link bin/kubernetes-sensor  /stackrox/bin/kubernetes-sensor
+COPY --link bin/sensor-upgrader    /stackrox/bin/sensor-upgrader
+COPY --link bin/admission-control  /stackrox/bin/admission-control
+COPY --link bin/config-controller  /stackrox/bin/config-controller
+COPY --link bin/roxagent           /stackrox/bin/roxagent
+COPY --link bin/roxctl*            /assets/downloads/cli/
 
 RUN ln -s /assets/downloads/cli/roxctl-linux-${TARGET_ARCH} /stackrox/roxctl && \
     ln -s /assets/downloads/cli/roxctl-linux-amd64 /assets/downloads/cli/roxctl-linux


### PR DESCRIPTION
## Description

**Status: Paused** — buildah on Ubuntu GHA runners hits ecosystem compatibility issues.

### What we tried
1. **Pre-installed buildah (1.33.7)** — no COPY --link support (needs >= 1.41)
2. **kubic repo upgrade** — tops out at 1.39.4, still no --link
3. **redhat-actions/podman-install** — installs podman 5.2.5 with buildah ~1.38, amd64 only
4. **Extract from container image** — dynamic linking (libsubid.so), segfaults on Ubuntu glibc
5. **go install from source** — needs CGO (libgpgme, libseccomp), 79s compile, failed
6. **Static binary built with Alpine musl** — compiles successfully (107s), but crun version mismatch on runner

### Root cause
Buildah is not a standalone binary — it depends on crun (OCI runtime), conmon, and containers-common. A static buildah 1.43 binary paired with Ubuntu's older crun produces "unknown version specified" errors when running RUN steps in Dockerfiles.

### What works
- **docker driver + inline cache** (PR #19806): 60% faster, proven, no compatibility issues
- **docker-container driver** (PR #19806 experiment): layer dedup works (0.1-0.8s/layer)
- **Stable ldflags** (PR #20234): enables per-binary layer reuse with any build tool

### Next steps
- Revisit when Ubuntu 25.10+ ships buildah >= 1.41 with matching runtime stack
- Or when GHA provides Fedora-based runners (native buildah support)