### PR TITLE
ROX-34585: update FIM e2e tests with auto-config

### DIFF
--- a/qa-tests-backend/src/test/groovy/FileActivityTest.groovy
+++ b/qa-tests-backend/src/test/groovy/FileActivityTest.groovy
@@ -18,7 +18,7 @@ class FileActivityTest extends BaseSpecification {
 
     static final private String DEPLOY_PATH = "/tmp/fa-deploy-${RUN_ID}"
     static final private String NODE_PATH = "/tmp/fa-node-${RUN_ID}"
-    static final private String POLICY_WILDCARD = "/tmp/fa-*"
+    static final private String POLICY_PATH = "/tmp/fa-*"
     static final private String DEPLOY_POLICY_NAME = "FA-E2E-deploy-${RUN_ID}"
     static final private String NODE_POLICY_NAME = "FA-E2E-node-${RUN_ID}"
 
@@ -33,7 +33,7 @@ class FileActivityTest extends BaseSpecification {
             .setName("fa-deploy-${RUN_ID}")
             .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-33-1")
             .setCommand(["/bin/sh", "-c",])
-            .setArgs(["while sleep 1; do touch ${DEPLOY_PATH}; done" as String,])
+            .setArgs(["while sleep 1; do echo >> ${DEPLOY_PATH}; done" as String,])
             .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
 
     @Shared
@@ -41,7 +41,7 @@ class FileActivityTest extends BaseSpecification {
             .setName("fa-node-${RUN_ID}")
             .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-33-1")
             .setCommand(["/bin/sh", "-c",])
-            .setArgs(["while sleep 1; do chroot /host sudo touch ${NODE_PATH}; done" as String,])
+            .setArgs(["while sleep 1; do chroot /host sudo sh -c 'echo >> ${NODE_PATH}'; done" as String,])
             .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
             .setPrivilegedFlag(true)
             .addHostMount("host-root", "/host")
@@ -53,13 +53,13 @@ class FileActivityTest extends BaseSpecification {
                         Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS, Constants.FACT_CONTAINER))
 
         deployPolicyID = PolicyService.createNewPolicy(createFileActivityPolicy(
-                DEPLOY_POLICY_NAME, POLICY_WILDCARD,
-                PolicyOuterClass.EventSource.DEPLOYMENT_EVENT, "OPEN"))
+                DEPLOY_POLICY_NAME, POLICY_PATH,
+                PolicyOuterClass.EventSource.DEPLOYMENT_EVENT))
         assert deployPolicyID
 
         nodePolicyID = PolicyService.createNewPolicy(createFileActivityPolicy(
-                NODE_POLICY_NAME, POLICY_WILDCARD,
-                PolicyOuterClass.EventSource.NODE_EVENT, "OPEN"))
+                NODE_POLICY_NAME, POLICY_PATH,
+                PolicyOuterClass.EventSource.NODE_EVENT))
         assert nodePolicyID
 
         orchestrator.createDeployment(deployDeployment)
@@ -94,7 +94,7 @@ class FileActivityTest extends BaseSpecification {
         "the alert contains file access violation details"
         def violations = AlertService.getViolations(
                 ListAlertsRequest.newBuilder()
-                        .setQuery("Policy:${DEPLOY_POLICY_NAME}")
+                        .setQuery("Deployment:${deployDeployment.name}+Policy:${DEPLOY_POLICY_NAME}")
                         .build())
         assert violations.size() >= 1
 
@@ -109,27 +109,24 @@ class FileActivityTest extends BaseSpecification {
         expect:
         "a node-level alert is triggered"
         assert Services.waitForNodeViolation(NODE_POLICY_NAME, 90)
+
+        and:
+        "the alert contains file access violation details"
+        def violations = AlertService.getViolations(
+                ListAlertsRequest.newBuilder()
+                        .setQuery("Policy:${NODE_POLICY_NAME}")
+                        .build())
+        assert violations.size() >= 1
+
+        def alert = AlertService.getViolation(violations[0].id)
+        assert alert.violationsList.size() > 0
+        assert alert.violationsList[0].type == AlertOuterClass.Alert.Violation.Type.FILE_ACCESS
+        assert alert.violationsList[0].message.contains(NODE_PATH)
     }
 
     @CompileStatic
     private static PolicyOuterClass.Policy createFileActivityPolicy(
-            String name, String path, PolicyOuterClass.EventSource eventSource, String... operations) {
-        def groups = [
-                PolicyOuterClass.PolicyGroup.newBuilder()
-                        .setFieldName("File Path")
-                        .addValues(PolicyOuterClass.PolicyValue.newBuilder().setValue(path))
-                        .build(),
-        ]
-
-        if (operations.length > 0) {
-            def opGroup = PolicyOuterClass.PolicyGroup.newBuilder()
-                    .setFieldName("File Operation")
-            operations.each { op ->
-                opGroup.addValues(PolicyOuterClass.PolicyValue.newBuilder().setValue(op))
-            }
-            groups << opGroup.build()
-        }
-
+            String name, String path, PolicyOuterClass.EventSource eventSource) {
         return PolicyOuterClass.Policy.newBuilder()
                 .setName(name)
                 .addLifecycleStages(PolicyOuterClass.LifecycleStage.RUNTIME)
@@ -140,7 +137,12 @@ class FileActivityTest extends BaseSpecification {
                 .addPolicySections(
                         PolicyOuterClass.PolicySection.newBuilder()
                                 .setSectionName("file-access")
-                                .addAllPolicyGroups(groups)
+                                .addPolicyGroups(
+                                        PolicyOuterClass.PolicyGroup.newBuilder()
+                                                .setFieldName("File Path")
+                                                .addValues(PolicyOuterClass.PolicyValue.newBuilder()
+                                                        .setValue(path))
+                                                .build())
                                 .build()
                 )
                 .build()

--- a/qa-tests-backend/src/test/groovy/FileActivityTest.groovy
+++ b/qa-tests-backend/src/test/groovy/FileActivityTest.groovy
@@ -1,5 +1,3 @@
-import static util.Helpers.waitForTrue
-
 import io.stackrox.proto.api.v1.AlertServiceOuterClass.ListAlertsRequest
 import io.stackrox.proto.storage.AlertOuterClass
 import io.stackrox.proto.storage.PolicyOuterClass
@@ -18,16 +16,35 @@ import spock.lang.Tag
 @Tag("PZ")
 class FileActivityTest extends BaseSpecification {
 
-    static final private String TEST_IMAGE =
-            "quay.io/rhacs-eng/qa-multi-arch:nginx-" +
-            "204a9a8e65061b10b92ad361dd6f406248404fe60efd5d6a8f2595f18bb37aad"
+    static final private String DEPLOY_PATH = "/tmp/fa-deploy-${RUN_ID}"
+    static final private String NODE_PATH = "/tmp/fa-node-${RUN_ID}"
+    static final private String POLICY_WILDCARD = "/tmp/fa-*"
+    static final private String DEPLOY_POLICY_NAME = "FA-E2E-deploy-${RUN_ID}"
+    static final private String NODE_POLICY_NAME = "FA-E2E-node-${RUN_ID}"
 
     @Shared
-    private final Deployment testDeployment = new Deployment()
-            .setName("fa-test-${RUN_ID}")
-            .setImage(TEST_IMAGE)
-            .setCommand(["sh", "-c", "sleep 3600"])
+    private String deployPolicyID
+
+    @Shared
+    private String nodePolicyID
+
+    @Shared
+    private final Deployment deployDeployment = new Deployment()
+            .setName("fa-deploy-${RUN_ID}")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-33-1")
+            .setCommand(["/bin/sh", "-c",])
+            .setArgs(["while sleep 1; do touch ${DEPLOY_PATH}; done" as String,])
             .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
+
+    @Shared
+    private final Deployment nodeDeployment = new Deployment()
+            .setName("fa-node-${RUN_ID}")
+            .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-33-1")
+            .setCommand(["/bin/sh", "-c",])
+            .setArgs(["while sleep 1; do chroot /host sudo touch ${NODE_PATH}; done" as String,])
+            .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
+            .setPrivilegedFlag(true)
+            .addHostMount("host-root", "/host")
 
     def setupSpec() {
         Assume.assumeTrue(
@@ -35,143 +52,63 @@ class FileActivityTest extends BaseSpecification {
                 orchestrator.containsDaemonSetContainer(
                         Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS, Constants.FACT_CONTAINER))
 
-        setFactEnv("/tmp/**/*", true)
+        deployPolicyID = PolicyService.createNewPolicy(createFileActivityPolicy(
+                DEPLOY_POLICY_NAME, POLICY_WILDCARD,
+                PolicyOuterClass.EventSource.DEPLOYMENT_EVENT, "OPEN"))
+        assert deployPolicyID
 
-        orchestrator.createDeployment(testDeployment)
-        assert Services.waitForDeployment(testDeployment)
+        nodePolicyID = PolicyService.createNewPolicy(createFileActivityPolicy(
+                NODE_POLICY_NAME, POLICY_WILDCARD,
+                PolicyOuterClass.EventSource.NODE_EVENT, "OPEN"))
+        assert nodePolicyID
+
+        orchestrator.createDeployment(deployDeployment)
+        orchestrator.createDeployment(nodeDeployment)
+        assert Services.waitForDeployment(deployDeployment)
+        assert Services.waitForDeployment(nodeDeployment)
     }
 
     def cleanupSpec() {
         if (orchestrator.containsDaemonSetContainer(
                 Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS, Constants.FACT_CONTAINER)) {
-            orchestrator.deleteDeployment(testDeployment)
-            removeFactEnv()
+            orchestrator.deleteDeployment(deployDeployment)
+            orchestrator.deleteDeployment(nodeDeployment)
+            resolveAlertsByPolicy(DEPLOY_POLICY_NAME)
+            resolveAlertsByPolicy(NODE_POLICY_NAME)
+            if (deployPolicyID) {
+                PolicyService.deletePolicy(deployPolicyID)
+            }
+            if (nodePolicyID) {
+                PolicyService.deletePolicy(nodePolicyID)
+            }
         }
     }
 
     @Tag("BAT")
     def "Verify deployment-level file activity alert is triggered"() {
-        given:
-        "a file activity policy for a unique path"
-        def path = "/tmp/fa-deploy-${RUN_ID}"
-        def policyName = "FA-E2E-deploy-${RUN_ID}"
-        def policy = createFileActivityPolicy(
-                policyName, path,
-                PolicyOuterClass.EventSource.DEPLOYMENT_EVENT, "CREATE")
-        def policyID = PolicyService.createNewPolicy(policy)
-        assert policyID
-
-        when:
-        "a file is created at that path inside the deployment"
-        assert orchestrator.execInContainer(testDeployment, "touch ${path}")
-
-        then:
+        expect:
         "an alert is triggered"
-        assert Services.waitForViolation(testDeployment.name, policyName, 90)
+        assert Services.waitForViolation(deployDeployment.name, DEPLOY_POLICY_NAME, 90)
 
         and:
         "the alert contains file access violation details"
         def violations = AlertService.getViolations(
                 ListAlertsRequest.newBuilder()
-                        .setQuery("Deployment:${testDeployment.name}+Policy:${policyName}")
+                        .setQuery("Policy:${DEPLOY_POLICY_NAME}")
                         .build())
         assert violations.size() >= 1
 
         def alert = AlertService.getViolation(violations[0].id)
         assert alert.violationsList.size() > 0
         assert alert.violationsList[0].type == AlertOuterClass.Alert.Violation.Type.FILE_ACCESS
-        assert alert.violationsList[0].message.contains(path)
-
-        cleanup:
-        resolveAlertsByPolicy(policyName)
-        if (policyID) {
-            PolicyService.deletePolicy(policyID)
-        }
+        assert alert.violationsList[0].message.contains(DEPLOY_PATH)
     }
 
     @Tag("BAT")
     def "Verify node-level file activity alert is triggered"() {
-        given:
-        "a file activity policy for a unique path with node event source"
-        def path = "/tmp/fa-node-${RUN_ID}"
-        def policyName = "FA-E2E-node-${RUN_ID}"
-        def policy = createFileActivityPolicy(
-                policyName, path,
-                PolicyOuterClass.EventSource.NODE_EVENT, "CREATE")
-        def policyID = PolicyService.createNewPolicy(policy)
-        assert policyID
-
-        and:
-        "a privileged deployment that can exec on the host"
-        def hostDeployment = new Deployment()
-                .setName("fa-host-${RUN_ID}")
-                .setImage("quay.io/rhacs-eng/qa-multi-arch:busybox-1-33-1")
-                .setCommand(["sh", "-c", "sleep 3600"])
-                .setNamespace(Constants.ORCHESTRATOR_NAMESPACE)
-                .setPrivilegedFlag(true)
-                .addHostMount("host-root", "/host")
-        orchestrator.createDeployment(hostDeployment)
-        assert Services.waitForDeployment(hostDeployment)
-
-        when:
-        "a file is created on the host via chroot"
-        // sudo is needed to trigger a node-level file event; without it the
-        // access is attributed to the container and no node alert fires.
-        assert orchestrator.execInContainer(hostDeployment, "chroot /host sudo touch ${path}")
-
-        then:
+        expect:
         "a node-level alert is triggered"
-        assert Services.waitForNodeViolation(policyName, 90)
-
-        cleanup:
-        if (hostDeployment) {
-            orchestrator.execInContainer(hostDeployment, "chroot /host sudo rm -f ${path}")
-            orchestrator.deleteDeployment(hostDeployment)
-        }
-        resolveAlertsByPolicy(policyName)
-        if (policyID) {
-            PolicyService.deletePolicy(policyID)
-        }
-    }
-
-    @CompileStatic
-    private void setFactEnv(String paths, boolean json) {
-        String jsonStr = Boolean.toString(json)
-        log.info "Setting FACT env on collector DaemonSet: FACT_PATHS=${paths}, FACT_JSON=${jsonStr}"
-
-        orchestrator.updateDaemonSetEnv(
-                Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS, Constants.FACT_CONTAINER,
-                "FACT_PATHS", paths)
-        orchestrator.updateDaemonSetEnv(
-                Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS, Constants.FACT_CONTAINER,
-                "FACT_JSON", jsonStr)
-
-        log.info "Waiting for collector DS to pick up FACT env vars and be ready"
-        waitForTrue(20, 10) {
-            orchestrator.daemonSetEnvVarUpdated(
-                    Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS, Constants.FACT_CONTAINER,
-                    "FACT_PATHS", paths) &&
-            orchestrator.daemonSetEnvVarUpdated(
-                    Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS, Constants.FACT_CONTAINER,
-                    "FACT_JSON", jsonStr) &&
-            orchestrator.daemonSetReady(Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS)
-        }
-    }
-
-    private void removeFactEnv() {
-        log.info "Removing FACT env vars from collector DaemonSet"
-
-        orchestrator.removeDaemonSetEnv(
-                Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS, Constants.FACT_CONTAINER,
-                "FACT_PATHS")
-        orchestrator.removeDaemonSetEnv(
-                Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS, Constants.FACT_CONTAINER,
-                "FACT_JSON")
-
-        log.info "Waiting for collector DS to be ready"
-        waitForTrue(20, 10) {
-            orchestrator.daemonSetReady(Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS)
-        }
+        assert Services.waitForNodeViolation(NODE_POLICY_NAME, 90)
     }
 
     @CompileStatic

--- a/qa-tests-backend/src/test/groovy/FileActivityTest.groovy
+++ b/qa-tests-backend/src/test/groovy/FileActivityTest.groovy
@@ -69,18 +69,15 @@ class FileActivityTest extends BaseSpecification {
     }
 
     def cleanupSpec() {
-        if (orchestrator.containsDaemonSetContainer(
-                Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS, Constants.FACT_CONTAINER)) {
-            orchestrator.deleteDeployment(deployDeployment)
-            orchestrator.deleteDeployment(nodeDeployment)
-            resolveAlertsByPolicy(DEPLOY_POLICY_NAME)
-            resolveAlertsByPolicy(NODE_POLICY_NAME)
-            if (deployPolicyID) {
-                PolicyService.deletePolicy(deployPolicyID)
-            }
-            if (nodePolicyID) {
-                PolicyService.deletePolicy(nodePolicyID)
-            }
+        orchestrator.deleteDeployment(deployDeployment)
+        orchestrator.deleteDeployment(nodeDeployment)
+        resolveAlertsByPolicy(DEPLOY_POLICY_NAME)
+        resolveAlertsByPolicy(NODE_POLICY_NAME)
+        if (deployPolicyID) {
+            PolicyService.deletePolicy(deployPolicyID)
+        }
+        if (nodePolicyID) {
+            PolicyService.deletePolicy(nodePolicyID)
         }
     }
 

--- a/qa-tests-backend/src/test/groovy/Services.groovy
+++ b/qa-tests-backend/src/test/groovy/Services.groovy
@@ -162,7 +162,7 @@ class Services extends BaseService {
         return null
     }
 
-    static waitForViolation(String deploymentName, String policyName, int timeoutSeconds = 30) {
+    static boolean waitForViolation(String deploymentName, String policyName, int timeoutSeconds = 30) {
         List<AlertOuterClass.ListAlert> violations = getViolationsWithTimeout(
                 deploymentName, policyName, timeoutSeconds)
         if (violations == null || violations.size() == 0) {
@@ -171,7 +171,7 @@ class Services extends BaseService {
         return violations != null && violations.size() > 0
     }
 
-    static waitForNodeViolation(String policyName, int timeoutSeconds = 30) {
+    static boolean waitForNodeViolation(String policyName, int timeoutSeconds = 30) {
         def query = "Policy:${policyName}+Violation State:ACTIVE+Entity Type:NODE"
         List<AlertOuterClass.ListAlert> violations = getViolationsHelper(query, policyName, timeoutSeconds)
         if (violations == null || violations.size() == 0) {
@@ -180,7 +180,7 @@ class Services extends BaseService {
         return violations != null && violations.size() > 0
     }
 
-    static waitForResolvedViolation(String deploymentName, String policyName, int timeoutSeconds = 30) {
+    static boolean waitForResolvedViolation(String deploymentName, String policyName, int timeoutSeconds = 30) {
         def query = "Deployment:${deploymentName}+Policy:${policyName}+Violation State:resolved"
         List<AlertOuterClass.ListAlert> violations = getViolationsHelper(query, policyName, timeoutSeconds)
         if (violations == null || violations.size() == 0) {
@@ -505,7 +505,7 @@ class Services extends BaseService {
     // When changing the timeout here, remember there might be other enclosing
     // timeout that should be in sync. For example,`globalTimeout` which aborts
     // tests but should be generally avoided.
-    static waitForDeployment(objects.Deployment deployment, int retries = 60, int interval = 5) {
+    static boolean waitForDeployment(objects.Deployment deployment, int retries = 60, int interval = 5) {
         if (deployment.deploymentUid == null) {
             LOG.info "deploymentID for [${deployment.name}] is null, checking orchestrator directly for deployment ID"
             deployment.deploymentUid = OrchestratorType.orchestrator.getDeploymentId(deployment)
@@ -517,7 +517,7 @@ class Services extends BaseService {
         return waitForDeploymentByID(deployment.deploymentUid, deployment.name, retries, interval)
     }
 
-    static waitForDeploymentByID(String id, String name, int retries = 30, int interval = 2) {
+    static boolean waitForDeploymentByID(String id, String name, int retries = 30, int interval = 2) {
         Timer t = new Timer(retries, interval)
         while (t.IsValid()) {
             if (roxDetectedDeployment(id, name)) {


### PR DESCRIPTION
## Description

Updates the file activity tests now that automatic configuration has merged in #19089.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI should be enough; will run ocp-4-21-qa-e2e-tests specifically to ensure everything works.
