### PR TITLE
ROX-34412: Add DeliveryStep for report configuration

### DIFF
--- a/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationForm.tsx
+++ b/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationForm.tsx
@@ -1,12 +1,9 @@
 import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
-import { Button, Card, CardBody, CardTitle, Flex, FlexItem, Tooltip } from '@patternfly/react-core';
-import { HelpIcon, PencilAltIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import { Button, Flex, FormSection, TextArea, TextInput } from '@patternfly/react-core';
+import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import type { FormikErrors } from 'formik';
 
-import { isDefaultEmailTemplate } from 'Components/EmailTemplate/EmailTemplate.utils';
-import EmailTemplateModal from 'Components/EmailTemplate/EmailTemplateModal';
-import type { TemplatePreviewArgs } from 'Components/EmailTemplate/EmailTemplateModal';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import useIndexKey from 'hooks/useIndexKey';
 import { fetchNotifierIntegrations } from 'services/NotifierIntegrationsService';
@@ -27,8 +24,6 @@ function splitAndTrimMailingListsString(mailingListsString: string): string[] {
 }
 
 export type NotifierConfigurationFormProps = {
-    customBodyDefault: string;
-    customSubjectDefault: string;
     errors: FormikErrors<unknown>;
     // Caller provides name of property in formik.values and PatternFly fieldId props.
     // For example:
@@ -38,26 +33,20 @@ export type NotifierConfigurationFormProps = {
     hasWriteAccessForIntegration: boolean;
     notifierConfigurations: NotifierConfiguration[];
     onDeleteLastNotifierConfiguration?: () => void;
-    renderTemplatePreview?: (args: TemplatePreviewArgs) => ReactElement;
     setFieldValue: (fieldId: string, value: unknown) => void;
 };
 
 function NotifierConfigurationForm({
-    customBodyDefault,
-    customSubjectDefault,
     errors,
     fieldIdPrefixForFormikAndPatternFly,
     hasWriteAccessForIntegration,
     notifierConfigurations,
     onDeleteLastNotifierConfiguration,
-    renderTemplatePreview,
     setFieldValue,
 }: NotifierConfigurationFormProps): ReactElement {
     const { keyFor } = useIndexKey();
     const [notifiers, setNotifiers] = useState<NotifierIntegrationBase[]>([]);
     const [isLoadingNotifiers, setIsLoadingNotifiers] = useState(false);
-    const [notifierConfigurationSelected, setNotifierConfigurationSelected] =
-        useState<NotifierConfiguration | null>(null);
 
     useEffect(() => {
         setIsLoadingNotifiers(true);
@@ -98,216 +87,128 @@ function NotifierConfigurationForm({
 
     return (
         <>
-            <Flex
-                direction={{ default: 'column' }}
-                gap={{ default: 'gapMd' }}
-                aria-label="Delivery destinations"
-            >
-                {notifierConfigurations.map((notifierConfiguration, index) => {
-                    const { emailConfig, notifierName } = notifierConfiguration;
-                    const { customBody, customSubject, mailingLists, notifierId } = emailConfig;
-                    const fieldId = `${fieldIdPrefixForFormikAndPatternFly}[${index}]`;
-                    const isDefaultEmailTemplateApplied = isDefaultEmailTemplate({
-                        customBody,
-                        customSubject,
-                    });
-                    return (
-                        <FlexItem key={keyFor(index)}>
-                            <Card>
-                                <CardTitle>
-                                    <Flex
-                                        alignItems={{
-                                            default: 'alignItemsCenter',
-                                        }}
-                                    >
-                                        <FlexItem flex={{ default: 'flex_1' }}>
-                                            Delivery destination
-                                        </FlexItem>
-                                        <FlexItem>
-                                            <Button
-                                                icon={<TrashIcon />}
-                                                variant="plain"
-                                                aria-label="Delete delivery destination"
-                                                onClick={() => {
-                                                    const notifierConfigurationsFiltered =
-                                                        notifierConfigurations.filter(
-                                                            (notifierConfigurationArg) =>
-                                                                notifierConfigurationArg !==
-                                                                notifierConfiguration
-                                                        );
-                                                    setFieldValue(
-                                                        fieldIdPrefixForFormikAndPatternFly,
-                                                        notifierConfigurationsFiltered
-                                                    );
-                                                    setMailingListsStrings(
-                                                        mailingListsStrings.filter(
-                                                            (_, i) => i !== index
-                                                        )
-                                                    );
-                                                    if (
-                                                        notifierConfigurationsFiltered.length ===
-                                                            0 &&
-                                                        onDeleteLastNotifierConfiguration
-                                                    ) {
-                                                        onDeleteLastNotifierConfiguration();
-                                                    }
-                                                }}
-                                            />
-                                        </FlexItem>
-                                    </Flex>
-                                </CardTitle>
-                                <CardBody>
-                                    <Flex
-                                        direction={{ default: 'column' }}
-                                        spaceItems={{ default: 'spaceItemsMd' }}
-                                    >
-                                        <NotifierMailingLists
-                                            errors={errors}
-                                            fieldIdPrefixForFormikAndPatternFly={fieldId}
-                                            hasWriteAccessForIntegration={
-                                                hasWriteAccessForIntegration
-                                            }
-                                            isLoadingNotifiers={isLoadingNotifiers}
-                                            mailingListsString={mailingListsStrings[index]}
-                                            notifierId={notifierId}
-                                            notifierName={notifierName}
-                                            notifiers={notifiers}
-                                            setMailingLists={(mailingListsString: string) => {
-                                                setFieldValue(
-                                                    `${fieldId}.emailConfig.mailingLists`,
-                                                    splitAndTrimMailingListsString(
-                                                        mailingListsString
-                                                    )
-                                                );
-                                                updateMailingListsString(index, mailingListsString);
-                                            }}
-                                            setNotifier={(notifier: NotifierIntegrationBase) => {
-                                                setFieldValue(fieldId, {
-                                                    emailConfig: {
-                                                        ...emailConfig,
-                                                        notifierId: notifier.id,
-                                                        mailingLists:
-                                                            mailingLists.length === 0
-                                                                ? splitAndTrimMailingListsString(
-                                                                      notifier.labelDefault
-                                                                  )
-                                                                : mailingLists,
-                                                    },
-                                                    notifierName: notifier.name,
-                                                });
-                                                updateMailingListsString(
-                                                    index,
-                                                    notifier.labelDefault
-                                                );
-                                            }}
-                                            setNotifiers={setNotifiers}
-                                        />
-                                        <FormLabelGroup
-                                            label="Email template"
-                                            labelHelp={
-                                                <Tooltip
-                                                    content={
-                                                        isDefaultEmailTemplateApplied ? (
-                                                            <div>
-                                                                Default template applied. Edit to
-                                                                customize.
-                                                            </div>
-                                                        ) : (
-                                                            <div>
-                                                                Custom template applied. Edit to
-                                                                customize.
-                                                            </div>
-                                                        )
-                                                    }
-                                                >
-                                                    <Button
-                                                        icon={
-                                                            <HelpIcon aria-label="More info for email template field" />
-                                                        }
-                                                        variant="plain"
-                                                        aria-label="More info for email template field"
-                                                        aria-describedby={`${fieldId}.customSubject`}
-                                                    />
-                                                </Tooltip>
-                                            }
-                                            fieldId={`${fieldId}.customSubject`}
-                                            errors={errors}
-                                            isRequired
-                                        >
-                                            <Button
-                                                variant="link"
-                                                isInline
-                                                icon={<PencilAltIcon />}
-                                                onClick={() => {
-                                                    setNotifierConfigurationSelected(
-                                                        notifierConfiguration
-                                                    );
-                                                }}
-                                                iconPosition="right"
-                                            >
-                                                {isDefaultEmailTemplateApplied
-                                                    ? 'Default template applied'
-                                                    : 'Custom template applied'}
-                                            </Button>
-                                        </FormLabelGroup>
-                                    </Flex>
-                                </CardBody>
-                            </Card>
-                        </FlexItem>
-                    );
-                })}
-                <FlexItem>
-                    <Button
-                        variant="link"
-                        icon={<PlusCircleIcon />}
-                        onClick={() => {
-                            const notifierConfiguration: NotifierConfiguration = {
-                                emailConfig: {
-                                    notifierId: '',
-                                    mailingLists: [],
-                                    customSubject: '',
-                                    customBody: '',
-                                },
-                                notifierName: '',
-                            };
-                            setFieldValue(fieldIdPrefixForFormikAndPatternFly, [
-                                ...notifierConfigurations,
-                                notifierConfiguration,
-                            ]);
-                            setMailingListsStrings([...mailingListsStrings, '']);
-                        }}
-                    >
-                        Add delivery destination
-                    </Button>
-                </FlexItem>
+            {notifierConfigurations.map((notifierConfiguration, index) => {
+                const { emailConfig, notifierName } = notifierConfiguration;
+                const { customBody, customSubject, mailingLists, notifierId } = emailConfig;
+                const fieldId = `${fieldIdPrefixForFormikAndPatternFly}[${index}]`;
+
+                return (
+                    <FormSection key={keyFor(index)} title="Destination" titleElement="h3">
+                        <Flex direction={{ default: 'row' }}>
+                            <Button
+                                variant="link"
+                                icon={<TrashIcon />}
+                                onClick={() => {
+                                    const notifierConfigurationsFiltered =
+                                        notifierConfigurations.filter(
+                                            (notifierConfigurationArg) =>
+                                                notifierConfigurationArg !== notifierConfiguration
+                                        );
+                                    setFieldValue(
+                                        fieldIdPrefixForFormikAndPatternFly,
+                                        notifierConfigurationsFiltered
+                                    );
+                                    setMailingListsStrings(
+                                        mailingListsStrings.filter((_, i) => i !== index)
+                                    );
+                                    if (
+                                        notifierConfigurationsFiltered.length === 0 &&
+                                        onDeleteLastNotifierConfiguration
+                                    ) {
+                                        onDeleteLastNotifierConfiguration();
+                                    }
+                                }}
+                            >
+                                Delete destination
+                            </Button>
+                        </Flex>
+                        <NotifierMailingLists
+                            errors={errors}
+                            fieldIdPrefixForFormikAndPatternFly={fieldId}
+                            hasWriteAccessForIntegration={hasWriteAccessForIntegration}
+                            isLoadingNotifiers={isLoadingNotifiers}
+                            mailingListsString={mailingListsStrings[index]}
+                            notifierId={notifierId}
+                            notifierName={notifierName}
+                            notifiers={notifiers}
+                            setMailingLists={(mailingListsString: string) => {
+                                setFieldValue(
+                                    `${fieldId}.emailConfig.mailingLists`,
+                                    splitAndTrimMailingListsString(mailingListsString)
+                                );
+                                updateMailingListsString(index, mailingListsString);
+                            }}
+                            setNotifier={(notifier: NotifierIntegrationBase) => {
+                                setFieldValue(fieldId, {
+                                    emailConfig: {
+                                        ...emailConfig,
+                                        notifierId: notifier.id,
+                                        mailingLists:
+                                            mailingLists.length === 0
+                                                ? splitAndTrimMailingListsString(
+                                                      notifier.labelDefault
+                                                  )
+                                                : mailingLists,
+                                    },
+                                    notifierName: notifier.name,
+                                });
+                                updateMailingListsString(index, notifier.labelDefault);
+                            }}
+                            setNotifiers={setNotifiers}
+                        />
+                        <FormLabelGroup
+                            label="Custom subject"
+                            fieldId="customSubject"
+                            errors={errors}
+                        >
+                            <TextInput
+                                type="text"
+                                id="customSubject"
+                                name="customSubject"
+                                value={customSubject}
+                                onChange={(_event, value) => {
+                                    setFieldValue(`${fieldId}.customSubject`, value);
+                                }}
+                            />
+                        </FormLabelGroup>
+                        <FormLabelGroup label="Custom body" fieldId="customBody" errors={errors}>
+                            <TextArea
+                                type="text"
+                                id="customBody"
+                                name="customBody"
+                                value={customBody}
+                                onChange={(_event, value) => {
+                                    setFieldValue(`${fieldId}.customBody`, value);
+                                }}
+                            />
+                        </FormLabelGroup>
+                    </FormSection>
+                );
+            })}
+            <Flex direction={{ default: 'row' }}>
+                <Button
+                    variant="link"
+                    icon={<PlusCircleIcon />}
+                    onClick={() => {
+                        const notifierConfiguration: NotifierConfiguration = {
+                            emailConfig: {
+                                notifierId: '',
+                                mailingLists: [],
+                                customSubject: '',
+                                customBody: '',
+                            },
+                            notifierName: '',
+                        };
+                        setFieldValue(fieldIdPrefixForFormikAndPatternFly, [
+                            ...notifierConfigurations,
+                            notifierConfiguration,
+                        ]);
+                        setMailingListsStrings([...mailingListsStrings, '']);
+                    }}
+                >
+                    Add destination
+                </Button>
             </Flex>
-            {notifierConfigurationSelected && (
-                <EmailTemplateModal
-                    customBodyDefault={customBodyDefault}
-                    customBodyInitial={notifierConfigurationSelected.emailConfig.customBody}
-                    customSubjectDefault={customSubjectDefault}
-                    customSubjectInitial={notifierConfigurationSelected.emailConfig.customSubject}
-                    onChange={({ customBody, customSubject }) => {
-                        const index = notifierConfigurations.indexOf(notifierConfigurationSelected);
-                        if (index >= 0) {
-                            const { emailConfig } = notifierConfigurationSelected;
-                            setFieldValue(`${fieldIdPrefixForFormikAndPatternFly}[${index}]`, {
-                                ...notifierConfigurationSelected,
-                                emailConfig: {
-                                    ...emailConfig,
-                                    customSubject,
-                                    customBody,
-                                },
-                            });
-                        }
-                    }}
-                    onClose={() => {
-                        setNotifierConfigurationSelected(null);
-                    }}
-                    renderTemplatePreview={renderTemplatePreview}
-                    title="Edit email template"
-                />
-            )}
         </>
     );
 }

--- a/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationForm.tsx
+++ b/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationForm.tsx
@@ -158,27 +158,31 @@ function NotifierConfigurationForm({
                         />
                         <FormLabelGroup
                             label="Custom subject"
-                            fieldId="customSubject"
+                            fieldId="emailConfig.customSubject"
                             errors={errors}
                         >
                             <TextInput
                                 type="text"
-                                id="customSubject"
-                                name="customSubject"
+                                id="emailConfig.customSubject"
+                                name="emailConfig.customSubject"
                                 value={customSubject}
                                 onChange={(_event, value) => {
-                                    setFieldValue(`${fieldId}.customSubject`, value);
+                                    setFieldValue(`${fieldId}.emailConfig.customSubject`, value);
                                 }}
                             />
                         </FormLabelGroup>
-                        <FormLabelGroup label="Custom body" fieldId="customBody" errors={errors}>
+                        <FormLabelGroup
+                            label="Custom body"
+                            fieldId="emailConfig.customBody"
+                            errors={errors}
+                        >
                             <TextArea
                                 type="text"
-                                id="customBody"
-                                name="customBody"
+                                id="emailConfig.customBody"
+                                name="emailConfig.customBody"
                                 value={customBody}
                                 onChange={(_event, value) => {
-                                    setFieldValue(`${fieldId}.customBody`, value);
+                                    setFieldValue(`${fieldId}.emailConfig.customBody`, value);
                                 }}
                             />
                         </FormLabelGroup>

--- a/ui/apps/platform/src/Components/NotifierConfiguration/NotifierMailingLists.tsx
+++ b/ui/apps/platform/src/Components/NotifierConfiguration/NotifierMailingLists.tsx
@@ -143,29 +143,35 @@ function NotifierMailingLists({
                 isRequired
                 label="Distribution list"
                 fieldId={`${fieldIdPrefixForFormikAndPatternFly}.emailConfig.mailingLists`}
-                helperText="Enter an audience, who will receive the scheduled report. Multiple email addresses can be entered with comma separators."
+                helperText="Multiple email addresses can be entered with comma separators."
                 errors={errors}
             >
-                <TextInput
-                    isRequired
-                    type="text"
-                    id={`${fieldIdPrefixForFormikAndPatternFly}.emailConfig.mailingLists`}
-                    value={mailingListsString}
-                    onChange={(_event, value) => setMailingLists(value)}
-                    placeholder="annie@example.com,jack@example.com"
-                />
+                <Flex direction={{ default: 'row' }} alignItems={{ default: 'alignItemsFlexEnd' }}>
+                    <FlexItem>
+                        <TextInput
+                            isRequired
+                            type="text"
+                            id={`${fieldIdPrefixForFormikAndPatternFly}.emailConfig.mailingLists`}
+                            value={mailingListsString}
+                            onChange={(_event, value) => setMailingLists(value)}
+                            placeholder="annie@example.com,jack@example.com"
+                        />
+                    </FlexItem>
+                    {!!notifierId && (
+                        <FlexItem>
+                            <Button
+                                variant="link"
+                                onClick={onSetToDefaultNotifierMailingLists}
+                                isDisabled={
+                                    mailingListsString === getMailingListsStringFromNotifier()
+                                }
+                            >
+                                Reset to default
+                            </Button>
+                        </FlexItem>
+                    )}
+                </Flex>
             </FormLabelGroup>
-            {!!notifierId && (
-                <div>
-                    <Button
-                        variant="link"
-                        onClick={onSetToDefaultNotifierMailingLists}
-                        isDisabled={mailingListsString === getMailingListsStringFromNotifier()}
-                    >
-                        Reset to default
-                    </Button>
-                </div>
-            )}
             <EmailNotifierModal
                 isOpen={isEmailNotifierModalOpen}
                 updateNotifierList={updateNotifierList}

--- a/ui/apps/platform/src/Components/Reports/Step/DeliveryStep.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/DeliveryStep.tsx
@@ -1,0 +1,48 @@
+import type { ReactElement } from 'react';
+import { Flex, Form, PageSection, Title } from '@patternfly/react-core';
+import type { FormikProps } from 'formik';
+
+import NotifierConfigurationForm from 'Components/NotifierConfiguration/NotifierConfigurationForm';
+import usePermissions from 'hooks/usePermissions';
+
+import type { DeliveryType } from '../reports.types';
+
+import ScheduleFormSection from './ScheduleFormSection';
+
+export type DeliveryStepProps<T extends DeliveryType = DeliveryType> = {
+    formik: FormikProps<T>;
+};
+
+function DeliveryStep<T extends DeliveryType = DeliveryType>({
+    formik,
+}: DeliveryStepProps<T>): ReactElement {
+    const { hasReadWriteAccess } = usePermissions();
+    const hasWriteAccessForIntegration = hasReadWriteAccess('Integration');
+
+    function onDeleteLastNotifierConfiguration() {
+        formik.setFieldValue('schedule', null);
+    }
+
+    return (
+        <PageSection>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+                <Title headingLevel="h2">Delivery</Title>
+                <Form isHorizontal isWidthLimited>
+                    <NotifierConfigurationForm
+                        errors={formik.errors}
+                        fieldIdPrefixForFormikAndPatternFly="notifiers"
+                        hasWriteAccessForIntegration={hasWriteAccessForIntegration}
+                        notifierConfigurations={formik.values.notifiers}
+                        onDeleteLastNotifierConfiguration={onDeleteLastNotifierConfiguration}
+                        setFieldValue={formik.setFieldValue}
+                    />
+                    {formik.values.notifiers.length !== 0 && (
+                        <ScheduleFormSection formik={formik} />
+                    )}
+                </Form>
+            </Flex>
+        </PageSection>
+    );
+}
+
+export default DeliveryStep;

--- a/ui/apps/platform/src/Components/Reports/Step/ScheduleFormSection.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/ScheduleFormSection.tsx
@@ -1,0 +1,161 @@
+import type { FormEvent, ReactElement } from 'react';
+import { FormSection, TimePicker } from '@patternfly/react-core';
+import type { FormikProps } from 'formik';
+
+import DayPickerDropdown from 'Components/PatternFly/DayPickerDropdown';
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
+import RepeatScheduleDropdown from 'Components/PatternFly/RepeatScheduleDropdown';
+import type {
+    DailySchedule,
+    MonthlySchedule,
+    ScheduleBase,
+    WeeklySchedule,
+} from 'types/schedule.proto';
+import { getHourMinuteStringFromScheduleBase } from 'utils/dateUtils';
+
+import type { DeliveryType } from '../reports.types';
+
+export type ScheduleFormSectionProps<T extends DeliveryType = DeliveryType> = {
+    formik: FormikProps<T>;
+};
+
+function ScheduleFormSection<T extends DeliveryType = DeliveryType>({
+    formik,
+}: ScheduleFormSectionProps<T>): ReactElement {
+    function handleSelectIntervalType(id: string, intervalType: string): void {
+        const scheduleBase: ScheduleBase = {
+            hour: formik.values.schedule?.hour ?? 0,
+            minute: formik.values.schedule?.minute ?? 0,
+        };
+
+        switch (intervalType) {
+            case 'DAILY': {
+                const schedule: DailySchedule = { ...scheduleBase, intervalType };
+                formik.setFieldValue('schedule', schedule);
+                break;
+            }
+            case 'WEEKLY': {
+                const schedule: WeeklySchedule = {
+                    ...scheduleBase,
+                    intervalType,
+                    daysOfWeek: { days: [] },
+                };
+                formik.setFieldValue('schedule', schedule);
+                break;
+            }
+            case 'MONTHLY': {
+                const schedule: MonthlySchedule = {
+                    ...scheduleBase,
+                    intervalType,
+                    daysOfMonth: { days: [] },
+                };
+                formik.setFieldValue('schedule', schedule);
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    function handleSelectDays(id: string, selection: string[]) {
+        formik.setFieldValue(
+            id,
+            selection.map((day) => Number(day)),
+            true
+        );
+    }
+
+    function onChangeTime(
+        _event: FormEvent<HTMLInputElement>,
+        _time: string,
+        hour: number | null | undefined,
+        minute: number | null | undefined
+    ): void {
+        // Arguments have null value if incorrect. Do not replace previous values.
+        if (typeof hour === 'number' && typeof minute === 'number') {
+            formik.setFieldValue('schedule.hour', hour);
+            formik.setFieldValue('schedule.minute', minute);
+        }
+    }
+
+    const fieldIdForDays =
+        formik.values.schedule?.intervalType === 'WEEKLY'
+            ? 'schedule.daysOfWeek.days'
+            : 'schedule.daysOfMonth.days';
+
+    return (
+        <FormSection title="Schedule" titleElement="h3">
+            <FormLabelGroup
+                label="Frequency"
+                fieldId="schedule.intervalType"
+                isRequired
+                errors={formik.errors}
+                touched={formik.touched}
+            >
+                <RepeatScheduleDropdown
+                    fieldId="schedule.intervalType"
+                    value={formik.values.schedule?.intervalType ?? ''}
+                    handleSelect={handleSelectIntervalType}
+                    includeDailyOption
+                    onBlur={formik.handleBlur}
+                />
+            </FormLabelGroup>
+            <FormLabelGroup
+                label="Days"
+                fieldId={fieldIdForDays}
+                errors={formik.errors}
+                isRequired={
+                    formik.values.schedule?.intervalType === 'WEEKLY' ||
+                    formik.values.schedule?.intervalType === 'MONTHLY'
+                }
+                touched={formik.touched}
+            >
+                {formik.values.schedule?.intervalType === 'WEEKLY' ||
+                formik.values.schedule?.intervalType === 'MONTHLY' ? (
+                    <DayPickerDropdown
+                        fieldId={fieldIdForDays}
+                        value={
+                            formik.values.schedule.intervalType === 'WEEKLY'
+                                ? formik.values.schedule.daysOfWeek.days.map((day) => String(day))
+                                : formik.values.schedule.daysOfMonth.days.map((day) => String(day))
+                        }
+                        handleSelect={handleSelectDays}
+                        intervalType={formik.values.schedule.intervalType}
+                        toggleId={fieldIdForDays}
+                        onBlur={() => {
+                            formik.setFieldTouched(fieldIdForDays, true);
+                        }}
+                    />
+                ) : (
+                    <>Not applicable</>
+                )}
+            </FormLabelGroup>
+            <FormLabelGroup
+                label="Time"
+                fieldId="time"
+                errors={formik.errors}
+                isRequired
+                touched={formik.touched}
+                helperText="Select or enter time between 00:00 and 23:59 UTC"
+            >
+                <TimePicker
+                    time={
+                        formik.values.schedule
+                            ? getHourMinuteStringFromScheduleBase(formik.values.schedule)
+                            : '00:00'
+                    }
+                    is24Hour
+                    onChange={onChangeTime}
+                    inputProps={{
+                        onBlur: formik.handleBlur,
+                        // name: 'parameters.time',
+                    }}
+                    invalidFormatErrorMessage="" // error messaging is handled by FormLabelGroup
+                    invalidMinMaxErrorMessage=""
+                />
+            </FormLabelGroup>
+        </FormSection>
+    );
+}
+
+export default ScheduleFormSection;

--- a/ui/apps/platform/src/Components/Reports/View/NotifierConfigurationDescriptionList.tsx
+++ b/ui/apps/platform/src/Components/Reports/View/NotifierConfigurationDescriptionList.tsx
@@ -6,7 +6,6 @@ import {
     DescriptionListTerm,
 } from '@patternfly/react-core';
 
-import { isDefaultEmailTemplate } from 'Components/EmailTemplate/EmailTemplate.utils';
 import type { NotifierConfiguration } from 'services/ReportsService.types';
 
 export type NotifierConfigurationDescriptionListProps = {
@@ -18,10 +17,6 @@ function NotifierConfigurationDescriptionList({
 }: NotifierConfigurationDescriptionListProps): ReactElement {
     const { emailConfig, notifierName } = notifier;
     const { customBody, customSubject, mailingLists } = emailConfig;
-    const hasDefaultEmailTemplate = isDefaultEmailTemplate({
-        customBody,
-        customSubject,
-    });
 
     return (
         <DescriptionList isCompact isHorizontal>
@@ -33,12 +28,18 @@ function NotifierConfigurationDescriptionList({
                 <DescriptionListTerm>Distribution list</DescriptionListTerm>
                 <DescriptionListDescription>{mailingLists.join(', ')}</DescriptionListDescription>
             </DescriptionListGroup>
-            <DescriptionListGroup>
-                <DescriptionListTerm>Email template</DescriptionListTerm>
-                <DescriptionListDescription>
-                    {hasDefaultEmailTemplate ? 'Default template' : 'Custom template'}
-                </DescriptionListDescription>
-            </DescriptionListGroup>
+            {customSubject && (
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Custom subject</DescriptionListTerm>
+                    <DescriptionListDescription>{customSubject}</DescriptionListDescription>
+                </DescriptionListGroup>
+            )}
+            {customBody && (
+                <DescriptionListGroup>
+                    <DescriptionListTerm>Custom body</DescriptionListTerm>
+                    <DescriptionListDescription>{customBody}</DescriptionListDescription>
+                </DescriptionListGroup>
+            )}
         </DescriptionList>
     );
 }

--- a/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReportConfiguration.tsx
+++ b/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ReportConfiguration.tsx
@@ -6,7 +6,7 @@ import { Divider, Flex, FlexItem, Form, PageSection, Title } from '@patternfly/r
 import NotifierConfigurationForm from 'Components/NotifierConfiguration/NotifierConfigurationForm';
 import usePermissions from 'hooks/usePermissions';
 
-import { getBodyDefault, getSubjectDefault } from '../compliance.scanConfigs.utils';
+// import { getBodyDefault, getSubjectDefault } from '../compliance.scanConfigs.utils';
 import type { ScanConfigFormValues } from '../compliance.scanConfigs.utils';
 
 function ReportConfiguration(): ReactElement {
@@ -29,11 +29,11 @@ function ReportConfiguration(): ReactElement {
             <Divider component="div" />
             <Form className="pf-v6-u-py-lg pf-v6-u-px-lg">
                 <NotifierConfigurationForm
-                    customBodyDefault={getBodyDefault(formik.values.profiles)}
-                    customSubjectDefault={getSubjectDefault(
-                        formik.values.parameters.name,
-                        formik.values.profiles
-                    )}
+                    // customBodyDefault={getBodyDefault(formik.values.profiles)}
+                    // customSubjectDefault={getSubjectDefault(
+                    //     formik.values.parameters.name,
+                    //     formik.values.profiles
+                    // )}
                     errors={formik.errors}
                     fieldIdPrefixForFormikAndPatternFly="report.notifierConfigurations"
                     hasWriteAccessForIntegration={hasWriteAccessForIntegration}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
@@ -9,6 +9,7 @@ import type {
     CompoundSearchFilterConfig,
     SelectSearchFilterAttribute,
 } from 'Components/CompoundSearchFilter/types';
+import DeliveryStep from 'Components/Reports/Step/DeliveryStep';
 import DetailsStep from 'Components/Reports/Step/DetailsStep';
 import type { ReportPageAction } from 'Components/Reports/reports.types';
 import { createReportConfiguration, updateReportConfiguration } from 'services/ReportsService';
@@ -113,7 +114,7 @@ function ImageVulnerabilityReportWizard({
                 )}
             </WizardStep>
             <WizardStep id="Delivery" name="Delivery" body={{ hasNoPadding: true }}>
-                <></>
+                <DeliveryStep formik={formik} />
             </WizardStep>
             <WizardStep
                 id="Review"

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/forms/DeliveryDestinationsForm.tsx
@@ -2,19 +2,19 @@ import type { ReactElement } from 'react';
 import { Alert, Divider, Flex, FlexItem, Form, PageSection, Title } from '@patternfly/react-core';
 import type { FormikProps } from 'formik';
 
-import type { TemplatePreviewArgs } from 'Components/EmailTemplate/EmailTemplateModal';
+// import type { TemplatePreviewArgs } from 'Components/EmailTemplate/EmailTemplateModal';
 import NotifierConfigurationForm from 'Components/NotifierConfiguration/NotifierConfigurationForm';
 import RepeatScheduleDropdown from 'Components/PatternFly/RepeatScheduleDropdown';
 import DayPickerDropdown from 'Components/PatternFly/DayPickerDropdown';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import usePermissions from 'hooks/usePermissions';
 
-import {
-    defaultEmailBody as customBodyDefault,
-    getDefaultEmailSubject,
-} from './emailTemplateFormUtils';
+// import {
+//     defaultEmailBody as customBodyDefault,
+//     getDefaultEmailSubject,
+// } from './emailTemplateFormUtils';
 import type { ReportFormValues } from './useReportFormValues';
-import EmailTemplatePreview from '../components/EmailTemplatePreview';
+// import EmailTemplatePreview from '../components/EmailTemplatePreview';
 
 export type DeliveryDestinationsFormProps = {
     title: string;
@@ -25,6 +25,7 @@ function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormPro
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForIntegration = hasReadWriteAccess('Integration');
 
+    /*
     const customSubjectDefault = getDefaultEmailSubject(
         formik.values.reportParameters.reportName,
         formik.values.reportParameters.reportScope?.name
@@ -44,6 +45,7 @@ function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormPro
             />
         );
     }
+    */
 
     function onDeleteLastNotifierConfiguration() {
         // Update only the schedule because spread ...formik.values overwrites deletion of last notifier.
@@ -97,8 +99,8 @@ function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormPro
                     <Flex direction={{ default: 'column' }}>
                         <FlexItem flex={{ default: 'flexNone' }}>
                             <NotifierConfigurationForm
-                                customBodyDefault={customBodyDefault}
-                                customSubjectDefault={customSubjectDefault}
+                                // customBodyDefault={customBodyDefault}
+                                // customSubjectDefault={customSubjectDefault}
                                 errors={formik.errors}
                                 fieldIdPrefixForFormikAndPatternFly="deliveryDestinations"
                                 hasWriteAccessForIntegration={hasWriteAccessForIntegration}
@@ -106,7 +108,7 @@ function DeliveryDestinationsForm({ title, formik }: DeliveryDestinationsFormPro
                                 onDeleteLastNotifierConfiguration={
                                     onDeleteLastNotifierConfiguration
                                 }
-                                renderTemplatePreview={renderTemplatePreview}
+                                // renderTemplatePreview={renderTemplatePreview}
                                 setFieldValue={formik.setFieldValue}
                             />
                         </FlexItem>


### PR DESCRIPTION
## Description

**Review**: Hide space because of indentation changes.

### Objective

Provide equivalent filter for scheduled reports as view-based reports

### Analysis

1. Find in Files `<NotifierConfigurationForm` has 2 results in 2 files:

    * ReportConfiguration.tsx file for compliance scan schedules

        * Derives `customBodyDefault` and `customSubjectDefaults` from values.
        * Does not have `renderTemplatePreview` prop.

    * DeliveryDestinationsForm.tsx file for vulnerability reports

        * Derives `customBodyDefault` and `customSubjectDefaults` from values.
        * Does have `renderTemplatePreview` function.

2. Schedule payload/response type is **equivalent**, although separate sources of truth from backend:

    * compliance scan schedules

        https://github.com/stackrox/stackrox/blob/master/proto/api/v2/common.proto#L14-L39

    * vulnerability reports

        https://github.com/stackrox/stackrox/blob/master/proto/api/v2/report_service.proto#L73-L98
    
    Frontend source of truth:

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/types/schedule.proto.ts

3. Schedule property name is **different**:

    * `scanSchedule` (frontend) from `scan_schedule` (backend) in compliance scan schedules

        https://github.com/stackrox/stackrox/blob/master/proto/api/v2/compliance_scan_configuration_service.proto#L39

    * `schedule` in vulnerability reports

        https://github.com/stackrox/stackrox/blob/master/proto/api/v2/report_service.proto#L26

### Solution

1. Edit NotifierConfigurationForm.tsx file.

    * Replace `EmailTemplateModal` with ordinary form elements for **Custom subject** and **Custom body** adapted from **Name** and **Description** in DetailsStep.tsx file.

    Therefore delete props:
    * `customBodyDefault`
    * `customSubjectDefault`
    * `renderTemplatePreview`

2. Add DeliveryStep.tsx file.

    * Reuse simplified `NotifierConfigurationForm` element.
 
    * Render potentially reusable `ScheduleFormSection` element.

3. Add ScheduleFormSection.tsx file.

    Adapt from compliance scan schedules wizard:
    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/ComplianceEnhanced/Schedules/Wizard/ScanConfigOptions.tsx

    * Especially because of 2 levels to access `days` array, be explicit about types in `handleSelectIntervalType` function.

    * Convert to and from number items `days` array. Too bad, so sad that `DayPickerDropdown` needs that.

    * Conditiooally render (instead of disable) `DayPickerDropdown` if and only if property exists.

    * Use `hour` and `minute` arguments (with dynamic type checking) in `onChangeTime` function.

4. Edit DetailsView.tsx file.

    * Replace **Default template** versus **Custom template** with `customSubject` and `customBody` in description list.

### Residue

1. Investigate how to define `DeliveryView` type to allow consistent use of either `scanSchedul` or `schedule`  property name, probably with help from **Brad** or **David**.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

### Testing and quality

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration click a linkm, click **Actions**, click **Edit report**, and then advance to **Delivery** step.

    Because no delivery destinations, see presence of **Add destinations** and absence of **Schedule**
    <img width="1439" height="892" alt="Delivery_Add_destination" src="https://github.com/user-attachments/assets/d7efb1da-7329-4af6-8344-004e86827e78" />

2. Click **Add destination**

    See input elements and presence of **Schedule**
    <img width="1440" height="892" alt="Delivery_added" src="https://github.com/user-attachments/assets/849054b9-f3c2-4b7c-97ea-5d6a44b10f19" />

3. Enter **Email notifier** and **Distribution list** and **Frequency Daily** and **Time 01:30**

    See **Not applicable** for **Days** note to Brad: slight pivot in conditional rendering for horizaontal form
    <img width="1440" height="892" alt="Delivery_Daily" src="https://github.com/user-attachments/assets/49bd038b-cab0-4976-a5e1-d5b9fbbd26d8" />

4. Advance to **Review** step
    <img width="1440" height="892" alt="Review_Daily" src="https://github.com/user-attachments/assets/818f6909-d99b-4584-b42e-96eb40e7ddbe" />

5. Go back to **Delivery** step and enter **Custom subject** and **Frequency Weekly**

    See input element for **Days**
    <img width="1440" height="892" alt="Delivery_Weekly" src="https://github.com/user-attachments/assets/1087c57e-8922-48d4-aa3a-98cf50beac98" />

6. Advance to **Review** step
    <img width="1439" height="892" alt="Review_Weekly" src="https://github.com/user-attachments/assets/9a3ca8d8-f8ad-4137-b389-54933639dbd7" />

7. Go back to **Delivery** step and enter **Custom body** and **Frequency Monthly**
    <img width="1440" height="892" alt="Delivery_Monthly" src="https://github.com/user-attachments/assets/e541e7ba-f822-4b2f-8de1-4029a475c63f" />

8. Advance to **Review** step
    <img width="1440" height="892" alt="Review_Monthly" src="https://github.com/user-attachments/assets/316de6ef-7d8b-4c20-9038-2aa56065cf8a" />

9. Go back to **Delivery**&&** step and click **Add destination** and then click **Delete destination** for both

    See absence of **Schedule**

10. Look at **Delivery** step for an existing report configuration

For reference, here is previous interface
<img width="1440" height="892" alt="DeliveryDestinationsForm" src="https://github.com/user-attachments/assets/894ac13e-06ff-46dd-8aa1-b02b37dfcc0a" />
