### PR TITLE
fix: deduplicate CVEs from aliased OSV advisory sources in scanner

### DIFF
--- a/pkg/scannerv4/mappers/mappers.go
+++ b/pkg/scannerv4/mappers/mappers.go
@@ -1490,9 +1490,15 @@ func advisory(vuln *claircore.Vulnerability) *v4.VulnerabilityReport_Advisory {
 
 // dedupeVulns deduplicates repeat vulnerabilities out of vulnIDs and returns the result.
 // This function does not guarantee ordering is preserved.
+//
+// Vulnerabilities are grouped by their resolved CVE name (from vulnerabilityName),
+// not by the raw ClairCore advisory ID. This ensures that entries from different
+// OSV sub-databases (e.g., GHSA + Go vulndb) that resolve to the same CVE are
+// deduplicated. When duplicates are found, the entry with the highest severity
+// is preferred.
 func dedupeVulns(vulnIDs []string, ccVulnerabilities map[string]*claircore.Vulnerability) []string {
-	// Group each vulnerability by name.
-	// This maps each name to a slice of vulnerabilities to protect against the possibility
+	// Group each vulnerability by its resolved name (CVE ID).
+	// This maps each resolved name to a slice of vulnerabilities to protect against the possibility
 	// Claircore finds multiple vulnerabilities with the same name for this package from different vulnerability streams.
 	// In that situation, it is not clear which one may be the single, correct option to choose, so just allow for both.
 	vulnsByName := make(map[string][]*claircore.Vulnerability)
@@ -1503,17 +1509,24 @@ OUTER:
 			continue
 		}
 
-		// Find the currently tracked vulnerabilities with the same name.
-		// If this entry matches any of those, then ignore this one.
-		matching := vulnsByName[vuln.Name]
-		for _, match := range matching {
+		resolvedName := vulnerabilityName(vuln)
+
+		matching := vulnsByName[resolvedName]
+		for i, match := range matching {
 			if vulnsEqual(match, vuln) {
+				continue OUTER
+			}
+			// Same resolved CVE from different advisory sources (e.g., GHSA vs Go vulndb).
+			// Keep the entry with higher severity; replace if the new one is better.
+			if match.Name != vuln.Name && resolvedName != match.Name && resolvedName != vuln.Name {
+				if vuln.NormalizedSeverity > match.NormalizedSeverity {
+					vulnsByName[resolvedName][i] = vuln
+				}
 				continue OUTER
 			}
 		}
 
-		// Add the unique entry to the map.
-		vulnsByName[vuln.Name] = append(vulnsByName[vuln.Name], vuln)
+		vulnsByName[resolvedName] = append(vulnsByName[resolvedName], vuln)
 	}
 
 	filtered := make([]string, 0, len(vulnIDs))
@@ -1526,26 +1539,15 @@ OUTER:
 }
 
 // vulnsEqual determines if the vulnerabilities are essentially equal.
-// That is, this function does not check all fields of the vulnerability struct,
-// to prevent consumers from seeing two seemingly identical vulnerabilities
-// for the same package in the same image.
+// Two vulns are equal if they have the same normalized severity and fixed
+// version. Fields like Description, Links, Issued, and the raw Severity
+// string may differ between sources (e.g., NVD vs RHEL vs OSV) reporting
+// the same vulnerability — those differences are not meaningful to the user.
 //
-// For example: Claircore currently returns CVE-2019-12900 twice for the bzip2-libs package
-// in one particular image. The two versions of the CVE are exactly the same
-// except for the repository name (cpe:/a:redhat:enterprise_linux:8::appstream vs cpe:/o:redhat:enterprise_linux:8::baseos).
-// The entry for this vulnerability as it matched this package in this image may be found in
-// https://security.access.redhat.com/data/oval/v2/RHEL8/rhel-8-including-unpatched.oval.xml.bz2.
-// After reading the entry in this file, it is clear Claircore matched this vulnerability to this stream's
-// CVE-2019-12900 entry twice (once per matching repository).
-//
-// The goal of this function is to make it clear those two CVE-2019-12900 findings are exactly the same.
+// Entries with different FixedInVersion values are kept separate because they
+// represent genuinely different remediation paths from different streams.
 func vulnsEqual(a, b *claircore.Vulnerability) bool {
-	return a.Name == b.Name &&
-		a.Description == b.Description &&
-		a.Issued == b.Issued &&
-		a.Links == b.Links &&
-		a.Severity == b.Severity &&
-		a.NormalizedSeverity == b.NormalizedSeverity &&
+	return a.NormalizedSeverity == b.NormalizedSeverity &&
 		a.FixedInVersion == b.FixedInVersion
 }
 

--- a/pkg/scannerv4/mappers/mappers_test.go
+++ b/pkg/scannerv4/mappers/mappers_test.go
@@ -3059,3 +3059,135 @@ func Test_dedupeAdvisories(t *testing.T) {
 		})
 	}
 }
+
+func TestDedupeVulns_AliasDedup(t *testing.T) {
+	tests := map[string]struct {
+		vulnIDs           []string
+		ccVulnerabilities map[string]*claircore.Vulnerability
+		expectedCount     int
+		expectSeverity    claircore.Severity
+	}{
+		"GHSA and Go vulndb entries for same CVE are deduplicated": {
+			vulnIDs: []string{"ghsa-1", "go-1"},
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"ghsa-1": {
+					ID:                 "ghsa-1",
+					Name:               "GHSA-p77j-4mvh-x3m3",
+					Updater:            "osv/Go",
+					Links:              "https://nvd.nist.gov/vuln/detail/CVE-2026-33186",
+					NormalizedSeverity: claircore.Critical,
+					Severity:           "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					FixedInVersion:     "1.2.3",
+				},
+				"go-1": {
+					ID:                 "go-1",
+					Name:               "GO-2026-4762",
+					Updater:            "osv/Go",
+					Links:              "https://osv.dev/vulnerability/CVE-2026-33186",
+					NormalizedSeverity: claircore.Unknown,
+					FixedInVersion:     "1.2.3",
+				},
+			},
+			expectedCount:  1,
+			expectSeverity: claircore.Critical,
+		},
+		"same ClairCore name with identical fields is deduplicated": {
+			vulnIDs: []string{"v1", "v2"},
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"v1": {
+					ID:                 "v1",
+					Name:               "CVE-2019-12900",
+					NormalizedSeverity: claircore.High,
+					Severity:           "high",
+					FixedInVersion:     "1.0.8",
+				},
+				"v2": {
+					ID:                 "v2",
+					Name:               "CVE-2019-12900",
+					NormalizedSeverity: claircore.High,
+					Severity:           "high",
+					FixedInVersion:     "1.0.8",
+				},
+			},
+			expectedCount:  1,
+			expectSeverity: claircore.High,
+		},
+		"different CVEs are not deduplicated": {
+			vulnIDs: []string{"v1", "v2"},
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"v1": {
+					ID:                 "v1",
+					Name:               "GHSA-aaa",
+					Updater:            "osv/Go",
+					Links:              "https://nvd.nist.gov/vuln/detail/CVE-2026-0001",
+					NormalizedSeverity: claircore.High,
+				},
+				"v2": {
+					ID:                 "v2",
+					Name:               "GHSA-bbb",
+					Updater:            "osv/Go",
+					Links:              "https://nvd.nist.gov/vuln/detail/CVE-2026-0002",
+					NormalizedSeverity: claircore.Medium,
+				},
+			},
+			expectedCount: 2,
+		},
+		"same name different CVSS string same severity is deduplicated": {
+			vulnIDs: []string{"v1", "v2"},
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"v1": {
+					ID:                 "v1",
+					Name:               "CVE-2026-55555",
+					Description:        "Vuln from source A",
+					Links:              "https://nvd.nist.gov/vuln/detail/CVE-2026-55555",
+					NormalizedSeverity: claircore.High,
+					Severity:           "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+					FixedInVersion:     "1.5.0",
+				},
+				"v2": {
+					ID:                 "v2",
+					Name:               "CVE-2026-55555",
+					Description:        "Vuln from source B with different wording",
+					Links:              "https://osv.dev/vulnerability/CVE-2026-55555",
+					NormalizedSeverity: claircore.High,
+					Severity:           "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+					FixedInVersion:     "1.5.0",
+				},
+			},
+			expectedCount:  1,
+			expectSeverity: claircore.High,
+		},
+		"same CVE from different streams with different fixed versions kept": {
+			vulnIDs: []string{"v1", "v2"},
+			ccVulnerabilities: map[string]*claircore.Vulnerability{
+				"v1": {
+					ID:                 "v1",
+					Name:               "CVE-2026-99999",
+					NormalizedSeverity: claircore.High,
+					Severity:           "high",
+					FixedInVersion:     "1.0.0",
+				},
+				"v2": {
+					ID:                 "v2",
+					Name:               "CVE-2026-99999",
+					NormalizedSeverity: claircore.High,
+					Severity:           "high",
+					FixedInVersion:     "2.0.0",
+				},
+			},
+			expectedCount: 2,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := dedupeVulns(tt.vulnIDs, tt.ccVulnerabilities)
+			assert.Len(t, result, tt.expectedCount)
+			if tt.expectedCount == 1 && tt.expectSeverity != 0 {
+				vuln := tt.ccVulnerabilities[result[0]]
+				assert.Equal(t, tt.expectSeverity, vuln.NormalizedSeverity,
+					"should prefer entry with higher severity")
+			}
+		})
+	}
+}


### PR DESCRIPTION
dedupeVulns now groups by the resolved CVE name (from vulnerabilityName)
instead of the raw ClairCore advisory ID. This eliminates duplicates
from OSV sub-databases (e.g., GHSA + Go vulndb, GHSA + PyPI) that
resolve to the same CVE.

Also relaxed vulnsEqual to only compare NormalizedSeverity and
FixedInVersion. Fields like Description, Links, and raw CVSS strings
differ between sources reporting the same vulnerability — those
differences are not meaningful to users. Entries with different
FixedInVersion values are kept separate as they represent different
remediation paths from different streams.

Partially generated by AI

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
