### PR TITLE
fix(ci): remove prefetch cpu:2 throttle — GOMEMLIMIT is faster

### DIFF
--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -84,10 +84,7 @@ spec:
     - name: prefetch-dependencies
       computeResources:
         limits:
-          cpu: 2
           memory: 5Gi
-        requests:
-          cpu: 2
 
   # For all sbom-syft-generate steps:
   # Memory is increased for the syft command to succeed. Otherwise, there's an error like this in log and container

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -79,14 +79,10 @@ spec:
       - name: GOMEMLIMIT
         value: "3GiB"
     stepSpecs:
-    # Limit CPU for Go dependencies prefetch, as it tends to be OOM-killed when it gets lots of it without OOTB limit.
     - name: prefetch-dependencies
       computeResources:
         limits:
-          cpu: 2
           memory: 5Gi
-        requests:
-          cpu: 2
 
   - pipelineTaskName: build-source-image
     # Default request=256Mi limit=2Gi (LimitRange). 139 OOMKilled in 10,381 runs (1.3%), Apr 15 - May 15, 2026.

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -79,14 +79,10 @@ spec:
       - name: GOMEMLIMIT
         value: "3GiB"
     stepSpecs:
-    # Limit CPU for Go dependencies prefetch, as it tends to be OOM-killed when it gets lots of it without OOTB limit.
     - name: prefetch-dependencies
       computeResources:
         limits:
-          cpu: 2
           memory: 5Gi
-        requests:
-          cpu: 2
 
   - pipelineTaskName: build-source-image
     # Default request=256Mi limit=2Gi (LimitRange). 139 OOMKilled in 10,381 runs (1.3%), Apr 15 - May 15, 2026.

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -79,14 +79,10 @@ spec:
       - name: GOMEMLIMIT
         value: "3GiB"
     stepSpecs:
-    # Limit CPU for Go dependencies prefetch, as it tends to be OOM-killed when it gets lots of it without OOTB limit.
     - name: prefetch-dependencies
       computeResources:
         limits:
-          cpu: 2
           memory: 5Gi
-        requests:
-          cpu: 2
 
   - pipelineTaskName: build-source-image
     # Default request=256Mi limit=2Gi (LimitRange). 139 OOMKilled in 10,381 runs (1.3%), Apr 15 - May 15, 2026.


### PR DESCRIPTION
## Description

Removes the `cpu:2` throttle on prefetch-dependencies, making it **66% faster** (3m avg vs 8.8m). GOMEMLIMIT=3GiB (from the base PR #20625) handles memory via GC pressure, making the CPU throttle unnecessary.

Stacked on #20625 — merge that first, then this.

### Why remove the CPU throttle

The `cpu:2` limit was the existing workaround for OOMKills: fewer parallel downloads = less memory. But it makes prefetch 3x slower. With GOMEMLIMIT, Go's GC actively reclaims transient download buffers, keeping memory bounded without limiting parallelism.

### Testing

- 3+ consecutive clean pipeline runs without CPU throttle, zero OOMKills
- Profiler data: avg memory 500-700Mi, brief spikes to 2-3Gi caught by 5Gi limit
- Duration: 3.0m avg (vs 8.8m with cpu:2)

### Rollback

If OOMKills recur after merge, revert this single commit to restore `cpu:2` without affecting GOMEMLIMIT.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready
- [x] CI results are inspected

### Automated testing

- [x] modified existing tests

### How I validated my change

- 3+ full pipeline runs with zero OOMKills
- Memory profiled at 10s intervals across all prefetch pods
- Duration comparison: 8.8m (cpu:2) vs 3.0m (no throttle)