### PR TITLE
ROX-33792: Skip release build tests on PRs for faster CI feedback

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,15 @@ change me!
 - [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
 - [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)
 
+<!--
+CI Optimization: By default, PRs run tests with GOTAGS="" only for faster feedback.
+Add the `ci-release-build` label to run tests with both GOTAGS="" and GOTAGS=release
+when you need full release variant testing. Use this for:
+- Changes to build system, release-sensitive code (pkg/sync/mutex*, pkg/buildinfo/)
+- Changes affecting Go build tags or conditional compilation
+- Critical PRs where you need comprehensive testing before merge
+-->
+
 ### Automated testing
 
 <!--

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -32,6 +32,12 @@ jobs:
       matrix:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
     runs-on: ubuntu-latest
+    # Skip release build tests on PRs unless ci-release-build label is present
+    # Skipped jobs satisfy required status checks
+    if: |
+      matrix.gotags != 'GOTAGS=release' ||
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'ci-release-build')
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     # Stable version ldflags for test caching: Go's test cache keys include
@@ -116,6 +122,12 @@ jobs:
         gotags: [ 'GOTAGS=""', 'GOTAGS=release' ]
         pg: [ '15' ]
     runs-on: ubuntu-latest
+    # Skip release build tests on PRs unless ci-release-build label is present
+    # Skipped jobs satisfy required status checks
+    if: |
+      matrix.gotags != 'GOTAGS=release' ||
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'ci-release-build')
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
     # Stable version ldflags for test caching: Go's test cache keys include

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,33 @@ When creating pull requests, you must follow these requirements:
   - include: problem definition, considered alternatives, explain whys for chosen solution, if applicable.
   - include benchmark results if applicable
 
+### CI Release Build Testing
+
+By default, PRs run tests with `GOTAGS=""` (debug build) only for faster feedback (~50% faster CI).
+Master/release branches and tags always run both `GOTAGS=""` and `GOTAGS=release` to ensure
+comprehensive coverage.
+
+**When to add the `ci-release-build` label:**
+
+Add this label to your PR when you need full release variant testing:
+- Changes to build system or release-sensitive code paths:
+  - `pkg/sync/mutex_*.go` (affects mutex deadlock detection)
+  - `pkg/buildinfo/buildinfo_*.go` (changes build flavor detection)
+  - `roxctl/maincommand/` (affects CLI command tree)
+  - Any files with `//go:build release` or `//go:build !release` tags
+- Changes to Go build tags or conditional compilation logic
+- Critical PRs where comprehensive testing is needed before merge
+- When debugging release-specific test failures
+
+**Why the optimization exists:**
+
+The codebase uses Go build tags to compile different code for debug vs release:
+- Debug builds (`GOTAGS=""`): Include deadlock detection, shorter timeouts, debug features
+- Release builds (`GOTAGS=release`): Production-optimized mutex, production timeouts, release command tree
+
+Running both variants on every PR doubles test time. The optimization skips release testing on
+PRs by default, but master branch CI still catches release-specific issues before deployment.
+
 ## Common Development Commands
 
 ### Build Commands


### PR DESCRIPTION
## Description

Problem: Unit tests run with both `GOTAGS=""` and `GOTAGS=release` on every PR, doubling test execution time.

Solution: Skip `GOTAGS=release` jobs on PRs unless `ci-release-build` label is present. Skipped jobs satisfy GitHub required status checks while avoiding expensive test execution.

Expected impact: 40-50% reduction in PR CI time with no loss of coverage since master branch still validates release builds before deployment.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
