### PR TITLE
ROX-34723: auto-set auto-upgrade label via _labels.tpl

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/_labels.tpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/_labels.tpl
@@ -25,9 +25,22 @@
 {{ $_ = set $labels "app.kubernetes.io/instance" $.Release.Name }}
 {{ $_ = set $labels "app.kubernetes.io/version" $.Chart.AppVersion }}
 {{ $_ = set $labels "app.kubernetes.io/part-of" "stackrox-secured-cluster-services" }}
+{{/* Derive the component from the template filename (e.g. sensor-rbac.yaml → sensor). */}}
 {{ $component := regexReplaceAll "^.*/(\\d{2}-)?(admission-control|collector|sensor|scanner-v4)[^/]*\\.yaml" $.Template.Name "${2}" }}
 {{ if not (contains "/" $component) }}
   {{ $_ = set $labels "app.kubernetes.io/component" $component }}
+  {{/*
+    The sensor auto-upgrader manages all three components (sensor, collector, admission-control)
+    as a single upgrade bundle and uses the auto-upgrade.stackrox.io/component label to discover
+    the resources it owns. For manifest-based installs (non-Helm, non-Operator), the upgrader
+    validates this label on all bundle objects before applying them. Missing it will cause the
+    auto-upgrade to fail. See also: sensor/upgrader/bundle/instantiator.go
+
+    Only set on resource metadata, not pod labels.
+  */}}
+  {{ if and (not $forPod) (or (eq $component "sensor") (eq $component "collector") (eq $component "admission-control")) }}
+    {{ $_ = set $labels "auto-upgrade.stackrox.io/component" "sensor" }}
+  {{ end }}
 {{ end }}
 {{ $metadataNames := list "labels" }}
 {{ if $forPod }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-netpol.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-netpol.yaml
@@ -8,7 +8,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "admission-control-no-ingress") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "networkpolicy" "admission-control-no-ingress") | nindent 4 }}
 spec:
@@ -31,7 +30,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "admission-control-monitoring") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "networkpolicy" "admission-control-monitoring") | nindent 4 }}
 spec:
@@ -55,7 +53,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "admission-control-monitoring-tls") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "networkpolicy" "admission-control-monitoring-tls") | nindent 4 }}
 spec:

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-pod-security.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-pod-security.yaml
@@ -7,7 +7,6 @@ metadata:
   name: stackrox-admission-control
   labels:
     {{- include "srox.labels" (list . "podsecuritypolicy" "stackrox-admission-control") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "podsecuritypolicy" "stackrox-admission-control") | nindent 4 }}
 spec:
@@ -42,7 +41,6 @@ metadata:
   name: stackrox-admission-control-psp
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox-admission-control-psp") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrole" "stackrox-admission-control-psp") | nindent 4 }}
 rules:
@@ -62,7 +60,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "stackrox-admission-control-psp") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "rolebinding" "stackrox-admission-control-psp") | nindent 4 }}
 roleRef:

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-rbac.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-rbac.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "serviceaccount" "admission-control") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "serviceaccount" "admission-control") | nindent 4 }}
 {{- if ._rox.mainImagePullSecrets._names }}
@@ -24,7 +23,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "role" "watch-config") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "role" "watch-config") | nindent 4 }}
 rules:
@@ -39,7 +37,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "admission-control-watch-config") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "rolebinding" "admission-control-watch-config") | nindent 4 }}
 subjects:

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-secret.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller-secret.yaml
@@ -13,7 +13,6 @@ metadata:
   labels:
     rhacs.redhat.com/tls: "true"
     {{- include "srox.labels" (list . "secret" "admission-control-tls") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: sensor
   annotations:
     {{- include "srox.annotations" (list . "secret" "admission-control-tls") | nindent 4 }}
     "helm.sh/hook": "pre-install,pre-upgrade"

--- a/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/admission-controller.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     {{- include "srox.labels" (list . "deployment" "admission-control") | nindent 4 }}
     app: admission-control
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "deployment" "admission-control") | nindent 4 }}
 spec:
@@ -189,7 +188,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "service" "admission-control") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "service" "admission-control") | nindent 4 }}
     {{- if ._rox.monitoring.openshift.enabled }}
@@ -224,7 +222,6 @@ metadata:
   name: stackrox
   labels:
     {{- include "srox.labels" (list . "validatingwebhookconfiguration" "stackrox") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "validatingwebhookconfiguration" "stackrox") | nindent 4 }}
 webhooks:

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector-netpol.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector-netpol.yaml.htpl
@@ -8,7 +8,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "collector-no-ingress") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "networkpolicy" "collector-no-ingress") | nindent 4 }}
 spec:
@@ -27,7 +26,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "collector-monitoring") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "networkpolicy" "collector-monitoring") | nindent 4 }}
 spec:

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector-pod-security.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector-pod-security.yaml
@@ -7,7 +7,6 @@ metadata:
   name: stackrox-collector-psp
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox-collector-psp") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrole" "stackrox-collector-psp") | nindent 4 }}
 rules:
@@ -27,7 +26,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "stackrox-collector-psp") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "rolebinding" "stackrox-collector-psp") | nindent 4 }}
 roleRef:
@@ -45,7 +43,6 @@ metadata:
   name: stackrox-collector
   labels:
     {{- include "srox.labels" (list . "podsecuritypolicy" "stackrox-collector") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "podsecuritypolicy" "stackrox-collector") | nindent 4 }}
 spec:

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector-rbac.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector-rbac.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "serviceaccount" "collector") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "serviceaccount" "collector") | nindent 4 }}
 {{- if or ._rox.collectorImagePullSecrets._names ._rox.mainImagePullSecrets._names }}

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector-scc.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector-scc.yaml
@@ -14,7 +14,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "role" "use-privileged-scc") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "role" "use-privileged-scc") | nindent 4 }}
 rules:
@@ -34,7 +33,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "collector-use-scc") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "rolebinding" "collector-use-scc") | nindent 4 }}
 roleRef:

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector-secret.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector-secret.yaml
@@ -12,7 +12,6 @@ metadata:
   labels:
     {{- include "srox.labels" (list . "secret" "collector-tls") | nindent 4 }}
     rhacs.redhat.com/tls: "true"
-    auto-upgrade.stackrox.io/component: sensor
   annotations:
     {{- include "srox.annotations" (list . "secret" "collector-tls") | nindent 4 }}
     "helm.sh/hook": "pre-install,pre-upgrade"

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -7,7 +7,6 @@ metadata:
     {{- include "srox.labels" (list . "daemonset" "collector") | nindent 4 }}
     service: collector
     app: collector
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "daemonset" "collector") | nindent 4 }}
   name: collector
@@ -347,7 +346,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "service" "compliance-metrics") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "service" "compliance-metrics") | nindent 4 }}
 spec:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-compliance-rbac.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-compliance-rbac.yaml
@@ -6,7 +6,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:edit-compliance") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:edit-compliance") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrole" "stackrox:edit-compliance") | nindent 4 }}
 rules:
@@ -23,7 +22,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:manage-compliance") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:manage-compliance") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrolebinding" "stackrox:manage-compliance") | nindent 4 }}
 subjects:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-netpol.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-netpol.yaml.htpl
@@ -8,7 +8,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "sensor") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "networkpolicy" "sensor") | nindent 4 }}
 spec:
@@ -54,7 +53,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "sensor-monitoring") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "networkpolicy" "sensor-monitoring") | nindent 4 }}
 spec:
@@ -78,7 +76,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "sensor-monitoring-tls") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "networkpolicy" "sensor-monitoring-tls") | nindent 4 }}
 spec:
@@ -102,7 +99,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "srox.labels" (list . "networkpolicy" "sensor-proxy") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "networkpolicy" "sensor-proxy") | nindent 4 }}
 spec:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-openshift-monitoring.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-openshift-monitoring.yaml
@@ -9,7 +9,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "srox.labels" (list . "role" "secured-cluster-prometheus-k8s") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "role" "secured-cluster-prometheus-k8s") | nindent 4 }}
 rules:
@@ -33,7 +32,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "secured-cluster-prometheus-k8s") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "rolebinding" "secured-cluster-prometheus-k8s") | nindent 4 }}
 roleRef:
@@ -59,7 +57,6 @@ metadata:
   namespace: openshift-monitoring
   labels:
     {{- include "srox.labels" (list . "servicemonitor" (print "sensor-monitor-" .Release.Namespace)) | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "servicemonitor" (print "sensor-monitor-" .Release.Namespace)) | nindent 4 }}
 spec:
@@ -93,7 +90,6 @@ metadata:
   namespace: openshift-monitoring
   labels:
     {{- include "srox.labels" (list . "servicemonitor" (print "admission-control-monitor-" .Release.Namespace)) | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "servicemonitor" (print "admission-control-monitor-" .Release.Namespace)) | nindent 4 }}
 spec:
@@ -126,7 +122,6 @@ metadata:
   namespace: kube-system
   labels:
     {{- include "srox.labels" (list . "rolebinding" (print "rhacs-sensor-auth-reader-" .Release.Namespace)) | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "rolebinding" (print "rhacs-sensor-auth-reader-" .Release.Namespace)) | nindent 4 }}
 roleRef:
@@ -150,7 +145,6 @@ metadata:
   namespace: kube-system
   labels:
     {{- include "srox.labels" (list . "rolebinding" (print "rhacs-admission-control-auth-reader-" .Release.Namespace)) | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "rolebinding" (print "rhacs-admission-control-auth-reader-" .Release.Namespace)) | nindent 4 }}
 roleRef:
@@ -178,7 +172,6 @@ metadata:
   namespace: openshift-monitoring
   labels:
     {{- include "srox.labels" (list . "prometheusrule" (print "sensor-telemeter-" .Release.Namespace )) | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "prometheusrule" (print "sensor-telemeter-" .Release.Namespace )) | nindent 4 }}
 spec:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-pod-security.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-pod-security.yaml
@@ -7,7 +7,6 @@ metadata:
   name: stackrox-sensor-psp
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox-sensor-psp") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrole" "stackrox-sensor-psp") | nindent 4 }}
 rules:
@@ -27,7 +26,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "stackrox-sensor-psp") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "rolebinding" "stackrox-sensor-psp") | nindent 4 }}
 roleRef:
@@ -48,7 +46,6 @@ metadata:
   name: stackrox-sensor
   labels:
     {{- include "srox.labels" (list . "podsecuritypolicy" "stackrox-sensor") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "podsecuritypolicy" "stackrox-sensor") | nindent 4 }}
 spec:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-rbac.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-rbac.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "serviceaccount" "sensor") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "serviceaccount" "sensor") | nindent 4 }}
 {{- if ._rox.mainImagePullSecrets._names }}
@@ -24,7 +23,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:view-cluster") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:view-cluster") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrole" "stackrox:view-cluster") | nindent 4 }}
 rules:
@@ -43,7 +41,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:monitor-cluster") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:monitor-cluster") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrolebinding" "stackrox:monitor-cluster") | nindent 4 }}
 subjects:
@@ -64,7 +61,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "role" "edit") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "role" "edit") | nindent 4 }}
 rules:
@@ -89,7 +85,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "rolebinding" "manage-namespace") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "rolebinding" "manage-namespace") | nindent 4 }}
 subjects:
@@ -107,7 +102,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:edit-workloads") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:edit-workloads") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrole" "stackrox:edit-workloads") | nindent 4 }}
 rules:
@@ -136,7 +130,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:enforce-policies") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:enforce-policies") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrolebinding" "stackrox:enforce-policies") | nindent 4 }}
 subjects:
@@ -154,7 +147,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:network-policies") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:network-policies") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrole" "stackrox:network-policies") | nindent 4 }}
 rules:
@@ -178,7 +170,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:network-policies-binding") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:network-policies-binding") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrolebinding" "stackrox:network-policies-binding") | nindent 4 }}
 subjects:
@@ -196,7 +187,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:update-namespaces") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:update-namespaces") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrole" "stackrox:update-namespaces") | nindent 4 }}
 rules:
@@ -212,7 +202,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:update-namespaces-binding") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:update-namespaces-binding") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrolebinding" "stackrox:update-namespaces-binding") | nindent 4 }}
 subjects:
@@ -230,7 +219,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:create-events") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:create-events") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrole" "stackrox:create-events") | nindent 4 }}
 rules:
@@ -248,7 +236,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:create-events-binding") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:create-events-binding") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrolebinding" "stackrox:create-events-binding") | nindent 4 }}
 subjects:
@@ -266,7 +253,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:review-tokens") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:review-tokens") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrole" "stackrox:review-tokens") | nindent 4 }}
 rules:
@@ -282,7 +268,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:review-tokens-binding") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:review-tokens-binding") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrolebinding" "stackrox:review-tokens-binding") | nindent 4 }}
 subjects:
@@ -300,7 +285,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:review-access") }}
   labels:
     {{- include "srox.labels" (list . "clusterrole" "stackrox:review-access") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrole" "stackrox:review-access") | nindent 4 }}
 rules:
@@ -316,7 +300,6 @@ metadata:
   name: {{ include "srox.globalResourceName" (list . "stackrox:review-access-binding") }}
   labels:
     {{- include "srox.labels" (list . "clusterrolebinding" "stackrox:review-access-binding") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "clusterrolebinding" "stackrox:review-access-binding") | nindent 4 }}
 subjects:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-secret.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-secret.yaml
@@ -14,7 +14,6 @@ metadata:
   labels:
     rhacs.redhat.com/tls: "true"
     {{- include "srox.labels" (list . "secret" "sensor-tls") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: sensor
   annotations:
     {{- include "srox.annotations" (list . "secret" "sensor-tls") | nindent 4 }}
     "helm.sh/hook": "pre-install,pre-upgrade"

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor-service-ca.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor-service-ca.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "secret" "service-ca") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: sensor
   annotations:
     {{- include "srox.annotations" (list . "secret" "service-ca") | nindent 4 }}
 type: Opaque

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -1,12 +1,5 @@
 {{- include "srox.init" . -}}
 
-{{- /*
-  Every resource in this file must have the auto-upgrade.stackrox.io/component label.
-  For manifest-based installs (non-Helm, non-Operator), the sensor-upgrader validates
-  this label on all bundle objects before applying them. Missing it will cause the
-  auto-upgrade to fail. See also: sensor/upgrader/bundle/instantiator.go
-*/ -}}
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,7 +8,6 @@ metadata:
   labels:
     {{- include "srox.labels" (list . "deployment" "sensor") | nindent 4 }}
     app: sensor
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "deployment" "sensor") | nindent 4 }}
 spec:
@@ -390,7 +382,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "service" "sensor") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "service" "sensor") | nindent 4 }}
     {{- if ._rox.monitoring.openshift.enabled }}
@@ -428,7 +419,6 @@ metadata:
   namespace: {{ ._rox._namespace | quote }}
   labels:
     {{- include "srox.labels" (list . "service" "sensor-proxy") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- $annotations := dict -}}
     {{- $_ := set $annotations "service.beta.openshift.io/serving-cert-secret-name" "sensor-proxy-tls" -}}
@@ -453,7 +443,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "service" "sensor-webhook") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: "sensor"
   annotations:
     {{- include "srox.annotations" (list . "service" "sensor-webhook") | nindent 4 }}
 spec:
@@ -476,7 +465,6 @@ metadata:
   namespace: {{ ._rox._namespace }}
   labels:
     {{- include "srox.labels" (list . "secret" "helm-effective-cluster-name") | nindent 4 }}
-    auto-upgrade.stackrox.io/component: sensor
   annotations:
     {{- $annotations := dict -}}
     {{- $_ := include "srox.getAnnotationTemplate" (list . "helm-hook_secret" $annotations) -}}

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/auto-upgrade-labels.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/auto-upgrade-labels.test.yaml
@@ -1,0 +1,67 @@
+name: "Test auto-upgrade labels required by the sensor auto-upgrader"
+defs: |
+  def autoUpgradeLabel:
+    .metadata.labels["auto-upgrade.stackrox.io/component"];
+
+  def isSensorBundleComponent:
+    .metadata.labels["app.kubernetes.io/component"] as $c |
+    $c == "sensor" or $c == "collector" or $c == "admission-control";
+
+values:
+  imagePullSecrets:
+    allowNone: true
+
+tests:
+- name: "all sensor bundle component resources carry the auto-upgrade label"
+  expect: |
+    [.objects[] | select(isSensorBundleComponent) | select(autoUpgradeLabel != "sensor") | "\(.kind)/\(.metadata.name)"]
+      | assertThat(length == 0)
+
+- name: "with PSP enabled"
+  values:
+    system:
+      enablePodSecurityPolicies: true
+  expect: |
+    [.objects[] | select(isSensorBundleComponent) | select(autoUpgradeLabel != "sensor") | "\(.kind)/\(.metadata.name)"]
+      | assertThat(length == 0)
+
+- name: "with TLS secrets created"
+  values:
+    createSecrets: true
+    sensor:
+      serviceTLS:
+        cert: "sensor cert"
+        key: "sensor key"
+    collector:
+      serviceTLS:
+        cert: "collector cert"
+        key: "collector key"
+    admissionControl:
+      serviceTLS:
+        cert: "ac cert"
+        key: "ac key"
+  expect: |
+    [.objects[] | select(isSensorBundleComponent) | select(autoUpgradeLabel != "sensor") | "\(.kind)/\(.metadata.name)"]
+      | assertThat(length == 0)
+
+- name: "with OpenShift SCC resources"
+  set:
+    env.openshift: 4
+  server:
+    availableSchemas:
+    - openshift-4.12
+  expect: |
+    [.objects[] | select(isSensorBundleComponent) | select(autoUpgradeLabel != "sensor") | "\(.kind)/\(.metadata.name)"]
+      | assertThat(length == 0)
+
+- name: "with OpenShift monitoring enabled"
+  set:
+    monitoring.openshift.enabled: true
+    env.openshift: 4
+  server:
+    availableSchemas:
+    - openshift-4.12
+    - com.coreos
+  expect: |
+    [.objects[] | select(isSensorBundleComponent) | select(autoUpgradeLabel != "sensor") | "\(.kind)/\(.metadata.name)"]
+      | assertThat(length == 0)

--- a/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/auto-upgrade-labels.test.yaml
+++ b/pkg/helm/charts/tests/securedclusterservices/testdata/helmtest/auto-upgrade-labels.test.yaml
@@ -17,14 +17,6 @@ tests:
     [.objects[] | select(isSensorBundleComponent) | select(autoUpgradeLabel != "sensor") | "\(.kind)/\(.metadata.name)"]
       | assertThat(length == 0)
 
-- name: "with PSP enabled"
-  values:
-    system:
-      enablePodSecurityPolicies: true
-  expect: |
-    [.objects[] | select(isSensorBundleComponent) | select(autoUpgradeLabel != "sensor") | "\(.kind)/\(.metadata.name)"]
-      | assertThat(length == 0)
-
 - name: "with TLS secrets created"
   values:
     createSecrets: true


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This is a more comprehensive follow up to the hot fix in https://github.com/stackrox/stackrox/pull/20616. 

The auto-upgrade.stackrox.io/component label was manually added in each secured-cluster template. This was error-prone: new resources could be added without it, silently breaking the sensor auto-upgrader.

The label is now set automatically in _labels.tpl for resources whose app.kubernetes.io/component is sensor, collector, or admission-control. Two template files were renamed (service-ca.yaml → sensor-service-ca.yaml, openshift-monitoring.yaml → sensor-openshift-monitoring.yaml) so the filename-based component regex assigns them the sensor component.

A helmtest verifies all sensor-bundle component resources carry the label.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Tested upgrade path from `4.9.6` to [5dee649](https://github.com/stackrox/stackrox/commit/5dee649c8af3b324d0c01f12fb3df234177b4aa8).

<img width="1206" height="667" alt="SCR-20260520-kmth" src="https://github.com/user-attachments/assets/db047e97-03e2-4ddd-b3be-540e5b4e3bf6" />

<img width="1216" height="671" alt="SCR-20260520-knar" src="https://github.com/user-attachments/assets/73c5339e-e756-4cd9-bc59-d9bbd4fa5435" />

<img width="631" height="336" alt="SCR-20260520-jfxu" src="https://github.com/user-attachments/assets/ac7a0597-54eb-4ca5-b2a4-6c0fcd70a8de" />