### PR TITLE
ROX-32482: Block deletion of declarative policies

### DIFF
--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/contextutil"
+	accesscontrol "github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	pkgDetection "github.com/stackrox/rox/pkg/detection"
 	"github.com/stackrox/rox/pkg/errorhelpers"
 	"github.com/stackrox/rox/pkg/errox"
@@ -336,6 +337,25 @@ func (s *serviceImpl) DeletePolicy(ctx context.Context, request *v1.ResourceByID
 	// Note: default policies cannot be deleted, only disabled
 	if policy.GetIsDefault() {
 		return nil, errors.Wrap(errox.InvalidArgs, "A default policy cannot be deleted. (You can disable a default policy, but not delete it.)")
+	}
+
+	// Declarative policies can only be deleted by the config-controller via its finalizer.
+	if policy.GetSource() == storage.PolicySource_DECLARATIVE {
+		identity, err := authn.IdentityFromContext(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to determine caller identity")
+		}
+		isConfigController := false
+		for _, role := range identity.Roles() {
+			if role.GetRoleName() == accesscontrol.ConfigController {
+				isConfigController = true
+				break
+			}
+		}
+		if !isConfigController {
+			return nil, errors.Wrap(errox.InvalidArgs,
+				"A declarative policy cannot be deleted via the API. Delete the SecurityPolicy custom resource instead.")
+		}
 	}
 
 	if err := s.policies.RemovePolicy(ctx, policy); err != nil {

--- a/central/policy/service/service_impl.go
+++ b/central/policy/service/service_impl.go
@@ -353,8 +353,8 @@ func (s *serviceImpl) DeletePolicy(ctx context.Context, request *v1.ResourceByID
 			}
 		}
 		if !isConfigController {
-			return nil, errors.Wrap(errox.InvalidArgs,
-				"A declarative policy cannot be deleted via the API. Delete the SecurityPolicy custom resource instead.")
+			return nil, errors.Wrap(errox.NotAuthorized,
+				"An externally managed policy can only be deleted by deleting the corresponding SecurityPolicy custom resource.")
 		}
 	}
 

--- a/central/policy/service/service_impl_test.go
+++ b/central/policy/service/service_impl_test.go
@@ -3,20 +3,24 @@ package service
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
+	pkgErrors "github.com/pkg/errors"
 	clusterMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	lifecycleMocks "github.com/stackrox/rox/central/detection/lifecycle/mocks"
 	"github.com/stackrox/rox/central/policy/datastore/mocks"
 	connectionMocks "github.com/stackrox/rox/central/sensor/service/connection/mocks"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	permissionsMocks "github.com/stackrox/rox/pkg/auth/permissions/mocks"
 	"github.com/stackrox/rox/pkg/booleanpolicy/fieldnames"
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
+	accesscontrol "github.com/stackrox/rox/pkg/defaults/accesscontrol"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/fixtures"
 	"github.com/stackrox/rox/pkg/grpc/authn"
@@ -913,7 +917,7 @@ func (s *PolicyServiceTestSuite) TestDeletingDefaultPolicyIsBlocked() {
 		IsDefault: true,
 	}
 	s.policies.EXPECT().GetPolicy(ctx, mockPolicy.GetId()).Return(mockPolicy, true, nil)
-	expectedErr := errors.Wrap(errox.InvalidArgs, "A default policy cannot be deleted. (You can disable a default policy, but not delete it.)")
+	expectedErr := pkgErrors.Wrap(errox.InvalidArgs, "A default policy cannot be deleted. (You can disable a default policy, but not delete it.)")
 
 	// act
 	fakeResourceByIDRequest := &v1.ResourceByID{Id: mockPolicy.GetId()}
@@ -942,8 +946,37 @@ func (s *PolicyServiceTestSuite) TestDeletingDeclarativePolicyIsBlocked() {
 
 	// assert
 	s.Require().Error(err)
+	s.True(errors.Is(err, errox.NotAuthorized))
 	s.Require().Nil(resp)
-	s.Contains(err.Error(), "declarative policy cannot be deleted via the API")
+	s.Contains(err.Error(), "externally managed policy")
+}
+
+func (s *PolicyServiceTestSuite) TestDeletingDeclarativePolicyByConfigControllerSucceeds() {
+	// arrange
+	mockRole := permissionsMocks.NewMockResolvedRole(s.mockCtrl)
+	mockRole.EXPECT().GetRoleName().Return(accesscontrol.ConfigController)
+
+	mockIdentity := authnMocks.NewMockIdentity(s.mockCtrl)
+	mockIdentity.EXPECT().Roles().Return([]permissions.ResolvedRole{mockRole})
+	ctx := authn.ContextWithIdentity(context.Background(), mockIdentity, s.T())
+
+	mockPolicy := &storage.Policy{
+		Id:     mockRequestOneID.GetPolicyIds()[0],
+		Source: storage.PolicySource_DECLARATIVE,
+	}
+	s.policies.EXPECT().GetPolicy(ctx, mockPolicy.GetId()).Return(mockPolicy, true, nil)
+	s.policies.EXPECT().RemovePolicy(ctx, mockPolicy).Return(nil)
+	s.mockLifecycleManager.EXPECT().RemovePolicy(mockPolicy.GetId()).Return(nil)
+	s.policies.EXPECT().GetAllPolicies(gomock.Any()).Return(nil, nil)
+	s.mockConnectionManager.EXPECT().PreparePoliciesAndBroadcast(gomock.Any())
+
+	// act
+	fakeResourceByIDRequest := &v1.ResourceByID{Id: mockPolicy.GetId()}
+	resp, err := s.tested.DeletePolicy(ctx, fakeResourceByIDRequest)
+
+	// assert
+	s.NoError(err)
+	s.NotNil(resp)
 }
 
 func (s *PolicyServiceTestSuite) TestDeletingNonExistentPolicyDoesNothing() {
@@ -967,9 +1000,9 @@ func (s *PolicyServiceTestSuite) TestDeletingPolicyErrOnDbError() {
 
 	// arrange
 	mockPolicyID := mockRequestOneID.GetPolicyIds()[0] // used only for the ID
-	dbErr := errors.New("the deebee has failed you")
+	dbErr := pkgErrors.New("the deebee has failed you")
 	s.policies.EXPECT().GetPolicy(ctx, mockPolicyID).Return(nil, true, dbErr)
-	expectedErr := errors.Wrap(dbErr, "DB error while trying to delete policy")
+	expectedErr := pkgErrors.Wrap(dbErr, "DB error while trying to delete policy")
 
 	// act
 	fakeResourceByIDRequest := &v1.ResourceByID{Id: mockPolicyID}

--- a/central/policy/service/service_impl_test.go
+++ b/central/policy/service/service_impl_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy/policyversion"
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/fixtures"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	authnMocks "github.com/stackrox/rox/pkg/grpc/authn/mocks"
 	mitreMocks "github.com/stackrox/rox/pkg/mitre/datastore/mocks"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/search"
@@ -920,6 +922,28 @@ func (s *PolicyServiceTestSuite) TestDeletingDefaultPolicyIsBlocked() {
 	// assert
 	s.Require().Error(err, expectedErr)
 	s.Require().Nil(resp)
+}
+
+func (s *PolicyServiceTestSuite) TestDeletingDeclarativePolicyIsBlocked() {
+	// arrange
+	mockIdentity := authnMocks.NewMockIdentity(s.mockCtrl)
+	mockIdentity.EXPECT().Roles().Return(nil)
+	ctx := authn.ContextWithIdentity(context.Background(), mockIdentity, s.T())
+
+	mockPolicy := &storage.Policy{
+		Id:     mockRequestOneID.GetPolicyIds()[0],
+		Source: storage.PolicySource_DECLARATIVE,
+	}
+	s.policies.EXPECT().GetPolicy(ctx, mockPolicy.GetId()).Return(mockPolicy, true, nil)
+
+	// act
+	fakeResourceByIDRequest := &v1.ResourceByID{Id: mockPolicy.GetId()}
+	resp, err := s.tested.DeletePolicy(ctx, fakeResourceByIDRequest)
+
+	// assert
+	s.Require().Error(err)
+	s.Require().Nil(resp)
+	s.Contains(err.Error(), "declarative policy cannot be deleted via the API")
 }
 
 func (s *PolicyServiceTestSuite) TestDeletingNonExistentPolicyDoesNothing() {

--- a/central/policy/service/service_impl_test.go
+++ b/central/policy/service/service_impl_test.go
@@ -930,8 +930,11 @@ func (s *PolicyServiceTestSuite) TestDeletingDefaultPolicyIsBlocked() {
 
 func (s *PolicyServiceTestSuite) TestDeletingDeclarativePolicyIsBlocked() {
 	// arrange
+	mockRole := permissionsMocks.NewMockResolvedRole(s.mockCtrl)
+	mockRole.EXPECT().GetRoleName().Return(accesscontrol.Admin)
+
 	mockIdentity := authnMocks.NewMockIdentity(s.mockCtrl)
-	mockIdentity.EXPECT().Roles().Return(nil)
+	mockIdentity.EXPECT().Roles().Return([]permissions.ResolvedRole{mockRole})
 	ctx := authn.ContextWithIdentity(context.Background(), mockIdentity, s.T())
 
 	mockPolicy := &storage.Policy{

--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -475,10 +475,15 @@ func (pc *PolicyAsCodeSuite) TearDownSuite() {
 	// TODO: Don't double delete
 	for _, policy := range pc.policies {
 		pc.T().Logf("Deleting policy with name \"%s\"", policy.GetName())
-		_, err := pc.policyClient.DeletePolicy(pc.ctx, &v1.ResourceByID{
-			Id: policy.GetId(),
-		})
-		pc.Require().NoError(err)
+		if policy.GetSource() == storage.PolicySource_DECLARATIVE {
+			err := pc.k8sClient.Delete(pc.ctx, policy.GetName(), metav1.DeleteOptions{})
+			pc.Require().NoError(err)
+		} else {
+			_, err := pc.policyClient.DeletePolicy(pc.ctx, &v1.ResourceByID{
+				Id: policy.GetId(),
+			})
+			pc.Require().NoError(err)
+		}
 	}
 
 	if pc.notifier != nil {

--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -24,7 +24,8 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.yaml.in/yaml/v3"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	grpcStatus "google.golang.org/grpc/status"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -440,7 +441,7 @@ func (pc *PolicyAsCodeSuite) deleteCRandObserveInCentral(k8sPolicy *v1alpha1.Sec
 	pc.Require().EventuallyWithT(func(collect *assert.CollectT) {
 		_, err := pc.policyClient.GetPolicy(pc.ctx, &v1.ResourceByID{Id: id})
 		if err != nil {
-			statusErr, _ := status.FromError(err)
+			statusErr, _ := grpcStatus.FromError(err)
 			if statusErr.Code() != codes.NotFound {
 				collect.Errorf("Unexpected error when geting policy: %s", err.Error())
 			}
@@ -477,12 +478,19 @@ func (pc *PolicyAsCodeSuite) TearDownSuite() {
 		pc.T().Logf("Deleting policy with name \"%s\"", policy.GetName())
 		if policy.GetSource() == storage.PolicySource_DECLARATIVE {
 			err := pc.k8sClient.Delete(pc.ctx, policy.GetName(), metav1.DeleteOptions{})
-			pc.Require().NoError(err)
+			if err != nil && !k8serr.IsNotFound(err) {
+				pc.Require().NoError(err)
+			}
 		} else {
 			_, err := pc.policyClient.DeletePolicy(pc.ctx, &v1.ResourceByID{
 				Id: policy.GetId(),
 			})
-			pc.Require().NoError(err)
+			if err != nil {
+				st, ok := grpcStatus.FromError(err)
+				if !ok || st.Code() != codes.NotFound {
+					pc.Require().NoError(err)
+				}
+			}
 		}
 	}
 

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
@@ -234,9 +234,11 @@ function PolicyDetail({
                                         isDisabled={isDefault || isExternalPolicy(policy)}
                                         onClick={() => setIsDeleteOpen(true)}
                                     >
-                                        {isDefault || isExternalPolicy(policy)
-                                            ? 'Cannot delete an externally managed policy'
-                                            : 'Delete policy'}
+                                        {isDefault
+                                            ? 'Cannot delete a default policy'
+                                            : isExternalPolicy(policy)
+                                              ? 'Cannot delete an externally managed policy'
+                                              : 'Delete policy'}
                                     </DropdownItem>
                                 )}
                             </MenuDropdown>

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
@@ -280,8 +280,8 @@ function PolicyDetail({
                 onConfirm={onConfirmDeletePolicy}
                 onCancel={onCancelDeletePolicy}
             >
-                This policy will be permanently removed from the system and will no longer
-                trigger violations.
+                This policy will be permanently removed from the system and will no longer trigger
+                violations.
             </ConfirmationModal>
             <ConfirmationModal
                 title={`Save policy as Custom Resource?`}

--- a/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Detail/PolicyDetail.tsx
@@ -231,11 +231,11 @@ function PolicyDetail({
                                 {hasWriteAccessForPolicy && (
                                     <DropdownItem
                                         key="Delete policy"
-                                        isDisabled={isDefault}
+                                        isDisabled={isDefault || isExternalPolicy(policy)}
                                         onClick={() => setIsDeleteOpen(true)}
                                     >
-                                        {isDefault
-                                            ? 'Cannot delete a default policy'
+                                        {isDefault || isExternalPolicy(policy)
+                                            ? 'Cannot delete an externally managed policy'
                                             : 'Delete policy'}
                                     </DropdownItem>
                                 )}
@@ -278,17 +278,8 @@ function PolicyDetail({
                 onConfirm={onConfirmDeletePolicy}
                 onCancel={onCancelDeletePolicy}
             >
-                {isExternalPolicy(policy) ? (
-                    <>
-                        This policy is managed externally and will only be removed from the system
-                        temporarily. The policy will not trigger violations until the next resync.
-                    </>
-                ) : (
-                    <>
-                        This policy will be permanently removed from the system and will no longer
-                        trigger violations.
-                    </>
-                )}
+                This policy will be permanently removed from the system and will no longer
+                trigger violations.
             </ConfirmationModal>
             <ConfirmationModal
                 title={`Save policy as Custom Resource?`}

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -153,13 +153,14 @@ function PoliciesTable({
     let numDisabled = 0;
     let numDeletable = 0;
     let numSaveable = 0;
-    selectedPolicies.forEach(({ disabled, isDefault, source }) => {
+    selectedPolicies.forEach((policy) => {
+        const { disabled, isDefault } = policy;
         if (disabled) {
             numDisabled += 1;
         } else {
             numEnabled += 1;
         }
-        if (!isDefault && source !== 'DECLARATIVE') {
+        if (!isDefault && !isExternalPolicy(policy)) {
             numDeletable += 1;
         }
         if (!isDefault) {
@@ -297,9 +298,9 @@ function PoliciesTable({
                                                 setDeletingIds(
                                                     selectedPolicies
                                                         .filter(
-                                                            ({ isDefault, source }) =>
-                                                                !isDefault &&
-                                                                source !== 'DECLARATIVE'
+                                                            (policy) =>
+                                                                !policy.isDefault &&
+                                                                !isExternalPolicy(policy)
                                                         )
                                                         .map(({ id }) => id)
                                                 )
@@ -409,7 +410,6 @@ function PoliciesTable({
                                         name,
                                         notifiers: notifierIds,
                                         severity,
-                                        source,
                                     } = policy;
                                     const isExpanded = expandedRowSet.has(id);
 
@@ -461,11 +461,11 @@ function PoliciesTable({
                                               {
                                                   title: isDefault
                                                       ? 'Cannot delete a default policy'
-                                                      : source === 'DECLARATIVE'
+                                                      : isExternalPolicy(policy)
                                                         ? 'Cannot delete an externally managed policy'
                                                         : 'Delete policy',
                                                   onClick: () => setDeletingIds([id]),
-                                                  isDisabled: isDefault || source === 'DECLARATIVE',
+                                                  isDisabled: isDefault || isExternalPolicy(policy),
                                               },
                                           ]
                                         : [exportPolicyAction, saveAsCustomResourceActionItem];

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -459,10 +459,11 @@ function PoliciesTable({
                                                   isSeparator: true,
                                               },
                                               {
-                                                  title:
-                                                      isDefault || source === 'DECLARATIVE'
-                                                          ? 'Cannot delete an externally managed policy'
-                                                          : 'Delete policy',
+                                                  title: isDefault
+                                                      ? 'Cannot delete a default policy'
+                                                      : source === 'DECLARATIVE'
+                                                        ? 'Cannot delete an externally managed policy'
+                                                        : 'Delete policy',
                                                   onClick: () => setDeletingIds([id]),
                                                   isDisabled:
                                                       isDefault || source === 'DECLARATIVE',

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -153,14 +153,16 @@ function PoliciesTable({
     let numDisabled = 0;
     let numDeletable = 0;
     let numSaveable = 0;
-    selectedPolicies.forEach(({ disabled, isDefault }) => {
+    selectedPolicies.forEach(({ disabled, isDefault, source }) => {
         if (disabled) {
             numDisabled += 1;
         } else {
             numEnabled += 1;
         }
-        if (!isDefault) {
+        if (!isDefault && source !== 'DECLARATIVE') {
             numDeletable += 1;
+        }
+        if (!isDefault) {
             numSaveable += 1;
         }
     });
@@ -294,7 +296,11 @@ function PoliciesTable({
                                             onClick={() =>
                                                 setDeletingIds(
                                                     selectedPolicies
-                                                        .filter(({ isDefault }) => !isDefault)
+                                                        .filter(
+                                                            ({ isDefault, source }) =>
+                                                                !isDefault &&
+                                                                source !== 'DECLARATIVE'
+                                                        )
                                                         .map(({ id }) => id)
                                                 )
                                             }
@@ -403,6 +409,7 @@ function PoliciesTable({
                                         name,
                                         notifiers: notifierIds,
                                         severity,
+                                        source,
                                     } = policy;
                                     const isExpanded = expandedRowSet.has(id);
 
@@ -452,11 +459,13 @@ function PoliciesTable({
                                                   isSeparator: true,
                                               },
                                               {
-                                                  title: isDefault
-                                                      ? 'Cannot delete a default policy'
-                                                      : 'Delete policy',
+                                                  title:
+                                                      isDefault || source === 'DECLARATIVE'
+                                                          ? 'Cannot delete an externally managed policy'
+                                                          : 'Delete policy',
                                                   onClick: () => setDeletingIds([id]),
-                                                  isDisabled: isDefault,
+                                                  isDisabled:
+                                                      isDefault || source === 'DECLARATIVE',
                                               },
                                           ]
                                         : [exportPolicyAction, saveAsCustomResourceActionItem];

--- a/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
+++ b/ui/apps/platform/src/Containers/Policies/Table/PoliciesTable.tsx
@@ -465,8 +465,7 @@ function PoliciesTable({
                                                         ? 'Cannot delete an externally managed policy'
                                                         : 'Delete policy',
                                                   onClick: () => setDeletingIds([id]),
-                                                  isDisabled:
-                                                      isDefault || source === 'DECLARATIVE',
+                                                  isDisabled: isDefault || source === 'DECLARATIVE',
                                               },
                                           ]
                                         : [exportPolicyAction, saveAsCustomResourceActionItem];


### PR DESCRIPTION
## Description

Declarative policies managed by SecurityPolicy CRs should only be deletable by the config-controller (via its finalizer), not by users through the UI or API. This prevents the config-controller from failing to reconcile when a policy is deleted externally (ROX-32482).

**API:** Added a guard in `DeletePolicy` that checks if the policy source is `DECLARATIVE` and rejects the request unless the caller has the `ConfigController` role.

**UI:** Disabled delete buttons and bulk delete actions for externally managed policies in both the policies table and detail views.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Added `TestDeletingDeclarativePolicyIsBlocked` unit test — passes
- TypeScript type-check passes (pre-existing errors only)
- Manual verification pending on a running cluster