### PR TITLE
ROX-32944: add caller hint to cursor names for traceability

### DIFF
--- a/central/image/datastore/store/v2/postgres/store.go
+++ b/central/image/datastore/store/v2/postgres/store.go
@@ -856,7 +856,7 @@ func (s *storeImpl) WalkByQuery(ctx context.Context, q *v1.Query, fn func(image 
 		}
 		return nil
 	}
-	err = pgSearch.RunCursorQueryForSchemaFn(ctx, pkgSchema.ImagesSchema, q, s.db, callback)
+	err = pgSearch.RunCursorQueryForSchemaFn(ctx, pkgSchema.ImagesSchema, q, s.db, "WalkByQuery", callback)
 	if err != nil {
 		return errors.Wrap(err, "cursor by query")
 	}
@@ -868,7 +868,7 @@ func (s *storeImpl) WalkMetadataByQuery(ctx context.Context, q *v1.Query, fn fun
 
 	q = applyDefaultSort(q)
 
-	err := pgSearch.RunCursorQueryForSchemaFn(ctx, pkgSchema.ImagesSchema, q, s.db, fn)
+	err := pgSearch.RunCursorQueryForSchemaFn(ctx, pkgSchema.ImagesSchema, q, s.db, "WalkMetadataByQuery", fn)
 	if err != nil {
 		return errors.Wrap(err, "cursor by query")
 	}

--- a/central/imagev2/datastore/store/postgres/store.go
+++ b/central/imagev2/datastore/store/postgres/store.go
@@ -874,7 +874,7 @@ func (s *storeImpl) WalkByQuery(ctx context.Context, q *v1.Query, fn func(image 
 		}
 		return nil
 	}
-	err = pgSearch.RunCursorQueryForSchemaFn(ctx, pkgSchema.ImagesV2Schema, q, s.db, callback)
+	err = pgSearch.RunCursorQueryForSchemaFn(ctx, pkgSchema.ImagesV2Schema, q, s.db, "WalkByQuery", callback)
 	if err != nil {
 		return errors.Wrap(err, "cursor by query")
 	}
@@ -886,7 +886,7 @@ func (s *storeImpl) WalkMetadataByQuery(ctx context.Context, q *v1.Query, fn fun
 
 	q = s.applyDefaultSort(q)
 
-	err := pgSearch.RunCursorQueryForSchemaFn(ctx, pkgSchema.ImagesV2Schema, q, s.db, fn)
+	err := pgSearch.RunCursorQueryForSchemaFn(ctx, pkgSchema.ImagesV2Schema, q, s.db, "WalkMetadataByQuery", fn)
 	if err != nil {
 		return errors.Wrap(err, "cursor by query")
 	}

--- a/central/node/datastore/store/postgres/store.go
+++ b/central/node/datastore/store/postgres/store.go
@@ -900,7 +900,7 @@ func (s *storeImpl) WalkByQuery(ctx context.Context, q *v1.Query, fn func(node *
 		return nil
 	}
 
-	err = pgSearch.RunCursorQueryForSchemaFn(ctx, pkgSchema.NodesSchema, q, s.db, callback)
+	err = pgSearch.RunCursorQueryForSchemaFn(ctx, pkgSchema.NodesSchema, q, s.db, "WalkByQuery", callback)
 	if err != nil {
 		return errors.Wrap(err, "cursor by query")
 	}

--- a/central/virtualmachine/v2/datastore/store/postgres/store.go
+++ b/central/virtualmachine/v2/datastore/store/postgres/store.go
@@ -729,13 +729,13 @@ func (s *storeImpl) GetMany(ctx context.Context, ids []string) ([]*storage.Virtu
 func (s *storeImpl) Walk(ctx context.Context, fn func(vm *storage.VirtualMachineV2) error) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.Walk, "VirtualMachineV2")
 
-	return pgSearch.RunCursorQueryForSchemaFn[storage.VirtualMachineV2](ctx, schema, search.EmptyQuery(), s.db, fn)
+	return pgSearch.RunCursorQueryForSchemaFn[storage.VirtualMachineV2](ctx, schema, search.EmptyQuery(), s.db, "Walk", fn)
 }
 
 func (s *storeImpl) WalkByQuery(ctx context.Context, q *v1.Query, fn func(vm *storage.VirtualMachineV2) error) error {
 	defer metrics.SetPostgresOperationDurationTime(time.Now(), ops.WalkByQuery, "VirtualMachineV2")
 
-	return pgSearch.RunCursorQueryForSchemaFn[storage.VirtualMachineV2](ctx, schema, q, s.db, fn)
+	return pgSearch.RunCursorQueryForSchemaFn[storage.VirtualMachineV2](ctx, schema, q, s.db, "WalkByQuery", fn)
 }
 
 // endregion Read operations

--- a/migrator/migrations/policymigrationhelper/categorypostgresstorefortest/postgres_policy_category_plugin.go
+++ b/migrator/migrations/policymigrationhelper/categorypostgresstorefortest/postgres_policy_category_plugin.go
@@ -49,7 +49,7 @@ func (s *storeImpl) GetAll(ctx context.Context) ([]*storeType, error) {
 // Walk iterates through each policy category
 func (s *storeImpl) Walk(ctx context.Context, fn func(obj *storage.PolicyCategory) error) error {
 	var sacQueryFilter *v1.Query
-	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, fn)
+	return pgSearch.RunCursorQueryForSchemaFn(ctx, schema, sacQueryFilter, s.db, "Walk", fn)
 }
 
 // New returns a new Store instance using the provided sql instance.

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -1159,7 +1159,7 @@ func RunQueryForSchemaFn[T any, PT pgutils.Unmarshaler[T]](ctx context.Context, 
 	return nil
 }
 
-func retryableGetCursorSession(ctx context.Context, schema *walker.Schema, q *v1.Query, db postgres.DB) (*cursorSession, error) {
+func retryableGetCursorSession(ctx context.Context, schema *walker.Schema, q *v1.Query, db postgres.DB, hint string) (*cursorSession, error) {
 	preparedQuery, err := prepareQuery(ctx, schema, q)
 	if err != nil {
 		return nil, err
@@ -1192,8 +1192,8 @@ func retryableGetCursorSession(ctx context.Context, schema *walker.Schema, q *v1
 		}
 	}
 
-	cursorSuffix := random.GenerateString(16, random.CaseInsensitiveAlpha)
-	cursorId := stringutils.JoinNonEmpty("_", preparedQuery.From, cursorSuffix)
+	cursorSuffix := random.GenerateString(4, random.CaseInsensitiveAlpha)
+	cursorId := stringutils.JoinNonEmpty("_", preparedQuery.From, hint, cursorSuffix)
 
 	_, err = tx.Exec(ctx, fmt.Sprintf("DECLARE %s CURSOR FOR %s", cursorId, queryStr), preparedQuery.Data...)
 	if err != nil {
@@ -1210,12 +1210,12 @@ func retryableGetCursorSession(ctx context.Context, schema *walker.Schema, q *v1
 	return &cursor, nil
 }
 
-func RunCursorQueryForSchemaFn[T any, PT pgutils.Unmarshaler[T]](ctx context.Context, schema *walker.Schema, q *v1.Query, db postgres.DB, callback func(obj PT) error) error {
+func RunCursorQueryForSchemaFn[T any, PT pgutils.Unmarshaler[T]](ctx context.Context, schema *walker.Schema, q *v1.Query, db postgres.DB, hint string, callback func(obj PT) error) error {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, cursorDefaultTimeout)
 	defer cancel()
 
 	cursor, err := pgutils.Retry2(ctx, func() (*cursorSession, error) {
-		return retryableGetCursorSession(ctx, schema, q, db)
+		return retryableGetCursorSession(ctx, schema, q, db, hint)
 	})
 	if err != nil {
 		return errors.Wrap(err, "prepare cursor")

--- a/pkg/search/postgres/common_pg_test.go
+++ b/pkg/search/postgres/common_pg_test.go
@@ -5,11 +5,16 @@ package postgres_test
 import (
 	"context"
 	"errors"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	conn "github.com/stackrox/rox/pkg/postgres/pgtest/conn"
 	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/tools/generate-helpers/pg-table-bindings/multitest/postgres"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,4 +43,112 @@ func TestContexCancellationInWalk(t *testing.T) {
 	})
 	assert.Equal(t, 1, count)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func queryCursorFromStatActivity(t *testing.T, hint string) string {
+	t.Helper()
+	ctx := context.Background()
+	adminConn, err := pgx.Connect(ctx, conn.GetConnectionStringWithDatabaseName(t, "postgres"))
+	require.NoError(t, err)
+	defer func() { _ = adminConn.Close(ctx) }()
+
+	var query string
+	err = adminConn.QueryRow(ctx,
+		"SELECT query FROM pg_stat_activity WHERE query LIKE '%FETCH%' AND query LIKE $1 AND state = 'idle in transaction'",
+		"%"+hint+"%",
+	).Scan(&query)
+	if err != nil {
+		return ""
+	}
+	return query
+}
+
+func TestCursorNameContainsHint(t *testing.T) {
+	testDB := pgtest.ForT(t)
+	ctx := sac.WithAllAccess(context.Background())
+	store := postgres.New(testDB.DB)
+
+	for _, s := range getTestStructs() {
+		require.NoError(t, store.Upsert(ctx, s))
+	}
+
+	cursorReady := make(chan struct{}, 1)
+	queryDone := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = store.Walk(ctx, func(_ *storage.TestStruct) error {
+			select {
+			case cursorReady <- struct{}{}:
+			default:
+			}
+			<-queryDone
+			return nil
+		})
+	}()
+
+	<-cursorReady
+
+	foundQuery := queryCursorFromStatActivity(t, "Walk")
+	close(queryDone)
+	wg.Wait()
+
+	require.NotEmpty(t, foundQuery, "expected to find a FETCH statement with the cursor hint in pg_stat_activity")
+
+	parts := strings.Fields(foundQuery)
+	require.GreaterOrEqual(t, len(parts), 4, "expected FETCH N FROM cursor_name")
+	cursorName := parts[len(parts)-1]
+
+	assert.True(t, strings.HasPrefix(cursorName, "test_structs_Walk_"),
+		"cursor name %q should start with test_structs_Walk_", cursorName)
+
+	t.Logf("cursor name: %s", cursorName)
+}
+
+func TestCursorNameWithWalkByQuery(t *testing.T) {
+	testDB := pgtest.ForT(t)
+	ctx := sac.WithAllAccess(context.Background())
+	store := postgres.New(testDB.DB)
+
+	testStructs := getTestStructs()
+	for _, s := range testStructs {
+		require.NoError(t, store.Upsert(ctx, s))
+	}
+
+	cursorReady := make(chan struct{}, 1)
+	queryDone := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		q := search.NewQueryBuilder().AddExactMatches(search.TestKey, testStructs[0].GetKey1()).ProtoQuery()
+		_ = store.WalkByQuery(ctx, q, func(_ *storage.TestStruct) error {
+			select {
+			case cursorReady <- struct{}{}:
+			default:
+			}
+			<-queryDone
+			return nil
+		})
+	}()
+
+	<-cursorReady
+
+	foundQuery := queryCursorFromStatActivity(t, "WalkByQuery")
+	close(queryDone)
+	wg.Wait()
+
+	require.NotEmpty(t, foundQuery, "expected to find a FETCH statement with WalkByQuery hint in pg_stat_activity")
+
+	parts := strings.Fields(foundQuery)
+	require.GreaterOrEqual(t, len(parts), 4)
+	cursorName := parts[len(parts)-1]
+
+	assert.True(t, strings.HasPrefix(cursorName, "test_structs_WalkByQuery_"),
+		"cursor name %q should start with test_structs_WalkByQuery_", cursorName)
+
+	t.Logf("cursor name: %s", cursorName)
 }

--- a/pkg/search/postgres/common_pg_test.go
+++ b/pkg/search/postgres/common_pg_test.go
@@ -6,8 +6,9 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"sync"
 	"testing"
+
+	"github.com/stackrox/rox/pkg/sync"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/stackrox/rox/generated/storage"
@@ -76,9 +77,7 @@ func TestCursorNameContainsHint(t *testing.T) {
 	queryDone := make(chan struct{})
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		_ = store.Walk(ctx, func(_ *storage.TestStruct) error {
 			select {
 			case cursorReady <- struct{}{}:
@@ -87,7 +86,7 @@ func TestCursorNameContainsHint(t *testing.T) {
 			<-queryDone
 			return nil
 		})
-	}()
+	})
 
 	<-cursorReady
 
@@ -121,9 +120,7 @@ func TestCursorNameWithWalkByQuery(t *testing.T) {
 	queryDone := make(chan struct{})
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		q := search.NewQueryBuilder().AddExactMatches(search.TestKey, testStructs[0].GetKey1()).ProtoQuery()
 		_ = store.WalkByQuery(ctx, q, func(_ *storage.TestStruct) error {
 			select {
@@ -133,7 +130,7 @@ func TestCursorNameWithWalkByQuery(t *testing.T) {
 			<-queryDone
 			return nil
 		})
-	}()
+	})
 
 	<-cursorReady
 

--- a/pkg/search/postgres/store.go
+++ b/pkg/search/postgres/store.go
@@ -206,23 +206,23 @@ func (s *genericStore[T, PT]) Search(ctx context.Context, q *v1.Query) ([]search
 	return RunSearchRequestForSchema(ctx, s.schema, q, s.db)
 }
 
-func (s *genericStore[T, PT]) walkByQuery(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
+func (s *genericStore[T, PT]) walkByQuery(ctx context.Context, query *v1.Query, hint string, fn func(obj PT) error) error {
 	query = s.applyQueryDefaults(query)
-	return RunCursorQueryForSchemaFn[T, PT](ctx, s.schema, query, s.db, fn)
+	return RunCursorQueryForSchemaFn[T, PT](ctx, s.schema, query, s.db, hint, fn)
 }
 
 // Walk iterates over all the objects in the store and applies the closure.
 func (s *genericStore[T, PT]) Walk(ctx context.Context, fn func(obj PT) error) error {
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.Walk)
 
-	return s.walkByQuery(ctx, search.EmptyQuery(), fn)
+	return s.walkByQuery(ctx, search.EmptyQuery(), "Walk", fn)
 }
 
 // WalkByQuery iterates over all the objects scoped by the query and applies the closure.
 func (s *genericStore[T, PT]) WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj PT) error) error {
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.WalkByQuery)
 
-	return s.walkByQuery(ctx, query, fn)
+	return s.walkByQuery(ctx, query, "WalkByQuery", fn)
 }
 
 // Get returns the object, if it exists from the store.


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Cursor names now include the calling method (e.g. Walk, WalkByQuery,
WalkMetadataByQuery) between the table name and random suffix, making
them traceable in pg_stat_activity. Format: {table}_{hint}_{random4}.

Also reduced random suffix from 16 to 4 chars since cursors only need
uniqueness within a single transaction.

Partially generated by AI

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

The unit test should be sufficient here.