### PR TITLE
ci: Add junit2jira integration to scan-images-with-roxctl job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1341,12 +1341,11 @@ jobs:
 
           registry="$(./scripts/ci/lib.sh registry_from_branding "${{ matrix.name }}")"
           image_ref="${registry}/${{ matrix.image }}:${release_tag}"
+          echo "image_ref=${image_ref}" >> "$GITHUB_OUTPUT"
 
           roxctl image scan --retries=10 --retry-delay=15 --force --severity=CRITICAL,IMPORTANT --output=sarif \
             --image="${image_ref}" \
             | tee results.sarif
-
-          echo "image_ref=${image_ref}" >> "$GITHUB_OUTPUT"
 
       - name: Convert SARIF to JUnit
         if: always()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1301,6 +1301,8 @@ jobs:
       # Needed for stackrox/central-login to create the JWT token.
       id-token: write
       security-events: write
+    env:
+      ARTIFACT_DIR: junit-reports/
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.define-job-matrix.outputs.matrix).scan_images_with_roxctl }}
@@ -1348,6 +1350,15 @@ jobs:
       #   with:
       #     category: ${{ matrix.image }}
       #     sarif_file: results.sarif
+
+      - name: Report junit failures in jira
+        uses: ./.github/actions/junit2jira
+        if: always()
+        with:
+          jira-user: ${{ secrets.JIRA_USER }}
+          jira-token: ${{ secrets.JIRA_TOKEN }}
+          gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+          directory: 'junit-reports'
 
   slack-on-build-failure:
     env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1328,6 +1328,7 @@ jobs:
           central-token: ${{ env.ROX_API_TOKEN }}
 
       - name: Scan images for vulnerabilities
+        id: scan
         env:
           BUILD_TAG: ${{ needs.define-job-matrix.outputs.build-tag }}
           SHORTCOMMIT: ${{ needs.define-job-matrix.outputs.short-commit }}
@@ -1339,10 +1340,18 @@ jobs:
           fi
 
           registry="$(./scripts/ci/lib.sh registry_from_branding "${{ matrix.name }}")"
+          image_ref="${registry}/${{ matrix.image }}:${release_tag}"
 
           roxctl image scan --retries=10 --retry-delay=15 --force --severity=CRITICAL,IMPORTANT --output=sarif \
-            --image="${registry}/${{ matrix.image }}:${release_tag}" \
+            --image="${image_ref}" \
             | tee results.sarif
+
+          echo "image_ref=${image_ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Convert SARIF to JUnit
+        if: always()
+        run: |
+          ./scripts/ci/sarif-to-junit.sh results.sarif "${{ steps.scan.outputs.image_ref }}"
 
       # TODO: re-enable roxctl scan results upload once quota issue has been resolved
       # - name: Upload roxctl scan results to GitHub Security tab

--- a/scripts/ci/sarif-to-junit.bats
+++ b/scripts/ci/sarif-to-junit.bats
@@ -226,3 +226,12 @@ EOF
     # Third: no underscore, use full ruleId as classname, "unknown" as name
     assert_output --partial '<testcase name="unknown" classname="no-underscore-format">'
 }
+
+@test "fails on malformed sarif" {
+    local sarif_file="${BATS_TEST_TMPDIR}/bad.sarif"
+    echo "not json" > "${sarif_file}"
+
+    run "${BATS_TEST_DIRNAME}/sarif-to-junit.sh" "${sarif_file}" "test-image:latest"
+    assert_failure
+    assert_output --partial 'Failed to parse SARIF'
+}

--- a/scripts/ci/sarif-to-junit.bats
+++ b/scripts/ci/sarif-to-junit.bats
@@ -1,0 +1,175 @@
+#!/usr/bin/env bats
+
+# Allow to run the tests locally provided that bats-helpers are installed in $HOME/bats-core
+bats_helpers_root="${HOME}/bats-core"
+if [[ ! -f "${bats_helpers_root}/bats-support/load.bash" ]]; then
+  # Location of bats-helpers in the CI image
+  bats_helpers_root="/usr/lib/node_modules"
+fi
+load "${bats_helpers_root}/bats-support/load.bash"
+load "${bats_helpers_root}/bats-assert/load.bash"
+
+function setup() {
+    source "${BATS_TEST_DIRNAME}/lib.sh"
+    ARTIFACT_DIR="${BATS_TEST_TMPDIR}/junit-reports"
+    mkdir -p "${ARTIFACT_DIR}"
+    export ARTIFACT_DIR
+}
+
+function teardown() {
+    rm -rf "${ARTIFACT_DIR}"
+}
+
+@test "missing arguments" {
+    run "${BATS_TEST_DIRNAME}/sarif-to-junit.sh"
+    assert_failure 1
+    assert_output --partial 'Usage:'
+}
+
+@test "sarif file not found" {
+    run "${BATS_TEST_DIRNAME}/sarif-to-junit.sh" nonexistent.sarif test-image:latest
+    assert_failure 1
+    assert_output --partial 'SARIF file not found'
+}
+
+@test "empty sarif report creates success record" {
+    local sarif_file="${BATS_TEST_TMPDIR}/empty.sarif"
+    cat > "${sarif_file}" <<'EOF'
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "roxctl"
+        }
+      },
+      "results": []
+    }
+  ]
+}
+EOF
+
+    run "${BATS_TEST_DIRNAME}/sarif-to-junit.sh" "${sarif_file}" "test-image:latest"
+    assert_success
+    assert_output --partial 'No vulnerabilities found'
+
+    # Verify success JUnit record was created
+    local junit_file="${ARTIFACT_DIR}/junit-misc/junit-test-image:latest.xml"
+    assert [ -f "${junit_file}" ]
+    run grep '<testsuite' "${junit_file}"
+    assert_success
+    assert_output --partial 'failures="0"'
+}
+
+@test "converts sarif violations to junit failures" {
+    local sarif_file="${BATS_TEST_TMPDIR}/violations.sarif"
+    cat > "${sarif_file}" <<'EOF'
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "roxctl",
+          "rules": []
+        }
+      },
+      "results": [
+        {
+          "ruleId": "CVE-2024-1234_nginx_1.19.0",
+          "level": "error",
+          "message": {
+            "text": "Critical vulnerability in nginx"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "quay.io/stackrox-io/main:4.6.0"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "CVE-2024-5678_openssl_1.1.1",
+          "level": "warning",
+          "message": {
+            "text": "Important vulnerability in openssl"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "quay.io/stackrox-io/main:4.6.0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+    run "${BATS_TEST_DIRNAME}/sarif-to-junit.sh" "${sarif_file}" "quay.io/stackrox-io/main:4.6.0"
+    assert_success
+    assert_output --partial 'Converted 2 vulnerabilities'
+
+    # Verify JUnit files were created for each CVE
+    local junit_file1="${ARTIFACT_DIR}/junit-misc/junit-CVE-2024-1234_nginx_1.19.0.xml"
+    local junit_file2="${ARTIFACT_DIR}/junit-misc/junit-CVE-2024-5678_openssl_1.1.1.xml"
+
+    assert [ -f "${junit_file1}" ]
+    assert [ -f "${junit_file2}" ]
+
+    # Verify first failure contains expected details
+    run cat "${junit_file1}"
+    assert_output --partial 'CVE-2024-1234'
+    assert_output --partial 'Severity: error'
+    assert_output --partial 'Critical vulnerability in nginx'
+    assert_output --partial 'failures="1"'
+
+    # Verify second failure
+    run cat "${junit_file2}"
+    assert_output --partial 'CVE-2024-5678'
+    assert_output --partial 'Severity: warning'
+    assert_output --partial 'Important vulnerability in openssl'
+}
+
+@test "handles sarif results without locations" {
+    local sarif_file="${BATS_TEST_TMPDIR}/no-location.sarif"
+    cat > "${sarif_file}" <<'EOF'
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "roxctl"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "CVE-2024-9999_test_1.0.0",
+          "level": "error",
+          "message": {
+            "text": "Test vulnerability"
+          }
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+    run "${BATS_TEST_DIRNAME}/sarif-to-junit.sh" "${sarif_file}" "test-image:latest"
+    assert_success
+    assert_output --partial 'Converted 1 vulnerabilities'
+
+    # Should still create JUnit record even without location
+    local junit_file="${ARTIFACT_DIR}/junit-misc/junit-CVE-2024-9999_test_1.0.0.xml"
+    assert [ -f "${junit_file}" ]
+}

--- a/scripts/ci/sarif-to-junit.bats
+++ b/scripts/ci/sarif-to-junit.bats
@@ -54,12 +54,16 @@ EOF
     assert_success
     assert_output --partial 'No vulnerabilities found'
 
-    # Verify success JUnit record was created
-    local junit_file="${ARTIFACT_DIR}/junit-misc/junit-test-image:latest.xml"
+    # Verify success JUnit record was created (one file per image)
+    local junit_file="${ARTIFACT_DIR}/junit-misc/junit-test-image_latest.xml"
     assert [ -f "${junit_file}" ]
-    run grep '<testsuite' "${junit_file}"
-    assert_success
+
+    # Verify structure: testsuite name is image name, no failures
+    run cat "${junit_file}"
+    assert_output --partial '<testsuite name="test-image:latest"'
+    assert_output --partial 'tests="1"'
     assert_output --partial 'failures="0"'
+    assert_output --partial '<testcase name="vulnerability-scan" classname="vulnerability-scan">'
 }
 
 @test "converts sarif violations to junit failures" {
@@ -118,25 +122,25 @@ EOF
     assert_success
     assert_output --partial 'Converted 2 vulnerabilities'
 
-    # Verify JUnit files were created for each CVE
-    local junit_file1="${ARTIFACT_DIR}/junit-misc/junit-CVE-2024-1234_nginx_1.19.0.xml"
-    local junit_file2="${ARTIFACT_DIR}/junit-misc/junit-CVE-2024-5678_openssl_1.1.1.xml"
+    # One JUnit file per image (testsuite), contains all vulnerabilities
+    local junit_file="${ARTIFACT_DIR}/junit-misc/junit-quay.io_stackrox-io_main_4.6.0.xml"
+    assert [ -f "${junit_file}" ]
 
-    assert [ -f "${junit_file1}" ]
-    assert [ -f "${junit_file2}" ]
+    # Verify testsuite structure: name is image, 2 tests, 2 failures
+    run cat "${junit_file}"
+    assert_output --partial '<testsuite name="quay.io/stackrox-io/main:4.6.0"'
+    assert_output --partial 'tests="2"'
+    assert_output --partial 'failures="2"'
 
-    # Verify first failure contains expected details
-    run cat "${junit_file1}"
-    assert_output --partial 'CVE-2024-1234'
-    assert_output --partial 'Severity: error'
+    # Verify first testcase: classname is CVE, name is component_version
+    assert_output --partial '<testcase name="nginx_1.19.0" classname="CVE-2024-1234">'
     assert_output --partial 'Critical vulnerability in nginx'
-    assert_output --partial 'failures="1"'
+    assert_output --partial 'Severity: error'
 
-    # Verify second failure
-    run cat "${junit_file2}"
-    assert_output --partial 'CVE-2024-5678'
-    assert_output --partial 'Severity: warning'
+    # Verify second testcase
+    assert_output --partial '<testcase name="openssl_1.1.1" classname="CVE-2024-5678">'
     assert_output --partial 'Important vulnerability in openssl'
+    assert_output --partial 'Severity: warning'
 }
 
 @test "handles sarif results without locations" {
@@ -170,6 +174,55 @@ EOF
     assert_output --partial 'Converted 1 vulnerabilities'
 
     # Should still create JUnit record even without location
-    local junit_file="${ARTIFACT_DIR}/junit-misc/junit-CVE-2024-9999_test_1.0.0.xml"
+    local junit_file="${ARTIFACT_DIR}/junit-misc/junit-test-image_latest.xml"
     assert [ -f "${junit_file}" ]
+
+    # Verify structure
+    run cat "${junit_file}"
+    assert_output --partial '<testsuite name="test-image:latest"'
+    assert_output --partial '<testcase name="test_1.0.0" classname="CVE-2024-9999">'
+}
+
+@test "parses CVE from ruleId correctly" {
+    local sarif_file="${BATS_TEST_TMPDIR}/parse-test.sarif"
+    cat > "${sarif_file}" <<'EOF'
+{
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {"driver": {"name": "roxctl"}},
+    "results": [
+      {
+        "ruleId": "CVE-2024-1234_nginx_1.19.0",
+        "level": "error",
+        "message": {"text": "Test with proper CVE format"}
+      },
+      {
+        "ruleId": "GHSA-abcd-1234_golang_1.20.0",
+        "level": "warning",
+        "message": {"text": "Test with GHSA format"}
+      },
+      {
+        "ruleId": "no-underscore-format",
+        "level": "note",
+        "message": {"text": "Test without underscore"}
+      }
+    ]
+  }]
+}
+EOF
+
+    run "${BATS_TEST_DIRNAME}/sarif-to-junit.sh" "${sarif_file}" "test:latest"
+    assert_success
+
+    local junit_file="${ARTIFACT_DIR}/junit-misc/junit-test_latest.xml"
+    run cat "${junit_file}"
+
+    # First: CVE-2024-1234 as classname, nginx_1.19.0 as name
+    assert_output --partial '<testcase name="nginx_1.19.0" classname="CVE-2024-1234">'
+
+    # Second: GHSA-abcd-1234 as classname, golang_1.20.0 as name
+    assert_output --partial '<testcase name="golang_1.20.0" classname="GHSA-abcd-1234">'
+
+    # Third: no underscore, use full ruleId as classname, "unknown" as name
+    assert_output --partial '<testcase name="unknown" classname="no-underscore-format">'
 }

--- a/scripts/ci/sarif-to-junit.bats
+++ b/scripts/ci/sarif-to-junit.bats
@@ -227,6 +227,36 @@ EOF
     assert_output --partial '<testcase name="unknown" classname="no-underscore-format">'
 }
 
+@test "sanitizes XML-special characters" {
+    local sarif_file="${BATS_TEST_TMPDIR}/special-chars.sarif"
+    cat > "${sarif_file}" <<'EOF'
+{
+  "version": "2.1.0",
+  "runs": [{
+    "tool": {"driver": {"name": "roxctl"}},
+    "results": [
+      {
+        "ruleId": "CVE-2024-1234_lib<\"test\">&apos_1.0",
+        "level": "error",
+        "message": {"text": "vuln with <special> & \"chars\""}
+      }
+    ]
+  }]
+}
+EOF
+
+    run "${BATS_TEST_DIRNAME}/sarif-to-junit.sh" "${sarif_file}" "image&<>name"
+    assert_success
+
+    local junit_file="${ARTIFACT_DIR}/junit-misc/junit-image&<>name.xml"
+    assert [ -f "${junit_file}" ]
+
+    run cat "${junit_file}"
+    # XML-special chars in attributes are replaced with spaces
+    refute_output --partial 'name="image&<>name"'
+    assert_output --partial 'name="image   name"'
+}
+
 @test "fails on malformed sarif" {
     local sarif_file="${BATS_TEST_TMPDIR}/bad.sarif"
     echo "not json" > "${sarif_file}"

--- a/scripts/ci/sarif-to-junit.sh
+++ b/scripts/ci/sarif-to-junit.sh
@@ -38,6 +38,9 @@ fi
 # SARIF structure: .runs[].results[] contains vulnerability findings
 # Each result has ruleId (CVE_component_version), message, and level (severity)
 
+jq_output="$(jq -r '.runs[].results[] | [.ruleId, .level, (.message.text // ""), (.locations[0].physicalLocation.artifactLocation.uri // "")] | @tsv' "$sarif_file")" \
+    || die "Failed to parse SARIF file: $sarif_file"
+
 testcases_xml=""
 vuln_count=0
 failure_count=0
@@ -69,7 +72,7 @@ ${message}"
     </testcase>
 "
     ((failure_count++)) || true
-done < <(jq -r '.runs[].results[] | [.ruleId, .level, (.message.text // ""), (.locations[0].physicalLocation.artifactLocation.uri // "")] | @tsv' "$sarif_file")
+done <<< "$jq_output"
 
 junit_dir="$(get_junit_misc_dir)"
 mkdir -p "${junit_dir}"

--- a/scripts/ci/sarif-to-junit.sh
+++ b/scripts/ci/sarif-to-junit.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 # sarif-to-junit.sh converts SARIF vulnerability scan results to JUnit XML format
 # for integration with junit2jira. This enables individual vulnerability tracking
 # in Jira rather than just job-level failure notifications.
 #
 # Usage: sarif-to-junit.sh <sarif-file> <image-name>
 
-source "$(dirname "$0")/lib.sh"
+SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+# shellcheck source=../../scripts/ci/lib.sh
+source "$SCRIPTS_ROOT/scripts/ci/lib.sh"
+
+set -euo pipefail
 
 if [[ "$#" -ne 2 ]]; then
     die "Usage: $0 <sarif-file> <image-name>"

--- a/scripts/ci/sarif-to-junit.sh
+++ b/scripts/ci/sarif-to-junit.sh
@@ -25,12 +25,10 @@ if [[ -z "${ARTIFACT_DIR:-}" ]]; then
     die "ARTIFACT_DIR environment variable must be set"
 fi
 
-# Extract vulnerabilities from SARIF and build JUnit XML
 # SARIF structure: .runs[].results[] contains vulnerability findings
 # Each result has ruleId (CVE_component_version), message, and level (severity)
 
-# Collect all test cases
-declare -a testcases=()
+testcases_xml=""
 vuln_count=0
 failure_count=0
 
@@ -41,51 +39,36 @@ while IFS=$'\t' read -r rule_id level message location; do
 
     ((vuln_count++)) || true
 
-    # Parse rule_id: "CVE-2024-1234_nginx_1.19.0" -> CVE="CVE-2024-1234", component="nginx_1.19.0"
-    # Use the full rule_id as fallback if parsing fails
-    cve_id="${rule_id%%_*}"
-    component_version="${rule_id#*_}"
-
-    # If parsing didn't split anything, use rule_id as CVE and "unknown" as component
-    if [[ "$cve_id" == "$rule_id" ]]; then
+    if [[ "$rule_id" =~ ^([^_]+)_(.+)$ ]]; then
+        cve_id="${BASH_REMATCH[1]}"
+        component_version="${BASH_REMATCH[2]}"
+    else
         cve_id="$rule_id"
         component_version="unknown"
     fi
 
-    # Build detailed failure message with vulnerability context
-    failure_details=$(cat <<EOF
-Vulnerability: ${rule_id}
+    failure_details="Vulnerability: ${rule_id}
 Severity: ${level}
 Component: ${location}
 Image: ${image_name}
 
-${message}
-EOF
-    )
+${message}"
 
-    # XML-escape the failure details (basic escaping for CDATA)
-    # CDATA can't contain ]]> so we don't need complex escaping, just use CDATA
-
-    testcases+=("$(cat <<EOF
-    <testcase name="${component_version}" classname="${cve_id}">
+    testcases_xml+="    <testcase name=\"${component_version}\" classname=\"${cve_id}\">
       <failure><![CDATA[${failure_details}]]></failure>
     </testcase>
-EOF
-    )")
+"
     ((failure_count++)) || true
 done < <(jq -r '.runs[].results[] | [.ruleId, .level, (.message.text // ""), (.locations[0].physicalLocation.artifactLocation.uri // "")] | @tsv' "$sarif_file")
 
-# Generate JUnit XML
 junit_dir="$(get_junit_misc_dir)"
 mkdir -p "${junit_dir}"
 
-# Use image name as testsuite name (sanitize for filename)
 suite_name="${image_name}"
 safe_filename="$(echo "${image_name}" | tr '/:' '_')"
 junit_file="${junit_dir}/junit-${safe_filename}.xml"
 
 if [[ $vuln_count -eq 0 ]]; then
-    # No vulnerabilities found - create success test suite
     cat > "${junit_file}" <<EOF
 <testsuite name="${suite_name}" tests="1" skipped="0" failures="0" errors="0">
   <testcase name="vulnerability-scan" classname="vulnerability-scan">
@@ -94,11 +77,9 @@ if [[ $vuln_count -eq 0 ]]; then
 EOF
     echo "No vulnerabilities found in SARIF report"
 else
-    # Create test suite with all vulnerability test cases
     cat > "${junit_file}" <<EOF
 <testsuite name="${suite_name}" tests="${vuln_count}" skipped="0" failures="${failure_count}" errors="0">
-$(printf '%s\n' "${testcases[@]}")
-</testsuite>
+${testcases_xml}</testsuite>
 EOF
     echo "Converted ${vuln_count} vulnerabilities from SARIF to JUnit"
 fi

--- a/scripts/ci/sarif-to-junit.sh
+++ b/scripts/ci/sarif-to-junit.sh
@@ -12,6 +12,14 @@ source "$SCRIPTS_ROOT/scripts/ci/lib.sh"
 
 set -euo pipefail
 
+xml_sanitize() {
+    printf '%s' "$1" | tr '&<>"'"'" ' '
+}
+
+cdata_sanitize() {
+    printf '%s' "$1" | sed 's/]]>/]] >/g'
+}
+
 if [[ "$#" -ne 2 ]]; then
     die "Usage: $0 <sarif-file> <image-name>"
 fi
@@ -56,8 +64,8 @@ Image: ${image_name}
 
 ${message}"
 
-    testcases_xml+="    <testcase name=\"${component_version}\" classname=\"${cve_id}\">
-      <failure><![CDATA[${failure_details}]]></failure>
+    testcases_xml+="    <testcase name=\"$(xml_sanitize "$component_version")\" classname=\"$(xml_sanitize "$cve_id")\">
+      <failure><![CDATA[$(cdata_sanitize "$failure_details")]]></failure>
     </testcase>
 "
     ((failure_count++)) || true
@@ -72,7 +80,7 @@ junit_file="${junit_dir}/junit-${safe_filename}.xml"
 
 if [[ $vuln_count -eq 0 ]]; then
     cat > "${junit_file}" <<EOF
-<testsuite name="${suite_name}" tests="1" skipped="0" failures="0" errors="0">
+<testsuite name="$(xml_sanitize "$suite_name")" tests="1" skipped="0" failures="0" errors="0">
   <testcase name="vulnerability-scan" classname="vulnerability-scan">
   </testcase>
 </testsuite>
@@ -80,7 +88,7 @@ EOF
     echo "No vulnerabilities found in SARIF report"
 else
     cat > "${junit_file}" <<EOF
-<testsuite name="${suite_name}" tests="${vuln_count}" skipped="0" failures="${failure_count}" errors="0">
+<testsuite name="$(xml_sanitize "$suite_name")" tests="${vuln_count}" skipped="0" failures="${failure_count}" errors="0">
 ${testcases_xml}</testsuite>
 EOF
     echo "Converted ${vuln_count} vulnerabilities from SARIF to JUnit"

--- a/scripts/ci/sarif-to-junit.sh
+++ b/scripts/ci/sarif-to-junit.sh
@@ -21,19 +21,39 @@ if [[ ! -f "$sarif_file" ]]; then
     die "SARIF file not found: $sarif_file"
 fi
 
-# Extract vulnerabilities from SARIF and create JUnit records
-# SARIF structure: .runs[].results[] contains vulnerability findings
-# Each result has ruleId (CVE), message, and level (severity)
+if [[ -z "${ARTIFACT_DIR:-}" ]]; then
+    die "ARTIFACT_DIR environment variable must be set"
+fi
 
-# Use process substitution to avoid subshell variable scope issues
+# Extract vulnerabilities from SARIF and build JUnit XML
+# SARIF structure: .runs[].results[] contains vulnerability findings
+# Each result has ruleId (CVE_component_version), message, and level (severity)
+
+# Collect all test cases
+declare -a testcases=()
 vuln_count=0
+failure_count=0
+
 while IFS=$'\t' read -r rule_id level message location; do
     if [[ -z "$rule_id" ]]; then
         continue
     fi
 
+    ((vuln_count++)) || true
+
+    # Parse rule_id: "CVE-2024-1234_nginx_1.19.0" -> CVE="CVE-2024-1234", component="nginx_1.19.0"
+    # Use the full rule_id as fallback if parsing fails
+    cve_id="${rule_id%%_*}"
+    component_version="${rule_id#*_}"
+
+    # If parsing didn't split anything, use rule_id as CVE and "unknown" as component
+    if [[ "$cve_id" == "$rule_id" ]]; then
+        cve_id="$rule_id"
+        component_version="unknown"
+    fi
+
     # Build detailed failure message with vulnerability context
-    details=$(cat <<EOF
+    failure_details=$(cat <<EOF
 Vulnerability: ${rule_id}
 Severity: ${level}
 Component: ${location}
@@ -43,15 +63,42 @@ ${message}
 EOF
     )
 
-    # Use CVE ID as both class and description for junit2jira
-    save_junit_failure "${rule_id}" "${rule_id}" "$details"
-    ((vuln_count++)) || true
+    # XML-escape the failure details (basic escaping for CDATA)
+    # CDATA can't contain ]]> so we don't need complex escaping, just use CDATA
+
+    testcases+=("$(cat <<EOF
+    <testcase name="${component_version}" classname="${cve_id}">
+      <failure><![CDATA[${failure_details}]]></failure>
+    </testcase>
+EOF
+    )")
+    ((failure_count++)) || true
 done < <(jq -r '.runs[].results[] | [.ruleId, .level, (.message.text // ""), (.locations[0].physicalLocation.artifactLocation.uri // "")] | @tsv' "$sarif_file")
 
+# Generate JUnit XML
+junit_dir="$(get_junit_misc_dir)"
+mkdir -p "${junit_dir}"
+
+# Use image name as testsuite name (sanitize for filename)
+suite_name="${image_name}"
+safe_filename="$(echo "${image_name}" | tr '/:' '_')"
+junit_file="${junit_dir}/junit-${safe_filename}.xml"
+
 if [[ $vuln_count -eq 0 ]]; then
-    # No vulnerabilities found - record success
-    save_junit_success "$(basename "$image_name")" "vulnerability scan"
+    # No vulnerabilities found - create success test suite
+    cat > "${junit_file}" <<EOF
+<testsuite name="${suite_name}" tests="1" skipped="0" failures="0" errors="0">
+  <testcase name="vulnerability-scan" classname="vulnerability-scan">
+  </testcase>
+</testsuite>
+EOF
     echo "No vulnerabilities found in SARIF report"
 else
+    # Create test suite with all vulnerability test cases
+    cat > "${junit_file}" <<EOF
+<testsuite name="${suite_name}" tests="${vuln_count}" skipped="0" failures="${failure_count}" errors="0">
+$(printf '%s\n' "${testcases[@]}")
+</testsuite>
+EOF
     echo "Converted ${vuln_count} vulnerabilities from SARIF to JUnit"
 fi

--- a/scripts/ci/sarif-to-junit.sh
+++ b/scripts/ci/sarif-to-junit.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# sarif-to-junit.sh converts SARIF vulnerability scan results to JUnit XML format
+# for integration with junit2jira. This enables individual vulnerability tracking
+# in Jira rather than just job-level failure notifications.
+#
+# Usage: sarif-to-junit.sh <sarif-file> <image-name>
+
+source "$(dirname "$0")/lib.sh"
+
+if [[ "$#" -ne 2 ]]; then
+    die "Usage: $0 <sarif-file> <image-name>"
+fi
+
+sarif_file="$1"
+image_name="$2"
+
+if [[ ! -f "$sarif_file" ]]; then
+    die "SARIF file not found: $sarif_file"
+fi
+
+# Extract vulnerabilities from SARIF and create JUnit records
+# SARIF structure: .runs[].results[] contains vulnerability findings
+# Each result has ruleId (CVE), message, and level (severity)
+
+# Use process substitution to avoid subshell variable scope issues
+vuln_count=0
+while IFS=$'\t' read -r rule_id level message location; do
+    if [[ -z "$rule_id" ]]; then
+        continue
+    fi
+
+    # Build detailed failure message with vulnerability context
+    details=$(cat <<EOF
+Vulnerability: ${rule_id}
+Severity: ${level}
+Component: ${location}
+Image: ${image_name}
+
+${message}
+EOF
+    )
+
+    # Use CVE ID as both class and description for junit2jira
+    save_junit_failure "${rule_id}" "${rule_id}" "$details"
+    ((vuln_count++)) || true
+done < <(jq -r '.runs[].results[] | [.ruleId, .level, (.message.text // ""), (.locations[0].physicalLocation.artifactLocation.uri // "")] | @tsv' "$sarif_file")
+
+if [[ $vuln_count -eq 0 ]]; then
+    # No vulnerabilities found - record success
+    save_junit_success "$(basename "$image_name")" "vulnerability scan"
+    echo "No vulnerabilities found in SARIF report"
+else
+    echo "Converted ${vuln_count} vulnerabilities from SARIF to JUnit"
+fi


### PR DESCRIPTION
## Description

Problem: The scan-images-with-roxctl job lacks failure tracking in Jira, making it harder to track and triage vulnerability scan failures across CI runs.

Solution: Integrate junit2jira action to automatically create Jira issues when vulnerability scans fail. The junit2jira action's built-in fallback mechanism (capture_job_failure_as_junit) creates synthetic JUnit records for non-test failures, enabling Jira tracking even though roxctl produces SARIF output rather than JUnit XML.

Changes:
- Added ARTIFACT_DIR env var required by capture_job_failure_as_junit
- Added junit2jira step with if: always() to capture both scan failures (critical vulnerabilities found) and infrastructure failures

Partially generated by AI.
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

You can view these issues at:
  - https://issues.redhat.com/browse/ROX-34792
  - https://issues.redhat.com/browse/ROX-34797