### PR TITLE
fix: use IS NULL instead of OR in alert migration queries

### DIFF
--- a/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_bench_test.go
+++ b/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_bench_test.go
@@ -26,20 +26,43 @@ func BenchmarkMigration(b *testing.B) {
 		name        string
 		alerts      int
 		deployments int
+		orphanPct   int // percentage of deployments that are orphaned (deleted)
 	}{
-		{"10k", 10_000, 500},
-		{"100k", 100_000, 2_000},
-		{"500k", 500_000, 4_000},
+		{"10k", 10_000, 500, 10},
+		{"100k", 100_000, 2_000, 10},
+		{"500k", 500_000, 4_000, 10},
 	}
 
 	for _, sz := range sizes {
 		b.Run(sz.name, func(b *testing.B) {
-			benchmarkMigration(b, sz.alerts, sz.deployments)
+			benchmarkMigration(b, sz.alerts, sz.deployments, sz.orphanPct)
 		})
 	}
 }
 
-func benchmarkMigration(b *testing.B, numAlerts, numDeployments int) {
+// BenchmarkMigrationLongRunning simulates a long-running cluster where most
+// deployments have been deleted. Based on observed data: ~2M alerts, 332K
+// distinct deployment IDs, only 657 still exist (~99.8% orphaned).
+// Scaled down to 500k alerts to keep benchmark runtime reasonable.
+func BenchmarkMigrationLongRunning(b *testing.B) {
+	sizes := []struct {
+		name        string
+		alerts      int
+		deployments int
+		orphanPct   int
+	}{
+		{"500k_95pct_orphan", 500_000, 4_000, 95},
+		{"500k_99pct_orphan", 500_000, 4_000, 99},
+	}
+
+	for _, sz := range sizes {
+		b.Run(sz.name, func(b *testing.B) {
+			benchmarkMigration(b, sz.alerts, sz.deployments, sz.orphanPct)
+		})
+	}
+}
+
+func benchmarkMigration(b *testing.B, numAlerts, numDeployments, orphanPct int) {
 	ctx := sac.WithAllAccess(context.Background())
 	db := pghelper.ForT(b, false)
 
@@ -50,7 +73,7 @@ func benchmarkMigration(b *testing.B, numAlerts, numDeployments int) {
 		b.Fatal(err)
 	}
 
-	deploymentIDs, orphanedIDs := insertBenchDeployments(b, ctx, db, numDeployments)
+	deploymentIDs, orphanedIDs := insertBenchDeployments(b, ctx, db, numDeployments, orphanPct)
 	insertBenchAlerts(b, ctx, db, numAlerts, deploymentIDs, orphanedIDs)
 
 	var totalAlerts int
@@ -81,13 +104,12 @@ func benchmarkMigration(b *testing.B, numAlerts, numDeployments int) {
 	}
 }
 
-func insertBenchDeployments(b *testing.B, ctx context.Context, db *pghelper.TestPostgres, numDeployments int) (live []string, orphaned []string) {
+func insertBenchDeployments(b *testing.B, ctx context.Context, db *pghelper.TestPostgres, numDeployments, orphanPct int) (live []string, orphaned []string) {
 	b.Helper()
 	deployTypes := []string{"Deployment", "DaemonSet", "StatefulSet", "Job", "CronJob", "Pod"}
 
 	live = make([]string, 0, numDeployments)
-	// 10% of deployments will be orphaned (deleted but alerts remain)
-	orphanCount := numDeployments / 10
+	orphanCount := numDeployments * orphanPct / 100
 	orphaned = make([]string, 0, orphanCount)
 
 	for i := 0; i < numDeployments; i++ {
@@ -228,6 +250,20 @@ func makeBenchAlert(index int, deployIDs []string, deployTypes []string) *storag
 		}
 	}
 
+	// Pad with violations to reach ~4.8KB serialized size (matches production avg).
+	padding := "This container image contains a package with a known vulnerability that could allow " +
+		"remote code execution. The CVE has a CVSS score of 8.1 and affects versions prior to the " +
+		"latest patch. Upgrade the package to the fixed version to remediate this finding. Review " +
+		"the deployment configuration and ensure that security contexts are properly configured " +
+		"with read-only root filesystem and non-root user requirements enforced at the pod level."
+	violations := make([]*storage.Alert_Violation, 0, 10)
+	for v := 0; v < 10; v++ {
+		violations = append(violations, &storage.Alert_Violation{
+			Message: fmt.Sprintf("Violation %d for %s in ns-%d: %s", v, depID, index%20, padding),
+		})
+	}
+	alert.Violations = violations
+
 	// ~10% resolved
 	if index%10 == 0 {
 		alert.State = storage.ViolationState_RESOLVED
@@ -256,5 +292,116 @@ func resetBenchColumns(b *testing.B, ctx context.Context, db *pghelper.TestPostg
 	// so the benchmark still measures the full work.
 	for _, col := range []string{"deployment_type", "enforcementcount"} {
 		_, _ = db.Exec(ctx, fmt.Sprintf("ALTER TABLE alerts DROP COLUMN IF EXISTS %s", col))
+	}
+}
+
+// BenchmarkOrphanedQueryComparison isolates the OR vs IS NULL query difference
+// using separate databases so neither variant benefits from the other's cached pages.
+// Uses 500k alerts at 99% orphan ratio with ~4.8KB rows to exceed shared_buffers.
+func BenchmarkOrphanedQueryComparison(b *testing.B) {
+	const (
+		numAlerts      = 500_000
+		numDeployments = 4_000
+		orphanPct      = 99
+	)
+
+	type queryVariant struct {
+		name       string
+		firstQuery string
+		nextQuery  string
+	}
+	queries := []queryVariant{
+		{
+			"with_or",
+			`SELECT a.id, a.serialized FROM alerts a
+			WHERE a.entitytype = $1
+			  AND (a.deployment_type IS NULL OR a.deployment_type = '')
+			ORDER BY a.id LIMIT $2`,
+			`SELECT a.id, a.serialized FROM alerts a
+			WHERE a.entitytype = $1
+			  AND (a.deployment_type IS NULL OR a.deployment_type = '')
+			  AND a.id > $2
+			ORDER BY a.id LIMIT $3`,
+		},
+		{
+			"is_null_only",
+			`SELECT a.id, a.serialized FROM alerts a
+			WHERE a.entitytype = $1
+			  AND a.deployment_type IS NULL
+			ORDER BY a.id LIMIT $2`,
+			`SELECT a.id, a.serialized FROM alerts a
+			WHERE a.entitytype = $1
+			  AND a.deployment_type IS NULL
+			  AND a.id > $2
+			ORDER BY a.id LIMIT $3`,
+		},
+	}
+
+	for _, q := range queries {
+		b.Run(q.name, func(b *testing.B) {
+			ctx := sac.WithAllAccess(context.Background())
+			db := pghelper.ForT(b, false)
+
+			pgutils.CreateTableFromModel(ctx, db.GetGormDB(), oldSchema.CreateTableAlertsStmt)
+			_, err := db.Exec(ctx,
+				`CREATE TABLE IF NOT EXISTS deployments (id UUID PRIMARY KEY, type VARCHAR)`)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			liveIDs, orphanedIDs := insertBenchDeployments(b, ctx, db, numDeployments, orphanPct)
+			insertBenchAlerts(b, ctx, db, numAlerts, liveIDs, orphanedIDs)
+
+			// Add the deployment_type column (NULL for all rows, simulating pre-migration state)
+			_, err = db.Exec(ctx, "ALTER TABLE alerts ADD COLUMN IF NOT EXISTS deployment_type VARCHAR")
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			var totalRows int
+			if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM alerts WHERE entitytype = $1", storage.Alert_DEPLOYMENT).Scan(&totalRows); err != nil {
+				b.Fatal(err)
+			}
+			b.Logf("Setup: %d deployment alerts, query=%s", totalRows, q.name)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				lastID := ""
+				batches := 0
+				for {
+					var rows interface {
+						Next() bool
+						Scan(...interface{}) error
+						Close()
+					}
+					var err error
+					if lastID == "" {
+						rows, err = db.Query(ctx, q.firstQuery, storage.Alert_DEPLOYMENT, batchSize)
+					} else {
+						rows, err = db.Query(ctx, q.nextQuery, storage.Alert_DEPLOYMENT, lastID, batchSize)
+					}
+					if err != nil {
+						b.Fatal(err)
+					}
+					count := 0
+					for rows.Next() {
+						var id string
+						var serialized []byte
+						if err := rows.Scan(&id, &serialized); err != nil {
+							rows.Close()
+							b.Fatal(err)
+						}
+						lastID = id
+						count++
+					}
+					rows.Close()
+					batches++
+					if count < batchSize {
+						break
+					}
+				}
+				b.Logf("Processed %d batches", batches)
+			}
+		})
 	}
 }

--- a/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_impl.go
+++ b/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_impl.go
@@ -57,7 +57,7 @@ func backfillDeploymentType(ctx context.Context, db postgres.DB) error {
 		`UPDATE alerts a SET deployment_type = d.type
 		 FROM deployments d
 		 WHERE a.deployment_id = d.id
-		   AND (a.deployment_type IS NULL OR a.deployment_type = '')
+		   AND a.deployment_type IS NULL
 		   AND a.entitytype = $1`,
 		storage.Alert_DEPLOYMENT,
 	)
@@ -112,14 +112,14 @@ func readOrphanedDeploymentTypes(db postgres.DB, ctx context.Context, lastID str
 		rows, err = db.Query(ctx,
 			`SELECT a.id, a.serialized FROM alerts a
 			WHERE a.entitytype = $1
-			  AND (a.deployment_type IS NULL OR a.deployment_type = '')
+			  AND a.deployment_type IS NULL
 			ORDER BY a.id LIMIT $2`,
 			storage.Alert_DEPLOYMENT, batchSize)
 	} else {
 		rows, err = db.Query(ctx,
 			`SELECT a.id, a.serialized FROM alerts a
 			WHERE a.entitytype = $1
-			  AND (a.deployment_type IS NULL OR a.deployment_type = '')
+			  AND a.deployment_type IS NULL
 			  AND a.id > $2
 			ORDER BY a.id LIMIT $3`,
 			storage.Alert_DEPLOYMENT, lastID, batchSize)


### PR DESCRIPTION
The OR deployment_type = '' clause forces per-row string comparison
that prevents efficient NULL bitmap filtering. On a long-running
cluster with 2M alerts (99.8% orphaned, 9GB table), EXPLAIN ANALYZE
showed 5x improvement per batch (9.2s to 1.8s). Empty string is an
intentional value from alert processing, not a missing column.

Also adds long-running cluster benchmark profiles (95%/99% orphan
ratio) and an isolated query comparison benchmark with ~4.8KB rows
matching production avg row size.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
