### PR TITLE
fix(central): Assume UNSPECIFIED compliance rule operator kind is RULE

### DIFF
--- a/central/convert/internaltov2storage/compliance_rule.go
+++ b/central/convert/internaltov2storage/compliance_rule.go
@@ -99,7 +99,10 @@ func centralToStorageRuleKind(kind central.ComplianceOperatorRuleV2_OperatorKind
 	case central.ComplianceOperatorRuleV2_CUSTOM_RULE:
 		return storage.ComplianceOperatorRuleV2_CUSTOM_RULE
 	case central.ComplianceOperatorRuleV2_OPERATOR_KIND_UNSPECIFIED:
-		return storage.ComplianceOperatorRuleV2_OPERATOR_KIND_UNSPECIFIED
+		// Older sensors do not set OperatorKind for regular (non-custom) rules,
+		// so UNSPECIFIED is treated as RULE. This fallback can be removed when
+		// versions that don't set OperatorKind (<= 4.10) are not supported.
+		return storage.ComplianceOperatorRuleV2_RULE
 	default:
 		log.Errorf("Unexpected rule operator kind %v", kind)
 		return storage.ComplianceOperatorRuleV2_OPERATOR_KIND_UNSPECIFIED

--- a/central/convert/internaltov2storage/compliance_rule_test.go
+++ b/central/convert/internaltov2storage/compliance_rule_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,6 +59,23 @@ func TestComplianceOperatorRule_ParentRuleAndRuleRefId(t *testing.T) {
 
 		assert.Equal(t, "kubelet-configure-tls-cert", result.GetParentRule())
 		assert.Equal(t, BuildNameRefID(clusterID, "kubelet-configure-tls-cert"), result.GetRuleRefId())
+	})
+
+	t.Run("unspecified OperatorKind is treated as RULE", func(t *testing.T) {
+		msg := &central.ComplianceOperatorRuleV2{
+			Id:     "rule-uid",
+			RuleId: "xccdf_org.ssgproject.content_rule_some_rule",
+			Name:   "some-rule",
+			Annotations: map[string]string{
+				v1alpha1.RuleIDAnnotationKey: "some-rule",
+			},
+		}
+
+		result := ComplianceOperatorRule(msg, clusterID)
+
+		assert.Equal(t, storage.ComplianceOperatorRuleV2_RULE, result.GetOperatorKind())
+		assert.Equal(t, "some-rule", result.GetParentRule())
+		assert.Equal(t, BuildNameRefID(clusterID, "some-rule"), result.GetRuleRefId())
 	})
 
 	t.Run("custom rule derives parentRule from RuleId, ignoring RuleIDAnnotationKey annotation", func(t *testing.T) {


### PR DESCRIPTION
## Description

Older sensors (<= 4.10) don't set `OperatorKind` on compliance rule V2 events (fixed going forward in #20499). When Central receives `UNSPECIFIED`, it should treat it as `RULE` rather than storing the zero-value, since those older sensors can only produce regular rules — custom rules didn't exist yet, and when they were introduced they set their kind explicitly.

This mimics how tailored profiles are handled in the central converter.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

Unit test covering the UNSPECIFIED-to-RULE mapping in `centralToStorageRuleKind`, verifying that the converted storage object gets `RULE` as `OperatorKind` and derives `parentRule` and `RuleRefId` correctly.