### PR TITLE
ROX-34691: fix Risk detail page horizontal nav state

### DIFF
--- a/ui/apps/platform/cypress/integration/risk/risk.test.js
+++ b/ui/apps/platform/cypress/integration/risk/risk.test.js
@@ -1,4 +1,5 @@
 import withAuth from '../../helpers/basicAuth';
+import navigationSelectors from '../../selectors/navigation';
 import { getRegExpForTitleWithBranding } from '../../helpers/title';
 import pf6 from '../../selectors/pf6';
 
@@ -19,6 +20,22 @@ describe('Risk', () => {
             visitRiskDeployments('Platform view');
 
             cy.get(RiskPageSelectors.risk).should('have.class', 'pf-m-current');
+        });
+
+        it('should maintain active horizontal nav state on detail page for each view', () => {
+            cy.wrap([
+                { urlParam: 'Applications view', activeTab: 'User Workloads' },
+                { urlParam: 'Platform view', activeTab: 'Platform' },
+                { urlParam: 'Full view', activeTab: 'All Deployments' },
+            ]).each(({ urlParam, activeTab }) => {
+                visitRiskDeployments(urlParam);
+                viewFirstRiskDeployment();
+
+                cy.get(`${navigationSelectors.horizontalNavLinks}:contains("${activeTab}")`).should(
+                    'have.class',
+                    'pf-m-current'
+                );
+            });
         });
 
         it('should have title and table column headings', () => {

--- a/ui/apps/platform/src/Containers/Risk/DeploymentNameColumn.tsx
+++ b/ui/apps/platform/src/Containers/Risk/DeploymentNameColumn.tsx
@@ -3,6 +3,7 @@ import find from 'lodash/find';
 import { Tooltip } from '@patternfly/react-core';
 import { CheckIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 
+import useFilteredWorkflowViewURLState from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
 import { riskBasePath } from 'routePaths';
 
 type DeploymentNameColumnProps = {
@@ -13,9 +14,11 @@ type DeploymentNameColumnProps = {
 };
 
 export function DeploymentNameColumn({ original }: DeploymentNameColumnProps) {
+    const { filteredWorkflowView } = useFilteredWorkflowViewURLState();
     const isSuspicious = find(original.baselineStatuses, {
         anomalousProcessesExecuted: true,
     });
+    const url = `${riskBasePath}/${original.deployment.id}?filteredWorkflowView=${filteredWorkflowView}`;
     // Borrow layout from IconText component.
     return (
         <div className="flex items-center">
@@ -30,9 +33,7 @@ export function DeploymentNameColumn({ original }: DeploymentNameColumnProps) {
                     </Tooltip>
                 )}
                 <span className="pf-v6-u-pl-sm pf-v6-u-text-nowrap">
-                    <Link to={`${riskBasePath}/${original.deployment.id}`}>
-                        {original.deployment.name}
-                    </Link>
+                    <Link to={url}>{original.deployment.name}</Link>
                 </span>
             </span>
         </div>

--- a/ui/apps/platform/src/Containers/Risk/RiskDetailsPage.tsx
+++ b/ui/apps/platform/src/Containers/Risk/RiskDetailsPage.tsx
@@ -15,13 +15,33 @@ import {
 import { useParams } from 'react-router-dom-v5-compat';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import type { FilteredWorkflowView } from 'Components/FilteredWorkflowViewSelector/types';
+import useFilteredWorkflowViewURLState from 'Components/FilteredWorkflowViewSelector/useFilteredWorkflowViewURLState';
 import LinkShim from 'Components/PatternFly/LinkShim/LinkShim';
 import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
-import { getLinkToDeploymentInNetworkGraph, riskBasePath } from 'routePaths';
+import {
+    getLinkToDeploymentInNetworkGraph,
+    riskFullViewPath,
+    riskPlatformViewPath,
+    riskUserWorkloadsViewPath,
+} from 'routePaths';
 import useIsRouteEnabled from 'hooks/useIsRouteEnabled';
 
 import RiskDetailTabs from './RiskDetailTabs';
 import useDeploymentWithRisk from './useDeploymentWithRisk';
+
+function getRiskBreadcrumb(filteredWorkflowView: FilteredWorkflowView) {
+    // Note: We cannot exhaustively check for all possible values of filteredWorkflowView because
+    // `FilteredWorkflowView` contains `Node view`, which is not a valid value for Risk.
+    // Therefore, we only check for the valid values for Risk.
+    if (filteredWorkflowView === 'Platform view') {
+        return { title: 'Platform risk', url: riskPlatformViewPath };
+    }
+    if (filteredWorkflowView === 'Full view') {
+        return { title: 'All deployment risk', url: riskFullViewPath };
+    }
+    return { title: 'User workload risk', url: riskUserWorkloadsViewPath };
+}
 
 function RiskDetailsPage(): ReactElement {
     const params = useParams();
@@ -30,14 +50,18 @@ function RiskDetailsPage(): ReactElement {
     const { data, isLoading, error } = useDeploymentWithRisk(deploymentId);
     const deploymentName = data?.deployment.name;
 
+    const { filteredWorkflowView } = useFilteredWorkflowViewURLState();
+
     const isRouteEnabled = useIsRouteEnabled();
     const isRouteEnabledForNetworkGraph = isRouteEnabled('network-graph');
+
+    const { title: breadcrumbTitle, url: breadcrumbUrl } = getRiskBreadcrumb(filteredWorkflowView);
 
     return (
         <>
             <PageBreadcrumb>
                 <Breadcrumb>
-                    <BreadcrumbItemLink to={riskBasePath}>Risk</BreadcrumbItemLink>
+                    <BreadcrumbItemLink to={breadcrumbUrl}>{breadcrumbTitle}</BreadcrumbItemLink>
                     <BreadcrumbItem>{deploymentName ?? <Skeleton width="200px" />}</BreadcrumbItem>
                 </Breadcrumb>
             </PageBreadcrumb>


### PR DESCRIPTION
## Description

The horizontal navigation on Risk detail pages always showed "User Workloads" as active, regardless of which view the user navigated from. The `filteredWorkflowView` URL parameter was not propagated from the list page links to the detail page.

**Root cause:** `DeploymentNameColumn` linked to `/main/risk/:id` without preserving the `filteredWorkflowView` query parameter. On the detail page, `useFilteredWorkflowViewURLState()` defaults to the first value ("Applications view") when the parameter is absent.

**Fix:**
- `DeploymentNameColumn` reads `filteredWorkflowView` from the URL via `useFilteredWorkflowViewURLState` and includes it in detail page links
- `RiskDetailsPage` reads the parameter and sets the breadcrumb title/link to match the active view
- No prop-drilling — both components read directly from the URL

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [x] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Added Cypress E2E test that verifies active nav state is preserved on detail pages for all three views (User Workloads, Platform, All Deployments)
<img width="1600" height="738" alt="image" src="https://github.com/user-attachments/assets/0dc1eb91-6868-484b-bea4-998acbc82e49" />
