### PR TITLE
ci: use skopeo for multi-arch image retagging

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -649,9 +649,6 @@ jobs:
         with:
           gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
-
       - name: Push matching collector and scanner images
         if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
         env:

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -506,7 +506,7 @@ registry_ro_login() {
 }
 
 push_matching_collector_scanner_images() {
-    info "Pushing collector & scanner images tagged with main-version using buildx imagetools"
+    info "Pushing collector & scanner images tagged with main-version using skopeo"
 
     if [[ "$#" -ne 1 ]]; then
         die "missing arg. usage: push_matching_collector_scanner_images <brand>"
@@ -518,7 +518,7 @@ push_matching_collector_scanner_images() {
     registry="$(registry_from_branding "$brand")"
 
     _retag() {
-        retry 5 true docker buildx imagetools create -t "$2" "$1"
+        skopeo copy --retry-times 5 --all "docker://$1" "docker://$2"
     }
 
     local main_tag


### PR DESCRIPTION
## Description

Switch from docker buildx imagetools to skopeo copy --all for retagging collector and scanner images. The buildx approach only copied amd64 manifests to stackrox-io registry, while skopeo properly preserves all architectures (amd64, arm64, ppc64le, s390x) from the source manifest list.

- https://github.com/stackrox/stackrox/issues/1614

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

```yaml
# docker manifest inspect quay.io/stackrox-io/collector:4.11.x-932-gb50529a807
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1402,
         "digest": "sha256:782cc9789f49e9e880be220594cbb85b5ed3ea068e8a0c971e80e6baf3bc258c",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1402,
         "digest": "sha256:e133db249f7f3698162b2bd97573356a6ce846378a0cf4ad0fd08a69cd1a3f32",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1403,
         "digest": "sha256:d0e2ad846899bb55f54790ad3e509cdc7b9d2b513929558a4ebf3f8a116a8764",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1402,
         "digest": "sha256:024a7a0be13aaeb88bda0d1d0aec394eb28a17201a604eca20af4c0268f86aee",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
# docker manifest inspect quay.io/stackrox-io/scanner:4.11.x-932-gb50529a807
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2416,
         "digest": "sha256:78114aa3f54875a796173ebcd1cc7db8765202ca6fbc8cb322950fc5d8f4618f",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2416,
         "digest": "sha256:2e945054ea13e715a80c8f7ca83cea644503864b1ff06025aa09b08dfeb45789",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2416,
         "digest": "sha256:a60642cfa29e615feebc5ede39554de46f5e0313d6c0b060af31c79247a8871c",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2416,
         "digest": "sha256:5912b319cf85a2a6b46f3121b405f8dcd1f3bf5589afada14d1915227176dc48",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```