### PR TITLE
ROX-34688: Populate container type when converting deployment to alert

### DIFF
--- a/pkg/alert/convert/convert.go
+++ b/pkg/alert/convert/convert.go
@@ -134,6 +134,7 @@ func toAlertDeploymentContainer(c *storage.Container) *storage.Alert_Deployment_
 	return &storage.Alert_Deployment_Container{
 		Name:  c.GetName(),
 		Image: c.GetImage(),
+		Type:  c.GetType(),
 	}
 }
 


### PR DESCRIPTION
## Description

Populate `Container Type` when converting deployment containers to alert containers in `toAlertDeploymentContainer()`. This is the final PR in a 3-PR stack fixing the violations "Container Type" filter (ROX-34688):

1. PR #20558 — Proto + codegen: add `type` field to `Alert.Deployment.Container`
2. PR #20559 — Migration: create `alerts_containers` child table
3. **This PR** — Conversion: populate the field so alerts carry the container type from the deployment

Without this, the new proto field would always be zero-valued even though the deployment has the correct container type.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Deployed a build from the full PR stack (`4.11.x-967-g9c29ebc664`) with `ROX_INIT_CONTAINER_SUPPORT` enabled. Created two deployments in a test namespace: one with an init container (`busybox:latest`) and one without, both using `nginx:latest` as the main container.

- **Total violations in namespace:** 10
- **Container Type: INIT filter:** returned 5 alerts, all from `with-init-containers` deployment only
- **Container Type: REGULAR filter:** returned 10 alerts (both deployments have regular containers)
- **UI validation:** Violations page filtered by Container Type → Init showed only `with-init-containers` entries, no false positives from the other deployment
