### PR TITLE
ROX-34181: replace ListVMCVEAffectedVMs with SQL view and pagination

### DIFF
--- a/central/views/vmcve/db_response.go
+++ b/central/views/vmcve/db_response.go
@@ -175,3 +175,25 @@ func (r *vmSeverityCountsResponse) GetSeverityCounts() common.ResourceCountByCVE
 		FixableUnknownSeverityCount:   r.FixableUnknownSeverityCount,
 	}
 }
+
+type affectedVMResponse struct {
+	VMID                   string  `db:"virtual_machine_id"`
+	VMName                 string  `db:"virtual_machine_name"`
+	MaxSeverity            int32   `db:"severity_max"`
+	IsFixable              bool    `db:"fixable_max"`
+	MaxCVSS                float32 `db:"cvss_max"`
+	GuestOS                string  `db:"guest_os"`
+	AffectedComponentCount int     `db:"component_id_count"`
+}
+
+func (r *affectedVMResponse) GetVMID() string                { return r.VMID }
+func (r *affectedVMResponse) GetVMName() string              { return r.VMName }
+func (r *affectedVMResponse) GetMaxSeverity() int32          { return r.MaxSeverity }
+func (r *affectedVMResponse) GetIsFixable() bool             { return r.IsFixable }
+func (r *affectedVMResponse) GetMaxCVSS() float32            { return r.MaxCVSS }
+func (r *affectedVMResponse) GetGuestOS() string             { return r.GuestOS }
+func (r *affectedVMResponse) GetAffectedComponentCount() int { return r.AffectedComponentCount }
+
+type affectedVMCount struct {
+	VMCount int `db:"virtual_machine_id_count"`
+}

--- a/central/views/vmcve/db_response.go
+++ b/central/views/vmcve/db_response.go
@@ -180,7 +180,7 @@ type affectedVMResponse struct {
 	VMID                   string  `db:"virtual_machine_id"`
 	VMName                 string  `db:"virtual_machine_name"`
 	MaxSeverity            int32   `db:"severity_max"`
-	IsFixable              bool    `db:"fixable_max"`
+	FixableCount           int     `db:"fixable_count"`
 	MaxCVSS                float32 `db:"cvss_max"`
 	GuestOS                string  `db:"guest_os"`
 	AffectedComponentCount int     `db:"component_id_count"`
@@ -189,7 +189,7 @@ type affectedVMResponse struct {
 func (r *affectedVMResponse) GetVMID() string                { return r.VMID }
 func (r *affectedVMResponse) GetVMName() string              { return r.VMName }
 func (r *affectedVMResponse) GetMaxSeverity() int32          { return r.MaxSeverity }
-func (r *affectedVMResponse) GetIsFixable() bool             { return r.IsFixable }
+func (r *affectedVMResponse) GetIsFixable() bool             { return r.FixableCount > 0 }
 func (r *affectedVMResponse) GetMaxCVSS() float32            { return r.MaxCVSS }
 func (r *affectedVMResponse) GetGuestOS() string             { return r.GuestOS }
 func (r *affectedVMResponse) GetAffectedComponentCount() int { return r.AffectedComponentCount }

--- a/central/views/vmcve/mocks/types.go
+++ b/central/views/vmcve/mocks/types.go
@@ -303,6 +303,21 @@ func (mr *MockCveViewMockRecorder) Count(ctx, q any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockCveView)(nil).Count), ctx, q)
 }
 
+// CountAffectedVMs mocks base method.
+func (m *MockCveView) CountAffectedVMs(ctx context.Context, q *v1.Query) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountAffectedVMs", ctx, q)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountAffectedVMs indicates an expected call of CountAffectedVMs.
+func (mr *MockCveViewMockRecorder) CountAffectedVMs(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountAffectedVMs", reflect.TypeOf((*MockCveView)(nil).CountAffectedVMs), ctx, q)
+}
+
 // CountBySeverity mocks base method.
 func (m *MockCveView) CountBySeverity(ctx context.Context, q *v1.Query) (common.ResourceCountByCVESeverity, error) {
 	m.ctrl.T.Helper()
@@ -346,6 +361,21 @@ func (m *MockCveView) Get(ctx context.Context, q *v1.Query) ([]vmcve.CveCore, er
 func (mr *MockCveViewMockRecorder) Get(ctx, q any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCveView)(nil).Get), ctx, q)
+}
+
+// GetAffectedVMs mocks base method.
+func (m *MockCveView) GetAffectedVMs(ctx context.Context, q *v1.Query) ([]vmcve.AffectedVMCore, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAffectedVMs", ctx, q)
+	ret0, _ := ret[0].([]vmcve.AffectedVMCore)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAffectedVMs indicates an expected call of GetAffectedVMs.
+func (mr *MockCveViewMockRecorder) GetAffectedVMs(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAffectedVMs", reflect.TypeOf((*MockCveView)(nil).GetAffectedVMs), ctx, q)
 }
 
 // GetCVEComponents mocks base method.
@@ -428,4 +458,126 @@ func (m *MockVMSeverityCounts) GetVMID() string {
 func (mr *MockVMSeverityCountsMockRecorder) GetVMID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMID", reflect.TypeOf((*MockVMSeverityCounts)(nil).GetVMID))
+}
+
+// MockAffectedVMCore is a mock of AffectedVMCore interface.
+type MockAffectedVMCore struct {
+	ctrl     *gomock.Controller
+	recorder *MockAffectedVMCoreMockRecorder
+	isgomock struct{}
+}
+
+// MockAffectedVMCoreMockRecorder is the mock recorder for MockAffectedVMCore.
+type MockAffectedVMCoreMockRecorder struct {
+	mock *MockAffectedVMCore
+}
+
+// NewMockAffectedVMCore creates a new mock instance.
+func NewMockAffectedVMCore(ctrl *gomock.Controller) *MockAffectedVMCore {
+	mock := &MockAffectedVMCore{ctrl: ctrl}
+	mock.recorder = &MockAffectedVMCoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAffectedVMCore) EXPECT() *MockAffectedVMCoreMockRecorder {
+	return m.recorder
+}
+
+// GetAffectedComponentCount mocks base method.
+func (m *MockAffectedVMCore) GetAffectedComponentCount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAffectedComponentCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetAffectedComponentCount indicates an expected call of GetAffectedComponentCount.
+func (mr *MockAffectedVMCoreMockRecorder) GetAffectedComponentCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAffectedComponentCount", reflect.TypeOf((*MockAffectedVMCore)(nil).GetAffectedComponentCount))
+}
+
+// GetGuestOS mocks base method.
+func (m *MockAffectedVMCore) GetGuestOS() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGuestOS")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetGuestOS indicates an expected call of GetGuestOS.
+func (mr *MockAffectedVMCoreMockRecorder) GetGuestOS() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGuestOS", reflect.TypeOf((*MockAffectedVMCore)(nil).GetGuestOS))
+}
+
+// GetIsFixable mocks base method.
+func (m *MockAffectedVMCore) GetIsFixable() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIsFixable")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetIsFixable indicates an expected call of GetIsFixable.
+func (mr *MockAffectedVMCoreMockRecorder) GetIsFixable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIsFixable", reflect.TypeOf((*MockAffectedVMCore)(nil).GetIsFixable))
+}
+
+// GetMaxCVSS mocks base method.
+func (m *MockAffectedVMCore) GetMaxCVSS() float32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxCVSS")
+	ret0, _ := ret[0].(float32)
+	return ret0
+}
+
+// GetMaxCVSS indicates an expected call of GetMaxCVSS.
+func (mr *MockAffectedVMCoreMockRecorder) GetMaxCVSS() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxCVSS", reflect.TypeOf((*MockAffectedVMCore)(nil).GetMaxCVSS))
+}
+
+// GetMaxSeverity mocks base method.
+func (m *MockAffectedVMCore) GetMaxSeverity() int32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxSeverity")
+	ret0, _ := ret[0].(int32)
+	return ret0
+}
+
+// GetMaxSeverity indicates an expected call of GetMaxSeverity.
+func (mr *MockAffectedVMCoreMockRecorder) GetMaxSeverity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxSeverity", reflect.TypeOf((*MockAffectedVMCore)(nil).GetMaxSeverity))
+}
+
+// GetVMID mocks base method.
+func (m *MockAffectedVMCore) GetVMID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVMID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetVMID indicates an expected call of GetVMID.
+func (mr *MockAffectedVMCoreMockRecorder) GetVMID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMID", reflect.TypeOf((*MockAffectedVMCore)(nil).GetVMID))
+}
+
+// GetVMName mocks base method.
+func (m *MockAffectedVMCore) GetVMName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVMName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetVMName indicates an expected call of GetVMName.
+func (mr *MockAffectedVMCoreMockRecorder) GetVMName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMName", reflect.TypeOf((*MockAffectedVMCore)(nil).GetVMName))
 }

--- a/central/views/vmcve/types.go
+++ b/central/views/vmcve/types.go
@@ -46,10 +46,23 @@ type CveView interface {
 	GetVMIDs(ctx context.Context, q *v1.Query) ([]string, error)
 	GetCVEComponents(ctx context.Context, q *v1.Query) ([]CVEComponentCore, error)
 	CountBySeverityPerVM(ctx context.Context, q *v1.Query) ([]VMSeverityCounts, error)
+	GetAffectedVMs(ctx context.Context, q *v1.Query) ([]AffectedVMCore, error)
+	CountAffectedVMs(ctx context.Context, q *v1.Query) (int, error)
 }
 
 // VMSeverityCounts provides per-VM severity counts.
 type VMSeverityCounts interface {
 	GetVMID() string
 	GetSeverityCounts() common.ResourceCountByCVESeverity
+}
+
+// AffectedVMCore provides per-VM aggregation for a specific CVE.
+type AffectedVMCore interface {
+	GetVMID() string
+	GetVMName() string
+	GetMaxSeverity() int32
+	GetIsFixable() bool
+	GetMaxCVSS() float32
+	GetGuestOS() string
+	GetAffectedComponentCount() int
 }

--- a/central/views/vmcve/view_impl.go
+++ b/central/views/vmcve/view_impl.go
@@ -186,7 +186,11 @@ func (v *vmCVECoreViewImpl) GetAffectedVMs(ctx context.Context, q *v1.Query) ([]
 		search.NewQuerySelect(search.ComponentID).AggrFunc(aggregatefunc.Count).Distinct().Proto(),
 	}
 	cloned.GroupBy = &v1.QueryGroupBy{
-		Fields: []string{search.VirtualMachineID.String()},
+		Fields: []string{
+			search.VirtualMachineID.String(),
+			search.VirtualMachineName.String(),
+			search.GuestOS.String(),
+		},
 	}
 
 	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)

--- a/central/views/vmcve/view_impl.go
+++ b/central/views/vmcve/view_impl.go
@@ -177,7 +177,10 @@ func (v *vmCVECoreViewImpl) GetAffectedVMs(ctx context.Context, q *v1.Query) ([]
 		search.NewQuerySelect(search.VirtualMachineID).Proto(),
 		search.NewQuerySelect(search.VirtualMachineName).Proto(),
 		search.NewQuerySelect(search.Severity).AggrFunc(aggregatefunc.Max).Proto(),
-		search.NewQuerySelect(search.Fixable).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.Fixable).AggrFunc(aggregatefunc.Count).
+			Filter("fixable_count",
+				search.NewQueryBuilder().AddBools(search.Fixable, true).ProtoQuery(),
+			).Proto(),
 		search.NewQuerySelect(search.CVSS).AggrFunc(aggregatefunc.Max).Proto(),
 		search.NewQuerySelect(search.GuestOS).Proto(),
 		search.NewQuerySelect(search.ComponentID).AggrFunc(aggregatefunc.Count).Distinct().Proto(),

--- a/central/views/vmcve/view_impl.go
+++ b/central/views/vmcve/view_impl.go
@@ -149,6 +149,57 @@ func (v *vmCVECoreViewImpl) CountBySeverityPerVM(ctx context.Context, q *v1.Quer
 	return ret, nil
 }
 
+func (v *vmCVECoreViewImpl) CountAffectedVMs(ctx context.Context, q *v1.Query) (int, error) {
+	if err := common.ValidateQuery(q); err != nil {
+		return 0, err
+	}
+
+	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
+	defer cancel()
+
+	result, err := pgSearch.RunSelectOneForSchema[affectedVMCount](queryCtx, v.db, v.schema, common.WithCountQuery(q, search.VirtualMachineID))
+	if err != nil {
+		return 0, err
+	}
+	if result == nil {
+		return 0, nil
+	}
+	return result.VMCount, nil
+}
+
+func (v *vmCVECoreViewImpl) GetAffectedVMs(ctx context.Context, q *v1.Query) ([]AffectedVMCore, error) {
+	if err := common.ValidateQuery(q); err != nil {
+		return nil, err
+	}
+
+	cloned := q.CloneVT()
+	cloned.Selects = []*v1.QuerySelect{
+		search.NewQuerySelect(search.VirtualMachineID).Proto(),
+		search.NewQuerySelect(search.VirtualMachineName).Proto(),
+		search.NewQuerySelect(search.Severity).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.Fixable).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.CVSS).AggrFunc(aggregatefunc.Max).Proto(),
+		search.NewQuerySelect(search.GuestOS).Proto(),
+		search.NewQuerySelect(search.ComponentID).AggrFunc(aggregatefunc.Count).Distinct().Proto(),
+	}
+	cloned.GroupBy = &v1.QueryGroupBy{
+		Fields: []string{search.VirtualMachineID.String()},
+	}
+
+	queryCtx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, queryTimeout)
+	defer cancel()
+
+	var ret []AffectedVMCore
+	err := pgSearch.RunSelectRequestForSchemaFn[affectedVMResponse](queryCtx, v.db, v.schema, cloned, func(r *affectedVMResponse) error {
+		ret = append(ret, r)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 	cloned := q.CloneVT()
 	cloned.Selects = []*v1.QuerySelect{

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/convert/storagetov2"
+	"github.com/stackrox/rox/central/views/common"
 	"github.com/stackrox/rox/central/views/vmcve"
 	componentDS "github.com/stackrox/rox/central/virtualmachine/component/v2/datastore"
 	cveDS "github.com/stackrox/rox/central/virtualmachine/cve/v2/datastore"
@@ -528,6 +529,7 @@ func (s *serviceImpl) ListVMCVEAffectedVMs(ctx context.Context, request *v2.List
 		searchQuery,
 		search.NewQueryBuilder().AddExactMatches(search.CVE, request.GetCveId()).ProtoQuery(),
 	)
+	searchQuery = common.UpdateSortAggs(searchQuery)
 	paginated.FillPaginationV2(searchQuery, request.GetQuery().GetPagination(), defaultPageSize)
 
 	countQuery := searchQuery.CloneVT()

--- a/central/virtualmachine/v2/service/service_impl.go
+++ b/central/virtualmachine/v2/service/service_impl.go
@@ -514,8 +514,7 @@ func (s *serviceImpl) GetVMCVEDetail(ctx context.Context, request *v2.GetVMCVEDe
 	}, nil
 }
 
-// ListVMCVEAffectedVMs returns VMs affected by a specific CVE.
-// TODO(ROX-34181): Replace with a SQL view to enable proper pagination.
+// ListVMCVEAffectedVMs returns VMs affected by a specific CVE with pagination.
 func (s *serviceImpl) ListVMCVEAffectedVMs(ctx context.Context, request *v2.ListVMCVEAffectedVMsRequest) (*v2.ListVMCVEAffectedVMsResponse, error) {
 	if request.GetCveId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "cve_id must be specified")
@@ -529,65 +528,36 @@ func (s *serviceImpl) ListVMCVEAffectedVMs(ctx context.Context, request *v2.List
 		searchQuery,
 		search.NewQueryBuilder().AddExactMatches(search.CVE, request.GetCveId()).ProtoQuery(),
 	)
+	paginated.FillPaginationV2(searchQuery, request.GetQuery().GetPagination(), defaultPageSize)
 
-	// Get all CVE records matching this CVE identifier to find affected VMs.
-	cves, err := s.cveDS.SearchRawVMCVEs(ctx, searchQuery)
+	countQuery := searchQuery.CloneVT()
+	countQuery.Pagination = nil
+	totalCount, err := s.cveView.CountAffectedVMs(ctx, countQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	// Build per-VM aggregation: for each VM, pick the highest severity CVE record.
-	type vmCVEInfo struct {
-		severity       v2.VulnerabilitySeverity
-		isFixable      bool
-		cvss           float32
-		componentCount int
-	}
-	vmMap := make(map[string]*vmCVEInfo)
-	for _, cve := range cves {
-		info, ok := vmMap[cve.GetVmV2Id()]
-		if !ok {
-			info = &vmCVEInfo{}
-			vmMap[cve.GetVmV2Id()] = info
-		}
-		info.componentCount++
-		severity := v2.VulnerabilitySeverity(cve.GetSeverity())
-		if severity > info.severity {
-			info.severity = severity
-			info.cvss = cve.GetPreferredCvss()
-		}
-		if cve.GetIsFixable() {
-			info.isFixable = true
-		}
-	}
-
-	vmIDs := make([]string, 0, len(vmMap))
-	for id := range vmMap {
-		vmIDs = append(vmIDs, id)
-	}
-
-	vms, _, err := s.vmDS.GetManyVirtualMachines(ctx, vmIDs)
+	affectedVMs, err := s.cveView.GetAffectedVMs(ctx, searchQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	rows := make([]*v2.VMCVEAffectedVMRow, 0, len(vms))
-	for _, vm := range vms {
-		info := vmMap[vm.GetId()]
+	rows := make([]*v2.VMCVEAffectedVMRow, 0, len(affectedVMs))
+	for _, vm := range affectedVMs {
 		rows = append(rows, &v2.VMCVEAffectedVMRow{
-			VmId:                   vm.GetId(),
-			VmName:                 vm.GetName(),
-			Severity:               info.severity,
-			IsFixable:              info.isFixable,
-			Cvss:                   info.cvss,
-			GuestOs:                vm.GetGuestOs(),
-			AffectedComponentCount: int32(info.componentCount),
+			VmId:                   vm.GetVMID(),
+			VmName:                 vm.GetVMName(),
+			Severity:               v2.VulnerabilitySeverity(vm.GetMaxSeverity()),
+			IsFixable:              vm.GetIsFixable(),
+			Cvss:                   vm.GetMaxCVSS(),
+			GuestOs:                vm.GetGuestOS(),
+			AffectedComponentCount: int32(vm.GetAffectedComponentCount()),
 		})
 	}
 
 	return &v2.ListVMCVEAffectedVMsResponse{
 		Vms:        rows,
-		TotalCount: int32(len(rows)),
+		TotalCount: int32(totalCount),
 	}, nil
 }
 

--- a/central/virtualmachine/v2/service/service_impl_test.go
+++ b/central/virtualmachine/v2/service/service_impl_test.go
@@ -845,20 +845,6 @@ func TestListVMCVEs(t *testing.T) {
 func TestListVMCVEAffectedVMs(t *testing.T) {
 	ctx := context.Background()
 
-	cve1 := &storage.VirtualMachineCVEV2{
-		Id:            "cve-uuid-1",
-		VmV2Id:        "vm-1",
-		VmComponentId: "comp-1",
-		CveBaseInfo:   &storage.CVEInfo{Cve: "CVE-2024-1234"},
-		PreferredCvss: 7.5,
-		Severity:      storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
-		IsFixable:     true,
-	}
-
-	vm1 := &storage.VirtualMachineV2{
-		Id: "vm-1", Name: "test-vm-1", GuestOs: "rhel-9",
-	}
-
 	tests := map[string]struct {
 		request       *v2.ListVMCVEAffectedVMsRequest
 		setupMock     func(*vmDSMocks.MockDataStore, *cveDSMocks.MockDataStore, *componentDSMocks.MockDataStore, *scanDSMocks.MockDataStore, *cveViewMocks.MockCveView)
@@ -873,18 +859,26 @@ func TestListVMCVEAffectedVMs(t *testing.T) {
 		},
 		"successful list": {
 			request: &v2.ListVMCVEAffectedVMsRequest{CveId: "CVE-2024-1234"},
-			setupMock: func(mockVM *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, _ *componentDSMocks.MockDataStore, _ *scanDSMocks.MockDataStore, _ *cveViewMocks.MockCveView) {
-				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return([]*storage.VirtualMachineCVEV2{cve1}, nil)
-				mockVM.EXPECT().GetManyVirtualMachines(ctx, gomock.Any()).Return([]*storage.VirtualMachineV2{vm1}, nil, nil)
+			setupMock: func(_ *vmDSMocks.MockDataStore, _ *cveDSMocks.MockDataStore, _ *componentDSMocks.MockDataStore, _ *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				mockView.EXPECT().CountAffectedVMs(ctx, gomock.Any()).Return(1, nil)
+				affectedVM := cveViewMocks.NewMockAffectedVMCore(gomock.NewController(t))
+				affectedVM.EXPECT().GetVMID().Return("vm-1").AnyTimes()
+				affectedVM.EXPECT().GetVMName().Return("test-vm-1").AnyTimes()
+				affectedVM.EXPECT().GetMaxSeverity().Return(int32(storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY)).AnyTimes()
+				affectedVM.EXPECT().GetIsFixable().Return(true).AnyTimes()
+				affectedVM.EXPECT().GetMaxCVSS().Return(float32(7.5)).AnyTimes()
+				affectedVM.EXPECT().GetGuestOS().Return("rhel-9").AnyTimes()
+				affectedVM.EXPECT().GetAffectedComponentCount().Return(1).AnyTimes()
+				mockView.EXPECT().GetAffectedVMs(ctx, gomock.Any()).Return([]vmcve.AffectedVMCore{affectedVM}, nil)
 			},
 			expectedCount: 1,
 		},
-		"cve search error": {
+		"count error": {
 			request: &v2.ListVMCVEAffectedVMsRequest{CveId: "CVE-2024-1234"},
-			setupMock: func(_ *vmDSMocks.MockDataStore, mockCVE *cveDSMocks.MockDataStore, _ *componentDSMocks.MockDataStore, _ *scanDSMocks.MockDataStore, _ *cveViewMocks.MockCveView) {
-				mockCVE.EXPECT().SearchRawVMCVEs(ctx, gomock.Any()).Return(nil, errors.New("search error"))
+			setupMock: func(_ *vmDSMocks.MockDataStore, _ *cveDSMocks.MockDataStore, _ *componentDSMocks.MockDataStore, _ *scanDSMocks.MockDataStore, mockView *cveViewMocks.MockCveView) {
+				mockView.EXPECT().CountAffectedVMs(ctx, gomock.Any()).Return(0, errors.New("count error"))
 			},
-			expectedError: "search error",
+			expectedError: "count error",
 		},
 	}
 


### PR DESCRIPTION
## Description

Add GetAffectedVMs and CountAffectedVMs to vmcve.CveView which do per-VM aggregation (MAX severity, MAX fixable, MAX CVSS, COUNT DISTINCT components) with GROUP BY vm_v2_id in SQL. Enables proper pagination via FillPaginationV2.

Replaces the previous approach of fetching all CVE records into memory, aggregating per-VM, then fetching all VM details.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Unit tests updated with generated view mocks.
