### PR TITLE
ROX-29929: add changelog for imageV2 data model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 - ROX-26033: Compliance now tracks tailored profiles and custom rules from the Compliance Operator. Tailored profiles can be included in scan configurations, and their check results are shown in the Coverage page and CSV reports.
 - ROX-34407: Deprecated fields to select optional columns NVD CVSS, EPSS Probability and Advisory from Vulnerability Reporting. These columns will be included by default next to similar columns. This change also affects column order in reports. 
 - ROX-33108: Added Component Version Column in Vulnerability Reporting.
+- ROX-32865: Images are now uniquely identified by the combination of name and digest, rather
+  than by digest alone. This new data model resolves several long-standing issues when multiple
+  images share the same digest but have different names (e.g., different registries or tags):
+  - Deployments now correctly distinguish images with the same digest but different names,
+    so each deployment shows its own image reference in VM dashboards and vice-versa.
+  - Vulnerability exceptions (deferrals, false positives) can now be correctly scoped to a
+    specific image name. Previously, a deferral/false-positive created for one image name
+    would leak to all images sharing the same digest.
+  - Policies now evaluate correctly per the deployed/checked image name and respect its
+    vulnerability exceptions, rather than being affected by shared-digest exception leakage.
 
 ### Removed Features
 


### PR DESCRIPTION
## Description

Add CHANGELOG.md entry for the new imageV2 data model (ROX-32865).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Changelog-only change, no code modifications.