### PR TITLE
ROX-34431: preserve DynamicConfig fields on cluster update

### DIFF
--- a/qa-tests-backend/src/main/groovy/services/ClusterService.groovy
+++ b/qa-tests-backend/src/main/groovy/services/ClusterService.groovy
@@ -10,7 +10,6 @@ import io.stackrox.proto.storage.ClusterOuterClass
 import io.stackrox.proto.storage.ClusterOuterClass.AdmissionControllerConfig
 import io.stackrox.proto.storage.ClusterOuterClass.Cluster
 import io.stackrox.proto.storage.ClusterOuterClass.ClusterMetadata.Type
-import io.stackrox.proto.storage.ClusterOuterClass.DynamicClusterConfig
 
 @CompileStatic
 @Slf4j
@@ -54,13 +53,13 @@ class ClusterService extends BaseService {
         if (currentCluster == null) {
             return false
         }
-        Cluster.Builder builder = currentCluster.toBuilder()
 
-        Cluster cluster = builder.setDynamicConfig(
-                DynamicClusterConfig.newBuilder()
-                        .setAdmissionControllerConfig(config)
-                        .build()
-        ).build()
+        Cluster cluster = currentCluster.toBuilder()
+                .setDynamicConfig(
+                        currentCluster.getDynamicConfig().toBuilder()
+                                .setAdmissionControllerConfig(config)
+                                .build()
+                ).build()
 
         return updateCluster(cluster)
     }
@@ -70,13 +69,13 @@ class ClusterService extends BaseService {
         if (currentCluster == null) {
             return false
         }
-        Cluster.Builder builder = currentCluster.toBuilder()
 
-        Cluster cluster = builder.setDynamicConfig(
-                DynamicClusterConfig.newBuilder()
-                        .setDisableAuditLogs(disableAuditLogs)
-                        .build()
-        ).build()
+        Cluster cluster = currentCluster.toBuilder()
+                .setDynamicConfig(
+                        currentCluster.getDynamicConfig().toBuilder()
+                                .setDisableAuditLogs(disableAuditLogs)
+                                .build()
+                ).build()
 
         return updateCluster(cluster)
     }


### PR DESCRIPTION
## Description

`ClusterService.updateAdmissionController()` and `updateAuditLogDynamicConfig()` replaced the entire `DynamicConfig` with a new one containing only the field they cared about, wiping all other fields — including `processIndicators.excludeNamespaceFilter`.

This caused `ProcessVisualizationTest."Verify process visualization on the excluded namespace"` to fail on non-Helm deployments (GKE race, EKS, AKS). On Helm deployments the filter is stored in `HelmConfig.DynamicConfig` which is read separately by `GetNamespaceFilter()`, so it survived the wipe.

The fix uses `currentCluster.getDynamicConfig().toBuilder()` instead of `DynamicClusterConfig.newBuilder()` so existing fields are preserved.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

GKE race condition QA E2E tests passed with this fix — `ProcessVisualizationTest."Verify process visualization on the excluded namespace"` no longer fails.