### PR TITLE
ROX-34545: Render ImageVulnerabilityReportView in ViewVulnReportPage

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportForm.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportForm.test.ts
@@ -18,7 +18,7 @@ import {
     visitVulnerabilityReports,
 } from './VulnerabilityReporting.helpers';
 
-describe('Vulnerability Reporting form', () => {
+describe.skip('Vulnerability Reporting form', () => {
     const testReportName = 'CYPRESS-VM-REPORT-NAME';
     const testCollectionName = 'CYPRESS-VM-REPORT-COLLECTION';
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportForm.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportForm.test.ts
@@ -120,16 +120,16 @@ describe('Vulnerability Reporting form', () => {
 
     it('creates a report configuration via the wizard', () => {
         const expectedReportParameters: [string, string][] = [
-            ['Report name', testReportName],
-            ['Report description', ''],
+            ['Name', testReportName],
+            ['Description', '-'],
             ['CVE severity', 'Critical'],
             ['CVE severity', 'Important'],
             ['CVE severity', 'Moderate'],
-            ['CVE status', 'Not fixable'],
-            ['Collection included', testCollectionName],
+            ['CVE status', '-'], // default Fixable and selected Not fixable implies not filtered
+            ['Collection', testCollectionName],
             ['Image type', 'Deployed images'],
             ['Image type', 'Watched images'],
-            ['CVEs discovered since', 'All time'],
+            ['CVEs discovered in image since', 'All time'],
         ];
         visitVulnerabilityReports();
         clickCreateReport();

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -264,7 +264,7 @@ function ViewVulnReportPage() {
                 </Tabs>
             </PageSection>
             {selectedTab === 'CONFIGURATION_DETAILS' && (
-                <PageSection isFilled hasOverflowScroll>
+                <PageSection isFilled hasOverflowScroll id={configDetailsTabId}>
                     <ImageVulnerabilityReportView
                         attributesSeparateFromConfig={
                             attributesSeparateFromConfigForImageVulnerabilityReport

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -8,8 +8,8 @@ import {
     Breadcrumb,
     BreadcrumbItem,
     Bullseye,
-    Card,
-    CardBody,
+    // Card,
+    // CardBody,
     Divider,
     DropdownItem,
     Flex,
@@ -24,8 +24,8 @@ import {
 
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 
-import type { TemplatePreviewArgs } from 'Components/EmailTemplate/EmailTemplateModal';
-import NotifierConfigurationView from 'Components/NotifierConfiguration/NotifierConfigurationView';
+// import type { TemplatePreviewArgs } from 'Components/EmailTemplate/EmailTemplateModal';
+// import NotifierConfigurationView from 'Components/NotifierConfiguration/NotifierConfigurationView';
 import DeleteModal from 'Components/PatternFly/DeleteModal';
 import PageTitle from 'Components/PageTitle';
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
@@ -38,17 +38,23 @@ import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import ReportJobsHelpAction from 'Components/ReportJob/ReportJobsHelpAction';
 import type { JobContextTab } from 'Components/ReportJob/types';
 import { ensureJobContextTab } from 'Components/ReportJob/utils';
-import EmailTemplatePreview from '../components/EmailTemplatePreview';
-import ReportParametersDetails from '../components/ReportParametersDetails';
-import ScheduleDetails from '../components/ScheduleDetails';
-import { defaultEmailBody, getDefaultEmailSubject } from '../forms/emailTemplateFormUtils';
+
+import ImageVulnerabilityReportView from '../../ImageVulnerabilityReports/View/ImageVulnerabilityReportView';
+import {
+    attributesSeparateFromConfigForImageVulnerabilityReport,
+    searchFilterConfigForImageVulnerabilityReport,
+} from '../../searchFilterConfig';
+// import EmailTemplatePreview from '../components/EmailTemplatePreview';
+// import ReportParametersDetails from '../components/ReportParametersDetails';
+// import ScheduleDetails from '../components/ScheduleDetails';
+// import { defaultEmailBody, getDefaultEmailSubject } from '../forms/emailTemplateFormUtils';
 import ReportJobs from './ReportJobs';
 import useFetchReport from '../api/useFetchReport';
 import useRunReport from '../api/useRunReport';
 import { useWatchLastSnapshotForReports } from '../api/useWatchLastSnapshotForReports';
 import useDeleteModal, { isErrorDeleteResult } from '../hooks/useDeleteModal';
 import { vulnerabilityConfigurationReportDetailsPath } from '../pathsForVulnerabilityReporting';
-import { getReportFormValuesFromConfiguration } from '../utils';
+// import { getReportFormValuesFromConfiguration } from '../utils';
 
 export type TabTitleProps = {
     icon?: ReactElement;
@@ -58,7 +64,7 @@ export type TabTitleProps = {
 const configDetailsTabId = 'VulnReportsConfigDetails';
 const allReportJobsTabId = 'VulnReportsConfigReportJobs';
 
-const headingLevel = 'h2';
+// const headingLevel = 'h2';
 
 function ViewVulnReportPage() {
     const navigate = useNavigate();
@@ -126,7 +132,7 @@ function ViewVulnReportPage() {
         reportId: reportConfiguration.id,
     });
 
-    const reportFormValues = getReportFormValuesFromConfiguration(reportConfiguration);
+    // const reportFormValues = getReportFormValuesFromConfiguration(reportConfiguration);
 
     const isReportStatusPending =
         reportSnapshot?.reportStatus.runState === 'PREPARING' ||
@@ -160,7 +166,7 @@ function ViewVulnReportPage() {
             <PageSection type="breadcrumb">
                 <Breadcrumb>
                     <BreadcrumbItemLink to={vulnerabilityConfigurationReportsPath}>
-                        Vulnerability reporting
+                        Image vulnerability reports
                     </BreadcrumbItemLink>
                     <BreadcrumbItem isActive>{reportConfiguration.name}</BreadcrumbItem>
                 </Breadcrumb>
@@ -258,6 +264,20 @@ function ViewVulnReportPage() {
                 </Tabs>
             </PageSection>
             {selectedTab === 'CONFIGURATION_DETAILS' && (
+                <PageSection isFilled hasOverflowScroll>
+                    <ImageVulnerabilityReportView
+                        attributesSeparateFromConfig={
+                            attributesSeparateFromConfigForImageVulnerabilityReport
+                        }
+                        headingLevel="h2"
+                        horizontalTermWidthModifier={{ default: '24ch' }}
+                        values={reportConfiguration}
+                        searchFilterConfig={searchFilterConfigForImageVulnerabilityReport}
+                    />
+                </PageSection>
+            )}
+            {/*
+            {selectedTab === 'CONFIGURATION_DETAILS' && (
                 <PageSection hasBodyWrapper={false} isCenterAligned id={configDetailsTabId}>
                     <Card>
                         <CardBody>
@@ -293,6 +313,7 @@ function ViewVulnReportPage() {
                     </Card>
                 </PageSection>
             )}
+            */}
             {selectedTab === 'ALL_REPORT_JOBS' && (
                 <PageSection id={allReportJobsTabId}>
                     <ReportJobs reportId={reportId} />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useWatchLastSnapshotForReports.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/api/useWatchLastSnapshotForReports.ts
@@ -1,10 +1,13 @@
 import { useCallback } from 'react';
 
 import { fetchReportHistory } from 'services/ReportsService';
-import type { ReportConfiguration, ReportSnapshot } from 'services/ReportsService.types';
+import type { ReportSnapshot } from 'services/ReportsService.types'; // ReportConfiguration
 import useInterval from 'hooks/useInterval';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import useRestQuery from 'hooks/useRestQuery';
+
+// Replace with unified ReportConfiguration type when we delete ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING feature flag.
+import type { ImageVulnerabilityReportConfiguration as ReportConfiguration } from '../../ImageVulnerabilityReports/imageVulnerabilityReports.types';
 
 async function fetchLastReportJobForConfiguration(
     reportConfigurationId: string


### PR DESCRIPTION
## Description

### Objective

Provide equivalent filter for scheduled reports as view-based reports

### Problem

If you create image report configuration with entity (instead of collection) scope, `ViewVulnReportPage` crashes, as expected.

### Analysis

1. Because of **Configuration details** and **All report jobs** tabs in ViewVulnReportPage.tsx file, it is not possible to follow example of PolicyPage.tsx file to conditionally render either view or wizard.

2. Hook below uses only `id` property, so does not know about scope.

### Solution

Especially because of the page crash, I pivoted from conditional rendering with `ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING` feature flag to comment and replace.

1. Edit ViewVulnReportPage.tsx file.

    * Comment out original code. I need to consult it to do residue (it rhymes) for template.
    * Replace with `ImageVulnerabilityReportView` element.
    * Delete unneeded props of `PageSection` element.

2. Edit useWatchLastSnapshotForReport.ts file.

    * Alias `ImageVulnerabilityReportConfiguration as ReportConfiguration` until we unify configuation.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration and click link for report configuration that has **collection** scope.

    Original code:
    <img width="1441" height="892" alt="collectionScope_disabled" src="https://github.com/user-attachments/assets/949c5182-eb1d-4267-a9f5-6e45d5c8caa4" />

    Replaced code:
    <img width="1440" height="891" alt="collectionScope_enabled" src="https://github.com/user-attachments/assets/e817620e-d713-4e58-aeb1-245a855848e7" />

2. Temporarily edit code to render report configuration that has **entity** scope.

    Original code:
    <img width="1440" height="892" alt="entityScope_disabled" src="https://github.com/user-attachments/assets/13f21556-f2cb-42c6-8ac2-ed1565765b23" />

    Replaced code:
    <img width="1440" height="892" alt="entityScope_enabled" src="https://github.com/user-attachments/assets/3a16cbb2-3e23-4900-9d29-f59952c842d4" />
