### PR TITLE
ROX-34491: Update CRS list table with improved columns

### DIFF
--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsTable.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/ClusterRegistrationSecretsTable.tsx
@@ -2,8 +2,30 @@ import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-import type { ClusterRegistrationSecret } from 'services/ClustersService';
+import DateDistance from 'Components/DateDistance';
+import type { ClusterRegistrationSecret, InitBundleAttribute } from 'services/ClustersService';
 import { clustersClusterRegistrationSecretsPath } from 'routePaths';
+
+const createdByDisplayKeys = ['name', 'username', 'email'];
+
+function getCreatedByDisplayValue(createdBy: ClusterRegistrationSecret['createdBy']): string {
+    const match = createdByDisplayKeys
+        .map((key) => createdBy.attributes.find((attr) => attr.key === key))
+        .find((attr): attr is InitBundleAttribute => attr !== undefined);
+
+    return match?.value ?? createdBy.id;
+}
+
+function getRegistrationsDisplay(
+    maxRegistrations: string,
+    registrationsInitiated: string[]
+): string {
+    const max = parseInt(maxRegistrations, 10);
+    if (!maxRegistrations || max === 0) {
+        return 'Unlimited';
+    }
+    return `${registrationsInitiated.length} / ${max} registered`;
+}
 
 export type ClusterRegistrationSecretsTableProps = {
     hasWriteAccessForClusterRegistrationSecrets: boolean;
@@ -24,8 +46,8 @@ function ClusterRegistrationSecretsTable({
                 <Tr>
                     <Th>Name</Th>
                     <Th>Created by</Th>
-                    <Th>Created at</Th>
-                    <Th>Expires at</Th>
+                    <Th>Expires in</Th>
+                    <Th>Registrations</Th>
                     {hasWriteAccessForClusterRegistrationSecrets && (
                         <Th screenReaderText="Row actions" />
                     )}
@@ -33,7 +55,17 @@ function ClusterRegistrationSecretsTable({
             </Thead>
             <Tbody>
                 {clusterRegistrationSecrets.map((clusterRegistrationSecret) => {
-                    const { createdAt, createdBy, expiresAt, id, name } = clusterRegistrationSecret;
+                    const {
+                        createdBy,
+                        expiresAt,
+                        id,
+                        maxRegistrations,
+                        name,
+                        registrationsInitiated,
+                    } = clusterRegistrationSecret;
+
+                    const createdByDisplay = getCreatedByDisplayValue(createdBy);
+                    const isExpired = new Date(expiresAt) < new Date();
 
                     return (
                         <Tr key={id}>
@@ -42,9 +74,17 @@ function ClusterRegistrationSecretsTable({
                                     {name}
                                 </Link>
                             </Td>
-                            <Td dataLabel="Created by">{createdBy.id}</Td>
-                            <Td dataLabel="Created at">{createdAt}</Td>
-                            <Td dataLabel="Expires at">{expiresAt}</Td>
+                            <Td dataLabel="Created by">{createdByDisplay}</Td>
+                            <Td dataLabel="Expires in">
+                                {isExpired ? (
+                                    'Expired'
+                                ) : (
+                                    <DateDistance date={expiresAt} asPhrase={false} />
+                                )}
+                            </Td>
+                            <Td dataLabel="Registrations">
+                                {getRegistrationsDisplay(maxRegistrations, registrationsInitiated)}
+                            </Td>
                             {hasWriteAccessForClusterRegistrationSecrets && (
                                 <Td isActionCell>
                                     <ActionsColumn


### PR DESCRIPTION
## Description

Updates the CRS title to smooth out UX and use additional API data:
- Instead of an opaque ID, attempt to show the user's `username`, `name`, or `email` address
- Remove the "created at" timestamp - this will still be visible on the detail page
- Change "Expires at" from a UNIX timestamp to a human readable relative date
- List the number of available registration left on a CRS, if applicable 



## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
<img width="1478" height="692" alt="image" src="https://github.com/user-attachments/assets/5412514d-f026-42c6-ae03-df6d2f8163f4" />
