### PR TITLE
ROX-19064: Sync Scanner V4 Secured Cluster CR

### DIFF
--- a/tests/e2e/yaml/secured-cluster-cr-with-scanner-v4.envsubst.yaml
+++ b/tests/e2e/yaml/secured-cluster-cr-with-scanner-v4.envsubst.yaml
@@ -16,12 +16,13 @@ spec:
         memory: "100Mi"
         cpu: "300m"
   perNode:
+    fileActivityMonitoring:
+      mode: $fam_mode_setting
     collector:
       resources:
         requests:
           memory: "100Mi"
           cpu: "100m"
-      collection: $collection_method
     compliance:
       resources:
         requests:
@@ -32,6 +33,8 @@ spec:
         requests:
           memory: "100Mi"
           cpu: "100m"
+  processIndicators:
+    excludeNamespaceRegex: namespace-without-persistence
   scanner:
     scannerComponent: $scanner_component_setting
     analyzer:


### PR DESCRIPTION
## Description

Sync various values between the Scanner V4 and Non Scanner V4 variations of `secured-cluster-cr.envsubst.yaml` to address current and potentially future CI failures when Scanner V4 is enabled.

In particular, [this run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/19236/pull-ci-stackrox-stackrox-master-ocp-4-21-qa-e2e-tests/2052106964338479104) shows a failure in the `ProcessVisualizationTest` that is/was addressed by adding:

```yaml
  processIndicators:
    excludeNamespaceRegex: namespace-without-persistence
```
The equiv value was added to the non-scanner v4 variant of the CR a few weeks ago as part of https://github.com/stackrox/stackrox/pull/20184

```
22:24:48 | ERROR | ProcessVisualizationTest  | Helpers                   | An exception occurred in test
Condition not satisfied:

receivedProcessPaths.size() == 0
|                    |      |
[/usr/sbin/nginx]    1      false

	at ProcessVisualizationTest.$spock_feature_1_4(ProcessVisualizationTest.groovy:371) [1 skipped]
	at util.OnFailureInterceptor.intercept(OnFailure.groovy:72) [8 skipped]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:157) [7 skipped]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:147)
	at util.OnFailureInterceptor.intercept(OnFailure.groovy:72) [5 skipped]
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61) [4 skipped]
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Against StackRox Scanner these changes will be tested by CI as part of this PR

Against Scanner V4 these changes were validated in https://github.com/stackrox/stackrox/pull/19236 and will be validated again in a future PR when Scanner V4 is officially turned on in CI.
