### PR TITLE
ROX-34357: avoid env update race condition

### DIFF
--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -571,67 +571,65 @@ class Kubernetes {
                 .spec.containers.findIndexOf { it.name == containerName } > -1
     }
 
+    @Retry(attempts = 3, delay = 2)
     void removeDaemonSetEnv(String ns, String name, String containerName, String key) {
         log.debug "Remove env var in ${ns}/${name}/${containerName}: ${key}"
-        withK8sClientRetry(3, 2) {
-            client.apps().daemonSets().inNamespace(ns).withName(name)
-                    .edit { d ->
-                        List<Container> containers = d.spec.template.spec.containers
-                        int containerIndex = containers.findIndexOf { it.name == containerName }
-                        if (containerIndex == -1) {
-                            throw new RuntimeException(
-                                    "Could not remove env var." +
-                                    " No container named ${containerName} in ${ns}/${name}")
-                        }
-                        List<EnvVar> envVars = containers.get(containerIndex).env
-                        envVars.removeIf { EnvVar e -> e.name == key }
-                        new DaemonSetBuilder(d)
-                                .editSpec()
-                                .editTemplate()
-                                .editSpec()
-                                .editContainer(containerIndex)
-                                .withEnv(envVars)
-                                .endContainer()
-                                .endSpec()
-                                .endTemplate()
-                                .endSpec()
-                                .build()
+        client.apps().daemonSets().inNamespace(ns).withName(name)
+                .edit { d ->
+                    List<Container> containers = d.spec.template.spec.containers
+                    int containerIndex = containers.findIndexOf { it.name == containerName }
+                    if (containerIndex == -1) {
+                        throw new RuntimeException(
+                                "Could not remove env var." +
+                                " No container named ${containerName} in ${ns}/${name}")
                     }
-        }
+                    List<EnvVar> envVars = containers.get(containerIndex).env
+                    envVars.removeIf { EnvVar e -> e.name == key }
+                    new DaemonSetBuilder(d)
+                            .editSpec()
+                            .editTemplate()
+                            .editSpec()
+                            .editContainer(containerIndex)
+                            .withEnv(envVars)
+                            .endContainer()
+                            .endSpec()
+                            .endTemplate()
+                            .endSpec()
+                            .build()
+                }
     }
 
+    @Retry(attempts = 3, delay = 2)
     void updateDaemonSetEnv(String ns, String name, String containerName, String key, String value) {
         log.debug "Update env var in ${ns}/${name}/${containerName}: ${key} = ${value}"
-        withK8sClientRetry(3, 2) {
-            client.apps().daemonSets().inNamespace(ns).withName(name)
-                    .edit { d ->
-                        List<Container> containers = d.spec.template.spec.containers
-                        int containerIndex = containers.findIndexOf { it.name == containerName }
-                        if (containerIndex == -1) {
-                            throw new RuntimeException(
-                                    "Could not update env var." +
-                                    " No container named ${containerName} in ${ns}/${name}")
-                        }
-                        List<EnvVar> envVars = containers.get(containerIndex).env
-                        int index = envVars.findIndexOf { EnvVar e -> e.name == key }
-                        if (index > -1) {
-                            envVars.get(index).value = value
-                        } else {
-                            envVars.add(new EnvVarBuilder().withName(key).withValue(value).build())
-                        }
-                        new DaemonSetBuilder(d)
-                                .editSpec()
-                                .editTemplate()
-                                .editSpec()
-                                .editContainer(containerIndex)
-                                .withEnv(envVars)
-                                .endContainer()
-                                .endSpec()
-                                .endTemplate()
-                                .endSpec()
-                                .build()
+        client.apps().daemonSets().inNamespace(ns).withName(name)
+                .edit { d ->
+                    List<Container> containers = d.spec.template.spec.containers
+                    int containerIndex = containers.findIndexOf { it.name == containerName }
+                    if (containerIndex == -1) {
+                        throw new RuntimeException(
+                                "Could not update env var." +
+                                " No container named ${containerName} in ${ns}/${name}")
                     }
-        }
+                    List<EnvVar> envVars = containers.get(containerIndex).env
+                    int index = envVars.findIndexOf { EnvVar e -> e.name == key }
+                    if (index > -1) {
+                        envVars.get(index).value = value
+                    } else {
+                        envVars.add(new EnvVarBuilder().withName(key).withValue(value).build())
+                    }
+                    new DaemonSetBuilder(d)
+                            .editSpec()
+                            .editTemplate()
+                            .editSpec()
+                            .editContainer(containerIndex)
+                            .withEnv(envVars)
+                            .endContainer()
+                            .endSpec()
+                            .endTemplate()
+                            .endSpec()
+                            .build()
+                }
     }
 
     boolean deploymentReady(String ns, String name) {

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -573,66 +573,65 @@ class Kubernetes {
 
     void removeDaemonSetEnv(String ns, String name, String containerName, String key) {
         log.debug "Remove env var in ${ns}/${name}/${containerName}: ${key}"
-        List<Container> containers = client.apps().daemonSets().inNamespace(ns).withName(name).get().spec.template
-                .spec.containers
-        int containerIndex = containers.findIndexOf { it.name == containerName }
-        if (containerIndex == -1) {
-            throw new RuntimeException("Could not remove env var. No container named ${containerName} in ${ns}/${name}")
+        withK8sClientRetry(3, 2) {
+            client.apps().daemonSets().inNamespace(ns).withName(name)
+                    .edit { d ->
+                        List<Container> containers = d.spec.template.spec.containers
+                        int containerIndex = containers.findIndexOf { it.name == containerName }
+                        if (containerIndex == -1) {
+                            throw new RuntimeException(
+                                    "Could not remove env var." +
+                                    " No container named ${containerName} in ${ns}/${name}")
+                        }
+                        List<EnvVar> envVars = containers.get(containerIndex).env
+                        envVars.removeIf { EnvVar e -> e.name == key }
+                        new DaemonSetBuilder(d)
+                                .editSpec()
+                                .editTemplate()
+                                .editSpec()
+                                .editContainer(containerIndex)
+                                .withEnv(envVars)
+                                .endContainer()
+                                .endSpec()
+                                .endTemplate()
+                                .endSpec()
+                                .build()
+                    }
         }
-        List<EnvVar> envVars = containers.get(containerIndex).env
-        envVars.removeIf { EnvVar it -> it.name == key }
-
-        client.apps().daemonSets().inNamespace(ns).withName(name)
-                .edit { d ->
-                    new DaemonSetBuilder(d)
-                            .editSpec()
-                            .editTemplate()
-                            .editSpec()
-                            .editContainer(containerIndex)
-                            .withEnv(envVars)
-                            .endContainer()
-                            .endSpec()
-                            .endTemplate()
-                            .endSpec()
-                            .build()
-                }
     }
 
     void updateDaemonSetEnv(String ns, String name, String containerName, String key, String value) {
         log.debug "Update env var in ${ns}/${name}/${containerName}: ${key} = ${value}"
-        List<Container> containers = client.apps().daemonSets().inNamespace(ns).withName(name).get().spec.template
-                .spec.containers
-        int containerIndex = containers.findIndexOf { it.name == containerName }
-        if (containerIndex == -1) {
-            throw new RuntimeException("Could not update env var. No container named ${containerName} in ${ns}/${name}")
+        withK8sClientRetry(3, 2) {
+            client.apps().daemonSets().inNamespace(ns).withName(name)
+                    .edit { d ->
+                        List<Container> containers = d.spec.template.spec.containers
+                        int containerIndex = containers.findIndexOf { it.name == containerName }
+                        if (containerIndex == -1) {
+                            throw new RuntimeException(
+                                    "Could not update env var." +
+                                    " No container named ${containerName} in ${ns}/${name}")
+                        }
+                        List<EnvVar> envVars = containers.get(containerIndex).env
+                        int index = envVars.findIndexOf { EnvVar e -> e.name == key }
+                        if (index > -1) {
+                            envVars.get(index).value = value
+                        } else {
+                            envVars.add(new EnvVarBuilder().withName(key).withValue(value).build())
+                        }
+                        new DaemonSetBuilder(d)
+                                .editSpec()
+                                .editTemplate()
+                                .editSpec()
+                                .editContainer(containerIndex)
+                                .withEnv(envVars)
+                                .endContainer()
+                                .endSpec()
+                                .endTemplate()
+                                .endSpec()
+                                .build()
+                    }
         }
-        log.debug "Container ${ns}/${name}/${containerName} found on index: ${containerIndex}"
-        List<EnvVar> envVars = containers.get(containerIndex).env
-        log.debug "Current env vars of ${ns}/${name}/${containerName}: ${envVars}"
-
-        int index = envVars.findIndexOf { EnvVar it -> it.name == key }
-        if (index > -1) {
-            log.debug "Env var ${key} found on index: ${index}"
-            envVars.get(index).value = value
-        } else {
-            log.debug "Env var ${key} not found. Adding it now"
-            envVars.add(new EnvVarBuilder().withName(key).withValue(value).build())
-        }
-
-        client.apps().daemonSets().inNamespace(ns).withName(name)
-                .edit { d ->
-                    new DaemonSetBuilder(d)
-                            .editSpec()
-                            .editTemplate()
-                            .editSpec()
-                            .editContainer(containerIndex)
-                            .withEnv(envVars)
-                            .endContainer()
-                            .endSpec()
-                            .endTemplate()
-                            .endSpec()
-                            .build()
-                }
     }
 
     boolean deploymentReady(String ns, String name) {


### PR DESCRIPTION
## Description

updateDaemonSetEnv and removeDaemonSetEnv read DaemonSet state before the edit() closure, causing 409 Conflict errors when called in quick succession. Moved state reading inside the closure and added retry logic.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI on ocp-4-21-fips-qa-e2e-tests should be enough - that's where it's failing most. 
