### PR TITLE
ROX-34719: Fix vuln report wizard discovered time issues

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizardPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizardPage.tsx
@@ -104,7 +104,7 @@ function ImageVulnerabilityReportWizardPage({
                     reportConfigurationFromFilters.vulnReportFilters = {
                         imageTypes,
                         query,
-                        sinceStartDate: `${yyyy}-${mm}-${dd}`,
+                        sinceStartDate: `${yyyy}-${mm}-${dd}T00:00:00.000Z`,
                     };
                 }
             }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersSince.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step3/ImageVulnerabilityFiltersSince.tsx
@@ -28,19 +28,19 @@ function ImageVulnerabilityFiltersSince<
     // 3. user selects custom date option again
     const [sinceStartDatePicked, setSinceStartDatePicked] = useState(
         'sinceStartDate' in formik.values.vulnReportFilters
-            ? formik.values.vulnReportFilters.sinceStartDate
+            ? formik.values.vulnReportFilters.sinceStartDate.substring(0, 10)
             : ''
     );
 
-    function onChangeStartDate(sinceStartDate: string) {
+    // date indicates a valid date. If valid, pass to formik as iso string. Otherwise, pass the input as is.
+    function onChangeStartDate(sinceStartDate: string, date?: Date) {
         setSinceStartDatePicked(sinceStartDate); // YYYY-MM-DD
-
         // For future entity scope only, replace helper function call with the following:
         // const { query } = formik.values.vulnReportFilters;
         const vulnReportFiltersWithoutCvesSince = getReportFiltersWithoutCvesSince(formik.values);
         formik.setFieldValue('vulnReportFilters', {
             ...vulnReportFiltersWithoutCvesSince,
-            sinceStartDate,
+            sinceStartDate: date ? `${sinceStartDate}T00:00:00.000Z` : sinceStartDate,
         });
     }
 
@@ -69,7 +69,9 @@ function ImageVulnerabilityFiltersSince<
                                 case 'sinceStartDate':
                                     formik.setFieldValue('vulnReportFilters', {
                                         ...vulnReportFiltersWithoutCvesSince,
-                                        sinceStartDate: sinceStartDatePicked,
+                                        sinceStartDate: sinceStartDatePicked
+                                            ? `${sinceStartDatePicked}T00:00:00.000Z`
+                                            : sinceStartDatePicked,
                                     });
                                     break;
                                 default:
@@ -114,10 +116,10 @@ function ImageVulnerabilityFiltersSince<
                     >
                         <DatePicker
                             name="vulnReportFilters.sinceStartDate"
-                            value={formik.values.vulnReportFilters.sinceStartDate}
+                            value={sinceStartDatePicked}
                             onBlur={formik.handleBlur}
-                            onChange={(_event, value) => {
-                                onChangeStartDate(value);
+                            onChange={(_event, value, date) => {
+                                onChangeStartDate(value, date);
                             }}
                             invalidFormatText="" // error messaging is handled by yup along with FormLabelGroup
                         />

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/imageVulnerabilityReportValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/imageVulnerabilityReportValidationSchemas.ts
@@ -71,11 +71,9 @@ function isCvesSinceValid(filters: CvesSince): boolean {
         if (!filters.sinceStartDate) {
             return false;
         }
-        // DatePicker stores dates as YYYY-MM-DD, reject anything that doesn't match
-        if (!/^\d{4}-\d{2}-\d{2}$/.test(filters.sinceStartDate)) {
-            return false;
-        }
-        return isValid(parse(filters.sinceStartDate));
+        // parse() is lenient. partial strings like "2026-10" pass isValid.
+        // Checking for "T" ensures the value is likely a full ISO timestamp.
+        return filters.sinceStartDate.includes('T') && isValid(parse(filters.sinceStartDate));
     }
     return false;
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/imageVulnerabilityReports.utils.ts
@@ -6,7 +6,6 @@ import type {
 } from 'services/ReportsService.types';
 import type { VulnerabilitySeverity } from 'types/cve.proto';
 import type { SearchFilter } from 'types/search';
-import { getDate } from 'utils/dateUtils';
 import { getUrlQueryStringForSearchFilter, searchValueAsArray } from 'utils/searchUtils';
 import { ensureExhaustive } from 'utils/type.utils';
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
@@ -72,7 +71,7 @@ export function getTextForCvesSince(vulnReportFilters: CvesSince) {
         return 'Last scheduled report that was successfully sent';
     }
     if ('sinceStartDate' in vulnReportFilters) {
-        return getDate(vulnReportFilters.sinceStartDate);
+        return vulnReportFilters.sinceStartDate.substring(0, 10);
     }
     return ensureExhaustive(vulnReportFilters);
 }


### PR DESCRIPTION
## Description

Fix CVE discovered date bugs in the image vulnerability report wizard.

The backend expects a ISO datetime, but the `DatePicker` value was being sent as a plain `YYYY-MM-DD` string, causing an error on POST. Additionally, converting the date using `Date.toISOString()` applied a local timezone offset, which shifted the displayed date back a day in the review step for users west of UTC.

Store the ISO datetime in formik by appending `T00:00:00.000Z` only when the `DatePicker` confirms the date is valid.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Manually tested the following:
- Tested setting a CVE discovered start time using the `DatePicker`, confirmed review step displayed properly and proper date format sent on POST
- Tested manually setting `DatePicker` with both valid and invalid formats, verified correct yup validation and `T00:00:00.000Z` appended when valid
- Verified creating a report from the results page with a CVE discovered after filter properly sets the `DatePicker` and adds the timestamp to formik
