### PR TITLE
ROX-34723: Add auto-upgrade label to sensor-proxy Service

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -1,5 +1,12 @@
 {{- include "srox.init" . -}}
 
+{{- /*
+  Every resource in this file must have the auto-upgrade.stackrox.io/component label.
+  For manifest-based installs (non-Helm, non-Operator), the sensor-upgrader validates
+  this label on all bundle objects before applying them. Missing it will cause the
+  auto-upgrade to fail. See also: sensor/upgrader/bundle/instantiator.go
+*/ -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -421,6 +421,7 @@ metadata:
   namespace: {{ ._rox._namespace | quote }}
   labels:
     {{- include "srox.labels" (list . "service" "sensor-proxy") | nindent 4 }}
+    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- $annotations := dict -}}
     {{- $_ := set $annotations "service.beta.openshift.io/serving-cert-secret-name" "sensor-proxy-tls" -}}


### PR DESCRIPTION
## Description

Add the `auto-upgrade.stackrox.io/component: "sensor"` label to the `sensor-proxy`
Service template, matching the pattern used by all other resources in the file.

The sensor-upgrader validates that all objects in the upgrade bundle carry this label.
The `sensor-proxy` Service (included for OpenShift clusters when
`ROX_OCP_CONSOLE_INTEGRATION` is enabled, which is the default) was missing it,
causing the upgrader to abort with:

```
  upgrade label auto-upgrade.stackrox.io/component of object stackrox/sensor-proxy[/v1, Kind=Service] has invalid value "", expected: "sensor"
```

## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature
  flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

  - [ ] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [ ] added compatibility tests
  - [ ] modified existing tests

### How I validated my change

I ran a manual upgrade on an OCP cluster with ACS installed using manifests (like in the user report).

(1) Started with some 4.9.x version
<img width="1246" height="835" alt="4 9 x" src="https://github.com/user-attachments/assets/76b1b215-bfbc-4520-afe2-dbe6d8e966af" />

(2) Upgraded Central to some 4.10.x version, observed upgrader failing with the same error as in the user report 
<img width="1257" height="803" alt="4 10 x" src="https://github.com/user-attachments/assets/d08dddee-1c75-446c-bed9-bc31244d6a8a" />

(3) Upgraded Central to the version with the fix and observed upgrader going through the process and bringing Sensor to the new version.
<img width="1260" height="783" alt="4 11 x+fix" src="https://github.com/user-attachments/assets/6f399944-4355-4378-bce0-afdf4053e316" />