### PR TITLE
ROX-34352: Move checks within retry

### DIFF
--- a/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
@@ -121,23 +121,21 @@ class DeploymentCheck extends BaseSpecification {
                 build()
         policyID = PolicyService.createNewPolicy(policy)
 
-        when:
+        then:
         withRetry(20, 5) {
             res = DetectionService.getDetectDeploytimeFromYAML(req)
+            assert res
+            assert res.getRemarks(0).getName() == DEPLOYMENT_CHECK
+            assert res.getRunsCount() == 1
+            def run = res.getRuns(0)
+            assert run
+            assert run.getAlertsCount() == 1
+            def alert = run.getAlerts(0)
+            assert alert
+            assert alert.getPolicy().getName() == DEPLOYMENT_CHECK
+            assert alert.getPolicy().getCategoriesCount() == 1
+            assert alert.getPolicy().getCategories(0) == DEPLOYMENT_CHECK_POLICY_CATEGORY
         }
-
-        then:
-        assert res
-        assert res.getRemarks(0).getName() == DEPLOYMENT_CHECK
-        assert res.getRunsCount() == 1
-        def run = res.getRuns(0)
-        assert run
-        assert run.getAlertsCount() == 1
-        def alert = run.getAlerts(0)
-        assert alert
-        assert alert.getPolicy().getName() == DEPLOYMENT_CHECK
-        assert alert.getPolicy().getCategoriesCount() == 1
-        assert alert.getPolicy().getCategories(0) == DEPLOYMENT_CHECK_POLICY_CATEGORY
     }
 
     @Tag("BAT")
@@ -153,19 +151,18 @@ class DeploymentCheck extends BaseSpecification {
         def req = builder.build()
         DetectionServiceOuterClass.DeployDetectionResponse res
 
-        when:
+        then:
         withRetry(20, 5) {
             res = DetectionService.getDetectDeploytimeFromYAML(req)
-        }
-        log.info "Got remarks:\n ${res.remarksList}"
+            log.info "Got remarks:\n ${res.remarksList}"
 
-        then:
-        assert res
-        assert res.getRemarksList().size() == 1
-        assert res.getRemarks(0).getName() == DEPLOYMENT_CHECK
-        assert res.getRemarks(0).getPermissionLevel() == Rbac.PermissionLevel.CLUSTER_ADMIN.toString()
-        assert res.getRemarks(0).getAppliedNetworkPoliciesList().size() == 1
-        assert res.getRemarks(0).getAppliedNetworkPolicies(0) == DEPLOYMENT_CHECK
+            assert res
+            assert res.getRemarksList().size() == 1
+            assert res.getRemarks(0).getName() == DEPLOYMENT_CHECK
+            assert res.getRemarks(0).getPermissionLevel() == Rbac.PermissionLevel.CLUSTER_ADMIN.toString()
+            assert res.getRemarks(0).getAppliedNetworkPoliciesList().size() == 1
+            assert res.getRemarks(0).getAppliedNetworkPolicies(0) == DEPLOYMENT_CHECK
+        }
     }
 
     @Tag("BAT")
@@ -184,17 +181,16 @@ class DeploymentCheck extends BaseSpecification {
         def req = builder.build()
         DetectionServiceOuterClass.DeployDetectionResponse res
 
-        when:
+        then:
         withRetry(20, 5) {
             res = DetectionService.getDetectDeploytimeFromYAML(req)
-        }
-        log.info "Got remarks:\n ${res.remarksList}"
+            log.info "Got remarks:\n ${res.remarksList}"
 
-        then:
-        assert res
-        assert res.getRemarksList().size() == 2
-        assert !res.getRemarksList().findAll { it.getName() == DEPLOYMENT_CHECK }.isEmpty()
-        assert !res.getRemarksList().findAll { it.getName() == secondDeployment }.isEmpty()
+            assert res
+            assert res.getRemarksList().size() == 2
+            assert !res.getRemarksList().findAll { it.getName() == DEPLOYMENT_CHECK }.isEmpty()
+            assert !res.getRemarksList().findAll { it.getName() == secondDeployment }.isEmpty()
+        }
     }
 
     static String createDeploymentYaml(String deploymentName, String namespace,

--- a/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
+++ b/qa-tests-backend/src/test/groovy/DeploymentCheck.groovy
@@ -121,20 +121,21 @@ class DeploymentCheck extends BaseSpecification {
                 build()
         policyID = PolicyService.createNewPolicy(policy)
 
-        then:
+        expect:
         withRetry(20, 5) {
             res = DetectionService.getDetectDeploytimeFromYAML(req)
-            assert res
-            assert res.getRemarks(0).getName() == DEPLOYMENT_CHECK
-            assert res.getRunsCount() == 1
-            def run = res.getRuns(0)
-            assert run
-            assert run.getAlertsCount() == 1
-            def alert = run.getAlerts(0)
-            assert alert
-            assert alert.getPolicy().getName() == DEPLOYMENT_CHECK
-            assert alert.getPolicy().getCategoriesCount() == 1
-            assert alert.getPolicy().getCategories(0) == DEPLOYMENT_CHECK_POLICY_CATEGORY
+            verifyAll(res) {
+                getRemarks(0).getName() == DEPLOYMENT_CHECK
+                getRunsCount() == 1
+                verifyAll(getRuns(0)) {
+                    getAlertsCount() == 1
+                    verifyAll(getAlerts(0).getPolicy()) {
+                        getName() == DEPLOYMENT_CHECK
+                        getCategoriesCount() == 1
+                        getCategories(0) == DEPLOYMENT_CHECK_POLICY_CATEGORY
+                    }
+                }
+            }
         }
     }
 
@@ -151,17 +152,20 @@ class DeploymentCheck extends BaseSpecification {
         def req = builder.build()
         DetectionServiceOuterClass.DeployDetectionResponse res
 
-        then:
+        expect:
         withRetry(20, 5) {
             res = DetectionService.getDetectDeploytimeFromYAML(req)
             log.info "Got remarks:\n ${res.remarksList}"
 
-            assert res
-            assert res.getRemarksList().size() == 1
-            assert res.getRemarks(0).getName() == DEPLOYMENT_CHECK
-            assert res.getRemarks(0).getPermissionLevel() == Rbac.PermissionLevel.CLUSTER_ADMIN.toString()
-            assert res.getRemarks(0).getAppliedNetworkPoliciesList().size() == 1
-            assert res.getRemarks(0).getAppliedNetworkPolicies(0) == DEPLOYMENT_CHECK
+            verifyAll(res) {
+                getRemarksList().size() == 1
+                verifyAll(getRemarks(0)) {
+                    getName() == DEPLOYMENT_CHECK
+                    getPermissionLevel() == Rbac.PermissionLevel.CLUSTER_ADMIN.toString()
+                    getAppliedNetworkPoliciesList().size() == 1
+                    getAppliedNetworkPolicies(0) == DEPLOYMENT_CHECK
+                }
+            }
         }
     }
 
@@ -181,15 +185,16 @@ class DeploymentCheck extends BaseSpecification {
         def req = builder.build()
         DetectionServiceOuterClass.DeployDetectionResponse res
 
-        then:
+        expect:
         withRetry(20, 5) {
             res = DetectionService.getDetectDeploytimeFromYAML(req)
             log.info "Got remarks:\n ${res.remarksList}"
 
-            assert res
-            assert res.getRemarksList().size() == 2
-            assert !res.getRemarksList().findAll { it.getName() == DEPLOYMENT_CHECK }.isEmpty()
-            assert !res.getRemarksList().findAll { it.getName() == secondDeployment }.isEmpty()
+            verifyAll(res) {
+                getRemarksList().size() == 2
+                !getRemarksList().findAll { it.getName() == DEPLOYMENT_CHECK }.isEmpty()
+                !getRemarksList().findAll { it.getName() == secondDeployment }.isEmpty()
+            }
         }
     }
 


### PR DESCRIPTION
## Description

In this case we have a situation where role binding is created in test setup and deployment is created in test. We could have a case where deployment is actually synced between sensor and central before syncing of RBAC. And with that we could have a situation that information about permission is incorrect. So we simply should wait a little bit longer.

This PR is simply moving all checks within retry loop.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] Run tests in CI
