### PR TITLE
fix(ui): Fix entity scope regex prefix display

### DIFF
--- a/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
+++ b/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
@@ -173,7 +173,7 @@ function getEntityScopeRulesFromSearchFilter(
 }
 
 export const ruleFieldValueMapper = ({ matchType, value }: RuleValue): string =>
-    matchType === 'EXACT' ? wrapInQuotes(value) : `r/${value}`;
+    matchType === 'EXACT' ? wrapInQuotes(value) : value;
 
 /**
  * Return search filter in EntityScopeCompoundSearchFilter component.


### PR DESCRIPTION
## Description

Fixes the "format of truth" for filter representation in memory, the URL, and in view based reports:

- REGEX will be stored as a raw string `value`
- EXACT match will be stored with double quotes `"value"`

The addition of the `r/` prefix is an implementation details of the search API specifically, and will only be prepended before those queries are sent. Otherwise this prefix will not be stored and will not be added to report configurations.

## Follow up

Unit tests coming in next PR.


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Create a view based report using a REGEX filter match. Save, edit, and save the report again, ensuring the `r/` prefix is not visible in search filter chips, and the previewed filter value does not contain `r/`:
<img width="1600" height="728" alt="image" src="https://github.com/user-attachments/assets/969eef68-b1bc-4a41-a514-f1a1d1ed710c" />
<img width="1600" height="821" alt="image" src="https://github.com/user-attachments/assets/fb914583-ec5f-49ab-a08c-23ac66b081b5" />

Before this change, so prefix in filter chip:
<img width="1600" height="800" alt="image" src="https://github.com/user-attachments/assets/e7f09eb2-58e0-49a3-a7b7-b9fd94e77754" />


