### PR TITLE
ROX-34673: Improve interaction for CVE status in Filters step

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersViewForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityFiltersViewForCollection.tsx
@@ -60,7 +60,7 @@ function ImageVulnerabilityFiltersViewForCollection({
                     <DescriptionListGroup>
                         <DescriptionListTerm>CVE status</DescriptionListTerm>
                         <DescriptionListDescription>
-                            {fixabilityLabels[fixability] ?? '-'}
+                            {fixabilityLabels[fixability] ?? 'Unfiltered by fixability'}
                         </DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
@@ -12,7 +12,14 @@ import { searchFilterConfigForClusterNamespaceDeployment } from 'Components/Enti
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import type { CollectionScope, EntityScope, ImageType } from 'services/ReportsService.types';
 
-import type { ImageVulnerabilityResourcesConfiguration } from '../../imageVulnerabilityReports.types';
+import type {
+    ImageVulnerabilityFiltersConfiguration,
+    ImageVulnerabilityResourcesConfiguration,
+} from '../../imageVulnerabilityReports.types';
+import {
+    replaceFiltersForCollectionFromQueryInConfiguration,
+    replaceFiltersForEntityFromFixabilityAndSeverityInConfiguration,
+} from '../../imageVulnerabilityReports.utils';
 
 import CollectionScopeSelect from './CollectionScopeSelect';
 import ImageTypeSelect from './ImageTypeSelect';
@@ -37,6 +44,17 @@ function ImageVulnerabilityResourcesStep<
             : { rules: [] }
     );
 
+    // Remember vulnReportFilters property for entityScope if user selects collectionScope,
+    // If user selects entityScope again, then restore it instead of having forgotten it.
+    // Forgive double type assertion until we delete deprecated collections.
+    const [vulnReportFiltersForEntityScope, setVulnReportFiltersForEntityScope] = useState<
+        ImageVulnerabilityResourcesConfiguration['vulnReportFilters']
+    >(
+        replaceFiltersForEntityFromFixabilityAndSeverityInConfiguration(
+            formik.values as unknown as ImageVulnerabilityFiltersConfiguration
+        ) as unknown as ImageVulnerabilityResourcesConfiguration['vulnReportFilters']
+    );
+
     function setImageTypes(imageTypes: ImageType[]) {
         formik.setFieldValue('vulnReportFilters.imageTypes', imageTypes);
     }
@@ -44,6 +62,16 @@ function ImageVulnerabilityResourcesStep<
     function onChangeToCollectionScope() {
         // Set resourceScope to remove entityScope property.
         formik.setFieldValue('resourceScope', { collectionScope: collectionScopeSelected });
+
+        setVulnReportFiltersForEntityScope(formik.values.vulnReportFilters);
+
+        // Forgive type assertion until we delete deprecated collections.
+        formik.setFieldValue(
+            'vulnReportFilters',
+            replaceFiltersForCollectionFromQueryInConfiguration(
+                formik.values as unknown as ImageVulnerabilityFiltersConfiguration
+            )
+        );
     }
 
     function setCollectionScope(collectionScope: CollectionScope) {
@@ -54,6 +82,7 @@ function ImageVulnerabilityResourcesStep<
     function onChangeToEntityScope() {
         // Set resourceScope to remove collectionScope property.
         formik.setFieldValue('resourceScope', { entityScope: entityScopeSelected });
+        formik.setFieldValue('vulnReportFilters', vulnReportFiltersForEntityScope);
     }
 
     function setEntityScope(entityScope: EntityScope) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersStepForCollection.tsx
@@ -2,17 +2,16 @@ import type { ReactElement } from 'react';
 import { Flex, Form, PageSection, Title } from '@patternfly/react-core';
 import type { FormikProps } from 'formik';
 
+import SearchFilterSelectExclusiveSingle from 'Components/CompoundSearchFilter/components/SearchFilterSelectExclusiveSingle';
 import SearchFilterSelectInclusive from 'Components/CompoundSearchFilter/components/SearchFilterSelectInclusive';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
 import type { OnSearchPayload } from 'Components/CompoundSearchFilter/types';
 import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
 
-import {
-    attributeForFixableInBackendAndViewBasedReport,
-    attributeForSeverityInBackendAndViewBasedReport,
-} from '../../../searchFilterConfig';
+import { attributeForSeverityInBackendAndViewBasedReport } from '../../../searchFilterConfig';
 import type { ImageVulnerabilityFiltersConfigurationForCollection } from '../../imageVulnerabilityReports.types';
 import {
+    attributeForFixabilityInFiltersStepForCollection,
     getFixabilityFromSearchFilter,
     getSearchFilterFromReportConfiguration,
     getSeveritiesFromSearchFilter,
@@ -74,8 +73,8 @@ function ImageVulnerabilityFiltersStepForCollection<
                         touched={formik.touched}
                         errors={formik.errors}
                     >
-                        <SearchFilterSelectInclusive
-                            attribute={attributeForFixableInBackendAndViewBasedReport}
+                        <SearchFilterSelectExclusiveSingle
+                            attribute={attributeForFixabilityInFiltersStepForCollection}
                             isSeparate
                             onSearch={onSearchFixibility}
                             searchFilter={searchFilter}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
@@ -1,3 +1,4 @@
+import type { SelectExclusiveSingleSearchFilterAttribute } from 'Components/CompoundSearchFilter/types';
 import type {
     CvesSince,
     Fixability,
@@ -6,7 +7,12 @@ import type {
 } from 'services/ReportsService.types';
 import type { VulnerabilitySeverity } from 'types/cve.proto';
 import type { SearchFilter } from 'types/search';
-import { getUrlQueryStringForSearchFilter, searchValueAsArray } from 'utils/searchUtils';
+import {
+    getRequestQueryStringForSearchFilter,
+    getSearchFilterFromSearchString,
+    getUrlQueryStringForSearchFilter,
+    searchValueAsArray,
+} from 'utils/searchUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 
@@ -105,41 +111,101 @@ export function getReportFiltersWithoutCvesSince(
     return { ...restWithoutCvesSince }; // that is, either { query } or { fixability, severities }
 }
 
+function getFixabilityFromFixableArray(fixableArray: string[]): Fixability {
+    const hasFixable = fixableArray.includes('true');
+    const hasNotFixable = fixableArray.includes('false');
+
+    if (hasFixable && !hasNotFixable) {
+        return 'FIXABLE';
+    }
+
+    if (!hasFixable && hasNotFixable) {
+        return 'NOT_FIXABLE';
+    }
+
+    return 'BOTH';
+}
+
+function getFixableArrayFromFixability(fixability: Fixability): string[] {
+    switch (fixability) {
+        case 'BOTH':
+            return []; // return neither instead of both, because it means unfiltered
+        case 'FIXABLE':
+            return ['true'];
+        case 'NOT_FIXABLE':
+            return ['false'];
+        default:
+            return ensureExhaustive(fixability);
+    }
+}
+
+// If previous resource scope was entityScope, return the equivalent filters for collectionScope.
+// TypeScript needs if statement and default return statement, but code does not call in that scenario.
+export function replaceFiltersForCollectionFromQueryInConfiguration({
+    vulnReportFilters,
+}: ImageVulnerabilityFiltersConfiguration): ImageVulnerabilityFiltersWithoutCvesSince & CvesSince {
+    if ('query' in vulnReportFilters) {
+        const { query, ...restOfFilters } = vulnReportFilters;
+        const searchFilter = getSearchFilterFromSearchString(query);
+
+        return {
+            ...restOfFilters,
+            fixability: getFixabilityFromFixableArray(searchValueAsArray(searchFilter.Fixable)),
+            severities: searchValueAsArray(searchFilter.Severity) as VulnerabilitySeverity[],
+        };
+    }
+
+    return vulnReportFilters;
+}
+
+// If initial resource scope is collectionScope, return the equivalent filters for entityScope,
+// otherwise return the original vulnReportFilters object for entityScope.
+export function replaceFiltersForEntityFromFixabilityAndSeverityInConfiguration({
+    vulnReportFilters,
+}: ImageVulnerabilityFiltersConfiguration): ImageVulnerabilityFiltersWithoutCvesSince & CvesSince {
+    if ('fixability' in vulnReportFilters && 'severities' in vulnReportFilters) {
+        const { fixability, severities, ...restOfFilters } = vulnReportFilters;
+
+        return {
+            ...restOfFilters,
+            query: getRequestQueryStringForSearchFilter({
+                Fixable: getFixableArrayFromFixability(fixability),
+                Severity: severities,
+            }),
+        };
+    }
+
+    return vulnReportFilters;
+}
+
+// Fixability type for report configuration differs from Fixable attribute in search filters.
+export const attributeForFixabilityInFiltersStepForCollection: SelectExclusiveSingleSearchFilterAttribute =
+    {
+        displayName: 'CVE status',
+        filterChipLabel: 'CVE status',
+        searchTerm: 'Fixable',
+        inputType: 'select-exclusive-single', // placeholder because interaction is Show snoozed CVEs button
+        inputProps: {
+            options: [
+                { label: 'Fixable', value: 'FIXABLE' }, // instead of ['true']
+                { label: 'Not fixable', value: 'NOT_FIXABLE' }, // instead of ['false']
+                { label: 'Unfiltered by fixability', value: 'BOTH' }, // instead of [] or ['true', 'false'] or ['false', 'true']
+            ],
+        },
+    };
+
+// Pseudo search filter (for select elements) corresponds to property names and preceding pseudo attribute.
 export function getSearchFilterFromReportConfiguration(
     vulnReportFilters: ImageVulnerabilityFiltersForCollectionWithoutCvesSince
 ): SearchFilter {
-    const fixable: string[] = [];
-
-    switch (vulnReportFilters.fixability) {
-        case 'BOTH':
-            fixable.push('true', 'false');
-            break;
-        case 'FIXABLE':
-            fixable.push('true');
-            break;
-        case 'NOT_FIXABLE':
-            fixable.push('false');
-            break;
-        default:
-            ensureExhaustive(vulnReportFilters.fixability);
-    }
-
     return {
-        Fixable: fixable,
-        Severity: vulnReportFilters.severities ?? [],
+        Fixable: vulnReportFilters.fixability,
+        Severity: vulnReportFilters.severities,
     };
 }
 
 export function getFixabilityFromSearchFilter(searchFilter: SearchFilter): Fixability {
-    const fixable = searchValueAsArray(searchFilter.Fixable);
-
-    if (fixable.includes('true') && !fixable.includes('false')) {
-        return 'FIXABLE';
-    }
-    if (fixable.includes('false') && !fixable.includes('true')) {
-        return 'NOT_FIXABLE';
-    }
-    return 'BOTH';
+    return searchValueAsArray(searchFilter.Fixable)[0] as Fixability;
 }
 
 export function getSeveritiesFromSearchFilter(searchFilter: SearchFilter) {


### PR DESCRIPTION
## Description

Follow up bug bash. Big or small, fix them (not quite) all.

**Review**: Hide space, in case it helps.

### Problems

1. Reported by **Brad**: For collection scope, **Filters** step has **CVE status** dropdown, which has 

2. Reported by **Mark**: After I select **Collection scope** in **Resources** stemp, **CVE severity** nor **CVE status** have default values on **Filters** step.

### Analysis

1. Although `SearchFilterSelectInclusive` elemen and attribute borrowed from `AdvancedFiltersToolbar` has 4 states with 2 states for unfiltered (both selected or both cleared) report configuration has only 3 states:

    ```ts
    export type Fixability = 'BOTH' | 'FIXABLE' | 'NOT_FIXABLE';
    ```

    Therefore, round trip conversion with `fixibility` as source of truth renders `'BOTH'` as both selected.

2. Because collection versus entity scope has alternative data structure for filters:

    * Initial values for entity scope in new report corfiguration do not need secound source of truth for collection scope, because function can convert/replace them.

    * In same way that **Resources** step remembers previous **scope**, in case user changes, and then changes back, it needs to remember previous filters.

### Solutions

1. Edit **Filters** step and utils files.

    * Replace `SearchFilterSelectInclusive` element and `attributeForFixableInBackendAndViewBasedReport` attribute
    * with `SearchFilterSelectExclusiveSingle` element and `attributeForFixabilityInFiltersStepForCollection` attribute

2. Edit **Resources** step and utils files.

    Instead of `initialImageVulnerabilityReportFiltersForCollection` as second source of truth that I had defined, but not yet used, write functions to convert the corresponding filters properties for the resources scopes:

    * `replaceFiltersForCollectionFromQueryInConfiguration`
    * `replaceFiltersForEntityFromFixabilityAndSeverityInConfiguration`

    Alternatives to type assertions are welcome. The business logic itself used most of my brain capacity.

### Residue

1. Edit utils file after **David** merges fix for non-standard case in #20432

    * Update initial values for entity scope to derive from single source of truth, and also to specify `'Vulnerability State': 'OBSERVED'` like landing pages for **Results**
    * Delete unneeded initial values for collection scope

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration?action=create go to **Resources** step, select **Collection scope**, select a collection, and then go to **Filters** step

    Before changes, see absence of default values
    <img width="1440" height="892" alt="Filters_absence" src="https://github.com/user-attachments/assets/f748b608-7e2c-4ce7-896d-5afcfe7ddb32" />

    After changes, see presence of default values
    <img width="1440" height="892" alt="Filters_presence" src="https://github.com/user-attachments/assets/d7947f08-8d53-4878-9274-63ef2c8401f2" />

2. Select unfiltered by **CVE status**

    Before changes, see both **Fixable** and **Not fixable** selected after you select **Fixable** and then clear **Fixable**
    <img width="1440" height="892" alt="Filters_BOTH_inclusive" src="https://github.com/user-attachments/assets/78d30c9c-be64-4795-bc54-45b32f894778" />

    After changes, select **Unfiltered by fixability**
    <img width="1440" height="892" alt="Filters_BOTH_exclusive" src="https://github.com/user-attachments/assets/f6aa2db2-19d9-4c21-951b-5c83b7b2b9b8" />

3. Go back to **Resources** step, select **Custom scope**, and then go to **Filters** step

    After changes, see corresponding values. **CVE status** has neither checkbox selected for unfiltered.
    <img width="1440" height="892" alt="Filters_entityScope" src="https://github.com/user-attachments/assets/fa85ac26-4da1-4f30-8d0f-69161dc3de9f" />

4. Select additional filters, go back to **Resources**, select **Collection scope**, select **Custom scope** again, and the go to **Filters** step

    After changes, see filters were remembered. By the way, the entity scope was also remembered.
    <img width="1440" height="892" alt="Filters_entityScope_additional" src="https://github.com/user-attachments/assets/30fb180e-1bd1-46cf-a7d1-4aa8c8ea845e" />
