### PR TITLE
fix(tests): Exclude VM scanning tests from general e2e test target

### DIFF
--- a/tests/vm_scanning_cluster_preflight_checks_test.go
+++ b/tests/vm_scanning_cluster_preflight_checks_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_cluster_preflight_test.go
+++ b/tests/vm_scanning_cluster_preflight_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_e2e_utils_test.go
+++ b/tests/vm_scanning_e2e_utils_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_utils_config_test.go
+++ b/tests/vm_scanning_utils_config_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_utils_test.go
+++ b/tests/vm_scanning_utils_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 


### PR DESCRIPTION


## Description

VM scanning tests had a `//go:build test_e2e || test_e2e_vm` constraint, which caused them to compile and execute under the general `test_e2e` tag used by `gke-nongroovy-e2e-tests`. That was not intended or planned.

Changed the build constraint on all 6 VM-scanning-specific test files to `//go:build test_e2e_vm`, so they are only compiled and run by the dedicated `make vm-scanning-tests` target.

Shared files (`common.go`, `common_test.go`, `common_matchers.go`) were left unchanged - they use a broader multi-tag constraint and serve non-VM tests.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Ran nongroovy tests in CI and made sure that no VM-related tests are executed:

1. [VM scanning tests](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/20746/pull-ci-stackrox-stackrox-master-ocp-4-21-vm-scanning-e2e-tests/2057410619786661888) - 55 tests passing
2. [Nongroovy e2e](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/20746/pull-ci-stackrox-stackrox-master-ocp-4-21-nongroovy-e2e-tests/2057410511930134528) - No VM e2e tests executed. Only `github.com/stackrox/rox/tests/vmhelpers: TestPlaceholder` which is a unit test that covers the helpers of the vm e2e tests. Currently, there is only a placeholder, but more will be added in https://github.com/stackrox/stackrox/pull/20128, https://github.com/stackrox/stackrox/pull/20129, and https://github.com/stackrox/stackrox/pull/20402

Ergo: only the unit-test `github.com/stackrox/rox/tests/vmhelpers: TestPlaceholder` (duration 0s) is executed in both targets. I will tackle that issue and make it run only once in a followup (provided the green CI).
