### PR TITLE
ROX-34617: Remove stale eslint-disable comment in useIntegrations

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
@@ -75,7 +75,6 @@ const useIntegrations = ({ source, type }: UseIntegrations): UseIntegrationsResp
                 return cloudSources;
             }
             default: {
-                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
                 throw new Error(`Unknown source ${source}`);
             }
         }


### PR DESCRIPTION
## Description

**Jira:** [ROX-34617](https://issues.redhat.com/browse/ROX-34617)

Part of cleaning up stale `eslint-disable` comments across the UI codebase. This one was in `useIntegrations.ts`, suppressing `@typescript-eslint/restrict-template-expressions` on a template literal in a `default` switch case. The rule no longer flags that line, so the disable comment is just noise at this point.

- Remove the unnecessary `eslint-disable-next-line` directive

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- No test changes needed; this is a comment-only removal with no logic change

### How I validated my change

- Ran lint to confirm the rule doesn't trigger on this line anymore
- No logic was touched, just the stale comment removed

[ROX-34617]: https://redhat.atlassian.net/browse/ROX-34617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ