### PR TITLE
ROX-34490: Add registration tracking fields to CRS detail page

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretDescription.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretDescription.tsx
@@ -29,6 +29,8 @@ function ClusterRegistrationSecretDescription({
     clusterRegistrationSecret,
 }: ClusterRegistrationSecretDescriptionProps): ReactElement {
     const groupedAttributes = groupAttributesByKey(clusterRegistrationSecret.createdBy.attributes);
+    const maxRegistrations = parseInt(clusterRegistrationSecret.maxRegistrations, 10) || 0;
+    const completedSet = new Set(clusterRegistrationSecret.registrationsCompleted);
 
     return (
         <Flex direction={{ default: 'column' }} gap={{ default: 'gapLg' }}>
@@ -61,7 +63,43 @@ function ClusterRegistrationSecretDescription({
                         {clusterRegistrationSecret.expiresAt}
                     </DescriptionListDescription>
                 </DescriptionListGroup>
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Max registrations</DescriptionListTerm>
+                    <DescriptionListDescription>
+                        {maxRegistrations === 0 ? 'Unlimited' : maxRegistrations}
+                    </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Used registrations</DescriptionListTerm>
+                    <DescriptionListDescription>
+                        {clusterRegistrationSecret.registrationsInitiated.length}
+                    </DescriptionListDescription>
+                </DescriptionListGroup>
             </DescriptionList>
+            {clusterRegistrationSecret.registrationsInitiated.length > 0 && (
+                <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
+                    <Title headingLevel="h2">
+                        {clusterRegistrationSecret.registrationsInitiated.length === 1
+                            ? 'Registered cluster'
+                            : 'Registered clusters'}
+                    </Title>
+                    <List isPlain>
+                        {clusterRegistrationSecret.registrationsInitiated.map((clusterName) => {
+                            const isComplete = completedSet.has(clusterName);
+                            return (
+                                <ListItem
+                                    key={clusterName}
+                                    className={isComplete ? '' : 'pf-v6-u-text-color-subtle'}
+                                >
+                                    {isComplete
+                                        ? clusterName
+                                        : `${clusterName} (registration not yet complete)`}
+                                </ListItem>
+                            );
+                        })}
+                    </List>
+                </Flex>
+            )}
             {groupedAttributes.size > 0 && (
                 <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
                     <Title headingLevel="h2">Attributes</Title>


### PR DESCRIPTION
## Description

Updates CRS detail page to add new fields returned by the API:

- Maximum permitted registrations
- Lists of cluster registrations intialized/completed

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

With unlimited registrations and no registered clusters:
<img width="1478" height="735" alt="image" src="https://github.com/user-attachments/assets/9c93c23d-75ec-4336-bc0d-124e2c41e4c6" />

With limited registrations and registered clusters. Note that the initialized, but not fully registered, cluster behavior is an edge cases that is technically possible, but very limited in time span. We handle the case here with a small affordance for completeness.
<img width="1478" height="735" alt="image" src="https://github.com/user-attachments/assets/31ead65c-a9ed-43e8-8873-4d2bf47549c3" />
<img width="1478" height="735" alt="image" src="https://github.com/user-attachments/assets/e3103831-988d-40e6-b38e-ac3b1b7128aa" />



