### PR TITLE
ROX-34761: Render ImageVulnerabilityReportView in ReportJobs

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ReportJobs.tsx
@@ -14,9 +14,7 @@ import {
     AlertGroup,
     Bullseye,
     Button,
-    Card,
     Content,
-    Divider,
     Flex,
     FlexItem,
     Pagination,
@@ -29,7 +27,7 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, FilterIcon } from '@patternfly/react-icons';
 
-import type { ConfiguredReportSnapshot, ReportConfiguration } from 'services/ReportsService.types';
+import type { ConfiguredReportSnapshot } from 'services/ReportsService.types';
 import { getDateTime } from 'utils/dateUtils';
 import useSet from 'hooks/useSet';
 import useURLPagination from 'hooks/useURLPagination';
@@ -41,21 +39,21 @@ import useAuthStatus from 'hooks/useAuthStatus';
 import DeleteModal from 'Components/PatternFly/DeleteModal';
 import EmptyStateTemplate from 'Components/EmptyStateTemplate/EmptyStateTemplate';
 import CheckboxSelect from 'Components/PatternFly/CheckboxSelect';
-import type { TemplatePreviewArgs } from 'Components/EmailTemplate/EmailTemplateModal';
-import NotifierConfigurationView from 'Components/NotifierConfiguration/NotifierConfigurationView';
 
 import { runStates } from 'types/reportJob';
 import type { RunState } from 'types/reportJob';
 import ReportJobStatus from 'Components/ReportJob/ReportJobStatus';
 
+import ImageVulnerabilityReportView from '../../ImageVulnerabilityReports/View/ImageVulnerabilityReportView';
+import type { ImageVulnerabilityReportConfiguration } from '../../ImageVulnerabilityReports/imageVulnerabilityReports.types';
+import {
+    attributesSeparateFromConfigForImageVulnerabilityReport,
+    searchFilterConfigForImageVulnerabilityReport,
+} from '../../searchFilterConfig';
+
 import { getRequestQueryString } from '../api/apiUtils';
 import useFetchReportHistory from '../api/useFetchReportHistory';
-import EmailTemplatePreview from '../components/EmailTemplatePreview';
-import ReportParametersDetails from '../components/ReportParametersDetails';
-import ScheduleDetails from '../components/ScheduleDetails';
-import { defaultEmailBody, getDefaultEmailSubject } from '../forms/emailTemplateFormUtils';
 import useDeleteDownloadModal from '../hooks/useDeleteDownloadModal';
-import { getReportFormValuesFromConfiguration } from '../utils';
 import JobDetails from './JobDetails';
 
 export type ReportJobsProps = {
@@ -237,37 +235,9 @@ function ReportJobs({ reportId }: ReportJobsProps) {
                         </Tbody>
                     )}
                     {reportSnapshots.map((reportSnapshot, rowIndex) => {
-                        const {
-                            reportConfigId,
-                            reportJobId,
-                            name,
-                            description,
-                            vulnReportFilters,
-                            collectionSnapshot,
-                            schedule,
-                            notifiers,
-                            reportStatus,
-                            user,
-                            isDownloadAvailable,
-                        } = reportSnapshot;
+                        const { reportJobId, reportStatus, user, isDownloadAvailable } =
+                            reportSnapshot;
                         const isExpanded = expandedRowSet.has(reportJobId);
-                        const reportConfiguration: ReportConfiguration = {
-                            id: reportConfigId,
-                            name,
-                            description: description ?? '',
-                            type: 'VULNERABILITY',
-                            vulnReportFilters,
-                            notifiers,
-                            schedule,
-                            resourceScope: {
-                                collectionScope: {
-                                    collectionId: collectionSnapshot.id,
-                                    collectionName: collectionSnapshot.name,
-                                },
-                            },
-                        };
-                        const formValues =
-                            getReportFormValuesFromConfiguration(reportConfiguration);
                         const areDownloadActionsDisabled = currentUser.userId !== user.id;
 
                         const rowActions = [
@@ -321,70 +291,34 @@ function ReportJobs({ reportId }: ReportJobsProps) {
                                 <Tr isExpanded={isExpanded}>
                                     <Td colSpan={5}>
                                         <ExpandableRowContent>
-                                            <Card className="pf-v6-u-m-md pf-v6-u-p-md">
-                                                <Flex>
-                                                    <FlexItem>
-                                                        <JobDetails
-                                                            reportStatus={reportStatus}
-                                                            isDownloadAvailable={
-                                                                isDownloadAvailable
-                                                            }
-                                                        />
-                                                    </FlexItem>
-                                                    <Divider
-                                                        component="div"
-                                                        className="pf-v6-u-my-md"
+                                            <Flex
+                                                direction={{ default: 'column' }}
+                                                spaceItems={{ default: 'spaceItemsLg' }}
+                                            >
+                                                <FlexItem>
+                                                    <JobDetails
+                                                        reportStatus={reportStatus}
+                                                        isDownloadAvailable={isDownloadAvailable}
                                                     />
-                                                    <FlexItem>
-                                                        <ReportParametersDetails
-                                                            headingLevel={headingLevel}
-                                                            formValues={formValues}
-                                                        />
-                                                    </FlexItem>
-                                                    <Divider
-                                                        component="div"
-                                                        className="pf-v6-u-my-md"
+                                                </FlexItem>
+                                                <FlexItem>
+                                                    <ImageVulnerabilityReportView
+                                                        attributesSeparateFromConfig={
+                                                            attributesSeparateFromConfigForImageVulnerabilityReport
+                                                        }
+                                                        headingLevel={headingLevel}
+                                                        horizontalTermWidthModifier={{
+                                                            default: '24ch',
+                                                        }}
+                                                        searchFilterConfig={
+                                                            searchFilterConfigForImageVulnerabilityReport
+                                                        }
+                                                        values={
+                                                            reportSnapshot as unknown as ImageVulnerabilityReportConfiguration
+                                                        }
                                                     />
-                                                    <FlexItem>
-                                                        <NotifierConfigurationView
-                                                            headingLevel={headingLevel}
-                                                            customBodyDefault={defaultEmailBody}
-                                                            customSubjectDefault={getDefaultEmailSubject(
-                                                                formValues.reportParameters
-                                                                    .reportName,
-                                                                formValues.reportParameters
-                                                                    .reportScope?.name
-                                                            )}
-                                                            notifierConfigurations={
-                                                                formValues.deliveryDestinations
-                                                            }
-                                                            renderTemplatePreview={({
-                                                                customBody,
-                                                                customSubject,
-                                                                customSubjectDefault,
-                                                            }: TemplatePreviewArgs) => (
-                                                                <EmailTemplatePreview
-                                                                    emailSubject={customSubject}
-                                                                    emailBody={customBody}
-                                                                    defaultEmailSubject={
-                                                                        customSubjectDefault
-                                                                    }
-                                                                    reportParameters={
-                                                                        formValues.reportParameters
-                                                                    }
-                                                                />
-                                                            )}
-                                                        />
-                                                    </FlexItem>
-                                                    <Divider
-                                                        component="div"
-                                                        className="pf-v6-u-my-md"
-                                                    />
-                                                    <FlexItem>
-                                                        <ScheduleDetails formValues={formValues} />
-                                                    </FlexItem>
-                                                </Flex>
-                                            </Card>
+                                                </FlexItem>
+                                            </Flex>
                                         </ExpandableRowContent>
                                     </Td>
                                 </Tr>


### PR DESCRIPTION
## Description

**Review**: Hide space because of indentation changes.

### Problem

Thank you, **Linda** and **David** for reporting the problem!

Page crash on **All report jobs** tab for report configuration that has entity scope.

### Analysis

My bad to miss the following:

1. ReportJobs.tsx file renders `ReportParametersDetails` element:

    * It assumes collection scope exists.

        Specifically, it overrides `resourceScope` property:

        ```ts
        resourceScope: {
            collectionScope: {
                collectionId: collectionSnapshot.id,
                collectionName: collectionSnapshot.name,
            },
        },
        ```

    * Transforms responds data structure.

### Solution

1. Edit ReportJobs.tsx file.

    * Replace `ReportParametersDetails` element with `ImageVulnerabilityReportView` element.

        Consistent with report configuration page and **Review** step of wizard.

    * Delete `getReportFormValuesFromConfiguration` function call.

    * Imitate ssearch filter configuration  in files:
    
        ImageVulnerabilityReportWizardPage.tsx
        ViewVulnReportPage.tsx

        ```ts
        import {
            attributesSeparateFromConfigForImageVulnerabilityReport,
            searchFilterConfigForImageVulnerabilityReport,
        } from '../../searchFilterConfig';
        ```

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration click link for report configuration that has **collection** scope, click **Actions**, click **Generate download**, click **All report jobs** tab, and then expand a row.

    Before changes, see `ReportParametersDetails` element:
    <img width="1440" height="892" alt="collectionScope_ReportParametersDetails" src="https://github.com/user-attachments/assets/1c824272-aff9-42b7-b666-7439a4fae0c3" />

    After changes, see `ImageVulnerabilityReportView` element:
    <img width="1440" height="892" alt="collectionScope_ImageVulnerabilityReportView" src="https://github.com/user-attachments/assets/9cd2fd44-10a9-4039-a754-95eb8ec8bc29" />

2. Ditto for report that has **entity** scope.

    See `ImageVulnerabilityReportView` element for **Review** step of wizard.
    <img width="1440" height="892" alt="entityScope_Review" src="https://github.com/user-attachments/assets/cd3588d4-b4ea-4c00-91b8-77000d7b5386" />

    See `ImageVulnerabilityReportView` element for report configuration page.
    <img width="1440" height="892" alt="entityScope_ViewVulnReportPage" src="https://github.com/user-attachments/assets/d8effd3c-6183-4fb2-acfc-4532c81213b4" />

    Before changes, see page crash in `ReportParametersDetails` element:
    <img width="1439" height="892" alt="entityScope_ReportParametersDetails" src="https://github.com/user-attachments/assets/866a2aab-835d-4e84-8b1a-c747619436e6" />

    After changes, see `ImageVulnerabilityReportView` element:
    <img width="1440" height="892" alt="entityScope_ImageVulnerabilityReportView" src="https://github.com/user-attachments/assets/8275bfbc-1c21-46b9-922e-402bf2a26a2f" />
