### PR TITLE
ROX-34498: Fix sensor cache invalidation for name-based keys

### DIFF
--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -93,7 +93,7 @@ func (h *handlerImpl) ProcessInvalidateImageCache(req *central.InvalidateImageCa
 
 		keysToDelete := make([]cache.Key, 0, len(req.GetImageKeys())*2)
 		for _, image := range req.GetImageKeys() {
-			keysToDelete = append(keysToDelete, cacheKeysFromImageKey(image)...)
+			keysToDelete = append(keysToDelete, cacheKeysToInvalidate(image)...)
 		}
 		h.imageCache.Remove(keysToDelete...)
 	}
@@ -136,12 +136,12 @@ func cacheKeyFromImageKey(imageKey *central.ImageKey) cache.Key {
 	return cache.Key(key)
 }
 
-// cacheKeysFromImageKey returns all possible cache keys for an ImageKey.
+// cacheKeysToInvalidate returns all possible cache keys for an ImageKey.
 // Images may be cached under either a digest-derived key (V2 UUID5 or raw
 // digest) or the full image name, depending on whether the deployment's
 // container image had a digest when it was first cached. Both keys must
 // be invalidated to avoid stale entries.
-func cacheKeysFromImageKey(imageKey *central.ImageKey) []cache.Key {
+func cacheKeysToInvalidate(imageKey *central.ImageKey) []cache.Key {
 	var keys []cache.Key
 	if centralcaps.Has(centralsensor.FlattenImageData) {
 		if id := imageKey.GetImageIdV2(); id != "" {

--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -91,6 +91,7 @@ func (h *handlerImpl) ProcessInvalidateImageCache(req *central.InvalidateImageCa
 	default:
 		h.admCtrlSettingsMgr.InvalidateImageCache(req.GetImageKeys())
 
+		// Each ImageKey may produce up to 2 cache keys (digest-derived + full name).
 		keysToDelete := make([]cache.Key, 0, len(req.GetImageKeys())*2)
 		for _, image := range req.GetImageKeys() {
 			keysToDelete = append(keysToDelete, cacheKeysToInvalidate(image)...)

--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -91,9 +91,9 @@ func (h *handlerImpl) ProcessInvalidateImageCache(req *central.InvalidateImageCa
 	default:
 		h.admCtrlSettingsMgr.InvalidateImageCache(req.GetImageKeys())
 
-		keysToDelete := make([]cache.Key, 0, len(req.GetImageKeys()))
+		keysToDelete := make([]cache.Key, 0, len(req.GetImageKeys())*2)
 		for _, image := range req.GetImageKeys() {
-			keysToDelete = append(keysToDelete, cacheKeyFromImageKey(image))
+			keysToDelete = append(keysToDelete, cacheKeysFromImageKey(image)...)
 		}
 		h.imageCache.Remove(keysToDelete...)
 	}
@@ -108,7 +108,7 @@ func (h *handlerImpl) ProcessRefreshImageCacheTTL(req *central.RefreshImageCache
 		return errors.Wrap(h.stopSig.Err(), "could not fulfill refresh image cache TTL request")
 	default:
 		for _, image := range req.GetImageKeys() {
-			if key := cacheKeyFromImageKey(image); key != "" {
+			for _, key := range cacheKeysFromImageKey(image) {
 				h.imageCache.Touch(key)
 			}
 		}
@@ -116,19 +116,26 @@ func (h *handlerImpl) ProcessRefreshImageCacheTTL(req *central.RefreshImageCache
 	return nil
 }
 
-// cacheKeyFromImageKey resolves the cache key from an ImageKey
-// proto, applying the V2/V1/fullName precedence based on the FlattenImageData capability.
-func cacheKeyFromImageKey(imageKey *central.ImageKey) cache.Key {
-	var key string
+// cacheKeysFromImageKey returns all possible cache keys for an ImageKey.
+// Images may be cached under either a digest-derived key (V2 UUID5 or raw
+// digest) or the full image name, depending on whether the deployment's
+// container image had a digest when it was first cached. Both keys must
+// be invalidated to avoid stale entries.
+func cacheKeysFromImageKey(imageKey *central.ImageKey) []cache.Key {
+	var keys []cache.Key
 	if centralcaps.Has(centralsensor.FlattenImageData) {
-		key = imageKey.GetImageIdV2()
+		if id := imageKey.GetImageIdV2(); id != "" {
+			keys = append(keys, cache.Key(id))
+		}
 	} else {
-		key = imageKey.GetImageId()
+		if id := imageKey.GetImageId(); id != "" {
+			keys = append(keys, cache.Key(id))
+		}
 	}
-	if key == "" {
-		key = imageKey.GetImageFullName()
+	if fullName := imageKey.GetImageFullName(); fullName != "" {
+		keys = append(keys, cache.Key(fullName))
 	}
-	return cache.Key(key)
+	return keys
 }
 
 func (h *handlerImpl) ResponsesC() <-chan *message.ExpiringMessage {

--- a/sensor/common/reprocessor/handler.go
+++ b/sensor/common/reprocessor/handler.go
@@ -107,13 +107,33 @@ func (h *handlerImpl) ProcessRefreshImageCacheTTL(req *central.RefreshImageCache
 	case <-h.stopSig.Done():
 		return errors.Wrap(h.stopSig.Err(), "could not fulfill refresh image cache TTL request")
 	default:
+		// Unlike invalidation, refresh intentionally touches only the
+		// digest-derived key and does not touch name-based entries.
+		// Name-based entries may refer to images with mutable tags
+		// (e.g. "latest"); refreshing them would delay expiry and
+		// risk serving stale data when the tag points to a new image.
 		for _, image := range req.GetImageKeys() {
-			for _, key := range cacheKeysFromImageKey(image) {
+			if key := cacheKeyFromImageKey(image); key != "" {
 				h.imageCache.Touch(key)
 			}
 		}
 	}
 	return nil
+}
+
+// cacheKeyFromImageKey resolves the cache key from an ImageKey
+// proto, applying the V2/V1/fullName precedence based on the FlattenImageData capability.
+func cacheKeyFromImageKey(imageKey *central.ImageKey) cache.Key {
+	var key string
+	if centralcaps.Has(centralsensor.FlattenImageData) {
+		key = imageKey.GetImageIdV2()
+	} else {
+		key = imageKey.GetImageId()
+	}
+	if key == "" {
+		key = imageKey.GetImageFullName()
+	}
+	return cache.Key(key)
 }
 
 // cacheKeysFromImageKey returns all possible cache keys for an ImageKey.

--- a/sensor/common/reprocessor/handler_test.go
+++ b/sensor/common/reprocessor/handler_test.go
@@ -52,7 +52,7 @@ func TestProcessInvalidateImageCache(t *testing.T) {
 		wantKept    []cache.Key
 	}{
 		{
-			name:    "without flatten uses ImageId",
+			name:    "without flatten uses ImageId and ImageFullName",
 			flatten: false,
 			cache: map[cache.Key]string{
 				"sha256:abc123": "docker.io/library/nginx:latest",
@@ -65,11 +65,11 @@ func TestProcessInvalidateImageCache(t *testing.T) {
 				{ImageId: "sha256:def456", ImageFullName: "quay.io/stackrox/main:4.0.0"},
 				{ImageFullName: "redis:alpine"},
 			},
-			wantRemoved: []cache.Key{"sha256:abc123", "sha256:def456", "redis:alpine"},
+			wantRemoved: []cache.Key{"sha256:abc123", "sha256:def456", "redis:alpine", "docker.io/library/nginx:latest", "quay.io/stackrox/main:4.0.0"},
 			wantKept:    []cache.Key{"nginx:latest"},
 		},
 		{
-			name:    "with flatten uses ImageIdV2",
+			name:    "with flatten uses ImageIdV2 and ImageFullName",
 			flatten: true,
 			cache: map[cache.Key]string{
 				"uuid-v5-id-1": "docker.io/library/nginx:latest",
@@ -82,8 +82,19 @@ func TestProcessInvalidateImageCache(t *testing.T) {
 				{ImageIdV2: "uuid-v5-id-2", ImageFullName: "quay.io/stackrox/main:4.0.0"},
 				{ImageFullName: "redis:alpine"},
 			},
-			wantRemoved: []cache.Key{"uuid-v5-id-1", "uuid-v5-id-2", "redis:alpine"},
+			wantRemoved: []cache.Key{"uuid-v5-id-1", "uuid-v5-id-2", "redis:alpine", "docker.io/library/nginx:latest", "quay.io/stackrox/main:4.0.0"},
 			wantKept:    []cache.Key{"nginx:latest"},
+		},
+		{
+			name:    "with flatten removes entry cached by full name when no digest was available",
+			flatten: true,
+			cache: map[cache.Key]string{
+				"docker.io/example/app:v1": "docker.io/example/app:v1",
+			},
+			imageKeys: []*central.ImageKey{
+				{ImageIdV2: "uuid-v5-id-app", ImageFullName: "docker.io/example/app:v1"},
+			},
+			wantRemoved: []cache.Key{"uuid-v5-id-app", "docker.io/example/app:v1"},
 		},
 	}
 


### PR DESCRIPTION
## Description

The sensor enricher cache may store images under their full image name (e.g. `docker.io/library/nginx:latest`) instead of the ID (UUID or SHA). This happens when a deployment's container image has no digest at the time of first enrichment -- `cache.GetKey()` falls back to the full name.

When a vulnerability exception (deferral / false positive) is approved, Central broadcasts an `InvalidateImageCache` message containing the digest-derived key and the full image name. However, `cacheKeyFromImageKey` used an either/or precedence: it returned the ID based key first, falling back to full name only when the ID was empty. Since Central always populates the ID field, the full name fallback was dead code.

This caused stale cache entries keyed by full name to persist, so deploy-time policy enforcement continued to fire on CVEs that had been marked as false positive -- until the 4-hour cache TTL expired.

**Fix**: Added `cacheKeysToInvalidate` which returns **all** possible cache keys (digest-derived ID AND full name). `ProcessInvalidateImageCache` now uses this to remove entries cached under either key format.

`ProcessRefreshImageCacheTTL` intentionally continues using the single digest-derived key (`cacheKeyFromImageKey`). Name-based entries may refer to images with mutable tags (e.g. "latest"); refreshing them would delay expiry and risk serving stale data when the tag points to a new image.

The admission controller was already handling both key formats correctly via its two-level cache design and is not affected.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Updated existing unit tests in `handler_test.go` to verify both digest-derived and full name keys are removed on invalidation
- Added new test case covering the specific bug scenario: image cached by full name (no digest available) is properly invalidated when Central sends ID + full name in the ImageKey
- All 6 tests pass in `sensor/common/reprocessor/handler_test.go`
- Verified admission controller is not affected (already handles both key formats)