### PR TITLE
fix(ui): Wrap this.skip in before function for compliance test

### DIFF
--- a/ui/apps/platform/cypress/integration/configmanagement/nodes.test.js
+++ b/ui/apps/platform/cypress/integration/configmanagement/nodes.test.js
@@ -75,11 +75,13 @@ describe('Configuration Management Nodes', () => {
         clickOnCountWidget('controls', 'entityList');
     });
 
-    describe('should go to controls table from widget link', function () {
+    describe('should go to controls table from widget link', () => {
         // Skip although Controls and CIS Kubernetes v1.5 are visible, because these tests assume compliance tests ran and triggered a scan (pardon rhyme).
-        if (!hasFeatureFlag('ROX_DEPRECATED_COMPLIANCE_DASHBOARD')) {
-            this.skip();
-        }
+        before(function () {
+            if (!hasFeatureFlag('ROX_DEPRECATED_COMPLIANCE_DASHBOARD')) {
+                this.skip();
+            }
+        });
 
         const entitiesKey2 = 'controls';
 


### PR DESCRIPTION
## Description

A conditional `this.skip()` snuck into a `describe` block, and needs to be wrapped with `before` to prevent a runtime error during tests.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Nightly CI, Monday.
