### PR TITLE
feat: group CVEs by (CVE name, severity) to surface conflicting assessments

### DIFF
--- a/central/graphql/resolvers/image_cve_core.go
+++ b/central/graphql/resolvers/image_cve_core.go
@@ -40,6 +40,7 @@ func init() {
 				"firstDiscoveredInSystem: Time",
 				"exceptionCount(requestStatus: [String]): Int!",
 				"images(pagination: Pagination): [Image!]!",
+				"severity: String!",
 				"topCVSS: Float!",
 				"publishedOn: Time",
 				"topNvdCVSS: Float!",
@@ -137,6 +138,10 @@ func (resolver *imageCVECoreResolver) AffectedImageCountBySeverity(ctx context.C
 
 func (resolver *imageCVECoreResolver) CVE(_ context.Context) string {
 	return resolver.data.GetCVE()
+}
+
+func (resolver *imageCVECoreResolver) Severity(_ context.Context) string {
+	return resolver.data.GetSeverity().String()
 }
 
 func (resolver *imageCVECoreResolver) Deployments(ctx context.Context, args struct{ Pagination *inputtypes.Pagination }) ([]*deploymentResolver, error) {

--- a/central/views/imagecve/db_response.go
+++ b/central/views/imagecve/db_response.go
@@ -4,28 +4,30 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/central/views/common"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 )
 
 type imageCVECoreResponse struct {
-	CVE                                string     `db:"cve"`
-	CVEIDs                             []string   `db:"cve_id"`
-	ImagesWithCriticalSeverity         int        `db:"critical_severity_count"`
-	FixableImagesWithCriticalSeverity  int        `db:"fixable_critical_severity_count"`
-	ImagesWithImportantSeverity        int        `db:"important_severity_count"`
-	FixableImagesWithImportantSeverity int        `db:"fixable_important_severity_count"`
-	ImagesWithModerateSeverity         int        `db:"moderate_severity_count"`
-	FixableImagesWithModerateSeverity  int        `db:"fixable_moderate_severity_count"`
-	ImagesWithLowSeverity              int        `db:"low_severity_count"`
-	FixableImagesWithLowSeverity       int        `db:"fixable_low_severity_count"`
-	ImagesWithUnknownSeverity          int        `db:"unknown_severity_count"`
-	FixableImagesWithUnknownSeverity   int        `db:"fixable_unknown_severity_count"`
-	TopCVSS                            *float32   `db:"cvss_max"`
-	AffectedImageCount                 int        `db:"image_sha_count"`
-	FirstDiscoveredInSystem            *time.Time `db:"cve_created_time_min"`
-	Published                          *time.Time `db:"cve_published_on_min"`
-	TopNVDCVSS                         *float32   `db:"nvd_cvss_max"`
-	AffectedImageCountV2               int        `db:"image_id_count"`
+	CVE                                string                         `db:"cve"`
+	CVEIDs                             []string                       `db:"cve_id"`
+	Severity                           *storage.VulnerabilitySeverity `db:"severity"`
+	ImagesWithCriticalSeverity         int                            `db:"critical_severity_count"`
+	FixableImagesWithCriticalSeverity  int                            `db:"fixable_critical_severity_count"`
+	ImagesWithImportantSeverity        int                            `db:"important_severity_count"`
+	FixableImagesWithImportantSeverity int                            `db:"fixable_important_severity_count"`
+	ImagesWithModerateSeverity         int                            `db:"moderate_severity_count"`
+	FixableImagesWithModerateSeverity  int                            `db:"fixable_moderate_severity_count"`
+	ImagesWithLowSeverity              int                            `db:"low_severity_count"`
+	FixableImagesWithLowSeverity       int                            `db:"fixable_low_severity_count"`
+	ImagesWithUnknownSeverity          int                            `db:"unknown_severity_count"`
+	FixableImagesWithUnknownSeverity   int                            `db:"fixable_unknown_severity_count"`
+	TopCVSS                            *float32                       `db:"cvss_max"`
+	AffectedImageCount                 int                            `db:"image_sha_count"`
+	FirstDiscoveredInSystem            *time.Time                     `db:"cve_created_time_min"`
+	Published                          *time.Time                     `db:"cve_published_on_min"`
+	TopNVDCVSS                         *float32                       `db:"nvd_cvss_max"`
+	AffectedImageCountV2               int                            `db:"image_id_count"`
 }
 
 func (c *imageCVECoreResponse) GetCVE() string {
@@ -78,6 +80,13 @@ func (c *imageCVECoreResponse) GetFirstDiscoveredInSystem() *time.Time {
 
 func (c *imageCVECoreResponse) GetPublishDate() *time.Time {
 	return c.Published
+}
+
+func (c *imageCVECoreResponse) GetSeverity() storage.VulnerabilitySeverity {
+	if c.Severity == nil {
+		return storage.VulnerabilitySeverity_UNKNOWN_VULNERABILITY_SEVERITY
+	}
+	return *c.Severity
 }
 
 type imageCVECoreCount struct {

--- a/central/views/imagecve/mocks/types.go
+++ b/central/views/imagecve/mocks/types.go
@@ -18,6 +18,7 @@ import (
 	common "github.com/stackrox/rox/central/views/common"
 	imagecve "github.com/stackrox/rox/central/views/imagecve"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	storage "github.com/stackrox/rox/generated/storage"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -113,6 +114,20 @@ func (m *MockCveCore) GetImagesBySeverity() common.ResourceCountByCVESeverity {
 func (mr *MockCveCoreMockRecorder) GetImagesBySeverity() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImagesBySeverity", reflect.TypeOf((*MockCveCore)(nil).GetImagesBySeverity))
+}
+
+// GetSeverity mocks base method.
+func (m *MockCveCore) GetSeverity() storage.VulnerabilitySeverity {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSeverity")
+	ret0, _ := ret[0].(storage.VulnerabilitySeverity)
+	return ret0
+}
+
+// GetSeverity indicates an expected call of GetSeverity.
+func (mr *MockCveCoreMockRecorder) GetSeverity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeverity", reflect.TypeOf((*MockCveCore)(nil).GetSeverity))
 }
 
 // GetPublishDate mocks base method.

--- a/central/views/imagecve/types.go
+++ b/central/views/imagecve/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackrox/rox/central/views"
 	"github.com/stackrox/rox/central/views/common"
 	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
 )
 
 // CveCore is an interface to get image CVE properties.
@@ -15,6 +16,7 @@ import (
 type CveCore interface {
 	GetCVE() string
 	GetCVEIDs() []string
+	GetSeverity() storage.VulnerabilitySeverity
 	GetImagesBySeverity() common.ResourceCountByCVESeverity
 	GetTopCVSS() float32
 	GetTopNVDCVSS() float32

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -187,7 +187,7 @@ func withSelectCVEIdentifiersQuery(q *v1.Query) *v1.Query {
 		search.NewQuerySelect(search.CVEID).Distinct().Proto(),
 	}
 	cloned.GroupBy = &v1.QueryGroupBy{
-		Fields: []string{search.CVE.String()},
+		Fields: []string{search.CVE.String(), search.Severity.String()},
 	}
 
 	// For pagination and sort to work properly, the filter query to get the CVEs needs to
@@ -219,6 +219,7 @@ func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 	cloned.Selects = []*v1.QuerySelect{
 		search.NewQuerySelect(search.CVE).Proto(),
 		search.NewQuerySelect(search.CVEID).Distinct().Proto(),
+		search.NewQuerySelect(search.Severity).Proto(),
 	}
 	if !options.SkipGetImagesBySeverity {
 		cloned.Selects = append(cloned.Selects,
@@ -241,7 +242,7 @@ func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 		cloned.Selects = append(cloned.Selects, search.NewQuerySelect(search.NVDCVSS).AggrFunc(aggregatefunc.Max).Proto())
 	}
 	cloned.GroupBy = &v1.QueryGroupBy{
-		Fields: []string{search.CVE.String()},
+		Fields: []string{search.CVE.String(), search.Severity.String()},
 	}
 
 	return cloned


### PR DESCRIPTION
Scanner can produce multiple entries for the same CVE with different
severities from different advisory sources. The view layer previously
grouped by CVE name alone, collapsing these into one row with inflated
severity bucket counts.

Add severity to the GROUP BY in both the identifier and response
queries, and expose severity as a field on ImageCVECore. CVEs with
conflicting severity assessments now appear as separate rows in the
UI without any frontend changes.

Partially generated by AI

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
