### PR TITLE
fix(ci): cancel in-progress Konflux runs on new PR commits

### DIFF
--- a/.tekton/central-db-build.yaml
+++ b/.tekton/central-db-build.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/create-custom-snapshot.yaml
+++ b/.tekton/create-custom-snapshot.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/retag-collector.yaml
+++ b/.tekton/retag-collector.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/retag-fact.yaml
+++ b/.tekton/retag-fact.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/retag-scanner-db-slim.yaml
+++ b/.tekton/retag-scanner-db-slim.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/retag-scanner-db.yaml
+++ b/.tekton/retag-scanner-db.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/retag-scanner-slim.yaml
+++ b/.tekton/retag-scanner-slim.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/retag-scanner.yaml
+++ b/.tekton/retag-scanner.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'

--- a/.tekton/scanner-v4-db-build.yaml
+++ b/.tekton/scanner-v4-db-build.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stackrox/stackrox?rev={{revision}}
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
## Description

Adds `pipelinesascode.tekton.dev/cancel-in-progress: "true"` to all 14 PipelineRun definitions in `.tekton/`.

When a new commit is pushed to a PR, Pipelines-as-Code will cancel any in-progress PipelineRuns for the same component from the previous commit. Only the latest commit's builds matter on PRs — intermediate builds waste cluster resources and contribute to memory pressure / OOM failures.

**Scoping:** Per the [Pipelines-as-Code docs](https://pipelinesascode.com/docs/guide/running/), cancellation is scoped by event type — PR-triggered runs only cancel other PR-triggered runs for the same PR, push-triggered runs only cancel runs targeting the same branch. However, since our CEL expressions match both push and pull_request events in the same PipelineRun definition, this needs verification to confirm that consecutive pushes to master do NOT cancel each other's builds.

**Alternative:** Ask Konflux admins to enable the global `enable-cancel-in-progress-on-pull-requests: "true"` setting, which explicitly only applies to pull requests.

**Validated live on PR #20597:** pushed a new commit while 8 PipelineRuns were in progress — all 8 immediately showed `CancelledRunningFinally` and new runs started for the latest commit.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No functional change — this is a Pipelines-as-Code annotation that controls PipelineRun lifecycle.

### How I validated my change

Tested on PR #20597: pushed a commit while 8 PipelineRuns were running. All 8 were cancelled (`CancelledRunningFinally`) and replaced by new runs for the latest commit within seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)