### PR TITLE
ROX-33601: prevent concurrent roxagent scans with flock guard

### DIFF
--- a/compliance/virtualmachines/roxagent/README.md
+++ b/compliance/virtualmachines/roxagent/README.md
@@ -41,6 +41,14 @@ sudo ./roxagent --daemon --index-interval 10m --host-path /custom/path --port 20
 
 The host receives these reports and forwards them to StackRox Central for vulnerability analysis.
 
+## Single-instance protection
+
+- roxagent uses a file lock at `/run/lock/roxagent/roxagent.lock` to prevent overlapping scans on the same VM.
+- In single-scan mode, if another agent is already running, the new invocation exits with an error.
+- In daemon mode, if another agent is scanning, the current cycle is skipped and retried at the next interval.
+- If the lock cannot be acquired (permissions or missing directory), a warning is logged and the scan proceeds without protection.
+- The lock is shared between host-binary and Quadlet/Podman runs via a bind mount.
+
 ## Deployment
 
 ### Using Quadlet (Recommended for RHEL VMs)

--- a/compliance/virtualmachines/roxagent/cmd/cmd.go
+++ b/compliance/virtualmachines/roxagent/cmd/cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -93,7 +94,7 @@ func RootCmd(ctx context.Context) *cobra.Command {
 			}
 			return nil
 		case lock.Held:
-			return fmt.Errorf("roxagent is already running; exiting")
+			return errors.New("roxagent is already running; exiting")
 		case lock.Unavailable:
 			log.Warnf(
 				"could not acquire lock at %s: %v; continuing without single-instance protection; concurrent runs may cause high host load",

--- a/compliance/virtualmachines/roxagent/cmd/cmd.go
+++ b/compliance/virtualmachines/roxagent/cmd/cmd.go
@@ -84,29 +84,18 @@ func RootCmd(ctx context.Context) *cobra.Command {
 			return nil
 		}
 
-		res, release, lockErr := lock.TryLock(lock.DefaultLockPath)
-		switch res {
-		case lock.Acquired:
-			defer release()
-			if err := index.RunSingle(ctx, cfg, client); err != nil {
-				return fmt.Errorf("running indexer: %w", err)
-			}
-			return nil
-		case lock.Held:
+		scanFn := func() error { return index.RunSingle(ctx, cfg, client) }
+		onHeld := func() error {
 			return fmt.Errorf("roxagent is already running (lock file is held at %s); exiting", lock.DefaultLockPath)
-		case lock.Unavailable:
-			log.Warnf(
-				"could not acquire lock at %s: %v; continuing without single-instance protection; concurrent runs may cause high host load",
-				lock.DefaultLockPath,
-				lockErr,
-			)
-			if err := index.RunSingle(ctx, cfg, client); err != nil {
-				return fmt.Errorf("running indexer: %w", err)
-			}
-			return nil
-		default:
-			return fmt.Errorf("unexpected lock result: %d", res)
 		}
+		onUnavailable := func(lockErr error) error {
+			log.Warnf("could not acquire lock at %s: %v; continuing without single-instance protection; concurrent runs may cause high host load", lock.DefaultLockPath, lockErr)
+			return scanFn()
+		}
+		if err := lock.RunWithLock(lock.DefaultLockPath, scanFn, onHeld, onUnavailable); err != nil {
+			return fmt.Errorf("running indexer: %w", err)
+		}
+		return nil
 	}
 	return &cmd
 }

--- a/compliance/virtualmachines/roxagent/cmd/cmd.go
+++ b/compliance/virtualmachines/roxagent/cmd/cmd.go
@@ -8,8 +8,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/common"
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/index"
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/lock"
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsock"
+	"github.com/stackrox/rox/pkg/logging"
 )
+
+var log = logging.LoggerForModule()
 
 const (
 	minDaemonIndexInterval = 10 * time.Minute
@@ -74,15 +78,35 @@ func RootCmd(ctx context.Context) *cobra.Command {
 			Verbose:  cfg.Verbose,
 		}
 		if cfg.DaemonMode {
-			if err := index.RunDaemon(ctx, cfg, client); err != nil {
+			if err := index.RunDaemon(ctx, cfg, client, lock.DefaultLockPath); err != nil {
 				return fmt.Errorf("running indexer daemon: %w", err)
 			}
 			return nil
 		}
-		if err := index.RunSingle(ctx, cfg, client); err != nil {
-			return fmt.Errorf("running indexer: %w", err)
+
+		res, release, lockErr := lock.TryLock(lock.DefaultLockPath)
+		switch res {
+		case lock.Acquired:
+			defer release()
+			if err := index.RunSingle(ctx, cfg, client); err != nil {
+				return fmt.Errorf("running indexer: %w", err)
+			}
+			return nil
+		case lock.Held:
+			return fmt.Errorf("roxagent is already running; exiting")
+		case lock.Unavailable:
+			log.Warnf(
+				"could not acquire lock at %s: %v; continuing without single-instance protection; concurrent runs may cause high host load",
+				lock.DefaultLockPath,
+				lockErr,
+			)
+			if err := index.RunSingle(ctx, cfg, client); err != nil {
+				return fmt.Errorf("running indexer: %w", err)
+			}
+			return nil
+		default:
+			return fmt.Errorf("unexpected lock result: %d", res)
 		}
-		return nil
 	}
 	return &cmd
 }

--- a/compliance/virtualmachines/roxagent/cmd/cmd.go
+++ b/compliance/virtualmachines/roxagent/cmd/cmd.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -94,7 +93,7 @@ func RootCmd(ctx context.Context) *cobra.Command {
 			}
 			return nil
 		case lock.Held:
-			return errors.New("roxagent is already running; exiting")
+			return fmt.Errorf("roxagent is already running (lock file is held at %s); exiting", lock.DefaultLockPath)
 		case lock.Unavailable:
 			log.Warnf(
 				"could not acquire lock at %s: %v; continuing without single-instance protection; concurrent runs may cause high host load",

--- a/compliance/virtualmachines/roxagent/index/index.go
+++ b/compliance/virtualmachines/roxagent/index/index.go
@@ -32,7 +32,9 @@ func RunDaemon(ctx context.Context, cfg *common.Config, client *vsock.Client, lo
 		return fmt.Errorf("delaying initial index: %w", err)
 	}
 
-	if err := runSingleWithLock(ctx, cfg, client, lockPath); err != nil {
+	scanFn := func() error { return RunSingle(ctx, cfg, client) }
+
+	if err := runWithLock(lockPath, scanFn); err != nil {
 		return fmt.Errorf("handling initial index: %w", err)
 	}
 
@@ -44,19 +46,19 @@ func RunDaemon(ctx context.Context, cfg *common.Config, client *vsock.Client, lo
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if err := runSingleWithLock(ctx, cfg, client, lockPath); err != nil {
+			if err := runWithLock(lockPath, scanFn); err != nil {
 				log.Errorf("Failed to handle index: %v", err)
 			}
 		}
 	}
 }
 
-func runSingleWithLock(ctx context.Context, cfg *common.Config, client *vsock.Client, lockPath string) error {
+func runWithLock(lockPath string, scanFn func() error) error {
 	res, release, lockErr := lock.TryLock(lockPath)
 	switch res {
 	case lock.Acquired:
 		defer release()
-		return RunSingle(ctx, cfg, client)
+		return scanFn()
 	case lock.Held:
 		log.Info("roxagent scan skipped because another agent is already running")
 		return nil
@@ -68,7 +70,7 @@ func runSingleWithLock(ctx context.Context, cfg *common.Config, client *vsock.Cl
 				lockErr,
 			)
 		})
-		return RunSingle(ctx, cfg, client)
+		return scanFn()
 	default:
 		return fmt.Errorf("unexpected lock result: %d", res)
 	}

--- a/compliance/virtualmachines/roxagent/index/index.go
+++ b/compliance/virtualmachines/roxagent/index/index.go
@@ -14,12 +14,9 @@ import (
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/sync"
 )
 
 var log = logging.LoggerForModule()
-
-var daemonLockUnavailableWarnOnce sync.Once
 
 const (
 	mappingClientTimeout = 30 * time.Second
@@ -33,9 +30,16 @@ func RunDaemon(ctx context.Context, cfg *common.Config, client *vsock.Client, lo
 	}
 
 	scanFn := func() error { return RunSingle(ctx, cfg, client) }
-	tryLockFn := func() (lock.Result, func(), error) { return lock.TryLock(lockPath) }
+	onLockHeld := func() error {
+		log.Info("roxagent scan skipped because another agent is already running")
+		return nil
+	}
+	onLockUnavailable := func(lockErr error) error {
+		log.Warnf("could not acquire lock at %s: %v; continuing without single-instance protection; concurrent runs may cause high host load", lockPath, lockErr)
+		return scanFn()
+	}
 
-	if err := runWithLock(lockPath, scanFn, tryLockFn); err != nil {
+	if err := lock.RunWithLock(lockPath, scanFn, onLockHeld, onLockUnavailable); err != nil {
 		return fmt.Errorf("handling initial index: %w", err)
 	}
 
@@ -47,34 +51,10 @@ func RunDaemon(ctx context.Context, cfg *common.Config, client *vsock.Client, lo
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if err := runWithLock(lockPath, scanFn, tryLockFn); err != nil {
+			if err := lock.RunWithLock(lockPath, scanFn, onLockHeld, onLockUnavailable); err != nil {
 				log.Errorf("Failed to handle index: %v", err)
 			}
 		}
-	}
-}
-
-// tryLockFn is injected so tests can stub lock outcomes without touching the filesystem.
-func runWithLock(lockPath string, scanFn func() error, tryLockFn func() (lock.Result, func(), error)) error {
-	res, release, lockErr := tryLockFn()
-	switch res {
-	case lock.Acquired:
-		defer release()
-		return scanFn()
-	case lock.Held:
-		log.Info("roxagent scan skipped because another agent is already running")
-		return nil
-	case lock.Unavailable:
-		daemonLockUnavailableWarnOnce.Do(func() {
-			log.Warnf(
-				"could not acquire lock at %s: %v; continuing without single-instance protection; concurrent runs may cause high host load",
-				lockPath,
-				lockErr,
-			)
-		})
-		return scanFn()
-	default:
-		return fmt.Errorf("unexpected lock result: %d", res)
 	}
 }
 

--- a/compliance/virtualmachines/roxagent/index/index.go
+++ b/compliance/virtualmachines/roxagent/index/index.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/stackrox/rox/compliance/node/index"
@@ -15,6 +14,7 @@ import (
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 var log = logging.LoggerForModule()

--- a/compliance/virtualmachines/roxagent/index/index.go
+++ b/compliance/virtualmachines/roxagent/index/index.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/stackrox/rox/compliance/node/index"
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/common"
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/lock"
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/vsock"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
@@ -17,16 +19,20 @@ import (
 
 var log = logging.LoggerForModule()
 
+var daemonLockUnavailableWarnOnce sync.Once
+
 const (
 	mappingClientTimeout = 30 * time.Second
 )
 
-func RunDaemon(ctx context.Context, cfg *common.Config, client *vsock.Client) error {
+// RunDaemon runs the indexer on an interval. lockPath is used for a non-blocking exclusive flock
+// around each scan so concurrent agent processes do not overload the host.
+func RunDaemon(ctx context.Context, cfg *common.Config, client *vsock.Client, lockPath string) error {
 	if err := applyRandomDelay(ctx, cfg.MaxInitialReportDelay); err != nil {
 		return fmt.Errorf("delaying initial index: %w", err)
 	}
 
-	if err := RunSingle(ctx, cfg, client); err != nil {
+	if err := runSingleWithLock(ctx, cfg, client, lockPath); err != nil {
 		return fmt.Errorf("handling initial index: %w", err)
 	}
 
@@ -38,10 +44,33 @@ func RunDaemon(ctx context.Context, cfg *common.Config, client *vsock.Client) er
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if err := RunSingle(ctx, cfg, client); err != nil {
+			if err := runSingleWithLock(ctx, cfg, client, lockPath); err != nil {
 				log.Errorf("Failed to handle index: %v", err)
 			}
 		}
+	}
+}
+
+func runSingleWithLock(ctx context.Context, cfg *common.Config, client *vsock.Client, lockPath string) error {
+	res, release, lockErr := lock.TryLock(lockPath)
+	switch res {
+	case lock.Acquired:
+		defer release()
+		return RunSingle(ctx, cfg, client)
+	case lock.Held:
+		log.Info("roxagent scan skipped because another agent is already running")
+		return nil
+	case lock.Unavailable:
+		daemonLockUnavailableWarnOnce.Do(func() {
+			log.Warnf(
+				"could not acquire lock at %s: %v; continuing without single-instance protection; concurrent runs may cause high host load",
+				lockPath,
+				lockErr,
+			)
+		})
+		return RunSingle(ctx, cfg, client)
+	default:
+		return fmt.Errorf("unexpected lock result: %d", res)
 	}
 }
 

--- a/compliance/virtualmachines/roxagent/index/index.go
+++ b/compliance/virtualmachines/roxagent/index/index.go
@@ -33,8 +33,9 @@ func RunDaemon(ctx context.Context, cfg *common.Config, client *vsock.Client, lo
 	}
 
 	scanFn := func() error { return RunSingle(ctx, cfg, client) }
+	tryLockFn := func() (lock.Result, func(), error) { return lock.TryLock(lockPath) }
 
-	if err := runWithLock(lockPath, scanFn); err != nil {
+	if err := runWithLock(lockPath, scanFn, tryLockFn); err != nil {
 		return fmt.Errorf("handling initial index: %w", err)
 	}
 
@@ -46,15 +47,16 @@ func RunDaemon(ctx context.Context, cfg *common.Config, client *vsock.Client, lo
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ticker.C:
-			if err := runWithLock(lockPath, scanFn); err != nil {
+			if err := runWithLock(lockPath, scanFn, tryLockFn); err != nil {
 				log.Errorf("Failed to handle index: %v", err)
 			}
 		}
 	}
 }
 
-func runWithLock(lockPath string, scanFn func() error) error {
-	res, release, lockErr := lock.TryLock(lockPath)
+// tryLockFn is injected so tests can stub lock outcomes without touching the filesystem.
+func runWithLock(lockPath string, scanFn func() error, tryLockFn func() (lock.Result, func(), error)) error {
+	res, release, lockErr := tryLockFn()
 	switch res {
 	case lock.Acquired:
 		defer release()

--- a/compliance/virtualmachines/roxagent/index/index_test.go
+++ b/compliance/virtualmachines/roxagent/index/index_test.go
@@ -1,0 +1,94 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/lock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runWithLock mirrors runSingleWithLock's lock switch logic but invokes scanFn instead of RunSingle.
+func runWithLock(lockPath string, scanFn func() error) (lock.Result, error) {
+	res, release, lockErr := lock.TryLock(lockPath)
+	switch res {
+	case lock.Acquired:
+		defer release()
+		return res, scanFn()
+	case lock.Held:
+		return res, nil
+	case lock.Unavailable:
+		_ = lockErr
+		return res, scanFn()
+	default:
+		return res, fmt.Errorf("unexpected lock result: %d", res)
+	}
+}
+
+func TestRunWithLock_orchestration(t *testing.T) {
+	tests := map[string]struct {
+		setup      func(t *testing.T) (lockPath string, cleanup func())
+		assertions func(t *testing.T, scanCalled bool, res lock.Result, err error)
+	}{
+		"should run scan when lock acquired": {
+			setup: func(t *testing.T) (string, func()) {
+				return filepath.Join(t.TempDir(), "test.lock"), nil
+			},
+			assertions: func(t *testing.T, scanCalled bool, res lock.Result, err error) {
+				assert.True(t, scanCalled)
+				assert.Equal(t, lock.Acquired, res)
+				assert.NoError(t, err)
+			},
+		},
+		"should skip scan when lock already held": {
+			setup: func(t *testing.T) (string, func()) {
+				lockPath := filepath.Join(t.TempDir(), "test.lock")
+				res, release, err := lock.TryLock(lockPath)
+				require.NoError(t, err)
+				require.Equal(t, lock.Acquired, res)
+				require.NotNil(t, release)
+				return lockPath, release
+			},
+			assertions: func(t *testing.T, scanCalled bool, res lock.Result, err error) {
+				assert.False(t, scanCalled)
+				assert.Equal(t, lock.Held, res)
+				assert.NoError(t, err)
+			},
+		},
+		"should run scan in degraded mode when lock unavailable": {
+			setup: func(t *testing.T) (string, func()) {
+				roDir := filepath.Join(t.TempDir(), "readonly")
+				require.NoError(t, os.MkdirAll(roDir, 0o755))
+				require.NoError(t, os.Chmod(roDir, 0o555))
+				cleanup := func() {
+					_ = os.Chmod(roDir, 0o755)
+				}
+				return filepath.Join(roDir, "test.lock"), cleanup
+			},
+			assertions: func(t *testing.T, scanCalled bool, res lock.Result, err error) {
+				assert.True(t, scanCalled)
+				assert.Equal(t, lock.Unavailable, res)
+				assert.NoError(t, err)
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			lockPath, cleanup := tt.setup(t)
+			if cleanup != nil {
+				defer cleanup()
+			}
+
+			var scanCalled bool
+			res, err := runWithLock(lockPath, func() error {
+				scanCalled = true
+				return nil
+			})
+			tt.assertions(t, scanCalled, res, err)
+		})
+	}
+}

--- a/compliance/virtualmachines/roxagent/index/index_test.go
+++ b/compliance/virtualmachines/roxagent/index/index_test.go
@@ -1,73 +1,60 @@
 package index
 
 import (
-	"os"
-	"path/filepath"
+	"errors"
 	"testing"
 
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/lock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
+
+// stubTryLock returns a tryLockFn that always produces the given lock outcome.
+// This decouples orchestration tests from the filesystem so they work
+// identically regardless of UID (including root in CI containers).
+func stubTryLock(res lock.Result, err error) func() (lock.Result, func(), error) {
+	return func() (lock.Result, func(), error) {
+		var release func()
+		if res == lock.Acquired {
+			release = func() {}
+		}
+		return res, release, err
+	}
+}
 
 func TestRunWithLock_orchestration(t *testing.T) {
 	tests := map[string]struct {
-		setup      func(t *testing.T) (lockPath string, cleanup func())
-		assertions func(t *testing.T, scanCalled bool, err error)
+		tryLockFn  func() (lock.Result, func(), error)
+		wantScan   bool
+		wantErrMsg string
 	}{
 		"should run scan when lock acquired": {
-			setup: func(t *testing.T) (string, func()) {
-				return filepath.Join(t.TempDir(), "test.lock"), nil
-			},
-			assertions: func(t *testing.T, scanCalled bool, err error) {
-				assert.True(t, scanCalled)
-				assert.NoError(t, err)
-			},
+			tryLockFn: stubTryLock(lock.Acquired, nil),
+			wantScan:  true,
 		},
 		"should skip scan when lock already held": {
-			setup: func(t *testing.T) (string, func()) {
-				lockPath := filepath.Join(t.TempDir(), "test.lock")
-				res, release, err := lock.TryLock(lockPath)
-				require.NoError(t, err)
-				require.Equal(t, lock.Acquired, res)
-				require.NotNil(t, release)
-				return lockPath, release
-			},
-			assertions: func(t *testing.T, scanCalled bool, err error) {
-				assert.False(t, scanCalled)
-				assert.NoError(t, err)
-			},
+			tryLockFn: stubTryLock(lock.Held, nil),
+			wantScan:  false,
 		},
 		"should run scan in degraded mode when lock unavailable": {
-			setup: func(t *testing.T) (string, func()) {
-				roDir := filepath.Join(t.TempDir(), "readonly")
-				require.NoError(t, os.MkdirAll(roDir, 0o755))
-				require.NoError(t, os.Chmod(roDir, 0o555))
-				cleanup := func() {
-					_ = os.Chmod(roDir, 0o755)
-				}
-				return filepath.Join(roDir, "test.lock"), cleanup
-			},
-			assertions: func(t *testing.T, scanCalled bool, err error) {
-				assert.True(t, scanCalled)
-				assert.NoError(t, err)
-			},
+			tryLockFn: stubTryLock(lock.Unavailable, errors.New("permission denied")),
+			wantScan:  true,
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			lockPath, cleanup := tt.setup(t)
-			if cleanup != nil {
-				defer cleanup()
-			}
-
 			var scanCalled bool
-			err := runWithLock(lockPath, func() error {
+			err := runWithLock("unused", func() error {
 				scanCalled = true
 				return nil
-			})
-			tt.assertions(t, scanCalled, err)
+			}, tt.tryLockFn)
+
+			assert.Equal(t, tt.wantScan, scanCalled)
+			if tt.wantErrMsg != "" {
+				assert.ErrorContains(t, err, tt.wantErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/compliance/virtualmachines/roxagent/index/index_test.go
+++ b/compliance/virtualmachines/roxagent/index/index_test.go
@@ -1,7 +1,6 @@
 package index
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,35 +10,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// runWithLock mirrors runSingleWithLock's lock switch logic but invokes scanFn instead of RunSingle.
-func runWithLock(lockPath string, scanFn func() error) (lock.Result, error) {
-	res, release, lockErr := lock.TryLock(lockPath)
-	switch res {
-	case lock.Acquired:
-		defer release()
-		return res, scanFn()
-	case lock.Held:
-		return res, nil
-	case lock.Unavailable:
-		_ = lockErr
-		return res, scanFn()
-	default:
-		return res, fmt.Errorf("unexpected lock result: %d", res)
-	}
-}
-
 func TestRunWithLock_orchestration(t *testing.T) {
 	tests := map[string]struct {
 		setup      func(t *testing.T) (lockPath string, cleanup func())
-		assertions func(t *testing.T, scanCalled bool, res lock.Result, err error)
+		assertions func(t *testing.T, scanCalled bool, err error)
 	}{
 		"should run scan when lock acquired": {
 			setup: func(t *testing.T) (string, func()) {
 				return filepath.Join(t.TempDir(), "test.lock"), nil
 			},
-			assertions: func(t *testing.T, scanCalled bool, res lock.Result, err error) {
+			assertions: func(t *testing.T, scanCalled bool, err error) {
 				assert.True(t, scanCalled)
-				assert.Equal(t, lock.Acquired, res)
 				assert.NoError(t, err)
 			},
 		},
@@ -52,9 +33,8 @@ func TestRunWithLock_orchestration(t *testing.T) {
 				require.NotNil(t, release)
 				return lockPath, release
 			},
-			assertions: func(t *testing.T, scanCalled bool, res lock.Result, err error) {
+			assertions: func(t *testing.T, scanCalled bool, err error) {
 				assert.False(t, scanCalled)
-				assert.Equal(t, lock.Held, res)
 				assert.NoError(t, err)
 			},
 		},
@@ -68,9 +48,8 @@ func TestRunWithLock_orchestration(t *testing.T) {
 				}
 				return filepath.Join(roDir, "test.lock"), cleanup
 			},
-			assertions: func(t *testing.T, scanCalled bool, res lock.Result, err error) {
+			assertions: func(t *testing.T, scanCalled bool, err error) {
 				assert.True(t, scanCalled)
-				assert.Equal(t, lock.Unavailable, res)
 				assert.NoError(t, err)
 			},
 		},
@@ -84,11 +63,11 @@ func TestRunWithLock_orchestration(t *testing.T) {
 			}
 
 			var scanCalled bool
-			res, err := runWithLock(lockPath, func() error {
+			err := runWithLock(lockPath, func() error {
 				scanCalled = true
 				return nil
 			})
-			tt.assertions(t, scanCalled, res, err)
+			tt.assertions(t, scanCalled, err)
 		})
 	}
 }

--- a/compliance/virtualmachines/roxagent/index/index_test.go
+++ b/compliance/virtualmachines/roxagent/index/index_test.go
@@ -1,60 +1,62 @@
 package index
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stackrox/rox/compliance/virtualmachines/roxagent/lock"
 	"github.com/stretchr/testify/assert"
 )
 
-// stubTryLock returns a tryLockFn that always produces the given lock outcome.
-// This decouples orchestration tests from the filesystem so they work
-// identically regardless of UID (including root in CI containers).
-func stubTryLock(res lock.Result, err error) func() (lock.Result, func(), error) {
-	return func() (lock.Result, func(), error) {
-		var release func()
-		if res == lock.Acquired {
-			release = func() {}
-		}
-		return res, release, err
-	}
-}
-
 func TestRunWithLock_orchestration(t *testing.T) {
 	tests := map[string]struct {
-		tryLockFn  func() (lock.Result, func(), error)
+		lockResult lock.Result
 		wantScan   bool
 		wantErrMsg string
 	}{
 		"should run scan when lock acquired": {
-			tryLockFn: stubTryLock(lock.Acquired, nil),
-			wantScan:  true,
+			lockResult: lock.Acquired,
+			wantScan:   true,
 		},
 		"should skip scan when lock already held": {
-			tryLockFn: stubTryLock(lock.Held, nil),
-			wantScan:  false,
+			lockResult: lock.Held,
+			wantScan:   false,
 		},
 		"should run scan in degraded mode when lock unavailable": {
-			tryLockFn: stubTryLock(lock.Unavailable, errors.New("permission denied")),
-			wantScan:  true,
+			lockResult: lock.Unavailable,
+			wantScan:   true,
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			var scanCalled bool
-			err := runWithLock("unused", func() error {
+			scanFn := func() error {
 				scanCalled = true
 				return nil
-			}, tt.tryLockFn)
+			}
+			onHeld := func() error { return nil }
+			onUnavailable := func(_ error) error { return scanFn() }
 
-			assert.Equal(t, tt.wantScan, scanCalled)
-			if tt.wantErrMsg != "" {
-				assert.ErrorContains(t, err, tt.wantErrMsg)
-			} else {
+			lockDir := t.TempDir()
+			lockPath := lockDir + "/test.lock"
+
+			switch tt.lockResult {
+			case lock.Acquired:
+				err := lock.RunWithLock(lockPath, scanFn, onHeld, onUnavailable)
+				assert.NoError(t, err)
+			case lock.Held:
+				res, release, err := lock.TryLock(lockPath)
+				assert.Equal(t, lock.Acquired, res)
+				assert.NoError(t, err)
+				defer release()
+				err = lock.RunWithLock(lockPath, scanFn, onHeld, onUnavailable)
+				assert.NoError(t, err)
+			case lock.Unavailable:
+				err := lock.RunWithLock("/proc/not-writable/test.lock", scanFn, onHeld, onUnavailable)
 				assert.NoError(t, err)
 			}
+
+			assert.Equal(t, tt.wantScan, scanCalled)
 		})
 	}
 }

--- a/compliance/virtualmachines/roxagent/lock/lock.go
+++ b/compliance/virtualmachines/roxagent/lock/lock.go
@@ -1,0 +1,60 @@
+package lock
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// DefaultLockPath is the default path for the roxagent singleton lock file.
+const DefaultLockPath = "/run/lock/roxagent/roxagent.lock"
+
+// Result is the outcome of TryLock.
+type Result int
+
+const (
+	// Acquired means the lock was taken; the release function must be called when done.
+	Acquired Result = iota
+	// Held means another process already holds the lock (non-blocking flock would block).
+	Held
+	// Unavailable means the lock could not be used (filesystem or permission error).
+	Unavailable
+)
+
+// TryLock attempts a non-blocking exclusive flock on path.
+// The parent directory is created with mode 0755 if missing. The lock file is created with 0600 if needed.
+//
+// On Acquired, release is non-nil and closes the file descriptor (releasing the flock).
+// On Held, release and err are nil.
+// On Unavailable, release is nil and err describes the failure.
+func TryLock(path string) (Result, func(), error) {
+	if path == "" {
+		return Unavailable, nil, errors.New("lock path is empty")
+	}
+
+	parent := filepath.Dir(path)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return Unavailable, nil, err
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return Unavailable, nil, err
+	}
+
+	// On Linux, EAGAIN and EWOULDBLOCK are the same errno for flock(2) with LOCK_NB,
+	// but we check both for clarity and resilience.
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return Held, nil, nil
+		}
+		return Unavailable, nil, err
+	}
+
+	release := func() {
+		_ = f.Close()
+	}
+	return Acquired, release, nil
+}

--- a/compliance/virtualmachines/roxagent/lock/lock.go
+++ b/compliance/virtualmachines/roxagent/lock/lock.go
@@ -8,6 +8,9 @@ import (
 )
 
 // DefaultLockPath is the default path for the roxagent singleton lock file.
+// /run/lock is a tmpfs directory (per FHS) that the kernel clears on reboot,
+// ensuring no stale locks persist after crashes. The Quadlet container unit
+// bind-mounts this path so the lock coordinates host-binary and container runs.
 const DefaultLockPath = "/run/lock/roxagent/roxagent.lock"
 
 // Result is the outcome of TryLock.
@@ -45,6 +48,7 @@ func TryLock(path string) (Result, func(), error) {
 
 	// On Linux, EAGAIN and EWOULDBLOCK are the same errno for flock(2) with LOCK_NB,
 	// but we check both for clarity and resilience.
+	// Explanation: LOCK_EX is the exclusive lock, and LOCK_NB is the non-blocking flag.
 	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		_ = f.Close()
 		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
@@ -54,7 +58,31 @@ func TryLock(path string) (Result, func(), error) {
 	}
 
 	release := func() {
+		// Explicitly unlock before closing. Closing the fd alone releases the flock on Linux,
+		// but issuing LOCK_UN first is a defensive practice adopted by many projects to avoid
+		// relying solely on fd-close semantics (e.g. if the fd were accidentally dup'd).
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 		_ = f.Close()
 	}
 	return Acquired, release, nil
+}
+
+// RunWithLock acquires the lock, runs fn, and releases.
+// onHeld is called when another process holds the lock.
+// onUnavailable is called when the lock cannot be used (permissions, missing mount, etc.).
+// If onHeld or onUnavailable return a non-nil error, RunWithLock returns that error.
+// If they return nil, RunWithLock returns nil (the caller chose to skip or degrade gracefully).
+func RunWithLock(path string, fn func() error, onHeld func() error, onUnavailable func(error) error) error {
+	res, release, lockErr := TryLock(path)
+	switch res {
+	case Acquired:
+		defer release()
+		return fn()
+	case Held:
+		return onHeld()
+	case Unavailable:
+		return onUnavailable(lockErr)
+	default:
+		return errors.New("unexpected lock result")
+	}
 }

--- a/compliance/virtualmachines/roxagent/lock/lock_test.go
+++ b/compliance/virtualmachines/roxagent/lock/lock_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTryLock_shouldAcquireLockOnValidTempPath(t *testing.T) {
+func TestTryLock_shouldAcquireAndReacquireAfterRelease(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "test.lock")
 	res, release, err := TryLock(lockPath)
 	require.NoError(t, err)
@@ -37,21 +37,6 @@ func TestTryLock_shouldReportHeldWhenLockAlreadyAcquired(t *testing.T) {
 	require.NoError(t, err2)
 	assert.Equal(t, Held, res2)
 	assert.Nil(t, release2)
-}
-
-func TestTryLock_shouldReleaseLockWhenReleaseFunctionCalled(t *testing.T) {
-	lockPath := filepath.Join(t.TempDir(), "test.lock")
-	res, release, err := TryLock(lockPath)
-	require.NoError(t, err)
-	require.Equal(t, Acquired, res)
-	require.NotNil(t, release)
-	release()
-
-	res2, release2, err2 := TryLock(lockPath)
-	require.NoError(t, err2)
-	assert.Equal(t, Acquired, res2)
-	require.NotNil(t, release2)
-	release2()
 }
 
 func TestTryLock_shouldCreateParentDirectoryIfMissing(t *testing.T) {

--- a/compliance/virtualmachines/roxagent/lock/lock_test.go
+++ b/compliance/virtualmachines/roxagent/lock/lock_test.go
@@ -1,0 +1,114 @@
+package lock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTryLock_shouldAcquireLockOnValidTempPath(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "test.lock")
+	res, release, err := TryLock(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, Acquired, res)
+	require.NotNil(t, release)
+
+	release()
+
+	res2, release2, err2 := TryLock(lockPath)
+	require.NoError(t, err2)
+	assert.Equal(t, Acquired, res2)
+	require.NotNil(t, release2)
+	release2()
+}
+
+func TestTryLock_shouldReportHeldWhenLockAlreadyAcquired(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "test.lock")
+	res1, release1, err1 := TryLock(lockPath)
+	require.NoError(t, err1)
+	require.Equal(t, Acquired, res1)
+	require.NotNil(t, release1)
+	defer release1()
+
+	res2, release2, err2 := TryLock(lockPath)
+	require.NoError(t, err2)
+	assert.Equal(t, Held, res2)
+	assert.Nil(t, release2)
+}
+
+func TestTryLock_shouldReleaseLockWhenReleaseFunctionCalled(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "test.lock")
+	res, release, err := TryLock(lockPath)
+	require.NoError(t, err)
+	require.Equal(t, Acquired, res)
+	require.NotNil(t, release)
+	release()
+
+	res2, release2, err2 := TryLock(lockPath)
+	require.NoError(t, err2)
+	assert.Equal(t, Acquired, res2)
+	require.NotNil(t, release2)
+	release2()
+}
+
+func TestTryLock_shouldCreateParentDirectoryIfMissing(t *testing.T) {
+	tmp := t.TempDir()
+	lockPath := filepath.Join(tmp, "subdir", "test.lock")
+	parent := filepath.Join(tmp, "subdir")
+
+	_, err := os.Stat(parent)
+	require.True(t, os.IsNotExist(err), "parent must not exist before TryLock")
+
+	res, release, err := TryLock(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, Acquired, res)
+	require.NotNil(t, release)
+	release()
+
+	info, err := os.Stat(parent)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestTryLock_invalidInputs(t *testing.T) {
+	tests := map[string]struct {
+		lockPath  string
+		setup     func(t *testing.T) string
+		errSubstr string
+	}{
+		"should report unavailable for empty path": {
+			lockPath:  "",
+			errSubstr: "lock path is empty",
+		},
+		"should report unavailable for unwritable parent": {
+			setup: func(t *testing.T) string {
+				roDir := filepath.Join(t.TempDir(), "readonly")
+				require.NoError(t, os.MkdirAll(roDir, 0o755))
+				require.NoError(t, os.Chmod(roDir, 0o555))
+				t.Cleanup(func() {
+					_ = os.Chmod(roDir, 0o755)
+				})
+				return filepath.Join(roDir, "test.lock")
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := tt.lockPath
+			if tt.setup != nil {
+				path = tt.setup(t)
+			}
+			res, release, err := TryLock(path)
+			assert.Equal(t, Unavailable, res)
+			assert.Nil(t, release)
+			require.Error(t, err)
+			if tt.errSubstr != "" {
+				assert.ErrorContains(t, err, tt.errSubstr)
+			}
+		})
+	}
+}

--- a/compliance/virtualmachines/roxagent/lock/lock_test.go
+++ b/compliance/virtualmachines/roxagent/lock/lock_test.go
@@ -61,39 +61,28 @@ func TestTryLock_shouldCreateParentDirectoryIfMissing(t *testing.T) {
 func TestTryLock_invalidInputs(t *testing.T) {
 	tests := map[string]struct {
 		lockPath  string
-		setup     func(t *testing.T) string
 		errSubstr string
 	}{
 		"should report unavailable for empty path": {
 			lockPath:  "",
 			errSubstr: "lock path is empty",
 		},
-		"should report unavailable for unwritable parent": {
-			setup: func(t *testing.T) string {
-				roDir := filepath.Join(t.TempDir(), "readonly")
-				require.NoError(t, os.MkdirAll(roDir, 0o755))
-				require.NoError(t, os.Chmod(roDir, 0o555))
-				t.Cleanup(func() {
-					_ = os.Chmod(roDir, 0o755)
-				})
-				return filepath.Join(roDir, "test.lock")
-			},
+		"should report unavailable when parent is not a directory": {
+			// /dev/null is a character device, not a directory. MkdirAll fails
+			// with ENOTDIR even when running as root, unlike chmod-based tests
+			// where root bypasses permission checks.
+			lockPath:  "/dev/null/test.lock",
+			errSubstr: "not a directory",
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			path := tt.lockPath
-			if tt.setup != nil {
-				path = tt.setup(t)
-			}
-			res, release, err := TryLock(path)
+			res, release, err := TryLock(tt.lockPath)
 			assert.Equal(t, Unavailable, res)
 			assert.Nil(t, release)
 			require.Error(t, err)
-			if tt.errSubstr != "" {
-				assert.ErrorContains(t, err, tt.errSubstr)
-			}
+			assert.ErrorContains(t, err, tt.errSubstr)
 		})
 	}
 }

--- a/compliance/virtualmachines/roxagent/quadlet/README.md
+++ b/compliance/virtualmachines/roxagent/quadlet/README.md
@@ -164,6 +164,17 @@ sudo journalctl -u roxagent.service
 2. Check compliance container logs in the collector pod
 3. Verify Sensor can reach Central
 
+### Agent reports lock warning
+
+If logs show `could not acquire lock at /run/lock/roxagent/roxagent.lock`, verify the lock directory exists and is writable:
+
+```bash
+ls -la /run/lock/roxagent/
+sudo mkdir -p /run/lock/roxagent
+```
+
+The install script creates this directory automatically. If it was removed (e.g., after a reboot on systems where `/run` is tmpfs), re-run `install.sh` or create it manually.
+
 ## Uninstallation
 
 ```bash

--- a/compliance/virtualmachines/roxagent/quadlet/README.md
+++ b/compliance/virtualmachines/roxagent/quadlet/README.md
@@ -13,6 +13,7 @@ This deployment uses [Podman Quadlet](https://docs.podman.io/en/latest/markdown/
 | `roxagent.container` | Quadlet container unit that runs roxagent |
 | `roxagent.timer` | Systemd timer that triggers hourly scans |
 | `roxagent-prep.service` | Prepares RPM database for scanning |
+| `roxagent-tmpfiles.conf` | Recreates `/run/lock/roxagent` on boot |
 | `install.sh` | Installation script for local or remote deployment |
 
 ## Prerequisites
@@ -173,7 +174,11 @@ ls -la /run/lock/roxagent/
 sudo mkdir -p /run/lock/roxagent
 ```
 
-The install script creates this directory automatically. If it was removed (e.g., after a reboot on systems where `/run` is tmpfs), re-run `install.sh` or create it manually.
+The install script creates this directory immediately and installs a `tmpfiles.d`
+rule so it is recreated automatically on boot. The prep service also runs
+`mkdir -p /run/lock/roxagent` before every scan as an extra safeguard. If the
+directory was removed manually while the system is running, re-run `install.sh`
+or create it manually.
 
 ## Uninstallation
 
@@ -182,5 +187,6 @@ sudo systemctl disable --now roxagent.timer
 sudo rm /etc/containers/systemd/roxagent.container
 sudo rm /etc/systemd/system/roxagent.timer
 sudo rm /etc/systemd/system/roxagent-prep.service
+sudo rm /etc/tmpfiles.d/roxagent.conf
 sudo systemctl daemon-reload
 ```

--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -13,11 +13,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 install_locally() {
     echo "Installing Quadlet units locally..."
 
-    sudo mkdir -p /run/lock/roxagent
-
     # Quadlet container file
     sudo mkdir -p /etc/containers/systemd/
     sudo cp "${SCRIPT_DIR}/roxagent.container" /etc/containers/systemd/
+    # restorecon resets SELinux labels so systemd/podman can read the new files.
     sudo restorecon -Rv /etc/containers/systemd/ 2>/dev/null || true
 
     # Timer and prep service go in standard systemd directory
@@ -29,6 +28,7 @@ install_locally() {
     sudo mkdir -p /etc/tmpfiles.d/
     sudo cp "${SCRIPT_DIR}/roxagent-tmpfiles.conf" /etc/tmpfiles.d/roxagent.conf
     sudo restorecon -Rv /etc/tmpfiles.d/roxagent.conf 2>/dev/null || true
+    # systemd-tmpfiles --create applies the rule now (creates /run/lock/roxagent immediately).
     sudo systemd-tmpfiles --create /etc/tmpfiles.d/roxagent.conf
 
     echo "Reloading systemd..."
@@ -55,11 +55,10 @@ install_remote() {
 
     # Install on remote
     ssh -p "${SSH_PORT}" "${REMOTE_HOST}" << 'EOF'
-        sudo mkdir -p /run/lock/roxagent
-
         # Quadlet container file
         sudo mkdir -p /etc/containers/systemd/
         sudo mv /tmp/roxagent.container /etc/containers/systemd/
+        # restorecon resets SELinux labels so systemd/podman can read the new files.
         sudo restorecon -Rv /etc/containers/systemd/ 2>/dev/null || true
 
         # Timer and prep service go in standard systemd directory
@@ -71,6 +70,7 @@ install_remote() {
         sudo mkdir -p /etc/tmpfiles.d/
         sudo mv /tmp/roxagent-tmpfiles.conf /etc/tmpfiles.d/roxagent.conf
         sudo restorecon -Rv /etc/tmpfiles.d/roxagent.conf 2>/dev/null || true
+        # systemd-tmpfiles --create applies the rule now (creates /run/lock/roxagent immediately).
         sudo systemd-tmpfiles --create /etc/tmpfiles.d/roxagent.conf
 
         echo "Reloading systemd..."

--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -25,6 +25,12 @@ install_locally() {
     sudo cp "${SCRIPT_DIR}/roxagent-prep.service" /etc/systemd/system/
     sudo restorecon -Rv /etc/systemd/system/roxagent.timer /etc/systemd/system/roxagent-prep.service 2>/dev/null || true
 
+    # Recreate the lock directory on every boot since /run is tmpfs.
+    sudo mkdir -p /etc/tmpfiles.d/
+    sudo cp "${SCRIPT_DIR}/roxagent-tmpfiles.conf" /etc/tmpfiles.d/roxagent.conf
+    sudo restorecon -Rv /etc/tmpfiles.d/roxagent.conf 2>/dev/null || true
+    sudo systemd-tmpfiles --create /etc/tmpfiles.d/roxagent.conf
+
     echo "Reloading systemd..."
     sudo systemctl daemon-reload
 
@@ -45,6 +51,7 @@ install_remote() {
     scp -P "${SSH_PORT}" "${SCRIPT_DIR}/roxagent.container" "${REMOTE_HOST}:/tmp/"
     scp -P "${SSH_PORT}" "${SCRIPT_DIR}/roxagent.timer" "${REMOTE_HOST}:/tmp/"
     scp -P "${SSH_PORT}" "${SCRIPT_DIR}/roxagent-prep.service" "${REMOTE_HOST}:/tmp/"
+    scp -P "${SSH_PORT}" "${SCRIPT_DIR}/roxagent-tmpfiles.conf" "${REMOTE_HOST}:/tmp/"
 
     # Install on remote
     ssh -p "${SSH_PORT}" "${REMOTE_HOST}" << 'EOF'
@@ -59,6 +66,12 @@ install_remote() {
         sudo mv /tmp/roxagent.timer /etc/systemd/system/
         sudo mv /tmp/roxagent-prep.service /etc/systemd/system/
         sudo restorecon -Rv /etc/systemd/system/roxagent.timer /etc/systemd/system/roxagent-prep.service 2>/dev/null || true
+
+        # Recreate the lock directory on every boot since /run is tmpfs.
+        sudo mkdir -p /etc/tmpfiles.d/
+        sudo mv /tmp/roxagent-tmpfiles.conf /etc/tmpfiles.d/roxagent.conf
+        sudo restorecon -Rv /etc/tmpfiles.d/roxagent.conf 2>/dev/null || true
+        sudo systemd-tmpfiles --create /etc/tmpfiles.d/roxagent.conf
 
         echo "Reloading systemd..."
         sudo systemctl daemon-reload

--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -13,6 +13,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 install_locally() {
     echo "Installing Quadlet units locally..."
 
+    sudo mkdir -p /run/lock/roxagent
+
     # Quadlet container file
     sudo mkdir -p /etc/containers/systemd/
     sudo cp "${SCRIPT_DIR}/roxagent.container" /etc/containers/systemd/
@@ -46,6 +48,8 @@ install_remote() {
 
     # Install on remote
     ssh -p "${SSH_PORT}" "${REMOTE_HOST}" << 'EOF'
+        sudo mkdir -p /run/lock/roxagent
+
         # Quadlet container file
         sudo mkdir -p /etc/containers/systemd/
         sudo mv /tmp/roxagent.container /etc/containers/systemd/

--- a/compliance/virtualmachines/roxagent/quadlet/roxagent-prep.service
+++ b/compliance/virtualmachines/roxagent/quadlet/roxagent-prep.service
@@ -6,6 +6,7 @@ Description=Prepare RPM database for StackRox VM Agent
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+ExecStartPre=/bin/mkdir -p /run/lock/roxagent
 ExecStart=/bin/rm -rf /tmp/roxagent-rpm
 ExecStart=/bin/cp -a /var/lib/rpm /tmp/roxagent-rpm
 ExecStart=/bin/chmod -R 755 /tmp/roxagent-rpm

--- a/compliance/virtualmachines/roxagent/quadlet/roxagent-tmpfiles.conf
+++ b/compliance/virtualmachines/roxagent/quadlet/roxagent-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /run/lock/roxagent 0755 root root -

--- a/compliance/virtualmachines/roxagent/quadlet/roxagent.container
+++ b/compliance/virtualmachines/roxagent/quadlet/roxagent.container
@@ -6,7 +6,8 @@ After=roxagent-prep.service
 
 [Container]
 # Replace with your StackRox main image tag
-Image=quay.io/stackrox-io/main:4.10.x-697-g3c843a274f
+Image=quay.io/stackrox-io/main:4.11.x-798-g8a5ad6ed58
+Pull=missing
 Exec=--host-path /host
 Network=host
 

--- a/compliance/virtualmachines/roxagent/quadlet/roxagent.container
+++ b/compliance/virtualmachines/roxagent/quadlet/roxagent.container
@@ -31,7 +31,8 @@ Volume=/run/lock/roxagent:/run/lock/roxagent:rw
 
 [Service]
 Type=oneshot
-TimeoutStartSec=300
+# First start can take longer on slow VMs
+TimeoutStartSec=600
 
 [Install]
 WantedBy=

--- a/compliance/virtualmachines/roxagent/quadlet/roxagent.container
+++ b/compliance/virtualmachines/roxagent/quadlet/roxagent.container
@@ -25,6 +25,8 @@ Volume=/etc/system-release-cpe:/host/etc/system-release-cpe:ro
 # DNF cache and state for repo-to-package mapping
 Volume=/var/cache/dnf:/host/var/cache/dnf:ro
 Volume=/var/lib/dnf:/host/var/lib/dnf:ro
+# Single-instance lock shared between host and container roxagent runs
+Volume=/run/lock/roxagent:/run/lock/roxagent:rw
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
## Description

When multiple `roxagent` instances run simultaneously on the same VM (e.g. timer-triggered Quadlet + manual troubleshooting run), they compete for CPU and filesystem I/O during host indexing, inflating scan duration and producing noisy performance data.

This adds a non-blocking `flock`-based guard at `/run/lock/roxagent/roxagent.lock` so only one scan executes at a time:

- **One-shot mode**: acquires the lock for the full scan/send lifecycle. If another agent holds it, exits immediately with an error.
- **Daemon mode**: acquires the lock per scan cycle. If contended, skips the cycle and retries at the next interval.
- **Lock unavailable** (permissions, missing mount): logs a loud warning and proceeds without protection so the feature keeps working even if the Quadlet bind mount is misconfigured.

The Quadlet container unit bind-mounts `/run/lock/roxagent` so the lock coordinates host-binary and Podman-based runs on the same VM.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

#### Manual tests on a VM (using binary):

✅ all passing

1:
```shell
# Hold the lock in background, then try to run the agent
sudo mkdir -p /run/lock/roxagent
sudo flock -xn /run/lock/roxagent/roxagent.lock -c "sleep 30" &
FLOCK_PID=$!

sudo /home/cloud-user/vm-agent-amd64 --port 818 --host-path /tmp/roxroot
# Expected: error mentioning "roxagent is already running"

kill $FLOCK_PID 2>/dev/null; wait $FLOCK_PID 2>/dev/null
```

2:
```shell
sudo /home/cloud-user/vm-agent-amd64 --port 818 --host-path /tmp/roxroot
# Expected: scans and sends (or fails to connect to vsock, but no lock error)
```

3:
```shell
# Session 1:
sudo /home/cloud-user/vm-agent-amd64 --port 818 --host-path /tmp/roxroot &
AGENT_PID=$!

# Session 2 (run ~1s later):
sudo /home/cloud-user/vm-agent-amd64 --port 818 --host-path /tmp/roxroot
# Expected: "roxagent is already running" error

wait $AGENT_PID
```

4:
```shell
# Make the lock FILE itself read-only on a read-only bind mount
sudo mkdir -p /run/lock/roxagent
sudo touch /run/lock/roxagent/roxagent.lock
sudo mount --bind /run/lock/roxagent /run/lock/roxagent
sudo mount -o remount,ro,bind /run/lock/roxagent

sudo /home/cloud-user/vm-agent-amd64 --port 818 --host-path /tmp/roxroot
# Expected: warning about lock unavailable, then proceeds with scan

# Cleanup
sudo umount /run/lock/roxagent
sudo rm -rf /run/lock/roxagent
sudo mkdir -p /run/lock/roxagent
sudo chmod 755 /run/lock/roxagent
```

5:
```shell
sudo /home/cloud-user/vm-agent-amd64 --port 818 --host-path /tmp/roxroot
# After it exits:
flock -xn /run/lock/roxagent/roxagent.lock -c "echo 'lock is free'"
# Expected: "lock is free"
```

#### Manual tests using Quadlet and to confirm that the `/run/lock/roxagent` gets created automatically:

0 (setup VM):
```
# From your dev machine, copy all quadlet files to the VM
virtctl scp -n openshift-cnv \
    compliance/virtualmachines/roxagent/quadlet/install.sh \
    cloud-user@vmi/rhel10-1:/tmp/

# Make sure that `Image=` has the correct tag!
virtctl scp -n openshift-cnv \
    compliance/virtualmachines/roxagent/quadlet/roxagent.container \
    cloud-user@vmi/rhel10-1:/tmp/

virtctl scp -n openshift-cnv \
    compliance/virtualmachines/roxagent/quadlet/roxagent.timer \
    cloud-user@vmi/rhel10-1:/tmp/

virtctl scp -n openshift-cnv \
    compliance/virtualmachines/roxagent/quadlet/roxagent-prep.service \
    cloud-user@vmi/rhel10-1:/tmp/

virtctl scp -n openshift-cnv \
    compliance/virtualmachines/roxagent/quadlet/roxagent-tmpfiles.conf \
    cloud-user@vmi/rhel10-1:/tmp/

virtctl ssh -n openshift-cnv cloud-user@vmi/rhel10-1

# On the VM:
cd /tmp && sudo bash install.sh
```

1:
```
# Run the install script
cd /tmp && sudo bash install.sh

# Verify the tmpfiles rule is in place
cat /etc/tmpfiles.d/roxagent.conf
# Expected: d /run/lock/roxagent 0755 root root -

# Verify the directory was created
ls -ld /run/lock/roxagent
# Expected: drwxr-xr-x root root /run/lock/roxagent
```

2 - simulate reboot:

```
# Remove the lock dir (simulates what a reboot does to tmpfs)
sudo rm -rf /run/lock/roxagent

# Verify it's gone
ls /run/lock/roxagent 2>&1
# Expected: No such file or directory

# Manually trigger what systemd does on boot
sudo systemd-tmpfiles --create

# Verify it came back
ls -ld /run/lock/roxagent
# Expected: drwxr-xr-x root root /run/lock/roxagent
```

3 - execute true reboot:

```
# Reboot the VM
sudo reboot
```

after the VM is up again:

```
# Check the lock directory exists (created by tmpfiles.d rule at boot)
ls -ld /run/lock/roxagent
# Expected: drwxr-xr-x root root /run/lock/roxagent

# Check the timer is active
sudo systemctl list-timers roxagent.timer
# Expected: timer listed and active

# Trigger a manual run through Quadlet
sudo systemctl start roxagent.service

# Check the logs
sudo journalctl -u roxagent.service --no-pager -n 30
# Expected: scan runs successfully, no lock warnings
```


4:

```
# Hold the lock from the host while Quadlet tries to run
sudo flock -xn /run/lock/roxagent/roxagent.lock -c "sleep 60" &
FLOCK_PID=$!

# Trigger the container run
sudo systemctl start roxagent.service     # this may take very long as the main image must be pulled to the VM

# Check logs — should show "roxagent is already running" or scan skipped
sudo journalctl -u roxagent.service --no-pager -n 10

kill $FLOCK_PID; wait $FLOCK_PID 2>/dev/null
```