### PR TITLE
ROX-34637: Hot reload TLS certificates in client connections

### DIFF
--- a/compliance/node/index/indexer.go
+++ b/compliance/node/index/indexer.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/scannerv4/mappers"
-	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/urlfmt"
 	pkgutils "github.com/stackrox/rox/pkg/utils"
 )
@@ -52,32 +51,24 @@ var (
 	layerDigest   = fmt.Sprintf("sha256:%s", strings.Repeat("a", 64))
 	ccLayerDigest = claircore.MustParseDigest(layerDigest)
 
-	clientOnce       sync.Once
-	defaultClient    *http.Client
-	defaultClientErr error
-)
-
-func getDefaultClient() (*http.Client, error) {
-	clientOnce.Do(func() {
-		clientCert, err := mtls.LeafCertificateFromFile()
-		if err != nil {
-			defaultClientErr = errors.Wrap(err, "obtaining defaultClient certificate")
-			return
-		}
-		defaultClient = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					// TODO: Should this always be set to true...?
-					InsecureSkipVerify: true,
-					Certificates:       []tls.Certificate{clientCert},
+	defaultClient = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				// TODO(ROX-34752): InsecureSkipVerify should be replaced with proper server verification.
+				InsecureSkipVerify: true,
+				GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+					cert, err := mtls.LeafCertificateFromFile()
+					if err != nil {
+						return nil, errors.Wrap(err, "loading client certificate")
+					}
+					return &cert, nil
 				},
-				Proxy: proxy.FromConfig(),
 			},
-			Timeout: 30 * time.Second,
-		}
-	})
-	return defaultClient, defaultClientErr
-}
+			Proxy: proxy.FromConfig(),
+		},
+		Timeout: 30 * time.Second,
+	}
+)
 
 // NodeIndexerConfig represents Scanner V4 node indexer configuration parameters.
 type NodeIndexerConfig struct {
@@ -202,11 +193,7 @@ func layer(ctx context.Context, digest string, hostPath string) (*claircore.Laye
 func runRepositoryScanner(ctx context.Context, cfg NodeIndexerConfig, l *claircore.Layer) ([]*claircore.Repository, error) {
 	client := cfg.Client
 	if client == nil {
-		var err error
-		client, err = getDefaultClient()
-		if err != nil {
-			return nil, errors.Wrap(err, "creating repository scanner http client - check TLS config")
-		}
+		client = defaultClient
 	}
 
 	scanner := rhel.RepositoryScanner{}

--- a/pkg/clientconn/client.go
+++ b/pkg/clientconn/client.go
@@ -119,14 +119,16 @@ func TLSConfig(server mtls.Subject, opts TLSConfigOptions) (*tls.Config, error) 
 	}
 
 	if opts.UseClientCert != DontUseClientCert {
-		clientCert, err := mtls.LeafCertificateFromFile()
-		if err != nil {
-			if opts.UseClientCert == MustUseClientCert {
-				return nil, errors.Wrap(err, "client credentials")
+		conf.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			cert, err := mtls.LeafCertificateFromFile()
+			if err != nil {
+				if opts.UseClientCert == MustUseClientCert {
+					return nil, err
+				}
+				log.Warnf("Failed to load client certificate for TLS connection: %v", err)
+				return &tls.Certificate{}, nil
 			}
-			log.Warnf("Failed to load client certificate for TLS connection: %v", err)
-		} else {
-			conf.Certificates = []tls.Certificate{clientCert}
+			return &cert, nil
 		}
 	}
 

--- a/pkg/clientconn/client_test.go
+++ b/pkg/clientconn/client_test.go
@@ -1,17 +1,22 @@
 package clientconn
 
 import (
+	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
+	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -137,4 +142,42 @@ func (t *ClientTestSuite) TestAuthenticatedHTTPTransport_WebSocket() {
 			t.Equal(http.StatusOK, resp.StatusCode)
 		})
 	}
+}
+
+func writeCertToFiles(t testing.TB, certDir string, cert *tls.Certificate) {
+	t.Helper()
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "cert.pem"), certPEM, 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "key.pem"), keyPEM, 0600))
+}
+
+func (t *ClientTestSuite) TestGetClientCertificate_ReloadsFromDisk() {
+	certDir := t.T().TempDir()
+	t.T().Setenv(mtls.CertFilePathEnvName, filepath.Join(certDir, "cert.pem"))
+	t.T().Setenv(mtls.KeyFileEnvName, filepath.Join(certDir, "key.pem"))
+
+	cert1 := testutils.IssueSelfSignedCert(t.T(), "first-cert")
+	writeCertToFiles(t.T(), certDir, &cert1)
+
+	conf, err := TLSConfig(mtls.CentralSubject, TLSConfigOptions{
+		UseClientCert:      MustUseClientCert,
+		InsecureSkipVerify: true,
+	})
+	t.Require().NoError(err)
+	t.Require().NotNil(conf.GetClientCertificate)
+
+	got1, err := conf.GetClientCertificate(nil)
+	t.Require().NoError(err)
+	t.Equal(cert1.Certificate[0], got1.Certificate[0])
+
+	cert2 := testutils.IssueSelfSignedCert(t.T(), "second-cert")
+	writeCertToFiles(t.T(), certDir, &cert2)
+
+	got2, err := conf.GetClientCertificate(nil)
+	t.Require().NoError(err)
+	t.Equal(cert2.Certificate[0], got2.Certificate[0], "GetClientCertificate should return the new cert after files changed")
+	t.NotEqual(got1.Certificate[0], got2.Certificate[0], "Certs should differ after rotation")
 }

--- a/pkg/mtls/README.md
+++ b/pkg/mtls/README.md
@@ -44,7 +44,7 @@
 ### Central has three independent cert-handling paths
 
 1. **TLS manager** (`TLSConfigHolder`) — incoming connections. Composes default cert (watched) + internal cert (watched) + sync.Once trust roots.
-2. **Outbound client connections** (`clientconn.TLSConfig`) — reads leaf from disk per connection, trust pool from `mtls.CACert()`.
+2. **Outbound client connections** (`clientconn.TLSConfig`) — reads leaf cert from disk on each TLS handshake, trust pool from `mtls.CACert()`.
 3. **TLS challenge endpoint** (`central/metadata/service`) — reads primary leaf via certwatch, issues secondary leaf with short validity and auto-renewal, reads CA via `mtls.CACert()`.
 
 ## Certificate caching
@@ -54,10 +54,6 @@ The following certificates are currently known to be cached at start-up and not 
 - CA material (`CACert()`, `SecondaryCACert()`, `CAForSigning()`, etc.) in `pkg/mtls/crypto.go`: `sync.Once`, never refreshed. Intentional — the Operator restarts all pods on CA change.
 
 - Sensor: all certs are effectively cached because `certinit` copies them to an emptyDir at startup. Client certs are also cached at construction (`centralclient.NewClient`, `StartProxyServer`, scanner client).
-- Scanner V4 (indexer/matcher) client certs: cached at dial time via `clientconn.TLSConfig`
-- Admission controller client cert for Sensor connection: `clientconn.AuthenticatedGRPCConnection` at startup
-- Compliance client cert for Sensor connection: `clientconn.AuthenticatedGRPCConnection` at startup
-
 
 ## Certificate management — who manages what
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

`clientconn.TLSConfig` now uses `tls.Config.GetClientCertificate` to re-read the leaf certificate from disk on each TLS handshake, instead of loading it once into `tls.Config.Certificates`. This propagates automatically to all code paths that build on it:
* `clientconn.AuthenticatedGRPCConnection`
* `clientconn.AuthenticatedHTTPTransport`
* `clientconn.GRPCConnection`
* `clientconn.HTTPTransport`

Services that benefit (all non-Sensor Go client connections):
* Central outbound
* Scanner V4 indexer/matcher
* Admission controller
* Compliance

Additionally, the compliance node indexer had its own `sync.Once`-cached client cert that bypassed `clientconn` entirely.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Tested with a client admission-control connection to sensor:
- Deployed a fake gRPC sensor that logs the client certificate serial from each TLS handshake
- Scaled down the real sensor, pointed admission-control at the fake sensor via the `sensor` Service
- Patched `tls-cert-admission-control` secret with a new cert, then killed the fake sensor to force reconnections
- All 3 admission-control pods reconnected presenting the new client cert serial