### PR TITLE
ROX-33341: Add vm4vm e2e tests

### DIFF
--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/virtualMachineCves/getVirtualMachine.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/virtualMachineCves/getVirtualMachine.json
@@ -1,0 +1,116 @@
+{
+    "id": "vm-001",
+    "namespace": "default",
+    "name": "cypress-vm-1",
+    "clusterId": "cluster-001",
+    "clusterName": "production-cluster",
+    "facts": {
+        "guestOS": "Red Hat Enterprise Linux 9.2",
+        "ipAddresses": "10.0.1.50",
+        "nodeName": "worker-node-1",
+        "activePodCount": "3",
+        "bootOrder": "disk,network"
+    },
+    "scan": {
+        "scanTime": "2025-04-15T10:30:00.000Z",
+        "operatingSystem": "rhel:9",
+        "components": [
+            {
+                "name": "openssl",
+                "version": "3.0.7-20.el9",
+                "vulns": [
+                    {
+                        "cve": "CVE-2024-0001",
+                        "advisory": {
+                            "name": "RHSA-2024:0001",
+                            "link": "https://access.redhat.com/errata/RHSA-2024:0001"
+                        },
+                        "cvss": 9.8,
+                        "summary": "Critical vulnerability in openssl",
+                        "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-0001",
+                        "fixedBy": "3.0.7-25.el9",
+                        "publishedOn": "2024-01-15T00:00:00.000Z",
+                        "lastModified": "2024-02-01T00:00:00.000Z",
+                        "firstSystemOccurrence": "2024-01-20T00:00:00.000Z",
+                        "severity": "CRITICAL_VULNERABILITY_SEVERITY",
+                        "cvssMetrics": [],
+                        "epss": {
+                            "epssProbability": 0.85,
+                            "epssPercentile": 0.97
+                        }
+                    },
+                    {
+                        "cve": "CVE-2024-0002",
+                        "advisory": {
+                            "name": "RHSA-2024:0002",
+                            "link": "https://access.redhat.com/errata/RHSA-2024:0002"
+                        },
+                        "cvss": 5.3,
+                        "summary": "Moderate vulnerability in openssl",
+                        "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-0002",
+                        "fixedBy": "3.0.7-25.el9",
+                        "publishedOn": "2024-02-10T00:00:00.000Z",
+                        "lastModified": "2024-03-01T00:00:00.000Z",
+                        "firstSystemOccurrence": "2024-02-15T00:00:00.000Z",
+                        "severity": "MODERATE_VULNERABILITY_SEVERITY",
+                        "cvssMetrics": [],
+                        "epss": {
+                            "epssProbability": 0.12,
+                            "epssPercentile": 0.45
+                        }
+                    }
+                ],
+                "source": "OS",
+                "topCvss": 9.8,
+                "riskScore": 9.8,
+                "architecture": "x86_64",
+                "notes": []
+            },
+            {
+                "name": "curl",
+                "version": "7.76.1-26.el9",
+                "vulns": [
+                    {
+                        "cve": "CVE-2024-0003",
+                        "advisory": {
+                            "name": "RHSA-2024:0003",
+                            "link": "https://access.redhat.com/errata/RHSA-2024:0003"
+                        },
+                        "cvss": 7.5,
+                        "summary": "Important vulnerability in curl",
+                        "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-0003",
+                        "fixedBy": "7.76.1-29.el9",
+                        "publishedOn": "2024-03-01T00:00:00.000Z",
+                        "lastModified": "2024-03-15T00:00:00.000Z",
+                        "firstSystemOccurrence": "2024-03-05T00:00:00.000Z",
+                        "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+                        "cvssMetrics": [],
+                        "epss": {
+                            "epssProbability": 0.45,
+                            "epssPercentile": 0.82
+                        }
+                    }
+                ],
+                "source": "OS",
+                "topCvss": 7.5,
+                "riskScore": 7.5,
+                "architecture": "x86_64",
+                "notes": []
+            },
+            {
+                "name": "systemd",
+                "version": "252-18.el9",
+                "vulns": [],
+                "source": "OS",
+                "topCvss": 0,
+                "riskScore": 0,
+                "architecture": "x86_64",
+                "notes": ["UNSCANNED"]
+            }
+        ],
+        "notes": []
+    },
+    "lastUpdated": "2025-04-15T10:30:00.000Z",
+    "vsockCid": 3,
+    "state": "RUNNING"
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/virtualMachineCves/listVirtualMachines.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/virtualMachineCves/listVirtualMachines.json
@@ -1,0 +1,188 @@
+{
+    "virtualMachines": [
+        {
+            "id": "vm-001",
+            "namespace": "default",
+            "name": "cypress-vm-1",
+            "clusterId": "cluster-001",
+            "clusterName": "production-cluster",
+            "facts": {
+                "guestOS": "Red Hat Enterprise Linux 9.2",
+                "ipAddresses": "10.0.1.50",
+                "nodeName": "worker-node-1",
+                "activePodCount": "3",
+                "bootOrder": "disk,network"
+            },
+            "scan": {
+                "scanTime": "2025-04-15T10:30:00.000Z",
+                "operatingSystem": "rhel:9",
+                "components": [
+                    {
+                        "name": "openssl",
+                        "version": "3.0.7-20.el9",
+                        "vulns": [
+                            {
+                                "cve": "CVE-2024-0001",
+                                "advisory": {
+                                    "name": "RHSA-2024:0001",
+                                    "link": "https://access.redhat.com/errata/RHSA-2024:0001"
+                                },
+                                "cvss": 9.8,
+                                "summary": "Critical vulnerability in openssl",
+                                "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-0001",
+                                "fixedBy": "3.0.7-25.el9",
+                                "publishedOn": "2024-01-15T00:00:00.000Z",
+                                "lastModified": "2024-02-01T00:00:00.000Z",
+                                "firstSystemOccurrence": "2024-01-20T00:00:00.000Z",
+                                "severity": "CRITICAL_VULNERABILITY_SEVERITY",
+                                "cvssMetrics": [],
+                                "epss": {
+                                    "epssProbability": 0.85,
+                                    "epssPercentile": 0.97
+                                }
+                            },
+                            {
+                                "cve": "CVE-2024-0002",
+                                "advisory": {
+                                    "name": "RHSA-2024:0002",
+                                    "link": "https://access.redhat.com/errata/RHSA-2024:0002"
+                                },
+                                "cvss": 5.3,
+                                "summary": "Moderate vulnerability in openssl",
+                                "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-0002",
+                                "fixedBy": "3.0.7-25.el9",
+                                "publishedOn": "2024-02-10T00:00:00.000Z",
+                                "lastModified": "2024-03-01T00:00:00.000Z",
+                                "firstSystemOccurrence": "2024-02-15T00:00:00.000Z",
+                                "severity": "MODERATE_VULNERABILITY_SEVERITY",
+                                "cvssMetrics": [],
+                                "epss": {
+                                    "epssProbability": 0.12,
+                                    "epssPercentile": 0.45
+                                }
+                            }
+                        ],
+                        "source": "OS",
+                        "topCvss": 9.8,
+                        "riskScore": 9.8,
+                        "architecture": "x86_64",
+                        "notes": []
+                    },
+                    {
+                        "name": "curl",
+                        "version": "7.76.1-26.el9",
+                        "vulns": [
+                            {
+                                "cve": "CVE-2024-0003",
+                                "advisory": {
+                                    "name": "RHSA-2024:0003",
+                                    "link": "https://access.redhat.com/errata/RHSA-2024:0003"
+                                },
+                                "cvss": 7.5,
+                                "summary": "Important vulnerability in curl",
+                                "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-0003",
+                                "fixedBy": "7.76.1-29.el9",
+                                "publishedOn": "2024-03-01T00:00:00.000Z",
+                                "lastModified": "2024-03-15T00:00:00.000Z",
+                                "firstSystemOccurrence": "2024-03-05T00:00:00.000Z",
+                                "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+                                "cvssMetrics": [],
+                                "epss": {
+                                    "epssProbability": 0.45,
+                                    "epssPercentile": 0.82
+                                }
+                            }
+                        ],
+                        "source": "OS",
+                        "topCvss": 7.5,
+                        "riskScore": 7.5,
+                        "architecture": "x86_64",
+                        "notes": []
+                    },
+                    {
+                        "name": "systemd",
+                        "version": "252-18.el9",
+                        "vulns": [],
+                        "source": "OS",
+                        "topCvss": 0,
+                        "riskScore": 0,
+                        "architecture": "x86_64",
+                        "notes": ["UNSCANNED"]
+                    }
+                ],
+                "notes": []
+            },
+            "lastUpdated": "2025-04-15T10:30:00.000Z",
+            "vsockCid": 3,
+            "state": "RUNNING"
+        },
+        {
+            "id": "vm-002",
+            "namespace": "monitoring",
+            "name": "cypress-vm-2",
+            "clusterId": "cluster-001",
+            "clusterName": "production-cluster",
+            "facts": {
+                "guestOS": "Red Hat Enterprise Linux 8.8",
+                "ipAddresses": "10.0.1.51",
+                "nodeName": "worker-node-2",
+                "activePodCount": "1",
+                "bootOrder": "disk"
+            },
+            "scan": {
+                "scanTime": "2025-04-14T08:15:00.000Z",
+                "operatingSystem": "rhel:8",
+                "components": [
+                    {
+                        "name": "kernel",
+                        "version": "4.18.0-477.el8",
+                        "vulns": [
+                            {
+                                "cve": "CVE-2024-0004",
+                                "advisory": {
+                                    "name": "",
+                                    "link": ""
+                                },
+                                "cvss": 4.0,
+                                "summary": "Low severity kernel vulnerability",
+                                "link": "https://nvd.nist.gov/vuln/detail/CVE-2024-0004",
+                                "publishedOn": "2024-04-01T00:00:00.000Z",
+                                "lastModified": "2024-04-15T00:00:00.000Z",
+                                "firstSystemOccurrence": "2024-04-05T00:00:00.000Z",
+                                "severity": "LOW_VULNERABILITY_SEVERITY",
+                                "cvssMetrics": [],
+                                "epss": {
+                                    "epssProbability": 0.02,
+                                    "epssPercentile": 0.15
+                                }
+                            }
+                        ],
+                        "source": "OS",
+                        "topCvss": 4.0,
+                        "riskScore": 4.0,
+                        "architecture": "x86_64",
+                        "notes": []
+                    }
+                ],
+                "notes": []
+            },
+            "lastUpdated": "2025-04-14T08:15:00.000Z",
+            "vsockCid": 4,
+            "state": "RUNNING"
+        },
+        {
+            "id": "vm-003",
+            "namespace": "default",
+            "name": "cypress-vm-3",
+            "clusterId": "cluster-002",
+            "clusterName": "staging-cluster",
+            "facts": {
+                "guestOS": "Red Hat Enterprise Linux 9.3"
+            },
+            "lastUpdated": "2025-04-13T12:00:00.000Z",
+            "vsockCid": 5,
+            "state": "STOPPED"
+        }
+    ],
+    "totalCount": 3
+}

--- a/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/VirtualMachineCve.helpers.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/VirtualMachineCve.helpers.ts
@@ -1,0 +1,66 @@
+import type { RouteHandler, RouteMatcherOptions } from 'cypress/types/net-stubbing';
+
+import { visit, visitWithStaticResponseForPermissions } from '../../../helpers/visit';
+
+export const listVirtualMachinesAlias = 'listVirtualMachines';
+export const getVirtualMachineAlias = 'getVirtualMachine';
+
+export const routeMatcherMapForVirtualMachines = {
+    [listVirtualMachinesAlias]: {
+        method: 'GET',
+        url: '/v2/virtualmachines?*',
+    },
+};
+
+export const routeMatcherMapForVirtualMachine = {
+    [getVirtualMachineAlias]: {
+        method: 'GET',
+        url: '/v2/virtualmachines/*',
+    },
+};
+
+export function visitVirtualMachineCvesOverviewPage(
+    routeMatcherMap?: Record<string, RouteMatcherOptions>,
+    staticResponseMap?: Record<string, RouteHandler>
+) {
+    visit('/main/vulnerabilities/virtual-machine-cves', routeMatcherMap, staticResponseMap);
+}
+
+export function visitVirtualMachineCvesOverviewPageWithStaticPermissions(
+    resourceToAccess: Record<string, string>,
+    routeMatcherMap?: Record<string, RouteMatcherOptions>,
+    staticResponseMap?: Record<string, RouteHandler>
+) {
+    visitWithStaticResponseForPermissions(
+        '/main/vulnerabilities/virtual-machine-cves',
+        { body: { resourceToAccess } },
+        routeMatcherMap,
+        staticResponseMap
+    );
+}
+
+export function visitVirtualMachinePage(
+    virtualMachineId: string,
+    routeMatcherMap?: Record<string, RouteMatcherOptions>,
+    staticResponseMap?: Record<string, RouteHandler>
+) {
+    visit(
+        `/main/vulnerabilities/virtual-machine-cves/virtualmachines/${virtualMachineId}`,
+        routeMatcherMap,
+        staticResponseMap
+    );
+}
+
+export function visitVirtualMachinePageWithStaticPermissions(
+    virtualMachineId: string,
+    resourceToAccess: Record<string, string>,
+    routeMatcherMap?: Record<string, RouteMatcherOptions>,
+    staticResponseMap?: Record<string, RouteHandler>
+) {
+    visitWithStaticResponseForPermissions(
+        `/main/vulnerabilities/virtual-machine-cves/virtualmachines/${virtualMachineId}`,
+        { body: { resourceToAccess } },
+        routeMatcherMap,
+        staticResponseMap
+    );
+}

--- a/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/virtualMachineCvesOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/virtualMachineCvesOverviewPage.test.ts
@@ -1,0 +1,166 @@
+import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
+import { assertCannotFindThePage } from '../../../helpers/visit';
+import { interceptAndWatchRequests } from '../../../helpers/request';
+import { paginateNext, paginatePrevious, sortByTableHeader } from '../../../helpers/tableHelpers';
+
+import {
+    listVirtualMachinesAlias,
+    routeMatcherMapForVirtualMachines,
+    visitVirtualMachineCvesOverviewPage,
+    visitVirtualMachineCvesOverviewPageWithStaticPermissions,
+} from './VirtualMachineCve.helpers';
+
+const fixturePathListVMs = 'vulnerabilities/virtualMachineCves/listVirtualMachines';
+
+describe('Virtual Machine CVEs - Overview Page', () => {
+    withAuth();
+
+    before(function () {
+        if (!hasFeatureFlag('ROX_VIRTUAL_MACHINES')) {
+            this.skip();
+        }
+    });
+
+    it('should restrict access to users without "Cluster" permission', () => {
+        visitVirtualMachineCvesOverviewPageWithStaticPermissions({});
+        assertCannotFindThePage();
+    });
+
+    it('should allow access to users with "Cluster" permission', () => {
+        visitVirtualMachineCvesOverviewPageWithStaticPermissions(
+            { Cluster: 'READ_ACCESS' },
+            routeMatcherMapForVirtualMachines,
+            {
+                [listVirtualMachinesAlias]: {
+                    fixture: fixturePathListVMs,
+                },
+            }
+        );
+        cy.get('h1').contains('Virtual machine vulnerabilities');
+    });
+
+    it('should render the overview page heading and description', () => {
+        visitVirtualMachineCvesOverviewPage(routeMatcherMapForVirtualMachines, {
+            [listVirtualMachinesAlias]: {
+                fixture: fixturePathListVMs,
+            },
+        });
+
+        cy.get('h1').contains('Virtual machine vulnerabilities');
+        cy.get('body').contains('Prioritize and remediate observed CVEs across virtual machines');
+    });
+
+    it('should render VM rows from fixture data', () => {
+        visitVirtualMachineCvesOverviewPage(routeMatcherMapForVirtualMachines, {
+            [listVirtualMachinesAlias]: {
+                fixture: fixturePathListVMs,
+            },
+        });
+
+        cy.get('tbody tr').should('have.length', 3);
+
+        cy.get('tbody tr')
+            .eq(0)
+            .within(() => {
+                cy.get('td[data-label="Virtual machine"]').contains('cypress-vm-1');
+                cy.get('td[data-label="Cluster"]').contains('production-cluster');
+                cy.get('td[data-label="Namespace"]').contains('default');
+            });
+
+        cy.get('tbody tr')
+            .eq(1)
+            .within(() => {
+                cy.get('td[data-label="Virtual machine"]').contains('cypress-vm-2');
+                cy.get('td[data-label="Namespace"]').contains('monitoring');
+            });
+
+        cy.get('tbody tr')
+            .eq(2)
+            .within(() => {
+                cy.get('td[data-label="Virtual machine"]').contains('cypress-vm-3');
+                cy.get('td[data-label="Cluster"]').contains('staging-cluster');
+            });
+    });
+
+    it('should link VM names to the correct detail page', () => {
+        visitVirtualMachineCvesOverviewPage(routeMatcherMapForVirtualMachines, {
+            [listVirtualMachinesAlias]: {
+                fixture: fixturePathListVMs,
+            },
+        });
+
+        cy.get('tbody tr td[data-label="Virtual machine"] a')
+            .first()
+            .then(($link) => {
+                const href = $link.attr('href');
+                expect(href).to.match(
+                    /\/main\/vulnerabilities\/virtual-machine-cves\/virtualmachines\/vm-001$/
+                );
+            });
+    });
+
+    it('should display an empty state when no VMs are returned', () => {
+        visitVirtualMachineCvesOverviewPage(routeMatcherMapForVirtualMachines, {
+            [listVirtualMachinesAlias]: {
+                body: { virtualMachines: [], totalCount: 0 },
+            },
+        });
+
+        cy.get('body').contains('No CVEs have been detected');
+    });
+
+    it('should sort by the Virtual machine column', () => {
+        interceptAndWatchRequests(routeMatcherMapForVirtualMachines, {
+            [listVirtualMachinesAlias]: {
+                fixture: fixturePathListVMs,
+            },
+        }).then(({ waitForRequests }) => {
+            visitVirtualMachineCvesOverviewPage();
+            waitForRequests();
+
+            sortByTableHeader('Virtual machine');
+            cy.wait(`@${listVirtualMachinesAlias}`).then((interception) => {
+                const { url } = interception.request;
+                expect(url).to.include('Virtual Machine Name');
+            });
+        });
+    });
+
+    it('should paginate through results', () => {
+        const paginatedFixture = {
+            body: {
+                virtualMachines: Array.from({ length: 20 }, (_, i) => ({
+                    id: `vm-${String(i + 1).padStart(3, '0')}`,
+                    namespace: 'default',
+                    name: `cypress-vm-${i + 1}`,
+                    clusterId: 'cluster-001',
+                    clusterName: 'production-cluster',
+                    lastUpdated: '2025-04-15T10:30:00.000Z',
+                    vsockCid: i + 3,
+                    state: 'RUNNING',
+                })),
+                totalCount: 50,
+            },
+        };
+
+        interceptAndWatchRequests(routeMatcherMapForVirtualMachines, {
+            [listVirtualMachinesAlias]: paginatedFixture,
+        }).then(({ waitForRequests }) => {
+            visitVirtualMachineCvesOverviewPage();
+            waitForRequests();
+
+            paginateNext();
+            cy.wait(`@${listVirtualMachinesAlias}`).then((interception) => {
+                const { url } = interception.request;
+                expect(url).to.include('query.pagination.offset=20');
+            });
+
+            paginatePrevious();
+            cy.wait(`@${listVirtualMachinesAlias}`).then((interception) => {
+                const { url } = interception.request;
+                expect(url).to.include('query.pagination.offset=0');
+            });
+        });
+    });
+});

--- a/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/virtualMachinePage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/virtualMachineCves/virtualMachinePage.test.ts
@@ -1,0 +1,169 @@
+import withAuth from '../../../helpers/basicAuth';
+import { hasFeatureFlag } from '../../../helpers/features';
+import { assertCannotFindThePage } from '../../../helpers/visit';
+
+import {
+    getVirtualMachineAlias,
+    routeMatcherMapForVirtualMachine,
+    visitVirtualMachinePage,
+    visitVirtualMachinePageWithStaticPermissions,
+} from './VirtualMachineCve.helpers';
+
+const vmId = 'vm-001';
+const fixturePathGetVM = 'vulnerabilities/virtualMachineCves/getVirtualMachine';
+
+function visitWithFixture() {
+    visitVirtualMachinePage(vmId, routeMatcherMapForVirtualMachine, {
+        [getVirtualMachineAlias]: { fixture: fixturePathGetVM },
+    });
+}
+
+describe('Virtual Machine CVEs - Virtual Machine Page', () => {
+    withAuth();
+
+    before(function () {
+        if (!hasFeatureFlag('ROX_VIRTUAL_MACHINES')) {
+            this.skip();
+        }
+    });
+
+    it('should restrict access to users without "Cluster" permission', () => {
+        visitVirtualMachinePageWithStaticPermissions(vmId, {});
+        assertCannotFindThePage();
+    });
+
+    it('should allow access to users with "Cluster" permission', () => {
+        visitVirtualMachinePageWithStaticPermissions(
+            vmId,
+            { Cluster: 'READ_ACCESS' },
+            routeMatcherMapForVirtualMachine,
+            {
+                [getVirtualMachineAlias]: { fixture: fixturePathGetVM },
+            }
+        );
+        cy.get('h1').contains('cypress-vm-1');
+    });
+
+    describe('Vulnerabilities tab', () => {
+        it('should render CVE rows from fixture data', () => {
+            visitWithFixture();
+
+            cy.get('tbody tr:not([class*="expandable"])').should('have.length', 3);
+
+            cy.get('tbody tr:not([class*="expandable"])')
+                .eq(0)
+                .within(() => {
+                    cy.get('td[data-label="CVE"]').contains('CVE-2024-0001');
+                    cy.get('td[data-label="CVE severity"]').should('exist');
+                    cy.get('td[data-label="CVE status"]').should('exist');
+                    cy.get('td[data-label="CVSS"]').should('exist');
+                    cy.get('td[data-label="EPSS probability"]').should('exist');
+                    cy.get('td[data-label="Affected components"]').contains('openssl');
+                });
+        });
+
+        it('should display the correct number of affected components', () => {
+            visitWithFixture();
+
+            cy.get('tbody tr:not([class*="expandable"])')
+                .eq(0)
+                .within(() => {
+                    cy.get('td[data-label="Affected components"]').contains('openssl');
+                });
+
+            cy.get('tbody tr:not([class*="expandable"])')
+                .eq(2)
+                .within(() => {
+                    cy.get('td[data-label="Affected components"]').contains('curl');
+                });
+        });
+
+        it('should expand a row to show the components sub-table', () => {
+            visitWithFixture();
+
+            cy.get('tbody tr:not([class*="expandable"])').eq(0).find('td button').first().click();
+
+            cy.get('tbody tr[class*="expandable"]')
+                .eq(0)
+                .within(() => {
+                    cy.get('td[data-label="Component"]').contains('openssl');
+                    cy.get('td[data-label="Version"]').contains('3.0.7-20.el9');
+                    cy.get('td[data-label="CVE fixed in"]').contains('3.0.7-25.el9');
+                    cy.get('td[data-label="Advisory"]').contains('RHSA-2024:0001');
+                });
+        });
+
+        it('should display an empty state when the VM has no vulnerabilities', () => {
+            visitVirtualMachinePage(vmId, routeMatcherMapForVirtualMachine, {
+                [getVirtualMachineAlias]: {
+                    body: {
+                        id: vmId,
+                        namespace: 'default',
+                        name: 'empty-vm',
+                        clusterId: 'cluster-001',
+                        clusterName: 'production-cluster',
+                        scan: {
+                            scanTime: '2025-04-15T10:30:00.000Z',
+                            operatingSystem: 'rhel:9',
+                            components: [],
+                            notes: [],
+                        },
+                        lastUpdated: '2025-04-15T10:30:00.000Z',
+                        vsockCid: 3,
+                        state: 'RUNNING',
+                    },
+                },
+            });
+
+            cy.get('body').contains('No CVEs were detected for this virtual machine');
+        });
+    });
+
+    describe('Components tab', () => {
+        it('should render component rows from fixture data', () => {
+            visitWithFixture();
+
+            cy.get('button').contains('Components').click();
+
+            cy.get('tbody tr').should('have.length', 3);
+
+            cy.get('tbody tr')
+                .eq(0)
+                .within(() => {
+                    cy.get('td[data-label="Name"]').should('exist');
+                    cy.get('td[data-label="Version"]').should('exist');
+                    cy.get('td[data-label="Status"]').should('exist');
+                });
+        });
+
+        it('should show scanned and unscanned statuses', () => {
+            visitWithFixture();
+
+            cy.get('button').contains('Components').click();
+
+            cy.get('td[data-label="Status"]').then(($cells) => {
+                const statuses = $cells.map((_, el) => el.innerText.trim()).get();
+                expect(statuses).to.include('Scanned');
+                expect(statuses).to.include('Not scanned');
+            });
+        });
+    });
+
+    describe('Breadcrumb navigation', () => {
+        it('should display VM name in breadcrumb', () => {
+            visitWithFixture();
+
+            cy.get('.pf-v6-c-breadcrumb__item').should('contain.text', 'Virtual Machines');
+            cy.get('.pf-v6-c-breadcrumb__item').should('contain.text', 'cypress-vm-1');
+        });
+
+        it('should link back to the overview page', () => {
+            visitWithFixture();
+
+            cy.get('.pf-v6-c-breadcrumb__item a')
+                .contains('Virtual Machines')
+                .should('have.attr', 'href')
+                .and('include', '/main/vulnerabilities/virtual-machine-cves');
+        });
+    });
+});


### PR DESCRIPTION
## Description

Add vm4vm e2e tests

Sets up foundation for e2e tests. Api will change in 5.0 release so fixtures will need to be updated, but tests should still pass as is when that happens

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Ran e2e tests
