### PR TITLE
perf(ci): skip npm ci in build/style on cache hit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -176,10 +176,17 @@ jobs:
         with:
           node-version-file: ui/package.json
 
-      - uses: ./.github/actions/cache-ui-dependencies
+      - name: Cache UI dependencies
+        id: cache-ui
+        uses: ./.github/actions/cache-ui-dependencies
 
       - name: Fetch UI deps
+        if: steps.cache-ui.outputs.cache-hit != 'true'
         run: make -C ui deps
+
+      - name: Skip UI deps on cache hit
+        if: steps.cache-ui.outputs.cache-hit == 'true'
+        run: touch ui/deps
 
       - name: Build UI
         run: make -C ui build
@@ -403,10 +410,17 @@ jobs:
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 
-    - uses: ./.github/actions/cache-ui-dependencies
+    - name: Cache UI dependencies
+      id: cache-ui
+      uses: ./.github/actions/cache-ui-dependencies
 
     - name: Fetch UI deps
+      if: steps.cache-ui.outputs.cache-hit != 'true'
       run: make -C ui deps
+
+    - name: Skip UI deps on cache hit
+      if: steps.cache-ui.outputs.cache-hit == 'true'
+      run: touch ui/deps
 
     - name: Generate OSS notice
       run: make ossls-notice

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -132,13 +132,19 @@ jobs:
         run: go mod download github.com/stackrox/scanner
 
       - name: Cache UI dependencies
+        id: cache-ui
         uses: ./.github/actions/cache-ui-dependencies
 
       - name: Cache QA Test dependencies
         uses: ./.github/actions/cache-gradle-dependencies
 
       - name: Fetch UI deps
+        if: steps.cache-ui.outputs.cache-hit != 'true'
         run: make -C ui deps
+
+      - name: Skip UI deps on cache hit
+        if: steps.cache-ui.outputs.cache-hit == 'true'
+        run: touch ui/deps
 
       - name: Cache ESLint results
         uses: ./.github/actions/cache-eslint

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -265,12 +265,14 @@ jobs:
 
     - name: Install UI dependencies
       if: steps.cache-ui.outputs.cache-hit != 'true'
-      working-directory: ui/apps/platform
-      run: npm ci
+      run: make -C ui deps
+
+    - name: Skip UI deps on cache hit
+      if: steps.cache-ui.outputs.cache-hit == 'true'
+      run: touch ui/deps
 
     - name: UI Unit Tests
-      working-directory: ui/apps/platform
-      run: npm run test
+      run: make ui-test
 
     - name: Publish Test Report
       uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
@@ -315,11 +317,19 @@ jobs:
       id: cache-ui
       uses: ./.github/actions/cache-ui-dependencies
 
+    - name: Install UI dependencies
+      if: steps.cache-ui.outputs.cache-hit != 'true'
+      run: make -C ui deps
+
+    - name: Skip UI deps on cache hit
+      if: steps.cache-ui.outputs.cache-hit == 'true'
+      run: touch ui/deps
+
     - name: UI Component Tests
       uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # ratchet:cypress-io/github-action@v7
       with:
         working-directory: ui/apps/platform
-        install: ${{ steps.cache-ui.outputs.cache-hit != 'true' }}
+        install: false
         command: npm run test-component -- --browser chrome
 
     - name: Upload Cypress test result artifacts


### PR DESCRIPTION
## Description

Extend the `cache-ui-dependencies` node_modules caching from #20741 to the `build.yaml` and `style.yaml` workflows.

On cache hit (key: `ui-deps-v1-${{ github.job }}-${{ hashFiles(inputs.lockFile) }}`), skip `make -C ui deps` (which runs `npm ci`, deleting the cached `node_modules/`) and touch the `deps` marker file so downstream make targets (`build`, `lint`) don't re-trigger installation.

Saves ~23-32s per job on cache hit.

**Changes:**
- `build.yaml`: 2 jobs (`pre-build-ui`, `check-generated-files`) — add `id: cache-ui`, conditional install, touchfile
- `style.yaml`: 1 job (`style-check`) — same pattern

+22 lines, -2 lines across 2 files.

## Testing and quality

- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### How I validated my change

CI validates: build and style jobs must pass. Cache miss run installs normally, cache hit run skips install.