### PR TITLE
ROX-34680: handle null deployment type for resolved alerts

### DIFF
--- a/central/alert/views/list_alert_scanner.go
+++ b/central/alert/views/list_alert_scanner.go
@@ -136,7 +136,7 @@ func (s *ListAlertScanner) Build() *storage.ListAlert {
 				ClusterId:      s.ClusterID.String,
 				Namespace:      s.Namespace.String,
 				NamespaceId:    s.NamespaceID.String,
-				DeploymentType: s.DeploymentType.String,
+				DeploymentType: deploymentTypeOrDefault(s.DeploymentType),
 				Inactive:       s.DeploymentInactive.Bool,
 			},
 		}
@@ -169,4 +169,11 @@ func (s *ListAlertScanner) Build() *storage.ListAlert {
 	}
 
 	return la
+}
+
+func deploymentTypeOrDefault(dt pgtype.Text) string {
+	if dt.Valid && dt.String != "" {
+		return dt.String
+	}
+	return "Deployment"
 }

--- a/central/alert/views/list_alert_scanner_test.go
+++ b/central/alert/views/list_alert_scanner_test.go
@@ -3,6 +3,7 @@ package views
 import (
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,5 +49,31 @@ func TestListAlertSelectProtosMatchDests(t *testing.T) {
 	for i, sel := range ListAlertSelectProtos {
 		assert.Equal(t, expectedOrder[i].String(), sel.GetField().GetName(),
 			"ListAlertSelectProtos[%d] field name mismatch", i)
+	}
+}
+
+func TestDeploymentTypeOrDefault(t *testing.T) {
+	cases := map[string]struct {
+		input    pgtype.Text
+		expected string
+	}{
+		"valid value": {
+			input:    pgtype.Text{String: "DaemonSet", Valid: true},
+			expected: "DaemonSet",
+		},
+		"null": {
+			input:    pgtype.Text{Valid: false},
+			expected: "Deployment",
+		},
+		"empty string": {
+			input:    pgtype.Text{String: "", Valid: true},
+			expected: "Deployment",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, deploymentTypeOrDefault(tc.input))
+		})
 	}
 }

--- a/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_impl.go
+++ b/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_impl.go
@@ -31,13 +31,7 @@ func migrate(database *types.Databases) error {
 		return errors.Wrap(err, "backfilling deployment_type")
 	}
 
-	// Step 3: Backfill deployment_type for orphaned alerts (deployment deleted)
-	// by reading the value from the serialized blob.
-	if err := backfillOrphanedDeploymentType(ctx, database.PostgresDB); err != nil {
-		return errors.Wrap(err, "backfilling orphaned deployment_type")
-	}
-
-	// Step 4: Backfill enforcement_count for all alerts with enforcement.
+	// Step 3: Backfill enforcement_count for all alerts with enforcement.
 	// This requires deserializing the blob to compute the count, then
 	// re-serializing to keep columns and blob consistent.
 	if err := backfillEnforcementCount(ctx, database.PostgresDB); err != nil {
@@ -66,116 +60,6 @@ func backfillDeploymentType(ctx context.Context, db postgres.DB) error {
 	}
 	log.WriteToStderrf("Backfilled deployment_type for %d alerts via JOIN", result.RowsAffected())
 	return nil
-}
-
-// backfillOrphanedDeploymentType handles alerts whose deployment has been deleted.
-// These must be read from the serialized blob since the deployments table no longer
-// has the record.
-func backfillOrphanedDeploymentType(ctx context.Context, db postgres.DB) error {
-	ctx, cancel := context.WithTimeout(ctx, types.DefaultMigrationTimeout)
-	defer cancel()
-
-	totalBackfilled := 0
-	lastID := ""
-
-	for {
-		ids, deployTypes, newLastID, err := readOrphanedDeploymentTypes(db, ctx, lastID)
-		if err != nil {
-			return err
-		}
-		lastID = newLastID
-
-		if len(ids) == 0 {
-			break
-		}
-
-		if err := batchUpdateDeploymentType(db, ctx, ids, deployTypes); err != nil {
-			return err
-		}
-
-		totalBackfilled += len(ids)
-		log.WriteToStderrf("Backfilled deployment_type for %d orphaned alerts (total: %d)", len(ids), totalBackfilled)
-
-		if len(ids) < batchSize {
-			break
-		}
-	}
-
-	log.WriteToStderrf("Successfully backfilled deployment_type for %d total orphaned alerts", totalBackfilled)
-	return nil
-}
-
-func readOrphanedDeploymentTypes(db postgres.DB, ctx context.Context, lastID string) (ids []string, deployTypes []string, newLastID string, err error) {
-	var rows pgx.Rows
-
-	if lastID == "" {
-		rows, err = db.Query(ctx,
-			`SELECT a.id, a.serialized FROM alerts a
-			WHERE a.entitytype = $1
-			  AND (a.deployment_type IS NULL OR a.deployment_type = '')
-			ORDER BY a.id LIMIT $2`,
-			storage.Alert_DEPLOYMENT, batchSize)
-	} else {
-		rows, err = db.Query(ctx,
-			`SELECT a.id, a.serialized FROM alerts a
-			WHERE a.entitytype = $1
-			  AND (a.deployment_type IS NULL OR a.deployment_type = '')
-			  AND a.id > $2
-			ORDER BY a.id LIMIT $3`,
-			storage.Alert_DEPLOYMENT, lastID, batchSize)
-	}
-	if err != nil {
-		return nil, nil, "", errors.Wrap(err, "querying orphaned deployment alerts")
-	}
-	defer rows.Close()
-
-	ids = make([]string, 0, batchSize)
-	deployTypes = make([]string, 0, batchSize)
-
-	for rows.Next() {
-		var id string
-		var serialized []byte
-		if err := rows.Scan(&id, &serialized); err != nil {
-			return nil, nil, "", errors.Wrap(err, "scanning orphaned alert row")
-		}
-
-		alert := &storage.Alert{}
-		if err := alert.UnmarshalVT(serialized); err != nil {
-			return nil, nil, "", errors.Wrapf(err, "deserializing alert %s", id)
-		}
-
-		ids = append(ids, id)
-		deployTypes = append(deployTypes, alert.GetDeployment().GetType())
-		newLastID = id
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, nil, "", errors.Wrap(err, "iterating orphaned alert rows")
-	}
-
-	return ids, deployTypes, newLastID, nil
-}
-
-func batchUpdateDeploymentType(db postgres.DB, ctx context.Context, ids []string, deployTypes []string) error {
-	conn, err := db.Acquire(ctx)
-	if err != nil {
-		return errors.Wrap(err, "acquiring connection")
-	}
-	defer conn.Release()
-
-	batch := &pgx.Batch{}
-	for i := range ids {
-		batch.Queue("UPDATE alerts SET deployment_type = $1 WHERE id = $2", deployTypes[i], ids[i])
-	}
-
-	results := conn.SendBatch(ctx, batch)
-	for i := 0; i < len(ids); i++ {
-		if _, err := results.Exec(); err != nil {
-			_ = results.Close()
-			return errors.Wrapf(err, "updating deployment_type for alert at index %d", i)
-		}
-	}
-	return results.Close()
 }
 
 // backfillEnforcementCount computes and stores enforcement_count for all

--- a/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_test.go
+++ b/migrator/migrations/m_223_to_m_224_add_deployment_type_and_enforcement_count_to_alerts/migration_test.go
@@ -143,11 +143,11 @@ func (s *migrationTestSuite) TestMigration() {
 	s.Require().NoError(err)
 	s.Equal("DaemonSet", deployType, "live deployment alert should get type from deployments table")
 
-	// Orphaned deployment: should get type from blob.
+	// Orphaned deployment: stays NULL (defaulted at read time, not migration time).
 	err = dbs.PostgresDB.QueryRow(s.ctx,
 		`SELECT COALESCE(deployment_type, '') FROM alerts WHERE id = $1`, alertIDs["deploy-orphan"]).Scan(&deployType)
 	s.Require().NoError(err)
-	s.Equal("StatefulSet", deployType, "orphaned deployment alert should get type from blob")
+	s.Equal("", deployType, "orphaned deployment alert should remain NULL (defaulted at read time)")
 
 	// Resource alert: should be NULL/empty (not a deployment).
 	err = dbs.PostgresDB.QueryRow(s.ctx,

--- a/pkg/alert/convert/convert.go
+++ b/pkg/alert/convert/convert.go
@@ -65,7 +65,7 @@ func populateListAlertEntityInfoForDeployment(listAlert *storage.ListAlert, depl
 			Namespace:      deployment.GetNamespace(),
 			NamespaceId:    deployment.GetNamespaceId(),
 			Inactive:       deployment.GetInactive(),
-			DeploymentType: deployment.GetType(),
+			DeploymentType: deploymentTypeOrDefault(deployment.GetType()),
 		},
 	}
 	listAlert.CommonEntityInfo = &storage.ListAlert_CommonEntityInfo{
@@ -75,6 +75,13 @@ func populateListAlertEntityInfoForDeployment(listAlert *storage.ListAlert, depl
 		NamespaceId:  deployment.GetNamespaceId(),
 		ResourceType: storage.ListAlert_DEPLOYMENT,
 	}
+}
+
+func deploymentTypeOrDefault(dt string) string {
+	if dt != "" {
+		return dt
+	}
+	return "Deployment"
 }
 
 func populateListAlertEntityInfoForNode(listAlert *storage.ListAlert, alert *storage.Alert) {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Remove the orphaned deployment_type backfill from the migration entirely.
Rewriting history of non-active alerts is not necessary.

Instead, default deployment_type to "Deployment" at read time in the
ListAlert scanner when the column is NULL. This applies only to
deployment entity alerts (the scanner branches on entity type). Orphaned
alerts are excluded from default ListAlerts queries (excludeResolved=true),
so the default is rarely surfaced.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Tested on a long running cluster.  Verified the migration was much faster and that the endpoints were returning generic Deployment for resolved alerts.  Active alerts were returning the more detailed value.