### PR TITLE
fix(compliance): remove useless error wrapping and fix punctuation

### DIFF
--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -273,11 +273,11 @@ func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *s
 	err := m.scanSettingDS.ScanConfigurationProfileExists(ctx, scanRequest.GetId(), profiles, clusters)
 	if err != nil {
 		log.Error(err)
-		return nil, errors.Wrapf(err, "Unable to create scan configuration named %q", scanRequest.GetScanConfigName())
+		return nil, err
 	}
 
 	if err := m.checkForExternalSSBConflicts(ctx, profiles, clusters); err != nil {
-		return nil, errors.Wrapf(err, "Unable to create scan configuration named %q.", scanRequest.GetScanConfigName())
+		return nil, err
 	}
 
 	// Get all profiles from the database to validate that they exist and are compatible

--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -93,7 +93,7 @@ func (m *managerImpl) ProcessComplianceOperatorInfo(ctx context.Context, complia
 	// TODO (ROX-18101):  Shouldn't happen once ROX-18101 is implemented.  Deferring more thorough handling
 	// of this condition to that ticket.
 	if len(existingIntegrations) > 1 {
-		return errors.Errorf("multiple compliance operators for cluster %q exist", complianceIntegration.GetClusterId())
+		return errors.Errorf("multiple compliance operators for cluster %q exist.", complianceIntegration.GetClusterId())
 	}
 
 	// Not found so an add
@@ -137,7 +137,7 @@ func (m *managerImpl) ProcessScanRequest(ctx context.Context, scanRequest *stora
 		return nil, err
 	}
 	if scanConfig != nil {
-		return nil, errors.Errorf("Scan configuration named %q already exists", scanRequest.GetScanConfigName())
+		return nil, errors.Errorf("Scan configuration named %q already exists.", scanRequest.GetScanConfigName())
 	}
 
 	scanRequest.Id = uuid.NewV4().String()
@@ -174,12 +174,12 @@ func (m *managerImpl) UpdateScanRequest(ctx context.Context, scanRequest *storag
 		return nil, err
 	}
 	if !found {
-		return nil, errors.Errorf("Scan configuration with ID %q does not exist", scanRequest.GetId())
+		return nil, errors.Errorf("Scan configuration with ID %q does not exist.", scanRequest.GetId())
 	}
 
 	// We are using scan schedule name as FK in scan results. Changing name would break relation.
 	if oldScanConfig.GetScanConfigName() != scanRequest.GetScanConfigName() {
-		return nil, errors.New("Changing the scan schedule name is not allowed")
+		return nil, errors.New("Changing the scan schedule name is not allowed.")
 	}
 
 	// TODO(ROX-22398): if we restrict cluster deletion, this is where we would do it before any updates are done.
@@ -290,7 +290,7 @@ func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *s
 	}
 
 	if len(returnedProfiles) != len(profiles) {
-		return nil, errors.Errorf("Unable to find all profiles for scan configuration named %q", scanRequest.GetScanConfigName())
+		return nil, errors.Errorf("Unable to find all profiles for scan configuration named %q.", scanRequest.GetScanConfigName())
 	}
 
 	// Validate profile kinds. UNSPECIFIED should not appear here because centralToStorageProfileKind
@@ -314,7 +314,7 @@ func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *s
 	err = m.scanSettingDS.UpsertScanConfiguration(ctx, scanRequest)
 	if err != nil {
 		log.Error(err)
-		return nil, errors.Errorf("Unable to save scan configuration named %q", scanRequest.GetScanConfigName())
+		return nil, errors.Errorf("Unable to save scan configuration named %q.", scanRequest.GetScanConfigName())
 	}
 
 	profileRefs := internaltov2storage.ScanConfigRefsToCentral(scanRequest.GetProfileRefs())
@@ -560,7 +560,7 @@ func (m *managerImpl) DeleteScan(ctx context.Context, scanID string) error {
 	}
 
 	if scanConfigName == "" {
-		return errors.Errorf("Unable to find scan configuration name for ID %q", scanID)
+		return errors.Errorf("Unable to find scan configuration name for ID %q.", scanID)
 	}
 
 	// send delete request to sensor
@@ -622,7 +622,7 @@ func convertSchedule(scanRequest *storage.ComplianceOperatorScanConfigurationV2)
 		}
 		cronValidator := gronx.New()
 		if !cronValidator.IsValid(cron) {
-			err = errors.Errorf("Schedule for scan configuration named %q is invalid", scanRequest.GetScanConfigName())
+			err = errors.Errorf("Schedule for scan configuration named %q is invalid.", scanRequest.GetScanConfigName())
 			log.Error(err)
 			return "", err
 		}

--- a/central/complianceoperator/v2/compliancemanager/manager_impl.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl.go
@@ -93,7 +93,7 @@ func (m *managerImpl) ProcessComplianceOperatorInfo(ctx context.Context, complia
 	// TODO (ROX-18101):  Shouldn't happen once ROX-18101 is implemented.  Deferring more thorough handling
 	// of this condition to that ticket.
 	if len(existingIntegrations) > 1 {
-		return errors.Errorf("multiple compliance operators for cluster %q exist.", complianceIntegration.GetClusterId())
+		return errors.Errorf("multiple compliance operators for cluster %q exist", complianceIntegration.GetClusterId())
 	}
 
 	// Not found so an add
@@ -132,12 +132,12 @@ func (m *managerImpl) ProcessScanRequest(ctx context.Context, scanRequest *stora
 	// Check if scan configuration already exists by name.
 	scanConfig, err := m.scanSettingDS.GetScanConfigurationByName(ctx, scanRequest.GetScanConfigName())
 	if err != nil {
-		err = errors.Wrapf(err, "Unable to create scan configuration named %q.", scanRequest.GetScanConfigName())
+		err = errors.Wrapf(err, "Unable to create scan configuration named %q", scanRequest.GetScanConfigName())
 		log.Error(err)
 		return nil, err
 	}
 	if scanConfig != nil {
-		return nil, errors.Errorf("Scan configuration named %q already exists.", scanRequest.GetScanConfigName())
+		return nil, errors.Errorf("Scan configuration named %q already exists", scanRequest.GetScanConfigName())
 	}
 
 	scanRequest.Id = uuid.NewV4().String()
@@ -169,17 +169,17 @@ func (m *managerImpl) UpdateScanRequest(ctx context.Context, scanRequest *storag
 	// Verify the scan configuration ID is valid
 	oldScanConfig, found, err := m.scanSettingDS.GetScanConfiguration(ctx, scanRequest.GetId())
 	if err != nil {
-		err = errors.Wrapf(err, "Unable to find scan configuration with ID %q.", scanRequest.GetId())
+		err = errors.Wrapf(err, "Unable to find scan configuration with ID %q", scanRequest.GetId())
 		log.Error(err)
 		return nil, err
 	}
 	if !found {
-		return nil, errors.Errorf("Scan configuration with ID %q does not exist.", scanRequest.GetId())
+		return nil, errors.Errorf("Scan configuration with ID %q does not exist", scanRequest.GetId())
 	}
 
 	// We are using scan schedule name as FK in scan results. Changing name would break relation.
 	if oldScanConfig.GetScanConfigName() != scanRequest.GetScanConfigName() {
-		return nil, errors.New("Changing the scan schedule name is not allowed.")
+		return nil, errors.New("Changing the scan schedule name is not allowed")
 	}
 
 	// TODO(ROX-22398): if we restrict cluster deletion, this is where we would do it before any updates are done.
@@ -273,7 +273,7 @@ func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *s
 	err := m.scanSettingDS.ScanConfigurationProfileExists(ctx, scanRequest.GetId(), profiles, clusters)
 	if err != nil {
 		log.Error(err)
-		return nil, errors.Wrapf(err, "Unable to create scan configuration named %q.", scanRequest.GetScanConfigName())
+		return nil, errors.Wrapf(err, "Unable to create scan configuration named %q", scanRequest.GetScanConfigName())
 	}
 
 	if err := m.checkForExternalSSBConflicts(ctx, profiles, clusters); err != nil {
@@ -286,11 +286,11 @@ func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *s
 		AddExactMatches(search.ComplianceOperatorProfileName, profiles...).ProtoQuery())
 
 	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to retrieve profiles for scan configuration named %q.", scanRequest.GetScanConfigName())
+		return nil, errors.Wrapf(err, "Unable to retrieve profiles for scan configuration named %q", scanRequest.GetScanConfigName())
 	}
 
 	if len(returnedProfiles) != len(profiles) {
-		return nil, errors.Errorf("Unable to find all profiles for scan configuration named %q.", scanRequest.GetScanConfigName())
+		return nil, errors.Errorf("Unable to find all profiles for scan configuration named %q", scanRequest.GetScanConfigName())
 	}
 
 	// Validate profile kinds. UNSPECIFIED should not appear here because centralToStorageProfileKind
@@ -314,7 +314,7 @@ func (m *managerImpl) processRequestToSensor(ctx context.Context, scanRequest *s
 	err = m.scanSettingDS.UpsertScanConfiguration(ctx, scanRequest)
 	if err != nil {
 		log.Error(err)
-		return nil, errors.Errorf("Unable to save scan configuration named %q.", scanRequest.GetScanConfigName())
+		return nil, errors.Errorf("Unable to save scan configuration named %q", scanRequest.GetScanConfigName())
 	}
 
 	profileRefs := internaltov2storage.ScanConfigRefsToCentral(scanRequest.GetProfileRefs())
@@ -556,11 +556,11 @@ func (m *managerImpl) DeleteScan(ctx context.Context, scanID string) error {
 	// Remove the scan configuration from the database
 	scanConfigName, err := m.scanSettingDS.DeleteScanConfiguration(ctx, scanID)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to delete scan configuration ID %q.", scanID)
+		return errors.Wrapf(err, "Unable to delete scan configuration ID %q", scanID)
 	}
 
 	if scanConfigName == "" {
-		return errors.Errorf("Unable to find scan configuration name for ID %q.", scanID)
+		return errors.Errorf("Unable to find scan configuration name for ID %q", scanID)
 	}
 
 	// send delete request to sensor
@@ -616,13 +616,13 @@ func convertSchedule(scanRequest *storage.ComplianceOperatorScanConfigurationV2)
 	if scanRequest.GetSchedule() != nil {
 		cron, err = schedule.ConvertToCronTab(scanRequest.GetSchedule())
 		if err != nil {
-			err = errors.Wrapf(err, "Unable to convert schedule for scan configuration named %q to cron.", scanRequest.GetScanConfigName())
+			err = errors.Wrapf(err, "Unable to convert schedule for scan configuration named %q to cron", scanRequest.GetScanConfigName())
 			log.Error(err)
 			return "", err
 		}
 		cronValidator := gronx.New()
 		if !cronValidator.IsValid(cron) {
-			err = errors.Errorf("Schedule for scan configuration named %q is invalid.", scanRequest.GetScanConfigName())
+			err = errors.Errorf("Schedule for scan configuration named %q is invalid", scanRequest.GetScanConfigName())
 			log.Error(err)
 			return "", err
 		}

--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -269,7 +269,7 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(gomock.Any(), mockScanName).Return(getTestRec(), nil).Times(1)
 			},
 			isErrorTest: true,
-			expectedErr: fmt.Sprintf("Scan configuration named %q already exists", mockScanName),
+			expectedErr: fmt.Sprintf("Scan configuration named %q already exists.", mockScanName),
 		},
 		{
 			desc:        "Scan configuration has duplicate profiles",

--- a/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
+++ b/central/complianceoperator/v2/compliancemanager/manager_impl_test.go
@@ -269,7 +269,7 @@ func (suite *complianceManagerTestSuite) TestProcessScanRequest() {
 				suite.scanConfigDS.EXPECT().GetScanConfigurationByName(gomock.Any(), mockScanName).Return(getTestRec(), nil).Times(1)
 			},
 			isErrorTest: true,
-			expectedErr: fmt.Sprintf("Scan configuration named %q already exists.", mockScanName),
+			expectedErr: fmt.Sprintf("Scan configuration named %q already exists", mockScanName),
 		},
 		{
 			desc:        "Scan configuration has duplicate profiles",

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -238,7 +238,7 @@ func (s *serviceImpl) ListComplianceScanConfigurations(ctx context.Context, quer
 
 	scanStatuses, err := convertStorageScanConfigToV2ScanStatuses(ctx, scanConfigs, s.scanConfigDS, s.complianceScanSettingBindingsDS, s.suiteDS, s.notifierDS)
 	if err != nil {
-		return nil, errors.Wrap(errox.InvalidArgs, "failed to convert compliance scan configurations")
+		return nil, errors.Wrap(errox.InvalidArgs, "failed to convert compliance scan configurations.")
 	}
 
 	scanConfigCount, err := s.scanConfigDS.CountScanConfigurations(ctx, countQuery)
@@ -520,7 +520,7 @@ func validateScanConfiguration(req *v2.ComplianceScanConfiguration) error {
 	}
 
 	if req.GetScanConfig() == nil {
-		return errors.Wrap(errox.InvalidArgs, "The scan configuration is nil")
+		return errors.Wrap(errox.InvalidArgs, "The scan configuration is nil.")
 	}
 
 	if len(req.GetScanConfig().GetProfiles()) == 0 {

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -212,7 +212,7 @@ func (s *serviceImpl) DeleteComplianceScanConfiguration(ctx context.Context, req
 
 	err = s.manager.DeleteScan(ctx, req.GetId())
 	if err != nil {
-		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
+		return nil, errox.InvalidArgs.CausedBy(err)
 	}
 
 	return &v2.Empty{}, nil

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -144,7 +144,7 @@ func (s *serviceImpl) CreateComplianceScanConfiguration(ctx context.Context, req
 	// Process scan request, config may be updated in the event of errors from sensor.
 	scanConfig, err := s.manager.ProcessScanRequest(ctx, scanConfig, clusterIDs)
 	if err != nil {
-		return nil, errors.Wrapf(errox.InvalidArgs, "Unable to process scan config. %v", err)
+		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 
 	return convertStorageScanConfigToV2(ctx, scanConfig, s.scanConfigDS)
@@ -169,7 +169,7 @@ func (s *serviceImpl) UpdateComplianceScanConfiguration(ctx context.Context, req
 	// Update scan request, config may be updated in the event of errors from sensor.
 	_, err := s.manager.UpdateScanRequest(ctx, scanConfig, clusterIDs)
 	if err != nil {
-		return nil, errors.Wrapf(errox.InvalidArgs, "Unable to process scan config. %v", err)
+		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 
 	return &v2.Empty{}, nil
@@ -212,7 +212,7 @@ func (s *serviceImpl) DeleteComplianceScanConfiguration(ctx context.Context, req
 
 	err = s.manager.DeleteScan(ctx, req.GetId())
 	if err != nil {
-		return nil, errors.Wrapf(errox.InvalidArgs, "Unable to delete scan config: %v", err)
+		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 
 	return &v2.Empty{}, nil
@@ -238,7 +238,7 @@ func (s *serviceImpl) ListComplianceScanConfigurations(ctx context.Context, quer
 
 	scanStatuses, err := convertStorageScanConfigToV2ScanStatuses(ctx, scanConfigs, s.scanConfigDS, s.complianceScanSettingBindingsDS, s.suiteDS, s.notifierDS)
 	if err != nil {
-		return nil, errors.Wrap(errox.InvalidArgs, "failed to convert compliance scan configurations.")
+		return nil, errors.Wrap(errox.InvalidArgs, "failed to convert compliance scan configurations")
 	}
 
 	scanConfigCount, err := s.scanConfigDS.CountScanConfigurations(ctx, countQuery)
@@ -520,7 +520,7 @@ func validateScanConfiguration(req *v2.ComplianceScanConfiguration) error {
 	}
 
 	if req.GetScanConfig() == nil {
-		return errors.Wrap(errox.InvalidArgs, "The scan configuration is nil.")
+		return errors.Wrap(errox.InvalidArgs, "The scan configuration is nil")
 	}
 
 	if len(req.GetScanConfig().GetProfiles()) == 0 {

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -144,7 +144,7 @@ func (s *serviceImpl) CreateComplianceScanConfiguration(ctx context.Context, req
 	// Process scan request, config may be updated in the event of errors from sensor.
 	scanConfig, err := s.manager.ProcessScanRequest(ctx, scanConfig, clusterIDs)
 	if err != nil {
-		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
+		return nil, errox.InvalidArgs.CausedBy(err)
 	}
 
 	return convertStorageScanConfigToV2(ctx, scanConfig, s.scanConfigDS)

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl.go
@@ -169,7 +169,7 @@ func (s *serviceImpl) UpdateComplianceScanConfiguration(ctx context.Context, req
 	// Update scan request, config may be updated in the event of errors from sensor.
 	_, err := s.manager.UpdateScanRequest(ctx, scanConfig, clusterIDs)
 	if err != nil {
-		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
+		return nil, errox.InvalidArgs.CausedBy(err)
 	}
 
 	return &v2.Empty{}, nil

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
@@ -185,7 +185,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestCreateComplianceScanConfigura
 	request.ScanConfig = nil
 	config, err = s.service.CreateComplianceScanConfiguration(allAccessContext, request)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "The scan configuration is nil.")
+	s.Require().Contains(err.Error(), "The scan configuration is nil")
 	s.Require().Nil(config)
 
 	request = getTestAPIRec()
@@ -228,7 +228,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestUpdateComplianceScanConfigura
 	request.ScanConfig = nil
 	_, err = s.service.UpdateComplianceScanConfiguration(allAccessContext, request)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "The scan configuration is nil.")
+	s.Require().Contains(err.Error(), "The scan configuration is nil")
 
 	// Test Case 4: No clusters
 	request = getTestAPIRec()
@@ -277,7 +277,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestDeleteComplianceScanConfigura
 
 	_, err = s.service.DeleteComplianceScanConfiguration(allAccessContext, &v2.ResourceByID{Id: failingID})
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "Unable to delete scan config")
+	s.Require().Contains(err.Error(), "manager error")
 }
 
 func (s *ComplianceScanConfigServiceTestSuite) TestCreateComplianceScanConfigurationScanExists() {
@@ -285,9 +285,9 @@ func (s *ComplianceScanConfigServiceTestSuite) TestCreateComplianceScanConfigura
 
 	request := getTestAPIRec()
 	storageRequest := convertV2ScanConfigToStorage(allAccessContext, request)
-	managerErr := errors.Errorf("Scan Configuration named %q already exists.", request.GetScanName())
+	managerErr := errors.Errorf("Scan Configuration named %q already exists", request.GetScanName())
 	s.manager.EXPECT().ProcessScanRequest(gomock.Any(), storageRequest, []string{fixtureconsts.Cluster1}).Return(nil, managerErr).Times(1)
-	expectedErr := errors.Wrapf(errox.InvalidArgs, "Unable to process scan config. Scan Configuration named %q already exists.", request.GetScanName())
+	expectedErr := errors.Wrap(errox.InvalidArgs, managerErr.Error())
 
 	config, err := s.service.CreateComplianceScanConfiguration(allAccessContext, request)
 	s.Require().Equal(expectedErr.Error(), err.Error())

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
@@ -287,10 +287,10 @@ func (s *ComplianceScanConfigServiceTestSuite) TestCreateComplianceScanConfigura
 	storageRequest := convertV2ScanConfigToStorage(allAccessContext, request)
 	managerErr := errors.Errorf("Scan configuration named %q already exists.", request.GetScanName())
 	s.manager.EXPECT().ProcessScanRequest(gomock.Any(), storageRequest, []string{fixtureconsts.Cluster1}).Return(nil, managerErr).Times(1)
-	expectedErr := errors.Wrap(errox.InvalidArgs, managerErr.Error())
 
 	config, err := s.service.CreateComplianceScanConfiguration(allAccessContext, request)
-	s.Require().Equal(expectedErr.Error(), err.Error())
+	s.Require().ErrorIs(err, errox.InvalidArgs)
+	s.Require().Contains(err.Error(), managerErr.Error())
 	s.Require().Nil(config)
 }
 

--- a/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
+++ b/central/complianceoperator/v2/scanconfigurations/service/service_impl_test.go
@@ -185,7 +185,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestCreateComplianceScanConfigura
 	request.ScanConfig = nil
 	config, err = s.service.CreateComplianceScanConfiguration(allAccessContext, request)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "The scan configuration is nil")
+	s.Require().Contains(err.Error(), "The scan configuration is nil.")
 	s.Require().Nil(config)
 
 	request = getTestAPIRec()
@@ -228,7 +228,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestUpdateComplianceScanConfigura
 	request.ScanConfig = nil
 	_, err = s.service.UpdateComplianceScanConfiguration(allAccessContext, request)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "The scan configuration is nil")
+	s.Require().Contains(err.Error(), "The scan configuration is nil.")
 
 	// Test Case 4: No clusters
 	request = getTestAPIRec()
@@ -285,7 +285,7 @@ func (s *ComplianceScanConfigServiceTestSuite) TestCreateComplianceScanConfigura
 
 	request := getTestAPIRec()
 	storageRequest := convertV2ScanConfigToStorage(allAccessContext, request)
-	managerErr := errors.Errorf("Scan Configuration named %q already exists", request.GetScanName())
+	managerErr := errors.Errorf("Scan configuration named %q already exists.", request.GetScanName())
 	s.manager.EXPECT().ProcessScanRequest(gomock.Any(), storageRequest, []string{fixtureconsts.Cluster1}).Return(nil, managerErr).Times(1)
 	expectedErr := errors.Wrap(errox.InvalidArgs, managerErr.Error())
 


### PR DESCRIPTION
## Description

The service layer wrapped manager errors with `"Unable to process scan config. %v"` and
`"Unable to delete scan config: %v"`, while the manager already provided descriptive
messages like `"Unable to create scan configuration named %q"`. This produced redundant
errors such as `Unable to process scan config. Unable to create scan configuration named "test".:`.

This PR:
1. Removes the outer wrapping in the service layer (create, update, delete paths) so
   the manager's message is passed through directly.
2. Strips trailing dots from error messages that wrap other errors (`Wrapf`/`Wrap` with
   a descriptive inner error), to avoid `"message.: inner error"` punctuation artifacts.

Leaf errors (`Errorf`, `New`, or `Wrap` around a sentinel like `errox.InvalidArgs`) keep
their trailing dots since they appear at the end of the error chain.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Ran unit tests for both affected packages:
- `go test ./central/complianceoperator/v2/compliancemanager/` — all tests pass
- `go test ./central/complianceoperator/v2/scanconfigurations/service/` — all tests pass