### PR TITLE
ROX-34715: Conditionally render resourceScope in report configuration

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityReportView.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/View/ImageVulnerabilityReportView.tsx
@@ -10,7 +10,10 @@ import DeliveryView from 'Components/Reports/View/DeliveryView';
 import DetailsView from 'Components/Reports/View/DetailsView';
 
 import type { ImageVulnerabilityReportConfiguration } from '../imageVulnerabilityReports.types';
-import { hasConfigurationForEntity } from '../imageVulnerabilityReports.utils';
+import {
+    hasConfigurationForCollection,
+    hasConfigurationForEntity,
+} from '../imageVulnerabilityReports.utils';
 
 import ImageVulnerabilityFiltersView from './ImageVulnerabilityFiltersView';
 import ImageVulnerabilityFiltersViewForCollection from './ImageVulnerabilityFiltersViewForCollection';
@@ -43,7 +46,7 @@ function ImageVulnerabilityReportView({
                 horizontalTermWidthModifier={horizontalTermWidthModifier}
                 values={values}
             />
-            {hasConfigurationForEntity(values) ? (
+            {hasConfigurationForEntity(values) && (
                 <ImageVulnerabilityFiltersView
                     attributesSeparateFromConfig={attributesSeparateFromConfig}
                     headingLevel={headingLevel}
@@ -51,7 +54,8 @@ function ImageVulnerabilityReportView({
                     searchFilterConfig={searchFilterConfig}
                     values={values}
                 />
-            ) : (
+            )}
+            {hasConfigurationForCollection(values) && (
                 <ImageVulnerabilityFiltersViewForCollection
                     headingLevel={headingLevel}
                     horizontalTermWidthModifier={horizontalTermWidthModifier}

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
@@ -16,6 +16,7 @@ import type {
     ImageVulnerabilityFiltersForCollectionWithoutCvesSince,
     ImageVulnerabilityFiltersWithoutCvesSince,
     ImageVulnerabilityReportConfiguration,
+    ImageVulnerabilityReportConfigurationForCollection,
     ImageVulnerabilityReportConfigurationForEntity,
     ImageVulnerabilityReportFiltersForEntity,
 } from './imageVulnerabilityReports.types';
@@ -58,6 +59,13 @@ export const initialImageVulnerabilityReportConfiguration: ImageVulnerabilityRep
 // TypeScript needs help because entityScope and vulnReportFilters have mutual dependencies.
 // entityScope implies query but not fixability nore severities
 // collectionScope implies fixability and severities but not query
+
+export function hasConfigurationForCollection(
+    values: ImageVulnerabilityReportConfiguration
+): values is ImageVulnerabilityReportConfigurationForCollection {
+    return 'collectionScope' in values.resourceScope;
+}
+
 export function hasConfigurationForEntity(
     values: ImageVulnerabilityReportConfiguration
 ): values is ImageVulnerabilityReportConfigurationForEntity {


### PR DESCRIPTION
## Description

TL;DR Replace ternary `?:` expression with independent conditional `&&` operators.

### Problem

Thank you, **Surabhi** and **Cong** for investigating roll back and roll forward scenarios.

Also to **David S.** for emphasizing its importance.

Just as `resourceScope: {}` for `resourceScope: entityScope: { rules: [] }` in downgrade scenario from 4.11 to previous version that does not have the feature, it will happen in the future in downgrade scenario for versions that do not yet have replacement for collection.

Even if central mitigates the problem by filtering out report collections that have ``resourceScope: {}`` the code needs independent rendering for minimum changed lines to add new replacement scope and delete `collectionScope` in the future.

### Analysis

Find in Files `hasConfigurationForEntity` has 2 results in 2 files

ImageVulnerabilityReportView.tsx file has ternary expression which assumes either entity scope or collection scope.

```tsx
{hasConfigurationForEntity(values) ? (
    <ImageVulnerabilityFiltersView … />
) : (
    <ImageVulnerabilityFiltersViewForCollection … />
)}
```

* In the future, there will be 3 instead of 2.
* In the farther future, there will be 2 instead of 3.

On other side of coin, ImageVulnerabilityResourcesView.tsx file has independent conditional rendering:

```tsx
{'collectionScope' in resourceScope && (
    <DescriptionListGroup>
        <DescriptionListTerm>Collection</DescriptionListTerm>
        <DescriptionListDescription>
            {resourceScope.collectionScope.collectionName}
        </DescriptionListDescription>
    </DescriptionListGroup>
)}
{'entityScope' in resourceScope && (
    <EntityScopeDescriptionListGroups entityScope={resourceScope.entityScope} />
)}
```

Ditto for ImageVulnerabilityReportWizard.tsx file:

```tsx
{hasFormikPropsForEntity(formik) && (
    <ImageVulnerabilityFiltersStep
        attributesSeparateFromConfig={attributesSeparateFromConfig}
        formik={formik}
        searchFilterConfig={searchFilterConfig}
    />
)}
{hasFormikPropsForCollection(formik) && (
    <ImageVulnerabilityFiltersStepForCollection formik={formik} />
)}
```

On edge of coin, ImageVulnerabilityResourcesStep.tsx file has (mostly) independent support:
* `useState`
* callback functions
* `Radio` elements

However, it does have one codependent condition:

```tsx
'collectionScope' in formik.values.resourceScope &&
!('entityScope' in formik.values.resourceScope)
```

### Solution

The solution is similar to ImageVulnerabilityReportWizard.tsx file.

1. Edit ImageVulnerabilityReportView.tsx file.

    * Replace ternary with independent conditional rendering.

2. Edit imageVulnerabilityReports.utils.ts file.

    * Too bad, so sad: need to add `hasConfigurationForCollection` function.

```ts
// TypeScript needs help because entityScope and vulnReportFilters have mutual dependencies.
// entityScope implies query but not fixability nore severities
// collectionScope implies fixability and severities but not query
```

### Residue

1. Previous versions might need backpatch for UI, unless central filters out report configurations that have `resourceScope: {}` property.

    Because central solution is needed for API independent of UI, and for report scheduling, and especially because fewer changed line, that seeems like most likely solution.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration and click a link to see report page.