### PR TITLE
ROX-34524: fix proxy fallback for non-HTTP schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 ### Technical Changes
 
 - OpenShift 3 support removed from all installation methods.
+- ROX-34524: Fixed proxy bypass for non-HTTP schemes (e.g., TLS checks) when only `HTTPS_PROXY`/`HTTP_PROXY` are configured without `ALL_PROXY`. Previously, sensor's lazy TLS registry initialization would fail in proxy-only environments.
 
 ## [4.10.0]
 

--- a/pkg/httputil/proxy/config.go
+++ b/pkg/httputil/proxy/config.go
@@ -157,7 +157,7 @@ func (c *proxyConfig) Compile(envCfg environmentConfig) *compiledConfig {
 	if httpProxyURL == nil {
 		httpProxyURL = allProxyURL
 	}
-	httpsProxyURL, err := getProxyURL(envCfg.HTTPSProxy, c.HTTP)
+	httpsProxyURL, err := getProxyURL(envCfg.HTTPSProxy, c.HTTPS)
 	if err != nil {
 		log.Warnf("Failed to obtain HTTPS proxy configuration: %v", err)
 	}
@@ -203,8 +203,15 @@ func (c *proxyConfig) Compile(envCfg environmentConfig) *compiledConfig {
 	httpCfg.HTTPProxy = urlToStringOrEmpty(httpProxyURL)
 	httpsCfg := baseCfg
 	httpsCfg.HTTPSProxy = urlToStringOrEmpty(httpsProxyURL)
+	// For non-http/https schemes (e.g., tcp:// used by AwareDialContext),
+	// fall back to HTTPS proxy when ALL_PROXY is not explicitly configured.
+	// This ensures TLS checks and other raw TCP dials respect HTTPS_PROXY.
+	otherProxyURL := allProxyURL
+	if otherProxyURL == nil {
+		otherProxyURL = httpsProxyURL
+	}
 	otherCfg := baseCfg
-	otherCfg.HTTPProxy = urlToStringOrEmpty(allProxyURL)
+	otherCfg.HTTPProxy = urlToStringOrEmpty(otherProxyURL)
 
 	cc := &compiledConfig{
 		httpFunc:  httpCfg.ProxyFunc(),
@@ -213,7 +220,7 @@ func (c *proxyConfig) Compile(envCfg environmentConfig) *compiledConfig {
 		envVars: map[string]string{
 			"http_proxy":  httpCfg.HTTPProxy,
 			"https_proxy": httpsCfg.HTTPSProxy,
-			"all_proxy":   otherCfg.HTTPProxy,
+			"all_proxy":   urlToStringOrEmpty(allProxyURL),
 			"no_proxy":    baseCfg.NoProxy,
 		},
 	}

--- a/pkg/httputil/proxy/config.go
+++ b/pkg/httputil/proxy/config.go
@@ -142,7 +142,7 @@ func getProxyURL(envSetting string, endpointCfg proxyEndpointConfig) (*url.URL, 
 	if err != nil {
 		errs.AddWrap(err, "parsing setting from config file")
 	}
-	return u, nil
+	return u, errs.ToError()
 }
 
 func (c *proxyConfig) Compile(envCfg environmentConfig) *compiledConfig {

--- a/pkg/httputil/proxy/config_test.go
+++ b/pkg/httputil/proxy/config_test.go
@@ -1,0 +1,262 @@
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http/httpproxy"
+)
+
+func TestCompileProxyFallbackForNonStandardSchemes(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "198.51.100.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	const (
+		httpsProxy = "http://https.proxy:3128"
+		httpProxy  = "http://http.proxy:3128"
+		allProxy   = "http://all.proxy:3128"
+	)
+
+	mustParseURL := func(s string) *url.URL {
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		return u
+	}
+
+	cases := map[string]struct {
+		envCfg        environmentConfig
+		reqURL        string
+		expectedProxy *url.URL
+	}{
+		"tcp scheme uses ALL_PROXY when set": {
+			envCfg: environmentConfig{
+				Config:   httpproxy.Config{HTTPSProxy: httpsProxy, HTTPProxy: httpProxy},
+				AllProxy: allProxy,
+			},
+			reqURL:        "tcp://quay.io:443",
+			expectedProxy: mustParseURL(allProxy),
+		},
+		"tcp scheme falls back to HTTPS_PROXY when ALL_PROXY is not set": {
+			envCfg: environmentConfig{
+				Config: httpproxy.Config{HTTPSProxy: httpsProxy, HTTPProxy: httpProxy},
+			},
+			reqURL:        "tcp://quay.io:443",
+			expectedProxy: mustParseURL(httpsProxy),
+		},
+		"tcp scheme falls back to HTTP_PROXY via HTTPS fallback chain": {
+			envCfg: environmentConfig{
+				Config: httpproxy.Config{HTTPProxy: httpProxy},
+			},
+			reqURL:        "tcp://quay.io:443",
+			expectedProxy: mustParseURL(httpProxy),
+		},
+		"tcp scheme returns nil when no proxy is configured": {
+			envCfg:        environmentConfig{},
+			reqURL:        "tcp://quay.io:443",
+			expectedProxy: nil,
+		},
+		"http scheme uses HTTP_PROXY unaffected by change": {
+			envCfg: environmentConfig{
+				Config: httpproxy.Config{HTTPProxy: httpProxy, HTTPSProxy: httpsProxy},
+			},
+			reqURL:        "http://example.com",
+			expectedProxy: mustParseURL(httpProxy),
+		},
+		"https scheme uses HTTPS_PROXY unaffected by change": {
+			envCfg: environmentConfig{
+				Config: httpproxy.Config{HTTPProxy: httpProxy, HTTPSProxy: httpsProxy},
+			},
+			reqURL:        "https://example.com",
+			expectedProxy: mustParseURL(httpsProxy),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg := proxyConfig{OmitDefaultExcludes: true}
+			compiled := cfg.Compile(tc.envCfg)
+
+			req, err := http.NewRequest(http.MethodGet, tc.reqURL, nil)
+			require.NoError(t, err)
+
+			proxyURL, err := compiled.ProxyURL(req)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedProxy, proxyURL)
+		})
+	}
+}
+
+func TestCompileEnvVarsNotPolluted(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "198.51.100.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	const (
+		httpsProxy = "http://https.proxy:3128"
+		httpProxy  = "http://http.proxy:3128"
+		allProxy   = "http://all.proxy:3128"
+	)
+
+	cases := map[string]struct {
+		envCfg           environmentConfig
+		expectedAllProxy string
+	}{
+		"all_proxy reflects ALL_PROXY when explicitly set": {
+			envCfg: environmentConfig{
+				Config:   httpproxy.Config{HTTPSProxy: httpsProxy, HTTPProxy: httpProxy},
+				AllProxy: allProxy,
+			},
+			expectedAllProxy: allProxy,
+		},
+		"all_proxy is empty when ALL_PROXY is not set even though HTTPS_PROXY is": {
+			envCfg: environmentConfig{
+				Config: httpproxy.Config{HTTPSProxy: httpsProxy, HTTPProxy: httpProxy},
+			},
+			expectedAllProxy: "",
+		},
+		"all_proxy is empty when no proxy is configured": {
+			envCfg:           environmentConfig{},
+			expectedAllProxy: "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg := proxyConfig{OmitDefaultExcludes: true}
+			compiled := cfg.Compile(tc.envCfg)
+
+			assert.Equal(t, tc.expectedAllProxy, compiled.envVars["all_proxy"],
+				"all_proxy env var must only reflect explicitly configured ALL_PROXY, never a fallback value")
+		})
+	}
+}
+
+func TestCompileTCPFallbackWithDefaultExcludes(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "198.51.100.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	const httpsProxy = "http://https.proxy:3128"
+
+	cfg := proxyConfig{OmitDefaultExcludes: false}
+	compiled := cfg.Compile(environmentConfig{
+		Config: httpproxy.Config{HTTPSProxy: httpsProxy},
+	})
+
+	mustParseURL := func(s string) *url.URL {
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		return u
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "tcp://quay.io:443", nil)
+	require.NoError(t, err)
+	proxyURL, err := compiled.ProxyURL(req)
+	require.NoError(t, err)
+	assert.Equal(t, mustParseURL(httpsProxy), proxyURL,
+		"tcp:// fallback must work when OmitDefaultExcludes is false")
+
+	reqExcluded, err := http.NewRequest(http.MethodGet, "tcp://central.stackrox:443", nil)
+	require.NoError(t, err)
+	proxyURL, err = compiled.ProxyURL(reqExcluded)
+	require.NoError(t, err)
+	assert.Nil(t, proxyURL,
+		"default excludes must still apply for tcp:// scheme")
+}
+
+func TestCompileYAMLConfigDrivenProxy(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "198.51.100.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	const (
+		yamlHTTPProxy  = "http://yaml-http.proxy:3128"
+		yamlHTTPSProxy = "http://yaml-https.proxy:3128"
+	)
+
+	mustParseURL := func(s string) *url.URL {
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		return u
+	}
+
+	cfg := proxyConfig{
+		HTTP:                proxyEndpointConfig{ProxyURL: yamlHTTPProxy},
+		HTTPS:               proxyEndpointConfig{ProxyURL: yamlHTTPSProxy},
+		OmitDefaultExcludes: true,
+	}
+	compiled := cfg.Compile(environmentConfig{})
+
+	t.Run("https scheme uses YAML HTTPS config", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+		require.NoError(t, err)
+		proxyURL, err := compiled.ProxyURL(req)
+		require.NoError(t, err)
+		assert.Equal(t, mustParseURL(yamlHTTPSProxy), proxyURL)
+	})
+
+	t.Run("http scheme uses YAML HTTP config", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+		require.NoError(t, err)
+		proxyURL, err := compiled.ProxyURL(req)
+		require.NoError(t, err)
+		assert.Equal(t, mustParseURL(yamlHTTPProxy), proxyURL)
+	})
+
+	t.Run("tcp scheme falls back to YAML HTTPS config", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "tcp://quay.io:443", nil)
+		require.NoError(t, err)
+		proxyURL, err := compiled.ProxyURL(req)
+		require.NoError(t, err)
+		assert.Equal(t, mustParseURL(yamlHTTPSProxy), proxyURL,
+			"tcp:// must fall back to HTTPS proxy from YAML config via c.HTTPS")
+	})
+}
+
+func TestCompileNoProxyExcludesTCPScheme(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "198.51.100.1")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	const httpsProxy = "http://https.proxy:3128"
+
+	mustParseURL := func(s string) *url.URL {
+		u, err := url.Parse(s)
+		require.NoError(t, err)
+		return u
+	}
+
+	cfg := proxyConfig{OmitDefaultExcludes: true}
+	compiled := cfg.Compile(environmentConfig{
+		Config: httpproxy.Config{
+			HTTPSProxy: httpsProxy,
+			NoProxy:    "quay.io,internal.example.com",
+		},
+	})
+
+	t.Run("tcp scheme excluded by NO_PROXY", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "tcp://quay.io:443", nil)
+		require.NoError(t, err)
+		proxyURL, err := compiled.ProxyURL(req)
+		require.NoError(t, err)
+		assert.Nil(t, proxyURL,
+			"NO_PROXY exclusions must apply to tcp:// scheme URLs")
+	})
+
+	t.Run("tcp scheme not excluded uses proxy", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "tcp://registry.redhat.io:443", nil)
+		require.NoError(t, err)
+		proxyURL, err := compiled.ProxyURL(req)
+		require.NoError(t, err)
+		assert.Equal(t, mustParseURL(httpsProxy), proxyURL,
+			"tcp:// to non-excluded host must use the proxy")
+	})
+
+	t.Run("tcp scheme excluded by wildcard NO_PROXY", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "tcp://foo.internal.example.com:443", nil)
+		require.NoError(t, err)
+		proxyURL, err := compiled.ProxyURL(req)
+		require.NoError(t, err)
+		assert.Nil(t, proxyURL,
+			"NO_PROXY subdomain exclusion must apply to tcp:// scheme")
+	})
+}


### PR DESCRIPTION
## Description

The lazy TLS check in sensor (and other `AwareDialContext` callers) constructs a synthetic `tcp://` URL to determine the proxy. `compiledConfig.ProxyURL()` routes unknown schemes through `otherFunc`, which only consulted `ALL_PROXY`. When only `HTTP_PROXY` / `HTTPS_PROXY` are set (the common case), the TLS check bypasses the proxy entirely and does a direct TCP dial, failing DNS resolution in proxy-only environments.

This fix makes `otherFunc` fall back to `httpsProxyURL` when `allProxyURL` is nil, aligning the fallback chain (`ALL_PROXY` -> `HTTPS_PROXY` -> `HTTP_PROXY`) for non-standard URL schemes with the existing http/https behavior.

Additionally:
- Fixes a pre-existing `c.HTTP` vs `c.HTTPS` typo (since 2019) that resolved the HTTPS proxy using the HTTP endpoint config from YAML. This was necessary because the fallback chain now widens its impact.
- Decouples `envVars["all_proxy"]` from the fallback so `SetEnv()` does not pollute the environment with a synthetic `ALL_PROXY` value.

JIRA: [ROX-34524](https://redhat.atlassian.net/browse/ROX-34524)

Code partially generated by AI.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

**Unit tests (16 cases across 5 functions):**

- `TestCompileProxyFallbackForNonStandardSchemes` -- core fix: `tcp://` fallback chain, `http://`/`https://` unaffected
- `TestCompileEnvVarsNotPolluted` -- `SetEnv()` does not leak synthetic `ALL_PROXY`
- `TestCompileTCPFallbackWithDefaultExcludes` -- fallback works with `OmitDefaultExcludes: false`
- `TestCompileYAMLConfigDrivenProxy` -- YAML config `proxyConfig.HTTP`/`HTTPS` fields, no env vars
- `TestCompileNoProxyExcludesTCPScheme` -- `NO_PROXY` exclusions apply to `tcp://` URLs

**Real cluster validation** -- tested on RHACS 4.10.0 disconnected OpenShift SNO cluster with proxy. Full results with logs and screenshots posted in the comments.

**Reproduction steps** (for maintainers):

<details>
<summary>Expand: Cluster validation procedure (Operator-managed RHACS)</summary>

#### Prerequisites

- An OpenShift cluster with RHACS deployed (both Central + SecuredCluster with local scanner)
- A web proxy reachable by the cluster
- Environment where direct DNS resolution for external hosts (e.g., `quay.io`) is blocked (proxy-only access)
- `HTTPS_PROXY` and `HTTP_PROXY` configured on the sensor pod. `ALL_PROXY` must **not** be set -- this is the scenario that triggers the bug

#### Step 1: Verify environment

```bash
# Confirm delegated scanning is active
oc -n stackrox exec deploy/sensor -- env | grep ROX_LOCAL_IMAGE_SCANNING
# Expected: ROX_LOCAL_IMAGE_SCANNING_ENABLED=true

# Confirm proxy config (ALL_PROXY must be absent)
oc -n stackrox exec deploy/sensor -- env | grep -i proxy
# Expected: HTTP_PROXY and HTTPS_PROXY set, ALL_PROXY absent
```

#### Step 2: Observe the bug (before fix)

```bash
oc -n stackrox logs deploy/sensor | grep -E "(lazy TLS|quay.io|registry.redhat.io)"
# Expected: "lazy TLS registry initialization: tls check skipped due to previous TLS check errors"
# for quay.io and registry.redhat.io integrations
```

#### Step 3: Build and deploy patched sensor

Cross-compile the sensor binary from the PR branch and patch it into the existing RHACS image:

```bash
# Fetch and checkout the PR branch
git fetch origin pull/20341/head:fix/proxy-tls-check-rox-34524
git checkout fix/proxy-tls-check-rox-34524

# Cross-compile the sensor binary for linux/amd64
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bin/linux_amd64/kubernetes ./sensor/kubernetes

# Create a patched image using the existing RHACS main image as base
CURRENT_IMAGE=$(oc -n stackrox get deploy/sensor -o jsonpath='{.spec.template.spec.containers[?(@.name=="sensor")].image}')

mkdir -p /tmp/sensor-patch
cp bin/linux_amd64/kubernetes /tmp/sensor-patch/kubernetes-sensor
cat > /tmp/sensor-patch/Dockerfile << EOF
FROM ${CURRENT_IMAGE}
COPY kubernetes-sensor /stackrox/bin/kubernetes-sensor
EOF

# Build and push
TAG=$(make --quiet tag)
podman build --platform linux/amd64 -t <your-registry>/sensor-patched:$TAG /tmp/sensor-patch/
podman push <your-registry>/sensor-patched:$TAG
```

Deploy by scaling down the operator (to prevent reconciliation reverting the image) and patching the sensor:

```bash
# Scale down operator to prevent reconciliation
oc -n rhacs-operator scale deploy/rhacs-operator-controller-manager --replicas=0

# Patch the sensor image
oc -n stackrox set image deploy/sensor sensor=<your-registry>/sensor-patched:$TAG

# Wait for rollout
oc -n stackrox rollout status deploy/sensor --timeout=120s

# Verify patched image is running
oc -n stackrox get deploy/sensor -o jsonpath='{.spec.template.spec.containers[?(@.name=="sensor")].image}'
```

#### Step 4: Validate the fix

```bash
# Check sensor logs -- lazy TLS errors for quay.io and registry.redhat.io should be gone
oc -n stackrox logs deploy/sensor --since=5m | grep -E "(lazy TLS|quay.io|registry.redhat.io)"

# Expected: images "enriched with metadata" instead of "tls check skipped"
```

Also check Central UI: Vulnerability Management > Images -- images from external registries should now show full CVE data instead of "Failed to retrieve metadata from the registry."

#### Step 5: Restore the operator

```bash
oc -n rhacs-operator scale deploy/rhacs-operator-controller-manager --replicas=1
# Operator will reconcile and revert sensor to the original image
```

#### Expected results

| Scenario | Before Fix | After Fix |
|----------|-----------|-----------|
| `HTTPS_PROXY` set, `ALL_PROXY` absent | `lazy TLS registry initialization: tls check skipped` | Images enriched successfully through proxy |
| `ALL_PROXY` set | Works (unchanged) | Works (unchanged) |
| No proxy configured | Direct connection | Direct connection (unchanged) |

</details>

[ROX-34524]: https://redhat.atlassian.net/browse/ROX-34524