### PR TITLE
perf(ci): remove container from pre-build-go-binaries (~59s saved)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -257,11 +257,6 @@ jobs:
       matrix: ${{ fromJson(needs.define-job-matrix.outputs.matrix).pre_build_go_binaries }}
     needs: define-job-matrix
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
-      volumes:
-        - /usr:/mnt/usr
-        - /opt:/mnt/opt
     env:
       BUILD_TAG: ${{ needs.define-job-matrix.outputs.build-tag }}
       SHORTCOMMIT: ${{ needs.define-job-matrix.outputs.short-commit }}


### PR DESCRIPTION
## Description

Remove the apollo-ci container from `pre-build-go-binaries` jobs in `build.yaml`. Run directly on ubuntu-latest.

Based on #20306 (simplified Go version tracking).

Go automatically downloads the needed toolchain version via `GOTOOLCHAIN=auto`. No C dependencies are needed (the codebase has zero `import "C"` — non-amd64 already builds with `CGO_ENABLED=0`).

**Saves ~59s container init** on the critical path to image push. `pre-build-go-binaries` is the bottleneck job (~326s) that blocks `build-and-push-main`.

### Expected timing

| | Before | After |
|--|--------|-------|
| Container init | 59s | 0s |
| Go compile | 166s | ~166s |
| Total | ~326s | ~267s |

## Testing

CI will validate that Go binaries compile correctly without the container.