### PR TITLE
ROX-29509: Reload TLS certificates in central-db and scanner-v4-db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ style: golangci-lint style-slim
 .PHONY: style-slim
 style-slim: \
 	blanks \
+	check-cert-watcher-sync \
 	check-service-protos \
 	github-actions-pin-check \
 	newlines \
@@ -262,6 +263,12 @@ fast-migrator-build: migrator-build-nodeps
 migrator-build-nodeps:
 	@echo "+ $@"
 	$(GOBUILD) migrator
+
+.PHONY: check-cert-watcher-sync
+check-cert-watcher-sync:
+	@echo "+ $@"
+	@diff image/postgres/scripts/cert-watcher.sh scanner/image/db/scripts/cert-watcher.sh \
+		|| (echo "ERROR: cert-watcher.sh files are out of sync" && exit 1)
 
 .PHONY: check-service-protos
 check-service-protos:

--- a/image/postgres/scripts/cert-watcher.sh
+++ b/image/postgres/scripts/cert-watcher.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+CERT_DIR="${ROX_CERT_DIR:-/run/secrets/stackrox.io/certs}"
+PGDATA="${PGDATA:-/var/lib/postgresql/data/pgdata}"
+POLL_INTERVAL="${ROX_CERT_POLL_INTERVAL:-5}"
+
+echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}s)"
+
+HASH=""
+while true; do
+    sleep "$POLL_INTERVAL"
+    NEW_HASH=$(md5sum "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null | md5sum | awk '{print $1}')
+    if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" != "$HASH" ]; then
+        if [ -n "$HASH" ]; then
+            echo "cert-watcher: TLS certificates changed, reloading PostgreSQL"
+            if ! pg_ctl reload -D "$PGDATA"; then
+                echo "cert-watcher: pg_ctl reload failed, will retry on next change"
+            fi
+        fi
+        HASH="$NEW_HASH"
+    fi
+done

--- a/image/postgres/scripts/cert-watcher.sh
+++ b/image/postgres/scripts/cert-watcher.sh
@@ -3,14 +3,14 @@ set -uo pipefail
 
 CERT_DIR="${ROX_CERT_DIR:-/run/secrets/stackrox.io/certs}"
 PGDATA="${PGDATA:-/var/lib/postgresql/data/pgdata}"
-POLL_INTERVAL="${ROX_CERT_POLL_INTERVAL:-5}"
+POLL_INTERVAL="${ROX_CERT_POLL_INTERVAL:-5s}"
 
 if ! command -v pg_ctl &>/dev/null; then
     echo "cert-watcher: ERROR: pg_ctl not found, certificate reload will not work"
     sleep infinity
 fi
 
-echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}s)"
+echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL})"
 
 HASH=""
 while true; do

--- a/image/postgres/scripts/cert-watcher.sh
+++ b/image/postgres/scripts/cert-watcher.sh
@@ -6,7 +6,8 @@ PGDATA="${PGDATA:-/var/lib/postgresql/data/pgdata}"
 POLL_INTERVAL="${ROX_CERT_POLL_INTERVAL:-5}"
 
 if ! command -v pg_ctl &>/dev/null; then
-    echo "cert-watcher: WARNING: pg_ctl not found, certificate reload will not work"
+    echo "cert-watcher: ERROR: pg_ctl not found, certificate reload will not work"
+    sleep infinity
 fi
 
 echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}s)"

--- a/image/postgres/scripts/cert-watcher.sh
+++ b/image/postgres/scripts/cert-watcher.sh
@@ -5,6 +5,10 @@ CERT_DIR="${ROX_CERT_DIR:-/run/secrets/stackrox.io/certs}"
 PGDATA="${PGDATA:-/var/lib/postgresql/data/pgdata}"
 POLL_INTERVAL="${ROX_CERT_POLL_INTERVAL:-5}"
 
+if ! command -v pg_ctl &>/dev/null; then
+    echo "cert-watcher: WARNING: pg_ctl not found, certificate reload will not work"
+fi
+
 echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}s)"
 
 HASH=""
@@ -15,7 +19,7 @@ while true; do
         if [ -n "$HASH" ]; then
             echo "cert-watcher: TLS certificates changed, reloading PostgreSQL"
             if ! pg_ctl reload -D "$PGDATA"; then
-                echo "cert-watcher: pg_ctl reload failed, will retry on next change"
+                echo "cert-watcher: pg_ctl reload failed"
             fi
         fi
         HASH="$NEW_HASH"

--- a/image/postgres/scripts/cert-watcher.sh
+++ b/image/postgres/scripts/cert-watcher.sh
@@ -14,7 +14,7 @@ echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}
 
 HASH=""
 while true; do
-    NEW_HASH=$(md5sum "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null | md5sum | awk '{print $1}')
+    NEW_HASH=$(cat "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null | md5sum | awk '{print $1}')
     if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" != "$HASH" ]; then
         if [ -n "$HASH" ]; then
             echo "cert-watcher: TLS certificates changed, reloading PostgreSQL"

--- a/image/postgres/scripts/cert-watcher.sh
+++ b/image/postgres/scripts/cert-watcher.sh
@@ -19,7 +19,8 @@ while true; do
         if [ -n "$HASH" ]; then
             echo "cert-watcher: TLS certificates changed, reloading PostgreSQL"
             if ! pg_ctl reload -D "$PGDATA"; then
-                echo "cert-watcher: pg_ctl reload failed"
+                echo "cert-watcher: pg_ctl reload failed, will retry"
+                continue
             fi
         fi
         HASH="$NEW_HASH"

--- a/image/postgres/scripts/cert-watcher.sh
+++ b/image/postgres/scripts/cert-watcher.sh
@@ -5,21 +5,24 @@ CERT_DIR="${ROX_CERT_DIR:-/run/secrets/stackrox.io/certs}"
 PGDATA="${PGDATA:-/var/lib/postgresql/data/pgdata}"
 POLL_INTERVAL="${ROX_CERT_POLL_INTERVAL:-5s}"
 
+# Timestamp format matches PostgreSQL.
+log() { echo "$(date -u '+%Y-%m-%d %H:%M:%S.%3N UTC') cert-watcher: $*"; }
+
 if ! command -v pg_ctl &>/dev/null; then
-    echo "cert-watcher: ERROR: pg_ctl not found, certificate reload will not work"
+    log "ERROR: pg_ctl not found, certificate reload will not work"
     sleep infinity
 fi
 
-echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}, pgdata: ${PGDATA})"
+log "watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}, pgdata: ${PGDATA})"
 
 HASH=""
 while true; do
     NEW_HASH=$(cat "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null | md5sum | awk '{print $1}')
     if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" != "$HASH" ]; then
         if [ -n "$HASH" ]; then
-            echo "cert-watcher: TLS certificates changed, reloading PostgreSQL"
+            log "TLS certificates changed, reloading PostgreSQL"
             if ! pg_ctl reload -D "$PGDATA"; then
-                echo "cert-watcher: pg_ctl reload failed, will retry"
+                log "pg_ctl reload failed, will retry"
                 continue
             fi
         fi

--- a/image/postgres/scripts/cert-watcher.sh
+++ b/image/postgres/scripts/cert-watcher.sh
@@ -13,18 +13,22 @@ if ! command -v pg_ctl &>/dev/null; then
     sleep infinity
 fi
 
+log "waiting for PostgreSQL to start..."
+while ! pg_ctl status -D "$PGDATA" >/dev/null 2>&1; do sleep 1s; done
+
 log "watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}, pgdata: ${PGDATA})"
 
+# HASH starts empty so the first iteration always triggers a reload. This is
+# harmless (postgres re-reads the same certs) and eliminates any race between
+# postgres startup and secret volume updates.
 HASH=""
 while true; do
     NEW_HASH=$(cat "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null | md5sum | awk '{print $1}')
     if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" != "$HASH" ]; then
-        if [ -n "$HASH" ]; then
-            log "TLS certificates changed, reloading PostgreSQL"
-            if ! pg_ctl reload -D "$PGDATA"; then
-                log "pg_ctl reload failed, will retry"
-                continue
-            fi
+        log "TLS certificates changed, reloading PostgreSQL"
+        if ! pg_ctl reload -D "$PGDATA"; then
+            log "pg_ctl reload failed, will retry"
+            continue
         fi
         HASH="$NEW_HASH"
     fi

--- a/image/postgres/scripts/cert-watcher.sh
+++ b/image/postgres/scripts/cert-watcher.sh
@@ -10,7 +10,7 @@ if ! command -v pg_ctl &>/dev/null; then
     sleep infinity
 fi
 
-echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL})"
+echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}, pgdata: ${PGDATA})"
 
 HASH=""
 while true; do

--- a/image/postgres/scripts/cert-watcher.sh
+++ b/image/postgres/scripts/cert-watcher.sh
@@ -14,7 +14,6 @@ echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}
 
 HASH=""
 while true; do
-    sleep "$POLL_INTERVAL"
     NEW_HASH=$(md5sum "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null | md5sum | awk '{print $1}')
     if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" != "$HASH" ]; then
         if [ -n "$HASH" ]; then
@@ -25,4 +24,5 @@ while true; do
         fi
         HASH="$NEW_HASH"
     fi
+    sleep "$POLL_INTERVAL"
 done

--- a/image/postgres/scripts/docker-entrypoint.sh
+++ b/image/postgres/scripts/docker-entrypoint.sh
@@ -370,6 +370,23 @@ _main() {
 		set -- "$@" -c "ssl_ciphers=${ROX_TLS_OPENSSL_CIPHERS}"
 	fi
 
+	# Watch for TLS certificate changes and reload PostgreSQL when detected.
+	(
+		CERT_DIR="/run/secrets/stackrox.io/certs"
+		MTIME=""
+		while true; do
+			sleep 60
+			NEW_MTIME=$(stat -c '%Y' "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null)
+			if [ -n "$NEW_MTIME" ] && [ "$NEW_MTIME" != "$MTIME" ]; then
+				if [ -n "$MTIME" ]; then
+					echo "TLS certificates changed, reloading PostgreSQL"
+					pg_ctl reload -D "$PGDATA"
+				fi
+				MTIME="$NEW_MTIME"
+			fi
+		done
+	) &
+
 	flock /var/lib/postgresql/data/pglock "$@" &
 	child=$!
 	echo "Waiting for child process $child to exit"

--- a/image/postgres/scripts/docker-entrypoint.sh
+++ b/image/postgres/scripts/docker-entrypoint.sh
@@ -370,23 +370,6 @@ _main() {
 		set -- "$@" -c "ssl_ciphers=${ROX_TLS_OPENSSL_CIPHERS}"
 	fi
 
-	# Watch for TLS certificate changes and reload PostgreSQL when detected.
-	(
-		CERT_DIR="/run/secrets/stackrox.io/certs"
-		MTIME=""
-		while true; do
-			sleep 60
-			NEW_MTIME=$(stat -c '%Y' "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null)
-			if [ -n "$NEW_MTIME" ] && [ "$NEW_MTIME" != "$MTIME" ]; then
-				if [ -n "$MTIME" ]; then
-					echo "TLS certificates changed, reloading PostgreSQL"
-					pg_ctl reload -D "$PGDATA"
-				fi
-				MTIME="$NEW_MTIME"
-			fi
-		done
-	) &
-
 	flock /var/lib/postgresql/data/pglock "$@" &
 	child=$!
 	echo "Waiting for child process $child to exit"

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -111,7 +111,7 @@ spec:
           mountPath: /run/secrets/stackrox.io/certs
         - name: shared-memory
           mountPath: /dev/shm
-      {{- include "srox.certWatcherSidecar" (list ._rox.scannerV4.db.image.fullRef "certs") | nindent 6 }}
+      {{- include "srox.certWatcherSidecar" (list . "scanner-v4-db" ._rox.scannerV4.db.image.fullRef "certs") | nindent 6 }}
       securityContext:
         fsGroup: 70
         runAsUser: 70

--- a/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
+++ b/image/templates/helm/shared/templates/02-scanner-v4-07-db-deployment.yaml
@@ -46,6 +46,7 @@ spec:
       {{- end }}
       serviceAccountName: scanner-v4
       terminationGracePeriodSeconds: 120
+      shareProcessNamespace: true
       initContainers:
       - name: init-db
         image: {{ ._rox.scannerV4.db.image.fullRef | quote }}
@@ -110,6 +111,7 @@ spec:
           mountPath: /run/secrets/stackrox.io/certs
         - name: shared-memory
           mountPath: /dev/shm
+      {{- include "srox.certWatcherSidecar" (list ._rox.scannerV4.db.image.fullRef "certs") | nindent 6 }}
       securityContext:
         fsGroup: 70
         runAsUser: 70

--- a/image/templates/helm/shared/templates/_cert-watcher.tpl
+++ b/image/templates/helm/shared/templates/_cert-watcher.tpl
@@ -5,12 +5,16 @@
     for TLS certificate changes and triggers a PostgreSQL reload via pg_ctl.
 
     Arguments (passed as a list):
-      0: the full image reference for the postgres container
-      1: the name of the volume containing the TLS certificates
+      0: the root context ($)
+      1: the deployment name (used for customize.envVars)
+      2: the full image reference for the postgres container
+      3: the name of the volume containing the TLS certificates
    */}}
 {{- define "srox.certWatcherSidecar" }}
-{{- $image := index . 0 -}}
-{{- $certVolumeName := index . 1 -}}
+{{- $ := index . 0 -}}
+{{- $deploymentName := index . 1 -}}
+{{- $image := index . 2 -}}
+{{- $certVolumeName := index . 3 -}}
 - name: cert-watcher
   image: {{ $image | quote }}
   command:
@@ -18,6 +22,7 @@
   env:
   - name: PGDATA
     value: "/var/lib/postgresql/data/pgdata"
+  {{- include "srox.envVars" (list $ "deployment" $deploymentName "cert-watcher") | nindent 2 }}
   volumeMounts:
   - name: {{ $certVolumeName }}
     mountPath: /run/secrets/stackrox.io/certs

--- a/image/templates/helm/shared/templates/_cert-watcher.tpl
+++ b/image/templates/helm/shared/templates/_cert-watcher.tpl
@@ -1,0 +1,38 @@
+{{/*
+    srox.certWatcherSidecar $args
+
+    This template produces the specification of a sidecar container that watches
+    for TLS certificate changes and triggers a PostgreSQL reload via pg_ctl.
+
+    Arguments (passed as a list):
+      0: the full image reference for the postgres container
+      1: the name of the volume containing the TLS certificates
+   */}}
+{{- define "srox.certWatcherSidecar" }}
+{{- $image := index . 0 -}}
+{{- $certVolumeName := index . 1 -}}
+- name: cert-watcher
+  image: {{ $image | quote }}
+  command:
+    - cert-watcher.sh
+  env:
+  - name: PGDATA
+    value: "/var/lib/postgresql/data/pgdata"
+  volumeMounts:
+  - name: {{ $certVolumeName }}
+    mountPath: /run/secrets/stackrox.io/certs
+    readOnly: true
+  - name: disk
+    mountPath: /var/lib/postgresql/data
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 50m
+      memory: 32Mi
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsUser: 70
+    runAsGroup: 70
+{{- end }}

--- a/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
@@ -74,6 +74,7 @@ spec:
       {{- end }}
       serviceAccountName: central-db
       terminationGracePeriodSeconds: 120
+      shareProcessNamespace: true
       initContainers:
       - name: init-db
         image: {{ ._rox.central.db.image.fullRef | quote }}
@@ -138,6 +139,30 @@ spec:
           mountPath: /run/secrets/stackrox.io/certs
         - mountPath: /dev/shm
           name: shared-memory
+      - name: cert-watcher
+        image: {{ ._rox.central.db.image.fullRef | quote }}
+        command:
+          - cert-watcher.sh
+        env:
+        - name: PGDATA
+          value: "/var/lib/postgresql/data/pgdata"
+        volumeMounts:
+        - name: central-db-tls-volume
+          mountPath: /run/secrets/stackrox.io/certs
+          readOnly: true
+        - name: disk
+          mountPath: /var/lib/postgresql/data
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 70
+          runAsGroup: 70
       securityContext:
         fsGroup: 70
       volumes:

--- a/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
@@ -139,30 +139,7 @@ spec:
           mountPath: /run/secrets/stackrox.io/certs
         - mountPath: /dev/shm
           name: shared-memory
-      - name: cert-watcher
-        image: {{ ._rox.central.db.image.fullRef | quote }}
-        command:
-          - cert-watcher.sh
-        env:
-        - name: PGDATA
-          value: "/var/lib/postgresql/data/pgdata"
-        volumeMounts:
-        - name: central-db-tls-volume
-          mountPath: /run/secrets/stackrox.io/certs
-          readOnly: true
-        - name: disk
-          mountPath: /var/lib/postgresql/data
-        resources:
-          requests:
-            cpu: 10m
-            memory: 16Mi
-          limits:
-            cpu: 50m
-            memory: 32Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          runAsUser: 70
-          runAsGroup: 70
+      {{- include "srox.certWatcherSidecar" (list ._rox.central.db.image.fullRef "central-db-tls-volume") | nindent 6 }}
       securityContext:
         fsGroup: 70
       volumes:

--- a/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-12-central-db.yaml
@@ -139,7 +139,7 @@ spec:
           mountPath: /run/secrets/stackrox.io/certs
         - mountPath: /dev/shm
           name: shared-memory
-      {{- include "srox.certWatcherSidecar" (list ._rox.central.db.image.fullRef "central-db-tls-volume") | nindent 6 }}
+      {{- include "srox.certWatcherSidecar" (list . "central-db" ._rox.central.db.image.fullRef "central-db-tls-volume") | nindent 6 }}
       securityContext:
         fsGroup: 70
       volumes:

--- a/pkg/mtls/README.md
+++ b/pkg/mtls/README.md
@@ -39,6 +39,7 @@
 - Operator TLS reconciliation: `operator/internal/central/extensions/reconcile_tls.go`
 - Sensor cert init (one-time copy at startup): `sensor/kubernetes/certinit/init_tls_certs.go`
 - Sensor cert refresh (TLS challenge + CA bundle): `sensor/kubernetes/certrefresh/`
+- Postgres DB cert reload (Central DB, Scanner V4 DB): `image/postgres/scripts/cert-watcher.sh`, `image/templates/helm/shared/templates/_cert-watcher.tpl`
 
 ### Central has three independent cert-handling paths
 
@@ -56,7 +57,7 @@ The following certificates are currently known to be cached at start-up and not 
 - Scanner V4 (indexer/matcher) client certs: cached at dial time via `clientconn.TLSConfig`
 - Admission controller client cert for Sensor connection: `clientconn.AuthenticatedGRPCConnection` at startup
 - Compliance client cert for Sensor connection: `clientconn.AuthenticatedGRPCConnection` at startup
-- Postgres (Central DB, Scanner DB, Scanner V4 DB): need SIGHUP to reload SSL certs
+
 
 ## Certificate management — who manages what
 

--- a/scanner/image/db/Dockerfile
+++ b/scanner/image/db/Dockerfile
@@ -21,7 +21,7 @@ ENV LANG="en_US.utf8"
 # This will be ignored if empty in the init script.
 COPY init-bundles/db-init.dump.zst /db-init.dump.zst
 
-COPY scripts/docker-entrypoint.sh scripts/init-entrypoint.sh /usr/local/bin/
+COPY scripts/docker-entrypoint.sh scripts/init-entrypoint.sh scripts/cert-watcher.sh /usr/local/bin/
 
 RUN dnf upgrade -y --nobest && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/scanner/image/db/scripts/cert-watcher.sh
+++ b/scanner/image/db/scripts/cert-watcher.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+CERT_DIR="${ROX_CERT_DIR:-/run/secrets/stackrox.io/certs}"
+PGDATA="${PGDATA:-/var/lib/postgresql/data/pgdata}"
+POLL_INTERVAL="${ROX_CERT_POLL_INTERVAL:-5}"
+
+echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}s)"
+
+HASH=""
+while true; do
+    sleep "$POLL_INTERVAL"
+    NEW_HASH=$(md5sum "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null | md5sum | awk '{print $1}')
+    if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" != "$HASH" ]; then
+        if [ -n "$HASH" ]; then
+            echo "cert-watcher: TLS certificates changed, reloading PostgreSQL"
+            if ! pg_ctl reload -D "$PGDATA"; then
+                echo "cert-watcher: pg_ctl reload failed, will retry on next change"
+            fi
+        fi
+        HASH="$NEW_HASH"
+    fi
+done

--- a/scanner/image/db/scripts/cert-watcher.sh
+++ b/scanner/image/db/scripts/cert-watcher.sh
@@ -3,14 +3,14 @@ set -uo pipefail
 
 CERT_DIR="${ROX_CERT_DIR:-/run/secrets/stackrox.io/certs}"
 PGDATA="${PGDATA:-/var/lib/postgresql/data/pgdata}"
-POLL_INTERVAL="${ROX_CERT_POLL_INTERVAL:-5}"
+POLL_INTERVAL="${ROX_CERT_POLL_INTERVAL:-5s}"
 
 if ! command -v pg_ctl &>/dev/null; then
     echo "cert-watcher: ERROR: pg_ctl not found, certificate reload will not work"
     sleep infinity
 fi
 
-echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}s)"
+echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL})"
 
 HASH=""
 while true; do

--- a/scanner/image/db/scripts/cert-watcher.sh
+++ b/scanner/image/db/scripts/cert-watcher.sh
@@ -5,6 +5,10 @@ CERT_DIR="${ROX_CERT_DIR:-/run/secrets/stackrox.io/certs}"
 PGDATA="${PGDATA:-/var/lib/postgresql/data/pgdata}"
 POLL_INTERVAL="${ROX_CERT_POLL_INTERVAL:-5}"
 
+if ! command -v pg_ctl &>/dev/null; then
+    echo "cert-watcher: WARNING: pg_ctl not found, certificate reload will not work"
+fi
+
 echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}s)"
 
 HASH=""

--- a/scanner/image/db/scripts/cert-watcher.sh
+++ b/scanner/image/db/scripts/cert-watcher.sh
@@ -14,7 +14,7 @@ echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}
 
 HASH=""
 while true; do
-    NEW_HASH=$(md5sum "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null | md5sum | awk '{print $1}')
+    NEW_HASH=$(cat "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null | md5sum | awk '{print $1}')
     if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" != "$HASH" ]; then
         if [ -n "$HASH" ]; then
             echo "cert-watcher: TLS certificates changed, reloading PostgreSQL"

--- a/scanner/image/db/scripts/cert-watcher.sh
+++ b/scanner/image/db/scripts/cert-watcher.sh
@@ -6,7 +6,8 @@ PGDATA="${PGDATA:-/var/lib/postgresql/data/pgdata}"
 POLL_INTERVAL="${ROX_CERT_POLL_INTERVAL:-5}"
 
 if ! command -v pg_ctl &>/dev/null; then
-    echo "cert-watcher: WARNING: pg_ctl not found, certificate reload will not work"
+    echo "cert-watcher: ERROR: pg_ctl not found, certificate reload will not work"
+    sleep infinity
 fi
 
 echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}s)"
@@ -19,7 +20,7 @@ while true; do
         if [ -n "$HASH" ]; then
             echo "cert-watcher: TLS certificates changed, reloading PostgreSQL"
             if ! pg_ctl reload -D "$PGDATA"; then
-                echo "cert-watcher: pg_ctl reload failed, will retry on next change"
+                echo "cert-watcher: pg_ctl reload failed"
             fi
         fi
         HASH="$NEW_HASH"

--- a/scanner/image/db/scripts/cert-watcher.sh
+++ b/scanner/image/db/scripts/cert-watcher.sh
@@ -19,7 +19,8 @@ while true; do
         if [ -n "$HASH" ]; then
             echo "cert-watcher: TLS certificates changed, reloading PostgreSQL"
             if ! pg_ctl reload -D "$PGDATA"; then
-                echo "cert-watcher: pg_ctl reload failed"
+                echo "cert-watcher: pg_ctl reload failed, will retry"
+                continue
             fi
         fi
         HASH="$NEW_HASH"

--- a/scanner/image/db/scripts/cert-watcher.sh
+++ b/scanner/image/db/scripts/cert-watcher.sh
@@ -5,21 +5,24 @@ CERT_DIR="${ROX_CERT_DIR:-/run/secrets/stackrox.io/certs}"
 PGDATA="${PGDATA:-/var/lib/postgresql/data/pgdata}"
 POLL_INTERVAL="${ROX_CERT_POLL_INTERVAL:-5s}"
 
+# Timestamp format matches PostgreSQL.
+log() { echo "$(date -u '+%Y-%m-%d %H:%M:%S.%3N UTC') cert-watcher: $*"; }
+
 if ! command -v pg_ctl &>/dev/null; then
-    echo "cert-watcher: ERROR: pg_ctl not found, certificate reload will not work"
+    log "ERROR: pg_ctl not found, certificate reload will not work"
     sleep infinity
 fi
 
-echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}, pgdata: ${PGDATA})"
+log "watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}, pgdata: ${PGDATA})"
 
 HASH=""
 while true; do
     NEW_HASH=$(cat "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null | md5sum | awk '{print $1}')
     if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" != "$HASH" ]; then
         if [ -n "$HASH" ]; then
-            echo "cert-watcher: TLS certificates changed, reloading PostgreSQL"
+            log "TLS certificates changed, reloading PostgreSQL"
             if ! pg_ctl reload -D "$PGDATA"; then
-                echo "cert-watcher: pg_ctl reload failed, will retry"
+                log "pg_ctl reload failed, will retry"
                 continue
             fi
         fi

--- a/scanner/image/db/scripts/cert-watcher.sh
+++ b/scanner/image/db/scripts/cert-watcher.sh
@@ -13,18 +13,22 @@ if ! command -v pg_ctl &>/dev/null; then
     sleep infinity
 fi
 
+log "waiting for PostgreSQL to start..."
+while ! pg_ctl status -D "$PGDATA" >/dev/null 2>&1; do sleep 1s; done
+
 log "watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}, pgdata: ${PGDATA})"
 
+# HASH starts empty so the first iteration always triggers a reload. This is
+# harmless (postgres re-reads the same certs) and eliminates any race between
+# postgres startup and secret volume updates.
 HASH=""
 while true; do
     NEW_HASH=$(cat "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null | md5sum | awk '{print $1}')
     if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" != "$HASH" ]; then
-        if [ -n "$HASH" ]; then
-            log "TLS certificates changed, reloading PostgreSQL"
-            if ! pg_ctl reload -D "$PGDATA"; then
-                log "pg_ctl reload failed, will retry"
-                continue
-            fi
+        log "TLS certificates changed, reloading PostgreSQL"
+        if ! pg_ctl reload -D "$PGDATA"; then
+            log "pg_ctl reload failed, will retry"
+            continue
         fi
         HASH="$NEW_HASH"
     fi

--- a/scanner/image/db/scripts/cert-watcher.sh
+++ b/scanner/image/db/scripts/cert-watcher.sh
@@ -10,7 +10,7 @@ if ! command -v pg_ctl &>/dev/null; then
     sleep infinity
 fi
 
-echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL})"
+echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}, pgdata: ${PGDATA})"
 
 HASH=""
 while true; do

--- a/scanner/image/db/scripts/cert-watcher.sh
+++ b/scanner/image/db/scripts/cert-watcher.sh
@@ -14,7 +14,6 @@ echo "cert-watcher: watching ${CERT_DIR} for changes (interval: ${POLL_INTERVAL}
 
 HASH=""
 while true; do
-    sleep "$POLL_INTERVAL"
     NEW_HASH=$(md5sum "$CERT_DIR"/server.crt "$CERT_DIR"/server.key 2>/dev/null | md5sum | awk '{print $1}')
     if [ -n "$NEW_HASH" ] && [ "$NEW_HASH" != "$HASH" ]; then
         if [ -n "$HASH" ]; then
@@ -25,4 +24,5 @@ while true; do
         fi
         HASH="$NEW_HASH"
     fi
+    sleep "$POLL_INTERVAL"
 done

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -794,6 +794,11 @@ EOT
     verify_deployment_scannerV4_env_var_set "stackrox" "central"
     verify_deployment_scannerV4_env_var_set "stackrox" "sensor"
 
+    _begin "verify-cert-watchers"
+
+    verify_cert_watcher_running "stackrox" "central-db"
+    verify_cert_watcher_running "stackrox" "scanner-v4-db"
+
     _end
 }
 
@@ -1114,6 +1119,23 @@ verify_scannerV4_matcher_deployed() {
     wait_for_ready_pods "${namespace}" "scanner-v4-db" 600
     wait_for_ready_pods "${namespace}" "scanner-v4-matcher" 600
     info "** Scanner V4 Matcher is deployed in namespace ${namespace}"
+}
+
+verify_cert_watcher_running() {
+    local namespace=${1:-stackrox}
+    local deployment=${2:-scanner-v4-db}
+    info "Verifying cert-watcher sidecar is running in ${namespace}/${deployment}..."
+    local retries=12
+    for ((i=1; i<=retries; i++)); do
+        if "${ORCH_CMD}" </dev/null -n "$namespace" logs "deploy/${deployment}" -c cert-watcher 2>/dev/null | grep -q "cert-watcher: watching"; then
+            info "** cert-watcher is running in ${namespace}/${deployment}"
+            return 0
+        fi
+        sleep 5
+    done
+    echo "ERROR: cert-watcher sidecar did not start correctly in ${namespace}/${deployment}"
+    "${ORCH_CMD}" </dev/null -n "$namespace" logs "deploy/${deployment}" -c cert-watcher || true
+    return 1
 }
 
 verify_deployment_scannerV4_env_var_set() {

--- a/tests/e2e/run-scanner-v4-install.bats
+++ b/tests/e2e/run-scanner-v4-install.bats
@@ -1127,7 +1127,7 @@ verify_cert_watcher_running() {
     info "Verifying cert-watcher sidecar is running in ${namespace}/${deployment}..."
     local retries=12
     for ((i=1; i<=retries; i++)); do
-        if "${ORCH_CMD}" </dev/null -n "$namespace" logs "deploy/${deployment}" -c cert-watcher 2>/dev/null | grep -q "cert-watcher: watching"; then
+        if "${ORCH_CMD}" </dev/null -n "$namespace" logs "deploy/${deployment}" -c cert-watcher 2>/dev/null | grep "cert-watcher: watching" >/dev/null; then
             info "** cert-watcher is running in ${namespace}/${deployment}"
             return 0
         fi


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR introduces TLS certificate hot reloading for `central-db` and `scanner-v4-db`, by means of a sidecar container that notifies PostgreSQL via `pg_ctl` to reload its configuration, when it detects a change in configuration.

The `cert-watcher.sh` script is duplicated between `image/postgres/scripts/` (central-db) and `scanner/image/db/scripts/` (scanner-v4-db) because these two images have separate build contexts and independent Dockerfiles with no existing mechanism for sharing scripts between them. This is consistent with how `docker-entrypoint.sh` and `init-entrypoint.sh` are already maintained independently in both locations.

Alternatives considered:
* adding the script in `docker-entrypoint.sh` is a simple solution, but it's not really observable (compared to the sidecar where we can inspect the logs of the `cert-watcher` container)
* a Go implementation would have the problem that we don't have Go building in the Postgres images, and we don't have `pg_ctl` in the main image

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Generated new certificates (with the CA from `central-tls`) and replaced `central-db-tls`.
Checked:
- `cert-watcher` sidecar logs:
```
2026-05-15 17:20:08.658 UTC cert-watcher: watching /run/secrets/stackrox.io/certs for changes (interval: 5s, pgdata: /var/lib/postgresql/data/pgdata)
2026-05-15 17:25:36.356 UTC cert-watcher: TLS certificates changed, reloading PostgreSQL
server signaled
```
- `central-db` postgres logs:
```
2026-05-15 17:25:36.358 UTC [22] LOG: received SIGHUP, reloading configuration files
```
- verified with `openssl s_client` that central-db now presents the new certificates

Also tried bogus certificates, in that case postgres refuses to load the new certs:
```
2026-05-08 13:12:07.556 UTC [22] LOG: received SIGHUP, reloading configuration files
2026-05-08 13:12:07.558 UTC [22] LOG: could not load server certificate file "/run/secrets/stackrox.io/certs/server.crt": no start line
2026-05-08 13:12:07.558 UTC [22] LOG: SSL configuration was not reloaded
```

The same tests were performed for `scanner-v4-db` as well.