### PR TITLE
ROX-34437: M2M - allow declarative configuration for Kubernetes issuer

### DIFF
--- a/central/auth/datastore/datastore_impl.go
+++ b/central/auth/datastore/datastore_impl.go
@@ -53,6 +53,17 @@ func encodeIssuer(config *storage.AuthMachineToMachineConfig) string {
 	return fmt.Sprintf("%s%s%s", origin, issuerSeparator, issuer)
 }
 
+// decodeIssuer extracts the raw issuer from an encoded issuer string.
+// The encoded format is "ORIGIN|issuer", this returns just the "issuer" part.
+func decodeIssuer(encodedIssuer string) string {
+	_, issuer, found := strings.Cut(encodedIssuer, issuerSeparator)
+	if found {
+		return issuer
+	}
+	// If not encoded, return as-is (for backwards compatibility)
+	return encodedIssuer
+}
+
 // withEncodedIssuer creates a copy of the config with the issuer field encoded.
 // This copy is used for database operations to ensure the unique constraint works per origin.
 func withEncodedIssuer(config *storage.AuthMachineToMachineConfig) *storage.AuthMachineToMachineConfig {
@@ -107,29 +118,44 @@ func (d *datastoreImpl) upsertAuthM2MConfigNoLock(ctx context.Context,
 		}
 	}
 
-	// Get the existing exchanger for the issuer, if any.
-	issuer := config.GetIssuer()
-	existingExchanger, _ := d.set.GetTokenExchanger(issuer)
+	// First, pull the stored configuration being updated, if it exists.
+	storedConfig, exists, err := d.getAuthM2MConfigNoLock(ctx, config.GetId())
+	if err != nil {
+		return nil, err
+	}
 
-	hasDiscrepantIssuer := false
-	storedConfigs := make([]*storage.AuthMachineToMachineConfig, 0, len(existingExchanger.Configs()))
-	var matchingConfig *storage.AuthMachineToMachineConfig
-	for _, exchangerConfig := range existingExchanger.Configs() {
-		// Get the existing stored config, if any.
-		storedConfig, exists, err := d.getAuthM2MConfigNoLock(ctx, exchangerConfig.GetId())
-		if err != nil {
-			return nil, err
-		}
-		if exists && storedConfig != nil {
-			if storedConfig.GetIssuer() != config.GetIssuer() {
-				hasDiscrepantIssuer = true
+	// Then, get the associated existing exchanger for the stored configuration's issuer.
+	var existingExchanger m2m.TokenExchanger
+	var storedConfigs []*storage.AuthMachineToMachineConfig
+	if exists && storedConfig != nil {
+		// Decode the issuer since the stored config has an encoded issuer but the
+		// token exchanger set uses raw issuers as keys.
+		rawIssuer := decodeIssuer(storedConfig.GetIssuer())
+		existingExchanger, _ = d.set.GetTokenExchanger(rawIssuer)
+
+		// Finally, get the configurations referenced by the exchanger.
+		if existingExchanger != nil {
+			exchangerConfigs := existingExchanger.Configs()
+			storedConfigs = make([]*storage.AuthMachineToMachineConfig, 0, len(exchangerConfigs))
+			for _, exchangerConfig := range exchangerConfigs {
+				sc, scExists, scErr := d.getAuthM2MConfigNoLock(ctx, exchangerConfig.GetId())
+				if scErr != nil {
+					return nil, scErr
+				}
+				if scExists && sc != nil {
+					storedConfigs = append(storedConfigs, sc)
+				}
 			}
-			if storedConfig.GetId() == config.GetId() {
-				matchingConfig = storedConfig
-			}
-			storedConfigs = append(storedConfigs, storedConfig)
 		}
 	}
+
+	// Determine the issuer for rollback operations (use stored config's issuer if available, otherwise new config's).
+	issuer := config.GetIssuer()
+	if storedConfig != nil && storedConfig.GetIssuer() != "" {
+		issuer = storedConfig.GetIssuer()
+	}
+
+	hasDiscrepantIssuer := exists && storedConfig != nil && storedConfig.GetIssuer() != config.GetIssuer()
 
 	// Create a transaction for the DB operation. Since we can potentially fail during in-memory operations (i.e.
 	// upserting the token exchanger in the set or removal) we want to make sure we can rollback DB changes.
@@ -152,11 +178,10 @@ func (d *datastoreImpl) upsertAuthM2MConfigNoLock(ctx context.Context,
 	}
 
 	// We need to ensure that any previously existing config is removed from the token exchanger set.
-	// Since this updated config may have updated the issuer, we need to fetch the existing, stored config from the
-	// database and ensure it's removed properly from the set. We do this at the end since we want the new config
-	// to successfully exist beforehand.
-	if hasDiscrepantIssuer && matchingConfig != nil {
-		if err := d.set.RemoveTokenExchanger(ctx, matchingConfig); err != nil {
+	// Since this updated config may have updated the issuer, we need to remove the stored config from the
+	// old exchanger. We do this at the end since we want the new config to successfully exist beforehand.
+	if hasDiscrepantIssuer && storedConfig != nil {
+		if err := d.set.RemoveTokenExchanger(ctx, storedConfig); err != nil {
 			return nil, d.wrapRollback(ctx, tx, err, issuer, storedConfigs, config, existingExchanger)
 		}
 	}

--- a/central/auth/datastore/datastore_impl.go
+++ b/central/auth/datastore/datastore_impl.go
@@ -23,6 +23,12 @@ import (
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
+const (
+	// issuerSeparator is used to encode the issuer field for database storage.
+	// The stored issuer is the concatenation of the traits origin and the issuer value.
+	issuerSeparator = "|"
+)
+
 var (
 	_ DataStore = (*datastoreImpl)(nil)
 
@@ -36,6 +42,25 @@ type datastoreImpl struct {
 	roleDataStore roleDataStore.DataStore
 
 	mutex sync.RWMutex
+}
+
+// encodeIssuer encodes the issuer field by concatenating the traits origin and the issuer value.
+// This allows different origins to have configurations with the same issuer URL.
+// Format: "ORIGIN|issuer_url" (e.g., "DECLARATIVE|https://example.com")
+func encodeIssuer(config *storage.AuthMachineToMachineConfig) string {
+	origin := config.GetTraits().GetOrigin().String()
+	issuer := config.GetIssuer()
+	return fmt.Sprintf("%s%s%s", origin, issuerSeparator, issuer)
+}
+
+// withEncodedIssuer creates a copy of the config with the issuer field encoded.
+// This copy is used for database operations to ensure the unique constraint works per origin.
+func withEncodedIssuer(config *storage.AuthMachineToMachineConfig) *storage.AuthMachineToMachineConfig {
+	// Clone the config to avoid modifying the original
+	encoded := config.CloneVT()
+	// Set the encoded issuer
+	encoded.Issuer = encodeIssuer(config)
+	return encoded
 }
 
 func (d *datastoreImpl) GetAuthM2MConfig(ctx context.Context, id string) (*storage.AuthMachineToMachineConfig, bool, error) {
@@ -82,14 +107,29 @@ func (d *datastoreImpl) upsertAuthM2MConfigNoLock(ctx context.Context,
 		}
 	}
 
-	// Get the existing stored config, if any.
-	storedConfig, exists, err := d.getAuthM2MConfigNoLock(ctx, config.GetId())
-	if err != nil {
-		return nil, err
-	}
-
 	// Get the existing exchanger for the issuer, if any.
-	existingExchanger, _ := d.set.GetTokenExchanger(config.GetIssuer())
+	issuer := config.GetIssuer()
+	existingExchanger, _ := d.set.GetTokenExchanger(issuer)
+
+	hasDiscrepantIssuer := false
+	storedConfigs := make([]*storage.AuthMachineToMachineConfig, 0, len(existingExchanger.Configs()))
+	var matchingConfig *storage.AuthMachineToMachineConfig
+	for _, exchangerConfig := range existingExchanger.Configs() {
+		// Get the existing stored config, if any.
+		storedConfig, exists, err := d.getAuthM2MConfigNoLock(ctx, exchangerConfig.GetId())
+		if err != nil {
+			return nil, err
+		}
+		if exists && storedConfig != nil {
+			if storedConfig.GetIssuer() != config.GetIssuer() {
+				hasDiscrepantIssuer = true
+			}
+			if storedConfig.GetId() == config.GetId() {
+				matchingConfig = storedConfig
+			}
+			storedConfigs = append(storedConfigs, storedConfig)
+		}
+	}
 
 	// Create a transaction for the DB operation. Since we can potentially fail during in-memory operations (i.e.
 	// upserting the token exchanger in the set or removal) we want to make sure we can rollback DB changes.
@@ -101,26 +141,28 @@ func (d *datastoreImpl) upsertAuthM2MConfigNoLock(ctx context.Context,
 	// Upsert the token exchanger first, ensuring the config is valid and a token exchanger can be successfully
 	// created from it.
 	if err := d.set.UpsertTokenExchanger(ctx, config); err != nil {
-		return nil, d.wrapRollback(ctx, tx, err, storedConfig, config, existingExchanger)
+		return nil, d.wrapRollback(ctx, tx, err, issuer, storedConfigs, config, existingExchanger)
 	}
 
 	// Upsert the config to the DB after the token exchanger has been successfully added.
-	if err := d.store.Upsert(ctx, config); err != nil {
-		return nil, d.wrapRollback(ctx, tx, err, storedConfig, config, existingExchanger)
+	// We use withEncodedIssuer to ensure the database issuer column contains "ORIGIN|issuer"
+	// for unique constraint enforcement per origin.
+	if err := d.store.Upsert(ctx, withEncodedIssuer(config)); err != nil {
+		return nil, d.wrapRollback(ctx, tx, err, issuer, storedConfigs, config, existingExchanger)
 	}
 
 	// We need to ensure that any previously existing config is removed from the token exchanger set.
 	// Since this updated config may have updated the issuer, we need to fetch the existing, stored config from the
 	// database and ensure it's removed properly from the set. We do this at the end since we want the new config
 	// to successfully exist beforehand.
-	if exists && config.GetIssuer() != storedConfig.GetIssuer() {
-		if err := d.set.RemoveTokenExchanger(storedConfig.GetIssuer()); err != nil {
-			return nil, d.wrapRollback(ctx, tx, err, storedConfig, config, existingExchanger)
+	if hasDiscrepantIssuer && matchingConfig != nil {
+		if err := d.set.RemoveTokenExchanger(ctx, matchingConfig); err != nil {
+			return nil, d.wrapRollback(ctx, tx, err, issuer, storedConfigs, config, existingExchanger)
 		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return nil, d.wrapRollback(ctx, tx, err, storedConfig, config, existingExchanger)
+		return nil, d.wrapRollback(ctx, tx, err, issuer, storedConfigs, config, existingExchanger)
 	}
 
 	return config, nil
@@ -206,7 +248,7 @@ func (d *datastoreImpl) RemoveAuthM2MConfig(ctx context.Context, id string) erro
 	if !exists {
 		return nil
 	}
-	if err := d.set.RemoveTokenExchanger(config.GetIssuer()); err != nil {
+	if err := d.set.RemoveTokenExchanger(ctx, config); err != nil {
 		return err
 	}
 
@@ -257,6 +299,7 @@ func newKubeM2MConfig(kubeSAIssuer string) *storage.AuthMachineToMachineConfig {
 		TokenExpirationDuration: "1h",
 		Mappings:                []*storage.AuthMachineToMachineConfig_Mapping{},
 		Issuer:                  kubeSAIssuer,
+		Traits:                  &storage.Traits{Origin: storage.Traits_DEFAULT},
 	}
 }
 
@@ -301,9 +344,16 @@ func (d *datastoreImpl) configureConfigControllerAccess(kubeSAConfig *storage.Au
 // wrapRollback wraps the error with potential rollback errors.
 // In the case the giving config is not nil, it will attempt to rollback the exchanger in the set in addition to
 // rolling back the transaction.
-func (d *datastoreImpl) wrapRollback(ctx context.Context, tx *pgPkg.Tx, err error,
-	storedConfig, newConfig *storage.AuthMachineToMachineConfig, existingExchanger m2m.TokenExchanger) error {
-	err = d.wrapRollBackSet(ctx, err, storedConfig, newConfig, existingExchanger)
+func (d *datastoreImpl) wrapRollback(
+	ctx context.Context,
+	tx *pgPkg.Tx,
+	err error,
+	issuer string,
+	storedConfigs []*storage.AuthMachineToMachineConfig,
+	newConfig *storage.AuthMachineToMachineConfig,
+	existingExchanger m2m.TokenExchanger,
+) error {
+	err = d.wrapRollBackSet(ctx, err, issuer, storedConfigs, newConfig, existingExchanger)
 	rollbackErr := tx.Rollback(ctx)
 	if rollbackErr != nil {
 		err = pkgErrors.Wrapf(rollbackErr, "rolling back due to: %v", err)
@@ -312,21 +362,27 @@ func (d *datastoreImpl) wrapRollback(ctx context.Context, tx *pgPkg.Tx, err erro
 	return err
 }
 
-func (d *datastoreImpl) wrapRollBackSet(ctx context.Context, err error, storedConfig,
-	newConfig *storage.AuthMachineToMachineConfig, existingExchanger m2m.TokenExchanger) error {
-	exchangerErr := d.set.RemoveTokenExchanger(newConfig.GetIssuer())
+func (d *datastoreImpl) wrapRollBackSet(
+	ctx context.Context,
+	err error,
+	issuer string,
+	storedConfigs []*storage.AuthMachineToMachineConfig,
+	newConfig *storage.AuthMachineToMachineConfig,
+	existingExchanger m2m.TokenExchanger,
+) error {
+	exchangerErr := d.set.RemoveTokenExchanger(ctx, newConfig)
 
 	// We have two configs to restore from: either a config has already existed within the DB for the given ID,
 	// or a token exchanger exists for the given issuer.
 	// We first attempt to restore the exchanger from the stored config. This is the case where e.g. an update to
 	// an existing config rendered as invalid.
-	// If no stored config is given, i.e. this is was not an update to an existing config, we rollback the changes
+	// If no stored config is given, i.e. this was not an update to an existing config, we rollback the changes
 	// from the existing exchanger config. This is the case where e.g. a new config was added with the same issuer
 	// as an existing config.
-	if storedConfig != nil {
-		exchangerErr = errors.Join(exchangerErr, d.set.RollbackExchanger(ctx, storedConfig))
-	} else if existingExchanger != nil && existingExchanger.Config() != nil {
-		exchangerErr = errors.Join(exchangerErr, d.set.RollbackExchanger(ctx, existingExchanger.Config()))
+	if len(storedConfigs) > 0 {
+		exchangerErr = errors.Join(exchangerErr, d.set.RollbackExchanger(ctx, issuer, storedConfigs))
+	} else if existingExchanger != nil && len(existingExchanger.Configs()) > 0 {
+		exchangerErr = errors.Join(exchangerErr, d.set.RollbackExchanger(ctx, issuer, existingExchanger.Configs()))
 	}
 
 	if exchangerErr != nil {

--- a/central/auth/datastore/datastore_impl_mocked_test.go
+++ b/central/auth/datastore/datastore_impl_mocked_test.go
@@ -72,9 +72,9 @@ func (s *datastoreMockedTestSuite) SetupTest() {
 
 	s.mockSet = mocks.NewMockTokenExchangerSet(s.mockCtrl)
 	s.mockSet.EXPECT().UpsertTokenExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	s.mockSet.EXPECT().RemoveTokenExchanger(gomock.Any()).Return(nil).AnyTimes()
+	s.mockSet.EXPECT().RemoveTokenExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	s.mockSet.EXPECT().GetTokenExchanger(gomock.Any()).Return(nil, true).AnyTimes()
-	s.mockSet.EXPECT().RollbackExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	s.mockSet.EXPECT().RollbackExchanger(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	s.authStore = mockAuthStore.NewMockStore(s.mockCtrl)
 	s.authDataStore = New(s.authStore, s.roleDataStore, s.mockSet)

--- a/central/auth/datastore/issuer_encoding_test.go
+++ b/central/auth/datastore/issuer_encoding_test.go
@@ -1,0 +1,99 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeIssuer(t *testing.T) {
+	tests := map[string]struct {
+		config   *storage.AuthMachineToMachineConfig
+		expected string
+	}{
+		"DECLARATIVE origin with issuer": {
+			config: &storage.AuthMachineToMachineConfig{
+				Issuer: "https://example.com",
+				Traits: &storage.Traits{
+					Origin: storage.Traits_DECLARATIVE,
+				},
+			},
+			expected: "DECLARATIVE|https://example.com",
+		},
+		"IMPERATIVE origin with issuer": {
+			config: &storage.AuthMachineToMachineConfig{
+				Issuer: "https://token.actions.githubusercontent.com",
+				Traits: &storage.Traits{
+					Origin: storage.Traits_IMPERATIVE,
+				},
+			},
+			expected: "IMPERATIVE|https://token.actions.githubusercontent.com",
+		},
+		"DEFAULT origin with issuer": {
+			config: &storage.AuthMachineToMachineConfig{
+				Issuer: "https://kubernetes.default.svc",
+				Traits: &storage.Traits{
+					Origin: storage.Traits_DEFAULT,
+				},
+			},
+			expected: "DEFAULT|https://kubernetes.default.svc",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			encoded := encodeIssuer(tc.config)
+			assert.Equal(t, tc.expected, encoded)
+		})
+	}
+}
+
+func TestWithEncodedIssuer(t *testing.T) {
+	tests := map[string]struct {
+		config         *storage.AuthMachineToMachineConfig
+		expectedIssuer string
+	}{
+		"DECLARATIVE origin preserves original config": {
+			config: &storage.AuthMachineToMachineConfig{
+				Id:     "test-id",
+				Issuer: "https://example.com",
+				Traits: &storage.Traits{
+					Origin: storage.Traits_DECLARATIVE,
+				},
+				Mappings: []*storage.AuthMachineToMachineConfig_Mapping{
+					{Key: "sub", ValueExpression: "test", Role: "Admin"},
+				},
+			},
+			expectedIssuer: "DECLARATIVE|https://example.com",
+		},
+		"original config is not modified": {
+			config: &storage.AuthMachineToMachineConfig{
+				Id:     "test-id-2",
+				Issuer: "https://original.com",
+				Traits: &storage.Traits{
+					Origin: storage.Traits_IMPERATIVE,
+				},
+			},
+			expectedIssuer: "IMPERATIVE|https://original.com",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			originalIssuer := tc.config.Issuer
+			encoded := withEncodedIssuer(tc.config)
+
+			// Verify the encoded config has the encoded issuer
+			assert.Equal(t, tc.expectedIssuer, encoded.Issuer)
+
+			// Verify the original config is unchanged
+			assert.Equal(t, originalIssuer, tc.config.Issuer)
+
+			// Verify other fields are preserved
+			assert.Equal(t, tc.config.Id, encoded.Id)
+			assert.Equal(t, tc.config.Traits.Origin, encoded.Traits.Origin)
+			assert.Equal(t, len(tc.config.Mappings), len(encoded.Mappings))
+		})
+	}
+}

--- a/central/auth/datastore/issuer_encoding_test.go
+++ b/central/auth/datastore/issuer_encoding_test.go
@@ -49,6 +49,41 @@ func TestEncodeIssuer(t *testing.T) {
 	}
 }
 
+func TestDecodeIssuer(t *testing.T) {
+	tests := map[string]struct {
+		encoded  string
+		expected string
+	}{
+		"DECLARATIVE encoded issuer": {
+			encoded:  "DECLARATIVE|https://example.com",
+			expected: "https://example.com",
+		},
+		"IMPERATIVE encoded issuer": {
+			encoded:  "IMPERATIVE|https://token.actions.githubusercontent.com",
+			expected: "https://token.actions.githubusercontent.com",
+		},
+		"DEFAULT encoded issuer": {
+			encoded:  "DEFAULT|https://kubernetes.default.svc",
+			expected: "https://kubernetes.default.svc",
+		},
+		"unencoded issuer (backwards compatibility)": {
+			encoded:  "https://plain.issuer.com",
+			expected: "https://plain.issuer.com",
+		},
+		"issuer with pipe in URL": {
+			encoded:  "DECLARATIVE|https://example.com/path|with|pipes",
+			expected: "https://example.com/path|with|pipes",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			decoded := decodeIssuer(tc.encoded)
+			assert.Equal(t, tc.expected, decoded)
+		})
+	}
+}
+
 func TestWithEncodedIssuer(t *testing.T) {
 	tests := map[string]struct {
 		config         *storage.AuthMachineToMachineConfig

--- a/central/auth/datastore/wrap_rollback_set_test.go
+++ b/central/auth/datastore/wrap_rollback_set_test.go
@@ -1,0 +1,148 @@
+package datastore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stackrox/rox/central/auth/m2m"
+	"github.com/stackrox/rox/central/auth/m2m/mocks"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_wrapRollBackSet(t *testing.T) {
+	ctx := context.Background()
+	testIssuer := "https://test.example.com"
+	originalErr := errors.New("original error")
+	removeErr := errors.New("remove error")
+	rollbackErr := errors.New("rollback error")
+
+	testConfig := &storage.AuthMachineToMachineConfig{
+		Id:     "test-id",
+		Issuer: testIssuer,
+	}
+
+	storedConfig1 := &storage.AuthMachineToMachineConfig{
+		Id:     "stored-1",
+		Issuer: testIssuer,
+	}
+
+	storedConfig2 := &storage.AuthMachineToMachineConfig{
+		Id:     "stored-2",
+		Issuer: testIssuer,
+	}
+
+	tests := map[string]struct {
+		storedConfigs          []*storage.AuthMachineToMachineConfig
+		setupExistingExchanger func(*gomock.Controller) m2m.TokenExchanger
+		setupMocks             func(*mocks.MockTokenExchangerSet)
+		expectedErrorContains  []string
+	}{
+		"success with stored configs - removes new config and rolls back to stored configs": {
+			storedConfigs: []*storage.AuthMachineToMachineConfig{storedConfig1, storedConfig2},
+			setupMocks: func(mockSet *mocks.MockTokenExchangerSet) {
+				mockSet.EXPECT().RemoveTokenExchanger(ctx, testConfig).Return(nil)
+				mockSet.EXPECT().RollbackExchanger(ctx, testIssuer, []*storage.AuthMachineToMachineConfig{storedConfig1, storedConfig2}).Return(nil)
+			},
+			expectedErrorContains: []string{"original error"},
+		},
+		"success with existing exchanger configs - removes new config and rolls back to exchanger configs": {
+			storedConfigs: nil,
+			setupExistingExchanger: func(ctrl *gomock.Controller) m2m.TokenExchanger {
+				exchanger := mocks.NewMockTokenExchanger(ctrl)
+				exchanger.EXPECT().Configs().Return([]*storage.AuthMachineToMachineConfig{storedConfig1}).AnyTimes()
+				return exchanger
+			},
+			setupMocks: func(mockSet *mocks.MockTokenExchangerSet) {
+				mockSet.EXPECT().RemoveTokenExchanger(ctx, testConfig).Return(nil)
+				mockSet.EXPECT().RollbackExchanger(ctx, testIssuer, []*storage.AuthMachineToMachineConfig{storedConfig1}).Return(nil)
+			},
+			expectedErrorContains: []string{"original error"},
+		},
+		"no stored configs and no existing exchanger - only removes new config": {
+			storedConfigs:          nil,
+			setupExistingExchanger: nil,
+			setupMocks: func(mockSet *mocks.MockTokenExchangerSet) {
+				mockSet.EXPECT().RemoveTokenExchanger(ctx, testConfig).Return(nil)
+			},
+			expectedErrorContains: []string{"original error"},
+		},
+		"existing exchanger with empty configs - only removes new config": {
+			storedConfigs: nil,
+			setupExistingExchanger: func(ctrl *gomock.Controller) m2m.TokenExchanger {
+				exchanger := mocks.NewMockTokenExchanger(ctrl)
+				exchanger.EXPECT().Configs().Return([]*storage.AuthMachineToMachineConfig{}).AnyTimes()
+				return exchanger
+			},
+			setupMocks: func(mockSet *mocks.MockTokenExchangerSet) {
+				mockSet.EXPECT().RemoveTokenExchanger(ctx, testConfig).Return(nil)
+			},
+			expectedErrorContains: []string{"original error"},
+		},
+		"remove fails with stored configs - joins remove error with rollback result": {
+			storedConfigs: []*storage.AuthMachineToMachineConfig{storedConfig1},
+			setupMocks: func(mockSet *mocks.MockTokenExchangerSet) {
+				mockSet.EXPECT().RemoveTokenExchanger(ctx, testConfig).Return(removeErr)
+				mockSet.EXPECT().RollbackExchanger(ctx, testIssuer, []*storage.AuthMachineToMachineConfig{storedConfig1}).Return(nil)
+			},
+			expectedErrorContains: []string{"rolling back due to", "original error", "remove error"},
+		},
+		"rollback fails with stored configs - joins rollback error": {
+			storedConfigs: []*storage.AuthMachineToMachineConfig{storedConfig1},
+			setupMocks: func(mockSet *mocks.MockTokenExchangerSet) {
+				mockSet.EXPECT().RemoveTokenExchanger(ctx, testConfig).Return(nil)
+				mockSet.EXPECT().RollbackExchanger(ctx, testIssuer, []*storage.AuthMachineToMachineConfig{storedConfig1}).Return(rollbackErr)
+			},
+			expectedErrorContains: []string{"rolling back due to", "original error", "rollback error"},
+		},
+		"both remove and rollback fail - joins all errors": {
+			storedConfigs: []*storage.AuthMachineToMachineConfig{storedConfig1},
+			setupMocks: func(mockSet *mocks.MockTokenExchangerSet) {
+				mockSet.EXPECT().RemoveTokenExchanger(ctx, testConfig).Return(removeErr)
+				mockSet.EXPECT().RollbackExchanger(ctx, testIssuer, []*storage.AuthMachineToMachineConfig{storedConfig1}).Return(rollbackErr)
+			},
+			expectedErrorContains: []string{"rolling back due to", "original error", "remove error", "rollback error"},
+		},
+		"prioritizes stored configs over existing exchanger configs": {
+			storedConfigs: []*storage.AuthMachineToMachineConfig{storedConfig1},
+			setupExistingExchanger: func(ctrl *gomock.Controller) m2m.TokenExchanger {
+				exchanger := mocks.NewMockTokenExchanger(ctrl)
+				// Configs() should not be called since we have storedConfigs
+				return exchanger
+			},
+			setupMocks: func(mockSet *mocks.MockTokenExchangerSet) {
+				mockSet.EXPECT().RemoveTokenExchanger(ctx, testConfig).Return(nil)
+				mockSet.EXPECT().RollbackExchanger(ctx, testIssuer, []*storage.AuthMachineToMachineConfig{storedConfig1}).Return(nil)
+			},
+			expectedErrorContains: []string{"original error"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			var existingExchanger m2m.TokenExchanger
+			if tc.setupExistingExchanger != nil {
+				existingExchanger = tc.setupExistingExchanger(ctrl)
+			}
+
+			mockSet := mocks.NewMockTokenExchangerSet(ctrl)
+			tc.setupMocks(mockSet)
+
+			ds := &datastoreImpl{
+				set: mockSet,
+			}
+
+			err := ds.wrapRollBackSet(ctx, originalErr, testIssuer, tc.storedConfigs, testConfig, existingExchanger)
+
+			assert.Error(t, err)
+			for _, expectedStr := range tc.expectedErrorContains {
+				assert.Contains(t, err.Error(), expectedStr)
+			}
+		})
+	}
+}

--- a/central/auth/m2m/claim_extractor.go
+++ b/central/auth/m2m/claim_extractor.go
@@ -10,8 +10,8 @@ type claimExtractor interface {
 	ExtractClaims(idToken *IDToken) (map[string][]string, error)
 }
 
-func newClaimExtractorFromConfig(config *storage.AuthMachineToMachineConfig) claimExtractor {
-	switch config.GetType() {
+func newClaimExtractorForType(configType storage.AuthMachineToMachineConfig_Type) claimExtractor {
+	switch configType {
 	case storage.AuthMachineToMachineConfig_GITHUB_ACTIONS:
 		return &githubClaimExtractor{}
 	case storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT:

--- a/central/auth/m2m/claim_extractor_test.go
+++ b/central/auth/m2m/claim_extractor_test.go
@@ -8,15 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_newClaimExtractorFromConfig(t *testing.T) {
+func Test_newClaimExtractorForType(t *testing.T) {
 	testNotImplementedErr := errox.NotImplemented
 
 	t.Run("GitHub Actions", func(t *testing.T) {
-		e := newClaimExtractorFromConfig(&storage.AuthMachineToMachineConfig{
-			Id:     "id1",
-			Issuer: "test",
-			Type:   storage.AuthMachineToMachineConfig_GITHUB_ACTIONS,
-		})
+		e := newClaimExtractorForType(storage.AuthMachineToMachineConfig_GITHUB_ACTIONS)
 		_, err := e.ExtractClaims(&IDToken{
 			Claims: func(a any) error {
 				return testNotImplementedErr
@@ -42,10 +38,7 @@ func Test_newClaimExtractorFromConfig(t *testing.T) {
 	})
 
 	t.Run("Generic", func(t *testing.T) {
-		e := newClaimExtractorFromConfig(&storage.AuthMachineToMachineConfig{
-			Id:   "id1",
-			Type: storage.AuthMachineToMachineConfig_GENERIC,
-		})
+		e := newClaimExtractorForType(storage.AuthMachineToMachineConfig_GENERIC)
 		_, err := e.ExtractClaims(&IDToken{
 			Claims: func(a any) error {
 				return testNotImplementedErr

--- a/central/auth/m2m/exchanger.go
+++ b/central/auth/m2m/exchanger.go
@@ -13,25 +13,40 @@ import (
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/uuid"
 )
 
 var (
 	_ TokenExchanger = (*machineToMachineTokenExchanger)(nil)
 )
 
+const (
+	m2mIssuerNamespace = "machine-to-machine-issuer"
+)
+
+// mapping clones storage.AuthMachineToMachineConfig_Mapping with a compiled regexp.
+type mapping struct {
+	key             string
+	valueExpression string
+	role            string
+	expression      *regexp.Regexp
+}
+
 // TokenExchanger will exchange a raw ID token to a Rox token (i.e. a Central access token).
-// This will be done based on an auth machine to machine config.
+// This will be done based on one or more auth machine to machine configs.
 //
 //go:generate mockgen-wrapper
 type TokenExchanger interface {
 	ExchangeToken(ctx context.Context, rawIDToken string) (string, error)
 	Provider() authproviders.Provider
-	Config() *storage.AuthMachineToMachineConfig
+	Configs() []*storage.AuthMachineToMachineConfig
+	TokenTTL() time.Duration
 }
 
 type machineToMachineTokenExchanger struct {
-	config            *storage.AuthMachineToMachineConfig
-	configRegExps     []*regexp.Regexp
+	configs           []*storage.AuthMachineToMachineConfig
+	mappings          []*mapping
+	tokenTTL          time.Duration
 	verifier          tokenVerifier
 	provider          authproviders.Provider
 	issuer            tokens.Issuer
@@ -39,9 +54,20 @@ type machineToMachineTokenExchanger struct {
 	roxClaimExtractor claimExtractor
 }
 
-// newTokenExchanger creates a new token exchanger based on an auth machine to machine config.
-func newTokenExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig,
-	roleDS roleDataStore.DataStore, issuerFactory tokens.IssuerFactory) (TokenExchanger, error) {
+// newTokenExchanger creates a new token exchanger based on auth machine to machine configs.
+func newTokenExchanger(
+	ctx context.Context,
+	configs []*storage.AuthMachineToMachineConfig,
+	roleDS roleDataStore.DataStore,
+	issuerFactory tokens.IssuerFactory,
+) (TokenExchanger, error) {
+	// Use the first config for initialization (backward compatibility)
+	config := configs[0]
+	configType := config.GetType()
+	configTypeString := configType.String()
+	configIssuer := config.GetIssuer()
+	configID := uuid.NewV5FromNonUUIDs(m2mIssuerNamespace, configIssuer).String()
+
 	tokenTTL, err := time.ParseDuration(config.GetTokenExpirationDuration())
 	// Technically, this shouldn't happen, as the config is expected to be validated beforehand (i.e. when added to the
 	// data store).
@@ -49,22 +75,23 @@ func newTokenExchanger(ctx context.Context, config *storage.AuthMachineToMachine
 		return nil, errors.Wrap(err, "parsing token expiration duration")
 	}
 
-	configRegExps := createRegexp(config)
+	mappings := compileMappings(config.GetMappings())
 
-	verifier, err := tokenVerifierFromConfig(ctx, config)
+	verifier, err := tokenVerifierFromConfig(ctx, configType, configIssuer)
 	if err != nil {
 		return nil, err
 	}
-	provider := newProviderFromConfig(config, newRoleMapper(config, roleDS, configRegExps))
-	roxClaimExtractor := newClaimExtractorFromConfig(config)
+	provider := newProviderFromConfig(configID, configTypeString, newRoleMapper(roleDS, mappings))
+	roxClaimExtractor := newClaimExtractorForType(configType)
 	issuer, err := issuerFactory.CreateIssuer(provider, tokens.WithTTL(tokenTTL))
 	if err != nil {
 		return nil, errors.Wrap(err, "creating token issuer")
 	}
 
 	return &machineToMachineTokenExchanger{
-		config:            config,
-		configRegExps:     configRegExps,
+		configs:           configs,
+		mappings:          mappings,
+		tokenTTL:          tokenTTL,
 		issuer:            issuer,
 		verifier:          verifier,
 		provider:          provider,
@@ -83,7 +110,7 @@ func (m *machineToMachineTokenExchanger) ExchangeToken(ctx context.Context, rawI
 		return "", errox.NoCredentials.New("ID token is invalid").CausedBy(err)
 	}
 
-	log.Debugf("Successfully validated ID token (sub=%q) for config %q", idToken.Subject, m.config.GetId())
+	log.Debugf("Successfully validated ID token (sub=%q) for config %q", idToken.Subject, m.configs[0].GetId())
 
 	claims, err := m.roxClaimExtractor.ExtractClaims(idToken)
 	if err != nil {
@@ -96,7 +123,7 @@ func (m *machineToMachineTokenExchanger) ExchangeToken(ctx context.Context, rawI
 	// Additionally, since the context will have no access, elevate it locally to fetch roles.
 	resolveRolesCtx := sac.WithGlobalAccessScopeChecker(ctx, sac.AllowFixedScopes(
 		sac.AccessModeScopeKeys(storage.Access_READ_ACCESS), sac.ResourceScopeKeys(resources.Access)))
-	_, err = resolveRolesForClaims(resolveRolesCtx, claims, m.roleDS, m.config.GetMappings(), m.configRegExps)
+	_, err = resolveRolesForClaims(resolveRolesCtx, claims, m.roleDS, m.mappings)
 	if err != nil {
 		return "", errox.NoCredentials.New("resolving roles for id token").CausedBy(err)
 	}
@@ -116,17 +143,27 @@ func (m *machineToMachineTokenExchanger) ExchangeToken(ctx context.Context, rawI
 	return tokenInfo.Token, nil
 }
 
-func (m *machineToMachineTokenExchanger) Config() *storage.AuthMachineToMachineConfig {
-	return m.config
+func (m *machineToMachineTokenExchanger) Configs() []*storage.AuthMachineToMachineConfig {
+	return m.configs
 }
 
-func createRegexp(config *storage.AuthMachineToMachineConfig) []*regexp.Regexp {
-	regExps := make([]*regexp.Regexp, 0, len(config.GetMappings()))
+func (m *machineToMachineTokenExchanger) TokenTTL() time.Duration {
+	return m.tokenTTL
+}
 
-	for _, mapping := range config.GetMappings() {
+// compileMappings converts storage mappings to internal mappings with compiled regexps.
+func compileMappings(storageMappings []*storage.AuthMachineToMachineConfig_Mapping) []*mapping {
+	mappings := make([]*mapping, 0, len(storageMappings))
+
+	for _, m := range storageMappings {
 		// The mapping value is validated on insert / update to contain a valid regexp, thus we can use MustCompile here.
-		regExps = append(regExps, regexp.MustCompile(mapping.GetValueExpression()))
+		mappings = append(mappings, &mapping{
+			key:             m.GetKey(),
+			valueExpression: m.GetValueExpression(),
+			role:            m.GetRole(),
+			expression:      regexp.MustCompile(m.GetValueExpression()),
+		})
 	}
 
-	return regExps
+	return mappings
 }

--- a/central/auth/m2m/kube_claim_extractor_test.go
+++ b/central/auth/m2m/kube_claim_extractor_test.go
@@ -11,10 +11,7 @@ import (
 func Test_kubeClaimExtractor(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 
-		e := newClaimExtractorFromConfig(&storage.AuthMachineToMachineConfig{
-			Id:   "id1",
-			Type: storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT,
-		})
+		e := newClaimExtractorForType(storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT)
 
 		claims, err := e.ExtractClaims(&IDToken{
 			Claims: func(v any) error {
@@ -50,10 +47,7 @@ func Test_kubeClaimExtractor(t *testing.T) {
 	})
 
 	t.Run("Kubernetes Token error", func(t *testing.T) {
-		e := newClaimExtractorFromConfig(&storage.AuthMachineToMachineConfig{
-			Id:   "id1",
-			Type: storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT,
-		})
+		e := newClaimExtractorForType(storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT)
 		testErr := errox.NotImplemented
 		_, err := e.ExtractClaims(&IDToken{
 			Claims: func(a any) error {

--- a/central/auth/m2m/mocks/exchanger.go
+++ b/central/auth/m2m/mocks/exchanger.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	storage "github.com/stackrox/rox/generated/storage"
 	authproviders "github.com/stackrox/rox/pkg/auth/authproviders"
@@ -42,18 +43,18 @@ func (m *MockTokenExchanger) EXPECT() *MockTokenExchangerMockRecorder {
 	return m.recorder
 }
 
-// Config mocks base method.
-func (m *MockTokenExchanger) Config() *storage.AuthMachineToMachineConfig {
+// Configs mocks base method.
+func (m *MockTokenExchanger) Configs() []*storage.AuthMachineToMachineConfig {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Config")
-	ret0, _ := ret[0].(*storage.AuthMachineToMachineConfig)
+	ret := m.ctrl.Call(m, "Configs")
+	ret0, _ := ret[0].([]*storage.AuthMachineToMachineConfig)
 	return ret0
 }
 
-// Config indicates an expected call of Config.
-func (mr *MockTokenExchangerMockRecorder) Config() *gomock.Call {
+// Configs indicates an expected call of Configs.
+func (mr *MockTokenExchangerMockRecorder) Configs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockTokenExchanger)(nil).Config))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Configs", reflect.TypeOf((*MockTokenExchanger)(nil).Configs))
 }
 
 // ExchangeToken mocks base method.
@@ -83,4 +84,18 @@ func (m *MockTokenExchanger) Provider() authproviders.Provider {
 func (mr *MockTokenExchangerMockRecorder) Provider() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Provider", reflect.TypeOf((*MockTokenExchanger)(nil).Provider))
+}
+
+// TokenTTL mocks base method.
+func (m *MockTokenExchanger) TokenTTL() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TokenTTL")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// TokenTTL indicates an expected call of TokenTTL.
+func (mr *MockTokenExchangerMockRecorder) TokenTTL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TokenTTL", reflect.TypeOf((*MockTokenExchanger)(nil).TokenTTL))
 }

--- a/central/auth/m2m/mocks/set.go
+++ b/central/auth/m2m/mocks/set.go
@@ -72,31 +72,31 @@ func (mr *MockTokenExchangerSetMockRecorder) HasExchangersConfigured() *gomock.C
 }
 
 // RemoveTokenExchanger mocks base method.
-func (m *MockTokenExchangerSet) RemoveTokenExchanger(issuer string) error {
+func (m *MockTokenExchangerSet) RemoveTokenExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveTokenExchanger", issuer)
+	ret := m.ctrl.Call(m, "RemoveTokenExchanger", ctx, config)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveTokenExchanger indicates an expected call of RemoveTokenExchanger.
-func (mr *MockTokenExchangerSetMockRecorder) RemoveTokenExchanger(issuer any) *gomock.Call {
+func (mr *MockTokenExchangerSetMockRecorder) RemoveTokenExchanger(ctx, config any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTokenExchanger", reflect.TypeOf((*MockTokenExchangerSet)(nil).RemoveTokenExchanger), issuer)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTokenExchanger", reflect.TypeOf((*MockTokenExchangerSet)(nil).RemoveTokenExchanger), ctx, config)
 }
 
 // RollbackExchanger mocks base method.
-func (m *MockTokenExchangerSet) RollbackExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error {
+func (m *MockTokenExchangerSet) RollbackExchanger(ctx context.Context, issuer string, configs []*storage.AuthMachineToMachineConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RollbackExchanger", ctx, config)
+	ret := m.ctrl.Call(m, "RollbackExchanger", ctx, issuer, configs)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RollbackExchanger indicates an expected call of RollbackExchanger.
-func (mr *MockTokenExchangerSetMockRecorder) RollbackExchanger(ctx, config any) *gomock.Call {
+func (mr *MockTokenExchangerSetMockRecorder) RollbackExchanger(ctx, issuer, configs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollbackExchanger", reflect.TypeOf((*MockTokenExchangerSet)(nil).RollbackExchanger), ctx, config)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollbackExchanger", reflect.TypeOf((*MockTokenExchangerSet)(nil).RollbackExchanger), ctx, issuer, configs)
 }
 
 // UpsertTokenExchanger mocks base method.

--- a/central/auth/m2m/provider.go
+++ b/central/auth/m2m/provider.go
@@ -3,7 +3,6 @@ package m2m
 import (
 	"fmt"
 
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
 	"github.com/stackrox/rox/pkg/auth/authproviders/tokenbased"
 	"github.com/stackrox/rox/pkg/auth/permissions"
@@ -11,11 +10,11 @@ import (
 
 // newProviderFromConfig returns a provider that can be used to extract tokens issued based on machine to machine
 // configs.
-func newProviderFromConfig(config *storage.AuthMachineToMachineConfig, rm permissions.RoleMapper) authproviders.Provider {
+func newProviderFromConfig(configID string, configType string, rm permissions.RoleMapper) authproviders.Provider {
 	return tokenbased.NewTokenAuthProvider(
-		config.GetId(),
-		fmt.Sprintf("%s-%s", config.GetType().String(), config.GetId()),
-		config.GetType().String(),
+		configID,
+		fmt.Sprintf("%s-%s", configType, configID),
+		configType,
 		tokenbased.WithRoleMapper(rm),
 	)
 }

--- a/central/auth/m2m/provider_test.go
+++ b/central/auth/m2m/provider_test.go
@@ -14,16 +14,13 @@ import (
 func TestNewProvider(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	cfgId := uuid.NewTestUUID(1).String()
-	config := &storage.AuthMachineToMachineConfig{
-		Id:   cfgId,
-		Type: storage.AuthMachineToMachineConfig_GENERIC,
-	}
+	configType := storage.AuthMachineToMachineConfig_GENERIC
 	mockRoleMapper := permissionsMocks.NewMockRoleMapper(mockCtrl)
-	provider := newProviderFromConfig(config, mockRoleMapper)
+	provider := newProviderFromConfig(cfgId, configType.String(), mockRoleMapper)
 	assert.NotNil(t, provider)
 	assert.Equal(t, cfgId, provider.ID())
-	providerName := fmt.Sprintf("%s-%s", storage.AuthMachineToMachineConfig_GENERIC.String(), cfgId)
+	providerName := fmt.Sprintf("%s-%s", configType.String(), cfgId)
 	assert.Equal(t, providerName, provider.Name())
-	assert.Equal(t, storage.AuthMachineToMachineConfig_GENERIC.String(), provider.Type())
+	assert.Equal(t, configType.String(), provider.Type())
 	assert.Equal(t, mockRoleMapper, provider.RoleMapper())
 }

--- a/central/auth/m2m/role_mapper.go
+++ b/central/auth/m2m/role_mapper.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 	roleDataStore "github.com/stackrox/rox/central/role/datastore"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth"
 	"github.com/stackrox/rox/pkg/auth/permissions"
 	"github.com/stackrox/rox/pkg/grpc/authn"
@@ -21,31 +20,28 @@ var (
 )
 
 type roleMapper struct {
-	config        *storage.AuthMachineToMachineConfig
-	configRegexps []*regexp.Regexp
-	roleDS        roleDataStore.DataStore
+	mappings []*mapping
+	roleDS   roleDataStore.DataStore
 }
 
-func newRoleMapper(config *storage.AuthMachineToMachineConfig, roleDS roleDataStore.DataStore,
-	configRegExps []*regexp.Regexp) *roleMapper {
+func newRoleMapper(roleDS roleDataStore.DataStore, mappings []*mapping) *roleMapper {
 	return &roleMapper{
-		config:        config,
-		configRegexps: configRegExps,
-		roleDS:        roleDS,
+		mappings: mappings,
+		roleDS:   roleDS,
 	}
 }
 
 func (r *roleMapper) FromUserDescriptor(ctx context.Context, user *permissions.UserDescriptor) ([]permissions.ResolvedRole, error) {
-	return resolveRolesForClaims(ctx, user.Attributes, r.roleDS, r.config.GetMappings(), r.configRegexps)
+	return resolveRolesForClaims(ctx, user.Attributes, r.roleDS, r.mappings)
 }
 
 func resolveRolesForClaims(ctx context.Context, claims map[string][]string, roleDS roleDataStore.DataStore,
-	mappings []*storage.AuthMachineToMachineConfig_Mapping, expressions []*regexp.Regexp) ([]permissions.ResolvedRole, error) {
+	mappings []*mapping) ([]permissions.ResolvedRole, error) {
 	rolesForUser := set.NewStringSet()
 
-	for i, mapping := range mappings {
-		if valuesMatch(expressions[i], claims[mapping.GetKey()]) {
-			rolesForUser.Add(mapping.GetRole())
+	for _, mapping := range mappings {
+		if valuesMatch(mapping.expression, claims[mapping.key]) {
+			rolesForUser.Add(mapping.role)
 		}
 	}
 

--- a/central/auth/m2m/role_mapper_test.go
+++ b/central/auth/m2m/role_mapper_test.go
@@ -80,7 +80,7 @@ func TestResolveRolesForClaims(t *testing.T) {
 		roleDSMock.EXPECT().GetAndResolveRole(gomock.Any(), roleName).Return(resolvedRole, nil)
 	}
 
-	resolvedRoles, err := resolveRolesForClaims(context.Background(), claims, roleDSMock, config.GetMappings(), createRegexp(config))
+	resolvedRoles, err := resolveRolesForClaims(context.Background(), claims, roleDSMock, compileMappings(config.GetMappings()))
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, resolvedRoles, []permissions.ResolvedRole{roles["Admin"], roles["Analyst"], roles["roxctl"]})
 }
@@ -108,7 +108,7 @@ func TestResolveRolesForClaimsList(t *testing.T) {
 		roleDSMock.EXPECT().GetAndResolveRole(gomock.Any(), roleName).Return(resolvedRole, nil)
 	}
 
-	resolvedRoles, err := resolveRolesForClaims(context.Background(), claims, roleDSMock, config.GetMappings(), createRegexp(config))
+	resolvedRoles, err := resolveRolesForClaims(context.Background(), claims, roleDSMock, compileMappings(config.GetMappings()))
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, resolvedRoles, []permissions.ResolvedRole{roles["Analyst"]})
 }

--- a/central/auth/m2m/set.go
+++ b/central/auth/m2m/set.go
@@ -24,14 +24,14 @@ var (
 //go:generate mockgen-wrapper
 type TokenExchangerSet interface {
 	UpsertTokenExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error
-	RemoveTokenExchanger(issuer string) error
+	RemoveTokenExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error
 	GetTokenExchanger(issuer string) (TokenExchanger, bool)
-	RollbackExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error
+	RollbackExchanger(ctx context.Context, issuer string, configs []*storage.AuthMachineToMachineConfig) error
 	HasExchangersConfigured() bool
 }
 
 // TokenExchangerFactory factory for creating a new token exchanger.
-type TokenExchangerFactory = func(ctx context.Context, config *storage.AuthMachineToMachineConfig, roleDS roleDataStore.DataStore, issuerFactory tokens.IssuerFactory) (TokenExchanger, error)
+type TokenExchangerFactory = func(ctx context.Context, configs []*storage.AuthMachineToMachineConfig, roleDS roleDataStore.DataStore, issuerFactory tokens.IssuerFactory) (TokenExchanger, error)
 
 // TokenExchangerSetSingleton creates a singleton holding all token exchangers for auth machine to machine configs.
 func TokenExchangerSetSingleton(roleDS roleDataStore.DataStore, issuerFactory tokens.IssuerFactory) TokenExchangerSet {
@@ -70,26 +70,49 @@ type tokenExchangerSet struct {
 // to retrieve additional metadata for token validation (i.e. JWKS metadata).
 // In case a token exchanger already exists for the given config, it will be replaced.
 func (t *tokenExchangerSet) UpsertTokenExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error {
+	configs := []*storage.AuthMachineToMachineConfig{config}
 	exchanger, exists := t.tokenExchangers[config.GetIssuer()]
+	if exists {
+		for _, exchangerConfig := range exchanger.Configs() {
+			if exchangerConfig.GetId() != config.GetId() {
+				configs = append(configs, exchangerConfig)
+			}
+		}
+	}
+	return t.upsertTokenExchanger(ctx, config.GetIssuer(), config.GetType(), configs)
+}
+
+// upsertTokenExchanger upserts a token exchanger based from the given configurations.
+// It will make sure the TokenExchanger is registered as a tokens.Source.
+// Note that during creation of the TokenExchanger, an external HTTP request is done to the OIDC issuer
+// to retrieve additional metadata for token validation (i.e. JWKS metadata).
+// In case a token exchanger already exists for the given config, it will be replaced.
+func (t *tokenExchangerSet) upsertTokenExchanger(
+	ctx context.Context,
+	issuer string,
+	configType storage.AuthMachineToMachineConfig_Type,
+	configs []*storage.AuthMachineToMachineConfig,
+) error {
+	exchanger, exists := t.tokenExchangers[issuer]
 	if exists {
 		// Need to unregister the source temporarily, otherwise we receive an error on creation that the
 		// source is already registered.
 		if err := t.issuerFactory.UnregisterSource(exchanger.Provider()); err != nil {
-			return pkgErrors.Wrapf(err, "unregistering source for config %s", config.GetId())
+			return pkgErrors.Wrapf(err, "unregistering source for config issuer %s", issuer)
 		}
 	}
 
-	tokenExchanger, err := t.tokenExchangerFactory(ctx, config, t.roleDS, t.issuerFactory)
+	tokenExchanger, err := t.tokenExchangerFactory(ctx, configs, t.roleDS, t.issuerFactory)
 	if err != nil {
-		return pkgErrors.Wrapf(err, "creating token exchanger for config %s", config.GetId())
+		return pkgErrors.Wrapf(err, "creating token exchanger for config issuer %s", issuer)
 	}
 
-	if config.GetType() == storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT {
+	if configType == storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT {
 		if serviceAccountIssuer, _ := GetKubernetesIssuer(); serviceAccountIssuer != "" {
 			t.tokenExchangers[serviceAccountIssuer] = tokenExchanger
 		}
 	}
-	t.tokenExchangers[config.GetIssuer()] = tokenExchanger
+	t.tokenExchangers[issuer] = tokenExchanger
 	return nil
 }
 
@@ -102,10 +125,31 @@ func (t *tokenExchangerSet) GetTokenExchanger(issuer string) (TokenExchanger, bo
 	return nil, false
 }
 
-// RemoveTokenExchanger removes the token exchanger for the specific configuration ID.
-// In case no config with the specific ID exists, nil will be returned.
-func (t *tokenExchangerSet) RemoveTokenExchanger(id string) error {
-	exchanger, exists := t.tokenExchangers[id]
+// RemoveTokenExchanger removes the token exchanger for the specific configuration.
+// In case no config with the specific issuer exists, nil will be returned.
+func (t *tokenExchangerSet) RemoveTokenExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error {
+	issuer := config.GetIssuer()
+	var filteredExchangerConfigs []*storage.AuthMachineToMachineConfig
+	var configType storage.AuthMachineToMachineConfig_Type
+	if exchanger, exists := t.tokenExchangers[issuer]; exists {
+		exchangerConfigs := exchanger.Configs()
+		for _, exchangerConfig := range exchangerConfigs {
+			if config.GetId() != exchangerConfig.GetId() {
+				configType = exchangerConfig.GetType()
+				filteredExchangerConfigs = append(filteredExchangerConfigs, exchangerConfig)
+			}
+		}
+	}
+	if len(filteredExchangerConfigs) == 0 {
+		return t.removeTokenExchanger(issuer)
+	}
+	return t.upsertTokenExchanger(ctx, issuer, configType, filteredExchangerConfigs)
+}
+
+// removeTokenExchanger removes the token exchanger for the specific issuer.
+// In case no config with the specific issuer exists, nil will be returned.
+func (t *tokenExchangerSet) removeTokenExchanger(issuer string) error {
+	exchanger, exists := t.tokenExchangers[issuer]
 	if !exists {
 		return nil
 	}
@@ -113,28 +157,34 @@ func (t *tokenExchangerSet) RemoveTokenExchanger(id string) error {
 	// We need to unregister the source with the issuer factory.
 	// This will lead to all tokens issued by the previous token exchanger to be rejected by Central.
 	if err := t.issuerFactory.UnregisterSource(exchanger.Provider()); err != nil {
-		log.Warnf("Unregistering source for config %s failed: %v", id, err)
+		log.Warnf("Unregistering source for config %s failed: %v", issuer, err)
 		return nil
 	}
 
-	delete(t.tokenExchangers, id)
+	delete(t.tokenExchangers, issuer)
 	return nil
 }
 
 // RollbackExchanger is used to roll back any changes made to an existing exchanger.
 // In particular, it will ensure that the source is correctly registered.
-func (t *tokenExchangerSet) RollbackExchanger(ctx context.Context, config *storage.AuthMachineToMachineConfig) error {
+func (t *tokenExchangerSet) RollbackExchanger(
+	ctx context.Context,
+	issuer string,
+	configs []*storage.AuthMachineToMachineConfig,
+) error {
 	// In case the config does not exist anymore, re-create it.
-	_, exists := t.tokenExchangers[config.GetIssuer()]
-	if !exists {
-		return t.UpsertTokenExchanger(ctx, config)
+	_, exists := t.tokenExchangers[issuer]
+	if exists {
+		if err := t.removeTokenExchanger(issuer); err != nil {
+			return err
+		}
 	}
-
-	// In case the config still exists, we remove and re-create it to ensure we have the correct state in our set.
-	if err := t.RemoveTokenExchanger(config.GetIssuer()); err != nil {
-		return err
+	var configType storage.AuthMachineToMachineConfig_Type
+	for _, config := range configs {
+		configType = config.GetType()
+		break
 	}
-	return t.UpsertTokenExchanger(ctx, config)
+	return t.upsertTokenExchanger(ctx, issuer, configType, configs)
 }
 
 // HasExchangersConfigured returns true if there is at least one configured

--- a/central/auth/m2m/token_verifier.go
+++ b/central/auth/m2m/token_verifier.go
@@ -21,23 +21,23 @@ type tokenVerifier interface {
 	VerifyIDToken(ctx context.Context, rawIDToken string) (*IDToken, error)
 }
 
-func tokenVerifierFromConfig(ctx context.Context, config *storage.AuthMachineToMachineConfig) (tokenVerifier, error) {
+func tokenVerifierFromConfig(ctx context.Context, configType storage.AuthMachineToMachineConfig_Type, issuer string) (tokenVerifier, error) {
 	tlsConfig, err := tlsConfigWithCustomCertPool()
 	if err != nil {
 		return nil, errors.Wrap(err, "creating TLS config for token verification")
 	}
 	roundTripper := proxy.RoundTripper(proxy.WithTLSConfig(tlsConfig))
-	if config.GetType() == storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT {
+	if configType == storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT {
 		// By default k8s requires authentication to fetch the OIDC resources for service account tokens
 		// https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery
 		roundTripper = &authenticatedRoundTripper{roundTripper, readK8sSAToken}
 	}
 	provider, err := oidc.NewProvider(
 		oidc.ClientContext(ctx, &http.Client{Timeout: time.Minute, Transport: roundTripper}),
-		config.GetIssuer(),
+		issuer,
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating OIDC provider for issuer %q", config.GetIssuer())
+		return nil, errors.Wrapf(err, "creating OIDC provider for issuer %q", issuer)
 	}
 
 	return &genericTokenVerifier{provider: provider}, nil

--- a/central/auth/service/service_impl_test.go
+++ b/central/auth/service/service_impl_test.go
@@ -748,7 +748,8 @@ func (s *authServiceAccessControlTestSuite) TestUpdateRollback() {
 	})
 	s.Require().NoError(err)
 
-	s.mockTokenExchanger.EXPECT().Config().Return(v1tostorage.AuthM2MConfig(newConfig)).Times(2)
+	expectedConfigs := []*storage.AuthMachineToMachineConfig{v1tostorage.AuthM2MConfig(newConfig)}
+	s.mockTokenExchanger.EXPECT().Configs().Return(expectedConfigs).Times(2)
 
 	// No error during rollback.
 	gomock.InOrder(
@@ -768,7 +769,7 @@ func (s *authServiceAccessControlTestSuite) TestUpdateRollback() {
 	})
 	s.Error(err)
 	s.NotContains(err.Error(), "rollback")
-	protoassert.Equal(s.T(), v1tostorage.AuthM2MConfig(newConfig), s.mockExchangerFactory.currentExchangerConfig)
+	protoassert.SlicesEqual(s.T(), expectedConfigs, s.mockExchangerFactory.currentExchangerConfigs)
 }
 
 func (s *authServiceAccessControlTestSuite) addRoles() {
@@ -804,13 +805,13 @@ func (s *authServiceAccessControlTestSuite) addRoles() {
 // Mocks used within tests.
 
 type mockExchangerFactory struct {
-	currentExchangerConfig *storage.AuthMachineToMachineConfig
-	mockExchanger          *mocks.MockTokenExchanger
+	currentExchangerConfigs []*storage.AuthMachineToMachineConfig
+	mockExchanger           *mocks.MockTokenExchanger
 }
 
 func (m *mockExchangerFactory) factory() m2m.TokenExchangerFactory {
-	return func(_ context.Context, config *storage.AuthMachineToMachineConfig, _ roleDataStore.DataStore, _ tokens.IssuerFactory) (m2m.TokenExchanger, error) {
-		m.currentExchangerConfig = config
+	return func(_ context.Context, configs []*storage.AuthMachineToMachineConfig, _ roleDataStore.DataStore, _ tokens.IssuerFactory) (m2m.TokenExchanger, error) {
+		m.currentExchangerConfigs = configs
 		return m.mockExchanger, nil
 	}
 }

--- a/central/declarativeconfig/updater/auth_machine_to_machine_updater_test.go
+++ b/central/declarativeconfig/updater/auth_machine_to_machine_updater_test.go
@@ -60,7 +60,7 @@ func (s *authMachineToMachineTestSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
 	mockSet := mocks.NewMockTokenExchangerSet(s.mockCtrl)
 	mockSet.EXPECT().UpsertTokenExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	mockSet.EXPECT().RemoveTokenExchanger(gomock.Any()).Return(nil).AnyTimes()
+	mockSet.EXPECT().RemoveTokenExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockSet.EXPECT().GetTokenExchanger(gomock.Any()).Return(nil, true).AnyTimes()
 	mockSet.EXPECT().RollbackExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 

--- a/central/declarativeconfig/updater/auth_machine_to_machine_updater_test.go
+++ b/central/declarativeconfig/updater/auth_machine_to_machine_updater_test.go
@@ -62,7 +62,7 @@ func (s *authMachineToMachineTestSuite) SetupTest() {
 	mockSet.EXPECT().UpsertTokenExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockSet.EXPECT().RemoveTokenExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockSet.EXPECT().GetTokenExchanger(gomock.Any()).Return(nil, true).AnyTimes()
-	mockSet.EXPECT().RollbackExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockSet.EXPECT().RollbackExchanger(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	s.db = pgtest.ForT(s.T())
 	s.roleDS = roleDataStore.GetTestPostgresDataStore(s.T(), s.db)
@@ -262,9 +262,9 @@ func (s *authMachineToMachineMockedTestSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
 	mockSet := mocks.NewMockTokenExchangerSet(s.mockCtrl)
 	mockSet.EXPECT().UpsertTokenExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	mockSet.EXPECT().RemoveTokenExchanger(gomock.Any()).Return(nil).AnyTimes()
+	mockSet.EXPECT().RemoveTokenExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockSet.EXPECT().GetTokenExchanger(gomock.Any()).Return(nil, true).AnyTimes()
-	mockSet.EXPECT().RollbackExchanger(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockSet.EXPECT().RollbackExchanger(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	s.roleDS = roleDataStoreMocks.NewMockDataStore(s.mockCtrl)
 	s.m2mConfigDS = m2mDataStoreMocks.NewMockDataStore(s.mockCtrl)

--- a/central/jwt/jwt.go
+++ b/central/jwt/jwt.go
@@ -102,14 +102,13 @@ func (v *m2mValidator) exchange(ctx context.Context, iss string, token string) (
 
 	cache, found := v.exchangedTokensCache[iss]
 	if !found {
-		if tokenTTL, err := time.ParseDuration(exchanger.Config().GetTokenExpirationDuration()); err == nil {
-			// TTL for the cached token should be less than the token TTL so that
-			// the cache doen't return expired tokens. Let's not cache tokens with
-			// TTL less than a 1 minute margin.
-			const margin = time.Minute
-			if tokenTTL > margin {
-				cache = expiringcache.NewExpiringCache[string, string](tokenTTL - margin)
-			}
+		tokenTTL := exchanger.TokenTTL()
+		// TTL for the cached token should be less than the token TTL so that
+		// the cache doen't return expired tokens. Let's not cache tokens with
+		// TTL less than a 1 minute margin.
+		const margin = time.Minute
+		if tokenTTL > margin {
+			cache = expiringcache.NewExpiringCache[string, string](tokenTTL - margin)
 		}
 		v.exchangedTokensCache[iss] = cache
 	}

--- a/central/jwt/jwt_test.go
+++ b/central/jwt/jwt_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/auth/m2m/mocks"
@@ -63,9 +64,10 @@ func TestM2MValidator(t *testing.T) {
 			},
 			setupExchangerSet: func(mes *mocks.MockTokenExchangerSet) {
 				mockExchanger := mocks.NewMockTokenExchanger(mockCtrl)
-				mockExchanger.EXPECT().Config().Times(1).Return(&storage.AuthMachineToMachineConfig{
+				mockExchanger.EXPECT().TokenTTL().Times(1).Return(time.Second)
+				mockExchanger.EXPECT().Configs().Times(1).Return([]*storage.AuthMachineToMachineConfig{&storage.AuthMachineToMachineConfig{
 					TokenExpirationDuration: "1h",
-				})
+				}})
 				mockExchanger.EXPECT().ExchangeToken(gomock.Any(), tokenWithIssuer("other-issuer")).
 					Return("exchanged-token", nil)
 				mes.EXPECT().GetTokenExchanger("other-issuer").
@@ -85,9 +87,10 @@ func TestM2MValidator(t *testing.T) {
 			token: tokenWithIssuer("failing-issuer"),
 			setupExchangerSet: func(mes *mocks.MockTokenExchangerSet) {
 				mockExchanger := mocks.NewMockTokenExchanger(mockCtrl)
-				mockExchanger.EXPECT().Config().Times(1).Return(&storage.AuthMachineToMachineConfig{
+				mockExchanger.EXPECT().TokenTTL().Times(1).Return(time.Second)
+				mockExchanger.EXPECT().Configs().Times(1).Return([]*storage.AuthMachineToMachineConfig{&storage.AuthMachineToMachineConfig{
 					TokenExpirationDuration: "1h",
-				})
+				}})
 				mockExchanger.EXPECT().ExchangeToken(gomock.Any(), tokenWithIssuer("failing-issuer")).
 					Return("", errTest)
 				mes.EXPECT().GetTokenExchanger("failing-issuer").
@@ -143,10 +146,11 @@ func TestTokenCache(t *testing.T) {
 
 	t.Run("1h expiration", func(t *testing.T) {
 		mockExchanger := mocks.NewMockTokenExchanger(mockCtrl)
-		mockExchanger.EXPECT().Config().Times(1).
-			Return(&storage.AuthMachineToMachineConfig{
+		mockExchanger.EXPECT().TokenTTL().Times(1).Return(time.Second)
+		mockExchanger.EXPECT().Configs().Times(1).
+			Return([]*storage.AuthMachineToMachineConfig{&storage.AuthMachineToMachineConfig{
 				TokenExpirationDuration: "1h",
-			})
+			}})
 
 		mes.EXPECT().GetTokenExchanger("1h-issuer").
 			Times(2).
@@ -168,10 +172,11 @@ func TestTokenCache(t *testing.T) {
 
 	t.Run("1m expiration", func(t *testing.T) {
 		mockExchanger := mocks.NewMockTokenExchanger(mockCtrl)
-		mockExchanger.EXPECT().Config().Times(1).
-			Return(&storage.AuthMachineToMachineConfig{
+		mockExchanger.EXPECT().TokenTTL().Times(1).Return(time.Second)
+		mockExchanger.EXPECT().Configs().Times(1).
+			Return([]*storage.AuthMachineToMachineConfig{&storage.AuthMachineToMachineConfig{
 				TokenExpirationDuration: "1m",
-			})
+			}})
 
 		mes.EXPECT().GetTokenExchanger("1m-issuer").
 			Times(2).


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

There is a conflict between the M2M configuration the system creates for the RHACS config-controller and the extension of declarative configuration to M2M config. The former creates a configuration for the Kubernetes issuer, which prevents the declarative configuration of M2M for that issuer.

This change changes the way the issuer is stored in DB in order to allow one configuration per issuer and per (traits) origin.

The change impacts:
- the auth datastore layer, which performs a conversion on the stored object. The issuer value pushed to database is the concatenation of the traits origin and the configured issuer.
- the token exchanger set, which is the in-memory representation of the M2M configurations for the referenced issuers
- the way these layers interact

The stored token exchanger objects in the TokenExchangerSet now aggregate of the existing M2M configurations into a single TokenExchanger object. Changes to any M2M config now trigger the re-creation of the exchanger(s) impacted by the change.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
