### PR TITLE
ROX-34464: Register apiClients integration source and tab routing

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ApiClientIntegrationsTab.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ApiClientIntegrationsTab.tsx
@@ -1,0 +1,17 @@
+import type { ReactElement } from 'react';
+import { Gallery } from '@patternfly/react-core';
+
+import type { IntegrationsTabProps } from './IntegrationsTab.types';
+import IntegrationsTabPage from './IntegrationsTabPage';
+
+const source = 'apiClients';
+
+function ApiClientIntegrationsTab({ sourcesEnabled }: IntegrationsTabProps): ReactElement {
+    return (
+        <IntegrationsTabPage source={source} sourcesEnabled={sourcesEnabled}>
+            <Gallery hasGutter>{/* ServiceNow VR tile will be added in Slice 2 */}</Gallery>
+        </IntegrationsTabPage>
+    );
+}
+
+export default ApiClientIntegrationsTab;

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsPage.tsx
@@ -11,6 +11,7 @@ import CreateIntegrationPage from './CreateIntegrationPage';
 import EditIntegrationPage from './EditIntegrationPage';
 import IntegrationDetailsPage from './IntegrationDetailsPage';
 
+import ApiClientIntegrationsTab from './IntegrationTiles/ApiClientIntegrationsTab';
 import AuthenticationIntegrationsTab from './IntegrationTiles/AuthenticationIntegrationsTab';
 import BackupIntegrationsTab from './IntegrationTiles/BackupIntegrationsTab';
 import CloudSourceIntegrationsTab from './IntegrationTiles/CloudSourceIntegrationsTab';
@@ -31,6 +32,7 @@ const integrationsTabElementMap: Record<IntegrationSource, IntegrationsTabElemen
     backups: BackupIntegrationsTab,
     cloudSources: CloudSourceIntegrationsTab,
     authProviders: AuthenticationIntegrationsTab,
+    apiClients: ApiClientIntegrationsTab,
 };
 
 const IntegrationsPage = (): ReactElement => {

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts
@@ -8,7 +8,10 @@ import {
     testIntegration,
     testIntegrationV2,
 } from 'services/IntegrationsService';
-import type { IntegrationOptions } from 'services/IntegrationsService';
+import type {
+    IntegrationOptions,
+    IntegrationSource as CrudIntegrationSource,
+} from 'services/IntegrationsService';
 import { generateAPIToken } from 'services/APITokensService';
 import { getAxiosErrorMessage, isTimeoutError } from 'utils/responseErrorUtils';
 
@@ -36,6 +39,8 @@ function useIntegrationActions(): UseIntegrationActionsResult {
         isEditing,
         params: { source, type },
     } = usePageState();
+    // This hook is only mounted on CRUD routes, so source is always a CRUD-capable source
+    const crudSource = source as CrudIntegrationSource;
     const fetchIntegrations = useFetchIntegrations(source);
     const integrationsListPath = `${integrationsPath}/${source}/${type}`;
 
@@ -46,8 +51,8 @@ function useIntegrationActions(): UseIntegrationActionsResult {
             if (isEditing) {
                 responseData =
                     typeof updatePassword === 'boolean'
-                        ? await saveIntegration(source, data, { updatePassword })
-                        : await saveIntegrationV2(source, data);
+                        ? await saveIntegration(crudSource, data, { updatePassword })
+                        : await saveIntegrationV2(crudSource, data);
                 navigate(integrationsListPath);
             } else if (type === 'apitoken') {
                 responseData = await generateAPIToken(data);
@@ -55,7 +60,7 @@ function useIntegrationActions(): UseIntegrationActionsResult {
                 responseData = await createMachineAccessConfig(data);
                 navigate(-1);
             } else {
-                responseData = await createIntegration(source, data);
+                responseData = await createIntegration(crudSource, data);
                 // we only want to redirect when creating a new non-apitoken integration
                 navigate(-1);
             }
@@ -70,9 +75,9 @@ function useIntegrationActions(): UseIntegrationActionsResult {
     async function onTest(data, { updatePassword }: IntegrationOptions = {}) {
         try {
             if (typeof updatePassword === 'boolean') {
-                await testIntegration(source, data, { updatePassword });
+                await testIntegration(crudSource, data, { updatePassword });
             } else {
-                await testIntegrationV2(source, data);
+                await testIntegrationV2(crudSource, data);
             }
             return { message: `The test was successful`, isError: false };
         } catch (error) {

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationActions.ts
@@ -39,7 +39,9 @@ function useIntegrationActions(): UseIntegrationActionsResult {
         isEditing,
         params: { source, type },
     } = usePageState();
-    // This hook is only mounted on CRUD routes, so source is always a CRUD-capable source
+    // The routing IntegrationSource type includes 'apiClients', which has no backend
+    // endpoints. This hook only mounts on create/edit routes, so 'apiClients' never
+    // reaches here. Safe to narrow to the CRUD-capable source type.
     const crudSource = source as CrudIntegrationSource;
     const fetchIntegrations = useFetchIntegrations(source);
     const integrationsListPath = `${integrationsPath}/${source}/${type}`;

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationPermissions.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrationPermissions.ts
@@ -47,6 +47,10 @@ const useIntegrationPermissions = (): UseIntegrationPermissionsResponse => {
             write: getHasReadWritePermission('Integration', userRolePermissions),
             read: getHasReadPermission('Integration', userRolePermissions),
         },
+        apiClients: {
+            write: getHasReadWritePermission('Integration', userRolePermissions),
+            read: getHasReadPermission('Integration', userRolePermissions),
+        },
     };
 };
 

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
@@ -408,7 +408,7 @@ export const integrationSourceTitleMap: Record<IntegrationSource, string> = {
     backups: 'Backup',
     cloudSources: 'Cloud source',
     authProviders: 'Authentication',
-    apiClients: 'API Clients',
+    apiClients: 'API clients',
 };
 
 export function getIntegrationTabPath(source: IntegrationSource) {

--- a/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
+++ b/ui/apps/platform/src/Containers/Integrations/utils/integrationsList.ts
@@ -360,6 +360,7 @@ const integrationSourceRequirementsMap: Record<IntegrationSource, IntegrationsRo
     backups: { centralCapabilityRequirement: 'centralCanUseCloudBackupIntegrations' },
     cloudSources: {},
     authProviders: {},
+    apiClients: {},
 };
 
 export type IntegrationsRoutePredicates = {
@@ -407,6 +408,7 @@ export const integrationSourceTitleMap: Record<IntegrationSource, string> = {
     backups: 'Backup',
     cloudSources: 'Cloud source',
     authProviders: 'Authentication',
+    apiClients: 'API Clients',
 };
 
 export function getIntegrationTabPath(source: IntegrationSource) {

--- a/ui/apps/platform/src/types/integration.ts
+++ b/ui/apps/platform/src/types/integration.ts
@@ -8,6 +8,7 @@ export const integrationSources = [
     'backups',
     'cloudSources',
     'authProviders',
+    'apiClients',
 ] as const;
 
 export type IntegrationSource = (typeof integrationSources)[number];


### PR DESCRIPTION
## Description

**Jira:** [ROX-34464](https://issues.redhat.com/browse/ROX-34464)

The ACS Integrations page has no way to surface third-party tools that connect to ACS from the outside (e.g., ServiceNow VR connector). This PR adds the routing and tab infrastructure so subsequent work can populate the tab with integration tiles.

- Add `apiClients` to the `integrationSources` array and all dependent maps (title, requirements, permissions)
- Create `ApiClientIntegrationsTab` stub component following the existing non-standard tab pattern (like CloudSources and AuthProviders)
- Register the tab in `IntegrationsPage` so `/integrations/apiClients` is routable
- Fix type mismatch in `useIntegrationActions` between the global `IntegrationSource` (which now includes `apiClients`) and the service-level type (which only covers sources with backend CRUD)

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] modified existing tests

### How I validated my change

- TypeScript type checking passes (`npm run tsc`)
- ESLint passes on all changed files
- The tab is a stub with no dynamic behavior; a Cypress component test will be added in a follow-up slice when the ServiceNow VR tile is populated

[ROX-34464]: https://redhat.atlassian.net/browse/ROX-34464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ