### PR TITLE
ROX-33123: Enable roxie deployment flow for first test suites

### DIFF
--- a/qa-tests-backend/src/test/groovy/AuditScrubbingTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AuditScrubbingTest.groovy
@@ -58,12 +58,14 @@ class AuditScrubbingTest extends BaseSpecification {
 
         when:
         "A POST request is made to the ExchangeToken API"
+        def encodedUser = URLEncoder.encode(username, 'UTF-8')
+        def encodedPass = URLEncoder.encode(password, 'UTF-8')
         RestAssured.given()
                 .relaxedHTTPSValidation()
                 .body(
                         JsonFormat.printer().print(
                                 AuthproviderService.ExchangeTokenRequest.newBuilder()
-                                    .setExternalToken("username=${username}&password=${password}")
+                                    .setExternalToken("username=${encodedUser}&password=${encodedPass}")
                                     .setState("${BASIC_AUTH_PROVIDER_ID}:${attemptId}")
                                     .setType("basic")))
                 .header("Referer", baseURL)

--- a/scripts/ci/jobs/gke_qa_e2e_tests.py
+++ b/scripts/ci/jobs/gke_qa_e2e_tests.py
@@ -18,4 +18,19 @@ os.environ["SCANNER_V4_DB_STORAGE_CLASS"] = "stackrox-gke-ssd"
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
+# This test suite has been migrated to use roxie for deployment (deploy_stackrox_with_roxie_compat()) instead of
+# the legacy deployment flow (deploy_stackrox()).
+#
+# The previous deployment mechanism used environment variables extensively for deployment configuration.
+# These variables were injected into deployment manifests and/or translated into roxctl command-line arguments
+# in multiple places, which makes the whole configuration setup difficult to maintain and reason about.
+#
+# The compatibility layer for roxie-based deployments (deploy_stackrox_with_roxie_compat()) is designed as a
+# drop-in replacement for the legacy deployment mechanism (deploy_stackrox()) and picks up the same environment
+# variables for configuration with the same defaulting behaviour.
+#
+# Long term, the goal is to migrate all test suites to use the modern roxie-based deployment mechanism,
+# where the entire deployment configuration is to be assembled explicitly in a YAML configuration file.
+os.environ["USE_ROXIE_DEPLOY"] = "true"
+
 make_qa_e2e_test_runner(cluster=GKECluster("qa-e2e-test")).run()

--- a/scripts/ci/jobs/ocp_qa_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_qa_e2e_tests.py
@@ -21,4 +21,19 @@ enable_sfa_for_ocp()
 os.environ["ROX_RISK_REPROCESSING_INTERVAL"] = "15s"
 os.environ["ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL"] = "30s"
 
+# This test suite has been migrated to use roxie for deployment (deploy_stackrox_with_roxie_compat()) instead of
+# the legacy deployment flow (deploy_stackrox()).
+#
+# The previous deployment mechanism used environment variables extensively for deployment configuration.
+# These variables were injected into deployment manifests and/or translated into roxctl command-line arguments
+# in multiple places, which makes the whole configuration setup difficult to maintain and reason about.
+#
+# The compatibility layer for roxie-based deployments (deploy_stackrox_with_roxie_compat()) is designed as a
+# drop-in replacement for the legacy deployment mechanism (deploy_stackrox()) and picks up the same environment
+# variables for configuration with the same defaulting behaviour.
+#
+# Long term, the goal is to migrate all test suites to use the modern roxie-based deployment mechanism,
+# where the entire deployment configuration is to be assembled explicitly in a YAML configuration file.
+os.environ["USE_ROXIE_DEPLOY"] = "true"
+
 make_qa_e2e_test_runner(cluster=AutomationFlavorsCluster()).run()


### PR DESCRIPTION
## Description

Follow-up to https://github.com/stackrox/stackrox/pull/20050.
This PR enables the roxie-based deployment flow for 
* gke-qa-e2e-tests
* ocp-qa-e2e-tests

It required a bug fix to one of the tests which was missing proper URL parameter encoding. This worked previously, because central's admin password was generated from a different character set.

## User-facing documentation

Nothing user-facing.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Just one test modified (bug fix, triggered by new roxie flow).

Failures in other test suites can be ignored for this PR, as they are not changed.

### How I validated my change

Just CI

e.g. here https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/stackrox_stackrox/20734/pull-ci-stackrox-stackrox-master-ocp-4-12-qa-e2e-tests/2059155012214329344/artifacts/qa-e2e-tests/stackrox-stackrox-e2e-test/build-log.txt

roxie is used there for deployment and tests pass!

