### PR TITLE
ROX-34185: Add ImageVulnerabilityFiltersSince for report wizard

### DIFF
--- a/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
@@ -23,17 +23,17 @@ export type FiltersQueryConfiguration = {
     };
 };
 
-export type FiltersQueryProps = {
+export type FiltersQueryProps<T extends FiltersQueryConfiguration = FiltersQueryConfiguration> = {
     attributesSeparateFromConfig: SelectSearchFilterAttribute[];
-    formik: FormikProps<FiltersQueryConfiguration>;
+    formik: FormikProps<T>;
     searchFilterConfig: CompoundSearchFilterConfig;
 };
 
-function FiltersQuery({
+function FiltersQuery<T extends FiltersQueryConfiguration = FiltersQueryConfiguration>({
     attributesSeparateFromConfig,
     formik,
     searchFilterConfig,
-}: FiltersQueryProps): ReactElement {
+}: FiltersQueryProps<T>): ReactElement {
     const searchFilter = getSearchFilterFromSearchString(formik.values.vulnReportFilters.query);
 
     function onFilterChange(searchFilterChanged: SearchFilter) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersView.tsx
@@ -17,7 +17,7 @@ import type {
 } from 'Components/CompoundSearchFilter/types';
 import { getSearchFilterFromSearchString } from 'utils/searchUtils';
 
-import type { ImageVulnerabilityFiltersConfiguration } from '../imageVulnerabilityReports.types';
+import type { ImageVulnerabilityFiltersConfigurationForEntity } from '../imageVulnerabilityReports.types';
 import { getTextForCvesSince } from '../imageVulnerabilityReports.utils';
 
 export type ImageVulnerabilityFiltersViewProps = {
@@ -25,7 +25,7 @@ export type ImageVulnerabilityFiltersViewProps = {
     headingLevel: 'h2' | 'h3';
     horizontalTermWidthModifier: BreakpointModifiers;
     searchFilterConfig: CompoundSearchFilterConfig;
-    values: ImageVulnerabilityFiltersConfiguration;
+    values: ImageVulnerabilityFiltersConfigurationForEntity;
 };
 
 function ImageVulnerabilityFiltersView({

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
@@ -27,8 +27,8 @@ import ImageVulnerabilityFiltersStepForCollection from './Step3/ImageVulnerabili
 import ImageVulnerabilityReviewStep from './Step5/ImageVulnerabilityReviewStep';
 
 // TypeScript needs help because entityScope and vulnReportFilters have mutual dependencies.
-// entityScope implies query but not fixibility nore severities
-// collectionScope implies fixibility and severities but not query
+// entityScope implies query but not fixability nore severities
+// collectionScope implies fixability and severities but not query
 
 export function hasFormikPropsForEntity(
     formik

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersSince.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersSince.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import { DatePicker, FormGroup, Grid, GridItem, SelectOption } from '@patternfly/react-core';
+import type { FormikProps } from 'formik';
+
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import SelectSingle from 'Components/SelectSingle/SelectSingle';
+
+import type { ImageVulnerabilityFiltersConfiguration } from '../../imageVulnerabilityReports.types';
+import {
+    getReportFiltersWithoutCvesSince,
+    getValueForCvesSince,
+} from '../../imageVulnerabilityReports.utils';
+
+export type ImageVulnerabilityFiltersSinceProps<
+    T extends ImageVulnerabilityFiltersConfiguration = ImageVulnerabilityFiltersConfiguration,
+> = {
+    formik: FormikProps<T>;
+};
+
+function ImageVulnerabilityFiltersSince<
+    T extends ImageVulnerabilityFiltersConfiguration = ImageVulnerabilityFiltersConfiguration,
+>({ formik }: ImageVulnerabilityFiltersSinceProps<T>): ReactElement {
+    // Initialize with either selected start date or unspecified value.
+    // Objective of local state is remember date in scenario:
+    // 1. user had specified start date
+    // 2. user selected a different option
+    // 3. user selects custom date option again
+    const [sinceStartDatePicked, setSinceStartDatePicked] = useState(
+        'sinceStartDate' in formik.values.vulnReportFilters
+            ? formik.values.vulnReportFilters.sinceStartDate
+            : ''
+    );
+
+    function onChangeStartDate(sinceStartDate: string) {
+        setSinceStartDatePicked(sinceStartDate); // YYYY-MM-DD
+
+        // For future entity scope only, replace helper function call with the following:
+        // const { query } = formik.values.vulnReportFilters;
+        const vulnReportFiltersWithoutCvesSince = getReportFiltersWithoutCvesSince(formik.values);
+        formik.setFieldValue('vulnReportFilters', {
+            ...vulnReportFiltersWithoutCvesSince,
+            sinceStartDate,
+        });
+    }
+
+    // Grid renders the related form groups side-by-side.
+    // https://www.patternfly.org/components/forms/form#grid-form
+    return (
+        <Grid hasGutter>
+            <GridItem span={6}>
+                <FormGroup label="CVEs discovered in image since" isRequired>
+                    <SelectSingle
+                        id="CvesSince"
+                        value={getValueForCvesSince(formik.values.vulnReportFilters)}
+                        handleSelect={(name: string, value: string) => {
+                            // For future entity scope only, replace helper function call with the following:
+                            // const { query } = formik.values.vulnReportFilters;
+                            const vulnReportFiltersWithoutCvesSince =
+                                getReportFiltersWithoutCvesSince(formik.values);
+
+                            switch (value) {
+                                case 'sinceLastSentScheduledReport':
+                                    formik.setFieldValue('vulnReportFilters', {
+                                        ...vulnReportFiltersWithoutCvesSince,
+                                        sinceLastSentScheduledReport: true,
+                                    });
+                                    break;
+                                case 'sinceStartDate':
+                                    formik.setFieldValue('vulnReportFilters', {
+                                        ...vulnReportFiltersWithoutCvesSince,
+                                        sinceStartDate: sinceStartDatePicked,
+                                    });
+                                    break;
+                                default:
+                                    formik.setFieldValue('vulnReportFilters', {
+                                        ...vulnReportFiltersWithoutCvesSince,
+                                        allVuln: true,
+                                    });
+                                    break;
+                            }
+                        }}
+                        menuAppendTo={() => document.body}
+                    >
+                        <SelectOption
+                            value="sinceLastSentScheduledReport"
+                            description="At least one delivery destination and schedule will be required in the next step."
+                        >
+                            Last scheduled report that was successfully sent
+                        </SelectOption>
+                        <SelectOption
+                            value="sinceStartDate"
+                            description="Custom start date for the discovered CVE that were run on-demand or downloaded"
+                        >
+                            Custom start date
+                        </SelectOption>
+                        <SelectOption
+                            value="allVuln"
+                            description="Show all detected CVEs from the beginning of cluster setup"
+                        >
+                            All time
+                        </SelectOption>
+                    </SelectSingle>
+                </FormGroup>
+            </GridItem>
+            {'sinceStartDate' in formik.values.vulnReportFilters && (
+                <GridItem span={6}>
+                    <FormLabelGroup
+                        label="Custom start date"
+                        isRequired
+                        fieldId="vulnReportFilters.sinceStartDate"
+                        errors={formik.errors}
+                    >
+                        <DatePicker
+                            name="vulnReportFilters.sinceStartDate"
+                            value={formik.values.vulnReportFilters.sinceStartDate}
+                            onBlur={formik.handleBlur}
+                            onChange={(_event, value) => {
+                                onChangeStartDate(value);
+                            }}
+                        />
+                    </FormLabelGroup>
+                </GridItem>
+            )}
+        </Grid>
+    );
+}
+
+export default ImageVulnerabilityFiltersSince;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStep.tsx
@@ -7,30 +7,40 @@ import type {
     SelectSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
 
-import type { ImageVulnerabilityReportConfigurationForEntity } from '../../imageVulnerabilityReports.types';
+import FiltersQuery from 'Components/Reports/Step/FiltersQuery';
 
-/* eslint-disable react/no-unused-prop-types */
+import type { ImageVulnerabilityFiltersConfigurationForEntity } from '../../imageVulnerabilityReports.types';
+
+import ImageVulnerabilityFiltersSince from './ImageVulnerabilityFiltersSince';
+
 export type ImageVulnerabilityFiltersStepProps<
-    T extends ImageVulnerabilityReportConfigurationForEntity =
-        ImageVulnerabilityReportConfigurationForEntity,
+    T extends ImageVulnerabilityFiltersConfigurationForEntity =
+        ImageVulnerabilityFiltersConfigurationForEntity,
 > = {
     attributesSeparateFromConfig: SelectSearchFilterAttribute[];
     formik: FormikProps<T>;
     searchFilterConfig: CompoundSearchFilterConfig;
 };
-/* eslint-enable react/no-unused-prop-types */
 
 function ImageVulnerabilityFiltersStep<
-    T extends ImageVulnerabilityReportConfigurationForEntity =
-        ImageVulnerabilityReportConfigurationForEntity,
->({ formik }: ImageVulnerabilityFiltersStepProps<T>): ReactElement {
+    T extends ImageVulnerabilityFiltersConfigurationForEntity =
+        ImageVulnerabilityFiltersConfigurationForEntity,
+>({
+    attributesSeparateFromConfig,
+    formik,
+    searchFilterConfig,
+}: ImageVulnerabilityFiltersStepProps<T>): ReactElement {
     return (
         <PageSection>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Filters</Title>
-                <Form>
-                    <>{formik.values.vulnReportFilters.query}</>
-                    {/* TODO cvesSince */}
+                <Form isHorizontal isWidthLimited>
+                    <ImageVulnerabilityFiltersSince formik={formik} />
+                    <FiltersQuery
+                        attributesSeparateFromConfig={attributesSeparateFromConfig}
+                        formik={formik}
+                        searchFilterConfig={searchFilterConfig}
+                    />
                 </Form>
             </Flex>
         </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
@@ -1,11 +1,25 @@
+import { useState } from 'react';
 import type { ReactElement } from 'react';
-import { Flex, Form, PageSection, Title } from '@patternfly/react-core';
-
+import { Flex, Form, FormGroup, PageSection, Title } from '@patternfly/react-core';
 import type { FormikProps } from 'formik';
 
-import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import SearchFilterSelectInclusive from 'Components/CompoundSearchFilter/components/SearchFilterSelectInclusive';
+import type { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
+import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
+import type { SearchFilter } from 'types/search';
 
+import {
+    attributeForFixableInBackendAndViewBasedReport,
+    attributeForSeverityInBackendAndViewBasedReport,
+} from '../../../searchFilterConfig';
 import type { ImageVulnerabilityFiltersConfigurationForCollection } from '../../imageVulnerabilityReports.types';
+import {
+    getFixabilityFromSearchFilter,
+    getSearchFilterFromReportConfiguration,
+    getSeveritiesFromSearchFilter,
+} from '../../imageVulnerabilityReports.utils';
+
+import ImageVulnerabilityFiltersSince from './ImageVulnerabilityFiltersSince';
 
 export type ImageVulnerabilityFiltersStepForCollectionProps<
     T extends ImageVulnerabilityFiltersConfigurationForCollection =
@@ -18,28 +32,54 @@ function ImageVulnerabilityFiltersStepForCollection<
     T extends ImageVulnerabilityFiltersConfigurationForCollection =
         ImageVulnerabilityFiltersConfigurationForCollection,
 >({ formik }: ImageVulnerabilityFiltersStepForCollectionProps<T>): ReactElement {
+    const [searchFilter, setSearchFilter] = useState<SearchFilter>(
+        getSearchFilterFromReportConfiguration(formik.values.vulnReportFilters)
+    );
+
+    function onSearchSeverity(payload: OnSearchPayload) {
+        const searchFilterUpdated = updateSearchFilter(searchFilter, payload);
+        formik.setFieldValue(
+            'vulnReportFilters.severities',
+            getSeveritiesFromSearchFilter(searchFilterUpdated)
+        );
+        setSearchFilter(searchFilterUpdated);
+    }
+
+    function onSearchFixibility(payload: OnSearchPayload) {
+        const searchFilterUpdated = updateSearchFilter(searchFilter, payload);
+        formik.setFieldValue(
+            'vulnReportFilters.fixability',
+            getFixabilityFromSearchFilter(searchFilterUpdated)
+        );
+        setSearchFilter(searchFilterUpdated);
+    }
+
     return (
         <PageSection>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Filters</Title>
-                <Form>
-                    <FormLabelGroup
+                <Form isHorizontal isWidthLimited>
+                    <ImageVulnerabilityFiltersSince formik={formik} />
+                    <FormGroup
                         label="CVE severity"
                         isRequired
-                        fieldId="vulnReportFilters.cveSeverities"
-                        errors={formik.errors}
+                        fieldId="vulnReportFilters.severities"
                     >
-                        <>{JSON.stringify(formik.values.vulnReportFilters.severities)}</>
-                    </FormLabelGroup>
-                    <FormLabelGroup
-                        label="CVE status"
-                        isRequired
-                        fieldId="vulnReportFilters.cveStatus"
-                        errors={formik.errors}
-                    >
-                        <>{formik.values.vulnReportFilters.fixability}</>
-                    </FormLabelGroup>
-                    {/* TODO Form includes fixability, severities, and cvesSince */}
+                        <SearchFilterSelectInclusive
+                            attribute={attributeForSeverityInBackendAndViewBasedReport}
+                            isSeparate
+                            onSearch={onSearchSeverity}
+                            searchFilter={searchFilter}
+                        />
+                    </FormGroup>
+                    <FormGroup label="CVE status" isRequired fieldId="vulnReportFilters.fixability">
+                        <SearchFilterSelectInclusive
+                            attribute={attributeForFixableInBackendAndViewBasedReport}
+                            isSeparate
+                            onSearch={onSearchFixibility}
+                            searchFilter={searchFilter}
+                        />
+                    </FormGroup>
                 </Form>
             </Flex>
         </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { Flex, Form, FormGroup, PageSection, Title } from '@patternfly/react-core';
 import type { FormikProps } from 'formik';
@@ -6,7 +5,6 @@ import type { FormikProps } from 'formik';
 import SearchFilterSelectInclusive from 'Components/CompoundSearchFilter/components/SearchFilterSelectInclusive';
 import type { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
 import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
-import type { SearchFilter } from 'types/search';
 
 import {
     attributeForFixableInBackendAndViewBasedReport,
@@ -32,26 +30,20 @@ function ImageVulnerabilityFiltersStepForCollection<
     T extends ImageVulnerabilityFiltersConfigurationForCollection =
         ImageVulnerabilityFiltersConfigurationForCollection,
 >({ formik }: ImageVulnerabilityFiltersStepForCollectionProps<T>): ReactElement {
-    const [searchFilter, setSearchFilter] = useState<SearchFilter>(
-        getSearchFilterFromReportConfiguration(formik.values.vulnReportFilters)
-    );
+    const searchFilter = getSearchFilterFromReportConfiguration(formik.values.vulnReportFilters);
 
     function onSearchSeverity(payload: OnSearchPayload) {
-        const searchFilterUpdated = updateSearchFilter(searchFilter, payload);
         formik.setFieldValue(
             'vulnReportFilters.severities',
-            getSeveritiesFromSearchFilter(searchFilterUpdated)
+            getSeveritiesFromSearchFilter(updateSearchFilter(searchFilter, payload))
         );
-        setSearchFilter(searchFilterUpdated);
     }
 
     function onSearchFixibility(payload: OnSearchPayload) {
-        const searchFilterUpdated = updateSearchFilter(searchFilter, payload);
         formik.setFieldValue(
             'vulnReportFilters.fixability',
-            getFixabilityFromSearchFilter(searchFilterUpdated)
+            getFixabilityFromSearchFilter(updateSearchFilter(searchFilter, payload))
         );
-        setSearchFilter(searchFilterUpdated);
     }
 
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.types.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.types.ts
@@ -26,16 +26,28 @@ export type ImageVulnerabilityResourcesConfiguration = {
 };
 
 export type ImageVulnerabilityFiltersConfiguration = {
-    vulnReportFilters: {
-        query: string;
-    } & CvesSince;
+    vulnReportFilters: ImageVulnerabilityFiltersWithoutCvesSince & CvesSince;
+};
+
+export type ImageVulnerabilityFiltersWithoutCvesSince =
+    | ImageVulnerabilityFiltersForEntityWithoutCvesSince
+    | ImageVulnerabilityFiltersForCollectionWithoutCvesSince;
+
+export type ImageVulnerabilityFiltersConfigurationForEntity = {
+    vulnReportFilters: ImageVulnerabilityFiltersForEntityWithoutCvesSince & CvesSince;
+};
+
+export type ImageVulnerabilityFiltersForEntityWithoutCvesSince = {
+    query: string;
 };
 
 export type ImageVulnerabilityFiltersConfigurationForCollection = {
-    vulnReportFilters: {
-        fixability: Fixability;
-        severities: VulnerabilitySeverity[];
-    } & CvesSince;
+    vulnReportFilters: ImageVulnerabilityFiltersForCollectionWithoutCvesSince & CvesSince;
+};
+
+export type ImageVulnerabilityFiltersForCollectionWithoutCvesSince = {
+    fixability: Fixability;
+    severities: VulnerabilitySeverity[];
 };
 
 export type DestinationsConfiguration = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
@@ -1,15 +1,20 @@
 import type {
     CvesSince,
+    Fixability,
     ImageType,
     VulnerabilityReportFilters,
 } from 'services/ReportsService.types';
+import type { VulnerabilitySeverity } from 'types/cve.proto';
 import type { SearchFilter } from 'types/search';
 import { getDate } from 'utils/dateUtils';
-import { getUrlQueryStringForSearchFilter } from 'utils/searchUtils';
+import { getUrlQueryStringForSearchFilter, searchValueAsArray } from 'utils/searchUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 
 import type {
+    ImageVulnerabilityFiltersConfiguration,
+    ImageVulnerabilityFiltersForCollectionWithoutCvesSince,
+    ImageVulnerabilityFiltersWithoutCvesSince,
     ImageVulnerabilityReportConfiguration,
     ImageVulnerabilityReportConfigurationForEntity,
     ImageVulnerabilityReportFiltersForEntity,
@@ -70,6 +75,76 @@ export function getTextForCvesSince(vulnReportFilters: CvesSince) {
         return getDate(vulnReportFilters.sinceStartDate);
     }
     return ensureExhaustive(vulnReportFilters);
+}
+// SelectOption value prop is property name.
+export function getValueForCvesSince(vulnReportFilters: CvesSince) {
+    if ('allVuln' in vulnReportFilters) {
+        return 'allVuln';
+    }
+    if ('sinceLastSentScheduledReport' in vulnReportFilters) {
+        return 'sinceLastSentScheduledReport';
+    }
+    if ('sinceStartDate' in vulnReportFilters) {
+        return 'sinceStartDate';
+    }
+    return ensureExhaustive(vulnReportFilters);
+}
+
+// For future entity scope only, replace helper function call with the following:
+// const { query } = formik.values.vulnReportFilters;
+export function getReportFiltersWithoutCvesSince(
+    values: ImageVulnerabilityFiltersConfiguration
+): ImageVulnerabilityFiltersWithoutCvesSince {
+    // Idiom to ignore properties is awkward because of disjunction.
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    // eslint-diable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error 2339
+    const { allVuln, sinceLastSentScheduledReport, sinceStartDate, ...restWithoutCvesSince } =
+        values.vulnReportFilters;
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+
+    return { ...restWithoutCvesSince }; // that is, either { query } or { fixibility, severities }
+}
+
+export function getSearchFilterFromReportConfiguration(
+    vulnReportFilters: ImageVulnerabilityFiltersForCollectionWithoutCvesSince
+): SearchFilter {
+    const fixable: string[] = [];
+
+    switch (vulnReportFilters.fixability) {
+        case 'BOTH':
+            fixable.push('true', 'false');
+            break;
+        case 'FIXABLE':
+            fixable.push('true');
+            break;
+        case 'NOT_FIXABLE':
+            fixable.push('false');
+            break;
+        default:
+            ensureExhaustive(vulnReportFilters.fixability);
+    }
+
+    return {
+        Fixable: fixable,
+        Severity: vulnReportFilters.severities ?? [],
+    };
+}
+
+export function getFixabilityFromSearchFilter(searchFilter: SearchFilter): Fixability {
+    const fixable = searchValueAsArray(searchFilter.Fixable);
+
+    if (fixable.includes('true') && !fixable.includes('false')) {
+        return 'FIXABLE';
+    }
+    if (fixable.includes('false') && !fixable.includes('true')) {
+        return 'NOT_FIXABLE';
+    }
+    return 'BOTH';
+}
+
+export function getSeveritiesFromSearchFilter(searchFilter: SearchFilter) {
+    return searchValueAsArray(searchFilter.Severity) as VulnerabilitySeverity[];
 }
 
 export const imageTypeLabelMap: Record<ImageType, string> = {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
@@ -56,8 +56,8 @@ export const initialImageVulnerabilityReportConfiguration: ImageVulnerabilityRep
     } as const;
 
 // TypeScript needs help because entityScope and vulnReportFilters have mutual dependencies.
-// entityScope implies query but not fixibility nore severities
-// collectionScope implies fixibility and severities but not query
+// entityScope implies query but not fixability nore severities
+// collectionScope implies fixability and severities but not query
 export function hasConfigurationForEntity(
     values: ImageVulnerabilityReportConfiguration
 ): values is ImageVulnerabilityReportConfigurationForEntity {
@@ -103,7 +103,7 @@ export function getReportFiltersWithoutCvesSince(
         values.vulnReportFilters;
     /* eslint-enable @typescript-eslint/no-unused-vars */
 
-    return { ...restWithoutCvesSince }; // that is, either { query } or { fixibility, severities }
+    return { ...restWithoutCvesSince }; // that is, either { query } or { fixability, severities }
 }
 
 export function getSearchFilterFromReportConfiguration(


### PR DESCRIPTION
## Description

### Objective

Provide equivalent filter for scheduled reports as view-based reports

### Analysis

Because wording of options is so specific and in case 3 separate `CvesSince` properties might not be pattern for future report configuration, let the component be specific to **image** vulnerability report configuration, even though the concept of time window for report is generic.

1. `CvesSince` represents 3 mutually exclusive properties:

    * `allVuln: true` 
    * `sinceLastSentScheduledReport: true`
    * `sinceStartDate: 'yyyy-mm-dd'`

    See **Solution** for the unusual need to remove the irrelevant two properties when user selects one.

2. ReportParametersForm.tsx file

    * renders `SelectSingle` for **CVEs discovered since**
    * renders `DatePicker` for `'START_DATE'`
    * updates `nofifiers` for `'SINCE_LAST_REPORT'`

        Imperative update has edge case that it does not undo update to `notifiers` if user subsequently selects a different options.

3. Even in current step, **CVEs discovered since** is separated from **CVE severity** and **CVE status** elements.

### Solution

1. Render **CVEs discovered in image since** preceding instead of following:

    * **CVE severity** and **CVE status** in step for collection scope
    * separate and compound search filter elements

2. Factor out component.

    * Add `getValueForCvesSince` function in utils file that corresponds to use of property name as `value` prop of corresponding `SelectOption` element.

    * Add `sinceStartDate` as component state for edge case that user selects option and enters date, selects a different option, and then selects the option again.

    * As mentioned in **Analysis**, use so-called immutable manual update idiom to add selected and omit irrelevant properties via `getReportFiltersWithoutCvesSince` function call.

3. Refactor types related to filters.

4. Add `getReportFiltersWithoutCvesSince` function to utils file.

5. Bonus:

    * Collection scope: Render generic search filter configuration and elements for **CVE severity** and **CVE status** with callback functions that convert to and from `searchFilter` object.
        Adapt from AdvancedFiltersToolbar.tsx file.
    * Entity scope: render `FiltersQuery` element.

### Residue

1. Render search filter elements for **CVE severity** and **CVE status** with callback functions to convert from `searchFilter` props to 

2. Conditionally render a warning alert and require destimations in **Delivery** step, which has secondary benefit to remove need for a callback function.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the functionality is gated by a feature flag
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration click a linkm, click **Actions**, click **Edit report**, and then click **CVEs discovered since** select element.

    Without changes for **collection** scope
    <img width="1440" height="892" alt="CVEs_discovered_since" src="https://github.com/user-attachments/assets/f40f7de9-1685-4b4e-8906-f6636b0d0d69" />

2. Temporary edit ViewVulnReportPage.tsx files to render wizard.

    Visit /main/vulnerabilities/reports/configuration click a link and then advance to **Filters** step

    With changes for **collection** scope
    <img width="1440" height="892" alt="All_time" src="https://github.com/user-attachments/assets/82bbcee1-d817-4b19-878d-20d5fdc15e7c" />

    Select **Custom start date** and then pick date
    <img width="1440" height="892" alt="sinceStartDate" src="https://github.com/user-attachments/assets/e3981d76-4451-459c-bf09-ad5a9220a75a" />

    Select **Last scheduled report that was successfully sent**
    <img width="1440" height="892" alt="sinceLastSentScheduledReport" src="https://github.com/user-attachments/assets/a6d54c31-076a-4e7f-82a4-a913eae8b470" />

    Select **Custom start date** and see previously picked date again

    With changes for **entity** scope with `query` string
    <img width="1440" height="892" alt="entityScope" src="https://github.com/user-attachments/assets/a9a74d3d-6af3-4336-a132-ec4212a08226" />
