### PR TITLE
ROX-33375: Add flat fields to Slack notifier payload

### DIFF
--- a/central/notifiers/slack/slack.go
+++ b/central/notifiers/slack/slack.go
@@ -16,9 +16,11 @@ import (
 	"github.com/stackrox/rox/pkg/administration/events/codes"
 	"github.com/stackrox/rox/pkg/administration/events/option"
 	"github.com/stackrox/rox/pkg/httputil/proxy"
+	"github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/logging"
 	mitreDS "github.com/stackrox/rox/pkg/mitre/datastore"
 	"github.com/stackrox/rox/pkg/notifiers"
+	"github.com/stackrox/rox/pkg/protoconv"
 	"github.com/stackrox/rox/pkg/retry"
 	"github.com/stackrox/rox/pkg/urlfmt"
 	"github.com/stackrox/rox/pkg/utils"
@@ -43,10 +45,26 @@ type slack struct {
 	mitreStore     mitreDS.AttackReadOnlyDataStore
 }
 
-// notification json struct for richly-formatted notifications
+// notification json struct for richly-formatted notifications.
+// Flat top-level fields are included alongside attachments so that Slack
+// workflow webhooks (which only support flat key-value pairs) can extract
+// individual alert properties as workflow variables.
 type notification struct {
-	Attachments []attachment `json:"attachments"`
+	Attachments []attachment `json:"attachments,omitempty"`
 	Text        string       `json:"text"`
+
+	Summary     string `json:"summary,omitempty"`
+	AlertID     string `json:"alert_id,omitempty"`
+	AlertURL    string `json:"alert_url,omitempty"`
+	Severity    string `json:"severity,omitempty"`
+	Time        string `json:"time,omitempty"`
+	Policy      string `json:"policy,omitempty"`
+	Cluster     string `json:"cluster,omitempty"`
+	Namespace   string `json:"namespace,omitempty"`
+	Entity      string `json:"entity,omitempty"`
+	EntityType  string `json:"entity_type,omitempty"`
+	Violations  string `json:"violations,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 // attachment json struct for attachments
@@ -122,23 +140,89 @@ func (*slack) Close(_ context.Context) error {
 	return nil
 }
 
+type entityMetadata struct {
+	name       string
+	entityType string
+	cluster    string
+	namespace  string
+}
+
+func getEntityMetadata(alert *storage.Alert) entityMetadata {
+	switch entity := alert.GetEntity().(type) {
+	case *storage.Alert_Deployment_:
+		return entityMetadata{
+			name:       entity.Deployment.GetName(),
+			entityType: "Deployment",
+			cluster:    entity.Deployment.GetClusterName(),
+			namespace:  entity.Deployment.GetNamespace(),
+		}
+	case *storage.Alert_Image:
+		return entityMetadata{
+			name:       types.Wrapper{GenericImage: entity.Image}.FullName(),
+			entityType: "Image",
+		}
+	case *storage.Alert_Resource_:
+		return entityMetadata{
+			name:       entity.Resource.GetName(),
+			entityType: "Resource",
+			cluster:    entity.Resource.GetClusterName(),
+			namespace:  entity.Resource.GetNamespace(),
+		}
+	case *storage.Alert_Node_:
+		return entityMetadata{
+			name:       entity.Node.GetName(),
+			entityType: "Node",
+			cluster:    entity.Node.GetClusterName(),
+		}
+	}
+	return entityMetadata{}
+}
+
+func violationMessages(alert *storage.Alert) string {
+	var msgs []string
+	for _, v := range alert.GetViolations() {
+		msgs = append(msgs, v.GetMessage())
+	}
+	if pv := alert.GetProcessViolation(); pv != nil {
+		msgs = append(msgs, pv.GetMessage())
+	}
+	return strings.Join(msgs, "\n")
+}
+
 // AlertNotify takes in an alert and generates the Slack message
 func (s *slack) AlertNotify(ctx context.Context, alert *storage.Alert) error {
 	body, err := s.getDescription(alert)
 	if err != nil {
 		return err
 	}
+	summary := notifiers.SummaryForAlert(alert)
 	attachments := []attachment{
 		{
 			FallBack:       body,
 			Color:          notifiers.GetAttachmentColor(alert.GetPolicy().GetSeverity()),
-			Pretext:        fmt.Sprintf("*%s*", notifiers.SummaryForAlert(alert)),
+			Pretext:        fmt.Sprintf("*%s*", summary),
 			Text:           body,
 			MarkDownFields: []string{"pretext", "text", "fields"},
 		},
 	}
+
+	meta := getEntityMetadata(alert)
+	alertLink := notifiers.AlertLink(s.Notifier.GetUiEndpoint(), alert)
+
 	notification := notification{
 		Attachments: attachments,
+		Summary:     summary,
+		AlertID:     alert.GetId(),
+		AlertURL:    alertLink,
+		Severity:    notifiers.SeverityString(alert.GetPolicy().GetSeverity()),
+		Time:        protoconv.ReadableTime(alert.GetTime()),
+		Policy:      alert.GetPolicy().GetName(),
+		Cluster:     meta.cluster,
+		Namespace:   meta.namespace,
+		Entity:      meta.name,
+		EntityType:  meta.entityType,
+		Violations:  violationMessages(alert),
+		Description: body,
 	}
 	jsonPayload, err := json.Marshal(&notification)
 	if err != nil {
@@ -194,6 +278,8 @@ func (s *slack) NetworkPolicyYAMLNotify(ctx context.Context, yaml string, cluste
 	}
 	notification := notification{
 		Attachments: attachments,
+		Cluster:     clusterName,
+		Description: body,
 	}
 	jsonPayload, err := json.Marshal(&notification)
 	if err != nil {

--- a/central/notifiers/slack/slack_test.go
+++ b/central/notifiers/slack/slack_test.go
@@ -4,6 +4,7 @@ package slack
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	mitreMocks "github.com/stackrox/rox/pkg/mitre/datastore/mocks"
 	notifierMocks "github.com/stackrox/rox/pkg/notifiers/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -68,4 +70,92 @@ func TestSlackTest(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	assert.NoError(t, s.Test(context.Background()))
+}
+
+func TestNotificationContainsFlatFields(t *testing.T) {
+	alert := fixtures.GetAlert()
+	s, mockCtrl := getSlackWithMock(t, &storage.Notifier{
+		UiEndpoint:   "https://stackrox.example.com",
+		LabelDefault: "https://hooks.slack.com/test",
+	})
+	defer mockCtrl.Finish()
+
+	body, err := s.getDescription(alert)
+	require.NoError(t, err)
+
+	meta := getEntityMetadata(alert)
+	n := notification{
+		Attachments: []attachment{{Text: body}},
+		Summary:     "test summary",
+		AlertID:     alert.GetId(),
+		Severity:    "High",
+		Policy:      alert.GetPolicy().GetName(),
+		Cluster:     meta.cluster,
+		Namespace:   meta.namespace,
+		Entity:      meta.name,
+		EntityType:  meta.entityType,
+		Violations:  violationMessages(alert),
+		Description: body,
+	}
+
+	data, err := json.Marshal(&n)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	assert.Equal(t, alert.GetId(), raw["alert_id"])
+	assert.Equal(t, "High", raw["severity"])
+	assert.Equal(t, alert.GetPolicy().GetName(), raw["policy"])
+	assert.Equal(t, "prod cluster", raw["cluster"])
+	assert.Equal(t, "stackrox", raw["namespace"])
+	assert.Equal(t, "nginx_server", raw["entity"])
+	assert.Equal(t, "Deployment", raw["entity_type"])
+	assert.Contains(t, raw["violations"], "CVE-2017-15804")
+	assert.Contains(t, raw["violations"], "This is a process violation")
+	assert.NotEmpty(t, raw["description"])
+	assert.NotNil(t, raw["attachments"], "attachments should still be present for legacy webhook compatibility")
+}
+
+func TestGetEntityMetadata(t *testing.T) {
+	cases := map[string]struct {
+		alert              *storage.Alert
+		expectedName       string
+		expectedEntityType string
+		expectedCluster    string
+		expectedNamespace  string
+	}{
+		"deployment": {
+			alert:              fixtures.GetAlert(),
+			expectedName:       "nginx_server",
+			expectedEntityType: "Deployment",
+			expectedCluster:    "prod cluster",
+			expectedNamespace:  "stackrox",
+		},
+		"resource": {
+			alert:              fixtures.GetResourceAlert(),
+			expectedName:       "my-secret",
+			expectedEntityType: "Resource",
+			expectedCluster:    "prod cluster",
+			expectedNamespace:  "stackrox",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			meta := getEntityMetadata(tc.alert)
+			assert.Equal(t, tc.expectedName, meta.name)
+			assert.Equal(t, tc.expectedEntityType, meta.entityType)
+			assert.Equal(t, tc.expectedCluster, meta.cluster)
+			assert.Equal(t, tc.expectedNamespace, meta.namespace)
+		})
+	}
+}
+
+func TestViolationMessages(t *testing.T) {
+	alert := fixtures.GetAlert()
+	msgs := violationMessages(alert)
+	assert.Contains(t, msgs, "CVE-2017-15804")
+	assert.Contains(t, msgs, "CVE-2017-15670")
+	assert.Contains(t, msgs, "This is a process violation")
 }

--- a/central/notifiers/slack/slack_test.go
+++ b/central/notifiers/slack/slack_test.go
@@ -139,6 +139,20 @@ func TestGetEntityMetadata(t *testing.T) {
 			expectedCluster:    "prod cluster",
 			expectedNamespace:  "stackrox",
 		},
+		"image": {
+			alert:              fixtures.GetImageAlert(),
+			expectedName:       "stackrox.io/srox/mongo:latest",
+			expectedEntityType: "Image",
+			expectedCluster:    "",
+			expectedNamespace:  "",
+		},
+		"node": {
+			alert:              fixtures.GetNodeAlert(),
+			expectedName:       "bbaaaaaa-bbbb-4011-0000-111111111111",
+			expectedEntityType: "Node",
+			expectedCluster:    "Cluster1",
+			expectedNamespace:  "",
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
## Description

### Background: Slack webhook types

Slack has two types of webhooks that accept JSON payloads:

1. **Legacy Incoming Webhooks** (endpoints prefixed with `/services`) — These render structured message formats like `attachments` (colored sidebar, formatted text, fields) directly into a Slack channel. They understand nested JSON structures like arrays of attachment objects.

2. **Workflow Builder Webhooks** (endpoints prefixed with `/triggers`) — These are triggers for Slack's Workflow Builder automation tool. They only extract **flat top-level key-value string pairs** from the incoming JSON and expose them as variables that users can insert into workflow steps (e.g. composing a message, routing to a channel). Nested JSON structures like arrays or objects are ignored entirely.

### Problem

The ACS Slack notifier sends all alert data inside a nested `attachments` array. This works with legacy incoming webhooks but produces empty/invisible results with Workflow Builder webhooks — none of the alert data can be extracted as workflow variables.

### Solution

This adds flat top-level string fields to the JSON payload **alongside** the existing `attachments`:

**Alert notifications:**
- `summary`, `alert_id`, `alert_url`, `severity`, `time`, `policy`
- `cluster`, `namespace`, `entity`, `entity_type`
- `violations` (newline-separated violation messages)
- `description` (full formatted alert body)

**Network policy YAML notifications:**
- `cluster`, `description`

Legacy incoming webhooks are unaffected — they render `attachments` as before and silently ignore unknown top-level fields. Workflow webhooks can now extract individual alert properties as variables.

Docs ticket: [ROX-34555](https://redhat.atlassian.net/browse/ROX-34555)

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Unit tests verify flat fields appear in marshaled JSON alongside attachments
- Unit tests cover entity metadata extraction for deployment and resource entity types
- Unit tests verify violation message concatenation including process violations
- Manually tested with a Slack Workflow Builder webhook — all flat fields populated correctly as workflow variables

Alert in Slack can be seen [here](https://redhat-internal.slack.com/archives/C740BUV25/p1778007737850389).

[ROX-34555]: https://redhat.atlassian.net/browse/ROX-34555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ