### PR TITLE
ROX-34666: fix log spam due to DeploymentConfig deprecation

### DIFF
--- a/pkg/k8sutil/client_config.go
+++ b/pkg/k8sutil/client_config.go
@@ -25,6 +25,7 @@ func GetK8sInClusterConfig() (*rest.Config, error) {
 		return nil, err
 	}
 	restCfg.ContentType = clientContentType
+	restCfg.WarningHandler = NewFilteredWarningHandler()
 
 	// Replacing raw IP address with kubernetes.default.svc
 	// allows for easier proxy configuration.

--- a/pkg/k8sutil/warning_handler.go
+++ b/pkg/k8sutil/warning_handler.go
@@ -1,15 +1,14 @@
 package k8sutil
 
 import (
-	"strings"
-
+	"github.com/stackrox/rox/pkg/set"
 	"k8s.io/client-go/rest"
 )
 
-// suppressedWarnings lists API server warning substrings that should be silently dropped.
-var suppressedWarnings = []string{
-	"DeploymentConfig is deprecated",
-}
+// suppressedWarnings contains API server warnings that should be silently dropped.
+var suppressedWarnings = set.NewFrozenStringSet(
+	"apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+",
+)
 
 // filteredWarningHandler delegates to the default WarningLogger but suppresses
 // known-noisy API server deprecation warnings that cannot be avoided.
@@ -18,10 +17,8 @@ type filteredWarningHandler struct {
 }
 
 func (h filteredWarningHandler) HandleWarningHeader(code int, agent string, text string) {
-	for _, substr := range suppressedWarnings {
-		if strings.Contains(text, substr) {
-			return
-		}
+	if suppressedWarnings.Contains(text) {
+		return
 	}
 	h.delegate.HandleWarningHeader(code, agent, text)
 }

--- a/pkg/k8sutil/warning_handler.go
+++ b/pkg/k8sutil/warning_handler.go
@@ -1,0 +1,34 @@
+package k8sutil
+
+import (
+	"strings"
+
+	"k8s.io/client-go/rest"
+)
+
+// suppressedWarnings lists API server warning substrings that should be silently dropped.
+var suppressedWarnings = []string{
+	"DeploymentConfig is deprecated",
+}
+
+// filteredWarningHandler delegates to the default WarningLogger but suppresses
+// known-noisy API server deprecation warnings that cannot be avoided.
+type filteredWarningHandler struct {
+	delegate rest.WarningHandler
+}
+
+func (h filteredWarningHandler) HandleWarningHeader(code int, agent string, text string) {
+	for _, substr := range suppressedWarnings {
+		if strings.Contains(text, substr) {
+			return
+		}
+	}
+	h.delegate.HandleWarningHeader(code, agent, text)
+}
+
+// NewFilteredWarningHandler returns a WarningHandler that suppresses known
+// noisy deprecation warnings while forwarding everything else to the default
+// client-go WarningLogger.
+func NewFilteredWarningHandler() rest.WarningHandler {
+	return filteredWarningHandler{delegate: rest.WarningLogger{}}
+}

--- a/pkg/k8sutil/warning_handler_test.go
+++ b/pkg/k8sutil/warning_handler_test.go
@@ -1,0 +1,49 @@
+package k8sutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type recordingHandler struct {
+	warnings []string
+}
+
+func (r *recordingHandler) HandleWarningHeader(_ int, _ string, text string) {
+	r.warnings = append(r.warnings, text)
+}
+
+func TestFilteredWarningHandler(t *testing.T) {
+	tests := map[string]struct {
+		code        int
+		text        string
+		shouldReach bool
+	}{
+		"DeploymentConfig deprecation is suppressed": {
+			code:        299,
+			text:        "apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+",
+			shouldReach: false,
+		},
+		"other warnings pass through": {
+			code:        299,
+			text:        "some.api/v1beta1 Widget is deprecated in v1.25+",
+			shouldReach: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			recorder := &recordingHandler{}
+			handler := filteredWarningHandler{delegate: recorder}
+			handler.HandleWarningHeader(tc.code, "test-agent", tc.text)
+
+			if tc.shouldReach {
+				assert.Len(t, recorder.warnings, 1)
+				assert.Equal(t, tc.text, recorder.warnings[0])
+			} else {
+				assert.Empty(t, recorder.warnings)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

`DeploymentConfig` is deprecated but still supported by OpenShift. As a result the k8s golang client emits regular deprecation warnings in Sensor that spam the logs:

```
I0512 11:19:29.166173 1 warnings.go:107] "Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+"
I0512 11:24:48.175139 1 warnings.go:107] "Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+"
I0512 11:32:26.183447 1 warnings.go:107] "Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+"
I0512 11:39:55.197485 1 warnings.go:107] "Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+"
I0512 11:46:54.208654 1 warnings.go:107] "Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+"
I0512 11:53:18.217936 1 warnings.go:107] "Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+"
I0512 12:02:15.227754 1 warnings.go:107] "Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+"
I0512 12:11:23.237773 1 warnings.go:107] "Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+"
I0512 12:19:21.247493 1 warnings.go:107] "Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+"
I0512 12:24:32.257132 1 warnings.go:107] "Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+"
I0512 12:29:41.265644 1 warnings.go:107] "Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+"
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Deployed fixed version and confirmed that no `DeploymentConfig` warnings appear in the logs.