### PR TITLE
ROX-34688: Add ContainerType field to Alert.Deployment.Container proto

### DIFF
--- a/central/alert/datastore/internal/store/postgres/store.go
+++ b/central/alert/datastore/internal/store/postgres/store.go
@@ -165,6 +165,31 @@ func insertIntoAlerts(batch *pgx.Batch, obj *storage.Alert) error {
 	finalStr := "INSERT INTO alerts (Id, Policy_Id, Policy_Name, Policy_Description, Policy_Disabled, Policy_Categories, Policy_Severity, Policy_EnforcementActions, Policy_LastUpdated, Policy_SORTName, Policy_SORTLifecycleStage, Policy_SORTEnforcement, LifecycleStage, ClusterId, ClusterName, Namespace, NamespaceId, Deployment_Id, Deployment_Name, Deployment_Type, Deployment_Inactive, Image_Id, Image_Name_Registry, Image_Name_Remote, Image_Name_Tag, Image_Name_FullName, Image_IdV2, Node_Id, Node_Name, Resource_ResourceType, Resource_Name, Enforcement_Action, Time, State, PlatformComponent, EntityType, EnforcementCount, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, Policy_Id = EXCLUDED.Policy_Id, Policy_Name = EXCLUDED.Policy_Name, Policy_Description = EXCLUDED.Policy_Description, Policy_Disabled = EXCLUDED.Policy_Disabled, Policy_Categories = EXCLUDED.Policy_Categories, Policy_Severity = EXCLUDED.Policy_Severity, Policy_EnforcementActions = EXCLUDED.Policy_EnforcementActions, Policy_LastUpdated = EXCLUDED.Policy_LastUpdated, Policy_SORTName = EXCLUDED.Policy_SORTName, Policy_SORTLifecycleStage = EXCLUDED.Policy_SORTLifecycleStage, Policy_SORTEnforcement = EXCLUDED.Policy_SORTEnforcement, LifecycleStage = EXCLUDED.LifecycleStage, ClusterId = EXCLUDED.ClusterId, ClusterName = EXCLUDED.ClusterName, Namespace = EXCLUDED.Namespace, NamespaceId = EXCLUDED.NamespaceId, Deployment_Id = EXCLUDED.Deployment_Id, Deployment_Name = EXCLUDED.Deployment_Name, Deployment_Type = EXCLUDED.Deployment_Type, Deployment_Inactive = EXCLUDED.Deployment_Inactive, Image_Id = EXCLUDED.Image_Id, Image_Name_Registry = EXCLUDED.Image_Name_Registry, Image_Name_Remote = EXCLUDED.Image_Name_Remote, Image_Name_Tag = EXCLUDED.Image_Name_Tag, Image_Name_FullName = EXCLUDED.Image_Name_FullName, Image_IdV2 = EXCLUDED.Image_IdV2, Node_Id = EXCLUDED.Node_Id, Node_Name = EXCLUDED.Node_Name, Resource_ResourceType = EXCLUDED.Resource_ResourceType, Resource_Name = EXCLUDED.Resource_Name, Enforcement_Action = EXCLUDED.Enforcement_Action, Time = EXCLUDED.Time, State = EXCLUDED.State, PlatformComponent = EXCLUDED.PlatformComponent, EntityType = EXCLUDED.EntityType, EnforcementCount = EXCLUDED.EnforcementCount, serialized = EXCLUDED.serialized"
 	batch.Queue(finalStr, values...)
 
+	var query string
+
+	for childIndex, child := range obj.GetDeployment().GetContainers() {
+		if err := insertIntoAlertsContainers(batch, child, obj.GetId(), childIndex); err != nil {
+			return err
+		}
+	}
+
+	query = "delete from alerts_containers where alerts_Id = $1 AND idx >= $2"
+	batch.Queue(query, pgutils.NilOrUUID(obj.GetId()), len(obj.GetDeployment().GetContainers()))
+	return nil
+}
+
+func insertIntoAlertsContainers(batch *pgx.Batch, obj *storage.Alert_Deployment_Container, alertID string, idx int) error {
+
+	values := []interface{}{
+		// parent primary keys start
+		pgutils.NilOrUUID(alertID),
+		idx,
+		obj.GetType(),
+	}
+
+	finalStr := "INSERT INTO alerts_containers (alerts_Id, idx, Type) VALUES($1, $2, $3) ON CONFLICT(alerts_Id, idx) DO UPDATE SET alerts_Id = EXCLUDED.alerts_Id, idx = EXCLUDED.idx, Type = EXCLUDED.Type"
+	batch.Queue(finalStr, values...)
+
 	return nil
 }
 
@@ -282,6 +307,45 @@ func copyFromAlerts(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, ob
 	})
 
 	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"alerts"}, copyColsAlerts, inputRows); err != nil {
+		return err
+	}
+
+	for _, obj := range objs {
+		if err := copyFromAlertsContainers(ctx, s, tx, obj.GetId(), obj.GetDeployment().GetContainers()...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+var copyColsAlertsContainers = []string{
+	"alerts_id",
+	"idx",
+	"type",
+}
+
+func copyFromAlertsContainers(ctx context.Context, s pgSearch.Deleter, tx *postgres.Tx, alertID string, objs ...*storage.Alert_Deployment_Container) error {
+	if len(objs) == 0 {
+		return nil
+	}
+
+	idx := 0
+	inputRows := pgx.CopyFromFunc(func() ([]any, error) {
+		if idx >= len(objs) {
+			return nil, nil
+		}
+		obj := objs[idx]
+		idx++
+
+		return []interface{}{
+			pgutils.NilOrUUID(alertID),
+			idx,
+			obj.GetType(),
+		}, nil
+	})
+
+	if _, err := tx.CopyFrom(ctx, pgx.Identifier{"alerts_containers"}, copyColsAlertsContainers, inputRows); err != nil {
 		return err
 	}
 

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -94,6 +94,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 	utils.Must(builder.AddType("Alert_Deployment_Container", []string{
 		"image: ContainerImage",
 		"name: String!",
+		"type: ContainerType!",
 	}))
 	utils.Must(builder.AddType("Alert_Enforcement", []string{
 		"action: EnforcementAction!",
@@ -2314,6 +2315,11 @@ func (resolver *alert_Deployment_ContainerResolver) Image(ctx context.Context) (
 func (resolver *alert_Deployment_ContainerResolver) Name(ctx context.Context) string {
 	value := resolver.data.GetName()
 	return value
+}
+
+func (resolver *alert_Deployment_ContainerResolver) Type(ctx context.Context) string {
+	value := resolver.data.GetType()
+	return value.String()
 }
 
 type alert_EnforcementResolver struct {

--- a/generated/api/v1/alert_service.swagger.json
+++ b/generated/api/v1/alert_service.swagger.json
@@ -745,6 +745,9 @@
         },
         "name": {
           "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/storageContainerType"
         }
       }
     },
@@ -1181,6 +1184,14 @@
         }
       },
       "title": "Next tag: 13"
+    },
+    "storageContainerType": {
+      "type": "string",
+      "enum": [
+        "REGULAR",
+        "INIT"
+      ],
+      "default": "REGULAR"
     },
     "storageEnforcementAction": {
       "type": "string",

--- a/generated/api/v1/detection_service.swagger.json
+++ b/generated/api/v1/detection_service.swagger.json
@@ -125,6 +125,9 @@
         },
         "name": {
           "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/storageContainerType"
         }
       }
     },

--- a/generated/storage/alert.pb.go
+++ b/generated/storage/alert.pb.go
@@ -1460,6 +1460,7 @@ type Alert_Deployment_Container struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Image         *ContainerImage        `protobuf:"bytes,3,opt,name=image,proto3" json:"image,omitempty" search:"-" sql:"ignore-fks,ignore-index"` // @gotags: search:"-" sql:"ignore-fks,ignore-index"
 	Name          string                 `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty"`
+	Type          ContainerType          `protobuf:"varint,11,opt,name=type,proto3,enum=storage.ContainerType" json:"type,omitempty" search:"Container Type"` // @gotags: search:"Container Type"
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1506,6 +1507,13 @@ func (x *Alert_Deployment_Container) GetName() string {
 		return x.Name
 	}
 	return ""
+}
+
+func (x *Alert_Deployment_Container) GetType() ContainerType {
+	if x != nil {
+		return x.Type
+	}
+	return ContainerType_REGULAR
 }
 
 type Alert_Violation_KeyValueAttrs struct {
@@ -1953,7 +1961,7 @@ var File_storage_alert_proto protoreflect.FileDescriptor
 
 const file_storage_alert_proto_rawDesc = "" +
 	"\n" +
-	"\x13storage/alert.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x18storage/deployment.proto\x1a\x19storage/file_access.proto\x1a\x1astorage/network_flow.proto\x1a\x14storage/policy.proto\x1a\x1fstorage/process_indicator.proto\"\x96\x1c\n" +
+	"\x13storage/alert.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x18storage/deployment.proto\x1a\x19storage/file_access.proto\x1a\x1astorage/network_flow.proto\x1a\x14storage/policy.proto\x1a\x1fstorage/process_indicator.proto\"\xc2\x1c\n" +
 	"\x05Alert\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12'\n" +
 	"\x06policy\x18\x02 \x01(\v2\x0f.storage.PolicyR\x06policy\x12@\n" +
@@ -1983,7 +1991,7 @@ const file_storage_alert_proto_rawDesc = "" +
 	"\x12platform_component\x18\x16 \x01(\bR\x11platformComponent\x12:\n" +
 	"\ventity_type\x18\x17 \x01(\x0e2\x19.storage.Alert.EntityTypeR\n" +
 	"entityType\x12+\n" +
-	"\x11enforcement_count\x18\x19 \x01(\x05R\x10enforcementCount\x1a\x80\x05\n" +
+	"\x11enforcement_count\x18\x19 \x01(\x05R\x10enforcementCount\x1a\xac\x05\n" +
 	"\n" +
 	"Deployment\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
@@ -2003,11 +2011,12 @@ const file_storage_alert_proto_rawDesc = "" +
 	"\binactive\x18\x0f \x01(\bR\binactive\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aN\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1az\n" +
 	"\tContainer\x12-\n" +
 	"\x05image\x18\x03 \x01(\v2\x17.storage.ContainerImageR\x05image\x12\x12\n" +
 	"\x04name\x18\n" +
-	" \x01(\tR\x04name\x1a>\n" +
+	" \x01(\tR\x04name\x12*\n" +
+	"\x04type\x18\v \x01(\x0e2\x16.storage.ContainerTypeR\x04type\x1a>\n" +
 	"\x10AnnotationsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a\xa3\x03\n" +
@@ -2198,8 +2207,9 @@ var file_storage_alert_proto_goTypes = []any{
 	(Severity)(0),                                      // 31: storage.Severity
 	(*FileAccess)(nil),                                 // 32: storage.FileAccess
 	(*ProcessIndicator)(nil),                           // 33: storage.ProcessIndicator
-	(L4Protocol)(0),                                    // 34: storage.L4Protocol
-	(NetworkEntityInfo_Type)(0),                        // 35: storage.NetworkEntityInfo.Type
+	(ContainerType)(0),                                 // 34: storage.ContainerType
+	(L4Protocol)(0),                                    // 35: storage.L4Protocol
+	(NetworkEntityInfo_Type)(0),                        // 36: storage.NetworkEntityInfo.Type
 }
 var file_storage_alert_proto_depIdxs = []int32{
 	26, // 0: storage.Alert.policy:type_name -> storage.Policy
@@ -2239,17 +2249,18 @@ var file_storage_alert_proto_depIdxs = []int32{
 	33, // 34: storage.Alert.ProcessViolation.processes:type_name -> storage.ProcessIndicator
 	30, // 35: storage.Alert.Enforcement.action:type_name -> storage.EnforcementAction
 	28, // 36: storage.Alert.Deployment.Container.image:type_name -> storage.ContainerImage
-	20, // 37: storage.Alert.Violation.KeyValueAttrs.attrs:type_name -> storage.Alert.Violation.KeyValueAttrs.KeyValueAttr
-	34, // 38: storage.Alert.Violation.NetworkFlowInfo.protocol:type_name -> storage.L4Protocol
-	21, // 39: storage.Alert.Violation.NetworkFlowInfo.source:type_name -> storage.Alert.Violation.NetworkFlowInfo.Entity
-	21, // 40: storage.Alert.Violation.NetworkFlowInfo.destination:type_name -> storage.Alert.Violation.NetworkFlowInfo.Entity
-	35, // 41: storage.Alert.Violation.NetworkFlowInfo.Entity.entity_type:type_name -> storage.NetworkEntityInfo.Type
-	4,  // 42: storage.ListAlert.CommonEntityInfo.resource_type:type_name -> storage.ListAlert.ResourceType
-	43, // [43:43] is the sub-list for method output_type
-	43, // [43:43] is the sub-list for method input_type
-	43, // [43:43] is the sub-list for extension type_name
-	43, // [43:43] is the sub-list for extension extendee
-	0,  // [0:43] is the sub-list for field type_name
+	34, // 37: storage.Alert.Deployment.Container.type:type_name -> storage.ContainerType
+	20, // 38: storage.Alert.Violation.KeyValueAttrs.attrs:type_name -> storage.Alert.Violation.KeyValueAttrs.KeyValueAttr
+	35, // 39: storage.Alert.Violation.NetworkFlowInfo.protocol:type_name -> storage.L4Protocol
+	21, // 40: storage.Alert.Violation.NetworkFlowInfo.source:type_name -> storage.Alert.Violation.NetworkFlowInfo.Entity
+	21, // 41: storage.Alert.Violation.NetworkFlowInfo.destination:type_name -> storage.Alert.Violation.NetworkFlowInfo.Entity
+	36, // 42: storage.Alert.Violation.NetworkFlowInfo.Entity.entity_type:type_name -> storage.NetworkEntityInfo.Type
+	4,  // 43: storage.ListAlert.CommonEntityInfo.resource_type:type_name -> storage.ListAlert.ResourceType
+	44, // [44:44] is the sub-list for method output_type
+	44, // [44:44] is the sub-list for method input_type
+	44, // [44:44] is the sub-list for extension type_name
+	44, // [44:44] is the sub-list for extension extendee
+	0,  // [0:44] is the sub-list for field type_name
 }
 
 func init() { file_storage_alert_proto_init() }

--- a/generated/storage/alert_vtproto.pb.go
+++ b/generated/storage/alert_vtproto.pb.go
@@ -29,6 +29,7 @@ func (m *Alert_Deployment_Container) CloneVT() *Alert_Deployment_Container {
 	r := new(Alert_Deployment_Container)
 	r.Image = m.Image.CloneVT()
 	r.Name = m.Name
+	r.Type = m.Type
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -565,6 +566,9 @@ func (this *Alert_Deployment_Container) EqualVT(that *Alert_Deployment_Container
 		return false
 	}
 	if this.Name != that.Name {
+		return false
+	}
+	if this.Type != that.Type {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1514,6 +1518,11 @@ func (m *Alert_Deployment_Container) MarshalToSizedBufferVT(dAtA []byte) (int, e
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Type != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Type))
+		i--
+		dAtA[i] = 0x58
 	}
 	if len(m.Name) > 0 {
 		i -= len(m.Name)
@@ -3090,6 +3099,9 @@ func (m *Alert_Deployment_Container) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.Type != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Type))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -3863,6 +3875,25 @@ func (m *Alert_Deployment_Container) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Name = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			m.Type = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Type |= ContainerType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -8072,6 +8103,25 @@ func (m *Alert_Deployment_Container) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.Name = stringValue
 			iNdEx = postIndex
+		case 11:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			m.Type = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Type |= ContainerType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/pkg/postgres/schema/alerts.go
+++ b/pkg/postgres/schema/alerts.go
@@ -20,7 +20,12 @@ var (
 	// CreateTableAlertsStmt holds the create statement for table `alerts`.
 	CreateTableAlertsStmt = &postgres.CreateStmts{
 		GormModel: (*Alerts)(nil),
-		Children:  []*postgres.CreateStmts{},
+		Children: []*postgres.CreateStmts{
+			&postgres.CreateStmts{
+				GormModel: (*AlertsContainers)(nil),
+				Children:  []*postgres.CreateStmts{},
+			},
+		},
 	}
 
 	// AlertsSchema is the go schema for table `alerts`.
@@ -41,6 +46,8 @@ var (
 const (
 	// AlertsTableName specifies the name of the table in postgres.
 	AlertsTableName = "alerts"
+	// AlertsContainersTableName specifies the name of the table in postgres.
+	AlertsContainersTableName = "alerts_containers"
 )
 
 // Alerts holds the Gorm model for Postgres table `alerts`.
@@ -83,4 +90,12 @@ type Alerts struct {
 	EntityType               storage.Alert_EntityType            `gorm:"column:entitytype;type:integer"`
 	EnforcementCount         int32                               `gorm:"column:enforcementcount;type:integer"`
 	Serialized               []byte                              `gorm:"column:serialized;type:bytea"`
+}
+
+// AlertsContainers holds the Gorm model for Postgres table `alerts_containers`.
+type AlertsContainers struct {
+	AlertsID  string                `gorm:"column:alerts_id;type:uuid;primaryKey"`
+	Idx       int                   `gorm:"column:idx;type:integer;primaryKey;index:alertscontainers_idx,type:btree"`
+	Type      storage.ContainerType `gorm:"column:type;type:integer"`
+	AlertsRef Alerts                `gorm:"foreignKey:alerts_id;references:id;belongsTo;constraint:OnDelete:CASCADE"`
 }

--- a/proto/storage/alert.proto
+++ b/proto/storage/alert.proto
@@ -26,6 +26,7 @@ message Alert {
     message Container {
       ContainerImage image = 3; // @gotags: search:"-" sql:"ignore-fks,ignore-index"
       string name = 10;
+      ContainerType type = 11; // @gotags: search:"Container Type"
     }
     repeated Container containers = 11;
     map<string, string> annotations = 14; // @gotags: sensorhash:"ignore"

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -549,6 +549,11 @@
                         "id": 10,
                         "name": "name",
                         "type": "string"
+                      },
+                      {
+                        "id": 11,
+                        "name": "type",
+                        "type": "ContainerType"
                       }
                     ]
                   }


### PR DESCRIPTION
## Description

Add `ContainerType type` field to `Alert.Deployment.Container` in the alert proto. This is the first PR in a stack to fix the violations "Container Type" filter, which currently returns false positives because the field doesn't exist on the alert proto — the search layer silently drops the filter and returns all alerts.

This PR contains only the proto change and all regenerated code. The migration (to create the `alerts_containers` child table) and conversion logic (to populate the field) follow in stacked PRs.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Verified `make proto-generated-srcs` and `make go-generated-srcs` succeed
- Confirmed the schema generator created the expected `alerts_containers` child table with `Type` column in `pkg/postgres/schema/alerts.go`

_**See manual test results from #20560**_
