### PR TITLE
ROX-34738: Expose operator_kind in ComplianceRule API response

### DIFF
--- a/central/convert/storagetov2/compliance_rule_service.go
+++ b/central/convert/storagetov2/compliance_rule_service.go
@@ -1,7 +1,6 @@
 package storagetov2
 
 import (
-	ruleutils "github.com/stackrox/rox/central/complianceoperator/v2/rules/utils"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
 )
@@ -28,7 +27,7 @@ func ComplianceRule(incoming *storage.ComplianceOperatorRuleV2) *v2.ComplianceRu
 		RuleId:       incoming.GetRuleId(),
 		Instructions: incoming.GetInstructions(),
 		Warning:      incoming.GetWarning(),
-		ParentRule:    incoming.GetParentRule(),
-		OperatorKind: v2.ComplianceRule_OperatorKind(ruleutils.CustomRuleEffectiveOperatorKind(incoming.GetOperatorKind())),
+		ParentRule:   incoming.GetParentRule(),
+		OperatorKind: v2.ComplianceRule_OperatorKind(incoming.GetOperatorKind()),
 	}
 }

--- a/central/convert/storagetov2/compliance_rule_service.go
+++ b/central/convert/storagetov2/compliance_rule_service.go
@@ -28,7 +28,7 @@ func ComplianceRule(incoming *storage.ComplianceOperatorRuleV2) *v2.ComplianceRu
 		RuleId:       incoming.GetRuleId(),
 		Instructions: incoming.GetInstructions(),
 		Warning:      incoming.GetWarning(),
-		ParentRule:    incoming.GetParentRule(),
+		ParentRule:   incoming.GetParentRule(),
 		OperatorKind: v2.ComplianceRule_OperatorKind(ruleutils.CustomRuleEffectiveOperatorKind(incoming.GetOperatorKind())),
 	}
 }

--- a/central/convert/storagetov2/compliance_rule_service.go
+++ b/central/convert/storagetov2/compliance_rule_service.go
@@ -1,6 +1,7 @@
 package storagetov2
 
 import (
+	ruleutils "github.com/stackrox/rox/central/complianceoperator/v2/rules/utils"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
 )
@@ -27,6 +28,7 @@ func ComplianceRule(incoming *storage.ComplianceOperatorRuleV2) *v2.ComplianceRu
 		RuleId:       incoming.GetRuleId(),
 		Instructions: incoming.GetInstructions(),
 		Warning:      incoming.GetWarning(),
-		ParentRule:   incoming.GetParentRule(),
+		ParentRule:    incoming.GetParentRule(),
+		OperatorKind: v2.ComplianceRule_OperatorKind(ruleutils.CustomRuleEffectiveOperatorKind(incoming.GetOperatorKind())),
 	}
 }

--- a/central/convert/storagetov2/compliance_rule_service.go
+++ b/central/convert/storagetov2/compliance_rule_service.go
@@ -1,6 +1,7 @@
 package storagetov2
 
 import (
+	ruleutils "github.com/stackrox/rox/central/complianceoperator/v2/rules/utils"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/generated/storage"
 )
@@ -27,7 +28,7 @@ func ComplianceRule(incoming *storage.ComplianceOperatorRuleV2) *v2.ComplianceRu
 		RuleId:       incoming.GetRuleId(),
 		Instructions: incoming.GetInstructions(),
 		Warning:      incoming.GetWarning(),
-		ParentRule:   incoming.GetParentRule(),
-		OperatorKind: v2.ComplianceRule_OperatorKind(incoming.GetOperatorKind()),
+		ParentRule:    incoming.GetParentRule(),
+		OperatorKind: v2.ComplianceRule_OperatorKind(ruleutils.CustomRuleEffectiveOperatorKind(incoming.GetOperatorKind())),
 	}
 }

--- a/central/convert/testutils/compliance_rules.go
+++ b/central/convert/testutils/compliance_rules.go
@@ -117,17 +117,17 @@ func GetRuleV2(_ *testing.T) *apiV2.ComplianceRule {
 	}
 
 	return &apiV2.ComplianceRule{
-		Id:          RuleUID,
-		RuleId:      ruleID,
-		Name:        "ocp-cis",
-		RuleType:    "node",
-		Title:       "test rule",
-		Description: "test description",
-		Rationale:   "test rationale",
-		Warning:     "test warning",
-		Severity:    "UNSET_RULE_SEVERITY",
-		Fixes:       fixes,
-		ParentRule:    "random-rule-name",
+		Id:           RuleUID,
+		RuleId:       ruleID,
+		Name:         "ocp-cis",
+		RuleType:     "node",
+		Title:        "test rule",
+		Description:  "test description",
+		Rationale:    "test rationale",
+		Warning:      "test warning",
+		Severity:     "UNSET_RULE_SEVERITY",
+		Fixes:        fixes,
+		ParentRule:   "random-rule-name",
 		OperatorKind: apiV2.ComplianceRule_RULE,
 	}
 }

--- a/central/convert/testutils/compliance_rules.go
+++ b/central/convert/testutils/compliance_rules.go
@@ -127,7 +127,8 @@ func GetRuleV2(_ *testing.T) *apiV2.ComplianceRule {
 		Warning:     "test warning",
 		Severity:    "UNSET_RULE_SEVERITY",
 		Fixes:       fixes,
-		ParentRule:  "random-rule-name",
+		ParentRule:    "random-rule-name",
+		OperatorKind: apiV2.ComplianceRule_RULE,
 	}
 }
 

--- a/generated/api/v2/compliance_common.pb.go
+++ b/generated/api/v2/compliance_common.pb.go
@@ -86,6 +86,55 @@ func (ComplianceCheckStatus) EnumDescriptor() ([]byte, []int) {
 	return file_api_v2_compliance_common_proto_rawDescGZIP(), []int{0}
 }
 
+type ComplianceRule_OperatorKind int32
+
+const (
+	ComplianceRule_OPERATOR_KIND_UNSPECIFIED ComplianceRule_OperatorKind = 0
+	ComplianceRule_RULE                      ComplianceRule_OperatorKind = 1
+	ComplianceRule_CUSTOM_RULE               ComplianceRule_OperatorKind = 2
+)
+
+// Enum value maps for ComplianceRule_OperatorKind.
+var (
+	ComplianceRule_OperatorKind_name = map[int32]string{
+		0: "OPERATOR_KIND_UNSPECIFIED",
+		1: "RULE",
+		2: "CUSTOM_RULE",
+	}
+	ComplianceRule_OperatorKind_value = map[string]int32{
+		"OPERATOR_KIND_UNSPECIFIED": 0,
+		"RULE":                      1,
+		"CUSTOM_RULE":               2,
+	}
+)
+
+func (x ComplianceRule_OperatorKind) Enum() *ComplianceRule_OperatorKind {
+	p := new(ComplianceRule_OperatorKind)
+	*p = x
+	return p
+}
+
+func (x ComplianceRule_OperatorKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ComplianceRule_OperatorKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_v2_compliance_common_proto_enumTypes[1].Descriptor()
+}
+
+func (ComplianceRule_OperatorKind) Type() protoreflect.EnumType {
+	return &file_api_v2_compliance_common_proto_enumTypes[1]
+}
+
+func (x ComplianceRule_OperatorKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ComplianceRule_OperatorKind.Descriptor instead.
+func (ComplianceRule_OperatorKind) EnumDescriptor() ([]byte, []int) {
+	return file_api_v2_compliance_common_proto_rawDescGZIP(), []int{0, 0}
+}
+
 // OperatorKind is the kind of the Compliance Operator resource that this
 // `ComplianceProfileSummary` was sourced from. ACS represents both Compliance
 // Operator `Profiles` and `TailoredProfiles` as compliance profiles.
@@ -125,11 +174,11 @@ func (x ComplianceProfileSummary_OperatorKind) String() string {
 }
 
 func (ComplianceProfileSummary_OperatorKind) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_v2_compliance_common_proto_enumTypes[1].Descriptor()
+	return file_api_v2_compliance_common_proto_enumTypes[2].Descriptor()
 }
 
 func (ComplianceProfileSummary_OperatorKind) Type() protoreflect.EnumType {
-	return &file_api_v2_compliance_common_proto_enumTypes[1]
+	return &file_api_v2_compliance_common_proto_enumTypes[2]
 }
 
 func (x ComplianceProfileSummary_OperatorKind) Number() protoreflect.EnumNumber {
@@ -142,21 +191,22 @@ func (ComplianceProfileSummary_OperatorKind) EnumDescriptor() ([]byte, []int) {
 }
 
 type ComplianceRule struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	RuleType      string                 `protobuf:"bytes,3,opt,name=rule_type,json=ruleType,proto3" json:"rule_type,omitempty"`
-	Severity      string                 `protobuf:"bytes,4,opt,name=severity,proto3" json:"severity,omitempty"`
-	Standard      string                 `protobuf:"bytes,5,opt,name=standard,proto3" json:"standard,omitempty"`
-	Control       string                 `protobuf:"bytes,6,opt,name=control,proto3" json:"control,omitempty"`
-	Title         string                 `protobuf:"bytes,7,opt,name=title,proto3" json:"title,omitempty"`
-	Description   string                 `protobuf:"bytes,8,opt,name=description,proto3" json:"description,omitempty"`
-	Rationale     string                 `protobuf:"bytes,9,opt,name=rationale,proto3" json:"rationale,omitempty"`
-	Fixes         []*ComplianceRule_Fix  `protobuf:"bytes,10,rep,name=fixes,proto3" json:"fixes,omitempty"`
-	Id            string                 `protobuf:"bytes,11,opt,name=id,proto3" json:"id,omitempty"`
-	RuleId        string                 `protobuf:"bytes,12,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
-	ParentRule    string                 `protobuf:"bytes,13,opt,name=parent_rule,json=parentRule,proto3" json:"parent_rule,omitempty"`
-	Instructions  string                 `protobuf:"bytes,14,opt,name=instructions,proto3" json:"instructions,omitempty"`
-	Warning       string                 `protobuf:"bytes,15,opt,name=warning,proto3" json:"warning,omitempty"`
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	Name          string                      `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	RuleType      string                      `protobuf:"bytes,3,opt,name=rule_type,json=ruleType,proto3" json:"rule_type,omitempty"`
+	Severity      string                      `protobuf:"bytes,4,opt,name=severity,proto3" json:"severity,omitempty"`
+	Standard      string                      `protobuf:"bytes,5,opt,name=standard,proto3" json:"standard,omitempty"`
+	Control       string                      `protobuf:"bytes,6,opt,name=control,proto3" json:"control,omitempty"`
+	Title         string                      `protobuf:"bytes,7,opt,name=title,proto3" json:"title,omitempty"`
+	Description   string                      `protobuf:"bytes,8,opt,name=description,proto3" json:"description,omitempty"`
+	Rationale     string                      `protobuf:"bytes,9,opt,name=rationale,proto3" json:"rationale,omitempty"`
+	Fixes         []*ComplianceRule_Fix       `protobuf:"bytes,10,rep,name=fixes,proto3" json:"fixes,omitempty"`
+	Id            string                      `protobuf:"bytes,11,opt,name=id,proto3" json:"id,omitempty"`
+	RuleId        string                      `protobuf:"bytes,12,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	ParentRule    string                      `protobuf:"bytes,13,opt,name=parent_rule,json=parentRule,proto3" json:"parent_rule,omitempty"`
+	Instructions  string                      `protobuf:"bytes,14,opt,name=instructions,proto3" json:"instructions,omitempty"`
+	Warning       string                      `protobuf:"bytes,15,opt,name=warning,proto3" json:"warning,omitempty"`
+	OperatorKind  ComplianceRule_OperatorKind `protobuf:"varint,16,opt,name=operator_kind,json=operatorKind,proto3,enum=v2.ComplianceRule_OperatorKind" json:"operator_kind,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -287,6 +337,13 @@ func (x *ComplianceRule) GetWarning() string {
 		return x.Warning
 	}
 	return ""
+}
+
+func (x *ComplianceRule) GetOperatorKind() ComplianceRule_OperatorKind {
+	if x != nil {
+		return x.OperatorKind
+	}
+	return ComplianceRule_OPERATOR_KIND_UNSPECIFIED
 }
 
 type ComplianceScanCluster struct {
@@ -1053,7 +1110,7 @@ var File_api_v2_compliance_common_proto protoreflect.FileDescriptor
 
 const file_api_v2_compliance_common_proto_rawDesc = "" +
 	"\n" +
-	"\x1eapi/v2/compliance_common.proto\x12\x02v2\x1a\x19api/v2/search_query.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe8\x03\n" +
+	"\x1eapi/v2/compliance_common.proto\x12\x02v2\x1a\x19api/v2/search_query.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf8\x04\n" +
 	"\x0eComplianceRule\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1b\n" +
 	"\trule_type\x18\x03 \x01(\tR\bruleType\x12\x1a\n" +
@@ -1070,12 +1127,17 @@ const file_api_v2_compliance_common_proto_rawDesc = "" +
 	"\vparent_rule\x18\r \x01(\tR\n" +
 	"parentRule\x12\"\n" +
 	"\finstructions\x18\x0e \x01(\tR\finstructions\x12\x18\n" +
-	"\awarning\x18\x0f \x01(\tR\awarning\x1aA\n" +
+	"\awarning\x18\x0f \x01(\tR\awarning\x12D\n" +
+	"\roperator_kind\x18\x10 \x01(\x0e2\x1f.v2.ComplianceRule.OperatorKindR\foperatorKind\x1aA\n" +
 	"\x03Fix\x12\x1a\n" +
 	"\bplatform\x18\x01 \x01(\tR\bplatform\x12\x1e\n" +
 	"\n" +
 	"disruption\x18\x02 \x01(\tR\n" +
-	"disruptionJ\x04\b\x02\x10\x03\"Y\n" +
+	"disruption\"H\n" +
+	"\fOperatorKind\x12\x1d\n" +
+	"\x19OPERATOR_KIND_UNSPECIFIED\x10\x00\x12\b\n" +
+	"\x04RULE\x10\x01\x12\x0f\n" +
+	"\vCUSTOM_RULE\x10\x02J\x04\b\x02\x10\x03\"Y\n" +
 	"\x15ComplianceScanCluster\x12\x1d\n" +
 	"\n" +
 	"cluster_id\x18\x01 \x01(\tR\tclusterId\x12!\n" +
@@ -1163,46 +1225,48 @@ func file_api_v2_compliance_common_proto_rawDescGZIP() []byte {
 	return file_api_v2_compliance_common_proto_rawDescData
 }
 
-var file_api_v2_compliance_common_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_api_v2_compliance_common_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_api_v2_compliance_common_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_api_v2_compliance_common_proto_goTypes = []any{
 	(ComplianceCheckStatus)(0),                        // 0: v2.ComplianceCheckStatus
-	(ComplianceProfileSummary_OperatorKind)(0),        // 1: v2.ComplianceProfileSummary.OperatorKind
-	(*ComplianceRule)(nil),                            // 2: v2.ComplianceRule
-	(*ComplianceScanCluster)(nil),                     // 3: v2.ComplianceScanCluster
-	(*ComplianceCheckStatusCount)(nil),                // 4: v2.ComplianceCheckStatusCount
-	(*ComplianceCheckResultStatusCount)(nil),          // 5: v2.ComplianceCheckResultStatusCount
-	(*ComplianceControl)(nil),                         // 6: v2.ComplianceControl
-	(*ComplianceBenchmark)(nil),                       // 7: v2.ComplianceBenchmark
-	(*ListComplianceProfileResults)(nil),              // 8: v2.ListComplianceProfileResults
-	(*ComplianceClusterOverallStats)(nil),             // 9: v2.ComplianceClusterOverallStats
-	(*ListComplianceClusterOverallStatsResponse)(nil), // 10: v2.ListComplianceClusterOverallStatsResponse
-	(*ComplianceProfileResultsRequest)(nil),           // 11: v2.ComplianceProfileResultsRequest
-	(*ComplianceProfileCheckRequest)(nil),             // 12: v2.ComplianceProfileCheckRequest
-	(*ComplianceProfileSummary)(nil),                  // 13: v2.ComplianceProfileSummary
-	(*ComplianceRule_Fix)(nil),                        // 14: v2.ComplianceRule.Fix
-	(*timestamppb.Timestamp)(nil),                     // 15: google.protobuf.Timestamp
-	(*RawQuery)(nil),                                  // 16: v2.RawQuery
+	(ComplianceRule_OperatorKind)(0),                  // 1: v2.ComplianceRule.OperatorKind
+	(ComplianceProfileSummary_OperatorKind)(0),        // 2: v2.ComplianceProfileSummary.OperatorKind
+	(*ComplianceRule)(nil),                            // 3: v2.ComplianceRule
+	(*ComplianceScanCluster)(nil),                     // 4: v2.ComplianceScanCluster
+	(*ComplianceCheckStatusCount)(nil),                // 5: v2.ComplianceCheckStatusCount
+	(*ComplianceCheckResultStatusCount)(nil),          // 6: v2.ComplianceCheckResultStatusCount
+	(*ComplianceControl)(nil),                         // 7: v2.ComplianceControl
+	(*ComplianceBenchmark)(nil),                       // 8: v2.ComplianceBenchmark
+	(*ListComplianceProfileResults)(nil),              // 9: v2.ListComplianceProfileResults
+	(*ComplianceClusterOverallStats)(nil),             // 10: v2.ComplianceClusterOverallStats
+	(*ListComplianceClusterOverallStatsResponse)(nil), // 11: v2.ListComplianceClusterOverallStatsResponse
+	(*ComplianceProfileResultsRequest)(nil),           // 12: v2.ComplianceProfileResultsRequest
+	(*ComplianceProfileCheckRequest)(nil),             // 13: v2.ComplianceProfileCheckRequest
+	(*ComplianceProfileSummary)(nil),                  // 14: v2.ComplianceProfileSummary
+	(*ComplianceRule_Fix)(nil),                        // 15: v2.ComplianceRule.Fix
+	(*timestamppb.Timestamp)(nil),                     // 16: google.protobuf.Timestamp
+	(*RawQuery)(nil),                                  // 17: v2.RawQuery
 }
 var file_api_v2_compliance_common_proto_depIdxs = []int32{
-	14, // 0: v2.ComplianceRule.fixes:type_name -> v2.ComplianceRule.Fix
-	0,  // 1: v2.ComplianceCheckStatusCount.status:type_name -> v2.ComplianceCheckStatus
-	4,  // 2: v2.ComplianceCheckResultStatusCount.check_stats:type_name -> v2.ComplianceCheckStatusCount
-	6,  // 3: v2.ComplianceCheckResultStatusCount.controls:type_name -> v2.ComplianceControl
-	5,  // 4: v2.ListComplianceProfileResults.profile_results:type_name -> v2.ComplianceCheckResultStatusCount
-	3,  // 5: v2.ComplianceClusterOverallStats.cluster:type_name -> v2.ComplianceScanCluster
-	4,  // 6: v2.ComplianceClusterOverallStats.check_stats:type_name -> v2.ComplianceCheckStatusCount
-	15, // 7: v2.ComplianceClusterOverallStats.last_scan_time:type_name -> google.protobuf.Timestamp
-	9,  // 8: v2.ListComplianceClusterOverallStatsResponse.scan_stats:type_name -> v2.ComplianceClusterOverallStats
-	16, // 9: v2.ComplianceProfileResultsRequest.query:type_name -> v2.RawQuery
-	16, // 10: v2.ComplianceProfileCheckRequest.query:type_name -> v2.RawQuery
-	7,  // 11: v2.ComplianceProfileSummary.standards:type_name -> v2.ComplianceBenchmark
-	1,  // 12: v2.ComplianceProfileSummary.operator_kind:type_name -> v2.ComplianceProfileSummary.OperatorKind
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	15, // 0: v2.ComplianceRule.fixes:type_name -> v2.ComplianceRule.Fix
+	1,  // 1: v2.ComplianceRule.operator_kind:type_name -> v2.ComplianceRule.OperatorKind
+	0,  // 2: v2.ComplianceCheckStatusCount.status:type_name -> v2.ComplianceCheckStatus
+	5,  // 3: v2.ComplianceCheckResultStatusCount.check_stats:type_name -> v2.ComplianceCheckStatusCount
+	7,  // 4: v2.ComplianceCheckResultStatusCount.controls:type_name -> v2.ComplianceControl
+	6,  // 5: v2.ListComplianceProfileResults.profile_results:type_name -> v2.ComplianceCheckResultStatusCount
+	4,  // 6: v2.ComplianceClusterOverallStats.cluster:type_name -> v2.ComplianceScanCluster
+	5,  // 7: v2.ComplianceClusterOverallStats.check_stats:type_name -> v2.ComplianceCheckStatusCount
+	16, // 8: v2.ComplianceClusterOverallStats.last_scan_time:type_name -> google.protobuf.Timestamp
+	10, // 9: v2.ListComplianceClusterOverallStatsResponse.scan_stats:type_name -> v2.ComplianceClusterOverallStats
+	17, // 10: v2.ComplianceProfileResultsRequest.query:type_name -> v2.RawQuery
+	17, // 11: v2.ComplianceProfileCheckRequest.query:type_name -> v2.RawQuery
+	8,  // 12: v2.ComplianceProfileSummary.standards:type_name -> v2.ComplianceBenchmark
+	2,  // 13: v2.ComplianceProfileSummary.operator_kind:type_name -> v2.ComplianceProfileSummary.OperatorKind
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_compliance_common_proto_init() }
@@ -1216,7 +1280,7 @@ func file_api_v2_compliance_common_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v2_compliance_common_proto_rawDesc), len(file_api_v2_compliance_common_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      3,
 			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/generated/api/v2/compliance_common.pb.go
+++ b/generated/api/v2/compliance_common.pb.go
@@ -86,12 +86,18 @@ func (ComplianceCheckStatus) EnumDescriptor() ([]byte, []int) {
 	return file_api_v2_compliance_common_proto_rawDescGZIP(), []int{0}
 }
 
+// OperatorKind is the kind of the Compliance Operator resource that this
+// `ComplianceRule` was sourced from. ACS represents both Compliance Operator
+// `Rules` and `CustomRules` as compliance rules.
 type ComplianceRule_OperatorKind int32
 
 const (
+	// The kind is unspecified.
 	ComplianceRule_OPERATOR_KIND_UNSPECIFIED ComplianceRule_OperatorKind = 0
-	ComplianceRule_RULE                      ComplianceRule_OperatorKind = 1
-	ComplianceRule_CUSTOM_RULE               ComplianceRule_OperatorKind = 2
+	// The kind is `Rule`.
+	ComplianceRule_RULE ComplianceRule_OperatorKind = 1
+	// The kind is `CustomRule`.
+	ComplianceRule_CUSTOM_RULE ComplianceRule_OperatorKind = 2
 )
 
 // Enum value maps for ComplianceRule_OperatorKind.

--- a/generated/api/v2/compliance_common_vtproto.pb.go
+++ b/generated/api/v2/compliance_common_vtproto.pb.go
@@ -58,6 +58,7 @@ func (m *ComplianceRule) CloneVT() *ComplianceRule {
 	r.ParentRule = m.ParentRule
 	r.Instructions = m.Instructions
 	r.Warning = m.Warning
+	r.OperatorKind = m.OperatorKind
 	if rhs := m.Fixes; rhs != nil {
 		tmpContainer := make([]*ComplianceRule_Fix, len(rhs))
 		for k, v := range rhs {
@@ -412,6 +413,9 @@ func (this *ComplianceRule) EqualVT(that *ComplianceRule) bool {
 		return false
 	}
 	if this.Warning != that.Warning {
+		return false
+	}
+	if this.OperatorKind != that.OperatorKind {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -880,6 +884,13 @@ func (m *ComplianceRule) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.OperatorKind != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.OperatorKind))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x80
 	}
 	if len(m.Warning) > 0 {
 		i -= len(m.Warning)
@@ -1729,6 +1740,9 @@ func (m *ComplianceRule) SizeVT() (n int) {
 	l = len(m.Warning)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.OperatorKind != 0 {
+		n += 2 + protohelpers.SizeOfVarint(uint64(m.OperatorKind))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -2598,6 +2612,25 @@ func (m *ComplianceRule) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Warning = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 16:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OperatorKind", wireType)
+			}
+			m.OperatorKind = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.OperatorKind |= ComplianceRule_OperatorKind(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -5001,6 +5034,25 @@ func (m *ComplianceRule) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.Warning = stringValue
 			iNdEx = postIndex
+		case 16:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OperatorKind", wireType)
+			}
+			m.OperatorKind = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.OperatorKind |= ComplianceRule_OperatorKind(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/api/v2/compliance_profile_service.swagger.json
+++ b/generated/api/v2/compliance_profile_service.swagger.json
@@ -464,7 +464,8 @@
         "RULE",
         "CUSTOM_RULE"
       ],
-      "default": "OPERATOR_KIND_UNSPECIFIED"
+      "default": "OPERATOR_KIND_UNSPECIFIED",
+      "description": "OperatorKind is the kind of the Compliance Operator resource that this\n`ComplianceRule` was sourced from. ACS represents both Compliance Operator\n`Rules` and `CustomRules` as compliance rules.\n\n - OPERATOR_KIND_UNSPECIFIED: The kind is unspecified.\n - RULE: The kind is `Rule`.\n - CUSTOM_RULE: The kind is `CustomRule`."
     },
     "v2ListComplianceProfileSummaryResponse": {
       "type": "object",

--- a/generated/api/v2/compliance_profile_service.swagger.json
+++ b/generated/api/v2/compliance_profile_service.swagger.json
@@ -451,8 +451,20 @@
         },
         "warning": {
           "type": "string"
+        },
+        "operatorKind": {
+          "$ref": "#/definitions/v2ComplianceRuleOperatorKind"
         }
       }
+    },
+    "v2ComplianceRuleOperatorKind": {
+      "type": "string",
+      "enum": [
+        "OPERATOR_KIND_UNSPECIFIED",
+        "RULE",
+        "CUSTOM_RULE"
+      ],
+      "default": "OPERATOR_KIND_UNSPECIFIED"
     },
     "v2ListComplianceProfileSummaryResponse": {
       "type": "object",

--- a/generated/api/v2/compliance_rule_service.swagger.json
+++ b/generated/api/v2/compliance_rule_service.swagger.json
@@ -221,7 +221,8 @@
         "RULE",
         "CUSTOM_RULE"
       ],
-      "default": "OPERATOR_KIND_UNSPECIFIED"
+      "default": "OPERATOR_KIND_UNSPECIFIED",
+      "description": "OperatorKind is the kind of the Compliance Operator resource that this\n`ComplianceRule` was sourced from. ACS represents both Compliance Operator\n`Rules` and `CustomRules` as compliance rules.\n\n - OPERATOR_KIND_UNSPECIFIED: The kind is unspecified.\n - RULE: The kind is `Rule`.\n - CUSTOM_RULE: The kind is `CustomRule`."
     },
     "v2Pagination": {
       "type": "object",

--- a/generated/api/v2/compliance_rule_service.swagger.json
+++ b/generated/api/v2/compliance_rule_service.swagger.json
@@ -208,8 +208,20 @@
         },
         "warning": {
           "type": "string"
+        },
+        "operatorKind": {
+          "$ref": "#/definitions/v2ComplianceRuleOperatorKind"
         }
       }
+    },
+    "v2ComplianceRuleOperatorKind": {
+      "type": "string",
+      "enum": [
+        "OPERATOR_KIND_UNSPECIFIED",
+        "RULE",
+        "CUSTOM_RULE"
+      ],
+      "default": "OPERATOR_KIND_UNSPECIFIED"
     },
     "v2Pagination": {
       "type": "object",

--- a/proto/api/v2/compliance_common.proto
+++ b/proto/api/v2/compliance_common.proto
@@ -28,9 +28,15 @@ message ComplianceRule {
   string parent_rule = 13;
   string instructions = 14;
   string warning = 15;
+  // OperatorKind is the kind of the Compliance Operator resource that this
+  // `ComplianceRule` was sourced from. ACS represents both Compliance Operator
+  // `Rules` and `CustomRules` as compliance rules.
   enum OperatorKind {
+    // The kind is unspecified.
     OPERATOR_KIND_UNSPECIFIED = 0;
+    // The kind is `Rule`.
     RULE = 1;
+    // The kind is `CustomRule`.
     CUSTOM_RULE = 2;
   }
   OperatorKind operator_kind = 16;

--- a/proto/api/v2/compliance_common.proto
+++ b/proto/api/v2/compliance_common.proto
@@ -28,6 +28,12 @@ message ComplianceRule {
   string parent_rule = 13;
   string instructions = 14;
   string warning = 15;
+  enum OperatorKind {
+    OPERATOR_KIND_UNSPECIFIED = 0;
+    RULE = 1;
+    CUSTOM_RULE = 2;
+  }
+  OperatorKind operator_kind = 16;
 }
 
 enum ComplianceCheckStatus {

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -1145,6 +1145,7 @@ func TestComplianceV2GetComplianceRule(t *testing.T) {
 		assert.NotEmpty(t, resp.GetTitle(), "Title should be non-empty")
 		assert.NotEmpty(t, resp.GetRuleType(), "RuleType should be non-empty")
 		assert.NotEmpty(t, resp.GetSeverity(), "Severity should be non-empty")
+		assert.Equal(t, v2.ComplianceRule_RULE, resp.GetOperatorKind(), "OperatorKind should be RULE for built-in rules")
 	})
 
 	t.Run("custom", func(t *testing.T) {

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -1145,6 +1145,7 @@ func TestComplianceV2GetComplianceRule(t *testing.T) {
 		assert.NotEmpty(t, resp.GetTitle(), "Title should be non-empty")
 		assert.NotEmpty(t, resp.GetRuleType(), "RuleType should be non-empty")
 		assert.NotEmpty(t, resp.GetSeverity(), "Severity should be non-empty")
+		assert.Equal(t, v2.ComplianceRule_RULE, resp.GetOperatorKind(), "OperatorKind should be RULE for built-in rules")
 	})
 
 	t.Run("custom", func(t *testing.T) {
@@ -1161,6 +1162,7 @@ func TestComplianceV2GetComplianceRule(t *testing.T) {
 			require.NotNil(c, resp)
 			assert.Equal(c, crName, resp.GetName())
 			assert.NotEmpty(c, resp.GetTitle(), "Title should be non-empty")
+			assert.Equal(c, v2.ComplianceRule_CUSTOM_RULE, resp.GetOperatorKind(), "OperatorKind should be CUSTOM_RULE")
 		}, 10*time.Second, 1*time.Second)
 	})
 

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -1176,5 +1176,6 @@ func TestComplianceV2GetComplianceRule(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Empty(t, resp.GetName())
+		assert.Equal(t, v2.ComplianceRule_OPERATOR_KIND_UNSPECIFIED, resp.GetOperatorKind())
 	})
 }

--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -1145,7 +1145,6 @@ func TestComplianceV2GetComplianceRule(t *testing.T) {
 		assert.NotEmpty(t, resp.GetTitle(), "Title should be non-empty")
 		assert.NotEmpty(t, resp.GetRuleType(), "RuleType should be non-empty")
 		assert.NotEmpty(t, resp.GetSeverity(), "Severity should be non-empty")
-		assert.Equal(t, v2.ComplianceRule_RULE, resp.GetOperatorKind(), "OperatorKind should be RULE for built-in rules")
 	})
 
 	t.Run("custom", func(t *testing.T) {


### PR DESCRIPTION
## Description

Expose the `operator_kind` field in the `ComplianceRule` API response. The storage proto `ComplianceOperatorRuleV2` already has this field (RULE / CUSTOM_RULE), but the API message `ComplianceRule` did not surface it. This is inconsistent with how profiles are handled — both `ComplianceProfile` and `ComplianceProfileSummary` already expose `operator_kind` in their API protos.

The conversion uses the existing `CustomRuleEffectiveOperatorKind` normalization function, which maps UNSPECIFIED → RULE for backward compatibility with sensors that don't set the field on built-in rules.

Stacked on #20464.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Built and deployed Central with these changes to a live OpenShift cluster
- Verified built-in rule returns `operatorKind: RULE` via REST API
- Verified custom rule (created without TailoredProfile) returns `operatorKind: CUSTOM_RULE`
- Verified non-existent rule returns `operatorKind: OPERATOR_KIND_UNSPECIFIED` (zero-value)
- Unit tests pass: `go test ./central/convert/storagetov2/... ./central/complianceoperator/v2/rules/...`

Note: code was partially generated by AI.