### PR TITLE
fix(operator): wipe fields when migrating to operator

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -140,6 +140,8 @@ spec:
         - name: certs
           secret:
             secretName: tls-cert-admission-control
+            optional: false
+            items: null
         {{- else }}
         - name: certs
           secret:

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -294,6 +294,8 @@ spec:
       - name: certs
         secret:
           secretName: tls-cert-collector
+          optional: false
+          items: null
       {{- else }}
       - name: certs
         secret:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -251,9 +251,7 @@ spec:
           mountPath: /etc/pki/ca-trust/
         - name: certs
           mountPath: /run/secrets/stackrox.io/certs/
-          {{- if not ._rox._securedClusterCertRefresh }}
-          readOnly: true
-          {{- end }}
+          readOnly: {{ (default false ._rox._securedClusterCertRefresh) | ternary "false" "true" }}
         {{- if ._rox._securedClusterCertRefresh }}
         - name: certs-legacy
           mountPath: /run/secrets/stackrox.io/certs-legacy/
@@ -296,6 +294,7 @@ spec:
       {{- if ._rox._securedClusterCertRefresh }}
       - name: certs
         emptyDir: {}
+        secret: null
       - name: certs-legacy
         secret:
           secretName: sensor-tls
@@ -313,6 +312,7 @@ spec:
           optional: true
       {{- else }}
       - name: certs
+        emptyDir: null
         secret:
           secretName: sensor-tls
           optional: true


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

When replacing a manifest-based sensor with operator (see https://github.com/stackrox/stackrox/pull/20155) the operator overwrites resources by applying any fields that helm evaluation provides. But it leaves untouched the fields that were previously specified (by manifests or helm) and are omitted when evaluating the chart in the scope of the operator reconciliation.

In practice this means for example:
- the certs volume mount remains readonly, breaking the copying of legacy certs:
  ```
  kubernetes/certinit: 2026/05/05 08:07:30.006524 init_tls_certs.go:105: Info: Using 3 legacy certificates from "/run/secrets/stackrox.io/certs-legacy/".                                                                            
  main: 2026/05/05 08:07:30.006583 main.go:65: Fatal: TLS certificate initialization failed: cannot copy files: writing certificate file to /run/secrets/stackrox.io/certs/ca.pem: open /run/secrets/stackrox.io/certs/ca.pem: read-only file system                                                                                                                                                                                                                    
  ```
- admission-control and collector get frankenstein-like volume definitions:

```
volumes:                                  
- name: certs                             
  secret:                                 
    defaultMode: 420                      
    items:                                
    - key: admission-control-cert.pem     
      path: cert.pem                      
    - key: admission-control-key.pem      
      path: key.pem                       
    - key: ca.pem                         
      path: ca.pem                        
    optional: true                        
    secretName: tls-cert-admission-control
```

Initially I noticed just the first issue. I had claude take a look at all manifests where a field could disappear when migrating from helm or manifests to operator, and it found these other places.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] not modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Tested manually with [this script](https://github.com/stackrox/stackrox/blob/porridge/test-script/manifest-replace.sh), first pointing it at current `master` (getting the issues mentioned above) and subsequently at this branch (getting a success).