### PR TITLE
fix(ci): replace actions/setup-go with custom action

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -59,11 +59,11 @@ runs:
             break
           fi
         done
+        echo "::add-matcher::${GITHUB_ACTION_PATH}/matchers.json"
         if [[ -n "$best" ]]; then
           echo "$best/bin" >> "$GITHUB_PATH"
           [[ ":$PATH:" == *":$HOME/go/bin:"* ]] || echo "$HOME/go/bin" >> "$GITHUB_PATH"
           echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
-          echo "::add-matcher::${GITHUB_ACTION_PATH}/matchers.json"
           echo "Using $("$best/bin/go" version) from $best"
         else
           echo "::warning::No suitable Go in hostedtoolcache (need >=$required), using system Go"

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -61,6 +61,7 @@ runs:
           echo "$best/bin" >> "$GITHUB_PATH"
           [[ ":$PATH:" == *":$HOME/go/bin:"* ]] || echo "$HOME/go/bin" >> "$GITHUB_PATH"
           echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
+          echo "::add-matcher::${GITHUB_ACTION_PATH}/matchers.json"
           echo "Using $("$best/bin/go" version) from $best"
         else
           echo "::warning::No suitable Go in hostedtoolcache (need >=$required), using system Go"

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -49,8 +49,10 @@ runs:
           required=$(grep '^go ' go.mod | awk '{print $2}')
           echo "::warning::No toolchain directive in go.mod — falling back to go directive ($required). Consider adding 'toolchain go<version>' to go.mod to pin the build version."
         fi
+        arch=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')
         best=""
-        for d in $(ls -d /opt/hostedtoolcache/go/*/x64 2>/dev/null | sort -rV); do
+        # Check /opt (host runner) and /mnt/opt (inside container jobs that mount /opt:/mnt/opt).
+        for d in $(ls -d /opt/hostedtoolcache/go/*/$arch /mnt/opt/hostedtoolcache/go/*/$arch 2>/dev/null | sort -rV); do
           ver=$(basename "$(dirname "$d")")
           if [ -x "$d/bin/go" ] && printf '%s\n%s\n' "$required" "$ver" | sort -V -C; then
             best="$d"

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -30,12 +30,12 @@ runs:
     #     when go.mod specifies a newer build version via `toolchain`.
     #
     # What this action does instead:
-    #   - Reads the `toolchain` directive first (falls back to `go`)
-    #     and finds the best matching Go pre-installed on the runner.
     #   - Sets GOTOOLCHAIN=auto so sub-modules can resolve their own
     #     toolchain requirements.
     #   - Manages GOCACHE with per-job keys (via key-suffix input) and
     #     trims stale entries in a post-step before cache save.
+    #   - Reads the `toolchain` directive first (falls back to `go`)
+    #     and finds the best matching Go pre-installed on the runner.
     - name: Setup Go
       run: |
         # Prefer toolchain directive (build version), fall back to go directive (minimum).

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -43,8 +43,11 @@ runs:
         # Prefer toolchain directive (build version), fall back to go directive (minimum).
         # The toolchain directive strips the "go" prefix: "toolchain go1.25.9" → "1.25.9".
         required=$(grep '^toolchain ' go.mod | awk '{print $2}' | sed 's/^go//')
-        if [[ -z "$required" ]]; then
+        if [[ -n "$required" ]]; then
+          echo "go.mod toolchain directive: go$required"
+        else
           required=$(grep '^go ' go.mod | awk '{print $2}')
+          echo "::warning::No toolchain directive in go.mod — falling back to go directive ($required). Consider adding 'toolchain go<version>' to go.mod to pin the build version."
         fi
         best=""
         for d in $(ls -d /opt/hostedtoolcache/go/*/x64 2>/dev/null | sort -rV); do

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -42,11 +42,11 @@ runs:
       run: |
         # Prefer toolchain directive (build version), fall back to go directive (minimum).
         # The toolchain directive strips the "go" prefix: "toolchain go1.25.9" → "1.25.9".
-        required=$(grep '^toolchain ' go.mod | awk '{print $2}' | sed 's/^go//')
+        required=$(grep '^toolchain ' go.mod | awk '{print $2}' | sed 's/^go//' || true)
         if [[ -n "$required" ]]; then
           echo "go.mod toolchain directive: go$required"
         else
-          required=$(grep '^go ' go.mod | awk '{print $2}')
+          required=$(grep '^go ' go.mod | awk '{print $2}' || true)
           echo "::warning::No toolchain directive in go.mod — falling back to go directive ($required). Consider adding 'toolchain go<version>' to go.mod to pin the build version."
         fi
         arch=$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -34,8 +34,9 @@ runs:
     #     toolchain requirements.
     #   - Manages GOCACHE with per-job keys (via key-suffix input) and
     #     trims stale entries in a post-step before cache save.
-    #   - Reads the `toolchain` directive first (falls back to `go`)
-    #     and finds the best matching Go pre-installed on the runner.
+    #   - Uses go.mod's `toolchain` directive to determine the build
+    #     version (falls back to `go` if unset), and finds the best
+    #     matching Go pre-installed on the runner.
     - name: Setup Go
       run: |
         # Prefer toolchain directive (build version), fall back to go directive (minimum).

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -17,12 +17,23 @@ runs:
   steps:
     # Activate the latest Go from hostedtoolcache that satisfies go.mod.
     # This replaces actions/setup-go — we avoid its downsides:
-    #   - setup-go sets GOTOOLCHAIN=local (breaks sub-module tool downloads)
-    #   - setup-go caches GOCACHE with a single key for all jobs — different
-    #     jobs (unit tests, postgres tests, style) write incompatible entries
-    #     into the same cache, and the cache grows unbounded without trimming
-    #   - setup-go reads the `go` directive, not `toolchain` (installs wrong version)
-    # Our approach: find the best pre-installed Go, add to PATH, set GOTOOLCHAIN=auto.
+    #
+    #   setup-go                          this action
+    #   ─────────────────────────────     ─────────────────────────────
+    #   sets GOTOOLCHAIN=local            sets GOTOOLCHAIN=auto
+    #   (breaks sub-module tool           (sub-modules can download
+    #    downloads that need a             their required toolchain
+    #    newer Go than go.mod)             versions automatically)
+    #
+    #   caches GOCACHE with one key       per-job cache keys with
+    #   for all jobs — different jobs      stale-entry trimming
+    #   overwrite each other's cache      (see key-suffix input and
+    #   and it grows unbounded             trim post-step below)
+    #
+    #   reads `go` directive, not         finds the best pre-installed
+    #   `toolchain` — installs the        Go that satisfies go.mod,
+    #   minimum version even when          using whichever patch the
+    #   a newer patch is available         runner image ships
     - name: Setup Go
       run: |
         required=$(grep '^go ' go.mod | awk '{print $2}')

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -32,8 +32,9 @@ runs:
     # What this action does instead:
     #   - Sets GOTOOLCHAIN=auto so sub-modules can resolve their own
     #     toolchain requirements.
-    #   - Manages GOCACHE with per-job keys (via key-suffix input) and
-    #     trims stale entries in a post-step before cache save.
+    #   - Keys GOCACHE per job (and per matrix entry via key-suffix)
+    #     so jobs don't overwrite each other, and trims stale entries
+    #     in a post-step before cache save.
     #   - Uses go.mod's `toolchain` directive to determine the build
     #     version (falls back to `go` if unset), and finds the best
     #     matching Go pre-installed on the runner.

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -30,13 +30,18 @@ runs:
     #   overwrite each other's cache      (see key-suffix input and
     #   and it grows unbounded             trim post-step below)
     #
-    #   reads `go` directive, not         finds the best pre-installed
-    #   `toolchain` — installs the        Go that satisfies go.mod,
-    #   minimum version even when          using whichever patch the
-    #   a newer patch is available         runner image ships
+    #   reads `go` directive, not         reads `toolchain` directive
+    #   `toolchain` — installs the        first (fall back to `go`),
+    #   minimum version even when          and finds the best match
+    #   a newer patch is available         pre-installed on the runner
     - name: Setup Go
       run: |
-        required=$(grep '^go ' go.mod | awk '{print $2}')
+        # Prefer toolchain directive (build version), fall back to go directive (minimum).
+        # The toolchain directive strips the "go" prefix: "toolchain go1.25.9" → "1.25.9".
+        required=$(grep '^toolchain ' go.mod | awk '{print $2}' | sed 's/^go//')
+        if [[ -z "$required" ]]; then
+          required=$(grep '^go ' go.mod | awk '{print $2}')
+        fi
         best=""
         for d in $(ls -d /opt/hostedtoolcache/go/*/x64 2>/dev/null | sort -rV); do
           ver=$(basename "$(dirname "$d")")

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -18,22 +18,24 @@ runs:
     # Activate the latest Go from hostedtoolcache that satisfies go.mod.
     # This replaces actions/setup-go — we avoid its downsides:
     #
-    #   setup-go                          this action
-    #   ─────────────────────────────     ─────────────────────────────
-    #   sets GOTOOLCHAIN=local            sets GOTOOLCHAIN=auto
-    #   (breaks sub-module tool           (sub-modules can download
-    #    downloads that need a             their required toolchain
-    #    newer Go than go.mod)             versions automatically)
+    # Problems with actions/setup-go:
+    #   - Sets GOTOOLCHAIN=local, which prevents sub-module tools from
+    #     auto-downloading their required Go versions.
+    #   - Caches GOCACHE with a single key shared across all jobs.
+    #     Different jobs (unit tests, postgres tests, style) write
+    #     incompatible entries into the same cache, and it grows
+    #     unbounded because setup-go never trims stale entries.
+    #   - Reads the `go` directive instead of `toolchain`, so it
+    #     installs the minimum language version (e.g. 1.25.0) even
+    #     when go.mod specifies a newer build version via `toolchain`.
     #
-    #   caches GOCACHE with one key       per-job cache keys with
-    #   for all jobs — different jobs      stale-entry trimming
-    #   overwrite each other's cache      (see key-suffix input and
-    #   and it grows unbounded             trim post-step below)
-    #
-    #   reads `go` directive, not         reads `toolchain` directive
-    #   `toolchain` — installs the        first (fall back to `go`),
-    #   minimum version even when          and finds the best match
-    #   a newer patch is available         pre-installed on the runner
+    # What this action does instead:
+    #   - Reads the `toolchain` directive first (falls back to `go`)
+    #     and finds the best matching Go pre-installed on the runner.
+    #   - Sets GOTOOLCHAIN=auto so sub-modules can resolve their own
+    #     toolchain requirements.
+    #   - Manages GOCACHE with per-job keys (via key-suffix input) and
+    #     trims stale entries in a post-step before cache save.
     - name: Setup Go
       run: |
         # Prefer toolchain directive (build version), fall back to go directive (minimum).

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -1,5 +1,8 @@
-name: Cache Go Dependencies
-description: Cache Go Dependencies
+name: Setup Go and Cache
+description: >
+  Activate the best available Go from the runner's hostedtoolcache,
+  override setup-go's problematic defaults, and manage GOCACHE with
+  stale-entry trimming and mtime stabilization for test caching.
 inputs:
   save:
     description: Whether this job saves caches on pushes to the default branch.
@@ -12,6 +15,33 @@ inputs:
 runs:
   using: composite
   steps:
+    # Activate the latest Go from hostedtoolcache that satisfies go.mod.
+    # This replaces actions/setup-go — we avoid its downsides:
+    #   - setup-go sets GOTOOLCHAIN=local (breaks sub-module tool downloads)
+    #   - setup-go enables GOCACHE caching by default (conflicts with ours)
+    #   - setup-go reads the `go` directive, not `toolchain` (installs wrong version)
+    # Our approach: find the best pre-installed Go, add to PATH, set GOTOOLCHAIN=auto.
+    - name: Setup Go
+      run: |
+        required=$(grep '^go ' go.mod | awk '{print $2}')
+        best=""
+        for d in $(ls -d /opt/hostedtoolcache/go/*/x64 2>/dev/null | sort -rV); do
+          ver=$(basename "$(dirname "$d")")
+          if [ -x "$d/bin/go" ] && printf '%s\n%s\n' "$required" "$ver" | sort -V -C; then
+            best="$d"
+            break
+          fi
+        done
+        if [[ -n "$best" ]]; then
+          echo "$best/bin" >> "$GITHUB_PATH"
+          [[ ":$PATH:" == *":$HOME/go/bin:"* ]] || echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
+          echo "Using $("$best/bin/go" version) from $best"
+        else
+          echo "::warning::No suitable Go in hostedtoolcache (need >=$required), using system Go"
+        fi
+      shell: bash
+
     - name: Determine Go cache paths
       id: cache-paths
       run: |

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -18,7 +18,9 @@ runs:
     # Activate the latest Go from hostedtoolcache that satisfies go.mod.
     # This replaces actions/setup-go — we avoid its downsides:
     #   - setup-go sets GOTOOLCHAIN=local (breaks sub-module tool downloads)
-    #   - setup-go enables GOCACHE caching by default (conflicts with ours)
+    #   - setup-go caches GOCACHE with a single key for all jobs — different
+    #     jobs (unit tests, postgres tests, style) write incompatible entries
+    #     into the same cache, and the cache grows unbounded without trimming
     #   - setup-go reads the `go` directive, not `toolchain` (installs wrong version)
     # Our approach: find the best pre-installed Go, add to PATH, set GOTOOLCHAIN=auto.
     - name: Setup Go

--- a/.github/actions/setup-go/matchers.json
+++ b/.github/actions/setup-go/matchers.json
@@ -1,0 +1,16 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "go",
+            "pattern": [
+                {
+                    "regexp": "^\\s*(.+\\.go):(?:(\\d+):(\\d+):)? (.*)",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "message": 4
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -244,11 +244,6 @@ jobs:
         uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # ratchet:joerick/pr-labels-action@v1.0.9
 
       - name: Setup Go and cache
-        if: |
-          needs.define-job-matrix.outputs.gotags == 'release'
-            || github.ref_name == 'master'
-            || github.event_name == 'workflow_call'
-            || contains(github.event.pull_request.labels.*.name, 'ci-build-cli')
         uses: ./.github/actions/setup-go
 
       - name: Build CLI

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -244,6 +244,11 @@ jobs:
         uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # ratchet:joerick/pr-labels-action@v1.0.9
 
       - uses: ./.github/actions/setup-go
+        if: |
+          needs.define-job-matrix.outputs.gotags == 'release'
+            || github.ref_name == 'master'
+            || github.event_name == 'workflow_call'
+            || contains(github.event.pull_request.labels.*.name, 'ci-build-cli')
 
       - name: Build CLI
         if: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -289,9 +289,9 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+      - uses: ./.github/actions/setup-go
         env:
           GOARCH: ${{ matrix.arch }}
-      - uses: ./.github/actions/setup-go
         with:
           # Only race needs a separate cache (-race/CGO_ENABLED=1 produces 39% unique entries).
           # Default and prerelease share 93% of entries and should use the same cache.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -243,7 +243,7 @@ jobs:
       - name: PR labels
         uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # ratchet:joerick/pr-labels-action@v1.0.9
 
-      - name: Cache Go dependencies
+      - name: Setup Go and cache
         if: |
           needs.define-job-matrix.outputs.gotags == 'release'
             || github.ref_name == 'master'
@@ -295,7 +295,7 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-      - name: Cache Go dependencies
+      - name: Setup Go and cache
         env:
           GOARCH: ${{ matrix.arch }}
         uses: ./.github/actions/setup-go
@@ -362,7 +362,7 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-      - name: Cache Go dependencies
+      - name: Setup Go and cache
         uses: ./.github/actions/setup-go
 
       - name: Download scanner module for proto generation
@@ -398,7 +398,7 @@ jobs:
       with:
         node-version-file: ui/package.json
 
-    - name: Cache Go dependencies
+    - name: Setup Go and cache
       uses: ./.github/actions/setup-go
 
     - uses: ./.github/actions/cache-ui-dependencies
@@ -433,7 +433,7 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-      - name: Cache Go dependencies
+      - name: Setup Go and cache
         uses: ./.github/actions/setup-go
 
       - uses: ./.github/actions/handle-tagged-build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -243,7 +243,7 @@ jobs:
       - name: PR labels
         uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # ratchet:joerick/pr-labels-action@v1.0.9
 
-        - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
 
       - name: Build CLI
         if: |
@@ -291,7 +291,7 @@ jobs:
 
         env:
           GOARCH: ${{ matrix.arch }}
-        - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
         with:
           # Only race needs a separate cache (-race/CGO_ENABLED=1 produces 39% unique entries).
           # Default and prerelease share 93% of entries and should use the same cache.
@@ -355,7 +355,7 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-        - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
 
       - name: Download scanner module for proto generation
         run: go mod download github.com/stackrox/scanner
@@ -390,7 +390,7 @@ jobs:
       with:
         node-version-file: ui/package.json
 
-      - uses: ./.github/actions/setup-go
+    - uses: ./.github/actions/setup-go
 
     - uses: ./.github/actions/cache-ui-dependencies
 
@@ -424,7 +424,7 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-        - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
 
       - uses: ./.github/actions/handle-tagged-build
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -243,8 +243,7 @@ jobs:
       - name: PR labels
         uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # ratchet:joerick/pr-labels-action@v1.0.9
 
-      - name: Setup Go and cache
-        uses: ./.github/actions/setup-go
+        - uses: ./.github/actions/setup-go
 
       - name: Build CLI
         if: |
@@ -290,10 +289,9 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-      - name: Setup Go and cache
         env:
           GOARCH: ${{ matrix.arch }}
-        uses: ./.github/actions/setup-go
+        - uses: ./.github/actions/setup-go
         with:
           # Only race needs a separate cache (-race/CGO_ENABLED=1 produces 39% unique entries).
           # Default and prerelease share 93% of entries and should use the same cache.
@@ -357,8 +355,7 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-      - name: Setup Go and cache
-        uses: ./.github/actions/setup-go
+        - uses: ./.github/actions/setup-go
 
       - name: Download scanner module for proto generation
         run: go mod download github.com/stackrox/scanner
@@ -393,8 +390,7 @@ jobs:
       with:
         node-version-file: ui/package.json
 
-    - name: Setup Go and cache
-      uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
 
     - uses: ./.github/actions/cache-ui-dependencies
 
@@ -428,8 +424,7 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-      - name: Setup Go and cache
-        uses: ./.github/actions/setup-go
+        - uses: ./.github/actions/setup-go
 
       - uses: ./.github/actions/handle-tagged-build
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -249,7 +249,7 @@ jobs:
             || github.ref_name == 'master'
             || github.event_name == 'workflow_call'
             || contains(github.event.pull_request.labels.*.name, 'ci-build-cli')
-        uses: ./.github/actions/cache-go-dependencies
+        uses: ./.github/actions/setup-go
 
       - name: Build CLI
         if: |
@@ -298,7 +298,7 @@ jobs:
       - name: Cache Go dependencies
         env:
           GOARCH: ${{ matrix.arch }}
-        uses: ./.github/actions/cache-go-dependencies
+        uses: ./.github/actions/setup-go
         with:
           # Only race needs a separate cache (-race/CGO_ENABLED=1 produces 39% unique entries).
           # Default and prerelease share 93% of entries and should use the same cache.
@@ -363,7 +363,7 @@ jobs:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
       - name: Cache Go dependencies
-        uses: ./.github/actions/cache-go-dependencies
+        uses: ./.github/actions/setup-go
 
       - name: Download scanner module for proto generation
         run: go mod download github.com/stackrox/scanner
@@ -399,7 +399,7 @@ jobs:
         node-version-file: ui/package.json
 
     - name: Cache Go dependencies
-      uses: ./.github/actions/cache-go-dependencies
+      uses: ./.github/actions/setup-go
 
     - uses: ./.github/actions/cache-ui-dependencies
 
@@ -434,7 +434,7 @@ jobs:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
       - name: Cache Go dependencies
-        uses: ./.github/actions/cache-go-dependencies
+        uses: ./.github/actions/setup-go
 
       - uses: ./.github/actions/handle-tagged-build
 

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -101,10 +101,9 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Setup Go and cache
       env:
         GOARCH: ${{ matrix.goarch }}
-      uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
 
     - uses: ./.github/actions/handle-tagged-build
 

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -101,9 +101,9 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+    - uses: ./.github/actions/setup-go
       env:
         GOARCH: ${{ matrix.goarch }}
-    - uses: ./.github/actions/setup-go
 
     - uses: ./.github/actions/handle-tagged-build
 

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -101,7 +101,7 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Cache Go dependencies
+    - name: Setup Go and cache
       env:
         GOARCH: ${{ matrix.goarch }}
       uses: ./.github/actions/setup-go

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -104,7 +104,7 @@ jobs:
     - name: Cache Go dependencies
       env:
         GOARCH: ${{ matrix.goarch }}
-      uses: ./.github/actions/cache-go-dependencies
+      uses: ./.github/actions/setup-go
 
     - uses: ./.github/actions/handle-tagged-build
 

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -103,7 +103,7 @@ jobs:
 
       env:
         GOARCH: ${{ matrix.goarch }}
-      - uses: ./.github/actions/setup-go
+    - uses: ./.github/actions/setup-go
 
     - uses: ./.github/actions/handle-tagged-build
 

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -33,8 +33,7 @@ jobs:
         su postgres -c 'initdb -D /tmp/data'
         su postgres -c 'pg_ctl -D /tmp/data start'
 
-    - name: Setup Go and cache
-      uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
 
     - name: Is Postgres ready
       run: pg_isready -h 127.0.0.1

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -34,7 +34,7 @@ jobs:
         su postgres -c 'pg_ctl -D /tmp/data start'
 
     - name: Cache Go dependencies
-      uses: ./.github/actions/cache-go-dependencies
+      uses: ./.github/actions/setup-go
 
     - name: Is Postgres ready
       run: pg_isready -h 127.0.0.1

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -33,7 +33,7 @@ jobs:
         su postgres -c 'initdb -D /tmp/data'
         su postgres -c 'pg_ctl -D /tmp/data start'
 
-      - uses: ./.github/actions/setup-go
+    - uses: ./.github/actions/setup-go
 
     - name: Is Postgres ready
       run: pg_isready -h 127.0.0.1

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -33,7 +33,7 @@ jobs:
         su postgres -c 'initdb -D /tmp/data'
         su postgres -c 'pg_ctl -D /tmp/data start'
 
-    - name: Cache Go dependencies
+    - name: Setup Go and cache
       uses: ./.github/actions/setup-go
 
     - name: Is Postgres ready

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -130,7 +130,7 @@ jobs:
           pycodestyle --version
 
       - name: Cache Go dependencies
-        uses: ./.github/actions/cache-go-dependencies
+        uses: ./.github/actions/setup-go
 
       - name: Download scanner module for proto generation
         run: go mod download github.com/stackrox/scanner

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -129,8 +129,7 @@ jobs:
           xmlstarlet --version
           pycodestyle --version
 
-      - name: Setup Go and cache
-        uses: ./.github/actions/setup-go
+        - uses: ./.github/actions/setup-go
 
       - name: Download scanner module for proto generation
         run: go mod download github.com/stackrox/scanner

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -129,7 +129,7 @@ jobs:
           xmlstarlet --version
           pycodestyle --version
 
-      - name: Cache Go dependencies
+      - name: Setup Go and cache
         uses: ./.github/actions/setup-go
 
       - name: Download scanner module for proto generation

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -129,7 +129,7 @@ jobs:
           xmlstarlet --version
           pycodestyle --version
 
-        - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
 
       - name: Download scanner module for proto generation
         run: go mod download github.com/stackrox/scanner

--- a/.github/workflows/test-bundle-helpers.yaml
+++ b/.github/workflows/test-bundle-helpers.yaml
@@ -87,7 +87,7 @@ jobs:
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
       - name: Cache Go dependencies
-        uses: ./.github/actions/cache-go-dependencies
+        uses: ./.github/actions/setup-go
 
       - name: Generate bundle with Python
         env:
@@ -143,7 +143,7 @@ jobs:
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
       - name: Cache Go dependencies
-        uses: ./.github/actions/cache-go-dependencies
+        uses: ./.github/actions/setup-go
 
       - name: Run Go unit tests
         run: |

--- a/.github/workflows/test-bundle-helpers.yaml
+++ b/.github/workflows/test-bundle-helpers.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Override GOTOOLCHAIN
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
-        - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
 
       - name: Generate bundle with Python
         env:
@@ -141,7 +141,7 @@ jobs:
       - name: Override GOTOOLCHAIN
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
-        - uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
 
       - name: Run Go unit tests
         run: |

--- a/.github/workflows/test-bundle-helpers.yaml
+++ b/.github/workflows/test-bundle-helpers.yaml
@@ -86,8 +86,7 @@ jobs:
       - name: Override GOTOOLCHAIN
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
-      - name: Setup Go and cache
-        uses: ./.github/actions/setup-go
+        - uses: ./.github/actions/setup-go
 
       - name: Generate bundle with Python
         env:
@@ -142,8 +141,7 @@ jobs:
       - name: Override GOTOOLCHAIN
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
-      - name: Setup Go and cache
-        uses: ./.github/actions/setup-go
+        - uses: ./.github/actions/setup-go
 
       - name: Run Go unit tests
         run: |

--- a/.github/workflows/test-bundle-helpers.yaml
+++ b/.github/workflows/test-bundle-helpers.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Override GOTOOLCHAIN
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
-      - name: Cache Go dependencies
+      - name: Setup Go and cache
         uses: ./.github/actions/setup-go
 
       - name: Generate bundle with Python
@@ -142,7 +142,7 @@ jobs:
       - name: Override GOTOOLCHAIN
         run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
-      - name: Cache Go dependencies
+      - name: Setup Go and cache
         uses: ./.github/actions/setup-go
 
       - name: Run Go unit tests

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -58,7 +58,7 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         free-disk-space: 30
 
-    - name: Cache Go dependencies
+    - name: Setup Go and cache
       uses: ./.github/actions/setup-go
       with:
         key-suffix: ${{ matrix.gotags }}
@@ -152,7 +152,7 @@ jobs:
         su postgres -c 'initdb -D /tmp/data'
         su postgres -c 'pg_ctl -D /tmp/data start'
 
-    - name: Cache Go dependencies
+    - name: Setup Go and cache
       uses: ./.github/actions/setup-go
       with:
         key-suffix: ${{ matrix.gotags }}
@@ -215,7 +215,7 @@ jobs:
         su postgres -c 'initdb -D /tmp/data'
         su postgres -c 'pg_ctl -D /tmp/data start'
 
-    - name: Cache Go dependencies
+    - name: Setup Go and cache
       uses: ./.github/actions/setup-go
 
     - name: Is Postgres ready
@@ -348,7 +348,7 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Cache Go dependencies
+    - name: Setup Go and cache
       uses: ./.github/actions/setup-go
 
     - uses: ./.github/actions/handle-tagged-build
@@ -447,7 +447,7 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Cache Go dependencies
+    - name: Setup Go and cache
       uses: ./.github/actions/setup-go
 
     - name: Login to Quay.io

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -58,8 +58,7 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         free-disk-space: 30
 
-    - name: Setup Go and cache
-      uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
       with:
         key-suffix: ${{ matrix.gotags }}
 
@@ -152,8 +151,7 @@ jobs:
         su postgres -c 'initdb -D /tmp/data'
         su postgres -c 'pg_ctl -D /tmp/data start'
 
-    - name: Setup Go and cache
-      uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
       with:
         key-suffix: ${{ matrix.gotags }}
 
@@ -215,8 +213,7 @@ jobs:
         su postgres -c 'initdb -D /tmp/data'
         su postgres -c 'pg_ctl -D /tmp/data start'
 
-    - name: Setup Go and cache
-      uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
 
     - name: Is Postgres ready
       run: pg_isready -h 127.0.0.1
@@ -348,8 +345,7 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Setup Go and cache
-      uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
 
     - uses: ./.github/actions/handle-tagged-build
 
@@ -447,8 +443,7 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-    - name: Setup Go and cache
-      uses: ./.github/actions/setup-go
+      - uses: ./.github/actions/setup-go
 
     - name: Login to Quay.io
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -58,7 +58,7 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         free-disk-space: 30
 
-      - uses: ./.github/actions/setup-go
+    - uses: ./.github/actions/setup-go
       with:
         key-suffix: ${{ matrix.gotags }}
 
@@ -151,7 +151,7 @@ jobs:
         su postgres -c 'initdb -D /tmp/data'
         su postgres -c 'pg_ctl -D /tmp/data start'
 
-      - uses: ./.github/actions/setup-go
+    - uses: ./.github/actions/setup-go
       with:
         key-suffix: ${{ matrix.gotags }}
 
@@ -213,7 +213,7 @@ jobs:
         su postgres -c 'initdb -D /tmp/data'
         su postgres -c 'pg_ctl -D /tmp/data start'
 
-      - uses: ./.github/actions/setup-go
+    - uses: ./.github/actions/setup-go
 
     - name: Is Postgres ready
       run: pg_isready -h 127.0.0.1
@@ -345,7 +345,7 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-      - uses: ./.github/actions/setup-go
+    - uses: ./.github/actions/setup-go
 
     - uses: ./.github/actions/handle-tagged-build
 
@@ -443,7 +443,7 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-      - uses: ./.github/actions/setup-go
+    - uses: ./.github/actions/setup-go
 
     - name: Login to Quay.io
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -59,7 +59,7 @@ jobs:
         free-disk-space: 30
 
     - name: Cache Go dependencies
-      uses: ./.github/actions/cache-go-dependencies
+      uses: ./.github/actions/setup-go
       with:
         key-suffix: ${{ matrix.gotags }}
 
@@ -153,7 +153,7 @@ jobs:
         su postgres -c 'pg_ctl -D /tmp/data start'
 
     - name: Cache Go dependencies
-      uses: ./.github/actions/cache-go-dependencies
+      uses: ./.github/actions/setup-go
       with:
         key-suffix: ${{ matrix.gotags }}
 
@@ -216,7 +216,7 @@ jobs:
         su postgres -c 'pg_ctl -D /tmp/data start'
 
     - name: Cache Go dependencies
-      uses: ./.github/actions/cache-go-dependencies
+      uses: ./.github/actions/setup-go
 
     - name: Is Postgres ready
       run: pg_isready -h 127.0.0.1
@@ -349,7 +349,7 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Cache Go dependencies
-      uses: ./.github/actions/cache-go-dependencies
+      uses: ./.github/actions/setup-go
 
     - uses: ./.github/actions/handle-tagged-build
 
@@ -448,7 +448,7 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
     - name: Cache Go dependencies
-      uses: ./.github/actions/cache-go-dependencies
+      uses: ./.github/actions/setup-go
 
     - name: Login to Quay.io
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4


### PR DESCRIPTION
## Description

Replace `actions/setup-go` and `cache-go-dependencies` with a single `.github/actions/setup-go` composite action that handles both Go activation and GOCACHE management.

**Why not actions/setup-go?**
- Sets `GOTOOLCHAIN=local` unconditionally (breaks sub-module tools)
- Caches GOCACHE with a single key shared across all jobs (cross-contamination, unbounded growth)
- Reads `go` directive instead of `toolchain` (installs minimum version, not build version)

**What this action does:**
- Activates the best Go from hostedtoolcache matching go.mod's `toolchain` directive (falls back to `go`)
- Sets `GOTOOLCHAIN=auto` for sub-module compatibility
- Per-job GOCACHE keys with stale-entry trimming
- Go problem matchers for inline error annotations on PRs
- Warns when no `toolchain` directive is set in go.mod

Workaround for golang/go#75031 (covdata bug with auto-downloaded toolchains): using hostedtoolcache Go provides a writable GOTOOLDIR where covdata can be built. Fixed upstream in Go 1.25.10 (backport via golang/go#78411).

## Testing and quality

- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### How I validated my change

- CI runs with the existing container-based jobs validate the action works
- Extensively tested Go version selection, GOTOOLCHAIN behavior, covdata fix, and hostedtoolcache activation in experiment PRs #20456, #20468, #20469
- Locally reproduced covdata bug on ubuntu:24.04 with non-root user