### PR TITLE
experiment: clear test cache on master for fresh test runs

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -23,8 +23,7 @@ runs:
       shell: bash
 
     - name: Cache Go Build (save)
-      # TODO: revert before merge — temporarily always-save to seed host-runner cache
-      if: inputs.save == 'true'
+      if: inputs.save == 'true' && (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
       with:
         path: ${{ steps.cache-paths.outputs.GOCACHE }}
@@ -32,8 +31,7 @@ runs:
         restore-keys: go-build-v1-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-
 
     - name: Cache Go Build (restore)
-      # TODO: revert before merge — matches the save condition above
-      if: ${{ !(inputs.save == 'true') }}
+      if: ${{ !(inputs.save == 'true' && (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)) }}
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/restore@v5
       with:
         path: ${{ steps.cache-paths.outputs.GOCACHE }}

--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -23,7 +23,8 @@ runs:
       shell: bash
 
     - name: Cache Go Build (save)
-      if: inputs.save == 'true' && (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
+      # TODO: revert before merge — temporarily always-save to seed host-runner cache
+      if: inputs.save == 'true'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
       with:
         path: ${{ steps.cache-paths.outputs.GOCACHE }}
@@ -31,7 +32,8 @@ runs:
         restore-keys: go-build-v1-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-
 
     - name: Cache Go Build (restore)
-      if: ${{ !(inputs.save == 'true' && (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)) }}
+      # TODO: revert before merge — matches the save condition above
+      if: ${{ !(inputs.save == 'true') }}
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/restore@v5
       with:
         path: ${{ steps.cache-paths.outputs.GOCACHE }}

--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -72,6 +72,16 @@ runs:
           after=$(du -sm "$gocache" 2>/dev/null | cut -f1);
           echo "GOCACHE trimmed: ${before:-0}MB -> ${after:-0}MB (removed $((${before:-0} - ${after:-0}))MB)"
 
+    - name: Clear test cache on default branch
+      if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+      run: |
+        # Master pushes should always run tests from scratch to catch real
+        # failures. Clearing the test cache preserves compilation cache
+        # (fast builds) while forcing all tests to re-execute.
+        go clean -testcache
+        echo "Cleared test cache for fresh master run"
+      shell: bash
+
     - name: Stabilize file mtimes for Go test cache
       run: |
         # Go's test cache validates inputs by (path, size, mtime) — NOT content.

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -40,16 +40,18 @@ jobs:
     env:
       BUILD_TAG: 0.0.0
       SHORTCOMMIT: "0000000"
-    container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
-      volumes:
-        - /usr:/mnt/usr
-        - /opt:/mnt/opt
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
       with:
-        fetch-depth: 0
+        go-version-file: go.mod
+        cache: false
+
+    - name: Override GOTOOLCHAIN
+      run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
     - uses: ./.github/actions/job-preamble
       with:
@@ -114,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
-        pg: [ '15' ]
+        pg: [ 'default', '15' ]
     runs-on: ubuntu-latest
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
@@ -124,37 +126,47 @@ jobs:
     env:
       BUILD_TAG: 0.0.0
       SHORTCOMMIT: "0000000"
-    container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
-      volumes:
-        - /usr:/mnt/usr
-        - /opt:/mnt/opt
+      POSTGRES_PASSWORD: testpassword
     steps:
-    - name: Set Postgres version
+    # Runner's postgres is initialized with C.UTF-8 locale (GHA default).
+    # Tests (e.g. central/splunk) require byte-order collation.
+    - name: Start Postgres (pre-installed)
+      if: matrix.pg == 'default'
       run: |
-        echo "/usr/pgsql-${{ matrix.pg }}/bin" >> "${GITHUB_PATH}"
+        sudo sed -i '/^host/s/scram-sha-256/trust/' /etc/postgresql/*/main/pg_hba.conf
+        sudo systemctl start postgresql.service
+        pg_isready
+
+    # Same base image as production (image/postgres/Dockerfile).
+    - name: Start Postgres (${{ matrix.pg }})
+      if: matrix.pg != 'default'
+      run: |
+        docker run --rm -d --name postgres --network=host \
+          -e POSTGRESQL_ADMIN_PASSWORD="$POSTGRES_PASSWORD" \
+          -e LANG=C.UTF-8 \
+          quay.io/sclorg/postgresql-${{ matrix.pg }}-c9s@sha256:77c1e962234c598f3ed2b5e581f0845fca333bd262e9b0ee542bf8fa96fbc03d
+        for i in $(seq 1 60); do pg_isready -h 127.0.0.1 && break; sleep 1; done || { docker logs postgres; exit 1; }
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
       with:
-        fetch-depth: 0
+        go-version-file: go.mod
+        cache: false
+
+    - name: Override GOTOOLCHAIN
+      run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Run Postgres
-      run: |
-        su postgres -c 'initdb -D /tmp/data'
-        su postgres -c 'pg_ctl -D /tmp/data start'
-
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
       with:
         key-suffix: ${{ matrix.gotags }}
-
-    - name: Is Postgres ready
-      run: pg_isready -h 127.0.0.1
 
     - name: Go Unit Tests
       run: ${{ matrix.gotags }} make go-postgres-unit-tests
@@ -187,35 +199,34 @@ jobs:
 
   go-bench:
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
-      volumes:
-        - /usr:/mnt/usr
-        - /opt:/mnt/opt
+    env:
+      BUILD_TAG: 0.0.0
+      SHORTCOMMIT: "0000000"
     steps:
-    - name: Set Postgres version
+    - name: Start Postgres
       run: |
-        echo "/usr/pgsql-15/bin" >> "${GITHUB_PATH}"
+        sudo sed -i '/^host/s/scram-sha-256/trust/' /etc/postgresql/*/main/pg_hba.conf
+        sudo systemctl start postgresql.service
+        pg_isready
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
       with:
-        fetch-depth: 0
+        go-version-file: go.mod
+        cache: false
+
+    - name: Override GOTOOLCHAIN
+      run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Run Postgres
-      run: |
-        su postgres -c 'initdb -D /tmp/data'
-        su postgres -c 'pg_ctl -D /tmp/data start'
-
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
-
-    - name: Is Postgres ready
-      run: pg_isready -h 127.0.0.1
 
     - name: Go Bench Tests
       run: make go-postgres-bench-tests

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -145,7 +145,7 @@ jobs:
           -e POSTGRESQL_ADMIN_PASSWORD="$POSTGRES_PASSWORD" \
           -e LANG=C.UTF-8 \
           quay.io/sclorg/postgresql-${{ matrix.pg }}-c9s@sha256:77c1e962234c598f3ed2b5e581f0845fca333bd262e9b0ee542bf8fa96fbc03d
-        for i in $(seq 1 60); do pg_isready -h 127.0.0.1 && break; sleep 1; done || { docker logs postgres; exit 1; }
+        timeout 60 bash -c 'until pg_isready -h 127.0.0.1; do sleep 1; done' || { docker logs postgres; exit 1; }
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -221,7 +221,7 @@ jobs:
           -e POSTGRESQL_ADMIN_PASSWORD="$POSTGRES_PASSWORD" \
           -e LANG=C.UTF-8 \
           quay.io/sclorg/postgresql-${{ matrix.pg }}-c9s@sha256:77c1e962234c598f3ed2b5e581f0845fca333bd262e9b0ee542bf8fa96fbc03d
-        for i in $(seq 1 60); do pg_isready -h 127.0.0.1 && break; sleep 1; done || { docker logs postgres; exit 1; }
+        timeout 60 bash -c 'until pg_isready -h 127.0.0.1; do sleep 1; done' || { docker logs postgres; exit 1; }
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -135,7 +135,7 @@ jobs:
       run: |
         sudo sed -i '/^host/s/scram-sha-256/trust/' /etc/postgresql/*/main/pg_hba.conf
         sudo systemctl start postgresql.service
-        pg_isready
+        timeout 60 bash -c 'until pg_isready; do sleep 1; done'
 
     # Same base image as production (image/postgres/Dockerfile).
     - name: Start Postgres (${{ matrix.pg }})
@@ -212,7 +212,7 @@ jobs:
       run: |
         sudo sed -i '/^host/s/scram-sha-256/trust/' /etc/postgresql/*/main/pg_hba.conf
         sudo systemctl start postgresql.service
-        pg_isready
+        timeout 60 bash -c 'until pg_isready; do sleep 1; done'
 
     - name: Start Postgres (${{ matrix.pg }})
       if: matrix.pg != 'default'

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -198,16 +198,30 @@ jobs:
         directory: 'junit-reports'
 
   go-bench:
+    strategy:
+      matrix:
+        pg: [ 'default', '15' ]
     runs-on: ubuntu-latest
     env:
       BUILD_TAG: 0.0.0
       SHORTCOMMIT: "0000000"
+      POSTGRES_PASSWORD: testpassword
     steps:
-    - name: Start Postgres
+    - name: Start Postgres (pre-installed)
+      if: matrix.pg == 'default'
       run: |
         sudo sed -i '/^host/s/scram-sha-256/trust/' /etc/postgresql/*/main/pg_hba.conf
         sudo systemctl start postgresql.service
         pg_isready
+
+    - name: Start Postgres (${{ matrix.pg }})
+      if: matrix.pg != 'default'
+      run: |
+        docker run --rm -d --name postgres --network=host \
+          -e POSTGRESQL_ADMIN_PASSWORD="$POSTGRES_PASSWORD" \
+          -e LANG=C.UTF-8 \
+          quay.io/sclorg/postgresql-${{ matrix.pg }}-c9s@sha256:77c1e962234c598f3ed2b5e581f0845fca333bd262e9b0ee542bf8fa96fbc03d
+        for i in $(seq 1 60); do pg_isready -h 127.0.0.1 && break; sleep 1; done || { docker logs postgres; exit 1; }
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -197,31 +197,20 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         directory: 'junit-reports'
 
+  # Benchmarks run each bench function once (-benchtime=1x -count=1) to verify
+  # they compile and execute without errors. A single postgres version is
+  # sufficient since go-postgres already tests against multiple versions.
   go-bench:
-    strategy:
-      matrix:
-        pg: [ 'default', '15' ]
     runs-on: ubuntu-latest
     env:
       BUILD_TAG: 0.0.0
       SHORTCOMMIT: "0000000"
-      POSTGRES_PASSWORD: testpassword
     steps:
-    - name: Start Postgres (pre-installed)
-      if: matrix.pg == 'default'
+    - name: Start Postgres
       run: |
         sudo sed -i '/^host/s/scram-sha-256/trust/' /etc/postgresql/*/main/pg_hba.conf
         sudo systemctl start postgresql.service
         timeout 60 bash -c 'until pg_isready; do sleep 1; done'
-
-    - name: Start Postgres (${{ matrix.pg }})
-      if: matrix.pg != 'default'
-      run: |
-        docker run --rm -d --name postgres --network=host \
-          -e POSTGRESQL_ADMIN_PASSWORD="$POSTGRES_PASSWORD" \
-          -e LANG=C.UTF-8 \
-          quay.io/sclorg/postgresql-${{ matrix.pg }}-c9s@sha256:77c1e962234c598f3ed2b5e581f0845fca333bd262e9b0ee542bf8fa96fbc03d
-        timeout 60 bash -c 'until pg_isready -h 127.0.0.1; do sleep 1; done' || { docker logs postgres; exit 1; }
 
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -241,8 +230,6 @@ jobs:
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
-      with:
-        key-suffix: ${{ matrix.pg }}
 
     - name: Go Bench Tests
       run: make go-postgres-bench-tests

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -166,7 +166,7 @@ jobs:
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
       with:
-        key-suffix: ${{ matrix.gotags }}
+        key-suffix: ${{ matrix.gotags }}-${{ matrix.pg }}
 
     - name: Go Unit Tests
       run: ${{ matrix.gotags }} make go-postgres-unit-tests
@@ -241,6 +241,8 @@ jobs:
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
+      with:
+        key-suffix: ${{ matrix.pg }}
 
     - name: Go Bench Tests
       run: make go-postgres-bench-tests

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -166,7 +166,7 @@ jobs:
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
       with:
-        key-suffix: ${{ matrix.gotags }}-${{ matrix.pg }}
+        key-suffix: ${{ matrix.gotags }}
 
     - name: Go Unit Tests
       run: ${{ matrix.gotags }} make go-postgres-unit-tests
@@ -241,8 +241,6 @@ jobs:
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
-      with:
-        key-suffix: ${{ matrix.pg }}
 
     - name: Go Bench Tests
       run: make go-postgres-bench-tests

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -380,14 +380,30 @@ func CreateLogger(module *Module, skip int, opts ...OptionsFunc) *LoggerImpl {
 	return result
 }
 
+// sharedFileWriters caches lumberjack writers by path so multiple loggers
+// share one writer instead of each creating their own. This prevents:
+// - 30+ goroutines for log rotation (one per lumberjack.Logger)
+// - 30+ independent file handles to the same file
+// - Potential log corruption from concurrent uncoordinated writes
+var sharedFileWriters = make(map[string]zapcore.WriteSyncer)
+
+func getOrCreateFileWriter(path string) zapcore.WriteSyncer {
+	if w, ok := sharedFileWriters[path]; ok {
+		return w
+	}
+	w := zapcore.AddSync(&lumberjack.Logger{
+		Filename:   path,
+		MaxSize:    env.LoggingMaxSizeMB.IntegerSetting(),
+		MaxBackups: env.LoggingMaxRotationFiles.IntegerSetting(),
+	})
+	sharedFileWriters[path] = w
+	return w
+}
+
 func withRotatingCores(lc *zap.Config, rotatingPaths []string) func(c zapcore.Core) zapcore.Core {
 	var cores = make([]zapcore.Core, 0, len(rotatingPaths))
 	for _, path := range rotatingPaths {
-		writer := zapcore.AddSync(&lumberjack.Logger{
-			Filename:   path,
-			MaxSize:    env.LoggingMaxSizeMB.IntegerSetting(),
-			MaxBackups: env.LoggingMaxRotationFiles.IntegerSetting(),
-		})
+		writer := getOrCreateFileWriter(path)
 		cores = append(cores, zapcore.NewCore(getEncoderForConfig(lc), writer, lc.Level))
 	}
 	return func(c zapcore.Core) zapcore.Core {


### PR DESCRIPTION
## Description

On master pushes, run `go clean -testcache` after GOCACHE restore. This:
- Preserves compilation cache (fast builds — compiled .a files kept)
- Forces all tests to re-execute (no cached test results from previous runs)
- PR branches continue to benefit from test caching for speed

This ensures master always validates tests against the actual database and environment, while PRs get the speed benefit of cached results.

Stacked on #19743.