### PR TITLE
ROX-33792: optimize CLI artifact upload by removing tar/gzip bundling

### DIFF
--- a/.github/actions/upload-artifact-with-retry/action.yaml
+++ b/.github/actions/upload-artifact-with-retry/action.yaml
@@ -16,6 +16,10 @@ inputs:
         error: Fail the action with an error message
         ignore: Do not output any warnings or errors, the action does not fail
     default: 'warn'
+  compression-level:
+    description: 'Compression level: 0 (none) to 9 (max). Default is 6 (zstd default)'
+    required: false
+    default: '6'
 runs:
   using: composite
   steps:
@@ -25,6 +29,7 @@ runs:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
         if-no-files-found: ${{ inputs.if-no-files-found }}
+        compression-level: ${{ inputs.compression-level }}
       continue-on-error: true
     - id: upload-artifact-try2
       if: steps.upload-artifact-try1.outcome == 'failure'
@@ -33,6 +38,7 @@ runs:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
         if-no-files-found: ${{ inputs.if-no-files-found }}
+        compression-level: ${{ inputs.compression-level }}
       continue-on-error: true
     - if: steps.upload-artifact-try2.outcome == 'failure'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
@@ -40,3 +46,4 @@ runs:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
         if-no-files-found: ${{ inputs.if-no-files-found }}
+        compression-level: ${{ inputs.compression-level }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -278,10 +278,13 @@ jobs:
             || contains(github.event.pull_request.labels.*.name, 'ci-build-cli')
         run: make cli
 
+      - name: Bundle build to preserve permissions
+        run: tar -cvf cli-build.tar bin
+
       - uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: cli-build
-          path: bin
+          path: cli-build.tar
           compression-level: 1
 
   pre-build-go-binaries:
@@ -358,8 +361,8 @@ jobs:
             GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=1 make build-prep main-build-nodeps
           fi
 
-      - name: Bundle build with tar (single file for reliable download)
-        run: tar -cf go-binaries-build.tar bin/linux_${{ matrix.arch }}
+      - name: Bundle the build to preserve permissions
+        run: tar -cvf go-binaries-build.tar bin/linux_${{ matrix.arch }}
 
       - uses: ./.github/actions/upload-artifact-with-retry
         with:
@@ -568,14 +571,18 @@ jobs:
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: cli-build
-          path: .
+
+      - name: Unpack cli build
+        run: |
+          tar xvf cli-build.tar
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: ${{ env.GO_BINARIES_BUILD_ARTIFACT }}
 
-      - name: Extract Go binaries
-        run: tar -xf go-binaries-build.tar
+      - name: Unpack Go binaries build
+        run: |
+          tar xvf go-binaries-build.tar
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:
@@ -827,7 +834,7 @@ jobs:
           name: go-binaries-build-${{ matrix.arch }}-default
 
       - name: Extract prebuilt binaries
-        run: tar -xf go-binaries-build.tar
+        run: tar xf go-binaries-build.tar
 
       - name: PR labels
         uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # ratchet:joerick/pr-labels-action@v1.0.9
@@ -945,8 +952,8 @@ jobs:
         with:
           name: go-binaries-build-${{ matrix.arch }}-${{ matrix.name }}
 
-      - name: Extract Go binaries
-        run: tar -xf go-binaries-build.tar
+      - name: Unpack Go binaries
+        run: tar xvf go-binaries-build.tar
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:
@@ -1117,14 +1124,18 @@ jobs:
     - uses: ./.github/actions/download-artifact-with-retry
       with:
         name: cli-build
-        path: .
+
+    - name: Unpack cli build
+      run: |
+        tar xvf cli-build.tar
 
     - uses: ./.github/actions/download-artifact-with-retry
       with:
         name: go-binaries-build-amd64-default
 
-    - name: Extract Go binaries
-      run: tar -xf go-binaries-build.tar
+    - name: Unpack Go binaries build
+      run: |
+        tar xvf go-binaries-build.tar
 
     - name: Scan
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -358,10 +358,13 @@ jobs:
             GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=1 make build-prep main-build-nodeps
           fi
 
+      - name: Bundle build with tar (single file for reliable download)
+        run: tar -cf go-binaries-build.tar bin/linux_${{ matrix.arch }}
+
       - uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: go-binaries-build-${{ matrix.arch }}-${{ matrix.name }}
-          path: bin/linux_${{ matrix.arch }}
+          path: go-binaries-build.tar
           compression-level: 1
 
   pre-build-docs:
@@ -570,7 +573,9 @@ jobs:
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: ${{ env.GO_BINARIES_BUILD_ARTIFACT }}
-          path: .
+
+      - name: Extract Go binaries
+        run: tar -xf go-binaries-build.tar
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:
@@ -820,7 +825,9 @@ jobs:
         uses: ./.github/actions/download-artifact-with-retry
         with:
           name: go-binaries-build-${{ matrix.arch }}-default
-          path: .
+
+      - name: Extract prebuilt binaries
+        run: tar -xf go-binaries-build.tar
 
       - name: PR labels
         uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # ratchet:joerick/pr-labels-action@v1.0.9
@@ -937,7 +944,9 @@ jobs:
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: go-binaries-build-${{ matrix.arch }}-${{ matrix.name }}
-          path: .
+
+      - name: Extract Go binaries
+        run: tar -xf go-binaries-build.tar
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:
@@ -1113,7 +1122,9 @@ jobs:
     - uses: ./.github/actions/download-artifact-with-retry
       with:
         name: go-binaries-build-amd64-default
-        path: .
+
+    - name: Extract Go binaries
+      run: tar -xf go-binaries-build.tar
 
     - name: Scan
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -357,10 +357,13 @@ jobs:
             GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=1 make build-prep main-build-nodeps
           fi
 
+      - name: Bundle build (tar only, no gzip compression)
+        run: tar -cf go-binaries-build.tar bin/linux_${{ matrix.arch }}
+
       - uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: go-binaries-build-${{ matrix.arch }}-${{ matrix.name }}
-          path: bin/linux_${{ matrix.arch }}
+          path: go-binaries-build.tar
 
   pre-build-docs:
     runs-on: ubuntu-latest
@@ -582,7 +585,9 @@ jobs:
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: ${{ env.GO_BINARIES_BUILD_ARTIFACT }}
-          path: .
+
+      - name: Unpack Go binaries build
+        run: tar -xf go-binaries-build.tar
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:
@@ -832,7 +837,9 @@ jobs:
         uses: ./.github/actions/download-artifact-with-retry
         with:
           name: go-binaries-build-${{ matrix.arch }}-default
-          path: .
+
+      - name: Extract prebuilt binaries
+        run: tar -xf go-binaries-build.tar
 
       - name: PR labels
         uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # ratchet:joerick/pr-labels-action@v1.0.9
@@ -949,7 +956,9 @@ jobs:
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: go-binaries-build-${{ matrix.arch }}-${{ matrix.name }}
-          path: .
+
+      - name: Unpack Go binaries
+        run: tar -xf go-binaries-build.tar
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:
@@ -1125,7 +1134,9 @@ jobs:
     - uses: ./.github/actions/download-artifact-with-retry
       with:
         name: go-binaries-build-amd64-default
-        path: .
+
+    - name: Unpack Go binaries build
+      run: tar -xf go-binaries-build.tar
 
     - name: Scan
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -278,13 +278,10 @@ jobs:
             || contains(github.event.pull_request.labels.*.name, 'ci-build-cli')
         run: make cli
 
-      - name: Bundle build to preserve permissions
-        run: tar -cvzf cli-build.tgz bin
-
       - uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: cli-build
-          path: cli-build.tgz
+          path: bin/
 
   pre-build-go-binaries:
     strategy:
@@ -569,10 +566,21 @@ jobs:
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: cli-build
+          path: .
 
-      - name: Unpack cli build
+      - name: Verify binary permissions after artifact download
         run: |
-          tar xvzf cli-build.tgz
+          # Verify binaries are executable
+          for binary in bin/*/roxctl bin/*/roxagent; do
+            if [ -f "$binary" ]; then
+              if [ ! -x "$binary" ]; then
+                echo "ERROR: $binary is not executable"
+                ls -la "$binary"
+                exit 1
+              fi
+              echo "✓ $binary is executable ($(stat -c '%a' "$binary"))"
+            fi
+          done
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:
@@ -1123,10 +1131,7 @@ jobs:
     - uses: ./.github/actions/download-artifact-with-retry
       with:
         name: cli-build
-
-    - name: Unpack cli build
-      run: |
-        tar xvzf cli-build.tgz
+        path: .
 
     - uses: ./.github/actions/download-artifact-with-retry
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -358,13 +358,10 @@ jobs:
             GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=1 make build-prep main-build-nodeps
           fi
 
-      - name: Bundle build (tar only, no gzip compression)
-        run: tar -cf go-binaries-build.tar bin/linux_${{ matrix.arch }}
-
       - uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: go-binaries-build-${{ matrix.arch }}-${{ matrix.name }}
-          path: go-binaries-build.tar
+          path: bin/linux_${{ matrix.arch }}
           compression-level: 1
 
   pre-build-docs:
@@ -573,9 +570,7 @@ jobs:
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: ${{ env.GO_BINARIES_BUILD_ARTIFACT }}
-
-      - name: Unpack Go binaries build
-        run: tar -xf go-binaries-build.tar
+          path: .
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:
@@ -825,9 +820,7 @@ jobs:
         uses: ./.github/actions/download-artifact-with-retry
         with:
           name: go-binaries-build-${{ matrix.arch }}-default
-
-      - name: Extract prebuilt binaries
-        run: tar -xf go-binaries-build.tar
+          path: .
 
       - name: PR labels
         uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # ratchet:joerick/pr-labels-action@v1.0.9
@@ -944,9 +937,7 @@ jobs:
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: go-binaries-build-${{ matrix.arch }}-${{ matrix.name }}
-
-      - name: Unpack Go binaries
-        run: tar -xf go-binaries-build.tar
+          path: .
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:
@@ -1122,9 +1113,7 @@ jobs:
     - uses: ./.github/actions/download-artifact-with-retry
       with:
         name: go-binaries-build-amd64-default
-
-    - name: Unpack Go binaries build
-      run: tar -xf go-binaries-build.tar
+        path: .
 
     - name: Scan
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -281,7 +281,7 @@ jobs:
       - uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: cli-build
-          path: bin/
+          path: bin
 
   pre-build-go-binaries:
     strategy:
@@ -357,13 +357,10 @@ jobs:
             GOOS=linux GOARCH=${{ matrix.arch }} CGO_ENABLED=1 make build-prep main-build-nodeps
           fi
 
-      - name: Bundle the build to preserve permissions
-        run: tar -cvzf go-binaries-build.tgz bin/linux_${{ matrix.arch }}
-
       - uses: ./.github/actions/upload-artifact-with-retry
         with:
           name: go-binaries-build-${{ matrix.arch }}-${{ matrix.name }}
-          path: go-binaries-build.tgz
+          path: bin/linux_${{ matrix.arch }}
 
   pre-build-docs:
     runs-on: ubuntu-latest
@@ -585,10 +582,7 @@ jobs:
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: ${{ env.GO_BINARIES_BUILD_ARTIFACT }}
-
-      - name: Unpack Go binaries build
-        run: |
-          tar xvzf go-binaries-build.tgz
+          path: .
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:
@@ -840,9 +834,6 @@ jobs:
           name: go-binaries-build-${{ matrix.arch }}-default
           path: .
 
-      - name: Extract prebuilt binaries
-        run: tar xzf go-binaries-build.tgz
-
       - name: PR labels
         uses: joerick/pr-labels-action@0543b277721e852d821c6738d449f2f4dea03d5f # ratchet:joerick/pr-labels-action@v1.0.9
 
@@ -958,9 +949,7 @@ jobs:
       - uses: ./.github/actions/download-artifact-with-retry
         with:
           name: go-binaries-build-${{ matrix.arch }}-${{ matrix.name }}
-
-      - name: Unpack Go binaries
-        run: tar xvzf go-binaries-build.tgz
+          path: .
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:
@@ -1136,10 +1125,7 @@ jobs:
     - uses: ./.github/actions/download-artifact-with-retry
       with:
         name: go-binaries-build-amd64-default
-
-    - name: Unpack Go binaries build
-      run: |
-        tar xvzf go-binaries-build.tgz
+        path: .
 
     - name: Scan
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -282,6 +282,7 @@ jobs:
         with:
           name: cli-build
           path: bin
+          compression-level: 1
 
   pre-build-go-binaries:
     strategy:
@@ -364,6 +365,7 @@ jobs:
         with:
           name: go-binaries-build-${{ matrix.arch }}-${{ matrix.name }}
           path: go-binaries-build.tar
+          compression-level: 1
 
   pre-build-docs:
     runs-on: ubuntu-latest
@@ -567,20 +569,6 @@ jobs:
         with:
           name: cli-build
           path: .
-
-      - name: Verify binary permissions after artifact download
-        run: |
-          # Verify binaries are executable
-          for binary in bin/*/roxctl bin/*/roxagent; do
-            if [ -f "$binary" ]; then
-              if [ ! -x "$binary" ]; then
-                echo "ERROR: $binary is not executable"
-                ls -la "$binary"
-                exit 1
-              fi
-              echo "✓ $binary is executable ($(stat -c '%a' "$binary"))"
-            fi
-          done
 
       - uses: ./.github/actions/download-artifact-with-retry
         with:


### PR DESCRIPTION
  ## Description

  Problem: `tar -cvzf` bundling in artifact uploads took ~60s per artifact due to gzip compression overhead.

  Solution: Replace gzip with faster approach:
  - Use `tar -cf` (bundling without compression)
  - Set `compression-level: 1` (fast zstd compression by GitHub Actions)
  - Tar still required as single-file artifacts download more reliably than multi-file directories

  Considered alternatives:
  - **Direct directory upload**: Attempted but failed - GitHub Actions has reliability issues downloading large multi-file artifacts (hundreds
  of binaries)
  - **Higher compression levels**: Slower with minimal size benefit for already-optimized binaries
  - **No bundling at all**: Single files download reliably, directories don't

  Why tar without gzip:
  - Tar provides bundling (single file) for reliable downloads
  - GitHub Actions v7+ applies zstd compression (faster than gzip)
  - Binaries compress poorly, so CPU time saved > network transfer penalty
  - `compression-level: 1` uses fast zstd mode

  Performance results:
  - Go binaries ~60s → 22s (38s improvement)
 
  ## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked
  above **OR** is not needed

  ## Testing and quality

  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the
  functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [x] CI results are
  [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

  ### Automated testing

  - [ ] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [ ] added compatibility tests
  - [ ] modified existing tests

  ### How I validated my change

  - Tested with PR build ([run 26050731779](https://github.com/stackrox/stackrox/actions/runs/26050731779)): all build-and-push-main jobs
  passed
  - Verified artifact upload/download/extract works correctly:
    - CLI: tar bundling + upload in ~1s (vs ~60s before)
    - Go binaries amd64: tar bundling + upload in ~22s (vs ~60s before)
  - Confirmed binaries remain executable and Docker builds succeed
  - No changes to test logic or build outputs, only CI workflow optimization