### PR TITLE
CVE occurrence awareness: expose datasource and source/severity aggregates

### DIFF
--- a/central/cve/image/v2/datastore/store/postgres/store.go
+++ b/central/cve/image/v2/datastore/store/postgres/store.go
@@ -120,10 +120,11 @@ func insertIntoImageCvesV2(batch *pgx.Batch, obj *storage.ImageCVEV2) error {
 		obj.GetAdvisory().GetLink(),
 		pgutils.NilOrString(obj.GetImageIdV2()),
 		protocompat.NilOrTime(obj.GetFixAvailableTimestamp()),
+		obj.GetDatasource(),
 		serialized,
 	}
 
-	finalStr := "INSERT INTO image_cves_v2 (Id, ImageId, CveBaseInfo_Cve, CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability, Cvss, Severity, ImpactScore, Nvdcvss, FirstImageOccurrence, State, IsFixable, FixedBy, ComponentId, Advisory_Name, Advisory_Link, ImageIdV2, FixAvailableTimestamp, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, ImageId = EXCLUDED.ImageId, CveBaseInfo_Cve = EXCLUDED.CveBaseInfo_Cve, CveBaseInfo_PublishedOn = EXCLUDED.CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt = EXCLUDED.CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability = EXCLUDED.CveBaseInfo_Epss_EpssProbability, Cvss = EXCLUDED.Cvss, Severity = EXCLUDED.Severity, ImpactScore = EXCLUDED.ImpactScore, Nvdcvss = EXCLUDED.Nvdcvss, FirstImageOccurrence = EXCLUDED.FirstImageOccurrence, State = EXCLUDED.State, IsFixable = EXCLUDED.IsFixable, FixedBy = EXCLUDED.FixedBy, ComponentId = EXCLUDED.ComponentId, Advisory_Name = EXCLUDED.Advisory_Name, Advisory_Link = EXCLUDED.Advisory_Link, ImageIdV2 = EXCLUDED.ImageIdV2, FixAvailableTimestamp = EXCLUDED.FixAvailableTimestamp, serialized = EXCLUDED.serialized"
+	finalStr := "INSERT INTO image_cves_v2 (Id, ImageId, CveBaseInfo_Cve, CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability, Cvss, Severity, ImpactScore, Nvdcvss, FirstImageOccurrence, State, IsFixable, FixedBy, ComponentId, Advisory_Name, Advisory_Link, ImageIdV2, FixAvailableTimestamp, Datasource, serialized) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, ImageId = EXCLUDED.ImageId, CveBaseInfo_Cve = EXCLUDED.CveBaseInfo_Cve, CveBaseInfo_PublishedOn = EXCLUDED.CveBaseInfo_PublishedOn, CveBaseInfo_CreatedAt = EXCLUDED.CveBaseInfo_CreatedAt, CveBaseInfo_Epss_EpssProbability = EXCLUDED.CveBaseInfo_Epss_EpssProbability, Cvss = EXCLUDED.Cvss, Severity = EXCLUDED.Severity, ImpactScore = EXCLUDED.ImpactScore, Nvdcvss = EXCLUDED.Nvdcvss, FirstImageOccurrence = EXCLUDED.FirstImageOccurrence, State = EXCLUDED.State, IsFixable = EXCLUDED.IsFixable, FixedBy = EXCLUDED.FixedBy, ComponentId = EXCLUDED.ComponentId, Advisory_Name = EXCLUDED.Advisory_Name, Advisory_Link = EXCLUDED.Advisory_Link, ImageIdV2 = EXCLUDED.ImageIdV2, FixAvailableTimestamp = EXCLUDED.FixAvailableTimestamp, Datasource = EXCLUDED.Datasource, serialized = EXCLUDED.serialized"
 	batch.Queue(finalStr, values...)
 
 	return nil
@@ -149,6 +150,7 @@ var copyColsImageCvesV2 = []string{
 	"advisory_link",
 	"imageidv2",
 	"fixavailabletimestamp",
+	"datasource",
 	"serialized",
 }
 
@@ -202,6 +204,7 @@ func copyFromImageCvesV2(ctx context.Context, s pgSearch.Deleter, tx *postgres.T
 			obj.GetAdvisory().GetLink(),
 			pgutils.NilOrString(obj.GetImageIdV2()),
 			protocompat.NilOrTime(obj.GetFixAvailableTimestamp()),
+			obj.GetDatasource(),
 			serialized,
 		}, nil
 	})

--- a/central/graphql/resolvers/image_cve_core.go
+++ b/central/graphql/resolvers/image_cve_core.go
@@ -36,12 +36,15 @@ func init() {
 				"affectedImageCountBySeverity: ResourceCountByCVESeverity!",
 				"cve: String!",
 				"deployments(pagination: Pagination): [Deployment!]!",
+				"distinctSeverityCount: Int!",
 				"distroTuples: [ImageVulnerability!]!",
 				"firstDiscoveredInSystem: Time",
 				"exceptionCount(requestStatus: [String]): Int!",
 				"images(pagination: Pagination): [Image!]!",
+				"occurrenceCount: Int!",
 				"topCVSS: Float!",
 				"publishedOn: Time",
+				"sourceCount: Int!",
 				"topNvdCVSS: Float!",
 			}),
 		schema.AddQuery("imageCVECount(query: String): Int!"),
@@ -295,6 +298,18 @@ func (resolver *imageCVECoreResolver) Images(ctx context.Context, args struct{ P
 
 func (resolver *imageCVECoreResolver) TopCVSS(_ context.Context) float64 {
 	return float64(resolver.data.GetTopCVSS())
+}
+
+func (resolver *imageCVECoreResolver) SourceCount(_ context.Context) int32 {
+	return int32(resolver.data.GetSourceCount())
+}
+
+func (resolver *imageCVECoreResolver) OccurrenceCount(_ context.Context) int32 {
+	return int32(resolver.data.GetOccurrenceCount())
+}
+
+func (resolver *imageCVECoreResolver) DistinctSeverityCount(_ context.Context) int32 {
+	return int32(resolver.data.GetDistinctSeverityCount())
 }
 
 func (resolver *imageCVECoreResolver) TopNVDCVSS(_ context.Context) float64 {

--- a/central/graphql/resolvers/image_cve_core_test.go
+++ b/central/graphql/resolvers/image_cve_core_test.go
@@ -159,6 +159,18 @@ func (s *ImageCVECoreResolverTestSuite) TestGetImageCVEMalformed() {
 	s.Error(err)
 }
 
+func (s *ImageCVECoreResolverTestSuite) TestOccurrenceInfoFields() {
+	mockCore := imageCVEViewMock.NewMockCveCore(s.mockCtrl)
+	mockCore.EXPECT().GetSourceCount().Return(2)
+	mockCore.EXPECT().GetOccurrenceCount().Return(5)
+	mockCore.EXPECT().GetDistinctSeverityCount().Return(3)
+
+	resolver := &imageCVECoreResolver{ctx: s.ctx, root: s.resolver, data: mockCore}
+	s.Equal(int32(2), resolver.SourceCount(s.ctx))
+	s.Equal(int32(5), resolver.OccurrenceCount(s.ctx))
+	s.Equal(int32(3), resolver.DistinctSeverityCount(s.ctx))
+}
+
 func (s *ImageCVECoreResolverTestSuite) TestGetImageCVENonEmpty() {
 	// without filter
 	expectedQ := search.NewQueryBuilder().AddExactMatches(search.CVE, "cve-xyz").ProtoQuery()

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -49,6 +49,7 @@ func init() {
 		schema.AddType("ImageVulnerability",
 			append(commonVulnerabilitySubResolvers,
 				"advisory: Advisory",
+				"datasource: String!",
 				"deploymentCount(query: String): Int!",
 				"deployments(query: String, pagination: Pagination): [Deployment!]!",
 				"discoveredAtImage(query: String): Time",
@@ -76,6 +77,7 @@ type ImageVulnerabilityResolver interface {
 	CommonVulnerabilityResolver
 
 	Advisory(ctx context.Context) (*advisoryResolver, error)
+	Datasource(ctx context.Context) string
 	DeploymentCount(ctx context.Context, args RawQuery) (int32, error)
 	Deployments(ctx context.Context, args PaginatedQuery) ([]*deploymentResolver, error)
 	DiscoveredAtImage(ctx context.Context, args RawQuery) (*graphql.Time, error)

--- a/central/graphql/resolvers/image_vulnerabilities_utilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities_utilities.go
@@ -82,6 +82,10 @@ func (resolver *imageCVEV2Resolver) ComponentId(ctx context.Context) string {
 	return value
 }
 
+func (resolver *imageCVEV2Resolver) Datasource(_ context.Context) string {
+	return resolver.data.GetDatasource()
+}
+
 func (resolver *imageCVEV2Resolver) CveBaseInfo(ctx context.Context) (*cVEInfoResolver, error) {
 	value := resolver.data.GetCveBaseInfo()
 	return resolver.root.wrapCVEInfo(value, true, nil)

--- a/central/views/imagecve/db_response.go
+++ b/central/views/imagecve/db_response.go
@@ -26,6 +26,9 @@ type imageCVECoreResponse struct {
 	Published                          *time.Time `db:"cve_published_on_min"`
 	TopNVDCVSS                         *float32   `db:"nvd_cvss_max"`
 	AffectedImageCountV2               int        `db:"image_id_count"`
+	SourceCount                        int        `db:"datasource_count"`
+	OccurrenceCount                    int        `db:"cve_id_count"`
+	DistinctSeverityCount              int        `db:"severity_count"`
 }
 
 func (c *imageCVECoreResponse) GetCVE() string {
@@ -78,6 +81,18 @@ func (c *imageCVECoreResponse) GetFirstDiscoveredInSystem() *time.Time {
 
 func (c *imageCVECoreResponse) GetPublishDate() *time.Time {
 	return c.Published
+}
+
+func (c *imageCVECoreResponse) GetSourceCount() int {
+	return c.SourceCount
+}
+
+func (c *imageCVECoreResponse) GetOccurrenceCount() int {
+	return c.OccurrenceCount
+}
+
+func (c *imageCVECoreResponse) GetDistinctSeverityCount() int {
+	return c.DistinctSeverityCount
 }
 
 type imageCVECoreCount struct {

--- a/central/views/imagecve/mocks/types.go
+++ b/central/views/imagecve/mocks/types.go
@@ -87,6 +87,20 @@ func (mr *MockCveCoreMockRecorder) GetCVEIDs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCVEIDs", reflect.TypeOf((*MockCveCore)(nil).GetCVEIDs))
 }
 
+// GetDistinctSeverityCount mocks base method.
+func (m *MockCveCore) GetDistinctSeverityCount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDistinctSeverityCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetDistinctSeverityCount indicates an expected call of GetDistinctSeverityCount.
+func (mr *MockCveCoreMockRecorder) GetDistinctSeverityCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDistinctSeverityCount", reflect.TypeOf((*MockCveCore)(nil).GetDistinctSeverityCount))
+}
+
 // GetFirstDiscoveredInSystem mocks base method.
 func (m *MockCveCore) GetFirstDiscoveredInSystem() *time.Time {
 	m.ctrl.T.Helper()
@@ -115,6 +129,20 @@ func (mr *MockCveCoreMockRecorder) GetImagesBySeverity() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImagesBySeverity", reflect.TypeOf((*MockCveCore)(nil).GetImagesBySeverity))
 }
 
+// GetOccurrenceCount mocks base method.
+func (m *MockCveCore) GetOccurrenceCount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOccurrenceCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetOccurrenceCount indicates an expected call of GetOccurrenceCount.
+func (mr *MockCveCoreMockRecorder) GetOccurrenceCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOccurrenceCount", reflect.TypeOf((*MockCveCore)(nil).GetOccurrenceCount))
+}
+
 // GetPublishDate mocks base method.
 func (m *MockCveCore) GetPublishDate() *time.Time {
 	m.ctrl.T.Helper()
@@ -127,6 +155,20 @@ func (m *MockCveCore) GetPublishDate() *time.Time {
 func (mr *MockCveCoreMockRecorder) GetPublishDate() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublishDate", reflect.TypeOf((*MockCveCore)(nil).GetPublishDate))
+}
+
+// GetSourceCount mocks base method.
+func (m *MockCveCore) GetSourceCount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSourceCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetSourceCount indicates an expected call of GetSourceCount.
+func (mr *MockCveCoreMockRecorder) GetSourceCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSourceCount", reflect.TypeOf((*MockCveCore)(nil).GetSourceCount))
 }
 
 // GetTopCVSS mocks base method.

--- a/central/views/imagecve/types.go
+++ b/central/views/imagecve/types.go
@@ -21,6 +21,9 @@ type CveCore interface {
 	GetAffectedImageCount() int
 	GetFirstDiscoveredInSystem() *time.Time
 	GetPublishDate() *time.Time
+	GetSourceCount() int
+	GetOccurrenceCount() int
+	GetDistinctSeverityCount() int
 }
 
 // CveView interface is like a SQL view that provides functionality to fetch the image CVE data

--- a/central/views/imagecve/view_impl.go
+++ b/central/views/imagecve/view_impl.go
@@ -240,6 +240,13 @@ func withSelectCVECoreResponseQuery(q *v1.Query, cveIDsToFilter []string, option
 	if !options.SkipGetTopNVDCVSS {
 		cloned.Selects = append(cloned.Selects, search.NewQuerySelect(search.NVDCVSS).AggrFunc(aggregatefunc.Max).Proto())
 	}
+	if !options.SkipGetOccurrenceInfo {
+		cloned.Selects = append(cloned.Selects,
+			search.NewQuerySelect(search.Datasource).AggrFunc(aggregatefunc.Count).Distinct().Proto(),
+			search.NewQuerySelect(search.CVEID).AggrFunc(aggregatefunc.Count).Distinct().Proto(),
+			search.NewQuerySelect(search.Severity).AggrFunc(aggregatefunc.Count).Distinct().Proto(),
+		)
+	}
 	cloned.GroupBy = &v1.QueryGroupBy{
 		Fields: []string{search.CVE.String()},
 	}

--- a/central/views/imagecve/view_test.go
+++ b/central/views/imagecve/view_test.go
@@ -997,6 +997,8 @@ func applyPaginationProps(baseTc *testCase, paginationTc testCase) {
 
 func (s *ImageCVEViewTestSuite) compileExpected(images []testImage, filter *filterImpl, options views.ReadOptions, less lessFunc) []CveCore {
 	cveMap := make(map[string]*imageCVECoreResponse)
+	datasourceSets := make(map[string]*set.StringSet)
+	severitySets := make(map[string]*set.Set[storage.VulnerabilitySeverity])
 
 	for _, image := range images {
 		if !filter.matchImage(image) {
@@ -1066,6 +1068,20 @@ func (s *ImageCVEViewTestSuite) compileExpected(images []testImage, filter *filt
 					val.CVEIDs = append(val.CVEIDs, id)
 				}
 
+				val.OccurrenceCount++
+				if ds := vuln.GetDatasource(); ds != "" {
+					if datasourceSets[val.CVE] == nil {
+						s := set.NewStringSet()
+						datasourceSets[val.CVE] = &s
+					}
+					datasourceSets[val.CVE].Add(ds)
+				}
+				if severitySets[val.CVE] == nil {
+					s := set.NewSet[storage.VulnerabilitySeverity]()
+					severitySets[val.CVE] = &s
+				}
+				severitySets[val.CVE].Add(vuln.GetSeverity())
+
 				val.TopCVSS = pointers.Float32(max(val.GetTopCVSS(), vuln.GetCvss()))
 
 				if val.GetFirstDiscoveredInSystem().After(vulnTime) {
@@ -1113,7 +1129,20 @@ func (s *ImageCVEViewTestSuite) compileExpected(images []testImage, filter *filt
 		sort.SliceStable(entry.CVEIDs, func(i, j int) bool {
 			return entry.CVEIDs[i] < entry.CVEIDs[j]
 		})
+		if ds := datasourceSets[entry.CVE]; ds != nil {
+			entry.SourceCount = ds.Cardinality()
+		}
+		if sv := severitySets[entry.CVE]; sv != nil {
+			entry.DistinctSeverityCount = sv.Cardinality()
+		}
 		expected = append(expected, entry)
+	}
+	if options.SkipGetOccurrenceInfo {
+		for _, entry := range expected {
+			entry.SourceCount = 0
+			entry.OccurrenceCount = 0
+			entry.DistinctSeverityCount = 0
+		}
 	}
 	if options.SkipGetImagesBySeverity {
 		for _, entry := range expected {
@@ -1473,5 +1502,8 @@ func assertResponsesAreEqual(t *testing.T, expected []CveCore, actual []CveCore,
 		assert.Equal(t, expected[i].GetAffectedImageCount(), flatCVE.GetAffectedImageCount())
 		assert.Equal(t, expected[i].GetFirstDiscoveredInSystem(), flatCVE.GetFirstDiscoveredInSystem())
 		assert.Equal(t, expected[i].GetPublishDate(), flatCVE.GetPublishDate())
+		assert.Equal(t, expected[i].GetSourceCount(), flatCVE.GetSourceCount())
+		assert.Equal(t, expected[i].GetOccurrenceCount(), flatCVE.GetOccurrenceCount())
+		assert.Equal(t, expected[i].GetDistinctSeverityCount(), flatCVE.GetDistinctSeverityCount())
 	}
 }

--- a/central/views/read_options.go
+++ b/central/views/read_options.go
@@ -8,6 +8,7 @@ type ReadOptions struct {
 	SkipGetAffectedImages          bool
 	SkipGetFirstDiscoveredInSystem bool
 	SkipPublishedDate              bool
+	SkipGetOccurrenceInfo          bool
 }
 
 // IsDefault returns true if all readoptions are set to default/false.
@@ -15,5 +16,6 @@ func (r *ReadOptions) IsDefault() bool {
 	return !r.SkipGetImagesBySeverity &&
 		!r.SkipGetTopCVSS &&
 		!r.SkipGetAffectedImages &&
-		!r.SkipGetFirstDiscoveredInSystem
+		!r.SkipGetFirstDiscoveredInSystem &&
+		!r.SkipGetOccurrenceInfo
 }

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/storage/cve.pb.go
+++ b/generated/storage/cve.pb.go
@@ -1590,7 +1590,7 @@ type ImageCVEV2 struct {
 	ImageIdV2   string                  `protobuf:"bytes,15,opt,name=image_id_v2,json=imageIdV2,proto3" json:"image_id_v2,omitempty" sql:"fk(ImageV2:id),index=btree,allow-null"` // @gotags: sql:"fk(ImageV2:id),index=btree,allow-null"
 	// Timestamp when the fix for this CVE was made available according to the sources.
 	FixAvailableTimestamp *timestamppb.Timestamp `protobuf:"bytes,16,opt,name=fix_available_timestamp,json=fixAvailableTimestamp,proto3" json:"fix_available_timestamp,omitempty" search:"CVE Fix Available Timestamp,hidden"` // @gotags: search:"CVE Fix Available Timestamp,hidden"
-	Datasource            string                 `protobuf:"bytes,17,opt,name=datasource,proto3" json:"datasource,omitempty"`
+	Datasource            string                 `protobuf:"bytes,17,opt,name=datasource,proto3" json:"datasource,omitempty" search:"Datasource,hidden" sql:"index=btree"`                                                      // @gotags: search:"Datasource,hidden" sql:"index=btree"
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }

--- a/pkg/postgres/schema/image_cves_v2.go
+++ b/pkg/postgres/schema/image_cves_v2.go
@@ -82,6 +82,7 @@ type ImageCvesV2 struct {
 	AdvisoryLink                   string                        `gorm:"column:advisory_link;type:varchar"`
 	ImageIDV2                      string                        `gorm:"column:imageidv2;type:varchar;index:imagecvesv2_imageidv2,type:btree"`
 	FixAvailableTimestamp          *time.Time                    `gorm:"column:fixavailabletimestamp;type:timestamp"`
+	Datasource                     string                        `gorm:"column:datasource;type:varchar;index:imagecvesv2_datasource,type:btree"`
 	Serialized                     []byte                        `gorm:"column:serialized;type:bytea"`
 	ImagesRef                      Images                        `gorm:"foreignKey:imageid;references:id;belongsTo;constraint:OnDelete:CASCADE"`
 	ImageComponentV2Ref            ImageComponentV2              `gorm:"foreignKey:componentid;references:id;belongsTo;constraint:OnDelete:CASCADE"`

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -69,6 +69,7 @@ var (
 	EPSSProbablity     = newFieldLabel("EPSS Probability")
 	AdvisoryName       = newFieldLabel("Advisory Name")
 	AdvisoryLink       = newFieldLabel("Advisory Link")
+	Datasource         = newFieldLabel("Datasource")
 
 	CVEInfo = newFieldLabel("CVE Info")
 

--- a/proto/storage/cve.proto
+++ b/proto/storage/cve.proto
@@ -199,7 +199,7 @@ message ImageCVEV2 {
 
   // Timestamp when the fix for this CVE was made available according to the sources.
   google.protobuf.Timestamp fix_available_timestamp = 16; // @gotags: search:"CVE Fix Available Timestamp,hidden"
-  string datasource = 17;
+  string datasource = 17; // @gotags: search:"Datasource,hidden" sql:"index=btree"
 }
 
 message NodeCVE {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/ImageCve/ImageCvePage.tsx
@@ -79,10 +79,13 @@ export const imageCveMetadataQuery = gql`
             cve
             firstDiscoveredInSystem
             publishedOn
+            sourceCount
+            distinctSeverityCount
             distroTuples {
                 summary
                 link
                 operatingSystem
+                datasource
                 cveBaseInfo {
                     epss {
                         epssProbability

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageVulnerabilitiesTable.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
-import { LabelGroup } from '@patternfly/react-core';
+import { Label, LabelGroup } from '@patternfly/react-core';
 import {
     ActionsColumn,
     ExpandableRowContent,
@@ -123,6 +123,7 @@ export const imageVulnerabilitiesFragment = gql`
         severity
         cve
         summary
+        datasource
         cvss
         scoreVersion
         nvdCvss
@@ -145,6 +146,7 @@ export type ImageVulnerability = {
     severity: string;
     cve: string;
     summary: string;
+    datasource: string;
     cvss: number;
     scoreVersion: string;
     nvdCvss: number;
@@ -257,6 +259,7 @@ function ImageVulnerabilitiesTable({
                             cve,
                             severity,
                             summary,
+                            datasource,
                             cvss,
                             scoreVersion,
                             nvdCvss,
@@ -301,6 +304,13 @@ function ImageVulnerabilitiesTable({
                                     isCompact
                                     vulnerabilityState={vulnerabilityState}
                                 />
+                            );
+                        }
+                        if (datasource) {
+                            labels.push(
+                                <Label key="datasource" variant="outline" isCompact>
+                                    {datasource}
+                                </Label>
                             );
                         }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/WorkloadCVEOverviewTable.tsx
@@ -12,7 +12,8 @@ import {
     Tr,
 } from '@patternfly/react-table';
 import type { IAction } from '@patternfly/react-table';
-import { Content, LabelGroup } from '@patternfly/react-core';
+import { Content, Label, LabelGroup, Tooltip } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import type { UseURLSortResult } from 'hooks/useURLSort';
@@ -141,6 +142,9 @@ export const cveListQuery = gql`
             firstDiscoveredInSystem
             publishedOn
             topNvdCVSS
+            sourceCount
+            occurrenceCount
+            distinctSeverityCount
             distroTuples {
                 summary
                 operatingSystem
@@ -183,6 +187,9 @@ export type ImageCVE = {
     firstDiscoveredInSystem: string | null;
     publishedOn: string | null;
     topNvdCVSS: number;
+    sourceCount: number;
+    occurrenceCount: number;
+    distinctSeverityCount: number;
     distroTuples: {
         summary: string;
         operatingSystem: string;
@@ -324,6 +331,8 @@ function WorkloadCVEOverviewTable({
                                 publishedOn,
                                 distroTuples,
                                 pendingExceptionCount,
+                                sourceCount,
+                                distinctSeverityCount,
                             },
                             rowIndex
                         ) => {
@@ -373,6 +382,29 @@ function WorkloadCVEOverviewTable({
                                         isCompact
                                         vulnerabilityState={vulnerabilityState}
                                     />
+                                );
+                            }
+                            if (sourceCount > 1) {
+                                labels.push(
+                                    <Label key="sourceCount" isCompact>
+                                        {sourceCount} sources
+                                    </Label>
+                                );
+                            }
+                            if (distinctSeverityCount > 1) {
+                                labels.push(
+                                    <Tooltip
+                                        key="severityDisagreement"
+                                        content="Sources report different severities for this CVE"
+                                    >
+                                        <Label
+                                            isCompact
+                                            color="gold"
+                                            icon={<ExclamationTriangleIcon />}
+                                        >
+                                            Severity varies by source
+                                        </Label>
+                                    </Tooltip>
                                 );
                             }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/CvePageHeader.tsx
@@ -1,5 +1,15 @@
 import type { ReactNode } from 'react';
-import { Content, Flex, Label, LabelGroup, List, ListItem, Title } from '@patternfly/react-core';
+import {
+    Content,
+    Flex,
+    Label,
+    LabelGroup,
+    List,
+    ListItem,
+    Title,
+    Tooltip,
+} from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import uniqBy from 'lodash/uniqBy';
 
 import ExternalLink from 'Components/PatternFly/IconText/ExternalLink';
@@ -22,10 +32,13 @@ export type CveMetadata = {
     cve: string;
     firstDiscoveredInSystem: string | null;
     publishedOn: string | null;
+    sourceCount?: number;
+    distinctSeverityCount?: number;
     distroTuples: {
         summary: string;
         link: string;
         operatingSystem: string;
+        datasource: string;
         cveBaseInfo: CveBaseInfo;
     }[];
 };
@@ -81,6 +94,23 @@ function CvePageHeader({ data }: CvePageHeaderProps) {
             </Label>
         );
     }
+    if (data.sourceCount && data.sourceCount > 1) {
+        labels.push(
+            <Label key="sourceCount">{data.sourceCount} sources</Label>
+        );
+    }
+    if (data.distinctSeverityCount && data.distinctSeverityCount > 1) {
+        labels.push(
+            <Tooltip
+                key="severityDisagreement"
+                content="Sources report different severities for this CVE"
+            >
+                <Label color="gold" icon={<ExclamationTriangleIcon />}>
+                    Severity varies by source
+                </Label>
+            </Tooltip>
+        );
+    }
 
     const prioritizedDistros = uniqBy(sortCveDistroList(data.distroTuples), getDistroLinkText);
     const topDistro = prioritizedDistros[0];
@@ -102,6 +132,11 @@ function CvePageHeader({ data }: CvePageHeaderProps) {
                                         {getDistroLinkText(distro)}
                                     </a>
                                 </ExternalLink>
+                                {distro.datasource && (
+                                    <Label variant="outline" isCompact className="pf-v6-u-ml-sm">
+                                        {distro.datasource}
+                                    </Label>
+                                )}
                             </ListItem>
                         ))}
                     </List>


### PR DESCRIPTION
Scanner creates duplicate CVE entries when multiple OSV advisories (GHSA +
Go vulndb) resolve to the same CVE. Rather than silently deduplicating,
this treats a CVE as a collection of assessments and surfaces source
awareness in the UI.

Backend:
- Add search/sql gotags to ImageCVEV2.datasource proto field with btree index
- Register Datasource search field label in pkg/search/options.go
- Add sourceCount (COUNT DISTINCT datasource), occurrenceCount (COUNT
  DISTINCT cve_id), distinctSeverityCount (COUNT DISTINCT severity) to
  CveCore view, gated by SkipGetOccurrenceInfo ReadOption
- Expose sourceCount, occurrenceCount, distinctSeverityCount on ImageCVECore
  GraphQL type and datasource on ImageVulnerability type

Frontend:
- CVE list table: show "{N} sources" label and amber "Severity varies by
  source" warning when sources disagree
- CVE detail header: same labels plus datasource badge on each distro tuple
- Per-image vulnerability table: show datasource as outline label per CVE

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
