### PR TITLE
ROX-34092: Remove PDF export from Compliance pages

### DIFF
--- a/ui/apps/platform/src/Components/ExportButton.jsx
+++ b/ui/apps/platform/src/Components/ExportButton.jsx
@@ -45,8 +45,8 @@ class ExportButton extends Component {
         customCsvExportHandler: PropTypes.func,
         page: PropTypes.string,
         disabled: PropTypes.bool,
-        isExporting: PropTypes.bool.isRequired,
-        setIsExporting: PropTypes.func.isRequired,
+        isExporting: PropTypes.bool,
+        setIsExporting: PropTypes.func,
     };
 
     static defaultProps = {
@@ -60,6 +60,8 @@ class ExportButton extends Component {
         customCsvExportHandler: null,
         page: '',
         disabled: false,
+        isExporting: false,
+        setIsExporting: () => {},
     };
 
     constructor(props) {

--- a/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/Dashboard/ComplianceDashboardPage.tsx
@@ -9,7 +9,6 @@ import ComplianceUsageDisclaimer, {
 } from 'Components/ComplianceUsageDisclaimer';
 import ExportButton from 'Components/ExportButton';
 import PageHeader from 'Components/PageHeader';
-import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import { resourceTypes } from 'constants/entityTypes';
 import useCaseTypes from 'constants/useCaseTypes';
 import { useBooleanLocalStorage } from 'hooks/useLocalStorage';
@@ -84,8 +83,6 @@ function ComplianceDashboardPage(): ReactElement {
     const [isManageStandardsModalOpen, setIsManageStandardsModalOpen] = useState(false);
 
     const client = useApolloClient();
-
-    const [isExporting, setIsExporting] = useState(false);
 
     const { runs, error, restartPolling, inProgressScanDetected, isCurrentScanIncomplete } =
         useComplianceRunStatuses(queriesToRefetchOnPollingComplete);
@@ -173,14 +170,11 @@ function ComplianceDashboardPage(): ReactElement {
                             textClass="hidden lg:block"
                             type="ALL"
                             page={useCaseTypes.COMPLIANCE}
-                            pdfId="capture-dashboard"
-                            isExporting={isExporting}
-                            setIsExporting={setIsExporting}
                         />
                     </div>
                 </div>
             </PageHeader>
-            <div className="flex-1 relative p-6 xxxl:p-8 bg-base-200" id="capture-dashboard">
+            <div className="flex-1 relative p-6 xxxl:p-8 bg-base-200">
                 {!isDisclaimerAccepted && (
                     <ComplianceUsageDisclaimer
                         onAccept={() => setIsDisclaimerAccepted(true)}
@@ -209,32 +203,24 @@ function ComplianceDashboardPage(): ReactElement {
                     <StandardsAcrossEntity
                         entityType={resourceTypes.CLUSTER}
                         bodyClassName="pr-4 py-1"
-                        className="pdf-page"
                     />
                     {isComplianceRouteEnabledForClusters && (
-                        <StandardsByEntity
-                            entityType={resourceTypes.CLUSTER}
-                            bodyClassName="p-4"
-                            className="pdf-page"
-                        />
+                        <StandardsByEntity entityType={resourceTypes.CLUSTER} bodyClassName="p-4" />
                     )}
                     {isComplianceRouteEnabledForNamespaces && (
                         <StandardsAcrossEntity
                             entityType={resourceTypes.NAMESPACE}
                             bodyClassName="px-4 pt-1"
-                            className="pdf-page"
                         />
                     )}
                     {isComplianceRouteEnabledForNodes && (
                         <StandardsAcrossEntity
                             entityType={resourceTypes.NODE}
                             bodyClassName="pr-4 py-1"
-                            className="pdf-page"
                         />
                     )}
                 </div>
             </div>
-            {isExporting && <BackdropExporting />}
             {errorMessageFetching ? (
                 <ManageStandardsError
                     onClose={onCloseManageStandardsError}

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Cluster.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Cluster.jsx
@@ -97,10 +97,7 @@ const ClusterPage = ({
                         ...query[searchParam],
                     };
                     contents = (
-                        <section
-                            id="capture-list"
-                            className="flex flex-col flex-1 overflow-y-auto h-full"
-                        >
+                        <section className="flex flex-col flex-1 overflow-y-auto h-full">
                             <ComplianceList
                                 entityType={listEntityType1}
                                 query={listQuery}
@@ -117,7 +114,6 @@ const ClusterPage = ({
                             className={`flex-1 relative bg-base-200 overflow-auto ${
                                 !sidePanelMode ? `p-6` : `p-4`
                             } `}
-                            id="capture-dashboard"
                         >
                             <div
                                 className={`grid ${

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Cluster.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Cluster.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 
 import entityTypes from 'constants/entityTypes';
 import EntityCompliance from 'Containers/Compliance/widgets/EntityCompliance';
@@ -10,7 +10,6 @@ import { CLUSTER_NAME as QUERY } from 'queries/cluster';
 import ComplianceList from 'Containers/Compliance/List/List';
 import ComplianceByStandards from 'Containers/Compliance/widgets/ComplianceByStandards';
 import Loader from 'Components/Loader';
-import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPageProps';
 import searchContext from 'Containers/searchContext';
 import isGQLLoading from 'utils/gqlLoading';
@@ -54,7 +53,6 @@ const ClusterPage = ({
     query,
     sidePanelMode,
 }) => {
-    const [isExporting, setIsExporting] = useState(false);
     const searchParam = useContext(searchContext);
 
     const { hasReadAccess } = usePermissions();
@@ -89,7 +87,6 @@ const ClusterPage = ({
                 }
                 const cluster = processData(data);
                 const { name, id } = cluster;
-                const pdfClassName = !sidePanelMode ? 'pdf-page' : '';
                 let contents;
 
                 if (listEntityType1 && !sidePanelMode) {
@@ -130,7 +127,7 @@ const ClusterPage = ({
                                 } sm:grid-columns-1 grid-gap-5`}
                             >
                                 <div
-                                    className={`grid s-2 md:grid-auto-fit md:grid-dense ${pdfClassName}`}
+                                    className="grid s-2 md:grid-auto-fit md:grid-dense"
                                     style={{ '--min-tile-width': '50%' }}
                                 >
                                     <div className="s-full pb-5">
@@ -153,7 +150,7 @@ const ClusterPage = ({
 
                                 {sidePanelMode && isComplianceRouteEnabledForEntities && (
                                     <div
-                                        className={`grid s-2 md:grid-auto-fit md:grid-dense ${pdfClassName}`}
+                                        className="grid s-2 md:grid-auto-fit md:grid-dense"
                                         style={{ '--min-tile-width': '50%' }}
                                     >
                                         {isComplianceRouteEnabledForNamespaces && (
@@ -199,8 +196,6 @@ const ClusterPage = ({
                                     listEntityType={listEntityType1}
                                     entityName={name}
                                     entityId={id}
-                                    isExporting={isExporting}
-                                    setIsExporting={setIsExporting}
                                 />
                                 <ResourceTabs
                                     entityId={entityId}
@@ -211,7 +206,6 @@ const ClusterPage = ({
                             </>
                         )}
                         {contents}
-                        {isExporting && <BackdropExporting />}
                     </section>
                 );
             }}

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Control.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Control.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 
 import entityTypes from 'constants/entityTypes';
 import Widget from 'Components/Widget';
@@ -10,7 +10,6 @@ import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPag
 import useCases from 'constants/useCaseTypes';
 import ComplianceList from 'Containers/Compliance/List/List';
 import Loader from 'Components/Loader';
-import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import PageNotFound from 'Components/PageNotFound';
 import searchContext from 'Containers/searchContext';
 import isGQLLoading from 'utils/gqlLoading';
@@ -28,7 +27,6 @@ const ControlPage = ({
     query,
     sidePanelMode,
 }) => {
-    const [isExporting, setIsExporting] = useState(false);
     const searchParam = useContext(searchContext);
 
     return (
@@ -50,7 +48,6 @@ const ControlPage = ({
                 const { results: control, complianceStandards: standards } = data;
                 const standard = standards.find((item) => item.id === control.standardId);
                 const { name, standardId, interpretationText, description } = control;
-                const pdfClassName = !sidePanelMode ? 'pdf-page' : '';
                 const standardName = standard ? standard.name : '';
                 let contents;
 
@@ -72,7 +69,6 @@ const ControlPage = ({
                                 entityType2={entityType2}
                                 entityListType2={entityListType2}
                                 entityId2={entityId2}
-                                className={pdfClassName}
                             />
                         </section>
                     );
@@ -96,13 +92,10 @@ const ControlPage = ({
                                     standardName={standardName}
                                     control={name}
                                     description={description}
-                                    className={`sx-2 ${pdfClassName}`}
+                                    className="sx-2"
                                 />
                                 {!!interpretationText.length && (
-                                    <Widget
-                                        className={`sx-2 ${pdfClassName}`}
-                                        header="Control guidance"
-                                    >
+                                    <Widget className="sx-2" header="Control guidance">
                                         <div className="p-4 leading-loose whitespace-pre-wrap">
                                             {interpretationText}
                                         </div>
@@ -115,28 +108,24 @@ const ControlPage = ({
                                             pageEntityType={entityTypes.CONTROL}
                                             pageEntity={control}
                                             standard={standardName}
-                                            className={pdfClassName}
                                         />
                                         <ControlRelatedResourceList
                                             listEntityType={entityTypes.NAMESPACE}
                                             pageEntityType={entityTypes.CONTROL}
                                             pageEntity={control}
                                             standard={standardName}
-                                            className={pdfClassName}
                                         />
                                         <ControlRelatedResourceList
                                             listEntityType={entityTypes.NODE}
                                             pageEntityType={entityTypes.CONTROL}
                                             pageEntity={control}
                                             standard={standardName}
-                                            className={pdfClassName}
                                         />
                                         <ControlRelatedResourceList
                                             listEntityType={entityTypes.DEPLOYMENT}
                                             pageEntityType={entityTypes.CONTROL}
                                             pageEntity={control}
                                             standard={standardName}
-                                            className={pdfClassName}
                                         />
                                     </>
                                 )}
@@ -154,8 +143,6 @@ const ControlPage = ({
                                     listEntityType={listEntityType1}
                                     entity={control}
                                     entityName={`${standardName} ${name}`}
-                                    isExporting={isExporting}
-                                    setIsExporting={setIsExporting}
                                 />
                                 <ResourceTabs
                                     entityId={entityId}
@@ -171,7 +158,6 @@ const ControlPage = ({
                             </>
                         )}
                         {contents}
-                        {isExporting && <BackdropExporting />}
                     </section>
                 );
             }}

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Control.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Control.jsx
@@ -58,10 +58,7 @@ const ControlPage = ({
                     };
 
                     contents = (
-                        <section
-                            id="capture-list"
-                            className="flex flex-col flex-1 overflow-y-auto h-full"
-                        >
+                        <section className="flex flex-col flex-1 overflow-y-auto h-full">
                             <ComplianceList
                                 entityType={listEntityType1}
                                 query={listQuery}
@@ -78,7 +75,6 @@ const ControlPage = ({
                             className={`flex-1 relative bg-base-200 overflow-auto ${
                                 !sidePanelMode ? `p-6` : `p-4`
                             } `}
-                            id="capture-dashboard"
                         >
                             <div
                                 className={`grid ${

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { gql } from '@apollo/client';
 import pluralize from 'pluralize';
@@ -7,7 +7,6 @@ import entityTypes from 'constants/entityTypes';
 import Widget from 'Components/Widget';
 import Query from 'Components/CacheFirstQuery';
 import Loader from 'Components/Loader';
-import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPageProps';
 import URLService from 'utils/URLService';
 import ComplianceList from 'Containers/Compliance/List/List';
@@ -60,7 +59,6 @@ const DeploymentPage = ({
     query,
     sidePanelMode,
 }) => {
-    const [isExporting, setIsExporting] = useState(false);
     const searchParam = useContext(searchContext);
     const match = useWorkflowMatch();
     const location = useLocation();
@@ -74,7 +72,6 @@ const DeploymentPage = ({
                 const deployment = processData(data);
                 const { name, id, labels, clusterName, namespace, clusterId, namespaceId } =
                     deployment;
-                const pdfClassName = !sidePanelMode ? 'pdf-page' : '';
                 let contents;
 
                 if (listEntityType1 && !sidePanelMode) {
@@ -123,7 +120,7 @@ const DeploymentPage = ({
                                 } sm:grid-columns-1 grid-gap-5`}
                             >
                                 <div
-                                    className={`grid s-2 md:grid-auto-fit md:grid-dense ${pdfClassName}`}
+                                    className="grid s-2 md:grid-auto-fit md:grid-dense"
                                     style={{ '--min-tile-width': '50%' }}
                                 >
                                     <div className="s-full pb-3">
@@ -155,7 +152,7 @@ const DeploymentPage = ({
                                 </div>
 
                                 <Widget
-                                    className={`sx-2 ${pdfClassName}`}
+                                    className="sx-2"
                                     header={`${labels.length} ${pluralize('Label', labels.length)}`}
                                 >
                                     <Labels labels={labels} />
@@ -179,8 +176,6 @@ const DeploymentPage = ({
                                     listEntityType={listEntityType1}
                                     entityName={name}
                                     entityId={id}
-                                    isExporting={isExporting}
-                                    setIsExporting={setIsExporting}
                                 />
                                 <ResourceTabs
                                     entityId={id}
@@ -191,7 +186,6 @@ const DeploymentPage = ({
                             </>
                         )}
                         {contents}
-                        {isExporting && <BackdropExporting />}
                     </section>
                 );
             }}

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Deployment.jsx
@@ -82,10 +82,7 @@ const DeploymentPage = ({
                         ...query[searchParam],
                     };
                     contents = (
-                        <section
-                            id="capture-list"
-                            className="flex flex-col flex-1 overflow-y-auto h-full"
-                        >
+                        <section className="flex flex-col flex-1 overflow-y-auto h-full">
                             <ComplianceList
                                 entityType={listEntityType1}
                                 query={listQuery}
@@ -110,7 +107,6 @@ const DeploymentPage = ({
                             className={`flex-1 relative bg-base-200 overflow-auto ${
                                 !sidePanelMode ? `p-6` : `p-4`
                             } `}
-                            id="capture-dashboard"
                         >
                             <div
                                 className={`grid ${

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Header.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Header.jsx
@@ -10,15 +10,7 @@ import usePermissions from 'hooks/usePermissions';
 
 import { entityNounSentenceCaseSingular } from '../entitiesForCompliance';
 
-const EntityHeader = ({
-    entityType,
-    listEntityType,
-    entityName,
-    entityId,
-    searchComponent,
-    isExporting,
-    setIsExporting,
-}) => {
+const EntityHeader = ({ entityType, listEntityType, entityName, entityId, searchComponent }) => {
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForCompliance = hasReadWriteAccess('Compliance');
 
@@ -29,8 +21,6 @@ const EntityHeader = ({
         ? `${pluralize(listEntityType)} ACROSS ${entityType} "${entityName.toUpperCase()}"`
         : `${entityType} "${entityName}"`;
     exportFilename = `${exportFilename} Report`;
-    const pdfId = listEntityType ? 'capture-list' : 'capture-dashboard';
-
     const scanCluster = entityType === entityTypes.CLUSTER ? entityId : '*';
     const scanStandard = entityType === entityTypes.STANDARD ? entityId : '*';
 
@@ -46,9 +36,6 @@ const EntityHeader = ({
                     type={entityType}
                     page={useCaseTypes.COMPLIANCE}
                     id={entityId}
-                    pdfId={pdfId}
-                    isExporting={isExporting}
-                    setIsExporting={setIsExporting}
                 />
             </div>
         </PageHeader>
@@ -61,8 +48,6 @@ EntityHeader.propTypes = {
     entityName: PropTypes.string,
     entityId: PropTypes.string,
     searchComponent: PropTypes.node,
-    isExporting: PropTypes.bool.isRequired,
-    setIsExporting: PropTypes.func.isRequired,
 };
 
 EntityHeader.defaultProps = {

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Header.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Header.jsx
@@ -31,12 +31,14 @@ const EntityHeader = ({ entityType, listEntityType, entityName, entityId, search
                 {hasWriteAccessForCompliance && scanCluster && (
                     <ScanButton text="Scan" clusterId={scanCluster} standardId={scanStandard} />
                 )}
-                <ExportButton
-                    fileName={exportFilename}
-                    type={entityType}
-                    page={useCaseTypes.COMPLIANCE}
-                    id={entityId}
-                />
+                {(entityType === entityTypes.CLUSTER || entityType === entityTypes.STANDARD) && (
+                    <ExportButton
+                        fileName={exportFilename}
+                        type={entityType}
+                        page={useCaseTypes.COMPLIANCE}
+                        id={entityId}
+                    />
+                )}
             </div>
         </PageHeader>
     );

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 import pluralize from 'pluralize';
 import { gql } from '@apollo/client';
 
@@ -12,7 +12,6 @@ import ResourceCount from 'Containers/Compliance/widgets/ResourceCount';
 import PageNotFound from 'Components/PageNotFound';
 import isGQLLoading from 'utils/gqlLoading';
 import Loader from 'Components/Loader';
-import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import Labels from 'Containers/Compliance/widgets/Labels';
 import EntityCompliance from 'Containers/Compliance/widgets/EntityCompliance';
 import entityTypes from 'constants/entityTypes';
@@ -69,7 +68,6 @@ const NamespacePage = ({
     query,
     sidePanelMode,
 }) => {
-    const [isExporting, setIsExporting] = useState(false);
     const searchParam = useContext(searchContext);
     return (
         <Query query={QUERY} variables={{ id: entityId }}>
@@ -87,7 +85,6 @@ const NamespacePage = ({
                 }
                 const namespace = processData(data);
                 const { name, id, clusterName, labels } = namespace;
-                const pdfClassName = !sidePanelMode ? 'pdf-page' : '';
                 let contents;
 
                 if (listEntityType1 && !sidePanelMode) {
@@ -128,7 +125,7 @@ const NamespacePage = ({
                                 } sm:grid-columns-1 grid-gap-5`}
                             >
                                 <div
-                                    className={`grid s-2 md:grid-auto-fit md:grid-dense ${pdfClassName}`}
+                                    className="grid s-2 md:grid-auto-fit md:grid-dense"
                                     style={{ '--min-tile-width': '50%' }}
                                 >
                                     <div className="s-full pb-3">
@@ -150,7 +147,7 @@ const NamespacePage = ({
                                 </div>
 
                                 <Widget
-                                    className={`sx-2 ${pdfClassName}`}
+                                    className="sx-2"
                                     header={`${labels.length} ${pluralize('Label', labels.length)}`}
                                 >
                                     <Labels labels={labels} />
@@ -163,7 +160,7 @@ const NamespacePage = ({
                                 {sidePanelMode && (
                                     <>
                                         <div
-                                            className={`grid sx-2 sy-1 md:grid-auto-fit md:grid-dense ${pdfClassName}`}
+                                            className="grid sx-2 sy-1 md:grid-auto-fit md:grid-dense"
                                             style={{ '--min-tile-width': '50%' }}
                                         >
                                             <div className="md:pr-3 pt-3">
@@ -190,8 +187,6 @@ const NamespacePage = ({
                                     listEntityType={listEntityType1}
                                     entityName={name}
                                     entityId={id}
-                                    isExporting={isExporting}
-                                    setIsExporting={setIsExporting}
                                 />
                                 <ResourceTabs
                                     entityId={id}
@@ -202,7 +197,6 @@ const NamespacePage = ({
                             </>
                         )}
                         {contents}
-                        {isExporting && <BackdropExporting />}
                     </section>
                 );
             }}

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Namespace.jsx
@@ -95,10 +95,7 @@ const NamespacePage = ({
                         ...query[searchParam],
                     };
                     contents = (
-                        <section
-                            id="capture-list"
-                            className="flex flex-col flex-1 overflow-y-auto h-full"
-                        >
+                        <section className="flex flex-col flex-1 overflow-y-auto h-full">
                             <ComplianceList
                                 entityType={listEntityType1}
                                 query={listQuery}
@@ -115,7 +112,6 @@ const NamespacePage = ({
                             className={`flex-1 relative bg-base-200 overflow-auto ${
                                 !sidePanelMode ? `p-6` : `p-4`
                             } `}
-                            id="capture-dashboard"
                         >
                             <div
                                 className={`grid ${

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Node.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Node.jsx
@@ -88,10 +88,7 @@ const NodePage = ({
                         ...query[searchParam],
                     };
                     contents = (
-                        <section
-                            id="capture-list"
-                            className="flex flex-col flex-1 overflow-y-auto h-full"
-                        >
+                        <section className="flex flex-col flex-1 overflow-y-auto h-full">
                             <ComplianceList
                                 entityType={listEntityType1}
                                 query={listQuery}
@@ -108,7 +105,6 @@ const NodePage = ({
                             className={`flex-1 relative bg-base-200 overflow-auto ${
                                 !sidePanelMode ? `p-6` : `p-4`
                             } `}
-                            id="capture-dashboard"
                         >
                             <div
                                 style={{ '--min-tile-height': '190px' }}

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Node.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Node.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 import pluralize from 'pluralize';
 
 import entityTypes from 'constants/entityTypes';
@@ -15,7 +15,6 @@ import InfoWidget from 'Components/InfoWidget';
 import Labels from 'Containers/Compliance/widgets/Labels';
 import EntityCompliance from 'Containers/Compliance/widgets/EntityCompliance';
 import Loader from 'Components/Loader';
-import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import ComplianceList from 'Containers/Compliance/List/List';
 import PageNotFound from 'Components/PageNotFound';
 import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPageProps';
@@ -51,7 +50,6 @@ const NodePage = ({
     query,
     sidePanelMode,
 }) => {
-    const [isExporting, setIsExporting] = useState(false);
     const searchParam = useContext(searchContext);
     return (
         <Query query={NODE_QUERY} variables={{ id: entityId }}>
@@ -80,7 +78,6 @@ const NodePage = ({
                     kernelVersion,
                     labels,
                 } = node;
-                const pdfClassName = !sidePanelMode ? 'pdf-page' : '';
                 let contents;
 
                 if (listEntityType1 && !sidePanelMode) {
@@ -122,7 +119,7 @@ const NodePage = ({
                                 } sm:grid-columns-1 grid-gap-5`}
                             >
                                 <div
-                                    className={`grid s-2 md:grid-auto-fit md:grid-dense ${pdfClassName}`}
+                                    className="grid s-2 md:grid-auto-fit md:grid-dense"
                                     style={{ '--min-tile-width': '50%' }}
                                 >
                                     <div className="s-full pb-3">
@@ -152,7 +149,7 @@ const NodePage = ({
                                 </div>
 
                                 <div
-                                    className={`grid s-2 md:grid-auto-fit md:grid-dense ${pdfClassName}`}
+                                    className="grid s-2 md:grid-auto-fit md:grid-dense"
                                     style={{ '--min-tile-width': '50%' }}
                                 >
                                     <div className="md:pr-3 pb-3">
@@ -195,7 +192,7 @@ const NodePage = ({
                                 </div>
 
                                 <Widget
-                                    className={`sx-2 ${pdfClassName}`}
+                                    className="sx-2"
                                     header={`${labels.length} ${pluralize('Label', labels.length)}`}
                                 >
                                     <Labels labels={labels} />
@@ -219,8 +216,6 @@ const NodePage = ({
                                     listEntityType={listEntityType1}
                                     entityName={name}
                                     entityId={id}
-                                    isExporting={isExporting}
-                                    setIsExporting={setIsExporting}
                                 />
                                 <ResourceTabs
                                     entityId={id}
@@ -235,7 +230,6 @@ const NodePage = ({
                             </>
                         )}
                         {contents}
-                        {isExporting && <BackdropExporting />}
                     </section>
                 );
             }}

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Standard.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Standard.jsx
@@ -16,7 +16,7 @@ const StandardPage = ({
         'Standard Id': entityId,
     };
     return (
-        <section className="flex flex-col h-full relative" id="capture-list">
+        <section className="flex flex-col h-full relative">
             <Header
                 entityType={entityTypes.CONTROL}
                 searchComponent={

--- a/ui/apps/platform/src/Containers/Compliance/Entity/Standard.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/Entity/Standard.jsx
@@ -1,6 +1,3 @@
-import { useState } from 'react';
-
-import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import entityTypes from 'constants/entityTypes';
 import ComplianceList from 'Containers/Compliance/List/List';
 import { entityPagePropTypes, entityPageDefaultProps } from 'constants/entityPageProps';
@@ -15,7 +12,6 @@ const StandardPage = ({
     entityListType2,
     entityId2,
 }) => {
-    const [isExporting, setIsExporting] = useState(false);
     const listQuery = {
         'Standard Id': entityId,
     };
@@ -30,8 +26,6 @@ const StandardPage = ({
                         shouldAddComplianceState
                     />
                 }
-                isExporting={isExporting}
-                setIsExporting={setIsExporting}
             />
             <ComplianceList
                 entityType={listEntityType1}
@@ -41,7 +35,6 @@ const StandardPage = ({
                 entityListType2={entityListType2}
                 entityId2={entityId2}
             />
-            {isExporting && <BackdropExporting />}
         </section>
     );
 };

--- a/ui/apps/platform/src/Containers/Compliance/List/Header.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/Header.jsx
@@ -34,12 +34,14 @@ const ListHeader = ({ entityType, searchComponent, standard }) => {
                 {hasWriteAccessForCompliance && standardId && (
                     <ScanButton text="Scan" standardId={standardId} />
                 )}
-                <ExportButton
-                    fileName={`${headerText} Compliance Report`}
-                    id={standardId || entityType}
-                    type={standardId ? 'STANDARD' : ''}
-                    page={useCaseTypes.COMPLIANCE}
-                />
+                {standardId && (
+                    <ExportButton
+                        fileName={`${headerText} Compliance Report`}
+                        id={standardId}
+                        type="STANDARD"
+                        page={useCaseTypes.COMPLIANCE}
+                    />
+                )}
             </div>
         </PageHeader>
     );

--- a/ui/apps/platform/src/Containers/Compliance/List/Header.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/Header.jsx
@@ -12,7 +12,7 @@ import usePermissions from 'hooks/usePermissions';
 
 // Disable to prevent merge conflict below if we need to cherry pick fix to previous release.
 /* eslint-disable prettier/prettier */
-const ListHeader = ({ entityType, searchComponent, standard, isExporting, setIsExporting }) => {
+const ListHeader = ({ entityType, searchComponent, standard }) => {
     const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForCompliance = hasReadWriteAccess('Compliance');
 
@@ -27,16 +27,6 @@ const ListHeader = ({ entityType, searchComponent, standard, isExporting, setIsE
 
     // If standardId is truthy, then standard page entity is CONTROL for address controls?s[standard]=WHAT_EVER&s[groupBy]=CATEGORY
     const subHeaderText = standardId ? 'Standard' : 'Resource list';
-    let tableOptions = null;
-    if (standardId) {
-        tableOptions = {
-            columnStyles: {
-                0: { columnWidth: 80 },
-                1: { columnWidth: 80 },
-                2: { columnWidth: 25 },
-            },
-        };
-    }
     return (
         <PageHeader header={headerText} subHeader={subHeaderText}>
             <div className="w-full">{searchComponent}</div>
@@ -49,10 +39,6 @@ const ListHeader = ({ entityType, searchComponent, standard, isExporting, setIsE
                     id={standardId || entityType}
                     type={standardId ? 'STANDARD' : ''}
                     page={useCaseTypes.COMPLIANCE}
-                    pdfId="capture-list"
-                    tableOptions={tableOptions}
-                    isExporting={isExporting}
-                    setIsExporting={setIsExporting}
                 />
             </div>
         </PageHeader>
@@ -63,8 +49,6 @@ ListHeader.propTypes = {
     searchComponent: PropTypes.element,
     entityType: PropTypes.string.isRequired,
     standard: PropTypes.string,
-    isExporting: PropTypes.bool.isRequired,
-    setIsExporting: PropTypes.func.isRequired,
 };
 
 ListHeader.defaultProps = {

--- a/ui/apps/platform/src/Containers/Compliance/List/List.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/List.jsx
@@ -45,7 +45,6 @@ const ComplianceList = ({ entityType, query, selectedRowId, noSearch }) => {
                     entityType={entityType}
                     query={query}
                     updateSelectedRow={setSelectedRowId}
-                    pdfId="capture-list"
                 />
             </div>
             {selectedRowId && (

--- a/ui/apps/platform/src/Containers/Compliance/List/Page.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/Page.jsx
@@ -20,30 +20,28 @@ const ComplianceListPage = () => {
     const { pageEntityListType, entityId1, entityType2, entityListType2, entityId2 } = params;
     const placeholder = `Filter ${pluralize(lowerCase(pageEntityListType))}`;
     return (
-        <>
-            <section className="flex flex-col h-full relative" id="capture-list">
-                <Header
-                    entityType={pageEntityListType}
-                    searchComponent={
-                        <ComplianceSearchInput
-                            placeholder={placeholder}
-                            categories={['COMPLIANCE']}
-                            shouldAddComplianceState
-                        />
-                    }
-                    standard={query.Standard || query.standard}
-                />
-                <ComplianceList
-                    entityType={pageEntityListType}
-                    query={query}
-                    selectedRowId={entityId1}
-                    entityType2={entityType2}
-                    entityListType2={entityListType2}
-                    entityId2={entityId2}
-                    noSearch
-                />
-            </section>
-        </>
+        <section className="flex flex-col h-full relative">
+            <Header
+                entityType={pageEntityListType}
+                searchComponent={
+                    <ComplianceSearchInput
+                        placeholder={placeholder}
+                        categories={['COMPLIANCE']}
+                        shouldAddComplianceState
+                    />
+                }
+                standard={query.Standard || query.standard}
+            />
+            <ComplianceList
+                entityType={pageEntityListType}
+                query={query}
+                selectedRowId={entityId1}
+                entityType2={entityType2}
+                entityListType2={entityListType2}
+                entityId2={entityId2}
+                noSearch
+            />
+        </section>
     );
 };
 

--- a/ui/apps/platform/src/Containers/Compliance/List/Page.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/Page.jsx
@@ -1,11 +1,10 @@
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom-v5-compat';
 import lowerCase from 'lodash/lowerCase';
 import pluralize from 'pluralize';
 
 import URLService from 'utils/URLService';
-import BackdropExporting from 'Components/PatternFly/BackdropExporting';
 import ComplianceList from 'Containers/Compliance/List/List';
 import searchContext from 'Containers/searchContext';
 import useWorkflowMatch from 'hooks/useWorkflowMatch';
@@ -13,7 +12,6 @@ import ComplianceSearchInput from '../ComplianceSearchInput';
 import Header from './Header';
 
 const ComplianceListPage = () => {
-    const [isExporting, setIsExporting] = useState(false);
     const location = useLocation();
     const match = useWorkflowMatch();
     const params = URLService.getParams(match, location);
@@ -34,8 +32,6 @@ const ComplianceListPage = () => {
                         />
                     }
                     standard={query.Standard || query.standard}
-                    isExporting={isExporting}
-                    setIsExporting={setIsExporting}
                 />
                 <ComplianceList
                     entityType={pageEntityListType}
@@ -47,7 +43,6 @@ const ComplianceListPage = () => {
                     noSearch
                 />
             </section>
-            {isExporting && <BackdropExporting />}
         </>
     );
 };

--- a/ui/apps/platform/src/Containers/Compliance/List/Table.jsx
+++ b/ui/apps/platform/src/Containers/Compliance/List/Table.jsx
@@ -15,7 +15,6 @@ import TablePagination from 'Components/TablePagination';
 import Query from 'Components/CacheFirstQuery';
 import NoResultsMessage from 'Components/NoResultsMessage';
 
-import createPDFTable from 'utils/pdfUtils';
 import { CLUSTERS_QUERY, NAMESPACES_QUERY, NODES_QUERY, DEPLOYMENTS_QUERY } from 'queries/table';
 import { LIST_STANDARD, STANDARDS_QUERY } from 'queries/standard';
 import queryService from 'utils/queryService';
@@ -188,14 +187,7 @@ function canFilterByComplianceState(filterQuery, complianceStateKey) {
     );
 }
 
-const ListTable = ({
-    searchComponent,
-    entityType,
-    query,
-    selectedRowId,
-    updateSelectedRow,
-    pdfId,
-}) => {
+const ListTable = ({ searchComponent, entityType, query, selectedRowId, updateSelectedRow }) => {
     const [page, setPage] = useState(0);
     // This is a client-side implementation of filtering by the "Compliance State" Search Option
     function filterByComplianceState(data, filterQuery, isControlList) {
@@ -311,10 +303,6 @@ const ListTable = ({
                             : '';
                         headerText = `${entityCountNoun}${groupedByText}`;
 
-                        if (tableData && tableData.length) {
-                            createPDFTable(tableData, entityType, query, pdfId, tableColumns);
-                        }
-
                         const tableElement = isControlList ? (
                             <TableGroup
                                 groups={tableData}
@@ -388,13 +376,11 @@ ListTable.propTypes = {
     }),
     selectedRowId: PropTypes.string,
     updateSelectedRow: PropTypes.func.isRequired,
-    pdfId: PropTypes.string,
 };
 
 ListTable.defaultProps = {
     searchComponent: null,
     selectedRowId: null,
-    pdfId: null,
     entityType: null,
     query: null,
 };

--- a/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
+++ b/ui/apps/platform/src/Containers/Compliance/widgets/ComplianceByStandards.tsx
@@ -57,7 +57,6 @@ function ComplianceByStandards({
                     entityId={entityId}
                     entityName={entityName}
                     entityType={entityType}
-                    className="pdf-page"
                 />
             ))}
         </>


### PR DESCRIPTION
## Description

**Jira:** [ROX-34092](https://issues.redhat.com/browse/ROX-34092)

The Compliance pages (Dashboard, Entity pages, List pages) still wire up PDF export through `ExportButton`, including `isExporting`/`setIsExporting` state, `BackdropExporting` overlay, `pdfId` capture anchors, `pdf-page` CSS classes, and `tableOptions` for PDF table formatting. This is part of the broader effort to remove jspdf from the codebase.

- Remove `isExporting`/`setIsExporting` state and `BackdropExporting` from all Compliance entity pages (Cluster, Control, Deployment, Namespace, Node, Standard) and list pages (Page)
- Remove `pdfId`, `isExporting`, `setIsExporting` props from `EntityHeader` and `ListHeader`
- Remove `pdfId` prop and `createPDFTable` call from `ListTable`
- Remove `pdf-page` and `pdfClassName` usage from Compliance entity pages and `ComplianceByStandards`
- Remove dead `id="capture-list"` and `id="capture-dashboard"` DOM attributes from all Compliance pages
- Remove unnecessary fragment wrapper in `ComplianceListPage`
- Make `isExporting` and `setIsExporting` optional in `ExportButton` with defaults, since Compliance callers no longer pass them

**Note:** This PR is scoped to Compliance pages only. ConfigManagement and VulnMgmt still use PDF export and are handled in separate PRs.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- TypeScript type checking passes with no errors (`npx tsc --noEmit`)
- Verified no remaining `pdf-page`, `pdfClassName`, `capture-list`, or `capture-dashboard` references in Compliance code
- Confirmed `BackdropExporting`, `WorkflowPDFExportButton`, and `pdfUtils` are still used by ConfigManagement/VulnMgmt (not orphaned)
- CSV export path in `ExportButton` is unaffected. Only the PDF branch is gated behind `pdfId`

### Screen recording

Before

https://github.com/user-attachments/assets/3dfb04e1-f9f2-4934-b106-b6db2a92c0eb

After

https://github.com/user-attachments/assets/79e32e2e-82f1-4dd3-aaf2-e2d7f5b220d8


[ROX-34092]: https://redhat.atlassian.net/browse/ROX-34092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ