### PR TITLE
ROX-34692: fix duplicate dashes on container arguments

### DIFF
--- a/ui/apps/platform/src/Components/ContainerArgumentsInfo.tsx
+++ b/ui/apps/platform/src/Components/ContainerArgumentsInfo.tsx
@@ -13,7 +13,7 @@ function ContainerArgumentsInfo({ args }: ContainerArgumentsInfoProps): ReactEle
                 <CardBody>
                     <List isPlain>
                         {args.map((arg) => (
-                            <ListItem key={arg}>--{arg}</ListItem>
+                            <ListItem key={arg}>{arg}</ListItem>
                         ))}
                     </List>
                 </CardBody>


### PR DESCRIPTION
## Description

Container arguments were displayed with an unconditional `--` prefix, causing args like `serve` to show as `--serve` and `--cache-dir=...` to show as `----cache-dir=...`. The UI should render arguments exactly as the API returns them.

One-line fix: removed the `--` prefix from `ContainerArgumentsInfo.tsx`.

## Future Nit

Should "Command" come before "Arguments" in the UI? Should they be merged?

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Before:
<img width="1600" height="708" alt="image" src="https://github.com/user-attachments/assets/439acac8-bb85-4878-a2ae-368637cdf35d" />

After:
<img width="1600" height="708" alt="image" src="https://github.com/user-attachments/assets/fe7a500c-82e3-4daa-b4c6-a6d6eda9653b" />

