### PR TITLE
chore(ui): bump axios to ^1.16.0

### DIFF
--- a/ui/apps/platform/package-lock.json
+++ b/ui/apps/platform/package-lock.json
@@ -22,7 +22,7 @@
                 "@patternfly/react-topology": "^5.4.1",
                 "@patternfly/react-user-feedback": "^5.0.0",
                 "@segment/analytics-next": "^1.81.1",
-                "axios": "1.15.1",
+                "axios": "^1.16.0",
                 "computed-style-to-inline-style": "^3.0.0",
                 "connected-react-router": "^6.9.3",
                 "d3-axis": "^1.0.12",
@@ -5616,12 +5616,12 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-            "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
                 "proxy-from-env": "^2.1.0"
             }

--- a/ui/apps/platform/package.json
+++ b/ui/apps/platform/package.json
@@ -25,7 +25,7 @@
         "@patternfly/react-topology": "^5.4.1",
         "@patternfly/react-user-feedback": "^5.0.0",
         "@segment/analytics-next": "^1.81.1",
-        "axios": "^1.15.1",
+        "axios": "^1.16.0",
         "computed-style-to-inline-style": "^3.0.0",
         "connected-react-router": "^6.9.3",
         "d3-axis": "^1.0.12",


### PR DESCRIPTION
Resolves cves related to `axios` and `follow-redirects`

Fixes the following CVES:

- CVE-2026-42044
- CVE-2026-40895