### PR TITLE
ROX-34560: Fix compliance operator CR apply for tests

### DIFF
--- a/tests/complianceoperator/create.sh
+++ b/tests/complianceoperator/create.sh
@@ -1,8 +1,19 @@
 #! /bin/bash
 
+set -euo pipefail
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if ! kubectl get crd compliancecheckresults.compliance.openshift.io; then
-    kubectl create -R -f "${DIR}/crds"
-    kubectl create -R -f "${DIR}/resources"
+    kubectl apply -R -f "${DIR}/crds"
+
+    # Wait for all compliance CRDs to be established before creating resources
+    # that depend on them. Without this, applying custom resources could fail.
+    # awk command will provide list of CRDs from "crds" dir.
+    # Format example: "crd/compliancecheckresults.compliance.openshift.io"
+    all_crds=()
+    while IFS='' read -r single_crd; do all_crds+=("$single_crd"); done < <(grep -rh '^  name:.*\.compliance\.openshift\.io' "${DIR}/crds/" | awk '{print "crd/" $2}')
+    kubectl wait --for condition=established --timeout=60s "${all_crds[@]}"
+
+    kubectl apply -R -f "${DIR}/resources"
 fi


### PR DESCRIPTION
## Description

Occasional CI failures are happening because custom resource definitions are not fully applied on a cluster, and then Kubernetes API is not aware of them. So when we start creating custom resources API calls fail.

This PR is adding a change to wait for custom resource definitions to be applied first and available in Kubernetes API and afterwards we apply custom resources.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] changed test helper scripts

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- [x] executed script parts locally to test that regex works and everything else
- [x] CI pipeline run

`gke-nongroovy-compatibility-tests` run here: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/20405/pull-ci-stackrox-stackrox-master-gke-nongroovy-compatibility-tests/2052390688472961024

Log part:
```
customresourcedefinition.apiextensions.k8s.io/compliancecheckresults.compliance.openshift.io created
customresourcedefinition.apiextensions.k8s.io/compliancesuites.compliance.openshift.io created
customresourcedefinition.apiextensions.k8s.io/complianceremediations.compliance.openshift.io created
namespace/openshift-compliance created
customresourcedefinition.apiextensions.k8s.io/profiles.compliance.openshift.io created
customresourcedefinition.apiextensions.k8s.io/rules.compliance.openshift.io created
customresourcedefinition.apiextensions.k8s.io/compliancescans.compliance.openshift.io created
customresourcedefinition.apiextensions.k8s.io/scansettings.compliance.openshift.io created
customresourcedefinition.apiextensions.k8s.io/scansettingbindings.compliance.openshift.io created
customresourcedefinition.apiextensions.k8s.io/tailoredprofiles.compliance.openshift.io created
customresourcedefinition.apiextensions.k8s.io/compliancecheckresults.compliance.openshift.io condition met
customresourcedefinition.apiextensions.k8s.io/compliancesuites.compliance.openshift.io condition met
customresourcedefinition.apiextensions.k8s.io/complianceremediations.compliance.openshift.io condition met
customresourcedefinition.apiextensions.k8s.io/profiles.compliance.openshift.io condition met
customresourcedefinition.apiextensions.k8s.io/rules.compliance.openshift.io condition met
customresourcedefinition.apiextensions.k8s.io/compliancescans.compliance.openshift.io condition met
customresourcedefinition.apiextensions.k8s.io/scansettings.compliance.openshift.io condition met
customresourcedefinition.apiextensions.k8s.io/scansettingbindings.compliance.openshift.io condition met
customresourcedefinition.apiextensions.k8s.io/tailoredprofiles.compliance.openshift.io condition met
```
