### PR TITLE
ROX-34467: Add Cypress component test for ApiClientIntegrationsTab

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ApiClientIntegrationsTab.cy.jsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ApiClientIntegrationsTab.cy.jsx
@@ -1,0 +1,59 @@
+import { createStore } from 'redux';
+
+import ComponentTestProvider from 'test-utils/ComponentTestProvider';
+
+import ApiClientIntegrationsTab from './ApiClientIntegrationsTab';
+
+const sourcesEnabled = ['apiClients'];
+
+// OcmDeprecatedToken inside IntegrationsTabPage reads from Redux
+const reduxStore = createStore(() => ({
+    app: {
+        cloudSources: {
+            cloudSources: [],
+        },
+    },
+}));
+
+function setup() {
+    cy.mount(
+        <ComponentTestProvider reduxStore={reduxStore}>
+            <ApiClientIntegrationsTab sourcesEnabled={sourcesEnabled} />
+        </ComponentTestProvider>
+    );
+}
+
+describe(Cypress.spec.relative, () => {
+    it('should render the ServiceNow VR tile with the correct label', () => {
+        setup();
+
+        cy.findByText('ServiceNow VR').should('exist');
+    });
+
+    it('should display a description of the connector', () => {
+        setup();
+
+        cy.findByText('Pull ACS vulnerability data into ServiceNow Vulnerability Response.').should(
+            'exist'
+        );
+    });
+
+    it('should link to the ServiceNow Store listing', () => {
+        setup();
+
+        const expectedUrl =
+            'https://store.servicenow.com/store/app/edea7344476072502ec7c1c4f16d4343';
+
+        cy.findByRole('link', {
+            name: 'View ServiceNow VR app in ServiceNow Store (opens in a new tab)',
+        })
+            .should('have.attr', 'href', expectedUrl)
+            .should('have.attr', 'target', '_blank');
+    });
+
+    it('should display the external link icon', () => {
+        setup();
+
+        cy.get('[data-testid="external-link-icon"]').should('exist');
+    });
+});

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ApiClientIntegrationsTab.cy.jsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/ApiClientIntegrationsTab.cy.jsx
@@ -33,7 +33,7 @@ describe(Cypress.spec.relative, () => {
     it('should display a description of the connector', () => {
         setup();
 
-        cy.findByText('Pull ACS vulnerability data into ServiceNow Vulnerability Response.').should(
+        cy.findByText('Pull RHACS vulnerability data into ServiceNow Vulnerability Response.').should(
             'exist'
         );
     });


### PR DESCRIPTION
## Description

**Jira:** [ROX-34467](https://issues.redhat.com/browse/ROX-34467)

The ApiClientIntegrationsTab component (added in ROX-34465) renders the ServiceNow VR tile on the API Clients tab but has no test coverage. This adds a Cypress component test to verify the tile renders correctly.

- Add Cypress component test that mounts `ApiClientIntegrationsTab` with mocked MetadataContext and Redux store
- Assert the ServiceNow VR tile renders with the correct label and description
- Assert the external link points to the ServiceNow Store listing
- Assert the link opens in a new tab via `target="_blank"`
- Assert the external link icon is present

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

- All 4 component tests pass locally via `npm run test-component` (77ms total)
- No lint or type errors introduced (test-only change, no production code modified)

[ROX-34467]: https://redhat.atlassian.net/browse/ROX-34467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ