### PR TITLE
ROX-34660: Hoist ActiveEntityChecker allocation to manager struct

### DIFF
--- a/sensor/common/networkflow/manager/manager_enrich_connection.go
+++ b/sensor/common/networkflow/manager/manager_enrich_connection.go
@@ -67,9 +67,7 @@ func (m *networkFlowManager) enrichHostConnections(now timestamp.MicroTS, hostCo
 func (m *networkFlowManager) enrichConnection(now timestamp.MicroTS, conn *connection, status *connStatus, enrichedConnections map[indicator.NetworkConn]timestamp.MicroTS) (EnrichmentResult, EnrichmentReasonConn) {
 	isFresh := status.isFresh(now)
 
-	// Use shared container resolution logic
-	activeChecker := &connectionActiveChecker{mutex: &m.activeConnectionsMutex, activeConnections: m.activeConnections}
-	containerResult := resolveContainerID(m, now, conn.containerID, status, activeChecker, *conn)
+	containerResult := resolveContainerID(m, now, conn.containerID, status, &m.connectionChecker, *conn)
 
 	if !containerResult.Found {
 		// There is a connection involving a container that Sensor does not recognize. In this case we may do two things:

--- a/sensor/common/networkflow/manager/manager_enrich_endpoint.go
+++ b/sensor/common/networkflow/manager/manager_enrich_endpoint.go
@@ -79,9 +79,7 @@ func (m *networkFlowManager) enrichContainerEndpoint(
 		status.enrichmentConsumption.consumedNetworkGraph = true
 	}
 
-	// Use shared container resolution logic
-	activeChecker := &endpointActiveChecker{mutex: &m.activeEndpointsMutex, activeEndpoints: m.activeEndpoints}
-	containerResult := resolveContainerID(m, now, ep.containerID, status, activeChecker, *ep)
+	containerResult := resolveContainerID(m, now, ep.containerID, status, &m.endpointChecker, *ep)
 
 	if !containerResult.Found {
 		// There is an endpoint involving a container that Sensor does not recognize. In this case we may do two things:

--- a/sensor/common/networkflow/manager/manager_impl.go
+++ b/sensor/common/networkflow/manager/manager_impl.go
@@ -146,6 +146,8 @@ func NewManager(
 	opts ...Option,
 ) Manager {
 	enricherTicker := time.NewTicker(enricherCycle)
+	activeConns := make(map[connection]*networkConnIndicatorWithAge)
+	activeEps := make(map[containerEndpoint]*containerEndpointIndicatorWithAge)
 	mgr := &networkFlowManager{
 		connectionsByHost:    make(map[string]*hostConnections),
 		clusterEntities:      clusterEntities,
@@ -157,10 +159,18 @@ func NewManager(
 		updateComputer:       updateComputer,
 		initialSync:          &atomic.Bool{},
 		enrichmentDoneSignal: concurrency.NewSignal(),
-		activeConnections:    make(map[connection]*networkConnIndicatorWithAge),
-		activeEndpoints:      make(map[containerEndpoint]*containerEndpointIndicatorWithAge),
+		activeConnections:    activeConns,
+		activeEndpoints:      activeEps,
 		stopper:              concurrency.NewStopper(),
 		pubSub:               pubSub,
+	}
+	mgr.endpointChecker = endpointActiveChecker{
+		mutex:           &mgr.activeEndpointsMutex,
+		activeEndpoints: activeEps,
+	}
+	mgr.connectionChecker = connectionActiveChecker{
+		mutex:             &mgr.activeConnectionsMutex,
+		activeConnections: activeConns,
 	}
 	maxAgeSetting := env.EnrichmentPurgerTickerMaxAge.DurationSetting()
 	if maxAgeSetting > 0 && maxAgeSetting <= enricherCycle {
@@ -215,6 +225,11 @@ type networkFlowManager struct {
 	// An endpoint is active until Collector sends a NetworkConnectionInfo message with `lastSeen` set to a non-nil value,
 	// or until Sensor decides that such message may never arrive and decides that a given endpoint is no longer active.
 	activeEndpoints map[containerEndpoint]*containerEndpointIndicatorWithAge
+
+	// Reusable checkers for resolveContainerID, initialized once at construction to
+	// avoid per-iteration heap allocations in the enrichment hot loop.
+	endpointChecker   endpointActiveChecker
+	connectionChecker connectionActiveChecker
 
 	sensorUpdates chan *message.ExpiringMessage
 

--- a/sensor/common/networkflow/manager/testing_test.go
+++ b/sensor/common/networkflow/manager/testing_test.go
@@ -25,6 +25,8 @@ func createManager(mockCtrl *gomock.Controller, enrichTicker <-chan time.Time) (
 	mockEntityStore := mocksManager.NewMockEntityStore(mockCtrl)
 	mockExternalStore := mocksExternalSrc.NewMockStore(mockCtrl)
 	mockDetector := mocksDetector.NewMockDetector(mockCtrl)
+	activeConns := make(map[connection]*networkConnIndicatorWithAge)
+	activeEps := make(map[containerEndpoint]*containerEndpointIndicatorWithAge)
 	mgr := &networkFlowManager{
 		clusterEntities:   mockEntityStore,
 		externalSrcs:      mockExternalStore,
@@ -35,9 +37,17 @@ func createManager(mockCtrl *gomock.Controller, enrichTicker <-chan time.Time) (
 		publicIPs:         newPublicIPsManager(),
 		enricherTicker:    time.NewTicker(time.Hour),
 		enricherTickerC:   enrichTicker,
-		activeConnections: make(map[connection]*networkConnIndicatorWithAge),
-		activeEndpoints:   make(map[containerEndpoint]*containerEndpointIndicatorWithAge),
+		activeConnections: activeConns,
+		activeEndpoints:   activeEps,
 		stopper:           concurrency.NewStopper(),
+	}
+	mgr.endpointChecker = endpointActiveChecker{
+		mutex:           &mgr.activeEndpointsMutex,
+		activeEndpoints: activeEps,
+	}
+	mgr.connectionChecker = connectionActiveChecker{
+		mutex:             &mgr.activeConnectionsMutex,
+		activeConnections: activeConns,
 	}
 	return mgr, mockEntityStore, mockExternalStore, mockDetector
 }


### PR DESCRIPTION
## Description

Production heap profiles for ROX-34660 showed significant lifetime allocations
at the `endpointActiveChecker` and `connectionActiveChecker` instantiation sites
inside `enrichContainerEndpoint` and `enrichConnection`. These checkers were
allocated on every iteration of the enrichment hot loop, and the compiler's
escape analysis confirms they escape to heap because `(*endpointActiveChecker).IsActive`
cannot be inlined (contains `defer`).

This change moves both checkers to fields on `networkFlowManager`, initialized
once at construction time. The enrichment functions now reference `&m.endpointChecker`
and `&m.connectionChecker` instead of allocating fresh structs.

**Why not rely on the compiler?** The `IsActive` method uses `defer` for mutex
unlock, which prevents inlining (`cannot inline: unhandled op DEFER`). This
forces the `&endpointActiveChecker{...}` literal to escape to heap on every
call. Hoisting to the struct eliminates the escape by design, independent of
compiler decisions.

### Escape analysis proof

**master** — checker escapes to heap in the enrichment hot path:

```
$ go build -gcflags='-m -m' ./sensor/common/networkflow/manager/... 2>&1 | grep endpointActiveChecker

sensor/common/networkflow/manager/enrichment.go:227:6: cannot inline (*endpointActiveChecker).IsActive: unhandled op DEFER
sensor/common/networkflow/manager/enrichment.go:229:2: can inline (*endpointActiveChecker).IsActive.deferwrap1 with cost 80 as: func() { (*sync.RWMutex).RUnlock(.autotmp_3) }
sensor/common/networkflow/manager/enrichment.go:229:15: (*endpointActiveChecker).IsActive capturing by value: .autotmp_3 (addr=false assign=false width=8)
sensor/common/networkflow/manager/enrichment.go:227:7: parameter c leaks to {heap} for (*endpointActiveChecker).IsActive with derefs=1:
sensor/common/networkflow/manager/manager_enrich_endpoint.go:83:19: &endpointActiveChecker{...} escapes to heap in (*networkFlowManager).enrichContainerEndpoint:
sensor/common/networkflow/manager/manager_enrich_endpoint.go:83:19:   flow: activeChecker ← &{storage for &endpointActiveChecker{...}}:
sensor/common/networkflow/manager/manager_enrich_endpoint.go:83:19:     from &endpointActiveChecker{...} (spill) at sensor/common/networkflow/manager/manager_enrich_endpoint.go:83:19
sensor/common/networkflow/manager/manager_enrich_endpoint.go:83:19:     from activeChecker := &endpointActiveChecker{...} (assign) at sensor/common/networkflow/manager/manager_enrich_endpoint.go:83:16
sensor/common/networkflow/manager/manager_enrich_endpoint.go:70:7: parameter m leaks to {storage for &endpointActiveChecker{...}} for (*networkFlowManager).enrichContainerEndpoint with derefs=0:
sensor/common/networkflow/manager/manager_enrich_endpoint.go:70:7:   flow: {storage for &endpointActiveChecker{...}} ← m:
sensor/common/networkflow/manager/manager_enrich_endpoint.go:70:7:     from endpointActiveChecker{...} (struct literal element) at sensor/common/networkflow/manager/manager_enrich_endpoint.go:83:41
sensor/common/networkflow/manager/manager_enrich_endpoint.go:83:19: &endpointActiveChecker{...} escapes to heap
```

**this branch** — checker is stored on the manager struct; no escape in the hot path:

```
$ go build -gcflags='-m -m' ./sensor/common/networkflow/manager/... 2>&1 | grep endpointActiveChecker  

sensor/common/networkflow/manager/enrichment.go:227:6: cannot inline (*endpointActiveChecker).IsActive: unhandled op DEFER
sensor/common/networkflow/manager/enrichment.go:229:2: can inline (*endpointActiveChecker).IsActive.deferwrap1 with cost 80 as: func() { (*sync.RWMutex).RUnlock(.autotmp_3) }
sensor/common/networkflow/manager/enrichment.go:229:15: (*endpointActiveChecker).IsActive capturing by value: .autotmp_3 (addr=false assign=false width=8)
sensor/common/networkflow/manager/enrichment.go:227:7: parameter c leaks to {heap} for (*endpointActiveChecker).IsActive with derefs=1:
sensor/common/networkflow/manager/manager_impl.go:151:9:     from endpointActiveChecker{...} (struct literal element) at sensor/common/networkflow/manager/manager_impl.go:167:45
sensor/common/networkflow/manager/manager_impl.go:151:9:     from mgr.endpointChecker = endpointActiveChecker{...} (assign) at sensor/common/networkflow/manager/manager_impl.go:167:22
sensor/common/networkflow/manager/manager_impl.go:150:19:     from endpointActiveChecker{...} (struct literal element) at sensor/common/networkflow/manager/manager_impl.go:167:45
sensor/common/networkflow/manager/manager_impl.go:150:19:     from mgr.endpointChecker = endpointActiveChecker{...} (assign) at sensor/common/networkflow/manager/manager_impl.go:167:22
```

No `escapes to heap` line — the checker lives within the manager struct, which
is already heap-allocated once at construction.

AI-Assisted: cursor, ~100% generated, user reviewed logic

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Ran unit tests locally for the affected package (`go test ./sensor/common/networkflow/manager/...`).

Verified escape analysis with `go build -gcflags='-m -m'` on both master and
this branch (see proof above) — the `&endpointActiveChecker{...} escapes to heap`
line is present on master and absent on this branch.

Ran micro-benchmarks but no change in performance was visible.

