### PR TITLE
ROX-34158: Refactor tests to be less impacted by low resources

### DIFF
--- a/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
@@ -120,27 +120,23 @@ func TestCredentialManager(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var changeCount atomic.Int32
 
-			// Use Eventually to retry the entire operation with a configurable timeout.
-			// This handles the k8s fake client potentially losing events.
-			require.EventuallyWithT(t, func(ct *assert.CollectT) {
-				k8sClient := fake.NewClientset()
-				manager := newCredentialsManagerImpl(k8sClient, namespace, secretName, func() {
-					changeCount.Add(1)
-				})
-				manager.Start()
-				defer manager.Stop()
-				require.Eventually(ct, manager.informer.HasSynced, 5*time.Second, 100*time.Millisecond)
+			k8sClient := fake.NewClientset()
+			manager := newCredentialsManagerImpl(k8sClient, namespace, secretName, func() {
+				changeCount.Add(1)
+			})
+			manager.Start()
+			defer manager.Stop()
+			require.Eventually(t, manager.informer.HasSynced, 30*time.Second, 100*time.Millisecond)
 
-				changeCount.Store(0)
-				require.NoError(ct, c.setupFn(k8sClient))
+			require.NoError(t, c.setupFn(k8sClient))
 
-				assert.Eventually(ct, func() bool {
-					manager.mutex.RLock()
-					defer manager.mutex.RUnlock()
-					return changeCount.Load() == int32(c.changes) &&
-						string(manager.stsConfig) == c.expected
-				}, 200*time.Millisecond, 10*time.Millisecond)
-			}, 10*time.Second, 200*time.Millisecond, "callbacks not invoked as expected or state incorrect (changes: %d/%d)",
+			assert.Eventually(t, func() bool {
+				manager.mutex.RLock()
+				defer manager.mutex.RUnlock()
+				return changeCount.Load() == int32(c.changes) &&
+					string(manager.stsConfig) == c.expected
+			}, 10*time.Second, 50*time.Millisecond,
+				"callbacks not invoked as expected or state incorrect (changes: %d/%d)",
 				changeCount.Load(), c.changes)
 		})
 	}

--- a/pkg/secretinformer/informer_test.go
+++ b/pkg/secretinformer/informer_test.go
@@ -111,42 +111,36 @@ func TestSecretInformer(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var onAddCnt, onUpdateCnt, onDeleteCnt atomic.Int32
 
-			// Use Eventually to retry the entire operation with a configurable timeout.
-			// This handles the k8s fake client potentially losing events.
-			require.EventuallyWithT(t, func(ct *assert.CollectT) {
-				k8sClient := fake.NewClientset()
-				informer := NewSecretInformer(
-					namespace,
-					secretName,
-					k8sClient,
-					func(s *v1.Secret) {
-						assert.Equal(ct, c.expectedData, string(s.Data[secretKey]))
-						onAddCnt.Add(1)
-					},
-					func(s *v1.Secret) {
-						assert.Equal(ct, c.expectedData, string(s.Data[secretKey]))
-						onUpdateCnt.Add(1)
-					},
-					func() {
-						onDeleteCnt.Add(1)
-					},
-				)
-				err := informer.Start()
-				require.NoError(ct, err)
-				defer informer.Stop()
-				require.Eventually(ct, informer.HasSynced, 5*time.Second, 100*time.Millisecond)
+			k8sClient := fake.NewClientset()
+			informer := NewSecretInformer(
+				namespace,
+				secretName,
+				k8sClient,
+				func(s *v1.Secret) {
+					assert.Equal(t, c.expectedData, string(s.Data[secretKey]))
+					onAddCnt.Add(1)
+				},
+				func(s *v1.Secret) {
+					assert.Equal(t, c.expectedData, string(s.Data[secretKey]))
+					onUpdateCnt.Add(1)
+				},
+				func() {
+					onDeleteCnt.Add(1)
+				},
+			)
+			err := informer.Start()
+			require.NoError(t, err)
+			defer informer.Stop()
+			require.Eventually(t, informer.HasSynced, 30*time.Second, 100*time.Millisecond)
 
-				onAddCnt.Store(0)
-				onUpdateCnt.Store(0)
-				onDeleteCnt.Store(0)
-				require.NoError(ct, c.setupFn(k8sClient))
+			require.NoError(t, c.setupFn(k8sClient))
 
-				assert.Eventually(ct, func() bool {
-					return onAddCnt.Load() == int32(c.expectedOnAddCnt) &&
-						onUpdateCnt.Load() == int32(c.expectedOnUpdateCnt) &&
-						onDeleteCnt.Load() == int32(c.expectedOnDeleteCnt)
-				}, 200*time.Millisecond, 10*time.Millisecond)
-			}, 10*time.Second, 200*time.Millisecond, "callbacks not invoked as expected (add: %d/%d, update: %d/%d, delete: %d/%d)",
+			assert.Eventually(t, func() bool {
+				return onAddCnt.Load() == int32(c.expectedOnAddCnt) &&
+					onUpdateCnt.Load() == int32(c.expectedOnUpdateCnt) &&
+					onDeleteCnt.Load() == int32(c.expectedOnDeleteCnt)
+			}, 10*time.Second, 50*time.Millisecond,
+				"callbacks not invoked as expected (add: %d/%d, update: %d/%d, delete: %d/%d)",
 				onAddCnt.Load(), c.expectedOnAddCnt, onUpdateCnt.Load(), c.expectedOnUpdateCnt,
 				onDeleteCnt.Load(), c.expectedOnDeleteCnt)
 		})


### PR DESCRIPTION
## Description

I was able to reproduce this test failure on machine with high load. Check ticket for details.

Main changes:
  1. Removed EventuallyWithT retry wrapper - each retry was spinning up a new fake.NewClientset() + informer, which is expensive under load
  2. HasSynced timeout: 5s -> 30s - gives the informer goroutines more time to sync even under CPU starvation
  3. Callback assertion timeout: 200ms -> 10s - the 200ms was the main problem; under load, goroutines simply can't deliver watch events that fast
  4. Polling interval: 10ms -> 50ms - less CPU spin-waiting

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] reproduce tests with fake load in VM
- [x] run test fix with the same load
- [x] run tests in CI

