### PR TITLE
ci: add path filters to bundle helpers workflow

### DIFF
--- a/.github/workflows/test-bundle-helpers.yaml
+++ b/.github/workflows/test-bundle-helpers.yaml
@@ -9,11 +9,23 @@ on:
     branches:
     - master
     - release-*
+    paths:
+    - '.github/**'
+    - 'operator/**'
+    - 'go.mod'
+    - 'go.sum'
+    - 'scripts/ci/**'
   pull_request:
     types:
     - opened
     - reopened
     - synchronize
+    paths:
+    - '.github/**'
+    - 'operator/**'
+    - 'go.mod'
+    - 'go.sum'
+    - 'scripts/ci/**'
 
 env:
  ROX_PRODUCT_BRANDING: RHACS_BRANDING


### PR DESCRIPTION
## Description

Add `paths:` filters to the "Test Bundle Helpers" GHA workflow so it only runs when relevant files change.

Tag pushes are unaffected (GHA ignores `paths` for tag events).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

CI-only change. The workflow file is valid YAML and follows the same `paths:` pattern used by other workflows in this repo (e.g. `emailsender-central-compatibility.yaml`).