### PR TITLE
fix(compliance): dispatch custom rules only if central supports them

### DIFF
--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorcustomrules.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorcustomrules.go
@@ -22,8 +22,8 @@ func NewCustomRuleDispatcher() *CustomRuleDispatcher {
 // ProcessEvent processes a custom rule event.
 // CustomRules are converted to ComplianceOperatorRuleV2 with OperatorKind=CUSTOM_RULE, following the same pattern as TailoredProfiles.
 func (c *CustomRuleDispatcher) ProcessEvent(obj, _ interface{}, action central.ResourceAction) *component.ResourceEvent {
-	// CustomRules are only supported by compliance V2
-	if !centralcaps.Has(centralsensor.ComplianceV2Integrations) {
+	// CustomRules support is tied to TailoredProfiles - centrals that don't support TPs don't support custom rules
+	if !centralcaps.Has(centralsensor.ComplianceV2TailoredProfiles) {
 		return nil
 	}
 

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorcustomrules_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorcustomrules_test.go
@@ -1,0 +1,93 @@
+package dispatchers
+
+import (
+	"testing"
+
+	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/sensor/common/centralcaps"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func customRuleToUnstructured(t *testing.T, cr *v1alpha1.CustomRule) *unstructured.Unstructured {
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
+	require.NoError(t, err)
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func testCustomRule() *v1alpha1.CustomRule {
+	return &v1alpha1.CustomRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "check-cm-marker",
+			Namespace: "openshift-compliance",
+			UID:       "custom-rule-uid",
+			Labels:    map[string]string{"app": "compliance"},
+			Annotations: map[string]string{
+				"note": "test annotation",
+			},
+		},
+		Spec: v1alpha1.CustomRuleSpec{
+			RulePayload: v1alpha1.RulePayload{
+				ID:           "xccdf_org.example_rule_check_cm_marker",
+				Title:        "Check CM Marker",
+				Description:  "Checks that a configmap marker exists",
+				Severity:     "high",
+				CheckType:    "Platform",
+				Instructions: "Ensure the configmap has the marker key",
+				AvailableFixes: []v1alpha1.FixDefinition{
+					{Platform: "ocp4", Disruption: "low"},
+				},
+			},
+		},
+	}
+}
+
+func TestCustomRuleProcessEvent_WithCapability(t *testing.T) {
+	centralcaps.Set([]centralsensor.CentralCapability{centralsensor.ComplianceV2TailoredProfiles})
+	t.Cleanup(func() { centralcaps.Set(nil) })
+
+	cr := testCustomRule()
+	dispatcher := NewCustomRuleDispatcher()
+	event := dispatcher.ProcessEvent(customRuleToUnstructured(t, cr), nil, central.ResourceAction_CREATE_RESOURCE)
+
+	require.NotNil(t, event)
+	require.Len(t, event.ForwardMessages, 1)
+
+	rule := event.ForwardMessages[0].GetComplianceOperatorRuleV2()
+	require.NotNil(t, rule)
+
+	assert.Equal(t, "custom-rule-uid", rule.GetId())
+	assert.Equal(t, "check-cm-marker", rule.GetName())
+	assert.Equal(t, "xccdf_org.example_rule_check_cm_marker", rule.GetRuleId())
+	assert.Equal(t, "Check CM Marker", rule.GetTitle())
+	assert.Equal(t, "Checks that a configmap marker exists", rule.GetDescription())
+	assert.Equal(t, "Platform", rule.GetRuleType())
+	assert.Equal(t, central.ComplianceOperatorRuleSeverity_HIGH_RULE_SEVERITY, rule.GetSeverity())
+	assert.Equal(t, central.ComplianceOperatorRuleV2_CUSTOM_RULE, rule.GetOperatorKind())
+	assert.Equal(t, "Ensure the configmap has the marker key", rule.GetInstructions())
+	require.Len(t, rule.GetFixes(), 1)
+	assert.Equal(t, "ocp4", rule.GetFixes()[0].GetPlatform())
+}
+
+func TestCustomRuleProcessEvent_WithoutCapability(t *testing.T) {
+	cases := map[string][]centralsensor.CentralCapability{
+		"only ComplianceV2Integrations": {centralsensor.ComplianceV2Integrations},
+		"no capabilities":               {},
+	}
+	for name, caps := range cases {
+		t.Run(name, func(t *testing.T) {
+			centralcaps.Set(caps)
+			t.Cleanup(func() { centralcaps.Set(nil) })
+
+			dispatcher := NewCustomRuleDispatcher()
+			event := dispatcher.ProcessEvent(customRuleToUnstructured(t, testCustomRule()), nil, central.ResourceAction_CREATE_RESOURCE)
+
+			assert.Nil(t, event)
+		})
+	}
+}

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorcustomrules_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorcustomrules_test.go
@@ -62,17 +62,17 @@ func TestCustomRuleProcessEvent_WithCapability(t *testing.T) {
 	rule := event.ForwardMessages[0].GetComplianceOperatorRuleV2()
 	require.NotNil(t, rule)
 
-	assert.Equal(t, "custom-rule-uid", rule.GetId())
-	assert.Equal(t, "check-cm-marker", rule.GetName())
-	assert.Equal(t, "xccdf_org.example_rule_check_cm_marker", rule.GetRuleId())
-	assert.Equal(t, "Check CM Marker", rule.GetTitle())
-	assert.Equal(t, "Checks that a configmap marker exists", rule.GetDescription())
-	assert.Equal(t, "Platform", rule.GetRuleType())
+	assert.Equal(t, string(cr.GetUID()), rule.GetId())
+	assert.Equal(t, cr.GetName(), rule.GetName())
+	assert.Equal(t, cr.Spec.ID, rule.GetRuleId())
+	assert.Equal(t, cr.Spec.Title, rule.GetTitle())
+	assert.Equal(t, cr.Spec.Description, rule.GetDescription())
+	assert.Equal(t, cr.Spec.CheckType, rule.GetRuleType())
 	assert.Equal(t, central.ComplianceOperatorRuleSeverity_HIGH_RULE_SEVERITY, rule.GetSeverity())
 	assert.Equal(t, central.ComplianceOperatorRuleV2_CUSTOM_RULE, rule.GetOperatorKind())
-	assert.Equal(t, "Ensure the configmap has the marker key", rule.GetInstructions())
+	assert.Equal(t, cr.Spec.Instructions, rule.GetInstructions())
 	require.Len(t, rule.GetFixes(), 1)
-	assert.Equal(t, "ocp4", rule.GetFixes()[0].GetPlatform())
+	assert.Equal(t, cr.Spec.AvailableFixes[0].Platform, rule.GetFixes()[0].GetPlatform())
 }
 
 func TestCustomRuleProcessEvent_WithoutCapability(t *testing.T) {

--- a/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorcustomrules_test.go
+++ b/sensor/kubernetes/complianceoperator/dispatchers/complianceoperatorcustomrules_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func customRuleToUnstructured(t *testing.T, cr *v1alpha1.CustomRule) *unstructured.Unstructured {
+	t.Helper()
 	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
 	require.NoError(t, err)
 	return &unstructured.Unstructured{Object: obj}


### PR DESCRIPTION
## Description

The custom rules dispatcher was gated on the `ComplianceV2Integrations` capability, but custom rules are tied to TailoredProfiles support. This meant custom rules could be dispatched to a Central that supports base V2 integrations but not yet TailoredProfiles/custom rules. Fix by checking `ComplianceV2TailoredProfiles` instead.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

Unit tests verify that custom rules are dispatched only when the `ComplianceV2TailoredProfiles` capability is present, and not when only `ComplianceV2Integrations` is advertised.