### PR TITLE
ROX-34762: Add microbenchmarks for queue lock changes

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -168,7 +168,6 @@ func (q *Queue[T]) Push(item T) {
 
 	q.notEmptySignal.Signal()
 	if q.counterMetric != nil {
-		// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
 		q.counterMetric.WithLabelValues(metrics.Add.String()).Inc()
 	}
 }

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -168,6 +168,7 @@ func (q *Queue[T]) Push(item T) {
 
 	q.notEmptySignal.Signal()
 	if q.counterMetric != nil {
+		// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
 		q.counterMetric.WithLabelValues(metrics.Add.String()).Inc()
 	}
 }

--- a/pkg/queue/queue_bench_test.go
+++ b/pkg/queue/queue_bench_test.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"fmt"
 	"runtime"
+	gosync "sync"
 	"sync/atomic"
 	"testing"
 
@@ -129,10 +130,6 @@ func BenchmarkPushPull_Concurrent(b *testing.B) {
 					)
 				}
 				q := NewQueue[int](opts...)
-				opsPerProducer := b.N / numProducers
-				if opsPerProducer == 0 {
-					opsPerProducer = 1
-				}
 
 				b.ResetTimer()
 
@@ -219,5 +216,50 @@ func BenchmarkRateLimitedLogger(b *testing.B) {
 		logging.GetRateLimitedLogger().WarnL(loggingRateLimiter,
 			"Queue (%s) size limit reached (%d). New items added to the queue will be dropped.",
 			"BenchQueue", 40960)
+	}
+}
+
+// busyWork burns CPU for approximately the given duration using a calibrated
+// spin loop. We avoid time.Sleep because its minimum granularity (~1ms) is
+// far too coarse for nanosecond-scale experiments.
+//
+//go:noinline
+func busyWork(approxNs int) {
+	// Each iteration of this loop takes ~1ns on modern hardware.
+	for range approxNs {
+		runtime.KeepAlive(approxNs)
+	}
+}
+
+// BenchmarkContention_CriticalSectionLength demonstrates the relationship
+// between critical section duration, goroutine count, and throughput.
+//
+// This is the key experiment: it proves that the same amount of work becomes
+// dramatically more expensive when done inside a contended lock. With 1
+// goroutine, doubling the critical section roughly doubles the time. With 64+
+// goroutines, doubling the critical section causes far worse degradation
+// because every goroutine must wait for every other goroutine's critical
+// section to complete.
+//
+// The hold_ns values are chosen to match the real queue scenario:
+//   - 60ns  ≈ pushLocked (PR branch: just length check + PushBack)
+//   - 1000ns ≈ Push on master (length check + logger + metrics + signal + PushBack)
+func BenchmarkContention_CriticalSectionLength(b *testing.B) {
+	for _, holdNs := range []int{60, 200, 500, 1000} {
+		for _, goroutines := range []int{1, 4, 16, 64, 256} {
+			name := fmt.Sprintf("hold=%dns/goroutines=%d", holdNs, goroutines)
+			b.Run(name, func(b *testing.B) {
+				var mu gosync.Mutex
+				b.SetParallelism(goroutines)
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						mu.Lock()
+						busyWork(holdNs)
+						mu.Unlock()
+					}
+				})
+			})
+		}
 	}
 }

--- a/pkg/queue/queue_bench_test.go
+++ b/pkg/queue/queue_bench_test.go
@@ -3,13 +3,13 @@ package queue
 import (
 	"fmt"
 	"runtime"
-	gosync "sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
+	pkgsync "github.com/stackrox/rox/pkg/sync"
 )
 
 func newCounterVec(name string) *prometheus.CounterVec {
@@ -249,7 +249,7 @@ func BenchmarkContention_CriticalSectionLength(b *testing.B) {
 		for _, goroutines := range []int{1, 4, 16, 64, 256} {
 			name := fmt.Sprintf("hold=%dns/goroutines=%d", holdNs, goroutines)
 			b.Run(name, func(b *testing.B) {
-				var mu gosync.Mutex
+				var mu pkgsync.Mutex
 				b.SetParallelism(goroutines)
 				b.ResetTimer()
 				b.RunParallel(func(pb *testing.PB) {

--- a/pkg/queue/queue_bench_test.go
+++ b/pkg/queue/queue_bench_test.go
@@ -31,189 +31,161 @@ func newDroppedCounter(prefix string) prometheus.Counter {
 	})
 }
 
-// BenchmarkPush_NotFull measures pure Push throughput at various starting depths.
-// The queue has no max size, so it grows freely without hitting the drop path.
-func BenchmarkPush_NotFull(b *testing.B) {
-	for _, depth := range []int{100, 1000, 10_000, 100_000} {
-		for _, withMetrics := range []bool{false, true} {
-			mname := "no_metrics"
-			if withMetrics {
-				mname = "with_metrics"
-			}
-			b.Run(fmt.Sprintf("depth=%d/%s", depth, mname), func(b *testing.B) {
-				opts := []OptionFunc[int]{}
-				if withMetrics {
-					opts = append(opts,
-						WithCounterVec[int](newCounterVec("push_notfull")),
-						WithDroppedMetric[int](newDroppedCounter("push_notfull_dropped")),
-					)
-				}
-				q := NewQueue[int](opts...)
-				for i := range depth {
-					q.Push(i)
-				}
-				i := 0
-				for b.Loop() {
-					q.Push(i)
-					i++
-				}
-			})
-		}
-	}
-}
-
-// BenchmarkPush_Full measures Push throughput when the queue is at capacity
-// (the drop path with logging and metrics) at various capacities.
+// BenchmarkPush_Full measures the true per-operation cost of pushing to a full
+// queue (the drop path with logging and metrics), single-threaded via b.Loop().
+//
+// This benchmark is intentionally separate from BenchmarkPush_Full_Concurrent
+// with producers=1. Despite both using a single producer, b.RunParallel
+// reports ~40% lower ns/op because it distributes iterations across
+// goroutine start/stop cycles, which changes the timing of the rate-limited
+// logger and gives an artificially low per-op number. b.Loop() runs all
+// iterations sequentially on one goroutine, providing the honest baseline.
+//
+// Capacity is fixed at 1. Varying it has no effect because the drop path only
+// checks list.Len() >= maxSize (O(1) regardless of size) and never touches
+// the queue contents.
 func BenchmarkPush_Full(b *testing.B) {
-	for _, capacity := range []int{1, 100, 1000} {
-		for _, withMetrics := range []bool{false, true} {
-			mname := "no_metrics"
-			if withMetrics {
-				mname = "with_metrics"
-			}
-			b.Run(fmt.Sprintf("capacity=%d/%s", capacity, mname), func(b *testing.B) {
-				opts := []OptionFunc[int]{
-					WithMaxSize[int](capacity),
-					WithQueueName[int]("BenchQueue"),
-				}
-				if withMetrics {
-					opts = append(opts,
-						WithCounterVec[int](newCounterVec("push_full")),
-						WithDroppedMetric[int](newDroppedCounter("push_full_dropped")),
-					)
-				}
-				q := NewQueue[int](opts...)
-				for i := range capacity {
-					q.Push(i)
-				}
-				i := 0
-				for b.Loop() {
-					q.Push(i)
-					i++
-				}
-			})
+	for _, withMetrics := range []bool{false, true} {
+		mname := "no_metrics"
+		if withMetrics {
+			mname = "with_metrics"
 		}
+		b.Run(mname, func(b *testing.B) {
+			opts := []OptionFunc[int]{
+				WithMaxSize[int](1),
+				WithQueueName[int]("BenchQueue"),
+			}
+			if withMetrics {
+				opts = append(opts,
+					WithCounterVec[int](newCounterVec("push_full")),
+					WithDroppedMetric[int](newDroppedCounter("push_full_dropped")),
+				)
+			}
+			q := NewQueue(opts...)
+			q.Push(0)
+			i := 0
+			for b.Loop() {
+				q.Push(i)
+				i++
+			}
+		})
 	}
 }
 
-// BenchmarkPull measures Pull throughput at various queue depths.
+// BenchmarkPull measures Pull throughput on a pre-filled queue.
 // Each iteration pulls one item and pushes it back to maintain constant depth.
+//
+// Depth is fixed at 100. The underlying container/list provides O(1)
+// Front/Remove/PushBack regardless of list length, so varying depth
+// has no effect on per-operation cost.
 func BenchmarkPull(b *testing.B) {
-	for _, size := range []int{100, 1000, 10_000, 100_000} {
+	for _, withMetrics := range []bool{false, true} {
+		mname := "no_metrics"
+		if withMetrics {
+			mname = "with_metrics"
+		}
+		b.Run(mname, func(b *testing.B) {
+			opts := []OptionFunc[int]{}
+			if withMetrics {
+				opts = append(opts,
+					WithCounterVec[int](newCounterVec("pull")),
+				)
+			}
+			q := NewQueue(opts...)
+			for i := range 100 {
+				q.Push(i)
+			}
+			for b.Loop() {
+				q.Push(q.Pull())
+			}
+		})
+	}
+}
+
+// BenchmarkPush_NotFull_Concurrent measures concurrent Push throughput on an
+// unbounded queue (success path only). A background goroutine drains the queue
+// to prevent unbounded memory growth.
+func BenchmarkPush_NotFull_Concurrent(b *testing.B) {
+	for _, numProducers := range []int{1, 4, 16, 64, 256} {
 		for _, withMetrics := range []bool{false, true} {
 			mname := "no_metrics"
 			if withMetrics {
 				mname = "with_metrics"
 			}
-			b.Run(fmt.Sprintf("depth=%d/%s", size, mname), func(b *testing.B) {
+			name := fmt.Sprintf("producers=%d/%s", numProducers, mname)
+			b.Run(name, func(b *testing.B) {
 				opts := []OptionFunc[int]{}
 				if withMetrics {
 					opts = append(opts,
-						WithCounterVec[int](newCounterVec("pull")),
+						WithCounterVec[int](newCounterVec("conc")),
+						WithDroppedMetric[int](newDroppedCounter("conc_drop")),
 					)
 				}
-				q := NewQueue[int](opts...)
-				for i := range size {
-					q.Push(i)
-				}
-				for b.Loop() {
-					q.Push(q.Pull())
-				}
-			})
-		}
-	}
-}
+				q := NewQueue(opts...)
 
-// BenchmarkPushPull_Concurrent measures concurrent Push/Pull throughput under
-// contention from multiple goroutines at various queue capacities.
-// This is the scenario closest to the production issue.
-func BenchmarkPushPull_Concurrent(b *testing.B) {
-	for _, capacity := range []int{100, 1000, 10_000} {
-		for _, numProducers := range []int{1, 4, 16, 64} {
-			for _, withMetrics := range []bool{false, true} {
-				mname := "no_metrics"
-				if withMetrics {
-					mname = "with_metrics"
-				}
-				name := fmt.Sprintf("capacity=%d/producers=%d/%s", capacity, numProducers, mname)
-				b.Run(name, func(b *testing.B) {
-					opts := []OptionFunc[int]{
-						WithMaxSize[int](capacity),
-						WithQueueName[int]("BenchQueue"),
+				b.SetParallelism(numProducers)
+
+				var done atomic.Bool
+				go func() {
+					for !done.Load() {
+						q.Pull()
+						runtime.Gosched()
 					}
-					if withMetrics {
-						opts = append(opts,
-							WithCounterVec[int](newCounterVec("conc")),
-							WithDroppedMetric[int](newDroppedCounter("conc_drop")),
-						)
+				}()
+
+				b.RunParallel(func(pb *testing.PB) {
+					i := 0
+					for pb.Next() {
+						q.Push(i)
+						i++
 					}
-					q := NewQueue[int](opts...)
-
-					b.SetParallelism(numProducers)
-
-					var done atomic.Bool
-					go func() {
-						for !done.Load() {
-							q.Pull()
-							runtime.Gosched()
-						}
-					}()
-
-					b.RunParallel(func(pb *testing.PB) {
-						i := 0
-						for pb.Next() {
-							q.Push(i)
-							i++
-						}
-					})
-					done.Store(true)
 				})
-			}
+				done.Store(true)
+			})
 		}
 	}
 }
 
 // BenchmarkPush_Full_Concurrent measures the specific production scenario:
-// many goroutines pushing to a completely full queue (all take the drop path)
-// at various capacities. This is the exact scenario from the bug report where
-// mutex hold time exceeded 10s.
+// many goroutines pushing to a completely full queue (all take the drop path).
+// This is the exact scenario from the bug report where mutex hold time exceeded 10s.
+//
+// Capacity is fixed at 1. Varying it has no effect because the drop path only
+// checks list.Len() >= maxSize (O(1) regardless of size) and never touches
+// the queue contents.
 func BenchmarkPush_Full_Concurrent(b *testing.B) {
-	for _, capacity := range []int{1, 100, 1000} {
-		for _, numProducers := range []int{1, 4, 16, 64, 256} {
-			for _, withMetrics := range []bool{false, true} {
-				mname := "no_metrics"
-				if withMetrics {
-					mname = "with_metrics"
-				}
-				name := fmt.Sprintf("capacity=%d/producers=%d/%s", capacity, numProducers, mname)
-				b.Run(name, func(b *testing.B) {
-					opts := []OptionFunc[int]{
-						WithMaxSize[int](capacity),
-						WithQueueName[int]("BenchQueue"),
-					}
-					if withMetrics {
-						opts = append(opts,
-							WithCounterVec[int](newCounterVec("fullconc")),
-							WithDroppedMetric[int](newDroppedCounter("fullconc_drop")),
-						)
-					}
-					q := NewQueue[int](opts...)
-					for i := range capacity {
-						q.Push(i)
-					}
-
-					runtime.GOMAXPROCS(runtime.NumCPU())
-					b.SetParallelism(numProducers)
-
-					b.RunParallel(func(pb *testing.PB) {
-						i := 0
-						for pb.Next() {
-							q.Push(i)
-							i++
-						}
-					})
-				})
+	for _, numProducers := range []int{1, 4, 16, 64, 256} {
+		for _, withMetrics := range []bool{false, true} {
+			mname := "no_metrics"
+			if withMetrics {
+				mname = "with_metrics"
 			}
+			name := fmt.Sprintf("producers=%d/%s", numProducers, mname)
+			b.Run(name, func(b *testing.B) {
+				opts := []OptionFunc[int]{
+					WithMaxSize[int](1),
+					WithQueueName[int]("BenchQueue"),
+				}
+				if withMetrics {
+					opts = append(opts,
+						WithCounterVec[int](newCounterVec("fullconc")),
+						WithDroppedMetric[int](newDroppedCounter("fullconc_drop")),
+					)
+				}
+				q := NewQueue(opts...)
+				q.Push(0)
+
+				runtime.GOMAXPROCS(runtime.NumCPU())
+				b.SetParallelism(numProducers)
+
+				b.RunParallel(func(pb *testing.PB) {
+					i := 0
+					for pb.Next() {
+						q.Push(i)
+						i++
+					}
+				})
+			})
 		}
 	}
 }

--- a/pkg/queue/queue_bench_test.go
+++ b/pkg/queue/queue_bench_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
-	"github.com/stackrox/rox/pkg/sync"
 )
 
 func newCounterVec(name string) *prometheus.CounterVec {
@@ -216,50 +215,5 @@ func BenchmarkRateLimitedLogger(b *testing.B) {
 		logging.GetRateLimitedLogger().WarnL(loggingRateLimiter,
 			"Queue (%s) size limit reached (%d). New items added to the queue will be dropped.",
 			"BenchQueue", 40960)
-	}
-}
-
-// busyWork burns CPU for approximately the given duration using a calibrated
-// spin loop. We avoid time.Sleep because its minimum granularity (~1ms) is
-// far too coarse for nanosecond-scale experiments.
-//
-//go:noinline
-func busyWork(approxNs int) {
-	// Each iteration of this loop takes ~1ns on modern hardware.
-	for range approxNs {
-		runtime.KeepAlive(approxNs)
-	}
-}
-
-// BenchmarkContention_CriticalSectionLength demonstrates the relationship
-// between critical section duration, goroutine count, and throughput.
-//
-// This is the key experiment: it proves that the same amount of work becomes
-// dramatically more expensive when done inside a contended lock. With 1
-// goroutine, doubling the critical section roughly doubles the time. With 64+
-// goroutines, doubling the critical section causes far worse degradation
-// because every goroutine must wait for every other goroutine's critical
-// section to complete.
-//
-// The hold_ns values are chosen to match the real queue scenario:
-//   - 60ns  ≈ pushLocked (PR branch: just length check + PushBack)
-//   - 1000ns ≈ Push on master (length check + logger + metrics + signal + PushBack)
-func BenchmarkContention_CriticalSectionLength(b *testing.B) {
-	for _, holdNs := range []int{60, 200, 500, 1000} {
-		for _, goroutines := range []int{1, 4, 16, 64, 256} {
-			name := fmt.Sprintf("hold=%dns/goroutines=%d", holdNs, goroutines)
-			b.Run(name, func(b *testing.B) {
-				var mu sync.Mutex
-				b.SetParallelism(goroutines)
-				b.ResetTimer()
-				b.RunParallel(func(pb *testing.PB) {
-					for pb.Next() {
-						mu.Lock()
-						busyWork(holdNs)
-						mu.Unlock()
-					}
-				})
-			})
-		}
 	}
 }

--- a/pkg/queue/queue_bench_test.go
+++ b/pkg/queue/queue_bench_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
-	pkgsync "github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/sync"
 )
 
 func newCounterVec(name string) *prometheus.CounterVec {
@@ -249,7 +249,7 @@ func BenchmarkContention_CriticalSectionLength(b *testing.B) {
 		for _, goroutines := range []int{1, 4, 16, 64, 256} {
 			name := fmt.Sprintf("hold=%dns/goroutines=%d", holdNs, goroutines)
 			b.Run(name, func(b *testing.B) {
-				var mu pkgsync.Mutex
+				var mu sync.Mutex
 				b.SetParallelism(goroutines)
 				b.ResetTimer()
 				b.RunParallel(func(pb *testing.PB) {

--- a/pkg/queue/queue_bench_test.go
+++ b/pkg/queue/queue_bench_test.go
@@ -1,0 +1,223 @@
+package queue
+
+import (
+	"fmt"
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/metrics"
+)
+
+func newCounterVec(name string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "test",
+		Subsystem: "queue",
+		Name:      name,
+	}, []string{"Operation"})
+}
+
+func newDroppedCounter(name string) prometheus.Counter {
+	return prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "test",
+		Subsystem: "queue",
+		Name:      name,
+	})
+}
+
+// BenchmarkPush_NotFull measures Push throughput when the queue has room.
+func BenchmarkPush_NotFull(b *testing.B) {
+	for _, withMetrics := range []bool{false, true} {
+		name := "no_metrics"
+		if withMetrics {
+			name = "with_metrics"
+		}
+		b.Run(name, func(b *testing.B) {
+			opts := []OptionFunc[int]{WithMaxSize[int](b.N + 1)}
+			if withMetrics {
+				opts = append(opts,
+					WithCounterVec[int](newCounterVec(fmt.Sprintf("push_notfull_%s_%d", name, b.N))),
+					WithDroppedMetric[int](newDroppedCounter(fmt.Sprintf("push_notfull_dropped_%s_%d", name, b.N))),
+				)
+			}
+			q := NewQueue[int](opts...)
+			b.ResetTimer()
+			for i := range b.N {
+				q.Push(i)
+			}
+		})
+	}
+}
+
+// BenchmarkPush_Full measures Push throughput when the queue is at capacity
+// (the drop path with logging and metrics).
+func BenchmarkPush_Full(b *testing.B) {
+	for _, withMetrics := range []bool{false, true} {
+		name := "no_metrics"
+		if withMetrics {
+			name = "with_metrics"
+		}
+		b.Run(name, func(b *testing.B) {
+			opts := []OptionFunc[int]{
+				WithMaxSize[int](1),
+				WithQueueName[int]("BenchQueue"),
+			}
+			if withMetrics {
+				opts = append(opts,
+					WithCounterVec[int](newCounterVec(fmt.Sprintf("push_full_%s_%d", name, b.N))),
+					WithDroppedMetric[int](newDroppedCounter(fmt.Sprintf("push_full_dropped_%s_%d", name, b.N))),
+				)
+			}
+			q := NewQueue[int](opts...)
+			q.Push(0) // fill the queue
+			b.ResetTimer()
+			for i := range b.N {
+				q.Push(i)
+			}
+		})
+	}
+}
+
+// BenchmarkPull measures Pull throughput from a pre-filled queue.
+func BenchmarkPull(b *testing.B) {
+	for _, withMetrics := range []bool{false, true} {
+		name := "no_metrics"
+		if withMetrics {
+			name = "with_metrics"
+		}
+		b.Run(name, func(b *testing.B) {
+			opts := []OptionFunc[int]{}
+			if withMetrics {
+				opts = append(opts,
+					WithCounterVec[int](newCounterVec(fmt.Sprintf("pull_%s_%d", name, b.N))),
+				)
+			}
+			q := NewQueue[int](opts...)
+			for i := range b.N {
+				q.Push(i)
+			}
+			b.ResetTimer()
+			for range b.N {
+				q.Pull()
+			}
+		})
+	}
+}
+
+// BenchmarkPushPull_Concurrent measures concurrent Push/Pull throughput under
+// contention from multiple goroutines. This is the scenario closest to the
+// production issue: many producers pushing while consumers pull.
+func BenchmarkPushPull_Concurrent(b *testing.B) {
+	for _, numProducers := range []int{1, 4, 16, 64} {
+		for _, withMetrics := range []bool{false, true} {
+			mname := "no_metrics"
+			if withMetrics {
+				mname = "with_metrics"
+			}
+			name := fmt.Sprintf("producers=%d/%s", numProducers, mname)
+			b.Run(name, func(b *testing.B) {
+				opts := []OptionFunc[int]{
+					WithMaxSize[int](1024),
+					WithQueueName[int]("BenchQueue"),
+				}
+				if withMetrics {
+					opts = append(opts,
+						WithCounterVec[int](newCounterVec(fmt.Sprintf("conc_%d_%s_%d", numProducers, mname, b.N))),
+						WithDroppedMetric[int](newDroppedCounter(fmt.Sprintf("conc_drop_%d_%s_%d", numProducers, mname, b.N))),
+					)
+				}
+				q := NewQueue[int](opts...)
+				opsPerProducer := b.N / numProducers
+				if opsPerProducer == 0 {
+					opsPerProducer = 1
+				}
+
+				b.ResetTimer()
+
+				var done atomic.Bool
+				// Consumer goroutine draining the queue.
+				go func() {
+					for !done.Load() {
+						q.Pull()
+						runtime.Gosched()
+					}
+				}()
+
+				b.RunParallel(func(pb *testing.PB) {
+					i := 0
+					for pb.Next() {
+						q.Push(i)
+						i++
+					}
+				})
+				done.Store(true)
+			})
+		}
+	}
+}
+
+// BenchmarkPush_Full_Concurrent measures the specific production scenario:
+// many goroutines pushing to a completely full queue (all take the drop path).
+// This is the exact scenario from the bug report where mutex hold time exceeded 10s.
+func BenchmarkPush_Full_Concurrent(b *testing.B) {
+	for _, numProducers := range []int{1, 4, 16, 64, 256} {
+		for _, withMetrics := range []bool{false, true} {
+			mname := "no_metrics"
+			if withMetrics {
+				mname = "with_metrics"
+			}
+			name := fmt.Sprintf("producers=%d/%s", numProducers, mname)
+			b.Run(name, func(b *testing.B) {
+				opts := []OptionFunc[int]{
+					WithMaxSize[int](1),
+					WithQueueName[int]("BenchQueue"),
+				}
+				if withMetrics {
+					opts = append(opts,
+						WithCounterVec[int](newCounterVec(fmt.Sprintf("fullconc_%d_%s_%d", numProducers, mname, b.N))),
+						WithDroppedMetric[int](newDroppedCounter(fmt.Sprintf("fullconc_drop_%d_%s_%d", numProducers, mname, b.N))),
+					)
+				}
+				q := NewQueue[int](opts...)
+				q.Push(0) // fill the queue
+
+				runtime.GOMAXPROCS(runtime.NumCPU())
+				b.SetParallelism(numProducers)
+				b.ResetTimer()
+
+				b.RunParallel(func(pb *testing.PB) {
+					i := 0
+					for pb.Next() {
+						q.Push(i)
+						i++
+					}
+				})
+			})
+		}
+	}
+}
+
+// BenchmarkPush_NotFull_WithPrometheusLabels isolates the cost of
+// prometheus.CounterVec.With(Labels{}).Inc() inside vs outside the lock.
+// The queue code calls this on every successful Push and Pull.
+func BenchmarkPush_NotFull_WithPrometheusLabels(b *testing.B) {
+	cv := newCounterVec(fmt.Sprintf("labels_bench_%d", b.N))
+	_ = cv.With(prometheus.Labels{"Operation": metrics.Add.String()}) // pre-warm
+	b.ResetTimer()
+	for range b.N {
+		cv.With(prometheus.Labels{"Operation": metrics.Add.String()}).Inc()
+	}
+}
+
+// BenchmarkRateLimitedLogger isolates the cost of the rate-limited logger call
+// that happens on the drop path (full queue).
+func BenchmarkRateLimitedLogger(b *testing.B) {
+	b.ResetTimer()
+	for range b.N {
+		logging.GetRateLimitedLogger().WarnL(loggingRateLimiter,
+			"Queue (%s) size limit reached (%d). New items added to the queue will be dropped.",
+			"BenchQueue", 40960)
+	}
+}

--- a/pkg/queue/queue_bench_test.go
+++ b/pkg/queue/queue_bench_test.go
@@ -151,6 +151,8 @@ func BenchmarkPushPull_Concurrent(b *testing.B) {
 					}
 					q := NewQueue[int](opts...)
 
+					b.SetParallelism(numProducers)
+
 					var done atomic.Bool
 					go func() {
 						for !done.Load() {

--- a/pkg/queue/queue_bench_test.go
+++ b/pkg/queue/queue_bench_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stackrox/rox/pkg/logging"
-	"github.com/stackrox/rox/pkg/metrics"
 )
 
 var benchSeq atomic.Int64
@@ -217,26 +215,5 @@ func BenchmarkPush_Full_Concurrent(b *testing.B) {
 				})
 			}
 		}
-	}
-}
-
-// BenchmarkPush_NotFull_WithPrometheusLabels isolates the cost of
-// prometheus.CounterVec.With(Labels{}).Inc() inside vs outside the lock.
-// The queue code calls this on every successful Push and Pull.
-func BenchmarkPush_NotFull_WithPrometheusLabels(b *testing.B) {
-	cv := newCounterVec("labels_bench")
-	_ = cv.With(prometheus.Labels{"Operation": metrics.Add.String()})
-	for b.Loop() {
-		cv.With(prometheus.Labels{"Operation": metrics.Add.String()}).Inc()
-	}
-}
-
-// BenchmarkRateLimitedLogger isolates the cost of the rate-limited logger call
-// that happens on the drop path (full queue).
-func BenchmarkRateLimitedLogger(b *testing.B) {
-	for b.Loop() {
-		logging.GetRateLimitedLogger().WarnL(loggingRateLimiter,
-			"Queue (%s) size limit reached (%d). New items added to the queue will be dropped.",
-			"BenchQueue", 40960)
 	}
 }

--- a/pkg/queue/queue_bench_test.go
+++ b/pkg/queue/queue_bench_test.go
@@ -11,186 +11,209 @@ import (
 	"github.com/stackrox/rox/pkg/metrics"
 )
 
-func newCounterVec(name string) *prometheus.CounterVec {
+var benchSeq atomic.Int64
+
+func uniqueName(prefix string) string {
+	return fmt.Sprintf("%s_%d", prefix, benchSeq.Add(1))
+}
+
+func newCounterVec(prefix string) *prometheus.CounterVec {
 	return prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "test",
 		Subsystem: "queue",
-		Name:      name,
+		Name:      uniqueName(prefix),
 	}, []string{"Operation"})
 }
 
-func newDroppedCounter(name string) prometheus.Counter {
+func newDroppedCounter(prefix string) prometheus.Counter {
 	return prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "test",
 		Subsystem: "queue",
-		Name:      name,
+		Name:      uniqueName(prefix),
 	})
 }
 
-// BenchmarkPush_NotFull measures Push throughput when the queue has room.
+// BenchmarkPush_NotFull measures pure Push throughput at various starting depths.
+// The queue has no max size, so it grows freely without hitting the drop path.
 func BenchmarkPush_NotFull(b *testing.B) {
-	for _, withMetrics := range []bool{false, true} {
-		name := "no_metrics"
-		if withMetrics {
-			name = "with_metrics"
-		}
-		b.Run(name, func(b *testing.B) {
-			opts := []OptionFunc[int]{WithMaxSize[int](b.N + 1)}
-			if withMetrics {
-				opts = append(opts,
-					WithCounterVec[int](newCounterVec(fmt.Sprintf("push_notfull_%s_%d", name, b.N))),
-					WithDroppedMetric[int](newDroppedCounter(fmt.Sprintf("push_notfull_dropped_%s_%d", name, b.N))),
-				)
-			}
-			q := NewQueue[int](opts...)
-			b.ResetTimer()
-			for i := range b.N {
-				q.Push(i)
-			}
-		})
-	}
-}
-
-// BenchmarkPush_Full measures Push throughput when the queue is at capacity
-// (the drop path with logging and metrics).
-func BenchmarkPush_Full(b *testing.B) {
-	for _, withMetrics := range []bool{false, true} {
-		name := "no_metrics"
-		if withMetrics {
-			name = "with_metrics"
-		}
-		b.Run(name, func(b *testing.B) {
-			opts := []OptionFunc[int]{
-				WithMaxSize[int](1),
-				WithQueueName[int]("BenchQueue"),
-			}
-			if withMetrics {
-				opts = append(opts,
-					WithCounterVec[int](newCounterVec(fmt.Sprintf("push_full_%s_%d", name, b.N))),
-					WithDroppedMetric[int](newDroppedCounter(fmt.Sprintf("push_full_dropped_%s_%d", name, b.N))),
-				)
-			}
-			q := NewQueue[int](opts...)
-			q.Push(0) // fill the queue
-			b.ResetTimer()
-			for i := range b.N {
-				q.Push(i)
-			}
-		})
-	}
-}
-
-// BenchmarkPull measures Pull throughput from a pre-filled queue.
-func BenchmarkPull(b *testing.B) {
-	for _, withMetrics := range []bool{false, true} {
-		name := "no_metrics"
-		if withMetrics {
-			name = "with_metrics"
-		}
-		b.Run(name, func(b *testing.B) {
-			opts := []OptionFunc[int]{}
-			if withMetrics {
-				opts = append(opts,
-					WithCounterVec[int](newCounterVec(fmt.Sprintf("pull_%s_%d", name, b.N))),
-				)
-			}
-			q := NewQueue[int](opts...)
-			for i := range b.N {
-				q.Push(i)
-			}
-			b.ResetTimer()
-			for range b.N {
-				q.Pull()
-			}
-		})
-	}
-}
-
-// BenchmarkPushPull_Concurrent measures concurrent Push/Pull throughput under
-// contention from multiple goroutines. This is the scenario closest to the
-// production issue: many producers pushing while consumers pull.
-func BenchmarkPushPull_Concurrent(b *testing.B) {
-	for _, numProducers := range []int{1, 4, 16, 64} {
+	for _, depth := range []int{100, 1000, 10_000, 100_000} {
 		for _, withMetrics := range []bool{false, true} {
 			mname := "no_metrics"
 			if withMetrics {
 				mname = "with_metrics"
 			}
-			name := fmt.Sprintf("producers=%d/%s", numProducers, mname)
-			b.Run(name, func(b *testing.B) {
+			b.Run(fmt.Sprintf("depth=%d/%s", depth, mname), func(b *testing.B) {
+				opts := []OptionFunc[int]{}
+				if withMetrics {
+					opts = append(opts,
+						WithCounterVec[int](newCounterVec("push_notfull")),
+						WithDroppedMetric[int](newDroppedCounter("push_notfull_dropped")),
+					)
+				}
+				q := NewQueue[int](opts...)
+				for i := range depth {
+					q.Push(i)
+				}
+				i := 0
+				for b.Loop() {
+					q.Push(i)
+					i++
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkPush_Full measures Push throughput when the queue is at capacity
+// (the drop path with logging and metrics) at various capacities.
+func BenchmarkPush_Full(b *testing.B) {
+	for _, capacity := range []int{1, 100, 1000} {
+		for _, withMetrics := range []bool{false, true} {
+			mname := "no_metrics"
+			if withMetrics {
+				mname = "with_metrics"
+			}
+			b.Run(fmt.Sprintf("capacity=%d/%s", capacity, mname), func(b *testing.B) {
 				opts := []OptionFunc[int]{
-					WithMaxSize[int](1024),
+					WithMaxSize[int](capacity),
 					WithQueueName[int]("BenchQueue"),
 				}
 				if withMetrics {
 					opts = append(opts,
-						WithCounterVec[int](newCounterVec(fmt.Sprintf("conc_%d_%s_%d", numProducers, mname, b.N))),
-						WithDroppedMetric[int](newDroppedCounter(fmt.Sprintf("conc_drop_%d_%s_%d", numProducers, mname, b.N))),
+						WithCounterVec[int](newCounterVec("push_full")),
+						WithDroppedMetric[int](newDroppedCounter("push_full_dropped")),
 					)
 				}
 				q := NewQueue[int](opts...)
-
-				b.ResetTimer()
-
-				var done atomic.Bool
-				// Consumer goroutine draining the queue.
-				go func() {
-					for !done.Load() {
-						q.Pull()
-						runtime.Gosched()
-					}
-				}()
-
-				b.RunParallel(func(pb *testing.PB) {
-					i := 0
-					for pb.Next() {
-						q.Push(i)
-						i++
-					}
-				})
-				done.Store(true)
+				for i := range capacity {
+					q.Push(i)
+				}
+				i := 0
+				for b.Loop() {
+					q.Push(i)
+					i++
+				}
 			})
+		}
+	}
+}
+
+// BenchmarkPull measures Pull throughput at various queue depths.
+// Each iteration pulls one item and pushes it back to maintain constant depth.
+func BenchmarkPull(b *testing.B) {
+	for _, size := range []int{100, 1000, 10_000, 100_000} {
+		for _, withMetrics := range []bool{false, true} {
+			mname := "no_metrics"
+			if withMetrics {
+				mname = "with_metrics"
+			}
+			b.Run(fmt.Sprintf("depth=%d/%s", size, mname), func(b *testing.B) {
+				opts := []OptionFunc[int]{}
+				if withMetrics {
+					opts = append(opts,
+						WithCounterVec[int](newCounterVec("pull")),
+					)
+				}
+				q := NewQueue[int](opts...)
+				for i := range size {
+					q.Push(i)
+				}
+				for b.Loop() {
+					q.Push(q.Pull())
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkPushPull_Concurrent measures concurrent Push/Pull throughput under
+// contention from multiple goroutines at various queue capacities.
+// This is the scenario closest to the production issue.
+func BenchmarkPushPull_Concurrent(b *testing.B) {
+	for _, capacity := range []int{100, 1000, 10_000} {
+		for _, numProducers := range []int{1, 4, 16, 64} {
+			for _, withMetrics := range []bool{false, true} {
+				mname := "no_metrics"
+				if withMetrics {
+					mname = "with_metrics"
+				}
+				name := fmt.Sprintf("capacity=%d/producers=%d/%s", capacity, numProducers, mname)
+				b.Run(name, func(b *testing.B) {
+					opts := []OptionFunc[int]{
+						WithMaxSize[int](capacity),
+						WithQueueName[int]("BenchQueue"),
+					}
+					if withMetrics {
+						opts = append(opts,
+							WithCounterVec[int](newCounterVec("conc")),
+							WithDroppedMetric[int](newDroppedCounter("conc_drop")),
+						)
+					}
+					q := NewQueue[int](opts...)
+
+					var done atomic.Bool
+					go func() {
+						for !done.Load() {
+							q.Pull()
+							runtime.Gosched()
+						}
+					}()
+
+					b.RunParallel(func(pb *testing.PB) {
+						i := 0
+						for pb.Next() {
+							q.Push(i)
+							i++
+						}
+					})
+					done.Store(true)
+				})
+			}
 		}
 	}
 }
 
 // BenchmarkPush_Full_Concurrent measures the specific production scenario:
-// many goroutines pushing to a completely full queue (all take the drop path).
-// This is the exact scenario from the bug report where mutex hold time exceeded 10s.
+// many goroutines pushing to a completely full queue (all take the drop path)
+// at various capacities. This is the exact scenario from the bug report where
+// mutex hold time exceeded 10s.
 func BenchmarkPush_Full_Concurrent(b *testing.B) {
-	for _, numProducers := range []int{1, 4, 16, 64, 256} {
-		for _, withMetrics := range []bool{false, true} {
-			mname := "no_metrics"
-			if withMetrics {
-				mname = "with_metrics"
-			}
-			name := fmt.Sprintf("producers=%d/%s", numProducers, mname)
-			b.Run(name, func(b *testing.B) {
-				opts := []OptionFunc[int]{
-					WithMaxSize[int](1),
-					WithQueueName[int]("BenchQueue"),
-				}
+	for _, capacity := range []int{1, 100, 1000} {
+		for _, numProducers := range []int{1, 4, 16, 64, 256} {
+			for _, withMetrics := range []bool{false, true} {
+				mname := "no_metrics"
 				if withMetrics {
-					opts = append(opts,
-						WithCounterVec[int](newCounterVec(fmt.Sprintf("fullconc_%d_%s_%d", numProducers, mname, b.N))),
-						WithDroppedMetric[int](newDroppedCounter(fmt.Sprintf("fullconc_drop_%d_%s_%d", numProducers, mname, b.N))),
-					)
+					mname = "with_metrics"
 				}
-				q := NewQueue[int](opts...)
-				q.Push(0) // fill the queue
-
-				runtime.GOMAXPROCS(runtime.NumCPU())
-				b.SetParallelism(numProducers)
-				b.ResetTimer()
-
-				b.RunParallel(func(pb *testing.PB) {
-					i := 0
-					for pb.Next() {
-						q.Push(i)
-						i++
+				name := fmt.Sprintf("capacity=%d/producers=%d/%s", capacity, numProducers, mname)
+				b.Run(name, func(b *testing.B) {
+					opts := []OptionFunc[int]{
+						WithMaxSize[int](capacity),
+						WithQueueName[int]("BenchQueue"),
 					}
+					if withMetrics {
+						opts = append(opts,
+							WithCounterVec[int](newCounterVec("fullconc")),
+							WithDroppedMetric[int](newDroppedCounter("fullconc_drop")),
+						)
+					}
+					q := NewQueue[int](opts...)
+					for i := range capacity {
+						q.Push(i)
+					}
+
+					runtime.GOMAXPROCS(runtime.NumCPU())
+					b.SetParallelism(numProducers)
+
+					b.RunParallel(func(pb *testing.PB) {
+						i := 0
+						for pb.Next() {
+							q.Push(i)
+							i++
+						}
+					})
 				})
-			})
+			}
 		}
 	}
 }
@@ -199,10 +222,9 @@ func BenchmarkPush_Full_Concurrent(b *testing.B) {
 // prometheus.CounterVec.With(Labels{}).Inc() inside vs outside the lock.
 // The queue code calls this on every successful Push and Pull.
 func BenchmarkPush_NotFull_WithPrometheusLabels(b *testing.B) {
-	cv := newCounterVec(fmt.Sprintf("labels_bench_%d", b.N))
-	_ = cv.With(prometheus.Labels{"Operation": metrics.Add.String()}) // pre-warm
-	b.ResetTimer()
-	for range b.N {
+	cv := newCounterVec("labels_bench")
+	_ = cv.With(prometheus.Labels{"Operation": metrics.Add.String()})
+	for b.Loop() {
 		cv.With(prometheus.Labels{"Operation": metrics.Add.String()}).Inc()
 	}
 }
@@ -210,8 +232,7 @@ func BenchmarkPush_NotFull_WithPrometheusLabels(b *testing.B) {
 // BenchmarkRateLimitedLogger isolates the cost of the rate-limited logger call
 // that happens on the drop path (full queue).
 func BenchmarkRateLimitedLogger(b *testing.B) {
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		logging.GetRateLimitedLogger().WarnL(loggingRateLimiter,
 			"Queue (%s) size limit reached (%d). New items added to the queue will be dropped.",
 			"BenchQueue", 40960)


### PR DESCRIPTION
## Description

This PR adds microbenchmarks for `pkg/queue` (`queue_bench_test.go`). There are **no production code changes** — `pkg/queue/queue.go` is identical to `master`.

The production changes (lock splitting, moving metrics/logging outside the critical section, `WithLabelValues` optimization) were already merged via PR #20435. These benchmarks were originally developed alongside that work to validate its impact and are now contributed separately as a standalone test artifact.

### Benchmarks

Four benchmarks are included, each parameterized with `no_metrics` / `with_metrics` to isolate the cost of Prometheus instrumentation:

| Benchmark | What it measures |
|-----------|-----------------|
| `BenchmarkPush_Full` | Single-threaded push to a full queue (the drop path with logging). Uses `b.Loop()` for honest sequential timing. Capacity fixed at 1 — varying it has no effect because the drop path only checks `list.Len() >= maxSize` (O(1)). |
| `BenchmarkPull` | Single-threaded pull from a pre-filled queue. Each iteration pulls one item and pushes it back to maintain constant depth. Depth fixed at 100 — `container/list` provides O(1) operations regardless of size. |
| `BenchmarkPush_NotFull_Concurrent` | Concurrent push to an unbounded queue (success path only). A background goroutine drains to prevent unbounded memory growth. Parameterized over producer counts (1, 4, 16, 64, 256) via `b.SetParallelism`. |
| `BenchmarkPush_Full_Concurrent` | Concurrent push to a full queue (all pushes take the drop path). This is the exact scenario from the original bug report where mutex hold time exceeded 10s. Parameterized over producer counts (1, 4, 16, 64, 256). |

**Why both `BenchmarkPush_Full` and `BenchmarkPush_Full_Concurrent/producers=1`?**

Despite both using a single producer, they measure different things. `BenchmarkPush_Full` uses `b.Loop()` which runs all iterations sequentially on one goroutine, providing the true per-operation baseline (~790 ns/op). `BenchmarkPush_Full_Concurrent/producers=1` uses `b.RunParallel` which distributes iterations across goroutine start/stop cycles, changing the timing of the rate-limited logger and yielding ~480 ns/op — an artificially lower number. Both are kept because the sequential benchmark gives the honest single-operation cost, while the concurrent benchmark with `producers=1` serves as the baseline for comparing how contention scales with more producers.

### Benchmark results

Run on Apple M3 Pro (arm64), Go 1.25, `-benchmem -count=6`, `MUTEX_WATCHDOG_TIMEOUT_SECS=0`:

<details>
<summary>Full benchmark output</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/stackrox/rox/pkg/queue
cpu: Apple M3 Pro
BenchmarkPush_Full/no_metrics-12                 1428778           802.4 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full/no_metrics-12                 1535587           782.6 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full/no_metrics-12                 1539465           780.1 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full/no_metrics-12                 1533729           782.7 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full/no_metrics-12                 1533343           784.1 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full/no_metrics-12                 1495348           797.3 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full/with_metrics-12               1515254           791.8 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full/with_metrics-12               1504052           796.8 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full/with_metrics-12               1303542           911.5 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full/with_metrics-12               1451875           818.4 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full/with_metrics-12               1507851           797.5 ns/op       736 B/op          9 allocs/op
BenchmarkPull/no_metrics-12                      7608246           157.3 ns/op        48 B/op          1 allocs/op
BenchmarkPull/no_metrics-12                      7623033           157.6 ns/op        48 B/op          1 allocs/op
BenchmarkPull/no_metrics-12                      7691173           156.9 ns/op        48 B/op          1 allocs/op
BenchmarkPull/no_metrics-12                      7641177           158.6 ns/op        48 B/op          1 allocs/op
BenchmarkPull/no_metrics-12                      7670976           157.6 ns/op        48 B/op          1 allocs/op
BenchmarkPull/with_metrics-12                    5965399           200.9 ns/op        48 B/op          1 allocs/op
BenchmarkPull/with_metrics-12                    5998669           202.1 ns/op        48 B/op          1 allocs/op
BenchmarkPull/with_metrics-12                    5984767           207.6 ns/op        48 B/op          1 allocs/op
BenchmarkPull/with_metrics-12                    5006265           220.2 ns/op        48 B/op          1 allocs/op
BenchmarkPull/with_metrics-12                    5995198           200.7 ns/op        48 B/op          1 allocs/op
BenchmarkPull/with_metrics-12                    5949912           202.2 ns/op        48 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=1/no_metrics-12           4676517           261.8 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=1/no_metrics-12           4806829           244.1 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=1/no_metrics-12           5011552           250.6 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=1/no_metrics-12           5348595           259.0 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=1/no_metrics-12           5059160           248.9 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=1/no_metrics-12           4915566           249.1 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=1/with_metrics-12         4519717           276.4 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=1/with_metrics-12         4460366           277.4 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=1/with_metrics-12         4562834           270.2 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=1/with_metrics-12         4687713           270.0 ns/op        56 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=1/with_metrics-12         4484931           275.4 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=1/with_metrics-12         4570754           272.5 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=4/no_metrics-12           4855806           243.4 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=4/no_metrics-12           5100960           243.1 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=4/no_metrics-12           4954879           250.6 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=4/no_metrics-12           4906047           250.4 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=4/no_metrics-12           4914553           246.7 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=4/no_metrics-12           4991959           242.2 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=4/with_metrics-12         4110309           300.9 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=4/with_metrics-12         4202875           293.8 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=4/with_metrics-12         4164918           294.9 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=4/with_metrics-12         4102376           286.8 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=4/with_metrics-12         4133260           284.3 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=4/with_metrics-12         4183855           284.0 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=16/no_metrics-12          4924255           232.8 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=16/no_metrics-12          5180263           255.6 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=16/no_metrics-12          4857627           247.9 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=16/no_metrics-12          5112064           242.1 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=16/no_metrics-12          5089617           260.9 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=16/no_metrics-12          4813644           248.6 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=16/with_metrics-12        4271043           292.5 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=16/with_metrics-12        4629247           285.3 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=16/with_metrics-12        4274894           298.5 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=16/with_metrics-12        4799553           287.9 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=16/with_metrics-12        4300041           283.5 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=16/with_metrics-12        4396142           291.3 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=64/no_metrics-12          4996296           229.8 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=64/no_metrics-12          5240444           235.4 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=64/no_metrics-12          4845940           237.0 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=64/no_metrics-12          5989118           242.0 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=64/no_metrics-12          5023280           242.2 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=64/no_metrics-12          4976126           251.2 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=64/with_metrics-12        4239720           290.4 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=64/with_metrics-12        4611626           275.6 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=64/with_metrics-12        4126210           293.9 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=64/with_metrics-12        4181618           277.6 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=64/with_metrics-12        4868809           252.8 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=64/with_metrics-12        4233784           291.2 ns/op        55 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=256/no_metrics-12         5139066           219.4 ns/op        54 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=256/no_metrics-12         5294814           253.9 ns/op        54 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=256/no_metrics-12         5094936           258.2 ns/op        54 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=256/no_metrics-12         5084676           262.1 ns/op        54 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=256/no_metrics-12         5152135           248.4 ns/op        54 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=256/no_metrics-12         5140658           248.9 ns/op        54 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=256/with_metrics-12       4345326           284.2 ns/op        54 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=256/with_metrics-12       4324820           292.2 ns/op        54 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=256/with_metrics-12       4782788           287.8 ns/op        54 B/op          1 allocs/op
BenchmarkPush_NotFull_Concurrent/producers=256/with_metrics-12       4300578           290.4 ns/op        54 B/op          1 allocs/op
BenchmarkPush_Full_Concurrent/producers=1/no_metrics-12              2528365           478.2 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=1/no_metrics-12              2505003           484.4 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=1/no_metrics-12              2487048           482.6 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=1/no_metrics-12              2466238           480.4 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=1/no_metrics-12              2271886           485.7 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=1/with_metrics-12            2456308           485.2 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=1/with_metrics-12            2481577           486.8 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=1/with_metrics-12            2475298           485.0 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=1/with_metrics-12            1919282           534.8 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=1/with_metrics-12            2176580           510.1 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=4/no_metrics-12              2254111           533.7 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=4/no_metrics-12              2249721           531.5 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=4/no_metrics-12              2275635           526.7 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=4/no_metrics-12              2273732           526.9 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=4/no_metrics-12              2274967           549.1 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=4/with_metrics-12            2263350           547.9 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=4/with_metrics-12            2222037           533.8 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=4/with_metrics-12            2266911           529.7 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=4/with_metrics-12            2272273           528.2 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=4/with_metrics-12            2254708           575.0 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=16/no_metrics-12             2168913           559.8 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=16/no_metrics-12             2147446           589.4 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=16/no_metrics-12             2134080           560.3 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=16/no_metrics-12             2136800           564.2 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=16/no_metrics-12             2156356           562.4 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=16/with_metrics-12           2138548           562.7 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=16/with_metrics-12           2141288           580.1 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=16/with_metrics-12           2141029           559.0 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=16/with_metrics-12           2143686           568.1 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=16/with_metrics-12           2139661           571.7 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=64/no_metrics-12             2105020           580.4 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=64/no_metrics-12             2096802           571.6 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=64/no_metrics-12             1997725           573.6 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=64/no_metrics-12             2086899           569.0 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=64/with_metrics-12           2105030           570.2 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=64/with_metrics-12           2107057           572.8 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=64/with_metrics-12           2117257           585.2 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=64/with_metrics-12           2111517           576.4 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=64/with_metrics-12           2034236           571.4 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=256/no_metrics-12            1932181           640.8 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=256/no_metrics-12            1864612           621.2 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=256/no_metrics-12            1949152           623.9 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=256/no_metrics-12            1847606           628.6 ns/op       737 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=256/no_metrics-12            1949248           629.3 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=256/with_metrics-12          1894500           637.8 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=256/with_metrics-12          1946088           630.4 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=256/with_metrics-12          1929128           646.2 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=256/with_metrics-12          1849178           637.9 ns/op       736 B/op          9 allocs/op
BenchmarkPush_Full_Concurrent/producers=256/with_metrics-12          1942837           625.3 ns/op       737 B/op          9 allocs/op
```

</details>

### How to read these results

Each benchmark name tells you the scenario:

- `Push_Full` = pushing to a full queue (the drop path with rate-limited logging)
- `Pull` = pulling from a pre-filled queue (success path)
- `Push_NotFull_Concurrent` = concurrent pushing to an unbounded queue (success path)
- `Push_Full_Concurrent` = concurrent pushing to a full queue (drop path — the production bug scenario)
- `producers=N` = number of concurrent goroutines
- `no_metrics` / `with_metrics` = whether Prometheus counters are registered

The `ns/op` column is time per operation (lower is better). `B/op` and `allocs/op` show memory allocation per operation.

### Key observations

| Benchmark | ns/op (typical) | Notes |
|-----------|-----------------|-------|
| `Push_Full` (sequential) | ~790 | True single-threaded baseline for the drop path |
| `Pull` (no metrics) | ~157 | Pure queue throughput — O(1) list operations |
| `Pull` (with metrics) | ~205 | Prometheus `WithLabelValues().Inc()` adds ~48 ns |
| `Push_NotFull_Concurrent` | ~245-290 | Scales flat across 1-256 producers; metrics add ~40 ns |
| `Push_Full_Concurrent/producers=1` | ~480 | Lower than sequential due to `b.RunParallel` framework effects (see above) |
| `Push_Full_Concurrent/producers=256` | ~630-640 | Contention adds ~33% over single-producer |

Metrics overhead is consistent (~40-50 ns for `WithLabelValues().Inc()`) and does not grow with producer count, confirming the `WithLabelValues` optimization avoids per-call map allocations.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Ran benchmarks locally with `go test -bench=. -benchmem -count=6 -timeout=10m ./pkg/queue/` (full results above)
- Existing queue unit tests pass without modification
- No production code changes — only benchmark test file added

AI-Assisted: cursor, benchmarks generated, user reviewed logic and results