### PR TITLE
ROX-34741: Fix collection validation to resource scope for pending reports

### DIFF
--- a/central/reports/common/utils.go
+++ b/central/reports/common/utils.go
@@ -50,13 +50,13 @@ func IsV2ReportConfig(config *storage.ReportConfiguration) bool {
 }
 
 // HasValidResourceScope returns true if the report config has a non-empty resource scope
-// containing either a collection ID or an entity scope. Returns false when ResourceScope
+// containing either a collection ID , entity scope etc. Returns false when ResourceScope
 // is nil or is an empty message with no scope_reference set. Later can happen in downgrade scenarios.
 func HasValidResourceScope(scope *storage.ResourceScope) bool {
-	if scope == nil {
+	if scope == nil || scope.GetScopeReference() == nil {
 		return false
 	}
-	return scope.GetCollectionId() != "" || scope.GetEntityScope() != nil
+	return true
 }
 
 // WithoutV2ReportConfigs adds a conjunction query to exclude v2 report configs

--- a/central/reports/common/utils.go
+++ b/central/reports/common/utils.go
@@ -49,6 +49,16 @@ func IsV2ReportConfig(config *storage.ReportConfiguration) bool {
 	return config.GetResourceScope() != nil
 }
 
+// HasValidResourceScope returns true if the report config has a non-empty resource scope
+// containing either a collection ID or an entity scope. Returns false when ResourceScope
+// is nil or is an empty message with no scope_reference set. Later can happen in downgrade scenarios.
+func HasValidResourceScope(scope *storage.ResourceScope) bool {
+	if scope == nil {
+		return false
+	}
+	return scope.GetCollectionId() != "" || scope.GetEntityScope() != nil
+}
+
 // WithoutV2ReportConfigs adds a conjunction query to exclude v2 report configs
 func WithoutV2ReportConfigs(query *v1.Query) *v1.Query {
 	return search.ConjunctionQuery(

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -343,19 +343,27 @@ func (s *scheduler) queuePendingReports() {
 			continue
 		}
 
-		collection, found, err := s.collectionDatastore.Get(scheduledCtx, snap.GetCollection().GetId())
-		if err != nil {
-			log.Errorf("Error finding collection ID '%s': %s", snap.GetCollection().GetId(), err)
-			continue
-		}
-		if !found {
-			log.Errorf("Collection ID '%s' not found", snap.GetCollection().GetId())
+
+		repRequest := &reportGen.ReportRequest{
+			ReportSnapshot: snap,
 		}
 
-		_, err = s.SubmitReportRequest(scheduledCtx, &reportGen.ReportRequest{
-			ReportSnapshot: snap,
-			Collection:     collection,
-		}, true)
+		if snap.GetCollection()!=nil{
+			collection, found, err := s.collectionDatastore.Get(scheduledCtx, snap.GetCollection().GetId())
+			if err != nil {
+				log.Errorf("Error finding collection ID '%s': %s", snap.GetCollection().GetId(), err)
+				continue
+			}
+			if !found {
+				log.Errorf("Collection ID '%s' not found", snap.GetCollection().GetId())
+			}
+
+			repRequest.Collection = collection
+
+		}
+
+
+		_, err = s.SubmitReportRequest(scheduledCtx, repRequest, true)
 		if err != nil {
 			log.Errorf("Error rescheduling pending report job for report config ID '%s': %s", snap.GetReportConfigurationId(), err)
 		}

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -343,8 +343,9 @@ func (s *scheduler) queuePendingReports() {
 			continue
 		}
 
-		if snap.GetResourceScope() == nil {
+		if !common.HasValidResourceScope(snap.GetResourceScope()) {
 			log.Errorf("Report configuration '%s' has an empty resource scope (no collection ID or entity scope)", snap.GetReportConfigurationId())
+			continue
 		}
 
 		repRequest := &reportGen.ReportRequest{
@@ -383,8 +384,10 @@ func (s *scheduler) queueScheduledReports() {
 		return
 	}
 	for _, rc := range reportConfigs {
-		if rc.GetResourceScope() == nil {
-			log.Errorf("Report configuration '%s' has an empty resource scope (no collection ID or entity scope)", rc.GetId())
+		if !common.HasValidResourceScope(rc.GetResourceScope()) {
+			log.Warnf("Skipping scheduled report for config '%s' (ID: %s): resource scope is empty",
+				rc.GetName(), rc.GetId())
+			continue
 		}
 		if rc.GetSchedule() != nil {
 			if err := s.UpsertReportSchedule(rc); err != nil {

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -385,7 +385,7 @@ func (s *scheduler) queueScheduledReports() {
 	}
 	for _, rc := range reportConfigs {
 		if !common.HasValidResourceScope(rc.GetResourceScope()) {
-			log.Warnf("Skipping scheduled report for config '%s' (ID: %s): resource scope is empty",
+			log.Errorf("Skipping scheduled report for config '%s' (ID: %s): resource scope is empty",
 				rc.GetName(), rc.GetId())
 			continue
 		}

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -343,12 +343,15 @@ func (s *scheduler) queuePendingReports() {
 			continue
 		}
 
+		if snap.GetResourceScope() == nil {
+			log.Errorf("Report configuration '%s' has an empty resource scope (no collection ID or entity scope)", snap.GetReportConfigurationId())
+		}
 
 		repRequest := &reportGen.ReportRequest{
 			ReportSnapshot: snap,
 		}
 
-		if snap.GetCollection()!=nil{
+		if snap.GetCollection() != nil {
 			collection, found, err := s.collectionDatastore.Get(scheduledCtx, snap.GetCollection().GetId())
 			if err != nil {
 				log.Errorf("Error finding collection ID '%s': %s", snap.GetCollection().GetId(), err)
@@ -361,7 +364,6 @@ func (s *scheduler) queuePendingReports() {
 			repRequest.Collection = collection
 
 		}
-
 
 		_, err = s.SubmitReportRequest(scheduledCtx, repRequest, true)
 		if err != nil {
@@ -381,6 +383,9 @@ func (s *scheduler) queueScheduledReports() {
 		return
 	}
 	for _, rc := range reportConfigs {
+		if rc.GetResourceScope() == nil {
+			log.Errorf("Report configuration '%s' has an empty resource scope (no collection ID or entity scope)", rc.GetId())
+		}
 		if rc.GetSchedule() != nil {
 			if err := s.UpsertReportSchedule(rc); err != nil {
 				log.Errorf("Error queuing scheduled report for report configuration with ID %s: %v", rc.GetId(), err)

--- a/central/reports/scheduler/v2/scheduler_impl_test.go
+++ b/central/reports/scheduler/v2/scheduler_impl_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stackrox/rox/central/reports/config/datastore/mocks"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 	"gopkg.in/robfig/cron.v2"
 )
 
@@ -75,4 +78,84 @@ func TestFindPreviousFireTimeReturnsZeroWhenNoFireInWindow(t *testing.T) {
 	// Now is March 1, 2027 (non-leap year). Feb 29 doesn't exist, so no fire in window.
 	previousFire := findPreviousFireTime(schedule, time.Date(2027, 3, 1, 0, 0, 0, 0, loc))
 	assert.True(t, previousFire.IsZero(), "Expected zero time when no fire exists in lookback window")
+}
+
+func TestQueueScheduledReportsSkipsEmptyResourceScope(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockReportConfigDS := mocks.NewMockDataStore(ctrl)
+
+	weeklySchedule := &storage.Schedule{
+		IntervalType: storage.Schedule_WEEKLY,
+		Interval: &storage.Schedule_DaysOfWeek_{
+			DaysOfWeek: &storage.Schedule_DaysOfWeek{
+				Days: []int32{1},
+			},
+		},
+	}
+
+	validCollectionScope := &storage.ReportConfiguration{
+		Id:   "config-with-collection",
+		Name: "Valid Collection Config",
+		Type: storage.ReportConfiguration_VULNERABILITY,
+		ResourceScope: &storage.ResourceScope{
+			ScopeReference: &storage.ResourceScope_CollectionId{CollectionId: "collection-1"},
+		},
+		Schedule: weeklySchedule,
+	}
+	validEntityScope := &storage.ReportConfiguration{
+		Id:   "config-with-entity-scope",
+		Name: "Valid Entity Scope Config",
+		Type: storage.ReportConfiguration_VULNERABILITY,
+		ResourceScope: &storage.ResourceScope{
+			ScopeReference: &storage.ResourceScope_EntityScope{
+				EntityScope: &storage.EntityScope{
+					Rules: []*storage.EntityScopeRule{
+						{
+							Entity: storage.EntityType_ENTITY_TYPE_NAMESPACE,
+							Field:  storage.EntityField_FIELD_NAME,
+							Values: []*storage.RuleValue{{Value: "production"}},
+						},
+					},
+				},
+			},
+		},
+		Schedule: weeklySchedule,
+	}
+	emptyResourceScope := &storage.ReportConfiguration{
+		Id:            "config-empty-scope",
+		Name:          "Empty Scope Config (downgrade scenario)",
+		Type:          storage.ReportConfiguration_VULNERABILITY,
+		ResourceScope: &storage.ResourceScope{},
+		Schedule:      weeklySchedule,
+	}
+	nilResourceScope := &storage.ReportConfiguration{
+		Id:            "config-nil-scope",
+		Name:          "Nil Scope Config",
+		Type:          storage.ReportConfiguration_VULNERABILITY,
+		ResourceScope: nil,
+		Schedule:      weeklySchedule,
+	}
+
+	mockReportConfigDS.EXPECT().
+		GetReportConfigurations(gomock.Any(), gomock.Any()).
+		Return([]*storage.ReportConfiguration{
+			validCollectionScope,
+			validEntityScope,
+			emptyResourceScope,
+			nilResourceScope,
+		}, nil)
+
+	cronScheduler := cron.New()
+	cronScheduler.Start()
+	defer cronScheduler.Stop()
+
+	s := newSchedulerImpl(mockReportConfigDS, nil, nil, nil, nil, nil, cronScheduler, nil)
+	s.queueScheduledReports()
+
+	// Only the two valid configs should have been scheduled
+	assert.Len(t, s.reportConfigToEntryIDs, 2)
+	assert.Contains(t, s.reportConfigToEntryIDs, "config-with-collection")
+	assert.Contains(t, s.reportConfigToEntryIDs, "config-with-entity-scope")
+	assert.NotContains(t, s.reportConfigToEntryIDs, "config-empty-scope")
+	assert.NotContains(t, s.reportConfigToEntryIDs, "config-nil-scope")
 }

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -215,6 +215,7 @@ func (s *serviceImpl) GetReportConfiguration(ctx context.Context, req *apiV2.Res
 	if !common.IsV2ReportConfig(config) {
 		return nil, errors.Wrap(errox.InvalidArgs, "report configuration does not belong to reporting version 2.0")
 	}
+	// Remove report configs with empty scope. This can happen after downgrade to a version that has less scoping methods and doesn't support the new scoping method.
 	if !common.HasValidResourceScope(config.GetResourceScope()) {
 		return nil, errors.Wrapf(errox.InvalidArgs,
 			"Report configuration '%s' has an empty resource scope (no collection ID or entity scope)", req.GetId())

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -192,9 +192,6 @@ func (s *serviceImpl) ListReportConfigurations(ctx context.Context, query *apiV2
 	v2Configs := make([]*apiV2.ReportConfiguration, 0, len(reportConfigs))
 
 	for _, config := range reportConfigs {
-		if !common.HasValidResourceScope(config.GetResourceScope()) {
-			continue
-		}
 		converted, err := s.convertProtoReportConfigurationToV2(config)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error converting storage report configuration with id %s to response", config.GetId())

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -192,7 +192,7 @@ func (s *serviceImpl) ListReportConfigurations(ctx context.Context, query *apiV2
 	v2Configs := make([]*apiV2.ReportConfiguration, 0, len(reportConfigs))
 
 	for _, config := range reportConfigs {
-		if config.GetResourceScope() == nil {
+		if !common.HasValidResourceScope(config.GetResourceScope()) {
 			continue
 		}
 		converted, err := s.convertProtoReportConfigurationToV2(config)
@@ -218,7 +218,7 @@ func (s *serviceImpl) GetReportConfiguration(ctx context.Context, req *apiV2.Res
 	if !common.IsV2ReportConfig(config) {
 		return nil, errors.Wrap(errox.InvalidArgs, "report configuration does not belong to reporting version 2.0")
 	}
-	if config.GetResourceScope() == nil {
+	if !common.HasValidResourceScope(config.GetResourceScope()) {
 		return nil, errors.Wrapf(errox.InvalidArgs,
 			"Report configuration '%s' has an empty resource scope (no collection ID or entity scope)", req.GetId())
 	}

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -192,6 +192,9 @@ func (s *serviceImpl) ListReportConfigurations(ctx context.Context, query *apiV2
 	v2Configs := make([]*apiV2.ReportConfiguration, 0, len(reportConfigs))
 
 	for _, config := range reportConfigs {
+		if config.GetResourceScope() == nil {
+			continue
+		}
 		converted, err := s.convertProtoReportConfigurationToV2(config)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Error converting storage report configuration with id %s to response", config.GetId())
@@ -214,6 +217,10 @@ func (s *serviceImpl) GetReportConfiguration(ctx context.Context, req *apiV2.Res
 	}
 	if !common.IsV2ReportConfig(config) {
 		return nil, errors.Wrap(errox.InvalidArgs, "report configuration does not belong to reporting version 2.0")
+	}
+	if config.GetResourceScope() == nil {
+		return nil, errors.Wrapf(errox.InvalidArgs,
+			"Report configuration '%s' has an empty resource scope (no collection ID or entity scope)", req.GetId())
 	}
 
 	converted, err := s.convertProtoReportConfigurationToV2(config)

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -297,6 +297,44 @@ func (s *ReportServiceTestSuite) TestListReportConfigurations() {
 	}
 }
 
+func (s *ReportServiceTestSuite) TestListReportConfigurationsFiltersEmptyResourceScope() {
+	allAccessContext := sac.WithAllAccess(context.Background())
+
+	validConfig := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
+	emptyResourceScopeConfig := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
+	emptyResourceScopeConfig.Id = "config-empty-scope"
+	emptyResourceScopeConfig.ResourceScope = &storage.ResourceScope{}
+
+	nilResourceScopeConfig := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
+	nilResourceScopeConfig.Id = "config-nil-scope"
+	nilResourceScopeConfig.ResourceScope = nil
+
+	expectedQ := func() *v1.Query {
+		query := search.ConjunctionQuery(
+			search.EmptyQuery(),
+			withoutV1ConfigsQuery)
+		query.Pagination = &v1.QueryPagination{Limit: maxPaginationLimit}
+		return query
+	}()
+
+	s.reportConfigDataStore.EXPECT().GetReportConfigurations(allAccessContext, expectedQ).
+		Return([]*storage.ReportConfiguration{validConfig, emptyResourceScopeConfig, nilResourceScopeConfig}, nil).Times(1)
+
+	s.notifierDataStore.EXPECT().GetNotifier(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ interface{}, id string) (*storage.Notifier, bool, error) {
+			return &storage.Notifier{Id: id, Name: id}, true, nil
+		}).AnyTimes()
+	s.collectionDataStore.EXPECT().Get(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ interface{}, id string) (*storage.ResourceCollection, bool, error) {
+			return &storage.ResourceCollection{Id: id, Name: id}, true, nil
+		}).AnyTimes()
+
+	configs, err := s.service.ListReportConfigurations(allAccessContext, &apiV2.RawQuery{Query: ""})
+	s.NoError(err)
+	s.Len(configs.GetReportConfigs(), 1)
+	s.Equal("report1", configs.GetReportConfigs()[0].GetId())
+}
+
 func (s *ReportServiceTestSuite) TestGetReportConfigurationByID() {
 	allAccessContext := sac.WithAllAccess(context.Background())
 	testCases := []struct {

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -297,44 +297,6 @@ func (s *ReportServiceTestSuite) TestListReportConfigurations() {
 	}
 }
 
-func (s *ReportServiceTestSuite) TestListReportConfigurationsFiltersEmptyResourceScope() {
-	allAccessContext := sac.WithAllAccess(context.Background())
-
-	validConfig := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
-	emptyResourceScopeConfig := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
-	emptyResourceScopeConfig.Id = "config-empty-scope"
-	emptyResourceScopeConfig.ResourceScope = &storage.ResourceScope{}
-
-	nilResourceScopeConfig := fixtures.GetValidReportConfigWithMultipleNotifiersV2()
-	nilResourceScopeConfig.Id = "config-nil-scope"
-	nilResourceScopeConfig.ResourceScope = nil
-
-	expectedQ := func() *v1.Query {
-		query := search.ConjunctionQuery(
-			search.EmptyQuery(),
-			withoutV1ConfigsQuery)
-		query.Pagination = &v1.QueryPagination{Limit: maxPaginationLimit}
-		return query
-	}()
-
-	s.reportConfigDataStore.EXPECT().GetReportConfigurations(allAccessContext, expectedQ).
-		Return([]*storage.ReportConfiguration{validConfig, emptyResourceScopeConfig, nilResourceScopeConfig}, nil).Times(1)
-
-	s.notifierDataStore.EXPECT().GetNotifier(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ interface{}, id string) (*storage.Notifier, bool, error) {
-			return &storage.Notifier{Id: id, Name: id}, true, nil
-		}).AnyTimes()
-	s.collectionDataStore.EXPECT().Get(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ interface{}, id string) (*storage.ResourceCollection, bool, error) {
-			return &storage.ResourceCollection{Id: id, Name: id}, true, nil
-		}).AnyTimes()
-
-	configs, err := s.service.ListReportConfigurations(allAccessContext, &apiV2.RawQuery{Query: ""})
-	s.NoError(err)
-	s.Len(configs.GetReportConfigs(), 1)
-	s.Equal("report1", configs.GetReportConfigs()[0].GetId())
-}
-
 func (s *ReportServiceTestSuite) TestGetReportConfigurationByID() {
 	allAccessContext := sac.WithAllAccess(context.Background())
 	testCases := []struct {

--- a/central/reports/validation/validate.go
+++ b/central/reports/validation/validate.go
@@ -303,6 +303,12 @@ func (v *Validator) ValidateAndGenerateReportRequest(
 	if !common.IsV2ReportConfig(config) {
 		return nil, errors.Wrap(errox.InvalidArgs, "report configuration does not belong to reporting version 2.0")
 	}
+	// Verify ResourceScope is non-nil
+	if config.GetResourceScope() == nil {
+		return nil, errors.Wrapf(errox.InvalidArgs,
+			"Report configuration '%s' has an empty resource scope (no collection ID or entity scope)",
+			configID)
+	}
 
 	if notificationMethod == storage.ReportStatus_EMAIL && len(config.GetNotifiers()) == 0 {
 		return nil, errors.Wrap(errox.InvalidArgs,

--- a/central/reports/validation/validate.go
+++ b/central/reports/validation/validate.go
@@ -304,7 +304,7 @@ func (v *Validator) ValidateAndGenerateReportRequest(
 		return nil, errors.Wrap(errox.InvalidArgs, "report configuration does not belong to reporting version 2.0")
 	}
 	// Verify ResourceScope is non-nil
-	if config.GetResourceScope() == nil {
+	if !common.HasValidResourceScope(config.GetResourceScope()) {
 		return nil, errors.Wrapf(errox.InvalidArgs,
 			"Report configuration '%s' has an empty resource scope (no collection ID or entity scope)",
 			configID)


### PR DESCRIPTION
This PR adds entity scope is non empty check in three places. 

1. queue pending reports -  when pending reports are queued by scheduler, collection is added to request. Logic to verify collection is non nil is changed to entity scope is non nil.  Without this check if entity scoped report config job will not get queued after restart. 

During downgrade testing from 4.11.x to 4.10 it was found that when user selects entity scope in 4.11 , resource scope field returned in config by List API is empty. Following changes makes sure API does not schedule or return reports in this case. 
2. when user requests instant download/email reports then validation for report verifies that entity scope is non nil 
3. List and get report config API does not return configs with non nil entity scope

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ X] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [X ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change


