### PR TITLE
ROX-34625: Fix restrict-template-expressions lint error in ui

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
@@ -3,6 +3,8 @@ import { useSelector } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { selectors } from 'reducers';
 
+import { ensureExhaustive } from 'utils/type.utils';
+
 import type { Integration, IntegrationSource, IntegrationType } from '../utils/integrationUtils';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -74,8 +76,11 @@ const useIntegrations = ({ source, type }: UseIntegrations): UseIntegrationsResp
                 }
                 return cloudSources;
             }
+            case 'apiClients': {
+                return []; // source does not use hook because it does not have any integrations
+            }
             default: {
-                return [];
+                return ensureExhaustive(source);
             }
         }
     }

--- a/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
+++ b/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
@@ -75,8 +75,7 @@ const useIntegrations = ({ source, type }: UseIntegrations): UseIntegrationsResp
                 return cloudSources;
             }
             default: {
-                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                throw new Error(`Unknown source ${source}`);
+                return [];
             }
         }
     }


### PR DESCRIPTION
## Description

### Problem

Inconsistency in CI lint which reports no errors and local lint:

```sh
npm run lint:fast-dev

…/stackrox/stackrox/ui/apps/platform/src/Containers/Integrations/hooks/useIntegrations.ts
  78:17  error  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/restrict-template-expressions')
```

To put it more bluntly, master is broken.

### Analysis

Credit to **David Vail** for summary:

> A possible flaw in the new eslint caching behavior? A change in one file causes a lint error in another file, and the error isn't detected because the latter file has not changed?

1. Disable comment because `source` is not string in `default` case, because cases include all valid values.

    https://typescript-eslint.io/rules/restrict-template-expressions/

    > This rule reports on values used in a template literal string that aren't strings

2. Recent change added `'apiClients'` to string enumeration type, so causes do not include all valid values.

    Because `source` in `default` case might be a string, no error, therefore unneeded disable comment becomes an error.

    https://github.com/stackrox/stackrox/pull/20351/changes#diff-b8ef96f4fbdec13f09d4c914d145d11eaf0b28ccc1b042881fa64bf586682438R11

### Solution

1. Because throw error will crash the page and default with disable comment hides potential errors:

    * Add `return []` for new `case 'apiClients'` with comment.
    * Add `ensureExhaustive(source)` for `default` case for sake of our future selves.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
4. `npm run lint:fast-dev` in ui/apps/platform folder.