### PR TITLE
fix: prevent scan watcher from deleting valid compliance results

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -370,16 +370,7 @@ func (m *managerImpl) HandleScan(sensorCtx context.Context, scan *storage.Compli
 		}
 		return err
 	}
-	numChecks, err := watcher.GetExpectedNumChecks(scan)
-	if err != nil {
-		log.Warnf("Failed to get expected number of checks from annotations for %s: %v", scan.GetScanName(), err)
-	}
-	w := m.getWatcher(sensorCtx, id, numChecks)
-	if w != nil {
-		return w.PushScan(scan)
-	}
-	log.Debugf("Received scan update after removing the watcher %+v", scan)
-	return nil
+	return m.getWatcher(sensorCtx, id).PushScan(scan)
 }
 
 func (m *managerImpl) updateMetrics() {
@@ -428,16 +419,11 @@ func (m *managerImpl) HandleScanRemove(scanID string) error {
 	return nil
 }
 
-func (m *managerImpl) getWatcher(sensorCtx context.Context, id string, numChecks int) watcher.ScanWatcher {
+func (m *managerImpl) getWatcher(sensorCtx context.Context, id string) watcher.ScanWatcher {
 	var scanWatcher watcher.ScanWatcher
 	concurrency.WithLock(&m.watchingScansLock, func() {
 		var found bool
-		// The check for `numChecks == 0` is here to prevent starting a watcher twice per scan.
-		// It may happen that additional status updates (e.g., state) from CO arrive
-		// after the watcher is removed from the watchingScans (i.e., we have all the checks).
-		// Not checking that would cause a new watcher to be created here and in some circumstances
-		// (when no e-mail is provided for notification), the watcher would time-out and delete the data from DB.
-		if scanWatcher, found = m.watchingScans[id]; !found && numChecks == 0 {
+		if scanWatcher, found = m.watchingScans[id]; !found {
 			scanWatcher = watcher.NewScanWatcher(m.automaticReportingCtx, sensorCtx, id, m.readyQueue)
 			m.watchingScans[id] = scanWatcher
 			m.watchingScansStartTime[id] = time.Now()
@@ -468,12 +454,7 @@ func (m *managerImpl) HandleResult(sensorCtx context.Context, result *storage.Co
 		}
 		return err
 	}
-	w := m.getWatcher(sensorCtx, id, 0)
-	if w != nil {
-		return w.PushCheckResult(result)
-	}
-	log.Debugf("Received check result update after removing the watcher %+v", result)
-	return nil
+	return m.getWatcher(sensorCtx, id).PushCheckResult(result)
 }
 
 // handleReadyScan pulls scans that are ready to be reported

--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -636,7 +636,7 @@ func (m *ManagerTestSuite) setupExpectCallsFromFailAllScans(sc *storage.Complian
 				GetScanConfigurationByName(gomock.Any(), gomock.Eq(sc.GetScanConfigName())).
 				Times(1).Return(sc, nil),
 			m.checkResultDataStore.EXPECT().
-				DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(true)).
+				DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(false)).
 				Times(1).Return(nil),
 			m.snapshotDataStore.EXPECT().
 				UpsertSnapshot(gomock.Any(), gomock.Any()).

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher.go
@@ -66,8 +66,7 @@ func DeleteOldResults(ctx context.Context, results *ScanWatcherResults, store re
 	if results == nil {
 		return errors.New("unable to delete old CheckResults from an nil ScanWatcherResults")
 	}
-	// If the scan failed we remove old and current results
-	includeCurrentResults := results.Error != nil
+	includeCurrentResults := errors.Is(results.Error, ErrScanRemoved)
 	scan := results.Scan
 	return store.DeleteOldResults(ctx, scan.GetLastStartedTime(), scan.GetScanRefId(), includeCurrentResults)
 }

--- a/central/complianceoperator/v2/report/manager/watcher/scanwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanwatcher_test.go
@@ -491,18 +491,46 @@ func TestDeleteOldResults(t *testing.T) {
 	t.Run("nil results should return an error", func(tt *testing.T) {
 		assert.Error(tt, DeleteOldResults(context.Background(), nil, ds))
 	})
-	t.Run("results with error should also delete current CheckResults", func(tt *testing.T) {
+	t.Run("results with ErrScanRemoved should delete current CheckResults", func(tt *testing.T) {
 		results := &ScanWatcherResults{
 			Scan: &storage.ComplianceOperatorScanV2{
 				ScanRefId:       "ref-id",
 				LastStartedTime: timeNow,
 			},
-			Error: errors.New("some error"),
+			Error: ErrScanRemoved,
 		}
 		ds.EXPECT().DeleteOldResults(gomock.Any(),
 			gomock.Eq(results.Scan.GetLastStartedTime()),
 			gomock.Eq(results.Scan.GetScanRefId()),
 			gomock.Eq(true)).Times(1).Return(nil)
+		assert.NoError(tt, DeleteOldResults(context.Background(), results, ds))
+	})
+	t.Run("results with ErrScanTimeout should not delete current CheckResults", func(tt *testing.T) {
+		results := &ScanWatcherResults{
+			Scan: &storage.ComplianceOperatorScanV2{
+				ScanRefId:       "ref-id",
+				LastStartedTime: timeNow,
+			},
+			Error: ErrScanTimeout,
+		}
+		ds.EXPECT().DeleteOldResults(gomock.Any(),
+			gomock.Eq(results.Scan.GetLastStartedTime()),
+			gomock.Eq(results.Scan.GetScanRefId()),
+			gomock.Eq(false)).Times(1).Return(nil)
+		assert.NoError(tt, DeleteOldResults(context.Background(), results, ds))
+	})
+	t.Run("results with ErrScanContextCancelled should not delete current CheckResults", func(tt *testing.T) {
+		results := &ScanWatcherResults{
+			Scan: &storage.ComplianceOperatorScanV2{
+				ScanRefId:       "ref-id",
+				LastStartedTime: timeNow,
+			},
+			Error: ErrScanContextCancelled,
+		}
+		ds.EXPECT().DeleteOldResults(gomock.Any(),
+			gomock.Eq(results.Scan.GetLastStartedTime()),
+			gomock.Eq(results.Scan.GetScanRefId()),
+			gomock.Eq(false)).Times(1).Return(nil)
 		assert.NoError(tt, DeleteOldResults(context.Background(), results, ds))
 	})
 	t.Run("results with no error should not delete current CheckResults", func(tt *testing.T) {


### PR DESCRIPTION
## Description

Two interacting bugs cause clusters to intermittently disappear from the compliance coverage dashboard ~2 hours after sensor restart + rescan.

**Bug 1 — `getWatcher` guard blocks legitimate scan events**: The `numChecks == 0` guard in `getWatcher()` prevents scan events with a persisted `check-count` annotation from creating or finding watchers. After the first scan, ALL subsequent scan events carry a non-zero `check-count` (the annotation persists on the ComplianceScan CR across runs). Since scan events and check results flow through independent goroutine pools with no ordering guarantee, the watcher never receives `totalChecks`, and completion is never satisfied → 40-minute timeout.

**Bug 2 — aggressive deletion on any watcher error**: `DeleteOldResults` sets `includeCurrent = (error != nil)`, which deletes ALL results (including current valid ones) on any watcher error — timeout, context cancellation, etc. When Bug 1 causes a timeout, Bug 2 wipes all check results for that scan. The cluster disappears from the coverage dashboard because visibility depends on having rows in `compliance_operator_check_result_v2`.

### Changes

1. **Removed `numChecks` parameter and `numChecks == 0` guard from `getWatcher`** — snapshot-based deduplication (`GetWatcherIDFromScan`) already prevents duplicate watchers for the same scan run. The guard was unnecessary and harmful.

2. **Narrowed `includeCurrent` in `DeleteOldResults` to only `ErrScanRemoved`** — only delete current results when the scan was explicitly removed (user deleted the scan config). Timeouts and context cancellation should NOT delete current results; the data is still valid.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Deployed patched and unpatched central to a live 2-cluster environment (ga-ocp4-cron-2 + remote) with scan config "test-coverage" (ocp4-cis + ocp4-cis-node profiles, 480 total check results).

**Reproduction (unpatched, 30s timeout)**:
- Triggered rescan → results dropped from 480 → 0 → recovered only after new scan completed
- Logs confirmed: `Timeout waiting for the scan to finish`, `Scan done with 57/94/89 checks` (watcher received checks but completion never triggered because totalChecks was 0)

**Verification (patched, 5m timeout)**:
- Triggered rescan → results held steady at 480 for the entire 4+ minute monitoring window
- Logs confirmed watchers completed normally: `TotalChecks=89, numCheckResults=89`, `Scan Config test-coverage done with 6 scans`

**Verification (patched, 30s timeout)**:
- Triggered rescan → old results correctly deleted (previous scan data), current results preserved
- Bug 2 fix (`includeCurrent=false` on timeout) prevents deletion of valid data

```
# Unpatched (bug reproduced):
[01:35:50] 480 total | 276ead93=240 | d5ae6c3a=240  ← baseline
[01:36:02] 0 total                                    ← ALL RESULTS DELETED
[01:37:04] 318 total                                   ← new results arriving
[01:37:40] 480 total                                   ← new scan completed

# Patched (5m timeout, fix verified):
[01:52:07] 480 total | 276ead93=240 | d5ae6c3a=240  ← baseline
[01:52:37] 480 total                                   ← stable
[01:53:07] 480 total                                   ← stable
... (held steady for 4+ minutes)
```