### PR TITLE
ROX-34455: Add console test intercepts for app-loaded detection

### DIFF
--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -57,7 +57,24 @@ const routeMatcherMap = {
     ...routeMatcherMapForComplianceLevelsByStandard,
 };
 
-const routeMatcherMapForConsole = undefined;
+const routeMatcherMapForConsole = {
+    mypermissions: {
+        method: 'GET',
+        url: '**/api-service/**/v1/mypermissions',
+    },
+    featureflags: {
+        method: 'GET',
+        url: '**/api-service/**/v1/featureflags',
+    },
+    metadata: {
+        method: 'GET',
+        url: '**/api-service/**/v1/metadata',
+    },
+    'config/public': {
+        method: 'GET',
+        url: '**/api-service/**/v1/config/public',
+    },
+};
 
 const basePath = '/main/dashboard';
 


### PR DESCRIPTION
## Description

OCP console Cypress tests fail in CI because the console UI occasionally takes >8s to load, exceeding `defaultCommandTimeout` (8s). The `routeMatcherMapForConsole` variable in `cypress/helpers/main.js` was `undefined`, so `visitConsoleMainDashboard` had no network intercepts to wait on before asserting DOM elements.

## Fix

Define `routeMatcherMapForConsole` with four ACS provider API endpoints (mypermissions, featureflags, metadata, config/public) that fire via `useEffect` after the console navigation renders. This leverages `requestTimeout` (20s) instead of `defaultCommandTimeout` (8s), giving the console time to load.

The `**/api-service/**` glob pattern matches the OpenShift Console proxy path and aligns with the existing convention in `cypress/integration-ocp/routes.ts`.

See recent failures:
https://redhat.atlassian.net/browse/ROX-34455
https://redhat.atlassian.net/browse/ROX-34474

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Local Cypress test runs.

CI.

Nightly CI (after the fact...)