### PR TITLE
chore(sensor): use rate-limited logging in pubsub lanes

### DIFF
--- a/sensor/common/pubsub/lane/blocking.go
+++ b/sensor/common/pubsub/lane/blocking.go
@@ -89,7 +89,7 @@ func (l *blockingLane) run() {
 				return
 			}
 			if err := l.handleEvent(event); err != nil {
-				log.Errorf("unable to handle event: %v", err)
+				rateLimitedLog.ErrorL(l.id.String(), "unable to handle event: %v", err)
 			}
 		}
 	}

--- a/sensor/common/pubsub/lane/concurrent.go
+++ b/sensor/common/pubsub/lane/concurrent.go
@@ -112,7 +112,7 @@ func (l *concurrentLane) handleEvent(event pubsub.Event) {
 	defer metrics.SetQueueSize(l.id, l.ch.Len())
 	consumers, err := l.getConsumersByTopic(event.Topic())
 	if err != nil {
-		log.Errorf("unable to handle event: %v", err)
+		rateLimitedLog.ErrorL(l.id.String(), "unable to handle event: %v", err)
 		metrics.RecordConsumerOperation(l.id, event.Topic(), pubsub.NoConsumers, metrics.NoConsumers)
 		return
 	}
@@ -130,7 +130,7 @@ func (l *concurrentLane) handleConsumerError(errC <-chan error) {
 	case err := <-errC:
 		if err != nil {
 			// TODO: consider adding a callback to inform of the error
-			log.Errorf("unable to handle event: %v", err)
+			rateLimitedLog.ErrorL(l.id.String(), "unable to handle event: %v", err)
 		}
 	case <-l.stopper.Flow().StopRequested():
 	}

--- a/sensor/common/pubsub/lane/lane.go
+++ b/sensor/common/pubsub/lane/lane.go
@@ -7,9 +7,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/pubsub"
 )
 
-var (
-	log = logging.LoggerForModule()
-)
+var rateLimitedLog = logging.GetRateLimitedLogger()
 
 type Config[T pubsub.Lane] struct {
 	id          pubsub.LaneID


### PR DESCRIPTION
## Description

Replace plain `log.Errorf` with rate-limited `ErrorL` in blocking and concurrent pubsub lanes.
The lane ID is used as the rate-limiter bucket key so each lane is throttled independently.

This prevents log spam when errors fire on every event in a burst (e.g., no consumers registered
for a topic, or a consumer callback consistently failing) — the same pattern used by `pkg/queue`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Existing unit tests in `sensor/common/pubsub/lane/` pass (13 subtests across blocking and concurrent lanes, including error handling tests).
- The change is a drop-in replacement of the logger call; behavior is identical except for rate limiting.