### PR TITLE
ROX-34716: remove Container Type filter from Violations

### DIFF
--- a/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.utils.ts
+++ b/ui/apps/platform/src/Containers/Violations/ViolationsTableSearchFilter.utils.ts
@@ -22,7 +22,6 @@ import {
 } from 'Components/CompoundSearchFilter/attributes/namespace';
 import {
     Annotation as DeploymentAnnotation,
-    ContainerType as DeploymentContainerType,
     ID as DeploymentID,
     Inactive as DeploymentInactive,
     Label as DeploymentLabel,
@@ -56,7 +55,6 @@ const allSearchFilterEntities: CompoundSearchFilterConfig = [
         searchCategory: 'ALERTS',
         attributes: [
             DeploymentAnnotation,
-            DeploymentContainerType,
             DeploymentID,
             DeploymentLabel,
             DeploymentName,


### PR DESCRIPTION
## Description

The `Container Type` search filter was recently added to the Violations page but is not relevant and does not function there (possible implementation post-4.11, but TBD). Removed `DeploymentContainerType` from the `allSearchFilterEntities` config in `ViolationsTableSearchFilter.utils.ts`. The filter remains available in all other locations (e.g. Vulnerability Management).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1600" height="738" alt="image" src="https://github.com/user-attachments/assets/b40b80bf-fbb4-4236-8ab2-676be6b6c942" />
<img width="1600" height="738" alt="image" src="https://github.com/user-attachments/assets/d3c338c1-0e50-49ad-a861-8fae6a482ed1" />
