### PR TITLE
chore(ci): Fix broken VulnMgmtTest

### DIFF
--- a/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtTest.groovy
@@ -198,7 +198,7 @@ query getComponentId(\$imageId: ID!, \$componentQuery: String) {
 
         imageDigest               | imageName           | component | cve              | severity | cvss
         RHEL_IMAGE_LEGACY_DIGEST  | RHEL_IMAGE_LEGACY   | "glib2"   | "CVE-2019-13012" | LOW      | 4.4
-        UBUNTU_IMAGE_DIGEST       | UBUNTU_IMAGE        | "gnupg2"  | "CVE-2022-3219"  | LOW      | 3.3
+        UBUNTU_IMAGE_DIGEST       | UBUNTU_IMAGE        | "systemd"  | "CVE-2023-7008" | LOW      | 5.9
     }
 
     @Unroll


### PR DESCRIPTION
## Description

```
22:54:30 | ERROR | VulnMgmtTest              | Helpers                   | An exception occurred in test
java.lang.NullPointerException: Cannot get property 'imageVulnerabilities' on null object
	at VulnMgmtTest.verifySeveritiesAndCvss(VulnMgmtTest.groovy:240)
	at VulnMgmtTest.$spock_feature_1_0(VulnMgmtTest.groovy:194)
Wrapped by: Condition failed with Exception:

verifySeveritiesAndCvss(imageDigest, imageName, component, cve, severity, cvss)
|                       |            |          |          |    |         |
|                       |            |          gnupg2     |    |         3.3
|                       |            |                     |    LOW_VULNERABILITY_SEVERITY
|                       |            |                     CVE-2022-3219
|                       |            quay.io/rhacs-eng/qa:ubuntu-22.04-amd64
|                       sha256:c9672795a48854502d9dc0f1b719ac36dd99259a2f8ce425904a5cb4ae0d60d2
java.lang.NullPointerException: Cannot get property 'imageVulnerabilities' on null object
	at VulnMgmtTest.verifySeveritiesAndCvss(VulnMgmtTest.groovy:240)
	at VulnMgmtTest.$spock_feature_1_0(VulnMgmtTest.groovy:194)

	at VulnMgmtTest.$spock_feature_1_0(VulnMgmtTest.groovy:194) [1 skipped]
	at util.OnFailureInterceptor.intercept(OnFailure.groovy:72) [8 skipped]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:157) [7 skipped]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:147)
	at util.OnFailureInterceptor.intercept(OnFailure.groovy:72) [5 skipped]
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61) [4 skipped]
 [4 skipped]
```


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

CI
