### PR TITLE
ROX-34552: Add yup validation to reports wizard

### DIFF
--- a/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationForm.tsx
+++ b/ui/apps/platform/src/Components/NotifierConfiguration/NotifierConfigurationForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { Button, Flex, FormSection, TextArea, TextInput } from '@patternfly/react-core';
 import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
-import type { FormikErrors } from 'formik';
+import type { FormikErrors, FormikTouched } from 'formik';
 
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import useIndexKey from 'hooks/useIndexKey';
@@ -34,6 +34,7 @@ export type NotifierConfigurationFormProps = {
     notifierConfigurations: NotifierConfiguration[];
     onDeleteLastNotifierConfiguration?: () => void;
     setFieldValue: (fieldId: string, value: unknown) => void;
+    touched?: FormikTouched<unknown>;
 };
 
 function NotifierConfigurationForm({
@@ -43,6 +44,7 @@ function NotifierConfigurationForm({
     notifierConfigurations,
     onDeleteLastNotifierConfiguration,
     setFieldValue,
+    touched,
 }: NotifierConfigurationFormProps): ReactElement {
     const { keyFor } = useIndexKey();
     const [notifiers, setNotifiers] = useState<NotifierIntegrationBase[]>([]);
@@ -125,6 +127,7 @@ function NotifierConfigurationForm({
                         <NotifierMailingLists
                             errors={errors}
                             fieldIdPrefixForFormikAndPatternFly={fieldId}
+                            touched={touched}
                             hasWriteAccessForIntegration={hasWriteAccessForIntegration}
                             isLoadingNotifiers={isLoadingNotifiers}
                             mailingListsString={mailingListsStrings[index]}
@@ -160,6 +163,7 @@ function NotifierConfigurationForm({
                             label="Custom subject"
                             fieldId="emailConfig.customSubject"
                             errors={errors}
+                            touched={touched}
                         >
                             <TextInput
                                 type="text"
@@ -175,6 +179,7 @@ function NotifierConfigurationForm({
                             label="Custom body"
                             fieldId="emailConfig.customBody"
                             errors={errors}
+                            touched={touched}
                         >
                             <TextArea
                                 type="text"

--- a/ui/apps/platform/src/Components/NotifierConfiguration/NotifierMailingLists.tsx
+++ b/ui/apps/platform/src/Components/NotifierConfiguration/NotifierMailingLists.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { Button, Flex, FlexItem, SelectOption, TextInput } from '@patternfly/react-core';
-import type { FormikErrors } from 'formik';
+import type { FormikErrors, FormikTouched } from 'formik';
 
 import EmailNotifierModal from 'Components/EmailNotifier/EmailNotifierModal';
 import SelectSingle from 'Components/SelectSingle';
@@ -29,6 +29,7 @@ type NotifierMailingListsProps = {
     setMailingLists: (mailingListsString: string) => void;
     setNotifier: (notifier: NotifierIntegrationBase) => void;
     setNotifiers: (notifiers: NotifierIntegrationBase[]) => void;
+    touched?: FormikTouched<unknown>;
 };
 
 function NotifierMailingLists({
@@ -43,6 +44,7 @@ function NotifierMailingLists({
     setMailingLists,
     setNotifier,
     setNotifiers,
+    touched,
 }: NotifierMailingListsProps): ReactElement {
     const [isEmailNotifierModalOpen, setIsEmailNotifierModalOpen] = useState(false);
 
@@ -109,13 +111,14 @@ function NotifierMailingLists({
             <FormLabelGroup
                 isRequired
                 label="Email notifier"
-                fieldId={`${fieldIdPrefixForFormikAndPatternFly}.notifier`}
+                fieldId={`${fieldIdPrefixForFormikAndPatternFly}.emailConfig.notifierId`}
                 errors={errors}
+                touched={touched}
             >
                 <Flex direction={{ default: 'row' }} alignItems={{ default: 'alignItemsFlexEnd' }}>
                     <FlexItem>
                         <SelectSingle
-                            id={`${fieldIdPrefixForFormikAndPatternFly}.notifier`}
+                            id={`${fieldIdPrefixForFormikAndPatternFly}.emailConfig.notifierId`}
                             isDisabled={isLoadingNotifiers}
                             toggleAriaLabel="Select a notifier"
                             value={notifierId}
@@ -145,6 +148,7 @@ function NotifierMailingLists({
                 fieldId={`${fieldIdPrefixForFormikAndPatternFly}.emailConfig.mailingLists`}
                 helperText="Multiple email addresses can be entered with comma separators."
                 errors={errors}
+                touched={touched}
             >
                 <Flex direction={{ default: 'row' }} alignItems={{ default: 'alignItemsFlexEnd' }}>
                     <FlexItem>

--- a/ui/apps/platform/src/Components/Reports/Step/DeliveryStep.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/DeliveryStep.tsx
@@ -35,6 +35,7 @@ function DeliveryStep<T extends DeliveryType = DeliveryType>({
                         notifierConfigurations={formik.values.notifiers}
                         onDeleteLastNotifierConfiguration={onDeleteLastNotifierConfiguration}
                         setFieldValue={formik.setFieldValue}
+                        touched={formik.touched}
                     />
                     {formik.values.notifiers.length !== 0 && (
                         <ScheduleFormSection formik={formik} />

--- a/ui/apps/platform/src/Components/Reports/Step/ScheduleFormSection.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/ScheduleFormSection.tsx
@@ -88,7 +88,6 @@ function ScheduleFormSection<T extends DeliveryType = DeliveryType>({
             <FormLabelGroup
                 label="Frequency"
                 fieldId="schedule.intervalType"
-                isRequired
                 errors={formik.errors}
                 touched={formik.touched}
             >
@@ -134,7 +133,10 @@ function ScheduleFormSection<T extends DeliveryType = DeliveryType>({
                 label="Time"
                 fieldId="time"
                 errors={formik.errors}
-                isRequired
+                isRequired={
+                    formik.values.schedule?.intervalType != null &&
+                    formik.values.schedule.intervalType !== 'UNSET'
+                }
                 touched={formik.touched}
                 helperText="Select or enter time between 00:00 and 23:59 UTC"
             >

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
@@ -1,9 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { Wizard, WizardStep } from '@patternfly/react-core';
+import { Wizard, WizardFooter, WizardStep, useWizardContext } from '@patternfly/react-core';
+import type { WizardStepType } from '@patternfly/react-core';
 import { useFormik } from 'formik';
 import type { FormikProps } from 'formik';
+import merge from 'lodash/merge';
+import set from 'lodash/set';
 
 import type {
     CompoundSearchFilterConfig,
@@ -15,6 +18,7 @@ import type { ReportPageAction } from 'Components/Reports/reports.types';
 import { createReportConfiguration, updateReportConfiguration } from 'services/ReportsService';
 import type { ReportConfiguration } from 'services/ReportsService.types';
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
+import * as yup from 'yup';
 
 import type {
     ImageVulnerabilityReportConfiguration,
@@ -22,6 +26,8 @@ import type {
     ImageVulnerabilityReportConfigurationForEntity,
 } from '../imageVulnerabilityReports.types';
 
+import { getValidationSchema } from './imageVulnerabilityReportValidationSchemas';
+import type { WizardStepId } from './imageVulnerabilityReportValidationSchemas';
 import ImageVulnerabilityResourcesStep from './Step2/ImageVulnerabilityResourcesStep';
 import ImageVulnerabilityFiltersStep from './Step3/ImageVulnerabilityFiltersStep';
 import ImageVulnerabilityFiltersStepForCollection from './Step3/ImageVulnerabilityFiltersStepForCollection';
@@ -43,6 +49,45 @@ export function hasFormikPropsForCollection(
     return 'collectionScope' in formik.values.resourceScope;
 }
 
+type ValidatingWizardFooterProps = {
+    formik: FormikProps<ImageVulnerabilityReportConfiguration>;
+    stepId: WizardStepId;
+    onClose: () => void;
+};
+
+function ValidatingWizardFooter({ formik, stepId, onClose }: ValidatingWizardFooterProps) {
+    const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
+
+    function handleNext() {
+        try {
+            // abortEarly is false so all errors on the current step are returned and can be touched
+            getValidationSchema(stepId).validateSync(formik.values, { abortEarly: false });
+            Promise.resolve(goToNextStep()).catch(() => {});
+        } catch (error) {
+            // touches fields that failed validation on the current step so errors are displayed
+            if (error instanceof yup.ValidationError) {
+                const touched: Record<string, unknown> = {};
+                error.inner.forEach((err) => {
+                    if (err.path) {
+                        set(touched, err.path, true);
+                    }
+                });
+                formik.setTouched(merge({}, formik.touched, touched));
+            }
+        }
+    }
+
+    return (
+        <WizardFooter
+            activeStep={activeStep}
+            isBackDisabled={stepId === 'Details'}
+            onNext={handleNext}
+            onBack={goToPrevStep}
+            onClose={onClose}
+        />
+    );
+}
+
 export type ImageVulnerabilityReportWizardProps = {
     attributesSeparateFromConfig: SelectSearchFilterAttribute[];
     initialValues: ImageVulnerabilityReportConfiguration;
@@ -58,9 +103,12 @@ function ImageVulnerabilityReportWizard({
 }: ImageVulnerabilityReportWizardProps): ReactElement {
     const navigate = useNavigate();
     const [error, setError] = useState<Error | null>(null);
+    const [stepId, setStepId] = useState<WizardStepId>('Details');
 
     const formik = useFormik({
         initialValues,
+        validateOnMount: true,
+        validationSchema: getValidationSchema(stepId),
         onSubmit: (values: ImageVulnerabilityReportConfiguration, { setSubmitting }) => {
             const request =
                 pageAction === 'edit'
@@ -86,22 +134,72 @@ function ImageVulnerabilityReportWizard({
         },
     });
 
-    const { dirty, isSubmitting, submitForm } = formik;
+    const { dirty, isSubmitting, isValid, submitForm, validateForm, values } = formik;
+
+    useEffect(() => {
+        validateForm(values).catch(() => {});
+    }, [stepId, validateForm, values]);
+
+    function isStepValid(id: WizardStepId): boolean {
+        try {
+            getValidationSchema(id).validateSync(formik.values);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    function onStepChange(_event: unknown, currentStep: WizardStepType): void {
+        setStepId(String(currentStep.id) as WizardStepId);
+    }
 
     function onClose() {
         // Go back either to reports table or page for existing report ore results page (for createFromFilters).
         navigate(-1);
     }
 
+    const detailsValid = isStepValid('Details');
+    const resourcesValid = isStepValid('Resources');
+    const filtersValid = isStepValid('Filters');
+    const deliveryValid = isStepValid('Delivery');
+
     return (
-        <Wizard onClose={onClose} onSave={submitForm}>
-            <WizardStep id="Details" name="Details" body={{ hasNoPadding: true }}>
+        <Wizard
+            onClose={onClose}
+            onSave={submitForm}
+            onStepChange={onStepChange}
+            isVisitRequired={pageAction !== 'edit' && pageAction !== 'clone'}
+        >
+            <WizardStep
+                id="Details"
+                name="Details"
+                body={{ hasNoPadding: true }}
+                footer={
+                    <ValidatingWizardFooter formik={formik} stepId="Details" onClose={onClose} />
+                }
+            >
                 <DetailsStep formik={formik} pageAction={pageAction} />
             </WizardStep>
-            <WizardStep id="Resources" name="Resources" body={{ hasNoPadding: true }}>
+            <WizardStep
+                id="Resources"
+                name="Resources"
+                body={{ hasNoPadding: true }}
+                isDisabled={!detailsValid}
+                footer={
+                    <ValidatingWizardFooter formik={formik} stepId="Resources" onClose={onClose} />
+                }
+            >
                 <ImageVulnerabilityResourcesStep formik={formik} />
             </WizardStep>
-            <WizardStep id="Filters" name="Filters" body={{ hasNoPadding: true }}>
+            <WizardStep
+                id="Filters"
+                name="Filters"
+                body={{ hasNoPadding: true }}
+                isDisabled={!detailsValid || !resourcesValid}
+                footer={
+                    <ValidatingWizardFooter formik={formik} stepId="Filters" onClose={onClose} />
+                }
+            >
                 {hasFormikPropsForEntity(formik) && (
                     <ImageVulnerabilityFiltersStep
                         attributesSeparateFromConfig={attributesSeparateFromConfig}
@@ -113,17 +211,26 @@ function ImageVulnerabilityReportWizard({
                     <ImageVulnerabilityFiltersStepForCollection formik={formik} />
                 )}
             </WizardStep>
-            <WizardStep id="Delivery" name="Delivery" body={{ hasNoPadding: true }}>
+            <WizardStep
+                id="Delivery"
+                name="Delivery"
+                body={{ hasNoPadding: true }}
+                isDisabled={!detailsValid || !resourcesValid || !filtersValid}
+                footer={
+                    <ValidatingWizardFooter formik={formik} stepId="Delivery" onClose={onClose} />
+                }
+            >
                 <DeliveryStep formik={formik} />
             </WizardStep>
             <WizardStep
                 id="Review"
                 name="Review"
                 body={{ hasNoPadding: true }}
+                isDisabled={!detailsValid || !resourcesValid || !filtersValid || !deliveryValid}
                 footer={{
                     isNextDisabled: !(
                         (dirty || pageAction === 'clone') &&
-                        // isValid &&
+                        isValid &&
                         !isSubmitting
                     ),
                     nextButtonProps: { isLoading: isSubmitting },

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
@@ -26,7 +26,7 @@ import type {
     ImageVulnerabilityReportConfigurationForEntity,
 } from '../imageVulnerabilityReports.types';
 
-import { getValidationSchema } from './imageVulnerabilityReportValidationSchemas';
+import { getValidationSchema, isWizardStepId } from './imageVulnerabilityReportValidationSchemas';
 import type { WizardStepId } from './imageVulnerabilityReportValidationSchemas';
 import ImageVulnerabilityResourcesStep from './Step2/ImageVulnerabilityResourcesStep';
 import ImageVulnerabilityFiltersStep from './Step3/ImageVulnerabilityFiltersStep';
@@ -80,7 +80,7 @@ function ValidatingWizardFooter({ formik, stepId, onClose }: ValidatingWizardFoo
     return (
         <WizardFooter
             activeStep={activeStep}
-            isBackDisabled={stepId === 'Details'}
+            isBackDisabled={stepId === 'details'}
             onNext={handleNext}
             onBack={goToPrevStep}
             onClose={onClose}
@@ -103,7 +103,7 @@ function ImageVulnerabilityReportWizard({
 }: ImageVulnerabilityReportWizardProps): ReactElement {
     const navigate = useNavigate();
     const [error, setError] = useState<Error | null>(null);
-    const [stepId, setStepId] = useState<WizardStepId>('Details');
+    const [stepId, setStepId] = useState<WizardStepId>('details');
 
     const formik = useFormik({
         initialValues,
@@ -150,7 +150,10 @@ function ImageVulnerabilityReportWizard({
     }
 
     function onStepChange(_event: unknown, currentStep: WizardStepType): void {
-        setStepId(String(currentStep.id) as WizardStepId);
+        const id = String(currentStep.id);
+        if (isWizardStepId(id)) {
+            setStepId(id);
+        }
     }
 
     function onClose() {
@@ -158,10 +161,10 @@ function ImageVulnerabilityReportWizard({
         navigate(-1);
     }
 
-    const detailsValid = isStepValid('Details');
-    const resourcesValid = isStepValid('Resources');
-    const filtersValid = isStepValid('Filters');
-    const deliveryValid = isStepValid('Delivery');
+    const isDetailsValid = isStepValid('details');
+    const isResourcesValid = isStepValid('resources');
+    const isFiltersValid = isStepValid('filters');
+    const isDeliveryValid = isStepValid('delivery');
 
     return (
         <Wizard
@@ -171,33 +174,33 @@ function ImageVulnerabilityReportWizard({
             isVisitRequired={pageAction !== 'edit' && pageAction !== 'clone'}
         >
             <WizardStep
-                id="Details"
+                id="details"
                 name="Details"
                 body={{ hasNoPadding: true }}
                 footer={
-                    <ValidatingWizardFooter formik={formik} stepId="Details" onClose={onClose} />
+                    <ValidatingWizardFooter formik={formik} stepId="details" onClose={onClose} />
                 }
             >
                 <DetailsStep formik={formik} pageAction={pageAction} />
             </WizardStep>
             <WizardStep
-                id="Resources"
+                id="resources"
                 name="Resources"
                 body={{ hasNoPadding: true }}
-                isDisabled={!detailsValid}
+                isDisabled={!isDetailsValid}
                 footer={
-                    <ValidatingWizardFooter formik={formik} stepId="Resources" onClose={onClose} />
+                    <ValidatingWizardFooter formik={formik} stepId="resources" onClose={onClose} />
                 }
             >
                 <ImageVulnerabilityResourcesStep formik={formik} />
             </WizardStep>
             <WizardStep
-                id="Filters"
+                id="filters"
                 name="Filters"
                 body={{ hasNoPadding: true }}
-                isDisabled={!detailsValid || !resourcesValid}
+                isDisabled={!isDetailsValid || !isResourcesValid}
                 footer={
-                    <ValidatingWizardFooter formik={formik} stepId="Filters" onClose={onClose} />
+                    <ValidatingWizardFooter formik={formik} stepId="filters" onClose={onClose} />
                 }
             >
                 {hasFormikPropsForEntity(formik) && (
@@ -212,21 +215,23 @@ function ImageVulnerabilityReportWizard({
                 )}
             </WizardStep>
             <WizardStep
-                id="Delivery"
+                id="delivery"
                 name="Delivery"
                 body={{ hasNoPadding: true }}
-                isDisabled={!detailsValid || !resourcesValid || !filtersValid}
+                isDisabled={!isDetailsValid || !isResourcesValid || !isFiltersValid}
                 footer={
-                    <ValidatingWizardFooter formik={formik} stepId="Delivery" onClose={onClose} />
+                    <ValidatingWizardFooter formik={formik} stepId="delivery" onClose={onClose} />
                 }
             >
                 <DeliveryStep formik={formik} />
             </WizardStep>
             <WizardStep
-                id="Review"
+                id="review"
                 name="Review"
                 body={{ hasNoPadding: true }}
-                isDisabled={!detailsValid || !resourcesValid || !filtersValid || !deliveryValid}
+                isDisabled={
+                    !isDetailsValid || !isResourcesValid || !isFiltersValid || !isDeliveryValid
+                }
                 footer={{
                     isNextDisabled: !(
                         (dirty || pageAction === 'clone') &&

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { ReactElement } from 'react';
-import { Flex, Form, FormGroup, PageSection, Radio, Title } from '@patternfly/react-core';
+import { Flex, Form, PageSection, Radio, Title } from '@patternfly/react-core';
 import type { FormikProps } from 'formik';
 
 import EntityScopeCompoundSearchFilter from 'Components/EntityScope/EntityScopeCompoundSearchFilter';
@@ -72,6 +72,7 @@ function ImageVulnerabilityResourcesStep<
                         label="Image type"
                         isRequired
                         fieldId="vulnReportFilters.imageTypes"
+                        touched={formik.touched}
                         errors={formik.errors}
                     >
                         <ImageTypeSelect
@@ -79,9 +80,12 @@ function ImageVulnerabilityResourcesStep<
                             setImageTypes={setImageTypes}
                         />
                     </FormLabelGroup>
-                    <FormGroup
+                    <FormLabelGroup
                         label="Resource scope (required for deployed images)"
                         isRequired={isResourceScopeRequired}
+                        fieldId="resourceScope"
+                        touched={formik.touched}
+                        errors={formik.errors}
                     >
                         <Flex
                             direction={{ default: 'column' }}
@@ -135,7 +139,7 @@ function ImageVulnerabilityResourcesStep<
                                 }
                             />
                         </Flex>
-                    </FormGroup>
+                    </FormLabelGroup>
                 </Form>
             </Flex>
         </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersSince.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersSince.tsx
@@ -109,6 +109,7 @@ function ImageVulnerabilityFiltersSince<
                         label="Custom start date"
                         isRequired
                         fieldId="vulnReportFilters.sinceStartDate"
+                        touched={formik.touched}
                         errors={formik.errors}
                     >
                         <DatePicker
@@ -118,6 +119,7 @@ function ImageVulnerabilityFiltersSince<
                             onChange={(_event, value) => {
                                 onChangeStartDate(value);
                             }}
+                            invalidFormatText="" // error messaging is handled by yup along with FormLabelGroup
                         />
                     </FormLabelGroup>
                 </GridItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
@@ -1,8 +1,9 @@
 import type { ReactElement } from 'react';
-import { Flex, Form, FormGroup, PageSection, Title } from '@patternfly/react-core';
+import { Flex, Form, PageSection, Title } from '@patternfly/react-core';
 import type { FormikProps } from 'formik';
 
 import SearchFilterSelectInclusive from 'Components/CompoundSearchFilter/components/SearchFilterSelectInclusive';
+import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import type { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
 import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
 
@@ -52,10 +53,12 @@ function ImageVulnerabilityFiltersStepForCollection<
                 <Title headingLevel="h2">Filters</Title>
                 <Form isHorizontal isWidthLimited>
                     <ImageVulnerabilityFiltersSince formik={formik} />
-                    <FormGroup
+                    <FormLabelGroup
                         label="CVE severity"
                         isRequired
                         fieldId="vulnReportFilters.severities"
+                        touched={formik.touched}
+                        errors={formik.errors}
                     >
                         <SearchFilterSelectInclusive
                             attribute={attributeForSeverityInBackendAndViewBasedReport}
@@ -63,15 +66,21 @@ function ImageVulnerabilityFiltersStepForCollection<
                             onSearch={onSearchSeverity}
                             searchFilter={searchFilter}
                         />
-                    </FormGroup>
-                    <FormGroup label="CVE status" isRequired fieldId="vulnReportFilters.fixability">
+                    </FormLabelGroup>
+                    <FormLabelGroup
+                        label="CVE status"
+                        isRequired
+                        fieldId="vulnReportFilters.fixability"
+                        touched={formik.touched}
+                        errors={formik.errors}
+                    >
                         <SearchFilterSelectInclusive
                             attribute={attributeForFixableInBackendAndViewBasedReport}
                             isSeparate
                             onSearch={onSearchFixibility}
                             searchFilter={searchFilter}
                         />
-                    </FormGroup>
+                    </FormLabelGroup>
                 </Form>
             </Flex>
         </PageSection>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/imageVulnerabilityReportValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/imageVulnerabilityReportValidationSchemas.ts
@@ -4,7 +4,7 @@ import * as yup from 'yup';
 import type { DeliveryType, DetailsType } from 'Components/Reports/reports.types';
 import type { Schedule } from 'types/schedule.proto';
 import { imageTypes } from 'services/ReportsService.types';
-import type { CvesSince, ImageType, NotifierConfiguration } from 'services/ReportsService.types';
+import type { CvesSince, ImageType } from 'services/ReportsService.types';
 import { vulnerabilitySeverities } from 'types/cve.proto';
 
 import { ensureExhaustive } from 'utils/type.utils';
@@ -161,44 +161,30 @@ const validationSchemaDelivery: yup.ObjectSchema<DeliveryType> = yup.object().sh
         .object()
         .nullable()
         .defined()
-        .test(
-            'schedule-required',
-            'Schedule is required when a delivery destination is added',
-            function test(value) {
-                const notifiers: NotifierConfiguration[] = this.parent?.notifiers ?? [];
-                if (notifiers.length === 0) {
-                    return true;
-                }
-                if (value == null) {
-                    return this.createError({
-                        path: 'schedule.intervalType',
-                        message: 'Schedule frequency is required',
-                    });
-                }
-                // Schedule is a union type that .shape() can't express.
-                // Cast so property access is type-checked.
-                const schedule = value as Schedule;
-                if (schedule.intervalType === 'UNSET') {
-                    return this.createError({
-                        path: 'schedule.intervalType',
-                        message: 'Schedule frequency is required',
-                    });
-                }
-                if ('daysOfWeek' in schedule && schedule.daysOfWeek.days.length === 0) {
-                    return this.createError({
-                        path: 'schedule.daysOfWeek.days',
-                        message: 'At least one day must be selected',
-                    });
-                }
-                if ('daysOfMonth' in schedule && schedule.daysOfMonth.days.length === 0) {
-                    return this.createError({
-                        path: 'schedule.daysOfMonth.days',
-                        message: 'At least one day must be selected',
-                    });
-                }
+        .test('schedule-days-required', 'At least one day must be selected', function test(value) {
+            if (value == null) {
                 return true;
             }
-        ) as unknown as yup.Schema<Schedule | null>,
+            // Schedule is a union type that .shape() can't express.
+            // Cast so property access is type-checked.
+            const schedule = value as Schedule;
+            if (schedule.intervalType === 'UNSET' || schedule.intervalType === 'DAILY') {
+                return true;
+            }
+            if ('daysOfWeek' in schedule && schedule.daysOfWeek.days.length === 0) {
+                return this.createError({
+                    path: 'schedule.daysOfWeek.days',
+                    message: 'At least one day must be selected',
+                });
+            }
+            if ('daysOfMonth' in schedule && schedule.daysOfMonth.days.length === 0) {
+                return this.createError({
+                    path: 'schedule.daysOfMonth.days',
+                    message: 'At least one day must be selected',
+                });
+            }
+            return true;
+        }) as unknown as yup.Schema<Schedule | null>,
 });
 
 export const wizardStepIds = ['details', 'resources', 'filters', 'delivery', 'review'] as const;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/imageVulnerabilityReportValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/imageVulnerabilityReportValidationSchemas.ts
@@ -1,0 +1,217 @@
+import { isValid, parse } from 'date-fns';
+import * as yup from 'yup';
+
+import type { DeliveryType, DetailsType } from 'Components/Reports/reports.types';
+import type { Schedule } from 'types/schedule.proto';
+import { imageTypes } from 'services/ReportsService.types';
+import type { CvesSince, ImageType, NotifierConfiguration } from 'services/ReportsService.types';
+import { vulnerabilitySeverities } from 'types/cve.proto';
+
+import type {
+    ImageVulnerabilityReportConfiguration,
+    ImageVulnerabilityReportConfigurationForCollection,
+    ImageVulnerabilityReportFiltersForEntity,
+    ImageVulnerabilityResourceScope,
+    ImageVulnerabilityResourcesConfiguration,
+} from '../imageVulnerabilityReports.types';
+
+const validationSchemaDetails: yup.ObjectSchema<DetailsType> = yup.object().shape({
+    name: yup.string().trim().required('Report name is required'),
+    description: yup.string().ensure(),
+});
+
+const validationSchemaResources: yup.ObjectSchema<ImageVulnerabilityResourcesConfiguration> = yup
+    .object()
+    .shape({
+        vulnReportFilters: yup.object().shape({
+            imageTypes: yup
+                .array()
+                .of(yup.string().oneOf(imageTypes).required())
+                .min(1, 'Select at least one image type')
+                .required(),
+        }),
+        resourceScope: yup
+            .object()
+            .test(
+                'resource-scope-required',
+                'Resource scope is required for deployed images',
+                function test(value) {
+                    // resourceScope can be either CollectionScope or EntityScope, which .shape()
+                    // can't express. Cast so property access is type checked.
+                    const resourceScope = value as ImageVulnerabilityResourceScope;
+                    const imageTypesValue: ImageType[] =
+                        this.parent?.vulnReportFilters?.imageTypes ?? [];
+                    const hasDeployed = imageTypesValue.includes('DEPLOYED');
+
+                    if (!hasDeployed) {
+                        return true;
+                    }
+
+                    if ('collectionScope' in resourceScope) {
+                        return Boolean(resourceScope.collectionScope.collectionId);
+                    }
+                    if ('entityScope' in resourceScope) {
+                        return resourceScope.entityScope.rules.length > 0;
+                    }
+                    return false;
+                }
+            ) as unknown as yup.Schema<ImageVulnerabilityResourceScope>,
+    });
+
+function isCvesSinceValid(filters: CvesSince): boolean {
+    if ('allVuln' in filters) {
+        return true;
+    }
+    if ('sinceLastSentScheduledReport' in filters) {
+        return true;
+    }
+    if ('sinceStartDate' in filters) {
+        if (!filters.sinceStartDate) {
+            return false;
+        }
+        // DatePicker stores dates as YYYY-MM-DD, reject anything that doesn't match
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(filters.sinceStartDate)) {
+            return false;
+        }
+        return isValid(parse(filters.sinceStartDate));
+    }
+    return false;
+}
+
+const validationSchemaFilters = yup.lazy((values: ImageVulnerabilityReportConfiguration) => {
+    if ('entityScope' in values.resourceScope) {
+        return yup.object().shape({
+            vulnReportFilters: yup
+                .object()
+                .test(
+                    'cves-since-entity',
+                    'CVE date range is required',
+                    function test(reportFilters) {
+                        // CvesSince is a union type that .shape() can't express.
+                        // cast so property access is type checked.
+                        const filters = reportFilters as ImageVulnerabilityReportFiltersForEntity;
+                        if ('sinceStartDate' in filters && !isCvesSinceValid(filters)) {
+                            return this.createError({
+                                path: 'vulnReportFilters.sinceStartDate',
+                                message: 'A valid start date is required',
+                            });
+                        }
+                        return isCvesSinceValid(filters);
+                    }
+                ),
+        });
+    }
+
+    return yup.object().shape({
+        vulnReportFilters: yup
+            .object()
+            .shape({
+                severities: yup
+                    .array()
+                    .of(yup.string().oneOf(vulnerabilitySeverities).required())
+                    .min(1, 'Select at least one CVE severity')
+                    .required('CVE severity is required'),
+                fixability: yup
+                    .string()
+                    .oneOf(['FIXABLE', 'NOT_FIXABLE', 'BOTH'])
+                    .required('CVE status is required'),
+            })
+            .test(
+                'cves-since-collection',
+                'CVE date range is required',
+                function test(reportFilters) {
+                    // CvesSince is a union type that .shape() can't express.
+                    // cast so property access is type checked.
+                    const filters =
+                        reportFilters as ImageVulnerabilityReportConfigurationForCollection['vulnReportFilters'];
+                    if ('sinceStartDate' in filters && !isCvesSinceValid(filters)) {
+                        return this.createError({
+                            path: 'vulnReportFilters.sinceStartDate',
+                            message: 'A valid start date is required',
+                        });
+                    }
+                    return isCvesSinceValid(filters);
+                }
+            ),
+    });
+});
+
+const validationSchemaDelivery: yup.ObjectSchema<DeliveryType> = yup.object().shape({
+    notifiers: yup
+        .array()
+        .of(
+            yup.object().shape({
+                emailConfig: yup.object().shape({
+                    notifierId: yup.string().required('Email notifier is required'),
+                    mailingLists: yup
+                        .array()
+                        .of(yup.string().required())
+                        .min(1, 'At least one distribution list email is required')
+                        .required(),
+                    customSubject: yup.string().defined(),
+                    customBody: yup.string().defined(),
+                }),
+                notifierName: yup.string().defined(),
+            })
+        )
+        .defined(),
+    schedule: yup
+        .object()
+        .nullable()
+        .defined()
+        .test(
+            'schedule-required',
+            'Schedule is required when a delivery destination is added',
+            function test(value) {
+                const notifiers: NotifierConfiguration[] = this.parent?.notifiers ?? [];
+                if (notifiers.length === 0) {
+                    return true;
+                }
+                if (value == null) {
+                    return this.createError({
+                        path: 'schedule.intervalType',
+                        message: 'Schedule frequency is required',
+                    });
+                }
+                // Schedule is a union type that .shape() can't express.
+                // Cast so property access is type-checked.
+                const schedule = value as Schedule;
+                if (schedule.intervalType === 'UNSET') {
+                    return this.createError({
+                        path: 'schedule.intervalType',
+                        message: 'Schedule frequency is required',
+                    });
+                }
+                if ('daysOfWeek' in schedule && schedule.daysOfWeek.days.length === 0) {
+                    return this.createError({
+                        path: 'schedule.daysOfWeek.days',
+                        message: 'At least one day must be selected',
+                    });
+                }
+                if ('daysOfMonth' in schedule && schedule.daysOfMonth.days.length === 0) {
+                    return this.createError({
+                        path: 'schedule.daysOfMonth.days',
+                        message: 'At least one day must be selected',
+                    });
+                }
+                return true;
+            }
+        ) as unknown as yup.Schema<Schedule | null>,
+});
+
+export type WizardStepId = 'Details' | 'Resources' | 'Filters' | 'Delivery' | 'Review';
+
+export function getValidationSchema(stepId: WizardStepId): yup.Schema | yup.Lazy<unknown> {
+    switch (stepId) {
+        case 'Details':
+            return validationSchemaDetails;
+        case 'Resources':
+            return validationSchemaResources;
+        case 'Filters':
+            return validationSchemaFilters;
+        case 'Delivery':
+            return validationSchemaDelivery;
+        default:
+            return yup.object().shape({});
+    }
+}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/imageVulnerabilityReportValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/imageVulnerabilityReportValidationSchemas.ts
@@ -7,6 +7,8 @@ import { imageTypes } from 'services/ReportsService.types';
 import type { CvesSince, ImageType, NotifierConfiguration } from 'services/ReportsService.types';
 import { vulnerabilitySeverities } from 'types/cve.proto';
 
+import { ensureExhaustive } from 'utils/type.utils';
+
 import type {
     ImageVulnerabilityReportConfiguration,
     ImageVulnerabilityReportConfigurationForCollection,
@@ -199,19 +201,26 @@ const validationSchemaDelivery: yup.ObjectSchema<DeliveryType> = yup.object().sh
         ) as unknown as yup.Schema<Schedule | null>,
 });
 
-export type WizardStepId = 'Details' | 'Resources' | 'Filters' | 'Delivery' | 'Review';
+export const wizardStepIds = ['details', 'resources', 'filters', 'delivery', 'review'] as const;
+export type WizardStepId = (typeof wizardStepIds)[number];
+
+export function isWizardStepId(id: string): id is WizardStepId {
+    return wizardStepIds.includes(id as WizardStepId);
+}
 
 export function getValidationSchema(stepId: WizardStepId): yup.Schema | yup.Lazy<unknown> {
     switch (stepId) {
-        case 'Details':
+        case 'details':
             return validationSchemaDetails;
-        case 'Resources':
+        case 'resources':
             return validationSchemaResources;
-        case 'Filters':
+        case 'filters':
             return validationSchemaFilters;
-        case 'Delivery':
+        case 'delivery':
             return validationSchemaDelivery;
-        default:
+        case 'review':
             return yup.object().shape({});
+        default:
+            return ensureExhaustive(stepId);
     }
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -230,7 +230,12 @@ export const attributeForSeverityInBackendAndViewBasedReport: SelectSearchFilter
 
 // Scheduled report has resources instead of cluster, deployment, namespace.
 export const searchFilterConfigForImageVulnerabilityReport = [
-    imageCVESearchFilterConfig,
+    {
+        ...imageCVESearchFilterConfig,
+        attributes: imageCVESearchFilterConfig.attributes.filter(
+            ({ searchTerm }) => searchTerm !== 'CVE Created Time'
+        ),
+    },
     imageSearchFilterConfig,
     imageComponentSearchFilterConfig,
 ];


### PR DESCRIPTION
## Description

Add yup validation to the image vulnerability reporting wizard.

Notes:

- Using a "validation on next" pattern. Next button is enabled, clicking it will expose any validation errors on the current page.
  - In particular this helps with validation on the resources step where it's difficult to determine when the radio selection has been "touched".
  - Takes advantage of `yup.ValidationError` where we can iterate over all fields on the current step and trigger the touched field.
-  Type casts in the validation schema. Yups `.test()` types the callback value from the schema, not our types. Union types like `CvesSince` and `Schedule` can't be expressed using `.shape()` so we're casting inside `.test()`. The benefit is property access is type checked so if fields change on the type, the schema gets a compile error. The alternative assume value used inside `.test()` is a simple object.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

#### Details Step:
<img width="1410" height="1176" alt="Screenshot 2026-05-12 at 5 28 34 PM" src="https://github.com/user-attachments/assets/fd5d4698-9fa4-4888-85df-72ad2c60878d" />

---

#### Resources Step:
<img width="1410" height="1176" alt="Screenshot 2026-05-12 at 5 29 00 PM" src="https://github.com/user-attachments/assets/20586a37-d1f4-47cf-9c57-810092db2d6e" />

---

#### Filters Step – Custom Scope:
<img width="1410" height="1176" alt="Screenshot 2026-05-12 at 5 29 17 PM" src="https://github.com/user-attachments/assets/9f411719-448b-4d8e-868a-cad68a1fb603" />

---

#### Filters Step – Collection Scope:
<img width="1410" height="1176" alt="Screenshot 2026-05-12 at 5 29 56 PM" src="https://github.com/user-attachments/assets/4f8a4d6f-c200-4ab0-ba19-0e3159383c32" />

---

#### Delivery Step:
<img width="1410" height="1176" alt="Screenshot 2026-05-12 at 5 29 35 PM" src="https://github.com/user-attachments/assets/140487f7-1cc8-45b6-ab65-befccdca129a" />
