### PR TITLE
ROX-19064: E2E Set Scanner V4 Vuln Bundle Allow List

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -415,10 +415,17 @@ function launch_central {
         )
       fi
 
-      if [[ "${SCANNER_V4_VULN_READINESS:-false}" == "true" && "${ROX_SCANNER_V4:-false}" != "false" ]]; then
-        helm_args+=(
-          --set customize.envVars.SCANNER_V4_MATCHER_READINESS=vulnerability
-        )
+      if [[ "${ROX_SCANNER_V4:-}" != "false" ]]; then
+        if [[ "${SCANNER_V4_VULN_READINESS:-false}" == "true" ]]; then
+          helm_args+=(
+            --set customize.envVars.SCANNER_V4_MATCHER_READINESS=vulnerability
+          )
+        fi
+        if [[ -n "${SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST:-}" ]]; then
+          helm_args+=(
+            --set-json "customize.envVars.SCANNER_V4_MATCHER_VULN_BUNDLE_ALLOWLIST=\"${SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST}\""
+          )
+        fi
       fi
 
       if [[ -n "$EXTERNAL_DB" ]]; then
@@ -551,6 +558,10 @@ function launch_central {
                 ${ORCH_CMD} -n stackrox patch deployment scanner-v4-db --patch "$(cat "${common_dir}/scanner-v4-db-patch.yaml")"
                 if [[ "${SCANNER_V4_VULN_READINESS:-false}" == "true" ]]; then
                   ${ORCH_CMD} -n stackrox set env deploy/scanner-v4-matcher SCANNER_V4_MATCHER_READINESS=vulnerability
+                fi
+                if [[ -n "${SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST:-}" ]]; then
+                  ${ORCH_CMD} -n stackrox set env deploy/scanner-v4-matcher \
+                    "SCANNER_V4_MATCHER_VULN_BUNDLE_ALLOWLIST=${SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST}"
                 fi
               fi
             else

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -23,6 +23,10 @@ export SFA_AGENT="${SFA_AGENT:-false}"
 export QA_TEST_DEBUG_LOGS="/tmp/qa-tests-backend-logs"
 export QA_DEPLOY_WAIT_INFO="/tmp/wait-for-kubectl-object"
 
+# Scanner V4 default vuln bundle allow list, various sources are omitted to speed up CI (ie: suse).
+# Can be overridden by individual jobs. Setting to "" will load data from all sources.
+export SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST="${SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST:-alpine,debian,epss,manual,nvd,osv,rhel-vex,stackrox-rhel-csaf,ubuntu}"
+
 # If `envsubst` is contained in a non-standard directory `env -i` won't be able to
 # execute it, even though it can be located via `$PATH`, hence we retrieve the absolute path of
 # `envsubst`` before passing it to `env`.
@@ -577,9 +581,15 @@ deploy_central_via_operator() {
         false) scannerV4ScannerComponent="Disabled" ;;
     esac
 
-    if [[ "${SCANNER_V4_VULN_READINESS:-false}" == "true" && "$scannerV4ScannerComponent" != "Disabled" ]]; then
-        customize_envVars+=$'\n      - name: SCANNER_V4_MATCHER_READINESS'
-        customize_envVars+=$'\n        value: "vulnerability"'
+    if [[ "$scannerV4ScannerComponent" != "Disabled" ]]; then
+        if [[ "${SCANNER_V4_VULN_READINESS:-false}" == "true" ]]; then
+            customize_envVars+=$'\n      - name: SCANNER_V4_MATCHER_READINESS'
+            customize_envVars+=$'\n        value: "vulnerability"'
+        fi
+        if [[ -n "${SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST:-}" ]]; then
+            customize_envVars+=$'\n      - name: SCANNER_V4_MATCHER_VULN_BUNDLE_ALLOWLIST'
+            customize_envVars+=$'\n        value: "'"${SCANNER_V4_CI_VULN_BUNDLE_ALLOWLIST}"'"'
+        fi
     fi
 
     local scannerV4DbPersistenceYaml


### PR DESCRIPTION
## Description

This PR filters the data that Scanner V4 loads in e2e tests to specific sources, leveraging the changes made in https://github.com/stackrox/stackrox/pull/19835 

The default value was placed in `tests/e2e/lib.sh` because that will be sourced by `.openshift-ci/dispatch.sh` before any other job specific code runs.  This allows the value to be overridden to the empty string `""` for jobs that may wish to load all vulns.

This change reduces initial load times from ~45 mins to ~15

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Against StackRox Scanner these changes will be tested by CI as part of this PR

Against Scanner V4 these changes were validated in https://github.com/stackrox/stackrox/pull/19236 and will be validated again in: https://github.com/stackrox/stackrox/pull/21098

```
{"level":"WARN","source":"github.com/stackrox/rox/scanner/matcher/updater/vuln.(*Updater).Start","time":"2026-05-05T02:44:37.809703433Z","msg":"vulnerability bundle allowlist is active: only listed bundles will be imported; do not use in production","host":"scanner-v4-matcher-68877cb888-nxtx5","bundles":"alpine, epss, manual, nvd, stackrox-rhel-csaf, debian, osv, rhel-vex, ubuntu"}
```