### PR TITLE
ROX-34769: Use native ARM64 runners and make docker.io login non-fatal

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -543,6 +543,7 @@ jobs:
 
       - name: Login to docker.io to mitigate rate limiting on downloading images
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
+        continue-on-error: true
         # Skip for external contributions.
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
@@ -868,6 +869,7 @@ jobs:
 
       - name: Login to docker.io to mitigate rate limiting on downloading images
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
+        continue-on-error: true
         # Skip for external contributions.
         if: |
           github.event_name == 'push' || !github.event.pull_request.head.repo.fork
@@ -907,7 +909,7 @@ jobs:
             echo "Operator image push completed successfully"
 
   build-and-push-scanner:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-latest' }}
     needs:
       - define-job-matrix
       - pre-build-go-binaries
@@ -932,14 +934,16 @@ jobs:
 
       - name: Login to docker.io to mitigate rate limiting on downloading images
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
+        continue-on-error: true
         if: |
-          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+          matrix.arch != 'amd64' && matrix.arch != 'arm64' &&
+          (github.event_name == 'push' || !github.event.pull_request.head.repo.fork)
         with:
           username: ${{ secrets.DOCKERHUB_CI_ACCOUNT_USERNAME }}
           password: ${{ secrets.DOCKERHUB_CI_ACCOUNT_PASSWORD }}
 
       - name: Set up QEMU
-        if: matrix.arch != 'amd64'
+        if: matrix.arch != 'amd64' && matrix.arch != 'arm64'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # ratchet:docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -546,7 +546,8 @@ jobs:
         continue-on-error: true
         # Skip for external contributions.
         if: |
-          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+          matrix.arch != 'amd64' && matrix.arch != 'arm64' &&
+          (github.event_name == 'push' || !github.event.pull_request.head.repo.fork)
         with:
           username: ${{ secrets.DOCKERHUB_CI_ACCOUNT_USERNAME }}
           password: ${{ secrets.DOCKERHUB_CI_ACCOUNT_PASSWORD }}
@@ -872,7 +873,8 @@ jobs:
         continue-on-error: true
         # Skip for external contributions.
         if: |
-          github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+          matrix.arch != 'amd64' && matrix.arch != 'arm64' &&
+          (github.event_name == 'push' || !github.event.pull_request.head.repo.fork)
         with:
           username: ${{ secrets.DOCKERHUB_CI_ACCOUNT_USERNAME }}
           password: ${{ secrets.DOCKERHUB_CI_ACCOUNT_PASSWORD }}


### PR DESCRIPTION
## Description

Scanner job was unnecessarily using QEMU emulation for ARM64 builds instead of native ubuntu-24.04-arm runners. 
docker.io login failures blocked all builds despite being only for rate limit mitigation.

Changes:
- Scanner job now uses native ARM64 runners (matches main/operator pattern)
- Added continue-on-error to all docker.io login steps (graceful degradation)
- Scanner skips docker.io login for ARM64 (no QEMU = no docker.io pulls)

Impact: Scanner ARM64 builds faster in every PR, docker.io issues no longer block any builds.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI