### PR TITLE
ROX-34489: Group CRS detail page attrs by key with header

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretDescription.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretDescription.tsx
@@ -4,52 +4,88 @@ import {
     DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
+    Flex,
+    List,
+    ListItem,
+    Title,
 } from '@patternfly/react-core';
 
-import type { ClusterRegistrationSecret } from 'services/ClustersService';
+import type { ClusterRegistrationSecret, InitBundleAttribute } from 'services/ClustersService';
 
 export type ClusterRegistrationSecretDescriptionProps = {
     clusterRegistrationSecret: ClusterRegistrationSecret;
 };
 
+function groupAttributesByKey(attributes: InitBundleAttribute[]): Map<string, string[]> {
+    const grouped = new Map<string, string[]>();
+    attributes.forEach(({ key, value }) => {
+        const existing = grouped.get(key) ?? [];
+        grouped.set(key, [...existing, value]);
+    });
+    return grouped;
+}
+
 function ClusterRegistrationSecretDescription({
     clusterRegistrationSecret,
 }: ClusterRegistrationSecretDescriptionProps): ReactElement {
+    const groupedAttributes = groupAttributesByKey(clusterRegistrationSecret.createdBy.attributes);
+
     return (
-        <DescriptionList isCompact isHorizontal className="pf-v6-u-p-lg">
-            <DescriptionListGroup>
-                <DescriptionListTerm>Name</DescriptionListTerm>
-                <DescriptionListDescription>
-                    {clusterRegistrationSecret.name}
-                </DescriptionListDescription>
-            </DescriptionListGroup>
-            <DescriptionListGroup>
-                <DescriptionListTerm>Created by</DescriptionListTerm>
-                <DescriptionListDescription>
-                    {clusterRegistrationSecret.createdBy.id}
-                </DescriptionListDescription>
-            </DescriptionListGroup>
-            {clusterRegistrationSecret.createdBy.attributes.map((attribute) => {
-                return (
-                    <DescriptionListGroup key={attribute.key}>
-                        <DescriptionListTerm>{attribute.key}</DescriptionListTerm>
-                        <DescriptionListDescription>{attribute.value}</DescriptionListDescription>
-                    </DescriptionListGroup>
-                );
-            })}
-            <DescriptionListGroup>
-                <DescriptionListTerm>Created at</DescriptionListTerm>
-                <DescriptionListDescription>
-                    {clusterRegistrationSecret.createdAt}
-                </DescriptionListDescription>
-            </DescriptionListGroup>
-            <DescriptionListGroup>
-                <DescriptionListTerm>Expires at</DescriptionListTerm>
-                <DescriptionListDescription>
-                    {clusterRegistrationSecret.expiresAt}
-                </DescriptionListDescription>
-            </DescriptionListGroup>
-        </DescriptionList>
+        <Flex direction={{ default: 'column' }} gap={{ default: 'gapLg' }}>
+            <DescriptionList
+                isCompact
+                isHorizontal
+                horizontalTermWidthModifier={{ default: '20ch' }}
+            >
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Name</DescriptionListTerm>
+                    <DescriptionListDescription>
+                        {clusterRegistrationSecret.name}
+                    </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Created by</DescriptionListTerm>
+                    <DescriptionListDescription>
+                        {clusterRegistrationSecret.createdBy.id}
+                    </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Created at</DescriptionListTerm>
+                    <DescriptionListDescription>
+                        {clusterRegistrationSecret.createdAt}
+                    </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Expires at</DescriptionListTerm>
+                    <DescriptionListDescription>
+                        {clusterRegistrationSecret.expiresAt}
+                    </DescriptionListDescription>
+                </DescriptionListGroup>
+            </DescriptionList>
+            {groupedAttributes.size > 0 && (
+                <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
+                    <Title headingLevel="h2">Attributes</Title>
+                    <DescriptionList
+                        isCompact
+                        isHorizontal
+                        horizontalTermWidthModifier={{ default: '20ch' }}
+                    >
+                        {Array.from(groupedAttributes.entries()).map(([key, values]) => (
+                            <DescriptionListGroup key={key}>
+                                <DescriptionListTerm>{key}</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <List isPlain>
+                                        {values.map((value) => (
+                                            <ListItem key={value}>{value}</ListItem>
+                                        ))}
+                                    </List>
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                        ))}
+                    </DescriptionList>
+                </Flex>
+            )}
+        </Flex>
     );
 }
 


### PR DESCRIPTION
## Description

As titled. Minor visual cleanup for CRS detail page before implementing new API changes.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Staging attributes redacted
<img width="1478" height="759" alt="image" src="https://github.com/user-attachments/assets/ce27aa43-1506-43ec-b163-f2a0e6311ec2" />
