### PR TITLE
ROX-34641: Skip unchanged endpoint Apply work

### DIFF
--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -2,6 +2,7 @@ package clusterentities
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -104,9 +105,22 @@ func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool)
 func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) {
 	defer e.updateMetricsNoLock()
 	if !incremental {
-		for deploymentID := range updates {
+		unchangedDeployments := set.NewStringSet()
+		for deploymentID, data := range updates {
+			if !data.isDeleteOnly() && e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
+				unchangedDeployments.Add(deploymentID)
+				continue
+			}
 			e.purgeNoLock(deploymentID)
 		}
+		for deploymentID, data := range updates {
+			if data.isDeleteOnly() || unchangedDeployments.Contains(deploymentID) {
+				// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
+				continue
+			}
+			e.applySingleNoLock(deploymentID, *data)
+		}
+		return
 	}
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
@@ -115,6 +129,37 @@ func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental
 		}
 		e.applySingleNoLock(deploymentID, *data)
 	}
+}
+
+func (e *endpointsStore) endpointsUnchangedNoLock(deploymentID string, newEndpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
+	currentEndpoints, found := e.reverseEndpointMap[deploymentID]
+	if !found {
+		return len(newEndpoints) == 0
+	}
+	if len(currentEndpoints) != len(newEndpoints) {
+		return false
+	}
+	for endpoint, newTargetInfos := range newEndpoints {
+		if !currentEndpoints.Contains(endpoint) {
+			return false
+		}
+
+		currentTargetInfos, found := e.endpointMap[endpoint][deploymentID]
+		if !found || len(currentTargetInfos) != len(newTargetInfos) {
+			return false
+		}
+		for _, targetInfo := range newTargetInfos {
+			if !currentTargetInfos.Contains(targetInfo) {
+				return false
+			}
+		}
+		for currentTargetInfo := range currentTargetInfos {
+			if !slices.Contains(newTargetInfos, currentTargetInfo) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (e *endpointsStore) purgeNoLock(deploymentID string) {

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -2,6 +2,7 @@ package clusterentities
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -131,6 +132,33 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) {
 	}
 }
 
+// endpointsUnchangedNoLock checks whether the incoming endpoints are
+// identical to the ones already stored for the given deployment.
+//
+// # Correctness
+//
+// The stored set (currentTargetInfos) is duplicate-free by definition.
+// The incoming slice (newTargetInfos) may contain duplicates.
+// We iterate the set and verify every element exists in the slice.
+// Combined with the length check |set| == |slice|, this is sufficient:
+// if every one of the n distinct set elements appears in a slice of length n,
+// the slice must be an exact permutation of the set (pigeonhole principle).
+// No separate duplicate-tracking structure is needed, so the function
+// allocates nothing on the heap.
+//
+// # Hint table
+//
+// For target lists above a small threshold, a stack-allocated [64]uint8 array
+// accelerates element lookup. The table maps ContainerPort % 64 to a 1-based
+// index into newTargetInfos. During lookup, the hint gives an O(1) candidate
+// position; if the candidate matches, we skip the linear scan entirely.
+//
+// Collisions (two ports mapping to the same bucket) are harmless: the last
+// writer wins during construction, and any lookup that finds a non-matching
+// candidate simply falls through to slices.Contains for that single element.
+// Correctness never depends on the hint table — it is purely a performance
+// optimisation that degrades gracefully from O(n) (no collisions) to O(n²)
+// (all collisions, equivalent to the plain linear scan path).
 func (e *endpointsStore) endpointsUnchangedNoLock(deploymentID string, newEndpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
 	currentEndpoints, found := e.reverseEndpointMap[deploymentID]
 	if !found {
@@ -139,7 +167,11 @@ func (e *endpointsStore) endpointsUnchangedNoLock(deploymentID string, newEndpoi
 	if len(currentEndpoints) != len(newEndpoints) {
 		return false
 	}
-	var seen set.Set[EndpointTargetInfo]
+
+	const hintBuckets = 64
+	const hintThreshold = 6
+	var hints [hintBuckets]uint8
+
 	for endpoint, newTargetInfos := range newEndpoints {
 		if !currentEndpoints.Contains(endpoint) {
 			return false
@@ -150,100 +182,32 @@ func (e *endpointsStore) endpointsUnchangedNoLock(deploymentID string, newEndpoi
 			return false
 		}
 
-		// Reuse one temporary set across endpoints to keep the unchanged fast path
-		// allocation-free while still rejecting duplicate entries in newTargetInfos.
-		clear(seen)
-		for _, ti := range newTargetInfos {
-			if seen.Contains(ti) {
-				return false
-			}
-			seen.Add(ti)
-			if !currentTargetInfos.Contains(ti) {
-				return false
-			}
-		}
-	}
-	return true
-}
+		n := len(newTargetInfos)
 
-func (e *endpointsStore) endpointsUnchangedNoLockBaseline(deploymentID string, newEndpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
-	currentEndpoints, found := e.reverseEndpointMap[deploymentID]
-	if !found {
-		return len(newEndpoints) == 0
-	}
-	if len(currentEndpoints) != len(newEndpoints) {
-		return false
-	}
-	for endpoint, newTargetInfos := range newEndpoints {
-		if !currentEndpoints.Contains(endpoint) {
-			return false
-		}
-
-		currentTargetInfos, found := e.endpointMap[endpoint][deploymentID]
-		if !found || len(currentTargetInfos) != len(newTargetInfos) {
-			return false
-		}
-
-		newSet := set.NewSet[EndpointTargetInfo]()
-		for _, ti := range newTargetInfos {
-			newSet.Add(ti)
-		}
-		if len(newSet) != len(currentTargetInfos) {
-			return false
-		}
-		for ti := range currentTargetInfos {
-			if !newSet.Contains(ti) {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-// endpointsUnchangedNoLockLinearScanThreshold is a magic number. AI cannot explain it, and I am too lazy to calculate it on paper.
-const endpointsUnchangedNoLockLinearScanThreshold = 8
-
-func (e *endpointsStore) endpointsUnchangedNoLockHybrid(deploymentID string, newEndpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
-	currentEndpoints, found := e.reverseEndpointMap[deploymentID]
-	if !found {
-		return len(newEndpoints) == 0
-	}
-	if len(currentEndpoints) != len(newEndpoints) {
-		return false
-	}
-	var seen set.Set[EndpointTargetInfo]
-	for endpoint, newTargetInfos := range newEndpoints {
-		if !currentEndpoints.Contains(endpoint) {
-			return false
-		}
-
-		currentTargetInfos, found := e.endpointMap[endpoint][deploymentID]
-		if !found || len(currentTargetInfos) != len(newTargetInfos) {
-			return false
-		}
-
-		if len(newTargetInfos) <= endpointsUnchangedNoLockLinearScanThreshold {
+		if n > hintThreshold && n <= 254 {
+			// Build hint table: ContainerPort % 64 → 1-based slice index.
+			// Zero means "no entry"; values 1..255 encode indices 0..254.
+			clear(hints[:])
 			for i, ti := range newTargetInfos {
-				if !currentTargetInfos.Contains(ti) {
+				hints[ti.ContainerPort%hintBuckets] = uint8(i + 1)
+			}
+			for ti := range currentTargetInfos {
+				// Try the O(1) hint first.
+				idx := int(hints[ti.ContainerPort%hintBuckets]) - 1
+				if idx >= 0 && idx < n && newTargetInfos[idx] == ti {
+					continue
+				}
+				// Hint missed (collision or empty bucket) — fall back to scan.
+				if !slices.Contains(newTargetInfos, ti) {
 					return false
 				}
-				for j := 0; j < i; j++ {
-					if newTargetInfos[j] == ti {
-						return false
-					}
+			}
+		} else {
+			// Small n: linear scan is cheaper than building the hint table.
+			for ti := range currentTargetInfos {
+				if !slices.Contains(newTargetInfos, ti) {
+					return false
 				}
-			}
-			continue
-		}
-
-		clear(seen)
-		for _, ti := range newTargetInfos {
-			if seen.Contains(ti) {
-				return false
-			}
-			seen.Add(ti)
-			if !currentTargetInfos.Contains(ti) {
-				return false
 			}
 		}
 	}

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -194,30 +194,28 @@ func (e *endpointsStore) endpointsUnchangedNoLock(deploymentID string, newEndpoi
 
 		n := len(newTargetInfos)
 
-		if n > hintThreshold && n <= 254 {
-			// Build hint table: ContainerPort % 64 → 1-based slice index.
-			// Zero means "no entry"; values 1..255 encode indices 0..254.
-			clear(hints[:])
-			for i, ti := range newTargetInfos {
-				hints[ti.ContainerPort%hintBuckets] = uint8(i + 1)
-			}
-			for ti := range currentTargetInfos {
-				// Try the O(1) hint first.
-				idx := int(hints[ti.ContainerPort%hintBuckets]) - 1
-				if idx >= 0 && idx < n && newTargetInfos[idx] == ti {
-					continue
-				}
-				// Hint missed (collision or empty bucket) — fall back to scan.
-				if !slices.Contains(newTargetInfos, ti) {
-					return false
-				}
-			}
-		} else {
-			// Small n: linear scan is cheaper than building the hint table.
+		if n <= hintThreshold || n > 254 {
 			for ti := range currentTargetInfos {
 				if !slices.Contains(newTargetInfos, ti) {
 					return false
 				}
+			}
+			continue
+		}
+
+		// Build hint table: ContainerPort % 64 → 1-based slice index.
+		// Zero means "no entry"; values 1..255 encode indices 0..254.
+		clear(hints[:])
+		for i, ti := range newTargetInfos {
+			hints[ti.ContainerPort%hintBuckets] = uint8(i + 1)
+		}
+		for ti := range currentTargetInfos {
+			idx := int(hints[ti.ContainerPort%hintBuckets]) - 1
+			if idx >= 0 && idx < n && newTargetInfos[idx] == ti {
+				continue
+			}
+			if !slices.Contains(newTargetInfos, ti) {
+				return false
 			}
 		}
 	}

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -104,18 +104,7 @@ func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool)
 func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) {
 	defer e.updateMetricsNoLock()
 	if !incremental {
-		for deploymentID, data := range updates {
-			if data.isDeleteOnly() {
-				// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
-				e.purgeNoLock(deploymentID)
-				continue
-			}
-			if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
-				continue
-			}
-			e.purgeNoLock(deploymentID)
-			e.applySingleNoLock(deploymentID, *data)
-		}
+		e.replaceNoLock(updates)
 		return
 	}
 	for deploymentID, data := range updates {
@@ -127,7 +116,57 @@ func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental
 	}
 }
 
+func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) {
+	for deploymentID, data := range updates {
+		if data.isDeleteOnly() {
+			// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
+			e.purgeNoLock(deploymentID)
+			continue
+		}
+		if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
+			continue
+		}
+		e.purgeNoLock(deploymentID)
+		e.applySingleNoLock(deploymentID, *data)
+	}
+}
+
 func (e *endpointsStore) endpointsUnchangedNoLock(deploymentID string, newEndpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
+	currentEndpoints, found := e.reverseEndpointMap[deploymentID]
+	if !found {
+		return len(newEndpoints) == 0
+	}
+	if len(currentEndpoints) != len(newEndpoints) {
+		return false
+	}
+	var seen set.Set[EndpointTargetInfo]
+	for endpoint, newTargetInfos := range newEndpoints {
+		if !currentEndpoints.Contains(endpoint) {
+			return false
+		}
+
+		currentTargetInfos, found := e.endpointMap[endpoint][deploymentID]
+		if !found || len(currentTargetInfos) != len(newTargetInfos) {
+			return false
+		}
+
+		// Reuse one temporary set across endpoints to keep the unchanged fast path
+		// allocation-free while still rejecting duplicate entries in newTargetInfos.
+		clear(seen)
+		for _, ti := range newTargetInfos {
+			if seen.Contains(ti) {
+				return false
+			}
+			seen.Add(ti)
+			if !currentTargetInfos.Contains(ti) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (e *endpointsStore) endpointsUnchangedNoLockBaseline(deploymentID string, newEndpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
 	currentEndpoints, found := e.reverseEndpointMap[deploymentID]
 	if !found {
 		return len(newEndpoints) == 0
@@ -144,15 +183,66 @@ func (e *endpointsStore) endpointsUnchangedNoLock(deploymentID string, newEndpoi
 		if !found || len(currentTargetInfos) != len(newTargetInfos) {
 			return false
 		}
-		newSet := make(map[EndpointTargetInfo]struct{}, len(newTargetInfos))
+
+		newSet := set.NewSet[EndpointTargetInfo]()
 		for _, ti := range newTargetInfos {
-			newSet[ti] = struct{}{}
+			newSet.Add(ti)
 		}
 		if len(newSet) != len(currentTargetInfos) {
 			return false
 		}
 		for ti := range currentTargetInfos {
-			if _, ok := newSet[ti]; !ok {
+			if !newSet.Contains(ti) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// endpointsUnchangedNoLockLinearScanThreshold is a magic number. AI cannot explain it, and I am too lazy to calculate it on paper.
+const endpointsUnchangedNoLockLinearScanThreshold = 8
+
+func (e *endpointsStore) endpointsUnchangedNoLockHybrid(deploymentID string, newEndpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
+	currentEndpoints, found := e.reverseEndpointMap[deploymentID]
+	if !found {
+		return len(newEndpoints) == 0
+	}
+	if len(currentEndpoints) != len(newEndpoints) {
+		return false
+	}
+	var seen set.Set[EndpointTargetInfo]
+	for endpoint, newTargetInfos := range newEndpoints {
+		if !currentEndpoints.Contains(endpoint) {
+			return false
+		}
+
+		currentTargetInfos, found := e.endpointMap[endpoint][deploymentID]
+		if !found || len(currentTargetInfos) != len(newTargetInfos) {
+			return false
+		}
+
+		if len(newTargetInfos) <= endpointsUnchangedNoLockLinearScanThreshold {
+			for i, ti := range newTargetInfos {
+				if !currentTargetInfos.Contains(ti) {
+					return false
+				}
+				for j := 0; j < i; j++ {
+					if newTargetInfos[j] == ti {
+						return false
+					}
+				}
+			}
+			continue
+		}
+
+		clear(seen)
+		for _, ti := range newTargetInfos {
+			if seen.Contains(ti) {
+				return false
+			}
+			seen.Add(ti)
+			if !currentTargetInfos.Contains(ti) {
 				return false
 			}
 		}

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -2,7 +2,6 @@ package clusterentities
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -105,19 +104,16 @@ func (e *endpointsStore) Apply(updates map[string]*EntityData, incremental bool)
 func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental bool) {
 	defer e.updateMetricsNoLock()
 	if !incremental {
-		unchangedDeployments := set.NewStringSet()
 		for deploymentID, data := range updates {
-			if !data.isDeleteOnly() && e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
-				unchangedDeployments.Add(deploymentID)
+			if data.isDeleteOnly() {
+				// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
+				e.purgeNoLock(deploymentID)
+				continue
+			}
+			if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
 				continue
 			}
 			e.purgeNoLock(deploymentID)
-		}
-		for deploymentID, data := range updates {
-			if data.isDeleteOnly() || unchangedDeployments.Contains(deploymentID) {
-				// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
-				continue
-			}
 			e.applySingleNoLock(deploymentID, *data)
 		}
 		return
@@ -148,13 +144,15 @@ func (e *endpointsStore) endpointsUnchangedNoLock(deploymentID string, newEndpoi
 		if !found || len(currentTargetInfos) != len(newTargetInfos) {
 			return false
 		}
-		for _, targetInfo := range newTargetInfos {
-			if !currentTargetInfos.Contains(targetInfo) {
-				return false
-			}
+		newSet := make(map[EndpointTargetInfo]struct{}, len(newTargetInfos))
+		for _, ti := range newTargetInfos {
+			newSet[ti] = struct{}{}
 		}
-		for currentTargetInfo := range currentTargetInfos {
-			if !slices.Contains(newTargetInfos, currentTargetInfo) {
+		if len(newSet) != len(currentTargetInfos) {
+			return false
+		}
+		for ti := range currentTargetInfos {
+			if _, ok := newSet[ti]; !ok {
 				return false
 			}
 		}

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -125,6 +125,16 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) {
 			continue
 		}
 		if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
+			// applySingleNoLock records a nil "seen" marker in reverseEndpointMap
+			// the first time a deployment arrives with zero endpoints (e.g. a pod
+			// exists but no Service selects it yet). That marker later prevents
+			// the endpoint-takeover path from incorrectly moving other deployments
+			// to history when this deployment finally acquires real endpoints.
+			// Because endpointsUnchangedNoLock short-circuits "not-in-store +
+			// empty" as unchanged, we must replicate the marker here.
+			if _, exists := e.reverseEndpointMap[deploymentID]; !exists && len(data.endpoints) == 0 {
+				e.reverseEndpointMap[deploymentID] = nil
+			}
 			continue
 		}
 		e.purgeNoLock(deploymentID)

--- a/sensor/common/clusterentities/store_endpoints_apply_bench_test.go
+++ b/sensor/common/clusterentities/store_endpoints_apply_bench_test.go
@@ -1,0 +1,74 @@
+package clusterentities
+
+import (
+	"fmt"
+	"testing"
+)
+
+func applyBenchGenerateEntityData(numEndpoints, targetsPerEndpoint int) *EntityData {
+	data := &EntityData{}
+	for endpointIdx := range numEndpoints {
+		endpoint := buildEndpoint(fmt.Sprintf("10.%d.%d.%d", (endpointIdx/65536)%256, (endpointIdx/256)%256, endpointIdx%256), 8080)
+		for targetIdx := range targetsPerEndpoint {
+			data.AddEndpoint(endpoint, EndpointTargetInfo{
+				ContainerPort: uint16(8080 + targetIdx),
+				PortName:      fmt.Sprintf("port-%d", targetIdx),
+			})
+		}
+	}
+	return data
+}
+
+func BenchmarkApplyUnchanged(b *testing.B) {
+	for _, tc := range []struct {
+		numEndpoints       int
+		targetsPerEndpoint int
+	}{
+		{numEndpoints: 10, targetsPerEndpoint: 2},
+		{numEndpoints: 50, targetsPerEndpoint: 4},
+		{numEndpoints: 200, targetsPerEndpoint: 4},
+	} {
+		name := fmt.Sprintf("ep%d_tgt%d", tc.numEndpoints, tc.targetsPerEndpoint)
+		b.Run(name, func(b *testing.B) {
+			store := newEndpointsStoreWithMemory(5)
+			data := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
+			updates := map[string]*EntityData{"depl-bench": data}
+			store.Apply(updates, false)
+
+			b.ResetTimer()
+			for b.Loop() {
+				store.Apply(updates, false)
+			}
+		})
+	}
+}
+
+func BenchmarkApplyChanged(b *testing.B) {
+	for _, tc := range []struct {
+		numEndpoints       int
+		targetsPerEndpoint int
+	}{
+		{numEndpoints: 10, targetsPerEndpoint: 2},
+		{numEndpoints: 50, targetsPerEndpoint: 4},
+		{numEndpoints: 200, targetsPerEndpoint: 4},
+	} {
+		name := fmt.Sprintf("ep%d_tgt%d", tc.numEndpoints, tc.targetsPerEndpoint)
+		b.Run(name, func(b *testing.B) {
+			store := newEndpointsStoreWithMemory(5)
+			dataA := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
+			dataB := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint+1)
+			updatesA := map[string]*EntityData{"depl-bench": dataA}
+			updatesB := map[string]*EntityData{"depl-bench": dataB}
+			store.Apply(updatesA, false)
+
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				if i%2 == 0 {
+					store.Apply(updatesB, false)
+				} else {
+					store.Apply(updatesA, false)
+				}
+			}
+		})
+	}
+}

--- a/sensor/common/clusterentities/store_endpoints_apply_bench_test.go
+++ b/sensor/common/clusterentities/store_endpoints_apply_bench_test.go
@@ -7,6 +7,42 @@ import (
 
 func applyBenchGenerateEntityData(numEndpoints, targetsPerEndpoint int) *EntityData {
 	data := &EntityData{}
+	// Duplicate endpoints
+	// Duplicate endpoints, different ports, same port names - makes no sense, but that is the duplication scenario
+	endpoint1 := buildEndpoint("10.0.0.1", 8080)
+	endpoint2 := buildEndpoint("10.0.0.1", 8081)
+	data.AddEndpoint(endpoint1, EndpointTargetInfo{
+		ContainerPort: 8080,
+		PortName:      "http",
+	})
+	data.AddEndpoint(endpoint2, EndpointTargetInfo{
+		ContainerPort: 8080,
+		PortName:      "http",
+	})
+	// Same ports different port IPs
+	endpoint3 := buildEndpoint("10.0.0.1", 8082)
+	endpoint4 := buildEndpoint("10.0.0.2", 8082)
+
+	data.AddEndpoint(endpoint3, EndpointTargetInfo{
+		ContainerPort: 8082,
+		PortName:      "http",
+	})
+	data.AddEndpoint(endpoint4, EndpointTargetInfo{
+		ContainerPort: 8082,
+		PortName:      "http",
+	})
+
+	endpoint := buildEndpoint("10.0.0.3", 8080)
+	data.AddEndpoint(endpoint, EndpointTargetInfo{
+		ContainerPort: 8080,
+		PortName:      "http",
+	})
+	data.AddEndpoint(endpoint, EndpointTargetInfo{
+		ContainerPort: 8080,
+		PortName:      "http",
+	})
+
+	// Random endpoints
 	for endpointIdx := range numEndpoints {
 		endpoint := buildEndpoint(fmt.Sprintf("10.%d.%d.%d", (endpointIdx/65536)%256, (endpointIdx/256)%256, endpointIdx%256), 8080)
 		for targetIdx := range targetsPerEndpoint {
@@ -35,7 +71,6 @@ func BenchmarkApplyUnchanged(b *testing.B) {
 			updates := map[string]*EntityData{"depl-bench": data}
 			store.Apply(updates, false)
 
-			b.ResetTimer()
 			for b.Loop() {
 				store.Apply(updates, false)
 			}
@@ -61,7 +96,6 @@ func BenchmarkApplyChanged(b *testing.B) {
 			updatesB := map[string]*EntityData{"depl-bench": dataB}
 			store.Apply(updatesA, false)
 
-			b.ResetTimer()
 			for i := 0; b.Loop(); i++ {
 				if i%2 == 0 {
 					store.Apply(updatesB, false)
@@ -69,6 +103,59 @@ func BenchmarkApplyChanged(b *testing.B) {
 					store.Apply(updatesA, false)
 				}
 			}
+		})
+	}
+}
+
+func BenchmarkEndpointsUnchangedNoLock(b *testing.B) {
+	for _, tc := range []struct {
+		numEndpoints       int
+		targetsPerEndpoint int
+	}{
+		{numEndpoints: 10, targetsPerEndpoint: 10},
+		{numEndpoints: 50, targetsPerEndpoint: 10},
+		{numEndpoints: 200, targetsPerEndpoint: 1},
+		{numEndpoints: 200, targetsPerEndpoint: 2},
+		{numEndpoints: 200, targetsPerEndpoint: 4},
+		{numEndpoints: 200, targetsPerEndpoint: 8},
+		{numEndpoints: 200, targetsPerEndpoint: 16},
+		{numEndpoints: 200, targetsPerEndpoint: 32},
+	} {
+		name := fmt.Sprintf("ep%d_tgt%d", tc.numEndpoints, tc.targetsPerEndpoint)
+		b.Run(name, func(b *testing.B) {
+			b.Run("baseline", func(b *testing.B) {
+				store := newEndpointsStoreWithMemory(5)
+				data := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
+				store.applyNoLock(map[string]*EntityData{"depl-bench": data}, false)
+
+				for b.Loop() {
+					if !store.endpointsUnchangedNoLockBaseline("depl-bench", data.endpoints) {
+						b.Fatal("expected endpoints to be unchanged")
+					}
+				}
+			})
+			b.Run("optimized", func(b *testing.B) {
+				store := newEndpointsStoreWithMemory(5)
+				data := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
+				store.applyNoLock(map[string]*EntityData{"depl-bench": data}, false)
+
+				for b.Loop() {
+					if !store.endpointsUnchangedNoLock("depl-bench", data.endpoints) {
+						b.Fatal("expected endpoints to be unchanged")
+					}
+				}
+			})
+			b.Run("hybrid", func(b *testing.B) {
+				store := newEndpointsStoreWithMemory(5)
+				data := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
+				store.applyNoLock(map[string]*EntityData{"depl-bench": data}, false)
+
+				for b.Loop() {
+					if !store.endpointsUnchangedNoLockHybrid("depl-bench", data.endpoints) {
+						b.Fatal("expected endpoints to be unchanged")
+					}
+				}
+			})
 		})
 	}
 }

--- a/sensor/common/clusterentities/store_endpoints_apply_bench_test.go
+++ b/sensor/common/clusterentities/store_endpoints_apply_bench_test.go
@@ -5,44 +5,12 @@ import (
 	"testing"
 )
 
+// applyBenchGenerateEntityData builds synthetic endpoint data for benchmarking.
+// All endpoints share the same external port (8080) with varying IPs, each
+// carrying targetsPerEndpoint distinct target infos with sequential container
+// ports and unique port names.
 func applyBenchGenerateEntityData(numEndpoints, targetsPerEndpoint int) *EntityData {
 	data := &EntityData{}
-	// Duplicate endpoints
-	// Duplicate endpoints, different ports, same port names - makes no sense, but that is the duplication scenario
-	endpoint1 := buildEndpoint("10.0.0.1", 8080)
-	endpoint2 := buildEndpoint("10.0.0.1", 8081)
-	data.AddEndpoint(endpoint1, EndpointTargetInfo{
-		ContainerPort: 8080,
-		PortName:      "http",
-	})
-	data.AddEndpoint(endpoint2, EndpointTargetInfo{
-		ContainerPort: 8080,
-		PortName:      "http",
-	})
-	// Same ports different port IPs
-	endpoint3 := buildEndpoint("10.0.0.1", 8082)
-	endpoint4 := buildEndpoint("10.0.0.2", 8082)
-
-	data.AddEndpoint(endpoint3, EndpointTargetInfo{
-		ContainerPort: 8082,
-		PortName:      "http",
-	})
-	data.AddEndpoint(endpoint4, EndpointTargetInfo{
-		ContainerPort: 8082,
-		PortName:      "http",
-	})
-
-	endpoint := buildEndpoint("10.0.0.3", 8080)
-	data.AddEndpoint(endpoint, EndpointTargetInfo{
-		ContainerPort: 8080,
-		PortName:      "http",
-	})
-	data.AddEndpoint(endpoint, EndpointTargetInfo{
-		ContainerPort: 8080,
-		PortName:      "http",
-	})
-
-	// Random endpoints
 	for endpointIdx := range numEndpoints {
 		endpoint := buildEndpoint(fmt.Sprintf("10.%d.%d.%d", (endpointIdx/65536)%256, (endpointIdx/256)%256, endpointIdx%256), 8080)
 		for targetIdx := range targetsPerEndpoint {
@@ -107,55 +75,44 @@ func BenchmarkApplyChanged(b *testing.B) {
 	}
 }
 
+// BenchmarkEndpointsUnchangedNoLock measures the unchanged-endpoints fast path
+// across all implementation variants.
+//
+// Realistic scenarios (based on how endpoints.go builds EntityData):
+//   - Each endpoint normally carries 1 target info (one service port mapping).
+//   - Endpoint count is driven by service type: ~10 for ClusterIP (pod IPs),
+//     ~50-200 for NodePort (one per node IP), 200-500 for large NodePort clusters.
+//
+// Stress-test scenarios use elevated targets-per-endpoint (8-32) to exercise
+// algorithmic scaling; these do not represent typical Kubernetes configurations.
 func BenchmarkEndpointsUnchangedNoLock(b *testing.B) {
 	for _, tc := range []struct {
+		name               string
 		numEndpoints       int
 		targetsPerEndpoint int
 	}{
-		{numEndpoints: 10, targetsPerEndpoint: 10},
-		{numEndpoints: 50, targetsPerEndpoint: 10},
-		{numEndpoints: 200, targetsPerEndpoint: 1},
-		{numEndpoints: 200, targetsPerEndpoint: 2},
-		{numEndpoints: 200, targetsPerEndpoint: 4},
-		{numEndpoints: 200, targetsPerEndpoint: 8},
-		{numEndpoints: 200, targetsPerEndpoint: 16},
-		{numEndpoints: 200, targetsPerEndpoint: 32},
+		// Realistic: 1-2 targets per endpoint, growing endpoint count.
+		// ClusterIP → pod IPs only; NodePort → one endpoint per node IP.
+		{name: "clusterip_small", numEndpoints: 10, targetsPerEndpoint: 2},
+		{name: "clusterip_medium", numEndpoints: 50, targetsPerEndpoint: 2},
+		{name: "nodeport_medium", numEndpoints: 100, targetsPerEndpoint: 2},
+		{name: "nodeport_large", numEndpoints: 200, targetsPerEndpoint: 2},
+		{name: "nodeport_xlarge", numEndpoints: 500, targetsPerEndpoint: 2},
+
+		// Stress test: targets per endpoint beyond realistic values.
+		{name: "stress_tgt4", numEndpoints: 500, targetsPerEndpoint: 4},
+		{name: "stress_tgt8", numEndpoints: 500, targetsPerEndpoint: 8},
+		{name: "stress_tgt16", numEndpoints: 500, targetsPerEndpoint: 16},
+		{name: "stress_tgt32", numEndpoints: 500, targetsPerEndpoint: 32},
 	} {
-		name := fmt.Sprintf("ep%d_tgt%d", tc.numEndpoints, tc.targetsPerEndpoint)
-		b.Run(name, func(b *testing.B) {
-			b.Run("baseline", func(b *testing.B) {
-				store := newEndpointsStoreWithMemory(5)
-				data := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
-				store.applyNoLock(map[string]*EntityData{"depl-bench": data}, false)
+		b.Run(tc.name, func(b *testing.B) {
+			store := newEndpointsStoreWithMemory(5)
+			data := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
+			store.applyNoLock(map[string]*EntityData{"depl-bench": data}, false)
 
-				for b.Loop() {
-					if !store.endpointsUnchangedNoLockBaseline("depl-bench", data.endpoints) {
-						b.Fatal("expected endpoints to be unchanged")
-					}
-				}
-			})
-			b.Run("optimized", func(b *testing.B) {
-				store := newEndpointsStoreWithMemory(5)
-				data := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
-				store.applyNoLock(map[string]*EntityData{"depl-bench": data}, false)
-
-				for b.Loop() {
-					if !store.endpointsUnchangedNoLock("depl-bench", data.endpoints) {
-						b.Fatal("expected endpoints to be unchanged")
-					}
-				}
-			})
-			b.Run("hybrid", func(b *testing.B) {
-				store := newEndpointsStoreWithMemory(5)
-				data := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
-				store.applyNoLock(map[string]*EntityData{"depl-bench": data}, false)
-
-				for b.Loop() {
-					if !store.endpointsUnchangedNoLockHybrid("depl-bench", data.endpoints) {
-						b.Fatal("expected endpoints to be unchanged")
-					}
-				}
-			})
+			for b.Loop() {
+				store.endpointsUnchangedNoLock("depl-bench", data.endpoints)
+			}
 		})
 	}
 }

--- a/sensor/common/clusterentities/store_endpoints_benchmark_test.go
+++ b/sensor/common/clusterentities/store_endpoints_benchmark_test.go
@@ -54,6 +54,37 @@ func BenchmarkEndpointsStoreAddToHistory(b *testing.B) {
 	}
 }
 
+func TestApplyNoLock_AllocationsForUnchangedDeployment(t *testing.T) {
+	store := newEndpointsStoreWithMemory(5)
+	data := benchmarkGenerateEntityData(50, 4)
+	updates := map[string]*EntityData{
+		"depl-bench": data,
+	}
+	store.Apply(updates, false)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		store.Apply(updates, false)
+	})
+
+	if allocs > 5 {
+		t.Fatalf("expected unchanged Apply to stay within allocation budget, got %.0f allocations", allocs)
+	}
+}
+
+func benchmarkGenerateEntityData(numEndpoints, targetsPerEndpoint int) *EntityData {
+	data := &EntityData{}
+	for endpointIdx := range numEndpoints {
+		endpoint := buildEndpoint(fmt.Sprintf("10.%d.%d.%d", (endpointIdx/65536)%256, (endpointIdx/256)%256, endpointIdx%256), 8080)
+		for targetIdx := range targetsPerEndpoint {
+			data.AddEndpoint(endpoint, EndpointTargetInfo{
+				ContainerPort: uint16(8080 + targetIdx),
+				PortName:      fmt.Sprintf("port-%d", targetIdx),
+			})
+		}
+	}
+	return data
+}
+
 // legacy is the version used in 4.10.0 and earlier (before backporting the fix).
 /*
 Running tool: /usr/local/go/bin/go test -test.fullpath=true -benchmem -run=^$ -bench ^BenchmarkEndpointsStoreAddToHistory$ github.com/stackrox/rox/sensor/common/clusterentities -count=1

--- a/sensor/common/clusterentities/store_endpoints_benchmark_test.go
+++ b/sensor/common/clusterentities/store_endpoints_benchmark_test.go
@@ -127,17 +127,3 @@ func BenchmarkApplySingleNoLock_AllocationsForNewDeployment(b *testing.B) {
 		})
 	}
 }
-
-func benchmarkGenerateEntityData(numEndpoints, targetsPerEndpoint int) *EntityData {
-	data := &EntityData{}
-	for endpointIdx := range numEndpoints {
-		endpoint := buildEndpoint(fmt.Sprintf("10.%d.%d.%d", (endpointIdx/65536)%256, (endpointIdx/256)%256, endpointIdx%256), 8080)
-		for targetIdx := range targetsPerEndpoint {
-			data.AddEndpoint(endpoint, EndpointTargetInfo{
-				ContainerPort: uint16(8080 + targetIdx),
-				PortName:      fmt.Sprintf("port-%d", targetIdx),
-			})
-		}
-	}
-	return data
-}

--- a/sensor/common/clusterentities/store_endpoints_benchmark_test.go
+++ b/sensor/common/clusterentities/store_endpoints_benchmark_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/set"
+	"github.com/stretchr/testify/assert"
 )
 
 func benchmarkSeedEndpointsStore(numEndpoints int) (*endpointsStore, string, net.NumericEndpoint) {
@@ -71,15 +72,7 @@ func TestApplyNoLock_AllocationsForUnchangedDeployment(t *testing.T) {
 		maxAllocs    = 10.0 // upper bound to catch regressions while tolerating minor runtime variations
 	)
 
-	if allocs > maxAllocs {
-		t.Fatalf("expected unchanged Apply to stay within allocation budget (target <= %.0f, max tolerated <= %.0f), got %.0f allocations",
-			targetAllocs, maxAllocs, allocs)
-	}
-
-	if allocs > targetAllocs {
-		t.Logf("unchanged Apply allocations above target budget: got %.0f allocations (target <= %.0f, max tolerated <= %.0f)",
-			allocs, targetAllocs, maxAllocs)
-	}
+	assert.InDelta(t, targetAllocs, allocs, maxAllocs, "unchanged Apply allocations should stay within target budget")
 }
 
 func benchmarkGenerateEntityData(numEndpoints, targetsPerEndpoint int) *EntityData {

--- a/sensor/common/clusterentities/store_endpoints_benchmark_test.go
+++ b/sensor/common/clusterentities/store_endpoints_benchmark_test.go
@@ -66,8 +66,19 @@ func TestApplyNoLock_AllocationsForUnchangedDeployment(t *testing.T) {
 		store.Apply(updates, false)
 	})
 
-	if allocs > 5 {
-		t.Fatalf("expected unchanged Apply to stay within allocation budget, got %.0f allocations", allocs)
+	const (
+		targetAllocs = 5.0  // desired steady-state budget for unchanged Apply
+		maxAllocs    = 10.0 // upper bound to catch regressions while tolerating minor runtime variations
+	)
+
+	if allocs > maxAllocs {
+		t.Fatalf("expected unchanged Apply to stay within allocation budget (target <= %.0f, max tolerated <= %.0f), got %.0f allocations",
+			targetAllocs, maxAllocs, allocs)
+	}
+
+	if allocs > targetAllocs {
+		t.Logf("unchanged Apply allocations above target budget: got %.0f allocations (target <= %.0f, max tolerated <= %.0f)",
+			allocs, targetAllocs, maxAllocs)
 	}
 }
 

--- a/sensor/common/clusterentities/store_endpoints_test.go
+++ b/sensor/common/clusterentities/store_endpoints_test.go
@@ -566,9 +566,7 @@ func (s *ClusterEntitiesStoreTestSuite) TestEndpointsUnchangedNoLockVariantsMatc
 				store.applyNoLock(map[string]*EntityData{"depl": c.current}, false)
 			}
 
-			s.Equal(c.wantUnchanged, store.endpointsUnchangedNoLockBaseline("depl", c.next))
 			s.Equal(c.wantUnchanged, store.endpointsUnchangedNoLock("depl", c.next))
-			s.Equal(c.wantUnchanged, store.endpointsUnchangedNoLockHybrid("depl", c.next))
 		})
 	}
 }

--- a/sensor/common/clusterentities/store_endpoints_test.go
+++ b/sensor/common/clusterentities/store_endpoints_test.go
@@ -409,3 +409,190 @@ func (s *ClusterEntitiesStoreTestSuite) TestEndpointTakeoverFastPathDoesNotPollu
 	s.Contains(reverseHistDeplA, ep1, "taken-over endpoint must be historical for previous owner")
 	s.NotContains(reverseHistDeplA, ep2, "unrelated endpoint must not be marked historical during single-endpoint takeover")
 }
+
+func buildEntityData(entries map[net.NumericEndpoint][]EndpointTargetInfo) *EntityData {
+	data := &EntityData{}
+	for endpoint, targetInfos := range entries {
+		for _, targetInfo := range targetInfos {
+			data.AddEndpoint(endpoint, targetInfo)
+		}
+	}
+	return data
+}
+
+func (s *ClusterEntitiesStoreTestSuite) TestEndpointsUnchangedNoLockVariantsMatchExpectedSemantics() {
+	ep1 := buildEndpoint("10.0.0.1", 80)
+	ep2 := buildEndpoint("10.0.0.2", 80)
+
+	cases := map[string]struct {
+		current       *EntityData
+		next          map[net.NumericEndpoint][]EndpointTargetInfo
+		wantUnchanged bool
+	}{
+		"empty current and empty next are unchanged": {
+			next:          map[net.NumericEndpoint][]EndpointTargetInfo{},
+			wantUnchanged: true,
+		},
+		"empty current and non-empty next are changed": {
+			next: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+				},
+			},
+			wantUnchanged: false,
+		},
+		"unchanged endpoints and target infos": {
+			current: buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+					{ContainerPort: 443, PortName: "https"},
+				},
+				ep2: {
+					{ContainerPort: 8080, PortName: "metrics"},
+				},
+			}),
+			next: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 443, PortName: "https"},
+					{ContainerPort: 80, PortName: "http"},
+				},
+				ep2: {
+					{ContainerPort: 8080, PortName: "metrics"},
+				},
+			},
+			wantUnchanged: true,
+		},
+		"same target info on distinct endpoints is unchanged": {
+			current: buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+				},
+				ep2: {
+					{ContainerPort: 80, PortName: "http"},
+				},
+			}),
+			next: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+				},
+				ep2: {
+					{ContainerPort: 80, PortName: "http"},
+				},
+			},
+			wantUnchanged: true,
+		},
+		"duplicate target infos are treated as changed": {
+			current: buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+				},
+			}),
+			next: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+					{ContainerPort: 80, PortName: "http"},
+				},
+			},
+			wantUnchanged: false,
+		},
+		"duplicate target infos can mask removal and are treated as changed": {
+			current: buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+					{ContainerPort: 443, PortName: "https"},
+				},
+			}),
+			next: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+					{ContainerPort: 80, PortName: "http"},
+				},
+			},
+			wantUnchanged: false,
+		},
+		"same length but different target info is treated as changed": {
+			current: buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+					{ContainerPort: 443, PortName: "https"},
+				},
+			}),
+			next: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+					{ContainerPort: 9090, PortName: "metrics"},
+				},
+			},
+			wantUnchanged: false,
+		},
+		"missing endpoint is treated as changed": {
+			current: buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+				},
+				ep2: {
+					{ContainerPort: 8080, PortName: "metrics"},
+				},
+			}),
+			next: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+				},
+			},
+			wantUnchanged: false,
+		},
+		"extra endpoint is treated as changed": {
+			current: buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+				},
+			}),
+			next: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {
+					{ContainerPort: 80, PortName: "http"},
+				},
+				ep2: {
+					{ContainerPort: 8080, PortName: "metrics"},
+				},
+			},
+			wantUnchanged: false,
+		},
+	}
+
+	for name, c := range cases {
+		s.Run(name, func() {
+			store := newEndpointsStoreWithMemory(5)
+			if c.current != nil {
+				store.applyNoLock(map[string]*EntityData{"depl": c.current}, false)
+			}
+
+			s.Equal(c.wantUnchanged, store.endpointsUnchangedNoLockBaseline("depl", c.next))
+			s.Equal(c.wantUnchanged, store.endpointsUnchangedNoLock("depl", c.next))
+			s.Equal(c.wantUnchanged, store.endpointsUnchangedNoLockHybrid("depl", c.next))
+		})
+	}
+}
+
+func (s *ClusterEntitiesStoreTestSuite) TestApplyCanonicalizesDuplicateTargetInfosWhenTheyMaskRemoval() {
+	ep := buildEndpoint("10.0.0.3", 8080)
+	httpTarget := EndpointTargetInfo{ContainerPort: 8080, PortName: "http"}
+	httpsTarget := EndpointTargetInfo{ContainerPort: 8443, PortName: "https"}
+
+	store := newEndpointsStoreWithMemory(5)
+	store.applyNoLock(map[string]*EntityData{
+		"depl": buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
+			ep: {httpTarget, httpsTarget},
+		}),
+	}, false)
+
+	store.applyNoLock(map[string]*EntityData{
+		"depl": buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
+			ep: {httpTarget, httpTarget},
+		}),
+	}, false)
+
+	targetInfos := store.endpointMap[ep]["depl"]
+	s.Len(targetInfos, 1)
+	s.True(targetInfos.Contains(httpTarget))
+	s.False(targetInfos.Contains(httpsTarget))
+}

--- a/sensor/common/clusterentities/store_endpoints_test.go
+++ b/sensor/common/clusterentities/store_endpoints_test.go
@@ -367,26 +367,125 @@ func buildExpectation(ip, deplID, portName string, location whereThingIsStored, 
 }
 
 func (s *ClusterEntitiesStoreTestSuite) TestEmptyEndpointUpdatePreservesSeenState() {
-	store := NewStore(5, nil, true)
-
-	// First update: deployment has a container but no endpoints (e.g., no Service yet).
-	noEndpoints := &EntityData{}
-	noEndpoints.AddContainerID("ctr-a", ContainerMetadata{DeploymentID: "deplA"})
-	store.Apply(map[string]*EntityData{"deplA": noEndpoints}, false)
-
-	// Second update: deployment gets a real endpoint, shared with deplB.
 	ep := buildEndpoint("10.0.0.1", 80)
-	deplB := &EntityData{}
-	deplB.AddEndpoint(ep, EndpointTargetInfo{ContainerPort: 80, PortName: "http"})
-	store.Apply(map[string]*EntityData{"deplB": deplB}, true)
+	httpTarget := EndpointTargetInfo{ContainerPort: 80, PortName: "http"}
 
-	deplA := &EntityData{}
-	deplA.AddEndpoint(ep, EndpointTargetInfo{ContainerPort: 80, PortName: "http"})
-	store.Apply(map[string]*EntityData{"deplA": deplA}, false)
+	type applyStep struct {
+		deploymentID string
+		data         *EntityData
+		incremental  bool
+	}
+	applyWithoutEndpoints := func(deplID string) applyStep {
+		d := &EntityData{}
+		d.AddContainerID("ctr-"+deplID, ContainerMetadata{DeploymentID: deplID})
+		return applyStep{deploymentID: deplID, data: d, incremental: false}
+	}
+	endpointUpdate := func(deplID string) applyStep {
+		d := &EntityData{}
+		d.AddEndpoint(ep, httpTarget)
+		return applyStep{deploymentID: deplID, data: d, incremental: true}
+	}
+	endpointOverwrite := func(deplID string) applyStep {
+		d := &EntityData{}
+		d.AddEndpoint(ep, httpTarget)
+		return applyStep{deploymentID: deplID, data: d, incremental: false}
+	}
 
-	// deplB must NOT have been moved to history — deplA was already "seen".
-	_, hasHistory := store.endpointsStore.reverseHistoricalEndpoints["deplB"]
-	s.False(hasHistory, "deplB should not be moved to history when deplA was previously seen with empty endpoints")
+	deplAResult := LookupResult{
+		Entity:         networkgraph.EntityForDeployment("deplA"),
+		ContainerPorts: []uint16{80},
+		PortNames:      []string{"http"},
+	}
+	deplBResult := LookupResult{
+		Entity:         networkgraph.EntityForDeployment("deplB"),
+		ContainerPorts: []uint16{80},
+		PortNames:      []string{"http"},
+	}
+
+	cases := map[string]struct {
+		steps     []applyStep
+		wantDeplA whereThingIsStored
+		wantDeplB whereThingIsStored
+	}{
+		"deployment seen with empty endpoints should not trigger takeover when it later acquires real endpoints": {
+			steps: []applyStep{
+				applyWithoutEndpoints("deplA"),
+				endpointUpdate("deplB"),
+				endpointOverwrite("deplA"),
+			},
+			wantDeplA: theMap,
+			wantDeplB: theMap,
+		},
+		"repeated empty applies should not corrupt the seen marker": {
+			steps: []applyStep{
+				applyWithoutEndpoints("deplA"),
+				applyWithoutEndpoints("deplA"),
+				applyWithoutEndpoints("deplA"),
+				endpointUpdate("deplB"),
+				endpointOverwrite("deplA"),
+			},
+			wantDeplA: theMap,
+			wantDeplB: theMap,
+		},
+		"unchanged real endpoints after empty start should hit the fast path without side effects": {
+			steps: []applyStep{
+				applyWithoutEndpoints("deplA"),
+				endpointUpdate("deplB"),
+				endpointOverwrite("deplA"),
+				endpointOverwrite("deplA"),
+			},
+			wantDeplA: theMap,
+			wantDeplB: theMap,
+		},
+		"two deployments both seen empty should not trigger takeover when they share the same endpoint": {
+			steps: []applyStep{
+				applyWithoutEndpoints("deplA"),
+				applyWithoutEndpoints("deplB"),
+				endpointOverwrite("deplA"),
+				endpointOverwrite("deplB"),
+			},
+			wantDeplA: theMap,
+			wantDeplB: theMap,
+		},
+		"unseen deployment should trigger takeover as expected": {
+			steps: []applyStep{
+				endpointUpdate("deplB"),
+				endpointOverwrite("deplA"),
+			},
+			wantDeplA: theMap,
+			wantDeplB: history,
+		},
+	}
+
+	for name, tc := range cases {
+		s.Run(name, func() {
+			store := NewStore(5, nil, true)
+			for _, step := range tc.steps {
+				store.Apply(map[string]*EntityData{step.deploymentID: step.data}, step.incremental)
+			}
+			current, historical, _, _ := store.endpointsStore.lookupEndpoint(ep, store.podIPsStore)
+			for _, want := range []struct {
+				result   LookupResult
+				location whereThingIsStored
+				label    string
+			}{
+				{deplAResult, tc.wantDeplA, "deplA"},
+				{deplBResult, tc.wantDeplB, "deplB"},
+			} {
+				switch want.location {
+				case theMap:
+					s.Contains(current, want.result, "%s should be current", want.label)
+					s.NotContains(historical, want.result, "%s should not be historical", want.label)
+				case history:
+					s.NotContains(current, want.result, "%s should not be current", want.label)
+					s.Contains(historical, want.result, "%s should be historical", want.label)
+				case nowhere:
+					s.NotContains(current, want.result, "%s should not be current", want.label)
+					s.NotContains(historical, want.result, "%s should not be historical", want.label)
+				}
+			}
+		})
+	}
 }
 
 func (s *ClusterEntitiesStoreTestSuite) TestEndpointTakeoverFastPathDoesNotPolluteReverseHistory() {


### PR DESCRIPTION
## Description

Detect when a non-incremental endpoint update exactly matches the current store state and skip the purge/reinsert cycle in that case. This avoids needless history churn and allocation-heavy no-op work for steady-state deployment updates while preserving the existing behavior for changed or delete-only updates.

This issue was observed on a customer cluster in the wild.

AI-Assisted: cursor, drafted and implemented a focused sensor performance optimization

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- CI 

#### Benchmark of the `Apply`

```
                             │     master (no fast path)   │       branch (hinted)               │
                             │           sec/op            │   sec/op     vs base                │
ApplyUnchanged/ep10_tgt2-12                14.045µ ± 7%     1.801µ ± 7%  -87.18% (p=0.000 n=10)
ApplyUnchanged/ep50_tgt4-12                76.213µ ± 2%     7.172µ ± 3%  -90.59% (p=0.000 n=10)
ApplyUnchanged/ep200_tgt4-12              307.27µ  ± 1%    28.53µ  ± 2%  -90.71% (p=0.000 n=10)
ApplyChanged/ep10_tgt2-12                  14.72µ  ± 2%    14.83µ  ± 0%   +0.74% (p=0.029 n=10)
ApplyChanged/ep50_tgt4-12                  79.44µ  ± 1%    79.85µ  ± 1%        ~ (p=0.190 n=10)
ApplyChanged/ep200_tgt4-12               323.6µ   ± 5%   322.1µ   ± 2%        ~ (p=0.912 n=10)
geomean                                    70.66µ          22.80µ        -67.73%

                             │     master (no fast path)   │       branch (hinted)                  │
                             │            B/op             │     B/op      vs base                  │
ApplyUnchanged/ep10_tgt2-12               16204.0 ± 0%       672.0 ± 0%  -95.85% (p=0.000 n=10)
ApplyUnchanged/ep50_tgt4-12               78477.0 ± 0%       672.0 ± 0%  -99.14% (p=0.000 n=10)
ApplyUnchanged/ep200_tgt4-12             313574.0 ± 0%       672.0 ± 0%  -99.79% (p=0.000 n=10)
ApplyChanged/ep10_tgt2-12                 15.83Ki ± 0%     15.83Ki ± 0%        ~ (p=1.000 n=10)
ApplyChanged/ep50_tgt4-12                 76.69Ki ± 0%     76.69Ki ± 0%        ~ (p=1.000 n=10)
ApplyChanged/ep200_tgt4-12               306.4Ki  ± 0%    306.4Ki  ± 0%        ~ (p=0.724 n=10)

                             │     master (no fast path)   │       branch (hinted)                 │
                             │          allocs/op          │  allocs/op   vs base                  │
ApplyUnchanged/ep10_tgt2-12               124.000 ± 0%       4.000 ± 0%  -96.77% (p=0.000 n=10)
ApplyUnchanged/ep50_tgt4-12               672.000 ± 0%       4.000 ± 0%  -99.40% (p=0.000 n=10)
ApplyUnchanged/ep200_tgt4-12             2630.000 ± 0%       4.000 ± 0%  -99.85% (p=0.000 n=10)
ApplyChanged/ep10_tgt2-12                  129.0  ± 0%      129.0  ± 0%        ~ (p=1.000 n=10)
ApplyChanged/ep50_tgt4-12                  697.0  ± 0%      697.0  ± 0%        ~ (p=1.000 n=10)
ApplyChanged/ep200_tgt4-12               2.729k   ± 0%     2.730k  ± 0%        ~ (p=1.000 n=10)
```

#### Benchmark results for `EndpointsUnchangedNoLock`

Cross-benchstat comparison (`-count=10`, Apple M3 Pro):

```
➜ benchstat /tmp/bench_baseline.txt /tmp/bench_optimized.txt /tmp/bench_hinted.txt /tmp/bench_noalloc.txt
                                             │ /tmp/bench_baseline.txt │       /tmp/bench_optimized.txt       │        /tmp/bench_hinted.txt        │        /tmp/bench_noalloc.txt        │
                                             │         sec/op          │    sec/op     vs base                │   sec/op     vs base                │    sec/op     vs base                │
EndpointsUnchangedNoLock/clusterip_small-12                1.594µ ± 1%    1.438µ ± 2%   -9.79% (p=0.000 n=10)   1.105µ ± 5%  -30.66% (p=0.000 n=10)   1.119µ ±  2%  -29.78% (p=0.000 n=10)
EndpointsUnchangedNoLock/clusterip_medium-12               7.753µ ± 2%    6.691µ ± 2%  -13.69% (p=0.000 n=10)   5.474µ ± 1%  -29.39% (p=0.000 n=10)   5.584µ ±  3%  -27.97% (p=0.000 n=10)
EndpointsUnchangedNoLock/nodeport_medium-12                15.67µ ± 1%    13.34µ ± 2%  -14.85% (p=0.000 n=10)   10.96µ ± 2%  -30.06% (p=0.000 n=10)   11.09µ ±  1%  -29.22% (p=0.000 n=10)
EndpointsUnchangedNoLock/nodeport_large-12                 32.29µ ± 1%    27.58µ ± 2%  -14.58% (p=0.000 n=10)   23.46µ ± 1%  -27.36% (p=0.000 n=10)   23.60µ ±  1%  -26.90% (p=0.000 n=10)
EndpointsUnchangedNoLock/nodeport_xlarge-12                84.37µ ± 1%    73.72µ ± 1%  -12.62% (p=0.000 n=10)   62.47µ ± 1%  -25.96% (p=0.000 n=10)   62.87µ ±  1%  -25.48% (p=0.000 n=10)
EndpointsUnchangedNoLock/stress_tgt4-12                   111.51µ ± 7%   109.83µ ± 5%        ~ (p=0.075 n=10)   70.99µ ± 1%  -36.33% (p=0.000 n=10)   71.27µ ±  5%  -36.08% (p=0.000 n=10)
EndpointsUnchangedNoLock/stress_tgt8-12                   157.63µ ± 1%   172.66µ ± 2%   +9.53% (p=0.000 n=10)   70.56µ ± 8%  -55.24% (p=0.000 n=10)   85.83µ ±  1%  -45.55% (p=0.000 n=10)
EndpointsUnchangedNoLock/stress_tgt16-12                   606.7µ ± 1%    315.6µ ± 1%  -47.99% (p=0.000 n=10)   130.4µ ± 0%  -78.50% (p=0.000 n=10)   195.7µ ±  2%  -67.75% (p=0.000 n=10)
EndpointsUnchangedNoLock/stress_tgt32-12                  1222.3µ ± 2%    593.4µ ± 1%  -51.45% (p=0.000 n=10)   204.2µ ± 2%  -83.29% (p=0.000 n=10)   414.0µ ± 12%  -66.13% (p=0.000 n=10)
geomean                                                    57.50µ         46.02µ       -19.96%                  28.64µ       -50.20%                  33.35µ        -42.01%

                                             │ /tmp/bench_baseline.txt │       /tmp/bench_optimized.txt       │           /tmp/bench_hinted.txt           │          /tmp/bench_noalloc.txt           │
                                             │          B/op           │     B/op      vs base                │     B/op      vs base                     │     B/op      vs base                     │
EndpointsUnchangedNoLock/clusterip_small-12                 0.0 ± 0%       336.0 ± 0%        ? (p=0.000 n=10)       0.0 ± 0%         ~ (p=1.000 n=10) ¹         0.0 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/clusterip_medium-12                0.0 ± 0%       336.0 ± 0%        ? (p=0.000 n=10)       0.0 ± 0%         ~ (p=1.000 n=10) ¹         0.0 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/nodeport_medium-12                 0.0 ± 0%       336.0 ± 0%        ? (p=0.000 n=10)       0.0 ± 0%         ~ (p=1.000 n=10) ¹         0.0 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/nodeport_large-12                  0.0 ± 0%       336.0 ± 0%        ? (p=0.000 n=10)       0.0 ± 0%         ~ (p=1.000 n=10) ¹         0.0 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/nodeport_xlarge-12                 0.0 ± 0%       336.0 ± 0%        ? (p=0.000 n=10)       0.0 ± 0%         ~ (p=1.000 n=10) ¹         0.0 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/stress_tgt4-12                     0.0 ± 0%       336.0 ± 0%        ? (p=0.000 n=10)       0.0 ± 0%         ~ (p=1.000 n=10) ¹         0.0 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/stress_tgt8-12                     0.0 ± 0%       336.0 ± 0%        ? (p=0.000 n=10)       0.0 ± 0%         ~ (p=1.000 n=10) ¹         0.0 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/stress_tgt16-12              878.908Ki ± 0%     2.086Ki ± 0%  -99.76% (p=0.000 n=10)   0.000Ki ± 0%  -100.00% (p=0.000 n=10)       0.000Ki ± 0%  -100.00% (p=0.000 n=10)
EndpointsUnchangedNoLock/stress_tgt32-12             2019.537Ki ± 0%     4.367Ki ± 0%  -99.78% (p=0.000 n=10)   0.000Ki ± 0%  -100.00% (p=0.000 n=10)       0.000Ki ± 0%  -100.00% (p=0.000 n=10)
geomean                                                              ²     550.2       ?                                      ?                       ² ³                 ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                             │ /tmp/bench_baseline.txt │      /tmp/bench_optimized.txt      │          /tmp/bench_hinted.txt          │         /tmp/bench_noalloc.txt          │
                                             │        allocs/op        │ allocs/op   vs base                │ allocs/op   vs base                     │ allocs/op   vs base                     │
EndpointsUnchangedNoLock/clusterip_small-12               0.000 ± 0%     2.000 ± 0%        ? (p=0.000 n=10)   0.000 ± 0%         ~ (p=1.000 n=10) ¹     0.000 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/clusterip_medium-12              0.000 ± 0%     2.000 ± 0%        ? (p=0.000 n=10)   0.000 ± 0%         ~ (p=1.000 n=10) ¹     0.000 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/nodeport_medium-12               0.000 ± 0%     2.000 ± 0%        ? (p=0.000 n=10)   0.000 ± 0%         ~ (p=1.000 n=10) ¹     0.000 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/nodeport_large-12                0.000 ± 0%     2.000 ± 0%        ? (p=0.000 n=10)   0.000 ± 0%         ~ (p=1.000 n=10) ¹     0.000 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/nodeport_xlarge-12               0.000 ± 0%     2.000 ± 0%        ? (p=0.000 n=10)   0.000 ± 0%         ~ (p=1.000 n=10) ¹     0.000 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/stress_tgt4-12                   0.000 ± 0%     2.000 ± 0%        ? (p=0.000 n=10)   0.000 ± 0%         ~ (p=1.000 n=10) ¹     0.000 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/stress_tgt8-12                   0.000 ± 0%     2.000 ± 0%        ? (p=0.000 n=10)   0.000 ± 0%         ~ (p=1.000 n=10) ¹     0.000 ± 0%         ~ (p=1.000 n=10) ¹
EndpointsUnchangedNoLock/stress_tgt16-12               2500.000 ± 0%     7.000 ± 0%  -99.72% (p=0.000 n=10)   0.000 ± 0%  -100.00% (p=0.000 n=10)       0.000 ± 0%  -100.00% (p=0.000 n=10)
EndpointsUnchangedNoLock/stress_tgt32-12               3500.000 ± 0%     9.000 ± 0%  -99.74% (p=0.000 n=10)   0.000 ± 0%  -100.00% (p=0.000 n=10)       0.000 ± 0%  -100.00% (p=0.000 n=10)
geomean                                                              ²   2.717       ?                                    ?                       ² ³               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean
```

### Summary

| Variant | Geomean vs baseline | Allocations | Notes |
|---------|-------------------|-------------|-------|
| baseline | — | Heavy at high N | Allocates a new `set.Set` per endpoint |
| optimized | -20% | 336 B always | Reuses `set.Set` across endpoints |
| hybrid | -42% | 0 at low N, allocates at high N | Small-N linear scan + large-N set (removed before benchstat, numbers from prior run) |
| **hinted** | **-50%** | **0 always** | **Chosen. Iterates stored set, uses stack hint table** |
| noalloc | -42% | 0 always | Iterates stored set, pure linear scan |

## Alternative implementations considered

<details>
<summary><b>baseline</b> — allocate a new set per endpoint (original implementation)</summary>

Converts the incoming `[]EndpointTargetInfo` slice to a `set.Set` on every call,
then compares sets. Simple and correct, but allocates on every invocation —
allocations grow linearly with endpoint count and explode at high target counts
(879 KiB at 16 targets/endpoint).

```go
func (e *endpointsStore) endpointsUnchangedNoLock(deploymentID string, newEndpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
	currentEndpoints, found := e.reverseEndpointMap[deploymentID]
	if !found {
		return len(newEndpoints) == 0
	}
	if len(currentEndpoints) != len(newEndpoints) {
		return false
	}
	for endpoint, newTargetInfos := range newEndpoints {
		if !currentEndpoints.Contains(endpoint) {
			return false
		}

		currentTargetInfos, found := e.endpointMap[endpoint][deploymentID]
		if !found || len(currentTargetInfos) != len(newTargetInfos) {
			return false
		}

		newSet := set.NewSet[EndpointTargetInfo]()
		for _, ti := range newTargetInfos {
			newSet.Add(ti)
		}
		if len(newSet) != len(currentTargetInfos) {
			return false
		}
		for ti := range currentTargetInfos {
			if !newSet.Contains(ti) {
				return false
			}
		}
	}
	return true
}
```

</details>

<details>
<summary><b>optimized</b> — reuse a single set across endpoints</summary>

Keeps a single `set.Set[EndpointTargetInfo]` across all endpoints in one call,
clearing it between iterations. Reduces allocation count from O(endpoints) to
O(1) amortised, but still allocates 336 B for the initial map bucket on first use.
~20% faster than baseline overall.

```go
func (e *endpointsStore) endpointsUnchangedNoLock(deploymentID string, newEndpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
	currentEndpoints, found := e.reverseEndpointMap[deploymentID]
	if !found {
		return len(newEndpoints) == 0
	}
	if len(currentEndpoints) != len(newEndpoints) {
		return false
	}
	var seen set.Set[EndpointTargetInfo]
	for endpoint, newTargetInfos := range newEndpoints {
		if !currentEndpoints.Contains(endpoint) {
			return false
		}

		currentTargetInfos, found := e.endpointMap[endpoint][deploymentID]
		if !found || len(currentTargetInfos) != len(newTargetInfos) {
			return false
		}

		clear(seen)
		for _, ti := range newTargetInfos {
			if seen.Contains(ti) {
				return false
			}
			seen.Add(ti)
			if !currentTargetInfos.Contains(ti) {
				return false
			}
		}
	}
	return true
}
```

</details>

<details>
<summary><b>hybrid</b> — linear scan for small N, set for large N</summary>

Uses a threshold (`endpointsUnchangedNoLockLinearScanThreshold = 8`): for small
target lists, does pairwise duplicate detection plus set-membership check without
allocating. For larger lists, falls back to the `set.Set`-based approach. ~42%
faster than baseline overall, zero-alloc for realistic workloads, but still
allocates at high target counts.

```go
const endpointsUnchangedNoLockLinearScanThreshold = 8

func (e *endpointsStore) endpointsUnchangedNoLockHybrid(deploymentID string, newEndpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
	currentEndpoints, found := e.reverseEndpointMap[deploymentID]
	if !found {
		return len(newEndpoints) == 0
	}
	if len(currentEndpoints) != len(newEndpoints) {
		return false
	}
	var seen set.Set[EndpointTargetInfo]
	for endpoint, newTargetInfos := range newEndpoints {
		if !currentEndpoints.Contains(endpoint) {
			return false
		}

		currentTargetInfos, found := e.endpointMap[endpoint][deploymentID]
		if !found || len(currentTargetInfos) != len(newTargetInfos) {
			return false
		}

		if len(newTargetInfos) <= endpointsUnchangedNoLockLinearScanThreshold {
			for i, ti := range newTargetInfos {
				if !currentTargetInfos.Contains(ti) {
					return false
				}
				for j := 0; j < i; j++ {
					if newTargetInfos[j] == ti {
						return false
					}
				}
			}
			continue
		}

		clear(seen)
		for _, ti := range newTargetInfos {
			if seen.Contains(ti) {
				return false
			}
			seen.Add(ti)
			if !currentTargetInfos.Contains(ti) {
				return false
			}
		}
	}
	return true
}
```

</details>

<details>
<summary><b>noalloc</b> — iterate stored set, linear scan in slice</summary>

Reverses the comparison direction: iterates the stored `set.Set` (which is
duplicate-free by construction) and checks each element against the incoming
slice via `slices.Contains`. Zero allocations in all scenarios. Correctness
relies on the pigeonhole principle: if every one of N distinct set elements
appears in a slice of length N, the slice is an exact permutation. ~42% faster
than baseline. Degrades to O(N²) when targets-per-endpoint is high.

```go
func (e *endpointsStore) endpointsUnchangedNoLockNoAllocations(deploymentID string, newEndpoints map[net.NumericEndpoint][]EndpointTargetInfo) bool {
	currentEndpoints, found := e.reverseEndpointMap[deploymentID]
	if !found {
		return len(newEndpoints) == 0
	}
	if len(currentEndpoints) != len(newEndpoints) {
		return false
	}
	for endpoint, newTargetInfos := range newEndpoints {
		if !currentEndpoints.Contains(endpoint) {
			return false
		}

		currentTargetInfos, found := e.endpointMap[endpoint][deploymentID]
		if !found || len(currentTargetInfos) != len(newTargetInfos) {
			return false
		}

		for ti := range currentTargetInfos {
			if !slices.Contains(newTargetInfos, ti) {
				return false
			}
		}
	}
	return true
}
```

</details>

### How to reproduce benchmarks

```bash
go test -bench 'BenchmarkEndpointsUnchangedNoLock' -benchmem -count=6 -timeout=15m \
  ./sensor/common/clusterentities/ 2>&1 | tee /tmp/bench_all.txt

for v in baseline optimized hinted noalloc; do
  rg "^(Benchmark.*/)${v}-" /tmp/bench_all.txt | sed "s|/${v}-|-|" > "/tmp/bench_${v}.txt"
done

benchstat /tmp/bench_baseline.txt /tmp/bench_optimized.txt /tmp/bench_hinted.txt /tmp/bench_noalloc.txt
```
