### PR TITLE
chore: add 4.8.11 to postgres upgrade test versions

### DIFF
--- a/tests/upgrade/postgres_run.sh
+++ b/tests/upgrade/postgres_run.sh
@@ -10,7 +10,7 @@ TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 EARLIER_TAG="4.6.2"
 EARLIER_SHA="ecff2a443c8b9a2dc7bf606162da89da81dd8e9e"
 CURRENT_TAG="$(make --quiet --no-print-directory tag)"
-PREVIOUS_RELEASES=("4.6.10" "4.7.9" "4.8.10" "4.9.5" "4.10.1")
+PREVIOUS_RELEASES=("4.6.10" "4.7.9" "4.8.11" "4.9.5" "4.10.1")
 
 # shellcheck source=../../scripts/lib.sh
 source "$TEST_ROOT/scripts/lib.sh"

--- a/tests/upgrade/postgres_upgrade_run.sh
+++ b/tests/upgrade/postgres_upgrade_run.sh
@@ -10,7 +10,7 @@ TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 EARLIER_TAG="4.7.2"
 EARLIER_SHA="ef2060ed332c7b8513cb9eb52b9745df9a8285cc"
 CURRENT_TAG="$(make --quiet --no-print-directory tag)"
-PREVIOUS_RELEASES=("4.7.3" "4.8.11")
+PREVIOUS_RELEASES=("4.7.3")
 
 # shellcheck source=../../scripts/lib.sh
 source "$TEST_ROOT/scripts/lib.sh"

--- a/tests/upgrade/postgres_upgrade_run.sh
+++ b/tests/upgrade/postgres_upgrade_run.sh
@@ -10,7 +10,7 @@ TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
 EARLIER_TAG="4.7.2"
 EARLIER_SHA="ef2060ed332c7b8513cb9eb52b9745df9a8285cc"
 CURRENT_TAG="$(make --quiet --no-print-directory tag)"
-PREVIOUS_RELEASES=("4.7.3")
+PREVIOUS_RELEASES=("4.7.3" "4.8.11")
 
 # shellcheck source=../../scripts/lib.sh
 source "$TEST_ROOT/scripts/lib.sh"


### PR DESCRIPTION
## Summary

- Adds 4.8.11 to the `PREVIOUS_RELEASES` list in the postgres upgrade test script
- Ensures CI verifies upgrade paths from 4.8.11

## Test plan

- [ ] CI upgrade tests pass with the new version in the list