### PR TITLE
ROX-34431: set namespace filter in roxctl deploy path

### DIFF
--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -961,6 +961,9 @@ function launch_sensor {
              "${extra_config[@]+"${extra_config[@]}"}"
         mv "sensor-${CLUSTER}" "$k8s_dir/sensor-deploy"
 
+        # roxctl sensor generate does not support setting dynamicConfig fields
+        # (e.g. processIndicators.excludeNamespaceFilter), so we patch the
+        # cluster via the API after creation.
         if [[ -n "$extra_json_dynamic_config" ]]; then
           echo "Updating cluster dynamic config after roxctl sensor generate..."
           local cluster_json

--- a/deploy/common/k8sbased.sh
+++ b/deploy/common/k8sbased.sh
@@ -946,6 +946,13 @@ function launch_sensor {
       helm upgrade --install -n "${sensor_namespace}" --create-namespace stackrox-secured-cluster-services "${sensor_helm_chart}" \
           "${helm_args[@]}" "${extra_helm_config[@]}"
     else
+      if [[ -n "${ROX_PROCESS_INDICATORS_PER_NAMESPACE}" ]]; then
+        if [[ -n "$extra_json_dynamic_config" ]]; then
+            extra_json_dynamic_config+=", "
+        fi
+        extra_json_dynamic_config+='"processIndicators": {"excludeNamespaceFilter": "namespace-without-persistence"}'
+      fi
+
       if [[ -x "$(command -v roxctl)" && "$(roxctl version)" == "$MAIN_IMAGE_TAG" ]]; then
         [[ -n "${ROX_ADMIN_PASSWORD}" ]] || { echo >&2 "ROX_ADMIN_PASSWORD not found! Cannot launch sensor."; return 1; }
         roxctl --endpoint "${API_ENDPOINT}" --ca "" --insecure-skip-tls-verify sensor generate --main-image-repository="${MAIN_IMAGE_REPO}" --central="$CLUSTER_API_ENDPOINT" --name="$CLUSTER" \
@@ -953,6 +960,22 @@ function launch_sensor {
              "${ORCH}" \
              "${extra_config[@]+"${extra_config[@]}"}"
         mv "sensor-${CLUSTER}" "$k8s_dir/sensor-deploy"
+
+        if [[ -n "$extra_json_dynamic_config" ]]; then
+          echo "Updating cluster dynamic config after roxctl sensor generate..."
+          local cluster_json
+          cluster_json="$(curl_central_retry \
+              "https://${API_ENDPOINT}/v1/clusters" \
+            | jq -r ".clusters[] | select(.name == \"${CLUSTER}\")")"
+          local cluster_id
+          cluster_id="$(echo "$cluster_json" | jq -r '.id')"
+          local updated_cluster
+          updated_cluster="$(echo "$cluster_json" | jq ".dynamicConfig += {${extra_json_dynamic_config}}")"
+          curl_central_retry -X PUT \
+              -d "$updated_cluster" \
+              "https://${API_ENDPOINT}/v1/clusters/${cluster_id}"
+        fi
+
         if [[ "${GENERATE_SCANNER_DEPLOYMENT_BUNDLE:-}" == "true" ]]; then
             roxctl --endpoint "${API_ENDPOINT}" --ca "" --insecure-skip-tls-verify scanner generate \
                   --output-dir="scanner-deploy" "${scanner_extra_config[@]+"${scanner_extra_config[@]}"}"
@@ -964,14 +987,6 @@ function launch_sensor {
             echo >&2 "ERROR: Unable to generate a Scanner deployment bundle, as has been requested by setting GENERATE_SCANNER_DEPLOYMENT_BUNDLE=true."
             echo >&2 "Please make sure to have a roxctl version ${MAIN_IMAGE_TAG} in PATH."
             exit 1
-        fi
-
-        if [[ -n "${ROX_PROCESS_INDICATORS_PER_NAMESPACE}" ]]; then
-          if [[ -n "$extra_json_dynamic_config" ]]; then
-              extra_json_dynamic_config+=", "
-          fi
-
-          extra_json_dynamic_config+='"processIndicators": {"excludeNamespaceFilter": "namespace-without-persistence"}'
         fi
 
         extra_json_config="${extra_json_config}, "'"dynamicConfig"'": {${extra_json_dynamic_config}}"


### PR DESCRIPTION
## Description

Follow-up to #20660. The `processIndicators.excludeNamespaceFilter` was configured in the Helm and `get_cluster_zip` deploy paths but not in the `roxctl sensor generate` path. EKS and AKS nightlies use `roxctl sensor generate`, so the filter was never set and `ProcessVisualizationTest."Verify process visualization on the excluded namespace"` fails consistently on those platforms.

The fix moves the `processIndicators` config addition before the roxctl/get_cluster_zip branch so it's available to both, and adds an API call after `roxctl sensor generate` to update the cluster's `dynamicConfig` with the filter.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

EKS/AKS nightly runs will validate this fix. The `ProcessVisualizationTest` is the regression test.