### PR TITLE
chore(ui): Replace cypress-vite with minimal webpack config

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -12,6 +12,7 @@ npm-debug.log*
 
 # test
 /apps/platform/cypress/downloads/
+/apps/platform/cypress/webpack-output
 /apps/platform/cypress/test-results
 /apps/platform/test-results
 

--- a/ui/apps/platform/cypress.config.js
+++ b/ui/apps/platform/cypress.config.js
@@ -1,11 +1,95 @@
 const path = require('path');
 
-const cypressVite = require('cypress-vite');
+const webpack = require('webpack');
 
-// This is needed because cypress-axe will attempt to resolve the axe.min.js file internally using CommonJS require,
-// which is not supported in Vite. Instead, we resolve the path to the file using CommonJS require in the cypress config
-// and make the path available at test runtime when injecting the axe core.
+// Resolve the axe-core path in Node so it can be passed to the browser via Cypress.env('AXE_CORE_PATH')
 const axeCorePath = require.resolve('axe-core/axe.min.js');
+
+const outputDir = path.resolve(__dirname, 'cypress/webpack-output');
+const compilers = {};
+
+function makeWebpackConfig(filePath) {
+    return {
+        mode: 'development',
+        devtool: 'inline-source-map',
+        entry: { [filePath.replace(/[/\\]/g, '_')]: filePath },
+        output: { path: outputDir, filename: '[name].js' },
+        resolve: { extensions: ['.ts', '.js'] },
+        module: {
+            rules: [
+                {
+                    test: /\.[jt]s$/,
+                    exclude: /node_modules/,
+                    use: {
+                        loader: 'ts-loader',
+                        options: {
+                            transpileOnly: true,
+                            configFile: path.resolve(__dirname, 'cypress/tsconfig.json'),
+                        },
+                    },
+                },
+            ],
+        },
+    };
+}
+
+function compile(compiler) {
+    return new Promise((resolve, reject) => {
+        compiler.run((err, stats) => {
+            if (err) {
+                return reject(err);
+            }
+            if (stats.hasErrors()) {
+                return reject(new Error(stats.toString({ errors: true })));
+            }
+            return resolve();
+        });
+    });
+}
+
+function webpackPreprocessor(file) {
+    const { filePath, shouldWatch } = file;
+    const bundlePath = path.join(outputDir, `${filePath.replace(/[/\\]/g, '_')}.js`);
+
+    if (shouldWatch) {
+        if (compilers[filePath]) {
+            return compilers[filePath].promise;
+        }
+
+        const compiler = webpack(makeWebpackConfig(filePath));
+        const bundle = { initial: true };
+        bundle.promise = new Promise((resolve, reject) => {
+            compiler.watch({}, (err, stats) => {
+                if (err || stats.hasErrors()) {
+                    const error = err || new Error(stats.toString({ errors: true }));
+                    reject(error);
+                    return;
+                }
+                resolve(bundlePath);
+                bundle.promise = Promise.resolve(bundlePath);
+                if (!bundle.initial) {
+                    file.emit('rerun');
+                }
+                bundle.initial = false;
+            });
+        });
+
+        compilers[filePath] = bundle;
+
+        file.on('close', () => {
+            delete compilers[filePath];
+            compiler.close(() => {});
+        });
+
+        return bundle.promise;
+    }
+
+    const compiler = webpack(makeWebpackConfig(filePath));
+    return compile(compiler).then(() => {
+        compiler.close(() => {});
+        return bundlePath;
+    });
+}
 
 /*
  * The helper function intended to provide automatic code completion for configuration in many popular code editors
@@ -48,7 +132,7 @@ module.exports = {
                     return path.join(...paths);
                 },
             });
-            on('file:preprocessor', cypressVite.vitePreprocessor());
+            on('file:preprocessor', webpackPreprocessor);
             return config;
         },
     },

--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -121,7 +121,6 @@
                 "css-loader": "^7.1.2",
                 "cypress": "^15.14.1",
                 "cypress-axe": "^1.7.0",
-                "cypress-vite": "^1.10.0",
                 "eslint": "^9.39.3",
                 "eslint-import-resolver-typescript": "^4.2.6",
                 "eslint-plugin-cypress": "^6.1.0",
@@ -6762,18 +6761,6 @@
             "peerDependencies": {
                 "axe-core": "^3 || ^4",
                 "cypress": "^10 || ^11 || ^12 || ^13 || ^14 || ^15"
-            }
-        },
-        "node_modules/cypress-vite": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/cypress-vite/-/cypress-vite-1.10.0.tgz",
-            "integrity": "sha512-jZtf8IGr3xDer0I/gE69OqvWK8c+Tbn6OQSUeH3h9xJTiitfyuYo/WvevjSNJICg4IV/pEjlUclqpBpc5KF9fQ==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "chokidar": "^2 || ^3 || ^4 || ^5",
-                "debug": "^2 || ^3 || ^4",
-                "vite": "^2.9 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8"
             }
         },
         "node_modules/cypress/node_modules/ci-info": {

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -95,7 +95,7 @@
         "yup": "^1.6.1"
     },
     "scripts": {
-        "clean": "rm -rf ./test-results ./cypress/test-results",
+        "clean": "rm -rf ./test-results ./cypress/test-results ./cypress/webpack-output",
         "start": "vite serve",
         "start:ocp-plugin": "NODE_ENV=development webpack serve --config webpack.ocp-plugin.config.js",
         "build": "tsc && NODE_OPTIONS=--max_old_space_size=4096 vite build",
@@ -150,7 +150,6 @@
         "css-loader": "^7.1.2",
         "cypress": "^15.14.1",
         "cypress-axe": "^1.7.0",
-        "cypress-vite": "^1.10.0",
         "eslint": "^9.39.3",
         "eslint-import-resolver-typescript": "^4.2.6",
         "eslint-plugin-cypress": "^6.1.0",


### PR DESCRIPTION
## Description

Removes cypress-vite and relies on a small webpack configuration and minimal calls to the webpack API to preprocess test files during Cypress e2e tests.

The minimal calls to the webpack API were chosen over `@cypress/webpackpreprocessor` due to the latter bringing in many peer dependencies that we do not use in our build system. A few tens of lines of code prevents a few dozen new dependencies (mostly babel) from being added to our package-lock.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

`npm run test-e2e` locally.
`npm run cypress-open` locally with file change watch testing.

CI