### PR TITLE
ROX-34186: Render collection and entity scope in Resources step

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/AttributeSelector.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/AttributeSelector.tsx
@@ -9,6 +9,7 @@ export type AttributeSelectorOnChange = (value: string | number | undefined) => 
 export type AttributeSelectorProps = {
     attributes: CompoundSearchFilterAttribute[];
     attribute: CompoundSearchFilterAttribute;
+    isDisabled: boolean;
     onChange: AttributeSelectorOnChange;
     menuToggleClassName?: string;
 };
@@ -16,6 +17,7 @@ export type AttributeSelectorProps = {
 function AttributeSelector({
     attributes,
     attribute,
+    isDisabled = false,
     onChange,
     menuToggleClassName,
 }: AttributeSelectorProps) {
@@ -23,6 +25,7 @@ function AttributeSelector({
         <ToolbarItem>
             <SimpleSelect
                 menuToggleClassName={menuToggleClassName}
+                isDisabled={isDisabled}
                 value={attribute.displayName}
                 onChange={onChange}
                 ariaLabelMenu="compound search filter attribute selector menu"

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.tsx
@@ -21,6 +21,7 @@ export type CompoundSearchFilterProps = {
     config: CompoundSearchFilterConfig;
     defaultEntity?: string;
     defaultAttribute?: string;
+    isDisabled?: boolean;
     searchFilter: SearchFilter;
     additionalContextFilter?: SearchFilter;
     onSearch: OnSearchCallback;
@@ -30,6 +31,7 @@ function CompoundSearchFilter({
     config,
     defaultEntity,
     defaultAttribute = 'Name',
+    isDisabled = false,
     searchFilter,
     additionalContextFilter,
     onSearch,
@@ -46,6 +48,7 @@ function CompoundSearchFilter({
                 <EntitySelector
                     menuToggleClassName="pf-v6-u-flex-shrink-0"
                     entity={entity}
+                    isDisabled={isDisabled}
                     onChange={(value) => {
                         setSelectedEntity(ensureString(value));
                         setSelectedAttribute(undefined);
@@ -61,6 +64,7 @@ function CompoundSearchFilter({
                         menuToggleClassName="pf-v6-u-flex-shrink-0"
                         attributes={entity.attributes}
                         attribute={attribute}
+                        isDisabled={isDisabled}
                         onChange={(value) => {
                             setSelectedAttribute(ensureString(value));
                         }}
@@ -73,6 +77,7 @@ function CompoundSearchFilter({
                     key={`${entity.displayName} ${attribute.displayName}`}
                     entity={entity}
                     attribute={attribute}
+                    isDisabled={isDisabled}
                     searchFilter={searchFilter}
                     additionalContextFilter={additionalContextFilter}
                     onSearch={(payload) => {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilterInputField.tsx
@@ -18,6 +18,7 @@ import SearchFilterText from './SearchFilterText';
 export type CompoundSearchFilterInputFieldProps = {
     entity: CompoundSearchFilterEntity;
     attribute: CompoundSearchFilterAttribute;
+    isDisabled?: boolean;
     onSearch: OnSearchCallback;
     searchFilter: SearchFilter;
     additionalContextFilter?: SearchFilter;
@@ -26,6 +27,7 @@ export type CompoundSearchFilterInputFieldProps = {
 function CompoundSearchFilterInputField({
     entity,
     attribute,
+    isDisabled = false,
     onSearch,
     searchFilter,
     additionalContextFilter,
@@ -33,18 +35,43 @@ function CompoundSearchFilterInputField({
     const { inputType } = attribute;
     switch (inputType) {
         case 'text':
-            return <SearchFilterText attribute={attribute} onSearch={onSearch} />;
+            return (
+                <SearchFilterText
+                    attribute={attribute}
+                    isDisabled={isDisabled}
+                    onSearch={onSearch}
+                />
+            );
         case 'date-picker':
-            return <SearchFilterConditionDate attribute={attribute} onSearch={onSearch} />;
+            return (
+                <SearchFilterConditionDate
+                    attribute={attribute}
+                    isDisabled={isDisabled}
+                    onSearch={onSearch}
+                />
+            );
         case 'condition-number':
-            return <SearchFilterConditionNumber attribute={attribute} onSearch={onSearch} />;
+            return (
+                <SearchFilterConditionNumber
+                    attribute={attribute}
+                    isDisabled={isDisabled}
+                    onSearch={onSearch}
+                />
+            );
         case 'condition-text':
-            return <SearchFilterConditionText attribute={attribute} onSearch={onSearch} />;
+            return (
+                <SearchFilterConditionText
+                    attribute={attribute}
+                    isDisabled={isDisabled}
+                    onSearch={onSearch}
+                />
+            );
         case 'autocomplete':
             return (
                 <SearchFilterAutocompleteSelect
                     additionalContextFilter={additionalContextFilter}
                     attribute={attribute}
+                    isDisabled={isDisabled}
                     onSearch={onSearch}
                     searchCategory={entity.searchCategory}
                     searchFilter={searchFilter}
@@ -54,6 +81,7 @@ function CompoundSearchFilterInputField({
             return (
                 <SearchFilterSelectExclusiveDouble
                     attribute={attribute}
+                    isDisabled={isDisabled}
                     onSearch={onSearch}
                     searchFilter={searchFilter}
                 />
@@ -62,6 +90,7 @@ function CompoundSearchFilterInputField({
             return (
                 <SearchFilterSelectExclusiveSingle
                     attribute={attribute}
+                    isDisabled={isDisabled}
                     onSearch={onSearch}
                     searchFilter={searchFilter}
                 />
@@ -70,6 +99,7 @@ function CompoundSearchFilterInputField({
             return (
                 <SearchFilterSelectInclusive
                     attribute={attribute}
+                    isDisabled={isDisabled}
                     onSearch={onSearch}
                     searchFilter={searchFilter}
                 />

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/EntitySelector.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/EntitySelector.tsx
@@ -8,16 +8,24 @@ export type EntitySelectorOnChange = (value: string | number | undefined) => voi
 
 export type EntitySelectorProps = {
     entity: CompoundSearchFilterEntity;
+    isDisabled: boolean;
     onChange: EntitySelectorOnChange;
     config: CompoundSearchFilterConfig;
     menuToggleClassName?: string;
 };
 
-function EntitySelector({ entity, onChange, config, menuToggleClassName }: EntitySelectorProps) {
+function EntitySelector({
+    entity,
+    isDisabled = false,
+    onChange,
+    config,
+    menuToggleClassName,
+}: EntitySelectorProps) {
     return (
         <ToolbarItem>
             <SimpleSelect
                 menuToggleClassName={menuToggleClassName}
+                isDisabled={isDisabled}
                 value={entity.displayName}
                 onChange={onChange}
                 ariaLabelMenu="compound search filter entity selector menu"

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocompleteSelect.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterAutocompleteSelect.tsx
@@ -11,6 +11,7 @@ import AutocompleteSelect from './AutocompleteSelect';
 export type SearchFilterAutocompleteSelectProps = {
     additionalContextFilter?: SearchFilter;
     attribute: GenericSearchFilterAttribute;
+    isDisabled?: boolean;
     onSearch: OnSearchCallback;
     searchCategory: string;
     searchFilter: SearchFilter;
@@ -19,6 +20,7 @@ export type SearchFilterAutocompleteSelectProps = {
 function SearchFilterAutocompleteSelect({
     additionalContextFilter,
     attribute,
+    isDisabled = false,
     onSearch,
     searchCategory,
     searchFilter,
@@ -46,6 +48,7 @@ function SearchFilterAutocompleteSelect({
                     searchCategory={searchCategory}
                     searchTerm={searchTerm}
                     value={value}
+                    isDisabled={isDisabled}
                     onChange={setValue}
                     onSearch={handleSearch}
                     textLabel={textLabel}
@@ -57,6 +60,7 @@ function SearchFilterAutocompleteSelect({
                 <Button
                     variant="control"
                     aria-label="Apply autocomplete input to search"
+                    isDisabled={isDisabled}
                     onClick={() => handleSearch(value)}
                     icon={<ArrowRightIcon />}
                 />

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionDate.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionDate.tsx
@@ -30,11 +30,16 @@ function dateParse(date: string): Date {
 
 export type SearchFilterConditionDateProps = {
     attribute: GenericSearchFilterAttribute;
+    isDisabled?: boolean;
     onSearch: OnSearchCallback;
     // does not depend on searchFilter
 };
 
-function SearchFilterConditionDate({ attribute, onSearch }: SearchFilterConditionDateProps) {
+function SearchFilterConditionDate({
+    attribute,
+    isDisabled = false,
+    onSearch,
+}: SearchFilterConditionDateProps) {
     const { searchTerm: category } = attribute;
 
     const [conditionExternal, setConditionExternal] = useState(dateConditions[1]);
@@ -44,6 +49,7 @@ function SearchFilterConditionDate({ attribute, onSearch }: SearchFilterConditio
         <>
             <ToolbarItem>
                 <SimpleSelect
+                    isDisabled={isDisabled}
                     value={conditionExternal}
                     onChange={(conditionSelected) =>
                         setConditionExternal(conditionSelected as (typeof dateConditions)[number])
@@ -64,6 +70,7 @@ function SearchFilterConditionDate({ attribute, onSearch }: SearchFilterConditio
                 <DatePicker
                     aria-label="Filter by date"
                     buttonAriaLabel="Filter by date toggle"
+                    isDisabled={isDisabled}
                     value={dateString}
                     onChange={(_, datePicked) => {
                         setDateString(datePicked);

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionNumber.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionNumber.tsx
@@ -22,11 +22,16 @@ function roundToOneDecimalPlace(value: number) {
 
 export type SearchFilterConditionNumberProps = {
     attribute: GenericSearchFilterAttribute;
+    isDisabled?: boolean;
     onSearch: OnSearchCallback;
     // does not depend on searchFilter
 };
 
-function SearchFilterConditionNumber({ attribute, onSearch }: SearchFilterConditionNumberProps) {
+function SearchFilterConditionNumber({
+    attribute,
+    isDisabled = false,
+    onSearch,
+}: SearchFilterConditionNumberProps) {
     const { searchTerm: category } = attribute;
 
     const [conditionExternal, setConditionExternal] = useState(conditions[0]);
@@ -52,6 +57,7 @@ function SearchFilterConditionNumber({ attribute, onSearch }: SearchFilterCondit
         <>
             <ToolbarItem>
                 <SimpleSelect
+                    isDisabled={isDisabled}
                     value={conditionExternal}
                     onChange={(conditionSelected) =>
                         setConditionExternal(conditionSelected as (typeof conditions)[number])
@@ -71,6 +77,7 @@ function SearchFilterConditionNumber({ attribute, onSearch }: SearchFilterCondit
             <ToolbarItem>
                 <NumberInput
                     inputAriaLabel="Condition value input"
+                    isDisabled={isDisabled}
                     value={value}
                     min={minValue}
                     max={maxValue}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionText.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionText.tsx
@@ -78,11 +78,16 @@ export function convertFromInternalToExternalConditionText(
 
 export type SearchFilterConditionTextProps = {
     attribute: ConditionTextFilterAttribute;
+    isDisabled?: boolean;
     onSearch: OnSearchCallback;
     // does not depend on searchFilter
 };
 
-function SearchFilterConditionText({ attribute, onSearch }: SearchFilterConditionTextProps) {
+function SearchFilterConditionText({
+    attribute,
+    isDisabled = false,
+    onSearch,
+}: SearchFilterConditionTextProps) {
     const { inputProps, searchTerm: category } = attribute;
     const {
         conditionProps: { conditionEntries },
@@ -118,6 +123,7 @@ function SearchFilterConditionText({ attribute, onSearch }: SearchFilterConditio
             aria-label="Condition selector toggle"
             ref={toggleRef}
             onClick={onToggleClick}
+            isDisabled={isDisabled}
             isExpanded={isOpen}
         >
             {conditionSelected[1]}
@@ -148,6 +154,7 @@ function SearchFilterConditionText({ attribute, onSearch }: SearchFilterConditio
                 <TextInput
                     aria-label="Condition value input"
                     className="ConditionTextInput"
+                    isDisabled={isDisabled}
                     onChange={(event: FormEvent<HTMLInputElement>) => {
                         const { value: changedText } = event.target as HTMLInputElement;
                         setExternalText(changedText);
@@ -160,7 +167,7 @@ function SearchFilterConditionText({ attribute, onSearch }: SearchFilterConditio
                 <Button
                     icon={<ArrowRightIcon />}
                     aria-label="Apply condition and number input to search"
-                    isDisabled={!validateExternalText(externalText)}
+                    isDisabled={isDisabled || !validateExternalText(externalText)}
                     onClick={() => {
                         const internalText = convertFromExternalToInternalText(externalText);
                         onSearch([

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterSelectExclusiveDouble.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterSelectExclusiveDouble.tsx
@@ -63,6 +63,7 @@ function getLabelOfSelectedOption(
 
 export type SearchFilterSelectExclusiveDoubleProps = {
     attribute: SelectExclusiveDoubleSearchFilterAttribute;
+    isDisabled?: boolean;
     isSeparate?: boolean; // default false if within CompoundSearchFilter
     onSearch: OnSearchCallback;
     searchFilter: SearchFilter;
@@ -70,6 +71,7 @@ export type SearchFilterSelectExclusiveDoubleProps = {
 
 function SearchFilterSelectExclusiveDouble({
     attribute,
+    isDisabled = false,
     isSeparate = false,
     onSearch,
     searchFilter,
@@ -96,6 +98,7 @@ function SearchFilterSelectExclusiveDouble({
         <ToolbarItem>
             <SelectSingle
                 id={category1}
+                isDisabled={isDisabled}
                 isFullWidth={false}
                 placeholderText={placeholderText}
                 toggleAriaLabel={`${placeholderText} select menu`}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterSelectExclusiveSingle.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterSelectExclusiveSingle.tsx
@@ -9,6 +9,7 @@ import type { OnSearchCallback, SelectExclusiveSingleSearchFilterAttribute } fro
 
 export type SearchFilterSelectExclusiveSingleProps = {
     attribute: SelectExclusiveSingleSearchFilterAttribute;
+    isDisabled?: boolean;
     isSeparate?: boolean; // default false if within CompoundSearchFilter
     onSearch: OnSearchCallback;
     searchFilter: SearchFilter;
@@ -16,6 +17,7 @@ export type SearchFilterSelectExclusiveSingleProps = {
 
 function SearchFilterSelectExclusiveSingle({
     attribute,
+    isDisabled = false,
     isSeparate = false,
     onSearch,
     searchFilter,
@@ -41,6 +43,7 @@ function SearchFilterSelectExclusiveSingle({
         <ToolbarItem>
             <SelectSingle
                 id={category}
+                isDisabled={isDisabled}
                 isFullWidth={false}
                 placeholderText={placeholderText}
                 toggleAriaLabel={`${placeholderText} select menu`}

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterSelectInclusive.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterSelectInclusive.tsx
@@ -16,6 +16,7 @@ import type { OnSearchCallback, SelectSearchFilterAttribute } from '../types';
 
 export type SearchFilterSelectInclusiveProps = {
     attribute: SelectSearchFilterAttribute;
+    isDisabled?: boolean;
     isSeparate?: boolean; // default false if within CompoundSearchFilter
     onSearch: OnSearchCallback;
     searchFilter: SearchFilter;
@@ -23,6 +24,7 @@ export type SearchFilterSelectInclusiveProps = {
 
 function SearchFilterSelectInclusive({
     attribute,
+    isDisabled = false,
     isSeparate = false,
     onSearch,
     searchFilter,
@@ -79,6 +81,7 @@ function SearchFilterSelectInclusive({
     return (
         <ToolbarItem>
             <CheckboxSelect
+                isDisabled={isDisabled}
                 selection={selection}
                 onChange={(checked, _value) => {
                     onSearch([

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterText.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterText.tsx
@@ -6,11 +6,16 @@ import type { GenericSearchFilterAttribute, OnSearchCallback } from '../types';
 
 export type SearchFilterTextProps = {
     attribute: GenericSearchFilterAttribute;
+    isDisabled?: boolean;
     onSearch: OnSearchCallback;
     // does not depend on searchFilter
 };
 
-function SearchFilterText({ attribute, onSearch }: SearchFilterTextProps): ReactElement {
+function SearchFilterText({
+    attribute,
+    isDisabled = false,
+    onSearch,
+}: SearchFilterTextProps): ReactElement {
     const { filterChipLabel, searchTerm: category } = attribute;
     const textLabel = `Filter results by ${filterChipLabel}`;
 
@@ -21,6 +26,7 @@ function SearchFilterText({ attribute, onSearch }: SearchFilterTextProps): React
             <SearchInput
                 aria-label={textLabel}
                 placeholder={textLabel}
+                isDisabled={isDisabled}
                 value={value}
                 onChange={(_event, _value) => setValue(_value)}
                 onSearch={(_event, _value) => {

--- a/ui/apps/platform/src/Components/EntityScope/EntityScopeCompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/EntityScope/EntityScopeCompoundSearchFilter.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import { Flex } from '@patternfly/react-core';
+
+import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
+import CompoundSearchFilterLabels from 'Components/CompoundSearchFilter/components/CompoundSearchFilterLabels';
+import type {
+    CompoundSearchFilterConfig,
+    OnSearchPayload,
+} from 'Components/CompoundSearchFilter/types';
+import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
+import type { EntityScope, EntityScopeRule } from 'services/ReportsService.types';
+import type { SearchFilter } from 'types/search';
+
+// Why searchFilterConfig and get functions as props?
+// Because nodes have cluster but not namespace nor deployment as entities.
+// Why not formik object as prop like FiltersQuery?
+// To allow possible reuse for saved entity scope in addition to report configuration.
+export type EntityScopeCompoundSearchFilterProps = {
+    entityScope: EntityScope | null;
+    getEntityScopeRulesFromSearchFilter: (searchFilter: SearchFilter) => EntityScopeRule[];
+    getSearchFilterFromEntityScopeRules: (rules: EntityScopeRule[]) => SearchFilter;
+    searchFilterConfig: CompoundSearchFilterConfig;
+    setEntityScope: (entityScope: EntityScope) => void;
+};
+
+// Although entity scope has structured rules instead of query string,
+// interaction via compound search filter is similar for resources and filters.
+// Caller is responsible for conditional rendering if no rules.
+// For example, rules are expected for Deployed imaged but not necessarily for Watched images.
+function EntityScopeCompoundSearchFilter({
+    entityScope,
+    getEntityScopeRulesFromSearchFilter,
+    getSearchFilterFromEntityScopeRules,
+    searchFilterConfig,
+    setEntityScope,
+}: EntityScopeCompoundSearchFilterProps): ReactElement {
+    const [searchFilter, setSearchFilter] = useState<SearchFilter>(
+        entityScope ? getSearchFilterFromEntityScopeRules(entityScope.rules) : {}
+    );
+
+    function onFilterChange(searchFilterChanged: SearchFilter) {
+        const rules = getEntityScopeRulesFromSearchFilter(searchFilterChanged);
+        setEntityScope({ rules });
+        setSearchFilter(searchFilterChanged);
+    }
+
+    function onSearch(payload: OnSearchPayload) {
+        onFilterChange(updateSearchFilter(searchFilter, payload));
+    }
+
+    return (
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+            <CompoundSearchFilter
+                config={searchFilterConfig}
+                isDisabled={entityScope === null}
+                onSearch={onSearch}
+                searchFilter={searchFilter}
+            />
+            {entityScope && (
+                <CompoundSearchFilterLabels
+                    attributesSeparateFromConfig={[]}
+                    config={searchFilterConfig}
+                    onFilterChange={onFilterChange}
+                    searchFilter={searchFilter}
+                />
+            )}
+        </Flex>
+    );
+}
+
+export default EntityScopeCompoundSearchFilter;

--- a/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
+++ b/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
@@ -96,22 +96,6 @@ const searchFieldLabelMapForClusterNamespaceDeployment: Record<
     EntityScopeRuleWithoutValues
 > = {
     ...searchFieldLabelMapForClusterNamespace,
-    'Namespace ID': {
-        entity: 'SCOPE_ENTITY_NAMESPACE',
-        field: 'FIELD_ID',
-    },
-    Namespace: {
-        entity: 'SCOPE_ENTITY_NAMESPACE',
-        field: 'FIELD_NAME',
-    },
-    'Namespace Label': {
-        entity: 'SCOPE_ENTITY_NAMESPACE',
-        field: 'FIELD_LABEL',
-    },
-    'Namespace Annotation': {
-        entity: 'SCOPE_ENTITY_NAMESPACE',
-        field: 'FIELD_ANNOTATION',
-    },
     'Deployment ID': {
         entity: 'SCOPE_ENTITY_DEPLOYMENT',
         field: 'FIELD_ID',

--- a/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
+++ b/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
@@ -10,6 +10,7 @@ import {
     getValueByCaseInsensitiveKey,
     isQuotedString,
     searchValueAsArray,
+    wrapInQuotes,
 } from 'utils/searchUtils';
 
 type EntityScopeSearchFieldLabelForCluster = Extract<
@@ -17,7 +18,18 @@ type EntityScopeSearchFieldLabelForCluster = Extract<
     'Cluster ID' | 'Cluster' | 'Cluster Label'
 >;
 
-type EntityScopeSearchFieldLabelForWorkload = Extract<
+type EntityScopeSearchFieldLabelForClusterNamespace = Extract<
+    SearchFieldLabel,
+    | 'Cluster ID'
+    | 'Cluster'
+    | 'Cluster Label'
+    | 'Namespace ID'
+    | 'Namespace'
+    | 'Namespace Label'
+    | 'Namespace Annotation'
+>;
+
+type EntityScopeSearchFieldLabelForClusterNamespaceDeployment = Extract<
     SearchFieldLabel,
     | 'Cluster ID'
     | 'Cluster'
@@ -56,11 +68,34 @@ const searchFieldLabelMapForCluster: Record<
     // 'Cluster Annotation' is not a search filter
 } as const;
 
-const searchFieldLabelMapForWorkload: Record<
-    EntityScopeSearchFieldLabelForWorkload,
+const searchFieldLabelMapForClusterNamespace: Record<
+    EntityScopeSearchFieldLabelForClusterNamespace,
     EntityScopeRuleWithoutValues
 > = {
     ...searchFieldLabelMapForCluster,
+    'Namespace ID': {
+        entity: 'SCOPE_ENTITY_NAMESPACE',
+        field: 'FIELD_ID',
+    },
+    Namespace: {
+        entity: 'SCOPE_ENTITY_NAMESPACE',
+        field: 'FIELD_NAME',
+    },
+    'Namespace Label': {
+        entity: 'SCOPE_ENTITY_NAMESPACE',
+        field: 'FIELD_LABEL',
+    },
+    'Namespace Annotation': {
+        entity: 'SCOPE_ENTITY_NAMESPACE',
+        field: 'FIELD_ANNOTATION',
+    },
+} as const;
+
+const searchFieldLabelMapForClusterNamespaceDeployment: Record<
+    EntityScopeSearchFieldLabelForClusterNamespaceDeployment,
+    EntityScopeRuleWithoutValues
+> = {
+    ...searchFieldLabelMapForClusterNamespace,
     'Namespace ID': {
         entity: 'SCOPE_ENTITY_NAMESPACE',
         field: 'FIELD_ID',
@@ -128,6 +163,35 @@ function getEntityScopeRulesFromSearchFilter(
     return rules;
 }
 
+export const ruleFieldValueMapper = ({ matchType, value }: RuleValue): string =>
+    matchType === 'EXACT' ? wrapInQuotes(value) : `r/${value}`;
+
+/**
+ * Return search filter in EntityScopeCompoundSearchFilter component.
+ */
+function getSearchFilterFromEntityScopeRules(
+    rules: EntityScopeRule[],
+    searchFieldLabelMap: Record<string, EntityScopeRuleWithoutValues>
+) {
+    const searchFilter: SearchFilter = {};
+
+    rules.forEach((rule) => {
+        const found = Object.entries(searchFieldLabelMap).find(
+            ([, { entity, field }]) => entity === rule.entity && field === rule.field
+        );
+
+        if (found) {
+            const [searchFieldLabel] = found;
+            const searchFilterValue = getValueByCaseInsensitiveKey(searchFilter, searchFieldLabel);
+            const searchFilterValues = searchValueAsArray(searchFilterValue);
+            const ruleValues = rule.values.map(ruleFieldValueMapper);
+            searchFilter[searchFieldLabel] = [...searchFilterValues, ...ruleValues];
+        }
+    });
+
+    return searchFilter;
+}
+
 /**
  * Return initial entity scope rules for corresponding search fields
  * when user creates node vulnerability report configuration from results page.
@@ -136,10 +200,43 @@ export function getEntityScopeRulesFromSearchFilterForCluster(searchFilter: Sear
     return getEntityScopeRulesFromSearchFilter(searchFilter, searchFieldLabelMapForCluster);
 }
 
+export function getSearchFilterFromEntityScopeRulesForCluster(rules: EntityScopeRule[]) {
+    return getSearchFilterFromEntityScopeRules(rules, searchFieldLabelMapForCluster);
+}
+
+/**
+ * Return initial entity scope rules for corresponding search fields
+ * when user creates either virtual machine vulnerability report configuration from results page.
+ */
+export function getEntityScopeRulesFromSearchFilterForClusterNamespace(searchFilter: SearchFilter) {
+    return getEntityScopeRulesFromSearchFilter(
+        searchFilter,
+        searchFieldLabelMapForClusterNamespace
+    );
+}
+
+export function getSearchFilterFromEntityScopeRulesForClusterNamespace(rules: EntityScopeRule[]) {
+    return getSearchFilterFromEntityScopeRules(rules, searchFieldLabelMapForClusterNamespace);
+}
+
 /**
  * Return initial entity scope rules for corresponding search fields
  * when user creates either violation or image vulnerability report configuration from results page.
  */
-export function getEntityScopeRulesFromSearchFilterForWorkload(searchFilter: SearchFilter) {
-    return getEntityScopeRulesFromSearchFilter(searchFilter, searchFieldLabelMapForWorkload);
+export function getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment(
+    searchFilter: SearchFilter
+) {
+    return getEntityScopeRulesFromSearchFilter(
+        searchFilter,
+        searchFieldLabelMapForClusterNamespaceDeployment
+    );
+}
+
+export function getSearchFilterFromEntityScopeRulesForClusterNamespaceDeployment(
+    rules: EntityScopeRule[]
+) {
+    return getSearchFilterFromEntityScopeRules(
+        rules,
+        searchFieldLabelMapForClusterNamespaceDeployment
+    );
 }

--- a/ui/apps/platform/src/Components/EntityScope/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Components/EntityScope/searchFilterConfig.ts
@@ -1,0 +1,67 @@
+import {
+    clusterIdAttribute,
+    clusterLabelAttribute,
+    clusterNameAttribute,
+} from 'Components/CompoundSearchFilter/attributes/cluster';
+import {
+    Annotation as deploymentAnnotationAttribute,
+    ID as deploymentIdAttribute,
+    Label as deploymentLabelAttribute,
+    Name as deploymentNameAttribute,
+} from 'Components/CompoundSearchFilter/attributes/deployment';
+import {
+    Annotation as namespaceAnnotationAttribute,
+    ID as namespaceIdAttribute,
+    Label as namespaceLabelAttribute,
+    Name as namespaceNameAttribute,
+} from 'Components/CompoundSearchFilter/attributes/namespace';
+import type { CompoundSearchFilterEntity } from 'Components/CompoundSearchFilter/types';
+
+const searchFilterEntityForCluster: CompoundSearchFilterEntity = {
+    displayName: 'Cluster',
+    searchCategory: 'CLUSTERS',
+    attributes: [
+        // 'Cluster Annotation' is not a search filter
+        clusterIdAttribute,
+        clusterLabelAttribute,
+        clusterNameAttribute,
+    ],
+};
+
+const searchFilterEntityForDeployment: CompoundSearchFilterEntity = {
+    displayName: 'Deployment',
+    searchCategory: 'DEPLOYMENTS',
+    attributes: [
+        deploymentAnnotationAttribute,
+        deploymentIdAttribute,
+        deploymentLabelAttribute,
+        deploymentNameAttribute,
+    ],
+};
+
+const searchFilterEntityForNamespace: CompoundSearchFilterEntity = {
+    displayName: 'Namespace',
+    searchCategory: 'NAMESPACES',
+    attributes: [
+        namespaceAnnotationAttribute,
+        namespaceIdAttribute,
+        namespaceLabelAttribute,
+        namespaceNameAttribute,
+    ],
+};
+
+// Node vulnerability report configuration.
+export const searchFilterConfigForCluster = [searchFilterEntityForCluster];
+
+// Virtual machine vulnerability report configuration.
+export const searchFilterConfigForClusterNamespace = [
+    searchFilterEntityForCluster,
+    searchFilterEntityForNamespace,
+];
+
+// Image vulnerability and violation report configuration.
+export const searchFilterConfigForClusterNamespaceDeployment = [
+    searchFilterEntityForCluster,
+    searchFilterEntityForDeployment,
+    searchFilterEntityForNamespace,
+];

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/CollectionScopeSelect.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/CollectionScopeSelect.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react';
+import { Alert, SelectOption } from '@patternfly/react-core';
+
+import SelectSingle from 'Components/SelectSingle';
+import useRestQuery from 'hooks/useRestQuery';
+import { listCollections } from 'services/CollectionsService';
+import type { CollectionScope } from 'services/ReportsService.types';
+import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
+
+function listCollectionsSorted() {
+    return listCollections({}, { field: 'Collection Name', reversed: false });
+}
+
+export type CollectionScopeSelectProps = {
+    collectionScope: CollectionScope | null;
+    setCollectionScope: (collectionScope: CollectionScope) => void;
+};
+
+function CollectionScopeSelect({
+    collectionScope,
+    setCollectionScope,
+}: CollectionScopeSelectProps): ReactElement {
+    const { data: collections, error } = useRestQuery(listCollectionsSorted);
+
+    if (error) {
+        return (
+            <Alert variant="danger" title="Unable to fetch collections" isInline component="p">
+                {getAxiosErrorMessage(error)}
+            </Alert>
+        );
+    }
+
+    function handleSelect(_id, collectionId: string) {
+        const collection = collections?.find((collection) => collection.id === collectionId);
+        if (collection) {
+            setCollectionScope({ collectionId, collectionName: collection.name });
+        }
+    }
+
+    return (
+        <SelectSingle
+            id="collectionScope"
+            isDisabled={!collectionScope}
+            placeholderText="Collection name"
+            toggleAriaLabel={'Collection select menu'}
+            value={collectionScope?.collectionId ?? ''}
+            handleSelect={handleSelect}
+        >
+            {(collections ?? []).map(({ id, name }) => (
+                <SelectOption key={id} value={id}>
+                    {name}
+                </SelectOption>
+            ))}
+        </SelectSingle>
+    );
+}
+
+export default CollectionScopeSelect;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageTypeSelect.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageTypeSelect.tsx
@@ -3,6 +3,7 @@ import { SelectOption } from '@patternfly/react-core';
 
 import CheckboxSelect from 'Components/CheckboxSelect';
 import type { ImageType } from 'services/ReportsService.types';
+import { toggleItemInArray } from 'utils/arrayUtils';
 
 import { imageTypeLabelMap } from '../../imageVulnerabilityReports.utils';
 
@@ -13,11 +14,7 @@ export type ImageTypeSelectProps = {
 
 function ImageTypeSelect({ imageTypes, setImageTypes }: ImageTypeSelectProps): ReactElement {
     function onChange(_, value) {
-        setImageTypes(
-            imageTypes.includes(value)
-                ? imageTypes.filter((imageType) => imageType !== value)
-                : [...imageTypes, value]
-        );
+        setImageTypes(toggleItemInArray(imageTypes, value));
     }
 
     return (

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageTypeSelect.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageTypeSelect.tsx
@@ -1,0 +1,34 @@
+import type { ReactElement } from 'react';
+import { SelectOption } from '@patternfly/react-core';
+
+import CheckboxSelect from 'Components/CheckboxSelect';
+import type { ImageType } from 'services/ReportsService.types';
+
+import { imageTypeLabelMap } from '../../imageVulnerabilityReports.utils';
+
+export type ImageTypeSelectProps = {
+    imageTypes: ImageType[];
+    setImageTypes: (imageTypes: ImageType[]) => void;
+};
+
+function ImageTypeSelect({ imageTypes, setImageTypes }: ImageTypeSelectProps): ReactElement {
+    function onChange(_, value) {
+        setImageTypes(
+            imageTypes.includes(value)
+                ? imageTypes.filter((imageType) => imageType !== value)
+                : [...imageTypes, value]
+        );
+    }
+
+    return (
+        <CheckboxSelect onChange={onChange} selection={imageTypes} toggleLabel="Image type">
+            {Object.entries(imageTypeLabelMap).map(([value, text]) => (
+                <SelectOption key={value} value={value}>
+                    {text}
+                </SelectOption>
+            ))}
+        </CheckboxSelect>
+    );
+}
+
+export default ImageTypeSelect;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
@@ -1,10 +1,21 @@
+import { useState } from 'react';
 import type { ReactElement } from 'react';
-import { Flex, Form, PageSection, Title } from '@patternfly/react-core';
+import { Flex, Form, FormGroup, PageSection, Radio, Title } from '@patternfly/react-core';
 import type { FormikProps } from 'formik';
 
+import EntityScopeCompoundSearchFilter from 'Components/EntityScope/EntityScopeCompoundSearchFilter';
+import {
+    getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment,
+    getSearchFilterFromEntityScopeRulesForClusterNamespaceDeployment,
+} from 'Components/EntityScope/entityScopeRules';
+import { searchFilterConfigForClusterNamespaceDeployment } from 'Components/EntityScope/searchFilterConfig';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import type { CollectionScope, EntityScope, ImageType } from 'services/ReportsService.types';
 
 import type { ImageVulnerabilityResourcesConfiguration } from '../../imageVulnerabilityReports.types';
+
+import CollectionScopeSelect from './CollectionScopeSelect';
+import ImageTypeSelect from './ImageTypeSelect';
 
 export type ImageVulnerabilityResourcesStepProps<
     T extends ImageVulnerabilityResourcesConfiguration = ImageVulnerabilityResourcesConfiguration,
@@ -15,21 +26,117 @@ export type ImageVulnerabilityResourcesStepProps<
 function ImageVulnerabilityResourcesStep<
     T extends ImageVulnerabilityResourcesConfiguration = ImageVulnerabilityResourcesConfiguration,
 >({ formik }: ImageVulnerabilityResourcesStepProps<T>): ReactElement {
+    const [collectionScopeSelected, setCollectionScopeSelected] = useState<CollectionScope>(
+        'collectionScope' in formik.values.resourceScope
+            ? formik.values.resourceScope.collectionScope
+            : { collectionId: '', collectionName: '' }
+    );
+    const [entityScopeSelected, setEntityScopeSelected] = useState<EntityScope>(
+        'entityScope' in formik.values.resourceScope
+            ? formik.values.resourceScope.entityScope
+            : { rules: [] }
+    );
+
+    function setImageTypes(imageTypes: ImageType[]) {
+        formik.setFieldValue('vulnReportFilters.imageTypes', imageTypes);
+    }
+
+    function onChangeToCollectionScope() {
+        // Set resourceScope to remove entityScope property.
+        formik.setFieldValue('resourceScope', { collectionScope: collectionScopeSelected });
+    }
+
+    function setCollectionScope(collectionScope: CollectionScope) {
+        setCollectionScopeSelected(collectionScope);
+        formik.setFieldValue('resourceScope.collectionScope', collectionScope);
+    }
+
+    function onChangeToEntityScope() {
+        // Set resourceScope to remove collectionScope property.
+        formik.setFieldValue('resourceScope', { entityScope: entityScopeSelected });
+    }
+
+    function setEntityScope(entityScope: EntityScope) {
+        setEntityScopeSelected(entityScope);
+        formik.setFieldValue('resourceScope.entityScope', entityScope);
+    }
+
+    const isResourceScopeRequired = formik.values.vulnReportFilters.imageTypes.includes('DEPLOYED');
+
     return (
         <PageSection>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Resources</Title>
-                <Form>
+                <Form isWidthLimited>
                     <FormLabelGroup
                         label="Image type"
                         isRequired
                         fieldId="vulnReportFilters.imageTypes"
                         errors={formik.errors}
                     >
-                        <>{JSON.stringify(formik.values.vulnReportFilters.imageTypes, null, 0)}</>
+                        <ImageTypeSelect
+                            imageTypes={formik.values.vulnReportFilters.imageTypes}
+                            setImageTypes={setImageTypes}
+                        />
                     </FormLabelGroup>
+                    <FormGroup
+                        label="Resource scope (required for deployed images)"
+                        isRequired={isResourceScopeRequired}
+                    >
+                        <Flex
+                            direction={{ default: 'column' }}
+                            spaceItems={{ default: 'spaceItemsLg' }}
+                        >
+                            <Radio
+                                id="collectionScope"
+                                isChecked={
+                                    'collectionScope' in formik.values.resourceScope &&
+                                    !('entityScope' in formik.values.resourceScope)
+                                }
+                                label="Collection scope"
+                                name="collectionScope"
+                                onChange={onChangeToCollectionScope}
+                                body={
+                                    <CollectionScopeSelect
+                                        collectionScope={
+                                            'collectionScope' in formik.values.resourceScope &&
+                                            !('entityScope' in formik.values.resourceScope)
+                                                ? formik.values.resourceScope.collectionScope
+                                                : null // disable select element
+                                        }
+                                        setCollectionScope={setCollectionScope}
+                                    />
+                                }
+                            />
+                            <Radio
+                                id="entityScope"
+                                isChecked={'entityScope' in formik.values.resourceScope}
+                                label="Custom scope"
+                                name="entityScope"
+                                onChange={onChangeToEntityScope}
+                                body={
+                                    <EntityScopeCompoundSearchFilter
+                                        entityScope={
+                                            'entityScope' in formik.values.resourceScope
+                                                ? formik.values.resourceScope.entityScope
+                                                : null // disable compound search filter
+                                        }
+                                        getEntityScopeRulesFromSearchFilter={
+                                            getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment
+                                        }
+                                        getSearchFilterFromEntityScopeRules={
+                                            getSearchFilterFromEntityScopeRulesForClusterNamespaceDeployment
+                                        }
+                                        searchFilterConfig={
+                                            searchFilterConfigForClusterNamespaceDeployment
+                                        }
+                                        setEntityScope={setEntityScope}
+                                    />
+                                }
+                            />
+                        </Flex>
+                    </FormGroup>
                 </Form>
-                {/* TODO resourceScope */}
             </Flex>
         </PageSection>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step5/ImageVulnerabilityReviewStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step5/ImageVulnerabilityReviewStep.tsx
@@ -8,22 +8,32 @@ import type {
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 
 import type { ImageVulnerabilityReportConfiguration } from '../../imageVulnerabilityReports.types';
+import ImageVulnerabilityReportView from '../../View/ImageVulnerabilityReportView';
 
-/* eslint-disable react/no-unused-prop-types */
 export type ImageVulnerabilityReviewStepProps = {
     attributesSeparateFromConfig: SelectSearchFilterAttribute[];
     error: Error | null;
     searchFilterConfig: CompoundSearchFilterConfig;
     values: ImageVulnerabilityReportConfiguration;
 };
-/* eslint-enable react/no-unused-prop-types */
 
-function ImageVulnerabilityReviewStep({ error }: ImageVulnerabilityReviewStepProps): ReactElement {
+function ImageVulnerabilityReviewStep({
+    attributesSeparateFromConfig,
+    error,
+    searchFilterConfig,
+    values,
+}: ImageVulnerabilityReviewStepProps): ReactElement {
     return (
         <PageSection>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Review</Title>
-                {/* ImageVulnerabilityReportView */}
+                <ImageVulnerabilityReportView
+                    attributesSeparateFromConfig={attributesSeparateFromConfig}
+                    headingLevel="h3"
+                    horizontalTermWidthModifier={{ default: '24ch' }}
+                    searchFilterConfig={searchFilterConfig}
+                    values={values}
+                />
                 {error && (
                     <Alert
                         variant="danger"


### PR DESCRIPTION
## Description

### Objective

Provide equivalent filter for scheduled reports as view-based reports

### Analysis

1. As a potential alternative, I considered auth provider **Rules**:

    * Key
    * Value
    * Role

2. Seeing 3 fields rememinded me to use compound search filter for both **Resources** and **Filters**

    With appropriate configuration:

    Resources: `searchFilterConfigForClusterNamespaceDeployment`
    Filters: `searchFilterConfigForImageVulnerabilityReport` already exists

    With pure functions so that `resourceScope.entityScope.rules` is source of truth, although reusable elements have `searchFilter` prop.

    * `getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment` already exists
    * `getSearchFilterFromEntityScopeRulesForClusterNamespaceDeployment` 

3. Although the round-trip conversion seems to work for **Name** field with either exact or regex match, key-value for annotation and label deserves closer investigation and unit tests. See **Residue** item 1.

### Solution

1. Add ImageTypeSelect.tsx files because form element was inline.

2. Add CollectionScopeSelect.tsx file because CollectionSelection.tsx

    * Does not support payload/response types (too bad, so sad).
    * Does support integration to create collection, which we can omit.

3. Edit entityScopeRules.ts file.

    * Support cluster and namespace for future virtual machine vulnerability report.
    * Add `getSearchFilterFromEntityScopeRules` function.

4. Add searchFilterConfig.ts file.

    Because **Cluster** has additional attributes in results that do not correspond to entity scope,
    specify relevant attributes only to prevent irrelevant attributes from leaking in from results.

5. Add EntityScopeCompoundSearchFilter.tsx file.

    Generic component receives which entites of cluster, namespace, deployment via props.

6. Edit ImageVulnerabilityResourcesStep.tsx file.

    * Render radio buttons for **Collection scope** and **Entity scope**
    * Enable or disable `CollectionScopeSelect` element
    * Enable or disable `EntityScopeCompoundSearchFilter` elements
        Apologies for so many secondary changes to add `isDisabled` prop.

7. Edit ImageVulnerabilitiesReviewStep file.

    * Render `ImageVulnerabilitiesReportView` element for consistency with future view page.

### Residue

1. Although the round-trip conversion seems to work for **Name** field with either exact or regex match, key-value for annotation and label deserves closer investigation and unit tests. See **Analysis** item 2.

    **David** might advise how to either reuse or add to searchUtils.ts file

2. Get wording for absence of resources or filters and decide how to display.

    Although collection scope is required even for **Watched images** only, it seems required for entity scope if **Deployed images** is selected, but not if **Watched images only** is selected.

    * `Alert` element in view
    * Form helper text from validation errors? Or `Alert` element?

3. To reduce changed files, and because **Filters** step is in review, follow up with option to hide **Clear filters** link in compound search filter labels.

4. Form validation! **Brad** might help,

5. Add file to render view or wizard when `ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING` ia enabled.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the functionality is gated by a feature flag
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

Temporary edit ViewVulnReportPage.tsx files to render **wizard** for report configuration.

1. Visit /main/vulnerabilities/reports/configuration click a link, and then advance to **Resources** step.

    Collection scope is existing report configuration
    <img width="1440" height="892" alt="CollectionScopeSelect_initial" src="https://github.com/user-attachments/assets/ad01dc5d-19b9-4356-88ed-b343a37ef3e9" />

2. Select a different collection
    <img width="1440" height="892" alt="CollectionScopeSelect_changed" src="https://github.com/user-attachments/assets/33ba0ae0-ad61-46ca-abf3-7e3676698d8d" />

3. Advance to **Review** step.
    <img width="1440" height="892" alt="CollectionScopeSelect_Review" src="https://github.com/user-attachments/assets/faadee82-36d8-4016-ad28-3a0317886fb0" />

4. Go back to **Resources** step and select **Custom scope**.

    Although I deleted the code, pending **Residue** item 2, here is what a warning `Alert` element might look like.
    <img width="1440" height="892" alt="EntityScope_Alert" src="https://github.com/user-attachments/assets/2551ad23-a974-432d-8d2a-f4b2af5dceca" />

5. Select **Cluster name** and **Namespace name** exact and **Deployment name** not exact.
    <img width="1440" height="892" alt="EntityScope_Name" src="https://github.com/user-attachments/assets/7b276263-29e4-4c7d-a964-36085a0515dc" />

6. Advance to **Review** step.
    <img width="1440" height="892" alt="EntityScope_Review" src="https://github.com/user-attachments/assets/6745a290-7bff-48e6-b8ee-ce99ae248d39" />

7. On **Resources** step

    * Test memory of collection or entity scope when I click ration buttons.
    * Test conditional rendering of required asterisk when I select or clear **Deployed images**.
    * After much `console.log` understand that advance to **Review** step and then return to **Resources** step loses its memory of the other scope selection because it was in component instance state (duh).
