### PR TITLE
ROX-33083: fix tls.Config data race in ALPN demux path

### DIFF
--- a/pkg/grpc/endpoints.go
+++ b/pkg/grpc/endpoints.go
@@ -202,9 +202,18 @@ func (c *EndpointConfig) instantiate(httpHandler http.Handler, grpcSrv *grpc.Ser
 			actualHTTPHandler = downgradingServer.CreateDowngradingHandler(grpcSrv, actualHTTPHandler, downgradingServer.PreferGRPCWeb(true))
 		}
 
+		// When both gRPC and HTTP are served over TLS, the ALPN demux
+		// listener is already accepting connections (and performing TLS
+		// handshakes) on tlsConf. Clone the config for the HTTP server so
+		// that http2.ConfigureServer does not mutate it concurrently.
+		httpTLSConf := tlsConf
+		if c.ServeGRPC && c.ServeHTTP && tlsConf != nil {
+			httpTLSConf = tlsConf.Clone()
+		}
+
 		httpSrv := &http.Server{
 			Handler:   actualHTTPHandler,
-			TLSConfig: tlsConf,
+			TLSConfig: httpTLSConf,
 			ErrorLog:  golog.New(httpErrorLogger{}, "", golog.LstdFlags),
 		}
 		if !c.NoHTTP2 {


### PR DESCRIPTION
## Description

A data race exists between two goroutines accessing the same `tls.Config` during sensor startup:

1. **Reader (TLS handshake):** The ALPN demux listener starts accepting connections immediately via a goroutine, performing TLS handshakes that read `tls.Config` fields (e.g., `NextProtos`).
2. **Writer (HTTP/2 setup):** `http2.ConfigureServer` mutates the same `tls.Config` (appending to `NextProtos`, setting `PreferServerCipherSuites`) during HTTP server initialization.

This only happens when both gRPC and HTTP are served over TLS, because `ALPNDemux` spawns a goroutine that accepts connections before `http2.ConfigureServer` runs.

**Fix:** Clone `tls.Config` for the HTTP server so `http2.ConfigureServer` mutates a separate object. The HTTP server never performs TLS handshakes itself in this path — it receives already-handshaked connections from the ALPN demux — so the clone is not used for TLS operations.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Ran `go test -race -count=1 -timeout=60s ./pkg/grpc/...` — all tests pass, including `TestMisdirectedRequests`.
- The race is a startup ordering issue only reproducible under `-race` in sensor integration tests; the existing `TestMisdirectedRequests` suite validates the affected code path.