### PR TITLE
ROX-34519: Populate VM scan OS from Scanner

### DIFF
--- a/pkg/scanners/scannerv4/scannerv4_test.go
+++ b/pkg/scanners/scannerv4/scannerv4_test.go
@@ -96,6 +96,7 @@ func TestGetVirtualMachineScan_Success(t *testing.T) {
 		indexReport                  *v4.IndexReport
 		expectedVulnerabilitiesCount int
 		expectedScanNotesCount       int
+		expectedOS                   string
 	}{
 		{
 			name: "successful enrichment with vulnerabilities",
@@ -121,6 +122,7 @@ func TestGetVirtualMachineScan_Success(t *testing.T) {
 			},
 			expectedVulnerabilitiesCount: 3,
 			expectedScanNotesCount:       0,
+			expectedOS:                   "unknown",
 		},
 		{
 			name: "successful enrichment with no vulnerabilities",
@@ -141,6 +143,7 @@ func TestGetVirtualMachineScan_Success(t *testing.T) {
 			},
 			expectedVulnerabilitiesCount: 0,
 			expectedScanNotesCount:       0,
+			expectedOS:                   "unknown",
 		},
 		{
 			name: "enrichment with empty package list",
@@ -155,6 +158,7 @@ func TestGetVirtualMachineScan_Success(t *testing.T) {
 			},
 			expectedVulnerabilitiesCount: 0,
 			expectedScanNotesCount:       0,
+			expectedOS:                   "unknown",
 		},
 		{
 			name: "enrichment with scan notes",
@@ -175,6 +179,7 @@ func TestGetVirtualMachineScan_Success(t *testing.T) {
 			},
 			expectedVulnerabilitiesCount: 0,
 			expectedScanNotesCount:       2,
+			expectedOS:                   "unknown",
 		},
 		{
 			name: "enrichment with multiple scan notes",
@@ -195,6 +200,35 @@ func TestGetVirtualMachineScan_Success(t *testing.T) {
 			},
 			expectedVulnerabilitiesCount: 1,
 			expectedScanNotesCount:       4, // Test with 4 notes to show cycling
+			expectedOS:                   "unknown",
+		},
+		{
+			name: "enrichment with single distribution",
+			vm: &storage.VirtualMachine{
+				Id:   "vm-id-6",
+				Name: "distributed-vm",
+			},
+			indexReport: &v4.IndexReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"pkg-1": {
+							Id:      "pkg-1",
+							Name:    "dist-package",
+							Version: "3.0.0",
+						},
+					},
+					Distributions: map[string]*v4.Distribution{
+						"rhel-9": {
+							Id:        "rhel-9",
+							Did:       "rhel",
+							VersionId: "9",
+						},
+					},
+				},
+			},
+			expectedVulnerabilitiesCount: 0,
+			expectedScanNotesCount:       0,
+			expectedOS:                   "rhel:9",
 		},
 	}
 
@@ -247,7 +281,7 @@ func TestGetVirtualMachineScan_Success(t *testing.T) {
 
 			// Verify scan metadata
 			assert.NotNil(t, tt.vm.GetScan().GetScanTime())
-			assert.Equal(t, "", tt.vm.GetScan().GetOperatingSystem())
+			assert.Equal(t, tt.expectedOS, tt.vm.GetScan().GetOperatingSystem())
 		})
 	}
 }

--- a/pkg/scanners/scannerv4/vm_convert.go
+++ b/pkg/scanners/scannerv4/vm_convert.go
@@ -9,9 +9,8 @@ import (
 // ToVirtualMachineScan converts a scan report to the format needed to enrich a virtual machine with scan data.
 func ToVirtualMachineScan(r *v4.VulnerabilityReport) *storage.VirtualMachineScan {
 	return &storage.VirtualMachineScan{
-		ScanTime: protocompat.TimestampNow(),
-		// TODO: find an actual operating system source
-		OperatingSystem: "",
+		ScanTime:        protocompat.TimestampNow(),
+		OperatingSystem: os(r),
 		Notes:           toVirtualMachineScanNotes(r.GetNotes()),
 		Components:      toVirtualMachineComponents(r),
 	}

--- a/pkg/scanners/scannerv4/vm_convert_test.go
+++ b/pkg/scanners/scannerv4/vm_convert_test.go
@@ -67,11 +67,12 @@ func TestNoVMConversionPanic(t *testing.T) {
 
 func TestToVirtualMachineScan(t *testing.T) {
 	testcases := []struct {
-		name     string
-		contents *v4.Contents
+		name       string
+		contents   *v4.Contents
+		expectedOS string
 	}{
 		{
-			name: "basic",
+			name: "basic without distribution",
 			contents: &v4.Contents{
 				Packages: map[string]*v4.Package{
 					"1": {
@@ -81,9 +82,10 @@ func TestToVirtualMachineScan(t *testing.T) {
 					},
 				},
 			},
+			expectedOS: "unknown",
 		},
 		{
-			name: "deprecated",
+			name: "deprecated without distribution",
 			contents: &v4.Contents{
 				PackagesDEPRECATED: []*v4.Package{
 					{
@@ -93,6 +95,27 @@ func TestToVirtualMachineScan(t *testing.T) {
 					},
 				},
 			},
+			expectedOS: "unknown",
+		},
+		{
+			name: "with single distribution",
+			contents: &v4.Contents{
+				Packages: map[string]*v4.Package{
+					"1": {
+						Id:      "1",
+						Name:    "my-test-package",
+						Version: "1.2.3",
+					},
+				},
+				Distributions: map[string]*v4.Distribution{
+					"rhel-9": {
+						Id:        "rhel-9",
+						Did:       "rhel",
+						VersionId: "9",
+					},
+				},
+			},
+			expectedOS: "rhel:9",
 		},
 	}
 	input := &v4.VulnerabilityReport{
@@ -114,39 +137,37 @@ func TestToVirtualMachineScan(t *testing.T) {
 		},
 	}
 
-	expected := &storage.VirtualMachineScan{
-		Notes: []storage.VirtualMachineScan_Note{
-			storage.VirtualMachineScan_OS_UNKNOWN,
-		},
-		Components: []*storage.EmbeddedVirtualMachineScanComponent{
-			{
-				Name:    "my-test-package",
-				Version: "1.2.3",
-				Vulnerabilities: []*storage.VirtualMachineVulnerability{
-					{
-						CveBaseInfo: &storage.VirtualMachineCVEInfo{
-							Cve: "CVE1-Name",
-						},
-						Severity: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
-						SetFixedBy: &storage.VirtualMachineVulnerability_FixedBy{
-							FixedBy: "v99",
-						},
+	expectedComponents := []*storage.EmbeddedVirtualMachineScanComponent{
+		{
+			Name:    "my-test-package",
+			Version: "1.2.3",
+			Vulnerabilities: []*storage.VirtualMachineVulnerability{
+				{
+					CveBaseInfo: &storage.VirtualMachineCVEInfo{
+						Cve: "CVE1-Name",
+					},
+					Severity: storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+					SetFixedBy: &storage.VirtualMachineVulnerability_FixedBy{
+						FixedBy: "v99",
 					},
 				},
-				Notes: []storage.EmbeddedVirtualMachineScanComponent_Note{
-					storage.EmbeddedVirtualMachineScanComponent_UNSCANNED,
-				},
+			},
+			Notes: []storage.EmbeddedVirtualMachineScanComponent_Note{
+				storage.EmbeddedVirtualMachineScanComponent_UNSCANNED,
 			},
 		},
+	}
+	expectedNotes := []storage.VirtualMachineScan_Note{
+		storage.VirtualMachineScan_OS_UNKNOWN,
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			input.Contents = tc.contents
 			actual := ToVirtualMachineScan(input)
-			protoassert.ElementsMatch(t, expected.GetComponents(), actual.GetComponents())
-			assert.Equal(t, expected.GetOperatingSystem(), actual.GetOperatingSystem())
-			assert.Equal(t, expected.GetNotes(), actual.GetNotes())
+			protoassert.ElementsMatch(t, expectedComponents, actual.GetComponents())
+			assert.Equal(t, tc.expectedOS, actual.GetOperatingSystem())
+			assert.Equal(t, expectedNotes, actual.GetNotes())
 		})
 	}
 }

--- a/pkg/virtualmachine/enricher/enricher_impl_test.go
+++ b/pkg/virtualmachine/enricher/enricher_impl_test.go
@@ -181,7 +181,7 @@ func TestEnrichVirtualMachineWithVulnerabilities_Success(t *testing.T) {
 
 			// Verify scan metadata
 			assert.NotNil(t, tt.vm.GetScan().GetScanTime())
-			assert.Equal(t, "", tt.vm.GetScan().GetOperatingSystem())
+			assert.Equal(t, "unknown", tt.vm.GetScan().GetOperatingSystem())
 		})
 	}
 }


### PR DESCRIPTION
## Description

This PR adds a fallback population of the OS field if it cannot be filled from data arriving from Sensor (https://github.com/stackrox/stackrox/pull/20337).

`ToVirtualMachineScan` was discarding the distribution data already present in the Scanner V4 `VulnerabilityReport`, hard-coding `OperatingSystem` to an empty string. 
This left `scan.operating_system` unpopulated for virtual machines, even though the same `os()` helper used by image scans was available in the same package.

Reuse `os()` to extract the distribution (e.g. `"rhel:9"`) from `VulnerabilityReport.Contents.Distributions`, matching the existing image scan behavior.

The field is filled only if empty - i.e., if the OS data was not transmitted from Sensor.

AI-Assisted: cursor, ~90% generated, user reviewed logic

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- CI
- E2E tests for the VM feature from [this branch](https://github.com/stackrox/stackrox/pull/20168)


