### PR TITLE
ROX-33631: Remove connections with unparseable IP addresses 

### DIFF
--- a/sensor/common/networkflow/manager/manager_enrich_connection.go
+++ b/sensor/common/networkflow/manager/manager_enrich_connection.go
@@ -279,8 +279,8 @@ func (m *networkFlowManager) handleConnectionEnrichmentResult(result EnrichmentR
 	case EnrichmentResultInvalidInput:
 		switch reason {
 		case EnrichmentReasonConnParsingIPFailed:
-			log.Debugf("Enrichment failed. Unable to parse IP address.")
-			return PostEnrichmentActionRetry
+			log.Debugf("Enrichment failed. Unable to parse IP address. Removing connection.")
+			return PostEnrichmentActionRemove
 		}
 	case EnrichmentResultSkipped:
 		switch reason {

--- a/sensor/common/networkflow/manager/manager_enrich_test.go
+++ b/sensor/common/networkflow/manager/manager_enrich_test.go
@@ -149,6 +149,21 @@ func (s *TestNetworkFlowManagerEnrichmentTestSuite) TestEnrichConnection() {
 				action: PostEnrichmentActionRetry,
 			},
 		},
+		"Non-fresh connection with invalid address should be removed": {
+			connPair:            createConnectionPair().incoming().invalidAddress().notFresh(),
+			enrichedConnections: make(map[indicator.NetworkConn]timestamp.MicroTS),
+			setupMocks: func(m *mockExpectations) {
+				m.expectContainerFound(dstID).expectEndpointNotFound().expectExternalNotFound()
+			},
+			expected: struct {
+				result    EnrichmentResult
+				action    PostEnrichmentAction
+				indicator *indicator.NetworkConn
+			}{
+				result: EnrichmentResultInvalidInput,
+				action: PostEnrichmentActionRemove,
+			},
+		},
 		"Outgoing connection with successful internal lookup should return the correct id": {
 			connPair:            createConnectionPair(),
 			enrichedConnections: make(map[indicator.NetworkConn]timestamp.MicroTS),

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/networkgraph"
 	"github.com/stackrox/rox/pkg/timestamp"
@@ -144,6 +145,11 @@ func (c *connectionPair) external() *connectionPair {
 
 func (c *connectionPair) invalidAddress() *connectionPair {
 	c.conn.remote.IPAndPort.Address = net.ParseIP("invalid")
+	return c
+}
+
+func (c *connectionPair) notFresh() *connectionPair {
+	c.status.firstSeen = timestamp.Now().Add(-env.ClusterEntityResolutionWaitPeriod.DurationSetting() * 2)
 	return c
 }
 


### PR DESCRIPTION
## Description

Connections with invalid/empty IP addresses reported by Collector were retried indefinitely in Sensor's network flow enrichment pipeline. When `enrichConnection` returns `EnrichmentResultInvalidInput` with reason `EnrichmentReasonConnParsingIPFailed`, the handler `handleConnectionEnrichmentResult` incorrectly mapped this to `PostEnrichmentActionRetry`. Since the IP address is immutable on the connection object, every subsequent enrichment tick re-processed the same connection with the same guaranteed-to-fail result.

This caused CPU churn, metric inflation (`parsing-ip-failed` counter growing continuously), and store noise on clusters with connections reporting empty IPs (observed: millions of retries on a customer cluster with ~5,700 pods).

The fix changes the action to `PostEnrichmentActionRemove`, which aligns with:
- The documented intent in `enrichment.go` (line 94: "do not retry the enrichment again")
- The endpoint enrichment handler which already returns `PostEnrichmentActionRemove` for `EnrichmentResultInvalidInput`

AI-Assisted: cursor, ~70% generated, user reviewed logic


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Unit tests only
