### PR TITLE
fix(sensor): skip image clone when name matches and fix forwarder race

### DIFF
--- a/pkg/admissioncontrol/utils.go
+++ b/pkg/admissioncontrol/utils.go
@@ -19,14 +19,14 @@ func SensorEventToAdmCtrlReq(event *central.SensorEvent) (*sensor.AdmCtrlUpdateR
 		return &sensor.AdmCtrlUpdateResourceRequest{
 			Action: event.GetAction(),
 			Resource: &sensor.AdmCtrlUpdateResourceRequest_Pod{
-				Pod: event.GetPod(),
+				Pod: event.GetPod().CloneVT(),
 			},
 		}, nil
 	case *central.SensorEvent_Deployment:
 		return &sensor.AdmCtrlUpdateResourceRequest{
 			Action: event.GetAction(),
 			Resource: &sensor.AdmCtrlUpdateResourceRequest_Deployment{
-				Deployment: event.GetDeployment(),
+				Deployment: event.GetDeployment().CloneVT(),
 			},
 		}, nil
 	case *central.SensorEvent_Namespace:

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -990,10 +990,12 @@ scanner-v4-db ${tag}
 END
             ;;
         *-race-condition-qa-e2e-tests)
+            local base_tag
+            base_tag="${STACKROX_BUILD_TAG:-"$(make --quiet --no-print-directory tag)"}"
             cat >> "${image_list}" << END
-central-db ${tag}
-main ${tag}-rcd
-roxctl ${tag}
+central-db ${base_tag}
+main ${base_tag}-rcd
+roxctl ${base_tag}
 END
             if is_in_PR_context && ! pr_has_label "ci-build-race-condition-debug"; then
                 echo "ERROR: Your PR is missing the \"ci-build-race-condition-debug\" label."

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/common/trace"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -381,9 +380,9 @@ func (e *enricher) getImages(ctx context.Context, deployment *storage.Deployment
 		imageName := imgResult.image.GetName()
 		deploymentImageName := deployment.GetContainers()[imgResult.containerIdx].GetImage().GetName()
 		image := imgResult.image
-		if !proto.Equal(imageName, deploymentImageName) {
-			// Clone only when we need to mutate the Name to avoid a race
-			// with the cached image.
+		if !compareImageName(imageName, deploymentImageName) {
+			// This will ensure that when we change the Name of the image
+			// that it will not cause a potential race condition
 			image = imgResult.image.CloneVT()
 			image.Name = deploymentImageName
 		}
@@ -424,4 +423,11 @@ func (e *enricher) outputChan() <-chan scanResult {
 
 func (e *enricher) stop() {
 	e.stopSig.Signal()
+}
+
+func compareImageName(x *storage.ImageName, y *storage.ImageName) bool {
+	return x.GetRegistry() == y.GetRegistry() &&
+		x.GetRemote() == y.GetRemote() &&
+		x.GetTag() == y.GetTag() &&
+		x.GetFullName() == y.GetFullName()
 }

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/store"
 	"github.com/stackrox/rox/sensor/common/trace"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -377,14 +378,16 @@ func (e *enricher) getImages(ctx context.Context, deployment *storage.Deployment
 	for i := 0; i < len(deployment.GetContainers()); i++ {
 		imgResult := <-imageChan
 
-		// This will ensure that when we change the Name of the image
-		// that it will not cause a potential race condition
-		image := *imgResult.image.CloneVT()
-		// Overwrite the image Name as a workaround to the fact that we fetch the image by ID
-		// The ID may actually have many names that refer to it. e.g. busybox:latest and busybox:1.31 could have the
-		// exact same ID
-		image.Name = deployment.GetContainers()[imgResult.containerIdx].GetImage().GetName()
-		images[imgResult.containerIdx] = &image
+		imageName := imgResult.image.GetName()
+		deploymentImageName := deployment.GetContainers()[imgResult.containerIdx].GetImage().GetName()
+		image := imgResult.image
+		if !proto.Equal(imageName, deploymentImageName) {
+			// Clone only when we need to mutate the Name to avoid a race
+			// with the cached image.
+			image = imgResult.image.CloneVT()
+			image.Name = deploymentImageName
+		}
+		images[imgResult.containerIdx] = image
 	}
 	return images
 }

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -379,17 +379,17 @@ func (e *enricher) getImages(ctx context.Context, deployment *storage.Deployment
 
 		imageName := imgResult.image.GetName()
 		deploymentImageName := deployment.GetContainers()[imgResult.containerIdx].GetImage().GetName()
-		image := *imgResult.image
+		image := imgResult.image
 		if !compareImageName(imageName, deploymentImageName) {
 			// This will ensure that when we change the Name of the image
 			// that it will not cause a potential race condition
-			image = *imgResult.image.CloneVT()
+			image = imgResult.image.CloneVT()
 			// Overwrite the image Name as a workaround to the fact that we fetch the image by ID
 			// The ID may actually have many names that refer to it. e.g. busybox:latest and busybox:1.31 could have the
 			// exact same ID
 			image.Name = deploymentImageName
 		}
-		images[imgResult.containerIdx] = &image
+		images[imgResult.containerIdx] = image
 	}
 	return images
 }

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -379,14 +379,17 @@ func (e *enricher) getImages(ctx context.Context, deployment *storage.Deployment
 
 		imageName := imgResult.image.GetName()
 		deploymentImageName := deployment.GetContainers()[imgResult.containerIdx].GetImage().GetName()
-		image := imgResult.image
+		image := *imgResult.image
 		if !compareImageName(imageName, deploymentImageName) {
 			// This will ensure that when we change the Name of the image
 			// that it will not cause a potential race condition
-			image = imgResult.image.CloneVT()
+			image = *imgResult.image.CloneVT()
+			// Overwrite the image Name as a workaround to the fact that we fetch the image by ID
+			// The ID may actually have many names that refer to it. e.g. busybox:latest and busybox:1.31 could have the
+			// exact same ID
 			image.Name = deploymentImageName
 		}
-		images[imgResult.containerIdx] = image
+		images[imgResult.containerIdx] = &image
 	}
 	return images
 }

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -377,8 +377,13 @@ func (e *enricher) getImages(ctx context.Context, deployment *storage.Deployment
 	for i := 0; i < len(deployment.GetContainers()); i++ {
 		imgResult := <-imageChan
 
+		if imgResult.image == nil {
+			continue
+		}
 		imageName := imgResult.image.GetName()
 		deploymentImageName := deployment.GetContainers()[imgResult.containerIdx].GetImage().GetName()
+		// Safe to use the cached pointer directly without cloning: all downstream
+		// consumers (e.g. ConstructImage) clone the image before mutating it.
 		image := imgResult.image
 		if !compareImageName(imageName, deploymentImageName) {
 			// This will ensure that when we change the Name of the image
@@ -428,9 +433,15 @@ func (e *enricher) stop() {
 	e.stopSig.Signal()
 }
 
-func compareImageName(x *storage.ImageName, y *storage.ImageName) bool {
+func compareImageName(x, y *storage.ImageName) bool {
+	if x == y {
+		return true
+	}
+	if x == nil || y == nil {
+		return false
+	}
 	// Using proto.Equal can be racy due to internal writes in the Equal function.
-	// We compare the fields manually to avoid races.
+	// Compare fields manually to avoid races.
 	return x.GetRegistry() == y.GetRegistry() &&
 		x.GetRemote() == y.GetRemote() &&
 		x.GetTag() == y.GetTag() &&

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -426,6 +426,8 @@ func (e *enricher) stop() {
 }
 
 func compareImageName(x *storage.ImageName, y *storage.ImageName) bool {
+	// Using proto.Equal can be racy due to internal writes in the Equal function.
+	// We compare the fields manually to avoid races.
 	return x.GetRegistry() == y.GetRegistry() &&
 		x.GetRemote() == y.GetRemote() &&
 		x.GetTag() == y.GetTag() &&


### PR DESCRIPTION
## Description

DO NOT REVIEW

Two fixes for sensor performance and correctness:

1. **Skip expensive CloneVT in getImages when image names match.** The enricher unconditionally deep-clones every image from the cache, even when the name does not need to be overwritten (the common case). Heap profiling showed this single clone was the 1st allocator at 710GB (36.7% of all allocations), contributing to OOM under file access load.

2. **Clone deployment/pod in SensorEventToAdmCtrlReq to fix a data race.** The message forwarder sends the same SensorEvent to both the central sender and the admission controller without cloning. HashEvent (read) on the central sender goroutine and stream.Send (write/marshal) on the admission controller goroutine race on the shared proto object.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Unit tests pass with -race flag
- Running GKE race condition e2e tests via ci-build-race-condition-debug label