### PR TITLE
ROX-34557: Unconditionally render Reports in NavigationSidebar

### DIFF
--- a/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Navigation/NavigationSidebar.tsx
@@ -62,7 +62,7 @@ const keyForPlatformConfiguration = 'Platform Configuration';
 const keyForCompliance = 'Compliance';
 const keyForVulnerabilities = 'Vulnerability Management';
 
-// Instead of removing argument, add disable comment for @typescript-eslint/no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDescription[] {
     const vulnerabilityManagementChildren: ChildDescription[] = [
         {
@@ -96,9 +96,7 @@ function getNavDescriptions(isFeatureFlagEnabled: IsFeatureFlagEnabled): NavDesc
         },
         {
             type: 'link',
-            content: isFeatureFlagEnabled('ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING')
-                ? 'Reports'
-                : 'Vulnerability Reporting',
+            content: 'Reports',
             path: vulnerabilityReportsPath,
             routeKey: 'vulnerabilities/reports',
         },

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -467,7 +467,7 @@ const vulnerabilitiesPathToLabelMap: Record<string, string> = {
     [vulnerabilitiesBasePath]: 'Vulnerabilities',
     [vulnerabilitiesPlatformCvesPath]: 'Platform CVEs',
     [vulnerabilitiesNodeCvesPath]: 'Node CVEs',
-    [vulnerabilityReportsPath]: 'Vulnerability Reporting',
+    [vulnerabilityReportsPath]: 'Reports',
     [exceptionManagementPath]: 'Exception Management',
 };
 


### PR DESCRIPTION
## Description

### Objective

Provide equivalent filter for schduled reports as view-based reports

### Analysis and Solution

1. More specific **Image vulnerability reports** supersedes more generic **Vulnerability reporting** in breadcrumbs, headings, and titles.

2. Consistent, shorter, and intentially more generic **Reports** in left navigation might reduce churn if it links to a vulnerability reports page analogous to (but not necessarily presented like) Ingtegrations.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration

    Original conditional code with `'ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING'` disabled:
    <img width="1440" height="892" alt="Vulnerability_reporting" src="https://github.com/user-attachments/assets/8f55168e-0eeb-4621-ac6f-b0c9a6a4cab8" />

    Replaced unconditional code:
    <img width="1440" height="892" alt="Reports" src="https://github.com/user-attachments/assets/4e9802c7-bbe9-44ed-81a6-4114028b5147" />
