### PR TITLE
chore(fix): Defend Scanner V4 against empty version header

### DIFF
--- a/pkg/scannerv4/client/client.go
+++ b/pkg/scannerv4/client/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -568,7 +569,7 @@ func setIndexerVersion(options callOptions, responseMetadata metadata.MD) {
 	}
 
 	options.version.Indexer = scannerv4.DefaultVersion
-	if versions := responseMetadata.Get(scannerv4.ServiceVersionHeader); len(versions) > 0 {
+	if versions := responseMetadata.Get(scannerv4.ServiceVersionHeader); len(versions) > 0 && strings.TrimSpace(versions[0]) != "" {
 		options.version.Indexer = versions[0]
 	}
 }
@@ -582,7 +583,7 @@ func setMatcherVersion(options callOptions, responseMetadata metadata.MD) {
 	}
 
 	options.version.Matcher = scannerv4.DefaultVersion
-	if versions := responseMetadata.Get(scannerv4.ServiceVersionHeader); len(versions) > 0 {
+	if versions := responseMetadata.Get(scannerv4.ServiceVersionHeader); len(versions) > 0 && strings.TrimSpace(versions[0]) != "" {
 		options.version.Matcher = versions[0]
 	}
 }

--- a/pkg/scannerv4/client/client_test.go
+++ b/pkg/scannerv4/client/client_test.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/scannerv4"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestSetServiceVersion(t *testing.T) {
+	tests := map[string]struct {
+		version          *scannerv4.Version
+		responseMetadata metadata.MD
+		expectedVersion  string
+	}{
+		"version from metadata is used": {
+			version:          &scannerv4.Version{},
+			responseMetadata: metadata.Pairs(scannerv4.ServiceVersionHeader, "v4.8.0"),
+			expectedVersion:  "v4.8.0",
+		},
+		"nil metadata uses default": {
+			version:          &scannerv4.Version{},
+			responseMetadata: nil,
+			expectedVersion:  scannerv4.DefaultVersion,
+		},
+		"empty metadata uses default": {
+			version:          &scannerv4.Version{},
+			responseMetadata: metadata.MD{},
+			expectedVersion:  scannerv4.DefaultVersion,
+		},
+		"header missing from metadata uses default": {
+			version:          &scannerv4.Version{},
+			responseMetadata: metadata.Pairs("other-header", "value"),
+			expectedVersion:  scannerv4.DefaultVersion,
+		},
+		"empty string version in metadata uses default": {
+			version:          &scannerv4.Version{},
+			responseMetadata: metadata.Pairs(scannerv4.ServiceVersionHeader, ""),
+			expectedVersion:  scannerv4.DefaultVersion,
+		},
+		"whitespace-only version in metadata uses default": {
+			version:          &scannerv4.Version{},
+			responseMetadata: metadata.Pairs(scannerv4.ServiceVersionHeader, "   "),
+			expectedVersion:  scannerv4.DefaultVersion,
+		},
+		"tab whitespace version in metadata uses default": {
+			version:          &scannerv4.Version{},
+			responseMetadata: metadata.Pairs(scannerv4.ServiceVersionHeader, "\t\n"),
+			expectedVersion:  scannerv4.DefaultVersion,
+		},
+		"nil version is a no-op": {
+			version:          nil,
+			responseMetadata: metadata.Pairs(scannerv4.ServiceVersionHeader, "v4.8.0"),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			options := callOptions{version: tt.version}
+			setMatcherVersion(options, tt.responseMetadata)
+			setIndexerVersion(options, tt.responseMetadata)
+
+			if tt.version == nil {
+				assert.Nil(t, options.version)
+			} else {
+				assert.Equal(t, tt.expectedVersion, tt.version.Matcher, "matcher version")
+				assert.Equal(t, tt.expectedVersion, tt.version.Indexer, "indexer version")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

https://github.com/stackrox/stackrox/pull/20512 changed scanner v4 image builds such that versions are no longer populated in the binary, this will be fixed but it revealed a scenario that we should defend against (this PR).

When the indexer/matcher returns an empty version header, that should be treated as if no version was returned and use the default `v4` version.  Otherwise, Central's enricher assumes the index reports from the secured cluster are for Scanner V2 - resulting in empty scans because the Scanner V2 index report has no components.

Verified the bug with a recent build from master that does not embed the versions in Scanner V4 binaries (`4.11.x-1022-g33ecfe690d`), note the delegated scan returns zero components, see below:

```
$ rctl image scan --image=registry.access.redhat.com/ubi9/ubi-minimal:9.4-1194 -f 2>/dev/null | tail
    ],
    "fetched": "2026-05-20T01:58:07.101691691Z"
  },
  "components": 106,
  "cves": 165,
  "fixableCves": 79,
  "lastUpdated": "2026-05-20T01:58:07.117987741Z",
  "riskScore": 9.900001,
  "topCvss": 9.8
}

$ rctl image scan --image=registry.access.redhat.com/ubi9/ubi-minimal:9.4-1194 -f --cluster=remote 2>/dev/null | tail
        }
      }
    ]
  },
  "components": 0,
  "cves": 0,
  "fixableCves": 0,
  "isClusterLocal": true,
  "topCvss": 0
}
```

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

Unit tests + manual test. After making the change and updating Sensor image (but keeping the broken Scanner V4 images in place), both central and delegated scans return proper results:

```sh
$ oc set image deploy/sensor sensor=quay.io/rhacs-eng/main:4.11.x-1062-g02c6c52b2d
deployment.apps/sensor image updated

$ rctl image scan --image=registry.access.redhat.com/ubi9/ubi-minimal:9.4-1194 -f 2>/dev/null | tail
    ],
    "fetched": "2026-05-20T02:24:11.404366603Z"
  },
  "components": 106,
  "cves": 165,
  "fixableCves": 79,
  "lastUpdated": "2026-05-20T02:24:11.421446022Z",
  "riskScore": 9.900001,
  "topCvss": 9.8
}

$ rctl image scan --image=registry.access.redhat.com/ubi9/ubi-minimal:9.4-1194 -f --cluster=remote 2>/dev/null | tail
    ]
  },
  "components": 106,
  "cves": 165,
  "fixableCves": 79,
  "lastUpdated": "2026-05-20T02:24:04.279514279Z",
  "isClusterLocal": true,
  "riskScore": 9.900001,
  "topCvss": 9.8
}
```
