### PR TITLE
chore(ci): reduce deployment check flake race

### DIFF
--- a/tests/common.go
+++ b/tests/common.go
@@ -208,10 +208,20 @@ func waitForDeploymentReadyInK8s(t testutils.T, deploymentName, namespace string
 				continue
 			}
 
-			// Ensure all pods are from the current generation (no old pods during rollout)
-			if deploy.Status.UpdatedReplicas > 0 && deploy.Status.UpdatedReplicas != deploy.Status.Replicas {
+			// Ensure all pods are from the current generation (no old pods during rollout).
+			if deploy.Spec.Replicas != nil && deploy.Status.UpdatedReplicas < *deploy.Spec.Replicas {
 				t.Logf("Deployment %q in namespace %q NOT ready: rollout incomplete (%d/%d updated replicas)",
-					deploymentName, namespace, deploy.Status.UpdatedReplicas, deploy.Status.Replicas)
+					deploymentName, namespace, deploy.Status.UpdatedReplicas, *deploy.Spec.Replicas)
+				continue
+			}
+			if deploy.Status.Replicas > deploy.Status.UpdatedReplicas {
+				t.Logf("Deployment %q in namespace %q NOT ready: old replicas pending termination (%d total, %d updated)",
+					deploymentName, namespace, deploy.Status.Replicas, deploy.Status.UpdatedReplicas)
+				continue
+			}
+			if deploy.Status.AvailableReplicas < deploy.Status.UpdatedReplicas {
+				t.Logf("Deployment %q in namespace %q NOT ready: updated replicas not yet available (%d/%d available)",
+					deploymentName, namespace, deploy.Status.AvailableReplicas, deploy.Status.UpdatedReplicas)
 				continue
 			}
 
@@ -993,8 +1003,16 @@ func (ks *KubernetesSuite) waitUntilK8sDeploymentReady(ctx context.Context, name
 			}
 
 			// Ensure all pods are from the current generation (no old pods during rollout).
-			if deploy.Status.UpdatedReplicas > 0 && deploy.Status.UpdatedReplicas != deploy.Status.Replicas {
-				ks.logf("deployment %q in namespace %q NOT ready, rollout incomplete (%d/%d updated replicas)", deploymentName, namespace, deploy.Status.UpdatedReplicas, deploy.Status.Replicas)
+			if deploy.Spec.Replicas != nil && deploy.Status.UpdatedReplicas < *deploy.Spec.Replicas {
+				ks.logf("deployment %q in namespace %q NOT ready, rollout incomplete (%d/%d updated replicas)", deploymentName, namespace, deploy.Status.UpdatedReplicas, *deploy.Spec.Replicas)
+				continue
+			}
+			if deploy.Status.Replicas > deploy.Status.UpdatedReplicas {
+				ks.logf("deployment %q in namespace %q NOT ready, old replicas pending termination (%d total, %d updated)", deploymentName, namespace, deploy.Status.Replicas, deploy.Status.UpdatedReplicas)
+				continue
+			}
+			if deploy.Status.AvailableReplicas < deploy.Status.UpdatedReplicas {
+				ks.logf("deployment %q in namespace %q NOT ready, updated replicas not yet available (%d/%d available)", deploymentName, namespace, deploy.Status.AvailableReplicas, deploy.Status.UpdatedReplicas)
 				continue
 			}
 


### PR DESCRIPTION
## Description

Attempts to address flake in deployment readiness check that could return prematurely.

The delegated scanning test has occasionally flaked ([example](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/20434/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/2052794442896642048)) (possibly other tests too), some errors observed:

  - `retrieving logs of pod "sensor-78bddb47db-cd79x" failed: the server could not find the requested resource` (old pod gone)
  - `retrieving logs of pod "sensor-7d5bfc74d4-2kdv5" failed: the server rejected our request for an unknown reason` (new pod not fully ready)

The root cause: is a sensor deployment rollout mid test vs. in test setup, which should not happen given the test setup waits for the updated sensor pod to be ready.

This PR modifies the utility methods that waits for deploys to include the additional checks from `kubectl rollout status` ([source](https://github.com/kubernetes/kubectl/blob/a0b5ff27443c6477528900e731c03cf2bd1bd302/pkg/polymorphichelpers/rollout_status.go#L59))





## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

CI