### PR TITLE
ROX-33361: Per-namespace process indicator persistence in manifests

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -718,6 +718,10 @@ function launch_sensor {
       fi
     fi
 
+    if [[ -n "${ROX_PROCESS_INDICATORS_PER_NAMESPACE}" ]]; then
+      extra_config+=("--exclude-namespace-filter=namespace-without-persistence")
+    fi
+
     rm -rf "${k8s_dir}/sensor-deploy"
     rm -rf "${k8s_dir}/scanner-deploy"
 

--- a/pkg/helm/charts/meta.go
+++ b/pkg/helm/charts/meta.go
@@ -61,6 +61,7 @@ type MetaValues struct {
 	TelemetryKey                     string
 	TelemetryEndpoint                string
 	AutoLockProcessBaselines         bool
+	ExcludeNamespaceFilter           string
 
 	AutoSensePodSecurityPolicies bool
 	EnablePodSecurityPolicies    bool // Only used in the Helm chart if AutoSensePodSecurityPolicies is false.

--- a/roxctl/maincommand/command_tree_debug.yaml
+++ b/roxctl/maincommand/command_tree_debug.yaml
@@ -2041,6 +2041,7 @@ sensor:
       - create-upgrader-sa
       - disable-tolerations
       - enable-pod-security-policies
+      - exclude-namespace-filter
       - istio-support
       - main-image-repository
       - name
@@ -2085,6 +2086,7 @@ sensor:
         - disable-tolerations
         - enable-pod-security-policies
         - endpoint
+        - exclude-namespace-filter
         - force-http1
         - help
         - insecure
@@ -2127,6 +2129,7 @@ sensor:
         - disable-tolerations
         - enable-pod-security-policies
         - endpoint
+        - exclude-namespace-filter
         - force-http1
         - help
         - insecure

--- a/roxctl/maincommand/command_tree_release.yaml
+++ b/roxctl/maincommand/command_tree_release.yaml
@@ -2002,6 +2002,7 @@ sensor:
       - create-upgrader-sa
       - disable-tolerations
       - enable-pod-security-policies
+      - exclude-namespace-filter
       - istio-support
       - main-image-repository
       - name
@@ -2046,6 +2047,7 @@ sensor:
         - disable-tolerations
         - enable-pod-security-policies
         - endpoint
+        - exclude-namespace-filter
         - force-http1
         - help
         - insecure
@@ -2088,6 +2090,7 @@ sensor:
         - disable-tolerations
         - enable-pod-security-policies
         - endpoint
+        - exclude-namespace-filter
         - force-http1
         - help
         - insecure

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -72,6 +72,7 @@ func defaultCluster() *storage.Cluster {
 			AutoLockProcessBaselinesConfig: &storage.AutoLockProcessBaselinesConfig{
 				Enabled: false,
 			},
+			ProcessIndicators: &storage.DynamicClusterConfig_ProcessIndicatorsConfig{},
 		},
 	}
 }
@@ -227,6 +228,8 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.AdmissionControllerFailOnError, "admission-controller-fail-on-error", false, "Fail the admission review request in case of errors or timeouts in request evaluation.")
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.DynamicConfig.AutoLockProcessBaselinesConfig.Enabled, "auto-lock-process-baselines", false, "Locks process baselines when their deployments leave the observation period.")
 	c.PersistentFlags().BoolVar(&ac.EnforceOnUpdates, "admission-controller-enforcement", true, "Enforce security policies on the admission review request.")
+
+	c.PersistentFlags().StringVar(&generateCmd.cluster.DynamicConfig.ProcessIndicators.ExcludeNamespaceFilter, "exclude-namespace-filter", "", "A regex specifying to not persist process indicators from specified namespaces.")
 
 	c.MarkFlagsMutuallyExclusive("admission-controller-enforce-on-creates", "admission-controller-enforcement")
 	c.MarkFlagsMutuallyExclusive("admission-controller-enforce-on-updates", "admission-controller-enforcement")


### PR DESCRIPTION
## Description

Commit 405c8cf ("ROX-33361: Per-namespace persistence for process indicators (#19957)") has introduced a possibility to configure per-namespace persistence for process indicators.

Allow to provide new dynamic config fields via roxctl, in the form:

    roxctl --exclude-namespace-filter="test-.*"

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

The issue is coming from nightlies failures, thus CI is sufficient.