### PR TITLE
ROX-34506: Add virtctl mode to roxagent's install.sh

### DIFF
--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -32,16 +32,38 @@ STAGED_INSTALL_FILES=(
     roxagent-tmpfiles.conf
 )
 
-# --- Transport abstraction ---------------------------------------------------
-# Each transport stores state here and uses the shared helpers:
-#   remote_copy <local-file> <remote-dest>   — copy a file to the target
-#   remote_exec                              — run a script from stdin on target
-
 TRANSPORT_KIND=""
 SSH_HOST=""
 SSH_PORT=""
 VIRTCTL_TARGET=""
 VIRTCTL_FLAGS=()
+
+main() {
+    if [ "${#}" -eq 0 ]; then
+        setup_transport_local
+        install_local
+    elif [ "${1}" = "--stage-dir" ]; then
+        if [ "${#}" -ne 2 ]; then
+            echo "usage: ${0} --stage-dir <dir>" >&2
+            exit 1
+        fi
+        install_from_stage_dir "${2}"
+    elif [ "${1}" = "virtctl" ]; then
+        shift
+        setup_transport_virtctl "${@}"
+        install_remote
+    else
+        setup_transport_ssh "${1}" "${2:-22}"
+        install_remote
+    fi
+
+    echo ""
+    echo "Done! The roxagent will run hourly."
+    echo ""
+    echo "To run immediately:  sudo systemctl start roxagent.service"
+    echo "To view logs:        sudo journalctl -u roxagent.service -f"
+    echo "To check timer:      sudo systemctl list-timers roxagent.timer"
+}
 
 remote_copy() {
     case "${TRANSPORT_KIND}" in
@@ -213,29 +235,4 @@ filter_container_file() {
     fi
 }
 
-# --- Main ---------------------------------------------------------------------
-
-if [ "${#}" -eq 0 ]; then
-    setup_transport_local
-    install_local
-elif [ "${1}" = "--stage-dir" ]; then
-    if [ "${#}" -ne 2 ]; then
-        echo "usage: ${0} --stage-dir <dir>" >&2
-        exit 1
-    fi
-    install_from_stage_dir "${2}"
-elif [[ "${1}" == "virtctl" ]]; then
-    shift
-    setup_transport_virtctl "${@}"
-    install_remote
-else
-    setup_transport_ssh "${1}" "${2:-22}"
-    install_remote
-fi
-
-echo ""
-echo "Done! The roxagent will run hourly."
-echo ""
-echo "To run immediately:  sudo systemctl start roxagent.service"
-echo "To view logs:        sudo journalctl -u roxagent.service -f"
-echo "To check timer:      sudo systemctl list-timers roxagent.timer"
+main "${@}"

--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -3,9 +3,9 @@
 #
 # Usage:
 #   ./install.sh                                                      # Install locally
-#   ./install.sh user@host                                            # SSH (port 22)
-#   ./install.sh user@host 2222                                       # SSH with custom port
-#   ./install.sh virtctl -n openshift-cnv cloud-user@vmi/rhel10-1     # Via virtctl
+#   ./install.sh -n openshift-cnv cloud-user@vmi/rhel10-1             # Via virtctl (default remote)
+#   ./install.sh --ssh user@host                                      # SSH (port 22)
+#   ./install.sh --ssh user@host 2222                                 # SSH with custom port
 
 set -euo pipefail
 
@@ -39,39 +39,58 @@ VIRTCTL_TARGET=""
 VIRTCTL_FLAGS=()
 
 main() {
-    if [ "${#}" -eq 0 ]; then
+    if [ $# -eq 0 ]; then
         setup_transport_local
         install_local
-    elif [ "${1}" = "--stage-dir" ]; then
-        if [ "${#}" -ne 2 ]; then
-            echo "usage: ${0} --stage-dir <dir>" >&2
+    elif [ "$1" = "--stage-dir" ]; then
+        if [ $# -ne 2 ]; then
+            echo "usage: $0 --stage-dir <dir>" >&2
             exit 1
         fi
-        install_from_stage_dir "${2}"
-    elif [ "${1}" = "virtctl" ]; then
+        install_from_stage_dir "$2"
+        return
+    elif [ "$1" = "--ssh" ]; then
         shift
-        setup_transport_virtctl "${@}"
+        if [ $# -lt 1 ]; then
+            usage
+            exit 1
+        fi
+        setup_transport_ssh "$1" "${2:-22}"
         install_remote
     else
-        setup_transport_ssh "${1}" "${2:-22}"
+        setup_transport_virtctl "$@"
         install_remote
     fi
 
     echo ""
-    echo "Done! The roxagent will run hourly."
+    echo "Done! The roxagent will run periodically."
     echo ""
     echo "To run immediately:  sudo systemctl start roxagent.service"
     echo "To view logs:        sudo journalctl -u roxagent.service -f"
     echo "To check timer:      sudo systemctl list-timers roxagent.timer"
 }
 
+usage() {
+    cat >&2 <<EOF
+Usage:
+  $0                                                # Install locally
+  $0 [virtctl-flags...] <user@vmi/name>            # Remote install via virtctl (default)
+  $0 --ssh <user@host> [port]                      # Remote install via SSH
+
+Examples:
+  $0 -n openshift-cnv cloud-user@vmi/rhel10-1
+  $0 --ssh root@192.168.1.10
+  $0 --ssh root@192.168.1.10 2222
+EOF
+}
+
 remote_copy() {
     case "${TRANSPORT_KIND}" in
         ssh)
-            scp -P "${SSH_PORT}" "${1}" "${SSH_HOST}:${2}"
+            scp -P "${SSH_PORT}" "$1" "${SSH_HOST}:$2"
             ;;
         virtctl)
-            virtctl scp "${VIRTCTL_FLAGS[@]}" "${1}" "${VIRTCTL_TARGET}:${2}"
+            virtctl scp "${VIRTCTL_FLAGS[@]}" "$1" "${VIRTCTL_TARGET}:$2"
             ;;
         *)
             echo "remote_copy called without a remote transport" >&2
@@ -101,18 +120,28 @@ setup_transport_local() {
 
 setup_transport_ssh() {
     TRANSPORT_KIND="ssh"
-    SSH_HOST="${1}"
+    SSH_HOST="$1"
     SSH_PORT="${2:-22}"
 }
 
 setup_transport_virtctl() {
+    if [ $# -eq 0 ]; then
+        echo "error: virtctl mode requires at least a target (e.g. cloud-user@vmi/rhel10-1)" >&2
+        echo "" >&2
+        usage
+        exit 1
+    fi
+
     # Expects virtctl flags + target, e.g.:
     #   -n openshift-cnv cloud-user@vmi/rhel10-1
     # The last positional arg is the target; everything else are flags.
     TRANSPORT_KIND="virtctl"
     VIRTCTL_TARGET="${*: -1}"
-    if (( ${#} > 1 )); then
-        VIRTCTL_FLAGS=("${@:1:${#}-1}")
+
+    local argc=$#
+    if (( argc > 1 )); then
+        # Collect all arguments except the last one (the target) as flags.
+        VIRTCTL_FLAGS=("${@:1:argc-1}")
     else
         VIRTCTL_FLAGS=()
     fi
@@ -140,7 +169,7 @@ SCRIPT
 }
 
 copy_remote_stage_files() {
-    local remote_stage_dir="${1}"
+    local remote_stage_dir="$1"
     local file
     for file in "${STAGED_INSTALL_FILES[@]}"; do
         remote_copy "${SCRIPT_DIR}/${file}" "${remote_stage_dir}/${file}"
@@ -148,9 +177,10 @@ copy_remote_stage_files() {
 }
 
 validate_stage_dir() {
-    local stage_dir="${1}"
+    local stage_dir="$1"
     local file
-    for file in roxagent.container roxagent.timer roxagent-prep.service roxagent-tmpfiles.conf; do
+    for file in "${STAGED_INSTALL_FILES[@]}"; do
+        [ "${file}" = "install.sh" ] && continue
         if [ ! -f "${stage_dir}/${file}" ]; then
             echo "missing staged file: ${stage_dir}/${file}" >&2
             return 1
@@ -159,7 +189,7 @@ validate_stage_dir() {
 }
 
 install_from_stage_dir() {
-    local stage_dir="${1}"
+    local stage_dir="$1"
     validate_stage_dir "${stage_dir}"
 
     echo "Installing Quadlet units from ${stage_dir}..."
@@ -220,7 +250,7 @@ SCRIPT
 # Produce a filtered roxagent.container on stdout, removing Volume= lines
 # whose host source path does not exist on this machine.
 filter_container_file() {
-    local file="${1}"
+    local file="$1"
     local pattern=""
     for p in "${OPTIONAL_HOST_PATHS[@]}"; do
         if [ ! -e "${p}" ]; then
@@ -235,4 +265,4 @@ filter_container_file() {
     fi
 }
 
-main "${@}"
+main "$@"

--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -10,6 +10,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Directory containing the Quadlet unit files (roxagent.container, .timer, etc.)
+# to install. Defaults to the script's own directory; override for testing.
+QUADLET_FILES_DIR="${QUADLET_FILES_DIR:-${SCRIPT_DIR}}"
 
 # Host paths that may not exist on all RHEL versions (e.g. DNF paths on
 # yum-only RHEL 8). Volume= lines referencing these are stripped when the
@@ -172,7 +175,7 @@ copy_remote_stage_files() {
     local remote_stage_dir="$1"
     local file
     for file in "${STAGED_INSTALL_FILES[@]}"; do
-        remote_copy "${SCRIPT_DIR}/${file}" "${remote_stage_dir}/${file}"
+        remote_copy "${QUADLET_FILES_DIR}/${file}" "${remote_stage_dir}/${file}"
     done
 }
 
@@ -224,7 +227,7 @@ install_from_stage_dir() {
 }
 
 install_local() {
-    install_from_stage_dir "${SCRIPT_DIR}"
+    install_from_stage_dir "${QUADLET_FILES_DIR}"
 }
 
 install_remote() {

--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -106,7 +106,7 @@ OPTIONAL_HOST_PATHS=(
 # Strip Volume= lines for host paths that don't exist on this machine
 pattern=""
 for p in "${OPTIONAL_HOST_PATHS[@]}"; do
-    if [ ! -d "$p" ]; then
+    if [ ! -e "$p" ]; then
         echo "  Stripping mount for missing path: $p"
         pattern="${pattern:+${pattern}|}Volume=${p}[:/]"
     fi

--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -2,9 +2,10 @@
 # Install roxagent Quadlet units on a RHEL VM
 #
 # Usage:
-#   ./install.sh                    # Install locally
-#   ./install.sh user@host          # Install on remote host via SSH
-#   ./install.sh user@host 2222     # Install on remote host with custom SSH port
+#   ./install.sh                                                      # Install locally
+#   ./install.sh user@host                                            # SSH (port 22)
+#   ./install.sh user@host 2222                                       # SSH with custom port
+#   ./install.sh virtctl -n openshift-cnv cloud-user@vmi/rhel10-1     # Via virtctl
 
 set -euo pipefail
 
@@ -22,6 +23,154 @@ OPTIONAL_HOST_PATHS=(
     /var/cache/dnf
     /var/lib/dnf
 )
+
+# --- Transport abstraction ---------------------------------------------------
+# Each transport stores state here and uses the shared helpers:
+#   remote_copy <local-file> <remote-dest>   — copy a file to the target
+#   remote_exec                              — run a script from stdin on target
+
+TRANSPORT_KIND=""
+SSH_HOST=""
+SSH_PORT=""
+VIRTCTL_TARGET=""
+VIRTCTL_FLAGS=()
+
+remote_copy() {
+    case "${TRANSPORT_KIND}" in
+        ssh)
+            scp -P "${SSH_PORT}" "$1" "${SSH_HOST}:$2"
+            ;;
+        virtctl)
+            virtctl scp "${VIRTCTL_FLAGS[@]}" "$1" "${VIRTCTL_TARGET}:$2"
+            ;;
+        *)
+            echo "remote_copy called without a remote transport" >&2
+            return 1
+            ;;
+    esac
+}
+
+remote_exec() {
+    case "${TRANSPORT_KIND}" in
+        ssh)
+            ssh -p "${SSH_PORT}" "${SSH_HOST}" bash -s
+            ;;
+        virtctl)
+            virtctl ssh "${VIRTCTL_FLAGS[@]}" "${VIRTCTL_TARGET}" --command 'bash -s'
+            ;;
+        *)
+            echo "remote_exec called without a remote transport" >&2
+            return 1
+            ;;
+    esac
+}
+
+setup_transport_local() {
+    TRANSPORT_KIND="local"
+}
+
+setup_transport_ssh() {
+    TRANSPORT_KIND="ssh"
+    SSH_HOST="$1"
+    SSH_PORT="${2:-22}"
+}
+
+setup_transport_virtctl() {
+    # Expects virtctl flags + target, e.g.:
+    #   -n openshift-cnv cloud-user@vmi/rhel10-1
+    # The last positional arg is the target; everything else are flags.
+    TRANSPORT_KIND="virtctl"
+    VIRTCTL_TARGET="${*: -1}"
+    if (( $# > 1 )); then
+        VIRTCTL_FLAGS=("${@:1:$#-1}")
+    else
+        VIRTCTL_FLAGS=()
+    fi
+}
+
+# --- Install logic (shared) --------------------------------------------------
+
+REMOTE_INSTALL_SCRIPT=$(cat << 'SCRIPT'
+set -euo pipefail
+
+OPTIONAL_HOST_PATHS=(
+    /etc/yum.repos.d
+    /etc/yum/repos.d
+    /etc/distro.repos.d
+    /etc/redhat-release
+    /etc/system-release-cpe
+    /var/cache/dnf
+    /var/lib/dnf
+)
+
+# Strip Volume= lines for host paths that don't exist on this machine
+pattern=""
+for p in "${OPTIONAL_HOST_PATHS[@]}"; do
+    if [ ! -d "$p" ]; then
+        echo "  Stripping mount for missing path: $p"
+        pattern="${pattern:+${pattern}|}Volume=${p}[:/]"
+    fi
+done
+if [ -n "$pattern" ]; then
+    grep -Ev "$pattern" /tmp/roxagent.container > /tmp/roxagent.container.filtered
+    mv /tmp/roxagent.container.filtered /tmp/roxagent.container
+fi
+
+# Quadlet container file
+sudo mkdir -p /etc/containers/systemd/
+sudo mv /tmp/roxagent.container /etc/containers/systemd/
+sudo restorecon -Rv /etc/containers/systemd/ 2>/dev/null || true
+
+# Timer and prep service
+sudo mv /tmp/roxagent.timer /etc/systemd/system/
+sudo mv /tmp/roxagent-prep.service /etc/systemd/system/
+sudo restorecon -Rv /etc/systemd/system/roxagent.timer /etc/systemd/system/roxagent-prep.service 2>/dev/null || true
+
+echo "Reloading systemd..."
+sudo systemctl daemon-reload
+
+echo "Enabling and starting timer..."
+sudo systemctl enable --now roxagent.timer
+
+echo "Status:"
+sudo systemctl list-timers roxagent.timer
+SCRIPT
+)
+
+install_local() {
+    echo "Installing Quadlet units locally..."
+
+    # Filter container file for missing optional paths
+    local filtered
+    filtered=$(filter_container_file "${SCRIPT_DIR}/roxagent.container")
+
+    sudo mkdir -p /etc/containers/systemd/
+    echo "$filtered" | sudo tee /etc/containers/systemd/roxagent.container >/dev/null
+    sudo restorecon -Rv /etc/containers/systemd/ 2>/dev/null || true
+
+    sudo cp "${SCRIPT_DIR}/roxagent.timer" /etc/systemd/system/
+    sudo cp "${SCRIPT_DIR}/roxagent-prep.service" /etc/systemd/system/
+    sudo restorecon -Rv /etc/systemd/system/roxagent.timer /etc/systemd/system/roxagent-prep.service 2>/dev/null || true
+
+    echo "Reloading systemd..."
+    sudo systemctl daemon-reload
+
+    echo "Enabling and starting timer..."
+    sudo systemctl enable --now roxagent.timer
+
+    echo "Status:"
+    sudo systemctl list-timers roxagent.timer
+}
+
+install_remote() {
+    echo "Copying files to target..."
+    remote_copy "${SCRIPT_DIR}/roxagent.container" /tmp/
+    remote_copy "${SCRIPT_DIR}/roxagent.timer" /tmp/
+    remote_copy "${SCRIPT_DIR}/roxagent-prep.service" /tmp/
+
+    echo "Running install on target..."
+    echo "$REMOTE_INSTALL_SCRIPT" | remote_exec
+}
 
 # Produce a filtered roxagent.container on stdout, removing Volume= lines
 # whose host source path does not exist on this machine.
@@ -41,8 +190,7 @@ filter_container_file() {
     fi
 }
 
-install_locally() {
-    echo "Installing Quadlet units locally..."
+# --- Main ---------------------------------------------------------------------
 
     # Quadlet container file (strip mounts for paths missing on this host)
     sudo mkdir -p /etc/containers/systemd/
@@ -142,10 +290,16 @@ EOF
 }
 
 # Main
-if [ "${#}" -eq 0 ]; then
-    install_locally
+if [ $# -eq 0 ]; then
+    setup_transport_local
+    install_local
+elif [[ "$1" == "virtctl" ]]; then
+    shift
+    setup_transport_virtctl "$@"
+    install_remote
 else
-    install_remote "${1}" "${2:-22}"
+    setup_transport_ssh "$1" "${2:-22}"
+    install_remote
 fi
 
 echo ""

--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -38,10 +38,10 @@ VIRTCTL_FLAGS=()
 remote_copy() {
     case "${TRANSPORT_KIND}" in
         ssh)
-            scp -P "${SSH_PORT}" "$1" "${SSH_HOST}:$2"
+            scp -P "${SSH_PORT}" "${1}" "${SSH_HOST}:${2}"
             ;;
         virtctl)
-            virtctl scp "${VIRTCTL_FLAGS[@]}" "$1" "${VIRTCTL_TARGET}:$2"
+            virtctl scp "${VIRTCTL_FLAGS[@]}" "${1}" "${VIRTCTL_TARGET}:${2}"
             ;;
         *)
             echo "remote_copy called without a remote transport" >&2
@@ -71,7 +71,7 @@ setup_transport_local() {
 
 setup_transport_ssh() {
     TRANSPORT_KIND="ssh"
-    SSH_HOST="$1"
+    SSH_HOST="${1}"
     SSH_PORT="${2:-22}"
 }
 
@@ -81,8 +81,8 @@ setup_transport_virtctl() {
     # The last positional arg is the target; everything else are flags.
     TRANSPORT_KIND="virtctl"
     VIRTCTL_TARGET="${*: -1}"
-    if (( $# > 1 )); then
-        VIRTCTL_FLAGS=("${@:1:$#-1}")
+    if (( ${#} > 1 )); then
+        VIRTCTL_FLAGS=("${@:1:${#}-1}")
     else
         VIRTCTL_FLAGS=()
     fi
@@ -106,13 +106,13 @@ OPTIONAL_HOST_PATHS=(
 # Strip Volume= lines for host paths that don't exist on this machine
 pattern=""
 for p in "${OPTIONAL_HOST_PATHS[@]}"; do
-    if [ ! -e "$p" ]; then
-        echo "  Stripping mount for missing path: $p"
+    if [ ! -e "${p}" ]; then
+        echo "  Stripping mount for missing path: ${p}"
         pattern="${pattern:+${pattern}|}Volume=${p}[:/]"
     fi
 done
-if [ -n "$pattern" ]; then
-    grep -Ev "$pattern" /tmp/roxagent.container > /tmp/roxagent.container.filtered
+if [ -n "${pattern}" ]; then
+    grep -Ev "${pattern}" /tmp/roxagent.container > /tmp/roxagent.container.filtered
     mv /tmp/roxagent.container.filtered /tmp/roxagent.container
 fi
 
@@ -125,6 +125,13 @@ sudo restorecon -Rv /etc/containers/systemd/ 2>/dev/null || true
 sudo mv /tmp/roxagent.timer /etc/systemd/system/
 sudo mv /tmp/roxagent-prep.service /etc/systemd/system/
 sudo restorecon -Rv /etc/systemd/system/roxagent.timer /etc/systemd/system/roxagent-prep.service 2>/dev/null || true
+
+# Recreate the lock directory on every boot since /run is tmpfs.
+sudo mkdir -p /etc/tmpfiles.d/
+sudo mv /tmp/roxagent-tmpfiles.conf /etc/tmpfiles.d/roxagent.conf
+sudo restorecon -Rv /etc/tmpfiles.d/roxagent.conf 2>/dev/null || true
+# systemd-tmpfiles --create applies the rule now (creates /run/lock/roxagent immediately).
+sudo systemd-tmpfiles --create /etc/tmpfiles.d/roxagent.conf
 
 echo "Reloading systemd..."
 sudo systemctl daemon-reload
@@ -139,58 +146,6 @@ SCRIPT
 
 install_local() {
     echo "Installing Quadlet units locally..."
-
-    # Filter container file for missing optional paths
-    local filtered
-    filtered=$(filter_container_file "${SCRIPT_DIR}/roxagent.container")
-
-    sudo mkdir -p /etc/containers/systemd/
-    echo "$filtered" | sudo tee /etc/containers/systemd/roxagent.container >/dev/null
-    sudo restorecon -Rv /etc/containers/systemd/ 2>/dev/null || true
-
-    sudo cp "${SCRIPT_DIR}/roxagent.timer" /etc/systemd/system/
-    sudo cp "${SCRIPT_DIR}/roxagent-prep.service" /etc/systemd/system/
-    sudo restorecon -Rv /etc/systemd/system/roxagent.timer /etc/systemd/system/roxagent-prep.service 2>/dev/null || true
-
-    echo "Reloading systemd..."
-    sudo systemctl daemon-reload
-
-    echo "Enabling and starting timer..."
-    sudo systemctl enable --now roxagent.timer
-
-    echo "Status:"
-    sudo systemctl list-timers roxagent.timer
-}
-
-install_remote() {
-    echo "Copying files to target..."
-    remote_copy "${SCRIPT_DIR}/roxagent.container" /tmp/
-    remote_copy "${SCRIPT_DIR}/roxagent.timer" /tmp/
-    remote_copy "${SCRIPT_DIR}/roxagent-prep.service" /tmp/
-
-    echo "Running install on target..."
-    echo "$REMOTE_INSTALL_SCRIPT" | remote_exec
-}
-
-# Produce a filtered roxagent.container on stdout, removing Volume= lines
-# whose host source path does not exist on this machine.
-filter_container_file() {
-    local file="${1}"
-    local pattern=""
-    for p in "${OPTIONAL_HOST_PATHS[@]}"; do
-        if [ ! -e "${p}" ]; then
-            echo "Stripping mount for missing path: ${p}" >&2
-            pattern="${pattern:+${pattern}|}Volume=${p}[:/]"
-        fi
-    done
-    if [ -z "${pattern}" ]; then
-        cat "${file}"
-    else
-        grep -Ev "${pattern}" "${file}"
-    fi
-}
-
-# --- Main ---------------------------------------------------------------------
 
     # Quadlet container file (strip mounts for paths missing on this host)
     sudo mkdir -p /etc/containers/systemd/
@@ -222,83 +177,46 @@ filter_container_file() {
 }
 
 install_remote() {
-    local REMOTE_HOST="${1}"
-    local SSH_PORT="${2:-22}"
+    echo "Copying files to target..."
+    remote_copy "${SCRIPT_DIR}/roxagent.container" /tmp/
+    remote_copy "${SCRIPT_DIR}/roxagent.timer" /tmp/
+    remote_copy "${SCRIPT_DIR}/roxagent-prep.service" /tmp/
+    remote_copy "${SCRIPT_DIR}/roxagent-tmpfiles.conf" /tmp/
 
-    echo "Installing Quadlet units on ${REMOTE_HOST} (port ${SSH_PORT})..."
-
-    # Copy files
-    scp -P "${SSH_PORT}" "${SCRIPT_DIR}/roxagent.container" "${REMOTE_HOST}:/tmp/"
-    scp -P "${SSH_PORT}" "${SCRIPT_DIR}/roxagent.timer" "${REMOTE_HOST}:/tmp/"
-    scp -P "${SSH_PORT}" "${SCRIPT_DIR}/roxagent-prep.service" "${REMOTE_HOST}:/tmp/"
-    scp -P "${SSH_PORT}" "${SCRIPT_DIR}/roxagent-tmpfiles.conf" "${REMOTE_HOST}:/tmp/"
-
-    # Install on remote — filter container file for missing optional paths
-    ssh -p "${SSH_PORT}" "${REMOTE_HOST}" << 'EOF'
-        set -euo pipefail
-
-        OPTIONAL_HOST_PATHS=(
-            /etc/yum.repos.d
-            /etc/yum/repos.d
-            /etc/distro.repos.d
-            /etc/redhat-release
-            /etc/system-release-cpe
-            /var/cache/dnf
-            /var/lib/dnf
-        )
-
-        # Strip Volume= lines for host paths that don't exist on this machine
-        pattern=""
-        for p in "${OPTIONAL_HOST_PATHS[@]}"; do
-            if [ ! -e "${p}" ]; then
-                echo "  Stripping mount for missing path: ${p}"
-                pattern="${pattern:+${pattern}|}Volume=${p}[:/]"
-            fi
-        done
-        if [ -n "${pattern}" ]; then
-            grep -Ev "${pattern}" /tmp/roxagent.container > /tmp/roxagent.container.filtered
-            mv /tmp/roxagent.container.filtered /tmp/roxagent.container
-        fi
-
-        # Quadlet container file
-        sudo mkdir -p /etc/containers/systemd/
-        sudo mv /tmp/roxagent.container /etc/containers/systemd/
-        # restorecon resets SELinux labels so systemd/podman can read the new files.
-        sudo restorecon -Rv /etc/containers/systemd/ 2>/dev/null || true
-
-        # Timer and prep service go in standard systemd directory
-        sudo mv /tmp/roxagent.timer /etc/systemd/system/
-        sudo mv /tmp/roxagent-prep.service /etc/systemd/system/
-        sudo restorecon -Rv /etc/systemd/system/roxagent.timer /etc/systemd/system/roxagent-prep.service 2>/dev/null || true
-
-        # Recreate the lock directory on every boot since /run is tmpfs.
-        sudo mkdir -p /etc/tmpfiles.d/
-        sudo mv /tmp/roxagent-tmpfiles.conf /etc/tmpfiles.d/roxagent.conf
-        sudo restorecon -Rv /etc/tmpfiles.d/roxagent.conf 2>/dev/null || true
-        # systemd-tmpfiles --create applies the rule now (creates /run/lock/roxagent immediately).
-        sudo systemd-tmpfiles --create /etc/tmpfiles.d/roxagent.conf
-
-        echo "Reloading systemd..."
-        sudo systemctl daemon-reload
-
-        echo "Enabling and starting timer..."
-        sudo systemctl enable --now roxagent.timer
-
-        echo "Status:"
-        sudo systemctl list-timers roxagent.timer
-EOF
+    echo "Running install on target..."
+    echo "${REMOTE_INSTALL_SCRIPT}" | remote_exec
 }
 
+# Produce a filtered roxagent.container on stdout, removing Volume= lines
+# whose host source path does not exist on this machine.
+filter_container_file() {
+    local file="${1}"
+    local pattern=""
+    for p in "${OPTIONAL_HOST_PATHS[@]}"; do
+        if [ ! -e "${p}" ]; then
+            echo "Stripping mount for missing path: ${p}" >&2
+            pattern="${pattern:+${pattern}|}Volume=${p}[:/]"
+        fi
+    done
+    if [ -z "${pattern}" ]; then
+        cat "${file}"
+    else
+        grep -Ev "${pattern}" "${file}"
+    fi
+}
+
+# --- Main ---------------------------------------------------------------------
+
 # Main
-if [ $# -eq 0 ]; then
+if [ "${#}" -eq 0 ]; then
     setup_transport_local
     install_local
-elif [[ "$1" == "virtctl" ]]; then
+elif [[ "${1}" == "virtctl" ]]; then
     shift
-    setup_transport_virtctl "$@"
+    setup_transport_virtctl "${@}"
     install_remote
 else
-    setup_transport_ssh "$1" "${2:-22}"
+    setup_transport_ssh "${1}" "${2:-22}"
     install_remote
 fi
 

--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -24,6 +24,14 @@ OPTIONAL_HOST_PATHS=(
     /var/lib/dnf
 )
 
+STAGED_INSTALL_FILES=(
+    install.sh
+    roxagent.container
+    roxagent.timer
+    roxagent-prep.service
+    roxagent-tmpfiles.conf
+)
+
 # --- Transport abstraction ---------------------------------------------------
 # Each transport stores state here and uses the shared helpers:
 #   remote_copy <local-file> <remote-dest>   — copy a file to the target
@@ -90,78 +98,65 @@ setup_transport_virtctl() {
 
 # --- Install logic (shared) --------------------------------------------------
 
-REMOTE_INSTALL_SCRIPT=$(cat << 'SCRIPT'
+create_remote_stage_dir() {
+    local output
+    output="$(
+        remote_exec <<'SCRIPT'
 set -euo pipefail
-
-OPTIONAL_HOST_PATHS=(
-    /etc/yum.repos.d
-    /etc/yum/repos.d
-    /etc/distro.repos.d
-    /etc/redhat-release
-    /etc/system-release-cpe
-    /var/cache/dnf
-    /var/lib/dnf
-)
-
-# Strip Volume= lines for host paths that don't exist on this machine
-pattern=""
-for p in "${OPTIONAL_HOST_PATHS[@]}"; do
-    if [ ! -e "${p}" ]; then
-        echo "  Stripping mount for missing path: ${p}"
-        pattern="${pattern:+${pattern}|}Volume=${p}[:/]"
-    fi
-done
-if [ -n "${pattern}" ]; then
-    grep -Ev "${pattern}" /tmp/roxagent.container > /tmp/roxagent.container.filtered
-    mv /tmp/roxagent.container.filtered /tmp/roxagent.container
-fi
-
-# Quadlet container file
-sudo mkdir -p /etc/containers/systemd/
-sudo mv /tmp/roxagent.container /etc/containers/systemd/
-sudo restorecon -Rv /etc/containers/systemd/ 2>/dev/null || true
-
-# Timer and prep service
-sudo mv /tmp/roxagent.timer /etc/systemd/system/
-sudo mv /tmp/roxagent-prep.service /etc/systemd/system/
-sudo restorecon -Rv /etc/systemd/system/roxagent.timer /etc/systemd/system/roxagent-prep.service 2>/dev/null || true
-
-# Recreate the lock directory on every boot since /run is tmpfs.
-sudo mkdir -p /etc/tmpfiles.d/
-sudo mv /tmp/roxagent-tmpfiles.conf /etc/tmpfiles.d/roxagent.conf
-sudo restorecon -Rv /etc/tmpfiles.d/roxagent.conf 2>/dev/null || true
-# systemd-tmpfiles --create applies the rule now (creates /run/lock/roxagent immediately).
-sudo systemd-tmpfiles --create /etc/tmpfiles.d/roxagent.conf
-
-echo "Reloading systemd..."
-sudo systemctl daemon-reload
-
-echo "Enabling and starting timer..."
-sudo systemctl enable --now roxagent.timer
-
-echo "Status:"
-sudo systemctl list-timers roxagent.timer
+stage_dir="$(mktemp -d "${TMPDIR:-/var/tmp}/roxagent-install.XXXXXX")"
+printf '__STAGE_DIR__=%s\n' "${stage_dir}"
 SCRIPT
-)
+    )"
 
-install_local() {
-    echo "Installing Quadlet units locally..."
+    local stage_dir
+    stage_dir="$(printf '%s\n' "${output}" | sed -n 's/^__STAGE_DIR__=//p' | tail -n 1)"
+    if [ -z "${stage_dir}" ]; then
+        echo "failed to determine remote stage dir" >&2
+        return 1
+    fi
+    printf '%s\n' "${stage_dir}"
+}
+
+copy_remote_stage_files() {
+    local remote_stage_dir="${1}"
+    local file
+    for file in "${STAGED_INSTALL_FILES[@]}"; do
+        remote_copy "${SCRIPT_DIR}/${file}" "${remote_stage_dir}/${file}"
+    done
+}
+
+validate_stage_dir() {
+    local stage_dir="${1}"
+    local file
+    for file in roxagent.container roxagent.timer roxagent-prep.service roxagent-tmpfiles.conf; do
+        if [ ! -f "${stage_dir}/${file}" ]; then
+            echo "missing staged file: ${stage_dir}/${file}" >&2
+            return 1
+        fi
+    done
+}
+
+install_from_stage_dir() {
+    local stage_dir="${1}"
+    validate_stage_dir "${stage_dir}"
+
+    echo "Installing Quadlet units from ${stage_dir}..."
 
     # Quadlet container file (strip mounts for paths missing on this host)
     sudo mkdir -p /etc/containers/systemd/
-    filter_container_file "${SCRIPT_DIR}/roxagent.container" \
+    filter_container_file "${stage_dir}/roxagent.container" \
         | sudo tee /etc/containers/systemd/roxagent.container >/dev/null
     # restorecon resets SELinux labels so systemd/podman can read the new files.
     sudo restorecon -Rv /etc/containers/systemd/ 2>/dev/null || true
 
     # Timer and prep service go in standard systemd directory
-    sudo cp "${SCRIPT_DIR}/roxagent.timer" /etc/systemd/system/
-    sudo cp "${SCRIPT_DIR}/roxagent-prep.service" /etc/systemd/system/
+    sudo cp "${stage_dir}/roxagent.timer" /etc/systemd/system/
+    sudo cp "${stage_dir}/roxagent-prep.service" /etc/systemd/system/
     sudo restorecon -Rv /etc/systemd/system/roxagent.timer /etc/systemd/system/roxagent-prep.service 2>/dev/null || true
 
     # Recreate the lock directory on every boot since /run is tmpfs.
     sudo mkdir -p /etc/tmpfiles.d/
-    sudo cp "${SCRIPT_DIR}/roxagent-tmpfiles.conf" /etc/tmpfiles.d/roxagent.conf
+    sudo cp "${stage_dir}/roxagent-tmpfiles.conf" /etc/tmpfiles.d/roxagent.conf
     sudo restorecon -Rv /etc/tmpfiles.d/roxagent.conf 2>/dev/null || true
     # systemd-tmpfiles --create applies the rule now (creates /run/lock/roxagent immediately).
     sudo systemd-tmpfiles --create /etc/tmpfiles.d/roxagent.conf
@@ -176,15 +171,28 @@ install_local() {
     sudo systemctl list-timers roxagent.timer
 }
 
+install_local() {
+    install_from_stage_dir "${SCRIPT_DIR}"
+}
+
 install_remote() {
+    local remote_stage_dir
+
+    echo "Preparing stage directory on target..."
+    remote_stage_dir="$(create_remote_stage_dir)"
+
     echo "Copying files to target..."
-    remote_copy "${SCRIPT_DIR}/roxagent.container" /tmp/
-    remote_copy "${SCRIPT_DIR}/roxagent.timer" /tmp/
-    remote_copy "${SCRIPT_DIR}/roxagent-prep.service" /tmp/
-    remote_copy "${SCRIPT_DIR}/roxagent-tmpfiles.conf" /tmp/
+    copy_remote_stage_files "${remote_stage_dir}"
 
     echo "Running install on target..."
-    echo "${REMOTE_INSTALL_SCRIPT}" | remote_exec
+    remote_exec <<SCRIPT
+set -euo pipefail
+cleanup() {
+    rm -rf "${remote_stage_dir}"
+}
+trap cleanup EXIT
+bash "${remote_stage_dir}/install.sh" --stage-dir "${remote_stage_dir}"
+SCRIPT
 }
 
 # Produce a filtered roxagent.container on stdout, removing Volume= lines
@@ -207,10 +215,15 @@ filter_container_file() {
 
 # --- Main ---------------------------------------------------------------------
 
-# Main
 if [ "${#}" -eq 0 ]; then
     setup_transport_local
     install_local
+elif [ "${1}" = "--stage-dir" ]; then
+    if [ "${#}" -ne 2 ]; then
+        echo "usage: ${0} --stage-dir <dir>" >&2
+        exit 1
+    fi
+    install_from_stage_dir "${2}"
 elif [[ "${1}" == "virtctl" ]]; then
     shift
     setup_transport_virtctl "${@}"

--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -76,9 +76,9 @@ main() {
 usage() {
     cat >&2 <<EOF
 Usage:
-  $0                                                # Install locally
-  $0 [virtctl-flags...] <user@vmi/name>            # Remote install via virtctl (default)
-  $0 --ssh <user@host> [port]                      # Remote install via SSH
+  $0                                           # Install locally
+  $0 [virtctl-flags...] <user@vmi/name>        # Remote install via virtctl (default)
+  $0 --ssh <user@host> [port]                  # Remote install via SSH
 
 Examples:
   $0 -n openshift-cnv cloud-user@vmi/rhel10-1

--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   ./install.sh                                                      # Install locally
-#   ./install.sh -n openshift-cnv cloud-user@vmi/rhel10-1             # Via virtctl (default remote)
+#   ./install.sh virtctl -n openshift-cnv cloud-user@vmi/rhel10-1     # Via virtctl
 #   ./install.sh --ssh user@host                                      # SSH (port 22)
 #   ./install.sh --ssh user@host 2222                                 # SSH with custom port
 
@@ -60,9 +60,13 @@ main() {
         fi
         setup_transport_ssh "$1" "${2:-22}"
         install_remote
-    else
+    elif [ "$1" = "virtctl" ]; then
+        shift
         setup_transport_virtctl "$@"
         install_remote
+    else
+        usage
+        exit 1
     fi
 
     echo ""
@@ -77,11 +81,11 @@ usage() {
     cat >&2 <<EOF
 Usage:
   $0                                           # Install locally
-  $0 [virtctl-flags...] <user@vmi/name>        # Remote install via virtctl (default)
+  $0 virtctl [virtctl-flags...] <user@vmi/name> # Remote install via virtctl
   $0 --ssh <user@host> [port]                  # Remote install via SSH
 
 Examples:
-  $0 -n openshift-cnv cloud-user@vmi/rhel10-1
+  $0 virtctl -n openshift-cnv cloud-user@vmi/rhel10-1
   $0 --ssh root@192.168.1.10
   $0 --ssh root@192.168.1.10 2222
 EOF
@@ -135,7 +139,7 @@ setup_transport_virtctl() {
         exit 1
     fi
 
-    # Expects virtctl flags + target, e.g.:
+    # Expects virtctl mode arguments after the explicit "virtctl" selector, e.g.:
     #   -n openshift-cnv cloud-user@vmi/rhel10-1
     # The last positional arg is the target; everything else are flags.
     TRANSPORT_KIND="virtctl"

--- a/compliance/virtualmachines/roxagent/quadlet/install.sh
+++ b/compliance/virtualmachines/roxagent/quadlet/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   ./install.sh                                                      # Install locally
-#   ./install.sh virtctl -n openshift-cnv cloud-user@vmi/rhel10-1     # Via virtctl
+#   ./install.sh --virtctl -n openshift-cnv cloud-user@vmi/rhel10-1   # Via virtctl
 #   ./install.sh --ssh user@host                                      # SSH (port 22)
 #   ./install.sh --ssh user@host 2222                                 # SSH with custom port
 
@@ -60,7 +60,7 @@ main() {
         fi
         setup_transport_ssh "$1" "${2:-22}"
         install_remote
-    elif [ "$1" = "virtctl" ]; then
+    elif [ "$1" = "--virtctl" ]; then
         shift
         setup_transport_virtctl "$@"
         install_remote
@@ -81,11 +81,11 @@ usage() {
     cat >&2 <<EOF
 Usage:
   $0                                           # Install locally
-  $0 virtctl [virtctl-flags...] <user@vmi/name> # Remote install via virtctl
+  $0 --virtctl [virtctl-flags...] <user@vmi/name> # Remote install via virtctl
   $0 --ssh <user@host> [port]                  # Remote install via SSH
 
 Examples:
-  $0 virtctl -n openshift-cnv cloud-user@vmi/rhel10-1
+  $0 --virtctl -n openshift-cnv cloud-user@vmi/rhel10-1
   $0 --ssh root@192.168.1.10
   $0 --ssh root@192.168.1.10 2222
 EOF
@@ -139,7 +139,7 @@ setup_transport_virtctl() {
         exit 1
     fi
 
-    # Expects virtctl mode arguments after the explicit "virtctl" selector, e.g.:
+    # Expects virtctl mode arguments after the explicit "--virtctl" selector, e.g.:
     #   -n openshift-cnv cloud-user@vmi/rhel10-1
     # The last positional arg is the target; everything else are flags.
     TRANSPORT_KIND="virtctl"

--- a/tests/e2e/bats/roxagent_quadlet_install.bats
+++ b/tests/e2e/bats/roxagent_quadlet_install.bats
@@ -1,9 +1,57 @@
 #!/usr/bin/env bats
 # shellcheck disable=SC1091
+#
+# Unit tests for compliance/virtualmachines/roxagent/quadlet/install.sh
+#
+# Test strategy:
+#   The install script calls external commands (sudo, ssh, scp, virtctl) that
+#   require privileges or remote hosts. To test locally without either, we place
+#   stub scripts on PATH (in BIN_DIR) that shadow the real binaries.
+#
+#   Stubs live in tests/e2e/bats/stubs/ as standalone executable scripts because
+#   the install script invokes them as external processes — bash functions
+#   (export -f) would not survive the child shell boundary reliably.
+#
+#   Three kinds of stubs are used:
+#     - sudo stub:       rewrites /etc/* paths into a temp FAKE_ROOT for assertion
+#     - recording stubs: log every call to CALL_LOG so tests can assert on args
+#     - unexpected stubs: fail immediately if invoked (tripwire guards)
+#
+#   See stubs/README or individual stub headers for details.
 
 load "../../../scripts/test_helpers.bats"
 
 INSTALL_SCRIPT_REL="compliance/virtualmachines/roxagent/quadlet/install.sh"
+
+# --- Test fixture content (container file variants) ---------------------------
+
+CONTAINER_ALL_PATHS_EXIST='[Container]
+Image=registry.example.com/roxagent:latest
+Volume=/etc/yum.repos.d:/etc/yum.repos.d:ro
+Volume=/data:/data:rw'
+
+CONTAINER_WITH_MISSING_PATHS='[Container]
+Image=registry.example.com/roxagent:latest
+Volume=/nonexistent/path1:/container/path1:ro
+Volume=/tmp:/container/tmp:rw
+Volume=/nonexistent/path2:/container/path2:ro'
+
+CONTAINER_MIXED_LINES='[Container]
+Image=registry.example.com/roxagent:latest
+Environment=SOME_VAR=value
+Volume=/missing/path:/dst:ro
+Label=com.example=test'
+
+# --- Test fixture content (staged install files) ------------------------------
+
+STAGE_CONTAINER='[Container]
+SENTINEL-CONTAINER=true'
+
+STAGE_TIMER='SENTINEL-TIMER=true'
+
+STAGE_PREP_SERVICE='SENTINEL-PREP=true'
+
+STAGE_TMPFILES_CONF='SENTINEL-TMPFILES=true'
 
 setup() {
     INSTALL_SCRIPT="${BATS_TEST_DIRNAME}/../../../${INSTALL_SCRIPT_REL}"
@@ -13,6 +61,7 @@ setup() {
     CALL_LOG="${BATS_TEST_TMPDIR}/calls.log"
 
     mkdir -p "${STAGE_DIR}" "${BIN_DIR}" "${FAKE_ROOT}"
+    # Truncate file to 0 bytes
     : > "${CALL_LOG}"
 
     export FAKE_ROOT
@@ -27,12 +76,41 @@ setup() {
 }
 
 # =============================================================================
+# Local install (no args)
+# =============================================================================
+
+@test "local install (no args) installs files from QUADLET_FILES_DIR into FAKE_ROOT" {
+    QUADLET_FILES_DIR="${STAGE_DIR}" run bash "${INSTALL_SCRIPT}"
+    assert_success
+    assert_output --partial "Done!"
+    assert_output --partial "periodically"
+
+    [ -f "${FAKE_ROOT}/etc/containers/systemd/roxagent.container" ]
+    [ -f "${FAKE_ROOT}/etc/systemd/system/roxagent.timer" ]
+    [ -f "${FAKE_ROOT}/etc/systemd/system/roxagent-prep.service" ]
+    [ -f "${FAKE_ROOT}/etc/tmpfiles.d/roxagent.conf" ]
+
+    run cat "${FAKE_ROOT}/etc/containers/systemd/roxagent.container"
+    assert_output --partial "SENTINEL-CONTAINER"
+
+    run cat "${FAKE_ROOT}/etc/systemd/system/roxagent.timer"
+    assert_output --partial "SENTINEL-TIMER"
+
+    run cat "${FAKE_ROOT}/etc/systemd/system/roxagent-prep.service"
+    assert_output --partial "SENTINEL-PREP"
+
+    run cat "${FAKE_ROOT}/etc/tmpfiles.d/roxagent.conf"
+    assert_output --partial "SENTINEL-TMPFILES"
+}
+
+# =============================================================================
 # Install from explicit stage dir (--stage-dir)
 # =============================================================================
 
 @test "--stage-dir installs all unit files to correct locations" {
     run bash "${INSTALL_SCRIPT}" --stage-dir "${STAGE_DIR}"
     assert_success
+    refute_output --partial "Done!"
 
     [ -f "${FAKE_ROOT}/etc/containers/systemd/roxagent.container" ]
     [ -f "${FAKE_ROOT}/etc/systemd/system/roxagent.timer" ]
@@ -183,34 +261,21 @@ setup() {
 
 @test "filter_container_file passes file through when all paths exist" {
     local container_file="${BATS_TEST_TMPDIR}/test.container"
-    cat > "${container_file}" <<'EOF'
-[Container]
-Image=registry.example.com/roxagent:latest
-Volume=/etc/yum.repos.d:/etc/yum.repos.d:ro
-Volume=/data:/data:rw
-EOF
+    printf '%s\n' "${CONTAINER_ALL_PATHS_EXIST}" > "${container_file}"
 
-    # Source the script in a subshell to get access to filter_container_file.
-    # Override OPTIONAL_HOST_PATHS to paths that DO exist.
+    # Override OPTIONAL_HOST_PATHS to paths that DO exist on any system.
     run bash -c "
         source '${INSTALL_SCRIPT}'  --source-only 2>/dev/null || true
         OPTIONAL_HOST_PATHS=(/tmp /var)
         filter_container_file '${container_file}'
     "
-    # Since /tmp and /var exist, no stripping occurs.
     assert_output --partial "Volume=/etc/yum.repos.d:/etc/yum.repos.d:ro"
     assert_output --partial "Volume=/data:/data:rw"
 }
 
 @test "filter_container_file strips Volume lines for missing paths" {
     local container_file="${BATS_TEST_TMPDIR}/test.container"
-    cat > "${container_file}" <<'EOF'
-[Container]
-Image=registry.example.com/roxagent:latest
-Volume=/nonexistent/path1:/container/path1:ro
-Volume=/tmp:/container/tmp:rw
-Volume=/nonexistent/path2:/container/path2:ro
-EOF
+    printf '%s\n' "${CONTAINER_WITH_MISSING_PATHS}" > "${container_file}"
 
     run bash -c "
         set -euo pipefail
@@ -228,13 +293,7 @@ EOF
 
 @test "filter_container_file preserves non-Volume lines unchanged" {
     local container_file="${BATS_TEST_TMPDIR}/test.container"
-    cat > "${container_file}" <<'EOF'
-[Container]
-Image=registry.example.com/roxagent:latest
-Environment=SOME_VAR=value
-Volume=/missing/path:/dst:ro
-Label=com.example=test
-EOF
+    printf '%s\n' "${CONTAINER_MIXED_LINES}" > "${container_file}"
 
     run bash -c "
         set -euo pipefail
@@ -256,14 +315,7 @@ EOF
 # =============================================================================
 
 @test "create_remote_stage_dir parses __STAGE_DIR__ marker from remote output" {
-    # Write an ssh stub that outputs the marker as a remote mktemp would
-    cat > "${BIN_DIR}/ssh" <<'EOF'
-#!/usr/bin/env bash
-# Simulate remote execution that outputs the stage dir marker
-cat <<'REMOTE'
-__STAGE_DIR__=/var/tmp/roxagent-install.ABC123
-REMOTE
-EOF
+    cp "${BATS_TEST_DIRNAME}/stubs/ssh-emit-marker" "${BIN_DIR}/ssh"
     chmod 0755 "${BIN_DIR}/ssh"
 
     run bash -c "
@@ -283,10 +335,7 @@ EOF
 }
 
 @test "create_remote_stage_dir fails when marker is missing" {
-    cat > "${BIN_DIR}/ssh" <<'EOF'
-#!/usr/bin/env bash
-echo "some garbage output without the marker"
-EOF
+    cp "${BATS_TEST_DIRNAME}/stubs/ssh-no-marker" "${BIN_DIR}/ssh"
     chmod 0755 "${BIN_DIR}/ssh"
 
     run bash -c "
@@ -312,6 +361,7 @@ EOF
     run bash -c "
         set -euo pipefail
         SCRIPT_DIR='${BATS_TEST_TMPDIR}'
+        QUADLET_FILES_DIR='${BATS_TEST_TMPDIR}'
         TRANSPORT_KIND=ssh
         SSH_HOST=testhost
         SSH_PORT=22
@@ -334,27 +384,7 @@ EOF
 }
 
 @test "install_remote heredoc includes cleanup trap with rm -rf" {
-    write_recording_stub ssh
-
-    # Mock create_remote_stage_dir to return a known path
-    cat > "${BIN_DIR}/ssh" <<'STUB'
-#!/usr/bin/env bash
-# First call: create_remote_stage_dir (output marker)
-# Subsequent calls: run the heredoc (just record stdin)
-if [ ! -f "${CALL_LOG}.ssh_call_count" ]; then
-    echo "0" > "${CALL_LOG}.ssh_call_count"
-fi
-count=$(cat "${CALL_LOG}.ssh_call_count")
-count=$((count + 1))
-echo "${count}" > "${CALL_LOG}.ssh_call_count"
-
-if [ "${count}" -eq 1 ]; then
-    echo "__STAGE_DIR__=/var/tmp/roxagent-install.FAKEXX"
-else
-    # Record the heredoc content that was piped in
-    cat >> "${CALL_LOG}.heredoc"
-fi
-STUB
+    cp "${BATS_TEST_DIRNAME}/stubs/ssh-counting-stub" "${BIN_DIR}/ssh"
     chmod 0755 "${BIN_DIR}/ssh"
     write_recording_stub scp
 
@@ -407,129 +437,46 @@ STUB
 # =============================================================================
 
 write_stage_files() {
-    cat > "${STAGE_DIR}/roxagent.container" <<'EOF'
-[Container]
-SENTINEL-CONTAINER=true
-EOF
-
-    cat > "${STAGE_DIR}/roxagent.timer" <<'EOF'
-SENTINEL-TIMER=true
-EOF
-
-    cat > "${STAGE_DIR}/roxagent-prep.service" <<'EOF'
-SENTINEL-PREP=true
-EOF
-
-    cat > "${STAGE_DIR}/roxagent-tmpfiles.conf" <<'EOF'
-SENTINEL-TMPFILES=true
-EOF
+    printf '%s\n' "${STAGE_CONTAINER}" > "${STAGE_DIR}/roxagent.container"
+    printf '%s\n' "${STAGE_TIMER}" > "${STAGE_DIR}/roxagent.timer"
+    printf '%s\n' "${STAGE_PREP_SERVICE}" > "${STAGE_DIR}/roxagent-prep.service"
+    printf '%s\n' "${STAGE_TMPFILES_CONF}" > "${STAGE_DIR}/roxagent-tmpfiles.conf"
 }
 
+# Place a fake "sudo" on PATH that intercepts file operations and redirects
+# them into FAKE_ROOT instead of real system directories.
+#
+# Example: "sudo cp foo /etc/systemd/system/" actually writes to
+#          "${FAKE_ROOT}/etc/systemd/system/foo", which tests can then inspect.
+#
+# See: stubs/sudo for the full list of supported commands.
 write_sudo_stub() {
-    cat > "${BIN_DIR}/sudo" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-
-rewrite_system_path() {
-    local path="${1}"
-    case "${path}" in
-        /etc/*|/run/*)
-            printf '%s%s\n' "${FAKE_ROOT}" "${path}"
-            ;;
-        *)
-            printf '%s\n' "${path}"
-            ;;
-    esac
-}
-
-cmd="${1}"
-shift
-
-case "${cmd}" in
-    mkdir)
-        args=()
-        for arg in "$@"; do
-            args+=("$(rewrite_system_path "${arg}")")
-        done
-        command mkdir "${args[@]}"
-        ;;
-    tee)
-        target="$(rewrite_system_path "${1}")"
-        command mkdir -p "$(dirname "${target}")"
-        cat > "${target}"
-        ;;
-    cp)
-        src="${1}"
-        dst="$(rewrite_system_path "${2}")"
-        if [[ "${2}" == */ ]]; then
-            command mkdir -p "${dst}"
-        else
-            command mkdir -p "$(dirname "${dst}")"
-        fi
-        command cp "${src}" "${dst}"
-        ;;
-    restorecon)
-        exit 0
-        ;;
-    systemd-tmpfiles|systemctl)
-        printf '%s %s\n' "${cmd}" "$*" >> "${FAKE_ROOT}/sudo.log"
-        exit 0
-        ;;
-    *)
-        printf 'unsupported sudo command: %s\n' "${cmd}" >&2
-        exit 1
-        ;;
-esac
-EOF
+    cp "${BATS_TEST_DIRNAME}/stubs/sudo" "${BIN_DIR}/sudo"
     chmod 0755 "${BIN_DIR}/sudo"
 }
 
+# Place a stub named $1 on PATH that immediately fails (exit 99) if called.
+# Used as a tripwire to verify that a command is never invoked in a given test.
+#
+# Example: write_unexpected_remote_stub ssh
+#          → if install.sh accidentally calls "ssh", the test fails with
+#            "unexpected ssh invocation: <args>"
 write_unexpected_remote_stub() {
-    local name="${1}"
-
-    cat > "${BIN_DIR}/${name}" <<EOF
-#!/usr/bin/env bash
-printf 'unexpected ${name} invocation: %s\n' "\$*" >&2
-exit 99
-EOF
+    local name="$1"
+    cp "${BATS_TEST_DIRNAME}/stubs/unexpected-stub" "${BIN_DIR}/${name}"
     chmod 0755 "${BIN_DIR}/${name}"
 }
 
+# Place a stub named $1 on PATH that logs every call to CALL_LOG for later
+# assertion. Also handles stdin draining for ssh-like commands (heredocs) and
+# emits __STAGE_DIR__ on the first ssh call so the remote staging flow works.
+#
+# Example: write_recording_stub scp
+#          → after install.sh runs, CALL_LOG contains lines like:
+#            "scp -P 22 /path/to/file user@host:/remote/path"
+#          which tests assert with: assert_output --partial "scp -P 22"
 write_recording_stub() {
-    local name="${1}"
-
-    cat > "${BIN_DIR}/${name}" <<'STUB'
-#!/usr/bin/env bash
-# Record the invocation to the shared call log.
-printf '%s %s\n' "$(basename "$0")" "$*" >> "${CALL_LOG}"
-
-cmd_name="$(basename "$0")"
-
-# Determine if this is a command that receives stdin (ssh/remote_exec).
-# scp-like calls (virtctl scp, scp) don't pipe stdin so we must not block.
-reads_stdin=false
-case "${cmd_name}" in
-    ssh)
-        reads_stdin=true
-        ;;
-    virtctl)
-        # "virtctl ssh ..." reads stdin; "virtctl scp ..." does not.
-        if [ "${1:-}" = "ssh" ]; then
-            reads_stdin=true
-        fi
-        ;;
-esac
-
-if [ "${reads_stdin}" = "true" ]; then
-    # First ssh-like call: emit the stage dir marker (for create_remote_stage_dir).
-    # Subsequent ssh-like calls: just drain stdin.
-    if [ ! -f "${CALL_LOG}.${cmd_name}_emitted_marker" ]; then
-        echo "__STAGE_DIR__=/var/tmp/roxagent-install.TESTXX"
-        touch "${CALL_LOG}.${cmd_name}_emitted_marker"
-    else
-        cat > /dev/null 2>&1 || true
-    fi
-fi
-STUB
+    local name="$1"
+    cp "${BATS_TEST_DIRNAME}/stubs/recording-stub" "${BIN_DIR}/${name}"
     chmod 0755 "${BIN_DIR}/${name}"
 }

--- a/tests/e2e/bats/roxagent_quadlet_install.bats
+++ b/tests/e2e/bats/roxagent_quadlet_install.bats
@@ -1,0 +1,535 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1091
+
+load "../../../scripts/test_helpers.bats"
+
+INSTALL_SCRIPT_REL="compliance/virtualmachines/roxagent/quadlet/install.sh"
+
+setup() {
+    INSTALL_SCRIPT="${BATS_TEST_DIRNAME}/../../../${INSTALL_SCRIPT_REL}"
+    STAGE_DIR="${BATS_TEST_TMPDIR}/custom-stage"
+    BIN_DIR="${BATS_TEST_TMPDIR}/bin"
+    FAKE_ROOT="${BATS_TEST_TMPDIR}/fake-root"
+    CALL_LOG="${BATS_TEST_TMPDIR}/calls.log"
+
+    mkdir -p "${STAGE_DIR}" "${BIN_DIR}" "${FAKE_ROOT}"
+    : > "${CALL_LOG}"
+
+    export FAKE_ROOT
+    export CALL_LOG
+    export PATH="${BIN_DIR}:${PATH}"
+
+    write_stage_files
+    write_sudo_stub
+    write_unexpected_remote_stub scp
+    write_unexpected_remote_stub ssh
+    write_unexpected_remote_stub virtctl
+}
+
+# =============================================================================
+# Install from explicit stage dir (--stage-dir)
+# =============================================================================
+
+@test "--stage-dir installs all unit files to correct locations" {
+    run bash "${INSTALL_SCRIPT}" --stage-dir "${STAGE_DIR}"
+    assert_success
+
+    [ -f "${FAKE_ROOT}/etc/containers/systemd/roxagent.container" ]
+    [ -f "${FAKE_ROOT}/etc/systemd/system/roxagent.timer" ]
+    [ -f "${FAKE_ROOT}/etc/systemd/system/roxagent-prep.service" ]
+    [ -f "${FAKE_ROOT}/etc/tmpfiles.d/roxagent.conf" ]
+
+    run cat "${FAKE_ROOT}/etc/containers/systemd/roxagent.container"
+    assert_output --partial "SENTINEL-CONTAINER"
+
+    run cat "${FAKE_ROOT}/etc/systemd/system/roxagent.timer"
+    assert_output --partial "SENTINEL-TIMER"
+
+    run cat "${FAKE_ROOT}/etc/systemd/system/roxagent-prep.service"
+    assert_output --partial "SENTINEL-PREP"
+
+    run cat "${FAKE_ROOT}/etc/tmpfiles.d/roxagent.conf"
+    assert_output --partial "SENTINEL-TMPFILES"
+}
+
+@test "--stage-dir does not invoke any remote transport" {
+    run bash "${INSTALL_SCRIPT}" --stage-dir "${STAGE_DIR}"
+    assert_success
+
+    # The unexpected stubs exit 99 if called; success means they weren't.
+    # Double-check the call log is empty.
+    run cat "${CALL_LOG}"
+    assert_output ""
+}
+
+@test "--stage-dir does not print the Done epilogue" {
+    run bash "${INSTALL_SCRIPT}" --stage-dir "${STAGE_DIR}"
+    assert_success
+    refute_output --partial "Done!"
+}
+
+# =============================================================================
+# Input validation / error cases
+# =============================================================================
+
+@test "--stage-dir without dir argument fails with usage" {
+    run bash "${INSTALL_SCRIPT}" --stage-dir
+    assert_failure
+    assert_output --partial "usage:"
+}
+
+@test "--stage-dir with nonexistent dir fails with missing file error" {
+    run bash "${INSTALL_SCRIPT}" --stage-dir "/nonexistent/path"
+    assert_failure
+    assert_output --partial "missing staged file"
+}
+
+@test "--ssh without host fails with usage" {
+    run bash "${INSTALL_SCRIPT}" --ssh
+    assert_failure
+    assert_output --partial "Usage:"
+}
+
+@test "virtctl mode with no target fails with error and usage" {
+    # This would happen if someone accidentally passes only --stage-dir-like
+    # args that don't match any known flag, BUT the current interface means
+    # bare args go to virtctl. The edge case is: what if the script is invoked
+    # in a way that setup_transport_virtctl gets 0 args? That can't happen via
+    # main() because the else branch requires $# > 0. But we test the error
+    # path via a quirk: "virtctl" was the old keyword; now bare args go to
+    # virtctl directly. So this test just verifies the usage text exists.
+    run bash "${INSTALL_SCRIPT}" --ssh
+    assert_failure
+    assert_output --partial "Usage:"
+    assert_output --partial "virtctl"
+}
+
+# =============================================================================
+# SSH mode (--ssh) argument dispatch
+# =============================================================================
+
+@test "--ssh user@host invokes scp and ssh with port 22" {
+    write_recording_stub scp
+    write_recording_stub ssh
+
+    run bash "${INSTALL_SCRIPT}" --ssh "testuser@10.0.0.1"
+    assert_success
+    assert_output --partial "Done!"
+
+    run cat "${CALL_LOG}"
+    # scp should be called with -P 22
+    assert_output --partial "scp -P 22"
+    assert_output --partial "testuser@10.0.0.1:"
+    # ssh should be called with -p 22
+    assert_output --partial "ssh -p 22 testuser@10.0.0.1"
+}
+
+@test "--ssh user@host 2222 uses custom port" {
+    write_recording_stub scp
+    write_recording_stub ssh
+
+    run bash "${INSTALL_SCRIPT}" --ssh "testuser@10.0.0.1" 2222
+    assert_success
+
+    run cat "${CALL_LOG}"
+    assert_output --partial "scp -P 2222"
+    assert_output --partial "ssh -p 2222 testuser@10.0.0.1"
+}
+
+# =============================================================================
+# Virtctl mode (default remote) argument dispatch
+# =============================================================================
+
+@test "virtctl mode with flags and target invokes virtctl scp/ssh correctly" {
+    write_recording_stub virtctl
+
+    run bash "${INSTALL_SCRIPT}" -n openshift-cnv "cloud-user@vmi/rhel10-1"
+    assert_success
+    assert_output --partial "Done!"
+
+    run cat "${CALL_LOG}"
+    # virtctl scp should pass -n openshift-cnv and the target
+    assert_output --partial "virtctl scp -n openshift-cnv"
+    assert_output --partial "cloud-user@vmi/rhel10-1:"
+    # virtctl ssh should pass the flags and target
+    assert_output --partial "virtctl ssh -n openshift-cnv cloud-user@vmi/rhel10-1"
+}
+
+@test "virtctl mode with only a target (no extra flags) works" {
+    write_recording_stub virtctl
+
+    run bash "${INSTALL_SCRIPT}" "cloud-user@vmi/rhel10-1"
+    assert_success
+
+    run cat "${CALL_LOG}"
+    assert_output --partial "virtctl scp"
+    assert_output --partial "cloud-user@vmi/rhel10-1:"
+    assert_output --partial "virtctl ssh"
+}
+
+@test "virtctl mode with multiple flags passes all flags" {
+    write_recording_stub virtctl
+
+    run bash "${INSTALL_SCRIPT}" -n openshift-cnv --local-ssh-opts="-o StrictHostKeyChecking=no" "cloud-user@vmi/rhel10-1"
+    assert_success
+
+    run cat "${CALL_LOG}"
+    assert_output --partial "virtctl scp -n openshift-cnv --local-ssh-opts=-o StrictHostKeyChecking=no"
+}
+
+# =============================================================================
+# filter_container_file
+# =============================================================================
+
+@test "filter_container_file passes file through when all paths exist" {
+    local container_file="${BATS_TEST_TMPDIR}/test.container"
+    cat > "${container_file}" <<'EOF'
+[Container]
+Image=registry.example.com/roxagent:latest
+Volume=/etc/yum.repos.d:/etc/yum.repos.d:ro
+Volume=/data:/data:rw
+EOF
+
+    # Source the script in a subshell to get access to filter_container_file.
+    # Override OPTIONAL_HOST_PATHS to paths that DO exist.
+    run bash -c "
+        source '${INSTALL_SCRIPT}'  --source-only 2>/dev/null || true
+        OPTIONAL_HOST_PATHS=(/tmp /var)
+        filter_container_file '${container_file}'
+    "
+    # Since /tmp and /var exist, no stripping occurs.
+    assert_output --partial "Volume=/etc/yum.repos.d:/etc/yum.repos.d:ro"
+    assert_output --partial "Volume=/data:/data:rw"
+}
+
+@test "filter_container_file strips Volume lines for missing paths" {
+    local container_file="${BATS_TEST_TMPDIR}/test.container"
+    cat > "${container_file}" <<'EOF'
+[Container]
+Image=registry.example.com/roxagent:latest
+Volume=/nonexistent/path1:/container/path1:ro
+Volume=/tmp:/container/tmp:rw
+Volume=/nonexistent/path2:/container/path2:ro
+EOF
+
+    run bash -c "
+        set -euo pipefail
+        OPTIONAL_HOST_PATHS=(/nonexistent/path1 /nonexistent/path2)
+        SCRIPT_DIR='${BATS_TEST_TMPDIR}'
+        source <(sed -n '/^filter_container_file/,/^}/p' '${INSTALL_SCRIPT}')
+        filter_container_file '${container_file}'
+    "
+    assert_success
+    assert_output --partial "Image=registry.example.com/roxagent:latest"
+    assert_output --partial "Volume=/tmp:/container/tmp:rw"
+    refute_output --partial "Volume=/nonexistent/path1"
+    refute_output --partial "Volume=/nonexistent/path2"
+}
+
+@test "filter_container_file preserves non-Volume lines unchanged" {
+    local container_file="${BATS_TEST_TMPDIR}/test.container"
+    cat > "${container_file}" <<'EOF'
+[Container]
+Image=registry.example.com/roxagent:latest
+Environment=SOME_VAR=value
+Volume=/missing/path:/dst:ro
+Label=com.example=test
+EOF
+
+    run bash -c "
+        set -euo pipefail
+        OPTIONAL_HOST_PATHS=(/missing/path)
+        SCRIPT_DIR='${BATS_TEST_TMPDIR}'
+        source <(sed -n '/^filter_container_file/,/^}/p' '${INSTALL_SCRIPT}')
+        filter_container_file '${container_file}'
+    "
+    assert_success
+    assert_output --partial "[Container]"
+    assert_output --partial "Image=registry.example.com/roxagent:latest"
+    assert_output --partial "Environment=SOME_VAR=value"
+    assert_output --partial "Label=com.example=test"
+    refute_output --partial "Volume=/missing/path"
+}
+
+# =============================================================================
+# Remote stage dir flow (mocked)
+# =============================================================================
+
+@test "create_remote_stage_dir parses __STAGE_DIR__ marker from remote output" {
+    # Write an ssh stub that outputs the marker as a remote mktemp would
+    cat > "${BIN_DIR}/ssh" <<'EOF'
+#!/usr/bin/env bash
+# Simulate remote execution that outputs the stage dir marker
+cat <<'REMOTE'
+__STAGE_DIR__=/var/tmp/roxagent-install.ABC123
+REMOTE
+EOF
+    chmod 0755 "${BIN_DIR}/ssh"
+
+    run bash -c "
+        set -euo pipefail
+        source <(
+            sed -n '/^TRANSPORT_KIND=/p; /^SSH_HOST=/p; /^SSH_PORT=/p' '${INSTALL_SCRIPT}'
+            sed -n '/^remote_exec/,/^}/p' '${INSTALL_SCRIPT}'
+            sed -n '/^create_remote_stage_dir/,/^}/p' '${INSTALL_SCRIPT}'
+        )
+        TRANSPORT_KIND=ssh
+        SSH_HOST=fake
+        SSH_PORT=22
+        create_remote_stage_dir
+    "
+    assert_success
+    assert_output "/var/tmp/roxagent-install.ABC123"
+}
+
+@test "create_remote_stage_dir fails when marker is missing" {
+    cat > "${BIN_DIR}/ssh" <<'EOF'
+#!/usr/bin/env bash
+echo "some garbage output without the marker"
+EOF
+    chmod 0755 "${BIN_DIR}/ssh"
+
+    run bash -c "
+        set -euo pipefail
+        source <(
+            sed -n '/^TRANSPORT_KIND=/p; /^SSH_HOST=/p; /^SSH_PORT=/p' '${INSTALL_SCRIPT}'
+            sed -n '/^remote_exec/,/^}/p' '${INSTALL_SCRIPT}'
+            sed -n '/^create_remote_stage_dir/,/^}/p' '${INSTALL_SCRIPT}'
+        )
+        TRANSPORT_KIND=ssh
+        SSH_HOST=fake
+        SSH_PORT=22
+        create_remote_stage_dir
+    "
+    assert_failure
+    assert_output --partial "failed to determine remote stage dir"
+}
+
+@test "copy_remote_stage_files copies all STAGED_INSTALL_FILES" {
+    write_recording_stub scp
+    # We need ssh stub too (for create_remote_stage_dir) but we only test copy here.
+
+    run bash -c "
+        set -euo pipefail
+        SCRIPT_DIR='${BATS_TEST_TMPDIR}'
+        TRANSPORT_KIND=ssh
+        SSH_HOST=testhost
+        SSH_PORT=22
+        CALL_LOG='${CALL_LOG}'
+        source <(
+            sed -n '/^STAGED_INSTALL_FILES=/,/^)/p' '${INSTALL_SCRIPT}'
+            sed -n '/^remote_copy/,/^}/p' '${INSTALL_SCRIPT}'
+            sed -n '/^copy_remote_stage_files/,/^}/p' '${INSTALL_SCRIPT}'
+        )
+        copy_remote_stage_files '/var/tmp/roxagent-install.XXXXXX'
+    "
+    assert_success
+
+    run cat "${CALL_LOG}"
+    assert_output --partial "install.sh"
+    assert_output --partial "roxagent.container"
+    assert_output --partial "roxagent.timer"
+    assert_output --partial "roxagent-prep.service"
+    assert_output --partial "roxagent-tmpfiles.conf"
+}
+
+@test "install_remote heredoc includes cleanup trap with rm -rf" {
+    write_recording_stub ssh
+
+    # Mock create_remote_stage_dir to return a known path
+    cat > "${BIN_DIR}/ssh" <<'STUB'
+#!/usr/bin/env bash
+# First call: create_remote_stage_dir (output marker)
+# Subsequent calls: run the heredoc (just record stdin)
+if [ ! -f "${CALL_LOG}.ssh_call_count" ]; then
+    echo "0" > "${CALL_LOG}.ssh_call_count"
+fi
+count=$(cat "${CALL_LOG}.ssh_call_count")
+count=$((count + 1))
+echo "${count}" > "${CALL_LOG}.ssh_call_count"
+
+if [ "${count}" -eq 1 ]; then
+    echo "__STAGE_DIR__=/var/tmp/roxagent-install.FAKEXX"
+else
+    # Record the heredoc content that was piped in
+    cat >> "${CALL_LOG}.heredoc"
+fi
+STUB
+    chmod 0755 "${BIN_DIR}/ssh"
+    write_recording_stub scp
+
+    run bash "${INSTALL_SCRIPT}" --ssh testuser@remotehost
+    assert_success
+
+    # Verify the heredoc sent to the remote includes cleanup
+    run cat "${CALL_LOG}.heredoc"
+    assert_output --partial "rm -rf"
+    assert_output --partial "trap cleanup EXIT"
+    assert_output --partial "--stage-dir"
+}
+
+# =============================================================================
+# Double-Done regression
+# =============================================================================
+
+@test "--stage-dir path does NOT print Done epilogue" {
+    run bash "${INSTALL_SCRIPT}" --stage-dir "${STAGE_DIR}"
+    assert_success
+    refute_output --partial "Done!"
+    refute_output --partial "periodically"
+}
+
+@test "SSH mode prints Done epilogue exactly once" {
+    write_recording_stub scp
+    write_recording_stub ssh
+
+    run bash "${INSTALL_SCRIPT}" --ssh "user@host"
+    assert_success
+
+    local count
+    count=$(echo "${output}" | grep -c "Done!" || true)
+    [ "${count}" -eq 1 ]
+}
+
+@test "virtctl mode prints Done epilogue exactly once" {
+    write_recording_stub virtctl
+
+    run bash "${INSTALL_SCRIPT}" -n openshift-cnv "cloud-user@vmi/rhel10-1"
+    assert_success
+
+    local count
+    count=$(echo "${output}" | grep -c "Done!" || true)
+    [ "${count}" -eq 1 ]
+}
+
+# =============================================================================
+# Helper functions
+# =============================================================================
+
+write_stage_files() {
+    cat > "${STAGE_DIR}/roxagent.container" <<'EOF'
+[Container]
+SENTINEL-CONTAINER=true
+EOF
+
+    cat > "${STAGE_DIR}/roxagent.timer" <<'EOF'
+SENTINEL-TIMER=true
+EOF
+
+    cat > "${STAGE_DIR}/roxagent-prep.service" <<'EOF'
+SENTINEL-PREP=true
+EOF
+
+    cat > "${STAGE_DIR}/roxagent-tmpfiles.conf" <<'EOF'
+SENTINEL-TMPFILES=true
+EOF
+}
+
+write_sudo_stub() {
+    cat > "${BIN_DIR}/sudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+rewrite_system_path() {
+    local path="${1}"
+    case "${path}" in
+        /etc/*|/run/*)
+            printf '%s%s\n' "${FAKE_ROOT}" "${path}"
+            ;;
+        *)
+            printf '%s\n' "${path}"
+            ;;
+    esac
+}
+
+cmd="${1}"
+shift
+
+case "${cmd}" in
+    mkdir)
+        args=()
+        for arg in "$@"; do
+            args+=("$(rewrite_system_path "${arg}")")
+        done
+        command mkdir "${args[@]}"
+        ;;
+    tee)
+        target="$(rewrite_system_path "${1}")"
+        command mkdir -p "$(dirname "${target}")"
+        cat > "${target}"
+        ;;
+    cp)
+        src="${1}"
+        dst="$(rewrite_system_path "${2}")"
+        if [[ "${2}" == */ ]]; then
+            command mkdir -p "${dst}"
+        else
+            command mkdir -p "$(dirname "${dst}")"
+        fi
+        command cp "${src}" "${dst}"
+        ;;
+    restorecon)
+        exit 0
+        ;;
+    systemd-tmpfiles|systemctl)
+        printf '%s %s\n' "${cmd}" "$*" >> "${FAKE_ROOT}/sudo.log"
+        exit 0
+        ;;
+    *)
+        printf 'unsupported sudo command: %s\n' "${cmd}" >&2
+        exit 1
+        ;;
+esac
+EOF
+    chmod 0755 "${BIN_DIR}/sudo"
+}
+
+write_unexpected_remote_stub() {
+    local name="${1}"
+
+    cat > "${BIN_DIR}/${name}" <<EOF
+#!/usr/bin/env bash
+printf 'unexpected ${name} invocation: %s\n' "\$*" >&2
+exit 99
+EOF
+    chmod 0755 "${BIN_DIR}/${name}"
+}
+
+write_recording_stub() {
+    local name="${1}"
+
+    cat > "${BIN_DIR}/${name}" <<'STUB'
+#!/usr/bin/env bash
+# Record the invocation to the shared call log.
+printf '%s %s\n' "$(basename "$0")" "$*" >> "${CALL_LOG}"
+
+cmd_name="$(basename "$0")"
+
+# Determine if this is a command that receives stdin (ssh/remote_exec).
+# scp-like calls (virtctl scp, scp) don't pipe stdin so we must not block.
+reads_stdin=false
+case "${cmd_name}" in
+    ssh)
+        reads_stdin=true
+        ;;
+    virtctl)
+        # "virtctl ssh ..." reads stdin; "virtctl scp ..." does not.
+        if [ "${1:-}" = "ssh" ]; then
+            reads_stdin=true
+        fi
+        ;;
+esac
+
+if [ "${reads_stdin}" = "true" ]; then
+    # First ssh-like call: emit the stage dir marker (for create_remote_stage_dir).
+    # Subsequent ssh-like calls: just drain stdin.
+    if [ ! -f "${CALL_LOG}.${cmd_name}_emitted_marker" ]; then
+        echo "__STAGE_DIR__=/var/tmp/roxagent-install.TESTXX"
+        touch "${CALL_LOG}.${cmd_name}_emitted_marker"
+    else
+        cat > /dev/null 2>&1 || true
+    fi
+fi
+STUB
+    chmod 0755 "${BIN_DIR}/${name}"
+}

--- a/tests/e2e/bats/roxagent_quadlet_install.bats
+++ b/tests/e2e/bats/roxagent_quadlet_install.bats
@@ -169,15 +169,16 @@ setup() {
 }
 
 @test "virtctl mode with no target fails with error and usage" {
-    # This would happen if someone accidentally passes only --stage-dir-like
-    # args that don't match any known flag, BUT the current interface means
-    # bare args go to virtctl. The edge case is: what if the script is invoked
-    # in a way that setup_transport_virtctl gets 0 args? That can't happen via
-    # main() because the else branch requires $# > 0. But we test the error
-    # path via a quirk: "virtctl" was the old keyword; now bare args go to
-    # virtctl directly. So this test just verifies the usage text exists.
-    run bash "${INSTALL_SCRIPT}" --ssh
+    run bash -c "
+        set -euo pipefail
+        source <(
+            sed -n '/^usage()/,/^}/p' '${INSTALL_SCRIPT}'
+            sed -n '/^setup_transport_virtctl()/,/^}/p' '${INSTALL_SCRIPT}'
+        )
+        setup_transport_virtctl
+    "
     assert_failure
+    assert_output --partial "error: virtctl mode requires at least a target"
     assert_output --partial "Usage:"
     assert_output --partial "virtctl"
 }

--- a/tests/e2e/bats/roxagent_quadlet_install.bats
+++ b/tests/e2e/bats/roxagent_quadlet_install.bats
@@ -169,18 +169,17 @@ setup() {
 }
 
 @test "virtctl mode with no target fails with error and usage" {
-    run bash -c "
-        set -euo pipefail
-        source <(
-            sed -n '/^usage()/,/^}/p' '${INSTALL_SCRIPT}'
-            sed -n '/^setup_transport_virtctl()/,/^}/p' '${INSTALL_SCRIPT}'
-        )
-        setup_transport_virtctl
-    "
+    run bash "${INSTALL_SCRIPT}" virtctl
     assert_failure
     assert_output --partial "error: virtctl mode requires at least a target"
     assert_output --partial "Usage:"
     assert_output --partial "virtctl"
+}
+
+@test "remote args without a mode selector fail with usage" {
+    run bash "${INSTALL_SCRIPT}" -n openshift-cnv "cloud-user@vmi/rhel10-1"
+    assert_failure
+    assert_output --partial "Usage:"
 }
 
 # =============================================================================
@@ -216,13 +215,13 @@ setup() {
 }
 
 # =============================================================================
-# Virtctl mode (default remote) argument dispatch
+# Virtctl mode argument dispatch
 # =============================================================================
 
 @test "virtctl mode with flags and target invokes virtctl scp/ssh correctly" {
     write_recording_stub virtctl
 
-    run bash "${INSTALL_SCRIPT}" -n openshift-cnv "cloud-user@vmi/rhel10-1"
+    run bash "${INSTALL_SCRIPT}" virtctl -n openshift-cnv "cloud-user@vmi/rhel10-1"
     assert_success
     assert_output --partial "Done!"
 
@@ -237,7 +236,7 @@ setup() {
 @test "virtctl mode with only a target (no extra flags) works" {
     write_recording_stub virtctl
 
-    run bash "${INSTALL_SCRIPT}" "cloud-user@vmi/rhel10-1"
+    run bash "${INSTALL_SCRIPT}" virtctl "cloud-user@vmi/rhel10-1"
     assert_success
 
     run cat "${CALL_LOG}"
@@ -249,7 +248,7 @@ setup() {
 @test "virtctl mode with multiple flags passes all flags" {
     write_recording_stub virtctl
 
-    run bash "${INSTALL_SCRIPT}" -n openshift-cnv --local-ssh-opts="-o StrictHostKeyChecking=no" "cloud-user@vmi/rhel10-1"
+    run bash "${INSTALL_SCRIPT}" virtctl -n openshift-cnv --local-ssh-opts="-o StrictHostKeyChecking=no" "cloud-user@vmi/rhel10-1"
     assert_success
 
     run cat "${CALL_LOG}"
@@ -264,10 +263,10 @@ setup() {
     local container_file="${BATS_TEST_TMPDIR}/test.container"
     printf '%s\n' "${CONTAINER_ALL_PATHS_EXIST}" > "${container_file}"
 
-    # Override OPTIONAL_HOST_PATHS to paths that DO exist on any system.
     run bash -c "
-        source '${INSTALL_SCRIPT}'  --source-only 2>/dev/null || true
+        set -euo pipefail
         OPTIONAL_HOST_PATHS=(/tmp /var)
+        source <(sed -n '/^filter_container_file/,/^}/p' '${INSTALL_SCRIPT}')
         filter_container_file '${container_file}'
     "
     assert_output --partial "Volume=/etc/yum.repos.d:/etc/yum.repos.d:ro"
@@ -425,7 +424,7 @@ setup() {
 @test "virtctl mode prints Done epilogue exactly once" {
     write_recording_stub virtctl
 
-    run bash "${INSTALL_SCRIPT}" -n openshift-cnv "cloud-user@vmi/rhel10-1"
+    run bash "${INSTALL_SCRIPT}" virtctl -n openshift-cnv "cloud-user@vmi/rhel10-1"
     assert_success
 
     local count

--- a/tests/e2e/bats/roxagent_quadlet_install.bats
+++ b/tests/e2e/bats/roxagent_quadlet_install.bats
@@ -169,7 +169,7 @@ setup() {
 }
 
 @test "virtctl mode with no target fails with error and usage" {
-    run bash "${INSTALL_SCRIPT}" virtctl
+    run bash "${INSTALL_SCRIPT}" --virtctl
     assert_failure
     assert_output --partial "error: virtctl mode requires at least a target"
     assert_output --partial "Usage:"
@@ -221,7 +221,7 @@ setup() {
 @test "virtctl mode with flags and target invokes virtctl scp/ssh correctly" {
     write_recording_stub virtctl
 
-    run bash "${INSTALL_SCRIPT}" virtctl -n openshift-cnv "cloud-user@vmi/rhel10-1"
+    run bash "${INSTALL_SCRIPT}" --virtctl -n openshift-cnv "cloud-user@vmi/rhel10-1"
     assert_success
     assert_output --partial "Done!"
 
@@ -236,7 +236,7 @@ setup() {
 @test "virtctl mode with only a target (no extra flags) works" {
     write_recording_stub virtctl
 
-    run bash "${INSTALL_SCRIPT}" virtctl "cloud-user@vmi/rhel10-1"
+    run bash "${INSTALL_SCRIPT}" --virtctl "cloud-user@vmi/rhel10-1"
     assert_success
 
     run cat "${CALL_LOG}"
@@ -248,7 +248,7 @@ setup() {
 @test "virtctl mode with multiple flags passes all flags" {
     write_recording_stub virtctl
 
-    run bash "${INSTALL_SCRIPT}" virtctl -n openshift-cnv --local-ssh-opts="-o StrictHostKeyChecking=no" "cloud-user@vmi/rhel10-1"
+    run bash "${INSTALL_SCRIPT}" --virtctl -n openshift-cnv --local-ssh-opts="-o StrictHostKeyChecking=no" "cloud-user@vmi/rhel10-1"
     assert_success
 
     run cat "${CALL_LOG}"
@@ -424,7 +424,7 @@ setup() {
 @test "virtctl mode prints Done epilogue exactly once" {
     write_recording_stub virtctl
 
-    run bash "${INSTALL_SCRIPT}" virtctl -n openshift-cnv "cloud-user@vmi/rhel10-1"
+    run bash "${INSTALL_SCRIPT}" --virtctl -n openshift-cnv "cloud-user@vmi/rhel10-1"
     assert_success
 
     local count

--- a/tests/e2e/bats/stubs/recording-stub
+++ b/tests/e2e/bats/stubs/recording-stub
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Generic recording stub for BATS tests.
+# Logs every invocation to CALL_LOG and handles stdin draining for commands
+# that receive heredocs (ssh, virtctl ssh).
+#
+# For the first ssh-like call, emits a __STAGE_DIR__ marker so that
+# create_remote_stage_dir() succeeds in tests.
+#
+# Requires: CALL_LOG environment variable set to a writable file path.
+
+printf '%s %s\n' "$(basename "$0")" "$*" >> "${CALL_LOG}"
+
+cmd_name="$(basename "$0")"
+
+# Determine if this is a command that receives stdin (ssh/remote_exec).
+# scp-like calls (virtctl scp, scp) don't pipe stdin so we must not block.
+reads_stdin=false
+case "${cmd_name}" in
+    ssh)
+        reads_stdin=true
+        ;;
+    virtctl)
+        # "virtctl ssh ..." reads stdin; "virtctl scp ..." does not.
+        if [ "${1:-}" = "ssh" ]; then
+            reads_stdin=true
+        fi
+        ;;
+esac
+
+if [ "${reads_stdin}" = "true" ]; then
+    # First ssh-like call: emit the stage dir marker (for create_remote_stage_dir).
+    # Subsequent ssh-like calls: just drain stdin.
+    if [ ! -f "${CALL_LOG}.${cmd_name}_emitted_marker" ]; then
+        echo "__STAGE_DIR__=/var/tmp/roxagent-install.TESTXX"
+        touch "${CALL_LOG}.${cmd_name}_emitted_marker"
+    else
+        cat > /dev/null 2>&1 || true
+    fi
+fi

--- a/tests/e2e/bats/stubs/ssh-counting-stub
+++ b/tests/e2e/bats/stubs/ssh-counting-stub
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SSH stub that tracks call count via CALL_LOG.
+# First call: emits the __STAGE_DIR__ marker (simulates create_remote_stage_dir).
+# Subsequent calls: records stdin (the heredoc) to CALL_LOG.heredoc for assertion.
+#
+# Requires: CALL_LOG environment variable.
+if [ ! -f "${CALL_LOG}.ssh_call_count" ]; then
+    echo "0" > "${CALL_LOG}.ssh_call_count"
+fi
+count=$(cat "${CALL_LOG}.ssh_call_count")
+count=$((count + 1))
+echo "${count}" > "${CALL_LOG}.ssh_call_count"
+
+if [ "${count}" -eq 1 ]; then
+    echo "__STAGE_DIR__=/var/tmp/roxagent-install.FAKEXX"
+else
+    cat >> "${CALL_LOG}.heredoc"
+fi

--- a/tests/e2e/bats/stubs/ssh-emit-marker
+++ b/tests/e2e/bats/stubs/ssh-emit-marker
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Simulates a remote mktemp that outputs the __STAGE_DIR__ marker.
+# Used to test create_remote_stage_dir parsing.
+echo "__STAGE_DIR__=/var/tmp/roxagent-install.ABC123"

--- a/tests/e2e/bats/stubs/ssh-no-marker
+++ b/tests/e2e/bats/stubs/ssh-no-marker
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Simulates a remote command that produces output without the __STAGE_DIR__ marker.
+# Used to test create_remote_stage_dir failure handling.
+echo "some garbage output without the marker"

--- a/tests/e2e/bats/stubs/sudo
+++ b/tests/e2e/bats/stubs/sudo
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Fake sudo stub for BATS tests.
+# Rewrites system paths (/etc/*, /run/*) into FAKE_ROOT so tests can verify
+# file placement without requiring real root privileges.
+#
+# Requires: FAKE_ROOT environment variable set to a temp directory.
+set -euo pipefail
+
+rewrite_system_path() {
+    local path="$1"
+    case "${path}" in
+        /etc/*|/run/*)
+            printf '%s%s\n' "${FAKE_ROOT}" "${path}"
+            ;;
+        *)
+            printf '%s\n' "${path}"
+            ;;
+    esac
+}
+
+cmd="$1"
+shift
+
+case "${cmd}" in
+    mkdir)
+        args=()
+        for arg in "$@"; do
+            args+=("$(rewrite_system_path "${arg}")")
+        done
+        command mkdir "${args[@]}"
+        ;;
+    tee)
+        target="$(rewrite_system_path "$1")"
+        command mkdir -p "$(dirname "${target}")"
+        cat > "${target}"
+        ;;
+    cp)
+        src="$1"
+        dst="$(rewrite_system_path "$2")"
+        if [[ "$2" == */ ]]; then
+            command mkdir -p "${dst}"
+        else
+            command mkdir -p "$(dirname "${dst}")"
+        fi
+        command cp "${src}" "${dst}"
+        ;;
+    restorecon)
+        exit 0
+        ;;
+    systemd-tmpfiles|systemctl)
+        printf '%s %s\n' "${cmd}" "$*" >> "${FAKE_ROOT}/sudo.log"
+        exit 0
+        ;;
+    *)
+        printf 'unsupported sudo command: %s\n' "${cmd}" >&2
+        exit 1
+        ;;
+esac

--- a/tests/e2e/bats/stubs/unexpected-stub
+++ b/tests/e2e/bats/stubs/unexpected-stub
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Stub that fails if invoked — used to verify a command is NOT called.
+# The actual command name is derived from $0 (the symlink/copy name).
+printf 'unexpected %s invocation: %s\n' "$(basename "$0")" "$*" >&2
+exit 99


### PR DESCRIPTION
## Description

The base Quadlet install in `compliance/virtualmachines/roxagent/quadlet/install.sh` still assumes that remote installs happen over plain `ssh` and `scp`. That is a poor fit for KubeVirt VMs, where the normal access pattern is `virtctl ssh` and `virtctl scp`. In practice, that meant the installer could not be used directly from a local machine for a VM such as `cloud-user@vmi/rhel10-1`.

This PR adds a `virtctl` transport mode to `install.sh` and routes remote copy and remote execution through a shared transport layer. The script now supports:

* local installation (no args)
* remote installation via `virtctl ssh`/`virtctl scp` (explicit `--virtctl` mode selector), for example:
  * `./install.sh --virtctl -n openshift-cnv cloud-user@vmi/rhel10-1`
* remote installation via `ssh`/`scp` (explicit `--ssh` flag):
  * `./install.sh --ssh user@host [port]`

The final branch also fixes a Bash scoping bug in the remote transport helpers. The initial implementation stored `host`, `port`, `target`, and `flags` in function-local variables and used them later from helper functions, which caused `set -u` unbound-variable failures during remote installs. Transport state is now kept at script scope so both `ssh` and `virtctl` remote installs work reliably.

Additionally fixes a double "Done!" output bug on remote installs: when the script re-invokes itself on the remote with `--stage-dir`, the remote `main()` now returns early to avoid a duplicate epilogue.

No change is intended for the local install path.

AI-Assisted: cursor, user directed scope

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

24 BATS tests cover argument parsing, mode dispatch, input validation, `filter_container_file`, remote staging flow (mocked transports), and a double-Done regression guard. Stubs shadow `sudo`, `ssh`, `scp`, and `virtctl` to test without privileges or remote hosts.

### How I validated my change

#### Ran BATS tests locally

```
➜ bats --tap tests/e2e/bats/roxagent_quadlet_install.bats
1..24
ok 1 local install (no args) installs files from QUADLET_FILES_DIR into FAKE_ROOT
ok 2 --stage-dir installs all unit files to correct locations
ok 3 --stage-dir does not invoke any remote transport
ok 4 --stage-dir does not print the Done epilogue
ok 5 --stage-dir without dir argument fails with usage
ok 6 --stage-dir with nonexistent dir fails with missing file error
ok 7 --ssh without host fails with usage
ok 8 virtctl mode with no target fails with error and usage
ok 9 remote args without a mode selector fail with usage
ok 10 --ssh user@host invokes scp and ssh with port 22
ok 11 --ssh user@host 2222 uses custom port
ok 12 virtctl mode with flags and target invokes virtctl scp/ssh correctly
ok 13 virtctl mode with only a target (no extra flags) works
ok 14 virtctl mode with multiple flags passes all flags
ok 15 filter_container_file passes file through when all paths exist
ok 16 filter_container_file strips Volume lines for missing paths
ok 17 filter_container_file preserves non-Volume lines unchanged
ok 18 create_remote_stage_dir parses __STAGE_DIR__ marker from remote output
ok 19 create_remote_stage_dir fails when marker is missing
ok 20 copy_remote_stage_files copies all STAGED_INSTALL_FILES
ok 21 install_remote heredoc includes cleanup trap with rm -rf
ok 22 --stage-dir path does NOT print Done epilogue
ok 23 SSH mode prints Done epilogue exactly once
ok 24 virtctl mode prints Done epilogue exactly once
```

#### Virtctl mode

Validated on a KubeVirt RHEL 10 VM that is normally accessed as:

* `virtctl ssh -n openshift-cnv cloud-user@vmi/rhel10-1`

Ran the installer from the local machine using the new transport mode:

```
➜ bash compliance/virtualmachines/roxagent/quadlet/install.sh --virtctl -n openshift-cnv cloud-user@vmi/rhel10-1

Preparing stage directory on target...
Copying files to target...
install.sh                        100% 7085    49.7KB/s   00:00
roxagent.container                100% 1552     7.3KB/s   00:00
roxagent.timer                    100%  617     4.6KB/s   00:00
roxagent-prep.service             100%  412     2.9KB/s   00:00
roxagent-tmpfiles.conf            100%   38     0.3KB/s   00:00
Running install on target...
Installing Quadlet units from /var/tmp/roxagent-install.iQ3hE9...
Stripping mount for missing path: /etc/yum/repos.d
Stripping mount for missing path: /etc/distro.repos.d
Stripping mount for missing path: /var/lib/dnf
Reloading systemd...
Enabling and starting timer...
Status:
NEXT                            LEFT LAST                         PASSED UNIT           ACTIVATES
Wed 2026-05-06 13:30:08 CEST 2h 8min Wed 2026-05-06 09:48:06 CEST 1h 33min ago roxagent.timer roxagent.service

Done! The roxagent will run periodically.

To run immediately:  sudo systemctl start roxagent.service
To view logs:        sudo journalctl -u roxagent.service -f
To check timer:      sudo systemctl list-timers roxagent.timer
```

#### Local mode

```
KUBECONFIG=<blah>
VM_NS=openshift-cnv
VM_TARGET=cloud-user@vmi/rhel10-1
QUADLET_DIR=compliance/virtualmachines/roxagent/quadlet
REMOTE_DIR=/home/cloud-user/roxagent-quadlet-test

# Copy files to a VM
➜ virtctl ssh -n "${VM_NS}" "${VM_TARGET}" --command "rm -rf ${REMOTE_DIR} && mkdir -p ${REMOTE_DIR}"
➜ for f in install.sh roxagent.container roxagent.timer roxagent-prep.service roxagent-tmpfiles.conf; do
  virtctl scp -n "${VM_NS}" "${QUADLET_DIR}/${f}" "${VM_TARGET}:${REMOTE_DIR}/${f}"
done

# Run on-VM
➜ virtctl ssh -n "${VM_NS}" "${VM_TARGET}" --command "cd ${REMOTE_DIR} && bash ./install.sh"

Installing Quadlet units from /home/cloud-user/roxagent-quadlet-test...
Stripping mount for missing path: /etc/yum/repos.d
Stripping mount for missing path: /etc/distro.repos.d
Stripping mount for missing path: /var/lib/dnf
Reloading systemd...
Enabling and starting timer...

Done! The roxagent will run periodically.

To run immediately:  sudo systemctl start roxagent.service
To view logs:        sudo journalctl -u roxagent.service -f
To check timer:      sudo systemctl list-timers roxagent.timer
```

#### SSH mode

In one shell, open port-forward:

```
VM_NS=openshift-cnv
virtctl port-forward -n "${VM_NS}" "vmi/rhel10-1" 22022:22
```

In another shell:

```
➜ bash compliance/virtualmachines/roxagent/quadlet/install.sh --ssh cloud-user@127.0.0.1 22022

Preparing stage directory on target...
Copying files to target...
install.sh                        100% 7085    47.1KB/s   00:00
roxagent.container                100% 1552    11.3KB/s   00:00
roxagent.timer                    100%  617     4.2KB/s   00:00
roxagent-prep.service             100%  412     3.2KB/s   00:00
roxagent-tmpfiles.conf            100%   38     0.3KB/s   00:00
Running install on target...
Installing Quadlet units from /var/tmp/roxagent-install.yukWdc...
Stripping mount for missing path: /etc/yum/repos.d
Stripping mount for missing path: /etc/distro.repos.d
Stripping mount for missing path: /var/lib/dnf
Reloading systemd...
Enabling and starting timer...

Done! The roxagent will run periodically.

To run immediately:  sudo systemctl start roxagent.service
To view logs:        sudo journalctl -u roxagent.service -f
To check timer:      sudo systemctl list-timers roxagent.timer
```