### PR TITLE
ROX-34522: enable background migration process by default

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -137,7 +137,7 @@ var (
 	// InitContainerSupport enables extraction, scanning, and evaluation of init containers in deployments.
 	InitContainerSupport = registerFeature("Enable init container support", "ROX_INIT_CONTAINER_SUPPORT")
 	// BackgroundMigration enables long-running background migrations in Central
-	BackgroundMigration = registerFeature("Enable long-running background migrations in Central", "ROX_BACKGROUND_MIGRATION")
+	BackgroundMigration = registerFeature("Enable long-running background migrations in Central", "ROX_BACKGROUND_MIGRATION", enabled)
 )
 
 // The following feature flags are related to Scanner V4.


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Enabling background migration process by default. Since we don't have any BG migration implemented, 4.11 will launch with the process enabled, but no migrations being executed.

I'm enabling this after an extensive tests against the long running cluster environment used for releases, see validation section. Overall this looks like a stable process, even under high resource pressure.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- Common upgrade/rollback edge cases have been tested manually in #20161
- The process implementation itself is tested by CI with PSQL integration and unit tests

### Additional manual test against the long running cluster environment used for the release process

The idea of this test is to test common cases for backfill migrations using migrations that previously let to incidents in reality.

**Test Setup**

As a test setup I'm using the long running clusters we use during ACS release processes.
I'm starting the long running cluster environment at ACS 4.10.1, let it accumulate data and then test example background migrations.

The 3 tables that are largest in usual installation are alerts, network_flows and process indicators.
This test was executed twice.
After 5d of runtime:
- 1.8M alerts
- 2M network flows
- 60k process indicators(that is a little low, but must suffice for now)
After 8d of runtime
- 2.2M alerts
- 2M network flows
- 100k process indicators

**Test Migrations**

I reimplemented 3 migrations from the real product to have accurate use cases for the test:
- m_212_to_m_213 a collumn backfill for process indicators that caused massive downtimes for 4.9 upgrade
- m_209_to_m_210 a collumns backfill for network_flows that also caused long downtimes for 4.8 upgrades
- m_223_to_m_224 a migrations on alerts from the upcoming upgrade to 4.11

The implementation does the following
- Reimplement schema migration by adding a duplicate column as a migrator migration
- Implement the actual backfill of that duplicate column as a background migration
- Use `Select x from y for update skip locked` for all BG migrations making sure we don't conflict with event processing

The testing implementation is stored in jmalsam/testing-bg-migrations branch in the stackrox repository.

**What we test**
1. Make a local build of the migration implementation and push that to my personal registry
2. Upgrade the long running cluster central to that image
3. Verify
    - Schema migration complete quickly and central reaches ready
    - Sensors reconnect when central reaches ready and before BG migrations finished
    - BG migrations complete eventually
    - Central/Sensor does not produce critical or unrecovarable errors during the process of running BG migrations while receiving usual sensor traffic

**Test Results**
TL;DR:
- Central reached ready after schema migration by migrator and its own init phase ✅ 
- Background migrations eventually finished. ✅ 
- No critical errors, crashes, connection termination during BG migrations ✅ 
- Monitoring shows that central memory and CPU consumption does not spike unpredictably during BG migrations ✅ 
- The DB was at it's memory limits during BG migration, but did neither crash nor cause any central errors ✅ 
- The additional locking logic for BG migration did not yield any deadlock errors ✅ 

**More details:**
- The alert migration was executed once by the migrator, once by the BG migration process
  - For 2.2M alerts: 17m with downtime for migrator, 1h15m without downtime for BG process
  - For 1.8M alerts: 9m with downtime for migrator, 35m without downtime for BG process
  - The alert migration took so long because of the nature of the long running cluster producing 98% orphaned alerts. This was identified as an edge case, that will be improved for 4.11 by #20517 
- The amount of alerts were crashing central on startup if DB queries time out with a `should` panic, reopened https://redhat.atlassian.net/browse/ROX-30686 because we by accident found a way to reproduce this bug
- Central logs of the test run are attached to this PR
  - a `cat central.log | grep -iE 'error|panic' yielded only errors from image registries and deployments not being found nothing can be attributed to BG migrations, DB errors, or events not being processed properly
[central.log](https://github.com/user-attachments/files/27697155/central.log)
- Monitoring for central shows a stable memory and CPU usage during the BG migration window, the initial spikes where central initializiation, BG migrations have not started at that point (verified by log timestamps)
<img width="1594" height="342" alt="image" src="https://github.com/user-attachments/assets/c8a11c6b-976c-40ed-928e-6a495fd3d332" />
- DB load was noticeable higher during the BG migration process and leveled of afterwards. It didn't cause any errors, though the pod was operating at it's memory limit
<img width="1594" height="342" alt="image" src="https://github.com/user-attachments/assets/f79d0dda-d018-4cd0-8c9d-72e864485c97" />




