### PR TITLE
chore(ui): bump axios to ^1.15.1

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -23,7 +23,7 @@
                 "@patternfly/react-topology": "^6.4.0",
                 "@patternfly/react-user-feedback": "^6.2.0",
                 "@segment/analytics-next": "^1.81.1",
-                "axios": "^1.12.0",
+                "axios": "1.15.1",
                 "computed-style-to-inline-style": "^3.0.0",
                 "connected-react-router": "^6.9.3",
                 "d3-axis": "^1.0.12",
@@ -5521,20 +5521,20 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-            "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+            "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/axios/node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -5548,10 +5548,13 @@
             }
         },
         "node_modules/axios/node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/babel-plugin-emotion": {
             "version": "9.2.11",
@@ -9428,15 +9431,16 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs= sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -26,7 +26,7 @@
         "@patternfly/react-topology": "^6.4.0",
         "@patternfly/react-user-feedback": "^6.2.0",
         "@segment/analytics-next": "^1.81.1",
-        "axios": "^1.12.0",
+        "axios": "^1.15.1",
         "computed-style-to-inline-style": "^3.0.0",
         "connected-react-router": "^6.9.3",
         "d3-axis": "^1.0.12",

--- a/ui/apps/platform/src/utils/fileUtils.ts
+++ b/ui/apps/platform/src/utils/fileUtils.ts
@@ -14,6 +14,9 @@ export function parseAxiosResponseAttachment(response: AxiosResponse): {
 } {
     const matches = filenameRegex.exec(response.headers['content-disposition'] ?? '');
     const filename = matches && matches[1] ? matches[1] : null;
-    const file = new Blob([response.data], { type: response.headers['content-type'] });
+    const contentType = response.headers['content-type'];
+    const file = new Blob([response.data], {
+        type: typeof contentType === 'string' ? contentType : undefined,
+    });
     return { file, filename };
 }


### PR DESCRIPTION
## Description

Bump axios from 1.12.0 to ^1.15.1 to fix:
- [CVE-2026-42035](https://access.redhat.com/security/cve/CVE-2026-42035)
- [CVE-2025-62718](https://access.redhat.com/security/cve/CVE-2025-62718)
- [CVE-2026-40175](https://access.redhat.com/security/cve/CVE-2026-40175)

Additionally, updated `fileUtils` due to axios tightening their type definitions on response headers.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Verified no breaking changes in axios changelog
- Logged in and checked basic CRUD