### PR TITLE
ROX-34094: Remove PDF export artifacts from VulnMgmt pages

### DIFF
--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtClusterOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtClusterOverview.jsx
@@ -82,7 +82,7 @@ const VulnMgmtClusterOverview = ({ data, entityContext }) => {
                     <div className={entityGridContainerClassName}>
                         <div className="s-1">
                             <Metadata
-                                className="h-full min-w-48 pdf-page"
+                                className="h-full min-w-48"
                                 keyValuePairs={metadataKeyValuePairs}
                                 statTiles={clusterStats}
                                 title="Details & Metadata"
@@ -118,7 +118,7 @@ const VulnMgmtClusterOverview = ({ data, entityContext }) => {
                 </CollapsibleSection>
 
                 <CollapsibleSection title="Cluster Findings">
-                    <div className="pdf-page pdf-stretch pdf-new flex relative rounded mb-4 ml-4 mr-4">
+                    <div className="flex relative rounded mb-4 ml-4 mr-4">
                         <BinderTabs>
                             <Tab title="Fixable Image CVEs">
                                 <TableWidgetFixableCves

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Component/VulnMgmtComponentOverview.jsx
@@ -89,7 +89,7 @@ function VulnMgmtComponentOverview({ data, entityContext }) {
                     <div className={entityGridContainerClassName}>
                         <div className="s-1">
                             <Metadata
-                                className="h-full min-w-48 bg-base-100 pdf-page"
+                                className="h-full min-w-48 bg-base-100"
                                 keyValuePairs={metadataKeyValuePairs}
                                 statTiles={componentStats}
                                 title="Details and metadata"
@@ -104,7 +104,7 @@ function VulnMgmtComponentOverview({ data, entityContext }) {
                     </div>
                 </CollapsibleSection>
                 <CollapsibleSection title="Component Findings">
-                    <div className="flex pdf-page pdf-stretch shadow rounded relative bg-base-100 mb-4 ml-4 mr-4">
+                    <div className="flex shadow rounded relative bg-base-100 mb-4 ml-4 mr-4">
                         <TableWidgetFixableCves
                             workflowState={workflowState}
                             entityContext={entityContext}

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cve/VulnMgmtCveOverview.jsx
@@ -150,19 +150,19 @@ const VulnMgmtCveOverview = ({ data, entityContext }) => {
                 <CollapsibleSection title="CVE Summary">
                     <div className="mx-4 grid-dense grid-auto-fit grid grid-gap-6 xxxl:grid-gap-8 lg:grid-columns-2 xl:grid-columns-3 mb-4">
                         <Metadata
-                            className="h-full min-w-48 bg-base-100 pdf-page s-2"
+                            className="h-full min-w-48 bg-base-100 s-2"
                             headerComponents={linkToMoreInfo}
                             keyValuePairs={metaDataDetails}
                             description={summary || 'No description available.'}
                             title="Description & Details"
                         />
                         <Metadata
-                            className="bg-base-100 min-h-48 pdf-page s-1"
+                            className="bg-base-100 min-h-48 s-1"
                             keyValuePairs={cvssScoreBreakdown}
                             title="CVSS Score Breakdown"
                         />
                         <Metadata
-                            className="bg-base-100 min-h-48 pdf-page s-1"
+                            className="bg-base-100 min-h-48 s-1"
                             keyValuePairs={scanningDetails}
                             title="Scanning Details"
                         />

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Deployment/VulnMgmtDeploymentOverview.jsx
@@ -67,7 +67,7 @@ const VulnMgmtDeploymentOverview = ({ data, entityContext }) => {
     const newEntityContext = { ...entityContext, ...currentEntity };
 
     const deploymentFindingsContent = (
-        <div className="flex pdf-page pdf-stretch pdf-new relative rounded mb-4 ml-4 mr-4">
+        <div className="flex relative rounded mb-4 ml-4 mr-4">
             <TableWidgetFixableCves
                 workflowState={workflowState}
                 entityContext={entityContext}
@@ -86,7 +86,7 @@ const VulnMgmtDeploymentOverview = ({ data, entityContext }) => {
                     <div className={entityGridContainerClassName}>
                         <div className="s-1">
                             <Metadata
-                                className="h-full min-w-48 bg-base-100 pdf-page"
+                                className="h-full min-w-48 bg-base-100"
                                 keyValuePairs={metadataKeyValuePairs}
                                 statTiles={deploymentStats}
                                 title="Details and metadata"

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Image/VulnMgmtImageOverview.jsx
@@ -137,7 +137,7 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
                     <div className={entityGridContainerClassName}>
                         <div className="s-1">
                             <Metadata
-                                className="h-full sm:min-h-64 min-w-48 bg-base-100 pdf-page"
+                                className="h-full sm:min-h-64 min-w-48 bg-base-100"
                                 keyValuePairs={metadataKeyValuePairs}
                                 statTiles={imageStats}
                                 title="Details and metadata"
@@ -152,7 +152,7 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
                     </div>
                 </CollapsibleSection>
                 <CollapsibleSection title="Dockerfile" defaultOpen={false}>
-                    <div className="flex pdf-page pdf-stretch pdf-new rounded relative mb-4 ml-4 mr-4">
+                    <div className="flex rounded relative mb-4 ml-4 mr-4">
                         <TableWidget
                             header={`${layers.length} ${pluralize(
                                 'layer',
@@ -169,7 +169,7 @@ const VulnMgmtImageOverview = ({ data, entityContext }) => {
                     </div>
                 </CollapsibleSection>
                 <CollapsibleSection id="image-findings" title="Image Findings" defaultOpen>
-                    <div className="flex pdf-page pdf-stretch pdf-new rounded relative mb-4 ml-4 mr-4 pb-20">
+                    <div className="flex rounded relative mb-4 ml-4 mr-4 pb-20">
                         <Alert
                             variant="warning"
                             isInline

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Namespace/VulnMgmtNamespaceOverview.jsx
@@ -95,7 +95,7 @@ const VulnMgmtNamespaceOverview = ({ data, entityContext }) => {
                     </div>
                 </CollapsibleSection>
                 <CollapsibleSection title="Namespace findings">
-                    <div className="flex pdf-page pdf-stretch pdf-new relative rounded mb-4 ml-4 mr-4">
+                    <div className="flex relative rounded mb-4 ml-4 mr-4">
                         <TableWidgetFixableCves
                             workflowState={workflowState}
                             entityContext={entityContext}

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtNodeOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Node/VulnMgmtNodeOverview.jsx
@@ -119,7 +119,7 @@ const VulnMgmtNodeOverview = ({ data, entityContext }) => {
                     <div className={entityGridContainerClassName}>
                         <div className="sx-2">
                             <Metadata
-                                className="h-full min-w-48 bg-base-100 pdf-page"
+                                className="h-full min-w-48 bg-base-100"
                                 keyValuePairs={metadataKeyValuePairs}
                                 statTiles={nodeStats}
                                 title="Details and metadata"
@@ -133,7 +133,7 @@ const VulnMgmtNodeOverview = ({ data, entityContext }) => {
                     </div>
                 </CollapsibleSection>
                 <CollapsibleSection title="Node Findings">
-                    <div className="flex pdf-page pdf-stretch pdf-new shadow relative rounded bg-base-100 mb-4 ml-4 mr-4">
+                    <div className="flex shadow relative rounded bg-base-100 mb-4 ml-4 mr-4">
                         <TableWidgetFixableCves
                             workflowState={workflowState}
                             entityContext={entityContext}

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPage.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPage.jsx
@@ -120,7 +120,7 @@ const WorkflowEntityPage = ({
         />
     ) : (
         <div className="flex w-full min-h-full bg-base-200">
-            <div className="w-full min-h-full" id="capture-widgets">
+            <div className="w-full min-h-full">
                 <OverviewComponent
                     data={result}
                     entityContext={entityContext}

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPage.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPage.jsx
@@ -120,13 +120,11 @@ const WorkflowEntityPage = ({
         />
     ) : (
         <div className="flex w-full min-h-full bg-base-200">
-            <div className="w-full min-h-full">
-                <OverviewComponent
-                    data={result}
-                    entityContext={entityContext}
-                    setRefreshTrigger={setRefreshTrigger}
-                />
-            </div>
+            <OverviewComponent
+                data={result}
+                entityContext={entityContext}
+                setRefreshTrigger={setRefreshTrigger}
+            />
         </div>
     );
 };

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPageLayout.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/WorkflowEntityPageLayout.jsx
@@ -67,8 +67,6 @@ const WorkflowEntityPageLayout = () => {
         entityContext[pageEntity.entityType] = pageEntity.entityId;
     }
 
-    const pdfId = pageListType ? 'capture-list' : 'capture-widgets';
-
     return (
         <workflowStateContext.Provider value={pageState}>
             <div className="flex flex-1 flex-col" style={style}>
@@ -88,7 +86,7 @@ const WorkflowEntityPageLayout = () => {
                 </PageHeader>
                 <EntityTabs entityType={pageEntityType} activeTab={pageListType} />
                 <div className="flex flex-1 w-full h-full relative z-0 overflow-hidden">
-                    <div className="h-full w-full overflow-auto" id={pdfId}>
+                    <div className="h-full w-full overflow-auto">
                         <EntityComponent
                             entityType={pageEntityType}
                             entityId={pageEntityId}

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.test.js
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/Cves/ListCVEs.utils.test.js
@@ -1,8 +1,3 @@
-/**
- * Reference Error: TextEncoder is not defined
- * Maybe because of ReactDOMRenderer.renderToString in pdfUtils.js file.
- */
-
 import entityTypes from 'constants/entityTypes';
 import useCases from 'constants/useCaseTypes';
 import WorkflowEntity from 'utils/WorkflowEntity';

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/EntityList.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/EntityList.jsx
@@ -1,4 +1,4 @@
-import { useContext, useRef, useLayoutEffect } from 'react';
+import { useContext, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import resolvePath from 'object-resolve-path';
@@ -8,7 +8,6 @@ import Table from 'Components/Table';
 import TablePagination from 'Components/TablePagination';
 import URLSearchInput from 'Components/URLSearchInput';
 import { searchCategories } from 'constants/entityTypes';
-import createPDFTable from 'utils/pdfUtils';
 import CheckboxTable from 'Components/CheckboxTable';
 
 import {
@@ -78,18 +77,6 @@ const EntityList = ({
 
     const placeholder = `Filter ${entityNounOrdinaryCasePlural[entityType]}`;
 
-    // need `useLayoutEffect` here to solve an edge case,
-    //   where the use have navigated to a single-page sublist,
-    //   then clicked "Open in current window",
-    //   then clicked the browser's back button
-    //   see: https://stack-rox.atlassian.net/browse/ROX-4450
-    useLayoutEffect(() => {
-        if (rowData.length) {
-            const query = {}; // TODO: improve sep. of concerns in pdfUtils
-            createPDFTable(rowData, entityType, query, 'capture-list', tableColumns);
-        }
-    }, [entityType, rowData, tableColumns]);
-
     const availableCategories = [searchCategories[entityType]];
     const headerComponents = (
         <>
@@ -118,7 +105,6 @@ const EntityList = ({
             columns={tableColumns}
             onRowClick={onRowClickHandler}
             idAttribute={idAttribute}
-            id="capture-list"
             selectedRowId={selectedRowId}
             noDataText={noDataText}
             SubComponent={SubComponent}
@@ -137,7 +123,6 @@ const EntityList = ({
                 columns={tableColumns}
                 onRowClick={onRowClickHandler}
                 idAttribute={idAttribute}
-                id="capture-list"
                 selectedRowId={selectedRowId}
                 noDataText={noDataText}
                 SubComponent={SubComponent}

--- a/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPageLayout.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/List/WorkflowListPageLayout.jsx
@@ -71,7 +71,7 @@ const WorkflowListPageLayout = () => {
                         </div>
                     </div>
                 </PageHeader>
-                <div className="h-full relative z-0 min-h-0 bg-base-100" id="capture-list">
+                <div className="h-full relative z-0 min-h-0 bg-base-100">
                     <ListComponent
                         entityListType={pageListType}
                         selectedRowId={selectedRow && selectedRow.entityId}

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/ClustersWithMostClusterVulnerabilities.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/ClustersWithMostClusterVulnerabilities.jsx
@@ -233,7 +233,7 @@ const ClustersWithMostClusterVulnerabilities = ({ entityContext, limit }) => {
 
     return (
         <Widget
-            className="h-full pdf-page"
+            className="h-full"
             header="Clusters with most orchestrator and Istio vulnerabilities"
             headerComponents={<ViewAllButton url={viewAllURL} />}
         >

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/CvesByCvssScore.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/CvesByCvssScore.jsx
@@ -152,7 +152,7 @@ const CvesByCvssScore = ({ entityContext, parentContext }) => {
     }
 
     return (
-        <Widget className="h-full pdf-page" header="CVEs by CVSS score" headerComponents={header}>
+        <Widget className="h-full" header="CVEs by CVSS score" headerComponents={header}>
             {content}
         </Widget>
     );

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabilities.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabilities.jsx
@@ -111,7 +111,7 @@ const MostCommonVulnerabilities = ({ entityContext, search, limit }) => {
 
     return (
         <Widget
-            className="h-full pdf-page"
+            className="h-full"
             header="Most common image vulnerabilities"
             headerComponents={<ViewAllButton url={viewAllURL} />}
         >

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabiltiesInDeployment.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/MostCommonVulnerabiltiesInDeployment.jsx
@@ -88,7 +88,7 @@ const MostCommonVulnerabiltiesInDeployment = ({ deploymentId, limit }) => {
 
     return (
         <Widget
-            className="h-full pdf-page"
+            className="h-full"
             header="Most common image vulnerabilities"
             headerComponents={<ViewAllButton url={viewAllURL} />}
         >

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/RecentlyDetectedImageVulnerabilities.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/RecentlyDetectedImageVulnerabilities.jsx
@@ -113,7 +113,7 @@ const RecentlyDetectedImageVulnerabilities = ({ entityContext, search, limit }) 
 
     return (
         <Widget
-            className="h-full pdf-page"
+            className="h-full"
             header="Recently detected image vulnerabilities"
             headerComponents={<ViewAllButton url={viewAllURL} />}
         >

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskiestEntities.jsx
@@ -402,7 +402,7 @@ const TopRiskiestEntities = ({ entityContext, search, limit }) => {
 
     return (
         <Widget
-            className="h-full pdf-page"
+            className="h-full"
             titleComponents={
                 <TextSelect value={selectedEntity} options={entities} onChange={onEntityChange} />
             }

--- a/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/widgets/TopRiskyEntitiesByVulnerabilities.jsx
@@ -324,7 +324,7 @@ const TopRiskyEntitiesByVulnerabilities = ({
 
     return (
         <Widget
-            className="h-full pdf-page pdf-stretch"
+            className="h-full"
             titleComponents={titleComponents}
             headerComponents={viewAll}
             bodyClassName="pr-2"


### PR DESCRIPTION
## Description

**Jira:** [ROX-34094](https://issues.redhat.com/browse/ROX-34094)

As part of the jspdf removal effort (ROX-34090), this PR cleans up PDF export artifacts from the Vulnerability Management 1.0 pages. CSS classes like `pdf-page`, `pdf-stretch`, and `pdf-new` were applied to elements across entity overview and widget components for PDF capture, and the `EntityList` component called `createPDFTable` from `pdfUtils` on every render via `useLayoutEffect`. With the PDF export feature being removed, these are now dead code.

- Remove all `pdf-page`, `pdf-stretch`, and `pdf-new` CSS class references from VulnMgmt entity overviews and widgets
- Remove `createPDFTable` import and `useLayoutEffect` call from `EntityList`
- Remove `id="capture-list"` and `id="capture-widgets"` attributes used only for PDF capture
- Remove unused `pdfId` variable from `WorkflowEntityPageLayout`
- Remove redundant wrapper `div` around `OverviewComponent` in `WorkflowEntityPage`
- Remove outdated comment referencing `pdfUtils.js` in `ListCVEs.utils.test.js`

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Verified linting and type checking pass on all modified files
- Confirmed the existing `ListCVEs.utils.test.js` test suite passes without the removed comment block
- Changes are purely cosmetic (removing dead CSS classes and unused code) with no logic changes -- existing tests cover the affected components

[ROX-34094]: https://redhat.atlassian.net/browse/ROX-34094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ