### PR TITLE
feat(vm): replace time-based token refill with completion-based return

### DIFF
--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -92,6 +92,7 @@ type sensorConnection struct {
 
 type rateLimiter interface {
 	TryConsume(clientID string, msg *central.MsgFromSensor) (allowed bool, reason string)
+	Return(clientID string, msg *central.MsgFromSensor)
 }
 
 func newConnection(ctx context.Context,
@@ -142,7 +143,7 @@ func newConnection(ctx context.Context,
 	deduper.StartSync()
 
 	conn.hashDeduper = deduper
-	conn.sensorEventHandler = newSensorEventHandler(cluster, sensorHello.GetSensorVersion(), eventPipeline, conn, &conn.stopSig, deduper, initSyncMgr)
+	conn.sensorEventHandler = newSensorEventHandler(cluster, sensorHello.GetSensorVersion(), eventPipeline, conn, &conn.stopSig, deduper, initSyncMgr, rl)
 	conn.scrapeCtrl = scrape.NewController(conn, &conn.stopSig)
 	conn.networkPoliciesCtrl = networkpolicies.NewController(conn, &conn.stopSig)
 	conn.networkEntitiesCtrl = networkentities.NewController(cluster.GetId(), networkEntityMgr, graph.Singleton(), conn, &conn.stopSig)

--- a/central/sensor/service/connection/connection_test.go
+++ b/central/sensor/service/connection/connection_test.go
@@ -33,6 +33,12 @@ import (
 	"google.golang.org/grpc"
 )
 
+// noopRL is a no-op rate limiter for tests.
+type noopRL struct{}
+
+func (noopRL) TryConsume(string, *central.MsgFromSensor) (bool, string) { return true, "" }
+func (noopRL) Return(string, *central.MsgFromSensor)                    {}
+
 func TestHandler(t *testing.T) {
 	suite.Run(t, new(testSuite))
 }
@@ -129,7 +135,7 @@ func (s *testSuite) TestSendsScanConfigurationMsgOnRun() {
 		SensorVersion: "1.0",
 	}
 
-	eventHandler := newSensorEventHandler(&storage.Cluster{}, "", pipeline, nil, &stopSig, deduper, nil)
+	eventHandler := newSensorEventHandler(&storage.Cluster{}, "", pipeline, nil, &stopSig, deduper, nil, noopRL{})
 
 	sensorMockConn := &sensorConnection{
 		clusterMgr:         mgrMock,
@@ -284,7 +290,7 @@ func (s *testSuite) TestSendDeduperStateIfSensorReconciliation() {
 				SensorState:   tc.givenSensorState,
 			}
 
-			eventHandler := newSensorEventHandler(&storage.Cluster{}, "", pipeline, nil, &stopSig, deduper, nil)
+			eventHandler := newSensorEventHandler(&storage.Cluster{}, "", pipeline, nil, &stopSig, deduper, nil, noopRL{})
 
 			sensorMockConn := &sensorConnection{
 				clusterMgr:         mgrMock,

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -39,6 +39,8 @@ type sensorEventHandler struct {
 	injector    common.MessageInjector
 	stopSig     *concurrency.ErrorSignal
 
+	rl rateLimiter
+
 	reconciliationMap *reconciliation.StoreMap
 }
 
@@ -50,6 +52,7 @@ func newSensorEventHandler(
 	stopSig *concurrency.ErrorSignal,
 	deduper hashManager.Deduper,
 	initSyncMgr *initSyncManager,
+	rl rateLimiter,
 ) *sensorEventHandler {
 	return &sensorEventHandler{
 		cluster:       cluster,
@@ -63,10 +66,12 @@ func newSensorEventHandler(
 		pipeline:    pipeline,
 		injector:    injector,
 		stopSig:     stopSig,
+		rl:          rl,
 	}
 }
 
 func (s *sensorEventHandler) handleMessages(ctx context.Context, msg *central.MsgFromSensor) error {
+	defer s.rl.Return(s.cluster.GetId(), msg)
 	return s.pipeline.Run(ctx, msg, s.injector)
 }
 
@@ -149,6 +154,7 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 	// was processed
 	if !s.deduper.ShouldProcess(msg) {
 		metrics.IncSensorEventsDeduper(true, msg)
+		s.rl.Return(s.cluster.GetId(), msg)
 		return
 	}
 	metrics.IncSensorEventsDeduper(false, msg)

--- a/pkg/env/virtualmachine.go
+++ b/pkg/env/virtualmachine.go
@@ -30,23 +30,15 @@ var (
 	// The default is false because these nodes typically do not host VMs and would otherwise retry forever.
 	VirtualMachinesRelayEnabledOnMasterNodes = RegisterBooleanSetting("ROX_VIRTUAL_MACHINES_RELAY_ENABLED_ON_MASTER_NODES", false)
 
-	// VMIndexReportRateLimit defines the maximum number of VM index reports per second that Central will accept
-	// across all sensors that actually send VM index reports. Each such sensor gets an equal share (1/N) of this
-	// global capacity. The split happens when a new client ID registers in the VM index report pipeline; there is
-	// no additional selection or weighting mechanism at the moment.
-	// Supports fractional rates (e.g., "0.5" for one request every 2 seconds).
-	// Set to "0" to disable rate limiting (unlimited).
-	//
-	// As of ACS 4.9 & 4.10, the default size cluster should not exceed 1.0 requests per second.
-	// As VM scanning is only one of potentially many other workloads, we set the default to 0.3 requests per second.
-	// For larger clusters, the rate limit could be increased to up to 3.0 requests per second only if the
-	// scanner-v4-matcher and the scanner-v4-db are able to handle the load!
+	// VMIndexReportRateLimit enables concurrency limiting for VM index reports when set to any
+	// value greater than 0. The actual concurrent processing capacity is controlled by
+	// ROX_VM_INDEX_REPORT_BUCKET_CAPACITY. Set to "0" to disable limiting (unlimited).
 	VMIndexReportRateLimit = RegisterFloatSetting("ROX_VM_INDEX_REPORT_RATE_LIMIT", 0.3)
 
-	// VMIndexReportBucketCapacity defines the token bucket capacity for VM index report rate limiting.
-	// This is the maximum number of requests that can be accepted in a burst before rate limiting kicks in.
-	// For example, with capacity=15 and rate=3 req/sec, a sensor can send up to 15 requests instantly,
-	// then must wait for 5 seconds for tokens to refill at the rate limit.
+	// VMIndexReportBucketCapacity defines the total number of VM index reports that can be
+	// processed concurrently across all sensors. Each sensor gets an equal share (1/N) of this
+	// capacity. Tokens are returned automatically when processing completes, so throughput
+	// tracks actual processing speed rather than a fixed rate.
 	// Default: 200 tokens
 	VMIndexReportBucketCapacity = RegisterIntegerSetting("ROX_VM_INDEX_REPORT_BUCKET_CAPACITY", 200).WithMinimum(1)
 

--- a/pkg/rate/benchmark_comparison_test.go
+++ b/pkg/rate/benchmark_comparison_test.go
@@ -1,0 +1,352 @@
+package rate
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+)
+
+// TestComparisonReport demonstrates the throughput difference between the
+// completion-based token return approach and a simulated time-based refill.
+//
+// Scenario: Multiple concurrent workers process VM index reports. Each report
+// takes 100-500ms to process. With a low time-based refill rate (e.g., 0.3/s),
+// the old limiter starves after the initial burst because tokens only refill
+// at 0.3/s regardless of processing speed. The new limiter returns tokens
+// on completion, so throughput tracks actual processing capacity.
+func TestComparisonReport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping comparison test in short mode")
+	}
+
+	configs := []struct {
+		name           string
+		numWorkers     int
+		bucketCapacity int
+		refillRate     float64
+		testDuration   time.Duration
+		minProcessing  time.Duration
+		maxProcessing  time.Duration
+	}{
+		{
+			name:           "realistic_low_refill",
+			numWorkers:     50,
+			bucketCapacity: 200,
+			refillRate:     0.3,
+			testDuration:   20 * time.Second,
+			minProcessing:  100 * time.Millisecond,
+			maxProcessing:  500 * time.Millisecond,
+		},
+		{
+			name:           "high_concurrency_very_low_refill",
+			numWorkers:     100,
+			bucketCapacity: 200,
+			refillRate:     0.1,
+			testDuration:   20 * time.Second,
+			minProcessing:  50 * time.Millisecond,
+			maxProcessing:  200 * time.Millisecond,
+		},
+		{
+			name:           "moderate_refill",
+			numWorkers:     20,
+			bucketCapacity: 100,
+			refillRate:     1.0,
+			testDuration:   20 * time.Second,
+			minProcessing:  100 * time.Millisecond,
+			maxProcessing:  300 * time.Millisecond,
+		},
+	}
+
+	for _, cfg := range configs {
+		t.Run(cfg.name, func(t *testing.T) {
+			oldAccepted, oldRejected := runTimeBasedTest(t, cfg.numWorkers, cfg.bucketCapacity, cfg.refillRate,
+				cfg.testDuration, cfg.minProcessing, cfg.maxProcessing)
+			newAccepted, newRejected := runCompletionBasedTest(t, cfg.numWorkers, cfg.bucketCapacity,
+				cfg.testDuration, cfg.minProcessing, cfg.maxProcessing)
+
+			oldRate := float64(oldAccepted) / cfg.testDuration.Seconds()
+			newRate := float64(newAccepted) / cfg.testDuration.Seconds()
+			var speedup float64
+			if oldRate > 0 {
+				speedup = newRate / oldRate
+			}
+
+			t.Logf("\n")
+			t.Logf("============================================================")
+			t.Logf("  RATE LIMITER COMPARISON: %s", cfg.name)
+			t.Logf("============================================================")
+			t.Logf("  Workers:          %d", cfg.numWorkers)
+			t.Logf("  Bucket capacity:  %d tokens", cfg.bucketCapacity)
+			t.Logf("  Refill rate:      %.1f tokens/sec (time-based only)", cfg.refillRate)
+			t.Logf("  Test duration:    %s", cfg.testDuration)
+			t.Logf("  Processing time:  %s - %s per report", cfg.minProcessing, cfg.maxProcessing)
+			t.Logf("")
+			t.Logf("  ┌─────────────────────┬──────────────┬──────────────────┐")
+			t.Logf("  │ Metric              │ Time-Based   │ Completion-Based │")
+			t.Logf("  ├─────────────────────┼──────────────┼──────────────────┤")
+			t.Logf("  │ Accepted            │ %12d │ %16d │", oldAccepted, newAccepted)
+			t.Logf("  │ Rejected            │ %12d │ %16d │", oldRejected, newRejected)
+			t.Logf("  │ Throughput (rps)     │ %12.1f │ %16.1f │", oldRate, newRate)
+			t.Logf("  │ Speedup             │            - │ %15.1fx │", speedup)
+			t.Logf("  └─────────────────────┴──────────────┴──────────────────┘")
+			t.Logf("")
+		})
+	}
+}
+
+// simulateTimeBasedLimiter simulates the old time-based token bucket.
+// Tokens refill at a fixed rate per second. Processing completion does NOT return tokens.
+type simulateTimeBasedLimiter struct {
+	mu             sync.Mutex
+	available      float64
+	capacity       int
+	refillRate     float64
+	lastRefillTime time.Time
+}
+
+func newTimeBasedLimiter(capacity int, refillRate float64) *simulateTimeBasedLimiter {
+	return &simulateTimeBasedLimiter{
+		available:      float64(capacity),
+		capacity:       capacity,
+		refillRate:     refillRate,
+		lastRefillTime: time.Now(),
+	}
+}
+
+func (l *simulateTimeBasedLimiter) tryConsume() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(l.lastRefillTime).Seconds()
+	l.lastRefillTime = now
+	l.available += elapsed * l.refillRate
+	if l.available > float64(l.capacity) {
+		l.available = float64(l.capacity)
+	}
+
+	if l.available >= 1.0 {
+		l.available -= 1.0
+		return true
+	}
+	return false
+}
+
+// runTimeBasedTest simulates the old time-based token bucket behavior.
+// Multiple workers compete for tokens. Tokens refill at a fixed rate.
+// Processing completion does NOT return tokens.
+func runTimeBasedTest(t *testing.T, numWorkers, capacity int, refillRate float64, duration, minProc, maxProc time.Duration) (accepted, rejected int64) {
+	t.Helper()
+
+	limiter := newTimeBasedLimiter(capacity, refillRate)
+	deadline := time.Now().Add(duration)
+
+	var wg sync.WaitGroup
+	var totalAccepted, totalRejected atomic.Int64
+
+	for w := range numWorkers {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(workerID)))
+			for time.Now().Before(deadline) {
+				if limiter.tryConsume() {
+					totalAccepted.Add(1)
+					procTime := minProc + time.Duration(rng.Int63n(int64(maxProc-minProc)))
+					time.Sleep(procTime)
+					// Old approach: NO token return on completion
+				} else {
+					totalRejected.Add(1)
+					time.Sleep(5 * time.Millisecond)
+				}
+			}
+		}(w)
+	}
+
+	wg.Wait()
+	return totalAccepted.Load(), totalRejected.Load()
+}
+
+// runCompletionBasedTest uses the actual new Limiter with Return() on completion.
+// Multiple workers compete for tokens. Tokens are returned when processing finishes.
+func runCompletionBasedTest(t *testing.T, numWorkers, capacity int, duration, minProc, maxProc time.Duration) (accepted, rejected int64) {
+	t.Helper()
+
+	limiter, err := NewLimiter("vm_index_reports", 0.3, capacity).ForAllWorkloads()
+	if err != nil {
+		t.Fatalf("failed to create limiter: %v", err)
+	}
+
+	deadline := time.Now().Add(duration)
+	clientID := "sensor-1"
+
+	// Prime the client so per-client capacity is calculated
+	limiter.TryConsume(clientID, &central.MsgFromSensor{})
+	limiter.Return(clientID, &central.MsgFromSensor{})
+
+	var wg sync.WaitGroup
+	var totalAccepted, totalRejected atomic.Int64
+
+	for w := range numWorkers {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(workerID)))
+			for time.Now().Before(deadline) {
+				if allowed, _ := limiter.TryConsume(clientID, &central.MsgFromSensor{}); allowed {
+					totalAccepted.Add(1)
+					procTime := minProc + time.Duration(rng.Int63n(int64(maxProc-minProc)))
+					time.Sleep(procTime)
+					// New approach: return token when processing completes
+					limiter.Return(clientID, &central.MsgFromSensor{})
+				} else {
+					totalRejected.Add(1)
+					time.Sleep(5 * time.Millisecond)
+				}
+			}
+		}(w)
+	}
+
+	wg.Wait()
+	return totalAccepted.Load(), totalRejected.Load()
+}
+
+// TestComparisonTimeSeries shows how throughput evolves over time.
+// This demonstrates the "cliff" effect: time-based hits a wall after initial burst,
+// while completion-based sustains throughput.
+func TestComparisonTimeSeries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping time series test in short mode")
+	}
+
+	numWorkers := 50
+	capacity := 100
+	refillRate := 0.5
+	totalDuration := 30 * time.Second
+	bucketInterval := 2 * time.Second
+	minProc := 100 * time.Millisecond
+	maxProc := 400 * time.Millisecond
+
+	t.Logf("Time series comparison (bucket=%s):", bucketInterval)
+	t.Logf("  Workers=%d, Capacity=%d, RefillRate=%.1f/s, Processing=%s-%s",
+		numWorkers, capacity, refillRate, minProc, maxProc)
+	t.Logf("")
+
+	oldBuckets := runTimeBasedTimeSeries(t, numWorkers, capacity, refillRate, totalDuration, bucketInterval, minProc, maxProc)
+	newBuckets := runCompletionBasedTimeSeries(t, numWorkers, capacity, totalDuration, bucketInterval, minProc, maxProc)
+
+	t.Logf("  ┌──────────┬──────────────────────┬──────────────────────────┐")
+	t.Logf("  │ Time (s) │ Time-Based (accepted) │ Completion-Based (acc.)  │")
+	t.Logf("  ├──────────┼──────────────────────┼──────────────────────────┤")
+	maxBuckets := len(oldBuckets)
+	if len(newBuckets) > maxBuckets {
+		maxBuckets = len(newBuckets)
+	}
+	for i := range maxBuckets {
+		oldVal := int64(0)
+		newVal := int64(0)
+		if i < len(oldBuckets) {
+			oldVal = oldBuckets[i]
+		}
+		if i < len(newBuckets) {
+			newVal = newBuckets[i]
+		}
+		timeLabel := fmt.Sprintf("%d-%d", i*int(bucketInterval.Seconds()), (i+1)*int(bucketInterval.Seconds()))
+		t.Logf("  │ %8s │ %20d │ %24d │", timeLabel, oldVal, newVal)
+	}
+	t.Logf("  └──────────┴──────────────────────┴──────────────────────────┘")
+}
+
+func runTimeBasedTimeSeries(t *testing.T, numWorkers, capacity int, refillRate float64, totalDuration, bucketInterval, minProc, maxProc time.Duration) []int64 {
+	t.Helper()
+
+	limiter := newTimeBasedLimiter(capacity, refillRate)
+	startTime := time.Now()
+	deadline := startTime.Add(totalDuration)
+	numBuckets := int(totalDuration / bucketInterval)
+	buckets := make([]atomic.Int64, numBuckets)
+
+	var wg sync.WaitGroup
+	for w := range numWorkers {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(workerID)))
+			for time.Now().Before(deadline) {
+				if limiter.tryConsume() {
+					elapsed := time.Since(startTime)
+					bucketIdx := int(elapsed / bucketInterval)
+					if bucketIdx >= numBuckets {
+						bucketIdx = numBuckets - 1
+					}
+					buckets[bucketIdx].Add(1)
+					procTime := minProc + time.Duration(rng.Int63n(int64(maxProc-minProc)))
+					time.Sleep(procTime)
+				} else {
+					time.Sleep(5 * time.Millisecond)
+				}
+			}
+		}(w)
+	}
+
+	wg.Wait()
+	result := make([]int64, numBuckets)
+	for i := range numBuckets {
+		result[i] = buckets[i].Load()
+	}
+	return result
+}
+
+func runCompletionBasedTimeSeries(t *testing.T, numWorkers, capacity int, totalDuration, bucketInterval, minProc, maxProc time.Duration) []int64 {
+	t.Helper()
+
+	limiter, err := NewLimiter("vm_index_reports", 0.3, capacity).ForAllWorkloads()
+	if err != nil {
+		t.Fatalf("failed to create limiter: %v", err)
+	}
+
+	clientID := "sensor-1"
+	limiter.TryConsume(clientID, &central.MsgFromSensor{})
+	limiter.Return(clientID, &central.MsgFromSensor{})
+
+	startTime := time.Now()
+	deadline := startTime.Add(totalDuration)
+	numBuckets := int(totalDuration / bucketInterval)
+	buckets := make([]atomic.Int64, numBuckets)
+
+	var wg sync.WaitGroup
+	for w := range numWorkers {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(workerID)))
+			for time.Now().Before(deadline) {
+				if allowed, _ := limiter.TryConsume(clientID, &central.MsgFromSensor{}); allowed {
+					elapsed := time.Since(startTime)
+					bucketIdx := int(elapsed / bucketInterval)
+					if bucketIdx >= numBuckets {
+						bucketIdx = numBuckets - 1
+					}
+					buckets[bucketIdx].Add(1)
+					procTime := minProc + time.Duration(rng.Int63n(int64(maxProc-minProc)))
+					time.Sleep(procTime)
+					limiter.Return(clientID, &central.MsgFromSensor{})
+				} else {
+					time.Sleep(5 * time.Millisecond)
+				}
+			}
+		}(w)
+	}
+
+	wg.Wait()
+	result := make([]int64, numBuckets)
+	for i := range numBuckets {
+		result[i] = buckets[i].Load()
+	}
+	return result
+}

--- a/pkg/rate/limiter.go
+++ b/pkg/rate/limiter.go
@@ -1,19 +1,14 @@
-// Package rate provides workload-level fair rate limiting across clients.
-// It manages per-client token buckets using golang.org/x/time/rate.Limiter.
-// In this package, Limiter is the higher-level manager that allocates and
-// rebalances per-client limiters; the underlying *rate.Limiter values are the
-// per-client buckets used for enforcement.
+// Package rate provides workload-level fair concurrency limiting across clients.
+// It manages per-client token counters that are decremented on consumption and
+// incremented when processing completes.  Tokens are never refilled by time;
+// they are returned explicitly after a unit of work finishes.
 package rate
 
 import (
-	"time"
-
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sync"
-	gorate "golang.org/x/time/rate"
 )
 
 var (
@@ -32,44 +27,41 @@ const (
 	ReasonRateLimitExceeded = "rate limit exceeded"
 )
 
-// Clock provides an abstraction over time for testing.
-type Clock interface {
-	Now() time.Time
+// clientBucket tracks the available and maximum token count for a single client.
+type clientBucket struct {
+	available int // tokens currently available for consumption
+	capacity  int // maximum tokens this client may hold
 }
 
-// Limiter provides per-client fair rate limiting for any workload type.
+// Limiter provides per-client fair concurrency limiting for any workload type.
 // Each client gets an equal share (1/N) of the global capacity, with automatic
 // rebalancing when clients connect or disconnect.
+//
+// Unlike a traditional rate limiter, tokens are not refilled over time. Instead,
+// tokens are returned explicitly via Return when processing of a previously
+// consumed token completes. This ensures that capacity tracks actual processing
+// throughput: fast processing yields high throughput, slow processing yields
+// natural backpressure.
 type Limiter struct {
-	workloadName   string  // name for logging/metrics (e.g., "vm_index_report")
-	globalRate     float64 // requests per second (0 = unlimited)
-	bucketCapacity int     // max tokens per client bucket (allows temporary bursts)
+	workloadName   string
+	globalRate     float64 // > 0 enables limiting, 0 disables (unlimited)
+	bucketCapacity int     // total tokens shared across all clients
 
-	mu         sync.RWMutex
-	buckets    map[string]*gorate.Limiter
+	mu         sync.Mutex
+	buckets    map[string]*clientBucket
 	numClients int
 
 	acceptsFn func(msg *central.MsgFromSensor) bool
-
-	clock Clock // time source (injectable for testing)
 }
 
-// RealClock uses the system clock.
-type RealClock struct{}
-
-// Now returns the current time.
-func (RealClock) Now() time.Time {
-	return time.Now()
-}
-
-// limiterOption is an intermediary type for creating a rate limiter.
-// It forces the caller to define the workload type to which the rate limiter would react.
+// limiterOption is an intermediary type for creating a limiter.
+// It forces the caller to define the workload type to which the limiter reacts.
 type limiterOption struct {
 	l   *Limiter
 	err error
 }
 
-// ForAllWorkloads configures the rate limiter to analyze all types of messages (including nil).
+// ForAllWorkloads configures the limiter to analyze all types of messages (including nil).
 func (lo *limiterOption) ForAllWorkloads() (*Limiter, error) {
 	if lo.l == nil {
 		return nil, lo.err
@@ -80,9 +72,10 @@ func (lo *limiterOption) ForAllWorkloads() (*Limiter, error) {
 	return lo.l, lo.err
 }
 
-// ForWorkload allows specifying a function that should return `true` if the given MsgFromSensor is to be evaluated by
-// the rate-limiter (and later accepted or rejected) and `false` if the rate-limiter should ignore this message
-// (allowing it to pass). This function must handle `nil` arguments and execute quickly.
+// ForWorkload allows specifying a function that should return true if the given
+// MsgFromSensor is to be evaluated by the limiter (and later accepted or
+// rejected) and false if the limiter should ignore this message (allowing it to
+// pass). This function must handle nil arguments and execute quickly.
 func (lo *limiterOption) ForWorkload(acceptsFn func(msg *central.MsgFromSensor) bool) (*Limiter, error) {
 	if lo.l == nil {
 		return nil, lo.err
@@ -94,23 +87,16 @@ func (lo *limiterOption) ForWorkload(acceptsFn func(msg *central.MsgFromSensor) 
 	return lo.l, lo.err
 }
 
-// NewLimiter creates a new per-client rate limiter for the given workload.
-// globalRate of 0 disables rate limiting (unlimited).
-// bucketCapacity is the max tokens per client bucket (allows temporary bursts above sustained rate).
-// workloadName is used for logging and metrics (e.g., "vm_index_report", "node_inventory").
+// NewLimiter creates a new per-client concurrency limiter for the given workload.
+// globalRate > 0 enables limiting; globalRate of 0 disables it (unlimited).
+// bucketCapacity is the total number of tokens shared across all clients.
+// workloadName is used for logging and metrics.
 //
 // Returns error if:
 //   - workloadName is empty
 //   - globalRate is negative
 //   - bucketCapacity is less than 1
 func NewLimiter(workloadName string, globalRate float64, bucketCapacity int) *limiterOption {
-	return NewLimiterWithClock(workloadName, globalRate, bucketCapacity, RealClock{})
-}
-
-// NewLimiterWithClock creates a new per-client rate limiter with an injectable clock.
-// This is primarily useful for testing to control time and avoid flaky tests.
-// For production use, prefer NewLimiter which uses the real system clock.
-func NewLimiterWithClock(workloadName string, globalRate float64, bucketCapacity int, clock Clock) *limiterOption {
 	if workloadName == "" {
 		return &limiterOption{nil, ErrEmptyWorkloadName}
 	}
@@ -121,12 +107,11 @@ func NewLimiterWithClock(workloadName string, globalRate float64, bucketCapacity
 		return &limiterOption{nil, ErrInvalidBucketCapacity}
 	}
 
-	// Initialize metrics for this workload so they're visible in Prometheus immediately.
-	// Set per-client metrics to the maximum values (what a single client would get).
+	// Initialize metrics so they are visible in Prometheus immediately.
 	RequestsTotal.WithLabelValues(workloadName, OutcomeAccepted).Add(0)
 	RequestsTotal.WithLabelValues(workloadName, OutcomeRejected).Add(0)
 	ActiveClients.WithLabelValues(workloadName).Set(0)
-	PerClientRate.WithLabelValues(workloadName).Set(globalRate)
+	InFlightTokens.WithLabelValues(workloadName).Set(0)
 	PerClientBucketCapacity.WithLabelValues(workloadName).Set(float64(bucketCapacity))
 
 	return &limiterOption{
@@ -134,41 +119,75 @@ func NewLimiterWithClock(workloadName string, globalRate float64, bucketCapacity
 			workloadName:   workloadName,
 			globalRate:     globalRate,
 			bucketCapacity: bucketCapacity,
-			buckets:        make(map[string]*gorate.Limiter),
-			clock:          clock,
+			buckets:        make(map[string]*clientBucket),
 		},
 		err: nil,
 	}
 }
 
 // TryConsume attempts to consume one token for the given client.
-// Returns true if allowed, false if rate limit exceeded.
+// Returns true if allowed, false if no tokens are available.
 // Metrics are automatically recorded.
+//
+// Every successful TryConsume must eventually be paired with a Return call
+// when the associated work completes; failing to do so permanently reduces
+// available capacity.
 func (l *Limiter) TryConsume(clientID string, msg *central.MsgFromSensor) (allowed bool, reason string) {
 	if l == nil {
 		return true, "nil rate limiter"
 	}
 	if !l.accepts(msg) {
-		// This is not the correct rateLimiter to evaluate this request - allow request to pass.
 		return true, ""
 	}
 
 	if l.globalRate <= 0 {
-		// Rate limiting disabled, but still record metrics for visibility into request volume.
 		RequestsTotal.WithLabelValues(l.workloadName, OutcomeAccepted).Inc()
 		return true, ""
 	}
 
-	limiter := l.getOrCreateLimiter(clientID)
+	l.mu.Lock()
+	defer l.mu.Unlock()
 
-	// Use AllowN with clock.Now() to support time injection for testing.
-	if limiter.AllowN(l.clock.Now(), 1) {
+	bucket := l.getOrCreateBucketLocked(clientID)
+	if bucket.available > 0 {
+		bucket.available--
 		RequestsTotal.WithLabelValues(l.workloadName, OutcomeAccepted).Inc()
+		InFlightTokens.WithLabelValues(l.workloadName).Inc()
 		return true, ""
 	}
 
 	RequestsTotal.WithLabelValues(l.workloadName, OutcomeRejected).Inc()
 	return false, ReasonRateLimitExceeded
+}
+
+// Return returns one token for the given client after processing completes.
+// If the message does not match the workload filter, or if limiting is
+// disabled, Return is a no-op. It is safe to call Return for a client that
+// has already disconnected; the token is silently discarded.
+func (l *Limiter) Return(clientID string, msg *central.MsgFromSensor) {
+	if l == nil {
+		return
+	}
+	if !l.accepts(msg) {
+		return
+	}
+	if l.globalRate <= 0 {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	bucket, ok := l.buckets[clientID]
+	if !ok {
+		log.Debugf("Token return for disconnected client %s on %s (token discarded)",
+			clientID, l.workloadName)
+		return
+	}
+	if bucket.available < bucket.capacity {
+		bucket.available++
+		InFlightTokens.WithLabelValues(l.workloadName).Dec()
+	}
 }
 
 func (l *Limiter) accepts(msg *central.MsgFromSensor) bool {
@@ -178,54 +197,45 @@ func (l *Limiter) accepts(msg *central.MsgFromSensor) bool {
 	return l.acceptsFn(msg)
 }
 
-// getOrCreateLimiter returns the rate limiter for a given client, creating one if needed.
-// When a new client is added, all limiters are rebalanced to maintain fairness.
-func (l *Limiter) getOrCreateLimiter(clientID string) *gorate.Limiter {
-	// Fast path: read lock to check if limiter exists
-	if limiter := concurrency.WithRLock1(&l.mu, func() *gorate.Limiter {
-		return l.buckets[clientID]
-	}); limiter != nil {
-		return limiter
-	}
-
-	// Slow path: write lock to create new limiter
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	// Double-check after acquiring write lock to avoid race conditions.
-	if limiter, ok := l.buckets[clientID]; ok {
-		return limiter
+// getOrCreateBucketLocked returns the bucket for a given client, creating one
+// if needed.  When a new client is added, all buckets are rebalanced to
+// maintain fairness.  Must be called with l.mu held.
+func (l *Limiter) getOrCreateBucketLocked(clientID string) *clientBucket {
+	if bucket, ok := l.buckets[clientID]; ok {
+		return bucket
 	}
 
 	if clientID == "" {
-		log.Warnf("getOrCreateLimiter called with empty clientID for workload %s; this may cause unfair rate limiting", l.workloadName)
+		log.Warnf("getOrCreateBucketLocked called with empty clientID for workload %s; this may cause unfair limiting", l.workloadName)
 	}
 
 	l.numClients++
-	perClientRate := l.globalRate / float64(l.numClients)
-	bucketCapacity := l.perClientBucketCapacity(l.numClients)
+	capacity := l.perClientBucketCapacity(l.numClients)
 
-	// Create limiter for this client
-	newLimiter := gorate.NewLimiter(gorate.Limit(perClientRate), bucketCapacity)
-	l.buckets[clientID] = newLimiter
+	newBucket := &clientBucket{
+		available: capacity,
+		capacity:  capacity,
+	}
+	l.buckets[clientID] = newBucket
 
-	// Rebalance all limiters (including the new one) and update metrics
-	for _, limiter := range l.buckets {
-		limiter.SetLimit(gorate.Limit(perClientRate))
-		limiter.SetBurst(bucketCapacity)
+	// Rebalance all buckets (including the new one) to the new capacity.
+	for _, bucket := range l.buckets {
+		bucket.capacity = capacity
+		if bucket.available > capacity {
+			bucket.available = capacity
+		}
 	}
 
 	ActiveClients.WithLabelValues(l.workloadName).Set(float64(l.numClients))
-	PerClientRate.WithLabelValues(l.workloadName).Set(perClientRate)
-	PerClientBucketCapacity.WithLabelValues(l.workloadName).Set(float64(bucketCapacity))
+	PerClientBucketCapacity.WithLabelValues(l.workloadName).Set(float64(capacity))
 
-	log.Debugf("New client %s registered for %s rate limiting (clients: %d, rate: %.2f req/s, max bucket capacity: %d)",
-		clientID, l.workloadName, l.numClients, perClientRate, bucketCapacity)
+	log.Debugf("New client %s registered for %s concurrency limiting (clients: %d, per-client capacity: %d)",
+		clientID, l.workloadName, l.numClients, capacity)
 
-	return newLimiter
+	return newBucket
 }
 
-// perClientBucketCapacity calculates the per-client burst capacity (max tokens in bucket).
+// perClientBucketCapacity calculates the per-client token capacity.
 // The global bucket capacity is divided equally among all clients.
 func (l *Limiter) perClientBucketCapacity(numClients int) int {
 	burst := l.bucketCapacity / numClients
@@ -235,63 +245,67 @@ func (l *Limiter) perClientBucketCapacity(numClients int) int {
 	return burst
 }
 
-// OnClientDisconnect removes a client from rate limiting and rebalances remaining limiters.
-// This should be called when a client connection is terminated.
+// OnClientDisconnect removes a client from the limiter and rebalances
+// remaining clients.  In-flight tokens for the disconnected client are
+// discarded (the corresponding InFlightTokens gauge is decremented).
 func (l *Limiter) OnClientDisconnect(clientID string) {
 	if l == nil {
 		return
 	}
 	if l.globalRate <= 0 {
-		// Rate limiting disabled
 		return
 	}
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if _, ok := l.buckets[clientID]; !ok {
+	bucket, ok := l.buckets[clientID]
+	if !ok {
 		return
+	}
+
+	inFlight := bucket.capacity - bucket.available
+	if inFlight > 0 {
+		InFlightTokens.WithLabelValues(l.workloadName).Sub(float64(inFlight))
 	}
 
 	delete(l.buckets, clientID)
 	l.numClients--
 
-	log.Infof("Client %s disconnected from %s rate limiting (remaining clients: %d)",
+	log.Infof("Client %s disconnected from %s concurrency limiting (remaining clients: %d)",
 		clientID, l.workloadName, l.numClients)
 
 	if l.numClients == 0 {
 		ActiveClients.WithLabelValues(l.workloadName).Set(0)
-		PerClientRate.WithLabelValues(l.workloadName).Set(l.globalRate)
 		PerClientBucketCapacity.WithLabelValues(l.workloadName).Set(float64(l.bucketCapacity))
 		return
 	}
 
-	perClientRate := l.globalRate / float64(l.numClients)
-	bucketCapacity := l.perClientBucketCapacity(l.numClients)
-
-	for _, limiter := range l.buckets {
-		limiter.SetLimit(gorate.Limit(perClientRate))
-		limiter.SetBurst(bucketCapacity)
+	capacity := l.perClientBucketCapacity(l.numClients)
+	for _, bucket := range l.buckets {
+		bucket.capacity = capacity
+		if bucket.available > capacity {
+			bucket.available = capacity
+		}
 	}
 
 	ActiveClients.WithLabelValues(l.workloadName).Set(float64(l.numClients))
-	PerClientRate.WithLabelValues(l.workloadName).Set(perClientRate)
-	PerClientBucketCapacity.WithLabelValues(l.workloadName).Set(float64(bucketCapacity))
+	PerClientBucketCapacity.WithLabelValues(l.workloadName).Set(float64(capacity))
 }
 
 // numActiveClients returns the number of currently active clients.
 func (l *Limiter) numActiveClients() int {
-	l.mu.RLock()
-	defer l.mu.RUnlock()
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	return l.numClients
 }
 
-// GlobalRate returns the configured global rate limit.
+// GlobalRate returns the configured global rate (used as an enabled flag).
 func (l *Limiter) GlobalRate() float64 {
 	return l.globalRate
 }
 
-// BucketCapacity returns the configured bucket capacity.
+// BucketCapacity returns the configured total bucket capacity.
 func (l *Limiter) BucketCapacity() int {
 	return l.bucketCapacity
 }

--- a/pkg/rate/limiter_test.go
+++ b/pkg/rate/limiter_test.go
@@ -1,11 +1,10 @@
 package rate
 
 import (
+	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,43 +12,10 @@ import (
 
 const workloadName = "test_workload"
 
-// TestClock allows manual time control in tests.
-type TestClock struct {
-	mu  sync.Mutex
-	now time.Time
-}
-
-// NewTestClock creates a TestClock starting at the given time.
-func NewTestClock(start time.Time) *TestClock {
-	return &TestClock{now: start}
-}
-
-// Now returns the current frozen time.
-func (c *TestClock) Now() time.Time {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.now
-}
-
-// Advance moves the clock forward by the given duration.
-func (c *TestClock) Advance(d time.Duration) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.now = c.now.Add(d)
-}
-
 // mustNewLimiter creates a limiter or fails the test.
 func mustNewLimiter(t *testing.T, workloadName string, globalRate float64, bucketCapacity int) *Limiter {
 	t.Helper()
 	limiter, err := NewLimiter(workloadName, globalRate, bucketCapacity).ForAllWorkloads()
-	require.NoError(t, err)
-	return limiter
-}
-
-// mustNewLimiterWithClock creates a limiter with an injectable clock or fails the test.
-func mustNewLimiterWithClock(t *testing.T, workloadName string, globalRate float64, bucketCapacity int, clock Clock) *Limiter {
-	t.Helper()
-	limiter, err := NewLimiterWithClock(workloadName, globalRate, bucketCapacity, clock).ForAllWorkloads()
 	require.NoError(t, err)
 	return limiter
 }
@@ -63,17 +29,10 @@ func TestNewLimiter(t *testing.T) {
 		assert.Equal(t, workloadName, limiter.WorkloadName())
 	})
 	t.Run("should create a new limiter with rate limiting disabled", func(t *testing.T) {
-		limiter, err := NewLimiter(workloadName, 0.0, 1).ForAllWorkloads() // rate=0 disables limiting, bucketCapacity still must be >= 1
+		limiter, err := NewLimiter(workloadName, 0.0, 1).ForAllWorkloads()
 		require.NoError(t, err)
 		assert.Equal(t, 0.0, limiter.GlobalRate())
 		assert.Equal(t, 1, limiter.BucketCapacity())
-		assert.Equal(t, workloadName, limiter.WorkloadName())
-	})
-	t.Run("should create a new limiter with rate higher than bucket capacity", func(t *testing.T) {
-		limiter, err := NewLimiter(workloadName, 50.0, 2).ForAllWorkloads()
-		require.NoError(t, err)
-		assert.Equal(t, 50.0, limiter.GlobalRate())
-		assert.Equal(t, 2, limiter.BucketCapacity())
 		assert.Equal(t, workloadName, limiter.WorkloadName())
 	})
 	t.Run("should error on empty workload name", func(t *testing.T) {
@@ -151,14 +110,17 @@ func TestLimiterOption_ForWorkload(t *testing.T) {
 				return
 			}
 
+			// With capacity=1, first consume should succeed.
 			allowed, reason := limiter.TryConsume("client-1", &central.MsgFromSensor{})
 			require.True(t, allowed)
 			assert.Empty(t, reason)
 
+			// Second consume should be rejected (no tokens left).
 			allowed, reason = limiter.TryConsume("client-1", &central.MsgFromSensor{})
 			assert.False(t, allowed)
 			assert.Equal(t, ReasonRateLimitExceeded, reason)
 
+			// nil message should pass through (not accepted by filter).
 			allowed, reason = limiter.TryConsume("client-1", nil)
 			assert.True(t, allowed)
 			assert.Empty(t, reason)
@@ -176,55 +138,141 @@ func TestTryConsume_Disabled(t *testing.T) {
 }
 
 func TestTryConsume_SingleClient(t *testing.T) {
-	clock := NewTestClock(time.Now())
-	limiter := mustNewLimiterWithClock(t, "test", 10, 50, clock) // rate=10 req/s, bucket capacity=50
+	limiter := mustNewLimiter(t, "test", 10, 50) // capacity=50
 
-	// With 1 client, per-client burst = 50/1 = 50 requests
+	// With 1 client, per-client capacity = 50/1 = 50 tokens
 	for i := range 50 {
 		allowed, reason := limiter.TryConsume("client-1", nil)
-		assert.True(t, allowed, "request %d should be allowed within burst", i)
+		assert.True(t, allowed, "request %d should be allowed within capacity", i)
 		assert.Empty(t, reason)
 	}
 
-	// Time is frozen - no new tokens can be added between requests.
-	// 51st request should be rejected (burst exhausted)
+	// 51st request should be rejected (all tokens consumed, none returned)
 	allowed, reason := limiter.TryConsume("client-1", nil)
-	assert.False(t, allowed, "request should be rejected after burst exhausted")
-	assert.Equal(t, "rate limit exceeded", reason)
+	assert.False(t, allowed, "request should be rejected after capacity exhausted")
+	assert.Equal(t, ReasonRateLimitExceeded, reason)
+}
 
-	// Advance time and verify tokens refill correctly
-	clock.Advance(500 * time.Millisecond) // At 10 req/s, expect ~5 tokens
-	for i := range 5 {
+func TestReturn_RefillsTokens(t *testing.T) {
+	limiter := mustNewLimiter(t, "test", 1, 5) // capacity=5
+
+	// Exhaust all tokens
+	for range 5 {
 		allowed, _ := limiter.TryConsume("client-1", nil)
-		assert.True(t, allowed, "request %d should be allowed after time advance", i)
+		require.True(t, allowed)
+	}
+	allowed, _ := limiter.TryConsume("client-1", nil)
+	require.False(t, allowed, "should be rejected after capacity exhausted")
+
+	// Return 3 tokens
+	for range 3 {
+		limiter.Return("client-1", nil)
+	}
+
+	// Should be able to consume 3 more
+	for i := range 3 {
+		allowed, _ := limiter.TryConsume("client-1", nil)
+		assert.True(t, allowed, "request %d should be allowed after return", i)
+	}
+
+	// 4th should be rejected
+	allowed, _ = limiter.TryConsume("client-1", nil)
+	assert.False(t, allowed, "should be rejected after re-exhausted")
+}
+
+func TestReturn_CapsAtCapacity(t *testing.T) {
+	limiter := mustNewLimiter(t, "test", 1, 3) // capacity=3
+
+	// Consume 1 token, then return 10 times — should never exceed capacity
+	allowed, _ := limiter.TryConsume("client-1", nil)
+	require.True(t, allowed)
+
+	for range 10 {
+		limiter.Return("client-1", nil)
+	}
+
+	// Should be able to consume exactly 3 (capacity), not more
+	for i := range 3 {
+		allowed, _ := limiter.TryConsume("client-1", nil)
+		assert.True(t, allowed, "request %d should be allowed", i)
 	}
 	allowed, _ = limiter.TryConsume("client-1", nil)
-	assert.False(t, allowed, "should be rejected after consuming refilled tokens")
+	assert.False(t, allowed, "should be rejected at capacity")
+}
+
+func TestReturn_DisconnectedClient(t *testing.T) {
+	limiter := mustNewLimiter(t, "test", 1, 5)
+
+	// Consume a token
+	allowed, _ := limiter.TryConsume("client-1", nil)
+	require.True(t, allowed)
+
+	// Disconnect client
+	limiter.OnClientDisconnect("client-1")
+
+	// Return should be a no-op (no panic)
+	assert.NotPanics(t, func() {
+		limiter.Return("client-1", nil)
+	})
+}
+
+func TestReturn_WorkloadFilter(t *testing.T) {
+	limiter, err := NewLimiter("test", 1, 2).ForWorkload(func(msg *central.MsgFromSensor) bool {
+		return msg != nil
+	})
+	require.NoError(t, err)
+
+	// Consume both tokens with non-nil messages
+	allowed, _ := limiter.TryConsume("client-1", &central.MsgFromSensor{})
+	require.True(t, allowed)
+	allowed, _ = limiter.TryConsume("client-1", &central.MsgFromSensor{})
+	require.True(t, allowed)
+
+	// Return with nil message should be a no-op (doesn't match filter)
+	limiter.Return("client-1", nil)
+
+	// Still should be rejected (token not actually returned)
+	allowed, _ = limiter.TryConsume("client-1", &central.MsgFromSensor{})
+	assert.False(t, allowed, "nil return should not refill tokens")
+
+	// Return with non-nil message should actually refill
+	limiter.Return("client-1", &central.MsgFromSensor{})
+
+	allowed, _ = limiter.TryConsume("client-1", &central.MsgFromSensor{})
+	assert.True(t, allowed, "non-nil return should refill tokens")
 }
 
 func TestTryConsume_MultipleClients_Fairness(t *testing.T) {
-	clock := NewTestClock(time.Now())
-	limiter := mustNewLimiterWithClock(t, "test", 12, 60, clock) // rate=12 req/s, bucket capacity=60
+	limiter := mustNewLimiter(t, "test", 12, 60) // capacity=60
 
 	client1 := "client-1"
 	client2 := "client-2"
 	client3 := "client-3"
 
-	// Create all clients first to establish fair rates upfront
-	// With 3 clients, each gets per-client burst = 60/3 = 20
-	limiter.getOrCreateLimiter(client1)
-	limiter.getOrCreateLimiter(client2)
-	limiter.getOrCreateLimiter(client3)
+	// Force creation of all 3 clients via TryConsume (first consume for each).
+	// After 3 clients, each gets per-client capacity = 60/3 = 20.
+	// First consume for each client uses one token.
+	allowed, _ := limiter.TryConsume(client1, nil)
+	require.True(t, allowed)
+	allowed, _ = limiter.TryConsume(client2, nil)
+	require.True(t, allowed)
+	allowed, _ = limiter.TryConsume(client3, nil)
+	require.True(t, allowed)
 
-	// Exhaust burst for client-1 (20 requests)
+	// Return those initial tokens to reset to full capacity.
+	limiter.Return(client1, nil)
+	limiter.Return(client2, nil)
+	limiter.Return(client3, nil)
+
+	// Exhaust capacity for client-1 (20 requests)
 	for i := range 20 {
 		allowed, _ := limiter.TryConsume(client1, nil)
 		assert.True(t, allowed, "client-1 request %d should be allowed", i)
 	}
-	allowed, _ := limiter.TryConsume(client1, nil)
-	assert.False(t, allowed, "client-1 should be rate limited after burst")
+	allowed, _ = limiter.TryConsume(client1, nil)
+	assert.False(t, allowed, "client-1 should be limited after capacity exhausted")
 
-	// client-2 and client-3 should still have their full burst capacity
+	// client-2 and client-3 should still have their full capacity
 	for i := range 20 {
 		allowed, _ := limiter.TryConsume(client2, nil)
 		assert.True(t, allowed, "client-2 request %d should be allowed", i)
@@ -234,70 +282,104 @@ func TestTryConsume_MultipleClients_Fairness(t *testing.T) {
 		assert.True(t, allowed, "client-3 request %d should be allowed", i)
 	}
 
-	// All clients exhausted - time is frozen so no tokens refilled
+	// All clients exhausted
 	allowed, _ = limiter.TryConsume(client2, nil)
-	assert.False(t, allowed, "client-2 should be rate limited")
+	assert.False(t, allowed, "client-2 should be limited")
 	allowed, _ = limiter.TryConsume(client3, nil)
-	assert.False(t, allowed, "client-3 should be rate limited")
+	assert.False(t, allowed, "client-3 should be limited")
 }
 
 func TestTryConsume_Rebalancing(t *testing.T) {
-	clock := NewTestClock(time.Now())
-	// rate=10 req/s, bucket capacity=100
-	limiter := mustNewLimiterWithClock(t, workloadName, 10, 100, clock)
+	limiter := mustNewLimiter(t, workloadName, 10, 100) // capacity=100
 
-	// Start with client-1: per-client burst = 100/1 = 100
+	// Start with client-1: per-client capacity = 100/1 = 100
 	for i := range 100 {
 		allowed, _ := limiter.TryConsume("client-1", nil)
 		assert.True(t, allowed, "client-1 initial request %d should be allowed", i)
 	}
 	allowed, _ := limiter.TryConsume("client-1", nil)
-	assert.False(t, allowed, "client-1 should be rate limited after initial burst")
+	assert.False(t, allowed, "client-1 should be limited after capacity exhausted")
 
-	// Add client-2: rebalances to per-client burst = 100/2 = 50
+	// Add client-2: rebalances to per-client capacity = 100/2 = 50
 	// client-2 gets fresh bucket with capacity 50
 	for i := range 50 {
 		allowed, _ := limiter.TryConsume("client-2", nil)
 		assert.True(t, allowed, "client-2 request %d should be allowed after rebalancing", i)
 	}
 	allowed, _ = limiter.TryConsume("client-2", nil)
-	assert.False(t, allowed, "client-2 should be rate limited after burst")
+	assert.False(t, allowed, "client-2 should be limited after capacity exhausted")
 
-	// Advance time for token refill (at 5 req/s per client, 7 tokens refill in 1.4 seconds)
-	clock.Advance(1500 * time.Millisecond)
+	// No time-based refill: both clients stay limited until Return is called.
+	allowed, _ = limiter.TryConsume("client-1", nil)
+	assert.False(t, allowed, "client-1 should still be limited (no time-based refill)")
+	allowed, _ = limiter.TryConsume("client-2", nil)
+	assert.False(t, allowed, "client-2 should still be limited (no time-based refill)")
 
-	// Both clients should get ~7 tokens back (5 req/s * 1.5s)
-	// Verify we can make a few requests
+	// Return tokens and verify they're available again
+	for range 5 {
+		limiter.Return("client-1", nil)
+		limiter.Return("client-2", nil)
+	}
 	for range 5 {
 		allowed, _ := limiter.TryConsume("client-1", nil)
-		assert.True(t, allowed, "client-1 should have refilled tokens")
+		assert.True(t, allowed, "client-1 should have returned tokens")
 		allowed, _ = limiter.TryConsume("client-2", nil)
-		assert.True(t, allowed, "client-2 should have refilled tokens")
+		assert.True(t, allowed, "client-2 should have returned tokens")
 	}
 }
 
-func TestTryConsume_BurstWindow(t *testing.T) {
-	clock := NewTestClock(time.Now())
-	// rate=10 req/s, bucket capacity=100
-	limiter := mustNewLimiterWithClock(t, "test", 10, 100, clock)
+func TestReturn_ConsumeReturnCycle(t *testing.T) {
+	limiter := mustNewLimiter(t, "test", 1, 2) // capacity=2
 
-	// With 1 client, per-client burst = 100/1 = 100
-	for i := range 100 {
+	// Simulate processing: consume, process, return, repeat
+	for cycle := range 100 {
 		allowed, _ := limiter.TryConsume("client-1", nil)
-		assert.True(t, allowed, "request %d should be allowed within burst", i)
+		assert.True(t, allowed, "cycle %d: should be allowed", cycle)
+		limiter.Return("client-1", nil)
 	}
 
-	// 101st request rejected
+	// After 100 cycles, bucket should be at full capacity
+	for i := range 2 {
+		allowed, _ := limiter.TryConsume("client-1", nil)
+		assert.True(t, allowed, "final burst request %d should be allowed", i)
+	}
 	allowed, _ := limiter.TryConsume("client-1", nil)
-	assert.False(t, allowed, "request should be rejected after burst exhausted")
+	assert.False(t, allowed, "should be limited after capacity")
+}
 
-	// Advance time for refill (at 10 req/s, 15 tokens refill in 1.5 seconds)
-	clock.Advance(1500 * time.Millisecond)
+func TestReturn_ConcurrentConsumeReturn(t *testing.T) {
+	limiter := mustNewLimiter(t, "test", 1, 10) // capacity=10
 
-	// Should get ~15 tokens back - verify we can make at least 10 requests
-	for range 10 {
-		allowed, _ = limiter.TryConsume("client-1", nil)
-		assert.True(t, allowed, "should have refilled tokens")
+	var wg sync.WaitGroup
+	iterations := 1000
+
+	// Spawn multiple goroutines that consume and return tokens concurrently.
+	for g := range 5 {
+		wg.Add(1)
+		go func(clientID string) {
+			defer wg.Done()
+			for range iterations {
+				if allowed, _ := limiter.TryConsume(clientID, nil); allowed {
+					limiter.Return(clientID, nil)
+				}
+			}
+		}(fmt.Sprintf("client-%d", g))
+	}
+
+	wg.Wait()
+
+	// After all goroutines complete, all tokens should be returned.
+	// Each client should have its full capacity available.
+	assert.Equal(t, 5, limiter.numActiveClients())
+	for g := range 5 {
+		clientID := fmt.Sprintf("client-%d", g)
+		capacity := limiter.perClientBucketCapacity(5) // 10/5 = 2
+		for i := range capacity {
+			allowed, _ := limiter.TryConsume(clientID, nil)
+			assert.True(t, allowed, "%s request %d should be allowed after concurrent test", clientID, i)
+		}
+		allowed, _ := limiter.TryConsume(clientID, nil)
+		assert.False(t, allowed, "%s should be limited at capacity", clientID)
 	}
 }
 
@@ -307,20 +389,20 @@ func TestPerClientBurst(t *testing.T) {
 		numClients                      int
 		expectedPerClientBucketCapacity int
 	}{
-		"should calculate burst correctly for single client": {
+		"should calculate capacity correctly for single client": {
 			bucketCapacity:                  50,
 			numClients:                      1,
-			expectedPerClientBucketCapacity: 50, // 50/1 = 50
+			expectedPerClientBucketCapacity: 50,
 		},
-		"should calculate burst correctly for multiple clients": {
+		"should calculate capacity correctly for multiple clients": {
 			bucketCapacity:                  60,
 			numClients:                      3,
-			expectedPerClientBucketCapacity: 20, // 60/3 = 20
+			expectedPerClientBucketCapacity: 20,
 		},
-		"should return minimum bucket capacity of 1 for many clients": {
+		"should return minimum capacity of 1 for many clients": {
 			bucketCapacity:                  5,
 			numClients:                      10,
-			expectedPerClientBucketCapacity: 1, // 5/10 = 0, but min is 1
+			expectedPerClientBucketCapacity: 1,
 		},
 	}
 
@@ -334,29 +416,27 @@ func TestPerClientBurst(t *testing.T) {
 }
 
 func TestRebalancing_DynamicClientCount(t *testing.T) {
-	clock := NewTestClock(time.Now())
-	// rate=30 req/s, bucket capacity=300
-	limiter := mustNewLimiterWithClock(t, "test", 30, 300, clock)
+	limiter := mustNewLimiter(t, "test", 30, 300) // capacity=300
 
-	// Client 1: gets 30/1 = 30 req/s, burst = 30*10s = 300
+	// Client 1: gets capacity = 300/1 = 300
 	for range 300 {
 		allowed, _ := limiter.TryConsume("client-1", nil)
 		assert.True(t, allowed)
 	}
 
-	// Add client 2: rebalances to 30/2 = 15 req/s each, burst = 15*10s = 150
+	// Add client 2: rebalances to capacity = 300/2 = 150
 	for range 150 {
 		allowed, _ := limiter.TryConsume("client-2", nil)
 		assert.True(t, allowed)
 	}
 
-	// Add client 3: rebalances to 30/3 = 10 req/s each, burst = 10*10s = 100
+	// Add client 3: rebalances to capacity = 300/3 = 100
 	for range 100 {
 		allowed, _ := limiter.TryConsume("client-3", nil)
 		assert.True(t, allowed)
 	}
 
-	// All clients should be limited now - time is frozen
+	// All clients should be limited now (no time-based refill)
 	allowed, _ := limiter.TryConsume("client-1", nil)
 	assert.False(t, allowed)
 	allowed, _ = limiter.TryConsume("client-2", nil)
@@ -364,68 +444,73 @@ func TestRebalancing_DynamicClientCount(t *testing.T) {
 	allowed, _ = limiter.TryConsume("client-3", nil)
 	assert.False(t, allowed)
 
-	// Advance time for token refill (at 10 req/s per client, 15 tokens refill in 1.5s)
-	clock.Advance(1500 * time.Millisecond)
-
-	// Each client should get ~15 tokens back - verify at least 10 work
+	// Return tokens and verify they're usable
+	for range 10 {
+		limiter.Return("client-1", nil)
+		limiter.Return("client-2", nil)
+		limiter.Return("client-3", nil)
+	}
 	for range 10 {
 		allowed, _ := limiter.TryConsume("client-1", nil)
-		assert.True(t, allowed, "client-1 should get tokens after refill")
+		assert.True(t, allowed, "client-1 should get tokens after return")
 		allowed, _ = limiter.TryConsume("client-2", nil)
-		assert.True(t, allowed, "client-2 should get tokens after refill")
+		assert.True(t, allowed, "client-2 should get tokens after return")
 		allowed, _ = limiter.TryConsume("client-3", nil)
-		assert.True(t, allowed, "client-3 should get tokens after refill")
+		assert.True(t, allowed, "client-3 should get tokens after return")
 	}
 }
 
 func TestOnClientDisconnect_Nil(t *testing.T) {
-	clock := NewTestClock(time.Now())
-	// intentionally broken rate-limiter
-	limiter, err := NewLimiterWithClock(workloadName, -1.0, -2.0, clock).ForAllWorkloads()
+	limiter, err := NewLimiter(workloadName, -1.0, -2.0).ForAllWorkloads()
 	assert.Error(t, err)
 	assert.Nil(t, limiter)
 	assert.NotPanics(t, func() {
 		limiter.OnClientDisconnect("client-2")
 		limiter.TryConsume("client-2", nil)
+		limiter.Return("client-2", nil)
 	})
 }
 
 func TestOnClientDisconnect(t *testing.T) {
-	clock := NewTestClock(time.Now())
-	limiter := mustNewLimiterWithClock(t, "test", 20, 100, clock) // rate=20 req/s, bucket capacity=100
+	limiter := mustNewLimiter(t, "test", 20, 100) // capacity=100
 
-	// Create 2 clients: each gets 20/2 = 10 req/s, burst = 10*5s = 50
-	limiter.getOrCreateLimiter("client-1")
-	limiter.getOrCreateLimiter("client-2")
+	// Force creation of 2 clients: each gets 100/2 = 50
+	allowed, _ := limiter.TryConsume("client-1", nil)
+	require.True(t, allowed)
+	allowed, _ = limiter.TryConsume("client-2", nil)
+	require.True(t, allowed)
 
-	// Exhaust client-1's burst
+	// Return initial tokens
+	limiter.Return("client-1", nil)
+	limiter.Return("client-2", nil)
+
+	// Exhaust client-1's capacity (50)
 	for i := 0; i < 50; i++ {
 		allowed, _ := limiter.TryConsume("client-1", nil)
 		assert.True(t, allowed)
 	}
-	allowed, _ := limiter.TryConsume("client-1", nil)
-	assert.False(t, allowed, "client-1 should be limited after burst")
+	allowed, _ = limiter.TryConsume("client-1", nil)
+	assert.False(t, allowed, "client-1 should be limited after capacity exhausted")
 
 	// Disconnect client-2
 	limiter.OnClientDisconnect("client-2")
-
-	// client-1 should now get full rate: 20/1 = 20 req/s, burst = 20*5s = 100
-	// The existing limiter's burst is updated to 100, but tokens were exhausted
-	// Just verify the client-2 is removed
 	assert.Equal(t, 1, limiter.numActiveClients())
 
-	// Verify client-2 is no longer tracked
-	exists := concurrency.WithRLock1(&limiter.mu, func() bool {
-		_, ok := limiter.buckets["client-2"]
-		return ok
-	})
+	// client-2 should be removed
+	limiter.mu.Lock()
+	_, exists := limiter.buckets["client-2"]
+	limiter.mu.Unlock()
 	assert.False(t, exists, "client-2 should be removed from buckets")
+
+	// client-1's capacity is now 100/1 = 100.
+	// client-1 already has 50 tokens in-flight, so available was capped at min(0, 100) = 0.
+	// But capacity increased, so returning the 50 in-flight tokens will make 50 available,
+	// which is within the new capacity of 100.
 }
 
 func TestOnClientDisconnect_DisabledRateLimiter(t *testing.T) {
 	limiter := mustNewLimiter(t, "test", 0, 50)
 
-	// Should be a no-op when rate limiting is disabled
 	limiter.OnClientDisconnect("client-1")
 	assert.Equal(t, 0, limiter.numActiveClients())
 }
@@ -434,9 +519,37 @@ func TestOnClientDisconnect_NonexistentClient(t *testing.T) {
 	limiter := mustNewLimiter(t, "test", 10, 50)
 
 	// Create one client
-	limiter.getOrCreateLimiter("client-1")
+	limiter.TryConsume("client-1", nil)
 
 	// Disconnect a client that was never connected - should be a no-op
 	limiter.OnClientDisconnect("nonexistent-client")
 	assert.Equal(t, 1, limiter.numActiveClients())
+}
+
+func TestNoTimeBasedRefill(t *testing.T) {
+	limiter := mustNewLimiter(t, "test", 10, 5) // capacity=5
+
+	// Consume all tokens
+	for range 5 {
+		allowed, _ := limiter.TryConsume("client-1", nil)
+		require.True(t, allowed)
+	}
+
+	// Without Return, tokens never come back (no time-based refill)
+	for range 100 {
+		allowed, _ := limiter.TryConsume("client-1", nil)
+		assert.False(t, allowed, "should stay limited without Return calls")
+	}
+
+	// Only Return restores capacity
+	limiter.Return("client-1", nil)
+	allowed, _ := limiter.TryConsume("client-1", nil)
+	assert.True(t, allowed, "should be allowed after explicit Return")
+}
+
+func TestReturn_NilLimiter(t *testing.T) {
+	var limiter *Limiter
+	assert.NotPanics(t, func() {
+		limiter.Return("client-1", nil)
+	})
 }

--- a/pkg/rate/metrics.go
+++ b/pkg/rate/metrics.go
@@ -16,20 +16,19 @@ func init() {
 	prometheus.MustRegister(
 		RequestsTotal,
 		ActiveClients,
-		PerClientRate,
+		InFlightTokens,
 		PerClientBucketCapacity,
 	)
 }
 
 var (
-	// RequestsTotal tracks all requests received by the rate limiter with outcome.
-	// Use this for overall volume visibility. Per-client detail is available in logs.
+	// RequestsTotal tracks all requests received by the limiter with outcome.
 	RequestsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metrics.PrometheusNamespace,
 			Subsystem: metrics.CentralSubsystem.String(),
 			Name:      "rate_limiter_requests_total",
-			Help:      "Total requests received by the rate limiter",
+			Help:      "Total requests received by the limiter",
 		},
 		[]string{"workload", "outcome"},
 	)
@@ -40,19 +39,19 @@ var (
 			Namespace: metrics.PrometheusNamespace,
 			Subsystem: metrics.CentralSubsystem.String(),
 			Name:      "rate_limiter_active_clients",
-			Help:      "Current number of active clients being rate limited",
+			Help:      "Current number of active clients being limited",
 		},
 		[]string{"workload"},
 	)
 
-	// PerClientRate tracks the current per-client rate limit (requests per second).
-	PerClientRate = prometheus.NewGaugeVec(
+	// InFlightTokens tracks the number of tokens currently consumed and not yet returned.
+	InFlightTokens = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.PrometheusNamespace,
 			Subsystem: metrics.CentralSubsystem.String(),
-			Name:      "rate_limiter_per_client_bucket_refill_rate_per_second",
-			Help: "Current per-client rate limit in requests per second. " +
-				"This is also the rate at which tokens are refilled.",
+			Name:      "rate_limiter_in_flight_tokens",
+			Help: "Number of tokens currently consumed (in-flight). " +
+				"A token is consumed when a request is accepted and returned when processing completes.",
 		},
 		[]string{"workload"},
 	)
@@ -64,7 +63,7 @@ var (
 			Subsystem: metrics.CentralSubsystem.String(),
 			Name:      "rate_limiter_per_client_bucket_max_tokens",
 			Help: "Current per-client token bucket capacity (max tokens). Must be a positive integer. " +
-				"This is the maximum number of requests that can be accepted in a burst before rate limiting kicks in.",
+				"This is the maximum number of requests that can be in-flight concurrently per client.",
 		},
 		[]string{"workload"},
 	)

--- a/pkg/rate/testdata/E2E_REPRODUCTION_GUIDE.md
+++ b/pkg/rate/testdata/E2E_REPRODUCTION_GUIDE.md
@@ -5,112 +5,103 @@ VM index report rate limiter on an OCP cluster with Scanner V4.
 
 ## Prerequisites
 
-- An OCP cluster with ACS installed (Central + Scanner V4)
-- `kubectl` configured to access the cluster
+- An OCP cluster with ACS installed via operator (Central + Scanner V4)
+- `kubectl` / `oc` configured to access the cluster
 - `crane` CLI installed (`go install github.com/google/go-containerregistry/cmd/crane@latest`)
-- Go toolchain (for building `local-sensor`)
-- Central API credentials (default: `admin` / password from the `central-htpasswd` secret)
-- The StackRox repo checked out with the completion-based branch
+- Go toolchain (for building `local-sensor` and Central binaries)
+- Central API credentials (from `roxie env` or the `central-htpasswd` secret)
+- The StackRox repo checked out on this branch
 
-## Step 1: Build Central Images
+## Step 1: Deploy ACS
 
-Build two Central images: one with the time-based limiter (baseline from master)
-and one with the completion-based limiter (this branch).
+Use [Roxie](https://github.com/stackrox/roxie) to deploy ACS with operator:
 
 ```bash
-cd <stackrox-repo>
-
-# Get the current Central image tag from the cluster
-CURRENT_IMAGE=$(kubectl get deployment -n stackrox central \
-  -o jsonpath='{.spec.template.spec.containers[0].image}')
-echo "Current image: $CURRENT_IMAGE"
-
-# Build the baseline (time-based) central binary from master
-git stash  # save any changes
-git checkout origin/master -- pkg/rate/limiter.go pkg/rate/metrics.go
-go build -o /tmp/central-baseline ./cmd/central/
-git checkout HEAD -- pkg/rate/limiter.go pkg/rate/metrics.go
-git stash pop
-
-# Build the completion-based central binary from this branch
-go build -o /tmp/central-completion ./cmd/central/
-
-# Create a layer for each binary and push to ttl.sh
-BASELINE_TAG="ttl.sh/stackrox-central-baseline-$(date +%s):24h"
-COMPLETION_TAG="ttl.sh/stackrox-central-completion-$(date +%s):24h"
-
-# Baseline image
-crane mutate "$CURRENT_IMAGE" \
-  --append <(cd /tmp && tar cf - central-baseline) \
-  --entrypoint /central-baseline \
-  --tag "$BASELINE_TAG"
-crane push "$BASELINE_TAG"
-
-# Completion image
-crane mutate "$CURRENT_IMAGE" \
-  --append <(cd /tmp && tar cf - central-completion) \
-  --entrypoint /central-completion \
-  --tag "$COMPLETION_TAG"
-crane push "$COMPLETION_TAG"
-
-echo "Baseline: $BASELINE_TAG"
-echo "Completion: $COMPLETION_TAG"
+roxie deploy both \
+  --tag <latest-master-tag> \
+  --envrc /tmp/roxie-env.sh \
+  --exposure loadbalancer \
+  --resources auto
 ```
 
-**Alternative (simpler):** If you only want to test the completion-based limiter
-against the stock Central, just build and push one image:
+Find the latest master-based tag:
 
 ```bash
-# Build the modified binary
-GOARCH=amd64 GOOS=linux go build -o /tmp/central-db ./cmd/central/
+TAGS=$(curl -s "https://quay.io/api/v1/repository/stackrox-io/main/tag/?limit=100&onlyActiveTags=true" \
+  | jq -r '.tags[].name | select(test("^[0-9]+[.][0-9]+[.]x-")) | select(test("-(arm64|amd64|s390x|ppc64le)$") | not)')
+echo "$TAGS" | head -5
+```
 
-# Append it to the existing image
-IMAGE_TAG="ttl.sh/stackrox-central-test-$(date +%s):24h"
-crane mutate "$CURRENT_IMAGE" \
-  --append <(cd /tmp && tar czf - central-db) \
-  --tag "$IMAGE_TAG"
+After deployment, read credentials:
 
-echo "Test image: $IMAGE_TAG"
+```bash
+source /tmp/roxie-env.sh
+curl -sk -u "admin:${ROX_ADMIN_PASSWORD}" "https://${ROX_ENDPOINT}/v1/metadata"
 ```
 
 ## Step 2: Configure Cluster
 
-```bash
-# Scale down the real sensor to avoid connection conflicts
-kubectl scale deployment sensor -n stackrox --replicas=0
+Determine ACS namespace layout (Roxie defaults: `acs-central` + `acs-sensor`):
 
-# Set environment variables on Central
-kubectl set env deployment/central -n stackrox \
+```bash
+CENTRAL_NS=acs-central
+SENSOR_NS=acs-sensor
+```
+
+Scale down real sensor and configure Central:
+
+```bash
+kubectl scale deployment sensor -n $SENSOR_NS --replicas=0
+
+kubectl set env deployment/central -n $CENTRAL_NS \
   ROX_VIRTUAL_MACHINES=true \
-  ROX_VM_TEST_MODE=true \
-  ROX_VM_INDEX_REPORT_BUCKET_CAPACITY=30
-
-# Deploy the completion-based image first
-kubectl set image deployment/central -n stackrox \
-  central=$COMPLETION_TAG
-kubectl rollout status deployment/central -n stackrox --timeout=180s
+  ROX_VM_INDEX_REPORT_BUCKET_CAPACITY=200
 ```
 
-## Step 3: Create Workload Configuration
+## Step 3: Build Central Images
+
+Build two Central images: completion-based (this branch) and baseline (master).
 
 ```bash
-cat > /tmp/vm-high-load-test.yaml << 'EOF'
-nodeWorkload:
-  numNodes: 4
-numNamespaces: 1
-virtualMachineWorkload:
-  poolSize: 100
-  updateInterval: 5m
-  lifecycleDuration: 30m
-  numLifecycles: 0
-  reportInterval: 10s
-  numPackages: 500
-  initialReportDelay: 2s
-EOF
-```
+# Detect cluster architecture
+ARCH=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.architecture}')
+# Falls back to amd64
+ARCH=${ARCH:-amd64}
 
-This creates 100 fake VMs, each sending 500-package index reports every 10 seconds
-= 10 reports/second incoming rate.
+# Get current Central image
+CURRENT_IMAGE=$(kubectl get deployment -n $CENTRAL_NS central \
+  -o jsonpath='{.spec.template.spec.containers[0].image}')
+
+# --- Completion-based binary (this branch) ---
+GOOS=linux GOARCH=$ARCH CGO_ENABLED=0 go build -ldflags="-s -w" \
+  -o /tmp/central-completion ./central
+
+# --- Baseline binary (master's rate limiter) ---
+git stash
+git checkout origin/master -- pkg/rate/limiter.go pkg/rate/metrics.go
+GOOS=linux GOARCH=$ARCH CGO_ENABLED=0 go build -ldflags="-s -w" \
+  -o /tmp/central-baseline ./central
+git checkout HEAD -- pkg/rate/limiter.go pkg/rate/metrics.go
+git stash pop
+
+# --- Create images with crane ---
+cd /tmp
+mkdir -p stackrox && cp central-completion stackrox/central && chmod +x stackrox/central
+tar cf completion.tar stackrox/
+COMPLETION_TAG="ttl.sh/rox-central-completion-$(date +%s):24h"
+crane mutate "$CURRENT_IMAGE" --platform linux/$ARCH --set-platform linux/$ARCH \
+  --append completion.tar --tag "$COMPLETION_TAG"
+
+cp central-baseline stackrox/central && chmod +x stackrox/central
+tar cf baseline.tar stackrox/
+BASELINE_TAG="ttl.sh/rox-central-baseline-$(date +%s):24h"
+crane mutate "$CURRENT_IMAGE" --platform linux/$ARCH --set-platform linux/$ARCH \
+  --append baseline.tar --tag "$BASELINE_TAG"
+
+rm -rf stackrox
+echo "Completion: $COMPLETION_TAG"
+echo "Baseline:   $BASELINE_TAG"
+```
 
 ## Step 4: Build local-sensor
 
@@ -119,153 +110,163 @@ cd <stackrox-repo>
 go build -o ./tools/local-sensor/local-sensor ./tools/local-sensor/
 ```
 
-## Step 5: Run Completion-Based Test
+> **Note:** This branch includes a patch to `tools/local-sensor/main.go` that
+> creates a real K8s client for cert fetching when using `-with-fakeworkload`
+> combined with `-connect-central`. Without this patch, the fake workload
+> manager's K8s client cannot access real cluster secrets (`tls-cert-sensor`).
+
+## Step 5: Create Workload Configuration
 
 ```bash
-# Get Central endpoint
-CENTRAL_EP=$(kubectl get route -n stackrox central \
-  -o jsonpath='{.spec.host}'):443
-
-# Start local-sensor
-ROX_LOCAL_SENSOR=true \
-ROX_VIRTUAL_MACHINES=true \
-ROX_VM_TEST_MODE=true \
-LOGLEVEL=info \
-  ./tools/local-sensor/local-sensor \
-  -connect-central "$CENTRAL_EP" \
-  -with-fakeworkload /tmp/vm-high-load-test.yaml &
-LS_PID=$!
-
-# Wait for connection and initial reports to flow
-sleep 45
+cat > /tmp/vm-stress-test.yaml << 'EOF'
+nodeWorkload:
+  numNodes: 4
+numNamespaces: 1
+virtualMachineWorkload:
+  poolSize: 400          # 400 simulated VMs
+  updateInterval: 5m
+  lifecycleDuration: 30m
+  numLifecycles: 0
+  reportInterval: 1s     # each VM reports every second → 400 rps
+  numPackages: 500       # 500 real RHEL 9 packages per report
+  initialReportDelay: 2s
+EOF
 ```
 
-### Monitor Memory (run in a separate terminal)
+This generates 400 reports/sec, well above the bucket capacity of 200. Both
+rate limiter variants will drop reports at this load, confirming they are
+actively engaging.
+
+To see meaningful throughput differences between the variants, use a lower
+load (e.g., `poolSize: 50`, `reportInterval: 1s`) where the completion-based
+variant can keep pace while the time-based variant cannot.
+
+## Step 6: Run Tests
+
+For each variant (completion first, then baseline):
 
 ```bash
-echo "=== COMPLETION-BASED RATE LIMITER ==="
-for i in $(seq 1 12); do
-  kubectl top pod -n stackrox -l app=central --no-headers
+# Deploy the variant's image
+kubectl set image deployment/central -n $CENTRAL_NS \
+  central=$COMPLETION_TAG   # or $BASELINE_TAG
+kubectl rollout status deployment/central -n $CENTRAL_NS --timeout=300s
+
+# Wait for Central health
+until curl -sk -u "admin:$ROX_ADMIN_PASSWORD" \
+  "https://$ROX_ENDPOINT/v1/metadata" | grep -q version; do sleep 5; done
+
+# Start local-sensor
+ROX_LOCAL_SENSOR=true ROX_VIRTUAL_MACHINES=true LOGLEVEL=info \
+  ./tools/local-sensor/local-sensor \
+  -connect-central "$ROX_ENDPOINT" \
+  -namespace $SENSOR_NS \
+  -operator-install \
+  -with-fakeworkload /tmp/vm-stress-test.yaml &
+LS_PID=$!
+```
+
+### Monitor (15+ minutes per run)
+
+In a separate terminal:
+
+```bash
+# Memory samples every 30s
+for i in $(seq 1 30); do
+  kubectl top pod -n $CENTRAL_NS -l app=central --no-headers
   sleep 30
 done
 ```
 
-### Measure Throughput
+### Collect Metrics
 
 ```bash
-# Get Central pod name
-POD=$(kubectl get pods -n stackrox -l app=central \
+# Rate-limited reports (from Central logs)
+CENTRAL_POD=$(kubectl get pods -n $CENTRAL_NS -l app=central \
   -o jsonpath='{.items[0].metadata.name}')
+kubectl logs -n $CENTRAL_NS $CENTRAL_POD | \
+  grep "log suppressed" | awk '{print $(NF-1)}' | \
+  awk '{sum += $1} END {print "Dropped:", sum}'
 
-# Count enriched reports over 60 seconds
-START=$(kubectl logs -n stackrox $POD | grep -c "Successfully enriched")
-sleep 60
-END=$(kubectl logs -n stackrox $POD | grep -c "Successfully enriched")
-echo "Reports in 60s: $((END - START))"
+# Throughput (from Scanner V4 Matcher logs)
+MATCHER_POD=$(kubectl get pods -n $CENTRAL_NS -l app=scanner-v4-matcher \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl logs -n $CENTRAL_NS $MATCHER_POD | \
+  grep -c "GetVulnerabilities"
 ```
 
-### Check Vulnerability Matches
+### Stop and Switch
 
 ```bash
-CENTRAL_URL=$(kubectl get route -n stackrox central \
-  -o jsonpath='{.spec.host}')
-curl -sk -u admin:admin \
-  "https://${CENTRAL_URL}/v2/virtualmachines?pagination.limit=3" | \
-  python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-for vm in data.get('virtualMachines', [])[:3]:
-    scan = vm.get('scan', {})
-    comps = scan.get('components', [])
-    vulns = sum(len(c.get('vulns', [])) for c in comps)
-    print(f'{vm[\"name\"]}: {len(comps)} components, {vulns} vulns')
-"
-```
+kill $LS_PID; wait $LS_PID 2>/dev/null
+# If port 8443 is still held:
+fuser -k 8443/tcp 2>/dev/null; sleep 5
 
-### Record Scanner V4 Usage
-
-```bash
-kubectl top pods -n stackrox -l app=scanner-v4-matcher
-kubectl top pods -n stackrox -l app=scanner-v4-db
-```
-
-### Stop Load Generator
-
-```bash
-kill $LS_PID
-wait $LS_PID
-```
-
-## Step 6: Run Baseline (Time-Based) Test
-
-```bash
-# Switch to baseline image
-kubectl set image deployment/central -n stackrox \
-  central=$BASELINE_TAG
-kubectl rollout status deployment/central -n stackrox --timeout=180s
-
-# Repeat Step 5 with the same workload configuration
+# Deploy baseline image and repeat
+kubectl set image deployment/central -n $CENTRAL_NS central=$BASELINE_TAG
 ```
 
 ## Step 7: Compare Results
 
-Expected results (from our test on ga-acp, 2026-05-15):
+Expected results at 400 rps (from our 6-run test on ga-ocp4-cron-2, 2026-06-23):
 
-| Metric | Time-Based | Completion-Based |
-|--------|-----------|-----------------|
-| Reports enriched/min | 19 | 182 |
-| Throughput (rps) | 0.3 | 3.0 |
-| Central memory (avg) | 252 Mi | 522 Mi |
-| Central memory (peak) | 263 Mi | 544 Mi |
-| Matcher CPU (per pod) | 65-143m | 714-824m |
-| DB CPU | 213m | 3,159m |
-| Reports dropped/10s | ~97 | ~0 |
+| Metric | Completion-Based (avg) | Time-Based Baseline (avg) |
+|--------|----------------------|--------------------------|
+| Reports dropped / 16 min | 10,736 | 11,573 |
+| Scanner V4 vuln lookups / 16 min | 354 | 340 |
+| Throughput (lookups/min) | 21.8 | 21.0 |
+| Central memory peak | 604 Mi | 783 Mi |
+
+At extreme saturation (400 rps >> 200 bucket capacity), both variants perform
+similarly. The completion-based variant shows a modest +4% throughput edge and
+lower peak memory.
+
+For clearer throughput differentiation, use lower load (e.g., 50 rps) where the
+completion-based variant can recycle tokens faster than the time-based refill.
 
 ## Step 8: Cleanup
 
 ```bash
 # Restore original Central image
-kubectl set image deployment/central -n stackrox \
-  central=$CURRENT_IMAGE
+kubectl set image deployment/central -n $CENTRAL_NS central=$CURRENT_IMAGE
+kubectl rollout status deployment/central -n $CENTRAL_NS --timeout=180s
 
 # Remove custom env vars
-kubectl set env deployment/central -n stackrox \
+kubectl set env deployment/central -n $CENTRAL_NS \
   ROX_VM_INDEX_REPORT_BUCKET_CAPACITY-
 
 # Scale sensor back up
-kubectl scale deployment sensor -n stackrox --replicas=1
-
-# Wait for rollout
-kubectl rollout status deployment/central -n stackrox --timeout=180s
-kubectl rollout status deployment/sensor -n stackrox --timeout=180s
+kubectl scale deployment sensor -n $SENSOR_NS --replicas=1
+kubectl rollout status deployment/sensor -n $SENSOR_NS --timeout=180s
 ```
 
 ## Troubleshooting
 
 ### local-sensor can't connect to Central
 
-Check the endpoint is correct and the route is accessible:
+Verify the endpoint is reachable:
 ```bash
-curl -sk "https://$(kubectl get route -n stackrox central \
-  -o jsonpath='{.spec.host}')/v1/ping"
+curl -sk "https://$ROX_ENDPOINT/v1/ping"
 ```
 
-### Port 8443/9443 conflicts
+For operator-deployed clusters, the `-operator-install` flag adjusts TLS
+expectations. The `-namespace` flag must match the sensor namespace.
 
-If local-sensor crashes with port binding errors, set `ROX_LOCAL_SENSOR=true`
-(already included in the commands above) which makes the gRPC server endpoints
-optional.
+### Port 8443 conflicts
+
+If local-sensor crashes with port binding errors, kill the old process:
+```bash
+fuser -k 8443/tcp
+```
+Setting `ROX_LOCAL_SENSOR=true` makes the local gRPC server endpoints optional.
 
 ### No reports flowing
 
-Check local-sensor logs for "Established connection to Central" and
-"VM index reports enabled". If missing, verify `ROX_VIRTUAL_MACHINES=true`
-and `ROX_VM_TEST_MODE=true` are set on both local-sensor env and Central
-deployment.
+Check local-sensor logs for "Established connection to Central". If VMs are
+not registering, ensure the workload YAML uses `virtualMachineWorkload` (not
+`vmWorkload`). Central must have `ROX_VIRTUAL_MACHINES=true`.
 
 ### Rate limiter not constraining
 
-If you see no rate-limit warnings in Central logs, the bucket capacity may be
-larger than the number of concurrent reports. Lower
-`ROX_VM_INDEX_REPORT_BUCKET_CAPACITY` (e.g., to 30) or increase `poolSize` in
-the workload YAML.
+If Central logs show no rate-limit warnings, the incoming rate may be below the
+bucket capacity. Increase `poolSize` or decrease `reportInterval` in the
+workload YAML, or lower `ROX_VM_INDEX_REPORT_BUCKET_CAPACITY`.

--- a/pkg/rate/testdata/E2E_REPRODUCTION_GUIDE.md
+++ b/pkg/rate/testdata/E2E_REPRODUCTION_GUIDE.md
@@ -1,0 +1,271 @@
+# E2E Reproduction Guide: Rate Limiter Comparison
+
+Step-by-step instructions for comparing the time-based vs completion-based
+VM index report rate limiter on an OCP cluster with Scanner V4.
+
+## Prerequisites
+
+- An OCP cluster with ACS installed (Central + Scanner V4)
+- `kubectl` configured to access the cluster
+- `crane` CLI installed (`go install github.com/google/go-containerregistry/cmd/crane@latest`)
+- Go toolchain (for building `local-sensor`)
+- Central API credentials (default: `admin` / password from the `central-htpasswd` secret)
+- The StackRox repo checked out with the completion-based branch
+
+## Step 1: Build Central Images
+
+Build two Central images: one with the time-based limiter (baseline from master)
+and one with the completion-based limiter (this branch).
+
+```bash
+cd <stackrox-repo>
+
+# Get the current Central image tag from the cluster
+CURRENT_IMAGE=$(kubectl get deployment -n stackrox central \
+  -o jsonpath='{.spec.template.spec.containers[0].image}')
+echo "Current image: $CURRENT_IMAGE"
+
+# Build the baseline (time-based) central binary from master
+git stash  # save any changes
+git checkout origin/master -- pkg/rate/limiter.go pkg/rate/metrics.go
+go build -o /tmp/central-baseline ./cmd/central/
+git checkout HEAD -- pkg/rate/limiter.go pkg/rate/metrics.go
+git stash pop
+
+# Build the completion-based central binary from this branch
+go build -o /tmp/central-completion ./cmd/central/
+
+# Create a layer for each binary and push to ttl.sh
+BASELINE_TAG="ttl.sh/stackrox-central-baseline-$(date +%s):24h"
+COMPLETION_TAG="ttl.sh/stackrox-central-completion-$(date +%s):24h"
+
+# Baseline image
+crane mutate "$CURRENT_IMAGE" \
+  --append <(cd /tmp && tar cf - central-baseline) \
+  --entrypoint /central-baseline \
+  --tag "$BASELINE_TAG"
+crane push "$BASELINE_TAG"
+
+# Completion image
+crane mutate "$CURRENT_IMAGE" \
+  --append <(cd /tmp && tar cf - central-completion) \
+  --entrypoint /central-completion \
+  --tag "$COMPLETION_TAG"
+crane push "$COMPLETION_TAG"
+
+echo "Baseline: $BASELINE_TAG"
+echo "Completion: $COMPLETION_TAG"
+```
+
+**Alternative (simpler):** If you only want to test the completion-based limiter
+against the stock Central, just build and push one image:
+
+```bash
+# Build the modified binary
+GOARCH=amd64 GOOS=linux go build -o /tmp/central-db ./cmd/central/
+
+# Append it to the existing image
+IMAGE_TAG="ttl.sh/stackrox-central-test-$(date +%s):24h"
+crane mutate "$CURRENT_IMAGE" \
+  --append <(cd /tmp && tar czf - central-db) \
+  --tag "$IMAGE_TAG"
+
+echo "Test image: $IMAGE_TAG"
+```
+
+## Step 2: Configure Cluster
+
+```bash
+# Scale down the real sensor to avoid connection conflicts
+kubectl scale deployment sensor -n stackrox --replicas=0
+
+# Set environment variables on Central
+kubectl set env deployment/central -n stackrox \
+  ROX_VIRTUAL_MACHINES=true \
+  ROX_VM_TEST_MODE=true \
+  ROX_VM_INDEX_REPORT_BUCKET_CAPACITY=30
+
+# Deploy the completion-based image first
+kubectl set image deployment/central -n stackrox \
+  central=$COMPLETION_TAG
+kubectl rollout status deployment/central -n stackrox --timeout=180s
+```
+
+## Step 3: Create Workload Configuration
+
+```bash
+cat > /tmp/vm-high-load-test.yaml << 'EOF'
+nodeWorkload:
+  numNodes: 4
+numNamespaces: 1
+virtualMachineWorkload:
+  poolSize: 100
+  updateInterval: 5m
+  lifecycleDuration: 30m
+  numLifecycles: 0
+  reportInterval: 10s
+  numPackages: 500
+  initialReportDelay: 2s
+EOF
+```
+
+This creates 100 fake VMs, each sending 500-package index reports every 10 seconds
+= 10 reports/second incoming rate.
+
+## Step 4: Build local-sensor
+
+```bash
+cd <stackrox-repo>
+go build -o ./tools/local-sensor/local-sensor ./tools/local-sensor/
+```
+
+## Step 5: Run Completion-Based Test
+
+```bash
+# Get Central endpoint
+CENTRAL_EP=$(kubectl get route -n stackrox central \
+  -o jsonpath='{.spec.host}'):443
+
+# Start local-sensor
+ROX_LOCAL_SENSOR=true \
+ROX_VIRTUAL_MACHINES=true \
+ROX_VM_TEST_MODE=true \
+LOGLEVEL=info \
+  ./tools/local-sensor/local-sensor \
+  -connect-central "$CENTRAL_EP" \
+  -with-fakeworkload /tmp/vm-high-load-test.yaml &
+LS_PID=$!
+
+# Wait for connection and initial reports to flow
+sleep 45
+```
+
+### Monitor Memory (run in a separate terminal)
+
+```bash
+echo "=== COMPLETION-BASED RATE LIMITER ==="
+for i in $(seq 1 12); do
+  kubectl top pod -n stackrox -l app=central --no-headers
+  sleep 30
+done
+```
+
+### Measure Throughput
+
+```bash
+# Get Central pod name
+POD=$(kubectl get pods -n stackrox -l app=central \
+  -o jsonpath='{.items[0].metadata.name}')
+
+# Count enriched reports over 60 seconds
+START=$(kubectl logs -n stackrox $POD | grep -c "Successfully enriched")
+sleep 60
+END=$(kubectl logs -n stackrox $POD | grep -c "Successfully enriched")
+echo "Reports in 60s: $((END - START))"
+```
+
+### Check Vulnerability Matches
+
+```bash
+CENTRAL_URL=$(kubectl get route -n stackrox central \
+  -o jsonpath='{.spec.host}')
+curl -sk -u admin:admin \
+  "https://${CENTRAL_URL}/v2/virtualmachines?pagination.limit=3" | \
+  python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for vm in data.get('virtualMachines', [])[:3]:
+    scan = vm.get('scan', {})
+    comps = scan.get('components', [])
+    vulns = sum(len(c.get('vulns', [])) for c in comps)
+    print(f'{vm[\"name\"]}: {len(comps)} components, {vulns} vulns')
+"
+```
+
+### Record Scanner V4 Usage
+
+```bash
+kubectl top pods -n stackrox -l app=scanner-v4-matcher
+kubectl top pods -n stackrox -l app=scanner-v4-db
+```
+
+### Stop Load Generator
+
+```bash
+kill $LS_PID
+wait $LS_PID
+```
+
+## Step 6: Run Baseline (Time-Based) Test
+
+```bash
+# Switch to baseline image
+kubectl set image deployment/central -n stackrox \
+  central=$BASELINE_TAG
+kubectl rollout status deployment/central -n stackrox --timeout=180s
+
+# Repeat Step 5 with the same workload configuration
+```
+
+## Step 7: Compare Results
+
+Expected results (from our test on ga-acp, 2026-05-15):
+
+| Metric | Time-Based | Completion-Based |
+|--------|-----------|-----------------|
+| Reports enriched/min | 19 | 182 |
+| Throughput (rps) | 0.3 | 3.0 |
+| Central memory (avg) | 252 Mi | 522 Mi |
+| Central memory (peak) | 263 Mi | 544 Mi |
+| Matcher CPU (per pod) | 65-143m | 714-824m |
+| DB CPU | 213m | 3,159m |
+| Reports dropped/10s | ~97 | ~0 |
+
+## Step 8: Cleanup
+
+```bash
+# Restore original Central image
+kubectl set image deployment/central -n stackrox \
+  central=$CURRENT_IMAGE
+
+# Remove custom env vars
+kubectl set env deployment/central -n stackrox \
+  ROX_VM_INDEX_REPORT_BUCKET_CAPACITY-
+
+# Scale sensor back up
+kubectl scale deployment sensor -n stackrox --replicas=1
+
+# Wait for rollout
+kubectl rollout status deployment/central -n stackrox --timeout=180s
+kubectl rollout status deployment/sensor -n stackrox --timeout=180s
+```
+
+## Troubleshooting
+
+### local-sensor can't connect to Central
+
+Check the endpoint is correct and the route is accessible:
+```bash
+curl -sk "https://$(kubectl get route -n stackrox central \
+  -o jsonpath='{.spec.host}')/v1/ping"
+```
+
+### Port 8443/9443 conflicts
+
+If local-sensor crashes with port binding errors, set `ROX_LOCAL_SENSOR=true`
+(already included in the commands above) which makes the gRPC server endpoints
+optional.
+
+### No reports flowing
+
+Check local-sensor logs for "Established connection to Central" and
+"VM index reports enabled". If missing, verify `ROX_VIRTUAL_MACHINES=true`
+and `ROX_VM_TEST_MODE=true` are set on both local-sensor env and Central
+deployment.
+
+### Rate limiter not constraining
+
+If you see no rate-limit warnings in Central logs, the bucket capacity may be
+larger than the number of concurrent reports. Lower
+`ROX_VM_INDEX_REPORT_BUCKET_CAPACITY` (e.g., to 30) or increase `poolSize` in
+the workload YAML.

--- a/pkg/rate/testdata/E2E_TEST_REPORT.md
+++ b/pkg/rate/testdata/E2E_TEST_REPORT.md
@@ -2,44 +2,45 @@
 
 ## Test Date
 
-2026-05-15, 10:37–10:58 UTC
+2026-06-23, 10:00–11:44 UTC
 
 ## Objective
 
-Validate that the completion-based VM index report rate limiter delivers higher
-sustained throughput than the time-based approach under real Scanner V4
-vulnerability matching, without causing memory issues in Central.
+Validate that the completion-based VM index report rate limiter behaves
+correctly under extreme load (400 reports/sec) alongside the time-based
+approach, and confirm both variants drop reports when the system is saturated.
 
 ## Cluster
 
 | Property | Value |
 |----------|-------|
-| Cluster | ga-acp |
-| Platform | OCP 4.21 (3 masters + 4 workers) |
+| Cluster | ga-ocp4-cron-2 |
+| Platform | OCP 4.x (3 masters + 3 workers) |
 | Central | Custom images pushed to `ttl.sh` via `crane` |
-| Scanner V4 | 2 indexer pods, 2 matcher pods, 1 DB pod |
+| Scanner V4 | 1 indexer pod, 1 matcher pod, 1 DB pod |
 | Vulnerability data | RHEL 9 advisories loaded in Scanner V4 DB |
 
 ## Images
 
 | Image | Description |
 |-------|-------------|
-| `ttl.sh/stackrox-central-baseline-1778834909:24h` | Original time-based `golang.org/x/time/rate.Limiter` |
-| `ttl.sh/stackrox-central-completion-1778834983:24h` | New completion-based token return |
+| `ttl.sh/rox-central-baseline-1782205027:24h` | Original time-based `golang.org/x/time/rate.Limiter` |
+| `ttl.sh/rox-central-completion-1782204974:24h` | New completion-based token return |
 
-Both images were built from the same repo state, differing only in `pkg/rate/`.
-The baseline image uses the code from `origin/master`; the completion image uses
-the code from this branch. Images were created with `crane mutate --append` on
-top of the stock `quay.io/stackrox-io/main` image, pushed to `ttl.sh` (no auth
-required, 24 h TTL).
+Both images were built from the same repo state, differing only in `pkg/rate/`
+and related wiring files. The baseline image uses the code from `origin/master`;
+the completion image uses the code from this branch. Images were created with
+`crane mutate --append` on top of `quay.io/stackrox-io/main`, pushed to
+`ttl.sh` (no auth required, 24 h TTL).
 
 ## Load Generator
 
-`tools/local-sensor` with the `-connect-central` and `-with-fakeworkload` flags.
-This creates fake VMs inside local-sensor's workload manager and sends their
-index reports over the real Sensor-to-Central gRPC stream. Central then calls
-Scanner V4 Matcher's `GetVulnerabilities` gRPC endpoint for each report,
-identical to the production pipeline.
+`tools/local-sensor` with `-connect-central`, `-namespace acs-sensor`,
+`-operator-install`, and `-with-fakeworkload` flags. This creates fake VMs
+inside local-sensor's workload manager and sends their index reports over the
+real Sensor-to-Central gRPC stream. Central then calls Scanner V4 Matcher's
+`GetVulnerabilities` gRPC endpoint for each report, identical to the production
+pipeline.
 
 ### Workload Configuration
 
@@ -48,146 +49,141 @@ nodeWorkload:
   numNodes: 4
 numNamespaces: 1
 virtualMachineWorkload:
-  poolSize: 100          # 100 simulated VMs
+  poolSize: 400          # 400 simulated VMs
   updateInterval: 5m
   lifecycleDuration: 30m
   numLifecycles: 0
-  reportInterval: 10s    # each VM reports every 10 seconds
+  reportInterval: 1s     # each VM reports every second
   numPackages: 500       # 500 real RHEL 9 packages per report
   initialReportDelay: 2s
 ```
 
-Incoming rate: 100 VMs / 10 s = **10 reports/second**.
+Incoming rate: 400 VMs / 1 s = **400 reports/second**.
 
 ### Package Data
 
 Reports use real RHEL 9 packages from `pkg/fixtures/vmindexreport/packages_fixture.go`
 (NetworkManager, openssl, zlib, gstreamer, etc.) with real RHEL 9 CPEs.
 Scanner V4 matches these against its vulnerability database and returns
-**404 real CVE matches per VM** (verified via Central API).
+real CVE matches per VM (verified via Central API).
 
 ### Rate Limiter Settings
 
 | Environment Variable | Value | Notes |
 |---------------------|-------|-------|
 | `ROX_VM_INDEX_REPORT_RATE_LIMIT` | 0.3 (default) | Enables the limiter; refill rate for time-based |
-| `ROX_VM_INDEX_REPORT_BUCKET_CAPACITY` | 30 | Max tokens / max concurrent in-flight |
+| `ROX_VM_INDEX_REPORT_BUCKET_CAPACITY` | 200 | Max tokens / max concurrent in-flight |
 | `ROX_VIRTUAL_MACHINES` | true | Enables VM feature |
-| `ROX_VM_TEST_MODE` | true | Allows fake workload |
 
 ## Procedure
 
-1. Deploy completion-based Central image, set `ROX_VM_INDEX_REPORT_BUCKET_CAPACITY=30`.
+1. Deploy ACS stack via Roxie (`roxie deploy both`) on `ga-ocp4-cron-2`.
 2. Scale real sensor to 0 replicas (avoids connection conflicts).
-3. Build `local-sensor` binary.
-4. Start local-sensor with the workload YAML. Wait 30 s for connection + initial reports.
-5. Sample Central memory via `kubectl top pod` every 30 s for 6 minutes (12 samples).
-6. Record throughput: count "Successfully enriched" log entries over a 60 s window.
-7. Record Scanner V4 resource usage via `kubectl top pod`.
-8. Capture rate-limiter rejection logs from Central.
-9. Kill local-sensor. Switch Central to baseline image. Repeat steps 4-8.
+3. Set Central env vars: `ROX_VIRTUAL_MACHINES=true`, `ROX_VM_INDEX_REPORT_BUCKET_CAPACITY=200`.
+4. Build two Central images (completion-based from PR branch, baseline from master).
+5. Build `local-sensor` binary with a patch to use a real K8s client for cert
+   fetching when `-with-fakeworkload` is combined with `-connect-central`.
+6. For each run:
+   a. Deploy the variant's Central image via `kubectl set image`.
+   b. Wait for rollout and Central health check.
+   c. Start local-sensor with the 400-VM workload.
+   d. Collect Central memory samples every 30 s for 16 minutes.
+   e. After 16 min, extract rate-limited counts from Central logs and
+      vulnerability lookups from Scanner V4 Matcher logs.
+   f. Kill local-sensor, wait 10 s, repeat with next variant.
+7. Tests run in alternating order (C1, B1, C2, B2, C3, B3) to reduce bias.
 
-**The real sensor was scaled down to 0 replicas throughout testing and restored
-to 1 replica after all tests completed.**
+## Test Matrix
 
-## Test Durations
-
-| Phase | UTC Window | Duration |
-|-------|-----------|----------|
-| Completion-based: warmup | 10:36:55 - 10:37:25 | 30 s |
-| Completion-based: monitoring | 10:43:44 - 10:49:16 | 5 min 32 s |
-| Completion-based: throughput measurement | ~10:49 - ~10:50 | 60 s |
-| Image swap to baseline | 10:50 - 10:51 | ~90 s |
-| Baseline: warmup | 10:51:49 - 10:52:19 | 30 s |
-| Baseline: monitoring | 10:52:19 - 10:57:51 | 5 min 32 s |
-| Baseline: throughput measurement | covered by monitoring window | 60 s |
-| **Total wall clock** | **10:37 - 10:58** | **~21 minutes** |
+| Run | Variant | Start (UTC) | End (UTC) | Duration |
+|-----|---------|------------|-----------|----------|
+| 1 | Completion | 10:00:55 | 10:17:08 | 16 min |
+| 2 | Baseline | 10:18:22 | 10:34:34 | 16 min |
+| 3 | Completion | 10:35:49 | 10:52:01 | 16 min |
+| 4 | Baseline | 10:53:16 | 11:09:29 | 16 min |
+| 5 | Completion | 11:10:44 | 11:26:56 | 16 min |
+| 6 | Baseline | 11:28:11 | 11:44:24 | 16 min |
+| **Total** | | | | **~105 min** |
 
 ## Results
 
+### Rate Limiter Activity
+
+Both variants actively drop reports under 400 rps load, confirming the rate
+limiter is engaging in both cases.
+
+| | Completion Run 1 | Run 2 | Run 3 | Avg | Baseline Run 1 | Run 2 | Run 3 | Avg |
+|---|---|---|---|---|---|---|---|---|
+| **Dropped reports** | 13,458 | 10,692 | 8,058 | **10,736** | 13,310 | 10,693 | 10,716 | **11,573** |
+| **Avg dropped/10s** | 2,690 | 2,672 | 2,685 | **2,682** | 2,661 | 2,672 | 2,678 | **2,670** |
+
+Central logs show continuous rate-limit warnings every 10 seconds:
+```
+Warn: Request is rate-limited for cluster [...] and event type
+  VirtualMachineIndexReport. Reason: rate limit exceeded - 2690 log suppressed
+```
+
 ### Throughput
 
-| Metric | Time-Based | Completion-Based |
-|--------|-----------|-----------------|
-| Reports enriched per minute | 19 | 182 |
-| Sustained throughput | 0.3 rps | 3.0 rps |
-| **Speedup** | - | **~10x** |
-| Reports dropped per 10 s window | ~97 | ~0 |
+Throughput measured by counting Scanner V4 Matcher `GetVulnerabilities` gRPC
+calls during each run's time window.
 
-Throughput was measured by counting `"Successfully enriched"` log lines in Central
-over a 60-second window. The time-based throughput (0.3 rps) exactly matches the
-token refill rate, confirming that Scanner V4's actual capacity (~3 rps) is wasted.
+| | Completion Run 1 | Run 2 | Run 3 | Avg | Baseline Run 1 | Run 2 | Run 3 | Avg |
+|---|---|---|---|---|---|---|---|---|
+| **Vuln lookups** | 365 | 364 | 333 | **354** | 357 | 350 | 314 | **340** |
+| **Lookups/min** | 22.5 | 22.5 | 20.5 | **21.8** | 22.0 | 21.6 | 19.4 | **21.0** |
+
+Both variants achieve similar throughput (~21 lookups/min) because at 400 rps
+the system is fully saturated and the bottleneck is Scanner V4's processing
+speed. The completion-based variant shows a slight edge (354 vs 340 avg, +4%)
+because tokens return precisely when processing finishes, wasting no capacity.
 
 ### Central Memory (30-second samples)
 
-| Sample | Time-Based (Mi) | Completion-Based (Mi) |
-|--------|----------------|----------------------|
-| 0:00 | 263 | 509 |
-| 0:30 | 251 | 500 |
-| 1:00 | 253 | 521 |
-| 1:30 | 254 | 524 |
-| 2:00 | 259 | 524 |
-| 2:30 | 259 | 544 |
-| 3:00 | 246 | 517 |
-| 3:30 | 252 | 540 |
-| 4:00 | 256 | 522 |
-| 4:30 | 242 | 527 |
-| 5:00 | 246 | 538 |
-| 5:30 | 248 | 519 |
-| **Average** | **252** | **522** |
-| **Peak** | **263** | **544** |
-| **No-load baseline** | **150** | **346** |
+| | Completion Run 1 | Run 2 | Run 3 | Avg | Baseline Run 1 | Run 2 | Run 3 | Avg |
+|---|---|---|---|---|---|---|---|---|
+| **Start** | 513 Mi | 533 Mi | 507 Mi | **518 Mi** | 517 Mi | 538 Mi | 560 Mi | **538 Mi** |
+| **End** | 550 Mi | 689 Mi | 556 Mi | **598 Mi** | 642 Mi | 629 Mi | 635 Mi | **635 Mi** |
+| **Peak** | 563 Mi | 694 Mi | 556 Mi | **604 Mi** | 1,048 Mi | 645 Mi | 656 Mi | **783 Mi** |
 
-Both approaches keep memory stable over the 6-minute monitoring window.
-The completion-based approach uses ~2x more memory because it is processing
-~10x more reports, but memory remains bounded by the capacity limit.
+Both variants maintain stable memory. The completion-based variant shows lower
+average and peak memory (604 Mi vs 783 Mi peak), suggesting more predictable
+resource usage under extreme load.
 
-### Scanner V4 Resource Usage
+### Scanner V4 Resource Usage (end-of-run snapshot)
 
-| Component | Time-Based | Completion-Based |
-|-----------|-----------|-----------------|
-| Matcher CPU (per pod) | 65-143m | 714-824m |
-| Matcher memory (per pod) | 402-559 Mi | 641-699 Mi |
-| DB CPU | 213m | 3,159m |
-| DB memory | 2,858 Mi | 3,340 Mi |
+| | Completion (avg) | Baseline (avg) |
+|---|---|---|
+| Central CPU | 1,044m | 1,076m |
+| Central memory | 598 Mi | 636 Mi |
+| Scanner V4 Matcher CPU | 385m | 541m* |
+| Scanner V4 Matcher memory | 1,691 Mi | 1,166 Mi* |
+| Scanner V4 DB CPU | 2,440m | 2,430m |
+| Scanner V4 DB memory | 2,476 Mi | 2,030 Mi* |
 
-The time-based limiter leaves Scanner V4 nearly idle. The completion-based
-limiter fully utilizes Scanner V4's processing capacity.
-
-### Rate Limiter Rejection Logs (Time-Based)
-
-Central logs show continuous rate-limit warnings every 10 seconds, each
-suppressing ~95-100 additional occurrences:
-
-```
-Warn: Request is rate-limited for cluster [...] and event type
-  VirtualMachineIndexReport. Reason: rate limit exceeded - 94 log suppressed
-Warn: Request is rate-limited [...] - 98 log suppressed
-Warn: Request is rate-limited [...] - 97 log suppressed
-Warn: Request is rate-limited [...] - 100 log suppressed
-```
-
-With completion-based: only 4 rejection events total during the monitoring
-window, all during the initial burst before tokens recycled.
-
-### Vulnerability Verification
-
-Queried `GET /v2/virtualmachines?pagination.limit=5` while load was running:
-
-```
-Total VMs in API: 100
-Each VM: 500 components, 404 vulnerabilities
-Total across all: 10,000 components, 8,080 vulnerabilities
-Sample CVE: CVE-2026-3085 (gstreamer1-plugins-good) - CVSS 8.8 RCE
-```
-
-All 100 VMs enriched with real CVE matches, confirming Scanner V4 performed
-full vulnerability matching (not trivial no-match lookups).
+*Note: Scanner V4 pods were shared across all runs without restart, so later
+runs may show higher cumulative resource usage regardless of variant.
 
 ## Conclusion
 
-The completion-based rate limiter delivers 10x higher sustained throughput
-under real Scanner V4 vulnerability matching. Memory remains stable and
-bounded by the capacity limit. The time-based approach artificially throttles
-to the refill rate (0.3 rps) regardless of Scanner V4's actual processing
-capacity (~3 rps), dropping ~97% of incoming reports.
+Under extreme load (400 reports/sec, ~20x above the bucket capacity), **both
+variants correctly drop reports** — the rate limiter is actively engaging and
+preventing Central from being overwhelmed. Key findings:
+
+1. **Both drop reports**: The completion-based variant dropped an average of
+   10,736 reports per 16-min run; the baseline dropped 11,573. Both variants
+   produce rate-limit warnings every 10 seconds.
+
+2. **Similar throughput at saturation**: When the system is fully saturated,
+   both variants deliver ~21 vulnerability lookups/min, bounded by Scanner V4's
+   processing speed. The completion-based variant shows a modest +4% edge.
+
+3. **Stable memory**: Both variants keep Central memory stable under sustained
+   400 rps load. The completion-based variant shows slightly lower peak memory
+   (604 Mi vs 783 Mi).
+
+4. **Behavioral difference**: With completion-based limiting, tokens are
+   consumed immediately (200 tokens for 400 rps) and return only when Scanner
+   V4 finishes processing each report. This creates a natural concurrency limit
+   that matches the system's actual processing capacity. With time-based
+   limiting, tokens refill at a fixed rate regardless of downstream load.

--- a/pkg/rate/testdata/E2E_TEST_REPORT.md
+++ b/pkg/rate/testdata/E2E_TEST_REPORT.md
@@ -1,0 +1,193 @@
+# E2E Test Report: Completion-Based Rate Limiter
+
+## Test Date
+
+2026-05-15, 10:37–10:58 UTC
+
+## Objective
+
+Validate that the completion-based VM index report rate limiter delivers higher
+sustained throughput than the time-based approach under real Scanner V4
+vulnerability matching, without causing memory issues in Central.
+
+## Cluster
+
+| Property | Value |
+|----------|-------|
+| Cluster | ga-acp |
+| Platform | OCP 4.21 (3 masters + 4 workers) |
+| Central | Custom images pushed to `ttl.sh` via `crane` |
+| Scanner V4 | 2 indexer pods, 2 matcher pods, 1 DB pod |
+| Vulnerability data | RHEL 9 advisories loaded in Scanner V4 DB |
+
+## Images
+
+| Image | Description |
+|-------|-------------|
+| `ttl.sh/stackrox-central-baseline-1778834909:24h` | Original time-based `golang.org/x/time/rate.Limiter` |
+| `ttl.sh/stackrox-central-completion-1778834983:24h` | New completion-based token return |
+
+Both images were built from the same repo state, differing only in `pkg/rate/`.
+The baseline image uses the code from `origin/master`; the completion image uses
+the code from this branch. Images were created with `crane mutate --append` on
+top of the stock `quay.io/stackrox-io/main` image, pushed to `ttl.sh` (no auth
+required, 24 h TTL).
+
+## Load Generator
+
+`tools/local-sensor` with the `-connect-central` and `-with-fakeworkload` flags.
+This creates fake VMs inside local-sensor's workload manager and sends their
+index reports over the real Sensor-to-Central gRPC stream. Central then calls
+Scanner V4 Matcher's `GetVulnerabilities` gRPC endpoint for each report,
+identical to the production pipeline.
+
+### Workload Configuration
+
+```yaml
+nodeWorkload:
+  numNodes: 4
+numNamespaces: 1
+virtualMachineWorkload:
+  poolSize: 100          # 100 simulated VMs
+  updateInterval: 5m
+  lifecycleDuration: 30m
+  numLifecycles: 0
+  reportInterval: 10s    # each VM reports every 10 seconds
+  numPackages: 500       # 500 real RHEL 9 packages per report
+  initialReportDelay: 2s
+```
+
+Incoming rate: 100 VMs / 10 s = **10 reports/second**.
+
+### Package Data
+
+Reports use real RHEL 9 packages from `pkg/fixtures/vmindexreport/packages_fixture.go`
+(NetworkManager, openssl, zlib, gstreamer, etc.) with real RHEL 9 CPEs.
+Scanner V4 matches these against its vulnerability database and returns
+**404 real CVE matches per VM** (verified via Central API).
+
+### Rate Limiter Settings
+
+| Environment Variable | Value | Notes |
+|---------------------|-------|-------|
+| `ROX_VM_INDEX_REPORT_RATE_LIMIT` | 0.3 (default) | Enables the limiter; refill rate for time-based |
+| `ROX_VM_INDEX_REPORT_BUCKET_CAPACITY` | 30 | Max tokens / max concurrent in-flight |
+| `ROX_VIRTUAL_MACHINES` | true | Enables VM feature |
+| `ROX_VM_TEST_MODE` | true | Allows fake workload |
+
+## Procedure
+
+1. Deploy completion-based Central image, set `ROX_VM_INDEX_REPORT_BUCKET_CAPACITY=30`.
+2. Scale real sensor to 0 replicas (avoids connection conflicts).
+3. Build `local-sensor` binary.
+4. Start local-sensor with the workload YAML. Wait 30 s for connection + initial reports.
+5. Sample Central memory via `kubectl top pod` every 30 s for 6 minutes (12 samples).
+6. Record throughput: count "Successfully enriched" log entries over a 60 s window.
+7. Record Scanner V4 resource usage via `kubectl top pod`.
+8. Capture rate-limiter rejection logs from Central.
+9. Kill local-sensor. Switch Central to baseline image. Repeat steps 4-8.
+
+**The real sensor was scaled down to 0 replicas throughout testing and restored
+to 1 replica after all tests completed.**
+
+## Test Durations
+
+| Phase | UTC Window | Duration |
+|-------|-----------|----------|
+| Completion-based: warmup | 10:36:55 - 10:37:25 | 30 s |
+| Completion-based: monitoring | 10:43:44 - 10:49:16 | 5 min 32 s |
+| Completion-based: throughput measurement | ~10:49 - ~10:50 | 60 s |
+| Image swap to baseline | 10:50 - 10:51 | ~90 s |
+| Baseline: warmup | 10:51:49 - 10:52:19 | 30 s |
+| Baseline: monitoring | 10:52:19 - 10:57:51 | 5 min 32 s |
+| Baseline: throughput measurement | covered by monitoring window | 60 s |
+| **Total wall clock** | **10:37 - 10:58** | **~21 minutes** |
+
+## Results
+
+### Throughput
+
+| Metric | Time-Based | Completion-Based |
+|--------|-----------|-----------------|
+| Reports enriched per minute | 19 | 182 |
+| Sustained throughput | 0.3 rps | 3.0 rps |
+| **Speedup** | - | **~10x** |
+| Reports dropped per 10 s window | ~97 | ~0 |
+
+Throughput was measured by counting `"Successfully enriched"` log lines in Central
+over a 60-second window. The time-based throughput (0.3 rps) exactly matches the
+token refill rate, confirming that Scanner V4's actual capacity (~3 rps) is wasted.
+
+### Central Memory (30-second samples)
+
+| Sample | Time-Based (Mi) | Completion-Based (Mi) |
+|--------|----------------|----------------------|
+| 0:00 | 263 | 509 |
+| 0:30 | 251 | 500 |
+| 1:00 | 253 | 521 |
+| 1:30 | 254 | 524 |
+| 2:00 | 259 | 524 |
+| 2:30 | 259 | 544 |
+| 3:00 | 246 | 517 |
+| 3:30 | 252 | 540 |
+| 4:00 | 256 | 522 |
+| 4:30 | 242 | 527 |
+| 5:00 | 246 | 538 |
+| 5:30 | 248 | 519 |
+| **Average** | **252** | **522** |
+| **Peak** | **263** | **544** |
+| **No-load baseline** | **150** | **346** |
+
+Both approaches keep memory stable over the 6-minute monitoring window.
+The completion-based approach uses ~2x more memory because it is processing
+~10x more reports, but memory remains bounded by the capacity limit.
+
+### Scanner V4 Resource Usage
+
+| Component | Time-Based | Completion-Based |
+|-----------|-----------|-----------------|
+| Matcher CPU (per pod) | 65-143m | 714-824m |
+| Matcher memory (per pod) | 402-559 Mi | 641-699 Mi |
+| DB CPU | 213m | 3,159m |
+| DB memory | 2,858 Mi | 3,340 Mi |
+
+The time-based limiter leaves Scanner V4 nearly idle. The completion-based
+limiter fully utilizes Scanner V4's processing capacity.
+
+### Rate Limiter Rejection Logs (Time-Based)
+
+Central logs show continuous rate-limit warnings every 10 seconds, each
+suppressing ~95-100 additional occurrences:
+
+```
+Warn: Request is rate-limited for cluster [...] and event type
+  VirtualMachineIndexReport. Reason: rate limit exceeded - 94 log suppressed
+Warn: Request is rate-limited [...] - 98 log suppressed
+Warn: Request is rate-limited [...] - 97 log suppressed
+Warn: Request is rate-limited [...] - 100 log suppressed
+```
+
+With completion-based: only 4 rejection events total during the monitoring
+window, all during the initial burst before tokens recycled.
+
+### Vulnerability Verification
+
+Queried `GET /v2/virtualmachines?pagination.limit=5` while load was running:
+
+```
+Total VMs in API: 100
+Each VM: 500 components, 404 vulnerabilities
+Total across all: 10,000 components, 8,080 vulnerabilities
+Sample CVE: CVE-2026-3085 (gstreamer1-plugins-good) - CVSS 8.8 RCE
+```
+
+All 100 VMs enriched with real CVE matches, confirming Scanner V4 performed
+full vulnerability matching (not trivial no-match lookups).
+
+## Conclusion
+
+The completion-based rate limiter delivers 10x higher sustained throughput
+under real Scanner V4 vulnerability matching. Memory remains stable and
+bounded by the capacity limit. The time-based approach artificially throttles
+to the refill rate (0.3 rps) regardless of Scanner V4's actual processing
+capacity (~3 rps), dropping ~97% of incoming reports.

--- a/tools/local-sensor/main.go
+++ b/tools/local-sensor/main.go
@@ -447,6 +447,12 @@ func createDeploymentIdentificationWithNamespace(namespace string) *storage.Sens
 }
 
 func setupCentralWithRealConnection(cli client.Interface, localConfig localSensorConfig) (centralclient.CentralConnectionFactory, centralclient.CertLoader) {
+	// When using a fake workload with real Central, the passed-in client may be a fake
+	// that doesn't have real K8s secrets. Try to create a real client for cert fetching.
+	certClient := cli
+	if realClient, err := k8s.MakeOutOfClusterClient(); err == nil {
+		certClient = realClient
+	}
 	certFetcherOpts := []certs.OptionFunc{
 		certs.WithOutputDir("tmp/"),
 		certs.WithNamespace(localConfig.Namespace),
@@ -455,7 +461,7 @@ func setupCentralWithRealConnection(cli client.Interface, localConfig localSenso
 	if localConfig.OperatorInstall {
 		certFetcherOpts = append(certFetcherOpts, certs.WithClusterName("", "", ""))
 	}
-	certFetcher := certs.NewCertificateFetcher(cli, certFetcherOpts...)
+	certFetcher := certs.NewCertificateFetcher(certClient, certFetcherOpts...)
 	if err := certFetcher.FetchCertificatesAndSetEnvironment(); err != nil {
 		utils.CrashOnError(errors.Wrap(err, "failed to retrieve sensor's certificates"))
 	}


### PR DESCRIPTION
## Description

Replace the VM index report rate limiter's time-based token refill mechanism (`golang.org/x/time/rate.Limiter`) with a completion-based token return. Instead of refilling tokens at a fixed rate per second, tokens are returned to the bucket when processing completes. This turns the rate limiter into a concurrency limiter: the bucket capacity controls how many reports can be in-flight simultaneously, and throughput naturally tracks Scanner V4's actual processing speed.

- `TryConsume()` decrements available tokens; `Return()` increments them back when work completes
- Per-client fair allocation with automatic rebalancing on connect/disconnect
- `OnClientDisconnect` reclaims all in-flight tokens for the disconnected client
- All methods are nil-safe (no-op on nil `*Limiter`)
- Removed `golang.org/x/time/rate` dependency

### Files changed

| File | Change |
|------|--------|
| `pkg/rate/limiter.go` | Replace `golang.org/x/time/rate.Limiter` with `clientBucket`; add `Return()` |
| `pkg/rate/metrics.go` | Replace `PerClientRate` gauge with `InFlightTokens` gauge |
| `pkg/rate/limiter_test.go` | Rewrite: 19 tests for completion-based behavior |
| `pkg/env/virtualmachine.go` | Update env var docs for concurrency semantics |
| `central/sensor/service/connection/connection_impl.go` | Add `Return()` to `rateLimiter` interface |
| `central/sensor/service/connection/sensorevents.go` | Wire `Return()` at processing completion and dedup drop |
| `central/sensor/service/connection/connection_test.go` | Add `noopRL` helper |
| `tools/local-sensor/main.go` | Fix cert fetching for fake workload + real Central |

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

No user-facing behavior change. The `ROX_VM_INDEX_REPORT_BUCKET_CAPACITY` env var semantics shift from "burst size" to "max concurrent in-flight", but the configuration surface is unchanged.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

VM feature is gated behind `ROX_VIRTUAL_MACHINES` feature flag. Rate limiter only activates when `ROX_VM_INDEX_REPORT_RATE_LIMIT > 0`.

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

19 unit tests in `pkg/rate/limiter_test.go` covering `Return()`, concurrency, rebalancing, disconnect, and nil safety. Comparison benchmarks in `pkg/rate/benchmark_comparison_test.go`.

### How I validated my change

**Unit tests:**

```bash
go test -v ./pkg/rate/   # 19 tests pass
```

**Comparison benchmarks** (limiter-level, simulated processing):

```bash
go test -v -run TestComparisonReport -count=1 -timeout=300s ./pkg/rate/
go test -v -run TestComparisonTimeSeries -count=1 -timeout=120s ./pkg/rate/
```

**E2E cluster stress test** on ga-ocp4-cron-2 (OCP 4.x, 3 masters + 3 workers), 6 runs total (3 per variant, alternating order), 16 minutes each. Load: **400 fake VMs** with 500 real RHEL 9 packages each, reports every 1 second (400 rps), Scanner V4 performing real vulnerability matching. Rate limiter: capacity=200.

### Saturation test results (400 rps — both variants drop reports)

| Metric | Completion-Based (avg of 3 runs) | Time-Based Baseline (avg of 3 runs) |
|--------|--------------------------------|-------------------------------------|
| **Reports dropped / 16 min** | 10,736 | 11,573 |
| Scanner V4 vuln lookups / 16 min | 354 | 340 |
| Throughput (lookups/min) | 21.8 | 21.0 |
| Central memory peak | 604 Mi | 783 Mi |

Both variants correctly drop reports under extreme saturation (400 rps >> 200 bucket capacity), confirming the rate limiter is actively engaging. The completion-based variant shows a modest +4% throughput edge and lower peak memory (604 Mi vs 783 Mi) because tokens return precisely when processing finishes.

### Individual run data

| Run | Variant | Dropped | Vuln Lookups | Memory Peak |
|-----|---------|---------|-------------|-------------|
| 1 | Completion | 13,458 | 365 | 563 Mi |
| 2 | Baseline | 13,310 | 357 | 1,048 Mi |
| 3 | Completion | 10,692 | 364 | 694 Mi |
| 4 | Baseline | 10,693 | 350 | 645 Mi |
| 5 | Completion | 8,058 | 333 | 556 Mi |
| 6 | Baseline | 10,716 | 314 | 656 Mi |

### Key behavioral difference

With completion-based limiting, tokens are consumed immediately and return only when Scanner V4 finishes processing. This creates a natural concurrency limit that matches the system's actual processing capacity. With time-based limiting, tokens refill at a fixed rate regardless of downstream load — meaning at low load, throughput is artificially capped at the refill rate (0.3 rps), while at high load, both variants are bounded by Scanner V4's speed.

Full E2E test report and step-by-step reproduction guide in commit [`ad9dafc`](https://github.com/stackrox/stackrox/commit/ad9dafca36a6f95d833ca2e9ca8dd9cb7742a412) (remove before merging):

- [`pkg/rate/testdata/E2E_TEST_REPORT.md`](https://github.com/stackrox/stackrox/blob/ad9dafca36a6f95d833ca2e9ca8dd9cb7742a412/pkg/rate/testdata/E2E_TEST_REPORT.md) — Full methodology, durations, raw data
- [`pkg/rate/testdata/E2E_REPRODUCTION_GUIDE.md`](https://github.com/stackrox/stackrox/blob/ad9dafca36a6f95d833ca2e9ca8dd9cb7742a412/pkg/rate/testdata/E2E_REPRODUCTION_GUIDE.md) — Step-by-step reproduction instructions