### PR TITLE
ROX-34639: Reduce applySingleNoLock allocation churn

### DIFF
--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -128,6 +128,9 @@ func (e *endpointsStore) purgeNoLock(deploymentID string) {
 
 func (e *endpointsStore) applySingleNoLock(deploymentID string, data EntityData) {
 	if len(data.endpoints) == 0 {
+		if _, exists := e.reverseEndpointMap[deploymentID]; !exists {
+			e.reverseEndpointMap[deploymentID] = nil
+		}
 		return
 	}
 

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -127,21 +127,27 @@ func (e *endpointsStore) purgeNoLock(deploymentID string) {
 }
 
 func (e *endpointsStore) applySingleNoLock(deploymentID string, data EntityData) {
+	if len(data.endpoints) == 0 {
+		return
+	}
+
 	dSet, deploymentFound := e.reverseEndpointMap[deploymentID]
 	if !deploymentFound || dSet == nil {
-		dSet = set.NewSet[net.NumericEndpoint]()
+		dSet = make(set.Set[net.NumericEndpoint], len(data.endpoints))
+		e.reverseEndpointMap[deploymentID] = dSet
 	}
 
 	for ep, targetInfos := range data.endpoints {
 		dSet.Add(ep)
-		e.reverseEndpointMap[deploymentID] = dSet
 
 		deploymentsOnThisEp, epFound := e.endpointMap[ep]
 		if !epFound {
-			e.endpointMap[ep] = make(map[string]set.Set[EndpointTargetInfo])
+			e.endpointMap[ep] = map[string]set.Set[EndpointTargetInfo]{
+				deploymentID: make(set.Set[EndpointTargetInfo], len(targetInfos)),
+			}
 		} else if !deploymentFound {
 			// New deployment, but the endpoint exists - the new deployment takes over the already existing endpoint
-			e.endpointMap[ep][deploymentID] = set.NewSet[EndpointTargetInfo]()
+			e.endpointMap[ep][deploymentID] = make(set.Set[EndpointTargetInfo], len(targetInfos))
 			// Mark all other deployments having with this endpoint as historical
 			for otherDeploymentID := range deploymentsOnThisEp {
 				// Currently added deployment is already in the map, so do not mark it historical
@@ -149,15 +155,13 @@ func (e *endpointsStore) applySingleNoLock(deploymentID string, data EntityData)
 					e.moveToHistory(otherDeploymentID, ep)
 				}
 			}
+		} else if _, targetFound := e.endpointMap[ep][deploymentID]; !targetFound {
+			e.endpointMap[ep][deploymentID] = make(set.Set[EndpointTargetInfo], len(targetInfos))
 		}
-		etiSet, targetFound := e.endpointMap[ep][deploymentID]
-		if !targetFound {
-			etiSet = set.NewSet[EndpointTargetInfo]()
-		}
+		etiSet := e.endpointMap[ep][deploymentID]
 		for _, tgtInfo := range targetInfos {
 			etiSet.Add(tgtInfo)
 		}
-		e.endpointMap[ep][deploymentID] = etiSet
 		// Endpoints previously marked as historical may need to be restored.
 		e.deleteFromHistory(deploymentID, ep)
 	}

--- a/sensor/common/clusterentities/store_endpoints_benchmark_test.go
+++ b/sensor/common/clusterentities/store_endpoints_benchmark_test.go
@@ -54,33 +54,6 @@ func BenchmarkEndpointsStoreAddToHistory(b *testing.B) {
 	}
 }
 
-func TestApplySingleNoLock_AllocationsForNewDeployment(t *testing.T) {
-	data := benchmarkGenerateEntityData(50, 4)
-
-	allocs := testing.AllocsPerRun(100, func() {
-		store := newEndpointsStoreWithMemory(5)
-		store.applySingleNoLock("depl-bench", *data)
-	})
-
-	if allocs > 220 {
-		t.Fatalf("expected applySingleNoLock to stay within allocation budget, got %.0f allocations", allocs)
-	}
-}
-
-func benchmarkGenerateEntityData(numEndpoints, targetsPerEndpoint int) *EntityData {
-	data := &EntityData{}
-	for endpointIdx := range numEndpoints {
-		endpoint := buildEndpoint(fmt.Sprintf("10.%d.%d.%d", (endpointIdx/65536)%256, (endpointIdx/256)%256, endpointIdx%256), 8080)
-		for targetIdx := range targetsPerEndpoint {
-			data.AddEndpoint(endpoint, EndpointTargetInfo{
-				ContainerPort: uint16(8080 + targetIdx),
-				PortName:      fmt.Sprintf("port-%d", targetIdx),
-			})
-		}
-	}
-	return data
-}
-
 // legacy is the version used in 4.10.0 and earlier (before backporting the fix).
 /*
 Running tool: /usr/local/go/bin/go test -test.fullpath=true -benchmem -run=^$ -bench ^BenchmarkEndpointsStoreAddToHistory$ github.com/stackrox/rox/sensor/common/clusterentities -count=1
@@ -98,3 +71,38 @@ BenchmarkEndpointsStoreAddToHistory/legacy_endpoints_5000-12 	    2221	    53532
 PASS
 ok  	github.com/stackrox/rox/sensor/common/clusterentities	7.895s
 */
+
+func BenchmarkApplySingleNoLock_AllocationsForNewDeployment(b *testing.B) {
+	for _, tc := range []struct {
+		name               string
+		numEndpoints       int
+		targetsPerEndpoint int
+	}{
+		{name: "50x4", numEndpoints: 50, targetsPerEndpoint: 4},
+		{name: "500x4", numEndpoints: 500, targetsPerEndpoint: 4},
+		{name: "5000x4", numEndpoints: 5000, targetsPerEndpoint: 4},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			data := benchmarkGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
+			b.ReportAllocs()
+			for b.Loop() {
+				store := newEndpointsStoreWithMemory(5)
+				store.applySingleNoLock("depl-bench", *data)
+			}
+		})
+	}
+}
+
+func benchmarkGenerateEntityData(numEndpoints, targetsPerEndpoint int) *EntityData {
+	data := &EntityData{}
+	for endpointIdx := range numEndpoints {
+		endpoint := buildEndpoint(fmt.Sprintf("10.%d.%d.%d", (endpointIdx/65536)%256, (endpointIdx/256)%256, endpointIdx%256), 8080)
+		for targetIdx := range targetsPerEndpoint {
+			data.AddEndpoint(endpoint, EndpointTargetInfo{
+				ContainerPort: uint16(8080 + targetIdx),
+				PortName:      fmt.Sprintf("port-%d", targetIdx),
+			})
+		}
+	}
+	return data
+}

--- a/sensor/common/clusterentities/store_endpoints_benchmark_test.go
+++ b/sensor/common/clusterentities/store_endpoints_benchmark_test.go
@@ -54,6 +54,33 @@ func BenchmarkEndpointsStoreAddToHistory(b *testing.B) {
 	}
 }
 
+func TestApplySingleNoLock_AllocationsForNewDeployment(t *testing.T) {
+	data := benchmarkGenerateEntityData(50, 4)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		store := newEndpointsStoreWithMemory(5)
+		store.applySingleNoLock("depl-bench", *data)
+	})
+
+	if allocs > 220 {
+		t.Fatalf("expected applySingleNoLock to stay within allocation budget, got %.0f allocations", allocs)
+	}
+}
+
+func benchmarkGenerateEntityData(numEndpoints, targetsPerEndpoint int) *EntityData {
+	data := &EntityData{}
+	for endpointIdx := range numEndpoints {
+		endpoint := buildEndpoint(fmt.Sprintf("10.%d.%d.%d", (endpointIdx/65536)%256, (endpointIdx/256)%256, endpointIdx%256), 8080)
+		for targetIdx := range targetsPerEndpoint {
+			data.AddEndpoint(endpoint, EndpointTargetInfo{
+				ContainerPort: uint16(8080 + targetIdx),
+				PortName:      fmt.Sprintf("port-%d", targetIdx),
+			})
+		}
+	}
+	return data
+}
+
 // legacy is the version used in 4.10.0 and earlier (before backporting the fix).
 /*
 Running tool: /usr/local/go/bin/go test -test.fullpath=true -benchmem -run=^$ -bench ^BenchmarkEndpointsStoreAddToHistory$ github.com/stackrox/rox/sensor/common/clusterentities -count=1

--- a/sensor/common/clusterentities/store_endpoints_test.go
+++ b/sensor/common/clusterentities/store_endpoints_test.go
@@ -366,6 +366,29 @@ func buildExpectation(ip, deplID, portName string, location whereThingIsStored, 
 	}
 }
 
+func (s *ClusterEntitiesStoreTestSuite) TestEmptyEndpointUpdatePreservesSeenState() {
+	store := NewStore(5, nil, true)
+
+	// First update: deployment has a container but no endpoints (e.g., no Service yet).
+	noEndpoints := &EntityData{}
+	noEndpoints.AddContainerID("ctr-a", ContainerMetadata{DeploymentID: "deplA"})
+	store.Apply(map[string]*EntityData{"deplA": noEndpoints}, false)
+
+	// Second update: deployment gets a real endpoint, shared with deplB.
+	ep := buildEndpoint("10.0.0.1", 80)
+	deplB := &EntityData{}
+	deplB.AddEndpoint(ep, EndpointTargetInfo{ContainerPort: 80, PortName: "http"})
+	store.Apply(map[string]*EntityData{"deplB": deplB}, true)
+
+	deplA := &EntityData{}
+	deplA.AddEndpoint(ep, EndpointTargetInfo{ContainerPort: 80, PortName: "http"})
+	store.Apply(map[string]*EntityData{"deplA": deplA}, false)
+
+	// deplB must NOT have been moved to history — deplA was already "seen".
+	_, hasHistory := store.endpointsStore.reverseHistoricalEndpoints["deplB"]
+	s.False(hasHistory, "deplB should not be moved to history when deplA was previously seen with empty endpoints")
+}
+
 func (s *ClusterEntitiesStoreTestSuite) TestEndpointTakeoverFastPathDoesNotPolluteReverseHistory() {
 	store := NewStore(5, nil, true)
 


### PR DESCRIPTION
## Description

Reduce avoidable allocation churn in `endpointsStore.applySingleNoLock()` by pre-sizing the per-deployment and per-endpoint collections and returning early for empty endpoint payloads. This keeps the hot path smaller without changing endpoint ownership or history semantics.

AI-Assisted: cursor, drafted and implemented a focused sensor performance optimization

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- CI & Benchmark

#### Benchmark results

Used `BenchmarkApplySingleNoLock_AllocationsForNewDeployment` from `sensor/common/clusterentities/store_endpoints_benchmark_test.go`.

Command:
- `go test ./sensor/common/clusterentities -run '^$' -bench '^BenchmarkApplySingleNoLock_AllocationsForNewDeployment$' -benchmem -count=100 -benchtime=500ms`

Environment:
- `darwin/arm64`
- `Apple M3 Pro`

`benchstat`:

```text
                                                        │        base         │        after        │
                                                        │       sec/op        │       sec/op        │
ApplySingleNoLock_AllocationsForNewDeployment/50x4-12         32.37µ ± 0%         29.15µ ± 0%   -9.95% (n=100)
ApplySingleNoLock_AllocationsForNewDeployment/500x4-12        350.1µ ± 0%         308.0µ ± 1%  -12.01% (n=100)
ApplySingleNoLock_AllocationsForNewDeployment/5000x4-12       3.512m ± 0%         3.158m ± 1%  -10.08% (n=100)
geomean                                                       341.4µ              304.9µ       -10.69%

                                                        │        base         │        after        │
                                                        │        B/op         │        B/op         │
ApplySingleNoLock_AllocationsForNewDeployment/50x4-12        47.02Ki ± 0%        43.02Ki ± 0%   -8.51% (n=100)
ApplySingleNoLock_AllocationsForNewDeployment/500x4-12       585.9Ki ± 0%        509.8Ki ± 0%  -12.99% (n=100)
ApplySingleNoLock_AllocationsForNewDeployment/5000x4-12      5.083Mi ± 0%        4.516Mi ± 0%  -11.15% (n=100)
geomean                                                      523.4Ki             466.3Ki       -10.90%

                                                        │        base         │        after        │
                                                        │      allocs/op      │      allocs/op      │
ApplySingleNoLock_AllocationsForNewDeployment/50x4-12          223.0 ± 0%           218.0 ± 0%  -2.24% (n=100)
ApplySingleNoLock_AllocationsForNewDeployment/500x4-12        2.039k ± 0%          2.026k ± 0%  -0.64% (n=100)
ApplySingleNoLock_AllocationsForNewDeployment/5000x4-12       20.10k ± 0%          20.07k ± 0%  -0.15% (n=100)
geomean                                                       2.091k               2.070k       -1.01%
```