### PR TITLE
ROX-34640: Reuse node IPs while building deployment endpoints

### DIFF
--- a/sensor/kubernetes/listener/resources/endpoints.go
+++ b/sensor/kubernetes/listener/resources/endpoints.go
@@ -99,13 +99,20 @@ func (m *endpointManagerImpl) addEndpointDataForPod(pod *v1.Pod, data *clusteren
 
 func (m *endpointManagerImpl) endpointDataForDeployment(w *deploymentWrap) *clusterentities.EntityData {
 	result := &clusterentities.EntityData{}
-	allNodeIPs := m.getAllNodeIPs()
 
 	for _, pod := range w.pods {
 		m.addEndpointDataForPod(pod, result)
 	}
 
-	for _, svc := range m.serviceStore.getMatchingServicesWithRoutes(w.Namespace, w.PodLabels) {
+	services := m.serviceStore.getMatchingServicesWithRoutes(w.Namespace, w.PodLabels)
+	var allNodeIPs []net.IPAddress
+	for _, svc := range services {
+		if svc.serviceWrap.Spec.Type == v1.ServiceTypeLoadBalancer || svc.serviceWrap.Spec.Type == v1.ServiceTypeNodePort {
+			allNodeIPs = m.getAllNodeIPs()
+			break
+		}
+	}
+	for _, svc := range services {
 		m.addEndpointDataForService(w, svc.serviceWrap, allNodeIPs, result)
 	}
 

--- a/sensor/kubernetes/listener/resources/endpoints.go
+++ b/sensor/kubernetes/listener/resources/endpoints.go
@@ -104,15 +104,13 @@ func (m *endpointManagerImpl) endpointDataForDeployment(w *deploymentWrap) *clus
 		m.addEndpointDataForPod(pod, result)
 	}
 
-	services := m.serviceStore.getMatchingServicesWithRoutes(w.Namespace, w.PodLabels)
 	var allNodeIPs []net.IPAddress
-	for _, svc := range services {
-		if svc.serviceWrap.Spec.Type == v1.ServiceTypeLoadBalancer || svc.serviceWrap.Spec.Type == v1.ServiceTypeNodePort {
+	for _, svc := range m.serviceStore.getMatchingServicesWithRoutes(w.Namespace, w.PodLabels) {
+		if allNodeIPs == nil &&
+			(svc.serviceWrap.Spec.Type == v1.ServiceTypeLoadBalancer ||
+				svc.serviceWrap.Spec.Type == v1.ServiceTypeNodePort) {
 			allNodeIPs = m.getAllNodeIPs()
-			break
 		}
-	}
-	for _, svc := range services {
 		m.addEndpointDataForService(w, svc.serviceWrap, allNodeIPs, result)
 	}
 

--- a/sensor/kubernetes/listener/resources/endpoints.go
+++ b/sensor/kubernetes/listener/resources/endpoints.go
@@ -105,11 +105,13 @@ func (m *endpointManagerImpl) endpointDataForDeployment(w *deploymentWrap) *clus
 	}
 
 	var allNodeIPs []net.IPAddress
+	var nodeIPsLoaded bool
 	for _, svc := range m.serviceStore.getMatchingServicesWithRoutes(w.Namespace, w.PodLabels) {
-		if allNodeIPs == nil &&
+		if !nodeIPsLoaded &&
 			(svc.serviceWrap.Spec.Type == v1.ServiceTypeLoadBalancer ||
 				svc.serviceWrap.Spec.Type == v1.ServiceTypeNodePort) {
 			allNodeIPs = m.getAllNodeIPs()
+			nodeIPsLoaded = true
 		}
 		m.addEndpointDataForService(w, svc.serviceWrap, allNodeIPs, result)
 	}

--- a/sensor/kubernetes/listener/resources/endpoints.go
+++ b/sensor/kubernetes/listener/resources/endpoints.go
@@ -99,13 +99,14 @@ func (m *endpointManagerImpl) addEndpointDataForPod(pod *v1.Pod, data *clusteren
 
 func (m *endpointManagerImpl) endpointDataForDeployment(w *deploymentWrap) *clusterentities.EntityData {
 	result := &clusterentities.EntityData{}
+	allNodeIPs := m.getAllNodeIPs()
 
 	for _, pod := range w.pods {
 		m.addEndpointDataForPod(pod, result)
 	}
 
 	for _, svc := range m.serviceStore.getMatchingServicesWithRoutes(w.Namespace, w.PodLabels) {
-		m.addEndpointDataForService(w, svc.serviceWrap, result)
+		m.addEndpointDataForService(w, svc.serviceWrap, allNodeIPs, result)
 	}
 
 	m.podStore.forEach(w.GetNamespace(), w.GetId(), func(p *storage.Pod) {
@@ -134,6 +135,14 @@ func (m *endpointManagerImpl) endpointDataForDeployment(w *deploymentWrap) *clus
 	})
 
 	return result
+}
+
+func (m *endpointManagerImpl) getAllNodeIPs() []net.IPAddress {
+	var allNodeIPs []net.IPAddress
+	for _, node := range m.nodeStore.getNodes() {
+		allNodeIPs = append(allNodeIPs, node.addresses...)
+	}
+	return allNodeIPs
 }
 
 func getAllServiceIPs(svc *v1.Service) (serviceIPs []net.IPAddress) {
@@ -180,17 +189,14 @@ func addEndpointDataForServicePort(deployment *deploymentWrap, serviceIPs []net.
 	}
 }
 
-func (m *endpointManagerImpl) addEndpointDataForService(deployment *deploymentWrap, svc *serviceWrap, data *clusterentities.EntityData) {
-	var allNodeIPs []net.IPAddress
+func (m *endpointManagerImpl) addEndpointDataForService(deployment *deploymentWrap, svc *serviceWrap, allNodeIPs []net.IPAddress, data *clusterentities.EntityData) {
+	var nodeIPs []net.IPAddress
 	if svc.Spec.Type == v1.ServiceTypeLoadBalancer || svc.Spec.Type == v1.ServiceTypeNodePort {
-		for _, node := range m.nodeStore.getNodes() {
-			allNodeIPs = append(allNodeIPs, node.addresses...)
-		}
+		nodeIPs = allNodeIPs
 	}
-
 	serviceIPs := getAllServiceIPs(svc.Service)
 	for _, port := range svc.Spec.Ports {
-		addEndpointDataForServicePort(deployment, serviceIPs, allNodeIPs, port, data)
+		addEndpointDataForServicePort(deployment, serviceIPs, nodeIPs, port, data)
 	}
 }
 

--- a/sensor/kubernetes/listener/resources/endpoints_bench_test.go
+++ b/sensor/kubernetes/listener/resources/endpoints_bench_test.go
@@ -1,0 +1,94 @@
+package resources
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/net"
+	"github.com/stackrox/rox/sensor/common/service"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func BenchmarkEndpointDataForDeployment_NodePortServices(b *testing.B) {
+	for _, tc := range []struct {
+		name        string
+		numServices int
+		numNodes    int
+	}{
+		{name: "services_10_nodes_10", numServices: 10, numNodes: 10},
+		{name: "services_100_nodes_10", numServices: 100, numNodes: 10},
+		{name: "services_100_nodes_100", numServices: 100, numNodes: 100},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			manager, deployment := benchmarkEndpointDataForDeploymentSetup(tc.numServices, tc.numNodes)
+			b.ReportAllocs()
+
+			for b.Loop() {
+				_ = manager.endpointDataForDeployment(deployment)
+			}
+		})
+	}
+}
+
+func benchmarkEndpointDataForDeploymentSetup(numServices, numNodes int) (*endpointManagerImpl, *deploymentWrap) {
+	serviceStore := newServiceStore()
+	nodeStore := newNodeStore()
+
+	labels := map[string]string{"app": "api"}
+	for i := range numServices {
+		serviceStore.addOrUpdateService(wrapService(&v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("svc-%d", i),
+				Namespace: "stackrox",
+				UID:       types.UID(fmt.Sprintf("svc-%d", i)),
+			},
+			Spec: v1.ServiceSpec{
+				Type:      v1.ServiceTypeNodePort,
+				ClusterIP: benchmarkIPv4(10, i),
+				Selector:  labels,
+				Ports: []v1.ServicePort{{
+					Name:       fmt.Sprintf("port-%d", i),
+					Port:       80,
+					NodePort:   int32(30_000 + i),
+					Protocol:   v1.ProtocolTCP,
+					TargetPort: intstr.FromInt32(int32(8_080 + i)),
+				}},
+			},
+		}))
+	}
+
+	for i := range numNodes {
+		nodeStore.addOrUpdateNode(&nodeWrap{
+			Node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("node-%d", i),
+				},
+			},
+			addresses: []net.IPAddress{
+				net.ParseIP(benchmarkIPv4(11, i*2)),
+				net.ParseIP(benchmarkIPv4(12, i*2+1)),
+			},
+		})
+	}
+
+	manager := newEndpointManager(serviceStore, newDeploymentStore(), newPodStore(), nodeStore, nil)
+	deployment := &deploymentWrap{
+		Deployment: &storage.Deployment{
+			Id:        "deployment-1",
+			Namespace: "stackrox",
+			PodLabels: labels,
+		},
+		portConfigs: map[service.PortRef]*storage.PortConfig{},
+	}
+
+	return manager, deployment
+}
+
+func benchmarkIPv4(firstOctet, idx int) string {
+	idx++
+	return fmt.Sprintf("%d.%d.%d.%d", firstOctet, (idx/65_536)%256, (idx/256)%256, idx%256)
+}

--- a/sensor/kubernetes/listener/resources/endpoints_test.go
+++ b/sensor/kubernetes/listener/resources/endpoints_test.go
@@ -1,11 +1,14 @@
 package resources
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/sensor/common/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -90,10 +93,14 @@ func TestEndpointDataForDeployment_ReusesFlattenedNodeIPsAcrossServices(t *testi
 		portConfigs: map[service.PortRef]*storage.PortConfig{},
 	})
 
-	if nodeStore.getNodesCalls != 1 {
-		t.Fatalf("expected getNodes to be called once per deployment build, got %d", nodeStore.getNodesCalls)
-	}
-	if data == nil {
-		t.Fatal("expected endpoint data to be returned")
+	require.Equal(t, 1, nodeStore.getNodesCalls, "getNodes should be called exactly once per deployment build")
+	require.NotNil(t, data, "expected endpoint data to be returned")
+
+	str := data.String()
+	for _, nodeIP := range []string{"10.0.0.10", "10.0.0.11"} {
+		for _, nodePort := range []int32{30080, 30081} {
+			ep := fmt.Sprintf("%s:%d", nodeIP, nodePort)
+			assert.Contains(t, str, ep, "expected NodePort endpoint %s in result", ep)
+		}
 	}
 }

--- a/sensor/kubernetes/listener/resources/endpoints_test.go
+++ b/sensor/kubernetes/listener/resources/endpoints_test.go
@@ -1,0 +1,99 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/net"
+	"github.com/stackrox/rox/sensor/common/service"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type countingNodeStore struct {
+	getNodesCalls int
+	nodes         []*nodeWrap
+}
+
+func (s *countingNodeStore) addOrUpdateNode(*nodeWrap) bool {
+	return false
+}
+
+func (s *countingNodeStore) removeNode(*storage.Node) {}
+
+func (s *countingNodeStore) getNode(string) *nodeWrap {
+	return nil
+}
+
+func (s *countingNodeStore) getNodes() []*nodeWrap {
+	s.getNodesCalls++
+	return s.nodes
+}
+
+func TestEndpointDataForDeployment_ReusesFlattenedNodeIPsAcrossServices(t *testing.T) {
+	serviceStore := newServiceStore()
+	serviceStore.addOrUpdateService(wrapService(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-1",
+			Namespace: "stackrox",
+			UID:       types.UID("svc-1"),
+		},
+		Spec: v1.ServiceSpec{
+			Type:     v1.ServiceTypeNodePort,
+			Selector: map[string]string{"app": "api"},
+			Ports: []v1.ServicePort{{
+				Name:       "http",
+				Port:       80,
+				NodePort:   30080,
+				Protocol:   v1.ProtocolTCP,
+				TargetPort: intstr.FromInt32(8080),
+			}},
+		},
+	}))
+	serviceStore.addOrUpdateService(wrapService(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-2",
+			Namespace: "stackrox",
+			UID:       types.UID("svc-2"),
+		},
+		Spec: v1.ServiceSpec{
+			Type:     v1.ServiceTypeNodePort,
+			Selector: map[string]string{"app": "api"},
+			Ports: []v1.ServicePort{{
+				Name:       "metrics",
+				Port:       81,
+				NodePort:   30081,
+				Protocol:   v1.ProtocolTCP,
+				TargetPort: intstr.FromInt32(8081),
+			}},
+		},
+	}))
+
+	nodeStore := &countingNodeStore{
+		nodes: []*nodeWrap{{
+			addresses: []net.IPAddress{
+				net.ParseIP("10.0.0.10"),
+				net.ParseIP("10.0.0.11"),
+			},
+		}},
+	}
+
+	manager := newEndpointManager(serviceStore, newDeploymentStore(), newPodStore(), nodeStore, nil)
+	data := manager.endpointDataForDeployment(&deploymentWrap{
+		Deployment: &storage.Deployment{
+			Id:        "deployment-1",
+			Namespace: "stackrox",
+			PodLabels: map[string]string{"app": "api"},
+		},
+		portConfigs: map[service.PortRef]*storage.PortConfig{},
+	})
+
+	if nodeStore.getNodesCalls != 1 {
+		t.Fatalf("expected getNodes to be called once per deployment build, got %d", nodeStore.getNodesCalls)
+	}
+	if data == nil {
+		t.Fatal("expected endpoint data to be returned")
+	}
+}


### PR DESCRIPTION
## Description

Flatten node IPs once while building endpoint data for a deployment and reuse that slice across all matching NodePort and LoadBalancer services. This removes repeated full-node traversals from the endpoint-building path without changing the resulting endpoint data.

Additionally, `getAllNodeIPs()` is only called when at least one matching service is of type NodePort or LoadBalancer, avoiding unnecessary O(nodes) traversal for ClusterIP-only deployments.

This issue was observed on a customer cluster in the wild.



AI-Assisted: cursor, drafted and implemented a focused sensor performance optimization

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- CI & Benchmark

#### Benchmark results

Added `sensor/kubernetes/listener/resources/endpoints_bench_test.go` to measure `endpointDataForDeployment()` for matching `NodePort` services.

Command:
`go test ./sensor/kubernetes/listener/resources -run '^$' -bench '^BenchmarkEndpointDataForDeployment_NodePortServices$' -benchmem -count=10 -benchtime=200ms`

Compared `origin/master` vs this branch with `benchstat`:

```text
goos: darwin
goarch: arm64
pkg: github.com/stackrox/rox/sensor/kubernetes/listener/resources
cpu: Apple M3 Pro
                                                                     │ .git/benchmarks/endpoints_master.txt │  .git/benchmarks/endpoints_head.txt  │
                                                                     │                sec/op                │    sec/op     vs base                │
EndpointDataForDeployment_NodePortServices/services_10_nodes_10-12                              26.29µ ± 6%   22.54µ ±  7%  -14.26% (p=0.000 n=10)
EndpointDataForDeployment_NodePortServices/services_100_nodes_10-12                             309.2µ ± 0%   271.9µ ± 19%  -12.08% (p=0.023 n=10)
EndpointDataForDeployment_NodePortServices/services_100_nodes_100-12                            2.603m ± 2%   2.277m ±  4%  -12.53% (p=0.002 n=10)
geomean                                                                                         276.6µ        240.8µ        -12.96%

                                                                     │ .git/benchmarks/endpoints_master.txt │  .git/benchmarks/endpoints_head.txt  │
                                                                     │                 B/op                 │     B/op      vs base                │
EndpointDataForDeployment_NodePortServices/services_10_nodes_10-12                             58.60Ki ± 0%   49.18Ki ± 0%  -16.08% (p=0.000 n=10)
EndpointDataForDeployment_NodePortServices/services_100_nodes_10-12                            871.3Ki ± 0%   767.7Ki ± 0%  -11.90% (p=0.000 n=10)
EndpointDataForDeployment_NodePortServices/services_100_nodes_100-12                           6.949Mi ± 0%   5.985Mi ± 0%  -13.87% (p=0.000 n=10)
geomean                                                                                        713.6Ki        613.9Ki       -13.96%

                                                                     │ .git/benchmarks/endpoints_master.txt │ .git/benchmarks/endpoints_head.txt  │
                                                                     │              allocs/op               │  allocs/op   vs base                │
EndpointDataForDeployment_NodePortServices/services_10_nodes_10-12                               309.0 ± 0%    255.0 ± 0%  -17.48% (p=0.000 n=10)
EndpointDataForDeployment_NodePortServices/services_100_nodes_10-12                             2.940k ± 0%   2.346k ± 0%  -20.20% (p=0.000 n=10)
EndpointDataForDeployment_NodePortServices/services_100_nodes_100-12                            21.36k ± 0%   20.46k ± 0%   -4.17% (p=0.000 n=10)
geomean                                                                                         2.687k        2.305k       -14.23%
```

All `benchstat` comparisons were statistically significant (`p ≤ 0.023`, `n=10`).