### PR TITLE
fix: default orphaned alert deployment_type instead of deserializing blobs

### DIFF
--- a/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_bench_test.go
+++ b/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_bench_test.go
@@ -12,6 +12,7 @@ import (
 	oldSchema "github.com/stackrox/rox/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/test/schema"
 	pghelper "github.com/stackrox/rox/migrator/migrations/postgreshelper"
 	"github.com/stackrox/rox/migrator/types"
+	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
@@ -81,13 +82,16 @@ func benchmarkMigration(b *testing.B, numAlerts, numDeployments int) {
 	}
 }
 
-func insertBenchDeployments(b *testing.B, ctx context.Context, db *pghelper.TestPostgres, numDeployments int) (live []string, orphaned []string) {
+func insertBenchDeployments(b *testing.B, ctx context.Context, db *pghelper.TestPostgres, numDeployments int, orphanPct ...int) (live []string, orphaned []string) {
 	b.Helper()
 	deployTypes := []string{"Deployment", "DaemonSet", "StatefulSet", "Job", "CronJob", "Pod"}
 
 	live = make([]string, 0, numDeployments)
-	// 10% of deployments will be orphaned (deleted but alerts remain)
-	orphanCount := numDeployments / 10
+	pct := 10
+	if len(orphanPct) > 0 {
+		pct = orphanPct[0]
+	}
+	orphanCount := numDeployments * pct / 100
 	orphaned = make([]string, 0, orphanCount)
 
 	for i := 0; i < numDeployments; i++ {
@@ -246,6 +250,92 @@ func makeBenchAlert(index int, deployIDs []string, deployTypes []string) *storag
 	}
 
 	return alert
+}
+
+// BenchmarkOrphanedBackfillComparison compares the orphaned deployment_type
+// backfill strategies using separate databases and production-scale data.
+// Based on the real long-running cluster: ~2M alerts, 332K distinct deployment
+// IDs, only 657 still exist (99.8% orphaned), 4.8KB avg row size.
+func BenchmarkOrphanedBackfillComparison(b *testing.B) {
+	const (
+		numAlerts      = 2_000_000
+		numDeployments = 4_000
+		orphanPct      = 99
+	)
+
+	type variant struct {
+		name     string
+		backfill func(ctx context.Context, db postgres.DB) error
+	}
+
+	variants := []variant{
+		{
+			"deserialize_batched",
+			backfillOrphanedDeploymentType,
+		},
+		{
+			"sql_default",
+			func(ctx context.Context, db postgres.DB) error {
+				ctx, cancel := context.WithTimeout(ctx, types.DefaultMigrationTimeout)
+				defer cancel()
+				result, err := db.Exec(ctx,
+					`UPDATE alerts SET deployment_type = 'Deployment'
+					 WHERE entitytype = $1
+					   AND deployment_type IS NULL
+					   AND deployment_id NOT IN (SELECT id FROM deployments)`,
+					storage.Alert_DEPLOYMENT,
+				)
+				if err != nil {
+					return err
+				}
+				b.Logf("sql_default updated %d rows", result.RowsAffected())
+				return nil
+			},
+		},
+	}
+
+	for _, v := range variants {
+		b.Run(v.name, func(b *testing.B) {
+			ctx := sac.WithAllAccess(context.Background())
+			db := pghelper.ForT(b, false)
+
+			pgutils.CreateTableFromModel(ctx, db.GetGormDB(), oldSchema.CreateTableAlertsStmt)
+			_, err := db.Exec(ctx,
+				`CREATE TABLE IF NOT EXISTS deployments (id UUID PRIMARY KEY, type VARCHAR)`)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			liveIDs, orphanedIDs := insertBenchDeployments(b, ctx, db, numDeployments, orphanPct)
+			insertBenchAlerts(b, ctx, db, numAlerts, liveIDs, orphanedIDs)
+
+			// Add the deployment_type column as NULL (pre-migration state).
+			_, err = db.Exec(ctx, "ALTER TABLE alerts ADD COLUMN IF NOT EXISTS deployment_type VARCHAR")
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// Run the JOIN backfill first (same for both variants).
+			if err := backfillDeploymentType(ctx, db.DB); err != nil {
+				b.Fatal(err)
+			}
+
+			var orphanCount int
+			if err := db.QueryRow(ctx,
+				"SELECT COUNT(*) FROM alerts WHERE entitytype = $1 AND deployment_type IS NULL",
+				storage.Alert_DEPLOYMENT).Scan(&orphanCount); err != nil {
+				b.Fatal(err)
+			}
+			b.Logf("Setup: %d total alerts, %d orphaned needing backfill", numAlerts, orphanCount)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := v.backfill(ctx, db.DB); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }
 
 func resetBenchColumns(b *testing.B, ctx context.Context, db *pghelper.TestPostgres) {

--- a/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_impl.go
+++ b/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_impl.go
@@ -68,114 +68,25 @@ func backfillDeploymentType(ctx context.Context, db postgres.DB) error {
 	return nil
 }
 
-// backfillOrphanedDeploymentType handles alerts whose deployment has been deleted.
-// These must be read from the serialized blob since the deployments table no longer
-// has the record.
+// backfillOrphanedDeploymentType sets deployment_type for alerts whose deployment
+// has been deleted. Since the deployment record no longer exists, we default to
+// "Deployment" rather than deserializing every blob.
 func backfillOrphanedDeploymentType(ctx context.Context, db postgres.DB) error {
 	ctx, cancel := context.WithTimeout(ctx, types.DefaultMigrationTimeout)
 	defer cancel()
 
-	totalBackfilled := 0
-	lastID := ""
-
-	for {
-		ids, deployTypes, newLastID, err := readOrphanedDeploymentTypes(db, ctx, lastID)
-		if err != nil {
-			return err
-		}
-		lastID = newLastID
-
-		if len(ids) == 0 {
-			break
-		}
-
-		if err := batchUpdateDeploymentType(db, ctx, ids, deployTypes); err != nil {
-			return err
-		}
-
-		totalBackfilled += len(ids)
-		log.WriteToStderrf("Backfilled deployment_type for %d orphaned alerts (total: %d)", len(ids), totalBackfilled)
-
-		if len(ids) < batchSize {
-			break
-		}
+	result, err := db.Exec(ctx,
+		`UPDATE alerts SET deployment_type = 'Deployment'
+		 WHERE entitytype = $1
+		   AND deployment_type IS NULL
+		   AND deployment_id NOT IN (SELECT id FROM deployments)`,
+		storage.Alert_DEPLOYMENT,
+	)
+	if err != nil {
+		return errors.Wrap(err, "defaulting deployment_type for orphaned alerts")
 	}
-
-	log.WriteToStderrf("Successfully backfilled deployment_type for %d total orphaned alerts", totalBackfilled)
+	log.WriteToStderrf("Defaulted deployment_type for %d orphaned alerts", result.RowsAffected())
 	return nil
-}
-
-func readOrphanedDeploymentTypes(db postgres.DB, ctx context.Context, lastID string) (ids []string, deployTypes []string, newLastID string, err error) {
-	var rows pgx.Rows
-
-	if lastID == "" {
-		rows, err = db.Query(ctx,
-			`SELECT a.id, a.serialized FROM alerts a
-			WHERE a.entitytype = $1
-			  AND (a.deployment_type IS NULL OR a.deployment_type = '')
-			ORDER BY a.id LIMIT $2`,
-			storage.Alert_DEPLOYMENT, batchSize)
-	} else {
-		rows, err = db.Query(ctx,
-			`SELECT a.id, a.serialized FROM alerts a
-			WHERE a.entitytype = $1
-			  AND (a.deployment_type IS NULL OR a.deployment_type = '')
-			  AND a.id > $2
-			ORDER BY a.id LIMIT $3`,
-			storage.Alert_DEPLOYMENT, lastID, batchSize)
-	}
-	if err != nil {
-		return nil, nil, "", errors.Wrap(err, "querying orphaned deployment alerts")
-	}
-	defer rows.Close()
-
-	ids = make([]string, 0, batchSize)
-	deployTypes = make([]string, 0, batchSize)
-
-	for rows.Next() {
-		var id string
-		var serialized []byte
-		if err := rows.Scan(&id, &serialized); err != nil {
-			return nil, nil, "", errors.Wrap(err, "scanning orphaned alert row")
-		}
-
-		alert := &storage.Alert{}
-		if err := alert.UnmarshalVT(serialized); err != nil {
-			return nil, nil, "", errors.Wrapf(err, "deserializing alert %s", id)
-		}
-
-		ids = append(ids, id)
-		deployTypes = append(deployTypes, alert.GetDeployment().GetType())
-		newLastID = id
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, nil, "", errors.Wrap(err, "iterating orphaned alert rows")
-	}
-
-	return ids, deployTypes, newLastID, nil
-}
-
-func batchUpdateDeploymentType(db postgres.DB, ctx context.Context, ids []string, deployTypes []string) error {
-	conn, err := db.Acquire(ctx)
-	if err != nil {
-		return errors.Wrap(err, "acquiring connection")
-	}
-	defer conn.Release()
-
-	batch := &pgx.Batch{}
-	for i := range ids {
-		batch.Queue("UPDATE alerts SET deployment_type = $1 WHERE id = $2", deployTypes[i], ids[i])
-	}
-
-	results := conn.SendBatch(ctx, batch)
-	for i := 0; i < len(ids); i++ {
-		if _, err := results.Exec(); err != nil {
-			_ = results.Close()
-			return errors.Wrapf(err, "updating deployment_type for alert at index %d", i)
-		}
-	}
-	return results.Close()
 }
 
 // backfillEnforcementCount computes and stores enforcement_count for all

--- a/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_test.go
+++ b/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_test.go
@@ -147,7 +147,7 @@ func (s *migrationTestSuite) TestMigration() {
 	err = dbs.PostgresDB.QueryRow(s.ctx,
 		`SELECT COALESCE(deployment_type, '') FROM alerts WHERE id = $1`, alertIDs["deploy-orphan"]).Scan(&deployType)
 	s.Require().NoError(err)
-	s.Equal("StatefulSet", deployType, "orphaned deployment alert should get type from blob")
+	s.Equal("Deployment", deployType, "orphaned deployment alert should default to Deployment")
 
 	// Resource alert: should be NULL/empty (not a deployment).
 	err = dbs.PostgresDB.QueryRow(s.ctx,


### PR DESCRIPTION
On long-running clusters most deployments are deleted, forcing the
migration to deserialize ~2M protobuf blobs to extract deployment_type.
This took 9+ minutes on a real cluster with 99.8% orphaned alerts.

Replace the batch deserialization loop with a single SQL UPDATE that
defaults orphaned alerts to 'Deployment'. Benchmarked at 2M alerts
with separate databases: 112s (deserialization) vs 63s (SQL default).
On the real I/O-bound cluster the improvement is larger since the
deserialization path issues thousands of sequential queries that
each hit disk.

Tradeoff: non-Deployment types (DaemonSet, StatefulSet) on orphaned
alerts get mislabeled. These are historical alerts whose deployments
no longer exist and are excluded from default ListAlerts queries.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
