### PR TITLE
ROX-34759: retry Scanner V4 vuln import on FK violation

### DIFF
--- a/scanner/datastore/postgres/matcher_store.go
+++ b/scanner/datastore/postgres/matcher_store.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/quay/claircore"
@@ -18,6 +19,11 @@ type MatcherStore interface {
 	datastore.MatcherStore
 
 	Distributions(ctx context.Context) ([]claircore.Distribution, error)
+
+	// ReindexVulnTables rebuilds indexes on the vuln and uo_vuln tables.
+	// This repairs index corruption that can cause persistent FK violations
+	// during vulnerability imports.
+	ReindexVulnTables(ctx context.Context) error
 }
 
 type matcherStore struct {
@@ -40,4 +46,13 @@ func InitPostgresMatcherStore(ctx context.Context, pool *pgxpool.Pool, doMigrati
 		MatcherStore: store,
 		pool:         pool,
 	}, nil
+}
+
+func (m *matcherStore) ReindexVulnTables(ctx context.Context) error {
+	for _, table := range []string{"vuln", "uo_vuln"} {
+		if _, err := m.pool.Exec(ctx, "REINDEX TABLE "+table); err != nil {
+			return fmt.Errorf("reindexing %s: %w", table, err)
+		}
+	}
+	return nil
 }

--- a/scanner/datastore/postgres/mocks/matcher_store.go
+++ b/scanner/datastore/postgres/mocks/matcher_store.go
@@ -248,6 +248,20 @@ func (mr *MockMatcherStoreMockRecorder) RecordUpdaterStatus(ctx, updaterName, up
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordUpdaterStatus", reflect.TypeOf((*MockMatcherStore)(nil).RecordUpdaterStatus), ctx, updaterName, updateTime, fingerprint, updaterError)
 }
 
+// ReindexVulnTables mocks base method.
+func (m *MockMatcherStore) ReindexVulnTables(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReindexVulnTables", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReindexVulnTables indicates an expected call of ReindexVulnTables.
+func (mr *MockMatcherStoreMockRecorder) ReindexVulnTables(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReindexVulnTables", reflect.TypeOf((*MockMatcherStore)(nil).ReindexVulnTables), ctx)
+}
+
 // UpdateEnrichments mocks base method.
 func (m *MockMatcherStore) UpdateEnrichments(ctx context.Context, kind string, fingerprint driver.Fingerprint, enrichments []driver.EnrichmentRecord) (uuid.UUID, error) {
 	m.ctrl.T.Helper()

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -502,8 +502,11 @@ func (u *Updater) updateBundle(ctx context.Context, zipF *zip.File, zipTime time
 			break
 		}
 		if attempt < maxImportAttempts && isFKViolation(importErr) {
-			slog.WarnContext(ctx, "foreign key violation during import (likely concurrent GC), retrying",
+			slog.WarnContext(ctx, "foreign key violation during import, reindexing and retrying",
 				"attempt", attempt, "reason", importErr)
+			if reindexErr := u.store.ReindexVulnTables(ctx); reindexErr != nil {
+				slog.ErrorContext(ctx, "failed to reindex vuln tables", "reason", reindexErr)
+			}
 			continue
 		}
 		return fmt.Errorf("importing vulnerabilities: %w", importErr)

--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/klauspost/compress/zstd"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln"
@@ -46,6 +47,8 @@ const (
 
 	defaultRetryMax   = 12
 	defaultRetryDelay = 10 * time.Second
+
+	maxImportAttempts = 3
 )
 
 var (
@@ -481,22 +484,29 @@ func (u *Updater) updateBundle(ctx context.Context, zipF *zip.File, zipTime time
 		return nil
 	}
 
-	r, err := zipF.Open()
-	if err != nil {
-		return fmt.Errorf("opening bundle: %w", err)
-	}
-	defer func() {
+	var importErr error
+	for attempt := 1; attempt <= maxImportAttempts; attempt++ {
+		r, err := zipF.Open()
+		if err != nil {
+			return fmt.Errorf("opening bundle: %w", err)
+		}
+		dec, err := zstd.NewReader(r)
+		if err != nil {
+			_ = r.Close()
+			return fmt.Errorf("creating zstd reader: %w", err)
+		}
+		importErr = u.importFunc(lCtx, dec)
+		dec.Close()
 		_ = r.Close()
-	}()
-
-	dec, err := zstd.NewReader(r)
-	if err != nil {
-		return fmt.Errorf("creating zstd reader: %w", err)
-	}
-	defer dec.Close()
-
-	if err := u.importFunc(lCtx, dec); err != nil {
-		return fmt.Errorf("importing vulnerabilities: %w", err)
+		if importErr == nil {
+			break
+		}
+		if attempt < maxImportAttempts && isFKViolation(importErr) {
+			slog.WarnContext(ctx, "foreign key violation during import (likely concurrent GC), retrying",
+				"attempt", attempt, "reason", importErr)
+			continue
+		}
+		return fmt.Errorf("importing vulnerabilities: %w", importErr)
 	}
 
 	err = u.metadataStore.SetLastVulnerabilityUpdate(lCtx, zipF.Name, zipTime)
@@ -604,6 +614,11 @@ func closeResponse(resp *http.Response) {
 	if resp != nil && resp.Body != nil {
 		utils.IgnoreError(resp.Body.Close)
 	}
+}
+
+func isFKViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23503"
 }
 
 func isRetryableDialError(err error) bool {

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/klauspost/compress/zstd"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/datastore"
 	"github.com/quay/claircore/libvuln/driver"
@@ -687,5 +689,122 @@ func TestUpdater_Import(t *testing.T) {
 		if !cmp.Equal(got, want) {
 			t.Error(cmp.Diff(got, want))
 		}
+	})
+}
+
+// makeZstZipFile creates a zip archive containing one entry with
+// zst-compressed empty payload and returns the zip.File for that entry.
+func makeZstZipFile(t *testing.T, name string) *zip.File {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create(name)
+	require.NoError(t, err)
+	enc, err := zstd.NewWriter(w)
+	require.NoError(t, err)
+	require.NoError(t, enc.Close())
+	require.NoError(t, zw.Close())
+	r, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	require.Len(t, r.File, 1)
+	return r.File[0]
+}
+
+func fkViolationError() error {
+	return &pgconn.PgError{
+		Code:    "23503",
+		Message: `insert or update on table "uo_vuln" violates foreign key constraint "uo_vuln_vuln_fkey"`,
+	}
+}
+
+func TestUpdateBundle_RetryOnFKViolation(t *testing.T) {
+	ctx := test.Logging(t)
+
+	t.Run("retries on FK violation and succeeds", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		metadataStore := mocks.NewMockMatcherMetadataStore(ctrl)
+
+		calls := 0
+		u := &Updater{
+			locker:        &testLocker{locker: updates.NewLocalLockSource()},
+			metadataStore: metadataStore,
+			importFunc: func(_ context.Context, _ io.Reader) error {
+				calls++
+				if calls == 1 {
+					return fkViolationError()
+				}
+				return nil
+			},
+		}
+
+		zipF := makeZstZipFile(t, "bundles/test.json.zst")
+		zipTime := time.Now()
+		prevTime := zipTime.Add(-time.Hour)
+
+		metadataStore.EXPECT().
+			GetOrSetLastVulnerabilityUpdate(gomock.Any(), zipF.Name, prevTime).
+			Return(prevTime, nil)
+		metadataStore.EXPECT().
+			SetLastVulnerabilityUpdate(gomock.Any(), zipF.Name, zipTime).
+			Return(nil)
+
+		err := u.updateBundle(ctx, zipF, zipTime, prevTime)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, calls, "import should be called twice (1 failure + 1 success)")
+	})
+
+	t.Run("does not retry non-FK errors", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		metadataStore := mocks.NewMockMatcherMetadataStore(ctrl)
+
+		calls := 0
+		u := &Updater{
+			locker:        &testLocker{locker: updates.NewLocalLockSource()},
+			metadataStore: metadataStore,
+			importFunc: func(_ context.Context, _ io.Reader) error {
+				calls++
+				return errors.New("some other error")
+			},
+		}
+
+		zipF := makeZstZipFile(t, "bundles/test.json.zst")
+		zipTime := time.Now()
+		prevTime := zipTime.Add(-time.Hour)
+
+		metadataStore.EXPECT().
+			GetOrSetLastVulnerabilityUpdate(gomock.Any(), zipF.Name, prevTime).
+			Return(prevTime, nil)
+
+		err := u.updateBundle(ctx, zipF, zipTime, prevTime)
+		assert.Error(t, err)
+		assert.Equal(t, 1, calls, "import should only be called once for non-FK errors")
+	})
+
+	t.Run("gives up after max attempts", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		metadataStore := mocks.NewMockMatcherMetadataStore(ctrl)
+
+		calls := 0
+		u := &Updater{
+			locker:        &testLocker{locker: updates.NewLocalLockSource()},
+			metadataStore: metadataStore,
+			importFunc: func(_ context.Context, _ io.Reader) error {
+				calls++
+				return fkViolationError()
+			},
+		}
+
+		zipF := makeZstZipFile(t, "bundles/test.json.zst")
+		zipTime := time.Now()
+		prevTime := zipTime.Add(-time.Hour)
+
+		metadataStore.EXPECT().
+			GetOrSetLastVulnerabilityUpdate(gomock.Any(), zipF.Name, prevTime).
+			Return(prevTime, nil)
+
+		err := u.updateBundle(ctx, zipF, zipTime, prevTime)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "importing vulnerabilities")
+		assert.Equal(t, maxImportAttempts, calls, "should exhaust all retry attempts")
 	})
 }

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -722,11 +722,13 @@ func TestUpdateBundle_RetryOnFKViolation(t *testing.T) {
 
 	t.Run("retries on FK violation and succeeds", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
+		store := mocks.NewMockMatcherStore(ctrl)
 		metadataStore := mocks.NewMockMatcherMetadataStore(ctrl)
 
 		calls := 0
 		u := &Updater{
 			locker:        &testLocker{locker: updates.NewLocalLockSource()},
+			store:         store,
 			metadataStore: metadataStore,
 			importFunc: func(_ context.Context, _ io.Reader) error {
 				calls++
@@ -744,6 +746,9 @@ func TestUpdateBundle_RetryOnFKViolation(t *testing.T) {
 		metadataStore.EXPECT().
 			GetOrSetLastVulnerabilityUpdate(gomock.Any(), zipF.Name, prevTime).
 			Return(prevTime, nil)
+		store.EXPECT().
+			ReindexVulnTables(gomock.Any()).
+			Return(nil)
 		metadataStore.EXPECT().
 			SetLastVulnerabilityUpdate(gomock.Any(), zipF.Name, zipTime).
 			Return(nil)
@@ -782,11 +787,13 @@ func TestUpdateBundle_RetryOnFKViolation(t *testing.T) {
 
 	t.Run("gives up after max attempts", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
+		store := mocks.NewMockMatcherStore(ctrl)
 		metadataStore := mocks.NewMockMatcherMetadataStore(ctrl)
 
 		calls := 0
 		u := &Updater{
 			locker:        &testLocker{locker: updates.NewLocalLockSource()},
+			store:         store,
 			metadataStore: metadataStore,
 			importFunc: func(_ context.Context, _ io.Reader) error {
 				calls++
@@ -801,6 +808,10 @@ func TestUpdateBundle_RetryOnFKViolation(t *testing.T) {
 		metadataStore.EXPECT().
 			GetOrSetLastVulnerabilityUpdate(gomock.Any(), zipF.Name, prevTime).
 			Return(prevTime, nil)
+		store.EXPECT().
+			ReindexVulnTables(gomock.Any()).
+			Return(nil).
+			Times(maxImportAttempts - 1)
 
 		err := u.updateBundle(ctx, zipF, zipTime, prevTime)
 		assert.Error(t, err)


### PR DESCRIPTION
## Description

Scanner V4 vulnerability definition updates fail with `SQLSTATE 23503` (FK violation on `uo_vuln_vuln_fkey`) when the `vuln` or `uo_vuln` table indexes are corrupted — or when ClairCore's GC races with an update transaction.

**Root cause:** Two scenarios produce the same FK violation:

1. **Persistent index corruption** — crashes, OOM kills, or disk errors can corrupt the primary key index on the `vuln` table. The FK check on `uo_vuln_vuln_fkey` uses this index to verify referenced rows exist. When the index is broken, the check fails even though the row is present in the heap. This is the likely cause in the reported case, where the error persists for weeks regardless of GC timing.

2. **Transient GC race** — ClairCore's `vulnCleanup` runs as an auto-committed `DELETE` outside any transaction. If it overlaps with an update transaction's `INSERT INTO uo_vuln`, the FK check blocks on GC's exclusive row lock and fails when GC commits the deletion.

**Fix:** On FK violation, run `REINDEX TABLE` on `vuln` and `uo_vuln` to rebuild their indexes, then retry the import (up to 3 attempts). This handles both scenarios: REINDEX repairs corrupted indexes, and the retry re-creates any rows deleted by a concurrent GC.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Reproduced the FK violation deterministically with a local PostgreSQL integration test using controlled transaction interleaving (10/10 reliable)
- Verified the E2E retry path through a real PostgreSQL database: FK violation on first attempt, REINDEX runs, real ClairCore `UpdateVulnerabilitiesIter` succeeds on retry, vuln and uo_vuln rows verified in the database (5/5 reliable)
- Unit tests verify: FK violations trigger REINDEX + retry, non-FK errors are not retried, max attempts are exhausted
- All existing tests pass, full `./scanner/...` build succeeds