### PR TITLE
fix(ui): Add updated fields to ClusterRegistrationSecret type

### DIFF
--- a/ui/apps/platform/src/services/ClustersService.ts
+++ b/ui/apps/platform/src/services/ClustersService.ts
@@ -225,7 +225,10 @@ export type ClusterRegistrationSecret = {
         attributes: InitBundleAttribute[];
     };
     expiresAt: string;
-    impactedClusters: ImpactedCluster[];
+    // Protobuf uint64 is serialized as a JSON string. Parse with parseInt when a numeric value is needed.
+    maxRegistrations: string;
+    registrationsInitiated: string[];
+    registrationsCompleted: string[];
 };
 
 export function fetchClusterInitBundles(): Promise<{ response: { items: ClusterInitBundle[] } }> {


### PR DESCRIPTION
## Description

As titled, updates UI types to match new proto definition: proto/api/v1/cluster_init_service.proto

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Types only
