### PR TITLE
fix(compliance): prevent intermittent deletion of check results

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -370,11 +370,7 @@ func (m *managerImpl) HandleScan(sensorCtx context.Context, scan *storage.Compli
 		}
 		return err
 	}
-	numChecks, err := watcher.GetExpectedNumChecks(scan)
-	if err != nil {
-		log.Warnf("Failed to get expected number of checks from annotations for %s: %v", scan.GetScanName(), err)
-	}
-	w := m.getWatcher(sensorCtx, id, numChecks)
+	w := m.getWatcher(sensorCtx, id)
 	if w != nil {
 		return w.PushScan(scan)
 	}
@@ -428,16 +424,11 @@ func (m *managerImpl) HandleScanRemove(scanID string) error {
 	return nil
 }
 
-func (m *managerImpl) getWatcher(sensorCtx context.Context, id string, numChecks int) watcher.ScanWatcher {
+func (m *managerImpl) getWatcher(sensorCtx context.Context, id string) watcher.ScanWatcher {
 	var scanWatcher watcher.ScanWatcher
 	concurrency.WithLock(&m.watchingScansLock, func() {
 		var found bool
-		// The check for `numChecks == 0` is here to prevent starting a watcher twice per scan.
-		// It may happen that additional status updates (e.g., state) from CO arrive
-		// after the watcher is removed from the watchingScans (i.e., we have all the checks).
-		// Not checking that would cause a new watcher to be created here and in some circumstances
-		// (when no e-mail is provided for notification), the watcher would time-out and delete the data from DB.
-		if scanWatcher, found = m.watchingScans[id]; !found && numChecks == 0 {
+		if scanWatcher, found = m.watchingScans[id]; !found {
 			scanWatcher = watcher.NewScanWatcher(m.automaticReportingCtx, sensorCtx, id, m.readyQueue)
 			m.watchingScans[id] = scanWatcher
 			m.watchingScansStartTime[id] = time.Now()
@@ -468,7 +459,7 @@ func (m *managerImpl) HandleResult(sensorCtx context.Context, result *storage.Co
 		}
 		return err
 	}
-	w := m.getWatcher(sensorCtx, id, 0)
+	w := m.getWatcher(sensorCtx, id)
 	if w != nil {
 		return w.PushCheckResult(result)
 	}

--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -636,7 +636,7 @@ func (m *ManagerTestSuite) setupExpectCallsFromFailAllScans(sc *storage.Complian
 				GetScanConfigurationByName(gomock.Any(), gomock.Eq(sc.GetScanConfigName())).
 				Times(1).Return(sc, nil),
 			m.checkResultDataStore.EXPECT().
-				DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(true)).
+				DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(false)).
 				Times(1).Return(nil),
 			m.snapshotDataStore.EXPECT().
 				UpsertSnapshot(gomock.Any(), gomock.Any()).

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
@@ -66,8 +66,7 @@ func DeleteOldResults(ctx context.Context, results *ScanWatcherResults, store re
 	if results == nil {
 		return errors.New("unable to delete old CheckResults from an nil ScanWatcherResults")
 	}
-	// If the scan failed we remove old and current results
-	includeCurrentResults := results.Error != nil
+	includeCurrentResults := errors.Is(results.Error, ErrScanRemoved)
 	scan := results.Scan
 	return store.DeleteOldResults(ctx, scan.GetLastStartedTime(), scan.GetScanRefId(), includeCurrentResults)
 }

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher_test.go
@@ -491,18 +491,46 @@ func TestDeleteOldResults(t *testing.T) {
 	t.Run("nil results should return an error", func(tt *testing.T) {
 		assert.Error(tt, DeleteOldResults(context.Background(), nil, ds))
 	})
-	t.Run("results with error should also delete current CheckResults", func(tt *testing.T) {
+	t.Run("results with ErrScanRemoved should delete current CheckResults", func(tt *testing.T) {
 		results := &ScanWatcherResults{
 			Scan: &storage.ComplianceOperatorScanV2{
 				ScanRefId:       "ref-id",
 				LastStartedTime: timeNow,
 			},
-			Error: errors.New("some error"),
+			Error: ErrScanRemoved,
 		}
 		ds.EXPECT().DeleteOldResults(gomock.Any(),
 			gomock.Eq(results.Scan.GetLastStartedTime()),
 			gomock.Eq(results.Scan.GetScanRefId()),
 			gomock.Eq(true)).Times(1).Return(nil)
+		assert.NoError(tt, DeleteOldResults(context.Background(), results, ds))
+	})
+	t.Run("results with ErrScanTimeout should not delete current CheckResults", func(tt *testing.T) {
+		results := &ScanWatcherResults{
+			Scan: &storage.ComplianceOperatorScanV2{
+				ScanRefId:       "ref-id",
+				LastStartedTime: timeNow,
+			},
+			Error: ErrScanTimeout,
+		}
+		ds.EXPECT().DeleteOldResults(gomock.Any(),
+			gomock.Eq(results.Scan.GetLastStartedTime()),
+			gomock.Eq(results.Scan.GetScanRefId()),
+			gomock.Eq(false)).Times(1).Return(nil)
+		assert.NoError(tt, DeleteOldResults(context.Background(), results, ds))
+	})
+	t.Run("results with ErrScanContextCancelled should not delete current CheckResults", func(tt *testing.T) {
+		results := &ScanWatcherResults{
+			Scan: &storage.ComplianceOperatorScanV2{
+				ScanRefId:       "ref-id",
+				LastStartedTime: timeNow,
+			},
+			Error: ErrScanContextCancelled,
+		}
+		ds.EXPECT().DeleteOldResults(gomock.Any(),
+			gomock.Eq(results.Scan.GetLastStartedTime()),
+			gomock.Eq(results.Scan.GetScanRefId()),
+			gomock.Eq(false)).Times(1).Return(nil)
 		assert.NoError(tt, DeleteOldResults(context.Background(), results, ds))
 	})
 	t.Run("results with no error should not delete current CheckResults", func(tt *testing.T) {


### PR DESCRIPTION
## Description

Fixes a bug where clusters intermittently disappear from the Compliance Coverage tab in RHACS. The root cause is a race condition between compliance check results and scan updates arriving at Central, combined with aggressive result deletion on watcher timeout.

**Problem:**
1. When the Compliance Operator sends scan results, check results often arrive before the scan update containing the `check-count` annotation. The watcher receives all check results but cannot determine completion (TotalChecks=0).
2. When the scan update finally arrives (with the check-count annotation), it is dropped by the `numChecks == 0` guard in `getWatcher()` because the watcher was already removed.
3. If the watcher times out, `DeleteOldResults` deletes current results because `includeCurrentResults` was set to `true` for any error, including timeout.
4. This causes all compliance results for the cluster to be deleted, making it disappear from the Coverage tab until the next scan cycle completes (~2 hours).

**Fix:**
- Remove the `numChecks == 0` guard from `getWatcher()`. The existing snapshot-based deduplication in `GetWatcherIDFromScan` already prevents reprocessing of already-handled scans, making this guard redundant and harmful for retry scans.
- Remove the now-unused `numChecks` parameter from `getWatcher()`.
- Narrow `DeleteOldResults` to only delete current results when a scan is explicitly removed (`ErrScanRemoved`), not on timeout (`ErrScanTimeout`) or context cancellation (`ErrScanContextCancelled`).

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Deployed the fix to a live OpenShift cluster (ga-ocp4-cron) running Compliance Operator 1.9
- Set `ROX_COMPLIANCE_SCAN_WATCHER_TIMEOUT=2m` to accelerate the timeout window
- **Before fix**: Central logs showed `TotalChecks=0, numCheckResults=89` followed by `Received scan update after removing the watcher` confirming late scan updates were dropped
- **After fix**: Central logs showed `Creating new ScanWatcher` confirming late scan updates properly create new watchers
- Triggered multiple rescans and confirmed results remained at 240 through multiple timeout cycles
- Watcher timeouts occurred as expected but `DeleteOldResults` preserved current results (`includeCurrentResults=false`)
- All unit tests pass for both `manager` and `watcher` packages