### PR TITLE
ROX-34619, ROX-34675: Fix bug in enhanced filters

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/email_formatter.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter.go
@@ -192,8 +192,8 @@ func validateSnapshot(snapshot *storage.ReportSnapshot) error {
 	if reportFilters == nil {
 		return errors.New("Report snapshot is missing vulnerability report filters")
 	}
-	if snapshot.GetCollection() == nil {
-		return errors.New("Report snapshot is missing collection snapshot")
+	if snapshot.GetResourceScope() == nil {
+		return errors.New("Report snapshot is missing resource scope")
 	}
 	if len(reportFilters.GetImageTypes()) == 0 {
 		return errors.New("Report snapshot is missing image type filters")

--- a/central/reports/scheduler/v2/reportgenerator/validate.go
+++ b/central/reports/scheduler/v2/reportgenerator/validate.go
@@ -20,7 +20,7 @@ func ValidateReportRequest(request *ReportRequest) error {
 		errorList.AddError(errors.New("Report request does not have a valid report snapshot with report status"))
 	}
 	// only check collection is non nil if report snapshot is for config based vuln reports
-	if request.ReportSnapshot.GetVulnReportFilters() != nil && request.Collection == nil {
+	if request.ReportSnapshot.GetVulnReportFilters() != nil && request.ReportSnapshot.GetResourceScope() == nil {
 		errorList.AddError(errors.New("Report request does not have a valid non-nil collection."))
 	}
 

--- a/central/reports/scheduler/v2/reportgenerator/validate.go
+++ b/central/reports/scheduler/v2/reportgenerator/validate.go
@@ -19,7 +19,7 @@ func ValidateReportRequest(request *ReportRequest) error {
 	} else if request.ReportSnapshot.GetReportStatus() == nil {
 		errorList.AddError(errors.New("Report request does not have a valid report snapshot with report status"))
 	}
-	// only check collection is non nil if report snapshot is for config based vuln reports
+	// only check resource scope is non nil if report snapshot is for config based vuln reports
 	if request.ReportSnapshot.GetVulnReportFilters() != nil && request.ReportSnapshot.GetResourceScope() == nil {
 		errorList.AddError(errors.New("Report request does not have a valid non-nil collection."))
 	}

--- a/central/reports/scheduler/v2/reportgenerator/validate.go
+++ b/central/reports/scheduler/v2/reportgenerator/validate.go
@@ -21,7 +21,7 @@ func ValidateReportRequest(request *ReportRequest) error {
 	}
 	// only check resource scope is non nil if report snapshot is for config based vuln reports
 	if request.ReportSnapshot.GetVulnReportFilters() != nil && request.ReportSnapshot.GetResourceScope() == nil {
-		errorList.AddError(errors.New("Report request does not have a valid non-nil collection."))
+		errorList.AddError(errors.New("Report request does not have a valid non-nil resource scope."))
 	}
 
 	return errorList.ToError()

--- a/central/reports/service/v2/convert.go
+++ b/central/reports/service/v2/convert.go
@@ -271,8 +271,16 @@ func (s *serviceImpl) convertProtoReportConfigurationToV2(config *storage.Report
 	}
 
 	if config.GetVulnReportFilters() != nil {
+		vulnReportFilter := s.convertProtoVulnReportFiltersToV2(config.GetVulnReportFilters())
+
+		if config.GetResourceScope().GetEntityScope() != nil {
+			// fixability field value does not matter for enhanced filters. Hence, set the value to BOTH to disable the field.
+			vulnReportFilter.Fixability = apiV2.VulnerabilityReportFilters_BOTH
+			// severities field not apply when enhanced filters are enabled. Hence, set the value to empty list.
+			vulnReportFilter.Severities = []apiV2.VulnerabilityReportFilters_VulnerabilitySeverity{}
+		}
 		ret.Filter = &apiV2.ReportConfiguration_VulnReportFilters{
-			VulnReportFilters: s.convertProtoVulnReportFiltersToV2(config.GetVulnReportFilters()),
+			VulnReportFilters: vulnReportFilter,
 		}
 	}
 
@@ -295,9 +303,9 @@ func (s *serviceImpl) convertProtoVulnReportFiltersToV2(filters *storage.Vulnera
 
 	ret := &apiV2.VulnerabilityReportFilters{
 		Fixability:             apiV2.VulnerabilityReportFilters_Fixability(filters.GetFixability()),
-		IncludeNvdCvss:         filters.GetIncludeNvdCvss(),
-		IncludeEpssProbability: filters.GetIncludeEpssProbability(),
-		IncludeAdvisory:        filters.GetIncludeAdvisory(),
+		IncludeNvdCvss:         true,
+		IncludeEpssProbability: true,
+		IncludeAdvisory:        true,
 	}
 	if features.VulnerabilityReportsEnhancedFiltering.Enabled() {
 		ret.Query = filters.GetQuery()

--- a/pkg/fixtures/report_configuration.go
+++ b/pkg/fixtures/report_configuration.go
@@ -96,6 +96,9 @@ func GetValidReportConfigWithMultipleNotifiersV2() *storage.ReportConfiguration 
 				CvesSince: &storage.VulnerabilityReportFilters_SinceLastSentScheduledReport{
 					SinceLastSentScheduledReport: true,
 				},
+				IncludeNvdCvss:         true,
+				IncludeAdvisory:        true,
+				IncludeEpssProbability: true,
 			},
 		},
 		Schedule: &storage.Schedule{

--- a/pkg/fixtures/report_configuration.go
+++ b/pkg/fixtures/report_configuration.go
@@ -235,6 +235,9 @@ func GetValidV2ReportConfigWithMultipleNotifiers() *v2.ReportConfiguration {
 				CvesSince: &v2.VulnerabilityReportFilters_SinceLastSentScheduledReport{
 					SinceLastSentScheduledReport: true,
 				},
+				IncludeEpssProbability: true,
+				IncludeAdvisory:        true,
+				IncludeNvdCvss:         true,
 			},
 		},
 		Schedule: &v2.ReportSchedule{

--- a/pkg/fixtures/report_snapshot.go
+++ b/pkg/fixtures/report_snapshot.go
@@ -16,6 +16,9 @@ func GetReportSnapshot() *storage.ReportSnapshot {
 			Id:   "collection-1",
 			Name: "collection-1",
 		},
+		ResourceScope: &storage.ResourceScope{
+			ScopeReference: &storage.ResourceScope_CollectionId{CollectionId: "collection-1"},
+		},
 		Schedule: &storage.Schedule{
 			IntervalType: storage.Schedule_WEEKLY,
 			Interval: &storage.Schedule_DaysOfWeek_{


### PR DESCRIPTION
This PR makes minor fixes in VM reporting API response 
- optional columns to always show true 
-  return empty list for severities and BOTH for fixability when entity scope is selected since filtering by these fields is disabled 
-  validate resource scope is set to collection/entity scope for config based reports 
- fix email formatter

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Deployed  a mail server and added notifier to ACS. Validated this change by sending instant email report with entity scope as scoping method and verifying the email and report in mail server

updating unit tests and manual testing by creating report config with POST /v2/reports/configurations to verify report config can be created for entity scope. Also validated the deprecated field values return by the API in response 
<img width="728" height="554" alt="Screenshot 2026-05-11 at 5 08 11 PM" src="https://github.com/user-attachments/assets/57d83225-87e3-44ec-bfab-aa7e65fec8ab" />


GET v2/reports/configurations  also returns expected values for deprecated fields
<img width="710" height="542" alt="Screenshot 2026-05-11 at 5 07 17 PM" src="https://github.com/user-attachments/assets/be27abb3-569c-43fb-a576-65991f4996c2" />
