### PR TITLE
ROX-33423: Use digest for image SHA in VM1 dashboard

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtEntityImage.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtEntityImage.jsx
@@ -34,6 +34,7 @@ const VulnMgmtEntityImage = ({
         query getImage($id: ID!, $query: String, $scopeQuery: String) {
             result: image(id: $id) {
                 id
+                digest
                 lastUpdated
                 ${entityContext[entityTypes.DEPLOYMENT] ? '' : 'deploymentCount(query: $query)'}
                 metadata {

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.jsx
@@ -24,6 +24,7 @@ import TableWidget from '../TableWidget';
 
 const emptyImage = {
     deploymentCount: 0,
+    digest: '',
     id: '',
     lastUpdated: '',
     metadata: {
@@ -81,7 +82,7 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
     const metadataKeyValuePairs = [
         {
             key: 'SHA',
-            value: safeData.id,
+            value: safeData.digest,
         },
         {
             key: 'Created',


### PR DESCRIPTION
## Description

With the flattened image data model, `image.id` now shows a UUID instead of a SHA. This switches the display to use `image.digest` which shows a SHA in both v1 and v2 of the image resolvers. In v1, the `image.id` and `image.digest` fields [are identical](https://github.com/stackrox/stackrox/blob/master/central/graphql/resolvers/images.go#L121) so this does not require feature flag gating.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1173" height="863" alt="image" src="https://github.com/user-attachments/assets/476e9da1-a4f4-4a36-8c4d-62741cd942de" />
