### PR TITLE
ROX-33638: bypass deduping queue for SYNC events

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -37,7 +37,7 @@ var (
 	ComplianceRemediationV2 = registerFeature("Enable Compliance Remediation feature", "ROX_COMPLIANCE_REMEDIATION", enabled)
 
 	// SensorAggregateDeploymentReferenceOptimization enables a performance improvement by aggregating deployment references when the same reference is queued for processing
-	SensorAggregateDeploymentReferenceOptimization = registerFeature("Enables a performance improvement by aggregating deployment references when the same reference is queued for processing", "ROX_AGGREGATE_DEPLOYMENT_REFERENCE_OPTIMIZATION")
+	SensorAggregateDeploymentReferenceOptimization = registerFeature("Enables a performance improvement by aggregating deployment references when the same reference is queued for processing", "ROX_AGGREGATE_DEPLOYMENT_REFERENCE_OPTIMIZATION", enabled)
 
 	// AttemptManifestDigest enables attempting to pull manifest digests from registries that historically did not
 	// support it but now appear to (ie: Nexus and RHEL).

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -37,7 +37,7 @@ var (
 	ComplianceRemediationV2 = registerFeature("Enable Compliance Remediation feature", "ROX_COMPLIANCE_REMEDIATION", enabled)
 
 	// SensorAggregateDeploymentReferenceOptimization enables a performance improvement by aggregating deployment references when the same reference is queued for processing
-	SensorAggregateDeploymentReferenceOptimization = registerFeature("Enables a performance improvement by aggregating deployment references when the same reference is queued for processing", "ROX_AGGREGATE_DEPLOYMENT_REFERENCE_OPTIMIZATION", enabled)
+	SensorAggregateDeploymentReferenceOptimization = registerFeature("Enables a performance improvement by aggregating deployment references when the same reference is queued for processing", "ROX_AGGREGATE_DEPLOYMENT_REFERENCE_OPTIMIZATION")
 
 	// AttemptManifestDigest enables attempting to pull manifest digests from registries that historically did not
 	// support it but now appear to (ie: Nexus and RHEL).

--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -39,6 +39,11 @@ type DeploymentReference struct {
 	// SkipResolving indicates whether the deployments need to be resolved or not. This is set to true when a re-process
 	// is triggered after receiving a message from central (e.g. UpdatedImage).
 	SkipResolving bool
+
+	// SkipDeduping bypasses the deduping queue and resolves the deployment inline.
+	// Used for SYNC events from the deployment dispatcher to ensure they reach central
+	// before the SyncedEvent for proper reconciliation tracking.
+	SkipDeduping bool
 }
 
 // ResourceEvent message used by the event pipeline's components
@@ -133,6 +138,13 @@ func WithForceDetection() DeploymentReferenceOption {
 func WithSkipResolving() DeploymentReferenceOption {
 	return func(dr *DeploymentReference) {
 		dr.SkipResolving = true
+	}
+}
+
+// WithSkipDeduping bypasses the deduping queue and resolves the deployment inline.
+func WithSkipDeduping() DeploymentReferenceOption {
+	return func(dr *DeploymentReference) {
+		dr.SkipDeduping = true
 	}
 }
 

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -247,7 +247,7 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 					skipResolving:    deploymentReference.SkipResolving,
 					forceDetection:   deploymentReference.ForceDetection,
 				}
-				if features.SensorAggregateDeploymentReferenceOptimization.Enabled() && r.deploymentRefQueue != nil {
+				if features.SensorAggregateDeploymentReferenceOptimization.Enabled() && r.deploymentRefQueue != nil && !deploymentReference.SkipDeduping {
 					r.deploymentRefQueue.Push(ref)
 				} else {
 					r.resolveDeployment(msg, ref)

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -488,6 +488,44 @@ func (s *resolverSuite) Test_Send_ForwardedMessagesAreSent() {
 	}
 }
 
+func (s *resolverSuite) Test_Send_SkipDedupingResolvesInline() {
+	for _, pubSubEnabled := range []bool{true, false} {
+		s.Run(fmt.Sprintf("with %s %t", features.SensorInternalPubSub.EnvVar(), pubSubEnabled), func() {
+			s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
+			resolver := s.newResolver(pubSubEnabled)
+			err := resolver.Start()
+			s.NoError(err)
+
+			messageReceived := sync.WaitGroup{}
+			messageReceived.Add(1)
+
+			s.givenPermissionLevelForDeployment("1234", storage.PermissionLevel_NONE)
+
+			// With SkipDeduping the deployment is resolved inline within processMessage,
+			// so Send is called exactly once with the resolved deployment included.
+			s.mockOutput.EXPECT().Send(&deploymentMatcher{
+				id:              "1234",
+				permissionLevel: storage.PermissionLevel_NONE,
+			}).Times(1).Do(func(arg0 interface{}) {
+				defer messageReceived.Done()
+			})
+
+			event := &component.ResourceEvent{
+				DeploymentReferences: []component.DeploymentReference{
+					{
+						Reference:            resolverStore.ResolveDeploymentIds("1234"),
+						ParentResourceAction: central.ResourceAction_UPDATE_RESOURCE,
+						SkipDeduping:         true,
+					},
+				},
+			}
+			s.dispatchEvent(event, resolver, pubSubEnabled)
+
+			messageReceived.Wait()
+		})
+	}
+}
+
 func (s *resolverSuite) Test_ToEvent_InitContainerFiltering() {
 	cases := map[string]struct {
 		caps               []centralsensor.CentralCapability

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -488,41 +488,56 @@ func (s *resolverSuite) Test_Send_ForwardedMessagesAreSent() {
 	}
 }
 
-func (s *resolverSuite) Test_Send_SkipDedupingResolvesInline() {
-	for _, pubSubEnabled := range []bool{true, false} {
-		s.Run(fmt.Sprintf("with %s %t", features.SensorInternalPubSub.EnvVar(), pubSubEnabled), func() {
-			s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
-			resolver := s.newResolver(pubSubEnabled)
-			err := resolver.Start()
-			s.NoError(err)
+func (s *resolverSuite) Test_Send_SkipDedupingBehavior() {
+	cases := map[string]struct {
+		skipDeduping  bool
+		expectedSends int
+	}{
+		"resolves inline producing a single Send": {
+			skipDeduping:  true,
+			expectedSends: 1,
+		},
+		"routes through queue producing two Sends": {
+			skipDeduping:  false,
+			expectedSends: 2,
+		},
+	}
 
-			messageReceived := sync.WaitGroup{}
-			messageReceived.Add(1)
+	for name, tc := range cases {
+		for _, pubSubEnabled := range []bool{true, false} {
+			s.Run(fmt.Sprintf("%s with %s %t", name, features.SensorInternalPubSub.EnvVar(), pubSubEnabled), func() {
+				s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
+				resolver := s.newResolver(pubSubEnabled)
+				err := resolver.Start()
+				s.NoError(err)
 
-			s.givenPermissionLevelForDeployment("1234", storage.PermissionLevel_NONE)
+				messageReceived := sync.WaitGroup{}
+				messageReceived.Add(tc.expectedSends)
 
-			// With SkipDeduping the deployment is resolved inline within processMessage,
-			// so Send is called exactly once with the resolved deployment included.
-			s.mockOutput.EXPECT().Send(&deploymentMatcher{
-				id:              "1234",
-				permissionLevel: storage.PermissionLevel_NONE,
-			}).Times(1).Do(func(arg0 interface{}) {
-				defer messageReceived.Done()
-			})
+				s.givenPermissionLevelForDeployment("1234", storage.PermissionLevel_NONE)
 
-			event := &component.ResourceEvent{
-				DeploymentReferences: []component.DeploymentReference{
-					{
-						Reference:            resolverStore.ResolveDeploymentIds("1234"),
-						ParentResourceAction: central.ResourceAction_UPDATE_RESOURCE,
-						SkipDeduping:         true,
+				s.mockOutput.EXPECT().Send(&deploymentMatcher{
+					id:                           "1234",
+					permissionLevel:              storage.PermissionLevel_NONE,
+					acceptableNumberOfMismatches: tc.expectedSends - 1,
+				}).Times(tc.expectedSends).Do(func(arg0 interface{}) {
+					defer messageReceived.Done()
+				})
+
+				event := &component.ResourceEvent{
+					DeploymentReferences: []component.DeploymentReference{
+						{
+							Reference:            resolverStore.ResolveDeploymentIds("1234"),
+							ParentResourceAction: central.ResourceAction_UPDATE_RESOURCE,
+							SkipDeduping:         tc.skipDeduping,
+						},
 					},
-				},
-			}
-			s.dispatchEvent(event, resolver, pubSubEnabled)
+				}
+				s.dispatchEvent(event, resolver, pubSubEnabled)
 
-			messageReceived.Wait()
-		})
+				messageReceived.Wait()
+			})
+		}
 	}
 }
 

--- a/sensor/kubernetes/listener/resources/deployments.go
+++ b/sensor/kubernetes/listener/resources/deployments.go
@@ -198,8 +198,11 @@ func (d *deploymentHandler) processWithType(obj, oldObj interface{}, action cent
 	} else {
 		// If re-sync is disabled, we don't need to process deployment relationships here. We pass a deployment
 		// references up the chain, which will be used to trigger the actual deployment event and detection.
-		events.AddDeploymentReference(resolver.ResolveDeploymentIds(deploymentWrap.GetId()),
-			component.WithParentResourceAction(action))
+		opts := []component.DeploymentReferenceOption{component.WithParentResourceAction(action)}
+		if action == central.ResourceAction_SYNC_RESOURCE {
+			opts = append(opts, component.WithSkipDeduping())
+		}
+		events.AddDeploymentReference(resolver.ResolveDeploymentIds(deploymentWrap.GetId()), opts...)
 	}
 
 	// Upsert/Delete at the end to avoid data race with other dispatchers


### PR DESCRIPTION
## Description

When `ROX_AGGREGATE_DEPLOYMENT_REFERENCE_OPTIMIZATION` is enabled, deployment references are aggregated through a deduping queue. However, SYNC events from the deployment dispatcher must reach Central before the `SyncedEvent` for proper reconciliation tracking. The deduping queue can delay or coalesce these events, breaking the reconciliation flow.

The fix introduces a `SkipDeduping` option on `DeploymentReference` that bypasses the deduping queue for SYNC events, resolving deployments inline instead.

**Note:** The feature flag is temporarily enabled in this PR for CI validation purposes and will be reverted once CI passes.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- [x] CI with the feature flag enabled.
  - gke e2e tests passed 10 times
  - gke nongroovy passed ~10 times (2 failures were unrelated). Notice previous to the rebase failures were also unrelated.
- [x] Unit tests