### PR TITLE
fix(ci): gate upstream brand builds behind label

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,27 +39,26 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
-      - name: Compute build metadata
+      - uses: ./.github/actions/handle-tagged-build
+
+      - name: Compute build tag
         id: build-tag
         run: |
-          # For tagged builds, the tag itself is the version.
-          # Otherwise, use git describe for the dev version string.
-          if [[ "${GITHUB_REF}" =~ ^refs/tags/(.*) ]]; then
-            TAG="${BASH_REMATCH[1]}"
-          else
-            TAG="$(git describe --tags --abbrev=10 --long --exclude '*-nightly-*')"
-          fi
+          TAG=$(make --quiet --no-print-directory tag)
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Compute short commit
         id: short-commit
-        run: echo "shortcommit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          SHORTCOMMIT=$(make --quiet --no-print-directory shortcommit)
+          echo "shortcommit=${SHORTCOMMIT}" >> "$GITHUB_OUTPUT"
 
       - name: Compute GOTAGS
         id: gotags
         run: |
           GOTAGS=""
           if [[ "${GITHUB_REF}" =~ ^refs/tags/ ]]; then
+            # Tag builds (release or nightly) get release GOTAGS
             GOTAGS="release"
           fi
           echo "gotags=${GOTAGS}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,83 +66,87 @@ jobs:
       - name: Define the matrix for build jobs
         id: define-job-matrix
         run: |
-          source './scripts/ci/lib.sh'
-
-          matrix='{
-            "pre_build_ui": { "branding":[] },
-            "pre_build_go_binaries": { "name":[], "arch":[] },
-            "build_and_push_main": { "name":[], "arch":[] },
-            "push_main_multiarch_manifests": { "name":[] },
-            "build_and_push_operator": { "name":[], "arch":[] },
-            "push_operator_multiarch_manifests": { "name":[] },
-            "scan_images_with_roxctl": { "name":[], "image":[], "exclude":[] }
-          }'
-
-          # The base matrix (RHACS is the downstream/release branding, always built)
-          matrix="$(jq '.pre_build_ui.branding += ["RHACS_BRANDING"]' <<< "$matrix")"
-
-          matrix="$(jq '.pre_build_go_binaries.name += ["default"]' <<< "$matrix")"
-          matrix="$(jq '.pre_build_go_binaries.arch += ["amd64", "arm64"]' <<< "$matrix")"
-
-          matrix="$(jq '.build_and_push_main.name += ["RHACS_BRANDING"]' <<< "$matrix")"
-          matrix="$(jq '.build_and_push_main.arch += ["amd64", "arm64"]' <<< "$matrix")"
-
-          matrix="$(jq '.push_main_multiarch_manifests.name += ["RHACS_BRANDING"]' <<< "$matrix")"
-
-          matrix="$(jq '.build_and_push_operator.name += ["RHACS_BRANDING"]' <<< "$matrix")"
-          matrix="$(jq '.build_and_push_operator.arch += ["amd64", "arm64"]' <<< "$matrix")"
-
-          matrix="$(jq '.push_operator_multiarch_manifests.name += ["RHACS_BRANDING"]' <<< "$matrix")"
-          matrix="$(jq '.push_operator_multiarch_manifests.archs = [.build_and_push_operator.arch | join(",")]' <<< "$matrix")"
-
-          matrix="$(jq '.scan_images_with_roxctl.name += ["RHACS_BRANDING"]' <<< "$matrix")"
-          matrix="$(jq '.scan_images_with_roxctl.image += ["central-db", "collector", "fact", "main", "roxctl", "scanner", "scanner-db", "scanner-db-slim", "scanner-slim", "stackrox-operator"]' <<< "$matrix")"
-
-          # Conditionally add upstream (STACKROX_BRANDING) builds
-          if ! is_in_PR_context || pr_has_label ci-build-upstream; then
-            matrix="$(jq '.pre_build_ui.branding += ["STACKROX_BRANDING"]' <<< "$matrix")"
-            matrix="$(jq '.build_and_push_main.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
-            matrix="$(jq '.push_main_multiarch_manifests.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
-            matrix="$(jq '.build_and_push_operator.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
-            matrix="$(jq '.push_operator_multiarch_manifests.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
-            matrix="$(jq '.scan_images_with_roxctl.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
-            # TODO(ROX-27191): remove the exclusion once there's a community operator.
-            matrix="$(jq '.scan_images_with_roxctl.exclude += [{ "name": "STACKROX_BRANDING", "image": "stackrox-operator" }]' <<< "$matrix")"
+          # Compute conditional flags from GHA context.
+          # For non-PR events (push to master/tags), all optional builds are enabled.
+          is_pr=$([[ -n "${GITHUB_BASE_REF:-}" ]] && echo true || echo false)
+          is_tagged=$([[ "${GITHUB_REF}" =~ ^refs/tags/ ]] && echo true || echo false)
+          if [[ "$is_pr" == "true" ]]; then
+            labels="$(jq -r '[.pull_request.labels[].name] | join(",")' "$GITHUB_EVENT_PATH")"
+            has_label() { [[ ",$labels," == *",$1,"* ]]; }
+          else
+            has_label() { return 0; }
           fi
+          to_jq() { $1 && echo true || echo false; }
 
-          if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
-            matrix="$(jq '.pre_build_go_binaries.arch += ["ppc64le", "s390x"]' <<< "$matrix")"
-            matrix="$(jq '.build_and_push_main.arch += ["ppc64le", "s390x"]' <<< "$matrix")"
-          fi;
+          upstream=$(to_jq "has_label ci-build-upstream")
+          all_arch=$(to_jq "has_label ci-build-all-arch")
+          prerelease=$(to_jq "has_label ci-build-prerelease")
+          race=$(to_jq "has_label ci-build-race-condition-debug")
 
-          # Conditionally add a prerelease build (binaries built with GOTAGS=release)
-          if ! is_tagged; then
-            if ! is_in_PR_context || pr_has_label ci-build-prerelease; then
-              matrix="$(jq '.pre_build_go_binaries.name += ["prerelease"]' <<< "$matrix")"
-              matrix="$(jq '.build_and_push_main.name += ["prerelease"]' <<< "$matrix")"
-              matrix="$(jq '.push_main_multiarch_manifests.name += ["prerelease"]' <<< "$matrix")"
-            fi
-          fi
+          echo "Flags: is_pr=$is_pr is_tagged=$is_tagged upstream=$upstream all_arch=$all_arch prerelease=$prerelease race=$race"
 
-          # Conditionally add a -race debug build (binaries built with -race)
-          if ! is_in_PR_context || pr_has_label ci-build-race-condition-debug; then
-            matrix="$(jq '.pre_build_go_binaries.name += ["race-condition-debug"]' <<< "$matrix")"
-            matrix="$(jq '.build_and_push_main.name += ["race-condition-debug"]' <<< "$matrix")"
-            matrix="$(jq '.push_main_multiarch_manifests.name += ["race-condition-debug"]' <<< "$matrix")"
-            # Exclude "arm64", "ppc64le", "s390x"
-            matrix="$(jq '.pre_build_go_binaries.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
-            matrix="$(jq '.pre_build_go_binaries.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
-            matrix="$(jq '.pre_build_go_binaries.exclude += [{ "name": "race-condition-debug", "arch": "s390x" }]' <<< "$matrix")"
-            matrix="$(jq '.build_and_push_main.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
-            matrix="$(jq '.build_and_push_main.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
-            matrix="$(jq '.build_and_push_main.exclude += [{ "name": "race-condition-debug", "arch": "s390x" }]' <<< "$matrix")"
-          fi
+          # Build the full matrix in a single jq expression.
+          # The structure is the template; conditions are inline via optional().
+          matrix="$(jq -n \
+            --argjson upstream "$upstream" \
+            --argjson all_arch "$all_arch" \
+            --argjson prerelease "$prerelease" \
+            --argjson race "$race" \
+            --argjson tagged "$is_tagged" \
+          '
+            def optional($flag; $items): if $flag then $items else [] end;
+            {
+              pre_build_ui: {
+                branding: (["RHACS_BRANDING"] + optional($upstream; ["STACKROX_BRANDING"]))
+              },
+              pre_build_go_binaries: {
+                name: (["default"]
+                  + optional(($tagged | not) and $prerelease; ["prerelease"])
+                  + optional($race; ["race-condition-debug"])),
+                arch: (["amd64", "arm64"] + optional($all_arch; ["ppc64le", "s390x"])),
+                exclude: optional($race;
+                  [{"name":"race-condition-debug","arch":"arm64"},
+                   {"name":"race-condition-debug","arch":"ppc64le"},
+                   {"name":"race-condition-debug","arch":"s390x"}])
+              },
+              build_and_push_main: {
+                name: (["RHACS_BRANDING"]
+                  + optional($upstream; ["STACKROX_BRANDING"])
+                  + optional(($tagged | not) and $prerelease; ["prerelease"])
+                  + optional($race; ["race-condition-debug"])),
+                arch: (["amd64", "arm64"] + optional($all_arch; ["ppc64le", "s390x"])),
+                exclude: optional($race;
+                  [{"name":"race-condition-debug","arch":"arm64"},
+                   {"name":"race-condition-debug","arch":"ppc64le"},
+                   {"name":"race-condition-debug","arch":"s390x"}])
+              },
+              push_main_multiarch_manifests: {
+                name: (["RHACS_BRANDING"]
+                  + optional($upstream; ["STACKROX_BRANDING"])
+                  + optional(($tagged | not) and $prerelease; ["prerelease"])
+                  + optional($race; ["race-condition-debug"]))
+              },
+              build_and_push_operator: {
+                name: (["RHACS_BRANDING"] + optional($upstream; ["STACKROX_BRANDING"])),
+                arch: (["amd64", "arm64"] + optional($all_arch; ["ppc64le", "s390x"]))
+              },
+              push_operator_multiarch_manifests: {
+                name: (["RHACS_BRANDING"] + optional($upstream; ["STACKROX_BRANDING"])),
+                archs: [(["amd64", "arm64"] + optional($all_arch; ["ppc64le", "s390x"])) | join(",")]
+              },
+              scan_images_with_roxctl: {
+                name: (["RHACS_BRANDING"] + optional($upstream; ["STACKROX_BRANDING"])),
+                image: ["central-db","collector","fact","main","roxctl","scanner",
+                        "scanner-db","scanner-db-slim","scanner-slim","stackrox-operator"],
+                exclude: optional($upstream;
+                  [{"name":"STACKROX_BRANDING","image":"stackrox-operator"}])
+              }
+            }
+          ')"
 
-          echo "Job matrix after conditionals:"
+          echo "Job matrix:"
           jq <<< "$matrix"
-
-          condensed="$(jq -c <<< "$matrix")"
-          echo "matrix=$condensed" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(jq -c <<< "$matrix")" >> "$GITHUB_OUTPUT"
 
   pre-build-ui:
     needs: define-job-matrix

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,87 +66,83 @@ jobs:
       - name: Define the matrix for build jobs
         id: define-job-matrix
         run: |
-          # Compute conditional flags from GHA context.
-          # For non-PR events (push to master/tags), all optional builds are enabled.
-          is_pr=$([[ -n "${GITHUB_BASE_REF:-}" ]] && echo true || echo false)
-          is_tagged=$([[ "${GITHUB_REF}" =~ ^refs/tags/ ]] && echo true || echo false)
-          if [[ "$is_pr" == "true" ]]; then
-            labels="$(jq -r '[.pull_request.labels[].name] | join(",")' "$GITHUB_EVENT_PATH")"
-            has_label() { [[ ",$labels," == *",$1,"* ]]; }
-          else
-            has_label() { return 0; }
+          source './scripts/ci/lib.sh'
+
+          matrix='{
+            "pre_build_ui": { "branding":[] },
+            "pre_build_go_binaries": { "name":[], "arch":[] },
+            "build_and_push_main": { "name":[], "arch":[] },
+            "push_main_multiarch_manifests": { "name":[] },
+            "build_and_push_operator": { "name":[], "arch":[] },
+            "push_operator_multiarch_manifests": { "name":[] },
+            "scan_images_with_roxctl": { "name":[], "image":[], "exclude":[] }
+          }'
+
+          # The base matrix (RHACS is the downstream/release branding, always built)
+          matrix="$(jq '.pre_build_ui.branding += ["RHACS_BRANDING"]' <<< "$matrix")"
+
+          matrix="$(jq '.pre_build_go_binaries.name += ["default"]' <<< "$matrix")"
+          matrix="$(jq '.pre_build_go_binaries.arch += ["amd64", "arm64"]' <<< "$matrix")"
+
+          matrix="$(jq '.build_and_push_main.name += ["RHACS_BRANDING"]' <<< "$matrix")"
+          matrix="$(jq '.build_and_push_main.arch += ["amd64", "arm64"]' <<< "$matrix")"
+
+          matrix="$(jq '.push_main_multiarch_manifests.name += ["RHACS_BRANDING"]' <<< "$matrix")"
+
+          matrix="$(jq '.build_and_push_operator.name += ["RHACS_BRANDING"]' <<< "$matrix")"
+          matrix="$(jq '.build_and_push_operator.arch += ["amd64", "arm64"]' <<< "$matrix")"
+
+          matrix="$(jq '.push_operator_multiarch_manifests.name += ["RHACS_BRANDING"]' <<< "$matrix")"
+          matrix="$(jq '.push_operator_multiarch_manifests.archs = [.build_and_push_operator.arch | join(",")]' <<< "$matrix")"
+
+          matrix="$(jq '.scan_images_with_roxctl.name += ["RHACS_BRANDING"]' <<< "$matrix")"
+          matrix="$(jq '.scan_images_with_roxctl.image += ["central-db", "collector", "fact", "main", "roxctl", "scanner", "scanner-db", "scanner-db-slim", "scanner-slim", "stackrox-operator"]' <<< "$matrix")"
+
+          # Conditionally add upstream (STACKROX_BRANDING) builds
+          if ! is_in_PR_context || pr_has_label ci-build-upstream; then
+            matrix="$(jq '.pre_build_ui.branding += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_main.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            matrix="$(jq '.push_main_multiarch_manifests.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_operator.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            matrix="$(jq '.push_operator_multiarch_manifests.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            matrix="$(jq '.scan_images_with_roxctl.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            # TODO(ROX-27191): remove the exclusion once there's a community operator.
+            matrix="$(jq '.scan_images_with_roxctl.exclude += [{ "name": "STACKROX_BRANDING", "image": "stackrox-operator" }]' <<< "$matrix")"
           fi
-          to_jq() { $1 && echo true || echo false; }
 
-          upstream=$(to_jq "has_label ci-build-upstream")
-          all_arch=$(to_jq "has_label ci-build-all-arch")
-          prerelease=$(to_jq "has_label ci-build-prerelease")
-          race=$(to_jq "has_label ci-build-race-condition-debug")
+          if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
+            matrix="$(jq '.pre_build_go_binaries.arch += ["ppc64le", "s390x"]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_main.arch += ["ppc64le", "s390x"]' <<< "$matrix")"
+          fi;
 
-          echo "Flags: is_pr=$is_pr is_tagged=$is_tagged upstream=$upstream all_arch=$all_arch prerelease=$prerelease race=$race"
+          # Conditionally add a prerelease build (binaries built with GOTAGS=release)
+          if ! is_tagged; then
+            if ! is_in_PR_context || pr_has_label ci-build-prerelease; then
+              matrix="$(jq '.pre_build_go_binaries.name += ["prerelease"]' <<< "$matrix")"
+              matrix="$(jq '.build_and_push_main.name += ["prerelease"]' <<< "$matrix")"
+              matrix="$(jq '.push_main_multiarch_manifests.name += ["prerelease"]' <<< "$matrix")"
+            fi
+          fi
 
-          # Build the full matrix in a single jq expression.
-          # The structure is the template; conditions are inline via optional().
-          matrix="$(jq -n \
-            --argjson upstream "$upstream" \
-            --argjson all_arch "$all_arch" \
-            --argjson prerelease "$prerelease" \
-            --argjson race "$race" \
-            --argjson tagged "$is_tagged" \
-          '
-            def optional($flag; $items): if $flag then $items else [] end;
-            {
-              pre_build_ui: {
-                branding: (["RHACS_BRANDING"] + optional($upstream; ["STACKROX_BRANDING"]))
-              },
-              pre_build_go_binaries: {
-                name: (["default"]
-                  + optional(($tagged | not) and $prerelease; ["prerelease"])
-                  + optional($race; ["race-condition-debug"])),
-                arch: (["amd64", "arm64"] + optional($all_arch; ["ppc64le", "s390x"])),
-                exclude: optional($race;
-                  [{"name":"race-condition-debug","arch":"arm64"},
-                   {"name":"race-condition-debug","arch":"ppc64le"},
-                   {"name":"race-condition-debug","arch":"s390x"}])
-              },
-              build_and_push_main: {
-                name: (["RHACS_BRANDING"]
-                  + optional($upstream; ["STACKROX_BRANDING"])
-                  + optional(($tagged | not) and $prerelease; ["prerelease"])
-                  + optional($race; ["race-condition-debug"])),
-                arch: (["amd64", "arm64"] + optional($all_arch; ["ppc64le", "s390x"])),
-                exclude: optional($race;
-                  [{"name":"race-condition-debug","arch":"arm64"},
-                   {"name":"race-condition-debug","arch":"ppc64le"},
-                   {"name":"race-condition-debug","arch":"s390x"}])
-              },
-              push_main_multiarch_manifests: {
-                name: (["RHACS_BRANDING"]
-                  + optional($upstream; ["STACKROX_BRANDING"])
-                  + optional(($tagged | not) and $prerelease; ["prerelease"])
-                  + optional($race; ["race-condition-debug"]))
-              },
-              build_and_push_operator: {
-                name: (["RHACS_BRANDING"] + optional($upstream; ["STACKROX_BRANDING"])),
-                arch: (["amd64", "arm64"] + optional($all_arch; ["ppc64le", "s390x"]))
-              },
-              push_operator_multiarch_manifests: {
-                name: (["RHACS_BRANDING"] + optional($upstream; ["STACKROX_BRANDING"])),
-                archs: [(["amd64", "arm64"] + optional($all_arch; ["ppc64le", "s390x"])) | join(",")]
-              },
-              scan_images_with_roxctl: {
-                name: (["RHACS_BRANDING"] + optional($upstream; ["STACKROX_BRANDING"])),
-                image: ["central-db","collector","fact","main","roxctl","scanner",
-                        "scanner-db","scanner-db-slim","scanner-slim","stackrox-operator"],
-                exclude: optional($upstream;
-                  [{"name":"STACKROX_BRANDING","image":"stackrox-operator"}])
-              }
-            }
-          ')"
+          # Conditionally add a -race debug build (binaries built with -race)
+          if ! is_in_PR_context || pr_has_label ci-build-race-condition-debug; then
+            matrix="$(jq '.pre_build_go_binaries.name += ["race-condition-debug"]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_main.name += ["race-condition-debug"]' <<< "$matrix")"
+            matrix="$(jq '.push_main_multiarch_manifests.name += ["race-condition-debug"]' <<< "$matrix")"
+            # Exclude "arm64", "ppc64le", "s390x"
+            matrix="$(jq '.pre_build_go_binaries.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
+            matrix="$(jq '.pre_build_go_binaries.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
+            matrix="$(jq '.pre_build_go_binaries.exclude += [{ "name": "race-condition-debug", "arch": "s390x" }]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_main.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_main.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_main.exclude += [{ "name": "race-condition-debug", "arch": "s390x" }]' <<< "$matrix")"
+          fi
 
-          echo "Job matrix:"
+          echo "Job matrix after conditionals:"
           jq <<< "$matrix"
-          echo "matrix=$(jq -c <<< "$matrix")" >> "$GITHUB_OUTPUT"
+
+          condensed="$(jq -c <<< "$matrix")"
+          echo "matrix=$condensed" >> "$GITHUB_OUTPUT"
 
   pre-build-ui:
     needs: define-job-matrix

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,8 +65,16 @@ jobs:
 
       - name: Define the matrix for build jobs
         id: define-job-matrix
+        env:
+          # PR labels that gate optional matrix entries.
+          # On non-PR events (master, tags), all are enabled regardless.
+          UPSTREAM: ${{ !github.base_ref || contains(github.event.pull_request.labels.*.name, 'ci-build-upstream') }}
+          ALL_ARCH: ${{ !github.base_ref || contains(github.event.pull_request.labels.*.name, 'ci-build-all-arch') }}
+          PRERELEASE: ${{ !github.base_ref || contains(github.event.pull_request.labels.*.name, 'ci-build-prerelease') }}
+          RACE: ${{ !github.base_ref || contains(github.event.pull_request.labels.*.name, 'ci-build-race-condition-debug') }}
+          TAGGED: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
-          source './scripts/ci/lib.sh'
+          echo "Flags: UPSTREAM=$UPSTREAM ALL_ARCH=$ALL_ARCH PRERELEASE=$PRERELEASE RACE=$RACE TAGGED=$TAGGED"
 
           matrix='{
             "pre_build_ui": { "branding":[] },
@@ -101,8 +109,7 @@ jobs:
           matrix="$(jq '.scan_images_with_roxctl.name += ["RHACS_BRANDING"]' <<< "$matrix")"
           matrix="$(jq '.scan_images_with_roxctl.image += ["central-db", "collector", "fact", "main", "roxctl", "scanner", "scanner-db", "scanner-db-slim", "scanner-slim", "stackrox-operator"]' <<< "$matrix")"
 
-          # Conditionally add upstream (STACKROX_BRANDING) builds
-          if ! is_in_PR_context || pr_has_label ci-build-upstream; then
+          if [[ "$UPSTREAM" == "true" ]]; then
             matrix="$(jq '.pre_build_ui.branding += ["STACKROX_BRANDING"]' <<< "$matrix")"
             matrix="$(jq '.build_and_push_main.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
             matrix="$(jq '.push_main_multiarch_manifests.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
@@ -114,39 +121,30 @@ jobs:
             matrix="$(jq '.scan_images_with_roxctl.exclude += [{ "name": "STACKROX_BRANDING", "image": "stackrox-operator" }]' <<< "$matrix")"
           fi
 
-          if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
+          if [[ "$ALL_ARCH" == "true" ]]; then
             matrix="$(jq '.pre_build_go_binaries.arch += ["ppc64le", "s390x"]' <<< "$matrix")"
             matrix="$(jq '.build_and_push_main.arch += ["ppc64le", "s390x"]' <<< "$matrix")"
-          fi;
-
-          # Conditionally add a prerelease build (binaries built with GOTAGS=release)
-          if ! is_tagged; then
-            if ! is_in_PR_context || pr_has_label ci-build-prerelease; then
-              matrix="$(jq '.pre_build_go_binaries.name += ["prerelease"]' <<< "$matrix")"
-              matrix="$(jq '.build_and_push_main.name += ["prerelease"]' <<< "$matrix")"
-              matrix="$(jq '.push_main_multiarch_manifests.name += ["prerelease"]' <<< "$matrix")"
-            fi
           fi
 
-          # Conditionally add a -race debug build (binaries built with -race)
-          if ! is_in_PR_context || pr_has_label ci-build-race-condition-debug; then
+          if [[ "$TAGGED" != "true" && "$PRERELEASE" == "true" ]]; then
+            matrix="$(jq '.pre_build_go_binaries.name += ["prerelease"]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_main.name += ["prerelease"]' <<< "$matrix")"
+            matrix="$(jq '.push_main_multiarch_manifests.name += ["prerelease"]' <<< "$matrix")"
+          fi
+
+          if [[ "$RACE" == "true" ]]; then
             matrix="$(jq '.pre_build_go_binaries.name += ["race-condition-debug"]' <<< "$matrix")"
             matrix="$(jq '.build_and_push_main.name += ["race-condition-debug"]' <<< "$matrix")"
             matrix="$(jq '.push_main_multiarch_manifests.name += ["race-condition-debug"]' <<< "$matrix")"
-            # Exclude "arm64", "ppc64le", "s390x"
-            matrix="$(jq '.pre_build_go_binaries.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
-            matrix="$(jq '.pre_build_go_binaries.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
-            matrix="$(jq '.pre_build_go_binaries.exclude += [{ "name": "race-condition-debug", "arch": "s390x" }]' <<< "$matrix")"
-            matrix="$(jq '.build_and_push_main.exclude = [{ "name": "race-condition-debug", "arch": "arm64" }]' <<< "$matrix")"
-            matrix="$(jq '.build_and_push_main.exclude += [{ "name": "race-condition-debug", "arch": "ppc64le" }]' <<< "$matrix")"
-            matrix="$(jq '.build_and_push_main.exclude += [{ "name": "race-condition-debug", "arch": "s390x" }]' <<< "$matrix")"
+            for arch in arm64 ppc64le s390x; do
+              matrix="$(jq --arg arch "$arch" '.pre_build_go_binaries.exclude += [{"name":"race-condition-debug","arch":$arch}]' <<< "$matrix")"
+              matrix="$(jq --arg arch "$arch" '.build_and_push_main.exclude += [{"name":"race-condition-debug","arch":$arch}]' <<< "$matrix")"
+            done
           fi
 
-          echo "Job matrix after conditionals:"
+          echo "Job matrix:"
           jq <<< "$matrix"
-
-          condensed="$(jq -c <<< "$matrix")"
-          echo "matrix=$condensed" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(jq -c <<< "$matrix")" >> "$GITHUB_OUTPUT"
 
   pre-build-ui:
     needs: define-job-matrix

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,7 @@ jobs:
             "push_main_multiarch_manifests": { "name":[] },
             "build_and_push_operator": { "name":[], "arch":[] },
             "push_operator_multiarch_manifests": { "name":[] },
+            "push_matching_collector_scanner": { "name":[] },
             "scan_images_with_roxctl": { "name":[], "image":[], "exclude":[] }
           }'
 
@@ -95,6 +96,8 @@ jobs:
           matrix="$(jq '.push_operator_multiarch_manifests.name += ["RHACS_BRANDING"]' <<< "$matrix")"
           matrix="$(jq '.push_operator_multiarch_manifests.archs = [.build_and_push_operator.arch | join(",")]' <<< "$matrix")"
 
+          matrix="$(jq '.push_matching_collector_scanner.name += ["RHACS_BRANDING"]' <<< "$matrix")"
+
           matrix="$(jq '.scan_images_with_roxctl.name += ["RHACS_BRANDING"]' <<< "$matrix")"
           matrix="$(jq '.scan_images_with_roxctl.image += ["central-db", "collector", "fact", "main", "roxctl", "scanner", "scanner-db", "scanner-db-slim", "scanner-slim", "stackrox-operator"]' <<< "$matrix")"
 
@@ -105,6 +108,7 @@ jobs:
             matrix="$(jq '.push_main_multiarch_manifests.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
             matrix="$(jq '.build_and_push_operator.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
             matrix="$(jq '.push_operator_multiarch_manifests.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            matrix="$(jq '.push_matching_collector_scanner.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
             matrix="$(jq '.scan_images_with_roxctl.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
             # TODO(ROX-27191): remove the exclusion once there's a community operator.
             matrix="$(jq '.scan_images_with_roxctl.exclude += [{ "name": "STACKROX_BRANDING", "image": "stackrox-operator" }]' <<< "$matrix")"
@@ -646,8 +650,7 @@ jobs:
     if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
-      matrix:
-        name: [RHACS_BRANDING, STACKROX_BRANDING]
+      matrix: ${{ fromJson(needs.define-job-matrix.outputs.matrix).push_matching_collector_scanner }}
     env:
       ROX_PRODUCT_BRANDING: ${{ matrix.name }}
       BUILD_TAG: ${{ needs.define-job-matrix.outputs.build-tag }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,26 +39,27 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
 
-      - uses: ./.github/actions/handle-tagged-build
-
-      - name: Compute build tag
+      - name: Compute build metadata
         id: build-tag
         run: |
-          TAG=$(make --quiet --no-print-directory tag)
+          # For tagged builds, the tag itself is the version.
+          # Otherwise, use git describe for the dev version string.
+          if [[ "${GITHUB_REF}" =~ ^refs/tags/(.*) ]]; then
+            TAG="${BASH_REMATCH[1]}"
+          else
+            TAG="$(git describe --tags --abbrev=10 --long --exclude '*-nightly-*')"
+          fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Compute short commit
         id: short-commit
-        run: |
-          SHORTCOMMIT=$(make --quiet --no-print-directory shortcommit)
-          echo "shortcommit=${SHORTCOMMIT}" >> "$GITHUB_OUTPUT"
+        run: echo "shortcommit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Compute GOTAGS
         id: gotags
         run: |
           GOTAGS=""
           if [[ "${GITHUB_REF}" =~ ^refs/tags/ ]]; then
-            # Tag builds (release or nightly) get release GOTAGS
             GOTAGS="release"
           fi
           echo "gotags=${GOTAGS}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,6 +69,7 @@ jobs:
           source './scripts/ci/lib.sh'
 
           matrix='{
+            "pre_build_ui": { "branding":[] },
             "pre_build_go_binaries": { "name":[], "arch":[] },
             "build_and_push_main": { "name":[], "arch":[] },
             "push_main_multiarch_manifests": { "name":[] },
@@ -77,25 +78,37 @@ jobs:
             "scan_images_with_roxctl": { "name":[], "image":[], "exclude":[] }
           }'
 
-          # The base matrix
+          # The base matrix (RHACS is the downstream/release branding, always built)
+          matrix="$(jq '.pre_build_ui.branding += ["RHACS_BRANDING"]' <<< "$matrix")"
+
           matrix="$(jq '.pre_build_go_binaries.name += ["default"]' <<< "$matrix")"
           matrix="$(jq '.pre_build_go_binaries.arch += ["amd64", "arm64"]' <<< "$matrix")"
 
-          matrix="$(jq '.build_and_push_main.name += ["RHACS_BRANDING", "STACKROX_BRANDING"]' <<< "$matrix")"
+          matrix="$(jq '.build_and_push_main.name += ["RHACS_BRANDING"]' <<< "$matrix")"
           matrix="$(jq '.build_and_push_main.arch += ["amd64", "arm64"]' <<< "$matrix")"
 
-          matrix="$(jq '.push_main_multiarch_manifests.name += ["RHACS_BRANDING", "STACKROX_BRANDING"]' <<< "$matrix")"
+          matrix="$(jq '.push_main_multiarch_manifests.name += ["RHACS_BRANDING"]' <<< "$matrix")"
 
-          matrix="$(jq '.build_and_push_operator.name += ["RHACS_BRANDING", "STACKROX_BRANDING"]' <<< "$matrix")"
+          matrix="$(jq '.build_and_push_operator.name += ["RHACS_BRANDING"]' <<< "$matrix")"
           matrix="$(jq '.build_and_push_operator.arch += ["amd64", "arm64"]' <<< "$matrix")"
 
-          matrix="$(jq '.push_operator_multiarch_manifests.name += ["RHACS_BRANDING", "STACKROX_BRANDING"]' <<< "$matrix")"
+          matrix="$(jq '.push_operator_multiarch_manifests.name += ["RHACS_BRANDING"]' <<< "$matrix")"
           matrix="$(jq '.push_operator_multiarch_manifests.archs = [.build_and_push_operator.arch | join(",")]' <<< "$matrix")"
 
-          matrix="$(jq '.scan_images_with_roxctl.name += ["RHACS_BRANDING", "STACKROX_BRANDING"]' <<< "$matrix")"
+          matrix="$(jq '.scan_images_with_roxctl.name += ["RHACS_BRANDING"]' <<< "$matrix")"
           matrix="$(jq '.scan_images_with_roxctl.image += ["central-db", "collector", "fact", "main", "roxctl", "scanner", "scanner-db", "scanner-db-slim", "scanner-slim", "stackrox-operator"]' <<< "$matrix")"
-          # TODO(ROX-27191): remove the exclusion once there's a community operator.
-          matrix="$(jq '.scan_images_with_roxctl.exclude += [{ "name": "STACKROX_BRANDING", "image": "stackrox-operator" }]' <<< "$matrix")"
+
+          # Conditionally add upstream (STACKROX_BRANDING) builds
+          if ! is_in_PR_context || pr_has_label ci-build-upstream; then
+            matrix="$(jq '.pre_build_ui.branding += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_main.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            matrix="$(jq '.push_main_multiarch_manifests.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            matrix="$(jq '.build_and_push_operator.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            matrix="$(jq '.push_operator_multiarch_manifests.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            matrix="$(jq '.scan_images_with_roxctl.name += ["STACKROX_BRANDING"]' <<< "$matrix")"
+            # TODO(ROX-27191): remove the exclusion once there's a community operator.
+            matrix="$(jq '.scan_images_with_roxctl.exclude += [{ "name": "STACKROX_BRANDING", "image": "stackrox-operator" }]' <<< "$matrix")"
+          fi
 
           if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
             matrix="$(jq '.pre_build_go_binaries.arch += ["ppc64le", "s390x"]' <<< "$matrix")"
@@ -132,10 +145,10 @@ jobs:
           echo "matrix=$condensed" >> "$GITHUB_OUTPUT"
 
   pre-build-ui:
+    needs: define-job-matrix
     strategy:
       fail-fast: false
-      matrix:
-        branding: [ RHACS_BRANDING, STACKROX_BRANDING ]
+      matrix: ${{ fromJson(needs.define-job-matrix.outputs.matrix).pre_build_ui }}
     env:
       ROX_PRODUCT_BRANDING: ${{ matrix.branding }}
       # For consistency with `image/rhel/konflux.Dockerfile`, see comment there.


### PR DESCRIPTION
## Description

Gate STACKROX_BRANDING (upstream/open-source) builds behind a new `ci-build-upstream` PR label.

**Why:** No test or e2e job consumes STACKROX-branded images — all Prow and GHA tests deploy RHACS-branded images from `quay.io/rhacs-eng`. The Go binaries are identical between brandings; only the UI bundle and container ENV differ. Building both brandings on every PR is wasted compute.

**What changes:** STACKROX_BRANDING matrix entries (UI, main, operator, roxctl-scan) are only included when the `ci-build-upstream` label is present on PRs. On non-PR events (master push, tags, release branches) both brandings are always built. The `pre-build-ui` job now uses the dynamic matrix from `define-job-matrix` instead of a hardcoded branding list.

**Removes from PR builds (~8 matrix jobs):**
- 1 pre-build-ui (STACKROX UI bundle)
- 2 build-and-push-main (STACKROX amd64 + arm64)
- 1 push-main-multiarch-manifests (STACKROX)
- 2 build-and-push-operator (STACKROX amd64 + arm64)
- 1 push-operator-multiarch-manifests (STACKROX)
- ~5 scan-images-with-roxctl (STACKROX images)

## Testing and quality

- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### How I validated my change

- CI run on this PR validates the PR case (RHACS-only matrix, no upstream label)
- To validate the full matrix, add the `ci-build-upstream` label