### PR TITLE
chore(scanner): migrate logging to slog and zlog/v2

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -54,8 +54,8 @@ jobs:
     - name: Create artifacts dir
       run: mkdir -p "$ARTIFACT_DIR"
 
-    - name: Cache Go dependencies
-      uses: ./.github/actions/cache-go-dependencies
+#    - name: Cache Go dependencies
+#      uses: ./.github/actions/cache-go-dependencies
 
     - name: Download scanner module for proto generation
       run: go mod download github.com/stackrox/scanner
@@ -159,8 +159,8 @@ jobs:
           xmlstarlet --version
           pycodestyle --version
 
-      - name: Cache Go dependencies
-        uses: ./.github/actions/cache-go-dependencies
+#      - name: Cache Go dependencies
+#        uses: ./.github/actions/cache-go-dependencies
 
       - name: Download scanner module for proto generation
         run: go mod download github.com/stackrox/scanner

--- a/.github/workflows/test-bundle-helpers.yaml
+++ b/.github/workflows/test-bundle-helpers.yaml
@@ -86,8 +86,7 @@ jobs:
       - name: Override GOTOOLCHAIN
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
-      - name: Cache Go dependencies
-        uses: ./.github/actions/cache-go-dependencies
+#      - name: Cache Go dependencies
 
       - name: Generate bundle with Python
         env:
@@ -142,8 +141,8 @@ jobs:
       - name: Override GOTOOLCHAIN
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
-      - name: Cache Go dependencies
-        uses: ./.github/actions/cache-go-dependencies
+#      - name: Cache Go dependencies
+#        uses: ./.github/actions/cache-go-dependencies
 
       - name: Run Go unit tests
         run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -56,10 +56,10 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         free-disk-space: 30
 
-    - name: Cache Go dependencies
-      uses: ./.github/actions/cache-go-dependencies
-      with:
-        key-suffix: ${{ matrix.gotags }}
+#    - name: Cache Go dependencies
+#      uses: ./.github/actions/cache-go-dependencies
+#      with:
+#        key-suffix: ${{ matrix.gotags }}
 
     - name: Go Unit Tests
       run: ${{ matrix.gotags }} make go-unit-tests

--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -19,8 +19,6 @@ import (
 	ccindexer "github.com/quay/claircore/indexer"
 	"github.com/quay/claircore/indexer/controller"
 	"github.com/quay/claircore/rhel"
-	"github.com/quay/zlog"
-	"github.com/rs/zerolog"
 	"github.com/stackrox/rox/compliance/node"
 	"github.com/stackrox/rox/compliance/utils"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
@@ -32,7 +30,6 @@ import (
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/urlfmt"
 	pkgutils "github.com/stackrox/rox/pkg/utils"
-	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -47,15 +44,7 @@ const (
 )
 
 var (
-	log          = logging.LoggerForModule()
-	zerologLevel = map[zapcore.Level]zerolog.Level{
-		zapcore.DebugLevel: zerolog.DebugLevel,
-		zapcore.InfoLevel:  zerolog.InfoLevel,
-		zapcore.WarnLevel:  zerolog.WarnLevel,
-		zapcore.ErrorLevel: zerolog.ErrorLevel,
-		zapcore.PanicLevel: zerolog.PanicLevel,
-		zapcore.FatalLevel: zerolog.FatalLevel,
-	}
+	log = logging.LoggerForModule()
 
 	// layerDigest is a dummy digest solely meant as a workaround to use Claircore.
 	// Claircore indexing requires layers to have a digest, which is not stored,
@@ -67,17 +56,6 @@ var (
 	defaultClient    *http.Client
 	defaultClientErr error
 )
-
-func init() {
-	// Default to info level.
-	logLevel := zerolog.InfoLevel
-	if level, ok := zerologLevel[logging.GetGlobalLogLevel()]; ok {
-		logLevel = level
-	}
-	l := zerolog.New(os.Stderr).
-		Level(logLevel)
-	zlog.Set(&l)
-}
 
 func getDefaultClient() (*http.Client, error) {
 	clientOnce.Do(func() {

--- a/go.mod
+++ b/go.mod
@@ -111,9 +111,8 @@ require (
 	github.com/prometheus/common v0.67.5
 	github.com/quay/claircore v1.5.53-0.20260402203018-c2f0b781a39b
 	github.com/quay/claircore/toolkit v1.6.0
-	github.com/quay/zlog v1.1.9
+	github.com/quay/zlog/v2 v2.1.1
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319
-	github.com/rs/zerolog v1.35.1
 	github.com/russellhaering/gosaml2 v0.11.0
 	github.com/russellhaering/goxmldsig v1.6.0
 	github.com/segmentio/analytics-go/v3 v3.3.0

--- a/go.sum
+++ b/go.sum
@@ -1299,8 +1299,8 @@ github.com/quay/claircore/updater/driver v1.0.0 h1:w7dAUjO3GBK6RjNyTZ2Kwz0l/Wuic
 github.com/quay/claircore/updater/driver v1.0.0/go.mod h1:My5aY1wBpgxcWaHQZ0VoPmmj/EzuH7fq4ntzJbos4OI=
 github.com/quay/goval-parser v0.8.8 h1:Uf+f9iF2GIR5GPUY2pGoa9il2+4cdES44ZlM0mWm4cA=
 github.com/quay/goval-parser v0.8.8/go.mod h1:Y0NTNfPYOC7yxsYKzJOrscTWUPq1+QbtHw4XpPXWPMc=
-github.com/quay/zlog v1.1.9 h1:O9/vfCUcGGUs0ukqQ77xPCJBPqpZBJ00jt7IUMsRco8=
-github.com/quay/zlog v1.1.9/go.mod h1:O7OCW9oe7igrswhjKlyOvTo2+6FPsV7L0/owWEX6JHE=
+github.com/quay/zlog/v2 v2.1.1 h1:rGzC4IA1Km2JfF9LENRalWdiavPUFwSn9M5TfMaC6rc=
+github.com/quay/zlog/v2 v2.1.1/go.mod h1:+FmBwcNIbXOKRWfaIqHGPF+g9WW4hn+OiomLN7eC/dM=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.5.3 h1:1/BDligzCa40GTllkDnY3Y5DTHuKCONbB2JcRyIfl20=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.5.3/go.mod h1:3dZmcLn3Qw6FLlWASn1g4y+YO9ycEFUOM+bhBmzLVKQ=
 github.com/redis/go-redis/extra/redisotel/v9 v9.5.3 h1:kuvuJL/+MZIEdvtb/kTBRiRgYaOmx1l+lYJyVdrRUOs=
@@ -1316,8 +1316,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=
-github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
 github.com/rubenv/sql-migrate v1.8.1 h1:EPNwCvjAowHI3TnZ+4fQu3a915OpnQoPAjTXCGOy2U0=
 github.com/rubenv/sql-migrate v1.8.1/go.mod h1:BTIKBORjzyxZDS6dzoiw6eAFYJ1iNlGAtjn4LGeVjS8=
 github.com/russellhaering/gosaml2 v0.11.0 h1:wlWm7dWMrpJBzh0xEOZof70nVen4f/2BEF8ZXaidJ9o=

--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -5,13 +5,14 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/toolkit/log"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/clientconn"
 	"github.com/stackrox/rox/pkg/env"
@@ -256,12 +257,7 @@ func (c *gRPCScanner) GetImageIndex(ctx context.Context, hashID string, callOpts
 		return nil, false, errIndexerNotConfigured
 	}
 
-	ctx = zlog.ContextWithValues(ctx,
-		"component", "scanner/client",
-		"method", "GetImageIndex",
-		"hash_id", hashID,
-	)
-
+	ctx = log.With(ctx, "method", "GetImageIndex", "hash_id", hashID)
 	options := makeCallOptions(callOpts...)
 
 	return c.getImageIndex(ctx, hashID, options)
@@ -273,12 +269,7 @@ func (c *gRPCScanner) GetOrCreateImageIndex(ctx context.Context, ref name.Digest
 		return nil, errIndexerNotConfigured
 	}
 
-	ctx = zlog.ContextWithValues(ctx,
-		"component", "scanner/client",
-		"method", "GetOrCreateImageIndex",
-		"image", ref.String(),
-	)
-
+	ctx = log.With(ctx, "method", "GetOrCreateImageIndex", "image", ref.String())
 	options := makeCallOptions(callOpts...)
 
 	return c.getOrCreateImageIndex(ctx, ref, auth, opt, options)
@@ -294,12 +285,7 @@ func (c *gRPCScanner) IndexAndScanImage(ctx context.Context, ref name.Digest, au
 		return nil, errMatcherNotConfigured
 	}
 
-	ctx = zlog.ContextWithValues(ctx,
-		"component", "scanner/client",
-		"method", "IndexAndScanImage",
-		"image", ref.String(),
-	)
-
+	ctx = log.With(ctx, "method", "IndexAndScanImage", "image", ref.String())
 	options := makeCallOptions(callOpts...)
 
 	ir, err := c.getOrCreateImageIndex(ctx, ref, auth, opt, options)
@@ -377,12 +363,7 @@ func (c *gRPCScanner) GetVulnerabilities(ctx context.Context, ref name.Digest, c
 		return nil, errMatcherNotConfigured
 	}
 
-	ctx = zlog.ContextWithValues(ctx,
-		"component", "scanner/client",
-		"method", "GetVulnerabilities",
-		"image", ref.String(),
-	)
-
+	ctx = log.With(ctx, "method", "GetVulnerabilities", "image", ref.String())
 	options := makeCallOptions(callOpts...)
 
 	return c.getVulnerabilities(ctx, getImageManifestID(ref), contents, options)
@@ -410,8 +391,7 @@ func (c *gRPCScanner) GetMatcherMetadata(ctx context.Context, callOpts ...CallOp
 		return nil, errMatcherNotConfigured
 	}
 
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/client", "method", "GetMatcherMetadata")
-
+	ctx = log.With(ctx, "method", "GetMatcherMetadata")
 	options := makeCallOptions(callOpts...)
 
 	var m *v4.Metadata
@@ -437,8 +417,7 @@ func (c *gRPCScanner) StoreImageIndex(ctx context.Context, ref name.Digest, inde
 		return errIndexerNotConfigured
 	}
 
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/client", "method", "StoreImageIndex")
-
+	ctx = log.With(ctx, "method", "StoreImageIndex", "image", ref.String())
 	req := &v4.StoreIndexReportRequest{
 		HashId:         getImageManifestID(ref),
 		IndexerVersion: indexerVersion,
@@ -453,7 +432,7 @@ func (c *gRPCScanner) StoreImageIndex(ctx context.Context, ref name.Digest, inde
 	if err != nil {
 		return fmt.Errorf("storing external index report: %w", err)
 	}
-	zlog.Debug(ctx).Err(err).Str("status", r.GetStatus()).Msg("received response from StoreIndexReport")
+	slog.DebugContext(ctx, "received response from StoreIndexReport", "status", r.GetStatus())
 
 	return nil
 }
@@ -465,7 +444,6 @@ func getImageManifestID(ref name.Digest) string {
 // retryWithBackoff is a utility function to wrap backoff.Retry to handle common
 // retryable gRPC codes.
 func retryWithBackoff(ctx context.Context, b backoff.BackOff, rpc string, op backoff.Operation) error {
-	ctx = zlog.ContextWithValues(ctx, "rpc", rpc)
 	f := func() error {
 		err := op()
 		if e, ok := status.FromError(err); ok {
@@ -480,7 +458,7 @@ func retryWithBackoff(ctx context.Context, b backoff.BackOff, rpc string, op bac
 		return err
 	}
 	return backoff.RetryNotify(f, backoff.WithContext(b, ctx), func(err error, duration time.Duration) {
-		zlog.Debug(ctx).Err(err).Dur("duration", duration).Msg("retrying gRPC call")
+		slog.DebugContext(ctx, "retrying gRPC call", "rpc", rpc, "reason", err, "duration", duration)
 	})
 }
 

--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"regexp"
 	"slices"
@@ -20,7 +21,6 @@ import (
 	"github.com/quay/claircore/rhel/rhcc"
 	"github.com/quay/claircore/rhel/vex"
 	"github.com/quay/claircore/toolkit/types/cpe"
-	"github.com/quay/zlog"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
@@ -614,13 +614,12 @@ func toProtoV4VulnerabilitiesMap(
 		}
 		metrics, err := cvssMetrics(ctx, v, name, &nvdVuln, csafAdvisory)
 		if err != nil {
-			zlog.Debug(ctx).
-				Err(err).
-				Str("vuln_id", v.ID).
-				Str("vuln_name", v.Name).
-				Str("vuln_updater", v.Updater).
-				Str("severity", v.Severity).
-				Msg("missing severity and/or CVSS score(s): proceeding with partial values")
+			slog.DebugContext(ctx, "missing severity and/or CVSS score(s): proceeding with partial values",
+				"vuln_id", v.ID,
+				"vuln_name", v.Name,
+				"vuln_updater", v.Updater,
+				"severity", v.Severity,
+				"reason", err)
 		}
 		var preferredCVSS *v4.VulnerabilityReport_Vulnerability_CVSS
 		if len(metrics) > 0 {
@@ -647,18 +646,15 @@ func toProtoV4VulnerabilitiesMap(
 		}
 		issued := issuedTime(vulnPublished, nvdVuln.Published)
 		if issued == nil {
-			zlog.Warn(ctx).
-				Str("vuln_id", v.ID).
-				Str("vuln_name", v.Name).
-				Str("vuln_updater", v.Updater).
-				Bool("feature_rh_cves_enabled", features.ScannerV4RedHatCVEs.Enabled()).
-				Bool("csaf_advisory_exists", csafAdvisoryExists).
-				// Use Str instead of Time because the latter will format the time into
-				// RFC3339 form, which may not be valid for this.
-				Str("csaf_advisory_release_date", csafAdvisory.ReleaseDate.String()).
-				Str("claircore_issued", v.Issued.String()).
-				Str("nvd_published", nvdVuln.Published).
-				Msg("issued time invalid: leaving empty")
+			slog.WarnContext(ctx, "issued time invalid: leaving empty",
+				"vuln_id", v.ID,
+				"vuln_name", v.Name,
+				"vuln_updater", v.Updater,
+				"feature_rh_cves_enabled", features.ScannerV4RedHatCVEs.Enabled(),
+				"csaf_advisory_exists", csafAdvisoryExists,
+				"csaf_advisory_release_date", csafAdvisory.ReleaseDate.String(),
+				"claircore_issued", v.Issued.String(),
+				"nvd_published", nvdVuln.Published)
 		}
 
 		fixed := fixedTime(csafAdvisory)
@@ -743,9 +739,8 @@ func toProtoV4VulnerabilitySeverity(ctx context.Context, ccSeverity claircore.Se
 	if mappedSeverity, ok := severityMapping[ccSeverity]; ok {
 		return mappedSeverity
 	}
-	zlog.Warn(ctx).
-		Str("claircore_severity", ccSeverity.String()).
-		Msgf("unknown ClairCore severity, mapping to %s", v4.VulnerabilityReport_Vulnerability_SEVERITY_UNSPECIFIED.String())
+	slog.WarnContext(ctx, "unknown Claircore severity, mapping to UNSPECIFIED",
+		"claircore_severity", ccSeverity.String())
 	return v4.VulnerabilityReport_Vulnerability_SEVERITY_UNSPECIFIED
 }
 
@@ -762,9 +757,8 @@ func toProtoV4VulnerabilitySeverityFromString(ctx context.Context, severity stri
 	case strings.EqualFold("critical", severity):
 		return v4.VulnerabilityReport_Vulnerability_SEVERITY_CRITICAL
 	default:
-		zlog.Warn(ctx).
-			Str("severity_string", severity).
-			Msgf("unknown severity, mapping to %s", v4.VulnerabilityReport_Vulnerability_SEVERITY_UNSPECIFIED.String())
+		slog.WarnContext(ctx, "unknown severity, mapping to UNSPECIFIED",
+			"severity_string", severity)
 		return v4.VulnerabilityReport_Vulnerability_SEVERITY_UNSPECIFIED
 	}
 }
@@ -1011,7 +1005,8 @@ func redhatCSAFAdvisories(ctx context.Context, enrichments map[string][]json.Raw
 	ret := make(map[string]csaf.Advisory)
 	for id, records := range items {
 		if len(records) != 1 {
-			zlog.Warn(ctx).Str("vuln_id", id).Msgf("unexpected number of CSAF enrichment records than expected (%d != 1)", len(records))
+			slog.WarnContext(ctx, "unexpected number of CSAF enrichment records",
+				"vuln_id", id, "count", len(records))
 		}
 		if len(records) == 0 {
 			// Unexpected, but ok... Ignore this.
@@ -1020,7 +1015,7 @@ func redhatCSAFAdvisories(ctx context.Context, enrichments map[string][]json.Raw
 		record := records[0]
 		if record.Name == "" {
 			// Unexpected, but ok... Ignore this.
-			zlog.Warn(ctx).Str("vuln_id", id).Msg("advisory incomplete")
+			slog.WarnContext(ctx, "advisory incomplete", "vuln_id", id)
 			continue
 		}
 		ret[id] = records[0]
@@ -1173,9 +1168,8 @@ func pkgFixedBy(enrichments map[string][]json.RawMessage) (map[string]string, er
 func cveEPSS(ctx context.Context, enrichments map[string][]json.RawMessage) (map[string]map[string]*epss.EPSSItem, error) {
 	enrichmentList := enrichments[epss.Type]
 	if len(enrichmentList) == 0 {
-		zlog.Warn(ctx).
-			Str("enrichments", epss.Type).
-			Msg("No EPSS enrichments found. Verify that the vulnerability enrichment data is available and complete.")
+		slog.WarnContext(ctx, "No EPSS enrichments found. Verify that the vulnerability enrichment data is available and complete.",
+			"enrichments", epss.Type)
 		return nil, nil
 	}
 
@@ -1187,9 +1181,8 @@ func cveEPSS(ctx context.Context, enrichments map[string][]json.RawMessage) (map
 	}
 
 	if len(epssItems) == 0 {
-		zlog.Warn(ctx).
-			Str("enrichments", epss.Type).
-			Msg("No EPSS enrichments found. Verify that the vulnerability enrichment data is available and complete.")
+		slog.WarnContext(ctx, "No EPSS enrichments found. Verify that the vulnerability enrichment data is available and complete.",
+			"enrichments", epss.Type)
 		return nil, nil
 	}
 

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -1,7 +1,6 @@
 package mappers
 
 import (
-	"context"
 	"slices"
 	"strings"
 	"testing"
@@ -10,6 +9,7 @@ import (
 	nvdschema "github.com/facebookincubator/nvdtools/cveapi/nvd/schema"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/enricher/epss"
+	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/toolkit/types/cpe"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/features"
@@ -299,9 +299,9 @@ func Test_ToProtoV4VulnerabilityReport(t *testing.T) {
 			wantErr: "",
 		},
 	}
-	ctx := context.Background()
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := test.Logging(t)
 			got, err := ToProtoV4VulnerabilityReport(ctx, tt.arg)
 			if tt.wantErr == "" {
 				assert.NoError(t, err)
@@ -451,9 +451,9 @@ func Test_ToProtoV4VulnerabilityReport_FilterNodeJS(t *testing.T) {
 			wantErr: "",
 		},
 	}
-	ctx := context.Background()
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := test.Logging(t)
 			got, err := ToProtoV4VulnerabilityReport(ctx, tt.arg)
 			if tt.wantErr == "" {
 				assert.NoError(t, err)
@@ -785,9 +785,9 @@ func TestToProtoV4VulnerabilityReport_FilterRHCCLayers(t *testing.T) {
 			wantErr: "",
 		},
 	}
-	ctx := context.Background()
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := test.Logging(t)
 			got, err := ToProtoV4VulnerabilityReport(ctx, tt.arg)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
@@ -1565,9 +1565,9 @@ func Test_toProtoV4VulnerabilitiesMapWithEPSS(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := test.Logging(t)
 			enableRedHatCVEs := "false"
 			t.Setenv(features.ScannerV4RedHatCVEs.EnvVar(), enableRedHatCVEs)
 			got, err := toProtoV4VulnerabilitiesMap(ctx, tt.ccVulnerabilities, tt.nvdVulns, tt.epssItems, nil)
@@ -2374,9 +2374,9 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 			},
 		},
 	}
-	ctx := context.Background()
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := test.Logging(t)
 			enableRedHatCVEs := "false"
 			if tt.enableRedHatCVEs {
 				enableRedHatCVEs = "true"
@@ -2391,7 +2391,7 @@ func Test_toProtoV4VulnerabilitiesMap(t *testing.T) {
 }
 
 func Test_convertToNormalizedSeverity(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	// Check all severities can be mapped.
 	for i := 0; i <= int(claircore.Critical); i++ {
 		ccS := claircore.Severity(i)

--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -5,15 +5,13 @@ import (
 	"flag"
 	"fmt"
 	golog "log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"time"
 
-	"github.com/quay/zlog"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/continuousprofiling"
 	"github.com/stackrox/rox/pkg/env"
@@ -85,15 +83,14 @@ func main() {
 	}
 
 	if err := continuousprofiling.SetupClient(continuousprofiling.DefaultConfig()); err != nil {
-		zlog.Error(ctx).Err(err).Msg("unable to start continuous profiling")
+		slog.ErrorContext(ctx, "unable to start continuous profiling", "reason", err)
 	}
 
-	ctx = zlog.ContextWithValues(ctx, "component", "main")
-	zlog.Info(ctx).Str("version", version.Version).Str("build_flavor", buildinfo.BuildFlavor).Msg("starting scanner")
+	slog.InfoContext(ctx, "starting scanner", "version", version.Version, "build_flavor", buildinfo.BuildFlavor)
 
 	// If certs was specified, configure the identity environment.
 	if p := cfg.MTLS.CertsDir; p != "" {
-		zlog.Info(ctx).Str("certs_prefix", p).Msg("identity certificates filename prefix changed")
+		slog.InfoContext(ctx, "identity certificates filename prefix changed", "certs_prefix", p)
 		utils.CrashOnError(os.Setenv(mtls.CAFileEnvName, filepath.Join(p, mtls.CACertFileName)))
 		utils.CrashOnError(os.Setenv(mtls.CAKeyFileEnvName, filepath.Join(p, mtls.CAKeyFileName)))
 		utils.CrashOnError(os.Setenv(mtls.CertFilePathEnvName, filepath.Join(p, mtls.ServiceCertFileName)))
@@ -102,10 +99,7 @@ func main() {
 
 	//  If proxy path is set, periodically check for updates.
 	if cfg.Proxy.ConfigDir != "" {
-		zlog.Info(ctx).
-			Str("dir", cfg.Proxy.ConfigDir).
-			Str("file", cfg.Proxy.ConfigFile).
-			Msg("proxy configured")
+		slog.InfoContext(ctx, "proxy configured", "dir", cfg.Proxy.ConfigDir, "file", cfg.Proxy.ConfigFile)
 		proxy.WatchProxyConfig(ctx, cfg.Proxy.ConfigDir, cfg.Proxy.ConfigFile, true)
 	}
 
@@ -119,16 +113,16 @@ func main() {
 	// Create backends.
 	backends, err := createBackends(ctx, cfg)
 	if err != nil {
-		zlog.Error(ctx).Err(err).Msg("failed to create backends")
+		slog.ErrorContext(ctx, "failed to create backends", "reason", err)
 		os.Exit(1)
 	}
 	defer backends.Close(ctx)
-	zlog.Info(ctx).Msg("backends created")
+	slog.InfoContext(ctx, "backends created")
 
 	// Initialize gRPC API service.
 	grpcSrv, err := createGRPCService(backends, cfg)
 	if err != nil {
-		zlog.Error(ctx).Err(err).Msg("failed to initialize gRPC")
+		slog.ErrorContext(ctx, "failed to initialize gRPC", "reason", err)
 		os.Exit(1)
 	}
 	grpcSrv.Start()
@@ -138,24 +132,19 @@ func main() {
 	sigC := make(chan os.Signal, 1)
 	signal.Notify(sigC, unix.SIGINT, unix.SIGTERM)
 	sig := <-sigC
-	zlog.Info(ctx).Str("signal", sig.String()).Send()
+	slog.InfoContext(ctx, "signal received", "signal", sig.String())
 }
 
-// initializeLogging Initialize zerolog and Quay's zlog.
-func initializeLogging(logLevel zerolog.Level) error {
+func initializeLogging(logLevel slog.Level) error {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return err
 	}
-	logger := zerolog.New(os.Stdout).
-		Level(logLevel).
-		With().
-		Timestamp().
-		Str("host", hostname).
-		Logger()
-	zlog.Set(&logger)
-	// Disable the default zerolog logger.
-	log.Logger = zerolog.Nop()
+	h := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	})
+	logger := slog.New(h).With("host", hostname)
+	slog.SetDefault(logger)
 	return nil
 }
 
@@ -224,19 +213,19 @@ func createBackends(ctx context.Context, cfg *config.Config) (*Backends, error) 
 	var b Backends
 	var err error
 	if cfg.Indexer.Enable {
-		zlog.Info(ctx).Msg("indexer is enabled")
+		slog.InfoContext(ctx, "indexer is enabled")
 		b.Indexer, err = indexer.NewIndexer(ctx, cfg.Indexer)
 		if err != nil {
 			return nil, fmt.Errorf("indexer: %w", err)
 		}
 	} else {
-		zlog.Info(ctx).Msg("indexer is disabled")
+		slog.InfoContext(ctx, "indexer is disabled")
 	}
 	if cfg.Matcher.Enable {
-		zlog.Info(ctx).Msg("matcher is enabled")
+		slog.InfoContext(ctx, "matcher is enabled")
 		if cfg.Matcher.RemoteIndexerEnabled {
 			// Create a remote indexer only if the matcher was configured to use one.
-			zlog.Info(ctx).Msg("remote indexer is enabled")
+			slog.InfoContext(ctx, "remote indexer is enabled")
 			b.RemoteIndexer, err = indexer.NewRemoteIndexer(ctx, cfg.Matcher.IndexerAddr)
 			if err != nil {
 				return nil, fmt.Errorf("matcher: remote indexer: %w", err)
@@ -247,7 +236,7 @@ func createBackends(ctx context.Context, cfg *config.Config) (*Backends, error) 
 			return nil, fmt.Errorf("matcher: %w", err)
 		}
 	} else {
-		zlog.Info(ctx).Msg("matcher is disabled")
+		slog.InfoContext(ctx, "matcher is disabled")
 	}
 	return &b, nil
 }
@@ -282,7 +271,7 @@ func (b *Backends) HealthCheck(ctx context.Context) bool {
 	}
 	for _, check := range checkList {
 		if err := check(ctx); err != nil {
-			zlog.Error(ctx).Err(err).Msg("scanner is not ready")
+			slog.ErrorContext(ctx, "scanner is not ready", "reason", err)
 			return false
 		}
 	}
@@ -325,7 +314,7 @@ func (b *Backends) Close(ctx context.Context) {
 		if backend.instance != nil {
 			err := backend.instance.Close(ctx)
 			if err != nil {
-				zlog.Error(ctx).Err(err).Msgf("closing %s", backend.name)
+				slog.ErrorContext(ctx, "error closing backend", "backend", backend.name, "reason", err)
 			}
 		}
 	}

--- a/scanner/cmd/scanner/main.go
+++ b/scanner/cmd/scanner/main.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/quay/claircore/toolkit/log"
+	"github.com/quay/zlog/v2"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/continuousprofiling"
 	"github.com/stackrox/rox/pkg/env"
@@ -140,8 +142,10 @@ func initializeLogging(logLevel slog.Level) error {
 	if err != nil {
 		return err
 	}
-	h := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: logLevel,
+	h := zlog.NewHandler(os.Stdout, &zlog.Options{
+		Level:      logLevel,
+		ContextKey: log.AttrsKey,
+		LevelKey:   log.LevelKey,
 	})
 	logger := slog.New(h).With("host", hostname)
 	slog.SetDefault(logger)

--- a/scanner/cmd/updater/main.go
+++ b/scanner/cmd/updater/main.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"time"
 
-	"github.com/quay/zlog"
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/scanner/internal/version"
 	"github.com/stackrox/rox/scanner/updater"
@@ -48,19 +48,17 @@ func main() {
 			}
 			const retries = 3
 			for attempt := 1; attempt <= retries; attempt++ {
-				zlog.Info(ctx).
-					Int("attempt", attempt).
-					Str("manual vulns URL", manualURL).
-					Str("output directory", outputDir).
-					Msg("exporting vulnerabilities")
+				slog.InfoContext(ctx, "exporting vulnerabilities",
+					"attempt", attempt,
+					"manual_vulns_url", manualURL,
+					"output_directory", outputDir)
 				err := tryExport(ctx, outputDir, &updater.ExportOptions{ManualVulnURL: manualURL})
 				if err != nil {
 					if errors.Is(err, context.DeadlineExceeded) {
-						zlog.Warn(ctx).
-							Err(err).
-							Int("attempt", attempt).
-							Int("retries", retries).
-							Msg("export failed; will retry if within retry limits")
+						slog.WarnContext(ctx, "export failed; will retry if within retry limits",
+							"reason", err,
+							"attempt", attempt,
+							"retries", retries)
 						continue
 					}
 					return fmt.Errorf("data export failed: %w", err)

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"log/slog"
 	"net"
 	"net/url"
 	"os"
@@ -16,7 +17,6 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/mitchellh/mapstructure"
-	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/utils"
@@ -64,7 +64,7 @@ var (
 		Proxy: ProxyConfig{
 			ConfigFile: "config.yaml",
 		},
-		LogLevel: zerolog.InfoLevel,
+		LogLevel: slog.LevelInfo,
 	}
 )
 
@@ -78,7 +78,7 @@ type Config struct {
 	GRPCListenAddr   string        `mapstructure:"grpc_listen_addr"`
 	MTLS             MTLSConfig    `mapstructure:"mtls"`
 	Proxy            ProxyConfig   `mapstructure:"proxy"`
-	LogLevel         zerolog.Level `mapstructure:"log_level"`
+	LogLevel         slog.Level    `mapstructure:"log_level"`
 }
 
 func (c *Config) validate() error {
@@ -372,17 +372,16 @@ func (c *ProxyConfig) validate() error {
 	return nil
 }
 
-// LogLevel is YAML serializable zerolog.Level
-type LogLevel zerolog.Level
+// LogLevel is YAML serializable slog.Level
+type LogLevel slog.Level
 
 // UnmarshalText implements YAML's TextUnmarshaler for LogLevel
 func (l *LogLevel) UnmarshalText(level []byte) error {
-	levelS := string(level)
-	zl, err := zerolog.ParseLevel(levelS)
+	sl, err := parseSlogLevel(string(level))
 	if err != nil {
-		return fmt.Errorf("unknown log_level string: %q", levelS)
+		return err
 	}
-	*l = LogLevel(zl)
+	*l = LogLevel(sl)
 	return nil
 }
 
@@ -400,9 +399,26 @@ func (d *Duration) UnmarshalText(dBytes []byte) error {
 	return nil
 }
 
-// stringToZeroLogLevelFunc returns a DecodeHookFunc that converts
-// strings to zerolog.Level
-func stringToZeroLogLevelFunc() mapstructure.DecodeHookFunc {
+func parseSlogLevel(s string) (slog.Level, error) {
+	switch strings.ToLower(s) {
+	case "trace", "debug":
+		return slog.LevelDebug, nil
+	case "info", "":
+		return slog.LevelInfo, nil
+	case "warn", "warning":
+		return slog.LevelWarn, nil
+	case "error", "fatal", "panic":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("unknown log_level string: %q", s)
+	}
+}
+
+// stringToSlogLevelFunc returns a DecodeHookFunc that converts
+// strings to slog.Level. This hook is used with mapstructure to enable
+// automatic conversion of string log level values in configuration files
+// to slog.Level types during unmarshaling.
+func stringToSlogLevelFunc() mapstructure.DecodeHookFunc {
 	return func(
 		f reflect.Type,
 		t reflect.Type,
@@ -410,10 +426,10 @@ func stringToZeroLogLevelFunc() mapstructure.DecodeHookFunc {
 		if f.Kind() != reflect.String {
 			return data, nil
 		}
-		if t != reflect.TypeOf(zerolog.InfoLevel) {
+		if t != reflect.TypeOf(slog.LevelInfo) {
 			return data, nil
 		}
-		return zerolog.ParseLevel(data.(string))
+		return parseSlogLevel(data.(string))
 	}
 }
 
@@ -446,7 +462,7 @@ func Load(r io.Reader) (*Config, error) {
 	if err := v.UnmarshalExact(&cfg, viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),
-		stringToZeroLogLevelFunc(),
+		stringToSlogLevelFunc(),
 	))); err != nil {
 		return nil, fmt.Errorf("loading config file: %w", err)
 	}

--- a/scanner/config/config.go
+++ b/scanner/config/config.go
@@ -415,9 +415,7 @@ func parseSlogLevel(s string) (slog.Level, error) {
 }
 
 // stringToSlogLevelFunc returns a DecodeHookFunc that converts
-// strings to slog.Level. This hook is used with mapstructure to enable
-// automatic conversion of string log level values in configuration files
-// to slog.Level types during unmarshaling.
+// strings to slog.Level.
 func stringToSlogLevelFunc() mapstructure.DecodeHookFunc {
 	return func(
 		f reflect.Type,

--- a/scanner/datastore/postgres/connect.go
+++ b/scanner/datastore/postgres/connect.go
@@ -2,11 +2,11 @@ package postgres
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/quay/claircore/datastore/postgres"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/retry"
 )
 
@@ -31,9 +31,9 @@ func Connect(ctx context.Context, connString string, applicationName string) (*p
 	err = retry.WithRetry(func() error {
 		return pool.Ping(ctx)
 	}, retry.Tries(connTries), retry.OnFailedAttempts(func(err error) {
-		zlog.Error(ctx).Err(err).Msg("failed to connect to postgres database")
+		slog.ErrorContext(ctx, "failed to connect to postgres database", "reason", err)
 	}), retry.BetweenAttempts(func(previousAttemptNumber int) {
-		zlog.Warn(ctx).Int("attempt", previousAttemptNumber+1).Msg("retrying connection to postgres database")
+		slog.WarnContext(ctx, "retrying connection to postgres database", "attempt", previousAttemptNumber+1)
 		time.Sleep(interval)
 	}))
 	if err != nil {

--- a/scanner/datastore/postgres/distributions.go
+++ b/scanner/datastore/postgres/distributions.go
@@ -3,10 +3,10 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"regexp"
 
 	"github.com/quay/claircore"
-	"github.com/quay/zlog"
 )
 
 // rhelCPE represents the expected pattern to identify a CPE which indicates a RHEL major version.
@@ -17,7 +17,6 @@ var rhelCPE = regexp.MustCompile(`^cpe:2\.3:o:redhat:enterprise_linux:(\d+)(?:\.
 //
 // A distribution is considered known if there exists at least one row in the vuln table which references it.
 func (m *matcherStore) Distributions(ctx context.Context) ([]claircore.Distribution, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/distributions/Distributions")
 
 	// As of ClairCore v1.5.29, all distributions may be identified by dist_id, dist_version_id, and dist_version except for RHEL.
 	// As of this version of ClairCore, RHEL vulnerabilities are not associated with a specific RHEL version, but rather just the CPE(s).
@@ -50,7 +49,7 @@ func (m *matcherStore) Distributions(ctx context.Context) ([]claircore.Distribut
 		if repoName != "" {
 			dist, err = rhelDist(repoName)
 			if err != nil {
-				zlog.Warn(ctx).Err(err).Msg("failed to parse repo_name; skipping...")
+				slog.WarnContext(ctx, "failed to parse repo_name; skipping...", "reason", err)
 				continue
 			}
 		}

--- a/scanner/datastore/postgres/distributions_test.go
+++ b/scanner/datastore/postgres/distributions_test.go
@@ -3,16 +3,16 @@
 package postgres
 
 import (
-	"context"
 	"testing"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDistributions(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	pool := testDB(t, ctx, "distributions_test")
 	store, err := InitPostgresMatcherStore(ctx, pool, true)
 	require.NoError(t, err)

--- a/scanner/datastore/postgres/external_index_report.go
+++ b/scanner/datastore/postgres/external_index_report.go
@@ -3,12 +3,12 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/pkg/errors"
 	"github.com/quay/claircore"
-	"github.com/quay/zlog"
 )
 
 // ErrDidNotUpdateRow indicates the row was not updated.
@@ -27,12 +27,6 @@ func (e *externalIndexStore) StoreIndexReport(
 	expiration time.Time,
 	shouldUpdateStoredReportFn func(iv string) bool,
 ) error {
-	ctx = zlog.ContextWithValues(
-		ctx,
-		"component",
-		"datastore/postgres/externalIndexStore.StoreIndexReport",
-	)
-
 	const selectIndexReport = `
 		SELECT indexer_version FROM external_index_report
 		WHERE hash_id = $1 FOR UPDATE`
@@ -79,8 +73,6 @@ func (e *externalIndexStore) StoreIndexReport(
 }
 
 func (e *externalIndexStore) GetIndexReport(ctx context.Context, hashID string) (*claircore.IndexReport, bool, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/externalIndexStore.GetIndexReport")
-
 	const selectIndexReport = `
 		SELECT index_report FROM external_index_report
 			WHERE hash_id = $1`
@@ -106,12 +98,6 @@ func (e *externalIndexStore) GCIndexReports(
 ) ([]string, error) {
 	o := makeReindexGCOpts(opts)
 
-	ctx = zlog.ContextWithValues(
-		ctx,
-		"component",
-		"datastore/postgres/externalIndexStore.GCIndexReports",
-	)
-
 	const deleteIndexReports = `
 		DELETE FROM external_index_report
 		WHERE hash_id IN (
@@ -132,7 +118,7 @@ func (e *externalIndexStore) GCIndexReports(
 	}
 	defer func() {
 		if commitErr := tx.Commit(ctx); commitErr != nil && !errors.Is(commitErr, pgx.ErrTxClosed) {
-			zlog.Warn(ctx).Err(commitErr).Msg("failed to commit GCIndexReports transaction")
+			slog.WarnContext(ctx, "failed to commit GCIndexReports transaction", "reason", commitErr)
 		}
 	}()
 
@@ -146,7 +132,7 @@ func (e *externalIndexStore) GCIndexReports(
 	for rows.Next() {
 		var hashID string
 		if err := rows.Scan(&hashID); err != nil {
-			zlog.Warn(ctx).Err(err).Msg("scanning deleted external index report row")
+			slog.WarnContext(ctx, "scanning deleted external index report row", "reason", err)
 			continue
 		}
 		deletedHashes = append(deletedHashes, hashID)

--- a/scanner/datastore/postgres/external_index_report_test.go
+++ b/scanner/datastore/postgres/external_index_report_test.go
@@ -3,17 +3,17 @@
 package postgres
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_ExternalIndexReport_GCIndexReports(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	pool := testDB(t, ctx, "external_index_report_test")
 	store, err := InitPostgresExternalIndexStore(ctx, pool, true)
 	require.NoError(t, err)

--- a/scanner/datastore/postgres/manifest_metadata.go
+++ b/scanner/datastore/postgres/manifest_metadata.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/quay/claircore"
-	"github.com/quay/zlog"
 )
 
 func (i *indexerMetadataStore) MigrateManifests(ctx context.Context, expiration time.Time) ([]string, error) {
@@ -17,8 +17,6 @@ func (i *indexerMetadataStore) MigrateManifests(ctx context.Context, expiration 
 	if i.store == nil {
 		return nil, errors.New("indexer store not defined")
 	}
-
-	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/indexerMetadataStore.MigrateManifests")
 
 	// insertMissingManifests inserts missing manifests from the manifest table into manifest_metadata,
 	// and it sets the expiration time to the given expiration.
@@ -40,7 +38,7 @@ func (i *indexerMetadataStore) MigrateManifests(ctx context.Context, expiration 
 	for rows.Next() {
 		var manifestID string
 		if err := rows.Scan(&manifestID); err != nil {
-			zlog.Warn(ctx).Err(err).Msg("scanning manifest row")
+			slog.WarnContext(ctx, "scanning manifest row", "reason", err)
 			continue
 		}
 		missingManifests = append(missingManifests, manifestID)
@@ -53,8 +51,6 @@ func (i *indexerMetadataStore) MigrateManifests(ctx context.Context, expiration 
 }
 
 func (i *indexerMetadataStore) StoreManifest(ctx context.Context, manifestID string, expiration time.Time) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/indexerMetadataStore.StoreManifest")
-
 	// insertManifest inserts the metadata into manifest_metadata, overwriting the previous expiration, if it exists.
 	const insertManifest = `
 		INSERT INTO manifest_metadata (manifest_id, expiration) VALUES
@@ -70,8 +66,6 @@ func (i *indexerMetadataStore) StoreManifest(ctx context.Context, manifestID str
 }
 
 func (i *indexerMetadataStore) ManifestExists(ctx context.Context, manifestID string) (bool, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/indexerMetadataStore.ManifestExists")
-
 	// selectManifest returns 1 if the given manifest exists in the table.
 	// If it does not exist, then no rows will be returned.
 	const selectManifest = `SELECT 1 FROM manifest_metadata WHERE manifest_id = $1`
@@ -92,8 +86,6 @@ func (i *indexerMetadataStore) ManifestExists(ctx context.Context, manifestID st
 
 func (i *indexerMetadataStore) GCManifests(ctx context.Context, expiration time.Time, opts ...ReindexGCOption) ([]string, error) {
 	o := makeReindexGCOpts(opts)
-
-	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/indexerMetadataStore.GCManifests")
 
 	const deleteManifests = `
 		DELETE FROM manifest_metadata
@@ -121,7 +113,7 @@ func (i *indexerMetadataStore) GCManifests(ctx context.Context, expiration time.
 	for rows.Next() {
 		var manifestID string
 		if err := rows.Scan(&manifestID); err != nil {
-			zlog.Warn(ctx).Err(err).Msg("scanning deleted manifest metadata row")
+			slog.WarnContext(ctx, "scanning deleted manifest metadata row", "reason", err)
 			continue
 		}
 		deletedManifests = append(deletedManifests, manifestID)
@@ -148,9 +140,9 @@ func (i *indexerMetadataStore) GCManifests(ctx context.Context, expiration time.
 			for _, d := range deletedDigs {
 				digs = append(digs, d.String())
 			}
-			zlog.Debug(ctx).Strs("deleted_manifests", digs).Msg("deleted manifests")
+			slog.DebugContext(ctx, "deleted manifests", "deleted_manifests", digs)
 		}
-		zlog.Info(ctx).Int("deleted_manifests", len(deletedDigs)).Msg("deleted manifests")
+		slog.InfoContext(ctx, "deleted manifests", "deleted_manifests", len(deletedDigs))
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/scanner/datastore/postgres/manifest_metadata_test.go
+++ b/scanner/datastore/postgres/manifest_metadata_test.go
@@ -3,18 +3,18 @@
 package postgres
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/datastore/postgres"
+	"github.com/quay/claircore/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_ManifestMetadata_MigrateManifests(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	pool := testDB(t, ctx, "manifest_metadata_migrate_manifests_test")
 	ccStore, err := postgres.InitPostgresIndexerStore(ctx, pool, true)
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func Test_ManifestMetadata_MigrateManifests(t *testing.T) {
 }
 
 func Test_ManifestMetadata(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	pool := testDB(t, ctx, "manifest_metadata_test")
 	store, err := InitPostgresIndexerMetadataStore(ctx, pool, true, IndexerMetadataStoreOpts{})
 	require.NoError(t, err)

--- a/scanner/datastore/postgres/vuln_update.go
+++ b/scanner/datastore/postgres/vuln_update.go
@@ -3,10 +3,10 @@ package postgres
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/quay/zlog"
 )
 
 // GetLastVulnerabilityUpdate implements MatcherMetadataStore.GetLastVulnerabilityUpdate.
@@ -85,7 +85,6 @@ func (m *matcherMetadataStore) GetOrSetLastVulnerabilityUpdate(ctx context.Conte
 // Removes all entries for inactive vulnerability bundles that are older than the
 // last know update.
 func (m *matcherMetadataStore) GCVulnerabilityUpdates(ctx context.Context, activeUpdaters []string, lastUpdate time.Time) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/matcherMetadataStore.GCVulnerabilityUpdates")
 	const deleteUnknownAndInactive = `
 		DELETE FROM last_vuln_update
 		WHERE NOT key = ANY($1) AND update_timestamp < $2
@@ -100,16 +99,16 @@ func (m *matcherMetadataStore) GCVulnerabilityUpdates(ctx context.Context, activ
 		var deletedRow string
 		err := rows.Scan(&deletedRow)
 		if err != nil {
-			zlog.Warn(ctx).Err(err).Msg("scanning deleted row")
+			slog.WarnContext(ctx, "scanning deleted row", "reason", err)
 			continue
 		}
 		deletedRows = append(deletedRows, deletedRow)
 	}
 	if err := rows.Err(); err != nil {
-		zlog.Warn(ctx).Err(err).Msg("reading deleted rows")
+		slog.WarnContext(ctx, "reading deleted rows", "reason", err)
 	}
 	if len(deletedRows) > 0 {
-		zlog.Info(ctx).Strs("deleted_bundles", deletedRows).Msg("deleted inactive vulnerability bundle(s)")
+		slog.InfoContext(ctx, "deleted inactive vulnerability bundle(s)", "deleted_bundles", deletedRows)
 	}
 	return nil
 }

--- a/scanner/datastore/postgres/vuln_update_test.go
+++ b/scanner/datastore/postgres/vuln_update_test.go
@@ -3,16 +3,16 @@
 package postgres
 
 import (
-	"context"
 	"testing"
 	"time"
 
+	"github.com/quay/claircore/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestVulnUpdateStore(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	pool := testDB(t, ctx, "vuln_update_test")
 	store, err := InitPostgresMatcherMetadataStore(ctx, pool, true)
 	require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestVulnUpdateStore(t *testing.T) {
 }
 
 func Test_CleanVulnerabilityUpdates(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	pool := testDB(t, ctx, "vuln_update_test")
 	store, err := InitPostgresMatcherMetadataStore(ctx, pool, true)
 	require.NoError(t, err)

--- a/scanner/enricher/csaf/csaf.go
+++ b/scanner/enricher/csaf/csaf.go
@@ -8,13 +8,14 @@ package csaf
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/toolkit/log"
 	"github.com/stackrox/rox/pkg/scannerv4/enricher/csaf"
 	"github.com/stackrox/rox/pkg/scannerv4/mappers"
 )
@@ -92,8 +93,6 @@ func (*Enricher) Name() string {
 // For each vulnerability in the report, determine if there is a Red Hat advisory associated with it and map that vulnerability
 // to the advisory's data, if applicable.
 func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *claircore.VulnerabilityReport) (string, []json.RawMessage, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "enricher/csaf/Enricher/Enrich")
-
 	m := make(map[string][]json.RawMessage)
 
 	erCache := make(map[string][]driver.EnrichmentRecord)
@@ -105,7 +104,7 @@ func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *cla
 			// Skipping...
 			continue
 		}
-		ctx := zlog.ContextWithValues(ctx, "original_vuln", v.Name, "advisory", advisoryName)
+		vulnCtx := log.With(ctx, "original_vuln", v.Name, "advisory", advisoryName)
 		rec, ok := erCache[advisoryName]
 		if !ok {
 			ts := []string{advisoryName}
@@ -116,9 +115,7 @@ func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *cla
 			}
 			erCache[advisoryName] = rec
 		}
-		zlog.Debug(ctx).
-			Int("count", len(rec)).
-			Msg("found records")
+		slog.DebugContext(vulnCtx, "found records", "count", len(rec))
 		for _, r := range rec {
 			m[id] = append(m[id], r.Enrichment)
 		}

--- a/scanner/enricher/csaf/csaf_test.go
+++ b/scanner/enricher/csaf/csaf_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/scannerv4/enricher/csaf"
 	"github.com/stretchr/testify/assert"
 )
@@ -61,7 +60,7 @@ var (
 )
 
 func TestConfigure(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := context.Background()
 
 	noopConfig := func(_ interface{}) error { return nil }
 	type configTestcase struct {
@@ -119,7 +118,7 @@ func TestConfigure(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			e := &Enricher{}
-			ctx := zlog.Test(ctx, t)
+			ctx := ctx
 			f := tc.Config
 			if f == nil {
 				f = noopConfig
@@ -143,7 +142,7 @@ func (eg enrichmentGetter) GetEnrichment(ctx context.Context, tags []string) ([]
 }
 
 func TestEnrich(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := context.Background()
 
 	g := enrichmentGetter(func(ctx context.Context, tags []string) ([]driver.EnrichmentRecord, error) {
 		return []driver.EnrichmentRecord{

--- a/scanner/enricher/csaf/csaf_test.go
+++ b/scanner/enricher/csaf/csaf_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/claircore/test"
 	"github.com/stackrox/rox/pkg/scannerv4/enricher/csaf"
 	"github.com/stretchr/testify/assert"
 )
@@ -60,8 +61,6 @@ var (
 )
 
 func TestConfigure(t *testing.T) {
-	ctx := context.Background()
-
 	noopConfig := func(_ interface{}) error { return nil }
 	type configTestcase struct {
 		Config func(interface{}) error
@@ -118,7 +117,7 @@ func TestConfigure(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
 			e := &Enricher{}
-			ctx := ctx
+			ctx := test.Logging(t)
 			f := tc.Config
 			if f == nil {
 				f = noopConfig
@@ -142,7 +141,7 @@ func (eg enrichmentGetter) GetEnrichment(ctx context.Context, tags []string) ([]
 }
 
 func TestEnrich(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 
 	g := enrichmentGetter(func(ctx context.Context, tags []string) ([]driver.EnrichmentRecord, error) {
 		return []driver.EnrichmentRecord{

--- a/scanner/enricher/csaf/fetcher.go
+++ b/scanner/enricher/csaf/fetcher.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -20,7 +21,6 @@ import (
 	"github.com/klauspost/compress/snappy"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/pkg/tmp"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/scanner/enricher/csaf/internal/zreader"
 )
@@ -74,7 +74,6 @@ func (fp *fingerprint) String() string {
 // This method fetches Red Hat's CSAF data (https://security.access.redhat.com/data/csaf/v2/advisories/),
 // unless configured otherwise, and returns a Snappy-compressed file with each advisory's data written to each line.
 func (e *Enricher) FetchEnrichment(ctx context.Context, hint driver.Fingerprint) (io.ReadCloser, driver.Fingerprint, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "enricher/csaf/Enricher/FetchEnrichment")
 	fp, err := parseFingerprint(hint)
 	if err != nil {
 		return nil, hint, err
@@ -90,16 +89,14 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, hint driver.Fingerprint)
 	var success bool
 	defer func() {
 		if err := cw.Close(); err != nil {
-			zlog.Warn(ctx).Err(err).Msg("unable to close snappy writer")
+			slog.WarnContext(ctx, "unable to close snappy writer", "reason", err)
 		}
 		if _, err := f.Seek(0, io.SeekStart); err != nil {
-			zlog.Warn(ctx).
-				Err(err).
-				Msg("unable to seek file back to start")
+			slog.WarnContext(ctx, "unable to seek file back to start", "reason", err)
 		}
 		if !success {
 			if err := f.Close(); err != nil {
-				zlog.Warn(ctx).Err(err).Msg("unable to close spool")
+				slog.WarnContext(ctx, "unable to close spool", "reason", err)
 			}
 		}
 	}()
@@ -110,9 +107,7 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, hint driver.Fingerprint)
 	if err != nil {
 		return nil, hint, fmt.Errorf("could not get compressed file URL: %w", err)
 	}
-	zlog.Debug(ctx).
-		Str("url", compressedURL.String()).
-		Msg("got compressed URL")
+	slog.DebugContext(ctx, "got compressed URL", "url", compressedURL.String())
 
 	fp.requestTime, err = e.getLastModified(ctx, compressedURL)
 	if err != nil {
@@ -201,10 +196,7 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, hint driver.Fingerprint)
 		return nil, hint, fmt.Errorf("error reading tar contents: %w", err)
 	}
 
-	zlog.Debug(ctx).
-		Str("enricher", e.Name()).
-		Int("entries written", entriesWritten).
-		Msg("finished writing compressed data to spool")
+	slog.DebugContext(ctx, "finished writing compressed data to spool", "enricher", e.Name(), "entries_written", entriesWritten)
 
 	fp.version = updaterVersion
 	fp.requestTime = time.Now()
@@ -375,7 +367,7 @@ func (e *Enricher) processChanges(ctx context.Context, w io.Writer, fp *fingerpr
 			if err != nil {
 				return fmt.Errorf("error reading from buffer: %w", err)
 			}
-			zlog.Debug(ctx).Str("url", advisoryURI.String()).Msg("copying body to file")
+			slog.DebugContext(ctx, "copying body to file", "url", advisoryURI.String())
 			err = json.Compact(&bc, buf.Bytes())
 			if err != nil {
 				return fmt.Errorf("error compressing JSON: %w", err)

--- a/scanner/enricher/csaf/fetcher_test.go
+++ b/scanner/enricher/csaf/fetcher_test.go
@@ -3,16 +3,16 @@ package csaf
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/klauspost/compress/snappy"
 	"github.com/quay/claircore/rhel/vex"
+	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/toolkit/types/csaf"
 )
 
 func TestFetchEnrichment(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	root, c := vex.ServeSecDB(t, "testdata/server.txtar")
 	enricher := &Enricher{}
 	err := enricher.Configure(ctx, func(v interface{}) error {

--- a/scanner/enricher/csaf/fetcher_test.go
+++ b/scanner/enricher/csaf/fetcher_test.go
@@ -9,11 +9,10 @@ import (
 	"github.com/klauspost/compress/snappy"
 	"github.com/quay/claircore/rhel/vex"
 	"github.com/quay/claircore/toolkit/types/csaf"
-	"github.com/quay/zlog"
 )
 
 func TestFetchEnrichment(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := context.Background()
 	root, c := vex.ServeSecDB(t, "testdata/server.txtar")
 	enricher := &Enricher{}
 	err := enricher.Configure(ctx, func(v interface{}) error {

--- a/scanner/enricher/csaf/parser_test.go
+++ b/scanner/enricher/csaf/parser_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/klauspost/compress/snappy"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/scannerv4/enricher/csaf"
 )
 
@@ -65,7 +64,7 @@ func TestParseEnrichment(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := zlog.Test(ctx, t)
+			ctx := ctx
 			f, err := os.Open(tc.filename)
 			if err != nil {
 				t.Fatalf("failed to open test data file %s: %v", tc.filename, err)

--- a/scanner/enricher/csaf/parser_test.go
+++ b/scanner/enricher/csaf/parser_test.go
@@ -2,7 +2,6 @@ package csaf
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -12,11 +11,11 @@ import (
 	"time"
 
 	"github.com/klauspost/compress/snappy"
+	"github.com/quay/claircore/test"
 	"github.com/stackrox/rox/pkg/scannerv4/enricher/csaf"
 )
 
 func TestParseEnrichment(t *testing.T) {
-	ctx := context.Background()
 	url, err := url.Parse(baseURL)
 	if err != nil {
 		t.Error(err)
@@ -64,7 +63,7 @@ func TestParseEnrichment(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := ctx
+			ctx := test.Logging(t)
 			f, err := os.Open(tc.filename)
 			if err != nil {
 				t.Fatalf("failed to open test data file %s: %v", tc.filename, err)

--- a/scanner/enricher/fixedby/fixedby.go
+++ b/scanner/enricher/fixedby/fixedby.go
@@ -7,6 +7,7 @@ package fixedby
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/url"
 	"strings"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/quay/claircore/ruby"
 	"github.com/quay/claircore/suse"
 	"github.com/quay/claircore/ubuntu"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/scannerv4/enricher/fixedby"
 )
 
@@ -63,8 +63,6 @@ func (e Enricher) Name() string { return fixedby.Name }
 
 // Enrich returns a mapping from package ID to the minimum version which fixes all vulnerabilities.
 func (e Enricher) Enrich(ctx context.Context, _ driver.EnrichmentGetter, vr *claircore.VulnerabilityReport) (string, []json.RawMessage, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "enricher/fixedby/Enricher.Enrich")
-
 	// package ID -> fixedBy version
 	m := make(map[string]string)
 	fixedBy := &claircore.IndexRecord{}
@@ -101,9 +99,7 @@ func (e Enricher) Enrich(ctx context.Context, _ driver.EnrichmentGetter, vr *cla
 		if len(env.RepositoryIDs) > 0 {
 			repo, ok := vr.Repositories[env.RepositoryIDs[0]]
 			if !ok {
-				zlog.Warn(ctx).
-					Str("package", pkg.Name).
-					Msg("invalid repo id, skipping")
+				slog.WarnContext(ctx, "invalid repo id, skipping", "package", pkg.Name)
 				// We could try again, but this is unexpected and indicates some other kind of issue.
 				// Just continue.
 				continue
@@ -116,9 +112,7 @@ func (e Enricher) Enrich(ctx context.Context, _ driver.EnrichmentGetter, vr *cla
 		matcher, versionType := findMatcher(ctx, fixedBy)
 		switch versionType {
 		case unknownVersionType:
-			zlog.Warn(ctx).
-				Str("package", pkg.Name).
-				Msg("unknown matcher, skipping")
+			slog.WarnContext(ctx, "unknown matcher, skipping", "package", pkg.Name)
 			continue
 		case semverVersionType, goSemverVersionType:
 			pkgVersion := pkg.Version
@@ -132,11 +126,7 @@ func (e Enricher) Enrich(ctx context.Context, _ driver.EnrichmentGetter, vr *cla
 			var err error
 			pkgSemver, err = semver.NewVersion(pkgVersion)
 			if err != nil {
-				zlog.Warn(ctx).
-					Err(err).
-					Str("package", pkg.Name).
-					Str("version", pkg.Version).
-					Msg("skipping")
+				slog.WarnContext(ctx, "skipping", "reason", err, "package", pkg.Name, "version", pkg.Version)
 				continue
 			}
 		default:
@@ -163,13 +153,7 @@ func (e Enricher) Enrich(ctx context.Context, _ driver.EnrichmentGetter, vr *cla
 				}
 				vulnSemver, err := semver.NewVersion(v.FixedInVersion)
 				if err != nil {
-					zlog.Warn(ctx).
-						Err(err).
-						Str("package", pkg.Name).
-						Str("vulnerability_id", v.ID).
-						Str("vulnerability", v.Name).
-						Str("fixed_in_version", v.FixedInVersion).
-						Msg("skipping")
+					slog.WarnContext(ctx, "skipping", "reason", err, "package", pkg.Name, "vulnerability_id", v.ID, "vulnerability", v.Name, "fixed_in_version", v.FixedInVersion)
 					continue
 				}
 				if pkgSemver.LessThan(vulnSemver) {
@@ -187,13 +171,7 @@ func (e Enricher) Enrich(ctx context.Context, _ driver.EnrichmentGetter, vr *cla
 				// with v.FixedInVersion.
 				vulnerable, err := matcher.Vulnerable(ctx, fixedBy, v)
 				if err != nil {
-					zlog.Warn(ctx).
-						Err(err).
-						Str("package", pkg.Name).
-						Str("vulnerability_id", v.ID).
-						Str("vulnerability", v.Name).
-						Str("fixed_in_version", v.FixedInVersion).
-						Msg("skipping")
+					slog.WarnContext(ctx, "skipping", "reason", err, "package", pkg.Name, "vulnerability_id", v.ID, "vulnerability", v.Name, "fixed_in_version", v.FixedInVersion)
 					continue
 				}
 				if !vulnerable {
@@ -220,9 +198,7 @@ func (e Enricher) Enrich(ctx context.Context, _ driver.EnrichmentGetter, vr *cla
 				fixedBy.Package.Version = version
 			default:
 				// Just log and skip.
-				zlog.Warn(ctx).
-					Str("version_type", versionType.String()).
-					Msg("unexpected version type, skipping")
+				slog.WarnContext(ctx, "unexpected version type, skipping", "version_type", versionType.String())
 				continue
 			}
 		}
@@ -268,7 +244,6 @@ func parseURLEncoding(v string) string {
 // version comparisons became tricky without knowing more specifics about the matcher and expected
 // version formatting. Doing it this way is easier for us.
 func findMatcher(ctx context.Context, record *claircore.IndexRecord) (matcher, versionType) {
-	ctx = zlog.ContextWithValues(ctx, "component", "enricher/fixedby/matcher")
 	// THE ORDERING IS SPECIFICALLY CHOSEN TO ENSURE WE CHOOSE
 	// THE CORRECT MATCHER.
 	// CHANGE IT AT YOUR OWN RISK.
@@ -308,7 +283,7 @@ func findMatcher(ctx context.Context, record *claircore.IndexRecord) (matcher, v
 	case (*ubuntu.Matcher)(nil).Filter(record):
 		return &ubuntu.Matcher{}, normalVersionType
 	default:
-		zlog.Error(ctx).Str("package", record.Package.Name).Msg("unable to determine matcher")
+		slog.ErrorContext(ctx, "unable to determine matcher", "package", record.Package.Name)
 		return nil, unknownVersionType
 	}
 }

--- a/scanner/enricher/fixedby/fixedby_test.go
+++ b/scanner/enricher/fixedby/fixedby_test.go
@@ -1,11 +1,11 @@
 package fixedby_test
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/toolkit/types/cpe"
 	"github.com/stackrox/rox/scanner/enricher/fixedby"
 	"github.com/stretchr/testify/assert"
@@ -1804,8 +1804,9 @@ func TestEnrich_Ubuntu(t *testing.T) {
 }
 
 func runTest(t *testing.T, tc testcase) {
+	ctx := test.Logging(t)
 	var e fixedby.Enricher
-	_, m, err := e.Enrich(context.Background(), nil, tc.report)
+	_, m, err := e.Enrich(ctx, nil, tc.report)
 	assert.NoError(t, err)
 
 	got := make(map[string]string)

--- a/scanner/enricher/nvd/nvd.go
+++ b/scanner/enricher/nvd/nvd.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -20,7 +21,7 @@ import (
 	"github.com/facebookincubator/nvdtools/cveapi/nvd/schema"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/toolkit/log"
 	"github.com/stackrox/rox/pkg/scannerv4/enricher/nvd"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/uuid"
@@ -79,7 +80,6 @@ func NewFactory() driver.UpdaterSetFactory {
 
 // Configure implements driver.Configurable.
 func (e *Enricher) Configure(ctx context.Context, f driver.ConfigUnmarshaler, c *http.Client) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "enricher/nvd/Enricher/Configure")
 	var cfg Config
 	e.c = c
 	if err := f(&cfg); err != nil {
@@ -96,9 +96,7 @@ func (e *Enricher) Configure(ctx context.Context, f driver.ConfigUnmarshaler, c 
 			return fmt.Errorf("feed file is not a regular file: %s", *cfg.FeedPath)
 		}
 		e.feedPath = *cfg.FeedPath
-		zlog.Info(ctx).
-			Str("feed_path", e.feedPath).
-			Msg("enricher configured with feed path")
+		slog.InfoContext(ctx, "enricher configured with feed path", "feed_path", e.feedPath)
 		return nil
 	}
 	if cfg.APIKey != nil {
@@ -130,11 +128,7 @@ func (e *Enricher) Configure(ctx context.Context, f driver.ConfigUnmarshaler, c 
 		e.feed, err = defaultFeed.Parse(".")
 		utils.CrashOnError(err)
 	}
-	zlog.Info(ctx).
-		Str("feed", e.feed.String()).
-		Bool("has_api_key", e.apiKey != "").
-		Dur("call_interval", e.callInterval).
-		Msg("enricher configured")
+	slog.InfoContext(ctx, "enricher configured", "feed", e.feed.String(), "has_api_key", e.apiKey != "", "call_interval", e.callInterval)
 	return nil
 }
 
@@ -145,10 +139,9 @@ func (*Enricher) Name() string {
 
 // FetchEnrichment implements driver.EnrichmentUpdater.
 func (e *Enricher) FetchEnrichment(ctx context.Context, _ driver.Fingerprint) (io.ReadCloser, driver.Fingerprint, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "enricher/nvd/Enricher/FetchEnrichment")
 	// Force a new hint, to signal updaters that this is new data.
 	hint := driver.Fingerprint(uuid.NewV4().String())
-	zlog.Info(ctx).Str("hint", string(hint)).Msg("starting fetch")
+	slog.InfoContext(ctx, "starting fetch", "hint", string(hint))
 	out, err := os.CreateTemp("", "enricher.nvd.")
 	if err != nil {
 		return nil, hint, err
@@ -158,7 +151,7 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, _ driver.Fingerprint) (i
 	defer func() {
 		if !success {
 			if err := out.Close(); err != nil {
-				zlog.Warn(ctx).Err(err).Msg("unable to close spool")
+				slog.WarnContext(ctx, "unable to close spool", "reason", err)
 			}
 		}
 	}()
@@ -193,7 +186,7 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, _ driver.Fingerprint) (i
 				for _, vuln := range apiResp.Vulnerabilities {
 					item := filterFields(vuln.CVE)
 					if item == nil {
-						zlog.Warn(ctx).Str("cve", vuln.CVE.ID).Msg("skipping CVE")
+						slog.WarnContext(ctx, "skipping CVE", "cve", vuln.CVE.ID)
 						totalSkippedCVEs++
 						continue
 					}
@@ -211,10 +204,7 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, _ driver.Fingerprint) (i
 					totalCVEs++
 					cvesFromQuery++
 				}
-				zlog.Info(ctx).
-					Int("count", cvesFromQuery).
-					Int("total", totalCVEs).
-					Msg("loaded vulnerabilities")
+				slog.InfoContext(ctx, "loaded vulnerabilities", "count", cvesFromQuery, "total", totalCVEs)
 				// Rudimentary rate-limiting.
 				time.Sleep(e.callInterval)
 			}
@@ -262,7 +252,7 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, _ driver.Fingerprint) (i
 			jsonIter(func(vuln *schema.CVEAPIJSON20DefCVEItem) bool {
 				item := filterFields(vuln.CVE)
 				if item == nil {
-					zlog.Warn(ctx).Str("cve", vuln.CVE.ID).Msg("skipping CVE")
+					slog.WarnContext(ctx, "skipping CVE", "cve", vuln.CVE.ID)
 					totalSkippedCVEs++
 					return true
 				}
@@ -288,10 +278,7 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, _ driver.Fingerprint) (i
 			}
 		}
 	}
-	zlog.Info(ctx).
-		Int("skipped", totalSkippedCVEs).
-		Int("total", totalCVEs).
-		Msg("loaded vulnerabilities")
+	slog.InfoContext(ctx, "loaded vulnerabilities", "skipped", totalSkippedCVEs, "total", totalCVEs)
 	// Reset so clients can read the items.
 	if _, err := out.Seek(0, io.SeekStart); err != nil {
 		return nil, hint, fmt.Errorf("unable to reset item feed: %w", err)
@@ -373,11 +360,9 @@ func (e *Enricher) feedURL(start time.Time, end time.Time, startIdx int) string 
 }
 
 func (e *Enricher) query(ctx context.Context, start, end time.Time, startIdx int) (*schema.CVEAPIJSON20, error) {
-	ctx = zlog.ContextWithValues(ctx, "start_index", strconv.Itoa(startIdx),
-		"start_time", start.String(),
-		"end_time", end.String())
+	ctx = log.With(ctx, "start_index", strconv.Itoa(startIdx), "start_time", start.String(), "end_time", end.String())
 	u := e.feedURL(start, end, startIdx)
-	zlog.Debug(ctx).Str("url", u).Msgf("starting NVD request")
+	slog.DebugContext(ctx, "starting NVD request", "url", u)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating HTTP request: %w", err)
@@ -402,10 +387,7 @@ func (e *Enricher) queryWithBackoff(ctx context.Context, req *http.Request) (api
 				break
 			}
 		}
-		zlog.Warn(ctx).
-			Int("attempt", i).
-			Err(err).
-			Msg("failed query attempt")
+		slog.WarnContext(ctx, "failed query attempt", "attempt", i, "reason", err)
 		// Wait some multiple of 3 seconds before next attempt.
 		time.Sleep(time.Duration(3*i) * time.Second)
 	}
@@ -417,10 +399,7 @@ func (e *Enricher) tryQuery(ctx context.Context, req *http.Request) (*http.Respo
 	if err != nil {
 		return nil, fmt.Errorf("fetching NVD API results: %w", err)
 	}
-	zlog.Debug(ctx).
-		Int("status", resp.StatusCode).
-		Str("nvd_message", req.Header.Get("message")).
-		Msg("NVD response")
+	slog.DebugContext(ctx, "NVD response", "status", resp.StatusCode, "nvd_message", req.Header.Get("message"))
 	if resp.StatusCode != http.StatusOK {
 		_ = resp.Body.Close()
 		return nil, fmt.Errorf("unexpected status code when querying %s: %d", req.URL.String(), resp.StatusCode)
@@ -441,7 +420,6 @@ func parseResponse(resp *http.Response) (*schema.CVEAPIJSON20, error) {
 
 // ParseEnrichment implements driver.EnrichmentUpdater.
 func (e *Enricher) ParseEnrichment(ctx context.Context, rc io.ReadCloser) ([]driver.EnrichmentRecord, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "enricher/nvd/Enricher/ParseEnrichment")
 	// Our Fetch method actually has all the smarts w/r/t to constructing the
 	// records, so this is just decoding in a loop.
 	defer func() {
@@ -455,9 +433,7 @@ func (e *Enricher) ParseEnrichment(ctx context.Context, rc io.ReadCloser) ([]dri
 		ret = append(ret, driver.EnrichmentRecord{})
 		err = dec.Decode(&ret[len(ret)-1])
 	}
-	zlog.Debug(ctx).
-		Int("count", len(ret)-1).
-		Msg("decoded enrichments")
+	slog.DebugContext(ctx, "decoded enrichments", "count", len(ret)-1)
 	if !errors.Is(err, io.EOF) {
 		return nil, err
 	}
@@ -473,8 +449,6 @@ var cveRegexp = regexp.MustCompile(`(?i:cve)[-_][0-9]{4}[-_][0-9]{4,}`)
 
 // Enrich implements driver.Enricher.
 func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *claircore.VulnerabilityReport) (string, []json.RawMessage, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "enricher/nvd/Enricher/Enrich")
-
 	// We return any CVSS blobs for CVEs mentioned in the free-form parts of the
 	// vulnerability.
 	m := make(map[string][]json.RawMessage)
@@ -482,8 +456,7 @@ func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *cla
 	erCache := make(map[string][]driver.EnrichmentRecord)
 	for id, v := range r.Vulnerabilities {
 		t := make(map[string]struct{})
-		ctx := zlog.ContextWithValues(ctx,
-			"vuln", v.Name)
+		vulnCtx := log.With(ctx, "vuln", v.Name)
 		for _, elem := range []string{
 			v.Description,
 			v.Name,
@@ -500,9 +473,7 @@ func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *cla
 		for m := range t {
 			ts = append(ts, m)
 		}
-		zlog.Debug(ctx).
-			Strs("cve", ts).
-			Msg("found CVEs")
+		slog.DebugContext(vulnCtx, "found CVEs", "cve", ts)
 
 		slices.Sort(ts)
 		cveKey := strings.Join(ts, "_")
@@ -515,9 +486,7 @@ func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *cla
 			}
 			erCache[cveKey] = rec
 		}
-		zlog.Debug(ctx).
-			Int("count", len(rec)).
-			Msg("found records")
+		slog.DebugContext(vulnCtx, "found records", "count", len(rec))
 		for _, r := range rec {
 			m[id] = append(m[id], r.Enrichment)
 		}

--- a/scanner/enricher/nvd/nvd_test.go
+++ b/scanner/enricher/nvd/nvd_test.go
@@ -17,11 +17,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/claircore/test"
 	"github.com/stackrox/rox/pkg/scannerv4/enricher/nvd"
 )
 
 func TestConfigure(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	tt := []configTestcase{
 		{
 			Name: "None",
@@ -87,7 +88,7 @@ type configTestcase struct {
 func (tc configTestcase) Run(ctx context.Context) func(*testing.T) {
 	e := &Enricher{}
 	return func(t *testing.T) {
-		ctx := ctx
+		ctx := test.Logging(t)
 		f := tc.Config
 		if f == nil {
 			f = noopConfig
@@ -106,7 +107,7 @@ func (tc configTestcase) Run(ctx context.Context) func(*testing.T) {
 func noopConfig(_ interface{}) error { return nil }
 
 func TestFetch(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	srv := mockServer(t)
 	tt := []fetchTestcase{
 		{
@@ -183,7 +184,7 @@ type fetchTestcase struct {
 func (tc fetchTestcase) Run(ctx context.Context, srv *httptest.Server) func(*testing.T) {
 	e := &Enricher{}
 	return func(t *testing.T) {
-		ctx := ctx
+		ctx := test.Logging(t)
 		f := func(i interface{}) error {
 			cfg, ok := i.(*Config)
 			if !ok {
@@ -246,7 +247,7 @@ func mockServer(t *testing.T) *httptest.Server {
 }
 
 func TestParse(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	srv := mockServer(t)
 	tt := []parseTestcase{
 		{
@@ -266,7 +267,7 @@ type parseTestcase struct {
 func (tc parseTestcase) Run(ctx context.Context, srv *httptest.Server) func(*testing.T) {
 	e := &Enricher{}
 	return func(t *testing.T) {
-		ctx := ctx
+		ctx := test.Logging(t)
 		f := func(i interface{}) error {
 			cfg, ok := i.(*Config)
 			if !ok {
@@ -301,7 +302,7 @@ func (tc parseTestcase) Run(ctx context.Context, srv *httptest.Server) func(*tes
 }
 
 func TestEnrich(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	g := newFakeGetter(t, "testdata/feed.json")
 	r := &claircore.VulnerabilityReport{
 		Vulnerabilities: map[string]*claircore.Vulnerability{

--- a/scanner/enricher/nvd/nvd_test.go
+++ b/scanner/enricher/nvd/nvd_test.go
@@ -17,12 +17,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/scannerv4/enricher/nvd"
 )
 
 func TestConfigure(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := context.Background()
 	tt := []configTestcase{
 		{
 			Name: "None",
@@ -88,7 +87,7 @@ type configTestcase struct {
 func (tc configTestcase) Run(ctx context.Context) func(*testing.T) {
 	e := &Enricher{}
 	return func(t *testing.T) {
-		ctx := zlog.Test(ctx, t)
+		ctx := ctx
 		f := tc.Config
 		if f == nil {
 			f = noopConfig
@@ -107,7 +106,7 @@ func (tc configTestcase) Run(ctx context.Context) func(*testing.T) {
 func noopConfig(_ interface{}) error { return nil }
 
 func TestFetch(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := context.Background()
 	srv := mockServer(t)
 	tt := []fetchTestcase{
 		{
@@ -184,7 +183,7 @@ type fetchTestcase struct {
 func (tc fetchTestcase) Run(ctx context.Context, srv *httptest.Server) func(*testing.T) {
 	e := &Enricher{}
 	return func(t *testing.T) {
-		ctx := zlog.Test(ctx, t)
+		ctx := ctx
 		f := func(i interface{}) error {
 			cfg, ok := i.(*Config)
 			if !ok {
@@ -247,7 +246,7 @@ func mockServer(t *testing.T) *httptest.Server {
 }
 
 func TestParse(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := context.Background()
 	srv := mockServer(t)
 	tt := []parseTestcase{
 		{
@@ -267,7 +266,7 @@ type parseTestcase struct {
 func (tc parseTestcase) Run(ctx context.Context, srv *httptest.Server) func(*testing.T) {
 	e := &Enricher{}
 	return func(t *testing.T) {
-		ctx := zlog.Test(ctx, t)
+		ctx := ctx
 		f := func(i interface{}) error {
 			cfg, ok := i.(*Config)
 			if !ok {
@@ -302,7 +301,7 @@ func (tc parseTestcase) Run(ctx context.Context, srv *httptest.Server) func(*tes
 }
 
 func TestEnrich(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := context.Background()
 	g := newFakeGetter(t, "testdata/feed.json")
 	r := &claircore.VulnerabilityReport{
 		Vulnerabilities: map[string]*claircore.Vulnerability{

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand/v2"
 	"net/http"
 	"net/url"
@@ -37,7 +38,6 @@ import (
 	"github.com/quay/claircore/rhel/rhcc"
 	"github.com/quay/claircore/rpm"
 	"github.com/quay/claircore/ruby"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
@@ -171,8 +171,6 @@ type localIndexer struct {
 
 // NewIndexer creates a new indexer.
 func NewIndexer(ctx context.Context, cfg config.IndexerConfig) (Indexer, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/backend/indexer.NewIndexer")
-
 	var success bool
 
 	pool, err := postgres.Connect(ctx, cfg.Database.ConnString, "libindex")
@@ -268,19 +266,19 @@ func NewIndexer(ctx context.Context, cfg config.IndexerConfig) (Indexer, error) 
 		// Start the manifest GC.
 		go func() {
 			if err := manifestManager.StartGC(); err != nil {
-				zlog.Error(ctx).Err(err).Msg("manifest GC failed")
+				slog.ErrorContext(ctx, "manifest GC failed", "reason", err)
 			}
 		}()
 	}
 
 	deleteIntervalStart := env.ScannerV4ManifestDeleteStart.DurationSetting()
 	if deleteIntervalStart < minManifestDeleteStart {
-		zlog.Warn(ctx).Msgf("configured manifest delete interval (%v) start is too small: setting to %v", deleteIntervalStart, minManifestDeleteStart)
+		slog.WarnContext(ctx, "configured manifest delete interval start too small, using minimum", "configured", deleteIntervalStart, "minimum", minManifestDeleteStart)
 		deleteIntervalStart = minManifestDeleteStart
 	}
 	deleteIntervalDuration := env.ScannerV4ManifestDeleteDuration.DurationSetting()
 	if deleteIntervalDuration < minManifestDeleteDuration {
-		zlog.Warn(ctx).Msgf("configured manifest delete interval (%v) duration is too small: setting to %v", deleteIntervalDuration, minManifestDeleteDuration)
+		slog.WarnContext(ctx, "configured manifest delete interval duration too small, using minimum", "configured", deleteIntervalDuration, "minimum", minManifestDeleteDuration)
 		deleteIntervalDuration = minManifestDeleteDuration
 	}
 
@@ -368,7 +366,6 @@ func newLibindex(ctx context.Context, indexerCfg config.IndexerConfig, client *h
 
 // Close closes the indexer.
 func (i *localIndexer) Close(ctx context.Context) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/backend/indexer.Close")
 	err := errors.Join(i.libIndex.Close(ctx), os.RemoveAll(i.root))
 	if features.ScannerV4ReIndex.Enabled() && i.manifestManager != nil {
 		err = errors.Join(err, i.manifestManager.StopGC())
@@ -389,8 +386,6 @@ func (i *localIndexer) Ready(ctx context.Context) error {
 // URL. This method performs a partial content request on each layer to generate
 // the layer's URI and headers.
 func (i *localIndexer) IndexContainerImage(ctx context.Context, hashID string, imageURL string, opts ...Option) (*claircore.IndexReport, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/backend/indexer.IndexContainerImage")
-
 	manifestDigest, err := createManifestDigest(hashID)
 	if err != nil {
 		return nil, err
@@ -414,10 +409,7 @@ func (i *localIndexer) IndexContainerImage(ctx context.Context, hashID string, i
 		Hash: manifestDigest,
 	}
 
-	zlog.Info(ctx).
-		Str("image_reference", imgRef.String()).
-		Int("layers_count", len(imgLayers)).
-		Msg("retrieving layers to populate container image manifest")
+	slog.InfoContext(ctx, "retrieving layers to populate container image manifest", "image_reference", imgRef.String(), "layers_count", len(imgLayers))
 	for _, layer := range imgLayers {
 		ccDigest, layerDigest, err := getLayerDigests(layer)
 		if err != nil {
@@ -521,16 +513,10 @@ func getLayerRequest(ctx context.Context, httpClient *http.Client, imgRef name.R
 	utils.IgnoreError(res.Body.Close)
 	if res.StatusCode != http.StatusPartialContent {
 		if exists, _ := regsNoRange.ContainsOrAdd(registryURL.Host, struct{}{}); !exists {
-			zlog.Warn(ctx).
-				Str("registry", registryURL.Host).
-				Msg("Range HTTP header may not be supported, so indexing may required about twice as many image pulls")
+			slog.WarnContext(ctx, "Range HTTP header may not be supported, so indexing may required about twice as many image pulls", "registry", registryURL.Host)
 		}
 
-		zlog.Debug(ctx).
-			Int("status_code", res.StatusCode).
-			Int("len", int(res.ContentLength)).
-			Str("url", u.String()).
-			Msg("server might not support requests with Range HTTP header")
+		slog.DebugContext(ctx, "server might not support requests with Range HTTP header", "status_code", res.StatusCode, "len", int(res.ContentLength), "url", u.String())
 	}
 	return res.Request, nil
 }
@@ -622,7 +608,6 @@ func createManifestDigest(hashID string) (claircore.Digest, error) {
 }
 
 func (i *localIndexer) StoreIndexReport(ctx context.Context, hashID string, indexerVersion string, report *claircore.IndexReport) (string, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/backend/indexer.StoreIndexReport")
 
 	var err error
 	report.Hash, err = createManifestDigest(hashID)

--- a/scanner/indexer/indexer_test.go
+++ b/scanner/indexer/indexer_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/quay/claircore/libindex"
 	"github.com/quay/claircore/libvuln/updates"
 	mockccindexer "github.com/quay/claircore/test/mock/indexer"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/scanner/config"
 	mockindexer "github.com/stackrox/rox/scanner/datastore/postgres/mocks"
 	"github.com/stretchr/testify/assert"
@@ -58,7 +57,7 @@ log_level: info
 `
 
 	ic := mustLoadIndexerConfig(t, strings.NewReader(cfg))
-	indexer, err := newLibindex(zlog.Test(context.Background(), t), ic, http.DefaultClient, "", store, nil)
+	indexer, err := newLibindex(context.Background(), ic, http.DefaultClient, "", store, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, indexer.Options.ScannerConfig.Repo["rhel-repository-scanner"])
 	assert.NotNil(t, indexer.Options.ScannerConfig.Package["rhel_containerscanner"])
@@ -66,7 +65,7 @@ log_level: info
 }
 
 func TestGetIndexReport(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := context.Background()
 
 	ctrl := gomock.NewController(t)
 	store := mockccindexer.NewMockStore(ctrl)

--- a/scanner/indexer/indexer_test.go
+++ b/scanner/indexer/indexer_test.go
@@ -1,7 +1,6 @@
 package indexer
 
 import (
-	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -13,6 +12,7 @@ import (
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libindex"
 	"github.com/quay/claircore/libvuln/updates"
+	"github.com/quay/claircore/test"
 	mockccindexer "github.com/quay/claircore/test/mock/indexer"
 	"github.com/stackrox/rox/scanner/config"
 	mockindexer "github.com/stackrox/rox/scanner/datastore/postgres/mocks"
@@ -57,7 +57,7 @@ log_level: info
 `
 
 	ic := mustLoadIndexerConfig(t, strings.NewReader(cfg))
-	indexer, err := newLibindex(context.Background(), ic, http.DefaultClient, "", store, nil)
+	indexer, err := newLibindex(test.Logging(t), ic, http.DefaultClient, "", store, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, indexer.Options.ScannerConfig.Repo["rhel-repository-scanner"])
 	assert.NotNil(t, indexer.Options.ScannerConfig.Package["rhel_containerscanner"])
@@ -65,7 +65,7 @@ log_level: info
 }
 
 func TestGetIndexReport(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 
 	ctrl := gomock.NewController(t)
 	store := mockccindexer.NewMockStore(ctrl)

--- a/scanner/indexer/manifest/manager.go
+++ b/scanner/indexer/manifest/manager.go
@@ -3,11 +3,11 @@ package manifest
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"math/rand/v2"
 	"time"
 
 	"github.com/quay/claircore/libvuln/updates"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/scanner/datastore/postgres"
@@ -89,19 +89,19 @@ func NewManager(ctx context.Context, metadataStore postgres.IndexerMetadataStore
 
 	interval := env.ScannerV4ManifestGCInterval.DurationSetting()
 	if interval < minGCInterval {
-		zlog.Warn(ctx).Msgf("configured manifest GC interval (%v) is too small: setting to %v", interval, minGCInterval)
+		slog.WarnContext(ctx, "configured manifest GC interval too small, using minimum", "configured", interval, "minimum", minGCInterval)
 		interval = minGCInterval
 	}
 
 	fullInterval := env.ScannerV4FullManifestGCInterval.DurationSetting()
 	if fullInterval < minFullGCInterval {
-		zlog.Warn(ctx).Msgf("configured full manifest GC interval (%v) is too small: setting to %v", fullInterval, minFullGCInterval)
+		slog.WarnContext(ctx, "configured full manifest GC interval too small, using minimum", "configured", fullInterval, "minimum", minFullGCInterval)
 		fullInterval = minFullGCInterval
 	}
 
 	gcThrottle := env.ScannerV4ManifestGCThrottle.IntegerSetting()
 	if gcThrottle < minGCThrottle {
-		zlog.Warn(ctx).Msgf("configured manifest GC throttle (%d) is too small: setting to %d", gcThrottle, minGCThrottle)
+		slog.WarnContext(ctx, "configured manifest GC throttle too small, using minimum", "configured", gcThrottle, "minimum", minGCThrottle)
 		gcThrottle = minGCThrottle
 	}
 
@@ -121,16 +121,12 @@ func NewManager(ctx context.Context, metadataStore postgres.IndexerMetadataStore
 
 // MigrateManifests migrates manifests into the manifest_metadata table.
 func (m *Manager) MigrateManifests(ctx context.Context, expiration time.Time) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "indexer/manifest/Manager.MigrateManifests")
-
 	// Use TryLock instead of Lock in case a migration is already happening.
 	// There is no need to run another one.
 	ctx, done := m.locker.TryLock(ctx, migrateName)
 	defer done()
 	if err := ctx.Err(); err != nil {
-		zlog.Debug(ctx).
-			Err(err).
-			Msg("lock context canceled, manifest migration already running")
+		slog.DebugContext(ctx, "lock context canceled, manifest migration already running", "reason", err)
 		return nil
 	}
 
@@ -139,28 +135,28 @@ func (m *Manager) MigrateManifests(ctx context.Context, expiration time.Time) er
 		return err
 	}
 	if len(ms) > 0 {
-		zlog.Debug(ctx).Strs("migrated_manifests", ms).Msg("migrated missing manifest metadata")
+		slog.DebugContext(ctx, "migrated missing manifest metadata", "migrated_manifests", ms)
 	}
-	zlog.Info(ctx).Int("migrated_manifests", len(ms)).Msg("migrated missing manifest metadata")
+	slog.InfoContext(ctx, "migrated missing manifest metadata", "migrated_manifests", len(ms))
 
 	return nil
 }
 
 // StartGC begins periodic garbage collection.
 func (m *Manager) StartGC() error {
-	ctx := zlog.ContextWithValues(m.gcCtx, "component", "indexer/manifest/Manager.StartGC")
+	ctx := m.gcCtx
 
 	if err := m.runFullGC(ctx); err != nil {
-		zlog.Error(ctx).Err(err).Msg("errors encountered during initial full manifest GC run")
+		slog.ErrorContext(ctx, "errors encountered during initial full manifest GC run", "reason", err)
 	}
 
 	interval := m.interval + jitter()
-	zlog.Info(ctx).Msgf("next manifest metadata GC run will be in about %v", interval)
+	slog.InfoContext(ctx, "next manifest metadata GC run scheduled", "interval", interval)
 	t := time.NewTimer(interval)
 	defer t.Stop()
 
 	fullInterval := m.fullInterval + jitter()
-	zlog.Info(ctx).Msgf("next full manifest metadata GC run will be in about %v", fullInterval)
+	slog.InfoContext(ctx, "next full manifest metadata GC run scheduled", "interval", fullInterval)
 	tFull := time.NewTimer(fullInterval)
 	defer tFull.Stop()
 
@@ -170,37 +166,35 @@ func (m *Manager) StartGC() error {
 			return ctx.Err()
 		case <-t.C:
 			if err := m.runGC(ctx); err != nil {
-				zlog.Error(ctx).Err(err).Msg("errors encountered during manifest GC run")
+				slog.ErrorContext(ctx, "errors encountered during manifest GC run", "reason", err)
 			}
 
 			interval = m.interval + jitter()
 			t.Reset(interval)
-			zlog.Info(ctx).Msgf("next manifest metadata GC run will be in about %v", interval)
+			slog.InfoContext(ctx, "next manifest metadata GC run scheduled", "interval", interval)
 		case <-tFull.C:
 			if err := m.runFullGC(ctx); err != nil {
-				zlog.Error(ctx).Err(err).Msg("errors encountered during full manifest GC run")
+				slog.ErrorContext(ctx, "errors encountered during full manifest GC run", "reason", err)
 			}
 
 			fullInterval = m.fullInterval + jitter()
 			tFull.Reset(fullInterval)
-			zlog.Info(ctx).Msgf("next full manifest metadata GC run will be in about %v", fullInterval)
+			slog.InfoContext(ctx, "next full manifest metadata GC run scheduled", "interval", fullInterval)
 		}
 	}
 }
 
 func (m *Manager) runFullGC(ctx context.Context) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "indexer/manifest/Manager.runFullGC")
-
 	// Use Lock instead of TryLock to ensure we get the lock
 	// and run a full GC.
 	ctx, done := m.locker.Lock(ctx, gcName)
 	defer done()
 	if err := ctx.Err(); err != nil {
-		zlog.Warn(ctx).Err(err).Msg("lock context canceled")
+		slog.WarnContext(ctx, "lock context canceled", "reason", err)
 		return err
 	}
 
-	zlog.Info(ctx).Msg("starting manifest metadata garbage collection")
+	slog.InfoContext(ctx, "starting manifest metadata garbage collection")
 
 	var ms []string
 	var irs []string
@@ -224,37 +218,29 @@ func (m *Manager) runFullGC(ctx context.Context) error {
 	}
 
 	if len(ms) > 0 {
-		zlog.Debug(ctx).Strs("deleted_manifest_metadata", ms).Msg("deleted expired manifest metadata")
+		slog.DebugContext(ctx, "deleted expired manifest metadata", "deleted_manifest_metadata", ms)
 	}
-	zlog.Info(ctx).Int("deleted_manifest_metadata", len(ms)).Msg("deleted expired manifest metadata")
+	slog.InfoContext(ctx, "deleted expired manifest metadata", "deleted_manifest_metadata", len(ms))
 
 	if len(irs) > 0 {
-		zlog.Debug(ctx).
-			Strs("deleted_external_index_reports", irs).
-			Msg("deleted expired external index reports")
+		slog.DebugContext(ctx, "deleted expired external index reports", "deleted_external_index_reports", irs)
 	}
-	zlog.Info(ctx).
-		Int("deleted_external_index_reports", len(irs)).
-		Msg("deleted expired external index reports")
+	slog.InfoContext(ctx, "deleted expired external index reports", "deleted_external_index_reports", len(irs))
 
 	return nil
 }
 
 func (m *Manager) runGC(ctx context.Context) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "indexer/manifest/Manager.runGC")
-
 	// Use TryLock instead of Lock in case a GC cycle is already happening.
 	// No need to run simultaneous GC operations.
 	ctx, done := m.locker.TryLock(ctx, gcName)
 	defer done()
 	if err := ctx.Err(); err != nil {
-		zlog.Debug(ctx).
-			Err(err).
-			Msg("lock context canceled, garbage collection already running")
+		slog.DebugContext(ctx, "lock context canceled, garbage collection already running", "reason", err)
 		return err
 	}
 
-	zlog.Info(ctx).Msg("starting manifest metadata garbage collection")
+	slog.InfoContext(ctx, "starting manifest metadata garbage collection")
 
 	ms, gcManifestsErr := m.runGCManifestsNoLock(ctx)
 	irs, gcIndexReportsErr := m.runGCIndexReportsNoLock(ctx)
@@ -264,18 +250,14 @@ func (m *Manager) runGC(ctx context.Context) error {
 	}
 
 	if len(ms) > 0 {
-		zlog.Debug(ctx).Strs("deleted_manifest_metadata", ms).Msg("deleted expired manifest metadata")
+		slog.DebugContext(ctx, "deleted expired manifest metadata", "deleted_manifest_metadata", ms)
 	}
-	zlog.Info(ctx).Int("deleted_manifest_metadata", len(ms)).Msg("deleted expired manifest metadata")
+	slog.InfoContext(ctx, "deleted expired manifest metadata", "deleted_manifest_metadata", len(ms))
 
 	if len(irs) > 0 {
-		zlog.Debug(ctx).
-			Strs("deleted_external_index_reports", irs).
-			Msg("deleted expired external index reports")
+		slog.DebugContext(ctx, "deleted expired external index reports", "deleted_external_index_reports", irs)
 	}
-	zlog.Info(ctx).
-		Int("deleted_external_index_reports", len(irs)).
-		Msg("deleted expired external index reports")
+	slog.InfoContext(ctx, "deleted expired external index reports", "deleted_external_index_reports", len(irs))
 
 	return nil
 }

--- a/scanner/indexer/remote.go
+++ b/scanner/indexer/remote.go
@@ -2,9 +2,10 @@ package indexer
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/quay/claircore"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/toolkit/log"
 	"github.com/stackrox/rox/pkg/scannerv4/client"
 	"github.com/stackrox/rox/pkg/scannerv4/mappers"
 )
@@ -39,11 +40,8 @@ func (r *remoteIndexer) Close(_ context.Context) error {
 
 // GetIndexReport calls the remote service to retrieve an IndexReport for the given hash ID.
 func (r *remoteIndexer) GetIndexReport(ctx context.Context, hashID string, _ bool) (*claircore.IndexReport, bool, error) {
-	ctx = zlog.ContextWithValues(ctx,
-		"component", "scanner/backend/remoteIndexer.GetIndexReport",
-		"hash_id", hashID,
-	)
-	zlog.Info(ctx).Msg("fetching index report from remote indexer")
+	ctx = log.With(ctx, "hash_id", hashID)
+	slog.InfoContext(ctx, "fetching index report from remote indexer")
 	resp, exists, err := r.indexer.GetImageIndex(ctx, hashID)
 	if err != nil {
 		return nil, false, err

--- a/scanner/internal/httputil/transport_deny.go
+++ b/scanner/internal/httputil/transport_deny.go
@@ -2,10 +2,10 @@ package httputil
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 
 	"github.com/pkg/errors"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -18,9 +18,6 @@ var (
 )
 
 func denyTransport(req *http.Request) (*http.Response, error) {
-	zlog.Error(context.Background()).
-		Str("method", req.Method).
-		Str("url", req.URL.String()).
-		Msg("denied HTTP request")
+	slog.ErrorContext(context.Background(), "denied HTTP request", "method", req.Method, "url", req.URL.String())
 	return nil, utils.ShouldErr(errTrafficDenied)
 }

--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -28,7 +29,6 @@ import (
 	"github.com/quay/claircore/ruby"
 	"github.com/quay/claircore/suse"
 	"github.com/quay/claircore/ubuntu"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/scanner/config"
@@ -95,8 +95,6 @@ type matcherImpl struct {
 
 // NewMatcher creates a new matcher.
 func NewMatcher(ctx context.Context, cfg config.MatcherConfig) (Matcher, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/backend/matcher.NewMatcher")
-
 	var success bool
 
 	pool, err := postgres.Connect(ctx, cfg.Database.ConnString, "libvuln")
@@ -145,7 +143,7 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig) (Matcher, error) 
 		csafEnabled = true
 		enrichers = append(enrichers, &csaf.Enricher{})
 	}
-	zlog.Info(ctx).Bool("enabled", csafEnabled).Msg("CSAF enrichment")
+	slog.InfoContext(ctx, "CSAF enrichment", "enabled", csafEnabled)
 	libVuln, err := libvuln.New(ctx, &libvuln.Options{
 		Store:                    store,
 		Locker:                   locker,
@@ -204,7 +202,7 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig) (Matcher, error) 
 	// Start the vulnerability updater.
 	go func() {
 		if err := vulnUpdater.Start(); err != nil {
-			zlog.Error(ctx).Err(err).Msg("vulnerability updater failed")
+			slog.ErrorContext(ctx, "vulnerability updater failed", "reason", err)
 		}
 	}()
 
@@ -222,12 +220,10 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig) (Matcher, error) 
 }
 
 func (m *matcherImpl) GetVulnerabilities(ctx context.Context, ir *claircore.IndexReport) (*claircore.VulnerabilityReport, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/backend/matcher.GetVulnerabilities")
 	return m.libVuln.Scan(ctx, ir)
 }
 
 func (m *matcherImpl) GetLastVulnerabilityUpdate(ctx context.Context) (time.Time, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/backend/matcher.GetLastVulnerabilityUpdate")
 	return m.metadataStore.GetLastVulnerabilityUpdate(ctx)
 }
 
@@ -241,7 +237,6 @@ func (m *matcherImpl) GetSBOM(ctx context.Context, ir *claircore.IndexReport, op
 
 // Close closes the matcher.
 func (m *matcherImpl) Close(ctx context.Context) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/backend/matcher.Close")
 	err := errors.Join(m.vulnUpdater.Stop(), m.libVuln.Close(ctx))
 	m.pool.Close()
 	return err

--- a/scanner/matcher/updater/vuln/dist.go
+++ b/scanner/matcher/updater/vuln/dist.go
@@ -2,10 +2,10 @@ package vuln
 
 import (
 	"context"
+	"log/slog"
 	"slices"
 
 	"github.com/quay/claircore"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/scanner/datastore/postgres"
 )
@@ -30,10 +30,9 @@ func newDistManager(store postgres.MatcherStore) *distManager {
 //
 // It is *not* safe to call update concurrently.
 func (dm *distManager) update(ctx context.Context) (err error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "updater/vuln/dists.update")
-	zlog.Info(ctx).Msg("updating vuln distributions")
+	slog.InfoContext(ctx, "updating vuln distributions")
 	defer func() {
-		zlog.Info(ctx).Bool("updated", err == nil).Msg("done updating vuln distributions")
+		slog.InfoContext(ctx, "done updating vuln distributions", "updated", err == nil)
 	}()
 
 	var dists []claircore.Distribution

--- a/scanner/matcher/updater/vuln/dist_test.go
+++ b/scanner/matcher/updater/vuln/dist_test.go
@@ -1,18 +1,18 @@
 package vuln
 
 import (
-	"context"
 	"errors"
 	"testing"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/test"
 	"github.com/stackrox/rox/scanner/datastore/postgres/mocks"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
 
 func TestDistManager(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	store := mocks.NewMockMatcherStore(gomock.NewController(t))
 	m := &distManager{
 		store: store,

--- a/scanner/matcher/updater/vuln/gc.go
+++ b/scanner/matcher/updater/vuln/gc.go
@@ -2,43 +2,40 @@ package vuln
 
 import (
 	"context"
+	"log/slog"
 	"time"
-
-	"github.com/quay/zlog"
 )
 
 const gcName = `garbage-collection`
 
 // runGCFullPeriodic runs garbage collection until completion, periodically.
 func (u *Updater) runGCFullPeriodic() {
-	ctx := zlog.ContextWithValues(u.ctx, "component", "matcher/updater/vuln/Updater.runFullGCPeriodic")
+	ctx := u.ctx
 
-	zlog.Info(ctx).Str("full_gc_interval", u.fullGCInterval.String()).Msg("starting periodic full GC")
+	slog.InfoContext(ctx, "starting periodic full GC", "full_gc_interval", u.fullGCInterval.String())
 	t := time.NewTicker(u.fullGCInterval)
 	defer t.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			zlog.Info(ctx).Err(ctx.Err()).Msg("stopping periodic full GC")
+			slog.InfoContext(ctx, "stopping periodic full GC", "reason", ctx.Err())
 			return
 		case <-t.C:
-			zlog.Info(ctx).Msg("full GC started")
+			slog.InfoContext(ctx, "full GC started")
 			u.runGCFull(ctx)
-			zlog.Info(ctx).Msg("full GC completed")
+			slog.InfoContext(ctx, "full GC completed")
 		}
 	}
 }
 
 // runGCFull runs garbage collection until completion.
 func (u *Updater) runGCFull(ctx context.Context) {
-	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.runGCFull")
-
 	// Use Lock instead of TryLock to ensure we get the lock
 	// and run a full GC.
 	ctx, done := u.locker.Lock(ctx, gcName)
 	defer done()
 	if err := ctx.Err(); err != nil {
-		zlog.Warn(ctx).Err(err).Msg("lock context canceled")
+		slog.WarnContext(ctx, "lock context canceled", "reason", err)
 		return
 	}
 
@@ -48,12 +45,12 @@ func (u *Updater) runGCFull(ctx context.Context) {
 	for i > 0 {
 		select {
 		case <-ctx.Done():
-			zlog.Error(ctx).Err(ctx.Err()).Msg("performing GC")
+			slog.ErrorContext(ctx, "performing GC", "reason", ctx.Err())
 			return
 		default:
 			i, err = u.runGCNoLock(ctx)
 			if err != nil {
-				zlog.Error(ctx).Err(err).Msg("performing GC")
+				slog.ErrorContext(ctx, "performing GC", "reason", err)
 				return
 			}
 		}
@@ -62,37 +59,30 @@ func (u *Updater) runGCFull(ctx context.Context) {
 
 // runGC runs a garbage collection cycle, once.
 func (u *Updater) runGC(ctx context.Context) {
-	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.runGC")
-
 	// Use TryLock instead of Lock because a GC cycle is already happening.
 	ctx, done := u.locker.TryLock(ctx, gcName)
 	defer done()
 	if err := ctx.Err(); err != nil {
-		zlog.Debug(ctx).
-			Err(err).
-			Msg("lock context canceled, garbage collection already running")
+		slog.DebugContext(ctx, "lock context canceled, garbage collection already running", "reason", err)
 		return
 	}
 
 	_, err := u.runGCNoLock(ctx)
 	if err != nil {
-		zlog.Error(ctx).Err(err).Msg("performing GC")
+		slog.ErrorContext(ctx, "performing GC", "reason", err)
 	}
 }
 
 // runGCNoLock runs the actual garbage collection cycle.
 // DO NOT CALL THIS UNLESS THE garbage-collection LOCK IS ACQUIRED.
 func (u *Updater) runGCNoLock(ctx context.Context) (int64, error) {
-	zlog.Info(ctx).Int("retention", u.updateRetention).Msg("GC started")
+	slog.InfoContext(ctx, "GC started", "retention", u.updateRetention)
 
 	i, err := u.store.GC(ctx, u.updateRetention)
 	if err != nil {
 		return i, err
 	}
 
-	zlog.Info(ctx).
-		Int64("remaining_ops", i).
-		Int("retention", u.updateRetention).
-		Msg("GC completed")
+	slog.InfoContext(ctx, "GC completed", "remaining_ops", i, "retention", u.updateRetention)
 	return i, nil
 }

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"math/rand"
 	"net"
 	"net/http"
@@ -26,7 +27,7 @@ import (
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/libvuln/updates"
 	"github.com/quay/claircore/pkg/ctxlock/v2"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/toolkit/log"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/scanner/datastore/postgres"
@@ -206,7 +207,6 @@ func validate(opts Opts) error {
 }
 
 func (u *Updater) Import(ctx context.Context, in io.Reader) (err error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.Import")
 	iter, iterErr := u.iterateFunc(in)
 	// For each update operation in the JSON blob file.
 	iter(func(op *driver.UpdateOperation, it jsonblob.RecordIter) bool {
@@ -219,16 +219,11 @@ func (u *Updater) Import(ctx context.Context, in io.Reader) (err error) {
 			// This only helps if updaters don't keep something that
 			// changes in the fingerprint.
 			if o.Fingerprint == op.Fingerprint {
-				zlog.Info(ctx).
-					Str("updater", op.Updater).
-					Msg("fingerprint match, skipping")
+				slog.InfoContext(ctx, "fingerprint match, skipping", "updater", op.Updater)
 				return true
 			}
 		}
-		zlog.Info(ctx).
-			Str("updater", op.Updater).
-			Str("kind", string(op.Kind)).
-			Msg("importing update")
+		slog.InfoContext(ctx, "importing update", "updater", op.Updater, "kind", string(op.Kind))
 		var ref uuid.UUID
 		count := 0
 		switch op.Kind {
@@ -257,18 +252,13 @@ func (u *Updater) Import(ctx context.Context, in io.Reader) (err error) {
 				}
 			})
 		default:
-			zlog.Warn(ctx).Str("kind", string(op.Kind)).Msg("unknown kind, skipping")
+			slog.WarnContext(ctx, "unknown kind, skipping", "kind", string(op.Kind))
 		}
 		if err != nil {
 			err = fmt.Errorf("updating %s: %w", op.Kind, err)
 			return false
 		}
-		zlog.Info(ctx).
-			Str("updater", op.Updater).
-			Str("kind", string(op.Kind)).
-			Str("ref", ref.String()).
-			Int("count", count).
-			Msg("update imported")
+		slog.InfoContext(ctx, "update imported", "updater", op.Updater, "kind", string(op.Kind), "ref", ref.String(), "count", count)
 		return true
 	})
 	if err := iterErr(); err != nil {
@@ -286,16 +276,16 @@ func (u *Updater) Import(ctx context.Context, in io.Reader) (err error) {
 // It is assumed the previous updater used the same root directory.
 // Any errors when attempting to remove pre-existing files are simply logged.
 func (u *Updater) tryRemoveExiting() {
-	ctx := zlog.ContextWithValues(u.ctx, "component", "matcher/updater/vuln/Updater.tryRemoveExiting")
+	ctx := u.ctx
 
 	files, err := fs.Glob(os.DirFS(u.root), updateFilePattern)
 	if err != nil {
-		zlog.Warn(ctx).Err(err).Msg("searching for previous update files to remove")
+		slog.WarnContext(ctx, "searching for previous update files to remove", "reason", err)
 		return
 	}
 	for _, file := range files {
 		if err := os.Remove(filepath.Join(u.root, file)); err != nil {
-			zlog.Warn(ctx).Err(err).Msgf("removing previous update file %s", file)
+			slog.WarnContext(ctx, "removing previous update file", "file", file, "reason", err)
 		}
 	}
 }
@@ -310,10 +300,10 @@ func (u *Updater) Stop() error {
 // Start periodically updates the vulnerability data.
 // Each period is adjusted by some amount of jitter.
 func (u *Updater) Start() error {
-	ctx := zlog.ContextWithValues(u.ctx, "component", "matcher/updater/vuln/Updater.Start")
+	ctx := u.ctx
 
 	if !u.vulnBundleAllowlist.IsEmpty() {
-		zlog.Warn(ctx).Str("bundles", u.vulnBundleAllowlist.ElementsString(", ")).Msg("vulnerability bundle allowlist is active: only listed bundles will be imported; do not use in production")
+		slog.WarnContext(ctx, "vulnerability bundle allowlist is active: only listed bundles will be imported; do not use in production", "bundles", u.vulnBundleAllowlist.ElementsString(", "))
 	}
 
 	if !u.skipGC {
@@ -321,7 +311,7 @@ func (u *Updater) Start() error {
 	}
 
 	if err := u.distManager.update(ctx); err != nil {
-		zlog.Warn(ctx).Err(err).Msg("failed to initialize known-distributions")
+		slog.WarnContext(ctx, "failed to initialize known-distributions", "reason", err)
 	}
 
 	// Start immediately, all matchers will compete to update each vulnerability
@@ -333,11 +323,11 @@ func (u *Updater) Start() error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-timer.C:
-			zlog.Info(ctx).Msg("starting update")
+			slog.InfoContext(ctx, "starting update")
 			if err := u.Update(ctx); err != nil {
-				zlog.Error(ctx).Err(err).Msg("errors encountered during updater run")
+				slog.ErrorContext(ctx, "errors encountered during updater run", "reason", err)
 			}
-			zlog.Info(ctx).Msg("completed update")
+			slog.InfoContext(ctx, "completed update")
 
 			// Skip jitter when vulns have never been loaded, so that
 			// failed initial attempts (e.g. Central not yet ready at startup)
@@ -357,19 +347,15 @@ func (u *Updater) Initialized(ctx context.Context) bool {
 	if u.initialized.Load() {
 		return true
 	}
-	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.Initialized")
 	ts, err := u.metadataStore.GetLastVulnerabilityUpdate(ctx)
 	if err != nil {
-		zlog.
-			Warn(ctx).
-			Err(err).
-			Msg("did not get previous vuln update timestamp")
+		slog.WarnContext(ctx, "did not get previous vuln update timestamp", "reason", err)
 		return false
 	}
 	if ts.IsZero() {
 		return false
 	}
-	zlog.Info(ctx).Msg("all vulnerability bundles were updated at least once: setting to initialized")
+	slog.InfoContext(ctx, "all vulnerability bundles were updated at least once: setting to initialized")
 	u.initialized.Store(true)
 	return true
 }
@@ -382,8 +368,6 @@ func (u *Updater) KnownDistributions() []claircore.Distribution {
 //
 // Note: periodic full GC will not be started.
 func (u *Updater) Update(ctx context.Context) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.Update")
-
 	var (
 		updated bool
 		err     error
@@ -399,7 +383,7 @@ func (u *Updater) Update(ctx context.Context) error {
 		u.runGC(ctx)
 	} else if !u.skipGC {
 		// Only log if GC is enabled to reduce noise when GC is disabled.
-		zlog.Info(ctx).Msg("no vulnerability updates: skipping GC")
+		slog.InfoContext(ctx, "no vulnerability updates: skipping GC")
 	}
 
 	return nil
@@ -408,18 +392,12 @@ func (u *Updater) Update(ctx context.Context) error {
 // runMultiBundleUpdate updates the vulnerability data with a multi-bundle and
 // returns a bool indicating if any updates actually happened.
 func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.runMultiBundleUpdate")
-
 	prevTime, err := u.metadataStore.GetLastVulnerabilityUpdate(ctx)
 	if err != nil {
-		zlog.Debug(ctx).
-			Err(err).
-			Msg("did not get previous vuln update timestamp")
+		slog.DebugContext(ctx, "did not get previous vuln update timestamp", "reason", err)
 		return false, err
 	}
-	zlog.Info(ctx).
-		Time("timestamp", prevTime).
-		Msg("previous vuln update")
+	slog.InfoContext(ctx, "previous vuln update", "timestamp", prevTime)
 
 	zipFile, zipTime, err := u.fetch(ctx, prevTime)
 	if err != nil {
@@ -427,15 +405,15 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 	}
 	if zipFile == nil {
 		// Nothing to update at this time.
-		zlog.Info(ctx).Msg("no new vulnerability update")
+		slog.InfoContext(ctx, "no new vulnerability update")
 		return false, nil
 	}
 	defer func() {
 		if err := zipFile.Close(); err != nil {
-			zlog.Error(ctx).Err(err).Msg("closing temp update file")
+			slog.ErrorContext(ctx, "closing temp update file", "reason", err)
 		}
 		if err := os.Remove(zipFile.Name()); err != nil {
-			zlog.Error(ctx).Err(err).Msgf("removing temp update file %q", zipFile.Name())
+			slog.ErrorContext(ctx, "removing temp update file", "file", zipFile.Name(), "reason", err)
 		}
 	}()
 
@@ -452,18 +430,18 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 	names := make([]string, 0, len(zipReader.File))
 	for i := range zipReader.File {
 		bundleF := zipReader.File[i]
-		ctx := zlog.ContextWithValues(ctx, "bundle", bundleF.Name)
 		if !u.isBundleAllowed(bundleF.Name) {
-			zlog.Info(ctx).Msg("skipping bundle (not in allowlist)")
+			slog.InfoContext(ctx, "skipping bundle (not in allowlist)", "bundle", bundleF.Name)
 			continue
 		}
 		names = append(names, bundleF.Name)
-		zlog.Info(ctx).Msg("starting bundle update")
-		if err := u.updateBundle(ctx, bundleF, zipTime, prevTime); err != nil {
-			zlog.Error(ctx).Err(err).Msg("updating bundle failed")
+		bundleCtx := log.With(ctx, "bundle", bundleF.Name)
+		slog.InfoContext(bundleCtx, "starting bundle update")
+		if err := u.updateBundle(bundleCtx, bundleF, zipTime, prevTime); err != nil {
+			slog.ErrorContext(bundleCtx, "updating bundle failed", "reason", err)
 			return false, fmt.Errorf("updating bundle %s: %w", bundleF.Name, err)
 		}
-		zlog.Info(ctx).Msg("completed bundle update")
+		slog.InfoContext(bundleCtx, "completed bundle update")
 	}
 
 	// Clean updaters that were deleted (not in the zip and older than this update).
@@ -484,13 +462,11 @@ func (u *Updater) runMultiBundleUpdate(ctx context.Context) (bool, error) {
 }
 
 func (u *Updater) updateBundle(ctx context.Context, zipF *zip.File, zipTime time.Time, prevTime time.Time) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.updateBundle")
-
 	// Use TryLock to prevent simultaneous updates for the same bundle.
 	lCtx, lDone := u.locker.TryLock(ctx, zipF.Name)
 	defer lDone()
 	if err := lCtx.Err(); err != nil {
-		zlog.Info(ctx).Err(err).Msg("skipping: did not obtain lock")
+		slog.InfoContext(ctx, "skipping: did not obtain lock", "reason", err)
 		return nil
 	}
 
@@ -501,10 +477,7 @@ func (u *Updater) updateBundle(ctx context.Context, zipF *zip.File, zipTime time
 		return fmt.Errorf("querying last update: %w", err)
 	}
 	if !lastTime.Before(zipTime) {
-		zlog.Info(ctx).
-			Time("last_update_time", lastTime).
-			Time("update_time", zipTime).
-			Msg("skipping: last update time is greater or equal to the zip archive time")
+		slog.InfoContext(ctx, "skipping: last update time is greater or equal to the zip archive time", "last_update_time", lastTime, "update_time", zipTime)
 		return nil
 	}
 
@@ -539,8 +512,6 @@ func (u *Updater) updateBundle(ctx context.Context, zipF *zip.File, zipTime time
 // If there have been no updates since prevTimestamp, the returned file will be nil.
 // It is up to the user to close and delete the returned file.
 func (u *Updater) fetch(ctx context.Context, prevTimestamp time.Time) (*os.File, time.Time, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "matcher/updater/vuln/Updater.fetch")
-
 	var resp *http.Response
 	var err error
 	for i, vulnURL := range u.urls {
@@ -553,7 +524,7 @@ func (u *Updater) fetch(ctx context.Context, prevTimestamp time.Time) (*os.File,
 			// trying only on 404s.
 			break
 		}
-		zlog.Info(ctx).Msgf("skipping vuln URL #%d (%s): it does not exist (404)", i, vulnURL)
+		slog.InfoContext(ctx, "skipping vuln URL: does not exist (404)", "index", i, "url", vulnURL)
 		closeResponse(resp)
 	}
 	if resp == nil {
@@ -579,10 +550,10 @@ func (u *Updater) fetch(ctx context.Context, prevTimestamp time.Time) (*os.File,
 			return
 		}
 		if err := f.Close(); err != nil {
-			zlog.Error(ctx).Err(err).Msg("closing temp update file")
+			slog.ErrorContext(ctx, "closing temp update file", "reason", err)
 		}
 		if err := os.Remove(f.Name()); err != nil {
-			zlog.Error(ctx).Err(err).Msgf("removing temp update file %q", f.Name())
+			slog.ErrorContext(ctx, "removing temp update file", "file", f.Name(), "reason", err)
 		}
 	}()
 
@@ -607,10 +578,7 @@ func (u *Updater) fetch(ctx context.Context, prevTimestamp time.Time) (*os.File,
 func (u *Updater) fetchFromURL(ctx context.Context, url string, prevTimestamp time.Time) (*http.Response, error) {
 	var resp *http.Response
 	for attempt := 1; attempt <= u.retryMax; attempt++ {
-		zlog.Info(ctx).
-			Str("url", url).
-			Int("attempt", attempt).
-			Msg("fetching vuln update")
+		slog.InfoContext(ctx, "fetching vuln update", "url", url, "attempt", attempt)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return nil, err
@@ -619,10 +587,7 @@ func (u *Updater) fetchFromURL(ctx context.Context, url string, prevTimestamp ti
 		req.Header.Set("X-Scanner-V4-Accept", "application/vnd.stackrox.scanner-v4.multi-bundle+zip")
 		resp, err = u.client.Do(req)
 		if attempt < u.retryMax && isRetryableDialError(err) {
-			zlog.Error(ctx).
-				Err(err).
-				Str("delay", u.retryDelay.String()).
-				Msg("retrying...")
+			slog.ErrorContext(ctx, "retrying...", "reason", err, "delay", u.retryDelay.String())
 			time.Sleep(u.retryDelay)
 			continue
 		}

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/libvuln/updates"
 	"github.com/quay/claircore/test"
-	"github.com/quay/zlog"
-	"github.com/rs/zerolog"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/scanner/datastore/postgres/mocks"
 	"github.com/stackrox/rox/scanner/updater/jsonblob"
@@ -284,10 +282,11 @@ func TestUpdater_Initialized(t *testing.T) {
 	})
 
 	t.Run("when not initialized and get last update fails then log return not ready", func(t *testing.T) {
-		b := &bytes.Buffer{}
-		l := zerolog.New(b)
-		zlog.Set(&l)
-		ctx := zlog.Test(context.Background(), t)
+		var buf bytes.Buffer
+		h := slog.NewJSONHandler(&buf, nil)
+		prev := slog.Default()
+		slog.SetDefault(slog.New(h))
+		ctx := context.Background()
 		ctrl := gomock.NewController(t)
 		metaMock := mocks.NewMockMatcherMetadataStore(ctrl)
 		metaMock.
@@ -300,9 +299,9 @@ func TestUpdater_Initialized(t *testing.T) {
 		u.initialized.Store(false)
 		got := u.Initialized(ctx)
 		assert.False(t, got, `expecting "not ready" got "ready"`)
-		assert.Contains(t, `"did not get previous vuln update timestamp"`, b.String())
-		assert.Contains(t, `"error":"last update failed (fake error)"`, b.String())
-		assert.Contains(t, `"level":"error"`, b.String())
+		assert.Contains(t, buf.String(), `did not get previous vuln update timestamp`)
+		assert.Contains(t, buf.String(), `last update failed (fake error)`)
+		assert.Contains(t, buf.String(), `WARN`)
 	})
 }
 
@@ -400,7 +399,7 @@ func TestIsRetryableDialError(t *testing.T) {
 }
 
 func TestUpdater_Import(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 
 	// Represents one vulnerability or enrichment iteration.

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -4,9 +4,11 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -107,7 +109,7 @@ func TestMultiBundleUpdate(t *testing.T) {
 	metadataStore.EXPECT().
 		GetLastVulnerabilityUpdate(gomock.Any()).
 		Return(time.Time{}, errors.New("err"))
-	err := u.Update(context.Background())
+	err := u.Update(test.Logging(t))
 	assert.Error(t, err)
 	assert.Nil(t, u.KnownDistributions())
 
@@ -136,7 +138,7 @@ func TestMultiBundleUpdate(t *testing.T) {
 	store.EXPECT().
 		Distributions(gomock.Any()).
 		Return(dists, nil)
-	err = u.Update(context.Background())
+	err = u.Update(test.Logging(t))
 	assert.NoError(t, err)
 	assert.Equal(t, dists, u.KnownDistributions())
 
@@ -144,7 +146,7 @@ func TestMultiBundleUpdate(t *testing.T) {
 	metadataStore.EXPECT().
 		GetLastVulnerabilityUpdate(gomock.Any()).
 		Return(now.Add(time.Minute), nil)
-	err = u.Update(context.Background())
+	err = u.Update(test.Logging(t))
 	assert.NoError(t, err)
 	assert.Equal(t, dists, u.KnownDistributions())
 }
@@ -163,19 +165,19 @@ func TestFetch(t *testing.T) {
 	}
 
 	// Fetch file, as it's modified after the given time.
-	f, timestamp, err := u.fetch(context.Background(), time.Time{})
+	f, timestamp, err := u.fetch(test.Logging(t), time.Time{})
 	require.NoError(t, err)
 	assert.NotNil(t, f)
 	assert.Equal(t, now, timestamp)
 
 	// Fetch file, as it's modified after the given time.
-	f, timestamp, err = u.fetch(context.Background(), now.Add(-time.Minute))
+	f, timestamp, err = u.fetch(test.Logging(t), now.Add(-time.Minute))
 	require.NoError(t, err)
 	assert.NotNil(t, f)
 	assert.Equal(t, now, timestamp)
 
 	// Do not fetch file, as it's not modified after the given time.
-	f, timestamp, err = u.fetch(context.Background(), now.Add(time.Minute))
+	f, timestamp, err = u.fetch(test.Logging(t), now.Add(time.Minute))
 	require.NoError(t, err)
 	assert.Nil(t, f)
 	assert.Equal(t, time.Time{}, timestamp)
@@ -203,7 +205,7 @@ func TestFetchRCBundle(t *testing.T) {
 		retryMax:   1,
 	}
 
-	f, timestamp, err := u.fetch(context.Background(), time.Time{})
+	f, timestamp, err := u.fetch(test.Logging(t), time.Time{})
 	require.NoError(t, err)
 	assert.NotNil(t, f)
 	assert.Equal(t, now, timestamp)
@@ -235,7 +237,7 @@ func TestFetchRCBundleFallback(t *testing.T) {
 		retryMax:   1,
 	}
 
-	f, timestamp, err := u.fetch(context.Background(), time.Time{})
+	f, timestamp, err := u.fetch(test.Logging(t), time.Time{})
 	require.NoError(t, err)
 	assert.NotNil(t, f)
 	assert.Equal(t, now, timestamp)
@@ -244,17 +246,19 @@ func TestFetchRCBundleFallback(t *testing.T) {
 
 func TestUpdater_Initialized(t *testing.T) {
 	t.Run("when initialized then return ready", func(t *testing.T) {
+		ctx := test.Logging(t)
 		ctrl := gomock.NewController(t)
 		metaMock := mocks.NewMockMatcherMetadataStore(ctrl)
 		u := Updater{
 			metadataStore: metaMock,
 		}
 		u.initialized.Store(true)
-		got := u.Initialized(context.Background())
+		got := u.Initialized(ctx)
 		assert.True(t, got, `expecting "ready" got "not ready"`)
 	})
 
 	t.Run("when not initialized and get last update is empty then return not ready", func(t *testing.T) {
+		ctx := test.Logging(t)
 		ctrl := gomock.NewController(t)
 		metaMock := mocks.NewMockMatcherMetadataStore(ctrl)
 		metaMock.
@@ -263,11 +267,12 @@ func TestUpdater_Initialized(t *testing.T) {
 		u := Updater{
 			metadataStore: metaMock,
 		}
-		got := u.Initialized(context.Background())
+		got := u.Initialized(ctx)
 		assert.False(t, got, `expecting "not ready" got "ready"`)
 	})
 
 	t.Run("when not initialized and get last update is not empty then return ready", func(t *testing.T) {
+		ctx := test.Logging(t)
 		ctrl := gomock.NewController(t)
 		metaMock := mocks.NewMockMatcherMetadataStore(ctrl)
 		metaMock.
@@ -277,7 +282,7 @@ func TestUpdater_Initialized(t *testing.T) {
 		u := Updater{
 			metadataStore: metaMock,
 		}
-		got := u.Initialized(context.Background())
+		got := u.Initialized(ctx)
 		assert.True(t, got, `expecting "ready" got "not ready"`)
 	})
 
@@ -286,6 +291,7 @@ func TestUpdater_Initialized(t *testing.T) {
 		h := slog.NewJSONHandler(&buf, nil)
 		prev := slog.Default()
 		slog.SetDefault(slog.New(h))
+		t.Cleanup(func() { slog.SetDefault(prev) })
 		ctx := context.Background()
 		ctrl := gomock.NewController(t)
 		metaMock := mocks.NewMockMatcherMetadataStore(ctrl)
@@ -299,9 +305,12 @@ func TestUpdater_Initialized(t *testing.T) {
 		u.initialized.Store(false)
 		got := u.Initialized(ctx)
 		assert.False(t, got, `expecting "not ready" got "ready"`)
-		assert.Contains(t, buf.String(), `did not get previous vuln update timestamp`)
-		assert.Contains(t, buf.String(), `last update failed (fake error)`)
-		assert.Contains(t, buf.String(), `WARN`)
+
+		var entry map[string]interface{}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+		assert.Equal(t, "did not get previous vuln update timestamp", entry["msg"])
+		assert.Contains(t, entry["reason"], "last update failed (fake error)")
+		assert.Equal(t, "WARN", entry["level"])
 	})
 }
 
@@ -399,7 +408,7 @@ func TestIsRetryableDialError(t *testing.T) {
 }
 
 func TestUpdater_Import(t *testing.T) {
-	ctx := context.Background()
+	ctx := test.Logging(t)
 	ctrl := gomock.NewController(t)
 
 	// Represents one vulnerability or enrichment iteration.

--- a/scanner/sbom/sbom_test.go
+++ b/scanner/sbom/sbom_test.go
@@ -1,34 +1,37 @@
 package sbom
 
 import (
-	"context"
 	"testing"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/test"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetSBOM(t *testing.T) {
 	t.Run("error on nil index report", func(t *testing.T) {
+		ctx := test.Logging(t)
 		s := NewSBOMer()
-		_, err := s.GetSBOM(context.Background(), nil, nil)
+		_, err := s.GetSBOM(ctx, nil, nil)
 
 		assert.ErrorContains(t, err, "index report is required")
 	})
 
 	t.Run("error on nil opts", func(t *testing.T) {
+		ctx := test.Logging(t)
 		ir := &claircore.IndexReport{}
 		s := NewSBOMer()
-		_, err := s.GetSBOM(context.Background(), ir, nil)
+		_, err := s.GetSBOM(ctx, ir, nil)
 
 		assert.ErrorContains(t, err, "opts is required")
 	})
 
 	t.Run("success", func(t *testing.T) {
+		ctx := test.Logging(t)
 		ir := &claircore.IndexReport{}
 		s := NewSBOMer()
 
-		sbom, err := s.GetSBOM(context.Background(), ir, &Options{})
+		sbom, err := s.GetSBOM(ctx, ir, &Options{})
 		assert.NoError(t, err)
 		assert.NotEmpty(t, sbom)
 	})

--- a/scanner/services/indexer.go
+++ b/scanner/services/indexer.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/toolkit/log"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
@@ -54,24 +55,23 @@ func NewIndexerService(indexer indexer.Indexer) *indexerService {
 }
 
 func (s *indexerService) CreateIndexReport(ctx context.Context, req *v4.CreateIndexReportRequest) (*v4.IndexReport, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/service/indexer.CreateIndexReport")
 	return s.createIndexReport(ctx, req)
 }
 
 // createIndexReport creates an Index Report for the given request.
 // This function writes logs using the given context.
 func (s *indexerService) createIndexReport(ctx context.Context, req *v4.CreateIndexReportRequest) (*v4.IndexReport, error) {
-	zlog.Info(ctx).Msg("creating index report for container image")
+	slog.InfoContext(ctx, "creating index report for container image")
 
 	// TODO We currently only support container images, hence we assume the resource
 	//      is of that type. When introducing nodes and other resources, this should
 	//      evolve.
 	resourceType := "containerimage"
 	if err := validators.ValidateContainerImageRequest(req); err != nil {
-		zlog.Error(ctx).Err(err).Msg("invalid request")
+		slog.ErrorContext(ctx, "invalid request", "reason", err)
 		return nil, err
 	}
-	ctx = zlog.ContextWithValues(ctx, "resource_type", resourceType, "hash_id", req.GetHashId())
+	ctx = log.With(ctx, "resource_type", resourceType, "hash_id", req.GetHashId())
 
 	// Setup authentication.
 	var opts []indexer.Option
@@ -84,18 +84,17 @@ func (s *indexerService) createIndexReport(ctx context.Context, req *v4.CreateIn
 	}
 	opts = append(opts, indexer.InsecureSkipTLSVerify(req.GetContainerImage().GetInsecureSkipTlsVerify()))
 	// Create index report.
-	zlog.Info(ctx).
-		Str("image_url", req.GetContainerImage().GetUrl()).
-		Bool("has_auth", hasAuth).
-		Bool("insecure_skip_tls_verify", req.GetContainerImage().GetInsecureSkipTlsVerify()).
-		Msg("creating index report for container image")
+	slog.InfoContext(ctx, "creating index report for container image",
+		"image_url", req.GetContainerImage().GetUrl(),
+		"has_auth", hasAuth,
+		"insecure_skip_tls_verify", req.GetContainerImage().GetInsecureSkipTlsVerify())
 	clairReport, err := s.indexer.IndexContainerImage(
 		ctx,
 		req.GetHashId(),
 		req.GetContainerImage().GetUrl(),
 		opts...)
 	if err != nil {
-		zlog.Error(ctx).Err(err).Send()
+		slog.ErrorContext(ctx, "indexing container image failed", "reason", err)
 		return nil, err
 	}
 	if !clairReport.Success {
@@ -103,7 +102,7 @@ func (s *indexerService) createIndexReport(ctx context.Context, req *v4.CreateIn
 	}
 	indexReport, err := mappers.ToProtoV4IndexReport(clairReport)
 	if err != nil {
-		zlog.Error(ctx).Err(err).Msg("internal error: converting to v4.IndexReport")
+		slog.ErrorContext(ctx, "internal error: converting to v4.IndexReport", "reason", err)
 		return nil, err
 	}
 	indexReport.HashId = req.GetHashId()
@@ -111,17 +110,14 @@ func (s *indexerService) createIndexReport(ctx context.Context, req *v4.CreateIn
 }
 
 func (s *indexerService) GetIndexReport(ctx context.Context, req *v4.GetIndexReportRequest) (*v4.IndexReport, error) {
-	ctx = zlog.ContextWithValues(ctx,
-		"component", "scanner/service/indexer.GetIndexReport",
-		"hash_id", req.GetHashId(),
-	)
-	zlog.Info(ctx).Msg("getting index report for container image")
+	ctx = log.With(ctx, "hash_id", req.GetHashId())
+	slog.InfoContext(ctx, "getting index report for container image")
 	ir, err := s.getIndexReport(ctx, req.GetHashId(), req.GetIncludeExternal())
 	switch {
 	case errors.Is(err, errox.NotFound):
-		zlog.Warn(ctx).Err(err).Send()
+		slog.WarnContext(ctx, "index report not found", "reason", err)
 	case err != nil:
-		zlog.Error(ctx).Err(err).Msg("internal error")
+		slog.ErrorContext(ctx, "internal error", "reason", err)
 	}
 	return ir, err
 }
@@ -144,21 +140,18 @@ func (s *indexerService) getIndexReport(ctx context.Context, hashID string, incl
 }
 
 func (s *indexerService) GetOrCreateIndexReport(ctx context.Context, req *v4.GetOrCreateIndexReportRequest) (*v4.IndexReport, error) {
-	ctx = zlog.ContextWithValues(ctx,
-		"component", "scanner/service/indexer.GetOrCreateIndexReport",
-		"hash_id", req.GetHashId(),
-	)
+	ctx = log.With(ctx, "hash_id", req.GetHashId())
 
-	zlog.Info(ctx).Msg("getting index report for container image")
+	slog.InfoContext(ctx, "getting index report for container image")
 	ir, err := s.getIndexReport(ctx, req.GetHashId(), false)
 	switch {
 	case errors.Is(err, nil):
 		return ir, nil
 	case errors.Is(err, errox.NotFound):
 		// Not found, log and go create.
-		zlog.Debug(ctx).Err(err).Msg("index report not found")
+		slog.DebugContext(ctx, "index report not found", "reason", err)
 	default:
-		zlog.Error(ctx).Err(err).Msg("internal error")
+		slog.ErrorContext(ctx, "internal error", "reason", err)
 		return nil, err
 	}
 
@@ -174,10 +167,7 @@ func (s *indexerService) GetOrCreateIndexReport(ctx context.Context, req *v4.Get
 }
 
 func (s *indexerService) HasIndexReport(ctx context.Context, req *v4.HasIndexReportRequest) (*v4.HasIndexReportResponse, error) {
-	ctx = zlog.ContextWithValues(ctx,
-		"component", "scanner/service/indexer.HasIndexReport",
-		"hash_id", req.GetHashId(),
-	)
+	ctx = log.With(ctx, "hash_id", req.GetHashId())
 	_, err := getClairIndexReport(ctx, s.indexer, req.GetHashId(), false)
 	var exists bool
 	switch {
@@ -186,25 +176,22 @@ func (s *indexerService) HasIndexReport(ctx context.Context, req *v4.HasIndexRep
 	case errors.Is(err, errox.NotFound):
 		exists = false
 	default:
-		zlog.Error(ctx).Err(err).Msg("failed retrieve index report")
+		slog.ErrorContext(ctx, "failed retrieve index report", "reason", err)
 		return nil, err
 	}
 	return &v4.HasIndexReportResponse{Exists: exists}, nil
 }
 
 func (s *indexerService) StoreIndexReport(ctx context.Context, req *v4.StoreIndexReportRequest) (*v4.StoreIndexReportResponse, error) {
-	ctx = zlog.ContextWithValues(ctx,
-		"component", "scanner/service/indexer.StoreIndexReport",
-		"hash_id", req.GetHashId(),
-	)
+	ctx = log.With(ctx, "hash_id", req.GetHashId())
 
 	resp := &v4.StoreIndexReportResponse{Status: "ERROR"}
 	if req.GetContents() == nil {
-		zlog.Debug(ctx).Msg("no contents, rejecting")
+		slog.DebugContext(ctx, "no contents, rejecting")
 		return resp, errox.InvalidArgs.New("empty contents")
 	}
 
-	zlog.Info(ctx).Msg("storing external index report")
+	slog.InfoContext(ctx, "storing external index report")
 	ir, err := parseIndexReport(req.GetContents())
 	if err != nil {
 		return resp, fmt.Errorf("parsing contents to index report: %w", err)

--- a/scanner/services/indexer_test.go
+++ b/scanner/services/indexer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/test"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/grpc/testutils"
 	"github.com/stackrox/rox/pkg/protoassert"
@@ -33,7 +34,7 @@ func TestIndexerServiceSuite(t *testing.T) {
 
 func (s *indexerServiceTestSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
-	s.ctx = context.Background()
+	s.ctx = test.Logging(s.T())
 	s.indexerMock = mocks.NewMockIndexer(s.mockCtrl)
 	s.service = NewIndexerService(s.indexerMock)
 }

--- a/scanner/services/matcher.go
+++ b/scanner/services/matcher.go
@@ -3,11 +3,12 @@ package services
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/quay/claircore"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/toolkit/log"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errox"
@@ -59,40 +60,39 @@ func NewMatcherService(matcher matcher.Matcher, indexer indexer.ReportGetter) *m
 }
 
 func (s *matcherService) GetVulnerabilities(ctx context.Context, req *v4.GetVulnerabilitiesRequest) (*v4.VulnerabilityReport, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "scanner/service/matcher.GetVulnerabilities")
 	if err := validators.ValidateGetVulnerabilitiesRequest(req); err != nil {
 		return nil, errox.InvalidArgs.CausedBy(err)
 	}
 	if err := s.matcher.Initialized(ctx); err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "the matcher is not initialized: %v", err)
 	}
-	ctx = zlog.ContextWithValues(ctx, "hash_id", req.GetHashId())
+	ctx = log.With(ctx, "hash_id", req.GetHashId())
 	// Get an index report to enrich: either using the indexer, or provided in the request.
 	var ir *claircore.IndexReport
 	var err error
 	if req.GetContents() == nil {
 		if s.disableEmptyContents {
-			zlog.Debug(ctx).Msg("no contents, rejecting")
+			slog.DebugContext(ctx, "no contents, rejecting")
 			return nil, errox.InvalidArgs.New("empty contents is disabled")
 		}
-		zlog.Debug(ctx).Msg("no contents, retrieving")
+		slog.DebugContext(ctx, "no contents, retrieving")
 		ir, err = getClairIndexReport(ctx, s.indexer, req.GetHashId(), false)
 	} else {
-		zlog.Info(ctx).Msg("has contents, parsing")
+		slog.InfoContext(ctx, "has contents, parsing")
 		ir, err = parseIndexReport(req.GetContents())
 	}
 	if err != nil {
 		return nil, err
 	}
-	zlog.Info(ctx).Msgf("getting vulnerabilities for index report %q", req.GetHashId())
+	slog.InfoContext(ctx, "getting vulnerabilities for index report", "hash_id", req.GetHashId())
 	ccReport, err := s.matcher.GetVulnerabilities(ctx, ir)
 	if err != nil {
-		zlog.Error(ctx).Err(err).Send()
+		slog.ErrorContext(ctx, "getting vulnerabilities failed", "reason", err)
 		return nil, err
 	}
 	report, err := mappers.ToProtoV4VulnerabilityReport(ctx, ccReport)
 	if err != nil {
-		zlog.Error(ctx).Err(err).Msg("internal error: converting to v4.VulnerabilityReport")
+		slog.ErrorContext(ctx, "internal error: converting to v4.VulnerabilityReport", "reason", err)
 		return nil, err
 	}
 	report.HashId = req.GetHashId()
@@ -169,25 +169,21 @@ func (s *matcherService) notes(ctx context.Context, vr *v4.VulnerabilityReport) 
 }
 
 func (s *matcherService) GetSBOM(ctx context.Context, req *v4.GetSBOMRequest) (*v4.GetSBOMResponse, error) {
-	ctx = zlog.ContextWithValues(ctx,
-		"component", "scanner/service/matcher.GetSBOM",
-		"id", req.GetId(),
-		"name", req.GetName(),
-	)
+	ctx = log.With(ctx, "id", req.GetId(), "name", req.GetName())
 
 	if err := validators.ValidateGetSBOMRequest(req); err != nil {
 		return nil, errox.InvalidArgs.CausedBy(err)
 	}
 
-	zlog.Info(ctx).Msgf("generating SBOM from index report (%d dists (%d deprecated), %d envs (%d deprecated), %d pkgs (%d deprecated), %d repos (%d deprecated))",
-		len(req.GetContents().GetDistributions()),
-		len(req.GetContents().GetDistributionsDEPRECATED()),
-		len(req.GetContents().GetEnvironments()),
-		len(req.GetContents().GetEnvironmentsDEPRECATED()),
-		len(req.GetContents().GetPackages()),
-		len(req.GetContents().GetPackagesDEPRECATED()),
-		len(req.GetContents().GetRepositories()),
-		len(req.GetContents().GetRepositoriesDEPRECATED()),
+	slog.InfoContext(ctx, "generating SBOM from index report",
+		"distributions", len(req.GetContents().GetDistributions()),
+		"distributions_deprecated", len(req.GetContents().GetDistributionsDEPRECATED()),
+		"environments", len(req.GetContents().GetEnvironments()),
+		"environments_deprecated", len(req.GetContents().GetEnvironmentsDEPRECATED()),
+		"packages", len(req.GetContents().GetPackages()),
+		"packages_deprecated", len(req.GetContents().GetPackagesDEPRECATED()),
+		"repositories", len(req.GetContents().GetRepositories()),
+		"repositories_deprecated", len(req.GetContents().GetRepositoriesDEPRECATED()),
 	)
 
 	// The remote indexer is not used. This creates flexibility and enables SBOMs to be generated
@@ -195,7 +191,7 @@ func (s *matcherService) GetSBOM(ctx context.Context, req *v4.GetSBOMRequest) (*
 	// indexed by indexer, such as Central scans from third party scanners).
 	ir, err := parseIndexReport(req.GetContents())
 	if err != nil {
-		zlog.Error(ctx).Err(err).Msg("parsing index report")
+		slog.ErrorContext(ctx, "parsing index report", "reason", err)
 		return nil, err
 	}
 
@@ -205,7 +201,7 @@ func (s *matcherService) GetSBOM(ctx context.Context, req *v4.GetSBOMRequest) (*
 		Comment:   fmt.Sprintf("Generated for '%s'", req.GetName()),
 	})
 	if err != nil {
-		zlog.Error(ctx).Err(err).Msg("generating SBOM")
+		slog.ErrorContext(ctx, "generating SBOM", "reason", err)
 		return nil, err
 	}
 

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/toolkit/types/cpe"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/pkg/grpc/testutils"
@@ -31,7 +32,7 @@ func TestMatcherServiceSuite(t *testing.T) {
 }
 func (s *matcherServiceTestSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
-	s.ctx = context.Background()
+	s.ctx = test.Logging(s.T())
 	s.matcherMock = matchermocks.NewMockMatcher(s.mockCtrl)
 	s.indexerMock = indexermocks.NewMockIndexer(s.mockCtrl)
 }

--- a/scanner/updater/export.go
+++ b/scanner/updater/export.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
+	stdlog "log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -18,7 +19,7 @@ import (
 	"github.com/quay/claircore/libvuln/jsonblob"
 	"github.com/quay/claircore/libvuln/updates"
 	"github.com/quay/claircore/rhel/vex"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/toolkit/log"
 	"github.com/stackrox/rox/scanner/enricher/csaf"
 	"github.com/stackrox/rox/scanner/enricher/nvd"
 	"github.com/stackrox/rox/scanner/updater/manual"
@@ -88,9 +89,9 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 		parsedInterval, err := time.ParseDuration(configuredInterval)
 		switch {
 		case err != nil:
-			log.Printf("invalid interval, using default (%v): %v", interval, err)
+			stdlog.Printf("invalid interval, using default (%v): %v", interval, err)
 		case parsedInterval < interval:
-			log.Printf("interval is too small (%v): using default (%v)", parsedInterval, interval)
+			stdlog.Printf("interval is too small (%v): using default (%v)", parsedInterval, interval)
 		default:
 			interval = parsedInterval
 		}
@@ -106,7 +107,7 @@ func Export(ctx context.Context, outputDir string, opts *ExportOptions) error {
 
 	// Export to bundle(s).
 	for name, o := range bundles {
-		ctx = zlog.ContextWithValues(ctx, "bundle", name)
+		ctx = log.With(ctx, "bundle", name)
 		w, err := zstdWriter(filepath.Join(outputDir, fmt.Sprintf("%s.json.zst", name)))
 		if err != nil {
 			return err
@@ -185,7 +186,8 @@ func rhelVexOpts() []updates.ManagerOption {
 		updates.WithEnabled([]string{rhelVexUpdaterName}),
 		updates.WithConfigs(map[string]driver.ConfigUnmarshaler{
 			rhelVexUpdaterName: func(i any) error {
-				ctx := zlog.ContextWithValues(context.Background(), "updater", rhelVexUpdaterName)
+				ctx := context.Background()
+				ctx = log.With(ctx, "updater", rhelVexUpdaterName)
 
 				// This function gets called for both the Factory and the Updater.
 				// We only need to configure the Factory (which has the CompressedFileTimeout field).
@@ -196,14 +198,10 @@ func rhelVexOpts() []updates.ManagerOption {
 					if timeout != "" {
 						parsedTimeout, err := time.ParseDuration(timeout)
 						if err != nil {
-							zlog.Warn(ctx).
-								Err(err).
-								Msg("using default STACKROX_RHEL_VEX_COMPRESSED_FILE_TIMEOUT due to invalid duration")
+							slog.WarnContext(ctx, "using default STACKROX_RHEL_VEX_COMPRESSED_FILE_TIMEOUT due to invalid duration", "reason", err)
 						} else {
 							cfg.CompressedFileTimeout = claircore.Duration(parsedTimeout)
-							zlog.Info(ctx).
-								Str("timeout", parsedTimeout.String()).
-								Msg("using compressed file timeout")
+							slog.InfoContext(ctx, "using compressed file timeout", "timeout", parsedTimeout.String())
 						}
 					}
 				case *vex.UpdaterConfig:

--- a/scanner/updater/manual/manual.go
+++ b/scanner/updater/manual/manual.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -16,7 +17,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/zlog"
 	"github.com/stackrox/rox/pkg/scannerv4/updater/manual"
 	"github.com/stackrox/rox/pkg/utils"
 	"go.yaml.in/yaml/v3"
@@ -76,8 +76,6 @@ func (u *updater) Name() string {
 
 // Fetch fetching data from a configurable URI.
 func (u *updater) Fetch(ctx context.Context, fingerprint driver.Fingerprint) (io.ReadCloser, driver.Fingerprint, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "updater/manual/manual.Fetch")
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.updateURL.String(), nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create request: %w", err)
@@ -89,7 +87,7 @@ func (u *updater) Fetch(ctx context.Context, fingerprint driver.Fingerprint) (io
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			zlog.Error(ctx).Err(err).Msg("failed to close response body")
+			slog.ErrorContext(ctx, "failed to close response body", "reason", err)
 		}
 	}()
 
@@ -100,9 +98,7 @@ func (u *updater) Fetch(ctx context.Context, fingerprint driver.Fingerprint) (io
 	if err != nil {
 		return nil, "", errors.Wrap(err, "creating scanner defs file")
 	}
-	zlog.Debug(ctx).
-		Str("filename", out.Name()).
-		Msg("opened temporary file for output")
+	slog.DebugContext(ctx, "opened temporary file for output", "filename", out.Name())
 
 	// Remove the file, as we do not need it anymore. We just need the pointer.
 	utils.IgnoreError(func() error {
@@ -140,10 +136,7 @@ func (u *updater) Fetch(ctx context.Context, fingerprint driver.Fingerprint) (io
 		return nil, "", fmt.Errorf("seek failed: %w", err)
 	}
 
-	zlog.Info(ctx).
-		Str("filename", out.Name()).
-		Str("fingerprint", string(checksum)).
-		Msg("fetched manual vulnerability yaml file")
+	slog.InfoContext(ctx, "fetched manual vulnerability yaml file", "filename", out.Name(), "fingerprint", string(checksum))
 	doClose = false
 	return out, driver.Fingerprint(checksum), nil
 }
@@ -195,15 +188,12 @@ func (u *updater) Parse(ctx context.Context, rc io.ReadCloser) ([]*claircore.Vul
 		clairVulns = append(clairVulns, cv)
 	}
 
-	zlog.Info(ctx).
-		Int("count", len(clairVulns)).
-		Msg("All manual vulnerabilities parsed")
+	slog.InfoContext(ctx, "All manual vulnerabilities parsed", "count", len(clairVulns))
 	return clairVulns, nil
 }
 
 // UpdaterSet initializes an updater set with a configured updater based on provided URI and client.
 func UpdaterSet(ctx context.Context, uri string) (driver.UpdaterSet, error) {
-	ctx = zlog.ContextWithValues(ctx, "component", "updater/manual/manual.UpdaterSet")
 	res := driver.NewUpdaterSet()
 	u, err := NewUpdater(client, uri)
 	if err != nil {
@@ -213,8 +203,6 @@ func UpdaterSet(ctx context.Context, uri string) (driver.UpdaterSet, error) {
 	if err := res.Add(u); err != nil {
 		return res, fmt.Errorf("failed to create new updater set: %w", err)
 	}
-	zlog.Info(ctx).
-		Str("url", u.updateURL.String()).
-		Msg("created manual updater set")
+	slog.InfoContext(ctx, "created manual updater set", "url", u.updateURL.String())
 	return res, nil
 }


### PR DESCRIPTION
## Description

Claircore has moved to `log/slog` for their logging library. Staying on `zlog/v1` means maintaining a (`zerolog`|`zlog/v1`)-to-slog bridge and carrying two logging dependencies that serve the same purpose. Aligning with upstream simplifies the dependency tree, keeps us compatible with future Claircore releases, and avoids maintaining "glue" code between the two logging libraries.

These changes migrate Scanner V4 from `github.com/quay/zlog` v1 (backed by `github.com/rs/zerolog`) to `log/slog` with `github.com/quay/zlog/v2` as the slog handler, and remove the `github.com/quay/zlog` v1 and `github.com/rs/zerolog` dependencies entirely. 

Notable changes:
- All `zlog.Info(ctx).Str(k, v).Msg(m)` calls replaced with `slog.InfoContext(ctx, m, k, v)`
- `zlog.ContextWithValues` replaced with `toolkit/log.With` where context-scoped attrs are needed
- `zerolog.Level` config replaced with `slog.Level`; `parseSlogLevel` handles the mapping (trace→debug,
fatal/panic→error)
- Scanner handler initialized via `zlog/v2.NewHandler` with `toolkit/log` context keys
- `context.Background()` in tests replaced with `test.Logging(t)` for claircore-integrated test logging
- Removed `"component"` context values. This has been replaced by the `source` field that `zlog/v2` provides.

Supersedes https://github.com/stackrox/stackrox/pull/18828.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Existing scanner unit tests pass with the new logging plumbing
- Verified `zlog` v1 and `zerolog` are no longer in `go.mod`
- No functional changes to scanner behavior; this is a logging backend swap

Example:
```
❯ k logs scanner-v4-matcher-5cbc8757ff-546vx --tail=10
pkg/grpc: 2026/05/01 04:23:41.701311 server.go:494: Info: TLS-enabled HTTP server listening on [::]:9443
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).runGCFullPeriodic","time":"2026-05-01T04:23:41.701413734Z","msg":"starting periodic full GC","host":"scanner-v4-matcher-5cbc8757ff-546vx","full_gc_interval":"24h0m0s"}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*distManager).update.func1","time":"2026-05-01T04:24:08.812090035Z","msg":"done updating vuln distributions","host":"scanner-v4-matcher-5cbc8757ff-546vx","updated":true}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).Start","time":"2026-05-01T04:24:08.812228702Z","msg":"starting update","host":"scanner-v4-matcher-5cbc8757ff-546vx"}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).runMultiBundleUpdate","time":"2026-05-01T04:24:08.813639118Z","msg":"previous vuln update","host":"scanner-v4-matcher-5cbc8757ff-546vx","timestamp":"2026-04-30T23:42:29Z"}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).fetchFromURL","time":"2026-05-01T04:24:08.813650993Z","msg":"fetching vuln update","host":"scanner-v4-matcher-5cbc8757ff-546vx","url":"https://central.stackrox.svc/api/extensions/scannerdefinitions?version=dev","attempt":1}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).runMultiBundleUpdate","time":"2026-05-01T04:24:08.905533362Z","msg":"no new vulnerability update","host":"scanner-v4-matcher-5cbc8757ff-546vx"}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).Update","time":"2026-05-01T04:24:08.905554737Z","msg":"no vulnerability updates: skipping GC","host":"scanner-v4-matcher-5cbc8757ff-546vx"}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).Start","time":"2026-05-01T04:24:08.905563029Z","msg":"completed update","host":"scanner-v4-matcher-5cbc8757ff-546vx"}
{"level":"INFO","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).Initialized","time":"2026-05-01T04:24:08.90583307Z","msg":"all vulnerability bundles were updated at least once: setting to initialized","host":"scanner-v4-matcher-5cbc8757ff-546vx"}
```