### PR TITLE
experiment: public setup-go for comparison with #20483

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -243,6 +243,11 @@ jobs:
       - name: PR labels
         uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # ratchet:joerick/pr-labels-action@v1.0.9
 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+      - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: Cache Go dependencies
         if: |
           needs.define-job-matrix.outputs.gotags == 'release'
@@ -295,6 +300,11 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+      - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: Cache Go dependencies
         env:
           GOARCH: ${{ matrix.arch }}
@@ -362,6 +372,11 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+      - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
 
@@ -398,6 +413,11 @@ jobs:
       with:
         node-version-file: ui/package.json
 
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+    - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 
@@ -433,6 +453,11 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+      - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
 

--- a/.github/workflows/scanner-build.yaml
+++ b/.github/workflows/scanner-build.yaml
@@ -101,6 +101,11 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+    - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
     - name: Cache Go dependencies
       env:
         GOARCH: ${{ matrix.goarch }}

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -33,6 +33,11 @@ jobs:
         su postgres -c 'initdb -D /tmp/data'
         su postgres -c 'pg_ctl -D /tmp/data start'
 
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+    - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -129,6 +129,11 @@ jobs:
           xmlstarlet --version
           pycodestyle --version
 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+      - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - name: Cache Go dependencies
         uses: ./.github/actions/cache-go-dependencies
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -58,6 +58,11 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         free-disk-space: 30
 
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+    - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
       with:
@@ -152,6 +157,11 @@ jobs:
         su postgres -c 'initdb -D /tmp/data'
         su postgres -c 'pg_ctl -D /tmp/data start'
 
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+    - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
       with:
@@ -215,6 +225,11 @@ jobs:
         su postgres -c 'initdb -D /tmp/data'
         su postgres -c 'pg_ctl -D /tmp/data start'
 
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+    - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 
@@ -348,6 +363,11 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+    - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 
@@ -447,6 +467,11 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+    - run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 


### PR DESCRIPTION
## Description

Direct comparison with PR #20483 (custom setup-go action).

This PR uses the standard `actions/setup-go@v5` with workarounds:
- `go-version-file: go.mod` to read version from go.mod
- `cache: false` to disable conflicting GOCACHE management
- `GOTOOLCHAIN=auto` override after each setup-go (it sets `local`)

Compare with #20483 which does all of this in a single action call
with no workarounds needed.

**Tradeoffs:**
| | This PR (public setup-go) | #20483 (custom action) |
|---|---|---|
| Lines per job | +5 (setup-go + override + cache) | +0 (just renamed action) |
| Maintenance | Upstream maintained | We maintain |
| GOTOOLCHAIN | Need override step | Built-in |
| Caching | Need `cache: false` | Built-in per-job keys |
| Version | Reads `go` not `toolchain` | Reads `toolchain` first |

Do not merge — experiment only.

## User-facing documentation

- [x] update is not needed

## Testing and quality

- [x] the change is production ready

### How I validated my change

CI comparison with #20483.