### PR TITLE
perf(ci): remove container from UI test jobs

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -1,10 +1,6 @@
 name: Cache Go Dependencies
 description: Cache Go Dependencies
 inputs:
-  save:
-    description: Whether this job saves caches on pushes to the default branch.
-    required: false
-    default: 'true'
   key-suffix:
     description: Extra suffix for cache keys (use to distinguish matrix entries that share github.job).
     required: false
@@ -27,17 +23,8 @@ runs:
         echo "KEY_SUFFIX=${suffix:+-$suffix}" >> "$GITHUB_OUTPUT"  # prepends dash if set
       shell: bash
 
-    - name: Cache Go Build (save)
-      if: inputs.save == 'true' && (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
+    - name: Cache Go Build
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
-      with:
-        path: ${{ steps.cache-paths.outputs.GOCACHE }}
-        key: go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-${{ steps.cache-paths.outputs.GOMOD_HASH }}-${{ steps.cache-paths.outputs.TAG }}
-        restore-keys: go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-${{ steps.cache-paths.outputs.GOMOD_HASH }}-
-
-    - name: Cache Go Build (restore)
-      if: ${{ !(inputs.save == 'true' && (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)) }}
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/restore@v5
       with:
         path: ${{ steps.cache-paths.outputs.GOCACHE }}
         key: go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-${{ steps.cache-paths.outputs.GOMOD_HASH }}-${{ steps.cache-paths.outputs.TAG }}

--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -1,6 +1,10 @@
 name: Cache Go Dependencies
 description: Cache Go Dependencies
 inputs:
+  save:
+    description: Whether this job saves caches on pushes to the default branch.
+    required: false
+    default: 'true'
   key-suffix:
     description: Extra suffix for cache keys (use to distinguish matrix entries that share github.job).
     required: false
@@ -23,8 +27,17 @@ runs:
         echo "KEY_SUFFIX=${suffix:+-$suffix}" >> "$GITHUB_OUTPUT"  # prepends dash if set
       shell: bash
 
-    - name: Cache Go Build
+    - name: Cache Go Build (save)
+      if: inputs.save == 'true' && (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
+      with:
+        path: ${{ steps.cache-paths.outputs.GOCACHE }}
+        key: go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-${{ steps.cache-paths.outputs.GOMOD_HASH }}-${{ steps.cache-paths.outputs.TAG }}
+        restore-keys: go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-${{ steps.cache-paths.outputs.GOMOD_HASH }}-
+
+    - name: Cache Go Build (restore)
+      if: ${{ !(inputs.save == 'true' && (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)) }}
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/restore@v5
       with:
         path: ${{ steps.cache-paths.outputs.GOCACHE }}
         key: go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-${{ steps.cache-paths.outputs.GOMOD_HASH }}-${{ steps.cache-paths.outputs.TAG }}

--- a/.github/actions/cache-ui-dependencies/action.yaml
+++ b/.github/actions/cache-ui-dependencies/action.yaml
@@ -9,10 +9,20 @@ runs:
   using: composite
   steps:
     - name: Cache UI Dependencies
+      if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
       with:
         path: |
           ~/.npm
           ~/.cache/Cypress
         key: npm-v4-${{ hashFiles(inputs.lockFile) }}
-        restore-keys: npm-v4-
+
+    - name: Restore UI Dependencies
+      if: ${{ !(github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) }}
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/restore@v5
+      with:
+        path: |
+          ~/.npm
+          ~/.cache/Cypress
+        key: npm-v3-${{ hashFiles(inputs.lockFile) }}
+        restore-keys: npm-v3-

--- a/.github/actions/cache-ui-dependencies/action.yaml
+++ b/.github/actions/cache-ui-dependencies/action.yaml
@@ -24,5 +24,5 @@ runs:
         path: |
           ~/.npm
           ~/.cache/Cypress
-        key: npm-v3-${{ hashFiles(inputs.lockFile) }}
-        restore-keys: npm-v3-
+        key: npm-v4-${{ hashFiles(inputs.lockFile) }}
+        restore-keys: npm-v4-

--- a/.github/actions/cache-ui-dependencies/action.yaml
+++ b/.github/actions/cache-ui-dependencies/action.yaml
@@ -15,8 +15,7 @@ runs:
         path: |
           ~/.npm
           ~/.cache/Cypress
-          /usr/local/share/.cache
-        key: npm-v3-${{ hashFiles(inputs.lockFile) }}
+        key: npm-v4-${{ hashFiles(inputs.lockFile) }}
 
     - name: Restore UI Dependencies
       if: ${{ !(github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) }}
@@ -25,6 +24,5 @@ runs:
         path: |
           ~/.npm
           ~/.cache/Cypress
-          /usr/local/share/.cache
         key: npm-v3-${{ hashFiles(inputs.lockFile) }}
         restore-keys: npm-v3-

--- a/.github/actions/cache-ui-dependencies/action.yaml
+++ b/.github/actions/cache-ui-dependencies/action.yaml
@@ -9,20 +9,10 @@ runs:
   using: composite
   steps:
     - name: Cache UI Dependencies
-      if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
       with:
         path: |
           ~/.npm
           ~/.cache/Cypress
         key: npm-v4-${{ hashFiles(inputs.lockFile) }}
-
-    - name: Restore UI Dependencies
-      if: ${{ !(github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) }}
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/restore@v5
-      with:
-        path: |
-          ~/.npm
-          ~/.cache/Cypress
-        key: npm-v3-${{ hashFiles(inputs.lockFile) }}
-        restore-keys: npm-v3-
+        restore-keys: npm-v4-

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -246,8 +246,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
-    container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -255,6 +253,11 @@ jobs:
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
+    - name: Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+      with:
+        node-version-file: ui/package.json
 
     - name: Cache UI dependencies
       uses: ./.github/actions/cache-ui-dependencies
@@ -288,8 +291,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
-    container:
-      image: quay.io/stackrox-io/apollo-ci:stackrox-ui-test-0.5.11@sha256:996ca7bf256805e4003f711a3915d5f7a86d58c9263bfca4402f0a0f3b47c025 # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-ui-test-0.5.11
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -297,6 +298,11 @@ jobs:
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
+    - name: Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+      with:
+        node-version-file: ui/package.json
 
     - name: Cache UI dependencies
       uses: ./.github/actions/cache-ui-dependencies


### PR DESCRIPTION
## Description

Remove the apollo-ci container images from the `ui` and `ui-component` jobs in the unit tests workflow. The containers (`stackrox-test`, `stackrox-ui-test`) only provided Node.js and Cypress -- both available on ubuntu-latest runners.

Changes:
- Remove `container:` blocks from both UI jobs (~55s init overhead each)
- Add `actions/setup-node` with `node-version-file: ui/package.json` (matches `build.yaml` and `style.yaml` patterns)

Cypress on ubuntu-latest confirmed working in #20345 (UI E2E tests).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI validates: both `ui` and `ui-component` jobs must pass without the container.