### PR TITLE
ROX-34737: fix double -rcd suffix in race test image tags

### DIFF
--- a/scripts/ci/bats/image_list.bats
+++ b/scripts/ci/bats/image_list.bats
@@ -30,10 +30,12 @@ function setup() {
   tag="$(make --quiet --no-print-directory tag)"
   local image_list
   image_list="$(mktemp)"
-  CI_JOB_NAME="master-race-condition-qa-e2e-tests" populate_stackrox_image_list "$image_list"
+  # Simulate the real job: gke_race_condition_qa_e2e_tests.py sets MAIN_IMAGE_TAG with -rcd
+  MAIN_IMAGE_TAG="${tag}-rcd" CI_JOB_NAME="master-race-condition-qa-e2e-tests" populate_stackrox_image_list "$image_list"
   run cat "${image_list}"
   assert_success
   assert_output --partial "main ${tag}-rcd"
+  refute_output --partial "-rcd-rcd"
   assert_output --partial "roxctl ${tag}"
   assert_output --partial "central-db ${tag}"
 }

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -990,10 +990,12 @@ scanner-v4-db ${tag}
 END
             ;;
         *-race-condition-qa-e2e-tests)
+            local base_tag="${tag%-rcd}"
+            local rcd_tag="${base_tag}-rcd"
             cat >> "${image_list}" << END
-central-db ${tag}
-main ${tag}-rcd
-roxctl ${tag}
+central-db ${base_tag}
+main ${rcd_tag}
+roxctl ${base_tag}
 END
             if is_in_PR_context && ! pr_has_label "ci-build-race-condition-debug"; then
                 echo "ERROR: Your PR is missing the \"ci-build-race-condition-debug\" label."


### PR DESCRIPTION
## Description

Fix double `-rcd` suffix in race condition test image tags. The Python job script (`gke_race_condition_qa_e2e_tests.py`) sets `MAIN_IMAGE_TAG` with `-rcd` appended, then `populate_stackrox_image_list` in `lib.sh` appends another `-rcd`, resulting in tags like `4.11.x-929-g...-rcd-rcd` which don't exist. Introduced in #20177

Use `STACKROX_BUILD_TAG` (the base tag without `-rcd`) for building the image list so `-rcd` is only appended once for `main`.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Running GKE race condition e2e tests to verify the image lookup works