### PR TITLE
ROX-34553: Render resourceScope in table of ConfigReportsTab

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportsTable.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/reportsTable.test.js
@@ -18,7 +18,7 @@ describe('Vulnerability Reports table', () => {
         visitVulnerabilityReports();
 
         cy.get('th:contains("Report")');
-        cy.get('th:contains("Collection")');
+        cy.get('th:contains("Resources")');
         cy.get('th:contains("Description")');
         cy.get('th:contains("My last job status")');
     });

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
@@ -25,7 +25,6 @@ import { ActionsColumn, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/reac
 import { ExclamationCircleIcon, FileIcon, SearchIcon } from '@patternfly/react-icons';
 
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
 import usePermissions from 'hooks/usePermissions';
 import useURLPagination from 'hooks/useURLPagination';
@@ -47,6 +46,10 @@ import MyLastJobStatus from 'Components/ReportJob/MyLastJobStatus';
 import useAuthStatus from 'hooks/useAuthStatus';
 import { reportDownloadURL } from 'services/ReportsService';
 
+import type {
+    ImageVulnerabilityReportConfiguration,
+    ImageVulnerabilityResourceScope,
+} from '../../ImageVulnerabilityReports/imageVulnerabilityReports.types';
 import useFetchReports from '../api/useFetchReports';
 import useRunReport from '../api/useRunReport';
 import { useWatchLastSnapshotForReports } from '../api/useWatchLastSnapshotForReports';
@@ -85,11 +88,6 @@ function ConfigReportsTab() {
 
     const isRouteEnabled = useIsRouteEnabled();
     const isCollectionsRouteEnabled = isRouteEnabled('collections');
-
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isEnhancedFilteringEnabled = isFeatureFlagEnabled(
-        'ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING'
-    );
 
     const { toasts, addToast, removeToast } = useToasts();
 
@@ -155,6 +153,14 @@ function ConfigReportsTab() {
         },
     });
 
+    // Because callback function exists independent of conditional rendering,
+    // TypeScript does not know for sure that it is has a collectionScope property.
+    function onClickCollectionLink(resourceScope: ImageVulnerabilityResourceScope) {
+        if ('collectionScope' in resourceScope) {
+            setCollectionModalId(resourceScope.collectionScope.collectionId);
+        }
+    }
+
     function onConfirmDeleteSelection() {
         const selectedIds = getSelectedIds();
         openDeleteModal(selectedIds);
@@ -185,16 +191,13 @@ function ConfigReportsTab() {
                     </Alert>
                 ))}
             </AlertGroup>
-            <PageTitle
-                title={`${isEnhancedFilteringEnabled ? 'Image vulnerability reports' : 'Vulnerability reporting'} - Report configurations`}
-            />
+            <PageTitle title="Image vulnerability reports - Scheduled reports" />
             <PageSection>
                 {runError && <Alert variant="danger" isInline title={runError} component="p" />}
                 <Flex direction={{ default: 'row' }} alignItems={{ default: 'alignItemsCenter' }}>
                     <FlexItem>
                         <Content component="p">
-                            Configure reports, define collections, and assign delivery destinations
-                            to report on vulnerabilities across the organization.
+                            Configure scheduled reports for image vulnerabilities.
                         </Content>
                     </FlexItem>
                     {reportConfigurations &&
@@ -276,12 +279,12 @@ function ConfigReportsTab() {
                                 <HelpIconTh
                                     popoverContent={
                                         <div>
-                                            A set of user-configured rules for selecting deployments
-                                            as part of the collection
+                                            A set of user-configured rules to select deployed images
+                                            either by Custom scope or by named collection
                                         </div>
                                     }
                                 >
-                                    Collection
+                                    Resources
                                 </HelpIconTh>
                                 <Th>Description</Th>
                                 <HelpIconTh
@@ -376,7 +379,8 @@ function ConfigReportsTab() {
                                 </Tr>
                             </Tbody>
                         )}
-                        {reportConfigurations.map((report, rowIndex) => {
+                        {reportConfigurations.map((reportArg, rowIndex) => {
+                            const report = reportArg as ImageVulnerabilityReportConfiguration; // ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING
                             const vulnReportURL = generatePath(
                                 vulnerabilityConfigurationReportDetailsPath,
                                 {
@@ -449,8 +453,6 @@ function ConfigReportsTab() {
                                     isDisabled: isReportStatusPending,
                                 },
                             ];
-                            const { collectionName, collectionId } =
-                                report.resourceScope.collectionScope;
 
                             return (
                                 <Tbody key={report.id}>
@@ -466,20 +468,29 @@ function ConfigReportsTab() {
                                         <Td dataLabel="Report">
                                             <Link to={vulnReportURL}>{report.name}</Link>
                                         </Td>
-                                        <Td dataLabel="Collection">
-                                            {isCollectionsRouteEnabled ? (
-                                                <Button
-                                                    variant="link"
-                                                    isInline
-                                                    onClick={() =>
-                                                        setCollectionModalId(collectionId)
-                                                    }
-                                                >
-                                                    {collectionName}
-                                                </Button>
-                                            ) : (
-                                                collectionName
-                                            )}
+                                        <Td dataLabel="Resources">
+                                            {'entityScope' in report.resourceScope &&
+                                                'Custom scope'}
+                                            {'collectionScope' in report.resourceScope &&
+                                                (isCollectionsRouteEnabled ? (
+                                                    <Button
+                                                        variant="link"
+                                                        isInline
+                                                        onClick={() =>
+                                                            onClickCollectionLink(
+                                                                report.resourceScope
+                                                            )
+                                                        }
+                                                    >
+                                                        {
+                                                            report.resourceScope.collectionScope
+                                                                .collectionName
+                                                        }
+                                                    </Button>
+                                                ) : (
+                                                    report.resourceScope.collectionScope
+                                                        .collectionName
+                                                ))}
                                         </Td>
                                         <Td dataLabel="Description">{report.description || '-'}</Td>
                                         <Td dataLabel="My last job status">

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportsTab.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ViewBasedReportsTab.tsx
@@ -13,7 +13,6 @@ import { getTableUIState } from 'utils/getTableUIState';
 import { ensureBoolean, ensureStringArray } from 'utils/ensure';
 import { toggleItemInArray } from 'utils/arrayUtils';
 import { createFilterTracker } from 'utils/analyticsEventTracking';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import useRestQuery from 'hooks/useRestQuery';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSort from 'hooks/useURLSort';
@@ -72,11 +71,6 @@ function ViewBasedReportsTab() {
         'false',
         'true',
     ]);
-
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isEnhancedFilteringEnabled = isFeatureFlagEnabled(
-        'ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING'
-    );
 
     const reportJobStatusFilters = useMemo(() => {
         return ensureStringArray(searchFilter['Report Job Status']);
@@ -152,9 +146,7 @@ function ViewBasedReportsTab() {
 
     return (
         <>
-            <PageTitle
-                title={`${isEnhancedFilteringEnabled ? 'Image vulnerability reports' : 'Vulnerability reporting'} - View-based reports`}
-            />
+            <PageTitle title="Image vulnerability reports - View-based reports" />
             <PageSection>
                 <Content component="p">
                     Check job status and download view-based reports in CSV format. Requests are

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
@@ -2,7 +2,6 @@ import { PageSection, Tab, Tabs, Title } from '@patternfly/react-core';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import PageTitle from 'Components/PageTitle';
-import useFeatureFlags from 'hooks/useFeatureFlags';
 import {
     vulnerabilityConfigurationReportsPath,
     vulnerabilityViewBasedReportsPath,
@@ -25,11 +24,6 @@ function VulnReportingLayout() {
     const location = useLocation();
     const navigate = useNavigate();
 
-    const { isFeatureFlagEnabled } = useFeatureFlags();
-    const isEnhancedFilteringEnabled = isFeatureFlagEnabled(
-        'ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING'
-    );
-
     const activeTabIndex = tabs.findIndex((tab) => location.pathname.startsWith(tab.path));
 
     const onTabSelect = (_event, tabIndex) => {
@@ -38,13 +32,9 @@ function VulnReportingLayout() {
 
     return (
         <>
-            <PageTitle title="Vulnerability reporting" />
+            <PageTitle title="Image vulnerability reports" />
             <PageSection>
-                <Title headingLevel="h1">
-                    {isEnhancedFilteringEnabled
-                        ? 'Image vulnerability reports'
-                        : 'Vulnerability reporting'}
-                </Title>
+                <Title headingLevel="h1">Image vulnerability reports</Title>
             </PageSection>
             <PageSection type="tabs">
                 <Tabs


### PR DESCRIPTION
## Description

**Review**: Hide space because of indentation changes.

### Objective

Provide equivalent filter for scheduled reports as view-based reports

### Problem

If you create image report configuration with entity (instead of collection) scope, `COnfigReportsTab` crashes, as expected.

### Analysis

1. ConfigReportsTab.tsx file renders **Collection** and assumes collection scope:

    ```ts
    const { collectionName, collectionId } =
        report.resourceScope.collectionScope;
    ```

### Solution

1. Edit ConfigReportsTab.tsx file.

    * Replace conditional rendering with **Image vulnerability reports** for title (and heading).
    * Replace **Collection** with **Resources** as table column heading.
    * Conditionally render either collection link or **Custom scope**

2. Edit reportsTable.test.js file.

    * Replace **Collection** with **Resources** as table column heading.

3. Edit ViewBasedReportsTab.tsx and VulnReportingLayout.tsx files.

    * Replace conditional rendering with **Image vulnerability reports** for title (and heading).

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [x] edited e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration and click link for report configuration that has **collection** scope.

    Original unconditional code:
    <img width="1440" height="892" alt="ConfigReportsTab_collectionScope_unconditional" src="https://github.com/user-attachments/assets/b039b257-d501-423b-a326-c52e99a254f7" />

    Replaced conditional code:
    <img width="1440" height="892" alt="ConfigReportsTab_collectionScope_conditional" src="https://github.com/user-attachments/assets/f8b476f7-1c33-4eb0-b25e-61a2facaec1b" />

2. Temporarily edit code to add report configuration that has **entity** scope.

    Original unconditional code:
    <img width="1440" height="892" alt="ConfigReportsTab_entityScope_unconditional" src="https://github.com/user-attachments/assets/c9aaab0d-8348-4d85-9806-1f6276b8036c" />

    Replaced conditional code:
    <img width="1440" height="892" alt="ConfigReportsTab_entityScope_conditional" src="https://github.com/user-attachments/assets/17558eef-1012-41d3-bacd-8ad36dc5594d" />

3. Click **Resources** link that has **collection** scope.

    Replaced conditional code:
    <img width="1440" height="966" alt="CollectionsFormModal" src="https://github.com/user-attachments/assets/214d1f2c-f62f-4de9-bf1c-b5d3d7c8f14b" />
