### PR TITLE
ROX-34559: Fix post-test failures in GHA nongroovy e2e workflow

### DIFF
--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -171,6 +171,7 @@ jobs:
       shell: python
       env:
         PYTHONUNBUFFERED: "1"
+        ROX_USERNAME: admin
       run: |
         import os, sys
         sys.path.append('.openshift-ci')

--- a/scripts/ci/collect-infrastructure-logs.sh
+++ b/scripts/ci/collect-infrastructure-logs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -eu
 
 # Collect k8s infrastructure Logs script


### PR DESCRIPTION
## Description

Two fixes for post-test failures in the GHA nongroovy e2e workflow ([ROX-34559](https://redhat.atlassian.net/browse/ROX-34559)):

1. **Missing `ROX_USERNAME` env var in post-test step**: The "Run post-test" step in `e2e-nongroovy-tests.yaml` invokes `PostClusterTest` from `.openshift-ci/post_tests.py`, which requires the `ROX_USERNAME` environment variable. The main e2e test step sets this via `tests/e2e/lib.sh`, but the post-test step runs in its own shell context and does not inherit it. This adds `ROX_USERNAME: admin` to the post-test step's env block, matching what `tests/e2e/lib.sh` exports during the test run.

2. **`BASH_SOURCE` in `/bin/sh` script**: `scripts/ci/collect-infrastructure-logs.sh` used `#!/bin/sh` as its shebang but referenced `BASH_SOURCE`, which is a bash-specific variable not available in POSIX sh. This changes the shebang to `#!/usr/bin/env bash` so the script runs under bash where `BASH_SOURCE` is defined.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

No user-facing changes; CI infrastructure fix only.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No new tests added. These are CI workflow and script fixes that are validated by the CI pipeline itself (the `gke-nongroovy-e2e-tests` job succeeding through the post-test phase).

### How I validated my change

The post-test step only runs on `push` events (master merges) or test failures, so it cannot be reliably validated on a PR. The fix is straightforward — adding a missing env var and correcting a shebang — and was confirmed by reading the failing logs directly.

[ROX-34559]: https://redhat.atlassian.net/browse/ROX-34559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ