### PR TITLE
ROX-32564: Add hummingbird as a known Scanner V4 distro

### DIFF
--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -265,6 +265,19 @@ func v4Package(p *claircore.Package) (*v4.Package, error) {
 	}, nil
 }
 
+// versionAgnosticDIDs lists distribution IDs whose vulnerability data is not
+// partitioned by version. A scanned image matching any of these DIDs is
+// considered supported regardless of its reported version.
+var versionAgnosticDIDs = map[string]bool{
+	"hummingbird": true,
+}
+
+// IsVersionAgnostic reports whether the given distribution ID uses
+// version-agnostic vulnerability matching.
+func IsVersionAgnostic(did string) bool {
+	return versionAgnosticDIDs[did]
+}
+
 // VersionID returns the distribution version ID.
 func VersionID(d *claircore.Distribution) string {
 	vID := d.VersionID

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -2634,6 +2634,31 @@ func Test_versionID(t *testing.T) {
 	}
 }
 
+func TestIsVersionAgnostic(t *testing.T) {
+	tests := map[string]struct {
+		did  string
+		want bool
+	}{
+		"hummingbird is version-agnostic": {
+			did:  "hummingbird",
+			want: true,
+		},
+		"rhel is not version-agnostic": {
+			did:  "rhel",
+			want: false,
+		},
+		"empty DID is not version-agnostic": {
+			did:  "",
+			want: false,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsVersionAgnostic(tt.did))
+		})
+	}
+}
+
 func Test_sortByNVDCVSS(t *testing.T) {
 	type args struct {
 		ids             []string

--- a/scanner/datastore/postgres/distributions.go
+++ b/scanner/datastore/postgres/distributions.go
@@ -13,6 +13,8 @@ import (
 // The purpose of this is to identify the major version represented by this CPE.
 var rhelCPE = regexp.MustCompile(`^cpe:2\.3:o:redhat:enterprise_linux:(\d+)(?:\.\d+)*:\*:\*:\*:\*:\*:\*:\*$`)
 
+var hummingbirdCPE = regexp.MustCompile(`^cpe:2\.3:a:redhat:hummingbird:\d+(?:\.\d+)*:\*:\*:\*:\*:\*:\*:\*$`)
+
 // Distributions retrieves the currently known distributions from the database.
 //
 // A distribution is considered known if there exists at least one row in the vuln table which references it.
@@ -21,7 +23,8 @@ func (m *matcherStore) Distributions(ctx context.Context) ([]claircore.Distribut
 	// As of ClairCore v1.5.29, all distributions may be identified by dist_id, dist_version_id, and dist_version except for RHEL.
 	// As of this version of ClairCore, RHEL vulnerabilities are not associated with a specific RHEL version, but rather just the CPE(s).
 	// So, to capture all RHEL distributions, we must also search for rows with column repo_name matching the expected RHEL-major-version-identifying CPE.
-	const selectDists = `SELECT DISTINCT dist_id, dist_version_id, dist_version, repo_name FROM vuln WHERE repo_name = '' OR repo_name LIKE 'cpe:2.3:o:redhat:enterprise_linux:%:*:*:*:*:*:*:*'`
+	// Hummingbird is a Red Hat product whose vulns also use CPE-based matching with no dist_* fields populated.
+	const selectDists = `SELECT DISTINCT dist_id, dist_version_id, dist_version, repo_name FROM vuln WHERE repo_name = '' OR repo_name LIKE 'cpe:2.3:o:redhat:enterprise_linux:%:*:*:*:*:*:*:*' OR repo_name LIKE 'cpe:2.3:a:redhat:hummingbird:%:*:*:*:*:*:*:*'`
 
 	rows, err := m.pool.Query(ctx, selectDists)
 	if err != nil {
@@ -47,7 +50,14 @@ func (m *matcherStore) Distributions(ctx context.Context) ([]claircore.Distribut
 			Version:   version,
 		}
 		if repoName != "" {
-			dist, err = rhelDist(repoName)
+			switch {
+			case rhelCPE.MatchString(repoName):
+				dist, err = rhelDist(repoName)
+			case hummingbirdCPE.MatchString(repoName):
+				dist = hummingbirdDist()
+			default:
+				err = fmt.Errorf("unexpected repo name: %s", repoName)
+			}
 			if err != nil {
 				slog.WarnContext(ctx, "failed to parse repo_name; skipping...", "reason", err)
 				continue
@@ -66,6 +76,12 @@ func (m *matcherStore) Distributions(ctx context.Context) ([]claircore.Distribut
 	}
 
 	return dists, nil
+}
+
+func hummingbirdDist() claircore.Distribution {
+	return claircore.Distribution{
+		DID: "hummingbird",
+	}
 }
 
 func rhelDist(repoName string) (claircore.Distribution, error) {

--- a/scanner/datastore/postgres/distributions.go
+++ b/scanner/datastore/postgres/distributions.go
@@ -54,7 +54,7 @@ func (m *matcherStore) Distributions(ctx context.Context) ([]claircore.Distribut
 			case rhelCPE.MatchString(repoName):
 				dist, err = rhelDist(repoName)
 			case hummingbirdCPE.MatchString(repoName):
-				dist = hummingbirdDist()
+				dist, err = hummingbirdDist()
 			default:
 				err = fmt.Errorf("unexpected repo name: %s", repoName)
 			}
@@ -78,10 +78,10 @@ func (m *matcherStore) Distributions(ctx context.Context) ([]claircore.Distribut
 	return dists, nil
 }
 
-func hummingbirdDist() claircore.Distribution {
+func hummingbirdDist() (claircore.Distribution, error) {
 	return claircore.Distribution{
 		DID: "hummingbird",
-	}
+	}, nil
 }
 
 func rhelDist(repoName string) (claircore.Distribution, error) {

--- a/scanner/datastore/postgres/distributions_test.go
+++ b/scanner/datastore/postgres/distributions_test.go
@@ -48,6 +48,9 @@ func TestDistributions(t *testing.T) {
 			VersionID: "",
 			Version:   "3.18",
 		},
+		{
+			DID: "hummingbird",
+		},
 	}
 	const insertDists = `
 INSERT INTO vuln (hash_kind, hash, dist_id, dist_version_id, dist_version, repo_name) VALUES
@@ -58,13 +61,36 @@ INSERT INTO vuln (hash_kind, hash, dist_id, dist_version_id, dist_version, repo_
     ('md5', 'fake5', 'alpine', '',      '3.18',          ''),
     ('md5', 'fake6', 'debian', '10',    '10 (buster)',   ''),
     ('md5', 'fake7', '',       '',      '',              'cpe:2.3:o:redhat:enterprise_linux:%:*:*:*:*:*:*:*'),
-    ('md5', 'fake8', '',       '',      '',              'cpe:2.3:o:redhat:enterprise_linux:10.1:*:*:*:*:*:*:*')`
+    ('md5', 'fake8', '',       '',      '',              'cpe:2.3:o:redhat:enterprise_linux:10.1:*:*:*:*:*:*:*'),
+    ('md5', 'fake9', '',       '',      '',              'cpe:2.3:a:redhat:hummingbird:1:*:*:*:*:*:*:*')`
 	_, err = pool.Exec(ctx, insertDists)
 	require.NoError(t, err)
 
 	dists, err := store.Distributions(ctx)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, expected, dists)
+}
+
+func TestHummingbirdDist(t *testing.T) {
+	dist := hummingbirdDist()
+	assert.Equal(t, claircore.Distribution{DID: "hummingbird"}, dist)
+}
+
+func TestHummingbirdCPE(t *testing.T) {
+	for _, tc := range []struct {
+		repoName string
+		match    bool
+	}{
+		{"cpe:2.3:a:redhat:hummingbird:1:*:*:*:*:*:*:*", true},
+		{"cpe:2.3:a:redhat:hummingbird:2:*:*:*:*:*:*:*", true},
+		{"cpe:2.3:a:redhat:hummingbird:1.0:*:*:*:*:*:*:*", true},
+		{"cpe:2.3:o:redhat:enterprise_linux:9:*:*:*:*:*:*:*", false},
+		{"cpe:2.3:a:redhat:other_product:1:*:*:*:*:*:*:*", false},
+	} {
+		t.Run(tc.repoName, func(t *testing.T) {
+			assert.Equal(t, tc.match, hummingbirdCPE.MatchString(tc.repoName))
+		})
+	}
 }
 
 func TestRHELDist(t *testing.T) {

--- a/scanner/datastore/postgres/distributions_test.go
+++ b/scanner/datastore/postgres/distributions_test.go
@@ -72,7 +72,8 @@ INSERT INTO vuln (hash_kind, hash, dist_id, dist_version_id, dist_version, repo_
 }
 
 func TestHummingbirdDist(t *testing.T) {
-	dist := hummingbirdDist()
+	dist, err := hummingbirdDist()
+	require.NoError(t, err)
 	assert.Equal(t, claircore.Distribution{DID: "hummingbird"}, dist)
 }
 

--- a/scanner/services/matcher.go
+++ b/scanner/services/matcher.go
@@ -161,7 +161,7 @@ func (s *matcherService) notes(ctx context.Context, vr *v4.VulnerabilityReport) 
 	knownDists := s.matcher.GetKnownDistributions(ctx)
 	known := slices.ContainsFunc(knownDists, func(dist claircore.Distribution) bool {
 		vID := mappers.VersionID(&dist)
-		return distID == dist.DID && versionID == vID
+		return distID == dist.DID && (mappers.IsVersionAgnostic(dist.DID) || versionID == vID)
 	})
 	if !known {
 		return []v4.VulnerabilityReport_Note{v4.VulnerabilityReport_NOTE_OS_UNSUPPORTED}

--- a/scanner/services/matcher_test.go
+++ b/scanner/services/matcher_test.go
@@ -243,6 +243,9 @@ func (s *matcherServiceTestSuite) Test_matcherService_notes() {
 			VersionID: "3.19",
 			Version:   "",
 		},
+		{
+			DID: "hummingbird",
+		},
 	}
 
 	srv := NewMatcherService(s.matcherMock, nil)
@@ -258,6 +261,23 @@ func (s *matcherServiceTestSuite) Test_matcherService_notes() {
 				"0": {
 					Did:       "alpine",
 					VersionId: "3.18",
+				},
+			},
+		},
+	})
+	s.Empty(notes)
+
+	// Hummingbird supported via DID-only match (no VersionID in known dist).
+	s.matcherMock.
+		EXPECT().
+		GetKnownDistributions(gomock.Any()).
+		Return(dists)
+	notes = srv.notes(s.ctx, &v4.VulnerabilityReport{
+		Contents: &v4.Contents{
+			Distributions: map[string]*v4.Distribution{
+				"0": {
+					Did:       "hummingbird",
+					VersionId: "20251124",
 				},
 			},
 		},


### PR DESCRIPTION
## Description

Modifies Scanner V4 to treat `hummingbird` as a known distribution. 

This is necessary so that `NOTE_OS_UNSUPPORTED` is not added to scan results - when that note is set the UI will show warnings:  "Unable to retrieve OS CVE data; only Language CVE data available. Only Language CVE information is shown." which is not accurate.

_The placement of `IsVersionAgnostic` and `versionAgnosticDIDs` isn't perfect, but follows the precedent set by the `VersionID` method (distro-specific knowledge in `mappers`)._



## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests


### How I validated my change

Tested by basing this PR on top of the [claircore bump](https://github.com/stackrox/stackrox/pull/20704), deploying, and then scanning hummingbird images:

<img width="956" height="580" alt="image" src="https://github.com/user-attachments/assets/c9308e5f-ae40-448c-bfa0-18b856d015ec" />

<img width="1229" height="586" alt="image" src="https://github.com/user-attachments/assets/70641d98-a944-4a38-ba57-5d5aa02326eb" />

Prior to this PR (and claircore distro changes) notice the image scanning incomplete warning and the OS being unidentified:

<img width="1235" height="741" alt="image" src="https://github.com/user-attachments/assets/986606ed-35ff-4323-abc3-58d3b72c71d2" />

<img width="1223" height="789" alt="image" src="https://github.com/user-attachments/assets/8d3fd073-cc6d-4584-8591-a7900ade80b7" />

