### PR TITLE
ROX-34029: Add e2e integration tests for init container support

### DIFF
--- a/qa-tests-backend/src/main/groovy/objects/Deployment.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/Deployment.groovy
@@ -58,6 +58,7 @@ class Deployment {
     Boolean readinessProbeDefined = false
     String serviceName
     String serviceAccountName
+    List<Map<String, Object>> initContainers = []
 
     Deployment setName(String n) {
         this.name = n
@@ -329,6 +330,15 @@ class Deployment {
 
     Deployment setServiceName(String name) {
         this.serviceName = name
+        return this
+    }
+
+    Deployment addInitContainer(String name, String image, List<String> command = ["sh", "-c", "echo init done"]) {
+        Map<String, Object> spec = new HashMap<>()
+        spec.put("name", name)
+        spec.put("image", image)
+        spec.put("command", command)
+        this.initContainers.add(spec)
         return this
     }
 

--- a/qa-tests-backend/src/main/groovy/objects/Deployment.groovy
+++ b/qa-tests-backend/src/main/groovy/objects/Deployment.groovy
@@ -334,11 +334,11 @@ class Deployment {
     }
 
     Deployment addInitContainer(String name, String image, List<String> command = ["sh", "-c", "echo init done"]) {
-        Map<String, Object> spec = new HashMap<>()
-        spec.put("name", name)
-        spec.put("image", image)
-        spec.put("command", command)
-        this.initContainers.add(spec)
+        this.initContainers.add([
+            name   : name,
+            image  : image,
+            command: command,
+        ])
         return this
     }
 

--- a/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
+++ b/qa-tests-backend/src/main/groovy/orchestratormanager/Kubernetes.groovy
@@ -2447,7 +2447,21 @@ class Kubernetes {
             )
         }
 
+        List<Container> k8sInitContainers = deployment.initContainers.collect { Map<String, Object> init ->
+            String initImage = init.get("image") as String
+            Container initContainer = new Container(
+                    name: init.get("name") as String,
+                    image: initImage,
+                    command: init.get("command") as List<String>,
+            )
+            if (Env.IMAGE_PULL_POLICY_FOR_QUAY_IO && initImage =~ /^quay.io/) {
+                initContainer.setImagePullPolicy(Env.IMAGE_PULL_POLICY_FOR_QUAY_IO)
+            }
+            return initContainer
+        }
+
         PodSpec podSpec = new PodSpec(
+                initContainers: k8sInitContainers,
                 containers: [container],
                 volumes: volumes,
                 imagePullSecrets: imagePullSecrets,

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -5,7 +5,9 @@ import io.stackrox.proto.storage.PolicyOuterClass
 import io.stackrox.proto.storage.ScopeOuterClass
 
 import objects.Deployment
+import org.junit.Assume
 import services.ClusterService
+import services.FeatureFlagService
 import services.ImageService
 import services.PolicyService
 import util.Timer
@@ -33,6 +35,7 @@ class AdmissionControllerTest extends BaseSpecification {
     static final private String BUSYBOX_NO_BYPASS        = "busybox-no-bypass"
     static final private String BUSYBOX_BYPASS           = "busybox-bypass"
     static final private String BUSYBOX_LATEST_TAG_IMAGE = "quay.io/rhacs-eng/qa-multi-arch-busybox:latest"
+    static final private String BUSYBOX_TAGGED_IMAGE     = "quay.io/rhacs-eng/qa-multi-arch:busybox-1-28"
 
     private final static String CLONED_POLICY_SUFFIX = "(${TEST_NAMESPACE})"
     private final static String LATEST_TAG = "Latest tag"
@@ -150,7 +153,7 @@ class AdmissionControllerTest extends BaseSpecification {
         when:
         "Create a deployment with a non-violating image"
         def modDeployment = deployment.clone()
-        modDeployment.image = "quay.io/rhacs-eng/qa-multi-arch:busybox-1-28"
+        modDeployment.image = BUSYBOX_TAGGED_IMAGE
         def created = orchestrator.createDeploymentNoWait(modDeployment)
         assert created
 
@@ -386,6 +389,45 @@ class AdmissionControllerTest extends BaseSpecification {
         desc               | initialValue | changedValue
         "namespace reload" | "backend"    | "frontend"
         "namespace removal"| "backend"    | null
+    }
+
+    @Unroll
+    @Tag("BAT")
+    def "Verify AC init container enforcement: #desc"() {
+        given:
+        "Feature flag for init container support is enabled"
+        Assume.assumeTrue(FeatureFlagService.isFeatureFlagEnabled("ROX_INIT_CONTAINER_SUPPORT"))
+
+        when:
+        "Create a deployment with init container(s)"
+        def deployment = new Deployment()
+                .setName("init-ac-${desc.replaceAll(' ', '-')}")
+                .setNamespace(TEST_NAMESPACE)
+                .setImagePrefetcherAffinity()
+                .setImage(mainImage)
+                .addLabel("app", "test")
+        initImages.eachWithIndex { String image, int i ->
+            deployment.addInitContainer("init-${i}", image)
+        }
+
+        def created = orchestrator.createDeploymentNoWait(deployment)
+
+        then:
+        "Verify admission controller allows or blocks based on which container violates policy"
+        assert created == allowed
+
+        cleanup:
+        if (created) {
+            deleteDeploymentWithCaution(deployment)
+        }
+
+        where:
+        desc              | mainImage                | initImages                                          | allowed
+        "1 init latest"   | BUSYBOX_TAGGED_IMAGE     | [BUSYBOX_LATEST_TAG_IMAGE]                          | true
+        "2 inits latest"  | BUSYBOX_TAGGED_IMAGE     | [BUSYBOX_LATEST_TAG_IMAGE, BUSYBOX_LATEST_TAG_IMAGE]| true
+        "mixed inits"     | BUSYBOX_TAGGED_IMAGE     | [BUSYBOX_LATEST_TAG_IMAGE, BUSYBOX_TAGGED_IMAGE]    | true
+        "main latest 1i"  | BUSYBOX_LATEST_TAG_IMAGE | [BUSYBOX_TAGGED_IMAGE]                              | false
+        "main latest 2i"  | BUSYBOX_LATEST_TAG_IMAGE | [BUSYBOX_TAGGED_IMAGE, BUSYBOX_TAGGED_IMAGE]        | false
     }
 
 }

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -6,7 +6,6 @@ import io.stackrox.proto.storage.ScopeOuterClass
 
 import objects.Deployment
 import services.ClusterService
-import services.FeatureFlagService
 import services.ImageService
 import services.PolicyService
 import util.Timer
@@ -392,7 +391,7 @@ class AdmissionControllerTest extends BaseSpecification {
     }
 
     @Tag("BAT")
-    @IgnoreIf({ !FeatureFlagService.isFeatureFlagEnabled("ROX_INIT_CONTAINER_SUPPORT") })
+    @IgnoreIf({ System.getenv("ROX_INIT_CONTAINER_SUPPORT") != "true" })
     def "Verify AC allows deployment with init containers"() {
         when:
         "Create a deployment with init containers"

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -5,13 +5,13 @@ import io.stackrox.proto.storage.PolicyOuterClass
 import io.stackrox.proto.storage.ScopeOuterClass
 
 import objects.Deployment
-import org.junit.Assume
 import services.ClusterService
 import services.FeatureFlagService
 import services.ImageService
 import services.PolicyService
 import util.Timer
 
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Tag
 import spock.lang.Unroll
@@ -392,11 +392,8 @@ class AdmissionControllerTest extends BaseSpecification {
     }
 
     @Tag("BAT")
+    @IgnoreIf({ !FeatureFlagService.isFeatureFlagEnabled("ROX_INIT_CONTAINER_SUPPORT") })
     def "Verify AC allows deployment with init containers"() {
-        given:
-        "Feature flag for init container support is enabled"
-        Assume.assumeTrue(FeatureFlagService.isFeatureFlagEnabled("ROX_INIT_CONTAINER_SUPPORT"))
-
         when:
         "Create a deployment with init containers"
         def deployment = new Deployment()

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -391,43 +391,33 @@ class AdmissionControllerTest extends BaseSpecification {
         "namespace removal"| "backend"    | null
     }
 
-    @Unroll
     @Tag("BAT")
-    def "Verify AC init container enforcement: #desc"() {
+    def "Verify AC allows deployment with init containers"() {
         given:
         "Feature flag for init container support is enabled"
         Assume.assumeTrue(FeatureFlagService.isFeatureFlagEnabled("ROX_INIT_CONTAINER_SUPPORT"))
 
         when:
-        "Create a deployment with init container(s)"
+        "Create a deployment with init containers"
         def deployment = new Deployment()
-                .setName("init-ac-${desc.replaceAll(' ', '-')}")
+                .setName("init-ac-test")
                 .setNamespace(TEST_NAMESPACE)
                 .setImagePrefetcherAffinity()
-                .setImage(mainImage)
+                .setImage(BUSYBOX_TAGGED_IMAGE)
                 .addLabel("app", "test")
-        initImages.eachWithIndex { String image, int i ->
-            deployment.addInitContainer("init-${i}", image)
-        }
+                .addInitContainer("init-0", BUSYBOX_LATEST_TAG_IMAGE)
+                .addInitContainer("init-1", BUSYBOX_TAGGED_IMAGE)
 
         def created = orchestrator.createDeploymentNoWait(deployment)
 
         then:
-        "Verify admission controller allows or blocks based on which container violates policy"
-        assert created == allowed
+        "Admission controller allows the deployment"
+        assert created
 
         cleanup:
         if (created) {
             deleteDeploymentWithCaution(deployment)
         }
-
-        where:
-        desc              | mainImage                | initImages                                          | allowed
-        "1 init latest"   | BUSYBOX_TAGGED_IMAGE     | [BUSYBOX_LATEST_TAG_IMAGE]                          | true
-        "2 inits latest"  | BUSYBOX_TAGGED_IMAGE     | [BUSYBOX_LATEST_TAG_IMAGE, BUSYBOX_LATEST_TAG_IMAGE]| true
-        "mixed inits"     | BUSYBOX_TAGGED_IMAGE     | [BUSYBOX_LATEST_TAG_IMAGE, BUSYBOX_TAGGED_IMAGE]    | true
-        "main 1 init"     | BUSYBOX_LATEST_TAG_IMAGE | [BUSYBOX_TAGGED_IMAGE]                              | false
-        "main 2 inits"    | BUSYBOX_LATEST_TAG_IMAGE | [BUSYBOX_TAGGED_IMAGE, BUSYBOX_TAGGED_IMAGE]        | false
     }
 
 }

--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -426,8 +426,8 @@ class AdmissionControllerTest extends BaseSpecification {
         "1 init latest"   | BUSYBOX_TAGGED_IMAGE     | [BUSYBOX_LATEST_TAG_IMAGE]                          | true
         "2 inits latest"  | BUSYBOX_TAGGED_IMAGE     | [BUSYBOX_LATEST_TAG_IMAGE, BUSYBOX_LATEST_TAG_IMAGE]| true
         "mixed inits"     | BUSYBOX_TAGGED_IMAGE     | [BUSYBOX_LATEST_TAG_IMAGE, BUSYBOX_TAGGED_IMAGE]    | true
-        "main latest 1i"  | BUSYBOX_LATEST_TAG_IMAGE | [BUSYBOX_TAGGED_IMAGE]                              | false
-        "main latest 2i"  | BUSYBOX_LATEST_TAG_IMAGE | [BUSYBOX_TAGGED_IMAGE, BUSYBOX_TAGGED_IMAGE]        | false
+        "main 1 init"     | BUSYBOX_LATEST_TAG_IMAGE | [BUSYBOX_TAGGED_IMAGE]                              | false
+        "main 2 inits"    | BUSYBOX_LATEST_TAG_IMAGE | [BUSYBOX_TAGGED_IMAGE, BUSYBOX_TAGGED_IMAGE]        | false
     }
 
 }

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -698,6 +698,15 @@ deploy_sensor_via_operator() {
         customize_envVars+=$'\n    - name: ROX_NETFLOW_CACHE_LIMITING'
         customize_envVars+=$'\n      value: "'"${ROX_NETFLOW_CACHE_LIMITING}"'"'
     fi
+    # Feature flags set via ci_export (line ~200) reach Sensor in non-operator
+    # deployments (GKE) through the shell environment. Operator-deployed Sensor
+    # (OCP) only gets env vars injected via the SecuredCluster CR's
+    # customize.envVars, which is built separately here. Flags that Sensor needs
+    # must be added explicitly below until they are enabled by default.
+    if [[ -n "${ROX_INIT_CONTAINER_SUPPORT:-}" ]]; then
+        customize_envVars+=$'\n    - name: ROX_INIT_CONTAINER_SUPPORT'
+        customize_envVars+=$'\n      value: "'"${ROX_INIT_CONTAINER_SUPPORT}"'"'
+    fi
 
     local scannerV4DbPersistenceYaml
     scannerV4DbPersistenceYaml="$(_scanner_v4_db_persistence_yaml)"

--- a/tests/images-to-prefetch.txt
+++ b/tests/images-to-prefetch.txt
@@ -24,6 +24,9 @@ quay.io/rhacs-eng/qa:nginx-1-14-alpine
 # Used by tests/tls_challenge_test.go
 quay.io/rhacs-eng/qa-multi-arch:nginx-1-17-1
 
+# Used by tests/init_container_test.go
+quay.io/rhacs-eng/qa-multi-arch-busybox:latest
+
 # Used by tests/active_vuln_test.go
 quay.io/rhacs-eng/qa-multi-arch:nginx-1.14.0
 quay.io/rhacs-eng/qa-multi-arch:nginx-1.18.0

--- a/tests/init_container_test.go
+++ b/tests/init_container_test.go
@@ -1,0 +1,400 @@
+//go:build test_e2e
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/pointers"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
+	"github.com/stretchr/testify/suite"
+	appsV1 "k8s.io/api/apps/v1"
+	coreV1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	busyboxLatest = "quay.io/rhacs-eng/qa-multi-arch-busybox:latest"
+	nginxLatest   = "quay.io/rhacs-eng/qa-multi-arch-nginx:latest"
+	nginxTagged   = "quay.io/rhacs-eng/qa-multi-arch:nginx-1.21.1"
+)
+
+type InitContainerSuite struct {
+	suite.Suite
+	deploymentService v1.DeploymentServiceClient
+	policyService     v1.PolicyServiceClient
+	alertService      v1.AlertServiceClient
+}
+
+func TestInitContainers(t *testing.T) {
+	suite.Run(t, new(InitContainerSuite))
+}
+
+func (s *InitContainerSuite) SetupSuite() {
+	conn := centralgrpc.GRPCConnectionToCentral(s.T())
+	s.deploymentService = v1.NewDeploymentServiceClient(conn)
+	s.policyService = v1.NewPolicyServiceClient(conn)
+	s.alertService = v1.NewAlertServiceClient(conn)
+
+	// Skip if init container support is not enabled on Central
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ffService := v1.NewFeatureFlagServiceClient(conn)
+	flags, err := ffService.GetFeatureFlags(ctx, &v1.Empty{})
+	s.Require().NoError(err)
+
+	for _, f := range flags.GetFeatureFlags() {
+		if f.GetEnvVar() == features.InitContainerSupport.EnvVar() {
+			if !f.GetEnabled() {
+				s.T().Skip("ROX_INIT_CONTAINER_SUPPORT is not enabled, skipping init container tests")
+			}
+			return
+		}
+	}
+	s.T().Skip("ROX_INIT_CONTAINER_SUPPORT feature flag not found")
+}
+
+func (s *InitContainerSuite) createDeploymentWithInitContainers(name, namespace string, initImages []string, mainImage string) {
+	t := s.T()
+	client := createK8sClient(t)
+
+	pullPolicy := coreV1.PullIfNotPresent
+	if policy := os.Getenv("IMAGE_PULL_POLICY_FOR_QUAY_IO"); policy != "" {
+		pullPolicy = coreV1.PullPolicy(policy)
+	}
+
+	initContainers := make([]coreV1.Container, len(initImages))
+	for i, img := range initImages {
+		p := pullPolicy
+		if !strings.HasPrefix(img, "quay.io/") {
+			p = coreV1.PullIfNotPresent
+		}
+		initContainers[i] = coreV1.Container{
+			Name:            fmt.Sprintf("init-%d", i),
+			Image:           img,
+			Command:         []string{"sh", "-c", "echo init done"},
+			ImagePullPolicy: p,
+		}
+	}
+
+	mainPullPolicy := pullPolicy
+	if !strings.HasPrefix(mainImage, "quay.io/") {
+		mainPullPolicy = coreV1.PullIfNotPresent
+	}
+
+	deployment := &appsV1.Deployment{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": name},
+		},
+		Spec: appsV1.DeploymentSpec{
+			Replicas: pointers.Int32(1),
+			Selector: &metaV1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: coreV1.PodTemplateSpec{
+				ObjectMeta: metaV1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: coreV1.PodSpec{
+					InitContainers: initContainers,
+					Containers:     []coreV1.Container{buildContainer(name, mainImage, mainPullPolicy)},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, err := client.AppsV1().Deployments(namespace).Create(ctx, deployment, metaV1.CreateOptions{})
+	s.Require().NoError(err)
+	t.Logf("Created deployment %q with %d init container(s) in namespace %q", name, len(initImages), namespace)
+}
+
+// waitForDeploymentWithContainers waits for a deployment to appear in Central with at least
+// expectedContainers containers and at least one enriched image.
+func (s *InitContainerSuite) waitForDeploymentWithContainers(deploymentName string, expectedContainers int) *storage.Deployment {
+	var result *storage.Deployment
+	qb := search.NewQueryBuilder().AddExactMatches(search.DeploymentName, deploymentName)
+
+	waitForCondition(s.T(), func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		listResp, err := s.deploymentService.ListDeployments(ctx, &v1.RawQuery{Query: qb.Query()})
+		if err != nil || len(listResp.GetDeployments()) == 0 {
+			return false
+		}
+
+		dep, err := s.deploymentService.GetDeployment(ctx, &v1.ResourceByID{Id: listResp.GetDeployments()[0].GetId()})
+		if err != nil || len(dep.GetContainers()) < expectedContainers {
+			return false
+		}
+
+		for _, c := range dep.GetContainers() {
+			if c.GetImage().GetId() != "" {
+				result = dep
+				return true
+			}
+		}
+		return false
+	}, fmt.Sprintf("deployment %s with %d containers", deploymentName, expectedContainers), waitTimeout, time.Second)
+
+	return result
+}
+
+func (s *InitContainerSuite) newLatestTagPolicy(name, namespace string) *storage.Policy {
+	return &storage.Policy{
+		Name:            name,
+		Description:     "Test policy for init container filtering",
+		Severity:        storage.Severity_HIGH_SEVERITY,
+		LifecycleStages: []storage.LifecycleStage{storage.LifecycleStage_DEPLOY},
+		Categories:      []string{"Test"},
+		Scope: []*storage.Scope{
+			{
+				Namespace: namespace,
+			},
+		},
+		PolicySections: []*storage.PolicySection{
+			{
+				PolicyGroups: []*storage.PolicyGroup{
+					{
+						FieldName: "Image Tag",
+						Values: []*storage.PolicyValue{
+							{Value: "latest"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (s *InitContainerSuite) createPolicyWithCleanup(policy *storage.Policy) *storage.Policy {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	createdPolicy, err := s.policyService.PostPolicy(ctx, &v1.PostPolicyRequest{Policy: policy})
+	s.Require().NoError(err)
+
+	s.T().Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		_, _ = s.policyService.DeletePolicy(ctx, &v1.ResourceByID{Id: createdPolicy.GetId()})
+	})
+
+	return createdPolicy
+}
+
+func (s *InitContainerSuite) waitForViolationAlert(deploymentName, policyName string, expectedCount int) {
+	query := search.NewQueryBuilder().
+		AddStrings(search.DeploymentName, deploymentName).
+		AddStrings(search.PolicyName, policyName).
+		AddStrings(search.ViolationState, storage.ViolationState_ACTIVE.String())
+
+	waitForAlert(s.T(), s.alertService, &v1.ListAlertsRequest{Query: query.Query()}, expectedCount)
+}
+
+func (s *InitContainerSuite) TestInitContainerExtraction() {
+	t := s.T()
+	ns := fmt.Sprintf("init-test-extract-%d", rand.IntN(10000))
+	createNamespaceWithLabels(t, ns, nil)
+	defer deleteNamespace(t, ns)
+
+	// Deploy with a fully-specified init container to verify field population
+	deployName := fmt.Sprintf("init-extract-%d", rand.IntN(10000))
+	client := createK8sClient(t)
+
+	pullPolicy := coreV1.PullIfNotPresent
+	if policy := os.Getenv("IMAGE_PULL_POLICY_FOR_QUAY_IO"); policy != "" {
+		pullPolicy = coreV1.PullPolicy(policy)
+	}
+
+	deployment := &appsV1.Deployment{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      deployName,
+			Namespace: ns,
+			Labels:    map[string]string{"app": deployName},
+		},
+		Spec: appsV1.DeploymentSpec{
+			Replicas: pointers.Int32(1),
+			Selector: &metaV1.LabelSelector{
+				MatchLabels: map[string]string{"app": deployName},
+			},
+			Template: coreV1.PodTemplateSpec{
+				ObjectMeta: metaV1.ObjectMeta{
+					Labels: map[string]string{"app": deployName},
+				},
+				Spec: coreV1.PodSpec{
+					InitContainers: []coreV1.Container{
+						{
+							Name:            "init-setup",
+							Image:           busyboxLatest,
+							Command:         []string{"sh", "-c", "echo hello > /work/init-output.txt"},
+							ImagePullPolicy: pullPolicy,
+							Env: []coreV1.EnvVar{
+								{Name: "INIT_VAR", Value: "init-value"},
+							},
+							Resources: coreV1.ResourceRequirements{
+								Requests: coreV1.ResourceList{
+									coreV1.ResourceCPU:    resource.MustParse("50m"),
+									coreV1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+								Limits: coreV1.ResourceList{
+									coreV1.ResourceCPU:    resource.MustParse("100m"),
+									coreV1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
+							SecurityContext: &coreV1.SecurityContext{
+								ReadOnlyRootFilesystem: pointers.Bool(true),
+							},
+							VolumeMounts: []coreV1.VolumeMount{
+								{Name: "shared-data", MountPath: "/work"},
+							},
+						},
+					},
+					Containers: []coreV1.Container{buildContainer(deployName, nginxLatest, pullPolicy)},
+					Volumes: []coreV1.Volume{
+						{
+							Name:         "shared-data",
+							VolumeSource: coreV1.VolumeSource{EmptyDir: &coreV1.EmptyDirVolumeSource{}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, err := client.AppsV1().Deployments(ns).Create(ctx, deployment, metaV1.CreateOptions{})
+	s.Require().NoError(err)
+	defer teardownDeploymentWithoutCheck(t, deployName, ns)
+
+	dep := s.waitForDeploymentWithContainers(deployName, 2)
+	s.Require().Len(dep.GetContainers(), 2)
+
+	var initContainer, regularContainer *storage.Container
+	for _, c := range dep.GetContainers() {
+		switch c.GetType() {
+		case storage.ContainerType_INIT:
+			initContainer = c
+		case storage.ContainerType_REGULAR:
+			regularContainer = c
+		}
+	}
+
+	// Verify types and images
+	s.Require().NotNil(initContainer, "expected an init container")
+	s.Require().NotNil(regularContainer, "expected a regular container")
+	s.Contains(initContainer.GetImage().GetName().GetFullName(), "busybox")
+	s.Contains(regularContainer.GetImage().GetName().GetFullName(), "nginx")
+
+	// Verify init container field population
+	s.Equal("init-setup", initContainer.GetName())
+	s.Equal([]string{"sh", "-c", "echo hello > /work/init-output.txt"}, initContainer.GetConfig().GetCommand())
+
+	envVars := initContainer.GetConfig().GetEnv()
+	s.Require().NotEmpty(envVars, "init container should have env vars")
+	var foundEnvVar bool
+	for _, e := range envVars {
+		if e.GetKey() == "INIT_VAR" && e.GetValue() == "init-value" {
+			foundEnvVar = true
+			break
+		}
+	}
+	s.True(foundEnvVar, "expected INIT_VAR=init-value in init container env")
+
+	s.True(initContainer.GetSecurityContext().GetReadOnlyRootFilesystem(), "init container should have readOnlyRootFilesystem")
+
+	s.Greater(initContainer.GetResources().GetCpuCoresRequest(), float32(0), "init container should have CPU request")
+	s.Greater(initContainer.GetResources().GetMemoryMbRequest(), float32(0), "init container should have memory request")
+
+	s.Require().NotEmpty(initContainer.GetVolumes(), "init container should have volumes")
+	s.Equal("/work", initContainer.GetVolumes()[0].GetDestination())
+
+	t.Logf("Init container extraction and field population verified")
+}
+
+func (s *InitContainerSuite) TestMultipleInitContainers() {
+	t := s.T()
+	ns := fmt.Sprintf("init-test-multi-%d", rand.IntN(10000))
+	createNamespaceWithLabels(t, ns, nil)
+	defer deleteNamespace(t, ns)
+
+	deployName := fmt.Sprintf("init-multi-%d", rand.IntN(10000))
+	s.createDeploymentWithInitContainers(deployName, ns, []string{busyboxLatest, busyboxLatest}, nginxLatest)
+	defer teardownDeploymentWithoutCheck(t, deployName, ns)
+
+	dep := s.waitForDeploymentWithContainers(deployName, 3)
+
+	s.Require().Len(dep.GetContainers(), 3)
+
+	var initCount, regularCount int
+	for _, c := range dep.GetContainers() {
+		switch c.GetType() {
+		case storage.ContainerType_INIT:
+			initCount++
+		case storage.ContainerType_REGULAR:
+			regularCount++
+		}
+	}
+
+	s.Equal(2, initCount, "expected 2 init containers")
+	s.Equal(1, regularCount, "expected 1 regular container")
+	t.Logf("Multiple init containers verified: %d init, %d regular", initCount, regularCount)
+}
+
+func (s *InitContainerSuite) TestPolicyFilteringInitNotViolated() {
+	t := s.T()
+	ns := fmt.Sprintf("init-test-policy-%d", rand.IntN(10000))
+	createNamespaceWithLabels(t, ns, nil)
+	defer deleteNamespace(t, ns)
+
+	createdPolicy := s.createPolicyWithCleanup(s.newLatestTagPolicy(
+		fmt.Sprintf("Test - Init Not Violated %d", rand.IntN(10000)), ns,
+	))
+
+	// Init container uses :latest (should be filtered), regular uses tagged image (no violation)
+	deployName := fmt.Sprintf("init-policy-no-alert-%d", rand.IntN(10000))
+	s.createDeploymentWithInitContainers(deployName, ns, []string{busyboxLatest}, nginxTagged)
+	defer teardownDeploymentWithoutCheck(t, deployName, ns)
+
+	s.waitForDeploymentWithContainers(deployName, 2)
+
+	s.waitForViolationAlert(deployName, createdPolicy.GetName(), 0)
+	t.Logf("Verified: init container with :latest tag did not trigger policy violation")
+}
+
+func (s *InitContainerSuite) TestPolicyFilteringRegularStillViolated() {
+	t := s.T()
+	ns := fmt.Sprintf("init-test-policy-reg-%d", rand.IntN(10000))
+	createNamespaceWithLabels(t, ns, nil)
+	defer deleteNamespace(t, ns)
+
+	createdPolicy := s.createPolicyWithCleanup(s.newLatestTagPolicy(
+		fmt.Sprintf("Test - Regular Still Violated %d", rand.IntN(10000)), ns,
+	))
+
+	// Both use :latest — regular should trigger violation, init should be filtered
+	deployName := fmt.Sprintf("init-policy-alert-%d", rand.IntN(10000))
+	s.createDeploymentWithInitContainers(deployName, ns, []string{busyboxLatest}, nginxLatest)
+	defer teardownDeploymentWithoutCheck(t, deployName, ns)
+
+	s.waitForDeploymentWithContainers(deployName, 2)
+
+	s.waitForViolationAlert(deployName, createdPolicy.GetName(), 1)
+	t.Logf("Verified: regular container with :latest tag triggered policy violation")
+}

--- a/tests/init_container_test.go
+++ b/tests/init_container_test.go
@@ -13,7 +13,6 @@ import (
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/pointers"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/testutils/centralgrpc"
@@ -42,27 +41,14 @@ func TestInitContainers(t *testing.T) {
 }
 
 func (s *InitContainerSuite) SetupSuite() {
+	if os.Getenv("ROX_INIT_CONTAINER_SUPPORT") != "true" {
+		s.T().Skip("ROX_INIT_CONTAINER_SUPPORT not enabled")
+	}
+
 	conn := centralgrpc.GRPCConnectionToCentral(s.T())
 	s.deploymentService = v1.NewDeploymentServiceClient(conn)
 	s.policyService = v1.NewPolicyServiceClient(conn)
 	s.alertService = v1.NewAlertServiceClient(conn)
-
-	// Skip if init container support is not enabled on Central
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	ffService := v1.NewFeatureFlagServiceClient(conn)
-	flags, err := ffService.GetFeatureFlags(ctx, &v1.Empty{})
-	s.Require().NoError(err)
-
-	for _, f := range flags.GetFeatureFlags() {
-		if f.GetEnvVar() == features.InitContainerSupport.EnvVar() {
-			if !f.GetEnabled() {
-				s.T().Skip("ROX_INIT_CONTAINER_SUPPORT is not enabled, skipping init container tests")
-			}
-			return
-		}
-	}
-	s.T().Skip("ROX_INIT_CONTAINER_SUPPORT feature flag not found")
 }
 
 func (s *InitContainerSuite) createDeploymentWithInitContainers(name, namespace string, initImages []string, mainImage string) {

--- a/tests/init_container_test.go
+++ b/tests/init_container_test.go
@@ -296,9 +296,10 @@ func (s *InitContainerSuite) TestInitContainerExtraction() {
 		}
 	}
 
-	// Verify types and images
 	s.Require().NotNil(initContainer, "expected an init container")
 	s.Require().NotNil(regularContainer, "expected a regular container")
+	s.Equal(storage.ContainerType_INIT, initContainer.GetType())
+	s.Equal(storage.ContainerType_REGULAR, regularContainer.GetType())
 	s.Contains(initContainer.GetImage().GetName().GetFullName(), "busybox")
 	s.Contains(regularContainer.GetImage().GetName().GetFullName(), "nginx")
 


### PR DESCRIPTION
## Description

Adds end-to-end integration tests for init container support. This validates the full flow gated behind the `ROX_INIT_CONTAINER_SUPPORT` feature flag: Sensor extraction, Central storage, field population, and deploy-time policy evaluation.

The Go e2e test suite (`tests/init_container_test.go`) covers:
- **Extraction**: Deploys a workload with a fully-specified init container (env vars, resources, security context, volumes) and verifies all fields are populated correctly in Central with `ContainerType_INIT`.
- **Multiple init containers**: Confirms a deployment with two init containers and one regular container is stored with the correct type counts.
- **Policy filtering**: Verifies that deploy-time "Latest tag" policies do **not** fire on init containers but **do** fire on regular containers using the same image tag.

The Groovy admission controller test (`AdmissionControllerTest.groovy`) confirms the admission controller correctly allows deployments where only init containers use `:latest`.

Supporting changes add `initContainers` support to the Groovy `Deployment` and `Kubernetes` orchestrator classes, and prefetch the `busybox:latest` image used by the Go tests.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

No user-facing documentation changes needed; these are test-only additions for an existing feature-flagged capability.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Relying on CI for validation
