### PR TITLE
fix(ci): use local git clone for compat test charts

### DIFF
--- a/.openshift-ci/compatibility_test.py
+++ b/.openshift-ci/compatibility_test.py
@@ -113,8 +113,8 @@ def run_compatibility_tests(testfunc, cluster_name):
                 )
                 os.environ.pop("COMPAT_HELM_REPO_NAME", None)
         else:
-            logging.info("There are currently no supported older versions or support exceptions that require compatibility "
-                         "testing.")
+            logging.info("There are currently no supported older versions or "
+                         "support exceptions that require compatibility testing.")
     finally:
         os.environ.pop("COMPAT_HELM_CHART_URL", None)
         if clone_dir:

--- a/.openshift-ci/compatibility_test.py
+++ b/.openshift-ci/compatibility_test.py
@@ -5,7 +5,10 @@ Runs version compatibility tests against the supplied testfunc
 """
 import logging
 import os
+import shutil
+import subprocess
 import sys
+import tempfile
 
 from pre_tests import (
     PreSystemTests,
@@ -18,48 +21,101 @@ from get_compatibility_test_tuples import (
     get_compatibility_test_tuples,
 )
 
+HELM_REPO_NAME = "tmp-srox-compat"
+HELM_CHARTS_GIT_REPO = "https://github.com/stackrox/helm-charts.git"
+HELM_CHART_URL_FALLBACK = "https://raw.githubusercontent.com/stackrox/helm-charts/main/opensource"
+
+
+def _clone_helm_charts_repo():
+    """Shallow-clone the helm-charts repo and return (clone_dir, file:// URL).
+
+    Uses GITHUB_TOKEN for authenticated access when available.
+    Returns (None, fallback_url) on failure.
+    """
+    clone_dir = tempfile.mkdtemp(prefix="helm-charts-clone-")
+    repo_url = HELM_CHARTS_GIT_REPO
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        repo_url = f"https://x-access-token:{token}@github.com/stackrox/helm-charts.git"
+    try:
+        subprocess.run(
+            ["git", "clone", "--depth", "1", repo_url, clone_dir],
+            check=True, timeout=120,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        chart_url = f"file://{clone_dir}/opensource"
+        logging.info("Cloned helm-charts repo to %s", clone_dir)
+        return clone_dir, chart_url
+    except Exception:
+        logging.warning("Failed to clone helm-charts repo, falling back to remote URL", exc_info=True)
+        shutil.rmtree(clone_dir, ignore_errors=True)
+        return None, HELM_CHART_URL_FALLBACK
+
 
 def run_compatibility_tests(testfunc, cluster_name):
     # start logging
     logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
-    # Get the test tuples (central_version, sensor_version) for supported versions with available helm charts
-    test_tuples = get_compatibility_test_tuples()
+    clone_dir, chart_url = _clone_helm_charts_repo()
+    os.environ["COMPAT_HELM_CHART_URL"] = chart_url
+    try:
+        # Get the test tuples (central_version, sensor_version) for supported versions with available helm charts
+        test_tuples = get_compatibility_test_tuples()
 
-    if len(test_tuples) > 0:
-        sets = []
-        for test_tuple in test_tuples:
-            os.environ["ROX_TELEMETRY_STORAGE_KEY_V1"] = 'DISABLED'
-            test_versions = f'{test_tuple.central_version}--{test_tuple.sensor_version}'
-
-            # expected version string is like 74.x.x for ACS 3.74 versions
-            is_3_74_sensor = test_tuple.sensor_version.startswith('74')
-
-            logging.info("Running compatibility tests for central-v%s, sensor-v%s with function %s",
-                         test_tuple.central_version, test_tuple.sensor_version, testfunc.__name__)
-
-            sets.append(
-                TestSet(
-                    f'version compatibility tests: {test_versions}',
-                    test=testfunc(test_tuple.central_version, test_tuple.sensor_version),
-                    post=PostClusterTest(
-                        collect_collector_metrics=not is_3_74_sensor,
-                        check_stackrox_logs=True,
-                        artifact_destination_prefix=test_versions,
-                    ),
-                    # Collection not supported on 3.74
-                    pre=CollectionMethodOverridePreTest("NO_COLLECTION" if is_3_74_sensor else "core_bpf")
-                )
+        if len(test_tuples) > 0:
+            subprocess.run(
+                ["helm", "repo", "add", HELM_REPO_NAME, chart_url],
+                check=True, timeout=120,
             )
-        ClusterTestSetsRunner(
-            cluster=GKECluster(cluster_name,
-                               machine_type="e2-standard-8", num_nodes=2),
-            initial_pre_test=PreSystemTests(),
-            sets=sets,
-            final_post=FinalPost(
-                store_qa_tests_data=True,
-            ),
-        ).run()
-    else:
-        logging.info("There are currently no supported older versions or support exceptions that require compatibility "
-                     "testing.")
+            subprocess.run(
+                ["helm", "repo", "update", HELM_REPO_NAME],
+                check=True, timeout=120,
+            )
+            os.environ["COMPAT_HELM_REPO_NAME"] = HELM_REPO_NAME
+            try:
+                sets = []
+                for test_tuple in test_tuples:
+                    os.environ["ROX_TELEMETRY_STORAGE_KEY_V1"] = 'DISABLED'
+                    test_versions = f'{test_tuple.central_version}--{test_tuple.sensor_version}'
+
+                    # expected version string is like 74.x.x for ACS 3.74 versions
+                    is_3_74_sensor = test_tuple.sensor_version.startswith('74')
+
+                    logging.info("Running compatibility tests for central-v%s, sensor-v%s with function %s",
+                                 test_tuple.central_version, test_tuple.sensor_version, testfunc.__name__)
+
+                    sets.append(
+                        TestSet(
+                            f'version compatibility tests: {test_versions}',
+                            test=testfunc(test_tuple.central_version, test_tuple.sensor_version),
+                            post=PostClusterTest(
+                                collect_collector_metrics=not is_3_74_sensor,
+                                check_stackrox_logs=True,
+                                artifact_destination_prefix=test_versions,
+                            ),
+                            # Collection not supported on 3.74
+                            pre=CollectionMethodOverridePreTest("NO_COLLECTION" if is_3_74_sensor else "core_bpf")
+                        )
+                    )
+                ClusterTestSetsRunner(
+                    cluster=GKECluster(cluster_name,
+                                       machine_type="e2-standard-8", num_nodes=2),
+                    initial_pre_test=PreSystemTests(),
+                    sets=sets,
+                    final_post=FinalPost(
+                        store_qa_tests_data=True,
+                    ),
+                ).run()
+            finally:
+                subprocess.run(
+                    ["helm", "repo", "remove", HELM_REPO_NAME],
+                    check=False, timeout=30,
+                )
+                os.environ.pop("COMPAT_HELM_REPO_NAME", None)
+        else:
+            logging.info("There are currently no supported older versions or support exceptions that require compatibility "
+                         "testing.")
+    finally:
+        os.environ.pop("COMPAT_HELM_CHART_URL", None)
+        if clone_dir:
+            shutil.rmtree(clone_dir, ignore_errors=True)

--- a/.openshift-ci/get_compatibility_test_tuples.py
+++ b/.openshift-ci/get_compatibility_test_tuples.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from get_latest_helm_chart_versions import (
     get_supported_helm_chart_versions,
     get_latest_helm_chart_version_for_specific_release,
+    helm_repo_session,
 )
 
 
@@ -88,73 +89,74 @@ def get_compatibility_test_tuples():
     # start logging
     logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
-    central_chart_versions, sensor_chart_versions = get_supported_helm_chart_versions()
+    with helm_repo_session():
+        central_chart_versions, sensor_chart_versions = get_supported_helm_chart_versions()
 
-    makefile_path = Path(__file__).parent.parent
-    latest_tag = subprocess.check_output(
-        ["make", "tag", "-C", makefile_path, "--quiet", "--no-print-director"],
-        shell=False,
-        encoding="utf-8",
-    ).strip()
+        makefile_path = Path(__file__).parent.parent
+        latest_tag = subprocess.check_output(
+            ["make", "tag", "-C", makefile_path, "--quiet", "--no-print-director"],
+            shell=False,
+            encoding="utf-8",
+        ).strip()
 
-    # Remove the versions that are newer than the version of the current branch.
-    # This will make sure we do not test with an old test suite newer versions.
-    # It is important to not test newer versions with old tests suites because
-    # old test suites might depend on endpoints that no longer exist in newer
-    # versions.
-    # There is no risk in excluding newer versions as the compatibility tests in
-    # their respective branches will test against older versions.
-    central_chart_versions = [i for i in central_chart_versions
-                              if not
-                              is_newer_version(current_version=latest_tag,
-                                               helm_version=i)]
-    sensor_chart_versions = [i for i in sensor_chart_versions
-                             if not
-                             is_newer_version(current_version=latest_tag,
-                                              helm_version=i)]
+        # Remove the versions that are newer than the version of the current branch.
+        # This will make sure we do not test with an old test suite newer versions.
+        # It is important to not test newer versions with old tests suites because
+        # old test suites might depend on endpoints that no longer exist in newer
+        # versions.
+        # There is no risk in excluding newer versions as the compatibility tests in
+        # their respective branches will test against older versions.
+        central_chart_versions = [i for i in central_chart_versions
+                                  if not
+                                  is_newer_version(current_version=latest_tag,
+                                                   helm_version=i)]
+        sensor_chart_versions = [i for i in sensor_chart_versions
+                                 if not
+                                 is_newer_version(current_version=latest_tag,
+                                                  helm_version=i)]
 
-    if len(central_chart_versions) == 0:
-        logging.info("Found no older central chart versions to test against according to the product lifecycles API.")
-    if len(sensor_chart_versions) == 0:
-        logging.info("Found no older sensor chart versions to test against according to the product lifecycles API.")
-    if len(central_chart_versions) == 0 or len(sensor_chart_versions) == 0:
-        logging.info("However versions with support exceptions will still be tested against.")
+        if len(central_chart_versions) == 0:
+            logging.info("Found no older central chart versions to test against according to the product lifecycles API.")
+        if len(sensor_chart_versions) == 0:
+            logging.info("Found no older sensor chart versions to test against according to the product lifecycles API.")
+        if len(central_chart_versions) == 0 or len(sensor_chart_versions) == 0:
+            logging.info("However versions with support exceptions will still be tested against.")
 
-    ChartVersions = namedtuple(
-        "Chart_versions", ["central_version", "sensor_version"])
+        ChartVersions = namedtuple(
+            "Chart_versions", ["central_version", "sensor_version"])
 
-    # Latest central vs sensor versions in sensor_chart_versions
-    test_tuples = [
-        ChartVersions(central_version=latest_tag,
-                      sensor_version=sensor_chart_version)
-        for sensor_chart_version in sensor_chart_versions
-    ]
-    # Latest sensor vs central versions in central_chart_versions
-    test_tuples.extend(
-        [
-            ChartVersions(central_version=central_chart_version,
-                          sensor_version=latest_tag)
-            for central_chart_version in central_chart_versions
+        # Latest central vs sensor versions in sensor_chart_versions
+        test_tuples = [
+            ChartVersions(central_version=latest_tag,
+                          sensor_version=sensor_chart_version)
+            for sensor_chart_version in sensor_chart_versions
         ]
-    )
-
-    # Currently there are no support exceptions, the last one expired on 2024-06-30, see:
-    # https://issues.redhat.com/browse/ROX-18223
-    # however a new support exception is being negotiated, add it here when it's ready
-    support_exceptions = [
-        ChartVersions(
-            central_version=latest_tag,
-            sensor_version=get_latest_helm_chart_version_for_specific_release(
-                "stackrox-secured-cluster-services", Release(major=3, minor=74)
-            ),
+        # Latest sensor vs central versions in central_chart_versions
+        test_tuples.extend(
+            [
+                ChartVersions(central_version=central_chart_version,
+                              sensor_version=latest_tag)
+                for central_chart_version in central_chart_versions
+            ]
         )
-    ]
 
-    test_tuples.extend(
-        support_exception
-        for support_exception in support_exceptions
-        if support_exception not in test_tuples
-    )
+        # Currently there are no support exceptions, the last one expired on 2024-06-30, see:
+        # https://issues.redhat.com/browse/ROX-18223
+        # however a new support exception is being negotiated, add it here when it's ready
+        support_exceptions = [
+            ChartVersions(
+                central_version=latest_tag,
+                sensor_version=get_latest_helm_chart_version_for_specific_release(
+                    "stackrox-secured-cluster-services", Release(major=3, minor=74)
+                ),
+            )
+        ]
+
+        test_tuples.extend(
+            support_exception
+            for support_exception in support_exceptions
+            if support_exception not in test_tuples
+        )
     return test_tuples
 
 

--- a/.openshift-ci/get_compatibility_test_tuples.py
+++ b/.openshift-ci/get_compatibility_test_tuples.py
@@ -116,9 +116,11 @@ def get_compatibility_test_tuples():
                                                   helm_version=i)]
 
         if len(central_chart_versions) == 0:
-            logging.info("Found no older central chart versions to test against according to the product lifecycles API.")
+            logging.info("Found no older central chart versions to test against "
+                         "according to the product lifecycles API.")
         if len(sensor_chart_versions) == 0:
-            logging.info("Found no older sensor chart versions to test against according to the product lifecycles API.")
+            logging.info("Found no older sensor chart versions to test against "
+                         "according to the product lifecycles API.")
         if len(central_chart_versions) == 0 or len(sensor_chart_versions) == 0:
             logging.info("However versions with support exceptions will still be tested against.")
 

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -9,10 +9,12 @@ recent patch for each found release.
 
 import json
 import logging
+import os
 import pathlib
 import re
 import subprocess
 import sys
+from contextlib import contextmanager
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
@@ -52,6 +54,30 @@ NUM_RELEASES_DEFAULT = 3
 # patch of the input release.
 sample_support_exception = Release(major=3, minor=74)
 
+_helm_repo_active = False
+
+
+@contextmanager
+def helm_repo_session():
+    """Add the helm chart repo once, yield, then remove it.
+
+    Reentrant: nested calls are no-ops so callers don't need to
+    coordinate who "owns" the repo lifecycle.
+    """
+    global _helm_repo_active
+    if _helm_repo_active:
+        yield
+        return
+
+    add_helm_repo()
+    try:
+        update_helm_repo()
+        _helm_repo_active = True
+        yield
+    finally:
+        _helm_repo_active = False
+        remove_helm_repo()
+
 
 def main(argv):
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
@@ -80,30 +106,18 @@ def main(argv):
 
 
 def get_latest_helm_chart_versions(chart_name, num_releases=NUM_RELEASES_DEFAULT):
-    add_helm_repo()
-    try:
-        update_helm_repo()
+    with helm_repo_session():
         return __get_latest_helm_chart_versions(chart_name, num_releases)
-    finally:
-        remove_helm_repo()
 
 
 def get_latest_helm_chart_version_for_specific_release(chart_name, release):
-    add_helm_repo()
-    try:
-        update_helm_repo()
+    with helm_repo_session():
         return __get_latest_helm_chart_version_for_specific_release(chart_name, release)
-    finally:
-        remove_helm_repo()
 
 
 def get_supported_helm_chart_versions():
-    add_helm_repo()
-    try:
-        update_helm_repo()
+    with helm_repo_session():
         return __get_supported_helm_chart_versions()
-    finally:
-        remove_helm_repo()
 
 
 def __get_supported_helm_chart_versions():
@@ -274,7 +288,12 @@ def version_to_release(version):
 
 def add_helm_repo():
     logging.info("Adding temp helm repository...")
-    run_command(ADD_REPO_CMD)
+    url_override = os.environ.get("COMPAT_HELM_CHART_URL")
+    if url_override:
+        cmd = f"helm repo add {HELM_REPO_NAME} {url_override}"
+    else:
+        cmd = ADD_REPO_CMD
+    run_command(cmd)
 
 
 def update_helm_repo():

--- a/.openshift-ci/get_latest_helm_chart_versions.py
+++ b/.openshift-ci/get_latest_helm_chart_versions.py
@@ -54,7 +54,7 @@ NUM_RELEASES_DEFAULT = 3
 # patch of the input release.
 sample_support_exception = Release(major=3, minor=74)
 
-_helm_repo_active = False
+_state = {"helm_repo_active": False}
 
 
 @contextmanager
@@ -64,18 +64,17 @@ def helm_repo_session():
     Reentrant: nested calls are no-ops so callers don't need to
     coordinate who "owns" the repo lifecycle.
     """
-    global _helm_repo_active
-    if _helm_repo_active:
+    if _state["helm_repo_active"]:
         yield
         return
 
     add_helm_repo()
     try:
         update_helm_repo()
-        _helm_repo_active = True
+        _state["helm_repo_active"] = True
         yield
     finally:
-        _helm_repo_active = False
+        _state["helm_repo_active"] = False
         remove_helm_repo()
 
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -99,9 +99,16 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
     ci_export OUTPUT_FORMAT "helm"
 
     # Repo name can't be too long or `helm search repo [REPO_NAME] -l` cuts off part of the name and the regex below fails.
-    helm_repo_name="tmp-srox-compat"
-    helm repo add "${helm_repo_name}" https://raw.githubusercontent.com/stackrox/helm-charts/main/opensource
-    helm repo update
+    local own_repo=false
+    if [[ -n "${COMPAT_HELM_REPO_NAME:-}" ]]; then
+        helm_repo_name="${COMPAT_HELM_REPO_NAME}"
+    else
+        helm_repo_name="tmp-srox-compat"
+        local helm_chart_url="${COMPAT_HELM_CHART_URL:-https://raw.githubusercontent.com/stackrox/helm-charts/main/opensource}"
+        helm repo add "${helm_repo_name}" "${helm_chart_url}"
+        helm repo update
+        own_repo=true
+    fi
 
     current_tag="$(make tag --quiet --no-print-directory)"
 
@@ -149,7 +156,9 @@ deploy_stackrox_with_custom_central_and_sensor_versions() {
 
     rm -rf "$charts_dir"
 
-    helm repo remove "${helm_repo_name}"
+    if [[ "${own_repo}" == "true" ]]; then
+        helm repo remove "${helm_repo_name}"
+    fi
     ci_export CENTRAL_CHART_DIR_OVERRIDE ""
     ci_export SENSOR_CHART_DIR_OVERRIDE ""
 }


### PR DESCRIPTION
## Description

The GKE version compatibility test job downloads helm charts from
`raw.githubusercontent.com` ~27 times per run when ~3 are sufficient.
This causes intermittent GitHub 429 rate-limiting failures
(e.g. build `2054474552271966208` on 2026-05-13).

**Option C**: Shallow-clone the `stackrox/helm-charts` repo once at
job start and serve charts via `file://` URL, eliminating all HTTP
requests to the GitHub CDN. The clone uses `GITHUB_TOKEN` for
authenticated access (available in Prow). Falls back to the remote
URL if the clone fails.

Also adds a reentrant `helm_repo_session()` context manager so the
Python layer does one `add/update/remove` cycle instead of ~4.

Compare with #20591 which deduplicates without cloning.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Validated via `/test gke-version-compatibility-tests` on this PR
- Falls back to original behavior if git clone fails
- Backward-compatible: standalone callers without `COMPAT_HELM_REPO_NAME` use original behavior