### PR TITLE
perf(sensor): use WithLabelValues to cut Prometheus label allocs

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -91,7 +91,8 @@ func (q *Queue[T]) Pull() T {
 	item := q.queue.Remove(q.queue.Front()).(T)
 
 	if q.counterMetric != nil {
-		q.counterMetric.With(prometheus.Labels{"Operation": metrics.Remove.String()}).Inc()
+		// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+		q.counterMetric.WithLabelValues(metrics.Remove.String()).Inc()
 	}
 
 	if q.queue.Len() == 0 {
@@ -146,7 +147,8 @@ func (q *Queue[T]) pull() (T, bool) {
 	item := q.queue.Remove(q.queue.Front()).(T)
 
 	if q.counterMetric != nil {
-		q.counterMetric.With(prometheus.Labels{"Operation": metrics.Remove.String()}).Inc()
+		// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+		q.counterMetric.WithLabelValues(metrics.Remove.String()).Inc()
 	}
 
 	if q.queue.Len() == 0 {
@@ -173,7 +175,8 @@ func (q *Queue[T]) Push(item T) {
 
 	defer q.notEmptySignal.Signal()
 	if q.counterMetric != nil {
-		q.counterMetric.With(prometheus.Labels{"Operation": metrics.Add.String()}).Inc()
+		// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+		q.counterMetric.WithLabelValues(metrics.Add.String()).Inc()
 	}
 	q.queue.PushBack(item)
 }

--- a/sensor/common/clusterentities/metrics/metrics.go
+++ b/sensor/common/clusterentities/metrics/metrics.go
@@ -53,32 +53,32 @@ var (
 )
 
 const (
-	containerStoreTypeCurrent    = "current"
-	containerStoreTypeHistorical = "historical"
+	storeTypeCurrent    = "current"
+	storeTypeHistorical = "historical"
 )
 
 // UpdateNumberOfContainerIDs updates the metric tracking the number of containers stored in-memory store
 func UpdateNumberOfContainerIDs(current, historical int) {
 	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
-	containersStored.WithLabelValues(containerStoreTypeCurrent).Set(float64(current))
+	containersStored.WithLabelValues(storeTypeCurrent).Set(float64(current))
 	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
-	containersStored.WithLabelValues(containerStoreTypeHistorical).Set(float64(historical))
+	containersStored.WithLabelValues(storeTypeHistorical).Set(float64(historical))
 }
 
 // UpdateNumberOfIPs updates the metric tracking the number of IPs stored in-memory store
 func UpdateNumberOfIPs(current, historical int) {
 	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
-	ipsStored.WithLabelValues(containerStoreTypeCurrent).Set(float64(current))
+	ipsStored.WithLabelValues(storeTypeCurrent).Set(float64(current))
 	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
-	ipsStored.WithLabelValues(containerStoreTypeHistorical).Set(float64(historical))
+	ipsStored.WithLabelValues(storeTypeHistorical).Set(float64(historical))
 }
 
 // UpdateNumberOfEndpoints updates the metric tracking the number of endpoints stored in-memory store
 func UpdateNumberOfEndpoints(current, historical int) {
 	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
-	endpointsStored.WithLabelValues(containerStoreTypeCurrent).Set(float64(current))
+	endpointsStored.WithLabelValues(storeTypeCurrent).Set(float64(current))
 	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
-	endpointsStored.WithLabelValues(containerStoreTypeHistorical).Set(float64(historical))
+	endpointsStored.WithLabelValues(storeTypeHistorical).Set(float64(historical))
 }
 
 // ObserveManyDeploymentsSharingSingleIP records a situation when one IP belongs to more than one container

--- a/sensor/common/clusterentities/metrics/metrics.go
+++ b/sensor/common/clusterentities/metrics/metrics.go
@@ -52,32 +52,45 @@ var (
 	}, []string{"store", "operation"})
 )
 
+const (
+	containerStoreTypeCurrent    = "current"
+	containerStoreTypeHistorical = "historical"
+)
+
 // UpdateNumberOfContainerIDs updates the metric tracking the number of containers stored in-memory store
 func UpdateNumberOfContainerIDs(current, historical int) {
-	containersStored.With(prometheus.Labels{"type": "current"}).Set(float64(current))
-	containersStored.With(prometheus.Labels{"type": "historical"}).Set(float64(historical))
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	containersStored.WithLabelValues(containerStoreTypeCurrent).Set(float64(current))
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	containersStored.WithLabelValues(containerStoreTypeHistorical).Set(float64(historical))
 }
 
 // UpdateNumberOfIPs updates the metric tracking the number of IPs stored in-memory store
 func UpdateNumberOfIPs(current, historical int) {
-	ipsStored.With(prometheus.Labels{"type": "current"}).Set(float64(current))
-	ipsStored.With(prometheus.Labels{"type": "historical"}).Set(float64(historical))
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	ipsStored.WithLabelValues(containerStoreTypeCurrent).Set(float64(current))
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	ipsStored.WithLabelValues(containerStoreTypeHistorical).Set(float64(historical))
 }
 
 // UpdateNumberOfEndpoints updates the metric tracking the number of endpoints stored in-memory store
 func UpdateNumberOfEndpoints(current, historical int) {
-	endpointsStored.With(prometheus.Labels{"type": "current"}).Set(float64(current))
-	endpointsStored.With(prometheus.Labels{"type": "historical"}).Set(float64(historical))
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	endpointsStored.WithLabelValues(containerStoreTypeCurrent).Set(float64(current))
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	endpointsStored.WithLabelValues(containerStoreTypeHistorical).Set(float64(historical))
 }
 
 // ObserveManyDeploymentsSharingSingleIP records a situation when one IP belongs to more than one container
 func ObserveManyDeploymentsSharingSingleIP(ip string) {
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
 	ipsHavingMultipleContainers.WithLabelValues(ip).Inc()
 }
 
 // ObserveStoreLockHeldDurationWithOperation records how long a store mutex was held
 // for the given high-level operation.
 func ObserveStoreLockHeldDurationWithOperation(store, operation string, duration time.Duration) {
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
 	storeLockHeldDurationSeconds.WithLabelValues(store, operation).Observe(duration.Seconds())
 }
 

--- a/sensor/common/detector/metrics/metrics.go
+++ b/sensor/common/detector/metrics/metrics.go
@@ -372,16 +372,14 @@ func ObserveTimeSpentInExponentialBackoff(t time.Duration) {
 
 // ObserveNetworkPolicyStoreState observes the metric.
 func ObserveNetworkPolicyStoreState(ns string, num int) {
-	networkPoliciesStored.With(prometheus.Labels{"k8sNamespace": ns}).Set(float64(num))
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	networkPoliciesStored.WithLabelValues(ns).Set(float64(num))
 }
 
 // ObserveNetworkPolicyStoreEvent observes the metric.
 func ObserveNetworkPolicyStoreEvent(event, namespace string, numSelectors int) {
-	networkPoliciesStoreEvents.With(prometheus.Labels{
-		"event":        event,
-		"k8sNamespace": namespace,
-		"numSelectors": fmt.Sprintf("%d", numSelectors),
-	}).Inc()
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	networkPoliciesStoreEvents.WithLabelValues(event, namespace, fmt.Sprintf("%d", numSelectors)).Inc()
 }
 
 // ObserveNodeScan observes the metric.
@@ -421,18 +419,14 @@ func ObserveNodeScanningAck(nodeName, ackType, messageType string, op AckOperati
 
 // AddBlockingScanCall records a call to blockingScan
 func AddBlockingScanCall(path string) {
-	detectorBlockScanCalls.With(prometheus.Labels{
-		"Operation": metrics.Add.String(),
-		"Path":      path,
-	}).Inc()
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	detectorBlockScanCalls.WithLabelValues(metrics.Add.String(), path).Inc()
 }
 
 // RemoveBlockingScanCall records a call to blockingScan has finished
 func RemoveBlockingScanCall() {
-	detectorBlockScanCalls.With(prometheus.Labels{
-		"Operation": metrics.Remove.String(),
-		"Path":      "",
-	}).Inc()
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	detectorBlockScanCalls.WithLabelValues(metrics.Remove.String(), "").Inc()
 }
 
 // SetScanCallDuration records the duration of the scan call to central/scanner
@@ -444,18 +438,14 @@ func SetScanCallDuration(start time.Time) {
 
 // AddScanAndSetCall records a call to ScanAndSet
 func AddScanAndSetCall(reason string) {
-	scanAndSetCall.With(prometheus.Labels{
-		"Operation": metrics.Add.String(),
-		"Reason":    reason,
-	}).Inc()
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	scanAndSetCall.WithLabelValues(metrics.Add.String(), reason).Inc()
 }
 
 // RemoveScanAndSetCall records a call to ScanAndSet has finished
 func RemoveScanAndSetCall(reason string) {
-	scanAndSetCall.With(prometheus.Labels{
-		"Operation": metrics.Remove.String(),
-		"Reason":    reason,
-	}).Inc()
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	scanAndSetCall.WithLabelValues(metrics.Remove.String(), reason).Inc()
 }
 
 // scannerConfigMu serialises UpdateScannerConfigurationInfo so that the

--- a/sensor/common/detector/metrics/metrics.go
+++ b/sensor/common/detector/metrics/metrics.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
@@ -379,7 +378,7 @@ func ObserveNetworkPolicyStoreState(ns string, num int) {
 // ObserveNetworkPolicyStoreEvent observes the metric.
 func ObserveNetworkPolicyStoreEvent(event, namespace string, numSelectors int) {
 	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
-	networkPoliciesStoreEvents.WithLabelValues(event, namespace, fmt.Sprintf("%d", numSelectors)).Inc()
+	networkPoliciesStoreEvents.WithLabelValues(event, namespace, strconv.Itoa(numSelectors)).Inc()
 }
 
 // ObserveNodeScan observes the metric.

--- a/sensor/common/metrics/counting_events.go
+++ b/sensor/common/metrics/counting_events.go
@@ -2,19 +2,18 @@ package metrics
 
 import (
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/sensor/common/messagestream"
 )
 
 func incrementSensorEvents(event *central.SensorEvent, typ string) {
-	labels := prometheus.Labels{
-		"Action":       event.GetAction().String(),
-		"ResourceType": metrics.GetResourceString(event),
-		"Type":         typ,
-	}
-	sensorEvents.With(labels).Inc()
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	sensorEvents.WithLabelValues(
+		event.GetAction().String(),
+		metrics.GetResourceString(event),
+		typ,
+	).Inc()
 }
 
 type countingMessageStream struct {

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -389,10 +389,8 @@ var (
 
 // IncrementEntityNotFound increments an instance of entity not found
 func IncrementEntityNotFound(kind, orientation string) {
-	entitiesNotFound.With(prometheus.Labels{
-		"kind":        kind,
-		"orientation": orientation,
-	}).Inc()
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	entitiesNotFound.WithLabelValues(kind, orientation).Inc()
 }
 
 // IncrementDetectorCacheHit increments the number of deployments deduped by the detector
@@ -510,10 +508,8 @@ func SetFileActivityBufferSize(size int) {
 
 // IncK8sEventCount increments the number of objects we're receiving from k8s
 func IncK8sEventCount(action string, resource string) {
-	k8sObjectCounts.With(prometheus.Labels{
-		"Action":   action,
-		"Resource": resource,
-	}).Inc()
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	k8sObjectCounts.WithLabelValues(action, resource).Inc()
 }
 
 // SetResourceProcessingDurationForResource sets the duration for how long it takes to process the resource
@@ -541,30 +537,29 @@ func DecOutputChannelSize() {
 	outputChannelSize.Dec()
 }
 
-func getResponsesChannelLabel(op string, msg *central.MsgFromSensor) prometheus.Labels {
-	msgType := "nil"
-	if msg.GetMsg() != nil {
-		msgType = strings.TrimPrefix(reflect.TypeOf(msg.GetMsg()).String(), "*central.MsgFromSensor_")
+func getResponsesChannelMessageType(msg *central.MsgFromSensor) string {
+	if msg.GetMsg() == nil {
+		return "nil"
 	}
-	return prometheus.Labels{
-		"MessageType": msgType,
-		Operation:     op,
-	}
+	return strings.TrimPrefix(reflect.TypeOf(msg.GetMsg()).String(), "*central.MsgFromSensor_")
 }
 
 // ResponsesChannelAdd increases the responsesChannelOperationCount's Add operation by 1
 func ResponsesChannelAdd(msg *central.MsgFromSensor) {
-	responsesChannelOperationCount.With(getResponsesChannelLabel(metrics.Add.String(), msg)).Inc()
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	responsesChannelOperationCount.WithLabelValues(metrics.Add.String(), getResponsesChannelMessageType(msg)).Inc()
 }
 
 // ResponsesChannelRemove increases the responsesChannelOperationCount's Remove operation by 1
 func ResponsesChannelRemove(msg *central.MsgFromSensor) {
-	responsesChannelOperationCount.With(getResponsesChannelLabel(metrics.Remove.String(), msg)).Inc()
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	responsesChannelOperationCount.WithLabelValues(metrics.Remove.String(), getResponsesChannelMessageType(msg)).Inc()
 }
 
 // ResponsesChannelDrop increases the responsesChannelDroppedCount by 1
 func ResponsesChannelDrop(msg *central.MsgFromSensor) {
-	responsesChannelOperationCount.With(getResponsesChannelLabel(metrics.Dropped.String(), msg)).Inc()
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	responsesChannelOperationCount.WithLabelValues(metrics.Dropped.String(), getResponsesChannelMessageType(msg)).Inc()
 }
 
 // SetTelemetryMetrics sets the cluster metrics for the telemetry metrics.

--- a/sensor/common/metrics/metrics.go
+++ b/sensor/common/metrics/metrics.go
@@ -586,16 +586,14 @@ func SetTelemetryMetrics(clusterIDPeeker func() string, cm *central.ClusterMetri
 
 // ObserveCentralReceiverProcessMessageDuration records the duration of a ProcessMessage call
 func ObserveCentralReceiverProcessMessageDuration(componentName string, duration time.Duration) {
-	componentProcessMessageDurationSeconds.With(prometheus.Labels{
-		ComponentName: componentName,
-	}).Observe(duration.Seconds())
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	componentProcessMessageDurationSeconds.WithLabelValues(componentName).Observe(duration.Seconds())
 }
 
 // IncrementCentralReceiverProcessMessageErrors increments the error count for a component's ProcessMessage call
 func IncrementCentralReceiverProcessMessageErrors(componentName string) {
-	componentProcessMessageErrorsCount.With(prometheus.Labels{
-		ComponentName: componentName,
-	}).Inc()
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	componentProcessMessageErrorsCount.WithLabelValues(componentName).Inc()
 }
 
 // ObserveInformerSyncDuration sets the sync duration metric for an informer.

--- a/sensor/common/metrics/sizing_events.go
+++ b/sensor/common/metrics/sizing_events.go
@@ -4,7 +4,6 @@ import (
 	"math"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/reflectutils"
 	"github.com/stackrox/rox/pkg/sensor/event"
@@ -25,15 +24,15 @@ func (s *sizingEventStream) incrementMetric(msg *central.MsgFromSensor) {
 	messageType = s.metricKey(messageType, eventType)
 
 	messageSize := float64(msg.SizeVT())
-	labels := prometheus.Labels{
-		"Type": messageType,
-	}
 
-	sensorMessageSizeSent.With(labels).Observe(messageSize)
-	sensorLastMessageSizeSent.With(labels).Set(messageSize)
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	sensorMessageSizeSent.WithLabelValues(messageType).Observe(messageSize)
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	sensorLastMessageSizeSent.WithLabelValues(messageType).Set(messageSize)
 
 	s.maxSeen[messageType] = math.Max(s.maxSeen[messageType], messageSize)
-	sensorMaxMessageSizeSent.With(labels).Set(s.maxSeen[messageType])
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	sensorMaxMessageSizeSent.WithLabelValues(messageType).Set(s.maxSeen[messageType])
 }
 
 func (s *sizingEventStream) metricKey(typ, eventType string) string {

--- a/sensor/kubernetes/listener/resources/metrics/metrics.go
+++ b/sensor/kubernetes/listener/resources/metrics/metrics.go
@@ -19,7 +19,8 @@ var (
 
 // UpdateNumberPodsInStored update number of pods stored
 func UpdateNumberPodsInStored(ns string, num int) {
-	podsStored.With(prometheus.Labels{"k8sNamespace": ns}).Set(float64(num))
+	// Using `WithLabelValues` instead of `With` to avoid extra memory allocations.
+	podsStored.WithLabelValues(ns).Set(float64(num))
 }
 
 func init() {


### PR DESCRIPTION
## Description

Prometheus `CounterVec`/`GaugeVec` `.With(prometheus.Labels{...})` allocates a label map on every call (typically **2 allocs/op, 336 B/op** in our micro-benchmark). On Sensor paths that fire per message, per queue operation, or per informer event, that adds avoidable GC pressure.

This change replaces `.With(Labels)` with `.WithLabelValues(...)` on high- and medium-frequency Sensor metric updates, with a short comment at each call site documenting the rationale.

**Tier 1 (hottest paths)**

- Central outbound pipeline: `counting_events`, `sizing_events`, buffered responses channel (`ResponsesChannelAdd`/`Remove`/`Drop`), `IncK8sEventCount`, `IncrementEntityNotFound`
- `pkg/queue`: Add/Remove counters on every `Push`/`Pull` (detector flow/PI/file-access queues, component queues, etc.)

**Tier 2 (significant paths)**

- Component `ProcessMessage` duration and error counters
- Cluster entities store gauges and lock-hold histogram
- Detector: network policy store, blocking scan, `ScanAndSet` counters
- Kubernetes listener pod store gauge


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Unit tests / CI (change is actually trivial)
- Run synthetic benchmark as an example of the allocation wins.

**Before / after (synthetic benchmark)**

`BenchmarkPrometheusVecWithVsWithLabelValues` models the two label shapes we touch most often (3-label `sensor_events`, 1-label `pkg/queue` Operation). On every sub-benchmark, `With(Labels)` costs **336 B/op, 2 allocs/op**; `WithLabelValues` costs **0 B/op, 0 allocs/op**. Metric semantics and label names are unchanged.

<details>
<summary>Benchmark source (<code>sensor/common/metrics/prometheus_labels_bench_test.go</code>) and results</summary>

**Results** (darwin/arm64, Apple M3 Pro, `-benchmem -count=1`):

```text
goos: darwin
goarch: arm64
pkg: github.com/stackrox/rox/sensor/common/metrics
cpu: Apple M3 Pro
BenchmarkPrometheusVecWithVsWithLabelValues/three_labels/With_Labels_map-12         	 5013308	       231.9 ns/op	     336 B/op	       2 allocs/op
BenchmarkPrometheusVecWithVsWithLabelValues/three_labels/WithLabelValues-12         	23340570	        52.75 ns/op	       0 B/op	       0 allocs/op
BenchmarkPrometheusVecWithVsWithLabelValues/one_label/With_Labels_map-12            	 7382101	       166.5 ns/op	     336 B/op	       2 allocs/op
BenchmarkPrometheusVecWithVsWithLabelValues/one_label/WithLabelValues-12            	50292850	        23.78 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/stackrox/rox/sensor/common/metrics	5.569s
```

**Source** — `sensor/common/metrics/prometheus_labels_bench_test.go`:

```go
package metrics

import (
	"testing"

	"github.com/prometheus/client_golang/prometheus"
	pkgmetrics "github.com/stackrox/rox/pkg/metrics"
)

// BenchmarkPrometheusVecWithVsWithLabelValues compares label lookup patterns used on
// Sensor hot paths before and after switching from CounterVec/GaugeVec.With(map) to
// WithLabelValues. The three-label case mirrors sensor_events (Central outbound
// counting); the one-label case mirrors pkg/queue Operation counters.
func BenchmarkPrometheusVecWithVsWithLabelValues(b *testing.B) {
	const (
		action       = "UPDATE"
		resourceType = "Deployment"
		streamType   = "unique"
		operation    = "ADD"
	)

	threeLabelCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
		Namespace: pkgmetrics.PrometheusNamespace,
		Subsystem: pkgmetrics.SensorSubsystem.String(),
		Name:      "bench_three_label_counter",
		Help:      "Synthetic counter for With vs WithLabelValues allocation comparison",
	}, []string{"Action", "ResourceType", "Type"})

	oneLabelCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
		Namespace: pkgmetrics.PrometheusNamespace,
		Subsystem: pkgmetrics.SensorSubsystem.String(),
		Name:      "bench_one_label_counter",
		Help:      "Synthetic counter for With vs WithLabelValues allocation comparison",
	}, []string{"Operation"})

	b.Run("three_labels/With_Labels_map", func(b *testing.B) {
		b.ReportAllocs()
		for b.Loop() {
			threeLabelCounter.With(prometheus.Labels{
				"Action":       action,
				"ResourceType": resourceType,
				"Type":         streamType,
			}).Inc()
		}
	})

	b.Run("three_labels/WithLabelValues", func(b *testing.B) {
		b.ReportAllocs()
		for b.Loop() {
			threeLabelCounter.WithLabelValues(action, resourceType, streamType).Inc()
		}
	})

	b.Run("one_label/With_Labels_map", func(b *testing.B) {
		b.ReportAllocs()
		for b.Loop() {
			oneLabelCounter.With(prometheus.Labels{
				"Operation": operation,
			}).Inc()
		}
	})

	b.Run("one_label/WithLabelValues", func(b *testing.B) {
		b.ReportAllocs()
		for b.Loop() {
			oneLabelCounter.WithLabelValues(operation).Inc()
		}
	})
}
```

</details>

**Out of scope (low rate, follow-up optional):** node-scan/compliance ACK metrics, scanner configuration gauges, VM index status labels, compliance operator command counters, one-shot component-queue dropped counter at init.
