### PR TITLE
ROX-29480: Log Sensor egress proxy for Central

### DIFF
--- a/pkg/httputil/proxy/proxy.go
+++ b/pkg/httputil/proxy/proxy.go
@@ -99,6 +99,26 @@ func TransportFunc(req *http.Request) (*url.URL, error) {
 	return FromConfig()(req)
 }
 
+// ProxyHostForURL returns the proxy host:port used for the given URL, or an
+// empty string if the request would connect directly.
+func ProxyHostForURL(endpoint string) string {
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		log.Warnf("Failed to build request for proxy lookup: %v", err)
+		return ""
+	}
+
+	proxyURL, err := TransportFunc(req)
+	if err != nil {
+		log.Warnf("Failed to resolve proxy for %s: %v", endpoint, err)
+		return ""
+	}
+	if proxyURL == nil {
+		return ""
+	}
+	return proxyURL.Host
+}
+
 // Without is a ProxyFunc for http.Transport that will always attempt a direct connection.
 func Without(options ...Option) http.RoundTripper {
 	transport := copyDefaultTransport()

--- a/pkg/httputil/proxy/proxy.go
+++ b/pkg/httputil/proxy/proxy.go
@@ -101,22 +101,22 @@ func TransportFunc(req *http.Request) (*url.URL, error) {
 
 // ProxyHostForURL returns the proxy host:port used for the given URL, or an
 // empty string if the request would connect directly.
-func ProxyHostForURL(endpoint string) string {
+func ProxyHostForURL(endpoint string) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
 		log.Warnf("Failed to build request for proxy lookup: %v", err)
-		return ""
+		return "", err
 	}
 
 	proxyURL, err := TransportFunc(req)
 	if err != nil {
 		log.Warnf("Failed to resolve proxy for %s: %v", endpoint, err)
-		return ""
+		return "", err
 	}
 	if proxyURL == nil {
-		return ""
+		return "", nil
 	}
-	return proxyURL.Host
+	return proxyURL.Host, nil
 }
 
 // Without is a ProxyFunc for http.Transport that will always attempt a direct connection.

--- a/pkg/httputil/proxy/proxy.go
+++ b/pkg/httputil/proxy/proxy.go
@@ -104,13 +104,11 @@ func TransportFunc(req *http.Request) (*url.URL, error) {
 func ProxyHostForURL(endpoint string) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
-		log.Warnf("Failed to build request for proxy lookup: %v", err)
 		return "", err
 	}
 
 	proxyURL, err := TransportFunc(req)
 	if err != nil {
-		log.Warnf("Failed to resolve proxy for %s: %v", endpoint, err)
 		return "", err
 	}
 	if proxyURL == nil {

--- a/pkg/httputil/proxy/proxy_host_test.go
+++ b/pkg/httputil/proxy/proxy_host_test.go
@@ -22,7 +22,8 @@ func TestProxyHostForURL(t *testing.T) {
 	tests := map[string]struct {
 		envCfg   environmentConfig
 		endpoint string
-		want     string
+		wantHost string
+		wantErr  string
 	}{
 		"should return proxy host when https proxy matches": {
 			envCfg: environmentConfig{
@@ -31,7 +32,7 @@ func TestProxyHostForURL(t *testing.T) {
 				},
 			},
 			endpoint: "https://central.example.com:443",
-			want:     "proxy.example.com:3128",
+			wantHost: "proxy.example.com:3128",
 		},
 		"should return empty string when host is excluded by no proxy": {
 			envCfg: environmentConfig{
@@ -41,33 +42,42 @@ func TestProxyHostForURL(t *testing.T) {
 				},
 			},
 			endpoint: "https://central.example.com:443",
-			want:     "",
+			wantHost: "",
 		},
 		"should return empty string when no proxy is configured": {
 			envCfg:   environmentConfig{},
 			endpoint: "https://central.example.com:443",
-			want:     "",
+			wantHost: "",
+		},
+		"should return error when request creation fails": {
+			endpoint: "://bad-url",
+			wantErr:  `parse "://bad-url": missing protocol scheme`,
+		},
+		"should return error when proxy resolution fails": {
+			endpoint: "https://central.example.com:443",
+			wantErr:  "proxy lookup failed",
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			globalProxyConfig.Store((&proxyConfig{OmitDefaultExcludes: true}).Compile(tc.envCfg))
-			assert.Equal(t, tc.want, ProxyHostForURL(tc.endpoint))
+			if tc.wantErr == "proxy lookup failed" {
+				globalProxyConfig.Store(&compiledConfig{
+					httpsFunc: func(*url.URL) (*url.URL, error) {
+						return nil, errors.New("proxy lookup failed")
+					},
+				})
+			} else {
+				globalProxyConfig.Store((&proxyConfig{OmitDefaultExcludes: true}).Compile(tc.envCfg))
+			}
+
+			gotHost, err := ProxyHostForURL(tc.endpoint)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.wantErr)
+			}
+			assert.Equal(t, tc.wantHost, gotHost)
 		})
 	}
-
-	t.Run("should return empty string when request creation fails", func(t *testing.T) {
-		assert.Equal(t, "", ProxyHostForURL("://bad-url"))
-	})
-
-	t.Run("should return empty string when proxy resolution fails", func(t *testing.T) {
-		globalProxyConfig.Store(&compiledConfig{
-			httpsFunc: func(*url.URL) (*url.URL, error) {
-				return nil, errors.New("proxy lookup failed")
-			},
-		})
-
-		assert.Equal(t, "", ProxyHostForURL("https://central.example.com:443"))
-	})
 }

--- a/pkg/httputil/proxy/proxy_host_test.go
+++ b/pkg/httputil/proxy/proxy_host_test.go
@@ -1,0 +1,73 @@
+package proxy
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/http/httpproxy"
+)
+
+func TestProxyHostForURL(t *testing.T) {
+	prev, _ := globalProxyConfig.Load().(*compiledConfig)
+	t.Cleanup(func() {
+		if prev != nil {
+			globalProxyConfig.Store(prev)
+			return
+		}
+		globalProxyConfig.Store(defaultProxyConfig)
+	})
+
+	tests := map[string]struct {
+		envCfg   environmentConfig
+		endpoint string
+		want     string
+	}{
+		"should return proxy host when https proxy matches": {
+			envCfg: environmentConfig{
+				Config: httpproxy.Config{
+					HTTPSProxy: "http://proxy.example.com:3128",
+				},
+			},
+			endpoint: "https://central.example.com:443",
+			want:     "proxy.example.com:3128",
+		},
+		"should return empty string when host is excluded by no proxy": {
+			envCfg: environmentConfig{
+				Config: httpproxy.Config{
+					HTTPSProxy: "http://proxy.example.com:3128",
+					NoProxy:    "central.example.com",
+				},
+			},
+			endpoint: "https://central.example.com:443",
+			want:     "",
+		},
+		"should return empty string when no proxy is configured": {
+			envCfg:   environmentConfig{},
+			endpoint: "https://central.example.com:443",
+			want:     "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			globalProxyConfig.Store((&proxyConfig{OmitDefaultExcludes: true}).Compile(tc.envCfg))
+			assert.Equal(t, tc.want, ProxyHostForURL(tc.endpoint))
+		})
+	}
+
+	t.Run("should return empty string when request creation fails", func(t *testing.T) {
+		assert.Equal(t, "", ProxyHostForURL("://bad-url"))
+	})
+
+	t.Run("should return empty string when proxy resolution fails", func(t *testing.T) {
+		globalProxyConfig.Store(&compiledConfig{
+			httpsFunc: func(*url.URL) (*url.URL, error) {
+				return nil, errors.New("proxy lookup failed")
+			},
+		})
+
+		assert.Equal(t, "", ProxyHostForURL("https://central.example.com:443"))
+	})
+}

--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -95,12 +95,16 @@ func NewClient(endpoint string) (*Client, error) {
 		},
 		Timeout: requestTimeout,
 	}
-	if proxyHost := proxy.ProxyHostForURL(endpoint); proxyHost != "" {
+	proxyHost, err := proxy.ProxyHostForURL(endpoint)
+	if err != nil {
+		log.Warnf("Central connection proxy lookup failed for %q: %v", endpoint, err)
+		setProxyToCentralMetric("", true)
+	} else if proxyHost != "" {
 		log.Infof("Central connection uses egress proxy %q", proxyHost)
-		setProxyToCentralMetric(proxyHost)
+		setProxyToCentralMetric(proxyHost, false)
 	} else {
 		log.Infof("Central connection uses direct connection (no proxy)")
-		setProxyToCentralMetric("")
+		setProxyToCentralMetric("", false)
 	}
 
 	return &Client{

--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -95,6 +95,13 @@ func NewClient(endpoint string) (*Client, error) {
 		},
 		Timeout: requestTimeout,
 	}
+	if proxyHost := proxy.ProxyHostForURL(endpoint); proxyHost != "" {
+		log.Infof("Central connection uses egress proxy %q", proxyHost)
+		setProxyToCentralMetric(proxyHost)
+	} else {
+		log.Infof("Central connection uses direct connection (no proxy)")
+		setProxyToCentralMetric("")
+	}
 
 	return &Client{
 		httpClient:     httpClient,

--- a/sensor/common/centralclient/metrics.go
+++ b/sensor/common/centralclient/metrics.go
@@ -1,0 +1,35 @@
+package centralclient
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/metrics"
+)
+
+var proxyToCentralEnabled = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: metrics.PrometheusNamespace,
+	Subsystem: metrics.SensorSubsystem.String(),
+	Name:      "proxy_to_central_enabled",
+	Help:      "Indicates whether Sensor connects to Central via an egress proxy. Value 1 means proxy is used.",
+})
+
+var proxyToCentralInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: metrics.PrometheusNamespace,
+	Subsystem: metrics.SensorSubsystem.String(),
+	Name:      "proxy_to_central_info",
+	Help:      "Reports whether Sensor connects to Central through a proxy or directly via the address label.",
+}, []string{"address"})
+
+func init() {
+	metrics.EmplaceCollector(proxyToCentralEnabled, proxyToCentralInfo)
+}
+
+func setProxyToCentralMetric(proxyHost string) {
+	proxyToCentralInfo.Reset()
+	if proxyHost != "" {
+		proxyToCentralEnabled.Set(1)
+		proxyToCentralInfo.WithLabelValues(proxyHost).Set(1)
+		return
+	}
+	proxyToCentralEnabled.Set(0)
+	proxyToCentralInfo.WithLabelValues("direct").Set(1)
+}

--- a/sensor/common/centralclient/metrics.go
+++ b/sensor/common/centralclient/metrics.go
@@ -23,8 +23,13 @@ func init() {
 	metrics.EmplaceCollector(proxyToCentralEnabled, proxyToCentralInfo)
 }
 
-func setProxyToCentralMetric(proxyHost string) {
+func setProxyToCentralMetric(proxyHost string, lookupFailed bool) {
 	proxyToCentralInfo.Reset()
+	if lookupFailed {
+		proxyToCentralEnabled.Set(0)
+		proxyToCentralInfo.WithLabelValues("unknown").Set(1)
+		return
+	}
 	if proxyHost != "" {
 		proxyToCentralEnabled.Set(1)
 		proxyToCentralInfo.WithLabelValues(proxyHost).Set(1)

--- a/sensor/common/centralclient/metrics_test.go
+++ b/sensor/common/centralclient/metrics_test.go
@@ -10,6 +10,7 @@ import (
 func TestSetProxyToCentralMetric(t *testing.T) {
 	tests := map[string]struct {
 		inputProxyHost string
+		lookupFailed   bool
 		wantEnabled    float64
 		wantInfoLabel  string
 	}{
@@ -23,10 +24,11 @@ func TestSetProxyToCentralMetric(t *testing.T) {
 			wantEnabled:    0,
 			wantInfoLabel:  "direct",
 		},
-		"literal direct value is treated as a proxy label": {
-			inputProxyHost: "direct",
-			wantEnabled:    1,
-			wantInfoLabel:  "direct",
+		"lookup failure reports unknown connection": {
+			inputProxyHost: "",
+			lookupFailed:   true,
+			wantEnabled:    0,
+			wantInfoLabel:  "unknown",
 		},
 	}
 
@@ -39,7 +41,7 @@ func TestSetProxyToCentralMetric(t *testing.T) {
 				proxyToCentralInfo.Reset()
 			})
 
-			setProxyToCentralMetric(tc.inputProxyHost)
+			setProxyToCentralMetric(tc.inputProxyHost, tc.lookupFailed)
 
 			assert.Equal(t, tc.wantEnabled, testutil.ToFloat64(proxyToCentralEnabled))
 			assert.Equal(t, 1.0, testutil.ToFloat64(proxyToCentralInfo.WithLabelValues(tc.wantInfoLabel)))

--- a/sensor/common/centralclient/metrics_test.go
+++ b/sensor/common/centralclient/metrics_test.go
@@ -1,0 +1,48 @@
+package centralclient
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetProxyToCentralMetric(t *testing.T) {
+	tests := map[string]struct {
+		inputProxyHost string
+		wantEnabled    float64
+		wantInfoLabel  string
+	}{
+		"proxy host enables proxy metrics": {
+			inputProxyHost: "proxy.example.com:3128",
+			wantEnabled:    1,
+			wantInfoLabel:  "proxy.example.com:3128",
+		},
+		"empty proxy host reports direct connection": {
+			inputProxyHost: "",
+			wantEnabled:    0,
+			wantInfoLabel:  "direct",
+		},
+		"literal direct value is treated as a proxy label": {
+			inputProxyHost: "direct",
+			wantEnabled:    1,
+			wantInfoLabel:  "direct",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			proxyToCentralEnabled.Set(-1)
+			proxyToCentralInfo.Reset()
+			t.Cleanup(func() {
+				proxyToCentralEnabled.Set(0)
+				proxyToCentralInfo.Reset()
+			})
+
+			setProxyToCentralMetric(tc.inputProxyHost)
+
+			assert.Equal(t, tc.wantEnabled, testutil.ToFloat64(proxyToCentralEnabled))
+			assert.Equal(t, 1.0, testutil.ToFloat64(proxyToCentralInfo.WithLabelValues(tc.wantInfoLabel)))
+		})
+	}
+}


### PR DESCRIPTION
## Description

Sensor already uses the shared egress proxy configuration for its HTTP connection
to Central, but it did not expose whether that path was proxied or direct.

This change adds:

- a small helper in `pkg/httputil/proxy` to resolve which proxy host would be
  used for a Central URL without making a network connection
- startup logging in `sensor/common/centralclient` for both proxied and direct
  Central connections
- Prometheus metrics for both the boolean state and connection metadata:
  `rox_sensor_proxy_to_central_enabled` and
  `rox_sensor_proxy_to_central_info{address=...}`

This keeps the signal easy to debug while avoiding logging credentials by only
recording `proxyURL.Host`.

AI-Assisted: cursor, implementation and tests for Sensor proxy observability

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Unit tests & CI only
- Manual on a cluster

#### Regular deployment

Sensor logs:
```
common/centralclient: 2026/05/27 11:23:13.407543 client.go:106: Info: Central connection uses direct connection (no proxy)
```
