### PR TITLE
ROX-34699: make file activity paths more specific in e2e tests

### DIFF
--- a/qa-tests-backend/src/test/groovy/FileActivityTest.groovy
+++ b/qa-tests-backend/src/test/groovy/FileActivityTest.groovy
@@ -18,7 +18,8 @@ class FileActivityTest extends BaseSpecification {
 
     static final private String DEPLOY_PATH = "/tmp/fa-deploy-${RUN_ID}"
     static final private String NODE_PATH = "/tmp/fa-node-${RUN_ID}"
-    static final private String POLICY_PATH = "/tmp/fa-*"
+    static final private String DEPLOY_POLICY_PATH = "/tmp/fa-deploy-*"
+    static final private String NODE_POLICY_PATH = "/tmp/fa-node-*"
     static final private String DEPLOY_POLICY_NAME = "FA-E2E-deploy-${RUN_ID}"
     static final private String NODE_POLICY_NAME = "FA-E2E-node-${RUN_ID}"
 
@@ -53,12 +54,12 @@ class FileActivityTest extends BaseSpecification {
                         Constants.STACKROX_NAMESPACE, Constants.COLLECTOR_DS, Constants.FACT_CONTAINER))
 
         deployPolicyID = PolicyService.createNewPolicy(createFileActivityPolicy(
-                DEPLOY_POLICY_NAME, POLICY_PATH,
+                DEPLOY_POLICY_NAME, DEPLOY_POLICY_PATH,
                 PolicyOuterClass.EventSource.DEPLOYMENT_EVENT))
         assert deployPolicyID
 
         nodePolicyID = PolicyService.createNewPolicy(createFileActivityPolicy(
-                NODE_POLICY_NAME, POLICY_PATH,
+                NODE_POLICY_NAME, NODE_POLICY_PATH,
                 PolicyOuterClass.EventSource.NODE_EVENT))
         assert nodePolicyID
 


### PR DESCRIPTION
## Description

To avoid cross-contamination of events across the two policies.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change
CI should be enough. 
