### PR TITLE
ROX-34653: Enable ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -123,7 +123,7 @@ var (
 	LabelBasedPolicyScoping = registerFeature("Enable cluster and namespace label-based policy scoping", "ROX_LABEL_BASED_POLICY_SCOPING", enabled)
 
 	// VulnerabilityReportsEnhancedFiltering enables filtering similar to view-based reports in scheduled vulnerability reports
-	VulnerabilityReportsEnhancedFiltering = registerFeature("Enables filtering similar to view-based reports in scheduled vulnerability reports", "ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING")
+	VulnerabilityReportsEnhancedFiltering = registerFeature("Enables filtering similar to view-based reports in scheduled vulnerability reports", "ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING", enabled)
 
 	// NodeVulnerabilityReports enables interface for (future) node vulnerability reports to develop in parallel with image vulnerability reports
 	NodeVulnerabilityReports = registerFeature("Enables interface for scheduled node vulnerability reports", "ROX_NODE_VULNERABILITY_REPORTS")


### PR DESCRIPTION
## Description

### Objective

Provide equivalent filter for schduled reports as view-based reports

### Analysis

Frontend code is already unconditional but backend code is conditional.

Find in Files `ROX_VULNERABILITY_REPORTS_ENHANCED_FILTERING` in stackrox folder has 9 results in 7 files
* list.go file: not yet `enabled`
* lib.sh file: `true`

Find in Files `VulnerabilityReportsEnhancedFiltering` in in stackrox folder has 13 results in 5 files
* central/reports folder has 4 files
* list.go file

### Solution

Enable so we can merge after bug bash and merge 2 contributions in review.

Best case, merge early enough on Tuesday so available Wednesday on staging demo.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI