### PR TITLE
chore(release): Add workflow to add user to team

### DIFF
--- a/.github/workflows/add-user-to-team.yml
+++ b/.github/workflows/add-user-to-team.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add user to organization team
+        id: add_step
         env:
           GH_TOKEN: ${{ secrets.STACKROX_TEAM_MGMT_TOKEN }}
           ORG_NAME: ${{ github.repository_owner }}
@@ -27,12 +28,12 @@ jobs:
           TEAM_SLUG: ${{ inputs.team_slug }}
         run: |
           echo "Adding $USER_TO_ADD to team $TEAM_SLUG in organization $ORG_NAME..."
-          
+
           # Using the GitHub CLI to add the user
           # This command adds the user as a 'member'. Use --role maintainer if needed.
 
           echo "Processing $USER_TO_ADD for team $TEAM_SLUG..."
-          
+
           # We capture the HTTP status code and the response body
           RESPONSE=$(gh api \
             --method PUT \
@@ -44,11 +45,30 @@ jobs:
 
           # Check the status code in the headers
           if echo "$RESPONSE" | grep -q "HTTP/.* 200"; then
-            echo "✅ $USER_TO_ADD was already a member. No changes needed."
+            MSG="✅ $USER_TO_ADD was already a member of $TEAM_SLUG. No changes needed."
           elif echo "$RESPONSE" | grep -q "HTTP/.* 201"; then
-            echo "🎉 $USER_TO_ADD has been successfully added/invited to the team."
+            MSG="🎉 $USER_TO_ADD has been successfully added/invited to the team, $TEAM_SLUG."
           else
-            echo "❌ Failed to add user. Full response below:"
-            echo "$RESPONSE"
+            MSG="❌ Failed to add user $USER_TO_ADD to team, $TEAM_SLUG.. Full response below:"
+            
             exit 1
           fi
+
+          if ERR=true
+
+          # Write it to the special GitHub output file
+          echo "message=$MSG" >> $GITHUB_OUTPUT
+          
+      - name: Slack notification
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # ratchet:slackapi/slack-github-action@v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "CMH5M8MHN" #forum-acs-eng-release
+            text: "Add user to release team in GitHub"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ steps.add_step.outputs.message }}"

--- a/.github/workflows/add-user-to-team.yml
+++ b/.github/workflows/add-user-to-team.yml
@@ -13,6 +13,7 @@ on:
         description: 'The slug of the team (e.g., "release-mgmt")'
         required: true
         type: string
+  push:  # Add this line temporarily
 
 jobs:
   # This workflow contains a single job

--- a/.github/workflows/add-user-to-team.yml
+++ b/.github/workflows/add-user-to-team.yml
@@ -13,7 +13,6 @@ on:
         description: 'The slug of the team (e.g., "release-mgmt")'
         required: true
         type: string
-  push:  # Add this line temporarily
 
 jobs:
   # This workflow contains a single job
@@ -44,9 +43,9 @@ jobs:
             -f role='member')
 
           # Check the status code in the headers
-          if echo "$RESPONSE" | grep -q "HTTP/2 200"; then
+          if echo "$RESPONSE" | grep -q "HTTP/.* 200"; then
             echo "✅ $USER_TO_ADD was already a member. No changes needed."
-          elif echo "$RESPONSE" | grep -q "HTTP/2 201"; then
+          elif echo "$RESPONSE" | grep -q "HTTP/.* 201"; then
             echo "🎉 $USER_TO_ADD has been successfully added/invited to the team."
           else
             echo "❌ Failed to add user. Full response below:"

--- a/.github/workflows/add-user-to-team.yml
+++ b/.github/workflows/add-user-to-team.yml
@@ -30,10 +30,25 @@ jobs:
           
           # Using the GitHub CLI to add the user
           # This command adds the user as a 'member'. Use --role maintainer if needed.
-          gh api \
+
+          echo "Processing $USER_TO_ADD for team $TEAM_SLUG..."
+          
+          # We capture the HTTP status code and the response body
+          RESPONSE=$(gh api \
             --method PUT \
+            -i \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /orgs/$ORG_NAME/teams/$TEAM_SLUG/memberships/$USER_TO_ADD \
-            -f role='member'
-          echo "Successfully sent invitation/added $USER_TO_ADD to $TEAM_SLUG."
+            -f role='member')
+
+          # Check the status code in the headers
+          if echo "$RESPONSE" | grep -q "HTTP/2 200"; then
+            echo "✅ $USER_TO_ADD was already a member. No changes needed."
+          elif echo "$RESPONSE" | grep -q "HTTP/2 201"; then
+            echo "🎉 $USER_TO_ADD has been successfully added/invited to the team."
+          else
+            echo "❌ Failed to add user. Full response below:"
+            echo "$RESPONSE"
+            exit 1
+          fi

--- a/.github/workflows/add-user-to-team.yml
+++ b/.github/workflows/add-user-to-team.yml
@@ -1,0 +1,39 @@
+name: Add User to Team
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+    inputs:
+      username:
+        description: 'The GitHub username to add'
+        required: true
+        type: string
+      team_slug:
+        description: 'The slug of the team (e.g., "release-mgmt")'
+        required: true
+        type: string
+
+jobs:
+  # This workflow contains a single job
+  add-to-team:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add user to organization team
+        env:
+          GH_TOKEN: ${{ secrets.STACKROX_TEAM_MGMT_TOKEN }}
+          ORG_NAME: ${{ github.repository_owner }}
+          USER_TO_ADD: ${{ inputs.username }}
+          TEAM_SLUG: ${{ inputs.team_slug }}
+        run: |
+          echo "Adding $USER_TO_ADD to team $TEAM_SLUG in organization $ORG_NAME..."
+          
+          # Using the GitHub CLI to add the user
+          # This command adds the user as a 'member'. Use --role maintainer if needed.
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /orgs/$ORG_NAME/teams/$TEAM_SLUG/memberships/$USER_TO_ADD \
+            -f role='member'
+          echo "Successfully sent invitation/added $USER_TO_ADD to $TEAM_SLUG."


### PR DESCRIPTION
## Description

Add a GitHub action which requires a manual trigger to run, takes a GitHub username and a stackrox organization team name, and adds that GitHub user to that stackrox team

Relies on a new secret in the stackrox/stackrox repo, with R+W access to stackrox org Team permission.

First secret created by me, and needs to be refreshed in 60 days.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request)  is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md)(https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

None

### How I validated my change

I tested in a dummy organization created in my personal GitHub account. Will also test in PR.
