### PR TITLE
ROX-34775: Call analyticsTrack for save report configuration

### DIFF
--- a/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizard.tsx
@@ -15,6 +15,7 @@ import type {
 import DeliveryStep from 'Components/Reports/Step/DeliveryStep';
 import DetailsStep from 'Components/Reports/Step/DetailsStep';
 import type { ReportPageAction } from 'Components/Reports/reports.types';
+import useAnalytics, { IMAGE_VULNERABILITY_REPORTS_WIZARD_SAVE_CLICKED } from 'hooks/useAnalytics';
 import { createReportConfiguration, updateReportConfiguration } from 'services/ReportsService';
 import type { ReportConfiguration } from 'services/ReportsService.types';
 import { vulnerabilityConfigurationReportsPath } from 'routePaths';
@@ -25,6 +26,7 @@ import type {
     ImageVulnerabilityReportConfigurationForCollection,
     ImageVulnerabilityReportConfigurationForEntity,
 } from '../imageVulnerabilityReports.types';
+import { getValueForCvesSince } from '../imageVulnerabilityReports.utils';
 
 import { getValidationSchema, isWizardStepId } from './imageVulnerabilityReportValidationSchemas';
 import type { WizardStepId } from './imageVulnerabilityReportValidationSchemas';
@@ -101,6 +103,7 @@ function ImageVulnerabilityReportWizard({
     pageAction,
     searchFilterConfig,
 }: ImageVulnerabilityReportWizardProps): ReactElement {
+    const { analyticsTrack } = useAnalytics();
     const navigate = useNavigate();
     const [error, setError] = useState<Error | null>(null);
     const [stepId, setStepId] = useState<WizardStepId>('details');
@@ -117,6 +120,20 @@ function ImageVulnerabilityReportWizard({
 
             request
                 .then((data) => {
+                    const { notifiers, resourceScope, schedule, vulnReportFilters } = values;
+                    const { imageTypes } = vulnReportFilters;
+                    analyticsTrack({
+                        event: IMAGE_VULNERABILITY_REPORTS_WIZARD_SAVE_CLICKED,
+                        properties: {
+                            action: pageAction,
+                            cvesSince: getValueForCvesSince(vulnReportFilters),
+                            imageTypes,
+                            intervalType: schedule?.intervalType ?? 'UNSET',
+                            notifiers: notifiers.length,
+                            resourceScope: Object.keys(resourceScope)[0] ?? '',
+                        },
+                    });
+
                     if (pageAction === 'edit') {
                         // Go back either to reports table or page for existing report.
                         navigate(-1);

--- a/ui/apps/platform/src/hooks/useAnalytics.ts
+++ b/ui/apps/platform/src/hooks/useAnalytics.ts
@@ -2,6 +2,8 @@ import { useCallback } from 'react';
 import Raven from 'raven-js';
 import mapValues from 'lodash/mapValues';
 
+import type { ReportPageAction } from 'Components/Reports/reports.types';
+import type { ImageType } from 'services/ReportsService.types';
 import type { Telemetry } from 'types/config.proto';
 import { ensureExhaustive, tupleTypeGuard } from 'utils/type.utils';
 import type { UnionFrom } from 'utils/type.utils';
@@ -54,6 +56,11 @@ export const NODE_CVE_FILTER_APPLIED = 'Node CVE Filter Applied';
 export const NODE_CVE_ENTITY_CONTEXT_VIEWED = 'Node CVE Entity Context View';
 export const PLATFORM_CVE_FILTER_APPLIED = 'Platform CVE Filter Applied';
 export const PLATFORM_CVE_ENTITY_CONTEXT_VIEWED = 'Platform CVE Entity Context View';
+
+// vulnerability reports
+
+export const IMAGE_VULNERABILITY_REPORTS_WIZARD_SAVE_CLICKED =
+    'Image Vulnerability Reports Wizard Save Clicked';
 
 // cluster-init-bundles
 export const CREATE_INIT_BUNDLE_CLICKED = 'Create Init Bundle Clicked';
@@ -357,6 +364,17 @@ export type AnalyticsEvent =
           properties: {
               type: 'CVE' | 'Cluster';
               page: 'Overview';
+          };
+      }
+    | {
+          event: typeof IMAGE_VULNERABILITY_REPORTS_WIZARD_SAVE_CLICKED;
+          properties: {
+              action: ReportPageAction;
+              cvesSince: 'allVuln' | 'sinceLastSentScheduledReport' | 'sinceStartDate';
+              imageTypes: ImageType[];
+              intervalType: 'DAILY' | 'MONTHLY' | 'WEEKLY' | 'UNSET';
+              notifiers: number;
+              resourceScope: string;
           };
       }
     /**


### PR DESCRIPTION
## Description

### Questions

1. Which resource scope?

    * Do users create new report configurations that have collection scope?
    * Do users save changes to report configurations that still have collection scope?

2. Multiplicity of image types: one or both?

    * Did image vulnerability reports need to support both image types in the same report configuration?

3. Multiplicity of notifiers: zero, one, or multiple?

    * Can new report configurations support just zero or one, instead of multiple?

4. Which schedule interval?

    * How often do users create reports without schedule for download only (no notifiers) or manual send?

5. Which time option?

6. Which action?

    * How often do users create report from filters on **Results** page?

### Analysis

1. useAnalytics.ts file

    * Event Name Constants
    * An AnalyticsEvent is either a simple string that represents the event name, or an object with an event name and additional properties.

2. Find in Files `analyticsTrack` has 63 results in 22 files

3. ScanConfigWizardForm.tsx file has most relevant action to imitate:

    `COMPLIANCE_SCHEDULES_WIZARD_SAVE_CLICKED`

### Solution

1. Edit useAnalytics.ts file.

    * Add `IMAGE_VULNERABILITY_REPORTS_WIZARD_SAVE_CLICKED` constant and corresponding type.

2. Edit ImageVulnerabilityReportWizard.tsx file.

    * Add `analyticsTrack` function call.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.
3. `npm run start` in ui/apps/platform folder with staging demo as central.

#### Manual testing

1. Visit /main/vulnerabilities/reports/configuration edit and save report configuration.

    See analytics event in Network panel of browser.
