### PR TITLE
ROX-34762: Move logging and metrics out of locks

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -80,25 +80,7 @@ func NewQueue[T comparable](opts ...OptionFunc[T]) *Queue[T] {
 // Pull will pull an item from the queue. If the queue is empty, the default value of T will be returned.
 // Note that his does not wait for items to be available in the queue, use PullBlocking instead.
 func (q *Queue[T]) Pull() T {
-	q.mutex.Lock()
-	defer q.mutex.Unlock()
-
-	if q.queue.Len() == 0 {
-		var nilT T
-		return nilT
-	}
-
-	item := q.queue.Remove(q.queue.Front()).(T)
-
-	if q.counterMetric != nil {
-		// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
-		q.counterMetric.WithLabelValues(metrics.Remove.String()).Inc()
-	}
-
-	if q.queue.Len() == 0 {
-		q.notEmptySignal.Reset()
-	}
-
+	item, _ := q.pull()
 	return item
 }
 
@@ -135,7 +117,7 @@ func (q *Queue[T]) Seq(waitable concurrency.Waitable) func(yield func(T) bool) {
 	}
 }
 
-func (q *Queue[T]) pull() (T, bool) {
+func (q *Queue[T]) innerPull() (T, bool) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
@@ -145,12 +127,6 @@ func (q *Queue[T]) pull() (T, bool) {
 	}
 
 	item := q.queue.Remove(q.queue.Front()).(T)
-
-	if q.counterMetric != nil {
-		// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
-		q.counterMetric.WithLabelValues(metrics.Remove.String()).Inc()
-	}
-
 	if q.queue.Len() == 0 {
 		q.notEmptySignal.Reset()
 	}
@@ -158,14 +134,31 @@ func (q *Queue[T]) pull() (T, bool) {
 	return item, true
 }
 
-// Push adds an item to the queue.
-// Note that in case the queue is full, no error will be returned but rather only a log emitted.
-func (q *Queue[T]) Push(item T) {
+func (q *Queue[T]) pull() (T, bool) {
+	item, ok := q.innerPull()
+	if ok && q.counterMetric != nil {
+		// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+		q.counterMetric.WithLabelValues(metrics.Remove.String()).Inc()
+	}
+	return item, ok
+}
+
+func (q *Queue[T]) innerPush(item T) bool {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
 	if q.maxSize != 0 && q.queue.Len() >= q.maxSize {
+		return false
+	}
 
+	q.queue.PushBack(item)
+	return true
+}
+
+// Push adds an item to the queue.
+// Note that in case the queue is full, no error will be returned but rather only a log emitted.
+func (q *Queue[T]) Push(item T) {
+	if !q.innerPush(item) {
 		logging.GetRateLimitedLogger().WarnL(loggingRateLimiter, "Queue (%s) size limit reached (%d). New items added to the queue will be dropped.", q.name, q.maxSize)
 		if q.droppedMetric != nil {
 			q.droppedMetric.Inc()
@@ -173,12 +166,11 @@ func (q *Queue[T]) Push(item T) {
 		return
 	}
 
-	defer q.notEmptySignal.Signal()
+	q.notEmptySignal.Signal()
 	if q.counterMetric != nil {
 		// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
 		q.counterMetric.WithLabelValues(metrics.Add.String()).Inc()
 	}
-	q.queue.PushBack(item)
 }
 
 // Len returns the number of elements in the queue.

--- a/sensor/common/filesystem/pipeline/pipeline.go
+++ b/sensor/common/filesystem/pipeline/pipeline.go
@@ -202,21 +202,20 @@ func cacheKey(containerID, processSignalID string) string {
 	return containerID + ":" + processSignalID
 }
 
-func (p *Pipeline) bufferActivity(fs *sensorAPI.FileActivity) {
-	process := fs.GetProcess()
-	if process == nil {
-		return
-	}
+type bufferResult int
 
-	key := cacheKey(process.GetContainerId(), process.GetId())
+const (
+	bufferOK bufferResult = iota
+	bufferFullGlobal
+	bufferFullPerProcess
+)
+
+func (p *Pipeline) bufferActivityLocked(key string, fs *sensorAPI.FileActivity) (bufferResult, int) {
 	p.activityMutex.Lock()
 	defer p.activityMutex.Unlock()
 
 	if p.totalBufferedActivity >= maxTotalBufferedActivities {
-		log.Warnf("File activity buffer is full (%d activities), dropping file activity for process %s",
-			maxTotalBufferedActivities, process.GetId())
-		metrics.IncrementFileActivityBufferDrops()
-		return
+		return bufferFullGlobal, 0
 	}
 
 	entry, exists := p.bufferedActivity[key]
@@ -229,15 +228,35 @@ func (p *Pipeline) bufferActivity(fs *sensorAPI.FileActivity) {
 	}
 
 	if len(entry.activities) >= maxBufferedActivitiesPerProcess {
-		log.Warnf("Too many buffered activities for process %s (limit: %d), dropping file activity",
-			process.GetId(), maxBufferedActivitiesPerProcess)
-		metrics.IncrementFileActivityBufferDrops()
-		return
+		return bufferFullPerProcess, 0
 	}
 
 	entry.activities = append(entry.activities, fs)
 	p.totalBufferedActivity++
-	metrics.SetFileActivityBufferSize(p.totalBufferedActivity)
+	return bufferOK, p.totalBufferedActivity
+}
+
+func (p *Pipeline) bufferActivity(fs *sensorAPI.FileActivity) {
+	process := fs.GetProcess()
+	if process == nil {
+		return
+	}
+
+	key := cacheKey(process.GetContainerId(), process.GetId())
+	result, bufferSize := p.bufferActivityLocked(key, fs)
+
+	switch result {
+	case bufferFullGlobal:
+		log.Warnf("File activity buffer is full (%d activities), dropping file activity for process %s",
+			maxTotalBufferedActivities, process.GetId())
+		metrics.IncrementFileActivityBufferDrops()
+	case bufferFullPerProcess:
+		log.Warnf("Too many buffered activities for process %s (limit: %d), dropping file activity",
+			process.GetId(), maxBufferedActivitiesPerProcess)
+		metrics.IncrementFileActivityBufferDrops()
+	default:
+		metrics.SetFileActivityBufferSize(bufferSize)
+	}
 }
 
 func (p *Pipeline) popBufferedActivity(key string) []*sensorAPI.FileActivity {
@@ -351,30 +370,37 @@ func (p *Pipeline) cleanupExpiredBuffers() {
 	}
 }
 
-func (p *Pipeline) pruneExpiredBuffers() {
+func (p *Pipeline) pruneExpiredBuffersLocked(now time.Time) (pruned, droppedActivities, bufferSize int) {
 	p.activityMutex.Lock()
 	defer p.activityMutex.Unlock()
-
-	now := time.Now()
-	pruned := 0
 
 	for key, entry := range p.bufferedActivity {
 		if now.Sub(entry.timestamp) > bufferedActivityTTL {
 			p.totalBufferedActivity -= len(entry.activities)
-			metrics.IncrementFileActivityBufferDropsBy(len(entry.activities))
+			droppedActivities += len(entry.activities)
 			delete(p.bufferedActivity, key)
 			pruned++
 		}
 	}
-
 	if p.totalBufferedActivity < 0 {
-		log.Warnf("totalBufferedActivity went negative (%d), resetting to 0 (possible accounting bug)", p.totalBufferedActivity)
+		bufferSize = p.totalBufferedActivity
 		p.totalBufferedActivity = 0
+	} else {
+		bufferSize = p.totalBufferedActivity
 	}
+	return pruned, droppedActivities, bufferSize
+}
 
+func (p *Pipeline) pruneExpiredBuffers() {
+	pruned, droppedActivities, bufferSize := p.pruneExpiredBuffersLocked(time.Now())
+
+	if bufferSize < 0 {
+		log.Warnf("totalBufferedActivity went negative (%d), resetting to 0 (possible accounting bug)", bufferSize)
+	}
 	if pruned > 0 {
+		metrics.IncrementFileActivityBufferDropsBy(droppedActivities)
+		metrics.SetFileActivityBufferSize(max(bufferSize, 0))
 		log.Debugf("Pruned %d expired file activity buffers (TTL: %v)", pruned, bufferedActivityTTL)
-		metrics.SetFileActivityBufferSize(p.totalBufferedActivity)
 	}
 }
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

In a test of the long running cluster with file activity. Sensor crashed multiple times. Some of those crashes had the following error

```
root logger: 2026/05/07 01:41:20.954400 logger.go:77: Warn: pkg/queue/queue.go:167 - Queue (FileAccessQueue) size limit reached (40960). New items added to the queue will be dropped. - 6877 log suppressed for limiter "pkg-queue"
root logger: 2026/05/07 01:43:39.071125 logger.go:77: Warn: pkg/queue/queue.go:167 - Queue (FileAccessQueue) size limit reached (40960). New items added to the queue will be dropped.
Action Mutex.Unlock took more than 10s to complete. Stack trace:
github.com/stackrox/rox/pkg/sync.(*Mutex).Unlock (github.com/stackrox/rox/pkg/sync/mutex_dev.go:88)
github.com/stackrox/rox/pkg/queue.(*Queue[...]).Push (github.com/stackrox/rox/pkg/queue/queue.go:171)
github.com/stackrox/rox/sensor/common/detector/queue.(*Queue[...]).Push (github.com/stackrox/rox/sensor/common/detector/queue/queue.go:55)
github.com/stackrox/rox/sensor/common/detector.(*detectorImpl).pushFileAccess (github.com/stackrox/rox/sensor/common/detector/detector.go:898)
github.com/stackrox/rox/sensor/common/detector.(*detectorImpl).ProcessFileAccess (github.com/stackrox/rox/sensor/common/detector/detector.go:871)
github.com/stackrox/rox/sensor/common/filesystem/pipeline.(*Pipeline).processEnrichedIndicator (github.com/stackrox/rox/sensor/common/filesystem/pipeline/pipeline.go:285)
github.com/stackrox/rox/sensor/common/pubsub/consumer.(*DefaultConsumer).Consume.func1.1 (github.com/stackrox/rox/sensor/common/pubsub/consumer/default.go:43)
github.com/stackrox/rox/sensor/common/pubsub/consumer.(*DefaultConsumer).Consume.func1 (github.com/stackrox/rox/sensor/common/pubsub/consumer/default.go:48)
runtime.goexit (runtime/asm_amd64.s:1693)
root logger: 2026/05/07 01:43:39.071543 logger.go:77: Warn: pkg/queue/queue.go:167 - Queue (FlowsQueue) size limit reached (40960). New items added to the queue will be dropped.
```

This error is caused by the lock in `Push` method in the queue timing out. To reduce the chances of this error occurring in the future, logging and metrics are moved outside of the lock.

Other metrics and logs are also moved out of locks in `pruneExpiredBuffers`  `sensor/common/filesystem/pipeline/pipeline.go`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Created a long running cluster. The workflow is at https://github.com/stackrox/test-gh-actions/actions/runs/25965870993/job/76329647709 
