### PR TITLE
ROX-34727: Add validation for image report query

### DIFF
--- a/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
@@ -1,5 +1,12 @@
 import type { ReactElement } from 'react';
-import { Alert, Flex, FormGroup } from '@patternfly/react-core';
+import {
+    Flex,
+    FormGroup,
+    FormHelperText,
+    HelperText,
+    HelperTextItem,
+} from '@patternfly/react-core';
+import { getIn } from 'formik';
 import type { FormikProps } from 'formik';
 
 import CompoundSearchFilter from 'Components/CompoundSearchFilter/components/CompoundSearchFilter';
@@ -73,9 +80,16 @@ function FiltersQuery<T extends FiltersQueryConfiguration = FiltersQueryConfigur
                         searchFilter={searchFilter}
                     />
                 ) : (
-                    <Alert variant="warning" title="TODO" isInline component="p">
-                        To be determined
-                    </Alert>
+                    getIn(formik.touched, 'vulnReportFilters.query') &&
+                    getIn(formik.errors, 'vulnReportFilters.query') && (
+                        <FormHelperText>
+                            <HelperText>
+                                <HelperTextItem variant="error">
+                                    {getIn(formik.errors, 'vulnReportFilters.query')}
+                                </HelperTextItem>
+                            </HelperText>
+                        </FormHelperText>
+                    )
                 )}
             </Flex>
         </>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/imageVulnerabilityReportValidationSchemas.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/imageVulnerabilityReportValidationSchemas.ts
@@ -83,6 +83,9 @@ const validationSchemaFilters = yup.lazy((values: ImageVulnerabilityReportConfig
         return yup.object().shape({
             vulnReportFilters: yup
                 .object()
+                .shape({
+                    query: yup.string().required('At least one filter is required'),
+                })
                 .test(
                     'cves-since-entity',
                     'CVE date range is required',


### PR DESCRIPTION
## Description

Add validation for query field on filters step of the image report wizard

- Uses formiks `getIn` to access the nested query errors/touched because formik types nested fields as optional.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1578" height="1159" alt="Screenshot 2026-05-15 at 10 13 57 AM" src="https://github.com/user-attachments/assets/0cd36345-7e7b-4155-82ea-7bca5ffa30e2" />

