### PR TITLE
ROX-33555: Use VMID:CID composite resource ID for VM index ACK/NACK

### DIFF
--- a/central/sensor/service/common/sensor_ack.go
+++ b/central/sensor/service/common/sensor_ack.go
@@ -1,10 +1,14 @@
 package common
 
 import (
+	"strings"
+
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 )
+
+const vmIndexACKResourceIDSeparator = ":"
 
 // SendSensorACK sends a SensorACK only when sensor capability support is explicitly advertised.
 func SendSensorACK(ctx concurrency.Waitable, action central.SensorACK_Action, messageType central.SensorACK_MessageType, resourceID, reason string, injector MessageInjector) {
@@ -28,6 +32,25 @@ func SendSensorACK(ctx concurrency.Waitable, action central.SensorACK_Action, me
 	}); err != nil {
 		log.Warnf("Failed injecting SensorACK (%v) for %v (resource_id=%s): %v", action, messageType, resourceID, err)
 	}
+}
+
+// VMIndexACKResourceID builds the correlation key for VM index ACK/NACK.
+//
+// The key prefers a VMID:CID pair when both are available:
+// - VMID avoids cross-VM collisions if a CID is reused by another VM.
+// - CID allows Compliance relay/UMH to correlate with CID-keyed retry/cache state.
+//
+// Limitation: this pair cannot distinguish multiple in-flight reports from the
+// same VM while it keeps the same CID; a stale ACK may still match the latest
+// VMID:CID entry.
+func VMIndexACKResourceID(vmID, vsockCID string) string {
+	if vmID == "" {
+		return vsockCID
+	}
+	if vsockCID == "" {
+		return vmID
+	}
+	return strings.Join([]string{vmID, vsockCID}, vmIndexACKResourceIDSeparator)
 }
 
 // SendLegacyNodeInventoryACK sends the legacy NodeInventoryACK message supported since version 4.1.

--- a/central/sensor/service/common/sensor_ack.go
+++ b/central/sensor/service/common/sensor_ack.go
@@ -53,6 +53,16 @@ func VMIndexACKResourceID(vmID, vsockCID string) string {
 	return strings.Join([]string{vmID, vsockCID}, vmIndexACKResourceIDSeparator)
 }
 
+// VMIDFromACKResourceID extracts the VM ID from a composite resource ID
+// produced by VMIndexACKResourceID. If the resource ID has no separator,
+// it is returned as-is (assumed to be a bare VM ID or CID).
+func VMIDFromACKResourceID(resourceID string) string {
+	if idx := strings.Index(resourceID, vmIndexACKResourceIDSeparator); idx >= 0 {
+		return resourceID[:idx]
+	}
+	return resourceID
+}
+
 // SendLegacyNodeInventoryACK sends the legacy NodeInventoryACK message supported since version 4.1.
 func SendLegacyNodeInventoryACK(ctx concurrency.Waitable, clusterID, nodeName string, action central.NodeInventoryACK_Action, messageType central.NodeInventoryACK_MessageType, injector MessageInjector) {
 	if injector == nil {

--- a/central/sensor/service/common/sensor_ack.go
+++ b/central/sensor/service/common/sensor_ack.go
@@ -53,16 +53,6 @@ func VMIndexACKResourceID(vmID, vsockCID string) string {
 	return strings.Join([]string{vmID, vsockCID}, vmIndexACKResourceIDSeparator)
 }
 
-// VMIDFromACKResourceID extracts the VM ID from a composite resource ID
-// produced by VMIndexACKResourceID. If the resource ID has no separator,
-// it is returned as-is (assumed to be a bare VM ID or CID).
-func VMIDFromACKResourceID(resourceID string) string {
-	if idx := strings.Index(resourceID, vmIndexACKResourceIDSeparator); idx >= 0 {
-		return resourceID[:idx]
-	}
-	return resourceID
-}
-
 // SendLegacyNodeInventoryACK sends the legacy NodeInventoryACK message supported since version 4.1.
 func SendLegacyNodeInventoryACK(ctx concurrency.Waitable, clusterID, nodeName string, action central.NodeInventoryACK_Action, messageType central.NodeInventoryACK_MessageType, injector MessageInjector) {
 	if injector == nil {

--- a/central/sensor/service/common/sensor_ack.go
+++ b/central/sensor/service/common/sensor_ack.go
@@ -1,8 +1,6 @@
 package common
 
 import (
-	"strings"
-
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
@@ -36,21 +34,18 @@ func SendSensorACK(ctx concurrency.Waitable, action central.SensorACK_Action, me
 
 // VMIndexACKResourceID builds the correlation key for VM index ACK/NACK.
 //
-// The key prefers a VMID:CID pair when both are available:
-// - VMID avoids cross-VM collisions if a CID is reused by another VM.
-// - CID allows Compliance relay/UMH to correlate with CID-keyed retry/cache state.
+// The format is always "vmID:vsockCID" with the separator present even when
+// one component is empty (e.g. ":100" or "vm-1:"). This makes it unambiguous
+// which part is which when debugging logs or parsing the resource ID.
 //
 // Limitation: this pair cannot distinguish multiple in-flight reports from the
 // same VM while it keeps the same CID; a stale ACK may still match the latest
 // VMID:CID entry.
 func VMIndexACKResourceID(vmID, vsockCID string) string {
-	if vmID == "" {
-		return vsockCID
+	if vmID == "" && vsockCID == "" {
+		return ""
 	}
-	if vsockCID == "" {
-		return vmID
-	}
-	return strings.Join([]string{vmID, vsockCID}, vmIndexACKResourceIDSeparator)
+	return vmID + vmIndexACKResourceIDSeparator + vsockCID
 }
 
 // SendLegacyNodeInventoryACK sends the legacy NodeInventoryACK message supported since version 4.1.

--- a/central/sensor/service/common/sensor_ack_test.go
+++ b/central/sensor/service/common/sensor_ack_test.go
@@ -57,16 +57,16 @@ func TestVMIndexACKResourceID(t *testing.T) {
 			expected: "vm-1:100",
 		},
 		{
-			name:     "returns vm id when cid is missing",
+			name:     "keeps separator when cid is missing",
 			vmID:     "vm-1",
 			vsockCID: "",
-			expected: "vm-1",
+			expected: "vm-1:",
 		},
 		{
-			name:     "returns cid when vm id is missing",
+			name:     "keeps separator when vm id is missing",
 			vmID:     "",
 			vsockCID: "100",
-			expected: "100",
+			expected: ":100",
 		},
 		{
 			name:     "returns empty string when both vm id and cid are missing",

--- a/central/sensor/service/common/sensor_ack_test.go
+++ b/central/sensor/service/common/sensor_ack_test.go
@@ -41,6 +41,50 @@ func TestSendSensorACK_InjectorWithoutCapabilitySupport(t *testing.T) {
 	assert.Empty(t, injector.messages, "should not send when SensorACKSupport capability is not advertised")
 }
 
+func TestVMIndexACKResourceID(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		vmID     string
+		vsockCID string
+		expected string
+	}{
+		{
+			name:     "returns pair when both vm id and cid are present",
+			vmID:     "vm-1",
+			vsockCID: "100",
+			expected: "vm-1:100",
+		},
+		{
+			name:     "returns vm id when cid is missing",
+			vmID:     "vm-1",
+			vsockCID: "",
+			expected: "vm-1",
+		},
+		{
+			name:     "returns cid when vm id is missing",
+			vmID:     "",
+			vsockCID: "100",
+			expected: "100",
+		},
+		{
+			name:     "returns empty string when both vm id and cid are missing",
+			vmID:     "",
+			vsockCID: "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actual := VMIndexACKResourceID(tc.vmID, tc.vsockCID)
+			assert.Equalf(t, tc.expected, actual, "expected resource id %q, but got %q", tc.expected, actual)
+		})
+	}
+}
+
 type mockInjector struct {
 	messages     []*central.MsgToSensor
 	injectErr    error

--- a/central/sensor/service/common/sensor_ack_test.go
+++ b/central/sensor/service/common/sensor_ack_test.go
@@ -85,6 +85,45 @@ func TestVMIndexACKResourceID(t *testing.T) {
 	}
 }
 
+func TestVMIDFromACKResourceID(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		resourceID string
+		expected   string
+	}{
+		{
+			name:       "extracts vm id from composite resource id",
+			resourceID: "vm-1:100",
+			expected:   "vm-1",
+		},
+		{
+			name:       "returns bare vm id as-is",
+			resourceID: "vm-1",
+			expected:   "vm-1",
+		},
+		{
+			name:       "returns empty string for empty input",
+			resourceID: "",
+			expected:   "",
+		},
+		{
+			name:       "extracts uuid vm id from composite",
+			resourceID: "d2696fad-8ef2-49f5-9726-499b1419be20:1289650420",
+			expected:   "d2696fad-8ef2-49f5-9726-499b1419be20",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actual := VMIDFromACKResourceID(tc.resourceID)
+			assert.Equalf(t, tc.expected, actual, "expected vm id %q, but got %q", tc.expected, actual)
+		})
+	}
+}
+
 type mockInjector struct {
 	messages     []*central.MsgToSensor
 	injectErr    error

--- a/central/sensor/service/common/sensor_ack_test.go
+++ b/central/sensor/service/common/sensor_ack_test.go
@@ -85,50 +85,6 @@ func TestVMIndexACKResourceID(t *testing.T) {
 	}
 }
 
-func TestVMIDFromACKResourceID(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name       string
-		resourceID string
-		expected   string
-	}{
-		{
-			name:       "extracts vm id from composite resource id",
-			resourceID: "vm-1:100",
-			expected:   "vm-1",
-		},
-		{
-			name:       "returns bare vm id as-is",
-			resourceID: "vm-1",
-			expected:   "vm-1",
-		},
-		{
-			name:       "returns empty string for empty input",
-			resourceID: "",
-			expected:   "",
-		},
-		{
-			name:       "extracts uuid vm id from composite",
-			resourceID: "d2696fad-8ef2-49f5-9726-499b1419be20:1289650420",
-			expected:   "d2696fad-8ef2-49f5-9726-499b1419be20",
-		},
-		{
-			name:       "returns bare CID as-is",
-			resourceID: "1289650420",
-			expected:   "1289650420",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			actual := VMIDFromACKResourceID(tc.resourceID)
-			assert.Equalf(t, tc.expected, actual, "expected vm id %q, but got %q", tc.expected, actual)
-		})
-	}
-}
-
 type mockInjector struct {
 	messages     []*central.MsgToSensor
 	injectErr    error

--- a/central/sensor/service/common/sensor_ack_test.go
+++ b/central/sensor/service/common/sensor_ack_test.go
@@ -113,6 +113,11 @@ func TestVMIDFromACKResourceID(t *testing.T) {
 			resourceID: "d2696fad-8ef2-49f5-9726-499b1419be20:1289650420",
 			expected:   "d2696fad-8ef2-49f5-9726-499b1419be20",
 		},
+		{
+			name:       "returns bare CID as-is",
+			resourceID: "1289650420",
+			expected:   "1289650420",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -187,7 +187,8 @@ func (c *sensorConnection) multiplexedPush(ctx context.Context, msg *central.Msg
 		)
 		c.emitRateLimitedAdminEvent(c.clusterID, reason)
 		if vmReport := msg.GetEvent().GetVirtualMachineIndexReport(); vmReport != nil {
-			common.SendSensorACK(ctx, central.SensorACK_NACK, central.SensorACK_VM_INDEX_REPORT, vmReport.GetId(), centralsensor.SensorACKReasonRateLimited, c)
+			resourceID := common.VMIndexACKResourceID(vmReport.GetId(), vmReport.GetIndex().GetVsockCid())
+			common.SendSensorACK(ctx, central.SensorACK_NACK, central.SensorACK_VM_INDEX_REPORT, resourceID, centralsensor.SensorACKReasonRateLimited, c)
 		}
 		return
 	}

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
@@ -108,13 +108,18 @@ func isMatcherNotReadyError(err error) bool {
 func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.MsgFromSensor, injector common.MessageInjector) error {
 	defer countMetrics.IncrementResourceProcessedCounter(pipeline.ActionToOperation(msg.GetEvent().GetAction()), metrics.VirtualMachineIndex)
 
-	if !features.VirtualMachines.Enabled() {
-		// ACK to prevent the sender from retrying when the feature is disabled on Central.
-		sendVMIndexACK(ctx, msg.GetEvent().GetVirtualMachineIndexReport().GetId(), centralsensor.SensorACKReasonFeatureDisabled, injector)
-		return nil
-	}
 	event := msg.GetEvent()
 	index := event.GetVirtualMachineIndexReport()
+	resourceID := ""
+	if index != nil {
+		resourceID = common.VMIndexACKResourceID(index.GetId(), index.GetIndex().GetVsockCid())
+	}
+
+	if !features.VirtualMachines.Enabled() {
+		// ACK to prevent the sender from retrying when the feature is disabled on Central.
+		sendVMIndexACK(ctx, resourceID, centralsensor.SensorACKReasonFeatureDisabled, injector)
+		return nil
+	}
 	if index == nil {
 		return errors.Errorf("unexpected resource type %T for virtual machine index report", event.GetResource())
 	}
@@ -124,14 +129,14 @@ func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 			event.GetAction().String(),
 			central.ResourceAction_SYNC_RESOURCE.String(),
 		)
-		sendVMIndexNACK(ctx, index.GetId(), centralsensor.SensorACKReasonUnsupportedAction, injector)
+		sendVMIndexNACK(ctx, resourceID, centralsensor.SensorACKReasonUnsupportedAction, injector)
 		return nil
 	}
 
 	log.Debugf("Received virtual machine index report: %s", index.GetId())
 
 	if clusterID == "" {
-		sendVMIndexNACK(ctx, index.GetId(), centralsensor.SensorACKReasonMissingClusterID, injector)
+		sendVMIndexNACK(ctx, resourceID, centralsensor.SensorACKReasonMissingClusterID, injector)
 		return errors.New("missing cluster ID in pipeline context")
 	}
 
@@ -141,26 +146,26 @@ func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 	// Extract Scanner V4 index report from VM index report event
 	indexV4 := index.GetIndex().GetIndexV4()
 	if indexV4 == nil {
-		sendVMIndexNACK(ctx, index.GetId(), centralsensor.SensorACKReasonMissingScanData, injector)
+		sendVMIndexNACK(ctx, resourceID, centralsensor.SensorACKReasonMissingScanData, injector)
 		return errors.Errorf("VM index report %s missing Scanner V4 index data", index.GetId())
 	}
 
 	// Enrich VM with vulnerabilities
 	err := p.enricher.EnrichVirtualMachineWithVulnerabilities(vm, indexV4)
 	if err != nil {
-		sendVMIndexNACK(ctx, index.GetId(), reasonForEnrichmentFailure(err), injector)
+		sendVMIndexNACK(ctx, resourceID, reasonForEnrichmentFailure(err), injector)
 		return errors.Wrapf(err, "failed to enrich VM %s with vulnerabilities", index.GetId())
 	}
 
 	// Store enriched VM via v1 or v2 path.
 	if features.VirtualMachinesEnhancedDataModel.Enabled() {
 		if err := p.storeV2Scan(ctx, clusterID, vm); err != nil {
-			sendVMIndexNACK(ctx, index.GetId(), centralsensor.SensorACKReasonStorageFailed, injector)
+			sendVMIndexNACK(ctx, resourceID, centralsensor.SensorACKReasonStorageFailed, injector)
 			return err
 		}
 	} else {
 		if err := p.storeV1Scan(ctx, vm); err != nil {
-			sendVMIndexNACK(ctx, index.GetId(), centralsensor.SensorACKReasonStorageFailed, injector)
+			sendVMIndexNACK(ctx, resourceID, centralsensor.SensorACKReasonStorageFailed, injector)
 			return err
 		}
 	}
@@ -168,7 +173,7 @@ func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 	log.Debugf("Successfully enriched and stored VM %s with %d components",
 		vm.GetId(), len(vm.GetScan().GetComponents()))
 
-	sendVMIndexACK(ctx, index.GetId(), "", injector)
+	sendVMIndexACK(ctx, resourceID, "", injector)
 	return nil
 }
 

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
@@ -382,6 +382,39 @@ func (suite *PipelineTestSuite) TestRun_SendsACKOnSuccess() {
 	suite.Empty(ack.GetReason())
 }
 
+func (suite *PipelineTestSuite) TestRun_SendsACKWithVMIDAndVsockCIDResourceID() {
+	suite.T().Setenv(features.VirtualMachines.EnvVar(), "true")
+	suite.T().Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), "false")
+	vmID := "vm-ack-vsock-correlation"
+	vsockCID := "1337"
+	msg := createVMIndexMessage(vmID, central.ResourceAction_SYNC_RESOURCE)
+	msg.GetEvent().GetVirtualMachineIndexReport().GetIndex().VsockCid = vsockCID
+
+	suite.enricher.EXPECT().
+		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
+		Return(nil)
+	suite.virtualMachineStore.EXPECT().
+		UpdateVirtualMachineScan(ctx, vmID, gomock.Any()).
+		Return(nil)
+
+	injector := &mockInjector{
+		capabilities: map[centralsensor.SensorCapability]bool{
+			centralsensor.SensorACKSupport: true,
+		},
+	}
+
+	err := suite.pipeline.Run(ctx, testClusterID, msg, injector)
+	suite.NoError(err)
+
+	suite.Require().Len(injector.messages, 1)
+	ack := injector.messages[0].GetSensorAck()
+	suite.Require().NotNil(ack)
+	suite.Equal(central.SensorACK_ACK, ack.GetAction())
+	suite.Equal(central.SensorACK_VM_INDEX_REPORT, ack.GetMessageType())
+	suite.Equal(vmID+":"+vsockCID, ack.GetResourceId(), "expected ACK resource_id to match VMID:CID pair for relay correlation")
+	suite.Empty(ack.GetReason())
+}
+
 func (suite *PipelineTestSuite) TestRun_NoACKWhenCapabilityMissing() {
 	suite.T().Setenv(features.VirtualMachines.EnvVar(), "true")
 	suite.T().Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), "false")

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
@@ -378,7 +378,7 @@ func (suite *PipelineTestSuite) TestRun_SendsACKOnSuccess() {
 	suite.Require().NotNil(ack)
 	suite.Equal(central.SensorACK_ACK, ack.GetAction())
 	suite.Equal(central.SensorACK_VM_INDEX_REPORT, ack.GetMessageType())
-	suite.Equal(vmID, ack.GetResourceId())
+	suite.Equal(vmID+":", ack.GetResourceId())
 	suite.Empty(ack.GetReason())
 }
 
@@ -464,7 +464,7 @@ func (suite *PipelineTestSuite) TestRun_NACKOnDBError() {
 	suite.Require().NotNil(ack)
 	suite.Equal(central.SensorACK_NACK, ack.GetAction())
 	suite.Equal(central.SensorACK_VM_INDEX_REPORT, ack.GetMessageType())
-	suite.Equal(vmID, ack.GetResourceId())
+	suite.Equal(vmID+":", ack.GetResourceId())
 	suite.Equal(centralsensor.SensorACKReasonStorageFailed, ack.GetReason())
 }
 
@@ -492,7 +492,7 @@ func (suite *PipelineTestSuite) TestRun_NACKOnEnrichmentError() {
 	suite.Require().NotNil(ack)
 	suite.Equal(central.SensorACK_NACK, ack.GetAction())
 	suite.Equal(central.SensorACK_VM_INDEX_REPORT, ack.GetMessageType())
-	suite.Equal(vmID, ack.GetResourceId())
+	suite.Equal(vmID+":", ack.GetResourceId())
 	suite.Equal(centralsensor.SensorACKReasonEnrichmentFailed, ack.GetReason())
 }
 
@@ -523,7 +523,7 @@ func (suite *PipelineTestSuite) TestRun_NACKOnMatcherNotInitializedError() {
 	suite.Require().NotNil(ack)
 	suite.Equal(central.SensorACK_NACK, ack.GetAction())
 	suite.Equal(central.SensorACK_VM_INDEX_REPORT, ack.GetMessageType())
-	suite.Equal(vmID, ack.GetResourceId())
+	suite.Equal(vmID+":", ack.GetResourceId())
 	suite.Equal(centralsensor.SensorACKReasonMatcherNotReady, ack.GetReason())
 }
 
@@ -547,7 +547,7 @@ func (suite *PipelineTestSuite) TestRun_NACKOnMissingClusterID() {
 	suite.Require().NotNil(ack)
 	suite.Equal(central.SensorACK_NACK, ack.GetAction())
 	suite.Equal(central.SensorACK_VM_INDEX_REPORT, ack.GetMessageType())
-	suite.Equal(vmID, ack.GetResourceId())
+	suite.Equal(vmID+":", ack.GetResourceId())
 	suite.Equal(centralsensor.SensorACKReasonMissingClusterID, ack.GetReason())
 }
 
@@ -600,7 +600,7 @@ func (suite *PipelineTestSuite) TestRun_NACKOnMissingScannerIndexPayload() {
 			suite.Require().NotNil(ack)
 			suite.Equal(central.SensorACK_NACK, ack.GetAction())
 			suite.Equal(central.SensorACK_VM_INDEX_REPORT, ack.GetMessageType())
-			suite.Equal(vmID, ack.GetResourceId())
+			suite.Equal(vmID+":", ack.GetResourceId())
 			suite.Equal(centralsensor.SensorACKReasonMissingScanData, ack.GetReason())
 		})
 	}
@@ -636,7 +636,7 @@ func TestPipelineRun_DisabledFeature(t *testing.T) {
 	assert.NotNil(t, ack)
 	assert.Equal(t, central.SensorACK_ACK, ack.GetAction())
 	assert.Equal(t, central.SensorACK_VM_INDEX_REPORT, ack.GetMessageType())
-	assert.Equal(t, vmID, ack.GetResourceId())
+	assert.Equal(t, vmID+":", ack.GetResourceId())
 	assert.Equal(t, centralsensor.SensorACKReasonFeatureDisabled, ack.GetReason())
 }
 

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -377,7 +377,9 @@ func (c *Compliance) handleComplianceACK(ack *sensor.MsgToCompliance_ComplianceA
 	case sensor.MsgToCompliance_ComplianceACK_NODE_INDEX_REPORT:
 		dispatchACK(c.umhNodeIndex, "node index", ack.GetAction(), ack.GetReason())
 	case sensor.MsgToCompliance_ComplianceACK_VM_INDEX_REPORT:
-		// TODO: Implement basic handling of VM_INDEX_REPORT ACK/NACK messages in ROX-33555.
+		// TODO: Implement VM_INDEX_REPORT ACK/NACK handling.
+		// ResourceId uses "vmID:vsockCID" format — extract the CID part after ":"
+		// to correlate with the relay's vsock-keyed state.
 	default:
 		log.Errorf("Unknown ComplianceACK message type: %s", ack.GetMessageType())
 	}

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -243,14 +243,22 @@ func (h *handlerImpl) forwardToCompliance(
 	}
 
 	// Resolve the VM's host node so the compliance multiplexer can route to
-	// the correct compliance connection. If the VM is unknown (e.g. deleted
-	// between send and ACK), broadcast to all connections as a fallback.
+	// the correct compliance connection.
 	var nodeName string
 	if resourceID != "" {
 		vmID := vmIDFromResourceID(resourceID)
 		if vmInfo := h.store.Get(virtualmachine.VMID(vmID)); vmInfo != nil {
 			nodeName = vmInfo.NodeName
 		}
+	}
+
+	// Drop the ACK when the target node is unknown rather than broadcasting.
+	// vsock CIDs are host-local and can collide across nodes; broadcasting
+	// would risk a compliance instance on another node matching the CID to
+	// the wrong VM. A deleted/migrated VM does not need its ACK delivered.
+	if nodeName == "" {
+		log.Debugf("Dropping VM ACK/NACK (resourceID=%s): VM not found in store, cannot route to node", resourceID)
+		return
 	}
 
 	msg := common.MessageToComplianceWithAddress{
@@ -267,7 +275,7 @@ func (h *handlerImpl) forwardToCompliance(
 		// Hostname is the node name (not the VM resource ID) used by the
 		// compliance multiplexer to route to the correct compliance connection.
 		Hostname:  nodeName,
-		Broadcast: nodeName == "",
+		Broadcast: false,
 	}
 
 	select {

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -357,8 +357,8 @@ func (h *handlerImpl) sendIndexReportEvent(
 // vmIDFromResourceID extracts the VM ID from a composite ACK resource ID
 // (format "vmID:vsockCID"). Returns the input as-is when no separator is found.
 func vmIDFromResourceID(resourceID string) string {
-	if vmID, _, found := strings.Cut(resourceID, ":"); found {
-		return vmID
+	if i := strings.IndexByte(resourceID, ':'); i >= 0 {
+		return resourceID[:i]
 	}
 	return resourceID
 }

--- a/sensor/common/virtualmachine/index/handler_impl.go
+++ b/sensor/common/virtualmachine/index/handler_impl.go
@@ -3,6 +3,7 @@ package index
 import (
 	"context"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -246,7 +247,8 @@ func (h *handlerImpl) forwardToCompliance(
 	// between send and ACK), broadcast to all connections as a fallback.
 	var nodeName string
 	if resourceID != "" {
-		if vmInfo := h.store.Get(virtualmachine.VMID(resourceID)); vmInfo != nil {
+		vmID := vmIDFromResourceID(resourceID)
+		if vmInfo := h.store.Get(virtualmachine.VMID(vmID)); vmInfo != nil {
 			nodeName = vmInfo.NodeName
 		}
 	}
@@ -350,4 +352,13 @@ func (h *handlerImpl) sendIndexReportEvent(
 	case <-h.stopper.Flow().StopRequested():
 	case toCentral <- msg:
 	}
+}
+
+// vmIDFromResourceID extracts the VM ID from a composite ACK resource ID
+// (format "vmID:vsockCID"). Returns the input as-is when no separator is found.
+func vmIDFromResourceID(resourceID string) string {
+	if vmID, _, found := strings.Cut(resourceID, ":"); found {
+		return vmID
+	}
+	return resourceID
 }

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/virtualmachine"
 	"github.com/stackrox/rox/sensor/common/virtualmachine/index/mocks"
 	vmmetrics "github.com/stackrox/rox/sensor/common/virtualmachine/metrics"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -690,4 +691,41 @@ func (s *virtualMachineHandlerSuite) TestStart_CalledTwice() {
 
 	err = s.handler.Start()
 	s.Require().ErrorIs(err, errStartMoreThanOnce)
+}
+
+func TestVmIDFromResourceID(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		resourceID string
+		expected   string
+	}{
+		"extracts vm id from composite resource id": {
+			resourceID: "vm-1:100",
+			expected:   "vm-1",
+		},
+		"returns bare vm id as-is": {
+			resourceID: "vm-1",
+			expected:   "vm-1",
+		},
+		"returns empty string for empty input": {
+			resourceID: "",
+			expected:   "",
+		},
+		"extracts uuid vm id from composite": {
+			resourceID: "d2696fad-8ef2-49f5-9726-499b1419be20:1289650420",
+			expected:   "d2696fad-8ef2-49f5-9726-499b1419be20",
+		},
+		"returns bare CID as-is": {
+			resourceID: "1289650420",
+			expected:   "1289650420",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, vmIDFromResourceID(tc.resourceID))
+		})
+	}
 }

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -417,7 +417,7 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance() {
 	}
 }
 
-func (s *virtualMachineHandlerSuite) TestForwardToCompliance_Broadcast() {
+func (s *virtualMachineHandlerSuite) TestForwardToCompliance_DropsWhenVMUnknown() {
 	err := s.handler.Start()
 	s.Require().NoError(err)
 	defer s.handler.Stop()
@@ -426,14 +426,14 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_Broadcast() {
 		resourceID string
 		expectedID string
 	}{
-		"should broadcast when resource ID is empty": {
+		"should drop when resource ID is empty": {
 			resourceID: "",
 		},
-		"should broadcast when VM not in store": {
+		"should drop when VM not in store": {
 			resourceID: "vm-deleted",
 			expectedID: "vm-deleted",
 		},
-		"should broadcast when VM from composite ID not in store": {
+		"should drop when VM from composite ID not in store": {
 			resourceID: "vm-deleted:999",
 			expectedID: "vm-deleted",
 		},
@@ -458,12 +458,9 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_Broadcast() {
 			s.Require().NoError(err)
 
 			select {
-			case got := <-s.handler.ComplianceC():
-				s.Equal(tc.resourceID, got.Msg.GetComplianceAck().GetResourceId())
-				s.Empty(got.Hostname)
-				s.True(got.Broadcast)
-			case <-time.After(100 * time.Millisecond):
-				s.Fail("timed out waiting for broadcast compliance ACK")
+			case <-s.handler.ComplianceC():
+				s.Fail("ACK should have been dropped when VM is unknown, not forwarded")
+			default:
 			}
 		})
 	}

--- a/sensor/common/virtualmachine/index/handler_impl_test.go
+++ b/sensor/common/virtualmachine/index/handler_impl_test.go
@@ -350,30 +350,41 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance() {
 	cases := map[string]struct {
 		centralAction  central.SensorACK_Action
 		resourceID     string
+		vmID           string
 		nodeName       string
 		reason         string
 		expectedAction sensor.MsgToCompliance_ComplianceACK_Action
 	}{
-		"should forward ACK to compliance": {
+		"should forward ACK to compliance with composite resource ID": {
 			centralAction:  central.SensorACK_ACK,
-			resourceID:     "vm-123",
+			resourceID:     "vm-123:100",
+			vmID:           "vm-123",
 			nodeName:       "node-a",
 			reason:         "all good",
 			expectedAction: sensor.MsgToCompliance_ComplianceACK_ACK,
 		},
-		"should forward NACK to compliance": {
+		"should forward NACK to compliance with composite resource ID": {
 			centralAction:  central.SensorACK_NACK,
-			resourceID:     "vm-456",
+			resourceID:     "vm-456:200",
+			vmID:           "vm-456",
 			nodeName:       "node-b",
 			reason:         "validation failed",
 			expectedAction: sensor.MsgToCompliance_ComplianceACK_NACK,
+		},
+		"should forward ACK with bare VM ID": {
+			centralAction:  central.SensorACK_ACK,
+			resourceID:     "vm-789",
+			vmID:           "vm-789",
+			nodeName:       "node-c",
+			reason:         "",
+			expectedAction: sensor.MsgToCompliance_ComplianceACK_ACK,
 		},
 	}
 
 	for name, tc := range cases {
 		s.Run(name, func() {
-			s.store.EXPECT().Get(virtualmachine.VMID(tc.resourceID)).Return(
-				&virtualmachine.Info{ID: virtualmachine.VMID(tc.resourceID), NodeName: tc.nodeName})
+			s.store.EXPECT().Get(virtualmachine.VMID(tc.vmID)).Return(
+				&virtualmachine.Info{ID: virtualmachine.VMID(tc.vmID), NodeName: tc.nodeName})
 
 			ctx := context.Background()
 			msg := &central.MsgToSensor{
@@ -412,19 +423,25 @@ func (s *virtualMachineHandlerSuite) TestForwardToCompliance_Broadcast() {
 
 	cases := map[string]struct {
 		resourceID string
+		expectedID string
 	}{
 		"should broadcast when resource ID is empty": {
 			resourceID: "",
 		},
 		"should broadcast when VM not in store": {
 			resourceID: "vm-deleted",
+			expectedID: "vm-deleted",
+		},
+		"should broadcast when VM from composite ID not in store": {
+			resourceID: "vm-deleted:999",
+			expectedID: "vm-deleted",
 		},
 	}
 
 	for name, tc := range cases {
 		s.Run(name, func() {
-			if tc.resourceID != "" {
-				s.store.EXPECT().Get(virtualmachine.VMID(tc.resourceID)).Return(nil)
+			if tc.expectedID != "" {
+				s.store.EXPECT().Get(virtualmachine.VMID(tc.expectedID)).Return(nil)
 			}
 
 			ctx := context.Background()


### PR DESCRIPTION
## Description

VM index ACK/NACK messages from Central previously used only the VM ID as the resource ID. 
The Compliance relay, however, tracks retry and rate-limiting state by VSOCK CID (the identifier of the virtio-vsock connection from a guest VM). 
Using only the VM ID meant the relay could not correlate an incoming ACK back to the correct CID-keyed entry.

Using only the CID was also not viable: VSOCK CIDs can be reassigned
when a VM is destroyed and a new one is created, so a stale ACK for a
previous VM could incorrectly match the new VM's entry if both happened
to share the same CID.

This PR introduces a `VMIndexACKResourceID(vmID, vsockCID)` helper that
builds a `VMID:CID` composite key when both values are available,
falling back to whichever is present. The VMID component avoids cross-VM
collisions, while the CID component allows the Compliance relay to
extract the CID portion for its internal state lookup.

The helper is used in the VM index pipeline and the connection-level
rate-limit NACK path. The Compliance-side parsing is in a separate PR.

AI-Assisted: cursor, ~70% generated, user reviewed logic

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Unit-tests
- Deployed on a cluster and looked into compliance debug logs:


#### Single VM - runs on worker d

```
...
virtualmachines/relay/stream: 2026/04/27 11:22:10.708103 vsock_index_report_stream.go:167: Info: Handling connection from vm(1289650420):1027367498
(...)
virtualmachines/relay/stream: 2026/04/27 11:22:10.736594 vsock_index_report_stream.go:175: Info: Finished handling connection from vm(1289650420):1027367498
virtualmachines/relay/sender: 2026/04/27 11:23:07.683275 index_report_sender.go:47: Info: Sending VM report to sensor (vsockCID: 1289650420)
(...)
main: 2026/04/27 11:23:07.722732 compliance.go:434: Debug: Received ComplianceACK: type=VM_INDEX_REPORT, action=ACK, resource_id=d2696fad-8ef2-49f5-9726-499b1419be20:1289650420, reason=
```

```
➜ oc get vmi rhel9-1 -n openshift-cnv -o yaml

apiVersion: kubevirt.io/v1
kind: VirtualMachineInstance
metadata:
  (...)
  name: rhel9-1
  namespace: openshift-cnv
  ownerReferences:
  - apiVersion: kubevirt.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: VirtualMachine
    name: rhel9-1
    uid: d2696fad-8ef2-49f5-9726-499b1419be20   <--- matches the ID in the ACK
...
```

#### Two VMs - each on a separate worker node

```
➜ oc get vmi rhel10-1 -n openshift-cnv -o yaml | grep uid

    uid: 58230e72-2e24-4eb6-9c4c-f58f7eb3b290

➜ oc get vmi rhel9-1 -n openshift-cnv -o yaml | grep uid

    uid: d2696fad-8ef2-49f5-9726-499b1419be20
```

Worker-b compliance
```
virtualmachines/relay/stream: 2026/04/27 13:13:23.829770 vsock_index_report_stream.go:167: Info: Handling connection from vm(598756980):3872235502
virtualmachines/relay/connutil: 2026/04/27 13:13:23.829812 connutil.go:19: Debug: Reading from connection (max bytes: 16777216, timeout: 10s)
virtualmachines/relay/stream: 2026/04/27 13:13:23.858624 vsock_index_report_stream.go:200: Debug: Parsing VM report (vsock CID: 598756980)
virtualmachines/relay/stream: 2026/04/27 13:13:23.861629 vsock_index_report_stream.go:175: Info: Finished handling connection from vm(598756980):3872235502
virtualmachines/relay/sender: 2026/04/27 13:13:23.861701 index_report_sender.go:47: Info: Sending VM report to sensor (vsockCID: 598756980)
main: 2026/04/27 13:13:23.911475 compliance.go:434: Debug: Received ComplianceACK: type=VM_INDEX_REPORT, action=ACK, resource_id=58230e72-2e24-4eb6-9c4c-f58f7eb3b290:598756980, reason=
```

Worker-d compliance:
```
virtualmachines/relay/stream: 2026/04/27 13:14:41.596706 vsock_index_report_stream.go:167: Info: Handling connection from vm(1289650420):1027367602
virtualmachines/relay/connutil: 2026/04/27 13:14:41.596752 connutil.go:19: Debug: Reading from connection (max bytes: 16777216, timeout: 10s)
virtualmachines/relay/stream: 2026/04/27 13:14:41.621558 vsock_index_report_stream.go:200: Debug: Parsing VM report (vsock CID: 1289650420)
virtualmachines/relay/stream: 2026/04/27 13:14:41.624125 vsock_index_report_stream.go:175: Info: Finished handling connection from vm(1289650420):1027367602
virtualmachines/relay/sender: 2026/04/27 13:14:41.624210 index_report_sender.go:47: Info: Sending VM report to sensor (vsockCID: 1289650420)
main: 2026/04/27 13:14:41.678608 compliance.go:434: Debug: Received ComplianceACK: type=VM_INDEX_REPORT, action=ACK, resource_id=d2696fad-8ef2-49f5-9726-499b1419be20:1289650420, reason=
```

^^ This shows that the Sensor routing based on the VMID-2-Node mapping works correctly and we do not broadcast the ACKs to all compliance nodes.
