### PR TITLE
ROX-34681: Add wait for RBAC to propagate in cluster

### DIFF
--- a/tests/roxctl/roxctl-k8s-context.sh
+++ b/tests/roxctl/roxctl-k8s-context.sh
@@ -10,6 +10,24 @@ eecho() {
   echo "$@" >&2
 }
 
+wait_for_rbac() {
+  local verb="$1" resource="$2" sa="$3" namespace="$4"
+  local max_attempts=30
+
+  echo "Waiting for RBAC to propagate..."
+  for _i in $(seq 1 "$max_attempts"); do
+    if kubectl auth can-i "$verb" "$resource" \
+        --as="system:serviceaccount:${namespace}:${sa}" \
+        -n "$namespace" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "RBAC propagation timed out waiting for ${sa} to ${verb} ${resource}" >&2
+  return 1
+}
+
 test_roxctl_cmd() {
   echo "Testing command: roxctl central whoami"
 
@@ -55,6 +73,7 @@ test_roxctl_cmd() {
   echo "Creating a service account with an insufficient role..."
   kubectl apply -f "tests/testdata/port-forward-role-bad.yaml"
   kubectl apply -f "tests/testdata/port-forward-sa.yaml"
+  wait_for_rbac "get" "services" "port-forward-sa" "stackrox"
   echo "Switching the context to use the service account token..."
   TOKEN=$(kubectl create token port-forward-sa)
   kubectl config set-credentials port-forward-user --token="$TOKEN"
@@ -78,6 +97,7 @@ test_roxctl_cmd() {
 
   echo "Updating the role with sufficient permissions..."
   kubectl apply -f "tests/testdata/port-forward-role-minimal.yaml"
+  wait_for_rbac "list" "pods" "port-forward-sa" "stackrox"
 
   echo "Switching back to the limited context..."
   kubectl config use-context port-forward-context


### PR DESCRIPTION
## Description

The issue that we see is that changes on RBAC are not fully applied in Kubernetes API and we immediately expect that to be applied.

Another case shows that even better: 
```
Switched to context "port-forward-context".
New context: port-forward-context
[FAIL] roxctl central whoami using current k8s context and insufficient role works
Captured output was:
ERROR:	establishing GRPC connection to retrieve user role information: could not get endpoint for gRPC connection: could not get endpoint forwarding to the central service in the current k8s context: port-forwarding error: cannot get central pod: failed to get central service: services "central" is forbidden: User "system:serviceaccount:stackrox:port-forward-sa" cannot get resource "services" in API group "" in the namespace "stackrox"
Switch to the original context...

..

Switched to context "port-forward-context".
[FAIL] roxctl central whoami using current k8s context fails
Captured output was:
ERROR:	establishing GRPC connection to retrieve user role information: could not get endpoint for gRPC connection: could not get endpoint forwarding to the central service in the current k8s context: port-forwarding error: cannot get central pod: cannot find a matching pod: pods is forbidden: User "system:serviceaccount:stackrox:port-forward-sa" cannot list resource "pods" in API group "" in the namespace "stackrox"
Switch to the original context...
```
in: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-stackrox-stackrox-master-merge-gke-nongroovy-e2e-tests/2054608284567998464

This PR is adding wait for actual RBAC to be applied.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] `shellcheck` locally
- [x] CI runs pipeline that is changed in this PR: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/20733/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/2057144709918232576
```
rolebinding.rbac.authorization.k8s.io/port-forward-rolebinding created
Waiting for RBAC to propagate...
yes
Switching the context to use the service account token...

..

Waiting for RBAC to propagate...
yes
Switching back to the limited context...
```
