### PR TITLE
ROX-34676: fix Cypress dashboard compliance intercept

### DIFF
--- a/ui/apps/platform/cypress/helpers/main.js
+++ b/ui/apps/platform/cypress/helpers/main.js
@@ -1,7 +1,7 @@
-import navSelectors from '../selectors/navigation';
 import pf6 from '../selectors/pf6';
 
-import { getRouteMatcherMapForGraphQL, interactAndWaitForResponses } from './request';
+import { hasFeatureFlag } from './features';
+import { getRouteMatcherMapForGraphQL } from './request';
 import { visit, visitConsole, visitWithStaticResponseForPermissions } from './visit';
 
 /*
@@ -46,16 +46,20 @@ const routeMatcherMapForComplianceLevelsByStandard = getRouteMatcherMapForGraphQ
     getAggregatedResultsOpname,
 ]);
 
-const routeMatcherMap = {
-    ...routeMatcherMapForSummaryCounts,
-    ...routeMatcherMapForSearchFilter,
-    ...routeMatcherMapForViolationsByPolicySeverity,
-    ...routeMatcherMapForImagesAtMostRisk,
-    ...routeMatcherMapForDeploymentsAtMostRisk,
-    ...routeMatcherMapForAgingImages,
-    ...routeMatcherMapForViolationsByPolicyCategory,
-    ...routeMatcherMapForComplianceLevelsByStandard,
-};
+function getRouteMatcherMap() {
+    return {
+        ...routeMatcherMapForSummaryCounts,
+        ...routeMatcherMapForSearchFilter,
+        ...routeMatcherMapForViolationsByPolicySeverity,
+        ...routeMatcherMapForImagesAtMostRisk,
+        ...routeMatcherMapForDeploymentsAtMostRisk,
+        ...routeMatcherMapForAgingImages,
+        ...routeMatcherMapForViolationsByPolicyCategory,
+        ...(hasFeatureFlag('ROX_DEPRECATED_COMPLIANCE_DASHBOARD')
+            ? routeMatcherMapForComplianceLevelsByStandard
+            : {}),
+    };
+}
 
 const routeMatcherMapForConsole = {
     mypermissions: {
@@ -82,20 +86,11 @@ const title = 'Dashboard';
 
 // visit helpers
 
-export function visitMainDashboardFromLeftNav() {
-    interactAndWaitForResponses(() => {
-        cy.get(`${navSelectors.navLinks}:contains("${title}")`).click();
-    }, routeMatcherMap);
-
-    cy.location('pathname').should('eq', basePath);
-    cy.get(`h1:contains("${title}")`);
-}
-
 /**
  * @param {Record<string, { body: unknown } | { fixture: string }>} [staticResponseMap]
  */
 export function visitMainDashboard(staticResponseMap) {
-    visit(basePath, routeMatcherMap, staticResponseMap);
+    visit(basePath, getRouteMatcherMap(), staticResponseMap);
 
     cy.get(`.pf-v6-c-nav__link.pf-m-current:contains("${title}")`);
     cy.get(`h1:contains("${title}")`);


### PR DESCRIPTION
## Description

`visitMainDashboard` waited for the `getAggregatedResults` GraphQL intercept unconditionally. When `ROX_DEPRECATED_COMPLIANCE_DASHBOARD` is `false` (nightlies), the compliance widget doesn't render and the request never fires, causing all tests that visit the dashboard to time out.

The fix conditionally includes the compliance intercept in `getRouteMatcherMap()` based on `hasFeatureFlag('ROX_DEPRECATED_COMPLIANCE_DASHBOARD')`. When the flag is true, tests still wait for the compliance background task to complete before proceeding. When false, the intercept is skipped.

Also removes the unused `visitMainDashboardFromLeftNav` helper and its dead imports (`navSelectors`, `interactAndWaitForResponses`).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI