### PR TITLE
ROX-34464: Add apiClients integration source with ServiceNow tile

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ApiClientsIntegrationsTab.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ApiClientsIntegrationsTab.tsx
@@ -1,0 +1,21 @@
+import type { ReactElement } from 'react';
+import { Gallery } from '@patternfly/react-core';
+
+import IntegrationsTabPage from './IntegrationsTabPage';
+import type { IntegrationsTabProps } from './IntegrationsTab.types';
+
+import ServiceNowTile from './ServiceNowTile';
+
+const source = 'apiClients';
+
+function ApiClientsIntegrationsTab({ sourcesEnabled }: IntegrationsTabProps): ReactElement {
+    return (
+        <IntegrationsTabPage source={source} sourcesEnabled={sourcesEnabled}>
+            <Gallery hasGutter>
+                <ServiceNowTile integrations={[]} />
+            </Gallery>
+        </IntegrationsTabPage>
+    );
+}
+
+export default ApiClientsIntegrationsTab;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ServiceNowTile.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ServiceNowTile.tsx
@@ -1,0 +1,30 @@
+import type { ReactElement } from 'react';
+
+import {
+    apiClientsSource as source,
+    getIntegrationsListPath,
+    serviceNowDescriptor as descriptor,
+} from '../utils/integrationsList';
+import IntegrationTile from './IntegrationTile';
+import { integrationTypeCounter } from './integrationTiles.utils';
+
+const { Logo, label, type } = descriptor;
+
+export type ServiceNowTileProps = {
+    integrations: { type: string }[];
+};
+
+function ServiceNowTile({ integrations }: ServiceNowTileProps): ReactElement {
+    const countIntegrations = integrationTypeCounter(integrations);
+
+    return (
+        <IntegrationTile
+            Logo={Logo}
+            label={label}
+            linkTo={getIntegrationsListPath(source, type)}
+            numIntegrations={countIntegrations('serviceNow')}
+        />
+    );
+}
+
+export default ServiceNowTile;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsPage.tsx
@@ -11,6 +11,7 @@ import CreateIntegrationPage from './CreateIntegrationPage';
 import EditIntegrationPage from './EditIntegrationPage';
 import IntegrationDetailsPage from './IntegrationDetailsPage';
 
+import ApiClientsIntegrationsTab from './IntegrationTiles/ApiClientsIntegrationsTab';
 import AuthenticationIntegrationsTab from './IntegrationTiles/AuthenticationIntegrationsTab';
 import BackupIntegrationsTab from './IntegrationTiles/BackupIntegrationsTab';
 import CloudSourceIntegrationsTab from './IntegrationTiles/CloudSourceIntegrationsTab';
@@ -31,6 +32,7 @@ const integrationsTabElementMap: Record<IntegrationSource, IntegrationsTabElemen
     backups: BackupIntegrationsTab,
     cloudSources: CloudSourceIntegrationsTab,
     authProviders: AuthenticationIntegrationsTab,
+    apiClients: ApiClientsIntegrationsTab,
 };
 
 const IntegrationsPage = (): ReactElement => {

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useFetchIntegrations.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useFetchIntegrations.ts
@@ -25,8 +25,8 @@ const useFetchIntegrations = (source: IntegrationSource): UseFetchIntegrationsRe
         if (source === 'authProviders') {
             dispatch(apitokensActions.fetchAPITokens.request());
             dispatch(machineAccessConfigsActions.fetchMachineAccessConfigs.request());
-        } else {
-            dispatch(fetchIntegrationsActionMap[source]);
+        } else if (source in fetchIntegrationsActionMap) {
+            dispatch(fetchIntegrationsActionMap[source as keyof typeof fetchIntegrationsActionMap]);
         }
     }
 

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationPermissions.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationPermissions.ts
@@ -47,6 +47,10 @@ const useIntegrationPermissions = (): UseIntegrationPermissionsResponse => {
             write: getHasReadWritePermission('Integration', userRolePermissions),
             read: getHasReadPermission('Integration', userRolePermissions),
         },
+        apiClients: {
+            write: getHasReadWritePermission('Integration', userRolePermissions),
+            read: getHasReadPermission('Integration', userRolePermissions),
+        },
     };
 };
 

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
@@ -74,6 +74,9 @@ const useIntegrations = ({ source, type }: UseIntegrations): UseIntegrationsResp
                 }
                 return cloudSources;
             }
+            case 'apiClients': {
+                return [];
+            }
             default: {
                 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
                 throw new Error(`Unknown source ${source}`);

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
@@ -332,7 +332,7 @@ export const apiClientsSource: IntegrationSource = 'apiClients';
 export const serviceNowDescriptor: ApiClientDescriptor = {
     // TODO: Replace with ServiceNow logo once available from UX
     Logo: RedhatSvg,
-    label: 'ServiceNow',
+    label: 'ServiceNow VR',
     type: 'serviceNow',
 };
 
@@ -426,7 +426,7 @@ export const integrationSourceTitleMap: Record<IntegrationSource, string> = {
     backups: 'Backup',
     cloudSources: 'Cloud source',
     authProviders: 'Authentication',
-    apiClients: 'API Clients',
+    apiClients: 'API clients',
 };
 
 export function getIntegrationTabPath(source: IntegrationSource) {

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
@@ -330,6 +330,7 @@ const cloudSourceDescriptors = [paladinCloudDescriptor, ocmDescriptor];
 export const apiClientsSource: IntegrationSource = 'apiClients';
 
 export const serviceNowDescriptor: ApiClientDescriptor = {
+    // TODO: Replace with ServiceNow logo once available from UX
     Logo: RedhatSvg,
     label: 'ServiceNow',
     type: 'serviceNow',

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
@@ -43,6 +43,7 @@ import type { CentralCapabilitiesFlags } from 'services/MetadataService';
 import type { FeatureFlagEnvVar } from 'types/featureFlag';
 import { integrationSources } from 'types/integration';
 import type {
+    ApiClientIntegrationType,
     AuthProviderType,
     BackupIntegrationType,
     CloudSourceIntegrationType,
@@ -80,6 +81,10 @@ export type NotifierIntegrationDescriptor = {
 
 export type SignatureIntegrationDescriptor = {
     type: SignatureIntegrationType;
+} & BaseIntegrationDescriptor;
+
+export type ApiClientDescriptor = {
+    type: ApiClientIntegrationType;
 } & BaseIntegrationDescriptor;
 
 export type CloudSourceDescriptor = {
@@ -322,6 +327,16 @@ export const ocmDescriptor: CloudSourceDescriptor = {
 
 const cloudSourceDescriptors = [paladinCloudDescriptor, ocmDescriptor];
 
+export const apiClientsSource: IntegrationSource = 'apiClients';
+
+export const serviceNowDescriptor: ApiClientDescriptor = {
+    Logo: RedhatSvg,
+    label: 'ServiceNow',
+    type: 'serviceNow',
+};
+
+const apiClientsDescriptors: ApiClientDescriptor[] = [serviceNowDescriptor];
+
 function getDescriptors(source: string): BaseIntegrationDescriptor[] {
     switch (source) {
         case 'imageIntegrations':
@@ -336,6 +351,8 @@ function getDescriptors(source: string): BaseIntegrationDescriptor[] {
             return authenticationTokensDescriptors;
         case 'cloudSources':
             return cloudSourceDescriptors;
+        case 'apiClients':
+            return apiClientsDescriptors;
         default:
             return [];
     }
@@ -360,6 +377,7 @@ const integrationSourceRequirementsMap: Record<IntegrationSource, IntegrationsRo
     backups: { centralCapabilityRequirement: 'centralCanUseCloudBackupIntegrations' },
     cloudSources: {},
     authProviders: {},
+    apiClients: {},
 };
 
 export type IntegrationsRoutePredicates = {
@@ -407,6 +425,7 @@ export const integrationSourceTitleMap: Record<IntegrationSource, string> = {
     backups: 'Backup',
     cloudSources: 'Cloud source',
     authProviders: 'Authentication',
+    apiClients: 'API Clients',
 };
 
 export function getIntegrationTabPath(source: IntegrationSource) {

--- a/ui/apps/platform/src/services/IntegrationsService.ts
+++ b/ui/apps/platform/src/services/IntegrationsService.ts
@@ -6,6 +6,7 @@ import { updateCloudSource } from './CloudSourceService';
 import type { UpdateCloudSourceRequest } from './CloudSourceService';
 
 export type IntegrationSource =
+    | 'apiClients'
     | 'authProviders'
     | 'backups'
     | 'imageIntegrations'
@@ -27,6 +28,8 @@ function getPath(source: IntegrationSource): string {
             return '/v1/auth/m2m';
         case 'cloudSources':
             return '/v1/cloud-sources';
+        case 'apiClients':
+            return '/v1/api-clients';
         default:
             return '';
     }

--- a/ui/apps/platform/src/types/integration.ts
+++ b/ui/apps/platform/src/types/integration.ts
@@ -8,6 +8,7 @@ export const integrationSources = [
     'backups',
     'cloudSources',
     'authProviders',
+    'apiClients',
 ] as const;
 
 export type IntegrationSource = (typeof integrationSources)[number];
@@ -17,6 +18,7 @@ export function isIntegrationSource(source: unknown): source is IntegrationSourc
 }
 
 export type IntegrationType =
+    | ApiClientIntegrationType
     | AuthProviderType
     | BackupIntegrationType
     | ImageIntegrationType
@@ -69,6 +71,8 @@ export type NotifierIntegrationType =
     | 'teams';
 
 export type SignatureIntegrationType = 'signature';
+
+export type ApiClientIntegrationType = 'serviceNow';
 
 export type CloudSourceIntegrationType = 'paladinCloud' | 'ocm';
 


### PR DESCRIPTION
## Description

**Jira:** [ROX-34464](https://issues.redhat.com/browse/ROX-34464)

This adds a new "API Clients" tab to the integrations page with a ServiceNow tile. Unlike other integration sources, there's no backend API for this yet. The tile will just link externally to the ServiceNow store listing rather than managing integrations through the platform.

A few things to note:
- The integrations data is intentionally hardcoded as empty since we don't have a backend API. `useIntegrations` returns `[]` for `apiClients` and `useFetchIntegrations` safely no-ops.
- The logo is a Red Hat SVG placeholder. I'm waiting on UX for the actual ServiceNow logo asset.
- I wired `apiClients` through the full integration source pattern (types, permissions, routing, service layer) so when we do add an API later, the scaffolding is already in place.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] modified existing tests

### How I validated my change

- TypeScript compiles without errors
- Confirmed the new source follows the same wiring pattern as existing sources (`cloudSources`, `authProviders`, etc.)
- Verified `useFetchIntegrations` safely no-ops for `apiClients` without runtime errors

[ROX-34464]: https://redhat.atlassian.net/browse/ROX-34464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ