### PR TITLE
ROX-34519: Populate VM scan OS from Sensor

### DIFF
--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
+	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
 	vmEnricher "github.com/stackrox/rox/pkg/virtualmachine/enricher"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -157,6 +158,10 @@ func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 		return errors.Wrapf(err, "failed to enrich VM %s with vulnerabilities", index.GetId())
 	}
 
+	if guestOS := p.lookupGuestOS(ctx, index.GetId()); guestOS != "" && guestOS != pkgVM.UnknownGuestOS && vm.Scan != nil {
+		vm.Scan.OperatingSystem = guestOS
+	}
+
 	// Store enriched VM via v1 or v2 path.
 	if features.VirtualMachinesEnhancedDataModel.Enabled() {
 		if err := p.storeV2Scan(ctx, clusterID, vm); err != nil {
@@ -198,4 +203,19 @@ func (p *pipelineImpl) storeV2Scan(ctx context.Context, clusterID string, vm *st
 		return errors.Wrapf(err, "failed to upsert v2 scan for VM %s", vm.GetId())
 	}
 	return nil
+}
+
+func (p *pipelineImpl) lookupGuestOS(ctx context.Context, vmID string) string {
+	if features.VirtualMachinesEnhancedDataModel.Enabled() {
+		vm, found, err := p.virtualMachineV2Store.GetVirtualMachine(ctx, vmID)
+		if err != nil || !found {
+			return ""
+		}
+		return vm.GetGuestOs()
+	}
+	vm, found, err := p.virtualMachineStore.GetVirtualMachine(ctx, vmID)
+	if err != nil || !found {
+		return ""
+	}
+	return vm.GetFacts()[pkgVM.GuestOSKey]
 }

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline.go
@@ -158,7 +158,7 @@ func (p *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 		return errors.Wrapf(err, "failed to enrich VM %s with vulnerabilities", index.GetId())
 	}
 
-	if guestOS := p.lookupGuestOS(ctx, index.GetId()); guestOS != "" && guestOS != pkgVM.UnknownGuestOS && vm.Scan != nil {
+	if guestOS := p.lookupGuestOS(ctx, index.GetId()); guestOS != "" && guestOS != pkgVM.UnknownGuestOS && vm.GetScan() != nil {
 		vm.Scan.OperatingSystem = guestOS
 	}
 
@@ -208,13 +208,21 @@ func (p *pipelineImpl) storeV2Scan(ctx context.Context, clusterID string, vm *st
 func (p *pipelineImpl) lookupGuestOS(ctx context.Context, vmID string) string {
 	if features.VirtualMachinesEnhancedDataModel.Enabled() {
 		vm, found, err := p.virtualMachineV2Store.GetVirtualMachine(ctx, vmID)
-		if err != nil || !found {
+		if err != nil {
+			log.Warnf("Failed to look up guest OS for VM %s: %v", vmID, err)
+			return ""
+		}
+		if !found {
 			return ""
 		}
 		return vm.GetGuestOs()
 	}
 	vm, found, err := p.virtualMachineStore.GetVirtualMachine(ctx, vmID)
-	if err != nil || !found {
+	if err != nil {
+		log.Warnf("Failed to look up guest OS for VM %s: %v", vmID, err)
+		return ""
+	}
+	if !found {
 		return ""
 	}
 	return vm.GetFacts()[pkgVM.GuestOSKey]

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
@@ -139,7 +139,6 @@ func (suite *PipelineTestSuite) TestRun_UpdateScanError() {
 	vmID := "vm-1"
 	msg := createVMIndexMessage(vmID, central.ResourceAction_SYNC_RESOURCE)
 
-	expectedError := errors.New("datastore error")
 	gomock.InOrder(
 		suite.enricher.EXPECT().
 			EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
@@ -149,7 +148,7 @@ func (suite *PipelineTestSuite) TestRun_UpdateScanError() {
 			Return(nil, false, nil),
 		suite.virtualMachineStore.EXPECT().
 			UpdateVirtualMachineScan(ctx, vmID, gomock.Any()).
-			Return(expectedError),
+			Return(errors.New("datastore error")),
 	)
 
 	err := suite.pipeline.Run(ctx, testClusterID, msg, nil)
@@ -251,14 +250,12 @@ func TestPipelineRun_DifferentActions(t *testing.T) {
 			msg := createVMIndexMessage(vmID, tt.action)
 
 			if tt.expectUpdate {
-				// Expect enricher to be called for action
 				enricher.EXPECT().
 					EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 					Return(nil)
 				virtualMachineStore.EXPECT().
 					GetVirtualMachine(gomock.Any(), vmID).
 					Return(nil, false, nil)
-
 				virtualMachineStore.EXPECT().
 					UpdateVirtualMachineScan(ctx, vmID, gomock.Any()).
 					Do(func(ctx context.Context, virtualMachineID string, _ *storage.VirtualMachineScan) {
@@ -680,7 +677,6 @@ func TestPipelineRunV2_StoresScanViaV2Datastore(t *testing.T) {
 		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(vm *storage.VirtualMachine, _ interface{}) error {
 			vm.Scan = &storage.VirtualMachineScan{
-				OperatingSystem: "rhel:9",
 				Components: []*storage.EmbeddedVirtualMachineScanComponent{
 					{Name: "test-pkg", Version: "1.0"},
 				},
@@ -778,7 +774,6 @@ func TestPipelineRunV2_NilScanNoUpsert(t *testing.T) {
 	vmID := "vm-v2-nil-scan"
 	msg := createVMIndexMessage(vmID, central.ResourceAction_SYNC_RESOURCE)
 
-	// Enricher succeeds but does NOT set vm.Scan (leaves it nil).
 	enricher.EXPECT().
 		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 		Return(nil)
@@ -788,7 +783,6 @@ func TestPipelineRunV2_NilScanNoUpsert(t *testing.T) {
 	virtualMachineV2Store.EXPECT().
 		EnsureVirtualMachineExists(gomock.Any(), vmID, testClusterID).
 		Return(nil)
-	// UpsertScan should NOT be called because ScanPartsFromV1Scan returns nil for a nil scan.
 
 	injector := &mockInjector{
 		capabilities: map[centralsensor.SensorCapability]bool{
@@ -826,7 +820,6 @@ func TestPipelineRunV2_NACKOnUpsertScanError(t *testing.T) {
 		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(vm *storage.VirtualMachine, _ interface{}) error {
 			vm.Scan = &storage.VirtualMachineScan{
-				OperatingSystem: "rhel:9",
 				Components: []*storage.EmbeddedVirtualMachineScanComponent{
 					{Name: "test-pkg", Version: "1.0"},
 				},
@@ -862,129 +855,90 @@ func TestPipelineRunV2_NACKOnUpsertScanError(t *testing.T) {
 
 func TestLookupGuestOS(t *testing.T) {
 	tests := map[string]struct {
-		enhancedDataModel bool
-		v1VM              *storage.VirtualMachine
-		v1Found           bool
-		v1StoreErr        bool
-		v2VM              *storage.VirtualMachineV2
-		v2Found           bool
-		v2StoreErr        bool
-		enricherOS        string
-		wantOS            string
+		v2Enabled bool
+		v1VM      *storage.VirtualMachine
+		v1Found   bool
+		v1Err     error
+		v2VM      *storage.VirtualMachineV2
+		v2Found   bool
+		v2Err     error
+		wantOS    string
 	}{
-		"v1 guest OS overrides enricher": {
+		"v1 guest OS populates scan": {
 			v1VM: &storage.VirtualMachine{
-				Facts: map[string]string{pkgVM.GuestOSKey: "Red Hat Enterprise Linux 10"},
+				Facts: map[string]string{pkgVM.GuestOSKey: "Red Hat Enterprise Linux 9"},
 			},
-			v1Found:    true,
-			enricherOS: "rhel:9",
-			wantOS:     "Red Hat Enterprise Linux 10",
+			v1Found: true,
+			wantOS:  "Red Hat Enterprise Linux 9",
 		},
-		"v2 guest OS overrides enricher": {
-			enhancedDataModel: true,
-			v2VM:              &storage.VirtualMachineV2{GuestOs: "Red Hat Enterprise Linux 10"},
-			v2Found:           true,
-			enricherOS:        "rhel:9",
-			wantOS:            "Red Hat Enterprise Linux 10",
+		"v2 guest OS populates scan": {
+			v2Enabled: true,
+			v2VM:      &storage.VirtualMachineV2{GuestOs: "Red Hat Enterprise Linux 9"},
+			v2Found:   true,
+			wantOS:    "Red Hat Enterprise Linux 9",
 		},
-		"v1 VM not found keeps enricher OS": {
-			v1Found:    false,
-			enricherOS: "rhel:9",
-			wantOS:     "rhel:9",
+		"v1 VM not found leaves scan OS empty": {
+			v1Found: false,
+			wantOS:  "",
 		},
-		"v2 VM not found keeps enricher OS": {
-			enhancedDataModel: true,
-			v2Found:           false,
-			enricherOS:        "rhel:9",
-			wantOS:            "rhel:9",
+		"v2 VM not found leaves scan OS empty": {
+			v2Enabled: true,
+			v2Found:   false,
+			wantOS:    "",
 		},
-		"v1 unknown guest OS keeps enricher OS": {
+		"v1 unknown guest OS leaves scan OS empty": {
 			v1VM: &storage.VirtualMachine{
 				Facts: map[string]string{pkgVM.GuestOSKey: pkgVM.UnknownGuestOS},
 			},
-			v1Found:    true,
-			enricherOS: "rhel:9",
-			wantOS:     "rhel:9",
+			v1Found: true,
+			wantOS:  "",
 		},
-		"v2 unknown guest OS keeps enricher OS": {
-			enhancedDataModel: true,
-			v2VM:              &storage.VirtualMachineV2{GuestOs: pkgVM.UnknownGuestOS},
-			v2Found:           true,
-			enricherOS:        "rhel:9",
-			wantOS:            "rhel:9",
+		"v2 unknown guest OS leaves scan OS empty": {
+			v2Enabled: true,
+			v2VM:      &storage.VirtualMachineV2{GuestOs: pkgVM.UnknownGuestOS},
+			v2Found:   true,
+			wantOS:    "",
 		},
-		"v1 empty guest OS keeps enricher OS": {
-			v1VM:       &storage.VirtualMachine{Facts: map[string]string{}},
-			v1Found:    true,
-			enricherOS: "rhel:9",
-			wantOS:     "rhel:9",
+		"v1 store error leaves scan OS empty": {
+			v1Err:  errors.New("db error"),
+			wantOS: "",
 		},
-		"v2 empty guest OS keeps enricher OS": {
-			enhancedDataModel: true,
-			v2VM:              &storage.VirtualMachineV2{GuestOs: ""},
-			v2Found:           true,
-			enricherOS:        "rhel:9",
-			wantOS:            "rhel:9",
-		},
-		"v1 store error keeps enricher OS": {
-			v1Found:    false,
-			enricherOS: "rhel:9",
-			wantOS:     "rhel:9",
-			v1StoreErr: true,
-		},
-		"v2 store error keeps enricher OS": {
-			enhancedDataModel: true,
-			v2Found:           false,
-			enricherOS:        "rhel:9",
-			wantOS:            "rhel:9",
-			v2StoreErr:        true,
+		"v2 store error leaves scan OS empty": {
+			v2Enabled: true,
+			v2Err:     errors.New("db error"),
+			wantOS:    "",
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Setenv(features.VirtualMachines.EnvVar(), "true")
-			if tt.enhancedDataModel {
+			if tt.v2Enabled {
 				t.Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), "true")
 			} else {
 				t.Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), "false")
 			}
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
-			enricher := vmEnricherMocks.NewMockVirtualMachineEnricher(ctrl)
+			ctrl := gomock.NewController(t)
+
+			vmID := "vm-guest-os"
+			msg := createVMIndexMessage(vmID, central.ResourceAction_SYNC_RESOURCE)
+
 			v1Store := virtualMachineDSMocks.NewMockDataStore(ctrl)
 			v2Store := virtualMachineV2DSMocks.NewMockDataStore(ctrl)
-
-			p := &pipelineImpl{
-				enricher:              enricher,
-				virtualMachineStore:   v1Store,
-				virtualMachineV2Store: v2Store,
-			}
-
-			vmID := "vm-guest-os-test"
-			msg := createVMIndexMessage(vmID, central.ResourceAction_SYNC_RESOURCE)
+			enricher := vmEnricherMocks.NewMockVirtualMachineEnricher(ctrl)
 
 			enricher.EXPECT().
 				EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 				DoAndReturn(func(vm *storage.VirtualMachine, _ interface{}) error {
-					vm.Scan = &storage.VirtualMachineScan{
-						OperatingSystem: tt.enricherOS,
-						Components: []*storage.EmbeddedVirtualMachineScanComponent{
-							{Name: "test-pkg", Version: "1.0"},
-						},
-					}
+					vm.Scan = &storage.VirtualMachineScan{}
 					return nil
 				})
 
-			if tt.enhancedDataModel {
-				var v2Err error
-				if tt.v2StoreErr {
-					v2Err = errors.New("db fail")
-				}
+			if tt.v2Enabled {
 				v2Store.EXPECT().
 					GetVirtualMachine(gomock.Any(), vmID).
-					Return(tt.v2VM, tt.v2Found, v2Err)
+					Return(tt.v2VM, tt.v2Found, tt.v2Err)
 				v2Store.EXPECT().
 					EnsureVirtualMachineExists(gomock.Any(), vmID, testClusterID).
 					Return(nil)
@@ -995,19 +949,21 @@ func TestLookupGuestOS(t *testing.T) {
 						return nil
 					})
 			} else {
-				var v1Err error
-				if tt.v1StoreErr {
-					v1Err = errors.New("db fail")
-				}
 				v1Store.EXPECT().
 					GetVirtualMachine(gomock.Any(), vmID).
-					Return(tt.v1VM, tt.v1Found, v1Err)
+					Return(tt.v1VM, tt.v1Found, tt.v1Err)
 				v1Store.EXPECT().
 					UpdateVirtualMachineScan(gomock.Any(), vmID, gomock.Any()).
 					DoAndReturn(func(_ context.Context, _ string, scan *storage.VirtualMachineScan) error {
 						assert.Equal(t, tt.wantOS, scan.GetOperatingSystem())
 						return nil
 					})
+			}
+
+			p := &pipelineImpl{
+				virtualMachineStore:   v1Store,
+				virtualMachineV2Store: v2Store,
+				enricher:              enricher,
 			}
 
 			err := p.Run(ctx, testClusterID, msg, nil)

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
@@ -139,18 +139,18 @@ func (suite *PipelineTestSuite) TestRun_UpdateScanError() {
 	vmID := "vm-1"
 	msg := createVMIndexMessage(vmID, central.ResourceAction_SYNC_RESOURCE)
 
-	// Expect enricher to be called successfully
-	suite.enricher.EXPECT().
-		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
-		Return(nil)
-	suite.virtualMachineStore.EXPECT().
-		GetVirtualMachine(gomock.Any(), vmID).
-		Return(nil, false, nil)
-
 	expectedError := errors.New("datastore error")
-	suite.virtualMachineStore.EXPECT().
-		UpdateVirtualMachineScan(ctx, vmID, gomock.Any()).
-		Return(expectedError)
+	gomock.InOrder(
+		suite.enricher.EXPECT().
+			EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
+			Return(nil),
+		suite.virtualMachineStore.EXPECT().
+			GetVirtualMachine(gomock.Any(), vmID).
+			Return(nil, false, nil),
+		suite.virtualMachineStore.EXPECT().
+			UpdateVirtualMachineScan(ctx, vmID, gomock.Any()).
+			Return(expectedError),
+	)
 
 	err := suite.pipeline.Run(ctx, testClusterID, msg, nil)
 	suite.Error(err)
@@ -865,8 +865,10 @@ func TestLookupGuestOS(t *testing.T) {
 		enhancedDataModel bool
 		v1VM              *storage.VirtualMachine
 		v1Found           bool
+		v1StoreErr        bool
 		v2VM              *storage.VirtualMachineV2
 		v2Found           bool
+		v2StoreErr        bool
 		enricherOS        string
 		wantOS            string
 	}{
@@ -924,6 +926,19 @@ func TestLookupGuestOS(t *testing.T) {
 			enricherOS:        "rhel:9",
 			wantOS:            "rhel:9",
 		},
+		"v1 store error keeps enricher OS": {
+			v1Found:    false,
+			enricherOS: "rhel:9",
+			wantOS:     "rhel:9",
+			v1StoreErr: true,
+		},
+		"v2 store error keeps enricher OS": {
+			enhancedDataModel: true,
+			v2Found:           false,
+			enricherOS:        "rhel:9",
+			wantOS:            "rhel:9",
+			v2StoreErr:        true,
+		},
 	}
 
 	for name, tt := range tests {
@@ -963,9 +978,13 @@ func TestLookupGuestOS(t *testing.T) {
 				})
 
 			if tt.enhancedDataModel {
+				var v2Err error
+				if tt.v2StoreErr {
+					v2Err = errors.New("db fail")
+				}
 				v2Store.EXPECT().
 					GetVirtualMachine(gomock.Any(), vmID).
-					Return(tt.v2VM, tt.v2Found, nil)
+					Return(tt.v2VM, tt.v2Found, v2Err)
 				v2Store.EXPECT().
 					EnsureVirtualMachineExists(gomock.Any(), vmID, testClusterID).
 					Return(nil)
@@ -976,9 +995,13 @@ func TestLookupGuestOS(t *testing.T) {
 						return nil
 					})
 			} else {
+				var v1Err error
+				if tt.v1StoreErr {
+					v1Err = errors.New("db fail")
+				}
 				v1Store.EXPECT().
 					GetVirtualMachine(gomock.Any(), vmID).
-					Return(tt.v1VM, tt.v1Found, nil)
+					Return(tt.v1VM, tt.v1Found, v1Err)
 				v1Store.EXPECT().
 					UpdateVirtualMachineScan(gomock.Any(), vmID, gomock.Any()).
 					DoAndReturn(func(_ context.Context, _ string, scan *storage.VirtualMachineScan) error {

--- a/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
+++ b/central/sensor/service/pipeline/virtualmachineindex/pipeline_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/features"
+	pkgVM "github.com/stackrox/rox/pkg/virtualmachine"
 	vmEnricherMocks "github.com/stackrox/rox/pkg/virtualmachine/enricher/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -142,6 +143,9 @@ func (suite *PipelineTestSuite) TestRun_UpdateScanError() {
 	suite.enricher.EXPECT().
 		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 		Return(nil)
+	suite.virtualMachineStore.EXPECT().
+		GetVirtualMachine(gomock.Any(), vmID).
+		Return(nil, false, nil)
 
 	expectedError := errors.New("datastore error")
 	suite.virtualMachineStore.EXPECT().
@@ -251,6 +255,9 @@ func TestPipelineRun_DifferentActions(t *testing.T) {
 				enricher.EXPECT().
 					EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 					Return(nil)
+				virtualMachineStore.EXPECT().
+					GetVirtualMachine(gomock.Any(), vmID).
+					Return(nil, false, nil)
 
 				virtualMachineStore.EXPECT().
 					UpdateVirtualMachineScan(ctx, vmID, gomock.Any()).
@@ -361,6 +368,9 @@ func (suite *PipelineTestSuite) TestRun_SendsACKOnSuccess() {
 		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 		Return(nil)
 	suite.virtualMachineStore.EXPECT().
+		GetVirtualMachine(gomock.Any(), vmID).
+		Return(nil, false, nil)
+	suite.virtualMachineStore.EXPECT().
 		UpdateVirtualMachineScan(ctx, vmID, gomock.Any()).
 		Return(nil)
 
@@ -394,6 +404,9 @@ func (suite *PipelineTestSuite) TestRun_SendsACKWithVMIDAndVsockCIDResourceID() 
 		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 		Return(nil)
 	suite.virtualMachineStore.EXPECT().
+		GetVirtualMachine(gomock.Any(), vmID).
+		Return(nil, false, nil)
+	suite.virtualMachineStore.EXPECT().
 		UpdateVirtualMachineScan(ctx, vmID, gomock.Any()).
 		Return(nil)
 
@@ -425,6 +438,9 @@ func (suite *PipelineTestSuite) TestRun_NoACKWhenCapabilityMissing() {
 		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 		Return(nil)
 	suite.virtualMachineStore.EXPECT().
+		GetVirtualMachine(gomock.Any(), vmID).
+		Return(nil, false, nil)
+	suite.virtualMachineStore.EXPECT().
 		UpdateVirtualMachineScan(ctx, vmID, gomock.Any()).
 		Return(nil)
 
@@ -446,6 +462,9 @@ func (suite *PipelineTestSuite) TestRun_NACKOnDBError() {
 	suite.enricher.EXPECT().
 		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 		Return(nil)
+	suite.virtualMachineStore.EXPECT().
+		GetVirtualMachine(gomock.Any(), vmID).
+		Return(nil, false, nil)
 	suite.virtualMachineStore.EXPECT().
 		UpdateVirtualMachineScan(ctx, vmID, gomock.Any()).
 		Return(errors.New("db error"))
@@ -669,6 +688,9 @@ func TestPipelineRunV2_StoresScanViaV2Datastore(t *testing.T) {
 			return nil
 		})
 	virtualMachineV2Store.EXPECT().
+		GetVirtualMachine(gomock.Any(), vmID).
+		Return(nil, false, nil)
+	virtualMachineV2Store.EXPECT().
 		EnsureVirtualMachineExists(gomock.Any(), vmID, testClusterID).
 		Return(nil)
 	virtualMachineV2Store.EXPECT().
@@ -716,6 +738,9 @@ func TestPipelineRunV2_NACKOnEnsureError(t *testing.T) {
 		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 		Return(nil)
 	virtualMachineV2Store.EXPECT().
+		GetVirtualMachine(gomock.Any(), vmID).
+		Return(nil, false, nil)
+	virtualMachineV2Store.EXPECT().
 		EnsureVirtualMachineExists(gomock.Any(), vmID, testClusterID).
 		Return(errors.New("ensure failed"))
 
@@ -757,6 +782,9 @@ func TestPipelineRunV2_NilScanNoUpsert(t *testing.T) {
 	enricher.EXPECT().
 		EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
 		Return(nil)
+	virtualMachineV2Store.EXPECT().
+		GetVirtualMachine(gomock.Any(), vmID).
+		Return(nil, false, nil)
 	virtualMachineV2Store.EXPECT().
 		EnsureVirtualMachineExists(gomock.Any(), vmID, testClusterID).
 		Return(nil)
@@ -806,6 +834,9 @@ func TestPipelineRunV2_NACKOnUpsertScanError(t *testing.T) {
 			return nil
 		})
 	virtualMachineV2Store.EXPECT().
+		GetVirtualMachine(gomock.Any(), vmID).
+		Return(nil, false, nil)
+	virtualMachineV2Store.EXPECT().
 		EnsureVirtualMachineExists(gomock.Any(), vmID, testClusterID).
 		Return(nil)
 	virtualMachineV2Store.EXPECT().
@@ -827,4 +858,137 @@ func TestPipelineRunV2_NACKOnUpsertScanError(t *testing.T) {
 	assert.NotNil(t, ack)
 	assert.Equal(t, central.SensorACK_NACK, ack.GetAction())
 	assert.Equal(t, centralsensor.SensorACKReasonStorageFailed, ack.GetReason())
+}
+
+func TestLookupGuestOS(t *testing.T) {
+	tests := map[string]struct {
+		enhancedDataModel bool
+		v1VM              *storage.VirtualMachine
+		v1Found           bool
+		v2VM              *storage.VirtualMachineV2
+		v2Found           bool
+		enricherOS        string
+		wantOS            string
+	}{
+		"v1 guest OS overrides enricher": {
+			v1VM: &storage.VirtualMachine{
+				Facts: map[string]string{pkgVM.GuestOSKey: "Red Hat Enterprise Linux 10"},
+			},
+			v1Found:    true,
+			enricherOS: "rhel:9",
+			wantOS:     "Red Hat Enterprise Linux 10",
+		},
+		"v2 guest OS overrides enricher": {
+			enhancedDataModel: true,
+			v2VM:              &storage.VirtualMachineV2{GuestOs: "Red Hat Enterprise Linux 10"},
+			v2Found:           true,
+			enricherOS:        "rhel:9",
+			wantOS:            "Red Hat Enterprise Linux 10",
+		},
+		"v1 VM not found keeps enricher OS": {
+			v1Found:    false,
+			enricherOS: "rhel:9",
+			wantOS:     "rhel:9",
+		},
+		"v2 VM not found keeps enricher OS": {
+			enhancedDataModel: true,
+			v2Found:           false,
+			enricherOS:        "rhel:9",
+			wantOS:            "rhel:9",
+		},
+		"v1 unknown guest OS keeps enricher OS": {
+			v1VM: &storage.VirtualMachine{
+				Facts: map[string]string{pkgVM.GuestOSKey: pkgVM.UnknownGuestOS},
+			},
+			v1Found:    true,
+			enricherOS: "rhel:9",
+			wantOS:     "rhel:9",
+		},
+		"v2 unknown guest OS keeps enricher OS": {
+			enhancedDataModel: true,
+			v2VM:              &storage.VirtualMachineV2{GuestOs: pkgVM.UnknownGuestOS},
+			v2Found:           true,
+			enricherOS:        "rhel:9",
+			wantOS:            "rhel:9",
+		},
+		"v1 empty guest OS keeps enricher OS": {
+			v1VM:       &storage.VirtualMachine{Facts: map[string]string{}},
+			v1Found:    true,
+			enricherOS: "rhel:9",
+			wantOS:     "rhel:9",
+		},
+		"v2 empty guest OS keeps enricher OS": {
+			enhancedDataModel: true,
+			v2VM:              &storage.VirtualMachineV2{GuestOs: ""},
+			v2Found:           true,
+			enricherOS:        "rhel:9",
+			wantOS:            "rhel:9",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(features.VirtualMachines.EnvVar(), "true")
+			if tt.enhancedDataModel {
+				t.Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), "true")
+			} else {
+				t.Setenv(features.VirtualMachinesEnhancedDataModel.EnvVar(), "false")
+			}
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			enricher := vmEnricherMocks.NewMockVirtualMachineEnricher(ctrl)
+			v1Store := virtualMachineDSMocks.NewMockDataStore(ctrl)
+			v2Store := virtualMachineV2DSMocks.NewMockDataStore(ctrl)
+
+			p := &pipelineImpl{
+				enricher:              enricher,
+				virtualMachineStore:   v1Store,
+				virtualMachineV2Store: v2Store,
+			}
+
+			vmID := "vm-guest-os-test"
+			msg := createVMIndexMessage(vmID, central.ResourceAction_SYNC_RESOURCE)
+
+			enricher.EXPECT().
+				EnrichVirtualMachineWithVulnerabilities(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(vm *storage.VirtualMachine, _ interface{}) error {
+					vm.Scan = &storage.VirtualMachineScan{
+						OperatingSystem: tt.enricherOS,
+						Components: []*storage.EmbeddedVirtualMachineScanComponent{
+							{Name: "test-pkg", Version: "1.0"},
+						},
+					}
+					return nil
+				})
+
+			if tt.enhancedDataModel {
+				v2Store.EXPECT().
+					GetVirtualMachine(gomock.Any(), vmID).
+					Return(tt.v2VM, tt.v2Found, nil)
+				v2Store.EXPECT().
+					EnsureVirtualMachineExists(gomock.Any(), vmID, testClusterID).
+					Return(nil)
+				v2Store.EXPECT().
+					UpsertScan(gomock.Any(), vmID, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, parts common.VMScanParts) error {
+						assert.Equal(t, tt.wantOS, parts.Scan.GetScanOs())
+						return nil
+					})
+			} else {
+				v1Store.EXPECT().
+					GetVirtualMachine(gomock.Any(), vmID).
+					Return(tt.v1VM, tt.v1Found, nil)
+				v1Store.EXPECT().
+					UpdateVirtualMachineScan(gomock.Any(), vmID, gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, scan *storage.VirtualMachineScan) error {
+						assert.Equal(t, tt.wantOS, scan.GetOperatingSystem())
+						return nil
+					})
+			}
+
+			err := p.Run(ctx, testClusterID, msg, nil)
+			assert.NoError(t, err)
+		})
+	}
 }


### PR DESCRIPTION
## Description

After enrichment, look up the VM's `guest_os` (populated from KubeVirt
informer data via Sensor) and use it as `scan.operating_system`. This
provides a human-readable OS name (e.g. "Red Hat Enterprise Linux 10")
instead of relying solely on the Scanner V4 distribution identifier.

The lookupGuestOS helper queries the v2 datastore (`VirtualMachineV2.guest_os`)
when the enhanced data model is enabled, falling back to the v1 facts map.
Values that are empty or "unknown" are ignored, preserving the enricher's
default.

See also a fallback option that populates OS from Scanner if the one added in this PR fails: https://github.com/stackrox/stackrox/pull/20336

Partially AI-generated.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- CI (unit tests)
- Manually on a cluster

Install ACS, create a VM and run an agent. Wait for the scan to arrive.

Before this change:

```shell
➜ curl -sk -u admin:admin 'https://localhost:8443/v2/virtualmachines' | jq '.virtualMachines[] | {id, name, namespace, scanOS: .scan.operatingSystem}'

{
  "id": "09164dea-8d42-4c00-a2f2-8bf97b69c79a",
  "name": "rhel10-1",
  "namespace": "openshift-cnv",
  "scanOS": null
}
```

after this change:

```shell
➜ curl -sk -u admin:admin 'https://localhost:8443/v2/virtualmachines' | jq '.virtualMachines[] | {id, name, namespace, scanOS: .scan.operatingSystem}'

{
  "id": "09164dea-8d42-4c00-a2f2-8bf97b69c79a",
  "name": "rhel10-1",
  "namespace": "openshift-cnv",
  "scanOS": "Red Hat Enterprise Linux"
}
```
