### PR TITLE
chore(util): Add scannerctl command to print claircore Vuln Report

### DIFF
--- a/scanner/cmd/scannerctl/ccvulnreport.go
+++ b/scanner/cmd/scannerctl/ccvulnreport.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/jackc/pgx/v5/pgxpool"
+	ccpostgres "github.com/quay/claircore/datastore/postgres"
+	"github.com/quay/claircore/libvuln"
+	"github.com/quay/claircore/pkg/ctxlock/v2"
+	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/scanner/datastore/postgres"
+	"github.com/stackrox/rox/scanner/indexer"
+	"github.com/stackrox/rox/scanner/internal/httputil"
+	"github.com/stackrox/rox/scanner/matcher"
+)
+
+const dbPasswordEnvVar = "ROX_SCANNERCTL_DB_PASSWORD"
+
+// ccVulnReportCmd creates the ccvulnreport command.
+func ccVulnReportCmd(ctx context.Context) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "ccvulnreport http(s)://<image-reference>",
+		Short: "Output the raw ClairCore vulnerability report for an already-indexed image.",
+		Long: "Output the raw ClairCore vulnerability report for an already-indexed image.\n" +
+			"The image reference must include a digest (e.g. https://registry/image:tag@sha256:...).\n" +
+			"Use 'scannerctl scan' or 'roxctl image scan' to index an image and retrieve its digest.",
+		Args: cobra.ExactArgs(1),
+	}
+
+	flags := cmd.PersistentFlags()
+	dbHost := flags.String(
+		"db-host",
+		"127.0.0.1",
+		"Database host (assumes an active port-forward to the scanner-v4-db pod).")
+	dbPort := flags.String(
+		"db-port",
+		"5432",
+		"Database port.")
+	dbPassword := flags.String(
+		"db-password",
+		"",
+		fmt.Sprintf("Database password (warning: debug only and unsafe, use env var %s). "+
+			"If unset, the password is retrieved from the scanner-v4-db-password k8s secret via kubectl.", dbPasswordEnvVar))
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		// Parse the image reference — must include a digest.
+		imageURL := args[0]
+		parsedURL, err := url.Parse(imageURL)
+		if err != nil {
+			return fmt.Errorf("invalid image URL: %w", err)
+		}
+		var nameOpts []name.Option
+		if parsedURL.Scheme == "http" {
+			nameOpts = append(nameOpts, name.Insecure)
+		}
+		imageRef := strings.TrimPrefix(imageURL, parsedURL.Scheme+"://")
+		ref, err := name.NewDigest(imageRef, nameOpts...)
+		if err != nil {
+			return fmt.Errorf("image reference must include a digest (e.g. registry/image:tag@sha256:...): %w", err)
+		}
+
+		// Get DB password from flag, env var, or k8s secret (in that order).
+		password, err := getScannerDBPassword(ctx, *dbPassword)
+		if err != nil {
+			return err
+		}
+
+		poolCfg, err := pgxpool.ParseConfig(fmt.Sprintf(
+			"host=%s port=%s user=postgres sslmode=disable pool_max_conns=5 client_encoding=UTF8",
+			*dbHost, *dbPort))
+		if err != nil {
+			return fmt.Errorf("failed to parse database config: %w", err)
+		}
+		poolCfg.ConnConfig.Password = password
+
+		pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+		if err != nil {
+			return fmt.Errorf("failed to connect to database: %w", err)
+		}
+		defer pool.Close()
+
+		log.Printf("Fetching index report from database...")
+		indexerStore, err := ccpostgres.InitPostgresIndexerStore(ctx, pool, false)
+		if err != nil {
+			return fmt.Errorf("failed to initialize indexer store: %w", err)
+		}
+		defer indexerStore.Close(ctx)
+
+		hashID := fmt.Sprintf("/v4/containerimage/%s", ref.DigestStr())
+		manifestDigest, err := indexer.CreateManifestDigest(hashID)
+		if err != nil {
+			return fmt.Errorf("failed to create manifest digest: %w", err)
+		}
+		ccIndexReport, found, err := indexerStore.IndexReport(ctx, manifestDigest)
+		if err != nil {
+			return fmt.Errorf("failed to get index report: %w", err)
+		}
+		if !found {
+			externalStore, err := postgres.InitPostgresExternalIndexStore(ctx, pool, false)
+			if err != nil {
+				return fmt.Errorf("failed to initialize external index store: %w", err)
+			}
+			ccIndexReport, found, err = externalStore.GetIndexReport(ctx, hashID)
+			if err != nil {
+				return fmt.Errorf("failed to get external index report: %w", err)
+			}
+			if !found {
+				return fmt.Errorf("index report not found for image %s — ensure the image is indexed before running this command", ref.DigestStr())
+			}
+			log.Printf("Found external index report with %d packages", len(ccIndexReport.Packages))
+		} else {
+			log.Printf("Found index report with %d packages", len(ccIndexReport.Packages))
+		}
+
+		store, err := postgres.InitPostgresMatcherStore(ctx, pool, false)
+		if err != nil {
+			return fmt.Errorf("failed to initialize matcher store: %w", err)
+		}
+
+		locker, err := ctxlock.New(ctx, pool)
+		if err != nil {
+			return fmt.Errorf("failed to create locker: %w", err)
+		}
+		defer locker.Close(ctx)
+
+		libVuln, err := libvuln.New(ctx, &libvuln.Options{
+			Store:                    store,
+			Locker:                   locker,
+			MatcherNames:             matcher.GetMatcherNames(),
+			Enrichers:                matcher.GetEnrichers(),
+			UpdateRetention:          libvuln.DefaultUpdateRetention,
+			DisableBackgroundUpdates: true,
+			Client:                   &http.Client{Transport: httputil.DenyTransport},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create libvuln: %w", err)
+		}
+		defer libVuln.Close(ctx)
+
+		log.Printf("Scanning for vulnerabilities...")
+		vulnReport, err := libVuln.Scan(ctx, ccIndexReport)
+		if err != nil {
+			return fmt.Errorf("failed to scan: %w", err)
+		}
+		log.Printf("Found %d vulnerabilities", len(vulnReport.Vulnerabilities))
+
+		reportJSON, err := json.MarshalIndent(vulnReport, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal report: %w", err)
+		}
+		fmt.Println(string(reportJSON))
+		return nil
+	}
+	return &cmd
+}
+
+// getScannerDBPassword returns the scanner DB password from the flag, env var,
+// or k8s secret (in that order).
+func getScannerDBPassword(ctx context.Context, flag string) (string, error) {
+	if flag != "" {
+		return flag, nil
+	}
+	if p := os.Getenv(dbPasswordEnvVar); p != "" {
+		return p, nil
+	}
+	log.Printf("db-password unspecified: retrieving from k8s secret (use %s to set directly)", dbPasswordEnvVar)
+	out, err := exec.CommandContext(ctx, "kubectl", "get", "secret", "scanner-v4-db-password",
+		"-o", "jsonpath={.data.password}").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get db password secret: %w", err)
+	}
+	p, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(out)))
+	if err != nil {
+		return "", fmt.Errorf("failed to decode password: %w", err)
+	}
+	return strings.TrimSpace(string(p)), nil
+}

--- a/scanner/cmd/scannerctl/ccvulnreport.go
+++ b/scanner/cmd/scannerctl/ccvulnreport.go
@@ -18,13 +18,14 @@ import (
 	"github.com/quay/claircore/libvuln"
 	"github.com/quay/claircore/pkg/ctxlock/v2"
 	"github.com/spf13/cobra"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/scanner/datastore/postgres"
 	"github.com/stackrox/rox/scanner/indexer"
 	"github.com/stackrox/rox/scanner/internal/httputil"
 	"github.com/stackrox/rox/scanner/matcher"
 )
 
-const dbPasswordEnvVar = "ROX_SCANNERCTL_DB_PASSWORD"
+const dbPasswordEnvVar = "ROX_SCANNERCTL_DB_PASSWORD" //nolint:gosec // Not a credential, just an env var name.
 
 // ccVulnReportCmd creates the ccvulnreport command.
 func ccVulnReportCmd(ctx context.Context) *cobra.Command {
@@ -94,7 +95,7 @@ func ccVulnReportCmd(ctx context.Context) *cobra.Command {
 		if err != nil {
 			return fmt.Errorf("failed to initialize indexer store: %w", err)
 		}
-		defer indexerStore.Close(ctx)
+		defer utils.IgnoreError(func() error { return indexerStore.Close(ctx) })
 
 		hashID := fmt.Sprintf("/v4/containerimage/%s", ref.DigestStr())
 		manifestDigest, err := indexer.CreateManifestDigest(hashID)
@@ -131,7 +132,7 @@ func ccVulnReportCmd(ctx context.Context) *cobra.Command {
 		if err != nil {
 			return fmt.Errorf("failed to create locker: %w", err)
 		}
-		defer locker.Close(ctx)
+		defer utils.IgnoreError(func() error { return locker.Close(ctx) })
 
 		libVuln, err := libvuln.New(ctx, &libvuln.Options{
 			Store:                    store,
@@ -145,7 +146,7 @@ func ccVulnReportCmd(ctx context.Context) *cobra.Command {
 		if err != nil {
 			return fmt.Errorf("failed to create libvuln: %w", err)
 		}
-		defer libVuln.Close(ctx)
+		defer utils.IgnoreError(func() error { return libVuln.Close(ctx) })
 
 		log.Printf("Scanning for vulnerabilities...")
 		vulnReport, err := libVuln.Scan(ctx, ccIndexReport)

--- a/scanner/cmd/scannerctl/ccvulnreport.go
+++ b/scanner/cmd/scannerctl/ccvulnreport.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/jackc/pgx/v5/pgxpool"
 	ccpostgres "github.com/quay/claircore/datastore/postgres"
+	cctypes "github.com/quay/claircore/datastore/postgres/types"
 	"github.com/quay/claircore/libvuln"
 	"github.com/quay/claircore/pkg/ctxlock/v2"
 	"github.com/spf13/cobra"
@@ -83,6 +84,7 @@ func ccVulnReportCmd(ctx context.Context) *cobra.Command {
 			return fmt.Errorf("failed to parse database config: %w", err)
 		}
 		poolCfg.ConnConfig.Password = password
+		poolCfg.AfterConnect = cctypes.ConnectRegisterTypes
 
 		pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
 		if err != nil {

--- a/scanner/cmd/scannerctl/ccvulnreport.go
+++ b/scanner/cmd/scannerctl/ccvulnreport.go
@@ -32,8 +32,8 @@ const dbPasswordEnvVar = "ROX_SCANNERCTL_DB_PASSWORD" //nolint:gosec // Not a cr
 func ccVulnReportCmd(ctx context.Context) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "ccvulnreport http(s)://<image-reference>",
-		Short: "Output the raw ClairCore vulnerability report for an already-indexed image.",
-		Long: "Output the raw ClairCore vulnerability report for an already-indexed image.\n" +
+		Short: "Output the raw Claircore vulnerability report for an already-indexed image.",
+		Long: "Output the raw Claircore vulnerability report for an already-indexed image.\n" +
 			"The image reference must include a digest (e.g. https://registry/image:tag@sha256:...).\n" +
 			"Use 'scannerctl scan' or 'roxctl image scan' to index an image and retrieve its digest.",
 		Args: cobra.ExactArgs(1),

--- a/scanner/cmd/scannerctl/main.go
+++ b/scanner/cmd/scannerctl/main.go
@@ -110,6 +110,7 @@ func rootCmd(ctx context.Context) *cobra.Command {
 	cmd.AddCommand(scaleCmd(ctx))
 	cmd.AddCommand(sbomCmd(ctx))
 	cmd.AddCommand(scanVM(ctx))
+	cmd.AddCommand(ccVulnReportCmd(ctx))
 	return &cmd
 }
 

--- a/scanner/indexer/indexer.go
+++ b/scanner/indexer/indexer.go
@@ -423,7 +423,7 @@ func (i *localIndexer) GetRepositoryToCPEMapping(ctx context.Context, ifModified
 // URL. This method performs a partial content request on each layer to generate
 // the layer's URI and headers.
 func (i *localIndexer) IndexContainerImage(ctx context.Context, hashID string, imageURL string, opts ...Option) (*claircore.IndexReport, error) {
-	manifestDigest, err := createManifestDigest(hashID)
+	manifestDigest, err := CreateManifestDigest(hashID)
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +560,7 @@ func getLayerRequest(ctx context.Context, httpClient *http.Client, imgRef name.R
 
 // GetIndexReport retrieves an IndexReport for the given hash ID if it exists and is up to date.
 func (i *localIndexer) GetIndexReport(ctx context.Context, hashID string, includeExternal bool) (*claircore.IndexReport, bool, error) {
-	manifestDigest, err := createManifestDigest(hashID)
+	manifestDigest, err := CreateManifestDigest(hashID)
 	if err != nil {
 		return nil, false, err
 	}
@@ -634,8 +634,8 @@ func (i *localIndexer) GetIndexReport(ctx context.Context, hashID string, includ
 	return nil, false, nil
 }
 
-// createManifestDigest creates a unique claircore.Digest from a Scanner's manifest hash ID.
-func createManifestDigest(hashID string) (claircore.Digest, error) {
+// CreateManifestDigest creates a unique claircore.Digest from a Scanner's manifest hash ID.
+func CreateManifestDigest(hashID string) (claircore.Digest, error) {
 	hashIDSum := sha512.Sum512([]byte(hashID))
 	d, err := claircore.NewDigest(claircore.SHA512, hashIDSum[:])
 	if err != nil {
@@ -647,7 +647,7 @@ func createManifestDigest(hashID string) (claircore.Digest, error) {
 func (i *localIndexer) StoreIndexReport(ctx context.Context, hashID string, indexerVersion string, report *claircore.IndexReport) (string, error) {
 
 	var err error
-	report.Hash, err = createManifestDigest(hashID)
+	report.Hash, err = CreateManifestDigest(hashID)
 	if err != nil {
 		return "", fmt.Errorf("creating claircore manifest digest: %w", err)
 	}

--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net/http"
 	"slices"
-	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -37,6 +36,7 @@ import (
 	"github.com/quay/claircore/ubuntu"
 	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/scanner/config"
 	"github.com/stackrox/rox/scanner/datastore/postgres"
 	"github.com/stackrox/rox/scanner/enricher/csaf"

--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -122,7 +122,7 @@ func init() {
 	matcherNames = append(matcherNames, m.Name())
 }
 
-// GetMatcherNames returns a copy of the ClairCore matcher names to use.
+// GetMatcherNames returns a copy of the Claircore matcher names to use.
 func GetMatcherNames() []string {
 	return slices.Clone(matcherNames)
 }

--- a/scanner/matcher/matcher.go
+++ b/scanner/matcher/matcher.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -107,6 +109,9 @@ var (
 			},
 		},
 	}
+
+	enrichersOnce    sync.Once
+	enabledEnrichers []driver.Enricher
 )
 
 func init() {
@@ -115,6 +120,26 @@ func init() {
 	mf := driver.MatcherStatic(&m)
 	registry.Register(m.Name(), mf)
 	matcherNames = append(matcherNames, m.Name())
+}
+
+// GetMatcherNames returns a copy of the ClairCore matcher names to use.
+func GetMatcherNames() []string {
+	return slices.Clone(matcherNames)
+}
+
+// GetEnrichers returns the list of enrichers to use for vulnerability scanning.
+func GetEnrichers() []driver.Enricher {
+	enrichersOnce.Do(func() {
+		enabledEnrichers = make([]driver.Enricher, 0, len(enrichers))
+		for _, e := range enrichers {
+			enabled := e.flag == nil || e.flag.Enabled()
+			slog.Info("enricher", "name", e.name, "enabled", enabled)
+			if enabled {
+				enabledEnrichers = append(enabledEnrichers, e.init())
+			}
+		}
+	})
+	return enabledEnrichers
 }
 
 // Matcher represents a vulnerability matcher.
@@ -184,19 +209,11 @@ func NewMatcher(ctx context.Context, cfg config.MatcherConfig, reportProvider in
 		Transport: httputil.DenyTransport,
 	}
 
-	enabledEnrichers := make([]driver.Enricher, 0, len(enrichers))
-	for _, e := range enrichers {
-		enabled := e.flag == nil || e.flag.Enabled()
-		slog.InfoContext(ctx, "enricher", "name", e.name, "enabled", enabled)
-		if !enabled {
-			continue
-		}
-		enabledEnrichers = append(enabledEnrichers, e.init())
-	}
+	enabledEnrichers := GetEnrichers()
 	libVuln, err := libvuln.New(ctx, &libvuln.Options{
 		Store:                    store,
 		Locker:                   locker,
-		MatcherNames:             matcherNames,
+		MatcherNames:             GetMatcherNames(),
 		Enrichers:                enabledEnrichers,
 		UpdateRetention:          libvuln.DefaultUpdateRetention,
 		DisableBackgroundUpdates: true,


### PR DESCRIPTION
## Description

Adds `ccvulnreport` subcommand to `scannerctl` that produces a claircore vulnerability report from an already scanned image in StackRox.

The intent was to produce a reasonably raw claircore vulnerability report bypassing any Scanner V4 (`mappers.go`) or Central (`convert.go`) modifications.

To do this the raw claircore index report is pulled directly from the Scanner V4 DB and matched by running libvuln locally pointed at the same Scanner V4 DB  (as opposed to modifying Scanner V4 APIs or attempting conversions)

To use:
1. Have StackRox scan an image or scan one manually via `roxctl image scan`, `scannerctl scan`, etc.
    - The intent here is to get an index report into the Scanner V4 DB
3. Set KUBECONFIG and port-forward to `scanner-v4-db`
4. Run new subcommand: `go run ./scanner/cmd/scannerctl https://...`

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

None - developer tool.

### How I validated my change

```sh
$ export KUBECONFIG=...
$ rctl image scan --image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:afdf92dd760966894188d826af2d26123739aa660424541ba7fb13fa16511957

# separate term
$ while true; do k port-forward -n 'stackrox' deploy/scanner-v4-db 5432:5432; sleep 0.5; done

$ go run ./scanner/cmd/scannerctl ccvulnreport https://quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:afdf92dd760966894188d826af2d26123739aa660424541ba7fb13fa16511957

2026/05/15 17:27:13 db-password unspecified: retrieving from k8s secret (use ROX_SCANNERCTL_DB_PASSWORD to set directly)
2026/05/15 17:27:13 Fetching index report from database...
2026/05/15 17:27:14 Found external index report with 275 packages
2026/05/15 17:27:14 INFO matchers created matcher.rhel-container-matcher=https://pkg.go.dev/github.com/quay/claircore/rhel/rhcc matcher.ubuntu-matcher=https://pkg.go.dev/github.com/quay/claircore/ubuntu matcher.nodejs=https://pkg.go.dev/github.com/quay/claircore/nodejs matcher.alpine-matcher=https://pkg.go.dev/github.com/quay/claircore/alpine matcher.aws-matcher=https://pkg.go.dev/github.com/quay/claircore/aws matcher.gobin=https://pkg.go.dev/github.com/quay/claircore/gobin matcher.oracle=https://pkg.go.dev/github.com/quay/claircore/oracle matcher.python=https://pkg.go.dev/github.com/quay/claircore/python matcher.rhel=https://pkg.go.dev/github.com/quay/claircore/rhel matcher.ruby-gem=https://pkg.go.dev/github.com/quay/claircore/ruby matcher.suse=https://pkg.go.dev/github.com/quay/claircore/suse matcher.debian-matcher=https://pkg.go.dev/github.com/quay/claircore/debian matcher.java-maven=https://pkg.go.dev/github.com/quay/claircore/java matcher.photon=https://pkg.go.dev/github.com/quay/claircore/photon
2026/05/15 17:27:14 INFO libvuln initialized
2026/05/15 17:27:14 Scanning for vulnerabilities...
2026/05/15 17:27:17 Found 62 vulnerabilities
{
  "manifest_hash": "sha512:2cf445d58f8eb25ef2947cad6bf647e3988716cd5107e78d4ff93af2d192a0de1297c0c9433af00c8892627e3b2e8763a70a7df97cca1e284ef49434cf84335f",
  "packages": {
    "98186": {
      "id": "98186",
      "name": "rhel9-6-els/rhel-minimal",
      "version": "1769661497",
      "kind": "source",
      "source": {
        "id": "98185",

```
