### PR TITLE
style(vm): Propagate test_e2e_vm through style check tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ run:
     - scanner_db_integration
     - sql_integration
     - test_e2e
+    - test_e2e_vm
   modules-download-mode: readonly
 output:
   formats:

--- a/Makefile
+++ b/Makefile
@@ -826,7 +826,7 @@ roxvet: $(ROXVET_BIN)
 	@# TODO(ROX-7574): Add options to ignore specific files or paths in roxvet
 	$(SILENT)go list -e ./... \
 	    | $(foreach d,$(skip-dirs),grep -v '$(d)' |) \
-	    xargs -n 1000 go vet -vettool "$(ROXVET_BIN)" -tags "sql_integration test_e2e test race destructive integration scanner_db_integration compliance externalbackups"
+	    xargs -n 1000 go vet -vettool "$(ROXVET_BIN)" -tags "sql_integration test_e2e test_e2e_vm test race destructive integration scanner_db_integration compliance externalbackups"
 
 ##########
 ## Misc ##


### PR DESCRIPTION

## Description

Add `test_e2e_vm` to the golangci-lint and roxvet tag lists so style
checks stay aligned with the new VM e2e test target and still cover
files guarded only by that tag.

AI-Assisted: cursor, minimal Makefile and linter tag update

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Style check in CI:

```
> Run make golangci-lint
(...)
level=info msg="[loader] Using build tags: [integration scanner_db_integration sql_integration test_e2e test_e2e_vm release]"
```
