### PR TITLE
ROX-29577: Fix virtctl CA download

### DIFF
--- a/tests/e2e/vm-scanning-lib.sh
+++ b/tests/e2e/vm-scanning-lib.sh
@@ -46,6 +46,7 @@ _use_existing_virtctl_binary_if_available() {
 }
 
 # Retrieves the cluster ingress CA bundle and prints its path to stdout.
+# Any diagnostic logging must go to stderr so command substitution captures only the path.
 # Dies if no trust material is available.
 _fetch_cluster_ingress_ca() {
     local ca_bundle
@@ -53,16 +54,16 @@ _fetch_cluster_ingress_ca() {
     if oc get configmap -n openshift-config-managed default-ingress-cert \
             -o jsonpath='{.data.ca-bundle\.crt}' > "$ca_bundle" 2>/dev/null \
        && [[ -s "$ca_bundle" ]]; then
-        info "Using ingress CA from default-ingress-cert configmap"
+        info "Using ingress CA from default-ingress-cert configmap" >&2
     elif oc get secret -n openshift-ingress-operator router-ca \
             -o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d > "$ca_bundle" \
          && [[ -s "$ca_bundle" ]]; then
-        info "Using ingress CA from router-ca secret"
+        info "Using ingress CA from router-ca secret" >&2
     else
         rm -f "$ca_bundle"
         die "Cluster ingress CA not available"
     fi
-    echo "$ca_bundle"
+    printf '%s\n' "$ca_bundle"
 }
 
 # Downloads and installs virtctl using the provided curl TLS arguments.


### PR DESCRIPTION
## Description

- The secure `virtctl` download path was failing even on clusters with a valid
  ingress CA bundle, which forced the VM-scanning lane down the insecure
  `curl -k` fallback in CI.
- The root cause was `_fetch_cluster_ingress_ca()` writing both the CA path and
  an `INFO:` log line to stdout. `ensure_virtctl_binary()` captures that output
  with command substitution, so `curl --cacert` received a multi-line string
  instead of a file path and failed with exit `77`.
- Fix `_fetch_cluster_ingress_ca()` so stdout contains only the temporary CA
  bundle path and the informational log is emitted on stderr, allowing the
  secure download path to succeed as intended.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- [e2e tests are green](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/20381/pull-ci-stackrox-stackrox-master-ocp-4-21-vm-scanning-e2e-tests/2052014735905263616)

- Reproduced the pre-fix failure locally with a local `KUBECONFIG`:

```bash
export KUBECONFIG=<local kubeconfig>
source tests/e2e/vm-scanning-lib.sh
ca_bundle="$(_fetch_cluster_ingress_ca)"
printf 'captured=%q\n' "$ca_bundle"
```

```text
captured=$'INFO: ... Using ingress CA from default-ingress-cert configmap\n/tmp/...'
```

```bash
export KUBECONFIG=<local kubeconfig>
source tests/e2e/vm-scanning-lib.sh
download_url="$(oc get consoleclidownload virtctl-clidownloads-kubevirt-hyperconverged -o jsonpath='{.spec.links[?(@.text=="Download virtctl for Linux for x86_64")].href}')"
ca_bundle="$(_fetch_cluster_ingress_ca)"
curl -sSIL --cacert "$ca_bundle" "$download_url"
echo "curl_exit=$?"
```

```text
curl: (77) error setting certificate verify locations:  CAfile: INFO: ... Using ingress CA from default-ingress-cert configmap
/tmp/... CApath: none
curl_exit=77
```

- Re-ran the same repro after the fix and verified that only the temp-file path
  is captured while the informational log still appears in the terminal:

```bash
export KUBECONFIG=<local kubeconfig>
source tests/e2e/vm-scanning-lib.sh
ca_bundle="$(_fetch_cluster_ingress_ca)"
printf 'captured=%q\n' "$ca_bundle"
```

```text
INFO: Wed May  6 12:35:14 CEST 2026: Using ingress CA from default-ingress-cert configmap
captured=/var/folders/hs/_m7s0nc54v74zxz1kzfdntdm0000gn/T/tmp.NUlKAMAjTt
```

- Verified from macOS that the returned CA bundle can be used for the real
  secure `ConsoleCLIDownload` endpoint, that the downloaded tarball contains
  `virtctl`, and that the extracted artifact is the expected Linux x86_64
  executable used in CI:

```bash
export KUBECONFIG=<local kubeconfig>
source tests/e2e/vm-scanning-lib.sh
download_url="$(oc get consoleclidownload virtctl-clidownloads-kubevirt-hyperconverged -o jsonpath='{.spec.links[?(@.text=="Download virtctl for Linux for x86_64")].href}')"
ca_bundle="$(_fetch_cluster_ingress_ca)"
printf 'download_url=%s\n' "$download_url"
curl -sSIL --cacert "$ca_bundle" "$download_url" >/dev/null
printf 'curl_exit=%s\n' "$?"
curl -sSL --cacert "$ca_bundle" "$download_url" | tar tz
tmpdir="$(mktemp -d)"
curl -sSL --cacert "$ca_bundle" "$download_url" | tar xz -C "$tmpdir"
file "$tmpdir/virtctl"
ls -l "$tmpdir/virtctl"
```

```text
INFO: Wed May  6 12:35:15 CEST 2026: Using ingress CA from default-ingress-cert configmap
download_url=https://hyperconverged-cluster-cli-download-openshift-cnv.apps.pr-05-04-vm.ocp.infra.rox.systems/amd64/linux/virtctl.tar.gz
curl_exit=0
virtctl
/tmp/.../virtctl: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=782c55099847a3b691394bd0b2aa4a3e5b0e50dd, for GNU/Linux 3.2.0, with debug_info, not stripped
-rwxr-xr-x ... /tmp/.../virtctl
```

AI-Assisted: cursor, reproduced the secure virtctl download failure and patched the CA path handling

