### PR TITLE
fix(ui): Fix report filter regex handling

### DIFF
--- a/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
+++ b/ui/apps/platform/src/Components/EntityScope/entityScopeRules.ts
@@ -173,7 +173,7 @@ function getEntityScopeRulesFromSearchFilter(
 }
 
 export const ruleFieldValueMapper = ({ matchType, value }: RuleValue): string =>
-    matchType === 'EXACT' ? wrapInQuotes(value) : `r/${value}`;
+    matchType === 'EXACT' ? wrapInQuotes(value) : value;
 
 /**
  * Return search filter in EntityScopeCompoundSearchFilter component.

--- a/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
+++ b/ui/apps/platform/src/Components/Reports/Step/FiltersQuery.tsx
@@ -20,6 +20,7 @@ import type {
 import { updateSearchFilter } from 'Components/CompoundSearchFilter/utils/utils';
 import type { SearchFilter } from 'types/search';
 import {
+    applyRegexSearchModifiers,
     getRequestQueryStringForSearchFilter,
     getSearchFilterFromSearchString,
 } from 'utils/searchUtils';
@@ -46,7 +47,7 @@ function FiltersQuery<T extends FiltersQueryConfiguration = FiltersQueryConfigur
     function onFilterChange(searchFilterChanged: SearchFilter) {
         formik.setFieldValue(
             'vulnReportFilters.query',
-            getRequestQueryStringForSearchFilter(searchFilterChanged)
+            getRequestQueryStringForSearchFilter(applyRegexSearchModifiers(searchFilterChanged))
         );
     }
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizardPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizardPage.tsx
@@ -26,6 +26,7 @@ import { fetchReportConfiguration } from 'services/ReportsService';
 import type { SearchFieldLabel } from 'types/searchOptions';
 import { getAxiosErrorMessage } from 'utils/responseErrorUtils';
 import {
+    applyRegexSearchModifiers,
     deleteKeysCaseInsensitive,
     getHasSearchApplied,
     getRequestQueryStringForSearchFilter,
@@ -152,7 +153,9 @@ function ImageVulnerabilityReportWizardPage({
             } // else imageTypes is initially unspecified (for example, Create report)
 
             reportConfigurationFromFilters.vulnReportFilters.query =
-                getRequestQueryStringForSearchFilter(searchFilterWithoutEntityScope);
+                getRequestQueryStringForSearchFilter(
+                    applyRegexSearchModifiers(searchFilterWithoutEntityScope)
+                );
 
             setReportConfiguration(reportConfigurationFromFilters);
         } else {

--- a/ui/apps/platform/src/utils/searchUtils.test.ts
+++ b/ui/apps/platform/src/utils/searchUtils.test.ts
@@ -13,6 +13,7 @@ import {
     getViewStateFromSearch,
     hasSearchKeyValue,
     isKeyValueSearchTerm,
+    removeRegexSearchModifiers,
     searchValueAsArray,
     wrapInQuotes,
 } from './searchUtils';
@@ -601,6 +602,158 @@ describe('searchUtils', () => {
                 Cluster: ['r/production'],
                 'Deployment Label': ['r/app=r/reporting'],
             });
+        });
+    });
+
+    describe('removeRegexSearchModifiers', () => {
+        it('strips regex prefix from text search values', () => {
+            const searchFilter = { Cluster: ['r/production'] };
+            const result = removeRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({ Cluster: ['production'] });
+        });
+
+        it('preserves quoted exact-match values', () => {
+            const searchFilter = { Cluster: ['"production"'] };
+            const result = removeRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({ Cluster: ['"production"'] });
+        });
+
+        it('handles mixed quoted and unquoted values', () => {
+            const searchFilter = {
+                Cluster: ['r/production', '"exact-match"', 'r/staging'],
+            };
+            const result = removeRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({
+                Cluster: ['production', '"exact-match"', 'staging'],
+            });
+        });
+
+        it('does not modify fields not in regexSearchOptions', () => {
+            const searchFilter = {
+                Cluster: ['r/production'],
+                'Random Field': 'value',
+            };
+            const result = removeRegexSearchModifiers(searchFilter);
+            expect(result.Cluster).toEqual(['production']);
+            expect(result['Random Field']).toEqual('value');
+        });
+
+        it('reverses label regex values with equals sign', () => {
+            const searchFilter = { 'Deployment Label': ['r/app=r/reporting'] };
+            const result = removeRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({ 'Deployment Label': ['app=reporting'] });
+        });
+
+        it('collapses label regex no-equals pair back to single value', () => {
+            const searchFilter = { 'Deployment Label': ['r/visa=r/.*', 'r/.*=r/visa'] };
+            const result = removeRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({ 'Deployment Label': ['visa'] });
+        });
+
+        it('reverses quoted label values with equals sign', () => {
+            const searchFilter = { 'Deployment Label': ['"app"="reporting"'] };
+            const result = removeRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({ 'Deployment Label': ['"app=reporting"'] });
+        });
+
+        it('collapses quoted label no-equals pair back to single value', () => {
+            const searchFilter = { 'Deployment Label': ['"visa"=r/.*', 'r/.*="visa"'] };
+            const result = removeRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({ 'Deployment Label': ['"visa"'] });
+        });
+
+        it('reverses label values with multiple unrelated regex pairs', () => {
+            const searchFilter = {
+                'Deployment Label': [
+                    '"visa"=r/.*',
+                    '"key"="val"',
+                    'r/.*=r/mastercard',
+                    'r/.*="visa"',
+                    'r/mastercard=r/.*',
+                ],
+            };
+            const result = removeRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({
+                'Deployment Label': ['"visa"', '"key=val"', 'mastercard'],
+            });
+        });
+
+        it('reverses all label search terms', () => {
+            const searchFilter = {
+                'Image Label': ['r/env=r/prod'],
+                'Node Label': ['r/role=r/worker'],
+                'Cluster Label': ['r/team=r/platform'],
+                'Namespace Label': ['r/app=r/web'],
+            };
+            const result = removeRegexSearchModifiers(searchFilter);
+            expect(result).toEqual({
+                'Image Label': ['env=prod'],
+                'Node Label': ['role=worker'],
+                'Cluster Label': ['team=platform'],
+                'Namespace Label': ['app=web'],
+            });
+        });
+    });
+
+    describe('applyRegexSearchModifiers and removeRegexSearchModifiers round-trip', () => {
+        it('round-trips plain text values', () => {
+            const original = { Cluster: ['production', 'staging'] };
+            expect(removeRegexSearchModifiers(applyRegexSearchModifiers(original))).toEqual(
+                original
+            );
+        });
+
+        it('round-trips exact-match values', () => {
+            const original = { Cluster: ['"production"'] };
+            expect(removeRegexSearchModifiers(applyRegexSearchModifiers(original))).toEqual(
+                original
+            );
+        });
+
+        it('round-trips mixed quoted and unquoted values', () => {
+            const original = { Cluster: ['production', '"exact-match"', 'staging'] };
+            expect(removeRegexSearchModifiers(applyRegexSearchModifiers(original))).toEqual(
+                original
+            );
+        });
+
+        it('round-trips label key=value regex', () => {
+            const original = { 'Deployment Label': ['app=reporting'] };
+            expect(removeRegexSearchModifiers(applyRegexSearchModifiers(original))).toEqual(
+                original
+            );
+        });
+
+        it('round-trips label no-equals regex', () => {
+            const original = { 'Deployment Label': ['visa'] };
+            expect(removeRegexSearchModifiers(applyRegexSearchModifiers(original))).toEqual(
+                original
+            );
+        });
+
+        it('round-trips label key=value exact', () => {
+            const original = { 'Deployment Label': ['"app=reporting"'] };
+            expect(removeRegexSearchModifiers(applyRegexSearchModifiers(original))).toEqual(
+                original
+            );
+        });
+
+        it('round-trips label no-equals exact', () => {
+            const original = { 'Deployment Label': ['"visa"'] };
+            expect(removeRegexSearchModifiers(applyRegexSearchModifiers(original))).toEqual(
+                original
+            );
+        });
+
+        it('round-trips a complex mixed filter', () => {
+            const original = {
+                Cluster: ['production', '"exact-cluster"'],
+                'Deployment Label': ['app=reporting', 'visa', '"env=prod"', '"team"'],
+                'Random Field': 'untouched',
+            };
+            expect(removeRegexSearchModifiers(applyRegexSearchModifiers(original))).toEqual(
+                original
+            );
         });
     });
 });

--- a/ui/apps/platform/src/utils/searchUtils.ts
+++ b/ui/apps/platform/src/utils/searchUtils.ts
@@ -159,7 +159,7 @@ export function getSearchFilterFromSearchString(searchString: string): SearchFil
         }
     });
 
-    return searchFilter;
+    return removeRegexSearchModifiers(searchFilter);
 }
 
 export function getUrlQueryStringForSearchFilter(
@@ -520,4 +520,70 @@ export function applyRegexSearchModifiers(searchFilter: SearchFilter): SearchFil
     });
 
     return regexSearchFilter;
+}
+
+function stripRegexPrefix(val: string): string {
+    if (isQuotedString(val)) {
+        return val;
+    }
+    return val.startsWith('r/') ? val.slice(2) : val;
+}
+
+// Strips formatting applied by formatPart in formatKeyValue: r/X→X, "X"→X, r/.*→''
+function unwrapLabelPart(part: string): string {
+    if (part === 'r/.*') {
+        return '';
+    }
+    return isQuotedString(part) ? part.slice(1, -1) : stripRegexPrefix(part);
+}
+
+// Inverts formatKeyValue: re-merges split label key=value pairs.
+// formatKeyValue produces X=r/.* + r/.*=X pairs for values without '=';
+// this collapses them back and unwraps the regex/exact formatting from each part.
+function reverseLabelValues(values: string[]): string[] {
+    const valueSet = new Set(values);
+
+    return values.flatMap((val) => {
+        const eqIdx = val.indexOf('=');
+        if (eqIdx === -1) {
+            return [stripRegexPrefix(val)];
+        }
+
+        const keyPart = val.slice(0, eqIdx);
+        const valPart = val.slice(eqIdx + 1);
+
+        // Drop complement (r/.*=X) when its primary (X=r/.*) exists
+        if (keyPart === 'r/.*' && valPart !== 'r/.*' && valueSet.has(`${valPart}=r/.*`)) {
+            return [];
+        }
+
+        // Collapse no-= pair primary (X=r/.*) back to just X
+        if (valPart === 'r/.*' && valueSet.has(`r/.*=${keyPart}`)) {
+            return [isQuotedString(keyPart) ? keyPart : stripRegexPrefix(keyPart)];
+        }
+
+        // Unwrap key=value: strip r/ or quotes from each side, rejoin
+        const isExact = isQuotedString(keyPart) || isQuotedString(valPart);
+        const joined = `${unwrapLabelPart(keyPart)}=${unwrapLabelPart(valPart)}`;
+        return [isExact ? wrapInQuotes(joined) : joined];
+    });
+}
+
+/**
+ * Reverses `applyRegexSearchModifiers`: strips `r/` prefixes and re-merges
+ * split label key=value pairs back into the SearchFilter format used by the UI.
+ */
+export function removeRegexSearchModifiers(searchFilter: SearchFilter): SearchFilter {
+    const cleanSearchFilter = cloneDeep(searchFilter);
+
+    Object.entries(cleanSearchFilter).forEach(([key, value]) => {
+        if (regexSearchOptions.some((option) => option.toLowerCase() === key.toLowerCase())) {
+            const values = searchValueAsArray(value);
+            cleanSearchFilter[key] = isKeyValueSearchTerm(key)
+                ? reverseLabelValues(values)
+                : values.map(stripRegexPrefix);
+        }
+    });
+
+    return cleanSearchFilter;
 }


### PR DESCRIPTION
## Description

Adds report configuration filter handling logic to:
1. Encapsulate use of `r/` strictly for use in `query` portion of request payload
2. Add reverse utils to extract `r/` prefix and double quotes to turn persisted query strings into standard `SearchFilter` syntax

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Apply search filters - one regex, one exact:
<img width="1615" height="806" alt="image" src="https://github.com/user-attachments/assets/c8849a90-1da7-4beb-b268-b10b287f531d" />
See correct display in filter bar during report config creation:
<img width="1615" height="806" alt="image" src="https://github.com/user-attachments/assets/67cf94d3-dd11-4e72-ad98-594522617548" />
See equivalent display in report preview:
<img width="1615" height="806" alt="image" src="https://github.com/user-attachments/assets/77423643-8616-4d8e-9480-b676289e0af6" />
See correct display in UI after save, and correct format in request payload:
<img width="1615" height="1090" alt="image" src="https://github.com/user-attachments/assets/5a447ef6-96c5-4994-a58e-ee4ae54416d5" />
See correct values in edit/save cycle:
<img width="1615" height="635" alt="image" src="https://github.com/user-attachments/assets/be39534e-a0c6-434d-b449-7c5052b8ccf2" />
See expected results in generated report, the exact `CVE-2025-1767` filter and the regex `2026`:
<img width="933" height="586" alt="image" src="https://github.com/user-attachments/assets/407f6d3f-fa06-40e9-ab59-d78507541a43" />


