### PR TITLE
ROX-34675:  Fix email body for entity scope

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/email_formatter.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter.go
@@ -89,7 +89,6 @@ func formatReportConfigDetails(snapshot *storage.ReportSnapshot, numDeployedImag
 	if err != nil {
 		return "", err
 	}
-	reportFilters := snapshot.GetVulnReportFilters()
 
 	writer.WriteString("<div>")
 
@@ -100,27 +99,38 @@ func formatReportConfigDetails(snapshot *storage.ReportSnapshot, numDeployedImag
 	formatSingleDetail(&writer, "Number of CVEs found",
 		fmt.Sprintf("%d in Deployed images", numDeployedImageCVEs),
 		fmt.Sprintf("%d in Watched images", numWatchedImageCVEs))
+	// Collection scope: show severity, fixability, collection, image types, CVEs since
+	reportFilters := snapshot.GetVulnReportFilters()
 
-	// Severities
-	// create a copy because severities will be sorted in descending order (critical, important, moderate, low)
-	severities := append([]storage.VulnerabilitySeverity{}, reportFilters.GetSeverities()...)
-	sort.Slice(severities, func(i, j int) bool {
-		return severities[i] > severities[j]
-	})
-	formatSingleDetail(&writer, "CVE severity", severities...)
+	if entityScope := snapshot.GetResourceScope().GetEntityScope(); entityScope != nil {
+		// Entity scope: show filter query and scope rules
+		reportFilters := snapshot.GetVulnReportFilters()
+		if query := reportFilters.GetQuery(); query != "" {
+			formatSingleDetail(&writer, "Filter", query)
+		}
+		scopeParts := formatEntityScope(entityScope)
+		if len(scopeParts) > 0 {
+			formatSingleDetail(&writer, "Report scope", scopeParts...)
+		}
+	} else {
 
-	// Fixability
-	fixabilities := expandFixability(reportFilters.GetFixability())
-	formatSingleDetail(&writer, "CVE status", fixabilities...)
+		// Severities
+		severities := append([]storage.VulnerabilitySeverity{}, reportFilters.GetSeverities()...)
+		sort.Slice(severities, func(i, j int) bool {
+			return severities[i] > severities[j]
+		})
+		formatSingleDetail(&writer, "CVE severity", severities...)
 
-	// Collection
-	formatSingleDetail(&writer, "Report scope", snapshot.GetCollection())
+		// Fixability
+		fixabilities := expandFixability(reportFilters.GetFixability())
+		formatSingleDetail(&writer, "CVE status", fixabilities...)
 
+		// Collection
+		formatSingleDetail(&writer, "Report scope", snapshot.GetCollection())
+	}
 	// Image types
-	// create a copy because image types will be sorted in ascending order (deployed, watched)
 	imageTypes := append([]storage.VulnerabilityReportFilters_ImageType{}, reportFilters.GetImageTypes()...)
 	sliceutils.NaturalSort(imageTypes)
-
 	formatSingleDetail(&writer, "Image type", imageTypes...)
 
 	// CVEs discovered since
@@ -129,6 +139,47 @@ func formatReportConfigDetails(snapshot *storage.ReportSnapshot, numDeployedImag
 	writer.WriteString("</div>")
 
 	return writer.String(), nil
+}
+
+func formatEntityScope(entityScope *storage.EntityScope) []string {
+	var parts []string
+	for _, rule := range entityScope.GetRules() {
+		entityType := friendlyEntityType(rule.GetEntity())
+		field := friendlyEntityField(rule.GetField())
+		values := make([]string, 0, len(rule.GetValues()))
+		for _, v := range rule.GetValues() {
+			values = append(values, v.GetValue())
+		}
+		parts = append(parts, fmt.Sprintf("%s %s: %s", entityType, field, strings.Join(values, ", ")))
+	}
+	return parts
+}
+
+var entityTypeToText = map[storage.EntityType]string{
+	storage.EntityType_ENTITY_TYPE_DEPLOYMENT: "Deployment",
+	storage.EntityType_ENTITY_TYPE_NAMESPACE:  "Namespace",
+	storage.EntityType_ENTITY_TYPE_CLUSTER:    "Cluster",
+}
+
+var entityFieldToText = map[storage.EntityField]string{
+	storage.EntityField_FIELD_ID:         "ID",
+	storage.EntityField_FIELD_NAME:       "Name",
+	storage.EntityField_FIELD_LABEL:      "Label",
+	storage.EntityField_FIELD_ANNOTATION: "Annotation",
+}
+
+func friendlyEntityType(t storage.EntityType) string {
+	if text, ok := entityTypeToText[t]; ok {
+		return text
+	}
+	return t.String()
+}
+
+func friendlyEntityField(f storage.EntityField) string {
+	if text, ok := entityFieldToText[f]; ok {
+		return text
+	}
+	return f.String()
 }
 
 func expandFixability(fixability storage.VulnerabilityReportFilters_Fixability) []storage.VulnerabilityReportFilters_Fixability {
@@ -192,8 +243,11 @@ func validateSnapshot(snapshot *storage.ReportSnapshot) error {
 	if reportFilters == nil {
 		return errors.New("Report snapshot is missing vulnerability report filters")
 	}
-	if snapshot.GetResourceScope() == nil {
-		return errors.New("Report snapshot is missing resource scope")
+
+	hasCollection := snapshot.GetCollection() != nil
+	hasEntityScope := snapshot.GetResourceScope().GetEntityScope() != nil
+	if !hasCollection && !hasEntityScope {
+		return errors.New("Report snapshot is missing both collection snapshot and entity scope")
 	}
 	if len(reportFilters.GetImageTypes()) == 0 {
 		return errors.New("Report snapshot is missing image type filters")

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter.go
@@ -108,7 +108,6 @@ func formatReportConfigDetails(snapshot *storage.ReportSnapshot, numDeployedImag
 
 	if entityScope := snapshot.GetResourceScope().GetEntityScope(); entityScope != nil {
 		// Entity scope: show filter query and scope rules
-		reportFilters := snapshot.GetVulnReportFilters()
 		if query := reportFilters.GetQuery(); query != "" {
 			formatSingleDetail(&writer, "Filter", query)
 		}

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter.go
@@ -44,15 +44,19 @@ func formatEmailSubject(subjectTemplate string, snapshot *storage.ReportSnapshot
 	if len(configName) > maxConfigNameLenInSubject {
 		configName = fmt.Sprintf("%s...", configName[0:maxConfigNameLenInSubject])
 	}
-	collectionName := snapshot.GetCollection().GetName()
-	if len(collectionName) > maxCollectionNameLenInSubject {
-		collectionName = fmt.Sprintf("%s...", collectionName[0:maxCollectionNameLenInSubject])
+	scopeName := "Custom Scope"
+	if snapshot.GetCollection() != nil {
+		scopeName = snapshot.GetCollection().GetName()
+	}
+
+	if len(scopeName) > maxCollectionNameLenInSubject {
+		scopeName = fmt.Sprintf("%s...", scopeName[0:maxCollectionNameLenInSubject])
 	}
 
 	data := &reportEmailSubjectFormat{
 		BrandedProductNameShort: branding.GetProductNameShort(),
 		ReportConfigName:        configName,
-		CollectionName:          collectionName,
+		CollectionName:          scopeName,
 	}
 	tmpl, err := template.New("emailSubject").Parse(subjectTemplate)
 	if err != nil {

--- a/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/email_formatter_test.go
@@ -184,5 +184,75 @@ func (s *EmailFormatterTestSuite) configDetailsTestCases() []configDetailsTestCa
 					</div>`,
 		},
 	}
+	cases = append(cases, s.entityScopeTestCases()...)
 	return cases
+}
+
+func (s *EmailFormatterTestSuite) entityScopeTestCases() []configDetailsTestCase {
+	return []configDetailsTestCase{
+		{
+			desc: "Entity scope with filter query cvss > 7",
+			snapshot: func() *storage.ReportSnapshot {
+				snap := fixtures.GetReportSnapshot()
+				snap.Collection = nil
+				snap.ResourceScope = &storage.ResourceScope{
+					ScopeReference: &storage.ResourceScope_EntityScope{
+						EntityScope: &storage.EntityScope{
+							Rules: []*storage.EntityScopeRule{
+								{
+									Entity: storage.EntityType_ENTITY_TYPE_NAMESPACE,
+									Field:  storage.EntityField_FIELD_NAME,
+									Values: []*storage.RuleValue{
+										{Value: "production"},
+										{Value: "staging"},
+									},
+								},
+								{
+									Entity: storage.EntityType_ENTITY_TYPE_CLUSTER,
+									Field:  storage.EntityField_FIELD_NAME,
+									Values: []*storage.RuleValue{
+										{Value: "main-cluster"},
+									},
+								},
+							},
+						},
+					},
+				}
+				snap.GetVulnReportFilters().Query = "CVSS > 7"
+				return snap
+			}(),
+			expectedHTML: `<div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Config name: </span>
+							<span>App Team 1 Report</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Number of CVEs found: </span>
+							<span>50 in Deployed images, 30 in Watched images</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Filter: </span>
+							<span>CVSS > 7</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Report scope: </span>
+							<span>Namespace Name: production, staging, Cluster Name: main-cluster</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								Image type: </span>
+							<span>Deployed images, Watched images</span>
+						</div>
+						<div style="padding: 0 0 10px 0">
+							<span style="font-weight: bold; margin-right: 10px">
+								CVEs discovered since: </span>
+							<span>All time</span>
+						</div>
+					</div>`,
+		},
+	}
 }


### PR DESCRIPTION
When entity scope is used for scoping reports, email body does not show scope and filter field. This PR adds the fields for entity scoped reports in the email. 

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality
Tested this change by adding unit tests 
manually tested the change by configuring report config with email notifier and entity scope. sent an email report 
Please see screenshot attached 
<img width="1103" height="536" alt="Screenshot 2026-05-15 at 8 45 43 AM" src="https://github.com/user-attachments/assets/cbfc9553-8ab9-408e-9b6b-4e09cd7e0245" />

