### PR TITLE
ROX-34712: Use source of truth for initial vulnerability report query

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizardPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizardPage.tsx
@@ -35,11 +35,11 @@ import {
     searchFilterConfigForImageVulnerabilityReport,
 } from '../../searchFilterConfig';
 
+import { defaultImageVulnerabilityReportConfiguration } from '../imageVulnerabilityReports.defaults';
 import type {
     ImageVulnerabilityReportConfiguration,
     ImageVulnerabilityReportConfigurationForEntity,
 } from '../imageVulnerabilityReports.types';
-import { initialImageVulnerabilityReportConfiguration } from '../imageVulnerabilityReports.utils';
 
 import ImageVulnerabilityReportWizard from './ImageVulnerabilityReportWizard';
 
@@ -75,14 +75,14 @@ function ImageVulnerabilityReportWizardPage({
                 })
                 .catch((error) => {
                     setError(error);
-                    setReportConfiguration(initialImageVulnerabilityReportConfiguration);
+                    setReportConfiguration(defaultImageVulnerabilityReportConfiguration);
                 })
                 .finally(() => {
                     setIsLoading(false);
                 });
         } else if (pageAction === 'createFromFilters' && getHasSearchApplied(searchFilter)) {
             const reportConfigurationFromFilters: ImageVulnerabilityReportConfigurationForEntity =
-                cloneDeep(initialImageVulnerabilityReportConfiguration);
+                cloneDeep(defaultImageVulnerabilityReportConfiguration);
 
             reportConfigurationFromFilters.resourceScope.entityScope.rules =
                 getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment(searchFilter);
@@ -118,7 +118,7 @@ function ImageVulnerabilityReportWizardPage({
 
             setReportConfiguration(reportConfigurationFromFilters);
         } else {
-            setReportConfiguration(initialImageVulnerabilityReportConfiguration); // create
+            setReportConfiguration(defaultImageVulnerabilityReportConfiguration); // create
         }
     }, [pageAction, reportId, searchFilter]);
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.defaults.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.defaults.ts
@@ -1,0 +1,39 @@
+import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
+
+import { defaultStorage } from '../WorkloadCves/Overview/WorkloadCvesOverviewPage';
+import { fixableStatusToFixability, severityLabelToSeverity } from '../utils/searchUtils';
+
+import type {
+    ImageVulnerabilityReportConfigurationForEntity,
+    ImageVulnerabilityReportFiltersForEntity,
+} from './imageVulnerabilityReports.types';
+
+const {
+    preferences: { defaultFilters },
+} = defaultStorage;
+
+const defaultVulnerabilityReportFiltersForEntity: ImageVulnerabilityReportFiltersForEntity = {
+    imageTypes: [],
+    query: getRequestQueryStringForSearchFilter({
+        Severity: defaultFilters.Severity.map(severityLabelToSeverity),
+        Fixable: defaultFilters.Fixable.map(fixableStatusToFixability),
+        'Vulnerability State': 'OBSERVED', // TODO single source of truth?
+    }),
+    allVuln: true,
+} as const;
+
+export const defaultImageVulnerabilityReportConfiguration: ImageVulnerabilityReportConfigurationForEntity =
+    {
+        id: '',
+        name: '',
+        description: '',
+        type: 'VULNERABILITY',
+        vulnReportFilters: defaultVulnerabilityReportFiltersForEntity,
+        notifiers: [],
+        schedule: null,
+        resourceScope: {
+            entityScope: {
+                rules: [],
+            },
+        },
+    } as const;

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
@@ -1,10 +1,5 @@
 import type { SelectExclusiveSingleSearchFilterAttribute } from 'Components/CompoundSearchFilter/types';
-import type {
-    CvesSince,
-    Fixability,
-    ImageType,
-    VulnerabilityReportFilters,
-} from 'services/ReportsService.types';
+import type { CvesSince, Fixability, ImageType } from 'services/ReportsService.types';
 import type { VulnerabilitySeverity } from 'types/cve.proto';
 import type { SearchFilter } from 'types/search';
 import {
@@ -16,6 +11,9 @@ import {
 import { ensureExhaustive } from 'utils/type.utils';
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 
+import { defaultStorage } from '../WorkloadCves/Overview/WorkloadCvesOverviewPage';
+import { fixableStatusToFixability, severityLabelToSeverity } from '../utils/searchUtils';
+
 import type {
     ImageVulnerabilityFiltersConfiguration,
     ImageVulnerabilityFiltersForCollectionWithoutCvesSince,
@@ -26,22 +24,18 @@ import type {
     ImageVulnerabilityReportFiltersForEntity,
 } from './imageVulnerabilityReports.types';
 
-export const initialImageVulnerabilityReportFiltersForCollection: VulnerabilityReportFilters = {
-    fixability: 'FIXABLE',
-    severities: ['CRITICAL_VULNERABILITY_SEVERITY', 'IMPORTANT_VULNERABILITY_SEVERITY'],
-    imageTypes: ['DEPLOYED', 'WATCHED'],
-    allVuln: true,
-    // TO BE DELETED
-    includeAdvisory: false,
-    includeEpssProbability: false,
-    // includeKnownExploit: false, // ROX_CISA_KEV
-    includeNvdCvss: false,
-} as const;
+const {
+    preferences: { defaultFilters },
+} = defaultStorage;
 
 export const initialVulnerabilityReportFiltersForEntity: ImageVulnerabilityReportFiltersForEntity =
     {
-        imageTypes: ['DEPLOYED', 'WATCHED'],
-        query: 'Severity:CRITICAL_VULNERABILITY_SEVERITY,IMPORTANT_VULNERABILITY_SEVERITY+Fixable:true',
+        imageTypes: [],
+        query: getRequestQueryStringForSearchFilter({
+            Severity: defaultFilters.Severity.map(severityLabelToSeverity),
+            Fixable: defaultFilters.Fixable.map(fixableStatusToFixability),
+            'Vulnerability State': 'OBSERVED', // TODO single source of truth?
+        }),
         allVuln: true,
     } as const;
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
@@ -11,9 +11,6 @@ import {
 import { ensureExhaustive } from 'utils/type.utils';
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 
-import { defaultStorage } from '../WorkloadCves/Overview/WorkloadCvesOverviewPage';
-import { fixableStatusToFixability, severityLabelToSeverity } from '../utils/searchUtils';
-
 import type {
     ImageVulnerabilityFiltersConfiguration,
     ImageVulnerabilityFiltersForCollectionWithoutCvesSince,
@@ -21,39 +18,7 @@ import type {
     ImageVulnerabilityReportConfiguration,
     ImageVulnerabilityReportConfigurationForCollection,
     ImageVulnerabilityReportConfigurationForEntity,
-    ImageVulnerabilityReportFiltersForEntity,
 } from './imageVulnerabilityReports.types';
-
-const {
-    preferences: { defaultFilters },
-} = defaultStorage;
-
-export const initialVulnerabilityReportFiltersForEntity: ImageVulnerabilityReportFiltersForEntity =
-    {
-        imageTypes: [],
-        query: getRequestQueryStringForSearchFilter({
-            Severity: defaultFilters.Severity.map(severityLabelToSeverity),
-            Fixable: defaultFilters.Fixable.map(fixableStatusToFixability),
-            'Vulnerability State': 'OBSERVED', // TODO single source of truth?
-        }),
-        allVuln: true,
-    } as const;
-
-export const initialImageVulnerabilityReportConfiguration: ImageVulnerabilityReportConfigurationForEntity =
-    {
-        id: '',
-        name: '',
-        description: '',
-        type: 'VULNERABILITY',
-        vulnReportFilters: initialVulnerabilityReportFiltersForEntity,
-        notifiers: [],
-        schedule: null,
-        resourceScope: {
-            entityScope: {
-                rules: [],
-            },
-        },
-    } as const;
 
 // TypeScript needs help because entityScope and vulnReportFilters have mutual dependencies.
 // entityScope implies query but not fixability nore severities

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -110,7 +110,7 @@ const descriptionForVulnerabilityStateMap: Record<VulnerabilityState, string> = 
         'View workload vulnerabilities identified as false positives and excluded from active prioritization',
 };
 
-const defaultStorage: VulnMgmtLocalStorage = {
+export const defaultStorage: VulnMgmtLocalStorage = {
     preferences: {
         defaultFilters: {
             Severity: ['Critical', 'Important'],


### PR DESCRIPTION
## Description

### Problem

1. Thank you, **Brad** for commenting that `query` string for report configurayion is redundant with `defaultFilters` for results pages.

2. Thank you, **Zhenpeng** for confirming that default filters need to include **Observed** for **Vulnerability state** for consistency with results pages.

3. Because recent discussion in cross-functional team about **Deployed images** versus **Watched iamges** gives evidence of confusion within RHACS, it is reasonable to suppose also confusion in the field.

### Analysis

1. `defaultFilters` has same field labels but different convention for values than `query` string

    Frontend has properties for search filter like:
    `Severity: ['Critical', 'Important']`
    `Fixable: ['Fixable']`

    Backend needs properties for search filter like:
    `Severity: ['CRITICAL_VULNERABILITY_SEVERITY', 'IMPORTANT_VULNERABILITY_SEVERITY']`
    `Fixable: ['true']`

    Functions return individual backend value given frontend:
    `severityLabelToSeverity`
    `fixableStatusToFixability`

    Backend `query` string includes after `getRequestQueryStringForSearchFilter` function call:
    `Severity:CRITICAL_VULNERABILITY_SEVERITY,IMPORTANT_VULNERABILITY_SEVERITY+Fixable:true`

2. Unlike `defaultFilters` there is not one source of truth for `'OBSERVED'` as default.

    Find in Files `'Observed'` has 35 results in 20 files
    
    Here are candidates for separate sources of truth:

    DeploymentPage.tsx
    ImagePage.tsx
    ImageCvePage.tsx
    DeploymentFilterLink.tsx
    NamespaceViewPage.tsx
    WorkloadCvesOverviewPage.tsx

3. Previous default report configuration included `imageType: ['DEPLOYED', 'WATCHED']` although beware that `imageTypes` plural is property name in backend type.

    It seems unlikely (to me, at least) that both deployed and watched inmages in same report is effective, or even likely to be needed. Why?

    * Watched images seems relevant to **development** persona.

    * Deployed images seems relevant to **operational** persona.

        Development persona does not have need to know **where** the images they build are deployed.
        Because RHACS can scan images in registries, why deploy them to be scanned, even in staging environment?

### Solution

1. ~Edit imageVulnerabilityReports.utils.ts file.~ Add imageVulnerabilityReports.defaults.ts file.

    This is first time that `npm run lint:fast-dev` caused me to miss a `no-cycle` error.

    Not sure why Visual Studio Code did not, unless I closed the tab, or did not open my eyes.

    * Compute `Fixable` and `Severity` from `defaultFilters` as single source of truty

        Thank you, **David** for consistent case of search field labels in #20432
    
    * Delete `initialImageVulnerabilityReportFiltersForCollection` because obsolete given functions to convert the corresponding filters properties for the resources scopes in #20565

    * Include `'Vulnerability State: 'OBSERVED'` property.

    * Replace default value for `imageTypes` plural so user chooses according to needs of recipients.

    Especially so user does not think that both deployed and watched is normal configuration.

3. Edit WorkloadCvesOverviewPage.tsx file.

    * Export `defaultStorage` that has `defaultFilters` with `Severity` and `Fixable` properties.

### Residue

1. Investigate potential single source of truth for `'OBSERVED'` value.

2. Evalute file location for single sources of truth.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
4. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration?action=create and then go to **Resources** step:

    Before changes, see both **Deployed images** and **Watched images** selected for **Image type**
    <img width="1440" height="892" alt="Resources_imageTypes_both" src="https://github.com/user-attachments/assets/59ea8a05-9ff0-4528-bfee-bb9d1eed9d12" />

    After changes, see neither **Deployed images** nor **Watched images** selected for **Image type** and validation error when you click **Next** button
    <img width="1440" height="892" alt="Resources_imageTypes_neither" src="https://github.com/user-attachments/assets/f7190cbc-342d-4c3f-b207-ade07c6980c8" />

2. Go to **Filters** step

    Before changes, see **Critical** and **Important** for **CVE severity** and **Fixable** for **CVE status**
    <img width="1440" height="892" alt="Filters_without_Vulnerability_State" src="https://github.com/user-attachments/assets/22112a0b-b1b9-4be3-b49c-3fb9e967a0ae" />

    After changes, see also **Observed** for **Vulnerability state**
    <img width="1440" height="892" alt="Filers_with_Vulnerability_State" src="https://github.com/user-attachments/assets/b9d3b329-e835-4bd7-a030-d79327b4f6b0" />
