### PR TITLE
ROX-34779: skip DeleteOldResults on scan watcher timeout

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -491,8 +491,10 @@ func (m *managerImpl) handleReadyScan() {
 				Observe(timeActive.Minutes())
 			delete(m.watchingScansStartTime, scanWatcherResult.WatcherID)
 		})
-		if err := watcher.DeleteOldResults(m.automaticReportingCtx, scanWatcherResult, m.checkResultDataStore); err != nil {
-			log.Errorf("unable to delete old CheckResults: %v", err)
+		if scanWatcherResult.Error == nil || errors.Is(scanWatcherResult.Error, watcher.ErrScanRemoved) {
+			if err := watcher.DeleteOldResults(m.automaticReportingCtx, scanWatcherResult, m.checkResultDataStore); err != nil {
+				log.Errorf("unable to delete old CheckResults: %v", err)
+			}
 		}
 		if errors.Is(scanWatcherResult.Error, watcher.ErrScanRemoved) {
 			log.Debugf("Scan %s was removed", scanWatcherResult.Scan.GetScanName())

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -495,6 +495,8 @@ func (m *managerImpl) handleReadyScan() {
 			if err := watcher.DeleteOldResults(m.automaticReportingCtx, scanWatcherResult, m.checkResultDataStore); err != nil {
 				log.Errorf("unable to delete old CheckResults: %v", err)
 			}
+		} else {
+			log.Debugf("Skipping DeleteOldResults for scan %s: %v", scanWatcherResult.Scan.GetScanName(), scanWatcherResult.Error)
 		}
 		if errors.Is(scanWatcherResult.Error, watcher.ErrScanRemoved) {
 			log.Debugf("Scan %s was removed", scanWatcherResult.Scan.GetScanName())

--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -282,6 +282,108 @@ func (m *ManagerTestSuite) TestFailedReportWithWatcherRunningAndNoNotifiers() {
 	handleWaitGroup(m.T(), &wg, 500*time.Millisecond, "reports to be generated")
 }
 
+func (m *ManagerTestSuite) TestHandleReadyScanDeleteOldResultsGate() {
+	now := protocompat.TimestampNow()
+	scan := &storage.ComplianceOperatorScanV2{
+		Id:              "scan-1",
+		ClusterId:       "cluster-1",
+		ScanConfigName:  "test-scan",
+		ScanRefId:       "ref-1",
+		LastStartedTime: now,
+	}
+
+	tests := map[string]struct {
+		err error
+	}{
+		"success should call DeleteOldResults": {
+			err: nil,
+		},
+		"ErrScanRemoved should call DeleteOldResults with includeCurrentResults": {
+			err: watcher.ErrScanRemoved,
+		},
+		"ErrScanTimeout should NOT call DeleteOldResults": {
+			err: watcher.ErrScanTimeout,
+		},
+		"ErrScanContextCancelled should NOT call DeleteOldResults": {
+			err: watcher.ErrScanContextCancelled,
+		},
+	}
+
+	for name, tc := range tests {
+		m.Run(name, func() {
+			ctrl := gomock.NewController(m.T())
+			checkResultDS := checkResultsMocks.NewMockDataStore(ctrl)
+			scanConfigDS := scanConfigurationDS.NewMockDataStore(ctrl)
+			scanDS := scanMocks.NewMockDataStore(ctrl)
+			profileDS := profileMocks.NewMockDataStore(ctrl)
+			snapshotDS := snapshotMocks.NewMockDataStore(ctrl)
+			integrationDS := integrationMocks.NewMockDataStore(ctrl)
+			suiteStore := suiteDS.NewMockDataStore(ctrl)
+			bindingsStore := bindingsDS.NewMockDataStore(ctrl)
+			generator := reportGen.NewMockComplianceReportGenerator(ctrl)
+
+			manager := New(scanConfigDS, scanDS, profileDS, snapshotDS, integrationDS, suiteStore, bindingsStore, checkResultDS, generator)
+			manager.Start()
+			managerImp := manager.(*managerImpl)
+
+			result := &watcher.ScanWatcherResults{
+				WatcherID: "watcher-1",
+				Scan:      scan,
+				Error:     tc.err,
+			}
+
+			done := make(chan struct{})
+			if tc.err == nil {
+				checkResultDS.EXPECT().
+					DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(false)).
+					Times(1).Return(nil)
+				scanConfigDS.EXPECT().
+					GetScanConfigurationByName(gomock.Any(), gomock.Eq(scan.GetScanConfigName())).
+					Times(1).
+					DoAndReturn(func(_ any, _ any) (*storage.ComplianceOperatorScanConfigurationV2, error) {
+						close(done)
+						return nil, errors.New("stop here")
+					})
+			} else if errors.Is(tc.err, watcher.ErrScanRemoved) {
+				// ErrScanRemoved hits continue (skips getOrCreateScanConfigWatcher),
+				// so there's no mock call we can hook into. Use DeleteOldResults
+				// DoAndReturn to signal completion instead.
+				checkResultDS.EXPECT().
+					DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(true)).
+					Times(1).
+					DoAndReturn(func(_, _, _, _ any) error {
+						close(done)
+						return nil
+					})
+			} else {
+				scanConfigDS.EXPECT().
+					GetScanConfigurationByName(gomock.Any(), gomock.Eq(scan.GetScanConfigName())).
+					Times(1).
+					DoAndReturn(func(_ any, _ any) (*storage.ComplianceOperatorScanConfigurationV2, error) {
+						close(done)
+						return nil, errors.New("stop here")
+					})
+			}
+
+			// Seed a start time entry so the metrics code doesn't panic.
+			concurrency.WithLock(&managerImp.watchingScansLock, func() {
+				managerImp.watchingScansStartTime[result.WatcherID] = time.Now()
+			})
+
+			managerImp.readyQueue.Push(result)
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				m.FailNow("timeout waiting for handleReadyScan to process the result")
+			}
+
+			manager.Stop()
+			ctrl.Finish()
+		})
+	}
+}
+
 func (m *ManagerTestSuite) TestHandleScan() {
 	m.scanConfigDataStore.EXPECT().GetScanConfigurations(gomock.Any(), gomock.Any()).AnyTimes().
 		Return(

--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -630,14 +630,11 @@ func (m *ManagerTestSuite) setupExpectCallsFromFinishAllScans(sc *storage.Compli
 
 func (m *ManagerTestSuite) setupExpectCallsFromFailAllScans(sc *storage.ComplianceOperatorScanConfigurationV2, scans []*storage.ComplianceOperatorScanV2, timestamp *timestamppb.Timestamp, numSnapshots int) []any {
 	var expectedCalls []any
-	for _, scan := range scans {
+	for range scans {
 		calls := []any{
 			m.scanConfigDataStore.EXPECT().
 				GetScanConfigurationByName(gomock.Any(), gomock.Eq(sc.GetScanConfigName())).
 				Times(1).Return(sc, nil),
-			m.checkResultDataStore.EXPECT().
-				DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(true)).
-				Times(1).Return(nil),
 			m.snapshotDataStore.EXPECT().
 				UpsertSnapshot(gomock.Any(), gomock.Any()).
 				Times(numSnapshots).Return(nil),

--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -293,19 +293,59 @@ func (m *ManagerTestSuite) TestHandleReadyScanDeleteOldResultsGate() {
 	}
 
 	tests := map[string]struct {
-		err error
+		err      error
+		expectFn func(done chan struct{}, checkResultDS *checkResultsMocks.MockDataStore, scanConfigDS *scanConfigurationDS.MockDataStore)
 	}{
 		"success should call DeleteOldResults": {
 			err: nil,
+			expectFn: func(done chan struct{}, checkResultDS *checkResultsMocks.MockDataStore, scanConfigDS *scanConfigurationDS.MockDataStore) {
+				checkResultDS.EXPECT().
+					DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(false)).
+					Times(1).Return(nil)
+				scanConfigDS.EXPECT().
+					GetScanConfigurationByName(gomock.Any(), gomock.Eq(scan.GetScanConfigName())).
+					Times(1).
+					DoAndReturn(func(_ any, _ any) (*storage.ComplianceOperatorScanConfigurationV2, error) {
+						close(done)
+						return nil, errors.New("stop here")
+					})
+			},
 		},
 		"ErrScanRemoved should call DeleteOldResults with includeCurrentResults": {
 			err: watcher.ErrScanRemoved,
+			expectFn: func(done chan struct{}, checkResultDS *checkResultsMocks.MockDataStore, scanConfigDS *scanConfigurationDS.MockDataStore) {
+				checkResultDS.EXPECT().
+					DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(true)).
+					Times(1).
+					DoAndReturn(func(_, _, _, _ any) error {
+						close(done)
+						return nil
+					})
+			},
 		},
 		"ErrScanTimeout should NOT call DeleteOldResults": {
 			err: watcher.ErrScanTimeout,
+			expectFn: func(done chan struct{}, checkResultDS *checkResultsMocks.MockDataStore, scanConfigDS *scanConfigurationDS.MockDataStore) {
+				scanConfigDS.EXPECT().
+					GetScanConfigurationByName(gomock.Any(), gomock.Eq(scan.GetScanConfigName())).
+					Times(1).
+					DoAndReturn(func(_ any, _ any) (*storage.ComplianceOperatorScanConfigurationV2, error) {
+						close(done)
+						return nil, errors.New("stop here")
+					})
+			},
 		},
 		"ErrScanContextCancelled should NOT call DeleteOldResults": {
 			err: watcher.ErrScanContextCancelled,
+			expectFn: func(done chan struct{}, checkResultDS *checkResultsMocks.MockDataStore, scanConfigDS *scanConfigurationDS.MockDataStore) {
+				scanConfigDS.EXPECT().
+					GetScanConfigurationByName(gomock.Any(), gomock.Eq(scan.GetScanConfigName())).
+					Times(1).
+					DoAndReturn(func(_ any, _ any) (*storage.ComplianceOperatorScanConfigurationV2, error) {
+						close(done)
+						return nil, errors.New("stop here")
+					})
+			},
 		},
 	}
 
@@ -333,37 +373,7 @@ func (m *ManagerTestSuite) TestHandleReadyScanDeleteOldResultsGate() {
 			}
 
 			done := make(chan struct{})
-			if tc.err == nil {
-				checkResultDS.EXPECT().
-					DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(false)).
-					Times(1).Return(nil)
-				scanConfigDS.EXPECT().
-					GetScanConfigurationByName(gomock.Any(), gomock.Eq(scan.GetScanConfigName())).
-					Times(1).
-					DoAndReturn(func(_ any, _ any) (*storage.ComplianceOperatorScanConfigurationV2, error) {
-						close(done)
-						return nil, errors.New("stop here")
-					})
-			} else if errors.Is(tc.err, watcher.ErrScanRemoved) {
-				// ErrScanRemoved hits continue (skips getOrCreateScanConfigWatcher),
-				// so there's no mock call we can hook into. Use DeleteOldResults
-				// DoAndReturn to signal completion instead.
-				checkResultDS.EXPECT().
-					DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(true)).
-					Times(1).
-					DoAndReturn(func(_, _, _, _ any) error {
-						close(done)
-						return nil
-					})
-			} else {
-				scanConfigDS.EXPECT().
-					GetScanConfigurationByName(gomock.Any(), gomock.Eq(scan.GetScanConfigName())).
-					Times(1).
-					DoAndReturn(func(_ any, _ any) (*storage.ComplianceOperatorScanConfigurationV2, error) {
-						close(done)
-						return nil, errors.New("stop here")
-					})
-			}
+			tc.expectFn(done, checkResultDS, scanConfigDS)
 
 			// Seed a start time entry so the metrics code doesn't panic.
 			concurrency.WithLock(&managerImp.watchingScansLock, func() {


### PR DESCRIPTION
## Description

Clusters intermittently disappear from the compliance coverage dashboard. The root cause is that `handleReadyScan` calls `DeleteOldResults` unconditionally when a scan watcher finishes — including on timeout. A timeout means the watcher couldn't confirm scan completion (check result count didn't match the expected total); it does NOT mean the existing data is invalid. But the unconditional deletion removes all check results for the scan, and since the dashboard is a live `GROUP BY cluster_id` query on the `compliance_operator_check_result_v2` table (no cache or materialized view), the cluster vanishes immediately.

### Root cause

The scan watcher lifecycle for rescans works as follows:

1. A scan completes — the DONE event carries `check-count > 0` (annotation persists from the previous run).
2. The `getWatcher` guard (`!found && numChecks == 0`) intentionally drops this event to prevent zombie watchers.
3. Check results arrive and create the watcher (HandleResult always passes numChecks=0).
4. A second DONE event eventually reaches the existing watcher and sets `totalChecks`.
5. If `totalChecks == numCheckResults`, the watcher completes successfully.
6. If `totalChecks != numCheckResults` (count mismatch), the watcher times out after 40 minutes.

On timeout, `handleReadyScan` called `DeleteOldResults` unconditionally, which resulted in the cluster disappears from the dashboard until the next successful scan produces fresh results.

### Evidence from production (ACS 4.10.2)

Customer diagnostic bundles show 13 scan watcher timeouts in a ~7-hour window. 10 had empty scan names (harmless — nil `Scan` field means `DeleteOldResults` returns early on empty `scanRefId`). Three had real scan names:

```
scanwatcher.go:284: Warn: Timeout waiting for the scan ocp4-cis to finish
manager_impl.go:562: Warn: The scan configuration <config> has not configured notifiers
scanwatcher.go:284: Warn: Timeout waiting for the scan ocp4-cis-node-master to finish
scanwatcher.go:284: Warn: Timeout waiting for the scan ocp4-cis-node-worker to finish
```

The timeout log (scanwatcher.go:283) prints `s.scanResults.Scan.GetScanName()`. A non-empty value proves the `Scan` field is populated (protobuf getters return zero value on nil receivers), which means `ScanRefId` and `LastStartedTime` are also set (populated via `handleScan` from a scan event). On 4.10.2 (commit 697d392ea2), these timeouts call `DeleteOldResults` unconditionally with `includeCurrentResults = true`, deleting all check results for those scans.

Customer observations match this mechanism:
- Clusters disappear after 8 hours or 1 day (depends on timeout + scan cycle timing).
- Different clusters disappear each time (depends on which scans hit a count mismatch).
- Triggering a rescan brings results back (new scan produces fresh check results).

### What changed

Gate `DeleteOldResults` in `handleReadyScan` so it is only called on success (`Error == nil`) or explicit scan removal (`ErrScanRemoved`). On timeout (`ErrScanTimeout`) or context cancellation (`ErrScanContextCancelled`), the call is skipped entirely. Old results remain visible until the next successful scan replaces them.

The `DeleteOldResults` function in `scanwatcher.go` is left unchanged — its `includeCurrentResults` logic (`results.Error != nil`) produces the correct value for the two cases that now reach it: success (`false`, preserves current results via `< $2`) and scan removal (`true`, cleans up everything via `<= $2`).

### Alternatives considered

- **Also narrow `includeCurrentResults` in `DeleteOldResults`**: We considered changing the condition from `results.Error != nil` to `errors.Is(results.Error, ErrScanRemoved)` as defense-in-depth. Dropped because the gate in `handleReadyScan` already prevents timeout/cancellation from reaching `DeleteOldResults`, making the narrowing redundant. The existing logic produces the correct value for the two remaining cases.
- **Remove the `getWatcher` guard entirely**: Would allow DONE events to create watchers directly, but the guard is intentional — it prevents zombie watchers in the no-notifier case. Not changed.
- **Fix the count mismatch root cause**: The reason `totalChecks != numCheckResults` on some clusters is still unknown (would need debug-level Central logs during a timeout). But the timeout behavior is wrong regardless — deleting results because a count didn't match is incorrect. This fix is orthogonal.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

**Bug reproduction (master binary, `ROX_COMPLIANCE_SCAN_WATCHER_TIMEOUT=120s`, forced timeouts via `totalChecks=9999`):**

Deployed master Central (unpatched) with instrumentation to force watcher timeouts. Triggered rescan on scan config with 240 results. All 3 scan watchers timed out (ocp4-cis, ocp4-cis-node-master, ocp4-cis-node-worker), `DeleteOldResults` called with `includeCurrentResults=true`, all results deleted:

```
[15:24:37] 240 (baseline)
[15:28:54] 0   (all results deleted — clusters disappear)
```

Central logs confirm the mechanism:
```
scanwatcher.go:283: Warn: Timeout waiting for the scan ocp4-cis-node-worker to finish
scanwatcher.go:283: Warn: Timeout waiting for the scan ocp4-cis to finish
scanwatcher.go:283: Warn: Timeout waiting for the scan ocp4-cis-node-master to finish
```

**Fix verification (fix branch binary, same 120s timeout, same forced timeouts):**

Deployed fixed Central with same `totalChecks=9999` instrumentation. Triggered rescan. All 3 watchers timed out at the same 120s mark, but `DeleteOldResults` was NOT called. Results remained at 240 through the entire timeout window and beyond:

```
[15:44:04] 240
[15:44:34] 240
[15:45:06] 240  (timeout fires at 15:45:55 — no effect)
[15:45:37] 240
[15:46:08] 240
[15:46:39] 240
[15:47:11] 240
[15:47:43] 240
[15:48:23] 240
[15:48:54] 240
[15:49:25] 240
[15:49:56] 240
[15:50:27] 240
[15:50:59] 240
```

Central logs confirm timeouts occurred but no deletion:
```
scanwatcher.go:283: Warn: Timeout waiting for the scan ocp4-cis-node-worker to finish
scanwatcher.go:283: Warn: Timeout waiting for the scan ocp4-cis to finish
scanwatcher.go:283: Warn: Timeout waiting for the scan ocp4-cis-node-master to finish
```
Zero `DeleteOldResults` calls in the log.

**Unit tests:** `TestHandleReadyScanDeleteOldResultsGate` added — table-driven test that pushes `ScanWatcherResults` directly to the manager's `readyQueue` with each error type and verifies via gomock strict mode that `DeleteOldResults` is called only for success and `ErrScanRemoved`, and not called for `ErrScanTimeout` or `ErrScanContextCancelled`. `TestFailedReportWithWatcherRunningAndNoNotifiers` updated — no longer expects `DeleteOldResults` to be called on watcher timeout.