### PR TITLE
ROX-33889: Add support for GO release tag in test runners

### DIFF
--- a/make/env.mk
+++ b/make/env.mk
@@ -65,6 +65,10 @@ endif
 
 ifneq ($(BUILD_TAG),)
 TAG := $(BUILD_TAG)
+# Prow CI needs "release" GOTAGS so that test binaries match the Central image built by GHA.
+ifdef OPENSHIFT_CI
+GOTAGS := $(if $(GOTAGS),$(GOTAGS)$(comma))$(RELEASE_GOTAGS)
+endif
 endif
 
 ifeq ($(TAG),)


### PR DESCRIPTION
## Description

Commit introduced by #19615 changed `env.mk` to derive `GOTAGS` from `GITHUB_REF` instead of `BUILD_TAG`, which broke Prow CI nightly jobs where `GITHUB_REF` is not available. Without `GOTAGS=release`, binaries built in Prow no longer match the release Central image built by GHA, causing `TestMetadataIsSetCorrectly` and `TestFeatureFlagSettings` to fail.

This fix restores `GOTAGS=release` in Prow by checking `OPENSHIFT_CI` when `BUILD_TAG` is set, without affecting GHA builds.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing test helper scripts

### How I validated my change

- **no validation:** This change can be validated only with tagged commit. My proposal is -> merge and check nightly. It's anyway broken.
