### PR TITLE
ROX-34093: Remove PDF export from Config Management pages

### DIFF
--- a/ui/apps/platform/src/Containers/ConfigManagement/ConfigMgmt.utils.test.js
+++ b/ui/apps/platform/src/Containers/ConfigManagement/ConfigMgmt.utils.test.js
@@ -1,8 +1,3 @@
-/**
- * Reference Error: TextEncoder is not defined
- * Maybe because of ReactDOMRenderer.renderToString in pdfUtils.js file.
- */
-
 import entityTypes from 'constants/entityTypes';
 import { getConfigMgmtCountQuery } from './ConfigMgmt.utils';
 

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/ConfigManagementDashboardPage.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/ConfigManagementDashboardPage.jsx
@@ -1,11 +1,9 @@
-import { useState } from 'react';
 import useCaseLabels from 'messages/useCase';
 import useCaseTypes from 'constants/useCaseTypes';
 import { standardTypes } from 'constants/entityTypes';
 import usePermissions from 'hooks/usePermissions';
 
 import DashboardLayout from 'Components/DashboardLayout';
-import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import Header from './Header/Header';
 
 import PolicyViolationsBySeverity from './widgets/PolicyViolationsBySeverity';
@@ -14,7 +12,6 @@ import UsersWithMostClusterAdminRoles from './widgets/UsersWithMostClusterAdminR
 import SecretsMostUsedAcrossDeployments from './widgets/SecretsMostUsedAcrossDeployments';
 
 const ConfigManagementDashboardPage = () => {
-    const [isExporting, setIsExporting] = useState(false);
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForPolicyViolationsBySeverity =
         hasReadAccess('Alert') && hasReadAccess('WorkflowAdministration');
@@ -24,29 +21,19 @@ const ConfigManagementDashboardPage = () => {
     const hasReadAccessForSecretsMostUsedAcrossDeployments =
         hasReadAccess('Deployment') && hasReadAccess('Secret');
     return (
-        <>
-            <DashboardLayout
-                headerText={useCaseLabels[useCaseTypes.CONFIG_MANAGEMENT]}
-                headerComponents={
-                    <Header isExporting={isExporting} setIsExporting={setIsExporting} />
-                }
-            >
-                {hasReadAccessForPolicyViolationsBySeverity && <PolicyViolationsBySeverity />}
-                {hasReadAccessForComplianceByControls && (
-                    <ComplianceByControls
-                        className="pdf-page"
-                        standardOptions={[standardTypes.CIS_Kubernetes_v1_5]}
-                    />
-                )}
-                {hasReadAccessForUsersWithMostClusterAdminRoles && (
-                    <UsersWithMostClusterAdminRoles />
-                )}
-                {hasReadAccessForSecretsMostUsedAcrossDeployments && (
-                    <SecretsMostUsedAcrossDeployments />
-                )}
-            </DashboardLayout>
-            {isExporting && <BackdropExporting />}
-        </>
+        <DashboardLayout
+            headerText={useCaseLabels[useCaseTypes.CONFIG_MANAGEMENT]}
+            headerComponents={<Header />}
+        >
+            {hasReadAccessForPolicyViolationsBySeverity && <PolicyViolationsBySeverity />}
+            {hasReadAccessForComplianceByControls && (
+                <ComplianceByControls standardOptions={[standardTypes.CIS_Kubernetes_v1_5]} />
+            )}
+            {hasReadAccessForUsersWithMostClusterAdminRoles && <UsersWithMostClusterAdminRoles />}
+            {hasReadAccessForSecretsMostUsedAcrossDeployments && (
+                <SecretsMostUsedAcrossDeployments />
+            )}
+        </DashboardLayout>
     );
 };
 export default ConfigManagementDashboardPage;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/Header.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/Header.jsx
@@ -1,13 +1,10 @@
-import PropTypes from 'prop-types';
-import ExportButton from 'Components/ExportButton';
-import useCaseTypes from 'constants/useCaseTypes';
 import usePermissions from 'hooks/usePermissions';
 import PoliciesTile from './PoliciesTile';
 import CISControlsTile from './CISControlsTile';
 import AppMenu from './AppMenu';
 import RBACMenu from './RBACMenu';
 
-const Header = ({ isExporting, setIsExporting }) => {
+const Header = () => {
     const { hasReadAccess } = usePermissions();
     const hasReadAccessForPoliciesTile = hasReadAccess('WorkflowAdministration');
     const hasReadAccessForCISControlsTile = hasReadAccess('Compliance');
@@ -23,23 +20,8 @@ const Header = ({ isExporting, setIsExporting }) => {
                     <RBACMenu />
                 </div>
             </div>
-            <div className="flex items-center self-center">
-                <ExportButton
-                    fileName="Config Management Dashboard Report"
-                    type={null}
-                    page={useCaseTypes.CONFIG_MANAGEMENT}
-                    pdfId="capture-dashboard"
-                    isExporting={isExporting}
-                    setIsExporting={setIsExporting}
-                />
-            </div>
         </div>
     );
-};
-
-Header.propTypes = {
-    isExporting: PropTypes.bool.isRequired,
-    setIsExporting: PropTypes.func.isRequired,
 };
 
 export default Header;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/Header.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/Header.jsx
@@ -10,7 +10,7 @@ const Header = () => {
     const hasReadAccessForCISControlsTile = hasReadAccess('Compliance');
     return (
         <div className="flex flex-1 justify-end">
-            <div className="border-base-400 border-r-2 mr-1 flex ">
+            <div className="flex">
                 {hasReadAccessForPoliciesTile && <PoliciesTile />}
                 {hasReadAccessForCISControlsTile && <CISControlsTile />}
                 <div className="flex w-32 mr-2">

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/Header.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/Header/Header.jsx
@@ -16,7 +16,7 @@ const Header = () => {
                 <div className="flex w-32 mr-2">
                     <AppMenu />
                 </div>
-                <div className="flex w-32 mr-3 ">
+                <div className="flex w-32 mr-3">
                     <RBACMenu />
                 </div>
             </div>

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/PolicyViolationsBySeverity.jsx
@@ -283,7 +283,7 @@ const PolicyViolationsBySeverity = () => {
                 }
                 return (
                     <Widget
-                        className="s-2 pdf-page"
+                        className="s-2"
                         header="Policy violations by severity"
                         headerComponents={viewAllLink}
                     >

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/SecretsMostUsedAcrossDeployments.jsx
@@ -140,7 +140,7 @@ const SecretsMostUsedAcrossDeployments = () => {
                 }
                 return (
                     <Widget
-                        className="s-2 overflow-hidden pdf-page"
+                        className="s-2 overflow-hidden"
                         header="Secrets most used across deployments"
                         headerComponents={viewAllLink}
                     >

--- a/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/UsersWithMostClusterAdminRoles.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Dashboard/widgets/UsersWithMostClusterAdminRoles.jsx
@@ -105,7 +105,7 @@ const UsersWithMostClusterAdminRoles = () => {
                 }
                 return (
                     <Widget
-                        className="s-2 overflow-hidden pdf-page"
+                        className="s-2 overflow-hidden"
                         header="Users with most cluster admin roles"
                         headerComponents={viewAllLink}
                     >

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityCluster.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityCluster.jsx
@@ -176,9 +176,9 @@ const ConfigManagementEntityCluster = ({
                 const totalControlCount = passingCount + failingCount + unknownCount;
 
                 return (
-                    <div className="w-full" id="capture-dashboard-stretch">
+                    <div className="w-full">
                         <CollapsibleSection title="Cluster Summary">
-                            <div className="flex flex-wrap pdf-page">
+                            <div className="flex flex-wrap">
                                 <Metadata
                                     className="mx-4 min-w-48 bg-base-100 min-h-48 mb-4"
                                     keyValuePairs={metadataKeyValuePairs}
@@ -240,7 +240,7 @@ const ConfigManagementEntityCluster = ({
                             </div>
                         </CollapsibleSection>
                         <CollapsibleSection title="Cluster Findings">
-                            <div className="flex pdf-page pdf-stretch relative rounded mb-4 ml-4 mr-4">
+                            <div className="flex relative rounded mb-4 ml-4 mr-4">
                                 <BinderTabs>
                                     <Tab title="Policies">
                                         <DeploymentsWithFailedPolicies

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityControl.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityControl.jsx
@@ -89,9 +89,9 @@ const ConfigManagementEntityControl = ({ id, entityListType, query, entityContex
                 } = entity;
 
                 return (
-                    <div className="w-full" id="capture-dashboard-stretch">
+                    <div className="w-full">
                         <CollapsibleSection title="Control Summary">
-                            <div className="flex flex-wrap pdf-page">
+                            <div className="flex flex-wrap">
                                 <ControlDetails
                                     standardId={standardId}
                                     control={name}
@@ -118,7 +118,7 @@ const ConfigManagementEntityControl = ({ id, entityListType, query, entityContex
                         </CollapsibleSection>
                         {!(entityContext && entityContext.NODE) && (
                             <CollapsibleSection title="Control Findings">
-                                <div className="flex pdf-page pdf-stretch shadow relative rounded bg-base-100 mb-4 ml-4 mr-4">
+                                <div className="flex shadow relative rounded bg-base-100 mb-4 ml-4 mr-4">
                                     <NodesWithFailedControls
                                         entityType="CONTROL"
                                         entityContext={{

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityImage.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityImage.jsx
@@ -181,9 +181,9 @@ const ConfigManagementEntityImage = ({
                     });
                 }
                 return (
-                    <div className="w-full" id="capture-dashboard-stretch">
+                    <div className="w-full">
                         <CollapsibleSection title="Image Summary">
-                            <div className="flex mb-4 flex-wrap pdf-page">
+                            <div className="flex mb-4 flex-wrap">
                                 <Metadata
                                     className="mx-4 bg-base-100 min-h-48 mb-4"
                                     keyValuePairs={metadataKeyValuePairs}
@@ -199,7 +199,7 @@ const ConfigManagementEntityImage = ({
                             </div>
                         </CollapsibleSection>
                         <CollapsibleSection title="Dockerfile">
-                            <div className="flex pdf-page pdf-stretch shadow relative rounded bg-base-100 mb-4 ml-4 mr-4">
+                            <div className="flex shadow relative rounded bg-base-100 mb-4 ml-4 mr-4">
                                 {layers.length === 0 && (
                                     <NoResultsMessage
                                         message="No layers available in this image"

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityNamespace.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityNamespace.jsx
@@ -133,9 +133,9 @@ const ConfigManagementEntityNamespace = ({
                 ];
 
                 return (
-                    <div className="w-full" id="capture-dashboard-stretch">
+                    <div className="w-full">
                         <CollapsibleSection title="Namespace Summary">
-                            <div className="flex flex-wrap pdf-page">
+                            <div className="flex flex-wrap">
                                 <Metadata
                                     className="mx-4 bg-base-100 min-h-48 mb-4"
                                     keyValuePairs={metadataKeyValuePairs}
@@ -183,7 +183,7 @@ const ConfigManagementEntityNamespace = ({
                             </div>
                         </CollapsibleSection>
                         <CollapsibleSection title="Namespace Findings">
-                            <div className="flex pdf-page pdf-stretch relative rounded mb-4 ml-4 mr-4">
+                            <div className="flex relative rounded mb-4 ml-4 mr-4">
                                 <DeploymentsWithFailedPolicies
                                     query={queryService.objectToWhereClause({
                                         Cluster: cluster.name,

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityNode.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityNode.jsx
@@ -165,9 +165,9 @@ const ConfigManagementEntityNode = ({
                 ];
 
                 return (
-                    <div className="w-full" id="capture-dashboard-stretch">
+                    <div className="w-full">
                         <CollapsibleSection title="Node Summary">
-                            <div className="flex mb-4 flex-wrap pdf-page">
+                            <div className="flex mb-4 flex-wrap">
                                 <Metadata
                                     className="mx-4 bg-base-100 min-h-48 mb-4"
                                     keyValuePairs={metadataKeyValuePairs}
@@ -193,7 +193,7 @@ const ConfigManagementEntityNode = ({
                         </CollapsibleSection>
                         {!(entityContext && entityContext.CONTROL) && (
                             <CollapsibleSection title="Node Findings">
-                                <div className="flex pdf-page pdf-stretch shadow relative rounded bg-base-100 mb-4 ml-4 mr-4">
+                                <div className="flex shadow relative rounded bg-base-100 mb-4 ml-4 mr-4">
                                     {failedComplianceResults.length === 0 && (
                                         <NoResultsMessage
                                             message="No nodes failing controls on this node"

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySecret.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySecret.jsx
@@ -279,9 +279,9 @@ const ConfigManagementEntitySecret = ({
                 ];
 
                 return (
-                    <div className="w-full" id="capture-dashboard-stretch">
+                    <div className="w-full">
                         <CollapsibleSection title="Secret Summary">
-                            <div className="flex mb-4 flex-wrap pdf-page">
+                            <div className="flex mb-4 flex-wrap">
                                 <Metadata
                                     className="mx-4 bg-base-100 min-h-48 mb-4"
                                     keyValuePairs={metadataKeyValuePairs}
@@ -306,7 +306,7 @@ const ConfigManagementEntitySecret = ({
                             </div>
                         </CollapsibleSection>
                         <CollapsibleSection title="Secret Values">
-                            <div className="flex pdf-page pdf-stretch mb-4 ml-4 mr-4">
+                            <div className="flex mb-4 ml-4 mr-4">
                                 <SecretValues files={files} />
                             </div>
                         </CollapsibleSection>

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityServiceAccount.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityServiceAccount.jsx
@@ -165,9 +165,9 @@ const ConfigManagementEntityServiceAccount = ({
                 const scopedPermissionsByCluster = [{ clusterId, clusterName, scopedPermissions }];
 
                 return (
-                    <div className="w-full" id="capture-dashboard-stretch">
+                    <div className="w-full">
                         <CollapsibleSection title="Service Account Summary">
-                            <div className="flex mb-4 flex-wrap pdf-page">
+                            <div className="flex mb-4 flex-wrap">
                                 <Metadata
                                     className="mx-4 bg-base-100 min-h-48 mb-4"
                                     keyValuePairs={metadataKeyValuePairs}
@@ -208,7 +208,7 @@ const ConfigManagementEntityServiceAccount = ({
                             </div>
                         </CollapsibleSection>
                         <CollapsibleSection title="Service Account Permissions">
-                            <div className="flex mb-4 pdf-page pdf-stretch">
+                            <div className="flex mb-4">
                                 <ClusterScopedPermissions
                                     scopedPermissionsByCluster={scopedPermissionsByCluster}
                                     className="mx-4 bg-base-100 w-full"

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySubject.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntitySubject.jsx
@@ -144,9 +144,9 @@ const ConfigManagementEntitySubject = ({
                 ];
 
                 return (
-                    <div className="w-full" id="capture-dashboard-stretch">
+                    <div className="w-full">
                         <CollapsibleSection title="Subject Summary">
-                            <div className="flex mb-4 flex-wrap pdf-page">
+                            <div className="flex mb-4 flex-wrap">
                                 <Metadata
                                     className="mx-4 bg-base-100 min-h-48 mb-4"
                                     keyValuePairs={metadataKeyValuePairs}
@@ -160,7 +160,7 @@ const ConfigManagementEntitySubject = ({
                             </div>
                         </CollapsibleSection>
                         <CollapsibleSection title="Subject Permissions">
-                            <div className="flex mb-4 pdf-page pdf-stretch">
+                            <div className="flex mb-4">
                                 <ClusterScopedPermissions
                                     scopedPermissionsByCluster={scopedPermissionsAcrossAllClusters}
                                     className="mx-4 bg-base-100"

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/ConfigManagementEntityDeployment.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Deployment/ConfigManagementEntityDeployment.jsx
@@ -169,9 +169,9 @@ const ConfigManagementEntityDeployment = ({
                 ];
 
                 return (
-                    <div className="w-full" id="capture-dashboard-stretch">
+                    <div className="w-full">
                         <CollapsibleSection title="Deployment Summary">
-                            <div className="flex mb-4 flex-wrap pdf-page">
+                            <div className="flex mb-4 flex-wrap">
                                 <Metadata
                                     className="mx-4 bg-base-100 min-h-48 mb-4"
                                     keyValuePairs={metadataKeyValuePairs}
@@ -220,7 +220,7 @@ const ConfigManagementEntityDeployment = ({
                             </div>
                         </CollapsibleSection>
                         <CollapsibleSection title="Deployment Findings">
-                            <div className="flex mb-4 pdf-page pdf-stretch">
+                            <div className="flex mb-4">
                                 <DeploymentFindings
                                     entityContext={entityContext}
                                     deploymentID={id}

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPage.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPage.jsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';
-import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import { searchParams } from 'constants/searchParams';
 import configMgmtPaginationContext, {
     MAIN_PAGINATION_PARAMS,
@@ -22,7 +21,6 @@ import Entity from '../Entity';
 
 const EntityPage = () => {
     const sidePanelRef = useRef(null);
-    const [isExporting, setIsExporting] = useState(false);
     const location = useLocation();
     const navigate = useNavigate();
     const match = useWorkflowMatch();
@@ -37,7 +35,6 @@ const EntityPage = () => {
     );
 
     const params = URLService.getParams(match, location);
-    const { urlParams } = URLService.getURL(match, location);
     const {
         pageEntityType,
         pageEntityId,
@@ -76,13 +73,7 @@ const EntityPage = () => {
     return (
         <workflowStateContext.Provider value={pageState}>
             <div className="flex flex-1 flex-col" style={style}>
-                <EntityPageHeader
-                    entityType={pageEntityType}
-                    entityId={pageEntityId}
-                    urlParams={urlParams}
-                    isExporting={isExporting}
-                    setIsExporting={setIsExporting}
-                />
+                <EntityPageHeader entityType={pageEntityType} entityId={pageEntityId} />
                 <Tabs
                     pageEntityId={pageEntityId}
                     entityType={pageEntityType}
@@ -91,7 +82,7 @@ const EntityPage = () => {
                 />
                 <div className="flex flex-1 w-full h-full relative z-0 overflow-hidden">
                     <configMgmtPaginationContext.Provider value={MAIN_PAGINATION_PARAMS}>
-                        <div className="h-full w-full overflow-auto" id="capture-list">
+                        <div className="h-full w-full overflow-auto">
                             <Entity
                                 entityType={pageEntityType}
                                 entityId={pageEntityId}
@@ -122,7 +113,6 @@ const EntityPage = () => {
                     </searchContext.Provider>
                 </div>
             </div>
-            {isExporting && <BackdropExporting />}
         </workflowStateContext.Provider>
     );
 };

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPageHeader.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPageHeader.jsx
@@ -20,13 +20,11 @@ const EntityPageHeader = ({ entityType, entityId }) => {
             subHeader={subHeader}
             classes="z-1 pr-0 ignore-react-onclickoutside"
         >
-            <div className="flex flex-1 justify-end h-full">
-                <div className="flex items-center pl-2">
-                    <EntitiesMenu
-                        text="All Entities"
-                        options={getConfigurationManagementEntityTypes()}
-                    />
-                </div>
+            <div className="flex flex-1 justify-end items-center h-full pl-2">
+                <EntitiesMenu
+                    text="All Entities"
+                    options={getConfigurationManagementEntityTypes()}
+                />
             </div>
         </PageHeader>
     );

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPageHeader.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/EntityPageHeader.jsx
@@ -1,26 +1,19 @@
 import PropTypes from 'prop-types';
 import upperFirst from 'lodash/upperFirst';
-import startCase from 'lodash/startCase';
 
 import PageHeader from 'Components/PageHeader';
-import ExportButton from 'Components/ExportButton';
 import EntitiesMenu from 'Components/workflow/EntitiesMenu';
 import useEntityName from 'hooks/useEntityName';
 import entityLabels from 'messages/entity';
 import { getConfigurationManagementEntityTypes } from 'utils/entityRelationships';
 
-const EntityPageHeader = ({ entityType, entityId, urlParams, isExporting, setIsExporting }) => {
+const EntityPageHeader = ({ entityType, entityId }) => {
     const safeEntityId = decodeURIComponent(entityId); // fix bug  ROX-4543-fix-bad-encoding-in-config-mgt-API-request
     const { entityName } = useEntityName(entityType, safeEntityId);
 
     const header = entityName || '-';
     const subHeader = upperFirst(entityLabels[entityType]);
-    const exportFilename = `${startCase(subHeader)} Report: "${header}"`;
 
-    let pdfId = 'capture-dashboard-stretch';
-    if (urlParams && urlParams.entityListType1) {
-        pdfId = 'capture-list';
-    }
     return (
         <PageHeader
             header={header}
@@ -28,16 +21,6 @@ const EntityPageHeader = ({ entityType, entityId, urlParams, isExporting, setIsE
             classes="z-1 pr-0 ignore-react-onclickoutside"
         >
             <div className="flex flex-1 justify-end h-full">
-                <div className="flex items-center">
-                    <ExportButton
-                        fileName={exportFilename}
-                        type={entityType}
-                        page="configManagement"
-                        pdfId={pdfId}
-                        isExporting={isExporting}
-                        setIsExporting={setIsExporting}
-                    />
-                </div>
                 <div className="flex items-center pl-2">
                     <EntitiesMenu
                         text="All Entities"
@@ -52,15 +35,6 @@ const EntityPageHeader = ({ entityType, entityId, urlParams, isExporting, setIsE
 EntityPageHeader.propTypes = {
     entityType: PropTypes.string.isRequired,
     entityId: PropTypes.string.isRequired,
-    urlParams: PropTypes.shape({
-        entityListType1: PropTypes.string,
-    }),
-    isExporting: PropTypes.bool.isRequired,
-    setIsExporting: PropTypes.func.isRequired,
-};
-
-EntityPageHeader.defaultProps = {
-    urlParams: null,
 };
 
 export default EntityPageHeader;

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/Policy/ConfigManagementEntityPolicy.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/Policy/ConfigManagementEntityPolicy.jsx
@@ -180,12 +180,12 @@ const ConfigManagementEntityPolicy = ({
                 ) : null;
 
                 return (
-                    <div className="w-full" id="capture-dashboard-stretch">
+                    <div className="w-full">
                         <CollapsibleSection
                             title="Policy Summary"
                             headerComponents={headerComponents}
                         >
-                            <div className="grid grid-gap-6 grid-columns-4 mx-4 grid-dense mb-4 pdf-page">
+                            <div className="grid grid-gap-6 grid-columns-4 mx-4 grid-dense mb-4">
                                 <Metadata
                                     className="sx-2 bg-base-100 min-h-48 h-full"
                                     keyValuePairs={metadataKeyValuePairs}
@@ -230,7 +230,7 @@ const ConfigManagementEntityPolicy = ({
                             title="Policy Findings"
                             dataTestId="policy-findings-section"
                         >
-                            <div className="flex mb-4 pdf-page pdf-stretch">
+                            <div className="flex mb-4">
                                 <PolicyFindings
                                     entityContext={entityContext}
                                     policyId={id}

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/DeploymentsWithFailedPolicies.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/DeploymentsWithFailedPolicies.jsx
@@ -90,7 +90,7 @@ const DeploymentsWithFailedPolicies = ({ query, message, entityContext }) => (
                     headerClassName: defaultHeaderClassName,
                     className: defaultColumnClassName,
                     accessor: 'name',
-                    Cell: ({ original, pdf }) => {
+                    Cell: ({ original }) => {
                         const { severity, categories, name } = original;
 
                         const groupHeader = (
@@ -98,11 +98,7 @@ const DeploymentsWithFailedPolicies = ({ query, message, entityContext }) => (
                                 <div className="flex flex-1">{name}</div>
                                 <div>
                                     <span>
-                                        Severity:{' '}
-                                        <PolicySeverityIconText
-                                            severity={severity}
-                                            isTextOnly={pdf}
-                                        />
+                                        Severity: <PolicySeverityIconText severity={severity} />
                                     </span>
                                     <span className="pl-2 pr-2">|</span>
                                     <span>Categories: {categories.join(',')}</span>

--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.tsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/widgets/FailedPoliciesAcrossDeployment.tsx
@@ -125,9 +125,9 @@ function FailedPoliciesAcrossDeployment({ deploymentID }: FailedPoliciesAcrossDe
                         Header: `Severity`,
                         headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                         className: `w-1/8 ${defaultColumnClassName}`,
-                        Cell: ({ original, pdf }) => {
+                        Cell: ({ original }) => {
                             const { severity } = original;
-                            return <PolicySeverityIconText severity={severity} isTextOnly={pdf} />;
+                            return <PolicySeverityIconText severity={severity} />;
                         },
                         accessor: 'severity',
                         sortMethod: sortSeverity,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListClusters.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListClusters.jsx
@@ -69,13 +69,9 @@ const buildTableColumns = (match, location) => {
             Header: `Cluster`,
             headerClassName: `w-1/8 ${defaultHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const url = getConfigMgmtPathForEntitiesAndId('CLUSTER', original.id);
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {original.name}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{original.name}</TableCellLink>;
             },
             accessor: 'name',
             id: clusterSortFields.CLUSTER,
@@ -92,11 +88,11 @@ const buildTableColumns = (match, location) => {
             Header: `Policy Status`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const {
                     policyStatus: { status },
                 } = original;
-                return <PolicyStatusIconText isPass={status === 'pass'} isTextOnly={pdf} />;
+                return <PolicyStatusIconText isPass={status === 'pass'} />;
             },
             id: 'status',
             accessor: (d) => d.policyStatus.status,
@@ -107,23 +103,19 @@ const buildTableColumns = (match, location) => {
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
             accessor: 'complianceControlCount',
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { complianceControlCount } = original;
                 const { passingCount, failingCount, unknownCount } = complianceControlCount;
                 const totalCount = passingCount + failingCount + unknownCount;
                 if (!totalCount) {
-                    return <NoEntitiesIconText text="No Controls" isTextOnly={pdf} />;
+                    return <NoEntitiesIconText text="No Controls" />;
                 }
                 const url = URLService.getURL(match, location)
                     .push(original.id)
                     .push('CONTROL')
                     .url();
                 const text = `${totalCount} ${pluralize('Controls', totalCount)}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             sortable: false,
         },
@@ -131,21 +123,17 @@ const buildTableColumns = (match, location) => {
             Header: `Users & Groups`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { subjectCount } = original;
                 if (!subjectCount) {
-                    return <NoEntitiesIconText text="No Users & Groups" isTextOnly={pdf} />;
+                    return <NoEntitiesIconText text="No Users & Groups" />;
                 }
                 const url = URLService.getURL(match, location)
                     .push(original.id)
                     .push('SUBJECT')
                     .url();
                 const text = `${subjectCount} ${pluralize('Users & Groups', subjectCount)}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             id: 'subjectCount',
             accessor: (d) => d.subjectCount,
@@ -155,10 +143,10 @@ const buildTableColumns = (match, location) => {
             Header: `Service Accounts`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { serviceAccountCount } = original;
                 if (!serviceAccountCount) {
-                    return <NoEntitiesIconText text="No Service Accounts" isTextOnly={pdf} />;
+                    return <NoEntitiesIconText text="No Service Accounts" />;
                 }
                 const url = URLService.getURL(match, location)
                     .push(original.id)
@@ -168,11 +156,7 @@ const buildTableColumns = (match, location) => {
                     'Service Accounts',
                     serviceAccountCount
                 )}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             id: 'serviceAccountCount',
             accessor: (d) => d.serviceAccountCount,
@@ -182,18 +166,14 @@ const buildTableColumns = (match, location) => {
             Header: `Roles`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { k8sRoleCount } = original;
                 if (!k8sRoleCount) {
-                    return <NoEntitiesIconText text="No Roles" isTextOnly={pdf} />;
+                    return <NoEntitiesIconText text="No Roles" />;
                 }
                 const url = URLService.getURL(match, location).push(original.id).push('ROLE').url();
                 const text = `${k8sRoleCount} ${pluralize('Roles', k8sRoleCount)}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             id: 'k8sRoleCount',
             accessor: (d) => d.k8sRoleCount,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListControls.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListControls.jsx
@@ -33,13 +33,9 @@ const tableColumns = [
         Header: `Control`,
         headerClassName: `w-1/2 ${defaultHeaderClassName}`,
         className: `w-1/2 ${defaultColumnClassName}`,
-        Cell: ({ original, pdf }) => {
+        Cell: ({ original }) => {
             const url = getConfigMgmtPathForEntitiesAndId('CONTROL', original.id);
-            return (
-                <TableCellLink pdf={pdf} url={url}>
-                    {original.control}
-                </TableCellLink>
-            );
+            return <TableCellLink url={url}>{original.control}</TableCellLink>;
         },
         accessor: 'control',
         sortMethod: sortVersion,
@@ -48,11 +44,11 @@ const tableColumns = [
         Header: `Control Status`,
         headerClassName: `w-1/8 ${defaultHeaderClassName}`,
         className: `w-1/8 ${defaultColumnClassName} capitalize`,
-        Cell: ({ original, pdf }) => {
+        Cell: ({ original }) => {
             if (original.status === COMPLIANCE_STATES['N/A']) {
-                return <NotApplicableIconText isTextOnly={pdf} />;
+                return <NotApplicableIconText />;
             }
-            return <PolicyStatusIconText isPass={original.status === 'Pass'} isTextOnly={pdf} />;
+            return <PolicyStatusIconText isPass={original.status === 'Pass'} />;
         },
         accessor: 'status',
         sortMethod: sortStatus,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListDeployments.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListDeployments.jsx
@@ -40,13 +40,9 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Deployment`,
             headerClassName: `w-1/8 ${defaultHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const url = getConfigMgmtPathForEntitiesAndId('DEPLOYMENT', original.id);
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {original.name}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{original.name}</TableCellLink>;
             },
             accessor: 'name',
             id: deploymentSortFields.DEPLOYMENT,
@@ -59,17 +55,13 @@ const buildTableColumns = (match, location, entityContext) => {
                   headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                   className: `w-1/8 ${defaultColumnClassName}`,
                   accessor: 'clusterName',
-                  Cell: ({ original, pdf }) => {
+                  Cell: ({ original }) => {
                       const { clusterName, clusterId, id } = original;
                       const url = URLService.getURL(match, location)
                           .push(id)
                           .push('CLUSTER', clusterId)
                           .url();
-                      return (
-                          <TableCellLink pdf={pdf} url={url}>
-                              {clusterName}
-                          </TableCellLink>
-                      );
+                      return <TableCellLink url={url}>{clusterName}</TableCellLink>;
                   },
                   id: deploymentSortFields.CLUSTER,
                   sortField: deploymentSortFields.CLUSTER,
@@ -81,17 +73,13 @@ const buildTableColumns = (match, location, entityContext) => {
                   headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                   className: `w-1/8 ${defaultColumnClassName}`,
                   accessor: 'namespace',
-                  Cell: ({ original, pdf }) => {
+                  Cell: ({ original }) => {
                       const { namespace, namespaceId, id } = original;
                       const url = URLService.getURL(match, location)
                           .push(id)
                           .push('NAMESPACE', namespaceId)
                           .url();
-                      return (
-                          <TableCellLink pdf={pdf} url={url}>
-                              {namespace}
-                          </TableCellLink>
-                      );
+                      return <TableCellLink url={url}>{namespace}</TableCellLink>;
                   },
                   id: deploymentSortFields.NAMESPACE,
                   sortField: deploymentSortFields.NAMESPACE,
@@ -100,9 +88,9 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Policy Status`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { policyStatus } = original;
-                return <PolicyStatusIconText isPass={policyStatus === 'pass'} isTextOnly={pdf} />;
+                return <PolicyStatusIconText isPass={policyStatus === 'pass'} />;
             },
             id: 'policyStatus',
             accessor: 'policyStatus',
@@ -112,18 +100,14 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Images`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { imageCount, id } = original;
                 if (imageCount === 0) {
                     return 'No images';
                 }
                 const url = URLService.getURL(match, location).push(id).push('IMAGE').url();
                 const text = `${imageCount} ${pluralize('image', imageCount)}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             accessor: 'imageCount',
             sortable: false,
@@ -132,18 +116,14 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Secrets`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { secretCount, id } = original;
                 if (secretCount === 0) {
                     return 'No secrets';
                 }
                 const url = URLService.getURL(match, location).push(id).push('SECRET').url();
                 const text = `${secretCount} ${pluralize('secret', secretCount)}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             accessor: 'secretCount',
             sortable: false,
@@ -155,17 +135,13 @@ const buildTableColumns = (match, location, entityContext) => {
                   headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                   className: `w-1/8 ${defaultColumnClassName}`,
                   accessor: 'serviceAccount',
-                  Cell: ({ original, pdf }) => {
+                  Cell: ({ original }) => {
                       const { serviceAccount, serviceAccountID, id } = original;
                       const url = URLService.getURL(match, location)
                           .push(id)
                           .push('SERVICE_ACCOUNT', serviceAccountID)
                           .url();
-                      return (
-                          <TableCellLink pdf={pdf} url={url}>
-                              {serviceAccount}
-                          </TableCellLink>
-                      );
+                      return <TableCellLink url={url}>{serviceAccount}</TableCellLink>;
                   },
                   id: deploymentSortFields.SERVICE_ACCOUNT,
                   sortField: deploymentSortFields.SERVICE_ACCOUNT,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListImages.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListImages.jsx
@@ -36,13 +36,9 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Image`,
             headerClassName: `w-1/8 ${defaultHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const url = getConfigMgmtPathForEntitiesAndId('IMAGE', original.id);
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {original.name.fullName}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{original.name.fullName}</TableCellLink>;
             },
             accessor: 'name.fullName',
             id: imageSortFields.NAME,
@@ -68,7 +64,7 @@ const buildTableColumns = (match, location, entityContext) => {
                   Header: `Deployments`,
                   headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
                   className: `w-1/8 ${defaultColumnClassName}`,
-                  Cell: ({ original, pdf }) => {
+                  Cell: ({ original }) => {
                       const { deployments, id } = original;
                       const num = deployments.length;
                       const text = `${num} ${pluralize('deployment', num)}`;
@@ -79,11 +75,7 @@ const buildTableColumns = (match, location, entityContext) => {
                           .push(id)
                           .push('DEPLOYMENT')
                           .url();
-                      return (
-                          <TableCellLink pdf={pdf} url={url}>
-                              {text}
-                          </TableCellLink>
-                      );
+                      return <TableCellLink url={url}>{text}</TableCellLink>;
                   },
                   accessor: 'deployments',
                   sortable: false,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNamespaces.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNamespaces.jsx
@@ -40,13 +40,9 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Namespace`,
             headerClassName: `w-1/8 ${defaultHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const url = getConfigMgmtPathForEntitiesAndId('NAMESPACE', original.metadata.id);
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {original.metadata.name}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{original.metadata.name}</TableCellLink>;
             },
             accessor: 'metadata.name',
             id: namespaceSortFields.NAMESPACE,
@@ -59,7 +55,7 @@ const buildTableColumns = (match, location, entityContext) => {
                   headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                   className: `w-1/8 ${defaultColumnClassName}`,
                   accessor: 'metadata.clusterName',
-                  Cell: ({ original, pdf }) => {
+                  Cell: ({ original }) => {
                       const { metadata } = original;
                       if (!metadata) {
                           return '-';
@@ -69,11 +65,7 @@ const buildTableColumns = (match, location, entityContext) => {
                           .push(id)
                           .push('CLUSTER', clusterId)
                           .url();
-                      return (
-                          <TableCellLink pdf={pdf} url={url}>
-                              {clusterName}
-                          </TableCellLink>
-                      );
+                      return <TableCellLink url={url}>{clusterName}</TableCellLink>;
                   },
                   id: namespaceSortFields.CLUSTER,
                   sortField: namespaceSortFields.CLUSTER,
@@ -82,11 +74,11 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Policy Status`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const {
                     policyStatus: { status },
                 } = original;
-                return <PolicyStatusIconText isPass={status === 'pass'} isTextOnly={pdf} />;
+                return <PolicyStatusIconText isPass={status === 'pass'} />;
             },
             id: 'status',
             accessor: (d) => d.policyStatus.status,
@@ -96,7 +88,7 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Secrets`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { numSecrets, metadata } = original;
                 if (!metadata || numSecrets === 0) {
                     return 'No Secrets';
@@ -104,11 +96,7 @@ const buildTableColumns = (match, location, entityContext) => {
                 const { id } = metadata;
                 const url = URLService.getURL(match, location).push(id).push('SECRET').url();
                 const text = `${numSecrets} ${pluralize('Secrets', numSecrets)}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             id: 'numSecrets',
             accessor: (d) => d.numSecrets,
@@ -118,7 +106,7 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Users & Groups`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { subjectsCount, metadata } = original;
                 if (!subjectsCount || subjectsCount === 0) {
                     return 'No Users & Groups';
@@ -126,11 +114,7 @@ const buildTableColumns = (match, location, entityContext) => {
                 const { id } = metadata;
                 const url = URLService.getURL(match, location).push(id).push('SUBJECT').url();
                 const text = `${subjectsCount} ${pluralize('Users & Groups', subjectsCount)}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             accessor: 'subjectCount',
             sortable: false,
@@ -139,7 +123,7 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Service Accounts`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { serviceAccountCount, metadata } = original;
                 if (!serviceAccountCount || serviceAccountCount === 0) {
                     return 'No Service Accounts';
@@ -153,11 +137,7 @@ const buildTableColumns = (match, location, entityContext) => {
                     'Service Accounts',
                     serviceAccountCount
                 )}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             accessor: 'serviceAccountCount',
             sortable: false,
@@ -166,7 +146,7 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Roles`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { k8sRoleCount, metadata } = original;
                 if (!k8sRoleCount || k8sRoleCount === 0) {
                     return 'No Roles';
@@ -174,11 +154,7 @@ const buildTableColumns = (match, location, entityContext) => {
                 const { id } = metadata;
                 const url = URLService.getURL(match, location).push(id).push('ROLE').url();
                 const text = `${k8sRoleCount} ${pluralize('Roles', k8sRoleCount)}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             accessor: 'k8sRoleCount',
             sortable: false,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNodes.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListNodes.jsx
@@ -57,13 +57,9 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Node`,
             headerClassName: `w-1/8 ${defaultHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const url = getConfigMgmtPathForEntitiesAndId('NODE', original.id);
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {original.name}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{original.name}</TableCellLink>;
             },
             accessor: 'name',
             id: nodeSortFields.NODE,
@@ -107,17 +103,13 @@ const buildTableColumns = (match, location, entityContext) => {
                   headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                   className: `w-1/8 ${defaultColumnClassName}`,
                   accessor: 'clusterName',
-                  Cell: ({ original, pdf }) => {
+                  Cell: ({ original }) => {
                       const { clusterName, clusterId, id } = original;
                       const url = URLService.getURL(match, location)
                           .push(id)
                           .push('CLUSTER', clusterId)
                           .url();
-                      return (
-                          <TableCellLink pdf={pdf} url={url}>
-                              {clusterName}
-                          </TableCellLink>
-                      );
+                      return <TableCellLink url={url}>{clusterName}</TableCellLink>;
                   },
                   id: nodeSortFields.CLUSTER,
                   sortField: nodeSortFields.CLUSTER,
@@ -129,24 +121,20 @@ const buildTableColumns = (match, location, entityContext) => {
                   headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
                   className: `w-1/8 ${defaultColumnClassName}`,
                   accessor: 'nodeComplianceControlCount',
-                  Cell: ({ original, pdf }) => {
+                  Cell: ({ original }) => {
                       const { nodeComplianceControlCount } = original;
                       const { passingCount, failingCount, unknownCount } =
                           nodeComplianceControlCount;
                       const controlCount = passingCount + failingCount + unknownCount;
                       if (!controlCount) {
-                          return <NoEntitiesIconText text="No Controls" isTextOnly={pdf} />;
+                          return <NoEntitiesIconText text="No Controls" />;
                       }
                       const url = URLService.getURL(match, location)
                           .push(original.id)
                           .push('CONTROL')
                           .url();
                       const text = `${controlCount} ${pluralize('Controls', controlCount)}`;
-                      return (
-                          <TableCellLink pdf={pdf} url={url}>
-                              {text}
-                          </TableCellLink>
-                      );
+                      return <TableCellLink url={url}>{text}</TableCellLink>;
                   },
                   sortable: false,
               },

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListPolicies.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListPolicies.jsx
@@ -37,13 +37,9 @@ const tableColumns = [
         Header: `Policy`,
         headerClassName: `w-1/4 ${defaultHeaderClassName}`,
         className: `w-1/4 ${defaultColumnClassName}`,
-        Cell: ({ original, pdf }) => {
+        Cell: ({ original }) => {
             const url = getConfigMgmtPathForEntitiesAndId('POLICY', original.id);
-            return (
-                <TableCellLink pdf={pdf} url={url}>
-                    {original.name}
-                </TableCellLink>
-            );
+            return <TableCellLink url={url}>{original.name}</TableCellLink>;
         },
         accessor: 'name',
         id: policySortFields.POLICY,
@@ -68,12 +64,12 @@ const tableColumns = [
         Header: `Policy Status`,
         headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
         className: `w-1/8 ${defaultColumnClassName}`,
-        Cell: ({ original, pdf }) => {
+        Cell: ({ original }) => {
             const { disabled, policyStatus } = original;
             return disabled ? (
-                <PolicyDisabledIconText isDisabled={disabled} isTextOnly={pdf} />
+                <PolicyDisabledIconText isDisabled={disabled} />
             ) : (
-                <PolicyStatusIconText isPass={policyStatus === 'pass'} isTextOnly={pdf} />
+                <PolicyStatusIconText isPass={policyStatus === 'pass'} />
             );
         },
         accessor: 'policyStatus',
@@ -84,8 +80,8 @@ const tableColumns = [
         headerClassName: `w-1/8 ${defaultHeaderClassName}`,
         className: `w-1/8 ${defaultColumnClassName}`,
         Cell: ({ original }) => {
-            const { severity, pdf } = original;
-            return <PolicySeverityIconText severity={severity} isTextOnly={pdf} />;
+            const { severity } = original;
+            return <PolicySeverityIconText severity={severity} />;
         },
         accessor: 'severity',
         sortMethod: sortSeverity,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListRoles.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListRoles.jsx
@@ -37,13 +37,9 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Role`,
             headerClassName: `w-1/8 ${defaultHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const url = getConfigMgmtPathForEntitiesAndId('ROLE', original.id);
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {original.name}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{original.name}</TableCellLink>;
             },
             accessor: 'name',
             id: roleSortFields.ROLE,
@@ -88,17 +84,13 @@ const buildTableColumns = (match, location, entityContext) => {
                   headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                   className: `w-1/8 ${defaultColumnClassName}`,
                   accessor: 'clusterName',
-                  Cell: ({ original, pdf }) => {
+                  Cell: ({ original }) => {
                       const { clusterName, clusterId, id } = original;
                       const url = URLService.getURL(match, location)
                           .push(id)
                           .push('CLUSTER', clusterId)
                           .url();
-                      return (
-                          <TableCellLink pdf={pdf} url={url}>
-                              {clusterName}
-                          </TableCellLink>
-                      );
+                      return <TableCellLink url={url}>{clusterName}</TableCellLink>;
                   },
                   id: roleSortFields.CLUSTER,
                   sortField: roleSortFields.CLUSTER,
@@ -107,7 +99,7 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Namespace Scope`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { roleNamespace, id } = original;
                 if (!roleNamespace) {
                     return 'Cluster-wide';
@@ -119,11 +111,7 @@ const buildTableColumns = (match, location, entityContext) => {
                     .push(id)
                     .push('NAMESPACE', namespaceId)
                     .url();
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {name}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{name}</TableCellLink>;
             },
             accessor: 'roleNamespace.metadata.name',
             sortable: false,
@@ -132,14 +120,14 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Users & Groups`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { serviceAccounts, subjects } = original;
                 const { length: serviceAccountsLength } = serviceAccounts;
                 const { length: subjectsLength } = subjects;
                 if (!subjectsLength) {
                     return !serviceAccountsLength ||
                         (serviceAccountsLength === 1 && serviceAccounts[0].message) ? (
-                        <NoEntitiesIconText text="No Users & Groups" isTextOnly={pdf} />
+                        <NoEntitiesIconText text="No Users & Groups" />
                     ) : (
                         'No Users & Groups'
                     );
@@ -150,18 +138,10 @@ const buildTableColumns = (match, location, entityContext) => {
                     .url();
                 const text = `${subjectsLength} ${pluralize('Users & Groups', subjectsLength)}`;
                 if (subjectsLength > 1) {
-                    return (
-                        <TableCellLink pdf={pdf} url={url}>
-                            {text}
-                        </TableCellLink>
-                    );
+                    return <TableCellLink url={url}>{text}</TableCellLink>;
                 }
                 const subject = subjects[0];
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {subject.name}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{subject.name}</TableCellLink>;
             },
             id: 'subjects',
             accessor: (d) => d.subjects,
@@ -171,7 +151,7 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Service Accounts`,
             headerClassName: `w-1/8 ${defaultHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { serviceAccounts, subjects, id } = original;
                 const { length: serviceAccountsLength } = serviceAccounts;
                 const { length: subjectsLength } = subjects;
@@ -180,7 +160,7 @@ const buildTableColumns = (match, location, entityContext) => {
                         (serviceAccountsLength === 1 && serviceAccounts[0].message)) &&
                     !subjectsLength
                 ) {
-                    return <NoEntitiesIconText text="No Service Accounts" isTextOnly={pdf} />;
+                    return <NoEntitiesIconText text="No Service Accounts" />;
                 }
                 if (!serviceAccountsLength) {
                     return 'No Service Accounts';
@@ -194,18 +174,10 @@ const buildTableColumns = (match, location, entityContext) => {
                     serviceAccountsLength
                 )}`;
                 if (serviceAccountsLength > 1) {
-                    return (
-                        <TableCellLink pdf={pdf} url={url}>
-                            {text}
-                        </TableCellLink>
-                    );
+                    return <TableCellLink url={url}>{text}</TableCellLink>;
                 }
                 const serviceAccount = serviceAccounts[0];
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {serviceAccount.name}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{serviceAccount.name}</TableCellLink>;
             },
             accessor: 'serviceAccounts',
             sortable: false,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSecrets.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSecrets.jsx
@@ -52,13 +52,9 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Secret`,
             headerClassName: `w-1/8 ${defaultHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const url = getConfigMgmtPathForEntitiesAndId('SECRET', original.id);
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {original.name}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{original.name}</TableCellLink>;
             },
             accessor: 'name',
             id: secretSortFields.SECRET,
@@ -101,17 +97,13 @@ const buildTableColumns = (match, location, entityContext) => {
                   headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                   className: `w-1/8 ${defaultColumnClassName}`,
                   accessor: 'clusterName',
-                  Cell: ({ original, pdf }) => {
+                  Cell: ({ original }) => {
                       const { clusterName, clusterId, id } = original;
                       const url = URLService.getURL(match, location)
                           .push(id)
                           .push('CLUSTER', clusterId)
                           .url();
-                      return (
-                          <TableCellLink pdf={pdf} url={url}>
-                              {clusterName}
-                          </TableCellLink>
-                      );
+                      return <TableCellLink url={url}>{clusterName}</TableCellLink>;
                   },
                   id: secretSortFields.CLUSTER,
                   sortField: secretSortFields.CLUSTER,
@@ -121,18 +113,14 @@ const buildTableColumns = (match, location, entityContext) => {
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
             accessor: 'deployments',
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { deploymentCount, id } = original;
                 if (!deploymentCount) {
                     return 'No Deployments';
                 }
                 const url = URLService.getURL(match, location).push(id).push('DEPLOYMENT').url();
                 const text = `${deploymentCount} ${pluralize('Deployment', deploymentCount)}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             sortable: false,
         },

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListServiceAccounts.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListServiceAccounts.jsx
@@ -35,13 +35,9 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Service Accounts`,
             headerClassName: `w-1/10 ${defaultHeaderClassName}`,
             className: `w-1/10 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const url = getConfigMgmtPathForEntitiesAndId('SERVICE_ACCOUNT', original.id);
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {original.name}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{original.name}</TableCellLink>;
             },
             accessor: 'name',
             id: serviceAccountSortFields.SERVCE_ACCOUNT,
@@ -65,17 +61,13 @@ const buildTableColumns = (match, location, entityContext) => {
                   headerClassName: `w-1/8 ${defaultHeaderClassName}`,
                   className: `w-1/8 ${defaultColumnClassName}`,
                   accessor: 'clusterName',
-                  Cell: ({ original, pdf }) => {
+                  Cell: ({ original }) => {
                       const { clusterName, clusterId, id } = original;
                       const url = URLService.getURL(match, location)
                           .push(id)
                           .push('CLUSTER', clusterId)
                           .url();
-                      return (
-                          <TableCellLink pdf={pdf} url={url}>
-                              {clusterName}
-                          </TableCellLink>
-                      );
+                      return <TableCellLink url={url}>{clusterName}</TableCellLink>;
                   },
                   id: serviceAccountSortFields.CLUSTER,
                   sortField: serviceAccountSortFields.CLUSTER,
@@ -87,7 +79,7 @@ const buildTableColumns = (match, location, entityContext) => {
                   headerClassName: `w-1/10 ${defaultHeaderClassName}`,
                   className: `w-1/10 ${defaultColumnClassName}`,
                   accessor: 'namespace',
-                  Cell: ({ original, pdf }) => {
+                  Cell: ({ original }) => {
                       const {
                           id,
                           saNamespace: { metadata },
@@ -100,11 +92,7 @@ const buildTableColumns = (match, location, entityContext) => {
                           .push(id)
                           .push('NAMESPACE', namespaceId)
                           .url();
-                      return (
-                          <TableCellLink pdf={pdf} url={url}>
-                              {name}
-                          </TableCellLink>
-                      );
+                      return <TableCellLink url={url}>{name}</TableCellLink>;
                   },
                   id: serviceAccountSortFields.NAMESPACE,
                   sortField: serviceAccountSortFields.NAMESPACE,
@@ -113,7 +101,7 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Roles`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { id, k8sRoles } = original;
                 const { length } = k8sRoles;
                 if (!length) {
@@ -122,11 +110,7 @@ const buildTableColumns = (match, location, entityContext) => {
                 const url = URLService.getURL(match, location).push(id).push('ROLE').url();
                 if (length > 1) {
                     const text = `${length} ${pluralize('Roles', length)}`;
-                    return (
-                        <TableCellLink pdf={pdf} url={url}>
-                            {text}
-                        </TableCellLink>
-                    );
+                    return <TableCellLink url={url}>{text}</TableCellLink>;
                 }
                 return original.k8sRoles[0].name;
             },
@@ -138,18 +122,14 @@ const buildTableColumns = (match, location, entityContext) => {
             Header: `Deployments`,
             headerClassName: `w-1/8 ${nonSortableHeaderClassName}`,
             className: `w-1/8 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { id, deploymentCount } = original;
                 if (!deploymentCount) {
                     return 'No Deployments';
                 }
                 const url = URLService.getURL(match, location).push(id).push('DEPLOYMENT').url();
                 const text = `${deploymentCount} ${pluralize('Deployment', deploymentCount)}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             accessor: 'deploymentCount',
             sortable: false,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSubjects.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ConfigManagementListSubjects.jsx
@@ -35,13 +35,9 @@ const buildTableColumns = (match, location) => {
             Header: 'Users & Groups',
             headerClassName: `w-1/10 ${defaultHeaderClassName}`,
             className: `w-1/10 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const url = getConfigMgmtPathForEntitiesAndId('SUBJECT', original.id);
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {original.name}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{original.name}</TableCellLink>;
             },
             accessor: 'name',
             id: subjectSortFields.SUBJECT,
@@ -76,7 +72,7 @@ const buildTableColumns = (match, location) => {
             Header: `Roles`,
             headerClassName: `w-1/10 ${nonSortableHeaderClassName}`,
             className: `w-1/10 ${defaultColumnClassName}`,
-            Cell: ({ original, pdf }) => {
+            Cell: ({ original }) => {
                 const { id, k8sRoles } = original;
                 const { length } = k8sRoles;
                 if (!length) {
@@ -85,11 +81,7 @@ const buildTableColumns = (match, location) => {
                 const url = URLService.getURL(match, location).push(id).push('ROLE').url();
                 const text =
                     length === 1 ? k8sRoles[0].name : `${length} ${pluralize('Role', length)}`;
-                return (
-                    <TableCellLink pdf={pdf} url={url}>
-                        {text}
-                    </TableCellLink>
-                );
+                return <TableCellLink url={url}>{text}</TableCellLink>;
             },
             accessor: 'k8sRoles',
             sortable: false,

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/List.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/List.jsx
@@ -20,7 +20,6 @@ import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import entityLabels from 'messages/entity';
 import { SEARCH_OPTIONS_QUERY } from 'queries/search';
 import isGQLLoading from 'utils/gqlLoading';
-import createPDFTable from 'utils/pdfUtils';
 import queryService from 'utils/queryService';
 import URLService from 'utils/URLService';
 
@@ -80,7 +79,6 @@ const List = ({
                         columns={tableColumns}
                         onRowClick={onRowClickHandler}
                         idAttribute={idAttribute}
-                        id="capture-list"
                         selectedRowId={selectedRowId}
                         noDataText={noDataText}
                         page={page}
@@ -147,9 +145,6 @@ const List = ({
 
     if (data) {
         const headerComponents = getHeaderComponents(totalResults);
-        if (data.length) {
-            createPDFTable(data, entityType, query, 'capture-list', tableColumns);
-        }
         return getRenderComponents(headerComponents, data, totalResults);
     }
 
@@ -158,7 +153,7 @@ const List = ({
         pagination: queryService.getPagination(tableSort, page, LIST_PAGE_SIZE),
     };
     return (
-        <section className="h-full w-full" id="capture-list">
+        <section className="h-full w-full">
             <Query query={query} variables={varsWithPagination}>
                 {({ loading, data: queryData }) => {
                     if (isGQLLoading(loading, data)) {
@@ -175,10 +170,6 @@ const List = ({
                     const tableRows = createTableRows(queryData) ?? [];
                     const totalCount = queryData?.count || 0;
                     const headerComponents = getHeaderComponents(totalCount);
-
-                    if (tableRows.length) {
-                        createPDFTable(tableRows, entityType, query, 'capture-list', tableColumns);
-                    }
                     return getRenderComponents(headerComponents, tableRows, totalCount);
                 }}
             </Query>

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ListFrontendPaginated.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ListFrontendPaginated.jsx
@@ -17,7 +17,6 @@ import useWorkflowMatch from 'hooks/useWorkflowMatch';
 import entityLabels from 'messages/entity';
 import { SEARCH_OPTIONS_QUERY } from 'queries/search';
 import isGQLLoading from 'utils/gqlLoading';
-import createPDFTable from 'utils/pdfUtils';
 import URLService from 'utils/URLService';
 
 const ListFrontendPaginated = ({
@@ -67,7 +66,6 @@ const ListFrontendPaginated = ({
                         columns={tableColumns}
                         onRowClick={onRowClickHandler}
                         idAttribute={idAttribute}
-                        id="capture-list"
                         selectedRowId={selectedRowId}
                         noDataText={noDataText}
                         page={page}
@@ -112,14 +110,11 @@ const ListFrontendPaginated = ({
 
     if (data) {
         const headerComponents = getHeaderComponents(data.length);
-        if (data.length) {
-            createPDFTable(data, entityType, query, 'capture-list', tableColumns);
-        }
         return getRenderComponents(headerComponents, data);
     }
 
     return (
-        <section className="h-full w-full" id="capture-list">
+        <section className="h-full w-full">
             <Query query={query} variables={variables}>
                 {({ loading, data: queryData }) => {
                     if (isGQLLoading(loading, data)) {
@@ -135,10 +130,6 @@ const ListFrontendPaginated = ({
                     }
                     const tableRows = createTableRows(queryData) ?? [];
                     const headerComponents = getHeaderComponents(tableRows.length);
-
-                    if (tableRows.length) {
-                        createPDFTable(tableRows, entityType, query, 'capture-list', tableColumns);
-                    }
                     return getRenderComponents(headerComponents, tableRows);
                 }}
             </Query>

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ListPage.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ListPage.jsx
@@ -1,15 +1,12 @@
-import { useCallback, useContext, useRef, useState } from 'react';
+import { useCallback, useContext, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import pluralize from 'pluralize';
 import upperFirst from 'lodash/upperFirst';
-import startCase from 'lodash/startCase';
 
 import SidePanelAnimatedArea from 'Components/animations/SidePanelAnimatedArea';
 import PageHeader from 'Components/PageHeader';
 import { PageBody } from 'Components/Panel';
 import EntitiesMenu from 'Components/workflow/EntitiesMenu';
-import ExportButton from 'Components/ExportButton';
-import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import configMgmtPaginationContext, {
     MAIN_PAGINATION_PARAMS,
     SIDEPANEL_PAGINATION_PARAMS,
@@ -32,7 +29,6 @@ const ListPage = () => {
     const location = useLocation();
     const navigate = useNavigate();
     const match = useWorkflowMatch();
-    const [isExporting, setIsExporting] = useState(false);
 
     const workflowState = parseURL(location);
     const { useCase, search, sort, paging } = workflowState;
@@ -61,7 +57,6 @@ const ListPage = () => {
     }
 
     const header = upperFirst(pluralize(entityLabels[pageEntityListType]));
-    const exportFilename = `${pluralize(startCase(header))} Report`;
     return (
         <workflowStateContext.Provider value={pageState}>
             <PageHeader
@@ -70,16 +65,6 @@ const ListPage = () => {
                 classes="pr-0 ignore-react-onclickoutside"
             >
                 <div className="flex flex-1 justify-end h-full">
-                    <div className="flex items-center">
-                        <ExportButton
-                            fileName={exportFilename}
-                            type={pageEntityListType}
-                            page="configManagement"
-                            pdfId="capture-list"
-                            isExporting={isExporting}
-                            setIsExporting={setIsExporting}
-                        />
-                    </div>
                     <div className="flex items-center pl-2">
                         <EntitiesMenu
                             text="All Entities"
@@ -114,7 +99,6 @@ const ListPage = () => {
                     </configMgmtPaginationContext.Provider>
                 </searchContext.Provider>
             </PageBody>
-            {isExporting && <BackdropExporting />}
         </workflowStateContext.Provider>
     );
 };

--- a/ui/apps/platform/src/Containers/ConfigManagement/List/ListPage.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/List/ListPage.jsx
@@ -64,13 +64,11 @@ const ListPage = () => {
                 subHeader="Entity list"
                 classes="pr-0 ignore-react-onclickoutside"
             >
-                <div className="flex flex-1 justify-end h-full">
-                    <div className="flex items-center pl-2">
-                        <EntitiesMenu
-                            text="All Entities"
-                            options={getConfigurationManagementEntityTypes()}
-                        />
-                    </div>
+                <div className="flex flex-1 justify-end items-center h-full pl-2">
+                    <EntitiesMenu
+                        text="All Entities"
+                        options={getConfigurationManagementEntityTypes()}
+                    />
                 </div>
             </PageHeader>
             <PageBody>


### PR DESCRIPTION
## Description

**Jira:** [ROX-34093](https://issues.redhat.com/browse/ROX-34093)

Config Management pages had PDF export wired up through ExportButton, BackdropExporting overlays, and a bunch of DOM capture IDs/CSS classes. Unlike other pages, Config Management has no CSV export support, so once PDF was removed the ExportButton was rendering nothing. This PR strips all of that out.

- Remove ExportButton, BackdropExporting, and `isExporting`/`setIsExporting` state from the dashboard, entity pages, and list pages
- Remove `createPDFTable` calls from List and ListFrontendPaginated
- Remove PDF-specific DOM IDs (`capture-dashboard-stretch`, `capture-list`) and CSS classes (`pdf-page`, `pdf-stretch`)
- Simplify component prop interfaces now that export-related props are gone (EntityPageHeader, Header, EntityPage, ListPage)
- Flatten wrapper elements that only existed to hold the BackdropExporting sibling
- Clean up the dead `pdf` Cell prop from 13 list/widget table column definitions (was always `undefined` after the `createPDFTable` removal)
- Remove stale `TextEncoder`/`pdfUtils` comment from test file and a leftover border divider from the dashboard header

Shared modules (ExportButton, BackdropExporting, pdfUtils, WorkflowPDFExportButton) are intentionally left in place since Compliance and VulnMgmt still use them.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- All 1432 unit tests pass (`npm run test -- --testPathPattern="ConfigManagement" --run`)
- ESLint passes cleanly on all 34 modified files
- Verified zero `pdf` references remain in the ConfigManagement directory after cleanup
- No Cypress E2E tests reference PDF export, so no risk of breakage there
- Purely subtractive change; no new logic introduced

[ROX-34093]: https://redhat.atlassian.net/browse/ROX-34093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ