### PR TITLE
ROX-33179: deprecate manifest and helm commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 ### Deprecated Features
 
+- The following `roxctl` commands related to manifest-based and helm-based installation are now deprecated.
+  They will be removed in a future release. Please use the operator for deployment management instead.
+  - `roxctl sensor generate {k8s,openshift}`
+  - `roxctl sensor get-bundle`
+  - `roxctl sensor generate-certs`
+  - `roxctl central generate {interactive,k8s,openshift}`
+  - `roxctl helm output {central-services,secured-cluster-services}`
+  - `roxctl helm derive-local-values`
+
 ### Technical Changes
 
 - OpenShift 3 support removed from all installation methods.

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -335,8 +335,9 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	centralGenerateCmd := &centralGenerateCommand{rendererConfig: &cfg, env: cliEnvironment}
 
 	c := &cobra.Command{
-		Use:   "generate",
-		Short: "Generate the required YAML configuration files containing the orchestrator objects to deploy StackRox Central",
+		Use:        "generate",
+		Short:      "Generate the required YAML configuration files containing the orchestrator objects to deploy StackRox Central",
+		Deprecated: common.DeprecatedInFavorOfOperator,
 	}
 
 	c.PersistentFlags().BoolVar(&centralGenerateCmd.rendererConfig.PasswordDisabled, "disable-admin-password", false,

--- a/roxctl/common/deprecation.go
+++ b/roxctl/common/deprecation.go
@@ -4,5 +4,5 @@ package common
 const DeprecatedCommandNotice = "This command is deprecated and will be removed in a future release."
 
 // DeprecatedInFavorOfOperator is a deprecation message for commands superseded by the operator.
-const DeprecatedInFavorOfOperator = "This command has been deprecated starting in release 4.11 and will be removed after two releases. " +
+const DeprecatedInFavorOfOperator = "This command is deprecated and will be removed in a future release. " +
 	"Use the StackRox operator for deployment management instead."

--- a/roxctl/common/deprecation.go
+++ b/roxctl/common/deprecation.go
@@ -2,3 +2,7 @@ package common
 
 // DeprecatedCommandNotice is a generic deprecation message for CLI commands.
 const DeprecatedCommandNotice = "This command is deprecated and will be removed in a future release."
+
+// DeprecatedInFavorOfOperator is a deprecation message for commands superseded by the operator.
+const DeprecatedInFavorOfOperator = "This command has been deprecated starting in release 4.11 and will be removed after two releases. " +
+	"Use the StackRox operator for deployment management instead."

--- a/roxctl/helm/derivelocalvalues/command.go
+++ b/roxctl/helm/derivelocalvalues/command.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/errox"
+	roxctlCommon "github.com/stackrox/rox/roxctl/common"
 	env "github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/helm/internal/common"
@@ -23,9 +24,10 @@ func Command(cliEnvironment env.Environment) *cobra.Command {
 	helmDeriveLocalValuesCmd := &helmDeriveLocalValuesCommand{env: cliEnvironment}
 
 	c := &cobra.Command{
-		Use:   fmt.Sprintf("derive-local-values --output <path> <%s>", common.MakePrettyChartNameList(supportedCharts...)),
-		Short: "Derive local Helm values from cluster configuration",
-		Args:  cobra.ExactArgs(1),
+		Use:        fmt.Sprintf("derive-local-values --output <path> <%s>", common.MakePrettyChartNameList(supportedCharts...)),
+		Short:      "Derive local Helm values from cluster configuration",
+		Deprecated: roxctlCommon.DeprecatedInFavorOfOperator,
+		Args:       cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			helmDeriveLocalValuesCmd.Construct(cmd, args[0])

--- a/roxctl/helm/output/output.go
+++ b/roxctl/helm/output/output.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/pkg/version"
+	roxctlCommon "github.com/stackrox/rox/roxctl/common"
 	env "github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/common/logger"
@@ -28,10 +29,11 @@ func Command(cliEnvironment env.Environment) *cobra.Command {
 	helmOutputCmd := &helmOutputCommand{env: cliEnvironment}
 
 	c := &cobra.Command{
-		Use:       fmt.Sprintf("output <%s>", common.PrettyChartNameList),
-		Short:     "Output a Helm Chart",
-		ValidArgs: []string{common.ChartCentralServices, common.ChartSecuredClusterServices},
-		Args:      cobra.ExactValidArgs(1),
+		Use:        fmt.Sprintf("output <%s>", common.PrettyChartNameList),
+		Short:      "Output a Helm Chart",
+		Deprecated: roxctlCommon.DeprecatedInFavorOfOperator,
+		ValidArgs:  []string{common.ChartCentralServices, common.ChartSecuredClusterServices},
+		Args:       cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			helmOutputCmd.Construct(args[0], cmd)
 

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -175,8 +175,9 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 
 	generateCmd := &sensorGenerateCommand{env: cliEnvironment, cluster: defaultCluster()}
 	c := &cobra.Command{
-		Use:   "generate",
-		Short: "Commands that generate files to deploy StackRox services into secured clusters",
+		Use:        "generate",
+		Short:      "Commands that generate files to deploy StackRox services into secured clusters",
+		Deprecated: common.DeprecatedInFavorOfOperator,
 		PersistentPreRunE: func(c *cobra.Command, _ []string) error {
 			return generateCmd.Construct(c)
 		},

--- a/roxctl/sensor/generatecerts/gen_certs.go
+++ b/roxctl/sensor/generatecerts/gen_certs.go
@@ -81,9 +81,10 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	var outputDir string
 
 	c := &cobra.Command{
-		Use:   "generate-certs <cluster-name-or-id>",
-		Short: "Download a YAML file with renewed certificates for StackRox Sensor, Collector, and Admission controller (if deployed)",
-		Args:  common.ExactArgsWithCustomErrMessage(1, "No cluster name or ID specified"),
+		Use:        "generate-certs <cluster-name-or-id>",
+		Short:      "Download a YAML file with renewed certificates for StackRox Sensor, Collector, and Admission controller (if deployed)",
+		Deprecated: common.DeprecatedInFavorOfOperator,
+		Args:       common.ExactArgsWithCustomErrMessage(1, "No cluster name or ID specified"),
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := downloadCerts(cliEnvironment, outputDir, args[0], flags.Timeout(c), flags.RetryTimeout(c)); err != nil {
 				return errors.Wrap(err, "error downloading regenerated certs")

--- a/roxctl/sensor/getbundle/get_bundle.go
+++ b/roxctl/sensor/getbundle/get_bundle.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/pkg/apiparams"
 	"github.com/stackrox/rox/pkg/istioutils"
+	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
 	"github.com/stackrox/rox/roxctl/sensor/util"
@@ -42,10 +43,11 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	var istioVersion string
 
 	c := &cobra.Command{
-		Use:   "get-bundle <cluster-name-or-id>",
-		Args:  cobra.ExactArgs(1),
-		Short: "Download a bundle with the files to deploy StackRox services into a cluster",
-		Long:  "Download a bundle with the required YAML configuration files to deploy StackRox Sensor, Collector, and Admission controller (optional).",
+		Use:        "get-bundle <cluster-name-or-id>",
+		Args:       cobra.ExactArgs(1),
+		Short:      "Download a bundle with the files to deploy StackRox services into a cluster",
+		Long:       "Download a bundle with the required YAML configuration files to deploy StackRox Sensor, Collector, and Admission controller (optional).",
+		Deprecated: common.DeprecatedInFavorOfOperator,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := downloadBundle(outputDir, args[0], flags.Timeout(c), createUpgraderSA, istioVersion, cliEnvironment); err != nil {
 				return errors.Wrap(err, "error downloading sensor bundle")

--- a/tests/roxctl/bats-tests/local/expect/roxctl--help.txt
+++ b/tests/roxctl/bats-tests/local/expect/roxctl--help.txt
@@ -8,7 +8,6 @@ Available Commands:
   completion           Generate shell completion scripts
   declarative-config   Commands that help manage declarative configuration
   deployment           Commands related to deployments
-  helm                 Commands related to StackRox Helm Charts
   image                Commands that you can run on a specific image
   scanner              Commands related to the Scanner service
   sensor               Commands related to deploying StackRox services in 


### PR DESCRIPTION
## Description

Deprecate roxctl commands for generating sensor/central deployment manifests and helm charts, starting in release 4.11. These commands will be removed after two releases. Users should use the StackRox operator for deployment management instead.

Deprecated commands:
- `roxctl sensor generate` (k8s, openshift)
- `roxctl sensor get-bundle`
- `roxctl sensor generate-certs`
- `roxctl central generate` (interactive, k8s, openshift)
- `roxctl helm output` (central-services, secured-cluster-services)
- `roxctl helm derive-local-values`

`roxctl sensor migrate-to-operator` is intentionally kept since it facilitates the transition.

Related docs ticket: https://redhat.atlassian.net/browse/ROX-33180

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- golangci-lint passes with 0 issues on all changed packages
- roxvet passes
- gopls diagnostics clean
- Cobra's `Deprecated` field is a well-established mechanism already used in the codebase (e.g. `roxctl netpol generate`)