### PR TITLE
feat(ui): Add label regex support to report configs

### DIFF
--- a/ui/apps/platform/src/Components/EntityScope/utils.test.ts
+++ b/ui/apps/platform/src/Components/EntityScope/utils.test.ts
@@ -1,10 +1,12 @@
 import type { EntityScopeRule } from 'services/ReportsService.types';
 import {
+    collapseMapRuleValues,
     getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment,
     getSearchFilterFromEntityScopeRules,
     getSearchFilterWithoutEntityScope,
     ruleValueToSearchValue,
     searchFieldLabelMapForClusterNamespaceDeployment,
+    searchValueToMapRuleValues,
     searchValueToRuleValue,
 } from './utils';
 
@@ -310,6 +312,50 @@ describe('EntityScope utils', () => {
         });
     });
 
+    describe('searchValueToMapRuleValues', () => {
+        it('expands equal-less regex to two rule values', () => {
+            expect(searchValueToMapRuleValues('visa')).toEqual([
+                { matchType: 'REGEX', value: 'visa=.*' },
+                { matchType: 'REGEX', value: '.*=visa' },
+            ]);
+        });
+
+        it('does not expand key=value regex', () => {
+            expect(searchValueToMapRuleValues('app=reporting')).toEqual([
+                { matchType: 'REGEX', value: 'app=reporting' },
+            ]);
+        });
+
+        it('does not expand key=value exact', () => {
+            expect(searchValueToMapRuleValues('"app=reporting"')).toEqual([
+                { matchType: 'EXACT', value: 'app=reporting' },
+            ]);
+        });
+    });
+
+    describe('collapseMapRuleValues', () => {
+        it('collapses complementary regex pair to single value', () => {
+            expect(
+                collapseMapRuleValues([
+                    { matchType: 'REGEX', value: 'visa=.*' },
+                    { matchType: 'REGEX', value: '.*=visa' },
+                ])
+            ).toEqual(['visa']);
+        });
+
+        it('passes through key=value without collapsing', () => {
+            expect(collapseMapRuleValues([{ matchType: 'REGEX', value: 'app=reporting' }])).toEqual(
+                ['app=reporting']
+            );
+        });
+
+        it('does not collapse when complement is missing', () => {
+            expect(collapseMapRuleValues([{ matchType: 'REGEX', value: 'visa=.*' }])).toEqual([
+                'visa=.*',
+            ]);
+        });
+    });
+
     describe('searchValueToRuleValue and ruleValueToSearchValue round-trip', () => {
         it('round-trips an EXACT value', () => {
             const original = '"production"';
@@ -337,6 +383,87 @@ describe('EntityScope utils', () => {
             const ruleValue = searchValueToRuleValue(original);
             const result = ruleValueToSearchValue(ruleValue);
             expect(result).toBe(original);
+        });
+    });
+
+    describe('equal-less label round-trip through full conversion', () => {
+        it('round-trips equal-less regex label through SearchFilter → rules → SearchFilter', () => {
+            const original = { 'Deployment Label': ['visa'] };
+            const rules =
+                getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment(original);
+            const result = getSearchFilterFromEntityScopeRules(
+                rules,
+                searchFieldLabelMapForClusterNamespaceDeployment
+            );
+            expect(result).toEqual(original);
+        });
+
+        it('round-trips mixed equal-less and key=value labels', () => {
+            const original = {
+                'Deployment Label': ['visa', '"app=web"', 'env=prod'],
+                Cluster: ['"production"'],
+            };
+            const rules =
+                getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment(original);
+            const result = getSearchFilterFromEntityScopeRules(
+                rules,
+                searchFieldLabelMapForClusterNamespaceDeployment
+            );
+            expect(result).toEqual(original);
+        });
+
+        it('does not expand equal-less values for non-map fields', () => {
+            const original = { Cluster: ['production'] };
+            const rules =
+                getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment(original);
+            expect(rules[0].values).toEqual([{ matchType: 'REGEX', value: 'production' }]);
+        });
+
+        it('round-trips equal-less regex label through rules → SearchFilter → rules', () => {
+            const originalRules: EntityScopeRule[] = [
+                {
+                    entity: 'SCOPE_ENTITY_DEPLOYMENT',
+                    field: 'FIELD_LABEL',
+                    values: [
+                        { matchType: 'REGEX', value: 'visa=.*' },
+                        { matchType: 'REGEX', value: '.*=visa' },
+                    ],
+                },
+            ];
+            const searchFilter = getSearchFilterFromEntityScopeRules(
+                originalRules,
+                searchFieldLabelMapForClusterNamespaceDeployment
+            );
+            const result =
+                getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment(searchFilter);
+            expect(result).toEqual(originalRules);
+        });
+
+        it('round-trips mixed equal-less and key=value labels through rules → SearchFilter → rules', () => {
+            const originalRules: EntityScopeRule[] = [
+                {
+                    entity: 'SCOPE_ENTITY_DEPLOYMENT',
+                    field: 'FIELD_LABEL',
+                    values: [
+                        { matchType: 'REGEX', value: 'visa=.*' },
+                        { matchType: 'REGEX', value: '.*=visa' },
+                        { matchType: 'EXACT', value: 'app=web' },
+                        { matchType: 'REGEX', value: 'env=prod' },
+                    ],
+                },
+                {
+                    entity: 'SCOPE_ENTITY_CLUSTER',
+                    field: 'FIELD_NAME',
+                    values: [{ matchType: 'EXACT', value: 'production' }],
+                },
+            ];
+            const searchFilter = getSearchFilterFromEntityScopeRules(
+                originalRules,
+                searchFieldLabelMapForClusterNamespaceDeployment
+            );
+            const result =
+                getEntityScopeRulesFromSearchFilterForClusterNamespaceDeployment(searchFilter);
+            expect(result).toEqual(originalRules);
         });
     });
 });

--- a/ui/apps/platform/src/Components/EntityScope/utils.ts
+++ b/ui/apps/platform/src/Components/EntityScope/utils.ts
@@ -139,10 +139,30 @@ export function getSearchFilterWithoutEntityScope(
     return searchFilterWithoutEntityScopeRules;
 }
 
+function isLabelOrAnnotationField(field: string): boolean {
+    return field === 'FIELD_LABEL' || field === 'FIELD_ANNOTATION';
+}
+
 export const searchValueToRuleValue = (value: string): RuleValue =>
     isQuotedString(value)
         ? { matchType: 'EXACT', value: value.slice(1, -1) }
         : { matchType: 'REGEX', value };
+
+// For label/annotation fields, equal-less values expand to two rule values
+// so the backend queries both the key and value sides of the map field.
+export function searchValueToMapRuleValues(value: string): RuleValue[] {
+    const raw = isQuotedString(value) ? value.slice(1, -1) : value;
+    const matchType = isQuotedString(value) ? 'EXACT' : 'REGEX';
+
+    if (raw.includes('=')) {
+        return [{ matchType, value: raw }];
+    }
+
+    return [
+        { matchType: 'REGEX', value: `${raw}=.*` },
+        { matchType: 'REGEX', value: `.*=${raw}` },
+    ];
+}
 
 /**
  * Return initial entity scope rules for corresponding search fields
@@ -164,7 +184,11 @@ function getEntityScopeRulesFromSearchFilter(
         if (ruleWithoutValues && searchFieldValues.length !== 0) {
             rules.push({
                 ...ruleWithoutValues,
-                values: searchFieldValues.map(searchValueToRuleValue),
+                values: searchFieldValues.flatMap((v) =>
+                    isLabelOrAnnotationField(ruleWithoutValues.field)
+                        ? searchValueToMapRuleValues(v)
+                        : [searchValueToRuleValue(v)]
+                ),
             });
         }
     });
@@ -174,6 +198,29 @@ function getEntityScopeRulesFromSearchFilter(
 
 export const ruleValueToSearchValue = ({ matchType, value }: RuleValue): string =>
     matchType === 'EXACT' ? wrapInQuotes(value) : value;
+
+// Collapses complementary equal-less pairs ([`value=.*`, `.*=value`]) back to a single
+// search value. Inverse of searchValueToMapRuleValues.
+export function collapseMapRuleValues(ruleValues: RuleValue[]): string[] {
+    const pairKeys = new Set(ruleValues.map(({ matchType, value }) => `${matchType}:${value}`));
+
+    return ruleValues.flatMap(({ matchType, value }) => {
+        if (value.startsWith('.*=')) {
+            if (pairKeys.has(`${matchType}:${value.slice(3)}=.*`)) {
+                return [];
+            }
+        }
+
+        if (value.endsWith('=.*') && !value.startsWith('.*=')) {
+            const raw = value.slice(0, -3);
+            if (pairKeys.has(`${matchType}:.*=${raw}`)) {
+                return [raw];
+            }
+        }
+
+        return [ruleValueToSearchValue({ matchType, value })];
+    });
+}
 
 /**
  * Return search filter in EntityScopeCompoundSearchFilter component.
@@ -193,7 +240,9 @@ export function getSearchFilterFromEntityScopeRules(
             const [searchFieldLabel] = found;
             const searchFilterValue = getValueByCaseInsensitiveKey(searchFilter, searchFieldLabel);
             const searchFilterValues = searchValueAsArray(searchFilterValue);
-            const ruleValues = rule.values.map(ruleValueToSearchValue);
+            const ruleValues = isLabelOrAnnotationField(rule.field)
+                ? collapseMapRuleValues(rule.values)
+                : rule.values.map(ruleValueToSearchValue);
             searchFilter[searchFieldLabel] = [...searchFilterValues, ...ruleValues];
         }
     });


### PR DESCRIPTION
## Description

**Requires https://github.com/stackrox/stackrox/pull/20688**

Adds support for serialization/deserialization of map based fields (label/annotation) between search filters and report entity scopes.

When a label search has no `=` (e.g. just `visa`), the UI now expands it to two rule values (`visa=.*` + `.*=visa`) so the backend can match against both the key and value sides of map fields.

Labels and Annotations are only relevant to report scoping, so there is no additional implementation for regular filters.

## Tangent

Note that because we cannot specify an EXACT match for one side and a REGEX match for another (e.g. like we do with search filters `"visa"=r/.*`), we default to a substring regex for the EXACT side of the label field when converting to entity scopes. This will theoretically result in *more* results than intended. In practice, this case is not possible in the UI due to EXACT only applying when a user selects an exact value from the autocomplete dropdown, and autocomplete options *always* include the `=` character.

Support for exact, equal-less label searches in the original search component was overkill in the initial implementation, since this isn't possible in the app with current code paths.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

In VM - search for a label that has key and value matching search query:
<img width="1614" height="1089" alt="image" src="https://github.com/user-attachments/assets/c47bde9e-6a17-45af-8c67-8032b34190ae" />
Apply equal-less search and see deployment results:
<img width="1614" height="1089" alt="image" src="https://github.com/user-attachments/assets/618bc76c-12d6-41da-b7b9-fae8ee90aee7" />
Create report config and see matching search filter chip label:
<img width="1614" height="1089" alt="image" src="https://github.com/user-attachments/assets/44950d1e-b110-47f2-bf47-8fc3426bd2a1" />
See expanded implication of equal-less value in verbose review:
<img width="1614" height="1089" alt="image" src="https://github.com/user-attachments/assets/3e3eb9de-2149-4e6d-bd0b-58dc88f1c792" />
Save the report config, generate a download, and verify the results contain only CVEs for the deployments matching above:
<img width="1421" height="631" alt="image" src="https://github.com/user-attachments/assets/f3b6ada1-bafc-472b-aa4b-db28a3d1cff6" />

