### PR TITLE
ROX-34802: normalize urls in auth providers

### DIFF
--- a/central/authprovider/service/service_impl.go
+++ b/central/authprovider/service/service_impl.go
@@ -192,6 +192,9 @@ func (s *serviceImpl) GetAuthProviders(_ context.Context, request *v1.GetAuthPro
 // PostAuthProvider inserts a new auth provider into the system.
 func (s *serviceImpl) PostAuthProvider(ctx context.Context, request *v1.PostAuthProviderRequest) (*storage.AuthProvider, error) {
 	providerReq := request.GetProvider()
+	if err := normalizeAuthProviderEndpoints(providerReq); err != nil {
+		return nil, err
+	}
 	if providerReq.GetName() == "" {
 		return nil, errox.InvalidArgs.CausedBy("no auth provider name specified")
 	}
@@ -216,6 +219,9 @@ func (s *serviceImpl) PostAuthProvider(ctx context.Context, request *v1.PostAuth
 
 // PutAuthProvider upserts an auth provider into the system.
 func (s *serviceImpl) PutAuthProvider(ctx context.Context, request *storage.AuthProvider) (*storage.AuthProvider, error) {
+	if err := normalizeAuthProviderEndpoints(request); err != nil {
+		return nil, err
+	}
 	if request.GetId() == "" {
 		return nil, errox.InvalidArgs.CausedBy("auth provider id is empty")
 	}
@@ -354,4 +360,25 @@ func (s *serviceImpl) ExchangeToken(ctx context.Context, request *v1.ExchangeTok
 		}
 	}
 	return response, nil
+}
+
+func normalizeAuthProviderEndpoints(provider *storage.AuthProvider) error {
+	if provider == nil {
+		return nil
+	}
+	if ep := provider.GetUiEndpoint(); ep != "" {
+		normalized, err := authproviders.NormalizeUIEndpoint(ep)
+		if err != nil {
+			return err
+		}
+		provider.UiEndpoint = normalized
+	}
+	for i, ep := range provider.GetExtraUiEndpoints() {
+		normalized, err := authproviders.NormalizeUIEndpoint(ep)
+		if err != nil {
+			return err
+		}
+		provider.ExtraUiEndpoints[i] = normalized
+	}
+	return nil
 }

--- a/central/authprovider/service/service_impl_test.go
+++ b/central/authprovider/service/service_impl_test.go
@@ -12,6 +12,7 @@ import (
 	permissionsMocks "github.com/stackrox/rox/pkg/auth/permissions/mocks"
 	authTokenMocks "github.com/stackrox/rox/pkg/auth/tokens/mocks"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -151,4 +152,55 @@ func (s *mockedAuthProviderServiceTestSuite) expectProviderAdditionToStore() {
 		AddAuthProvider(gomock.Any(), gomock.Any()).
 		Times(1).
 		Return(nil)
+}
+
+func TestNormalizeAuthProviderEndpoints(t *testing.T) {
+	cases := map[string]struct {
+		input            *storage.AuthProvider
+		expectedEndpoint string
+		expectedExtraEPs []string
+		wantErr          bool
+	}{
+		"nil provider": {
+			input: nil,
+		},
+		"strips scheme and infers port": {
+			input: &storage.AuthProvider{
+				UiEndpoint:       "https://central.example.com",
+				ExtraUiEndpoints: []string{"http://localhost:8080", "central.example.com"},
+			},
+			expectedEndpoint: "central.example.com:443",
+			expectedExtraEPs: []string{"localhost:8080", "central.example.com:443"},
+		},
+		"already canonical": {
+			input: &storage.AuthProvider{
+				UiEndpoint:       "central.example.com:443",
+				ExtraUiEndpoints: []string{"localhost:8080"},
+			},
+			expectedEndpoint: "central.example.com:443",
+			expectedExtraEPs: []string{"localhost:8080"},
+		},
+		"rejects empty extra endpoint": {
+			input: &storage.AuthProvider{
+				UiEndpoint:       "central.example.com:443",
+				ExtraUiEndpoints: []string{""},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := normalizeAuthProviderEndpoints(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			if tc.input != nil {
+				assert.Equal(t, tc.expectedEndpoint, tc.input.GetUiEndpoint())
+				assert.Equal(t, tc.expectedExtraEPs, tc.input.GetExtraUiEndpoints())
+			}
+		})
+	}
 }

--- a/generated/api/v1/auth_service.swagger.json
+++ b/generated/api/v1/auth_service.swagger.json
@@ -355,7 +355,8 @@
           "type": "string"
         },
         "uiEndpoint": {
-          "type": "string"
+          "type": "string",
+          "description": "The UI endpoint of the Central instance, e.g. \"central.example.com:443\".\nURLs with scheme (e.g. \"https://central.example.com\") are accepted and\nnormalized to host:port format. If no port is given, 443 is assumed."
         },
         "enabled": {
           "type": "boolean"
@@ -379,7 +380,7 @@
           "items": {
             "type": "string"
           },
-          "description": "UI endpoints which to allow in addition to `ui_endpoint`. I.e., if a login request\nis coming from any of these, the auth request will use these for the callback URL,\nnot ui_endpoint."
+          "description": "UI endpoints which to allow in addition to `ui_endpoint`. I.e., if a login request\nis coming from any of these, the auth request will use these for the callback URL,\nnot ui_endpoint. Same format rules as `ui_endpoint` apply."
         },
         "active": {
           "type": "boolean"

--- a/generated/api/v1/authprovider_service.swagger.json
+++ b/generated/api/v1/authprovider_service.swagger.json
@@ -318,7 +318,8 @@
           "type": "string"
         },
         "uiEndpoint": {
-          "type": "string"
+          "type": "string",
+          "description": "The UI endpoint of the Central instance, e.g. \"central.example.com:443\".\nURLs with scheme (e.g. \"https://central.example.com\") are accepted and\nnormalized to host:port format. If no port is given, 443 is assumed."
         },
         "enabled": {
           "type": "boolean"
@@ -342,7 +343,7 @@
           "items": {
             "type": "string"
           },
-          "description": "UI endpoints which to allow in addition to `ui_endpoint`. I.e., if a login request\nis coming from any of these, the auth request will use these for the callback URL,\nnot ui_endpoint."
+          "description": "UI endpoints which to allow in addition to `ui_endpoint`. I.e., if a login request\nis coming from any of these, the auth request will use these for the callback URL,\nnot ui_endpoint. Same format rules as `ui_endpoint` apply."
         },
         "active": {
           "type": "boolean"
@@ -478,7 +479,8 @@
           "type": "string"
         },
         "uiEndpoint": {
-          "type": "string"
+          "type": "string",
+          "description": "The UI endpoint of the Central instance, e.g. \"central.example.com:443\".\nURLs with scheme (e.g. \"https://central.example.com\") are accepted and\nnormalized to host:port format. If no port is given, 443 is assumed."
         },
         "enabled": {
           "type": "boolean"
@@ -502,7 +504,7 @@
           "items": {
             "type": "string"
           },
-          "description": "UI endpoints which to allow in addition to `ui_endpoint`. I.e., if a login request\nis coming from any of these, the auth request will use these for the callback URL,\nnot ui_endpoint."
+          "description": "UI endpoints which to allow in addition to `ui_endpoint`. I.e., if a login request\nis coming from any of these, the auth request will use these for the callback URL,\nnot ui_endpoint. Same format rules as `ui_endpoint` apply."
         },
         "active": {
           "type": "boolean"

--- a/generated/storage/auth_provider.pb.go
+++ b/generated/storage/auth_provider.pb.go
@@ -24,12 +24,15 @@ const (
 
 // Next Tag: 15.
 type AuthProvider struct {
-	state      protoimpl.MessageState `protogen:"open.v1"`
-	Id         string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk"`     // @gotags: sql:"pk"
-	Name       string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" sql:"unique" search:"AuthProvider Name,hidden"` // @gotags: sql:"unique" search:"AuthProvider Name,hidden"
-	Type       string                 `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
-	UiEndpoint string                 `protobuf:"bytes,4,opt,name=ui_endpoint,json=uiEndpoint,proto3" json:"ui_endpoint,omitempty"`
-	Enabled    bool                   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk"`     // @gotags: sql:"pk"
+	Name  string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty" sql:"unique" search:"AuthProvider Name,hidden"` // @gotags: sql:"unique" search:"AuthProvider Name,hidden"
+	Type  string                 `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
+	// The UI endpoint of the Central instance, e.g. "central.example.com:443".
+	// URLs with scheme (e.g. "https://central.example.com") are accepted and
+	// normalized to host:port format. If no port is given, 443 is assumed.
+	UiEndpoint string `protobuf:"bytes,4,opt,name=ui_endpoint,json=uiEndpoint,proto3" json:"ui_endpoint,omitempty"`
+	Enabled    bool   `protobuf:"varint,5,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	// Config holds auth provider specific configuration. Each configuration options
 	// are different based on the given auth provider type.
 	// OIDC:
@@ -65,7 +68,7 @@ type AuthProvider struct {
 	Validated bool `protobuf:"varint,8,opt,name=validated,proto3" json:"validated,omitempty"`
 	// UI endpoints which to allow in addition to `ui_endpoint`. I.e., if a login request
 	// is coming from any of these, the auth request will use these for the callback URL,
-	// not ui_endpoint.
+	// not ui_endpoint. Same format rules as `ui_endpoint` apply.
 	ExtraUiEndpoints   []string                          `protobuf:"bytes,9,rep,name=extra_ui_endpoints,json=extraUiEndpoints,proto3" json:"extra_ui_endpoints,omitempty"`
 	Active             bool                              `protobuf:"varint,10,opt,name=active,proto3" json:"active,omitempty"`
 	RequiredAttributes []*AuthProvider_RequiredAttribute `protobuf:"bytes,11,rep,name=required_attributes,json=requiredAttributes,proto3" json:"required_attributes,omitempty"`

--- a/pkg/auth/authproviders/util.go
+++ b/pkg/auth/authproviders/util.go
@@ -1,11 +1,16 @@
 package authproviders
 
 import (
+	"errors"
+	"net"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/httputil"
+	"github.com/stackrox/rox/pkg/urlfmt"
 )
 
 // Some common user identity attribute keys.
@@ -15,6 +20,43 @@ const (
 	UseridAttribute = "userid"
 	NameAttribute   = "name"
 )
+
+// missingPortErr is the error string returned by net.SplitHostPort when no port is present.
+const missingPortErr = "missing port in address"
+
+// NormalizeUIEndpoint validates and converts a UI endpoint to canonical host:port format.
+// It strips URL schemes, defaults to port 443 when no port is given,
+// and removes paths and trailing slashes.
+func NormalizeUIEndpoint(endpoint string) (string, error) {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return "", errox.InvalidArgs.New("UI endpoint must not be empty")
+	}
+
+	// Ensure a scheme is present so url.Parse can extract the host correctly.
+	withScheme := urlfmt.FormatURL(endpoint, urlfmt.HTTPS, urlfmt.NoTrailingSlash)
+	hostPort := urlfmt.GetServerFromURL(withScheme)
+	if hostPort == "" {
+		return "", errox.InvalidArgs.Newf("UI endpoint %q is not a valid host[:port]", endpoint)
+	}
+
+	host, port, err := net.SplitHostPort(hostPort)
+	switch {
+	case err == nil && port == "":
+		// Trailing colon with no port (e.g. "example.com:").
+		return host + ":443", nil
+	case err == nil:
+		return hostPort, nil
+	default:
+		// "missing port in address" is the only expected error here — malformed
+		// inputs like unbracketed IPv6 are already rejected by GetServerFromURL.
+		var addrErr *net.AddrError
+		if errors.As(err, &addrErr) && addrErr.Err == missingPortErr {
+			return hostPort + ":443", nil
+		}
+		return "", errox.InvalidArgs.Newf("UI endpoint %q is not a valid host[:port]: %v", endpoint, err)
+	}
+}
 
 // AllUIEndpoints returns all UI endpoints for a given auth provider, with the default UI endpoint first.
 func AllUIEndpoints(providerProto *storage.AuthProvider) []string {

--- a/pkg/auth/authproviders/util_test.go
+++ b/pkg/auth/authproviders/util_test.go
@@ -1,0 +1,132 @@
+package authproviders
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeUIEndpoint(t *testing.T) {
+	cases := map[string]struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		"already canonical host:port": {
+			input:    "central.example.com:443",
+			expected: "central.example.com:443",
+		},
+		"bare hostname defaults to port 443": {
+			input:    "central.example.com",
+			expected: "central.example.com:443",
+		},
+		"https scheme stripped, port 443 inferred": {
+			input:    "https://central.example.com",
+			expected: "central.example.com:443",
+		},
+		"https scheme with explicit port preserved": {
+			input:    "https://central.example.com:8443",
+			expected: "central.example.com:8443",
+		},
+		"http scheme stripped, defaults to port 443": {
+			input:    "http://central.example.com",
+			expected: "central.example.com:443",
+		},
+		"http scheme with explicit port preserved": {
+			input:    "http://central.example.com:8080",
+			expected: "central.example.com:8080",
+		},
+		"trailing slash stripped": {
+			input:    "https://central.example.com/",
+			expected: "central.example.com:443",
+		},
+		"path stripped": {
+			input:    "https://central.example.com/some/path",
+			expected: "central.example.com:443",
+		},
+		"trailing slash on bare host:port": {
+			input:    "central.example.com:443/",
+			expected: "central.example.com:443",
+		},
+		"localhost with port": {
+			input:    "localhost:8000",
+			expected: "localhost:8000",
+		},
+		"localhost without port": {
+			input:    "localhost",
+			expected: "localhost:443",
+		},
+		"IP address with port": {
+			input:    "192.168.1.1:443",
+			expected: "192.168.1.1:443",
+		},
+		"IP address without port": {
+			input:    "192.168.1.1",
+			expected: "192.168.1.1:443",
+		},
+		"https IP address": {
+			input:    "https://192.168.1.1",
+			expected: "192.168.1.1:443",
+		},
+		"custom port without scheme": {
+			input:    "central.example.com:9443",
+			expected: "central.example.com:9443",
+		},
+		"empty string": {
+			wantErr: true,
+		},
+		"whitespace only": {
+			input:   "   ",
+			wantErr: true,
+		},
+		"trailing colon defaults to port 443": {
+			input:    "central.example.com:",
+			expected: "central.example.com:443",
+		},
+		"https trailing colon defaults to port 443": {
+			input:    "https://central.example.com:",
+			expected: "central.example.com:443",
+		},
+		"non-numeric port": {
+			input:   "central.example.com:abc",
+			wantErr: true,
+		},
+		"http localhost": {
+			input:    "http://localhost:8080",
+			expected: "localhost:8080",
+		},
+		"http loopback IP": {
+			input:    "http://127.0.0.1:8080",
+			expected: "127.0.0.1:8080",
+		},
+		"IPv6 loopback with brackets gets default port": {
+			input:    "[::1]",
+			expected: "[::1]:443",
+		},
+		"IPv6 loopback with port": {
+			input:    "[::1]:8080",
+			expected: "[::1]:8080",
+		},
+		"https IPv6 loopback": {
+			input:    "https://[::1]",
+			expected: "[::1]:443",
+		},
+		"https IPv6 loopback with port": {
+			input:    "https://[::1]:8443",
+			expected: "[::1]:8443",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			result, err := NormalizeUIEndpoint(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/declarativeconfig/auth_provider.go
+++ b/pkg/declarativeconfig/auth_provider.go
@@ -79,9 +79,11 @@ type AuthProvider struct {
 	Name string `yaml:"name,omitempty"`
 	// TODO: ROX-14148 if left empty, no default group should be created
 	MinimumRoleName string `yaml:"minimumRole,omitempty"`
-	// The UIEndpoint should be given without scheme (http:// | https://) but including the port, e.g. localhost:443
+	// UIEndpoint is the endpoint of the Central UI, e.g. "central.example.com:443".
+	// Schemes (http:// or https://) are accepted and stripped automatically.
+	// If no port is given, 443 is assumed.
 	UIEndpoint string `yaml:"uiEndpoint,omitempty"`
-	// The ExtraUIEndpoints should be given without scheme (http:// | https://) but including the port, e.g. localhost:443
+	// ExtraUIEndpoints are additional allowed UI endpoints, with the same format rules as UIEndpoint.
 	ExtraUIEndpoints   []string            `yaml:"extraUIEndpoints,omitempty"`
 	Groups             []Group             `yaml:"groups,omitempty"`
 	RequiredAttributes []RequiredAttribute `yaml:"requiredAttributes,omitempty"`

--- a/pkg/declarativeconfig/transform/auth_provider.go
+++ b/pkg/declarativeconfig/transform/auth_provider.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/authproviders"
 	"github.com/stackrox/rox/pkg/auth/authproviders/iap"
 	"github.com/stackrox/rox/pkg/auth/authproviders/oidc"
 	"github.com/stackrox/rox/pkg/auth/authproviders/openshift"
@@ -47,14 +48,19 @@ func (a *authProviderTransform) Transform(configuration declarativeconfig.Config
 		return nil, errors.Wrap(err, "transforming auth provider configuration")
 	}
 
+	uiEndpoint, extraUIEndpoints, err := normalizeUIEndpoints(authProviderConfig.UIEndpoint, authProviderConfig.ExtraUIEndpoints)
+	if err != nil {
+		return nil, errors.Wrap(err, "normalizing auth provider UI endpoints")
+	}
+
 	// The assumption is that, when the auth provider will be stored later on, the DefaultLoginURL option is used,
 	// thus we do not set the login URL explicitly, even though we could.
 	authProviderProto := &storage.AuthProvider{
 		Id:                 declarativeconfig.NewDeclarativeAuthProviderUUID(authProviderConfig.Name).String(),
 		Name:               authProviderConfig.Name,
 		Type:               providerType,
-		UiEndpoint:         authProviderConfig.UIEndpoint,
-		ExtraUiEndpoints:   authProviderConfig.ExtraUIEndpoints,
+		UiEndpoint:         uiEndpoint,
+		ExtraUiEndpoints:   extraUIEndpoints,
 		Enabled:            true, // Enabled is required to be set to ensure the auth provider listed as ready for login.
 		Active:             true, // Active signals at least one user has logged in with the auth provider and disables modification in the UI.
 		Config:             providerConfig,
@@ -125,6 +131,21 @@ func getConfig(authProviderConfig *declarativeconfig.AuthProvider) (map[string]s
 	default:
 		return nil, errox.InvalidArgs.Newf("unsupported auth provider type %q given", authProviderType)
 	}
+}
+
+func normalizeUIEndpoints(primary string, extra []string) (string, []string, error) {
+	normalizedPrimary, err := authproviders.NormalizeUIEndpoint(primary)
+	if err != nil {
+		return "", nil, err
+	}
+	normalizedExtra := make([]string, len(extra))
+	for i, ep := range extra {
+		normalizedExtra[i], err = authproviders.NormalizeUIEndpoint(ep)
+		if err != nil {
+			return "", nil, err
+		}
+	}
+	return normalizedPrimary, normalizedExtra, nil
 }
 
 func getRequiredAttributes(requiredAttributesConfig []declarativeconfig.RequiredAttribute) []*storage.AuthProvider_RequiredAttribute {

--- a/pkg/declarativeconfig/transform/auth_provider_test.go
+++ b/pkg/declarativeconfig/transform/auth_provider_test.go
@@ -262,8 +262,8 @@ func TestTransformAuthProvider(t *testing.T) {
 	assert.Equal(t, expectedAuthProviderID, authProviderProto.GetId())
 	assert.Equal(t, authProvider.Name, authProviderProto.GetName())
 
-	assert.Equal(t, authProvider.UIEndpoint, authProviderProto.GetUiEndpoint())
-	assert.ElementsMatch(t, authProvider.ExtraUIEndpoints, authProviderProto.GetExtraUiEndpoints())
+	assert.Equal(t, "localhost:8000", authProviderProto.GetUiEndpoint())
+	assert.ElementsMatch(t, []string{"localhost:8080", "127.0.0.1:8080"}, authProviderProto.GetExtraUiEndpoints())
 
 	assert.Empty(t, authProviderProto.GetLoginUrl())
 
@@ -401,8 +401,8 @@ func TestUniversalTransformAuthProvider(t *testing.T) {
 	assert.Equal(t, expectedAuthProviderID, authProviderProto.GetId())
 	assert.Equal(t, authProvider.Name, authProviderProto.GetName())
 
-	assert.Equal(t, authProvider.UIEndpoint, authProviderProto.GetUiEndpoint())
-	assert.ElementsMatch(t, authProvider.ExtraUIEndpoints, authProviderProto.GetExtraUiEndpoints())
+	assert.Equal(t, "localhost:8000", authProviderProto.GetUiEndpoint())
+	assert.ElementsMatch(t, []string{"localhost:8080", "127.0.0.1:8080"}, authProviderProto.GetExtraUiEndpoints())
 
 	assert.Empty(t, authProviderProto.GetLoginUrl())
 
@@ -443,6 +443,32 @@ func TestUniversalTransformAuthProvider(t *testing.T) {
 		assert.Equal(t, authProvider.Groups[id].AttributeKey, group.GetProps().GetKey())
 		assert.Equal(t, authProvider.Groups[id].AttributeValue, group.GetProps().GetValue())
 	}
+}
+
+func TestTransformAuthProvider_NormalizesUIEndpoints(t *testing.T) {
+	authProvider := &declarativeconfig.AuthProvider{
+		Name:             "test-auth-provider",
+		UIEndpoint:       "https://central.example.com",
+		ExtraUIEndpoints: []string{"http://localhost:8080", "central.example.com"},
+		OIDCConfig: &declarativeconfig.OIDCConfig{
+			Issuer:       "http://some-issuer",
+			CallbackMode: "auto",
+			ClientID:     "some-client-id",
+			ClientSecret: "some-client-secret",
+		},
+	}
+
+	transformer := newAuthProviderTransformer()
+	protos, err := transformer.Transform(authProvider)
+	require.NoError(t, err)
+
+	require.Contains(t, protos, authProviderType)
+	require.Len(t, protos[authProviderType], 1)
+	authProviderProto, ok := protos[authProviderType][0].(*storage.AuthProvider)
+	require.True(t, ok)
+
+	assert.Equal(t, "central.example.com:443", authProviderProto.GetUiEndpoint())
+	assert.Equal(t, []string{"localhost:8080", "central.example.com:443"}, authProviderProto.GetExtraUiEndpoints())
 }
 
 func TestTransformAuthProvider_NoMinimumRoleName(t *testing.T) {

--- a/proto/storage/auth_provider.proto
+++ b/proto/storage/auth_provider.proto
@@ -13,6 +13,9 @@ message AuthProvider {
   string id = 1; // @gotags: sql:"pk"
   string name = 2; // @gotags: sql:"unique" search:"AuthProvider Name,hidden"
   string type = 3;
+  // The UI endpoint of the Central instance, e.g. "central.example.com:443".
+  // URLs with scheme (e.g. "https://central.example.com") are accepted and
+  // normalized to host:port format. If no port is given, 443 is assumed.
   string ui_endpoint = 4;
   bool enabled = 5;
   // Config holds auth provider specific configuration. Each configuration options
@@ -50,7 +53,7 @@ message AuthProvider {
 
   // UI endpoints which to allow in addition to `ui_endpoint`. I.e., if a login request
   // is coming from any of these, the auth request will use these for the callback URL,
-  // not ui_endpoint.
+  // not ui_endpoint. Same format rules as `ui_endpoint` apply.
   repeated string extra_ui_endpoints = 9;
   bool active = 10;
 


### PR DESCRIPTION
## Description

When configuring auth providers via the API, roxctl CLI, or declarative config,
the UI endpoint must be specified in `host:port` format (e.g.
`central.example.com:443`). Equivalent values like `https://central.example.com`
or `central.example.com` are silently accepted but cause the OAuth callback
matching to fail at runtime, since the stored value never matches the incoming
request hostname.

The browser-based UI is not affected — it auto-populates the endpoint from
`window.location.host`, which is already in the correct format.

This PR adds write-time normalization that converts UI endpoints to canonical
`host:port` format. Schemes are stripped, paths and trailing slashes are removed,
and port 443 is assumed when none is given. Inputs like
`https://central.example.com`, `central.example.com:443`, and
`central.example.com` all normalize to `central.example.com:443`.

Normalization is applied in both entry paths: the API service layer
(`PostAuthProvider`, `PutAuthProvider`) and the declarative config transform.
Invalid inputs (empty endpoints, non-numeric ports) are rejected with clear
error messages.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above
**OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality
is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are
[inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

I used declarative config to define an auth provider with `https://` schema.

```
apiVersion: v1
kind: Secret
metadata:
  name: declarative-config
  namespace: stackrox
stringData:
  auth-provider.yaml: |
    name: auth0-test
    minimumRole: "Admin"
    uiEndpoint: "https://central-reencrypt-stackrox.apps.sh-05-26-1.ocp.infra.rox.systems"
    oidc:
      issuer: "https://dev-z37ozk088wpwkg74.us.auth0.com"
      mode: "auto"
      clientID: "PkMIAQN1XfugVy0gZZePN3JJmSFFAAd8"
      clientSecret: "*****"
```

#### Before fix

The `redirect_uri` for the identity provider would be generated as `redirect_uri=https://https://central-reencrypt-stackrox.apps.sh-05-26-1.ocp.infra.rox.systems/sso/providers/oidc/callback` and the identity provider would reject it.

<img width="745" height="531" alt="SCR-20260526-lobn" src="https://github.com/user-attachments/assets/8214181f-18bc-4e45-b55d-7632874b110f" />

API response:
```
{
    "authProviders": [
        {
            "id": "b1891d3b-e70e-55c3-ae2d-b875401677d8",
            "name": "auth0-test",
            "type": "oidc",
            "uiEndpoint": "https://central-reencrypt-stackrox.apps.sh-05-26-1.ocp.infra.rox.systems", # <--- not normalized
            "enabled": true,
            "config": {
                "client_id": "PkMIAQN1XfugVy0gZZePN3JJmSFFAAd8",
                "client_secret": "*****",
                "extra_scopes": "",
                "issuer": "https://dev-z37ozk088wpwkg74.us.auth0.com",
                "mode": "post"
            },
            "loginUrl": "/sso/login/b1891d3b-e70e-55c3-ae2d-b875401677d8",
            "validated": false,
            "extraUiEndpoints": [],
            "active": true,
            "requiredAttributes": [],
            "traits": {
                "mutabilityMode": "ALLOW_MUTATE",
                "visibility": "VISIBLE",
                "origin": "DECLARATIVE",
                "expiresAt": null
            },
            "claimMappings": {},
            "lastUpdated": "2026-05-26T10:49:31.768396696Z"
        }
    ]
}
```

#### After fix

<img width="611" height="251" alt="SCR-20260526-lspo" src="https://github.com/user-attachments/assets/ff051346-016c-4137-b996-92d473067ef3" />

Normalized API response:

```
{
    "authProviders": [
        {
            "id": "b1891d3b-e70e-55c3-ae2d-b875401677d8",
            "name": "auth0-test",
            "type": "oidc",
            "uiEndpoint": "central-reencrypt-stackrox.apps.sh-05-26-1.ocp.infra.rox.systems:443", # <--- normalized value here
            "enabled": true,
            "config": {
                "client_id": "PkMIAQN1XfugVy0gZZePN3JJmSFFAAd8",
                "client_secret": "*****",
                "extra_scopes": "",
                "issuer": "https://dev-z37ozk088wpwkg74.us.auth0.com",
                "mode": "post"
            },
            "loginUrl": "/sso/login/b1891d3b-e70e-55c3-ae2d-b875401677d8",
            "validated": false,
            "extraUiEndpoints": [],
            "active": true,
            "requiredAttributes": [],
            "traits": {
                "mutabilityMode": "ALLOW_MUTATE",
                "visibility": "VISIBLE",
                "origin": "DECLARATIVE",
                "expiresAt": null
            },
            "claimMappings": {},
            "lastUpdated": "2026-05-26T10:41:09.876955796Z"
        }
    ]
}
```