### PR TITLE
ROX-34512: Deduplicate CVE aliases in Scanner V4 mapper

### DIFF
--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -417,7 +417,7 @@ func toProtoV4PackageVulnerabilitiesMap(ccPkgVulnerabilities map[string][]string
 			// We will take the version of the advisory associated with the highest NVD CVSS score.
 			vulnIDs = dedupeAdvisories(vulnIDs, vulnerabilities)
 		}
-		// Lastly, sort by severity in case we may still have any duplications we missed previously.
+		vulnIDs = dedupeCVEs(vulnIDs, vulnerabilities)
 		sortBySeverity(vulnIDs, vulnerabilities)
 		pkgVulns[id] = &v4.StringList{
 			Values: vulnIDs,
@@ -1534,6 +1534,58 @@ func vulnsEqual(a, b *claircore.Vulnerability) bool {
 		a.Severity == b.Severity &&
 		a.NormalizedSeverity == b.NormalizedSeverity &&
 		a.FixedInVersion == b.FixedInVersion
+}
+
+// dedupeCVEs deduplicates vulnerabilities that resolved to the same CVE name
+// from different advisory sources (e.g., GHSA and Go vulndb entries that are aliases of the same CVE).
+// When duplicates are found, the entry with the highest NormalizedSeverity is kept;
+// if severities are equal, the entry with richer CVSS data wins.
+func dedupeCVEs(vulnIDs []string, protoVulns map[string]*v4.VulnerabilityReport_Vulnerability) []string {
+	filtered := make([]string, 0, len(vulnIDs))
+	seen := make(map[string]int) // CVE name -> index in filtered
+	for _, vulnID := range vulnIDs {
+		vuln := protoVulns[vulnID]
+		if vuln == nil {
+			continue
+		}
+		name := vuln.GetName()
+		if !cveIDPattern.MatchString(name) {
+			filtered = append(filtered, vulnID)
+			continue
+		}
+		if idx, ok := seen[name]; ok {
+			existing := protoVulns[filtered[idx]]
+			if preferVuln(vuln, existing) {
+				filtered[idx] = vulnID
+			}
+			continue
+		}
+		seen[name] = len(filtered)
+		filtered = append(filtered, vulnID)
+	}
+	return filtered
+}
+
+// preferVuln returns true if candidate should replace existing during CVE deduplication.
+func preferVuln(candidate, existing *v4.VulnerabilityReport_Vulnerability) bool {
+	if candidate.GetNormalizedSeverity() != existing.GetNormalizedSeverity() {
+		return candidate.GetNormalizedSeverity() > existing.GetNormalizedSeverity()
+	}
+	return hasCVSSData(candidate) && !hasCVSSData(existing)
+}
+
+func hasCVSSData(vuln *v4.VulnerabilityReport_Vulnerability) bool {
+	if c := vuln.GetCvss(); c != nil {
+		if c.GetV3() != nil || c.GetV2() != nil {
+			return true
+		}
+	}
+	for _, m := range vuln.GetCvssMetrics() {
+		if m.GetV3() != nil || m.GetV2() != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // dedupeAdvisories deduplicates repeat advisories out of vulnIDs and returns the result.

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -219,7 +219,7 @@ func Test_ToProtoV4VulnerabilityReport(t *testing.T) {
 			},
 			wantErr: "",
 		},
-		"when there are similar vulnerabilities with different severities and updaters then they are not filtered": {
+		"when there are similar vulnerabilities with different severities and updaters then the higher severity is kept": {
 			arg: &claircore.VulnerabilityReport{
 				Hash: claircore.MustParseDigest("sha256:9124cd5256c6d674f6b11a4d01fea8148259be1f66ca2cf9dfbaafc83c31874e"),
 				Vulnerabilities: map[string]*claircore.Vulnerability{
@@ -291,7 +291,7 @@ func Test_ToProtoV4VulnerabilityReport(t *testing.T) {
 				},
 				PackageVulnerabilities: map[string]*v4.StringList{
 					"sample pkg id": {
-						Values: []string{"1", "0"}, // "1" has a higher severity
+						Values: []string{"1"}, // "1" has a higher severity; "0" is deduplicated as a same-CVE alias
 					},
 				},
 				Contents: &v4.Contents{},
@@ -3030,6 +3030,171 @@ func Test_dedupeAdvisories(t *testing.T) {
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
 			got := dedupeAdvisories(tt.vulnIDs, tt.vulns)
+			assert.ElementsMatch(t, tt.expected, got)
+		})
+	}
+}
+
+func Test_dedupeCVEs(t *testing.T) {
+	testcases := map[string]struct {
+		vulnIDs  []string
+		vulns    map[string]*v4.VulnerabilityReport_Vulnerability
+		expected []string
+	}{
+		"aliases with different severities keeps higher": {
+			vulnIDs: []string{"ghsa-1", "go-1"},
+			vulns: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"ghsa-1": {
+					Id:                 "ghsa-1",
+					Name:               "CVE-2022-23648",
+					Severity:           "High",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
+				},
+				"go-1": {
+					Id:                 "go-1",
+					Name:               "CVE-2022-23648",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_UNSPECIFIED,
+				},
+			},
+			expected: []string{"ghsa-1"},
+		},
+		"aliases with higher severity second replaces first": {
+			vulnIDs: []string{"go-1", "ghsa-1"},
+			vulns: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"go-1": {
+					Id:                 "go-1",
+					Name:               "CVE-2022-23648",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_UNSPECIFIED,
+				},
+				"ghsa-1": {
+					Id:                 "ghsa-1",
+					Name:               "CVE-2022-23648",
+					Severity:           "High",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
+				},
+			},
+			expected: []string{"ghsa-1"},
+		},
+		"same severity prefers entry with CVSS data": {
+			vulnIDs: []string{"a", "b"},
+			vulns: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"a": {
+					Id:                 "a",
+					Name:               "CVE-2023-0001",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+				},
+				"b": {
+					Id:                 "b",
+					Name:               "CVE-2023-0001",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+					Cvss: &v4.VulnerabilityReport_Vulnerability_CVSS{
+						V3: &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+							BaseScore: 6.5,
+							Vector:    "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+						},
+					},
+				},
+			},
+			expected: []string{"b"},
+		},
+		"same severity both without CVSS keeps first": {
+			vulnIDs: []string{"a", "b"},
+			vulns: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"a": {
+					Id:                 "a",
+					Name:               "CVE-2023-0001",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+				},
+				"b": {
+					Id:                 "b",
+					Name:               "CVE-2023-0001",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+				},
+			},
+			expected: []string{"a"},
+		},
+		"non-CVE names pass through": {
+			vulnIDs: []string{"a", "b", "c"},
+			vulns: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"a": {
+					Id:   "a",
+					Name: "GHSA-5wvp-7f3h-6wmm",
+				},
+				"b": {
+					Id:   "b",
+					Name: "RHSA-2021:0735",
+				},
+				"c": {
+					Id:                 "c",
+					Name:               "CVE-2023-0001",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+				},
+			},
+			expected: []string{"a", "b", "c"},
+		},
+		"no duplicates preserves all": {
+			vulnIDs: []string{"a", "b"},
+			vulns: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"a": {
+					Id:                 "a",
+					Name:               "CVE-2023-0001",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+				},
+				"b": {
+					Id:                 "b",
+					Name:               "CVE-2023-0002",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_LOW,
+				},
+			},
+			expected: []string{"a", "b"},
+		},
+		"nil vuln in map is skipped": {
+			vulnIDs: []string{"a", "b"},
+			vulns: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"a": nil,
+				"b": {
+					Id:                 "b",
+					Name:               "CVE-2023-0001",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_LOW,
+				},
+			},
+			expected: []string{"b"},
+		},
+		"mixed CVE and non-CVE with duplicates": {
+			vulnIDs: []string{"ghsa-1", "go-1", "rhsa-1", "ghsa-2", "go-2"},
+			vulns: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"ghsa-1": {
+					Id:                 "ghsa-1",
+					Name:               "CVE-2022-23648",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
+				},
+				"go-1": {
+					Id:                 "go-1",
+					Name:               "CVE-2022-23648",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_UNSPECIFIED,
+				},
+				"rhsa-1": {
+					Id:   "rhsa-1",
+					Name: "RHSA-2021:0735",
+				},
+				"ghsa-2": {
+					Id:                 "ghsa-2",
+					Name:               "CVE-2023-25761",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+				},
+				"go-2": {
+					Id:                 "go-2",
+					Name:               "CVE-2023-25761",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_CRITICAL,
+				},
+			},
+			expected: []string{"ghsa-1", "rhsa-1", "go-2"},
+		},
+	}
+
+	for name, tt := range testcases {
+		t.Run(name, func(t *testing.T) {
+			got := dedupeCVEs(tt.vulnIDs, tt.vulns)
 			assert.ElementsMatch(t, tt.expected, got)
 		})
 	}


### PR DESCRIPTION
OSV advisory databases (GHSA, Go vulndb, PyPI) emit separate entries for
the same CVE. After name resolution both map to the same CVE-* but
dedupeVulns groups by raw ClairCore name, so they survive as duplicates.

Add dedupeCVEs() operating on proto vulns post-name-resolution: groups by
resolved CVE name, keeps highest NormalizedSeverity, breaks ties by
preferring entries with CVSS v2/v3 data.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
