### PR TITLE
ROX-34654: Fix missing null check crash on risk page

### DIFF
--- a/ui/apps/platform/src/Containers/Risk/RiskDetailTabs.tsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskDetailTabs.tsx
@@ -15,7 +15,7 @@ const processDiscoveryTab = 'Process discovery';
 
 export type RiskDetailTabsProps = {
     deployment: Deployment;
-    risk: Risk | null;
+    risk: Risk | null | undefined;
 };
 
 function RiskDetailTabs({ deployment, risk }: RiskDetailTabsProps) {

--- a/ui/apps/platform/src/Containers/Risk/RiskDetailTabs.tsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskDetailTabs.tsx
@@ -1,4 +1,4 @@
-import { Flex, PageSection, Tab, TabTitleText, Tabs } from '@patternfly/react-core';
+import { Alert, Flex, PageSection, Tab, TabTitleText, Tabs } from '@patternfly/react-core';
 
 import usePermissions from 'hooks/usePermissions';
 import useURLStringUnion from 'hooks/useURLStringUnion';
@@ -15,7 +15,7 @@ const processDiscoveryTab = 'Process discovery';
 
 export type RiskDetailTabsProps = {
     deployment: Deployment;
-    risk: Risk;
+    risk: Risk | null;
 };
 
 function RiskDetailTabs({ deployment, risk }: RiskDetailTabsProps) {
@@ -57,16 +57,21 @@ function RiskDetailTabs({ deployment, risk }: RiskDetailTabsProps) {
                 </Tabs>
             </PageSection>
             <PageSection id={activeTabKey}>
-                {activeTabKey === riskIndicatorsTab && (
-                    <Flex
-                        direction={{ default: 'column' }}
-                        spaceItems={{ default: 'spaceItemsMd' }}
-                    >
-                        {risk.results.map((result) => (
-                            <RiskIndicatorCard key={result.name} result={result} />
-                        ))}
-                    </Flex>
-                )}
+                {activeTabKey === riskIndicatorsTab &&
+                    (risk ? (
+                        <Flex
+                            direction={{ default: 'column' }}
+                            spaceItems={{ default: 'spaceItemsMd' }}
+                        >
+                            {risk.results.map((result) => (
+                                <RiskIndicatorCard key={result.name} result={result} />
+                            ))}
+                        </Flex>
+                    ) : (
+                        <Alert variant="warning" isInline title="Risk not found" component="p">
+                            Risk for selected deployment may not have been processed.
+                        </Alert>
+                    ))}
                 {activeTabKey === deploymentDetailsTab && (
                     <div className="flex flex-1 flex-col relative">
                         <div className="absolute w-full">

--- a/ui/apps/platform/src/services/DeploymentsService.ts
+++ b/ui/apps/platform/src/services/DeploymentsService.ts
@@ -152,5 +152,5 @@ export function fetchDeploymentWithRisk(id: string): Promise<DeploymentWithRisk>
 
 export type DeploymentWithRisk = {
     deployment: Deployment;
-    risk: Risk;
+    risk?: Risk;
 };


### PR DESCRIPTION
## Description

As titled, a recent refactor overlooked that all API object fields can be null. A deployment's `risk` score frequently is.

## Future discussion

The nullable state of all API response object fields cannot be statically determined, and is not communicated as part of the API. Current UI code only declares nullable when explicitly discussed with the backend team. Otherwise, the UI treats API types as a pinky promise. Is there a better way? Can we/should we mark everything nullable in the API types and deal with the optionality in consuming code?

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

With a nullable `risk` field in the API response:
<img width="1600" height="738" alt="image" src="https://github.com/user-attachments/assets/1fe23ebd-1b58-4d63-90b7-1cba2c35e1ae" />
