### PR TITLE
ROX-34147: Remove GOTOOLCHAIN=local enforcement from Makefiles

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -150,25 +150,6 @@ jobs:
           condensed="$(jq -c <<< "$matrix")"
           echo "matrix=$condensed" >> "$GITHUB_OUTPUT"
 
-  # Ensures go.mod doesn't require a Go version newer than what Konflux
-  # builders support. Remove once Konflux tracks upstream Go releases:
-  # https://github.com/stackrox/stackrox/pull/19737
-  go-version-ceiling:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-        with:
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
-        with:
-          go-version: '1.25.7'
-          cache: false
-
-      - name: Verify go.mod is compatible with Konflux builders
-        run: go mod tidy
-
   pre-build-ui:
     strategy:
       fail-fast: false
@@ -1237,7 +1218,6 @@ jobs:
       - build-and-push-operator
       - build-and-push-scanner
       - build-operator-bundle
-      - go-version-ceiling
       - pre-build-cli
       - pre-build-docs
       - pre-build-go-binaries

--- a/Makefile
+++ b/Makefile
@@ -368,11 +368,9 @@ deps: $(shell find $(BASE_DIR) -name "go.sum")
 	@echo "+ $@"
 	$(SILENT)$(eval GOMOCK_REFLECT_DIRS=`find . -type d -name 'gomock_reflect_*'`)
 	$(SILENT)test -z $(GOMOCK_REFLECT_DIRS) || { echo "Found leftover gomock directories. Please remove them and rerun make deps!"; echo $(GOMOCK_REFLECT_DIRS); exit 1; }
-ifdef CI
-	$(SILENT)GOTOOLCHAIN=local go mod tidy || { >&2 echo "Go toolchain does not match with installed Go version. This is a compatibility check that prevents breaking downstream builds. If you really need to update the toolchain version, ask in #forum-acs-golang" ; exit 1 ; }
-	$(SILENT)git diff --exit-code -- go.mod go.sum || { echo "go.mod/go.sum files were updated after running 'go mod tidy', run this command on your local machine and commit the results." ; exit 1 ; }
-else
 	$(SILENT)go mod tidy
+ifdef CI
+	$(SILENT)git diff --exit-code -- go.mod go.sum || { echo "go.mod/go.sum files were updated after running 'go mod tidy', run this command on your local machine and commit the results." ; exit 1 ; }
 endif
 	$(SILENT)touch $@
 

--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -148,7 +148,6 @@ endif
 	@echo "+ $@"
 	$(SILENT)go mod tidy
 ifdef CI
-	$(SILENT)GOTOOLCHAIN=local go mod tidy || { >&2 echo "Go toolchain does not match with installed Go version. This is a compatibility check that prevents breaking downstream builds. If you really need to update the toolchain version, ask in #forum-acs-golang" ; exit 1 ; }
 	$(SILENT)git diff --exit-code -- ../go.mod ../go.sum || { echo "go.mod/go.sum files were updated after running 'go mod tidy', run this command on your local machine and commit the results." ; exit 1 ; }
 endif
 	$(SILENT)go mod verify


### PR DESCRIPTION
## Description

Removes the blanket GOTOOLCHAIN=local constraint that blocks Go toolchain downloads in CI. The Konflux compatibility checks now validate Go version compatibility in the actual build environment, making this simulation unnecessary.
- #19737
- #19024 

Changes:
- Makefile: Remove GOTOOLCHAIN=local enforcement, keep git diff check
- scanner/Makefile: Remove GOTOOLCHAIN=local enforcement, keep git diff check

The git diff check remains to ensure developers commit go mod tidy results. Konflux checks will catch actual compatibility issues before merge.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change


