### PR TITLE
fix(ui): Fix issues in global search link creation (ROX-34726)

### DIFF
--- a/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/FilterLinks.tsx
@@ -34,11 +34,17 @@ function FilterLinks({
 
         return (
             <Flex spaceItems={{ default: 'spaceItemsMd' }}>
-                {filterLinks.map(({ basePath, linkText }) => (
-                    <FlexItem key={linkText}>
-                        <Link to={`${basePath}?${queryString}`}>{linkText}</Link>
-                    </FlexItem>
-                ))}
+                {filterLinks.map(({ basePath, linkText, searchParams }) => {
+                    const extra = searchParams ? `${searchParams}&` : '';
+                    const separator = basePath.includes('?') ? '&' : '?';
+                    return (
+                        <FlexItem key={linkText}>
+                            <Link to={`${basePath}${separator}${extra}${queryString}`}>
+                                {linkText}
+                            </Link>
+                        </FlexItem>
+                    );
+                })}
             </Flex>
         );
     }

--- a/ui/apps/platform/src/Containers/Search/ViewLinks.test.ts
+++ b/ui/apps/platform/src/Containers/Search/ViewLinks.test.ts
@@ -1,0 +1,62 @@
+import { buildViewLinkUrl, resolveParams } from './ViewLinks';
+
+describe('resolveParams', () => {
+    it('should replace a single :param', () => {
+        expect(resolveParams('s=:name', { name: 'nginx' })).toBe('s=nginx');
+    });
+
+    it('should replace multiple :params', () => {
+        expect(
+            resolveParams('ns=:name&cluster=:locationTextForCategory', {
+                name: 'default',
+                locationTextForCategory: 'remote',
+            })
+        ).toBe('ns=default&cluster=remote');
+    });
+
+    it('should preserve unmatched :params', () => {
+        expect(resolveParams('s=:missing', {})).toBe('s=:missing');
+    });
+
+    it('should return string unchanged when no :params present', () => {
+        expect(resolveParams('filteredWorkflowView=Full view', { id: '123' })).toBe(
+            'filteredWorkflowView=Full view'
+        );
+    });
+});
+
+describe('buildViewLinkUrl', () => {
+    it('should resolve :id in a simple path', () => {
+        expect(buildViewLinkUrl('/main/risk/:id', { id: 'abc123' }, undefined)).toBe(
+            '/main/risk/abc123'
+        );
+    });
+
+    it('should append searchParams to a simple path', () => {
+        expect(
+            buildViewLinkUrl('/main/risk/:id', { id: 'abc123' }, 'filteredWorkflowView=Full view')
+        ).toBe('/main/risk/abc123?filteredWorkflowView=Full view');
+    });
+
+    it('should resolve :params in basePath query string separately from path', () => {
+        const basePath = '/main/vulnerabilities/namespace-view?s[Namespace]=^:name$';
+        expect(buildViewLinkUrl(basePath, { name: 'stackrox' }, undefined)).toBe(
+            '/main/vulnerabilities/namespace-view?s[Namespace]=^stackrox$'
+        );
+    });
+
+    it('should combine basePath query and searchParams', () => {
+        const basePath = '/main/page?existing=value';
+        expect(buildViewLinkUrl(basePath, {}, 'extra=param')).toBe(
+            '/main/page?existing=value&extra=param'
+        );
+    });
+
+    it('should fall back to the path pattern when :param has no value', () => {
+        expect(buildViewLinkUrl('/main/risk/:id', {}, undefined)).toBe('/main/risk/:id');
+    });
+
+    it('should handle path without any :params or query', () => {
+        expect(buildViewLinkUrl('/main/risk', {}, undefined)).toBe('/main/risk');
+    });
+});

--- a/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
+++ b/ui/apps/platform/src/Containers/Search/ViewLinks.tsx
@@ -15,16 +15,42 @@ type ViewLinksProps = {
     searchResultCategoryMap: SearchResultCategoryMap;
 };
 
+export function resolveParams(template: string, params: Partial<Record<string, unknown>>): string {
+    return template.replace(/:(\w+)/g, (match, key) => {
+        const value = params[key];
+        // We cannot easily restrict the type of the value to a string without a large refactor, so we
+        // disable the rule and rely on what testing we have for now...
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        return value != null ? String(value) : match;
+    });
+}
+
+export function buildViewLinkUrl(
+    basePath: string,
+    searchResult: Partial<Record<string, unknown>>,
+    searchParams: string | undefined
+): string {
+    const queryIndex = basePath.indexOf('?');
+    const pathPattern = queryIndex >= 0 ? basePath.slice(0, queryIndex) : basePath;
+    const baseQuery = queryIndex >= 0 ? basePath.slice(queryIndex + 1) : undefined;
+
+    const path = safeGeneratePath(pathPattern, searchResult, pathPattern);
+    const resolvedBaseQuery = baseQuery ? resolveParams(baseQuery, searchResult) : undefined;
+    const queryParts = [resolvedBaseQuery, searchParams].filter(Boolean).join('&');
+
+    return queryParts ? `${path}?${queryParts}` : path;
+}
+
 function ViewLinks({ searchResult, searchResultCategoryMap }: ViewLinksProps): ReactElement {
     const { viewLinks } = searchResultCategoryMap[searchResult.category] ?? {};
 
     if (viewLinks?.length) {
         return (
             <Flex spaceItems={{ default: 'spaceItemsMd' }}>
-                {viewLinks.map(({ basePath, linkText }) => (
+                {viewLinks.map(({ basePath, linkText, searchParams }) => (
                     <FlexItem key={linkText}>
                         <Link
-                            to={safeGeneratePath(basePath, searchResult, basePath)}
+                            to={buildViewLinkUrl(basePath, searchResult, searchParams)}
                             className="pf-v6-u-text-nowrap"
                         >
                             {linkText}

--- a/ui/apps/platform/src/Containers/Search/searchCategories.ts
+++ b/ui/apps/platform/src/Containers/Search/searchCategories.ts
@@ -37,12 +37,14 @@ type SearchLinkDescriptor = {
     basePath: string;
     linkText: string;
     routeKey: RouteKey;
+    searchParams?: string;
 };
 
 const filterOnRisk: SearchLinkDescriptor = {
     basePath: riskBasePath,
     linkText: 'Risk',
     routeKey: 'risk',
+    searchParams: 'filteredWorkflowView=Full view',
 };
 
 const filterOnViolations: SearchLinkDescriptor = {
@@ -90,6 +92,7 @@ function getSearchResultCategoryMap(
                     basePath: `${riskBasePath}/:id`,
                     linkText: 'Risk',
                     routeKey: 'risk',
+                    searchParams: 'filteredWorkflowView=Full view',
                 },
             ],
         },


### PR DESCRIPTION
## Description

Primary Objective: Sends links from Global Search -> Risk using the "All Deployments" subnavigation. Risk links in this location cannot be definitively determined to be "User workloads" or "Platform workloads", so we send to the "All workloads" view to prevent broken links.

Bonus Objective: Vulnerability Management links were already broken here, passing literal `:param` values instead of the expected interpolated parameters. Cleans up the handling of link creation in the section and adds tests so that these links and future links work reliably.

## Future

I'd like better handling of values here (no `unknown` type), more comprehensive testing, and maybe some tighter TypeScript control, but time is of the essence for this release. Some additional tests and actual fixed bugs will have to do for now.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<img width="1600" height="666" alt="image" src="https://github.com/user-attachments/assets/ed04a25d-0b42-472f-ad5e-359e56875fef" />
<img width="1600" height="666" alt="image" src="https://github.com/user-attachments/assets/f6f23fd3-0c24-447f-9d42-591980bc7353" />
<img width="1600" height="666" alt="image" src="https://github.com/user-attachments/assets/e0dd9344-6969-40c6-a83f-998e25c85db8" />
<img width="1600" height="666" alt="image" src="https://github.com/user-attachments/assets/febb5dc8-46ce-450e-ba7b-0d239161df3d" />



