### PR TITLE
ROX-34642: Diff-based endpoint updates in replaceNoLock

### DIFF
--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -120,10 +120,15 @@ func (e *endpointsStore) applyNoLock(updates map[string]*EntityData, incremental
 func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) {
 	for deploymentID, data := range updates {
 		if data.isDeleteOnly() {
-			// A call to Apply() with empty payload of the updates map (no values) is meant to be a delete operation.
+			// A call to Apply()->replaceNoLock() with empty payload of the updates map (no values) is meant to be a delete operation.
 			e.purgeNoLock(deploymentID)
 			continue
 		}
+		// Fast path: if all endpoints are identical, skip the diff entirely.
+		// endpointsUnchangedNoLock handles all edge cases cheaply:
+		// - deployment not in store + empty new → true in O(1)
+		// - deployment not in store + non-empty new → false in O(1)
+		// - deployment in store with nil set + empty new → true (length match)
 		if e.endpointsUnchangedNoLock(deploymentID, data.endpoints) {
 			// applySingleNoLock records a nil "seen" marker in reverseEndpointMap
 			// the first time a deployment arrives with zero endpoints (e.g. a pod
@@ -137,9 +142,111 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) {
 			}
 			continue
 		}
-		e.purgeNoLock(deploymentID)
-		e.applySingleNoLock(deploymentID, *data)
+		currentEndpoints, deploymentKnown := e.reverseEndpointMap[deploymentID]
+		if !deploymentKnown {
+			// Brand-new deployment: use the full insert path which handles endpoint takeover.
+			e.applySingleNoLock(deploymentID, *data)
+			continue
+		}
+		e.diffReplaceNoLock(deploymentID, currentEndpoints, data.endpoints)
 	}
+}
+
+// diffReplaceNoLock applies an endpoint update by computing a per-endpoint diff
+// against the current store state. Only endpoints that were actually added, removed,
+// or had their target info changed are touched. Unchanged endpoints are left in place,
+// avoiding the O(M × T) allocation cost of the purge-all/reinsert-all cycle.
+//
+// The three passes (removed, added/changed, re-check) each iterate at most M endpoints
+// with O(T) per-endpoint target comparison, giving O(M × T) total read-only work for
+// the comparison, plus O(k × T) mutation work proportional to the k endpoints that
+// actually changed.
+func (e *endpointsStore) diffReplaceNoLock(deploymentID string, currentEndpoints set.Set[net.NumericEndpoint], newEndpoints map[net.NumericEndpoint][]EndpointTargetInfo) {
+	// Pass 1: endpoints removed (in current but not in new) → move to history.
+	for ep := range currentEndpoints {
+		if _, inNew := newEndpoints[ep]; !inNew {
+			e.moveToHistory(deploymentID, ep)
+		}
+	}
+
+	// Pass 2: endpoints added or changed.
+	for ep, newTargetInfos := range newEndpoints {
+		if !currentEndpoints.Contains(ep) {
+			// New endpoint: insert directly.
+			e.insertSingleEndpointNoLock(deploymentID, ep, newTargetInfos)
+			continue
+		}
+		if e.targetInfoUnchangedNoLock(deploymentID, ep, newTargetInfos) {
+			continue
+		}
+		// Changed: move old to history, then insert the new target info set.
+		e.moveToHistory(deploymentID, ep)
+		e.insertSingleEndpointNoLock(deploymentID, ep, newTargetInfos)
+	}
+}
+
+// insertSingleEndpointNoLock inserts one endpoint's target info for an existing
+// deployment. Unlike applySingleNoLock, it does not perform deployment-takeover
+// checks (those only apply when a deployment is first seen).
+func (e *endpointsStore) insertSingleEndpointNoLock(deploymentID string, ep net.NumericEndpoint, targetInfos []EndpointTargetInfo) {
+	dSet := e.reverseEndpointMap[deploymentID]
+	if dSet == nil {
+		dSet = make(set.Set[net.NumericEndpoint], 1)
+		e.reverseEndpointMap[deploymentID] = dSet
+	}
+	dSet.Add(ep)
+
+	if _, ok := e.endpointMap[ep]; !ok {
+		e.endpointMap[ep] = make(map[string]set.Set[EndpointTargetInfo], 1)
+	}
+	etiSet := make(set.Set[EndpointTargetInfo], len(targetInfos))
+	for _, ti := range targetInfos {
+		etiSet.Add(ti)
+	}
+	e.endpointMap[ep][deploymentID] = etiSet
+	e.deleteFromHistory(deploymentID, ep)
+}
+
+// targetInfoUnchangedNoLock checks whether one endpoint's target info set is
+// identical to what is already stored. Uses the same pigeonhole + hint-table
+// approach as endpointsUnchangedNoLock, comparing |set| elements against a
+// slice of equal length.
+func (e *endpointsStore) targetInfoUnchangedNoLock(deploymentID string, ep net.NumericEndpoint, newTargetInfos []EndpointTargetInfo) bool {
+	currentTargetInfos, found := e.endpointMap[ep][deploymentID]
+	if !found {
+		return len(newTargetInfos) == 0
+	}
+	if len(currentTargetInfos) != len(newTargetInfos) {
+		return false
+	}
+	n := len(newTargetInfos)
+
+	const hintBuckets = 64
+	const hintThreshold = 6
+
+	if n <= hintThreshold || n > 254 {
+		for ti := range currentTargetInfos {
+			if !slices.Contains(newTargetInfos, ti) {
+				return false
+			}
+		}
+		return true
+	}
+
+	var hints [hintBuckets]uint8
+	for i, ti := range newTargetInfos {
+		hints[ti.ContainerPort%hintBuckets] = uint8(i + 1)
+	}
+	for ti := range currentTargetInfos {
+		idx := int(hints[ti.ContainerPort%hintBuckets]) - 1
+		if idx >= 0 && idx < n && newTargetInfos[idx] == ti {
+			continue
+		}
+		if !slices.Contains(newTargetInfos, ti) {
+			return false
+		}
+	}
+	return true
 }
 
 // endpointsUnchangedNoLock checks whether the incoming endpoints are

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -149,6 +149,11 @@ func (e *endpointsStore) replaceNoLock(updates map[string]*EntityData) {
 			continue
 		}
 		e.diffReplaceNoLock(deploymentID, currentEndpoints, data.endpoints)
+		if len(data.endpoints) == 0 {
+			if _, exists := e.reverseEndpointMap[deploymentID]; !exists {
+				e.reverseEndpointMap[deploymentID] = nil
+			}
+		}
 	}
 }
 

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -174,19 +174,37 @@ func (e *endpointsStore) diffReplaceNoLock(deploymentID string, currentEndpoints
 		}
 	}
 
-	// Pass 2: endpoints added or changed.
+	// Pass 2: endpoints added or changed target info.
+	// History recording for changed target info is deferred to Pass 3 so
+	// that the common path (unchanged / newly added) stays allocation-free.
+	// addToHistory must read the old etiSet, so it runs before the in-place
+	// clear+refill in Pass 3.
+	var changedTargetInfoEps []net.NumericEndpoint
 	for ep, newTargetInfos := range newEndpoints {
 		if !currentEndpoints.Contains(ep) {
-			// New endpoint: insert directly.
 			e.insertSingleEndpointNoLock(deploymentID, ep, newTargetInfos)
 			continue
 		}
 		if e.targetInfoUnchangedNoLock(deploymentID, ep, newTargetInfos) {
 			continue
 		}
-		// Changed: move old to history, then insert the new target info set.
-		e.moveToHistory(deploymentID, ep)
-		e.insertSingleEndpointNoLock(deploymentID, ep, newTargetInfos)
+		changedTargetInfoEps = append(changedTargetInfoEps, ep)
+	}
+
+	// Pass 3: apply changed target infos.
+	// This is the rare path (target info changes while the endpoint IP:port
+	// stays the same). Recording history and updating the set in-place is
+	// kept out of the hot comparison loop above.
+	recordHistory := e.historyEnabled()
+	for _, ep := range changedTargetInfoEps {
+		if recordHistory {
+			e.addToHistory(deploymentID, ep)
+		}
+		etiSet := e.endpointMap[ep][deploymentID]
+		clear(etiSet)
+		for _, ti := range newEndpoints[ep] {
+			etiSet.Add(ti)
+		}
 	}
 }
 

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -216,6 +216,12 @@ func (e *endpointsStore) insertSingleEndpointNoLock(deploymentID string, ep net.
 // identical to what is already stored. Uses the same pigeonhole + hint-table
 // approach as endpointsUnchangedNoLock, comparing |set| elements against a
 // slice of equal length.
+//
+// The comparison logic intentionally duplicates the inner hot path from
+// endpointsUnchangedNoLock. Extracting a shared helper made local
+// BenchmarkApply{Unchanged,Changed} runs about 3-7% slower and
+// BenchmarkEndpointsUnchangedNoLock about 3% slower, with no B/op or
+// allocs/op improvement.
 func (e *endpointsStore) targetInfoUnchangedNoLock(deploymentID string, ep net.NumericEndpoint, newTargetInfos []EndpointTargetInfo) bool {
 	currentTargetInfos, found := e.endpointMap[ep][deploymentID]
 	if !found {

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -231,46 +231,29 @@ func (e *endpointsStore) insertSingleEndpointNoLock(deploymentID string, ep net.
 }
 
 // targetInfoUnchangedNoLock checks whether one endpoint's target info set is
-// identical to what is already stored. Uses the same pigeonhole + hint-table
-// approach as endpointsUnchangedNoLock, comparing |set| elements against a
+// identical to what is already stored, comparing |set| elements against a
 // slice of equal length.
 //
-// The comparison logic intentionally duplicates the inner hot path from
-// endpointsUnchangedNoLock. Extracting a shared helper made local
-// BenchmarkApply{Unchanged,Changed} runs about 3-7% slower and
-// BenchmarkEndpointsUnchangedNoLock about 3% slower, with no B/op or
-// allocs/op improvement.
+// The simple set-iteration + slices.Contains loop is the fastest
+// zero-allocation approach when comparing a set against a slice.
+// Benchmarked on Apple M3 Pro (count=6, N≤6):
+//
+//	n=1  ~30 ns/op  0 allocs
+//	n=2  ~37 ns/op  0 allocs
+//	n=3  ~43 ns/op  0 allocs
+//	n=4  ~50 ns/op  0 allocs
+//	n=5  ~56 ns/op  0 allocs
+//	n=6  ~62 ns/op  0 allocs
+//
+// Cases with more than 6 target infos per endpoint are extremely rare in
+// practice (typically 1-4), so we accept the O(n²) cost rather than adding
+// hint-table complexity that would almost never be exercised.
 func (e *endpointsStore) targetInfoUnchangedNoLock(deploymentID string, ep net.NumericEndpoint, newTargetInfos []EndpointTargetInfo) bool {
-	currentTargetInfos, found := e.endpointMap[ep][deploymentID]
-	if !found {
-		return len(newTargetInfos) == 0
-	}
+	currentTargetInfos := e.endpointMap[ep][deploymentID]
 	if len(currentTargetInfos) != len(newTargetInfos) {
 		return false
 	}
-	n := len(newTargetInfos)
-
-	const hintBuckets = 64
-	const hintThreshold = 6
-
-	if n <= hintThreshold || n > 254 {
-		for ti := range currentTargetInfos {
-			if !slices.Contains(newTargetInfos, ti) {
-				return false
-			}
-		}
-		return true
-	}
-
-	var hints [hintBuckets]uint8
-	for i, ti := range newTargetInfos {
-		hints[ti.ContainerPort%hintBuckets] = uint8(i + 1)
-	}
 	for ti := range currentTargetInfos {
-		idx := int(hints[ti.ContainerPort%hintBuckets]) - 1
-		if idx >= 0 && idx < n && newTargetInfos[idx] == ti {
-			continue
-		}
 		if !slices.Contains(newTargetInfos, ti) {
 			return false
 		}

--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -219,14 +219,15 @@ func (e *endpointsStore) insertSingleEndpointNoLock(deploymentID string, ep net.
 	}
 	dSet.Add(ep)
 
-	if _, ok := e.endpointMap[ep]; !ok {
-		e.endpointMap[ep] = make(map[string]set.Set[EndpointTargetInfo], 1)
-	}
 	etiSet := make(set.Set[EndpointTargetInfo], len(targetInfos))
 	for _, ti := range targetInfos {
 		etiSet.Add(ti)
 	}
-	e.endpointMap[ep][deploymentID] = etiSet
+	if _, ok := e.endpointMap[ep]; !ok {
+		e.endpointMap[ep] = map[string]set.Set[EndpointTargetInfo]{deploymentID: etiSet}
+	} else {
+		e.endpointMap[ep][deploymentID] = etiSet
+	}
 	e.deleteFromHistory(deploymentID, ep)
 }
 

--- a/sensor/common/clusterentities/store_endpoints_apply_bench_test.go
+++ b/sensor/common/clusterentities/store_endpoints_apply_bench_test.go
@@ -75,6 +75,49 @@ func BenchmarkApplyChanged(b *testing.B) {
 	}
 }
 
+// BenchmarkApplyPartialChange measures the scenario from ROX-34642: a deployment
+// with many endpoints where only one endpoint changes per update. The baseline
+// purge-all/reinsert-all approach moves all N endpoints to history and back even
+// when only 1 changed.
+func BenchmarkApplyPartialChange(b *testing.B) {
+	for _, tc := range []struct {
+		numEndpoints       int
+		targetsPerEndpoint int
+	}{
+		{numEndpoints: 50, targetsPerEndpoint: 2},
+		{numEndpoints: 200, targetsPerEndpoint: 2},
+		{numEndpoints: 200, targetsPerEndpoint: 4},
+		{numEndpoints: 500, targetsPerEndpoint: 2},
+	} {
+		name := fmt.Sprintf("ep%d_tgt%d", tc.numEndpoints, tc.targetsPerEndpoint)
+		b.Run(name, func(b *testing.B) {
+			store := newEndpointsStoreWithMemory(5)
+			dataA := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
+			updatesA := map[string]*EntityData{"depl-bench": dataA}
+			store.Apply(updatesA, false)
+
+			// Build a variant with one endpoint's target info changed.
+			dataB := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
+			for ep, tis := range dataB.endpoints {
+				if len(tis) > 0 {
+					tis[0] = EndpointTargetInfo{ContainerPort: 9999, PortName: "changed"}
+					dataB.endpoints[ep] = tis
+					break
+				}
+			}
+			updatesB := map[string]*EntityData{"depl-bench": dataB}
+
+			for i := 0; b.Loop(); i++ {
+				if i%2 == 0 {
+					store.Apply(updatesB, false)
+				} else {
+					store.Apply(updatesA, false)
+				}
+			}
+		})
+	}
+}
+
 // BenchmarkEndpointsUnchangedNoLock measures the unchanged-endpoints fast path
 // across all implementation variants.
 //

--- a/sensor/common/clusterentities/store_endpoints_apply_bench_test.go
+++ b/sensor/common/clusterentities/store_endpoints_apply_bench_test.go
@@ -98,13 +98,13 @@ func BenchmarkApplyPartialChange(b *testing.B) {
 
 			// Build a variant with one endpoint's target info changed.
 			dataB := applyBenchGenerateEntityData(tc.numEndpoints, tc.targetsPerEndpoint)
-			for ep, tis := range dataB.endpoints {
-				if len(tis) > 0 {
-					tis[0] = EndpointTargetInfo{ContainerPort: 9999, PortName: "changed"}
-					dataB.endpoints[ep] = tis
-					break
-				}
+			ep := buildEndpoint("10.0.0.0", 8080)
+			tis, ok := dataB.endpoints[ep]
+			if !ok || len(tis) == 0 {
+				b.Fatalf("benchmark setup invariant broken: endpoint %v missing or empty", ep)
 			}
+			tis[0] = EndpointTargetInfo{ContainerPort: 9999, PortName: "changed"}
+			dataB.endpoints[ep] = tis
 			updatesB := map[string]*EntityData{"depl-bench": dataB}
 
 			for i := 0; b.Loop(); i++ {

--- a/sensor/common/clusterentities/store_endpoints_test.go
+++ b/sensor/common/clusterentities/store_endpoints_test.go
@@ -670,6 +670,183 @@ func (s *ClusterEntitiesStoreTestSuite) TestEndpointsUnchangedNoLockVariantsMatc
 	}
 }
 
+// TestDiffReplaceNoLock exercises the per-endpoint diff path in replaceNoLock.
+// Each case starts from an initial state, applies a non-incremental update, and
+// verifies that endpoints end up in the correct location (current map, history, or nowhere).
+func (s *ClusterEntitiesStoreTestSuite) TestDiffReplaceNoLock() {
+	ep1 := buildEndpoint("10.0.0.1", 80)
+	ep2 := buildEndpoint("10.0.0.2", 80)
+	ep3 := buildEndpoint("10.0.0.3", 80)
+	httpTarget := EndpointTargetInfo{ContainerPort: 80, PortName: "http"}
+	httpsTarget := EndpointTargetInfo{ContainerPort: 443, PortName: "https"}
+	metricsTarget := EndpointTargetInfo{ContainerPort: 9090, PortName: "metrics"}
+
+	mkExpect := func(ip string, containerPort uint16, portName string, loc whereThingIsStored) expectation {
+		return expectation{
+			query:        buildEndpoint(ip, 80),
+			wantLocation: loc,
+			wantLookupResult: LookupResult{
+				Entity:         networkgraph.EntityForDeployment("depl"),
+				ContainerPorts: []uint16{containerPort},
+				PortNames:      []string{portName},
+			},
+		}
+	}
+
+	cases := map[string]struct {
+		initial      map[net.NumericEndpoint][]EndpointTargetInfo
+		update       map[net.NumericEndpoint][]EndpointTargetInfo
+		expectations []expectation
+	}{
+		"partial change: one endpoint modified, others unchanged": {
+			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpTarget},
+				ep2: {httpTarget},
+				ep3: {httpTarget},
+			},
+			update: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpsTarget},
+				ep2: {httpTarget},
+				ep3: {httpTarget},
+			},
+			expectations: []expectation{
+				mkExpect("10.0.0.1", 443, "https", theMap),
+				mkExpect("10.0.0.2", 80, "http", theMap),
+				mkExpect("10.0.0.3", 80, "http", theMap),
+			},
+		},
+		"endpoint removed: should move to history": {
+			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpTarget},
+				ep2: {httpTarget},
+			},
+			update: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpTarget},
+			},
+			expectations: []expectation{
+				mkExpect("10.0.0.1", 80, "http", theMap),
+				mkExpect("10.0.0.2", 80, "http", history),
+			},
+		},
+		"endpoint added: should appear in current map": {
+			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpTarget},
+			},
+			update: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpTarget},
+				ep2: {metricsTarget},
+			},
+			expectations: []expectation{
+				mkExpect("10.0.0.1", 80, "http", theMap),
+				mkExpect("10.0.0.2", 9090, "metrics", theMap),
+			},
+		},
+		"target info changed on same endpoint: new replaces old, no history residue": {
+			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpTarget},
+			},
+			update: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpsTarget},
+			},
+			expectations: []expectation{
+				mkExpect("10.0.0.1", 443, "https", theMap),
+				// deleteFromHistory in insertSingleEndpointNoLock clears the history
+				// entry for this (deployment, endpoint) pair, matching the original
+				// applySingleNoLock behavior.
+				mkExpect("10.0.0.1", 80, "http", nowhere),
+			},
+		},
+		"all endpoints removed: should all move to history": {
+			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpTarget},
+				ep2: {httpTarget},
+			},
+			update: map[net.NumericEndpoint][]EndpointTargetInfo{},
+			expectations: []expectation{
+				mkExpect("10.0.0.1", 80, "http", history),
+				mkExpect("10.0.0.2", 80, "http", history),
+			},
+		},
+		"all endpoints unchanged: no history pollution": {
+			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpTarget},
+				ep2: {httpsTarget},
+			},
+			update: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpTarget},
+				ep2: {httpsTarget},
+			},
+			expectations: []expectation{
+				mkExpect("10.0.0.1", 80, "http", theMap),
+				mkExpect("10.0.0.2", 443, "https", theMap),
+			},
+		},
+	}
+	for name, tc := range cases {
+		s.Run(name, func() {
+			store := NewStore(5, nil, true)
+			store.Apply(map[string]*EntityData{"depl": buildEntityData(tc.initial)}, false)
+			store.Apply(map[string]*EntityData{"depl": buildEntityData(tc.update)}, false)
+
+			for _, want := range tc.expectations {
+				current, historical, _, _ := store.endpointsStore.lookupEndpoint(want.query, store.podIPsStore)
+				switch want.wantLocation {
+				case theMap:
+					s.Containsf(current, want.wantLookupResult, "expected endpoint %s in current", want.query.IPAndPort.String())
+					s.NotContainsf(historical, want.wantLookupResult, "expected endpoint %s NOT in history", want.query.IPAndPort.String())
+				case history:
+					s.NotContainsf(current, want.wantLookupResult, "expected endpoint %s NOT in current", want.query.IPAndPort.String())
+					s.Containsf(historical, want.wantLookupResult, "expected endpoint %s in history", want.query.IPAndPort.String())
+				case nowhere:
+					s.NotContainsf(current, want.wantLookupResult, "expected endpoint %s NOT in current", want.query.IPAndPort.String())
+					s.NotContainsf(historical, want.wantLookupResult, "expected endpoint %s NOT in history", want.query.IPAndPort.String())
+				}
+			}
+		})
+	}
+}
+
+// TestDiffReplaceHistoryExpiry verifies that endpoints moved to history by the
+// diff path expire correctly after the configured number of ticks.
+func (s *ClusterEntitiesStoreTestSuite) TestDiffReplaceHistoryExpiry() {
+	ep1 := buildEndpoint("10.0.0.1", 80)
+	ep2 := buildEndpoint("10.0.0.2", 80)
+	httpTarget := EndpointTargetInfo{ContainerPort: 80, PortName: "http"}
+
+	store := NewStore(2, nil, true)
+	store.Apply(map[string]*EntityData{
+		"depl": buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
+			ep1: {httpTarget},
+			ep2: {httpTarget},
+		}),
+	}, false)
+
+	// Remove ep2 via partial update (diff path).
+	store.Apply(map[string]*EntityData{
+		"depl": buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
+			ep1: {httpTarget},
+		}),
+	}, false)
+
+	// ep2 should now be in history.
+	_, hist, _, _ := store.endpointsStore.lookupEndpoint(ep2, store.podIPsStore)
+	s.NotEmpty(hist, "removed endpoint should be in history immediately after diff-replace")
+
+	// Tick 1: still in history.
+	store.RecordTick()
+	_, hist, _, _ = store.endpointsStore.lookupEndpoint(ep2, store.podIPsStore)
+	s.NotEmpty(hist, "removed endpoint should still be in history after 1 tick")
+
+	// Tick 2: history expires (memorySize=2).
+	store.RecordTick()
+	_, hist, _, _ = store.endpointsStore.lookupEndpoint(ep2, store.podIPsStore)
+	s.Empty(hist, "removed endpoint should have expired from history after 2 ticks")
+
+	// ep1 should still be current throughout.
+	cur, _, _, _ := store.endpointsStore.lookupEndpoint(ep1, store.podIPsStore)
+	s.NotEmpty(cur, "unchanged endpoint should still be in current map")
+}
+
 func (s *ClusterEntitiesStoreTestSuite) TestApplyCanonicalizesDuplicateTargetInfosWhenTheyMaskRemoval() {
 	ep := buildEndpoint("10.0.0.3", 8080)
 	httpTarget := EndpointTargetInfo{ContainerPort: 8080, PortName: "http"}

--- a/sensor/common/clusterentities/store_endpoints_test.go
+++ b/sensor/common/clusterentities/store_endpoints_test.go
@@ -704,11 +704,16 @@ func (s *ClusterEntitiesStoreTestSuite) TestDiffReplaceNoLock() {
 	}
 
 	cases := map[string]struct {
+		memorySize   uint16
 		initial      map[net.NumericEndpoint][]EndpointTargetInfo
 		update       map[net.NumericEndpoint][]EndpointTargetInfo
 		expectations []expectation
+		// afterTicks maps tick count → expectations checked after that many
+		// RecordTick calls. Used to verify history expiry behavior.
+		afterTicks map[int][]expectation
 	}{
 		"partial change: one endpoint modified, others unchanged": {
+			memorySize: 5,
 			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
 				ep1: {httpTarget},
 				ep2: {httpTarget},
@@ -726,6 +731,7 @@ func (s *ClusterEntitiesStoreTestSuite) TestDiffReplaceNoLock() {
 			},
 		},
 		"endpoint removed: should move to history": {
+			memorySize: 5,
 			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
 				ep1: {httpTarget},
 				ep2: {httpTarget},
@@ -739,6 +745,7 @@ func (s *ClusterEntitiesStoreTestSuite) TestDiffReplaceNoLock() {
 			},
 		},
 		"endpoint added: should appear in current map": {
+			memorySize: 5,
 			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
 				ep1: {httpTarget},
 			},
@@ -751,7 +758,8 @@ func (s *ClusterEntitiesStoreTestSuite) TestDiffReplaceNoLock() {
 				mkExpect("10.0.0.2", 9090, "metrics", theMap),
 			},
 		},
-		"target info changed on same endpoint: new replaces old, no history residue": {
+		"target info changed on same endpoint: old target info moves to history": {
+			memorySize: 5,
 			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
 				ep1: {httpTarget},
 			},
@@ -760,13 +768,58 @@ func (s *ClusterEntitiesStoreTestSuite) TestDiffReplaceNoLock() {
 			},
 			expectations: []expectation{
 				mkExpect("10.0.0.1", 443, "https", theMap),
-				// deleteFromHistory in insertSingleEndpointNoLock clears the history
-				// entry for this (deployment, endpoint) pair, matching the original
-				// applySingleNoLock behavior.
-				mkExpect("10.0.0.1", 80, "http", nowhere),
+				mkExpect("10.0.0.1", 80, "http", history),
+			},
+		},
+		"target info changed: old info expires from history after configured ticks": {
+			memorySize: 2,
+			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpTarget},
+			},
+			update: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpsTarget},
+			},
+			expectations: []expectation{
+				mkExpect("10.0.0.1", 443, "https", theMap),
+				mkExpect("10.0.0.1", 80, "http", history),
+			},
+			afterTicks: map[int][]expectation{
+				1: {
+					mkExpect("10.0.0.1", 443, "https", theMap),
+					mkExpect("10.0.0.1", 80, "http", history),
+				},
+				2: {
+					mkExpect("10.0.0.1", 443, "https", theMap),
+					mkExpect("10.0.0.1", 80, "http", nowhere),
+				},
+			},
+		},
+		"endpoint removed: history expires after configured ticks": {
+			memorySize: 2,
+			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpTarget},
+				ep2: {httpTarget},
+			},
+			update: map[net.NumericEndpoint][]EndpointTargetInfo{
+				ep1: {httpTarget},
+			},
+			expectations: []expectation{
+				mkExpect("10.0.0.1", 80, "http", theMap),
+				mkExpect("10.0.0.2", 80, "http", history),
+			},
+			afterTicks: map[int][]expectation{
+				1: {
+					mkExpect("10.0.0.1", 80, "http", theMap),
+					mkExpect("10.0.0.2", 80, "http", history),
+				},
+				2: {
+					mkExpect("10.0.0.1", 80, "http", theMap),
+					mkExpect("10.0.0.2", 80, "http", nowhere),
+				},
 			},
 		},
 		"all endpoints removed: should all move to history": {
+			memorySize: 5,
 			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
 				ep1: {httpTarget},
 				ep2: {httpTarget},
@@ -778,6 +831,7 @@ func (s *ClusterEntitiesStoreTestSuite) TestDiffReplaceNoLock() {
 			},
 		},
 		"all endpoints unchanged: no history pollution": {
+			memorySize: 5,
 			initial: map[net.NumericEndpoint][]EndpointTargetInfo{
 				ep1: {httpTarget},
 				ep2: {httpsTarget},
@@ -792,9 +846,10 @@ func (s *ClusterEntitiesStoreTestSuite) TestDiffReplaceNoLock() {
 			},
 		},
 	}
+
 	for name, tc := range cases {
 		s.Run(name, func() {
-			store := NewStore(5, nil, true)
+			store := NewStore(tc.memorySize, nil, true)
 			store.Apply(map[string]*EntityData{"depl": buildEntityData(tc.initial)}, false)
 			store.Apply(map[string]*EntityData{"depl": buildEntityData(tc.update)}, false)
 
@@ -812,49 +867,28 @@ func (s *ClusterEntitiesStoreTestSuite) TestDiffReplaceNoLock() {
 					s.NotContainsf(historical, want.wantLookupResult, "expected endpoint %s NOT in history", want.query.IPAndPort.String())
 				}
 			}
+
+			lastTick := slices.Max(append(slices.Collect(maps.Keys(tc.afterTicks)), 0))
+			for t := range lastTick {
+				tick := t + 1
+				store.RecordTick()
+				for _, want := range tc.afterTicks[tick] {
+					current, historical, _, _ := store.endpointsStore.lookupEndpoint(want.query, store.podIPsStore)
+					switch want.wantLocation {
+					case theMap:
+						s.Containsf(current, want.wantLookupResult, "after tick %d: expected endpoint %s in current", tick, want.query.IPAndPort.String())
+						s.NotContainsf(historical, want.wantLookupResult, "after tick %d: expected endpoint %s NOT in history", tick, want.query.IPAndPort.String())
+					case history:
+						s.NotContainsf(current, want.wantLookupResult, "after tick %d: expected endpoint %s NOT in current", tick, want.query.IPAndPort.String())
+						s.Containsf(historical, want.wantLookupResult, "after tick %d: expected endpoint %s in history", tick, want.query.IPAndPort.String())
+					case nowhere:
+						s.NotContainsf(current, want.wantLookupResult, "after tick %d: expected endpoint %s NOT in current", tick, want.query.IPAndPort.String())
+						s.NotContainsf(historical, want.wantLookupResult, "after tick %d: expected endpoint %s NOT in history", tick, want.query.IPAndPort.String())
+					}
+				}
+			}
 		})
 	}
-}
-
-// TestDiffReplaceHistoryExpiry verifies that endpoints moved to history by the
-// diff path expire correctly after the configured number of ticks.
-func (s *ClusterEntitiesStoreTestSuite) TestDiffReplaceHistoryExpiry() {
-	ep1 := buildEndpoint("10.0.0.1", 80)
-	ep2 := buildEndpoint("10.0.0.2", 80)
-	httpTarget := EndpointTargetInfo{ContainerPort: 80, PortName: "http"}
-
-	store := NewStore(2, nil, true)
-	store.Apply(map[string]*EntityData{
-		"depl": buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
-			ep1: {httpTarget},
-			ep2: {httpTarget},
-		}),
-	}, false)
-
-	// Remove ep2 via partial update (diff path).
-	store.Apply(map[string]*EntityData{
-		"depl": buildEntityData(map[net.NumericEndpoint][]EndpointTargetInfo{
-			ep1: {httpTarget},
-		}),
-	}, false)
-
-	// ep2 should now be in history.
-	_, hist, _, _ := store.endpointsStore.lookupEndpoint(ep2, store.podIPsStore)
-	s.NotEmpty(hist, "removed endpoint should be in history immediately after diff-replace")
-
-	// Tick 1: still in history.
-	store.RecordTick()
-	_, hist, _, _ = store.endpointsStore.lookupEndpoint(ep2, store.podIPsStore)
-	s.NotEmpty(hist, "removed endpoint should still be in history after 1 tick")
-
-	// Tick 2: history expires (memorySize=2).
-	store.RecordTick()
-	_, hist, _, _ = store.endpointsStore.lookupEndpoint(ep2, store.podIPsStore)
-	s.Empty(hist, "removed endpoint should have expired from history after 2 ticks")
-
-	// ep1 should still be current throughout.
-	cur, _, _, _ := store.endpointsStore.lookupEndpoint(ep1, store.podIPsStore)
-	s.NotEmpty(cur, "unchanged endpoint should still be in current map")
 }
 
 func (s *ClusterEntitiesStoreTestSuite) TestApplyCanonicalizesDuplicateTargetInfosWhenTheyMaskRemoval() {

--- a/sensor/common/clusterentities/store_endpoints_test.go
+++ b/sensor/common/clusterentities/store_endpoints_test.go
@@ -447,6 +447,16 @@ func (s *ClusterEntitiesStoreTestSuite) TestEmptyEndpointUpdatePreservesSeenStat
 			wantDeplA: theMap,
 			wantDeplB: theMap,
 		},
+		"known deployment that goes empty through diff replace should keep seen marker": {
+			steps: []applyStep{
+				endpointOverwrite("deplA"),
+				applyWithoutEndpoints("deplA"),
+				endpointUpdate("deplB"),
+				endpointOverwrite("deplA"),
+			},
+			wantDeplA: theMap,
+			wantDeplB: theMap,
+		},
 		"unseen deployment should trigger takeover as expected": {
 			steps: []applyStep{
 				endpointUpdate("deplB"),

--- a/sensor/common/clusterentities/store_endpoints_test.go
+++ b/sensor/common/clusterentities/store_endpoints_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stackrox/rox/pkg/net"
 	"github.com/stackrox/rox/pkg/networkgraph"
+	"github.com/stackrox/rox/pkg/set"
 )
 
 type expectation struct {
@@ -913,4 +914,83 @@ func (s *ClusterEntitiesStoreTestSuite) TestApplyCanonicalizesDuplicateTargetInf
 	s.Len(targetInfos, 1)
 	s.True(targetInfos.Contains(httpTarget))
 	s.False(targetInfos.Contains(httpsTarget))
+}
+
+func (s *ClusterEntitiesStoreTestSuite) TestTargetInfoUnchangedNoLock() {
+	ep := buildEndpoint("10.0.0.1", 8080)
+	deplID := "depl-1"
+
+	ti1 := EndpointTargetInfo{ContainerPort: 8080, PortName: "http"}
+	ti2 := EndpointTargetInfo{ContainerPort: 8443, PortName: "https"}
+	ti3 := EndpointTargetInfo{ContainerPort: 9090, PortName: "metrics"}
+
+	cases := map[string]struct {
+		stored []EndpointTargetInfo
+		input  []EndpointTargetInfo
+		want   bool
+	}{
+		"should return true when both are empty": {
+			stored: nil,
+			input:  nil,
+			want:   true,
+		},
+		"should return true when nothing stored and input is empty slice": {
+			stored: nil,
+			input:  []EndpointTargetInfo{},
+			want:   true,
+		},
+		"should return false when nothing stored but input is non-empty": {
+			stored: nil,
+			input:  []EndpointTargetInfo{ti1},
+			want:   false,
+		},
+		"should return false when stored but input is empty": {
+			stored: []EndpointTargetInfo{ti1},
+			input:  []EndpointTargetInfo{},
+			want:   false,
+		},
+		"should return true for single identical element": {
+			stored: []EndpointTargetInfo{ti1},
+			input:  []EndpointTargetInfo{ti1},
+			want:   true,
+		},
+		"should return false for single different element": {
+			stored: []EndpointTargetInfo{ti1},
+			input:  []EndpointTargetInfo{ti2},
+			want:   false,
+		},
+		"should return true for multiple elements same order": {
+			stored: []EndpointTargetInfo{ti1, ti2, ti3},
+			input:  []EndpointTargetInfo{ti1, ti2, ti3},
+			want:   true,
+		},
+		"should return true for multiple elements different order": {
+			stored: []EndpointTargetInfo{ti1, ti2, ti3},
+			input:  []EndpointTargetInfo{ti3, ti1, ti2},
+			want:   true,
+		},
+		"should return false when lengths differ": {
+			stored: []EndpointTargetInfo{ti1, ti2},
+			input:  []EndpointTargetInfo{ti1, ti2, ti3},
+			want:   false,
+		},
+		"should return false when one element differs": {
+			stored: []EndpointTargetInfo{ti1, ti2},
+			input:  []EndpointTargetInfo{ti1, ti3},
+			want:   false,
+		},
+	}
+
+	for name, tc := range cases {
+		s.Run(name, func() {
+			store := newEndpointsStoreWithMemory(5)
+			if len(tc.stored) > 0 {
+				store.endpointMap[ep] = map[string]set.Set[EndpointTargetInfo]{
+					deplID: set.NewSet(tc.stored...),
+				}
+			}
+			got := store.targetInfoUnchangedNoLock(deplID, ep, tc.input)
+			s.Equal(tc.want, got)
+		})
+	}
 }


### PR DESCRIPTION
## Description

Non-incremental endpoint updates (`Apply(updates, false)`) used to purge all
endpoints for a deployment and reinsert them from scratch on every call, even
when only a single endpoint changed. For deployments behind NodePort services
(200-500 endpoints), this caused thousands of unnecessary allocations per
update cycle, creating GC pressure in Sensor.

This PR replaces the purge-all/reinsert-all cycle with a three-pass diff approach:

1. **Fast path** (`endpointsUnchangedNoLock`) - Added in #20462: O(1)-alloc shortcut when nothing
   changed - the common steady-state case. Uses a stack-allocated hint table
   for target info comparison to avoid heap allocations entirely.
2. **Diff path** (`diffReplaceNoLock`): per-endpoint diff that only touches
   added, removed, or changed endpoints. Mutation cost is O(k × T) where k is
   the number of endpoints that actually changed, not the total M.
   - **Removed endpoints** are moved to history (Pass 1).
   - **New endpoints** are inserted via `insertSingleEndpointNoLock` (Pass 2).
   - **Changed target info** is updated in-place via `clear(etiSet)` + refill,
     avoiding one map delete and one `set.Set` allocation per changed endpoint.
     Old target info is properly recorded in history (Pass 3).
3. **Full insert** (`applySingleNoLock`): only used for brand-new deployments
   that need endpoint-takeover logic.

### Correctness fix: history preservation for changed target info

The old purge-all/reinsert-all path had a latent bug: `addToHistory` recorded
old target info in the history maps, but `deleteFromHistory` inside
`insertSingleEndpointNoLock` immediately removed it, silently discarding the
history entry. The diff path fixes this by calling `addToHistory` without
`deleteFromHistory` for changed target info, so old values are retained in
history until expiry. This scenario (same endpoint IP:port, different container
port or port name) is uncommon in practice but is now handled correctly.

The alternative considered was improving the existing purge/reinsert to allocate
less (e.g., reuse maps), but that still does O(M) history moves per update.
The diff approach avoids the moves entirely for unchanged endpoints.

AI-Assisted: cursor, ~70% generated, user reviewed logic and benchmarks


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Unit tests & benchmarks

### Benchstat (10 runs, after rebase onto current master - with history enabled)

```
goos: darwin
goarch: arm64
pkg: github.com/stackrox/rox/sensor/common/clusterentities
cpu: Apple M3 Pro
                                 │ /tmp/bench_rebased_baseline.txt │    /tmp/bench_rebased_branch.txt    │
                                 │             sec/op              │   sec/op     vs base                │
ApplyUnchanged/ep10_tgt2-12                            1.769µ ± 5%   1.675µ ± 1%   -5.29% (p=0.008 n=10)
ApplyUnchanged/ep50_tgt4-12                            6.805µ ± 1%   6.850µ ± 1%        ~ (p=0.363 n=10)
ApplyUnchanged/ep200_tgt4-12                           27.19µ ± 3%   27.22µ ± 1%        ~ (p=0.481 n=10)
ApplyChanged/ep10_tgt2-12                             12.982µ ± 3%   6.530µ ± 2%  -49.71% (p=0.000 n=10)
ApplyChanged/ep50_tgt4-12                              70.15µ ± 1%   36.77µ ± 1%  -47.59% (p=0.000 n=10)
ApplyChanged/ep200_tgt4-12                             285.1µ ± 0%   150.7µ ± 1%  -47.14% (p=0.000 n=10)
ApplyPartialChange/ep50_tgt2-12                        64.18µ ± 1%   11.31µ ± 2%  -82.38% (p=0.000 n=10)
ApplyPartialChange/ep200_tgt2-12                      267.43µ ± 0%   45.43µ ± 2%  -83.01% (p=0.000 n=10)
ApplyPartialChange/ep200_tgt4-12                      294.92µ ± 1%   50.84µ ± 2%  -82.76% (p=0.000 n=10)
ApplyPartialChange/ep500_tgt2-12                       714.4µ ± 2%   119.8µ ± 1%  -83.23% (p=0.000 n=10)
geomean                                                56.07µ        22.64µ       -59.63%

                                 │ /tmp/bench_rebased_baseline.txt │     /tmp/bench_rebased_branch.txt      │
                                 │              B/op               │     B/op      vs base                  │
ApplyUnchanged/ep10_tgt2-12                             672.0 ± 0%     672.0 ± 0%        ~ (p=1.000 n=10) ¹
ApplyUnchanged/ep50_tgt4-12                             672.0 ± 0%     672.0 ± 0%        ~ (p=1.000 n=10) ¹
ApplyUnchanged/ep200_tgt4-12                            672.0 ± 0%     672.0 ± 0%        ~ (p=1.000 n=10) ¹
ApplyChanged/ep10_tgt2-12                            15.271Ki ± 0%   2.553Ki ± 0%  -83.28% (p=0.000 n=10)
ApplyChanged/ep50_tgt4-12                            72.687Ki ± 0%   9.022Ki ± 0%  -87.59% (p=0.000 n=10)
ApplyChanged/ep200_tgt4-12                           288.35Ki ± 0%   34.66Ki ± 0%  -87.98% (p=0.000 n=10)
ApplyPartialChange/ep50_tgt2-12                       74180.0 ± 0%     742.0 ± 0%  -99.00% (p=0.000 n=10)
ApplyPartialChange/ep200_tgt2-12                     294269.0 ± 0%     742.0 ± 0%  -99.75% (p=0.000 n=10)
ApplyPartialChange/ep200_tgt4-12                     295075.0 ± 0%     746.0 ± 0%  -99.75% (p=0.000 n=10)
ApplyPartialChange/ep500_tgt2-12                     821684.0 ± 0%     742.0 ± 0%  -99.91% (p=0.000 n=10)
geomean                                               29.10Ki        1.512Ki       -94.80%
¹ all samples are equal

                                 │ /tmp/bench_rebased_baseline.txt │     /tmp/bench_rebased_branch.txt     │
                                 │            allocs/op            │  allocs/op   vs base                  │
ApplyUnchanged/ep10_tgt2-12                             4.000 ± 0%    4.000 ± 0%        ~ (p=1.000 n=10) ¹
ApplyUnchanged/ep50_tgt4-12                             4.000 ± 0%    4.000 ± 0%        ~ (p=1.000 n=10) ¹
ApplyUnchanged/ep200_tgt4-12                            4.000 ± 0%    4.000 ± 0%        ~ (p=1.000 n=10) ¹
ApplyChanged/ep10_tgt2-12                              128.00 ± 0%    44.00 ± 0%  -65.62% (p=0.000 n=10)
ApplyChanged/ep50_tgt4-12                               692.0 ± 0%    286.0 ± 0%  -58.67% (p=0.000 n=10)
ApplyChanged/ep200_tgt4-12                             2.721k ± 0%   1.113k ± 0%  -59.10% (p=0.000 n=10)
ApplyPartialChange/ep50_tgt2-12                       567.000 ± 0%    8.000 ± 0%  -98.59% (p=0.000 n=10)
ApplyPartialChange/ep200_tgt2-12                     2221.000 ± 0%    8.000 ± 0%  -99.64% (p=0.000 n=10)
ApplyPartialChange/ep200_tgt4-12                      2621.00 ± 0%    10.00 ± 0%  -99.62% (p=0.000 n=10)
ApplyPartialChange/ep500_tgt2-12                     5525.000 ± 0%    8.000 ± 0%  -99.86% (p=0.000 n=10)
geomean                                                 221.3         18.46       -91.66%
¹ all samples are equal
```

#### Benchmark explanation

**ApplyUnchanged** is flat — the fast-path (endpointsUnchangedNoLock) is already
on master and this PR does not change that code path.

**ApplyChanged** (all endpoints have different target info) improves because the
diff path updates each endpoint's target info set in-place via clear+refill
instead of the old purge-all/reinsert-all cycle. On master, every Apply call
deletes all endpoints from the current maps, allocates a fresh set.Set for
each one, re-adds them, and performs a redundant add+delete on the history
maps. The diff path skips all of that: the endpoint never leaves the current
maps, no new set.Set is allocated (the existing map buckets are reused), and
history is recorded once without being immediately discarded. This eliminates
~6 map operations and 1 heap allocation per endpoint per update cycle.

**ApplyPartialChange** (1 out of N endpoints changed) improves the most because
the diff path skips unchanged endpoints entirely. On master, even a single
changed endpoint triggers a full purge and reinsert of all N endpoints. The
diff path only touches the one endpoint that actually changed — the other
N-1 endpoints are compared in O(T) each (via targetInfoUnchangedNoLock) and
left in place with zero mutations. The cost drops from O(N × T) mutations
to O(N × T) read-only comparisons plus O(1 × T) mutations.