### PR TITLE
ROX-34774: Disable clone and edit actions if unknown resourceScope

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -33,6 +33,7 @@ import NotFoundMessage from 'Components/NotFoundMessage/NotFoundMessage';
 import usePermissions from 'hooks/usePermissions';
 import useToasts from 'hooks/patternfly/useToasts';
 import type { Toast } from 'hooks/patternfly/useToasts';
+import type { ReportConfiguration } from 'services/ReportsService.types';
 
 import MenuDropdown from 'Components/PatternFly/MenuDropdown';
 import ReportJobsHelpAction from 'Components/ReportJob/ReportJobsHelpAction';
@@ -55,6 +56,12 @@ import { useWatchLastSnapshotForReports } from '../api/useWatchLastSnapshotForRe
 import useDeleteModal, { isErrorDeleteResult } from '../hooks/useDeleteModal';
 import { vulnerabilityConfigurationReportDetailsPath } from '../pathsForVulnerabilityReporting';
 // import { getReportFormValuesFromConfiguration } from '../utils';
+
+// resourceScope: {} after roll back to previous version that does not support a newer resource scope.
+// Do not let user clone or edit report configuration which might cause worse problems after roll forward.
+function isResourceScopeAbsent({ resourceScope }: ReportConfiguration) {
+    return Object.keys(resourceScope).length === 0;
+}
 
 export type TabTitleProps = {
     icon?: ReactElement;
@@ -189,7 +196,11 @@ function ViewVulnReportPage() {
                                     onClick={() => {
                                         navigate(`${vulnReportPageURL}?action=edit`);
                                     }}
-                                    isDisabled={isReportStatusPending || isRunning}
+                                    isDisabled={
+                                        isReportStatusPending ||
+                                        isRunning ||
+                                        isResourceScopeAbsent(reportConfiguration)
+                                    }
                                 >
                                     Edit report
                                 </DropdownItem>
@@ -222,6 +233,7 @@ function ViewVulnReportPage() {
                                     onClick={() => {
                                         navigate(`${vulnReportPageURL}?action=clone`);
                                     }}
+                                    isDisabled={isResourceScopeAbsent(reportConfiguration)}
                                 >
                                     Clone report
                                 </DropdownItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/ViewVulnReport/ViewVulnReportPage.tsx
@@ -211,7 +211,8 @@ function ViewVulnReportPage() {
                                     isDisabled={
                                         isReportStatusPending ||
                                         isRunning ||
-                                        reportConfiguration.notifiers.length === 0
+                                        reportConfiguration.notifiers.length === 0 ||
+                                        isResourceScopeAbsent(reportConfiguration)
                                     }
                                     description={
                                         reportConfiguration.notifiers.length === 0
@@ -224,7 +225,11 @@ function ViewVulnReportPage() {
                                 <DropdownItem
                                     key="Generate download"
                                     onClick={() => runReport(reportId, 'DOWNLOAD')}
-                                    isDisabled={isReportStatusPending || isRunning}
+                                    isDisabled={
+                                        isReportStatusPending ||
+                                        isRunning ||
+                                        isResourceScopeAbsent(reportConfiguration)
+                                    }
                                 >
                                     Generate download
                                 </DropdownItem>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
@@ -422,7 +422,9 @@ function ConfigReportsTab() {
                                         runReport(report.id, 'EMAIL');
                                     },
                                     isDisabled:
-                                        isReportStatusPending || report.notifiers.length === 0,
+                                        isReportStatusPending ||
+                                        report.notifiers.length === 0 ||
+                                        isResourceScopeAbsent(reportArg),
                                 },
                                 {
                                     title: 'Generate download',
@@ -430,7 +432,8 @@ function ConfigReportsTab() {
                                         event.preventDefault();
                                         runReport(report.id, 'DOWNLOAD');
                                     },
-                                    isDisabled: isReportStatusPending,
+                                    isDisabled:
+                                        isReportStatusPending || isResourceScopeAbsent(reportArg),
                                 },
                                 {
                                     title: 'Clone report',

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/ConfigReportsTab.tsx
@@ -58,6 +58,13 @@ import useDeleteModal, {
     isSuccessDeleteResult,
 } from '../hooks/useDeleteModal';
 import { vulnerabilityConfigurationReportDetailsPath } from '../pathsForVulnerabilityReporting';
+import type { ReportConfiguration } from 'services/ReportsService.types';
+
+// resourceScope: {} after roll back to previous version that does not support a newer resource scope.
+// Do not let user clone or edit report configuration which might cause worse problems after roll forward.
+function isResourceScopeAbsent({ resourceScope }: ReportConfiguration) {
+    return Object.keys(resourceScope).length === 0;
+}
 
 const CreateReportsButton = () => {
     return (
@@ -398,7 +405,8 @@ function ConfigReportsTab() {
                                         event.preventDefault();
                                         navigate(`${vulnReportURL}?action=edit`);
                                     },
-                                    isDisabled: isReportStatusPending,
+                                    isDisabled:
+                                        isReportStatusPending || isResourceScopeAbsent(reportArg),
                                 },
                                 {
                                     isSeparator: true,
@@ -430,6 +438,7 @@ function ConfigReportsTab() {
                                         event.preventDefault();
                                         navigate(`${vulnReportURL}?action=clone`);
                                     },
+                                    isDisabled: isResourceScopeAbsent(reportArg),
                                 },
                                 {
                                     isSeparator: true,


### PR DESCRIPTION
## Description

### Problem

1. Absence of resource scope `resourceScope: {}` is possible after roll back to previous version.

2. Proposed solution for central to filter out report configurations is harder than initially expected because of pagination.

    However, central will not run report configurations that have absence of resource scope.

3. If user changes resource scope on **Resources** step of wizard, the problem might become even worse on roll forward, because central had stored the unexpected resource scope and it seems theoretically possible for it to have double resource scope.

### Analysis

1. User interface has conditional rendering of expected `resourceScope` so pages do not crash.

2. Find interactions to clone or edit report configuration.

    Find in Files **Clone report** in src/Containers/Vulnerabilities folder

    * CloneVulnReportPage.tsx file is not reachable
    * ViewVulnReportPage.tsx file has **Actions** dropdown
    * ConfigReportsTab.tsx file has row actions.    

    Find in Files **Edit report** in src/Containers/Vulnerabilities folder

    * EditVulnReportPage.tsx file is not reachable
    * ViewVulnReportPage.tsx file has **Actions** dropdown
    * ConfigReportsTab.tsx file has row actions.    

### Solution

1. Disable clone/edit actions if `resourceScope` has no property keys.

    Pending refactoring of VulnerabilityReporting folder, I copied the helper function.

    * ViewVulnReportPage.tsx file has **Actions** dropdown
    * ConfigReportsTab.tsx file has row actions.    

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration and see that actions are enabled for report configurations.

    * kebab menu of table row
    * **Actions** dropdown of report configuration page

2. Out of an abundance of caution, temporarily edit to spread `resourceScope: {}` into report configuration and  see a disabled action.
