### PR TITLE
ROX-34733: Filter report search config by feature flag

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizardPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizardPage.tsx
@@ -13,12 +13,14 @@ import {
 import { cloneDeep } from 'lodash';
 
 import BreadcrumbItemLink from 'Components/BreadcrumbItemLink';
+import { getSearchFilterConfigWithFeatureFlagDependency } from 'Components/CompoundSearchFilter/utils/utils';
 import {
     getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment,
     getSearchFilterWithoutEntityScope,
 } from 'Components/EntityScope/entityScopeRules';
 import PageTitle from 'Components/PageTitle';
 import type { ReportPageAction } from 'Components/Reports/reports.types';
+import useFeatureFlags from 'hooks/useFeatureFlags';
 import useURLSearch from 'hooks/useURLSearch';
 import { fetchReportConfiguration } from 'services/ReportsService';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
@@ -51,7 +53,14 @@ function ImageVulnerabilityReportWizardPage({
     pageAction,
 }: ImageVulnerabilityReportWizardPageProps): ReactElement {
     const { reportId } = useParams();
+    const { isFeatureFlagEnabled } = useFeatureFlags();
     const { searchFilter } = useURLSearch();
+
+    // Keep getSearchFilterConfigWithFeatureFlagDependency for ROX_SCANNER_V4.
+    const searchFilterConfig = getSearchFilterConfigWithFeatureFlagDependency(
+        isFeatureFlagEnabled,
+        searchFilterConfigForImageVulnerabilityReport
+    );
 
     // Initialize null for conditional (non) rendering of wizard element
     // until after asynchronous clone, edit, or createFromFilters updates state,
@@ -169,7 +178,7 @@ function ImageVulnerabilityReportWizardPage({
                                 }
                                 initialValues={reportConfiguration}
                                 pageAction={pageAction}
-                                searchFilterConfig={searchFilterConfigForImageVulnerabilityReport}
+                                searchFilterConfig={searchFilterConfig}
                             />
                         </PageSection>
                     ) : null}


### PR DESCRIPTION
## Description

Apply `getSearchFilterConfigWithFeatureFlagDependency` in `ImageVulnerabilityReportWizardPage` so that filters are based on feature flag

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Confirmed `KnownExploit`, `EPSSProbability` and `Source` don't show up without proper feature flag
