### PR TITLE
ROX-34497: Switch process argument and lineage metrics to bytes

### DIFF
--- a/central/processindicator/datastore/metrics.go
+++ b/central/processindicator/datastore/metrics.go
@@ -1,8 +1,6 @@
 package datastore
 
 import (
-	"unicode/utf8"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/metrics"
@@ -41,7 +39,7 @@ var (
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "process_upserted_args_size",
-		Help:      "Distribution of process argument sizes in characters for upserted indicators",
+		Help:      "Distribution of process argument sizes in bytes for upserted indicators",
 		Buckets:   []float64{0, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
 	})
 
@@ -49,7 +47,7 @@ var (
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "process_upserted_args_size_total",
-		Help:      "Total upserted process argument sizes in characters by cluster and namespace",
+		Help:      "Total upserted process argument sizes in bytes by cluster and namespace",
 	}, []string{"cluster", "namespace"})
 
 	processUpsertedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -77,7 +75,7 @@ var (
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "process_upserted_lineage_size",
-		Help:      "Distribution of process lineage sizes in characters for upserted indicators",
+		Help:      "Distribution of process lineage sizes in bytes for upserted indicators",
 		Buckets:   []float64{0, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
 	})
 
@@ -85,7 +83,7 @@ var (
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "process_upserted_lineage_size_total",
-		Help:      "Total upserted process lineage sizes in characters by cluster and namespace",
+		Help:      "Total upserted process lineage sizes in bytes by cluster and namespace",
 	}, []string{"cluster", "namespace"})
 )
 
@@ -102,22 +100,14 @@ func incrementProcessPruningCacheMissesMetric() {
 	processPruningCacheMisses.Inc()
 }
 
-// getProcessArgsSizeChars safely calculates the size of process args in characters (runes).
-// Returns 0 if signal or args are nil/empty.
-func getProcessArgsSizeChars(indicator *storage.ProcessIndicator) int {
+func getProcessArgsSizeBytes(indicator *storage.ProcessIndicator) int {
 	if indicator == nil || indicator.GetSignal() == nil {
 		return 0
 	}
-	// RuneCountInString returns the number of UTF-8 characters.
-	// For ASCII this is going to be equivalent to len(), but
-	// it is not going to be equivalent for special characters.
-	// len() is O(1), but RuneCountInString is O(n).
-	return utf8.RuneCountInString(indicator.GetSignal().GetArgs())
+	return len(indicator.GetSignal().GetArgs())
 }
 
-// getProcessLineageSizeChars safely calculates the total size of process lineage in characters (runes).
-// Returns 0 if signal or lineage are nil/empty.
-func getProcessLineageSizeChars(indicator *storage.ProcessIndicator) int {
+func getProcessLineageSizeBytes(indicator *storage.ProcessIndicator) int {
 	if indicator == nil || indicator.GetSignal() == nil {
 		return 0
 	}
@@ -127,29 +117,29 @@ func getProcessLineageSizeChars(indicator *storage.ProcessIndicator) int {
 		return 0
 	}
 
-	totalChars := 0
+	totalBytes := 0
 	for _, info := range lineageInfo {
 		if info != nil {
-			totalChars += utf8.RuneCountInString(info.GetParentExecFilePath())
+			totalBytes += len(info.GetParentExecFilePath())
 		}
 	}
 
-	return totalChars
+	return totalBytes
 }
 
 // recordProcessIndicatorsBatchAdded records metrics for a batch of process indicators successfully written to DB.
 func recordProcessIndicatorsBatchAdded(indicators []*storage.ProcessIndicator) {
 	for _, indicator := range indicators {
-		argsSizeChars := getProcessArgsSizeChars(indicator)
-		lineageSizeChars := getProcessLineageSizeChars(indicator)
+		argsSizeBytes := getProcessArgsSizeBytes(indicator)
+		lineageSizeBytes := getProcessLineageSizeBytes(indicator)
 		clusterID := indicator.GetClusterId()
 		namespace := indicator.GetNamespace()
 
-		processUpsertedArgsSizeHistogram.Observe(float64(argsSizeChars))
-		processUpsertedArgsSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(argsSizeChars))
+		processUpsertedArgsSizeHistogram.Observe(float64(argsSizeBytes))
+		processUpsertedArgsSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(argsSizeBytes))
 		processUpsertedCount.WithLabelValues(clusterID, namespace).Inc()
-		processUpsertedLineageSizeHistogram.Observe(float64(lineageSizeChars))
-		processUpsertedLineageSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(lineageSizeChars))
+		processUpsertedLineageSizeHistogram.Observe(float64(lineageSizeBytes))
+		processUpsertedLineageSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(lineageSizeBytes))
 	}
 }
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Switch to getting the lengths of process indicator arguments and lineage in bytes instead of characters. The change is made, because getting the number of characters is O(n) and getting the number of bytes is O(1).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Deployed ACS, created a port forward, and got the metrics.

```
rox_central_process_queue_length 19
# HELP rox_central_process_upserted_args_size Distribution of process argument sizes in bytes for upserted indicators
# TYPE rox_central_process_upserted_args_size histogram
rox_central_process_upserted_args_size_bucket{le="0"} 27
rox_central_process_upserted_args_size_bucket{le="8"} 48
rox_central_process_upserted_args_size_bucket{le="16"} 96
rox_central_process_upserted_args_size_bucket{le="32"} 144
rox_central_process_upserted_args_size_bucket{le="64"} 189
rox_central_process_upserted_args_size_bucket{le="128"} 223
rox_central_process_upserted_args_size_bucket{le="256"} 268
rox_central_process_upserted_args_size_bucket{le="512"} 280
rox_central_process_upserted_args_size_bucket{le="1024"} 284
rox_central_process_upserted_args_size_bucket{le="2048"} 285
rox_central_process_upserted_args_size_bucket{le="4096"} 286
rox_central_process_upserted_args_size_bucket{le="8192"} 286
rox_central_process_upserted_args_size_bucket{le="16384"} 286
rox_central_process_upserted_args_size_bucket{le="32768"} 286
rox_central_process_upserted_args_size_bucket{le="65536"} 286
rox_central_process_upserted_args_size_bucket{le="+Inf"} 286
rox_central_process_upserted_args_size_sum 28375
rox_central_process_upserted_args_size_count 286
# HELP rox_central_process_upserted_args_size_total Total upserted process argument sizes in bytes by cluster and namespace
# TYPE rox_central_process_upserted_args_size_total counter
rox_central_process_upserted_args_size_total{cluster="4b18db8d-919f-4f5e-9269-d4ea379a432a",namespace="gke-managed-cim"} 1747
rox_central_process_upserted_args_size_total{cluster="4b18db8d-919f-4f5e-9269-d4ea379a432a",namespace="gmp-system"} 6193
rox_central_process_upserted_args_size_total{cluster="4b18db8d-919f-4f5e-9269-d4ea379a432a",namespace="kube-system"} 14803
rox_central_process_upserted_args_size_total{cluster="4b18db8d-919f-4f5e-9269-d4ea379a432a",namespace="stackrox"} 5632
```

```
# HELP rox_central_process_upserted_lineage_size Distribution of process lineage sizes in bytes for upserted indicators
# TYPE rox_central_process_upserted_lineage_size histogram
rox_central_process_upserted_lineage_size_bucket{le="0"} 120
rox_central_process_upserted_lineage_size_bucket{le="8"} 120
rox_central_process_upserted_lineage_size_bucket{le="16"} 146
rox_central_process_upserted_lineage_size_bucket{le="32"} 183
rox_central_process_upserted_lineage_size_bucket{le="64"} 286
rox_central_process_upserted_lineage_size_bucket{le="128"} 286
rox_central_process_upserted_lineage_size_bucket{le="256"} 286
rox_central_process_upserted_lineage_size_bucket{le="512"} 286
rox_central_process_upserted_lineage_size_bucket{le="1024"} 286
rox_central_process_upserted_lineage_size_bucket{le="2048"} 286
rox_central_process_upserted_lineage_size_bucket{le="4096"} 286
rox_central_process_upserted_lineage_size_bucket{le="8192"} 286
rox_central_process_upserted_lineage_size_bucket{le="16384"} 286
rox_central_process_upserted_lineage_size_bucket{le="32768"} 286
rox_central_process_upserted_lineage_size_bucket{le="65536"} 286
rox_central_process_upserted_lineage_size_bucket{le="+Inf"} 286
rox_central_process_upserted_lineage_size_sum 6804
rox_central_process_upserted_lineage_size_count 286
# HELP rox_central_process_upserted_lineage_size_total Total upserted process lineage sizes in bytes by cluster and namespace
# TYPE rox_central_process_upserted_lineage_size_total counter
rox_central_process_upserted_lineage_size_total{cluster="4b18db8d-919f-4f5e-9269-d4ea379a432a",namespace="gke-managed-cim"} 0
rox_central_process_upserted_lineage_size_total{cluster="4b18db8d-919f-4f5e-9269-d4ea379a432a",namespace="gmp-system"} 0
rox_central_process_upserted_lineage_size_total{cluster="4b18db8d-919f-4f5e-9269-d4ea379a432a",namespace="kube-system"} 5471
rox_central_process_upserted_lineage_size_total{cluster="4b18db8d-919f-4f5e-9269-d4ea379a432a",namespace="stackrox"} 1333
```
