### PR TITLE
fix: Add periodic reconciliation to config-controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 ## [NEXT RELEASE]
 
 ### Added Features
+- The config-controller now periodically reconciles SecurityPolicy CRs (default: every 30 minutes), detecting drift if policies are modified or deleted directly in Central. The interval is configurable via the `ROX_CONFIG_CONTROLLER_RECONCILE_INTERVAL` environment variable.
 - ROX-26769: Central API for generating CRSs now supports specifying an upper bound for cluster
   registrations using the new field "max_registrations".
   roxctl's "central crs generate" supports specifying a maximum number of cluster registrations

--- a/config-controller/internal/controller/policy_controller.go
+++ b/config-controller/internal/controller/policy_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	configstackroxiov1alpha1 "github.com/stackrox/rox/config-controller/api/v1alpha1"
@@ -36,7 +37,8 @@ import (
 )
 
 const (
-	policyFinalizer = "securitypolicies.config.stackrox.io/finalizer"
+	policyFinalizer   = "securitypolicies.config.stackrox.io/finalizer"
+	reconcileInterval = 5 * time.Minute
 )
 
 var (
@@ -246,7 +248,10 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, errors.Wrap(err, errMsg)
 	}
 
-	return ctrl.Result{}, retErr
+	if retErr != nil {
+		return ctrl.Result{}, retErr
+	}
+	return ctrl.Result{RequeueAfter: reconcileInterval}, nil
 }
 
 func (r *SecurityPolicyReconciler) UpdateCentralCaches(policyCR *configstackroxiov1alpha1.SecurityPolicy, ctx context.Context, refreshFunc func(context.Context) error) (ctrl.Result, error) {

--- a/config-controller/internal/controller/policy_controller.go
+++ b/config-controller/internal/controller/policy_controller.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	policyFinalizer   = "securitypolicies.config.stackrox.io/finalizer"
-	reconcileInterval = 5 * time.Minute
+	reconcileInterval = 30 * time.Minute
 )
 
 var (

--- a/config-controller/internal/controller/policy_controller.go
+++ b/config-controller/internal/controller/policy_controller.go
@@ -19,11 +19,11 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	configstackroxiov1alpha1 "github.com/stackrox/rox/config-controller/api/v1alpha1"
 	"github.com/stackrox/rox/config-controller/pkg/client"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/logging"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -37,8 +37,7 @@ import (
 )
 
 const (
-	policyFinalizer   = "securitypolicies.config.stackrox.io/finalizer"
-	reconcileInterval = 30 * time.Minute
+	policyFinalizer = "securitypolicies.config.stackrox.io/finalizer"
 )
 
 var (
@@ -251,7 +250,7 @@ func (r *SecurityPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if retErr != nil {
 		return ctrl.Result{}, retErr
 	}
-	return ctrl.Result{RequeueAfter: reconcileInterval}, nil
+	return ctrl.Result{RequeueAfter: env.ConfigControllerReconcileInterval.DurationSetting()}, nil
 }
 
 func (r *SecurityPolicyReconciler) UpdateCentralCaches(policyCR *configstackroxiov1alpha1.SecurityPolicy, ctx context.Context, refreshFunc func(context.Context) error) (ctrl.Result, error) {

--- a/pkg/env/config_controller.go
+++ b/pkg/env/config_controller.go
@@ -1,0 +1,8 @@
+package env
+
+import "time"
+
+var (
+	// ConfigControllerReconcileInterval sets the periodic reconciliation interval for the config-controller.
+	ConfigControllerReconcileInterval = registerDurationSetting("ROX_CONFIG_CONTROLLER_RECONCILE_INTERVAL", 30*time.Minute)
+)


### PR DESCRIPTION
## Description

The SecurityPolicy reconciler previously only ran on spec changes (generation-based event filter) with no periodic re-check. If the policy state in Central drifted (e.g., external deletion), the controller would not notice until the next pod restart or spec change.

New configurable RequeueAfter interval which is 30m by default. Returns `RequeueAfter` with the configured interval on successful reconciliation so the controller periodically verifies that the desired state in Central matches the SecurityPolicy CRs.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- `go build ./config-controller/...` compiles successfully
- Manual verification done on a running cluster