### PR TITLE
chore(ui): bump axios to ^1.16.0 (#20267)

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -22,7 +22,7 @@
                 "@patternfly/react-table": "^5.2.2",
                 "@patternfly/react-topology": "^5.2.1",
                 "@patternfly/react-user-feedback": "^5.0.0",
-                "axios": "^1.12.0",
+                "axios": "^1.15.1",
                 "computed-style-to-inline-style": "^3.0.0",
                 "connected-react-router": "^6.9.3",
                 "core-js": "^3.45.0",
@@ -6860,20 +6860,20 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
-            "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+            "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/axios/node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -6887,10 +6887,13 @@
             }
         },
         "node_modules/axios/node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/babel-plugin-emotion": {
             "version": "9.2.11",
@@ -10783,15 +10786,16 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs= sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },

--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -22,7 +22,7 @@
                 "@patternfly/react-table": "^5.2.2",
                 "@patternfly/react-topology": "^5.2.1",
                 "@patternfly/react-user-feedback": "^5.0.0",
-                "axios": "^1.15.1",
+                "axios": "^1.16.0",
                 "computed-style-to-inline-style": "^3.0.0",
                 "connected-react-router": "^6.9.3",
                 "core-js": "^3.45.0",
@@ -6860,12 +6860,12 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-            "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
                 "proxy-from-env": "^2.1.0"
             }

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -25,7 +25,7 @@
         "@patternfly/react-table": "^5.2.2",
         "@patternfly/react-topology": "^5.2.1",
         "@patternfly/react-user-feedback": "^5.0.0",
-        "axios": "^1.12.0",
+        "axios": "^1.15.1",
         "connected-react-router": "^6.9.3",
         "computed-style-to-inline-style": "^3.0.0",
         "core-js": "^3.45.0",

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -25,7 +25,7 @@
         "@patternfly/react-table": "^5.2.2",
         "@patternfly/react-topology": "^5.2.1",
         "@patternfly/react-user-feedback": "^5.0.0",
-        "axios": "^1.15.1",
+        "axios": "^1.16.0",
         "connected-react-router": "^6.9.3",
         "computed-style-to-inline-style": "^3.0.0",
         "core-js": "^3.45.0",

--- a/ui/apps/platform/src/utils/fileUtils.ts
+++ b/ui/apps/platform/src/utils/fileUtils.ts
@@ -14,6 +14,9 @@ export function parseAxiosResponseAttachment(response: AxiosResponse): {
 } {
     const matches = filenameRegex.exec(response.headers['content-disposition'] ?? '');
     const filename = matches && matches[1] ? matches[1] : null;
-    const file = new Blob([response.data], { type: response.headers['content-type'] });
+    const contentType = response.headers['content-type'];
+    const file = new Blob([response.data], {
+        type: typeof contentType === 'string' ? contentType : undefined,
+    });
     return { file, filename };
 }


### PR DESCRIPTION
Resolves cves related to `follow-redirects` and `axios`

Fixes the following CVES:

- CVE-2026-42035
- CVE-2026-42044
- CVE-2026-42041
- CVE-2026-42039
- CVE-2026-42043
- CVE-2026-42033
- CVE-2026-40895
- CVE-2026-40175
- CVE-2025-62718