### PR TITLE
ROX-34743: Clear entityScope.rules when imageTypes has WATCHED only

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizardPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizardPage.tsx
@@ -23,12 +23,14 @@ import type { ReportPageAction } from 'Components/Reports/reports.types';
 import useFeatureFlags from 'hooks/useFeatureFlags';
 import useURLSearch from 'hooks/useURLSearch';
 import { fetchReportConfiguration } from 'services/ReportsService';
+import type { SearchFieldLabel } from 'types/searchOptions';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import {
     deleteKeysCaseInsensitive,
     getHasSearchApplied,
     getRequestQueryStringForSearchFilter,
     getValueByCaseInsensitiveKey,
+    searchValueAsArray,
 } from 'utils/searchUtils';
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
 
@@ -44,6 +46,14 @@ import type {
 } from '../imageVulnerabilityReports.types';
 
 import ImageVulnerabilityReportWizard from './ImageVulnerabilityReportWizard';
+
+const searchFilterLabelsForImages: SearchFieldLabel[] = [
+    'Image',
+    'Image Label',
+    // 'Image OS' did not seem as relevant a heuristic (see below)
+    'Image Registry',
+    'Image Tag',
+] as const;
 
 type ImageVulnerabilityReportWizardPageProps = {
     pageAction: ReportPageAction;
@@ -93,8 +103,10 @@ function ImageVulnerabilityReportWizardPage({
             const reportConfigurationFromFilters: ImageVulnerabilityReportConfigurationForEntity =
                 cloneDeep(defaultImageVulnerabilityReportConfiguration);
 
-            reportConfigurationFromFilters.resourceScope.entityScope.rules =
+            const rules =
                 getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment(searchFilter);
+
+            reportConfigurationFromFilters.resourceScope.entityScope.rules = rules;
 
             // Inconsistency in time filter:
             // CVE Created Time from results means first discovered in system.
@@ -102,8 +114,8 @@ function ImageVulnerabilityReportWizardPage({
             // Therefore:
             // Call deleteKeysCaseInsensitive function to delete from search filter for query.
             // If relation is After then set corresponding property of report configuration.
-            const searchFieldLabel = 'CVE Created Time';
-            const value = getValueByCaseInsensitiveKey(searchFilter, searchFieldLabel);
+            const searchFieldLabelForTime = 'CVE Created Time';
+            const value = getValueByCaseInsensitiveKey(searchFilter, searchFieldLabelForTime);
             if (typeof value === 'string' && value.startsWith('>')) {
                 const result = />(\d\d)\/(\d\d)\/(\d\d\d\d)/.exec(value);
                 if (Array.isArray(result)) {
@@ -118,12 +130,29 @@ function ImageVulnerabilityReportWizardPage({
                 }
             }
 
+            const searchFilterWithoutEntityScope = getSearchFilterWithoutEntityScope(
+                deleteKeysCaseInsensitive(searchFilter, [searchFieldLabelForTime])
+            );
+
+            // Presence of entity scope rules is heuristice for DEPLOYED images.
+            // Search filter from results is heuristic for WATCHED images.
+            const platformComponent = searchValueAsArray(
+                searchFilterWithoutEntityScope['Platform Component']
+            );
+
+            if (rules.length !== 0) {
+                reportConfigurationFromFilters.vulnReportFilters.imageTypes = ['DEPLOYED'];
+            } else if (
+                Object.keys(searchFilterWithoutEntityScope).some((key) =>
+                    searchFilterLabelsForImages.includes(key as SearchFieldLabel)
+                ) ||
+                (platformComponent.length === 1 && platformComponent[0] === '-') // Inactive images
+            ) {
+                reportConfigurationFromFilters.vulnReportFilters.imageTypes = ['WATCHED'];
+            } // else imageTypes is initially unspecified (for example, Create report)
+
             reportConfigurationFromFilters.vulnReportFilters.query =
-                getRequestQueryStringForSearchFilter(
-                    getSearchFilterWithoutEntityScope(
-                        deleteKeysCaseInsensitive(searchFilter, [searchFieldLabel])
-                    )
-                );
+                getRequestQueryStringForSearchFilter(searchFilterWithoutEntityScope);
 
             setReportConfiguration(reportConfigurationFromFilters);
         } else {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
@@ -10,7 +10,12 @@ import {
 } from 'Components/EntityScope/entityScopeRules';
 import { searchFilterConfigForClusterNamespaceDeployment } from 'Components/EntityScope/searchFilterConfig';
 import FormLabelGroup from 'Components/PatternFly/FormLabelGroup';
-import type { CollectionScope, EntityScope, ImageType } from 'services/ReportsService.types';
+import type {
+    CollectionScope,
+    EntityScope,
+    EntityScopeRule,
+    ImageType,
+} from 'services/ReportsService.types';
 
 import type {
     ImageVulnerabilityFiltersConfiguration,
@@ -23,6 +28,10 @@ import {
 
 import CollectionScopeSelect from './CollectionScopeSelect';
 import ImageTypeSelect from './ImageTypeSelect';
+
+function hasWatchedImagesOnly(imageTypes: ImageType[]) {
+    return imageTypes.length === 1 && imageTypes[0] === 'WATCHED';
+}
 
 export type ImageVulnerabilityResourcesStepProps<
     T extends ImageVulnerabilityResourcesConfiguration = ImageVulnerabilityResourcesConfiguration,
@@ -55,8 +64,26 @@ function ImageVulnerabilityResourcesStep<
         ) as unknown as ImageVulnerabilityResourcesConfiguration['vulnReportFilters']
     );
 
+    // Remember rules property of entityScope if user selects WATCHED only.
+    // If user selects DEPLOYED again, then restore it instead of having forgotten it.
+    const [rulesSelected, setRulesSelected] = useState<EntityScopeRule[]>([]);
+
     function setImageTypes(imageTypes: ImageType[]) {
         formik.setFieldValue('vulnReportFilters.imageTypes', imageTypes);
+
+        if ('entityScope' in formik.values.resourceScope) {
+            const { rules } = formik.values.resourceScope.entityScope;
+            if (hasWatchedImagesOnly(imageTypes)) {
+                setRulesSelected(rules);
+                if (rules.length !== 0) {
+                    formik.setFieldValue('resourceScope.entityScope.rules', []);
+                }
+            } else if (imageTypes.includes('DEPLOYED')) {
+                if (rules.length === 0 && rulesSelected.length !== 0) {
+                    formik.setFieldValue('resourceScope.entityScope.rules', rulesSelected);
+                }
+            }
+        }
     }
 
     function onChangeToCollectionScope() {
@@ -150,7 +177,10 @@ function ImageVulnerabilityResourcesStep<
                                 body={
                                     <EntityScopeCompoundSearchFilter
                                         entityScope={
-                                            'entityScope' in formik.values.resourceScope
+                                            'entityScope' in formik.values.resourceScope &&
+                                            !hasWatchedImagesOnly(
+                                                formik.values.vulnReportFilters.imageTypes
+                                            )
                                                 ? formik.values.resourceScope.entityScope
                                                 : null // disable compound search filter
                                         }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/Step2/ImageVulnerabilityResourcesStep.tsx
@@ -80,6 +80,13 @@ function ImageVulnerabilityResourcesStep<
                 }
             } else if (imageTypes.includes('DEPLOYED')) {
                 if (rules.length === 0 && rulesSelected.length !== 0) {
+                    // rules.length === 0 if either
+                    // no rules yet (especially for Create report) or
+                    // rules had been cleared when imageTypes became WATCHED only
+                    // rulesSelected.length !== 0 if
+                    // non-empty rules had been remembered when imageTypes became WATCHED only
+                    // Given the following statement, second condition might be redundant:
+                    setRulesSelected([]); // remembered rules become stale after having been restored
                     formik.setFieldValue('resourceScope.entityScope.rules', rulesSelected);
                 }
             }


### PR DESCRIPTION
## Description

### Problem

Thank you **Surabhi** and **Cong** for reporting this problem.

1. If **Image type** has **Watched images** only on **Resources** step, and if **Custom scope** is selected for **Resource scope** than compound search filter has been enabled, but rules for cluster, deployment, namespace are not relevant.

2. It is more subtle if **Image types** is unspecified.

    I replaced **both** selected with **neither** selected in #20594

### Analysis

1. `EntityScopeCompoundSearchFilter` has `entityScope={null}` property for disabled.

    * However, initial value is in `searchFilter` of component state, for the scenario that user changes **Image type** to include **Deployed images** option.

        Although this becomes a second source of truth, it seems to work out okay.

    * **Resources** step component itself needs to clear `rules` array **and** remember its value for the scenario mentioned above.

2. At least for **Create scheduled report** from results page, use entity scope rules or search filter as heuristic to select either **Deployed images** or **Watched images** as a courtesy.

### Solution

1. Edit ImageVulnerabilityResourcesStep.tsx file.

    * Add `rulesSelected` in component state.

        ```ts
        // Remember rules property of entityScope if user selects WATCHED only.
        // If user selects DEPLOYED again, then restore it instead of having forgotten it.
        ```

    * Add business logic to clear or restore rules in `setImageTypes` function.

    * Add condition with `hasWatchedImagesOnly` function call to disable `EntityScopeCompoundSearchFilter` element.

2. Edit ImageVulnerabilityReportWizardPage.tsx file.

    * Add heuristic conditions to select `'DEPLOYED'` or `'WATCHED'` for `imageTypes` property according to search filter when user creates scheduled report from view.

### Residue

1. Although keeping multiple selection for backward compatibility, it seems worthwhile to consider image type as part of user decision, for example **Create report** with dropdown options **Deployed images** and **Watched images** so that **Resources** step appears in relevant state.

    This follows precedent of Auth providers in Access Control and also Integrations, where initial choice of **which** authentication method or **which** integration increases clarity and reduces complexity.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

Create scheduled report with heuristic for deployed images:

1. Visit /main/vulnerabilities/platform select filters, click **Create report**, click **Create scheduled report**, and then go to **Resources** step of wizard.
    <img width="1440" height="892" alt="DEPLOYED_Platform" src="https://github.com/user-attachments/assets/9854a4c4-9c2c-425c-816e-d9bdcfa6ce98" />

    Because of entity scope rules, see:

    * **Deployed images** for **Image type**
    * Compound search filter labels for **Cluster name**, **Deployment name**, **Namespace name**
    <img width="1441" height="892" alt="DEPLOYED_Resources" src="https://github.com/user-attachments/assets/101944a8-2a68-4f32-b6ed-290294b0e011" />

2. Select **Watched images** and then clear **Deployed images**

    See **Custom scope** selected, compound search filter is disabled, and labels are absent.

3. Select **Deployed images** again.

    See compound search filter is enabled and labels are present.

4. Go to **Filters** step.

    See search filter labels that correspond to horizontal navigation, tabs, and default filters.
    <img width="1440" height="892" alt="DEPLOYED_Filters" src="https://github.com/user-attachments/assets/6676b1fc-b729-4992-b7f1-bd9b6988aa57" />

Create scheduled report with heuristic for watched images:

1. Visit /main/vulnerabilities/platform select filters, click **Create report**, click **Create scheduled report**, and then go to **Resources** step of wizard.
    <img width="1440" height="892" alt="WATCHED_Platform" src="https://github.com/user-attachments/assets/8b0a3f75-3a44-40d9-99b1-05b37e811676" />

    Because search filters for images instead of entity scope rules, see:

    * **Watched images** for **Image type**
    * See **Custom scope** selected, compound search filter is disabled, and labels are labels are absent.
    <img width="1440" height="892" alt="WATCHED_Resources" src="https://github.com/user-attachments/assets/07ebd43a-e20b-4ad7-abb6-9cbe33123535" />

2. Select **Deployed images**

    See compound search filter is enabled and labels are absent.

3. Clear **Deployed images** again.

    See compound search filter is disabled, and labels are absent.

4. Go to **Filters** step.

    See search filter labels that include **Moderate** for **CVE severity** and also image name.
    <img width="1440" height="892" alt="WATCHED_Filters" src="https://github.com/user-attachments/assets/e2a5c37f-fe12-456d-a330-0709ff7d759f" />

Create report from report configurations

1. Visit /main/vulnerabilities/reports/configuration?action=create and go to **Resources** step

    * **Image type** has no initial selection
    * **Custom scope** is selected, compound search filter is enabled, and labels are absent.
    <img width="1440" height="892" alt="Create_report_Resources" src="https://github.com/user-attachments/assets/35fc37f1-07bc-42df-a80e-bc556e42158d" />

2. Go to **Filters** step.

    See search filter labels that correspond to default filters plus **Observed** for **Vulnerability state**.
    <img width="1440" height="892" alt="Create_report_Filters" src="https://github.com/user-attachments/assets/cfcf37db-e835-4ff1-937f-caf369b28783" />
