### PR TITLE
ROX-34672: Improve layout in image vulnerability reports wizard

### DIFF
--- a/ui/apps/platform/src/Components/EntityScope/EntityScopeCompoundSearchFilter.tsx
+++ b/ui/apps/platform/src/Components/EntityScope/EntityScopeCompoundSearchFilter.tsx
@@ -50,7 +50,7 @@ function EntityScopeCompoundSearchFilter({
     }
 
     return (
-        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+        <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
             <CompoundSearchFilter
                 config={searchFilterConfig}
                 isDisabled={entityScope === null}

--- a/ui/apps/platform/src/Components/Reports/Step/DetailsStep.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/DetailsStep.tsx
@@ -19,7 +19,7 @@ function DetailsStep<T extends DetailsType = DetailsType>({
         <PageSection>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
                 <Title headingLevel="h2">Details</Title>
-                <Form>
+                <Form isWidthLimited>
                     <FormLabelGroup
                         label="Name"
                         isRequired

--- a/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
@@ -58,7 +58,7 @@ function FiltersQuery<T extends FiltersQueryConfiguration = FiltersQueryConfigur
                     />
                 </FormGroup>
             ))}
-            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
                 <CompoundSearchFilter
                     config={searchFilterConfig}
                     onSearch={onSearch}


### PR DESCRIPTION
## Description

Follow up bug bash. Big or small, fix them (not quite) all.

### Problems

1. Reported by **Mark**: Input elements on **Details** step have inconsistent width compared to other steps.

2. Reported by **Mansur**: Spacing between `CompoundSearchFilter` and `CompoundSearchFilterLabels` is inconsistent with `AdvancedFiltersToolbar` in results pages.

### Analysis

1. In `DetailsStep` component only, `Form` element lacks `isWidthLimited` prop.

    https://www.patternfly.org/components/forms/form#limit-width

3. In `EntityScopeCompoundSearchFilter` and `FiltersQuery` components, `Flex` has `spaceItems={{ default: 'spaceItemsLg' }}` but `AdvancedFiltersToolbar` has 0.5rem small gap from `Toolbar` element.

    Although my decision to render generic `Flex` instead of specific `Toolbar` element in `Form` still makes sense, it was my bad not to specify equivalent spacing.

### Solutions

1. Add prop.

2. Adjust spacing.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit https://localhost:3000/main/vulnerabilities/reports/configuration?action=create

    Original unlimited width without proo:
    <img width="1920" height="892" alt="DetailsStep_without_prop" src="https://github.com/user-attachments/assets/048f9180-2968-4387-9a87-21cafae266f9" />

    Improved limited width with prop:
    <img width="1920" height="892" alt="DetailsStep_with_prop" src="https://github.com/user-attachments/assets/84f9c080-c82e-4eef-8c42-a50e1968f178" />

2. Advance to **Resources** step:

    Original inconsistent spacing:
    <img width="1920" height="889" alt="EntityScopeCompoundSearchFilter_Lg" src="https://github.com/user-attachments/assets/c16bd57b-8eda-4faa-9332-2062c03cdb96" />

    Improved consistent spacing:
    <img width="1920" height="892" alt="EntityScopeCompoundSearchFilter_Sm" src="https://github.com/user-attachments/assets/3e7bb7da-c045-4846-a44c-2628e68a7c08" />

    Results page for comparison:
    <img width="1920" height="892" alt="AdvancedFiltersToolbar" src="https://github.com/user-attachments/assets/f577e463-6420-4e33-9712-5e1afcbf4e6d" />

3. Advance to **Filters** step:

    Original inconsistent spacing:
    <img width="1920" height="892" alt="FiltersQuery_Lg" src="https://github.com/user-attachments/assets/c405057c-bf9b-4a3b-856c-b55e8f055dac" />

    Improved consistent spacing:
    <img width="1920" height="892" alt="FiltersQuery_Sm" src="https://github.com/user-attachments/assets/5d2f604c-f416-41dd-a027-ff90c454e261" />
