### PR TITLE
ROX-29577: Preflight vmhelper unit tests

### DIFF
--- a/tests/vm_scanning_pull_secret_test.go
+++ b/tests/vm_scanning_pull_secret_test.go
@@ -1,0 +1,126 @@
+//go:build test_e2e || test_e2e_vm
+
+package tests
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	coreV1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func writeDockerConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	path := t.TempDir() + "/config.json"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func newVMScanningSuiteForPullSecretTest(t *testing.T, client *kubefake.Clientset, namespace, secretPath string) *VMScanningSuite {
+	t.Helper()
+	s := &VMScanningSuite{
+		cfg: &vmScanConfig{
+			ImagePullSecretPath: secretPath,
+		},
+		k8sClient: client,
+		namespace: namespace,
+	}
+	s.SetT(t)
+	return s
+}
+
+func TestEnsureImagePullSecret_UpdatesExistingSecretUsingFetchedResourceVersion(t *testing.T) {
+	t.Parallel()
+
+	const namespace = "vm-scan-test"
+	secretPath := writeDockerConfigFile(t, `{"auths":{"quay.io":{"auth":"new"}}}`)
+
+	client := kubefake.NewSimpleClientset(
+		&coreV1.Secret{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:            vmImagePullSecretName,
+				Namespace:       namespace,
+				ResourceVersion: "7",
+			},
+			Type: coreV1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				coreV1.DockerConfigJsonKey: []byte(`{"auths":{"quay.io":{"auth":"old"}}}`),
+			},
+		},
+		&coreV1.ServiceAccount{
+			ObjectMeta: metaV1.ObjectMeta{
+				Name:      "default",
+				Namespace: namespace,
+			},
+		},
+	)
+	client.PrependReactor("update", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateAction := action.(k8stesting.UpdateAction)
+		secret := updateAction.GetObject().(*coreV1.Secret)
+		if secret.ResourceVersion == "" {
+			return true, nil, apierrors.NewInvalid(
+				coreV1.SchemeGroupVersion.WithKind("Secret").GroupKind(),
+				secret.Name,
+				field.ErrorList{field.Required(field.NewPath("metadata", "resourceVersion"), "must be set for an update")},
+			)
+		}
+		return false, nil, nil
+	})
+
+	s := newVMScanningSuiteForPullSecretTest(t, client, namespace, secretPath)
+
+	s.ensureImagePullSecret(t.Context())
+
+	secret, err := client.CoreV1().Secrets(namespace).Get(t.Context(), vmImagePullSecretName, metaV1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "7", secret.ResourceVersion)
+	require.Equal(t, `{"auths":{"quay.io":{"auth":"new"}}}`, string(secret.Data[coreV1.DockerConfigJsonKey]))
+
+	sa, err := client.CoreV1().ServiceAccounts(namespace).Get(t.Context(), "default", metaV1.GetOptions{})
+	require.NoError(t, err)
+	require.Contains(t, sa.ImagePullSecrets, coreV1.LocalObjectReference{Name: vmImagePullSecretName})
+}
+
+func TestEnsureImagePullSecret_WaitsForDefaultServiceAccountToAppear(t *testing.T) {
+	t.Parallel()
+
+	const namespace = "vm-scan-test"
+	secretPath := writeDockerConfigFile(t, `{"auths":{"quay.io":{"auth":"new"}}}`)
+	client := kubefake.NewSimpleClientset()
+
+	var getAttempts atomic.Int32
+	client.PrependReactor("get", "serviceaccounts", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		getAction := action.(k8stesting.GetAction)
+		if getAction.GetName() != "default" || getAction.GetNamespace() != namespace {
+			return false, nil, nil
+		}
+
+		if getAttempts.Add(1) == 1 {
+			require.NoError(t, client.Tracker().Add(&coreV1.ServiceAccount{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "default",
+					Namespace: namespace,
+				},
+			}))
+			return true, nil, apierrors.NewNotFound(coreV1.Resource("serviceaccounts"), "default")
+		}
+		return false, nil, nil
+	})
+
+	s := newVMScanningSuiteForPullSecretTest(t, client, namespace, secretPath)
+
+	s.ensureImagePullSecret(t.Context())
+
+	require.GreaterOrEqual(t, getAttempts.Load(), int32(2))
+	sa, err := client.CoreV1().ServiceAccounts(namespace).Get(t.Context(), "default", metaV1.GetOptions{})
+	require.NoError(t, err)
+	require.Contains(t, sa.ImagePullSecrets, coreV1.LocalObjectReference{Name: vmImagePullSecretName})
+}

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -74,12 +73,6 @@ const (
 	// k8sResourcePollInterval is the polling cadence for waiting on k8s
 	// resources (namespace deletion, service account readiness, etc.).
 	k8sResourcePollInterval = 2 * time.Second
-
-	// defaultServiceAccountWaitTimeout is the ceiling for waiting on the
-	// default service account to appear in a newly-created namespace.
-	defaultServiceAccountWaitTimeout = 10 * time.Second
-
-	vmImagePullSecretName = "vm-image-pull-secret" //nolint:gosec // G101: not a credential, just the k8s Secret resource name
 )
 
 // VMHandle tracks a KubeVirt VM used by the suite (persistent or transient).
@@ -399,7 +392,8 @@ func (s *VMScanningSuite) provisionVMs(specs []vmhelpers.VMSpec) {
 		s.logf("provision VMs: namespace %q already exists; reusing it", s.namespace)
 	}
 
-	s.ensureImagePullSecret(ctx)
+	require.NoError(s.T(), vmhelpers.EnsureImagePullSecret(ctx, s.k8sClient, s.logf, s.namespace, vmhelpers.ImagePullSecretName, s.cfg.ImagePullSecretPath),
+		"ensure image pull secret ready in namespace %q", s.namespace)
 
 	for _, sp := range specs {
 		req := s.vmSpecToRequest(sp)
@@ -451,80 +445,6 @@ func (s *VMScanningSuite) provisionVMs(specs []vmhelpers.VMSpec) {
 	}
 
 	s.logf("VM placement:\n%s", s.vmPlacementSummary(ctx))
-}
-
-func (s *VMScanningSuite) ensureImagePullSecret(ctx context.Context) {
-	if s.cfg.ImagePullSecretPath == "" {
-		return
-	}
-	s.logf("provision VMs: creating image pull secret from %q", s.cfg.ImagePullSecretPath)
-	dockerCfg, err := os.ReadFile(s.cfg.ImagePullSecretPath)
-	require.NoError(s.T(), err, "read image pull secret file %q", s.cfg.ImagePullSecretPath)
-
-	secret := &coreV1.Secret{
-		ObjectMeta: metaV1.ObjectMeta{Name: vmImagePullSecretName},
-		Type:       coreV1.SecretTypeDockerConfigJson,
-		Data:       map[string][]byte{coreV1.DockerConfigJsonKey: dockerCfg},
-	}
-	_, err = s.k8sClient.CoreV1().Secrets(s.namespace).Create(ctx, secret, metaV1.CreateOptions{})
-	if apierrors.IsAlreadyExists(err) {
-		existingSecret, getErr := s.k8sClient.CoreV1().Secrets(s.namespace).Get(ctx, vmImagePullSecretName, metaV1.GetOptions{})
-		require.NoError(s.T(), getErr, "get existing image pull secret %q in namespace %q", vmImagePullSecretName, s.namespace)
-		existingSecret.Type = coreV1.SecretTypeDockerConfigJson
-		if existingSecret.Data == nil {
-			existingSecret.Data = make(map[string][]byte)
-		}
-		existingSecret.Data[coreV1.DockerConfigJsonKey] = dockerCfg
-		_, err = s.k8sClient.CoreV1().Secrets(s.namespace).Update(ctx, existingSecret, metaV1.UpdateOptions{})
-	}
-	require.NoError(s.T(), err, "ensure image pull secret %q in namespace %q", vmImagePullSecretName, s.namespace)
-
-	// Wait for the default SA to exist before attempting the update.
-	_, err = s.waitForDefaultServiceAccount(ctx)
-	require.NoError(s.T(), err, "wait for default service account in namespace %q", s.namespace)
-
-	// The SA controller may still be mutating the freshly-created default SA
-	// (e.g. patching token secrets), so a single Get+Update can hit an
-	// optimistic concurrency conflict. Retry exactly like the DaemonSet
-	// update in ensureComplianceMetricsEnv.
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		sa, getErr := s.k8sClient.CoreV1().ServiceAccounts(s.namespace).Get(ctx, "default", metaV1.GetOptions{})
-		if getErr != nil {
-			return getErr
-		}
-		for _, ref := range sa.ImagePullSecrets {
-			if ref.Name == vmImagePullSecretName {
-				return nil
-			}
-		}
-		sa.ImagePullSecrets = append(sa.ImagePullSecrets, coreV1.LocalObjectReference{Name: vmImagePullSecretName})
-		_, updateErr := s.k8sClient.CoreV1().ServiceAccounts(s.namespace).Update(ctx, sa, metaV1.UpdateOptions{})
-		return updateErr
-	})
-	require.NoError(s.T(), err, "link image pull secret to default service account in namespace %q", s.namespace)
-	s.logf("provision VMs: image pull secret %q ready in namespace %q", vmImagePullSecretName, s.namespace)
-}
-
-func (s *VMScanningSuite) waitForDefaultServiceAccount(ctx context.Context) (*coreV1.ServiceAccount, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, defaultServiceAccountWaitTimeout)
-	defer cancel()
-
-	var serviceAccount *coreV1.ServiceAccount
-	err := wait.PollUntilContextCancel(waitCtx, k8sResourcePollInterval, true, func(ctx context.Context) (bool, error) {
-		sa, err := s.k8sClient.CoreV1().ServiceAccounts(s.namespace).Get(ctx, "default", metaV1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
-		serviceAccount = sa
-		return true, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return serviceAccount, nil
 }
 
 // vmPlacementSummary returns a diagnostic table mapping each persistent VM to

--- a/tests/vmhelpers/guest_test.go
+++ b/tests/vmhelpers/guest_test.go
@@ -1,0 +1,96 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// exitError returns an *exec.ExitError with the given exit code.
+func exitError(t *testing.T, code int) *exec.ExitError {
+	t.Helper()
+	err := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, code, exitErr.ExitCode())
+	return exitErr
+}
+
+func TestClassifySSHFailure_Smoke(t *testing.T) {
+	t.Parallel()
+
+	exit255 := exitError(t, 255)
+	exit1 := exitError(t, 1)
+
+	tests := map[string]struct {
+		stderr    string
+		err       error
+		wantSSH   bool
+		wantRetry bool
+		wantCat   string
+	}{
+		"banner timeout is retryable ssh transport": {
+			stderr: "Connection timed out during banner exchange", err: exit255,
+			wantSSH: true, wantRetry: true, wantCat: "banner-timeout",
+		},
+		"auth failure is terminal ssh transport": {
+			stderr: "Permission denied (publickey)", err: exit255,
+			wantSSH: true, wantRetry: false, wantCat: "authentication",
+		},
+		"remote command failure is not ssh transport": {
+			stderr: "metadata already locked by 3814", err: exit1,
+			wantSSH: false, wantRetry: false, wantCat: "",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			gotSSH, gotRetry, gotCat := classifySSHFailure(tc.stderr, tc.err)
+			require.Equal(t, tc.wantSSH, gotSSH, "isSSH")
+			require.Equal(t, tc.wantRetry, gotRetry, "retryable")
+			require.Equal(t, tc.wantCat, gotCat, "category")
+		})
+	}
+}
+
+func TestSSHReachabilityPolicy_ClassifyFailureStopsEarlyOnAuthThreshold(t *testing.T) {
+	t.Parallel()
+
+	policy := SSHReachabilityPolicy{
+		PollInterval:                10 * time.Second,
+		ProbeTimeout:                20 * time.Second,
+		AuthFailureThreshold:        3,
+		BannerTimeoutThreshold:      6,
+		NetworkUnreachableThreshold: 36,
+		ProbeTimeoutThreshold:       6,
+	}
+	counters := &sshProbeCounters{authFailures: policy.AuthFailureThreshold - 1}
+	decision := policy.classifyFailure(
+		counters,
+		Virtctl{Username: "cloud-user"},
+		errors.New("exit status 255"),
+		"Permission denied (publickey,gssapi-keyex,gssapi-with-mic).",
+	)
+
+	require.Error(t, decision.terminalErr)
+	require.ErrorIs(t, decision.terminalErr, ErrSSHAuthenticationFailed)
+	require.Contains(t, decision.detail, "ssh auth not accepted")
+}
+
+func TestFormatGuestCommandOutputForError(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "<no guest stdout/stderr>", FormatGuestCommandOutputForError(" \n\t "))
+	require.Equal(t, "status output", FormatGuestCommandOutputForError("status output"))
+
+	long := strings.Repeat("x", guestCommandErrorMaxLen+50)
+	got := FormatGuestCommandOutputForError(long)
+	require.Contains(t, got, "(truncated from")
+	require.True(t, strings.HasPrefix(got, strings.Repeat("x", guestCommandErrorMaxLen)))
+}

--- a/tests/vmhelpers/guest_test.go
+++ b/tests/vmhelpers/guest_test.go
@@ -1,4 +1,4 @@
-//go:build test
+//go:build test && !test_e2e && !test_e2e_vm
 
 package vmhelpers
 

--- a/tests/vmhelpers/pull_secret.go
+++ b/tests/vmhelpers/pull_secret.go
@@ -1,0 +1,121 @@
+package vmhelpers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	coreV1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	// ImagePullSecretName is the name of the k8s Secret used to pull VM guest
+	// images from a private registry.
+	ImagePullSecretName = "vm-image-pull-secret" //nolint:gosec // G101: not a credential, just the k8s Secret resource name
+
+	// defaultServiceAccountPollInterval is the polling cadence while waiting
+	// for the default ServiceAccount to appear in a freshly-created namespace.
+	defaultServiceAccountPollInterval = 2 * time.Second
+
+	// defaultServiceAccountWaitTimeout is the ceiling for waiting on the
+	// default service account to appear in a namespace.
+	defaultServiceAccountWaitTimeout = 10 * time.Second
+)
+
+// EnsureImagePullSecret creates or updates a docker-config-json image pull
+// secret in ns from the docker config JSON at secretPath, and links it to the
+// namespace's default ServiceAccount. It is a no-op when secretPath is empty.
+func EnsureImagePullSecret(ctx context.Context, k8sClient kubernetes.Interface, logf func(string, ...any), ns, secretName, secretPath string) error {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	if secretPath == "" {
+		return nil
+	}
+
+	logf("provision VMs: creating image pull secret from %q", secretPath)
+	dockerCfg, err := os.ReadFile(secretPath)
+	if err != nil {
+		return fmt.Errorf("read image pull secret file %q: %w", secretPath, err)
+	}
+
+	secret := &coreV1.Secret{
+		ObjectMeta: metaV1.ObjectMeta{Name: secretName},
+		Type:       coreV1.SecretTypeDockerConfigJson,
+		Data:       map[string][]byte{coreV1.DockerConfigJsonKey: dockerCfg},
+	}
+	_, err = k8sClient.CoreV1().Secrets(ns).Create(ctx, secret, metaV1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		var existingSecret *coreV1.Secret
+		existingSecret, err = k8sClient.CoreV1().Secrets(ns).Get(ctx, secretName, metaV1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("get existing image pull secret %q in namespace %q: %w", secretName, ns, err)
+		}
+		existingSecret.Type = coreV1.SecretTypeDockerConfigJson
+		if existingSecret.Data == nil {
+			existingSecret.Data = make(map[string][]byte)
+		}
+		existingSecret.Data[coreV1.DockerConfigJsonKey] = dockerCfg
+		_, err = k8sClient.CoreV1().Secrets(ns).Update(ctx, existingSecret, metaV1.UpdateOptions{})
+	}
+	if err != nil {
+		return fmt.Errorf("ensure image pull secret %q in namespace %q: %w", secretName, ns, err)
+	}
+
+	// Wait for the default SA to exist before attempting the update.
+	if _, err = waitForDefaultServiceAccount(ctx, k8sClient, ns); err != nil {
+		return fmt.Errorf("wait for default service account in namespace %q: %w", ns, err)
+	}
+
+	// The SA controller may still be mutating the freshly-created default SA
+	// (e.g. patching token secrets), so a single Get+Update can hit an
+	// optimistic concurrency conflict. Retry exactly like the DaemonSet
+	// update in EnsureComplianceMetricsEnv.
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		sa, getErr := k8sClient.CoreV1().ServiceAccounts(ns).Get(ctx, "default", metaV1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		for _, ref := range sa.ImagePullSecrets {
+			if ref.Name == secretName {
+				return nil
+			}
+		}
+		sa.ImagePullSecrets = append(sa.ImagePullSecrets, coreV1.LocalObjectReference{Name: secretName})
+		_, updateErr := k8sClient.CoreV1().ServiceAccounts(ns).Update(ctx, sa, metaV1.UpdateOptions{})
+		return updateErr
+	})
+	if err != nil {
+		return fmt.Errorf("link image pull secret to default service account in namespace %q: %w", ns, err)
+	}
+	logf("provision VMs: image pull secret %q ready in namespace %q", secretName, ns)
+	return nil
+}
+
+func waitForDefaultServiceAccount(ctx context.Context, k8sClient kubernetes.Interface, ns string) (*coreV1.ServiceAccount, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, defaultServiceAccountWaitTimeout)
+	defer cancel()
+
+	var serviceAccount *coreV1.ServiceAccount
+	err := wait.PollUntilContextCancel(waitCtx, defaultServiceAccountPollInterval, true, func(ctx context.Context) (bool, error) {
+		sa, err := k8sClient.CoreV1().ServiceAccounts(ns).Get(ctx, "default", metaV1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		serviceAccount = sa
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return serviceAccount, nil
+}

--- a/tests/vmhelpers/pull_secret_test.go
+++ b/tests/vmhelpers/pull_secret_test.go
@@ -1,8 +1,9 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test && !test_e2e && !test_e2e_vm
 
-package tests
+package vmhelpers
 
 import (
+	"errors"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -24,19 +26,6 @@ func writeDockerConfigFile(t *testing.T, content string) string {
 	return path
 }
 
-func newVMScanningSuiteForPullSecretTest(t *testing.T, client *kubefake.Clientset, namespace, secretPath string) *VMScanningSuite {
-	t.Helper()
-	s := &VMScanningSuite{
-		cfg: &vmScanConfig{
-			ImagePullSecretPath: secretPath,
-		},
-		k8sClient: client,
-		namespace: namespace,
-	}
-	s.SetT(t)
-	return s
-}
-
 func TestEnsureImagePullSecret_UpdatesExistingSecretUsingFetchedResourceVersion(t *testing.T) {
 	t.Parallel()
 
@@ -46,7 +35,7 @@ func TestEnsureImagePullSecret_UpdatesExistingSecretUsingFetchedResourceVersion(
 	client := kubefake.NewSimpleClientset(
 		&coreV1.Secret{
 			ObjectMeta: metaV1.ObjectMeta{
-				Name:            vmImagePullSecretName,
+				Name:            ImagePullSecretName,
 				Namespace:       namespace,
 				ResourceVersion: "7",
 			},
@@ -75,18 +64,17 @@ func TestEnsureImagePullSecret_UpdatesExistingSecretUsingFetchedResourceVersion(
 		return false, nil, nil
 	})
 
-	s := newVMScanningSuiteForPullSecretTest(t, client, namespace, secretPath)
+	err := EnsureImagePullSecret(t.Context(), client, t.Logf, namespace, ImagePullSecretName, secretPath)
+	require.NoError(t, err)
 
-	s.ensureImagePullSecret(t.Context())
-
-	secret, err := client.CoreV1().Secrets(namespace).Get(t.Context(), vmImagePullSecretName, metaV1.GetOptions{})
+	secret, err := client.CoreV1().Secrets(namespace).Get(t.Context(), ImagePullSecretName, metaV1.GetOptions{})
 	require.NoError(t, err)
 	require.Equal(t, "7", secret.ResourceVersion)
 	require.Equal(t, `{"auths":{"quay.io":{"auth":"new"}}}`, string(secret.Data[coreV1.DockerConfigJsonKey]))
 
 	sa, err := client.CoreV1().ServiceAccounts(namespace).Get(t.Context(), "default", metaV1.GetOptions{})
 	require.NoError(t, err)
-	require.Contains(t, sa.ImagePullSecrets, coreV1.LocalObjectReference{Name: vmImagePullSecretName})
+	require.Contains(t, sa.ImagePullSecrets, coreV1.LocalObjectReference{Name: ImagePullSecretName})
 }
 
 func TestEnsureImagePullSecret_WaitsForDefaultServiceAccountToAppear(t *testing.T) {
@@ -115,12 +103,44 @@ func TestEnsureImagePullSecret_WaitsForDefaultServiceAccountToAppear(t *testing.
 		return false, nil, nil
 	})
 
-	s := newVMScanningSuiteForPullSecretTest(t, client, namespace, secretPath)
-
-	s.ensureImagePullSecret(t.Context())
+	err := EnsureImagePullSecret(t.Context(), client, t.Logf, namespace, ImagePullSecretName, secretPath)
+	require.NoError(t, err)
 
 	require.GreaterOrEqual(t, getAttempts.Load(), int32(2))
 	sa, err := client.CoreV1().ServiceAccounts(namespace).Get(t.Context(), "default", metaV1.GetOptions{})
 	require.NoError(t, err)
-	require.Contains(t, sa.ImagePullSecrets, coreV1.LocalObjectReference{Name: vmImagePullSecretName})
+	require.Contains(t, sa.ImagePullSecrets, coreV1.LocalObjectReference{Name: ImagePullSecretName})
+}
+
+func TestEnsureImagePullSecret_RetriesServiceAccountLinkOnConflict(t *testing.T) {
+	t.Parallel()
+
+	const namespace = "vm-scan-test"
+	secretPath := writeDockerConfigFile(t, `{"auths":{"quay.io":{"auth":"new"}}}`)
+
+	client := kubefake.NewSimpleClientset(
+		&coreV1.ServiceAccount{
+			ObjectMeta: metaV1.ObjectMeta{Name: "default", Namespace: namespace},
+		},
+	)
+	updateAttempts := 0
+	client.PrependReactor("update", "serviceaccounts", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateAttempts++
+		if updateAttempts == 1 {
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Resource: "serviceaccounts"},
+				"default",
+				errors.New("conflict"),
+			)
+		}
+		return false, nil, nil
+	})
+
+	err := EnsureImagePullSecret(t.Context(), client, t.Logf, namespace, ImagePullSecretName, secretPath)
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, updateAttempts, 2)
+	sa, err := client.CoreV1().ServiceAccounts(namespace).Get(t.Context(), "default", metaV1.GetOptions{})
+	require.NoError(t, err)
+	require.Contains(t, sa.ImagePullSecrets, coreV1.LocalObjectReference{Name: ImagePullSecretName})
 }

--- a/tests/vmhelpers/virtctl_test.go
+++ b/tests/vmhelpers/virtctl_test.go
@@ -1,4 +1,4 @@
-//go:build test
+//go:build test && !test_e2e && !test_e2e_vm
 
 package vmhelpers
 

--- a/tests/vmhelpers/virtctl_test.go
+++ b/tests/vmhelpers/virtctl_test.go
@@ -1,0 +1,170 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSHCommandArgs_UsesIdentityAndNamespace(t *testing.T) {
+	t.Parallel()
+
+	virt := Virtctl{
+		Path:           "/usr/bin/virtctl",
+		IdentityFile:   "/tmp/id_rsa",
+		Username:       "cloud-user",
+		KnownHostsFile: "/dev/null",
+	}
+	args := virt.buildSSHArgs("stackrox", "vm-rhel9", "sudo", "true")
+	require.Equal(t, []string{
+		"/usr/bin/virtctl", "ssh",
+		"--namespace", "stackrox",
+		"--identity-file", "/tmp/id_rsa",
+		"--known-hosts", "/dev/null",
+		"--local-ssh-opts", "-o StrictHostKeyChecking=no",
+		"--local-ssh-opts", "-o IdentitiesOnly=yes",
+		"--local-ssh-opts", "-o ConnectTimeout=5",
+		"--local-ssh-opts", "-o UserKnownHostsFile=/dev/null",
+		"--username", "cloud-user",
+		"vmi/vm-rhel9",
+		"--command", `"sudo" "true"`,
+	}, args)
+}
+
+func TestBuildVirtctlSSHCommand_QuotesArguments(t *testing.T) {
+	t.Parallel()
+
+	got := buildVirtctlSSHCommand("sh", "-c", `echo "hello world" && true`)
+	require.Equal(t, `"sh" "-c" "echo \"hello world\" && true"`, got)
+}
+
+func TestSCPToArgs_RemoteTargetShape(t *testing.T) {
+	t.Parallel()
+
+	virt := Virtctl{
+		Path:           "/usr/bin/virtctl",
+		IdentityFile:   "/tmp/id_rsa",
+		Username:       "cloud-user",
+		KnownHostsFile: "/dev/null",
+	}
+	args := virt.buildSCPToArgs("stackrox", "vm-rhel9", "/local/roxagent", "/usr/local/bin/roxagent")
+	require.Equal(t, []string{
+		"/usr/bin/virtctl", "scp",
+		"--namespace", "stackrox",
+		"--identity-file", "/tmp/id_rsa",
+		"--known-hosts", "/dev/null",
+		"--local-ssh-opts", "-o StrictHostKeyChecking=no",
+		"--local-ssh-opts", "-o IdentitiesOnly=yes",
+		"--local-ssh-opts", "-o ConnectTimeout=5",
+		"--local-ssh-opts", "-o UserKnownHostsFile=/dev/null",
+		"--username", "cloud-user",
+		"/local/roxagent", "vmi/vm-rhel9:/usr/local/bin/roxagent",
+	}, args)
+}
+
+func TestSummarizeVirtctlCommand_SSHWithRemoteCommand(t *testing.T) {
+	t.Parallel()
+
+	virt := Virtctl{
+		Path:           "/usr/bin/virtctl",
+		IdentityFile:   "/tmp/id_rsa",
+		Username:       "cloud-user",
+		KnownHostsFile: "/dev/null",
+	}
+	args := virt.buildSSHArgs("stackrox", "vm-rhel9", "sudo", "true")
+	require.Equal(t, `virtctl ssh vmi/vm-rhel9 command="sudo" "true"`, summarizeVirtctlCommand(args))
+}
+
+func TestSummarizeVirtctlCommand_SCP(t *testing.T) {
+	t.Parallel()
+
+	virt := Virtctl{
+		Path:           "/usr/bin/virtctl",
+		IdentityFile:   "/tmp/id_rsa",
+		Username:       "cloud-user",
+		KnownHostsFile: "/dev/null",
+	}
+	args := virt.buildSCPToArgs("stackrox", "vm-rhel9", "/local/roxagent", "/usr/local/bin/roxagent")
+	require.Equal(t, "virtctl scp vmi/vm-rhel9:/usr/local/bin/roxagent", summarizeVirtctlCommand(args))
+}
+
+func TestVirtctlRun_RespectsContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	virt := Virtctl{
+		Logf: func(string, ...any) {},
+	}
+	_, _, err := virt.run(ctx, []string{"sh", "-c", "sleep 5"})
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(start), 3*time.Second, "virtctl run should terminate promptly on context deadline")
+}
+
+func TestVirtctlRunLogsStreamsOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	var logs []string
+	virt := Virtctl{
+		Logf: func(format string, args ...any) {
+			logs = append(logs, formatMessage(format, args...))
+		},
+	}
+
+	stdout, stderr, err := virt.run(context.Background(), []string{
+		"/bin/sh", "-c", "printf 'stdout-line\\n'; printf 'stderr-line\\n' >&2",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "stdout-line\n", stdout)
+	require.Equal(t, "stderr-line\n", stderr)
+	require.NotEmpty(t, logs)
+
+	lastLog := logs[len(logs)-1]
+	require.Contains(t, lastLog, "remote command complete")
+	require.Contains(t, lastLog, "stdout:\nstdout-line")
+	require.Contains(t, lastLog, "stderr:\nstderr-line")
+}
+
+func TestVirtctlRun_PanicsWithoutLogf(t *testing.T) {
+	t.Parallel()
+
+	require.Panics(t, func() {
+		_, _, _ = (Virtctl{}).run(context.Background(), []string{
+			"/bin/sh", "-c", "printf 'stdout-line\\n'; printf 'stderr-line\\n' >&2",
+		})
+	})
+}
+
+func TestFormatRemoteCommandStreamsForInlineLogTruncatesStdout(t *testing.T) {
+	t.Parallel()
+
+	var stdoutLines []string
+	for i := range 2*inlineLogMaxHeadTailLines + 1 {
+		stdoutLines = append(stdoutLines, fmt.Sprintf("stdout-line-%03d", i))
+	}
+
+	formatted := formatRemoteCommandStreamsForInlineLog(strings.Join(stdoutLines, "\n"), "")
+
+	require.Contains(t, formatted, "stdout:\nstdout-line-000")
+	require.Contains(t, formatted, "... (1 lines truncated) ...")
+	require.Contains(t, formatted, "stdout-line-200")
+}
+
+func formatMessage(format string, args ...any) string {
+	return fmt.Sprintf(format, args...)
+}

--- a/tests/vmhelpers/vm_test.go
+++ b/tests/vmhelpers/vm_test.go
@@ -1,0 +1,264 @@
+//go:build test
+
+package vmhelpers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	coreV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+)
+
+func TestRenderCloudInit_Content(t *testing.T) {
+	t.Parallel()
+
+	output := renderCloudInit(VMRequest{
+		GuestUser:    "cloud-user",
+		SSHPublicKey: "ssh-rsa AAAATEST",
+	})
+	for _, want := range []string{
+		"ssh_authorized_keys:",
+		"ssh-rsa AAAATEST",
+		"cloud-user",
+		"name:",
+		"NOPASSWD:ALL",
+	} {
+		require.Contains(t, output, want)
+	}
+}
+
+func TestCreateVirtualMachine_RequiresRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		req     VMRequest
+		wantErr string
+	}{
+		"missing Name": {
+			req: VMRequest{
+				Namespace:    "ns",
+				Image:        "quay.io/example/rhel9:latest",
+				GuestUser:    "cloud-user",
+				SSHPublicKey: "ssh-rsa AAAA",
+			},
+			wantErr: "VMRequest Name, Namespace, Image, GuestUser, and SSHPublicKey are required",
+		},
+		"missing Namespace": {
+			req: VMRequest{
+				Name:         "vm",
+				Image:        "quay.io/example/rhel9:latest",
+				GuestUser:    "cloud-user",
+				SSHPublicKey: "ssh-rsa AAAA",
+			},
+			wantErr: "VMRequest Name, Namespace, Image, GuestUser, and SSHPublicKey are required",
+		},
+		"missing Image": {
+			req: VMRequest{
+				Name:         "vm",
+				Namespace:    "ns",
+				GuestUser:    "cloud-user",
+				SSHPublicKey: "ssh-rsa AAAA",
+			},
+			wantErr: "VMRequest Name, Namespace, Image, GuestUser, and SSHPublicKey are required",
+		},
+		"missing GuestUser": {
+			req: VMRequest{
+				Name:         "vm",
+				Namespace:    "ns",
+				Image:        "quay.io/example/rhel9:latest",
+				SSHPublicKey: "ssh-rsa AAAA",
+			},
+			wantErr: "VMRequest Name, Namespace, Image, GuestUser, and SSHPublicKey are required",
+		},
+		"missing SSHPublicKey": {
+			req: VMRequest{
+				Name:      "vm",
+				Namespace: "ns",
+				Image:     "quay.io/example/rhel9:latest",
+				GuestUser: "cloud-user",
+			},
+			wantErr: "VMRequest Name, Namespace, Image, GuestUser, and SSHPublicKey are required",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := CreateVirtualMachine(context.Background(), nil, tt.req)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestCreateVirtualMachine_SetsDefaultMemoryRequest(t *testing.T) {
+	t.Parallel()
+	client := &captureDynamicClient{}
+	req := VMRequest{
+		Name:         "vm-rhel9",
+		Namespace:    "ns",
+		Image:        "registry.redhat.io/rhel9/rhel-guest-image",
+		GuestUser:    "cloud-user",
+		SSHPublicKey: "ssh-rsa AAAA",
+	}
+
+	err := CreateVirtualMachine(context.Background(), client, req)
+	require.NoError(t, err)
+	require.Equal(t, vmGVR, client.resource)
+	require.Equal(t, req.Namespace, client.namespace)
+	require.NotNil(t, client.created)
+
+	got, found, err := unstructured.NestedString(client.created.Object, "spec", "template", "spec", "domain", "resources", "requests", "memory")
+	require.NoError(t, err)
+	require.True(t, found, "expected memory request in VM manifest")
+	require.Equal(t, defaultVMMemoryRequest, got)
+
+	vsockEnabled, found, err := unstructured.NestedBool(client.created.Object, "spec", "template", "spec", "domain", "devices", "autoattachVSOCK")
+	require.NoError(t, err)
+	require.True(t, found, "expected autoattachVSOCK in VM manifest")
+	require.True(t, vsockEnabled, "expected autoattachVSOCK=true in VM manifest")
+
+	cores, found, err := unstructured.NestedFieldNoCopy(client.created.Object, "spec", "template", "spec", "domain", "cpu", "cores")
+	require.NoError(t, err)
+	require.True(t, found, "expected domain.cpu.cores in VM manifest")
+	require.EqualValues(t, uint64(3), cores, "expected VM cpu cores to be 3")
+}
+
+type captureDynamicClient struct {
+	resource  schema.GroupVersionResource
+	namespace string
+	created   *unstructured.Unstructured
+}
+
+func (c *captureDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &captureResourceClient{
+		parent:   c,
+		resource: resource,
+	}
+}
+
+type captureResourceClient struct {
+	parent    *captureDynamicClient
+	resource  schema.GroupVersionResource
+	namespace string
+}
+
+func (c *captureResourceClient) Namespace(namespace string) dynamic.ResourceInterface {
+	return &captureResourceClient{
+		parent:    c.parent,
+		resource:  c.resource,
+		namespace: namespace,
+	}
+}
+
+func (c *captureResourceClient) Create(_ context.Context, obj *unstructured.Unstructured, _ metav1.CreateOptions, _ ...string) (*unstructured.Unstructured, error) {
+	c.parent.resource = c.resource
+	c.parent.namespace = c.namespace
+	c.parent.created = obj
+	return obj, nil
+}
+
+func (*captureResourceClient) Update(context.Context, *unstructured.Unstructured, metav1.UpdateOptions, ...string) (*unstructured.Unstructured, error) {
+	return nil, errors.New("unexpected Update call")
+}
+
+func (*captureResourceClient) UpdateStatus(context.Context, *unstructured.Unstructured, metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	return nil, errors.New("unexpected UpdateStatus call")
+}
+
+func (*captureResourceClient) Delete(context.Context, string, metav1.DeleteOptions, ...string) error {
+	return errors.New("unexpected Delete call")
+}
+
+func (*captureResourceClient) DeleteCollection(context.Context, metav1.DeleteOptions, metav1.ListOptions) error {
+	return errors.New("unexpected DeleteCollection call")
+}
+
+func (*captureResourceClient) Get(context.Context, string, metav1.GetOptions, ...string) (*unstructured.Unstructured, error) {
+	return nil, errors.New("unexpected Get call")
+}
+
+func (*captureResourceClient) List(context.Context, metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return nil, errors.New("unexpected List call")
+}
+
+func (*captureResourceClient) Watch(context.Context, metav1.ListOptions) (watch.Interface, error) {
+	return nil, errors.New("unexpected Watch call")
+}
+
+func (*captureResourceClient) Patch(context.Context, string, types.PatchType, []byte, metav1.PatchOptions, ...string) (*unstructured.Unstructured, error) {
+	return nil, errors.New("unexpected Patch call")
+}
+
+func (*captureResourceClient) Apply(context.Context, string, *unstructured.Unstructured, metav1.ApplyOptions, ...string) (*unstructured.Unstructured, error) {
+	return nil, errors.New("unexpected Apply call")
+}
+
+func (*captureResourceClient) ApplyStatus(context.Context, string, *unstructured.Unstructured, metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	return nil, errors.New("unexpected ApplyStatus call")
+}
+
+func TestVMFailureConditionDetail(t *testing.T) {
+	t.Parallel()
+
+	vm := &kubevirtv1.VirtualMachine{
+		Status: kubevirtv1.VirtualMachineStatus{
+			Conditions: []kubevirtv1.VirtualMachineCondition{
+				{
+					Type:    kubevirtv1.VirtualMachineFailure,
+					Status:  coreV1.ConditionTrue,
+					Reason:  "FailedCreate",
+					Message: "no memory requested",
+				},
+			},
+		},
+	}
+
+	detail, terminal := vmFailureConditionDetail(vm)
+	require.True(t, terminal)
+	require.Contains(t, detail, "FailedCreate")
+	require.Contains(t, detail, "no memory requested")
+}
+
+func TestWaitForVirtualMachineInstanceRunning_FailsFastOnTerminalVMIPhase(t *testing.T) {
+	t.Parallel()
+
+	vmi := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "kubevirt.io/v1",
+			"kind":       "VirtualMachineInstance",
+			"metadata": map[string]any{
+				"namespace": "ns",
+				"name":      "vm-rhel9",
+			},
+			"status": map[string]any{
+				"phase": "Failed",
+			},
+		},
+	}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			vmiGVR: "VirtualMachineInstanceList",
+		},
+		vmi,
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := WaitForVirtualMachineInstanceRunning(t, ctx, client, "ns", "vm-rhel9")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "VMI reached terminal phase")
+}

--- a/tests/vmhelpers/vm_test.go
+++ b/tests/vmhelpers/vm_test.go
@@ -1,4 +1,4 @@
-//go:build test
+//go:build test && !test_e2e && !test_e2e_vm
 
 package vmhelpers
 


### PR DESCRIPTION
## Description

Unit tests covering the VM scanning e2e helper code merged in #20127. Split into a separate PR to keep the e2e helper diff smaller and reviewable.

Covers:
- `tests/vmhelpers/guest_test.go` — SSH error classification, output formatting/truncation, activation status parsing
- `tests/vmhelpers/virtctl_test.go` — SSH argument construction, command summaries, timeout behavior
- `tests/vmhelpers/vm_test.go` — cloud-init rendering, VM creation validation, VM wait helpers with fake k8s dynamic clients
- `tests/vmhelpers/pull_secret_test.go` — `EnsureImagePullSecret` create/update paths with fake k8s clients

Rebasing onto master after #21292 (ROX-34875, "move VM scanning helper tests to vmhelpers") landed required an extra adaptation commit to match the unit/e2e test-file split established there:
- Extracted the `ensureImagePullSecret`/`waitForDefaultServiceAccount` logic out of `VMScanningSuite` (`tests/vm_scanning_suite_test.go`) into a new exported `vmhelpers.EnsureImagePullSecret` helper (`tests/vmhelpers/pull_secret.go`), since the previous unit tests for it lived under the `test_e2e_vm` build tag and doubled as part of the e2e run instead of being isolated unit tests.
- Moved/renamed its unit tests from `tests/vm_scanning_pull_secret_test.go` to `tests/vmhelpers/pull_secret_test.go` under the standard `test && !test_e2e && !test_e2e_vm` tag.
- Updated `guest_test.go`, `virtctl_test.go`, `vm_test.go` from the older `//go:build test` tag to `test && !test_e2e && !test_e2e_vm` to match the rest of the package.

AI-assisted: This change was partially generated by AI.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- All tests pass locally: `make -C tests TESTFLAGS="-race -p 1" vm-scanning-unit-tests`
- After rebasing onto master (post #21292 merge): `go build`, `go vet`, and `golangci-lint` are clean on all changed files (`tests/vm_scanning_suite_test.go`, `tests/vmhelpers/pull_secret.go`, `tests/vmhelpers/pull_secret_test.go`, `tests/vmhelpers/guest_test.go`, `tests/vmhelpers/virtctl_test.go`, `tests/vmhelpers/vm_test.go`) under both the `test` and `test_e2e_vm` build tags
- CI green on previous push (before rebase onto master after #20127 merge)
