### PR TITLE
ROX-34659: Avoid label map allocations in flow enrichment

### DIFF
--- a/sensor/common/networkflow/manager/manager_enrich_connection.go
+++ b/sensor/common/networkflow/manager/manager_enrich_connection.go
@@ -107,6 +107,9 @@ func (m *networkFlowManager) enrichConnection(now timestamp.MicroTS, conn *conne
 		port = conn.remote.IPAndPort.Port
 	}
 
+	// Keep the flow counter label values in metric registration order: direction,
+	// namespace. These WithLabelValues calls sit on the enrichment hot path and
+	// intentionally avoid map-based labels to stay allocation-free.
 	// Cannot find any entity when looking by endpoint and IP address.
 	if len(lookupResults) == 0 {
 		// If the address is set and is not resolvable, we want to we wait for `clusterEntityResolutionWaitPeriod` time
@@ -326,6 +329,9 @@ func updateConnectionMetric(now timestamp.MicroTS, action PostEnrichmentAction, 
 	fresh := strconv.FormatBool(status.isFresh(now))
 	isExternal := strconv.FormatBool(status.isExternal)
 
+	// Keep this hot-path metric update on WithLabelValues and reuse the
+	// precomputed strings above. The argument order must stay in sync with the
+	// label registration in sensor/common/networkflow/metrics/metrics.go.
 	flowMetrics.FlowEnrichmentEventsConnection.WithLabelValues(
 		containerIDFound,
 		string(result),

--- a/sensor/common/networkflow/manager/manager_enrich_connection.go
+++ b/sensor/common/networkflow/manager/manager_enrich_connection.go
@@ -3,7 +3,6 @@ package manager
 import (
 	"strconv"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
@@ -108,11 +107,6 @@ func (m *networkFlowManager) enrichConnection(now timestamp.MicroTS, conn *conne
 		port = conn.remote.IPAndPort.Port
 	}
 
-	metricDirection := prometheus.Labels{
-		"direction": direction,
-		"namespace": container.Namespace,
-	}
-
 	// Cannot find any entity when looking by endpoint and IP address.
 	if len(lookupResults) == 0 {
 		// If the address is set and is not resolvable, we want to we wait for `clusterEntityResolutionWaitPeriod` time
@@ -169,14 +163,14 @@ func (m *networkFlowManager) enrichConnection(now timestamp.MicroTS, conn *conne
 			if !status.enrichmentConsumption.consumedNetworkGraph {
 				// Count internal metrics even if central lacks `NetworkGraphInternalEntitiesSupported` capability.
 				if isExternal {
-					flowMetrics.ExternalFlowCounter.With(metricDirection).Inc()
+					flowMetrics.ExternalFlowCounter.WithLabelValues(direction, container.Namespace).Inc()
 				} else {
-					flowMetrics.InternalFlowCounter.With(metricDirection).Inc()
+					flowMetrics.InternalFlowCounter.WithLabelValues(direction, container.Namespace).Inc()
 				}
 			}
 		} else {
 			if !status.enrichmentConsumption.consumedNetworkGraph {
-				flowMetrics.NetworkEntityFlowCounter.With(metricDirection).Inc()
+				flowMetrics.NetworkEntityFlowCounter.WithLabelValues(direction, container.Namespace).Inc()
 			}
 			lookupResults = []clusterentities.LookupResult{
 				{
@@ -187,7 +181,7 @@ func (m *networkFlowManager) enrichConnection(now timestamp.MicroTS, conn *conne
 		}
 	} else {
 		if !status.enrichmentConsumption.consumedNetworkGraph {
-			flowMetrics.NetworkEntityFlowCounter.With(metricDirection).Inc()
+			flowMetrics.NetworkEntityFlowCounter.WithLabelValues(direction, container.Namespace).Inc()
 		}
 		status.enrichmentConsumption.consumedNetworkGraph = true
 		if conn.incoming {
@@ -324,16 +318,24 @@ func deactivateConnectionNoLock(conn *connection,
 }
 
 func updateConnectionMetric(now timestamp.MicroTS, action PostEnrichmentAction, result EnrichmentResult, reason EnrichmentReasonConn, status *connStatus) {
-	flowMetrics.FlowEnrichmentEventsConnection.With(prometheus.Labels{
-		"containerIDfound": strconv.FormatBool(status.containerIDFound),
-		"result":           string(result),
-		"action":           string(action),
-		"isHistorical":     strconv.FormatBool(status.historicalContainerID),
-		"reason":           string(reason),
-		"isClosed":         strconv.FormatBool(status.isClosed()),
-		"rotten":           strconv.FormatBool(status.rotten),
-		"mature":           strconv.FormatBool(status.pastContainerResolutionDeadline(now)),
-		"fresh":            strconv.FormatBool(status.isFresh(now)),
-		"isExternal":       strconv.FormatBool(status.isExternal),
-	}).Inc()
+	containerIDFound := strconv.FormatBool(status.containerIDFound)
+	isHistorical := strconv.FormatBool(status.historicalContainerID)
+	isClosed := strconv.FormatBool(status.isClosed())
+	rotten := strconv.FormatBool(status.rotten)
+	mature := strconv.FormatBool(status.pastContainerResolutionDeadline(now))
+	fresh := strconv.FormatBool(status.isFresh(now))
+	isExternal := strconv.FormatBool(status.isExternal)
+
+	flowMetrics.FlowEnrichmentEventsConnection.WithLabelValues(
+		containerIDFound,
+		string(result),
+		string(action),
+		isHistorical,
+		string(reason),
+		isClosed,
+		rotten,
+		mature,
+		fresh,
+		isExternal,
+	).Inc()
 }

--- a/sensor/common/networkflow/manager/manager_enrich_endpoint.go
+++ b/sensor/common/networkflow/manager/manager_enrich_endpoint.go
@@ -3,7 +3,6 @@ package manager
 import (
 	"strconv"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/networkgraph"
@@ -260,27 +259,39 @@ func updateEndpointMetric(now timestamp.MicroTS,
 	result EnrichmentResult, resultPLOP EnrichmentResult,
 	reason EnrichmentReasonEp, reasonPLOP EnrichmentReasonEp,
 	status *connStatus) {
-	flowMetrics.FlowEnrichmentEventsEndpoint.With(prometheus.Labels{
-		"containerIDfound": strconv.FormatBool(status.containerIDFound),
-		"result":           string(result),
-		"action":           string(action),
-		"isHistorical":     strconv.FormatBool(status.historicalContainerID),
-		"reason":           string(reason),
-		"isClosed":         strconv.FormatBool(status.isClosed()),
-		"rotten":           strconv.FormatBool(status.rotten),
-		"mature":           strconv.FormatBool(status.pastContainerResolutionDeadline(now)),
-		"fresh":            strconv.FormatBool(status.isFresh(now))},
+	containerIDFound := strconv.FormatBool(status.containerIDFound)
+	isHistorical := strconv.FormatBool(status.historicalContainerID)
+	isClosed := strconv.FormatBool(status.isClosed())
+	rotten := strconv.FormatBool(status.rotten)
+	mature := strconv.FormatBool(status.pastContainerResolutionDeadline(now))
+	fresh := strconv.FormatBool(status.isFresh(now))
+
+	// Keep these hot-path metric updates on WithLabelValues and reuse the precomputed
+	// strings above. The old prometheus.Labels map literals allocated on every
+	// enrichment pass and showed up in ROX-34659 benchmarks as avoidable GC pressure
+	// while this code runs under the hostConns mutex. The argument order must stay in
+	// sync with the label registration in sensor/common/networkflow/metrics/metrics.go.
+	flowMetrics.FlowEnrichmentEventsEndpoint.WithLabelValues(
+		containerIDFound,
+		string(result),
+		string(action),
+		isHistorical,
+		string(reason),
+		isClosed,
+		rotten,
+		mature,
+		fresh,
 	).Inc()
 
-	flowMetrics.HostProcessesEnrichmentEvents.With(prometheus.Labels{
-		"containerIDfound": strconv.FormatBool(status.containerIDFound),
-		"result":           string(resultPLOP),
-		"action":           string(action),
-		"isHistorical":     strconv.FormatBool(status.historicalContainerID),
-		"reason":           string(reasonPLOP),
-		"isClosed":         strconv.FormatBool(status.isClosed()),
-		"rotten":           strconv.FormatBool(status.rotten),
-		"mature":           strconv.FormatBool(status.pastContainerResolutionDeadline(now)),
-		"fresh":            strconv.FormatBool(status.isFresh(now))},
+	flowMetrics.HostProcessesEnrichmentEvents.WithLabelValues(
+		containerIDFound,
+		string(resultPLOP),
+		string(action),
+		isHistorical,
+		string(reasonPLOP),
+		isClosed,
+		rotten,
+		mature,
+		fresh,
 	).Inc()
 }

--- a/sensor/common/networkflow/manager/metrics_bench_test.go
+++ b/sensor/common/networkflow/manager/metrics_bench_test.go
@@ -2,16 +2,16 @@ package manager
 
 import (
 	"testing"
-	"time"
 
-	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/timestamp"
 	flowMetrics "github.com/stackrox/rox/sensor/common/networkflow/metrics"
 )
 
 func benchmarkConnStatus(now timestamp.MicroTS) *connStatus {
 	return &connStatus{
-		firstSeen:             now.Add(-env.ContainerIDResolutionGracePeriod.DurationSetting() - time.Second),
+		// Keep the benchmark independent from env tunables while still exercising
+		// mature=true and fresh=false label values.
+		firstSeen:             timestamp.MicroTS(0),
 		lastSeen:              now,
 		containerIDFound:      true,
 		historicalContainerID: true,

--- a/sensor/common/networkflow/manager/metrics_perf_test.go
+++ b/sensor/common/networkflow/manager/metrics_perf_test.go
@@ -1,0 +1,56 @@
+package manager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/timestamp"
+	flowMetrics "github.com/stackrox/rox/sensor/common/networkflow/metrics"
+)
+
+func benchmarkConnStatus(now timestamp.MicroTS) *connStatus {
+	return &connStatus{
+		firstSeen:             now.Add(-env.ContainerIDResolutionGracePeriod.DurationSetting() - time.Second),
+		lastSeen:              now,
+		containerIDFound:      true,
+		historicalContainerID: true,
+		rotten:                true,
+	}
+}
+
+func BenchmarkUpdateEndpointMetric(b *testing.B) {
+	flowMetrics.FlowEnrichmentEventsEndpoint.Reset()
+	flowMetrics.HostProcessesEnrichmentEvents.Reset()
+
+	now := timestamp.Now()
+	action := PostEnrichmentActionCheckRemove
+	resultNG := EnrichmentResultSuccess
+	resultPLOP := EnrichmentResultSkipped
+	reasonNG := EnrichmentReasonEpSuccessInactive
+	reasonPLOP := EnrichmentReasonEpFeaturePlopDisabled
+	status := benchmarkConnStatus(now)
+	updateEndpointMetric(now, action, resultNG, resultPLOP, reasonNG, reasonPLOP, status)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		updateEndpointMetric(now, action, resultNG, resultPLOP, reasonNG, reasonPLOP, status)
+	}
+}
+
+func BenchmarkUpdateConnectionMetric(b *testing.B) {
+	flowMetrics.FlowEnrichmentEventsConnection.Reset()
+
+	now := timestamp.Now()
+	action := PostEnrichmentActionCheckRemove
+	result := EnrichmentResultSuccess
+	reason := EnrichmentReasonConnSuccess
+	status := benchmarkConnStatus(now)
+	status.isExternal = true
+	updateConnectionMetric(now, action, result, reason, status)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		updateConnectionMetric(now, action, result, reason, status)
+	}
+}


### PR DESCRIPTION
## Description

This change removes per-call Prometheus label map allocations from the
network flow enrichment hot path.

A dev-mode Sensor crash investigation on a long-running cluster with real
workload traced `SIGABRT` (`Mutex.Unlock took more than 10s to complete`)
to the `enrichConnections` call chain in
`sensor/common/networkflow/manager`. Heap profiling (`alloc_space`)
identified `updateEndpointMetric` as the single largest allocator in the
process: 1.34 TB of lifetime allocations, or 28.9% of total Sensor
allocations. Those metrics run while `hostConns.mutex` is held; with
481K active endpoints, the old `prometheus.Labels` map literals created
962K heap-allocated maps per enrichment tick and roughly 1.3 GB of
garbage.

This PR:

- replaces the hot `With(prometheus.Labels{...})` calls in
  `updateEndpointMetric` and `updateConnectionMetric` with
  `WithLabelValues(...)`
- applies the same trivial label-map-to-ordered-values conversion to the
  adjacent `direction`/`namespace` flow metrics in `enrichConnection`
- adds a focused microbenchmark file that keeps the committed proof scoped
  to the two profile-identified helper functions
- documents in code why these calls intentionally avoid map-based labels
  and why label order must stay aligned with metric registration

AI-Assisted: cursor, ~70% generated, user reviewed benchmark scope and
final shape

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

No unit tests were added because the change is behavior-preserving and the
requested evidence is a focused allocation benchmark.

### How I validated my change

- Unit tests.
- Collected before/after benchmark samples locally with
  `go test ./sensor/common/networkflow/manager -run '^$' -bench 'Benchmark(UpdateEndpointMetric|UpdateConnectionMetric)$' -benchmem -count=10`
  and compared them with `benchstat`.

Full `benchstat` output for the two committed benchmarks:

```text
goos: darwin
goarch: arm64
pkg: github.com/stackrox/rox/sensor/common/networkflow/manager
cpu: Apple M3 Pro
                                   │ /tmp/rox34659-before.txt │      /tmp/rox34659-two-bench.txt      │
                                   │          sec/op          │   sec/op     vs base                  │
UpdateEndpointMetric-12                          1133.5n ± 6%   287.7n ± 1%  -74.62% (p=0.000 n=10)
UpdateConnectionMetric-12                         581.2n ± 4%   153.4n ± 1%  -73.61% (p=0.000 n=10)

                                   │ /tmp/rox34659-before.txt │         /tmp/rox34659-two-bench.txt         │
                                   │           B/op           │     B/op      vs base                       │
UpdateEndpointMetric-12                          1.297Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=10)
UpdateConnectionMetric-12                          664.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)

                                   │ /tmp/rox34659-before.txt │        /tmp/rox34659-two-bench.txt        │
                                   │        allocs/op         │ allocs/op   vs base                       │
UpdateEndpointMetric-12                            8.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
UpdateConnectionMetric-12                          4.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```
