### PR TITLE
fix(tls): Missing internal certificates should be an error

### DIFF
--- a/central/tlsconfig/manager_impl_test.go
+++ b/central/tlsconfig/manager_impl_test.go
@@ -209,7 +209,7 @@ func (s *managerTestSuite) TestLoadInternalCertificateFromDirectory() {
 func (s *managerTestSuite) TestLoadInternalCertificateFromDirectoryMissingFiles() {
 	dir := s.T().TempDir()
 	cert, err := LoadInternalCertificateFromDirectory(dir)
-	s.NoError(err)
+	s.Error(err)
 	s.Nil(cert)
 }
 

--- a/central/tlsconfig/tlsconfig.go
+++ b/central/tlsconfig/tlsconfig.go
@@ -201,13 +201,9 @@ func LoadInternalCertificateFromDirectory(dir string) (*tls.Certificate, error) 
 	certFile := filepath.Join(dir, mtls.ServiceCertFileName)
 	keyFile := filepath.Join(dir, mtls.ServiceKeyFileName)
 
-	if filesExist, err := fileutils.AllExist(certFile, keyFile); err != nil || !filesExist {
-		return nil, err
-	}
-
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return nil, errors.Wrap(err, "loading internal certificate")
+		return nil, errors.Wrapf(err, "loading internal certificate from %q", dir)
 	}
 
 	trustPool, err := verifier.TrustedCertPool()


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

https://github.com/stackrox/stackrox/pull/20075 introduced a minor logic error: missing internal certificates should be considered an error in `LoadInternalCertificateFromDirectory` (unlike `MaybeGetDefaultTLSCertificateFromDirectory`, where it's perfectly fine to not have a default TLS cert).

Relates to ROX-34179

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI should be sufficient.
