### PR TITLE
ROX-29120: roxctl: clarify image scan legacy output deprecations

### DIFF
--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -96,8 +96,6 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	// Deprecated flag
 	// The error message will be prefixed by "command <command-name> has been deprecated".
-	//
-	// TODO(ROX-29120): This may NOT be removed until we find another place to put this or we replace this with another equivalent format.
 	c.Flags().StringVarP(&imageScanCmd.format, "format", "", "json", "Format of the output. Choose output format from json and csv.")
 	utils.Must(c.Flags().MarkDeprecated("format", deprecationNote))
 

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -85,6 +85,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	}
 
 	objectPrinterFactory.AddFlags(c)
+	// provide flag usage, including supported values and default.
 	c.Flag("output").Usage = outputFlagUsage(customPrinterFactories...)
 
 	c.Flags().StringVarP(&imageScanCmd.image, "image", "i", "", "Image name and reference. (e.g. nginx:latest or nginx@sha256:...).")

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -31,6 +31,8 @@ const (
 	legacyOutputMigrationNote = "NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating."
 	deprecationNote           = "please use --output/-o to specify the output format. " +
 		legacyOutputMigrationNote
+	defaultLegacyJSONInfoNote = "Default image scan output currently uses deprecated legacy-json for backwards compatibility. " +
+		"Use --output=json to migrate to the new JSON output format. NOTE: it contains breaking changes in the format."
 	legacyJSONOutputFormat          = "legacy-json"
 	legacyCSVOutputFormat           = "legacy-csv"
 	legacyJSONOutputDeprecationNote = "please use --output=json to migrate to the new JSON output format. " + legacyOutputMigrationNote
@@ -138,6 +140,9 @@ func (i *imageScanCommand) Construct(_ []string, cmd *cobra.Command, f *printer.
 			i.env.Logger().WarnfLn("Output format %q has been deprecated, %s", f.OutputFormat, deprecationNote)
 		}
 		return nil
+	}
+	if !cmd.Flag("format").Changed && !cmd.Flag("output").Changed {
+		i.env.Logger().InfofLn("%s", defaultLegacyJSONInfoNote)
 	}
 
 	// Only create the printer when the old, deprecated output format is not used

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -37,7 +37,7 @@ const (
 	legacyCSVOutputFormat           = "legacy-csv"
 	legacyJSONOutputDeprecationNote = "please use --output=json to migrate to the new JSON output format. " + legacyOutputMigrationNote
 	legacyCSVOutputDeprecationNote  = "please use --output=csv to migrate to the new CSV output format. " + legacyOutputMigrationNote
-	outputFlagUsage                 = "Output format. Choose one of: table | csv | json | sarif | legacy-json | legacy-csv. If omitted, defaults to deprecated legacy-json for backwards compatibility."
+	outputFlagUsageSuffix           = ". If omitted, defaults to deprecated legacy-json for backwards compatibility."
 )
 
 var (
@@ -54,9 +54,12 @@ var (
 func Command(cliEnvironment environment.Environment) *cobra.Command {
 	imageScanCmd := &imageScanCommand{env: cliEnvironment}
 
-	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table",
-		append(supportedObjectPrinters,
-			printer.NewSarifPrinterFactory(printers.SarifVulnerabilityReport, scan.SarifJSONPathExpressions, &imageScanCmd.image))...)
+	customPrinterFactories := append(
+		slices.Clone(supportedObjectPrinters),
+		printer.NewSarifPrinterFactory(printers.SarifVulnerabilityReport, scan.SarifJSONPathExpressions, &imageScanCmd.image),
+	)
+
+	objectPrinterFactory, err := printer.NewObjectPrinterFactory("table", customPrinterFactories...)
 	// should not happen when using default values, must be a programming error
 	utils.Must(err)
 	// Set the Output Format to empty, so by default the new output format will not be used and the legacy one will be
@@ -82,7 +85,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	}
 
 	objectPrinterFactory.AddFlags(c)
-	c.Flag("output").Usage = outputFlagUsage
+	c.Flag("output").Usage = outputFlagUsage(customPrinterFactories...)
 
 	c.Flags().StringVarP(&imageScanCmd.image, "image", "i", "", "Image name and reference. (e.g. nginx:latest or nginx@sha256:...).")
 	c.Flags().BoolVarP(&imageScanCmd.force, "force", "f", false, "Bypass Central's cache for the image and force a new pull from the Scanner.")
@@ -166,6 +169,20 @@ func legacyOutputFormat(outputFormat string) (string, string, bool) {
 	default:
 		return "", "", false
 	}
+}
+
+func outputFlagUsage(customPrinterFactories ...printer.CustomPrinterFactory) string {
+	supportedFormats := make([]string, 0, len(customPrinterFactories)+2)
+	for _, customPrinterFactory := range customPrinterFactories {
+		for _, format := range customPrinterFactory.SupportedFormats() {
+			if !slices.Contains(supportedFormats, format) {
+				supportedFormats = append(supportedFormats, format)
+			}
+		}
+	}
+
+	supportedFormats = append(supportedFormats, legacyJSONOutputFormat, legacyCSVOutputFormat)
+	return "Output format. Choose one of: " + strings.Join(supportedFormats, " | ") + outputFlagUsageSuffix
 }
 
 // Validate will validate the injected values and check whether it's possible to execute the operation with the

--- a/roxctl/image/scan/scan.go
+++ b/roxctl/image/scan/scan.go
@@ -28,8 +28,14 @@ import (
 )
 
 const (
-	deprecationNote = "please use --output/-o to specify the output format. " +
-		"NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating."
+	legacyOutputMigrationNote = "NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating."
+	deprecationNote           = "please use --output/-o to specify the output format. " +
+		legacyOutputMigrationNote
+	legacyJSONOutputFormat          = "legacy-json"
+	legacyCSVOutputFormat           = "legacy-csv"
+	legacyJSONOutputDeprecationNote = "please use --output=json to migrate to the new JSON output format. " + legacyOutputMigrationNote
+	legacyCSVOutputDeprecationNote  = "please use --output=csv to migrate to the new CSV output format. " + legacyOutputMigrationNote
+	outputFlagUsage                 = "Output format. Choose one of: table | csv | json | sarif | legacy-json | legacy-csv. If omitted, defaults to deprecated legacy-json for backwards compatibility."
 )
 
 var (
@@ -74,6 +80,7 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	}
 
 	objectPrinterFactory.AddFlags(c)
+	c.Flag("output").Usage = outputFlagUsage
 
 	c.Flags().StringVarP(&imageScanCmd.image, "image", "i", "", "Image name and reference. (e.g. nginx:latest or nginx@sha256:...).")
 	c.Flags().BoolVarP(&imageScanCmd.force, "force", "f", false, "Bypass Central's cache for the image and force a new pull from the Scanner.")
@@ -125,13 +132,14 @@ func (i *imageScanCommand) Construct(_ []string, cmd *cobra.Command, f *printer.
 		return common.ErrInvalidCommandOption.CausedBy(err)
 	}
 
-	// There is a case where cobra is not printing the deprecation warning to stderr, when a deprecated flag is not
-	// specified, but has default values. So, when --format is left with default values and --output is not specified,
-	// we manually print the deprecation note. We do not need to do this when i.e. --format csv is used, because
-	// then a deprecated flag will be explicitly used and cobra will take over the printing of the deprecation note.
-	if !cmd.Flag("format").Changed && !cmd.Flag("output").Changed {
-		i.env.Logger().WarnfLn("Flag --format has been deprecated, %s", deprecationNote)
+	if legacyFormat, deprecationNote, isLegacy := legacyOutputFormat(f.OutputFormat); isLegacy {
+		i.format = legacyFormat
+		if cmd.Flag("output").Changed {
+			i.env.Logger().WarnfLn("Output format %q has been deprecated, %s", f.OutputFormat, deprecationNote)
+		}
+		return nil
 	}
+
 	// Only create the printer when the old, deprecated output format is not used
 	// TODO(ROX-8303): This can be removed once the old output format is fully deprecated
 	if f.OutputFormat != "" {
@@ -144,6 +152,17 @@ func (i *imageScanCommand) Construct(_ []string, cmd *cobra.Command, f *printer.
 	}
 
 	return nil
+}
+
+func legacyOutputFormat(outputFormat string) (string, string, bool) {
+	switch outputFormat {
+	case legacyJSONOutputFormat:
+		return "json", legacyJSONOutputDeprecationNote, true
+	case legacyCSVOutputFormat:
+		return "csv", legacyCSVOutputDeprecationNote, true
+	default:
+		return "", "", false
+	}
 }
 
 // Validate will validate the injected values and check whether it's possible to execute the operation with the

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -442,6 +442,26 @@ func (s *imageScanTestSuite) TestFormatFlagDeprecationMessage() {
 	s.Assert().False(strings.Contains(output.String(), "please use --format="))
 }
 
+func (s *imageScanTestSuite) TestLegacyOutputDeprecationMessageEndToEnd() {
+	conn, closeF := s.createGRPCMockImageService(testComponents)
+	defer closeF()
+
+	env, out, errOut := s.newTestMockEnvironmentWithConn(conn)
+	cmd := Command(env)
+	cmd.Flags().Duration("timeout", 1*time.Minute, "")
+	cmd.Flags().Duration("retry-timeout", 1*time.Minute, "")
+	cmd.SetArgs([]string{"--output=legacy-json", "--image", s.defaultImageScanCommand.image})
+
+	err := cmd.Execute()
+	s.Require().NoError(err)
+
+	expectedOutput, err := os.ReadFile(path.Join("testdata", "legacy_testComponents.json"))
+	s.Require().NoError(err)
+	s.Assert().JSONEq(string(expectedOutput), out.String())
+	s.Assert().Contains(errOut.String(), `Output format "legacy-json" has been deprecated`)
+	s.Assert().Contains(errOut.String(), "please use --output=json to migrate to the new JSON output format")
+}
+
 func (s *imageScanTestSuite) TestValidate() {
 	jsonPrinter, err := printer.NewJSONPrinterFactory(false, false).CreatePrinter("json")
 	s.Require().NoError(err)

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -443,23 +443,53 @@ func (s *imageScanTestSuite) TestFormatFlagDeprecationMessage() {
 }
 
 func (s *imageScanTestSuite) TestLegacyOutputDeprecationMessageEndToEnd() {
-	conn, closeF := s.createGRPCMockImageService(testComponents)
-	defer closeF()
+	cases := map[string]struct {
+		outputFlag         string
+		expectedOutputFile string
+		expectedDeprecMsg  string
+		expectedMigration  string
+		jsonCompare        bool
+	}{
+		"legacy-json should print deprecation warning and produce legacy JSON output": {
+			outputFlag:         "legacy-json",
+			expectedOutputFile: "legacy_testComponents.json",
+			expectedDeprecMsg:  `Output format "legacy-json" has been deprecated`,
+			expectedMigration:  "please use --output=json to migrate to the new JSON output format",
+			jsonCompare:        true,
+		},
+		"legacy-csv should print deprecation warning and produce legacy CSV output": {
+			outputFlag:         "legacy-csv",
+			expectedOutputFile: "legacy_testComponents.csv",
+			expectedDeprecMsg:  `Output format "legacy-csv" has been deprecated`,
+			expectedMigration:  "please use --output=csv to migrate to the new CSV output format",
+		},
+	}
 
-	env, out, errOut := s.newTestMockEnvironmentWithConn(conn)
-	cmd := Command(env)
-	cmd.Flags().Duration("timeout", 1*time.Minute, "")
-	cmd.Flags().Duration("retry-timeout", 1*time.Minute, "")
-	cmd.SetArgs([]string{"--output=legacy-json", "--image", s.defaultImageScanCommand.image})
+	for name, c := range cases {
+		s.Run(name, func() {
+			conn, closeF := s.createGRPCMockImageService(testComponents)
+			defer closeF()
 
-	err := cmd.Execute()
-	s.Require().NoError(err)
+			env, out, errOut := s.newTestMockEnvironmentWithConn(conn)
+			cmd := Command(env)
+			cmd.Flags().Duration("timeout", 1*time.Minute, "")
+			cmd.Flags().Duration("retry-timeout", 1*time.Minute, "")
+			cmd.SetArgs([]string{"--output=" + c.outputFlag, "--image", s.defaultImageScanCommand.image})
 
-	expectedOutput, err := os.ReadFile(path.Join("testdata", "legacy_testComponents.json"))
-	s.Require().NoError(err)
-	s.Assert().JSONEq(string(expectedOutput), out.String())
-	s.Assert().Contains(errOut.String(), `Output format "legacy-json" has been deprecated`)
-	s.Assert().Contains(errOut.String(), "please use --output=json to migrate to the new JSON output format")
+			err := cmd.Execute()
+			s.Require().NoError(err)
+
+			expectedOutput, err := os.ReadFile(path.Join("testdata", c.expectedOutputFile))
+			s.Require().NoError(err)
+			if c.jsonCompare {
+				s.Assert().JSONEq(string(expectedOutput), out.String())
+			} else {
+				s.Assert().Equal(string(expectedOutput), out.String())
+			}
+			s.Assert().Contains(errOut.String(), c.expectedDeprecMsg)
+			s.Assert().Contains(errOut.String(), c.expectedMigration)
+		})
+	}
 }
 
 func (s *imageScanTestSuite) TestValidate() {

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -363,6 +363,7 @@ func (s *imageScanTestSuite) TestConstruct() {
 }
 
 func (s *imageScanTestSuite) TestDeprecationNote() {
+	expectedDefaultLegacyJSONInfoNote := "INFO:\tDefault image scan output currently uses deprecated legacy-json for backwards compatibility. Use --output=json to migrate to the new JSON output format. NOTE: it contains breaking changes in the format.\n"
 	expectedLegacyJSONDeprecationNote := "WARN:\tOutput format \"legacy-json\" has been deprecated, please use --output=json to migrate to the new JSON output format. NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating.\n"
 	expectedLegacyCSVDeprecationNote := "WARN:\tOutput format \"legacy-csv\" has been deprecated, please use --output=csv to migrate to the new CSV output format. NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating.\n"
 
@@ -372,7 +373,9 @@ func (s *imageScanTestSuite) TestDeprecationNote() {
 		outputFormat  string
 		expectedNote  string
 	}{
-		"default values are not changed, the deprecation warning should not be printed": {},
+		"default values are not changed, an informational note should be printed": {
+			expectedNote: expectedDefaultLegacyJSONInfoNote,
+		},
 		"changes in format, deprecation warning should not be printed": {
 			formatChanged: true,
 		},

--- a/roxctl/image/scan/scan_test.go
+++ b/roxctl/image/scan/scan_test.go
@@ -3,11 +3,11 @@ package scan
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"path"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -296,6 +296,7 @@ func (s *imageScanTestSuite) TestConstruct() {
 
 	cases := map[string]struct {
 		legacyFormat       string
+		expectedFormat     string
 		printerFactory     *printer.ObjectPrinterFactory
 		standardizedFormat bool
 		printer            printer.ObjectPrinter
@@ -307,9 +308,30 @@ func (s *imageScanTestSuite) TestConstruct() {
 			standardizedFormat: true,
 			printer:            jsonPrinter,
 		},
-		"legacy output format should never create printers with empty output format": {
+		"default output should use legacy JSON without creating a printer": {
+			expectedFormat: "json",
 			legacyFormat:   "json",
 			printerFactory: emptyOutputFormatPrinterFactory,
+		},
+		"explicit legacy JSON output should use legacy JSON without creating a printer": {
+			expectedFormat: "json",
+			legacyFormat:   "json",
+			printerFactory: func() *printer.ObjectPrinterFactory {
+				factory, err := printer.NewObjectPrinterFactory("json", jsonFactory)
+				s.Require().NoError(err)
+				factory.OutputFormat = "legacy-json"
+				return factory
+			}(),
+		},
+		"explicit legacy CSV output should use legacy CSV without creating a printer": {
+			expectedFormat: "csv",
+			legacyFormat:   "json",
+			printerFactory: func() *printer.ObjectPrinterFactory {
+				factory, err := printer.NewObjectPrinterFactory("json", jsonFactory)
+				s.Require().NoError(err)
+				factory.OutputFormat = "legacy-csv"
+				return factory
+			}(),
 		},
 		"invalid printer factory should return an error": {
 			printerFactory: invalidObjPrinterFactory,
@@ -333,6 +355,7 @@ func (s *imageScanTestSuite) TestConstruct() {
 			}
 
 			s.Assert().Equal(c.printer, imgScanCmd.printer)
+			s.Assert().Equal(c.expectedFormat, imgScanCmd.format)
 			s.Assert().Equal(c.standardizedFormat, imgScanCmd.standardizedFormat)
 			s.Assert().Equal(1*time.Minute, imgScanCmd.timeout)
 		})
@@ -340,28 +363,37 @@ func (s *imageScanTestSuite) TestConstruct() {
 }
 
 func (s *imageScanTestSuite) TestDeprecationNote() {
-	expectedDeprecationNote := fmt.Sprintf("WARN:\tFlag --format has been deprecated, %s\n", deprecationNote)
-	emptyOutputFormatPrinterFactory, err := printer.NewObjectPrinterFactory("json", printer.NewJSONPrinterFactory(false, false))
-	s.Require().NoError(err)
-	emptyOutputFormatPrinterFactory.OutputFormat = ""
+	expectedLegacyJSONDeprecationNote := "WARN:\tOutput format \"legacy-json\" has been deprecated, please use --output=json to migrate to the new JSON output format. NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating.\n"
+	expectedLegacyCSVDeprecationNote := "WARN:\tOutput format \"legacy-csv\" has been deprecated, please use --output=csv to migrate to the new CSV output format. NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating.\n"
 
 	cases := map[string]struct {
-		formatChanged    bool
-		outputChanged    bool
-		printDeprecation bool
+		formatChanged bool
+		outputChanged bool
+		outputFormat  string
+		expectedNote  string
 	}{
-		"default values are not changed, the deprecation warning should be printed": {
-			printDeprecation: true,
-		},
+		"default values are not changed, the deprecation warning should not be printed": {},
 		"changes in format, deprecation warning should not be printed": {
 			formatChanged: true,
 		},
 		"changes in output format, deprecation warning should not be printed": {
 			outputChanged: true,
+			outputFormat:  "json",
 		},
 		"changes in both format and output format, deprecation warning should not be printed": {
 			outputChanged: true,
 			formatChanged: true,
+			outputFormat:  "json",
+		},
+		"explicit legacy JSON output should print deprecation warning": {
+			outputChanged: true,
+			outputFormat:  "legacy-json",
+			expectedNote:  expectedLegacyJSONDeprecationNote,
+		},
+		"explicit legacy CSV output should print deprecation warning": {
+			outputChanged: true,
+			outputFormat:  "legacy-csv",
+			expectedNote:  expectedLegacyCSVDeprecationNote,
 		},
 	}
 
@@ -371,19 +403,40 @@ func (s *imageScanTestSuite) TestDeprecationNote() {
 			io, _, _, errOut := io.TestIO()
 			imgScanCmd.env = environment.NewTestCLIEnvironment(s.T(), io, printer.DefaultColorPrinter())
 			cmd := Command(imgScanCmd.env)
+			printerFactory, err := printer.NewObjectPrinterFactory("json", printer.NewJSONPrinterFactory(false, false))
+			s.Require().NoError(err)
+			printerFactory.OutputFormat = c.outputFormat
 			cmd.Flags().Duration("timeout", 1*time.Minute, "")
 			cmd.Flags().Duration("retry-timeout", 1*time.Minute, "")
 			cmd.Flag("format").Changed = c.formatChanged
 			cmd.Flag("output").Changed = c.outputChanged
 
-			_ = imgScanCmd.Construct(nil, cmd, emptyOutputFormatPrinterFactory)
-			if c.printDeprecation {
-				s.Assert().Equal(expectedDeprecationNote, errOut.String())
+			_ = imgScanCmd.Construct(nil, cmd, printerFactory)
+			if c.expectedNote != "" {
+				s.Assert().Equal(c.expectedNote, errOut.String())
 			} else {
 				s.Assert().Empty(errOut.String())
 			}
 		})
 	}
+}
+
+func (s *imageScanTestSuite) TestFormatFlagDeprecationMessage() {
+	testIO, _, _, _ := io.TestIO()
+	env := environment.NewTestCLIEnvironment(s.T(), testIO, printer.DefaultColorPrinter())
+	cmd := Command(env)
+
+	var output bytes.Buffer
+	cmd.SetErr(&output)
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"scan", "--format", "json", "--help"})
+
+	err := cmd.Execute()
+	s.Require().NoError(err)
+
+	s.Assert().Contains(output.String(), "Flag --format has been deprecated")
+	s.Assert().Contains(output.String(), "please use --output/-o to specify the output format")
+	s.Assert().False(strings.Contains(output.String(), "please use --format="))
 }
 
 func (s *imageScanTestSuite) TestValidate() {


### PR DESCRIPTION
## Description

This change makes `roxctl image scan` deprecation guidance less confusing.

- Keep the default behavior on the legacy JSON output path when users omit
  `--output`, but make that compatibility mode explicit with an informational
  note.
- Add explicit deprecated `--output=legacy-json` and `--output=legacy-csv`
  aliases so the legacy formats are visible and named directly.
- Derive the `--output` help text from the actual registered output formats so
  the CLI help stays aligned with supported behavior.
- Ensure all deprecation messages point users toward non-deprecated
  `--output` values, and call out that the new JSON/CSV formats have breaking
  changes.

AI-Assisted: cursor, roxctl image scan deprecation flow and tests

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Ran focused local `go test` coverage for `roxctl/image/scan` around the
  changed deprecation behavior and legacy output handling.
- Added focused end-to-end Cobra parsing coverage for `--output=legacy-json`
  so the user-facing flag path is exercised directly.
- Rebuilt `roxctl` locally.
- Validated manually against a local Central on `localhost:8443` using local
  admin credentials. Example stderr behavior:

  ```text
  $ ROX_ADMIN_PASSWORD=<local-admin-password> roxctl image scan --endpoint localhost:8443 --insecure-skip-tls-verify --image nginx:1.14 --force >/dev/null
  INFO: Default image scan output currently uses deprecated legacy-json for backwards compatibility. Use --output=json to migrate to the new JSON output format. NOTE: it contains breaking changes in the format.

  $ ROX_ADMIN_PASSWORD=<local-admin-password> roxctl image scan --endpoint localhost:8443 --insecure-skip-tls-verify --image nginx:1.14 --force --format json >/dev/null
  WARN: Flag --format has been deprecated, please use --output/-o to specify the output format. NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating.

  $ ROX_ADMIN_PASSWORD=<local-admin-password> roxctl image scan --endpoint localhost:8443 --insecure-skip-tls-verify --image nginx:1.14 --force --output=legacy-json >/dev/null
  WARN: Output format "legacy-json" has been deprecated, please use --output=json to migrate to the new JSON output format. NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating.

  $ ROX_ADMIN_PASSWORD=<local-admin-password> roxctl image scan --endpoint localhost:8443 --insecure-skip-tls-verify --image nginx:1.14 --force --output=legacy-csv >/dev/null
  WARN: Output format "legacy-csv" has been deprecated, please use --output=csv to migrate to the new CSV output format. NOTE: The new JSON / CSV format contains breaking changes, make sure you adapt to the new structure before migrating.
  ```
