### PR TITLE
ROX-34652: runtime detection of invalid PostgreSQL indexes

### DIFF
--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -20,6 +20,7 @@ func init() {
 		PostgresMaximumConnections,
 		PostgresTableLiveTuples,
 		PostgresTableDeadTuples,
+		PostgresInvalidIndexes,
 	)
 }
 
@@ -115,4 +116,11 @@ var (
 		Name:      "postgres_dead_tuples",
 		Help:      "dead tuples for the table",
 	}, []string{"table"})
+
+	PostgresInvalidIndexes = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "postgres_invalid_indexes",
+		Help:      "number of invalid indexes in the database",
+	})
 )

--- a/central/globaldb/metrics/metrics.go
+++ b/central/globaldb/metrics/metrics.go
@@ -117,10 +117,10 @@ var (
 		Help:      "dead tuples for the table",
 	}, []string{"table"})
 
-	PostgresInvalidIndexes = prometheus.NewGauge(prometheus.GaugeOpts{
+	PostgresInvalidIndexes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "postgres_invalid_indexes",
-		Help:      "number of invalid indexes in the database",
-	})
+		Help:      "invalid indexes in the database (1 per invalid index)",
+	}, []string{"index_name", "table_name"})
 )

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -2,11 +2,16 @@ package globaldb
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/central/globaldb/metrics"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/administration/events"
+	"github.com/stackrox/rox/pkg/administration/events/stream"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres"
@@ -88,6 +93,11 @@ SELECT
 	totalConnectionQuery = `SELECT state, COUNT(datid) FROM pg_stat_activity WHERE state IS NOT NULL GROUP BY state;`
 
 	maxConnectionQuery = `SELECT current_setting('max_connections')::int;`
+
+	invalidIndexQuery = `SELECT s.relname, s.indexrelname
+		FROM pg_stat_user_indexes s
+		JOIN pg_index ix ON ix.indexrelid = s.indexrelid
+		WHERE ix.indisvalid = false`
 
 	pgStatStatementsMax = 1000
 )
@@ -378,6 +388,15 @@ func getMaxConnections(ctx context.Context, db postgres.DB) {
 }
 
 func startMonitoringPostgres(ctx context.Context, db postgres.DB, postgresConfig *postgres.Config) {
+	go func() {
+		t := time.NewTicker(1 * time.Hour)
+		defer t.Stop()
+		CollectPostgresIndexStats(ctx, db)
+		for range t.C {
+			CollectPostgresIndexStats(ctx, db)
+		}
+	}()
+
 	t := time.NewTicker(1 * time.Minute)
 	defer t.Stop()
 	for range t.C {
@@ -385,5 +404,60 @@ func startMonitoringPostgres(ctx context.Context, db postgres.DB, postgresConfig
 		CollectPostgresDatabaseStats(postgresConfig)
 		CollectPostgresConnectionStats(ctx, db)
 		CollectPostgresTupleStats(ctx, db)
+	}
+}
+
+// CollectPostgresIndexStats checks for invalid indexes, exports a Prometheus metric,
+// and produces an administration event if any are found.
+func CollectPostgresIndexStats(ctx context.Context, db postgres.DB) {
+	ctx, cancel := context.WithTimeout(ctx, PostgresQueryTimeout)
+	defer cancel()
+
+	rows, err := db.Query(ctx, invalidIndexQuery)
+	if err != nil {
+		log.Errorf("error checking for invalid indexes: %v", err)
+		metrics.PostgresInvalidIndexes.Set(0)
+		return
+	}
+	defer rows.Close()
+
+	type invalidIndex struct {
+		tableName string
+		indexName string
+	}
+	var invalidIndexes []invalidIndex
+
+	for rows.Next() {
+		var idx invalidIndex
+		if err := rows.Scan(&idx.tableName, &idx.indexName); err != nil {
+			log.Errorf("error scanning row for invalid index data: %v", err)
+			return
+		}
+		invalidIndexes = append(invalidIndexes, idx)
+	}
+	if err := rows.Err(); err != nil {
+		log.Errorf("error reading invalid index rows: %v", err)
+	}
+
+	metrics.PostgresInvalidIndexes.Set(float64(len(invalidIndexes)))
+
+	if len(invalidIndexes) > 0 {
+		var details strings.Builder
+		for i, idx := range invalidIndexes {
+			if i > 0 {
+				details.WriteString(", ")
+			}
+			fmt.Fprintf(&details, "%s (table: %s)", idx.indexName, idx.tableName)
+		}
+
+		stream.Singleton().Produce(&events.AdministrationEvent{
+			Type:         storage.AdministrationEventType_ADMINISTRATION_EVENT_TYPE_GENERIC,
+			Level:        storage.AdministrationEventLevel_ADMINISTRATION_EVENT_LEVEL_WARNING,
+			Domain:       events.DefaultDomain,
+			Message:      fmt.Sprintf("Detected %d invalid PostgreSQL index(es): %s", len(invalidIndexes), details.String()),
+			ResourceType: "Database",
+			ResourceName: "central-db",
+			Hint:         "Invalid indexes can degrade query performance and may indicate a failed index creation or migration. To fix, run: REINDEX INDEX CONCURRENTLY <index_name>; for each invalid index. If the problem persists, contact Red Hat support.",
+		})
 	}
 }

--- a/central/globaldb/postgres.go
+++ b/central/globaldb/postgres.go
@@ -416,7 +416,7 @@ func CollectPostgresIndexStats(ctx context.Context, db postgres.DB) {
 	rows, err := db.Query(ctx, invalidIndexQuery)
 	if err != nil {
 		log.Errorf("error checking for invalid indexes: %v", err)
-		metrics.PostgresInvalidIndexes.Set(0)
+		metrics.PostgresInvalidIndexes.Reset()
 		return
 	}
 	defer rows.Close()
@@ -439,7 +439,13 @@ func CollectPostgresIndexStats(ctx context.Context, db postgres.DB) {
 		log.Errorf("error reading invalid index rows: %v", err)
 	}
 
-	metrics.PostgresInvalidIndexes.Set(float64(len(invalidIndexes)))
+	metrics.PostgresInvalidIndexes.Reset()
+	for _, idx := range invalidIndexes {
+		metrics.PostgresInvalidIndexes.With(prometheus.Labels{
+			"index_name": idx.indexName,
+			"table_name": idx.tableName,
+		}).Set(1)
+	}
 
 	if len(invalidIndexes) > 0 {
 		var details strings.Builder

--- a/central/globaldb/postgres_test.go
+++ b/central/globaldb/postgres_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stackrox/rox/central/globaldb/metrics"
 	"github.com/stackrox/rox/pkg/postgres/pgconfig"
@@ -108,7 +109,7 @@ func (s *PostgresUtilitySuite) TestCollectPostgresIndexStats() {
 
 	// On a clean test DB there should be no invalid indexes.
 	CollectPostgresIndexStats(ctx, tp.DB)
-	s.Equal(0.0, testutil.ToFloat64(metrics.PostgresInvalidIndexes))
+	s.Equal(0, testutil.CollectAndCount(metrics.PostgresInvalidIndexes))
 
 	// Create a table and index, then mark the index invalid.
 	_, err := tp.DB.Exec(ctx, "CREATE TABLE test_invalid_idx_check (id int)")
@@ -119,7 +120,11 @@ func (s *PostgresUtilitySuite) TestCollectPostgresIndexStats() {
 	s.Require().NoError(err)
 
 	CollectPostgresIndexStats(ctx, tp.DB)
-	s.Equal(1.0, testutil.ToFloat64(metrics.PostgresInvalidIndexes))
+	s.Equal(1, testutil.CollectAndCount(metrics.PostgresInvalidIndexes))
+	s.Equal(1.0, testutil.ToFloat64(metrics.PostgresInvalidIndexes.With(prometheus.Labels{
+		"index_name": "test_idx",
+		"table_name": "test_invalid_idx_check",
+	})))
 
 	// Clean up: restore validity so DROP works cleanly.
 	_, err = tp.DB.Exec(ctx, "UPDATE pg_index SET indisvalid = true WHERE indexrelid = 'test_idx'::regclass")
@@ -128,5 +133,5 @@ func (s *PostgresUtilitySuite) TestCollectPostgresIndexStats() {
 	s.Require().NoError(err)
 
 	CollectPostgresIndexStats(ctx, tp.DB)
-	s.Equal(0.0, testutil.ToFloat64(metrics.PostgresInvalidIndexes))
+	s.Equal(0, testutil.CollectAndCount(metrics.PostgresInvalidIndexes))
 }

--- a/central/globaldb/postgres_test.go
+++ b/central/globaldb/postgres_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stackrox/rox/central/globaldb/metrics"
 	"github.com/stackrox/rox/pkg/postgres/pgconfig"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
 	"github.com/stackrox/rox/pkg/sac"
@@ -97,4 +99,34 @@ func (s *PostgresUtilitySuite) TestCollectPostgresStats() {
 	stats = CollectPostgresStats(ctx, tp.DB)
 	s.NotNil(stats)
 	s.Equal(false, stats.DatabaseAvailable)
+}
+
+func (s *PostgresUtilitySuite) TestCollectPostgresIndexStats() {
+	ctx := sac.WithAllAccess(context.Background())
+	tp := pgtest.ForT(s.T())
+	defer tp.Close()
+
+	// On a clean test DB there should be no invalid indexes.
+	CollectPostgresIndexStats(ctx, tp.DB)
+	s.Equal(0.0, testutil.ToFloat64(metrics.PostgresInvalidIndexes))
+
+	// Create a table and index, then mark the index invalid.
+	_, err := tp.DB.Exec(ctx, "CREATE TABLE test_invalid_idx_check (id int)")
+	s.Require().NoError(err)
+	_, err = tp.DB.Exec(ctx, "CREATE INDEX test_idx ON test_invalid_idx_check (id)")
+	s.Require().NoError(err)
+	_, err = tp.DB.Exec(ctx, "UPDATE pg_index SET indisvalid = false WHERE indexrelid = 'test_idx'::regclass")
+	s.Require().NoError(err)
+
+	CollectPostgresIndexStats(ctx, tp.DB)
+	s.Equal(1.0, testutil.ToFloat64(metrics.PostgresInvalidIndexes))
+
+	// Clean up: restore validity so DROP works cleanly.
+	_, err = tp.DB.Exec(ctx, "UPDATE pg_index SET indisvalid = true WHERE indexrelid = 'test_idx'::regclass")
+	s.Require().NoError(err)
+	_, err = tp.DB.Exec(ctx, "DROP TABLE test_invalid_idx_check")
+	s.Require().NoError(err)
+
+	CollectPostgresIndexStats(ctx, tp.DB)
+	s.Equal(0.0, testutil.ToFloat64(metrics.PostgresInvalidIndexes))
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Hourly check queries pg_stat_user_indexes joined with pg_index for
indisvalid = false. Exports postgres_invalid_indexes Prometheus gauge
and produces an administration event (WARNING) listing affected indexes
with remediation hint.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

```
# HELP rox_central_postgres_invalid_indexes invalid indexes in the database (1 per invalid index)
# TYPE rox_central_postgres_invalid_indexes gauge
rox_central_postgres_invalid_indexes{index_name="alerts_state",table_name="alerts"} 1
rox_central_postgres_invalid_indexes{index_name="alerts_time",table_name="alerts"} 1
```