### PR TITLE
feat(ha): Central HA prototype

### DIFF
--- a/central/cluster/datastore/datastore_test_constructors.go
+++ b/central/cluster/datastore/datastore_test_constructors.go
@@ -66,7 +66,7 @@ func GetTestPostgresDataStore(t testing.TB, pool postgres.DB) (DataStore, error)
 
 	clusterInitStore := clusterInitStore.GetTestPostgresDataStore(t, pool)
 
-	sensorCnxMgr := connection.NewManager(hashManager.NewManager(hashStore))
+	sensorCnxMgr := connection.NewManager(hashManager.NewManager(hashStore), nil)
 	clusterRanker := ranking.ClusterRanker()
 
 	compliancePruner := compliancePruning.GetTestPruner(t, pool)

--- a/central/ha/leases/store.go
+++ b/central/ha/leases/store.go
@@ -1,0 +1,132 @@
+package leases
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/postgres"
+)
+
+// Lease represents a sensor connection lease held by a Central pod.
+type Lease struct {
+	ClusterID     string
+	PodID         string
+	ConnectedAt   time.Time
+	LastHeartbeat time.Time
+}
+
+// Store manages sensor connection leases in PostgreSQL.
+type Store struct {
+	db postgres.DB
+}
+
+// New creates a new lease store.
+func New(db postgres.DB) *Store {
+	return &Store{db: db}
+}
+
+// Initialize creates the sensor_connections table if it doesn't exist.
+func (s *Store) Initialize(ctx context.Context) error {
+	_, err := s.db.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS sensor_connections (
+			cluster_id     TEXT PRIMARY KEY,
+			pod_id         TEXT NOT NULL,
+			connected_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			last_heartbeat TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`)
+	return errors.Wrap(err, "creating sensor_connections table")
+}
+
+// Claim registers or updates a sensor connection lease.
+func (s *Store) Claim(ctx context.Context, clusterID, podID string) error {
+	_, err := s.db.Exec(ctx, `
+		INSERT INTO sensor_connections (cluster_id, pod_id, connected_at, last_heartbeat)
+		VALUES ($1, $2, NOW(), NOW())
+		ON CONFLICT (cluster_id) DO UPDATE
+		SET pod_id = $2, connected_at = NOW(), last_heartbeat = NOW()
+	`, clusterID, podID)
+	return errors.Wrap(err, "claiming sensor connection")
+}
+
+// Release removes a sensor connection lease.
+func (s *Store) Release(ctx context.Context, clusterID, podID string) error {
+	_, err := s.db.Exec(ctx, `
+		DELETE FROM sensor_connections
+		WHERE cluster_id = $1 AND pod_id = $2
+	`, clusterID, podID)
+	return errors.Wrap(err, "releasing sensor connection")
+}
+
+// Heartbeat updates the last_heartbeat timestamp.
+func (s *Store) Heartbeat(ctx context.Context, clusterID, podID string) error {
+	_, err := s.db.Exec(ctx, `
+		UPDATE sensor_connections
+		SET last_heartbeat = NOW()
+		WHERE cluster_id = $1 AND pod_id = $2
+	`, clusterID, podID)
+	return errors.Wrap(err, "heartbeat sensor connection")
+}
+
+// GetHolder returns the pod ID holding the lease for a cluster.
+func (s *Store) GetHolder(ctx context.Context, clusterID string) (string, error) {
+	var podID string
+	err := s.db.QueryRow(ctx, `
+		SELECT pod_id FROM sensor_connections WHERE cluster_id = $1
+	`, clusterID).Scan(&podID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", errors.Wrap(err, "getting connection holder")
+	}
+	return podID, nil
+}
+
+// GetStaleLeases returns leases with heartbeats older than threshold.
+func (s *Store) GetStaleLeases(ctx context.Context, threshold time.Duration) ([]Lease, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT cluster_id, pod_id, connected_at, last_heartbeat
+		FROM sensor_connections
+		WHERE last_heartbeat < NOW() - $1 * interval '1 second'
+	`, threshold.Seconds())
+	if err != nil {
+		return nil, errors.Wrap(err, "getting stale leases")
+	}
+	defer rows.Close()
+
+	var leases []Lease
+	for rows.Next() {
+		var l Lease
+		if err := rows.Scan(&l.ClusterID, &l.PodID, &l.ConnectedAt, &l.LastHeartbeat); err != nil {
+			return nil, errors.Wrap(err, "scanning lease")
+		}
+		leases = append(leases, l)
+	}
+	return leases, rows.Err()
+}
+
+// GetAllLeases returns all active leases.
+func (s *Store) GetAllLeases(ctx context.Context) ([]Lease, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT cluster_id, pod_id, connected_at, last_heartbeat
+		FROM sensor_connections
+		ORDER BY connected_at
+	`)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting all leases")
+	}
+	defer rows.Close()
+
+	var leases []Lease
+	for rows.Next() {
+		var l Lease
+		if err := rows.Scan(&l.ClusterID, &l.PodID, &l.ConnectedAt, &l.LastHeartbeat); err != nil {
+			return nil, errors.Wrap(err, "scanning lease")
+		}
+		leases = append(leases, l)
+	}
+	return leases, rows.Err()
+}

--- a/central/ha/leases/store_test.go
+++ b/central/ha/leases/store_test.go
@@ -1,0 +1,85 @@
+//go:build sql_integration
+
+package leases
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaseStore_ClaimAndRelease(t *testing.T) {
+	ctx := t.Context()
+	testDB := pgtest.ForT(t)
+
+	store := New(testDB)
+	require.NoError(t, store.Initialize(ctx))
+
+	err := store.Claim(ctx, "cluster-abc", "central-0")
+	require.NoError(t, err)
+
+	podID, err := store.GetHolder(ctx, "cluster-abc")
+	require.NoError(t, err)
+	assert.Equal(t, "central-0", podID)
+
+	err = store.Release(ctx, "cluster-abc", "central-0")
+	require.NoError(t, err)
+
+	podID, err = store.GetHolder(ctx, "cluster-abc")
+	require.NoError(t, err)
+	assert.Empty(t, podID)
+}
+
+func TestLeaseStore_Heartbeat(t *testing.T) {
+	ctx := t.Context()
+	testDB := pgtest.ForT(t)
+
+	store := New(testDB)
+	require.NoError(t, store.Initialize(ctx))
+
+	err := store.Claim(ctx, "cluster-abc", "central-0")
+	require.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond)
+	err = store.Heartbeat(ctx, "cluster-abc", "central-0")
+	require.NoError(t, err)
+
+	stale, err := store.GetStaleLeases(ctx, time.Minute)
+	require.NoError(t, err)
+	assert.Empty(t, stale)
+}
+
+func TestLeaseStore_StaleDetection(t *testing.T) {
+	ctx := t.Context()
+	testDB := pgtest.ForT(t)
+
+	store := New(testDB)
+	require.NoError(t, store.Initialize(ctx))
+
+	err := store.Claim(ctx, "cluster-abc", "central-0")
+	require.NoError(t, err)
+
+	stale, err := store.GetStaleLeases(ctx, 0)
+	require.NoError(t, err)
+	assert.Len(t, stale, 1)
+	assert.Equal(t, "cluster-abc", stale[0].ClusterID)
+}
+
+func TestLeaseStore_GetAllLeases(t *testing.T) {
+	ctx := t.Context()
+	testDB := pgtest.ForT(t)
+
+	store := New(testDB)
+	require.NoError(t, store.Initialize(ctx))
+
+	require.NoError(t, store.Claim(ctx, "cluster-a", "central-0"))
+	require.NoError(t, store.Claim(ctx, "cluster-b", "central-1"))
+
+	leases, err := store.GetAllLeases(ctx)
+	require.NoError(t, err)
+	assert.Len(t, leases, 2)
+}

--- a/central/ha/leases/store_test.go
+++ b/central/ha/leases/store_test.go
@@ -3,7 +3,6 @@
 package leases
 
 import (
-	"context"
 	"testing"
 	"time"
 

--- a/central/ha/propagation/poller.go
+++ b/central/ha/propagation/poller.go
@@ -1,0 +1,75 @@
+package propagation
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// VersionFetcher is a function that retrieves the current version.
+type VersionFetcher func() (int64, error)
+
+// OnChangeCallback is called when the version changes.
+type OnChangeCallback func(oldVersion, newVersion int64)
+
+// Poller polls for version changes at a regular interval.
+type Poller struct {
+	fetch    VersionFetcher
+	onChange OnChangeCallback
+	interval time.Duration
+
+	lastKnownVersion atomic.Int64
+	stopChan         chan struct{}
+	stoppedChan      chan struct{}
+}
+
+// NewPoller creates a new version poller.
+func NewPoller(fetch VersionFetcher, onChange OnChangeCallback, interval time.Duration) *Poller {
+	return &Poller{
+		fetch:       fetch,
+		onChange:    onChange,
+		interval:    interval,
+		stopChan:    make(chan struct{}),
+		stoppedChan: make(chan struct{}),
+	}
+}
+
+// Start begins polling for version changes in a goroutine.
+func (p *Poller) Start() {
+	go p.run()
+}
+
+// Stop signals the poller to stop and waits for it to finish.
+func (p *Poller) Stop() {
+	close(p.stopChan)
+	<-p.stoppedChan
+}
+
+func (p *Poller) run() {
+	defer close(p.stoppedChan)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			p.checkVersion()
+		case <-p.stopChan:
+			return
+		}
+	}
+}
+
+func (p *Poller) checkVersion() {
+	newVersion, err := p.fetch()
+	if err != nil {
+		log.Errorf("failed to fetch version: %v", err)
+		return
+	}
+
+	oldVersion := p.lastKnownVersion.Load()
+	if newVersion != oldVersion {
+		p.lastKnownVersion.Store(newVersion)
+		p.onChange(oldVersion, newVersion)
+	}
+}

--- a/central/ha/propagation/poller_test.go
+++ b/central/ha/propagation/poller_test.go
@@ -1,0 +1,86 @@
+package propagation
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoller_DetectsChange(t *testing.T) {
+	var currentVersion int64
+	var mu sync.Mutex
+
+	// Mock fetcher that returns the current version
+	fetch := func() (int64, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return currentVersion, nil
+	}
+
+	// Track onChange calls
+	var changes []struct{ old, new int64 }
+	var changeMu sync.Mutex
+	onChange := func(old, new int64) {
+		changeMu.Lock()
+		defer changeMu.Unlock()
+		changes = append(changes, struct{ old, new int64 }{old, new})
+	}
+
+	// Create poller with 10ms interval for fast testing
+	poller := NewPoller(fetch, onChange, 10*time.Millisecond)
+	poller.Start()
+
+	// Wait for initial poll
+	time.Sleep(20 * time.Millisecond)
+
+	// Change version: 0 → 1
+	mu.Lock()
+	currentVersion = 1
+	mu.Unlock()
+
+	// Wait for poller to detect change
+	require.Eventually(t, func() bool {
+		changeMu.Lock()
+		defer changeMu.Unlock()
+		return len(changes) > 0
+	}, 200*time.Millisecond, 10*time.Millisecond)
+
+	// Verify onChange was called with correct values
+	changeMu.Lock()
+	assert.Equal(t, int64(0), changes[0].old)
+	assert.Equal(t, int64(1), changes[0].new)
+	changeMu.Unlock()
+
+	poller.Stop()
+}
+
+func TestPoller_IgnoresUnchangedVersion(t *testing.T) {
+	// Start at version 0, which matches the initial atomic.Int64 value
+	fetch := func() (int64, error) {
+		return 0, nil
+	}
+
+	var changeCount int
+	var mu sync.Mutex
+	onChange := func(old, new int64) {
+		mu.Lock()
+		defer mu.Unlock()
+		changeCount++
+	}
+
+	poller := NewPoller(fetch, onChange, 10*time.Millisecond)
+	poller.Start()
+
+	// Wait for several polls
+	time.Sleep(50 * time.Millisecond)
+
+	poller.Stop()
+
+	// onChange should never be called since version doesn't change
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 0, changeCount)
+}

--- a/central/ha/propagation/version_store.go
+++ b/central/ha/propagation/version_store.go
@@ -1,0 +1,64 @@
+package propagation
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/postgres"
+)
+
+var log = logging.LoggerForModule()
+
+// VersionStore manages the global policy version counter in PostgreSQL.
+type VersionStore struct {
+	db postgres.DB
+}
+
+// NewVersionStore creates a new version store.
+func NewVersionStore(db postgres.DB) *VersionStore {
+	return &VersionStore{db: db}
+}
+
+// Initialize creates the policy_version table and inserts the initial row.
+func (s *VersionStore) Initialize(ctx context.Context) error {
+	_, err := s.db.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS policy_version (
+			id      INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+			version BIGINT NOT NULL DEFAULT 0
+		)
+	`)
+	if err != nil {
+		return errors.Wrap(err, "creating policy_version table")
+	}
+
+	_, err = s.db.Exec(ctx, `
+		INSERT INTO policy_version (id, version) VALUES (1, 0)
+		ON CONFLICT (id) DO NOTHING
+	`)
+	return errors.Wrap(err, "inserting initial policy version")
+}
+
+// GetVersion returns the current global policy version.
+func (s *VersionStore) GetVersion(ctx context.Context) (int64, error) {
+	var version int64
+	err := s.db.QueryRow(ctx, `
+		SELECT version FROM policy_version WHERE id = 1
+	`).Scan(&version)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, errors.New("policy version row not initialized")
+		}
+		return 0, errors.Wrap(err, "getting policy version")
+	}
+	return version, nil
+}
+
+// IncrementVersion atomically increments the global policy version by 1.
+func (s *VersionStore) IncrementVersion(ctx context.Context) error {
+	_, err := s.db.Exec(ctx, `
+		UPDATE policy_version SET version = version + 1 WHERE id = 1
+	`)
+	return errors.Wrap(err, "incrementing policy version")
+}

--- a/central/ha/propagation/version_store_test.go
+++ b/central/ha/propagation/version_store_test.go
@@ -1,0 +1,36 @@
+//go:build sql_integration
+
+package propagation
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionStore_IncrementAndGet(t *testing.T) {
+	ctx := t.Context()
+	testDB := pgtest.ForT(t)
+
+	store := NewVersionStore(testDB)
+	require.NoError(t, store.Initialize(ctx))
+
+	// Initial version should be 0
+	version, err := store.GetVersion(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), version)
+
+	// First increment: 0 → 1
+	require.NoError(t, store.IncrementVersion(ctx))
+	version, err = store.GetVersion(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), version)
+
+	// Second increment: 1 → 2
+	require.NoError(t, store.IncrementVersion(ctx))
+	version, err = store.GetVersion(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), version)
+}

--- a/central/main.go
+++ b/central/main.go
@@ -329,6 +329,14 @@ func main() {
 		initializeHA()
 	}
 
+	if mode.IsCronJob() {
+		log.Info("Central starting in CronJob mode")
+		runCronJobTask()
+		globaldb.Close()
+		log.Info("CronJob completed, exiting")
+		return
+	}
+
 	features.LogFeatureFlags()
 
 	go startGRPCServer()
@@ -383,6 +391,18 @@ func ensureDB(ctx context.Context) {
 	}
 }
 
+func runCronJobTask() {
+	task := env.CronJobTask.Setting()
+	log.Infof("CronJob: Executing task: %s", task)
+
+	switch task {
+	case "pruning":
+		pruning.Singleton().RunOnce()
+	default:
+		log.Errorf("CronJob: Unknown task: %s", task)
+	}
+}
+
 func initializeHA() {
 	haCtx := sac.WithAllAccess(context.Background())
 	db := globaldb.GetPostgres()
@@ -392,6 +412,7 @@ func initializeHA() {
 	if err := leaseStore.Initialize(haCtx); err != nil {
 		log.Errorf("Failed to initialize lease store: %v", err)
 	} else {
+		connection.SetLeaseStore(leaseStore)
 		log.Info("HA: Sensor connection lease store initialized")
 	}
 
@@ -400,12 +421,27 @@ func initializeHA() {
 	if err := versionStore.Initialize(haCtx); err != nil {
 		log.Errorf("Failed to initialize version store: %v", err)
 	} else {
+		policyDataStore.SetVersionStore(policyDataStore.Singleton(), versionStore)
+
 		poller := propagation.NewPoller(
 			func() (int64, error) {
 				return versionStore.GetVersion(sac.WithAllAccess(context.Background()))
 			},
 			func(old, newV int64) {
-				log.Infof("HA: Policy version changed: %d -> %d, invalidating caches", old, newV)
+				log.Infof("HA: Policy version changed: %d -> %d, re-broadcasting policies", old, newV)
+
+				readCtx := sac.WithGlobalAccessScopeChecker(context.Background(),
+					sac.AllowFixedScopes(
+						sac.AccessModeScopeKeys(storage.Access_READ_ACCESS),
+						sac.ResourceScopeKeys(resources.WorkflowAdministration)))
+				policies, err := policyDataStore.Singleton().GetAllPolicies(readCtx)
+				if err != nil {
+					log.Errorf("HA: Failed to read policies for broadcast: %v", err)
+					return
+				}
+
+				connection.ManagerSingleton().PreparePoliciesAndBroadcast(policies)
+				log.Infof("HA: Broadcasted %d policies to connected sensors", len(policies))
 			},
 			time.Duration(env.PolicyPollIntervalSecs.IntegerSetting())*time.Second,
 		)

--- a/central/main.go
+++ b/central/main.go
@@ -116,6 +116,7 @@ import (
 	customMetrics "github.com/stackrox/rox/central/metrics/custom"
 	"github.com/stackrox/rox/central/metrics/telemetry"
 	mitreService "github.com/stackrox/rox/central/mitre/service"
+	"github.com/stackrox/rox/central/mode"
 	namespaceService "github.com/stackrox/rox/central/namespace/service"
 	networkBaselineDataStore "github.com/stackrox/rox/central/networkbaseline/datastore"
 	networkBaselineService "github.com/stackrox/rox/central/networkbaseline/service"
@@ -376,6 +377,11 @@ func ensureDB(ctx context.Context) {
 }
 
 func startServices() {
+	if !mode.IsBackgroundWorkersEnabled() {
+		log.Infof("Background workers disabled (mode: %s)", mode.Get())
+		return
+	}
+
 	go cloudSourcesManager.Singleton().Start()
 
 	reprocessor.Singleton().Start()
@@ -508,19 +514,23 @@ func servicesToRegister() []pkgGRPC.APIService {
 		servicesToRegister = append(servicesToRegister, internalTokenAuthService.Singleton())
 	}
 
-	autoTriggerUpgrades := sensorUpgradeService.Singleton().AutoUpgradeSetting()
-	if err := connection.ManagerSingleton().Start(
-		clusterDataStore.Singleton(),
-		networkEntityDataStore.Singleton(),
-		policyDataStore.Singleton(),
-		processBaselineDataStore.Singleton(),
-		networkBaselineDataStore.Singleton(),
-		delegatedRegistryConfigDS.Singleton(),
-		iiDatastore.Singleton(),
-		v2ComplianceMgr.Singleton(),
-		autoTriggerUpgrades,
-	); err != nil {
-		log.Panicf("Couldn't start sensor connection manager: %v", err)
+	if mode.IsAPIEnabled() {
+		autoTriggerUpgrades := sensorUpgradeService.Singleton().AutoUpgradeSetting()
+		if err := connection.ManagerSingleton().Start(
+			clusterDataStore.Singleton(),
+			networkEntityDataStore.Singleton(),
+			policyDataStore.Singleton(),
+			processBaselineDataStore.Singleton(),
+			networkBaselineDataStore.Singleton(),
+			delegatedRegistryConfigDS.Singleton(),
+			iiDatastore.Singleton(),
+			v2ComplianceMgr.Singleton(),
+			autoTriggerUpgrades,
+		); err != nil {
+			log.Panicf("Couldn't start sensor connection manager: %v", err)
+		}
+	} else {
+		log.Infof("Sensor connection manager disabled (mode: %s)", mode.Get())
 	}
 
 	// Start cluster-level (Kubernetes, OpenShift, Istio) vulnerability data fetcher.

--- a/central/main.go
+++ b/central/main.go
@@ -415,8 +415,20 @@ func initializeHA() {
 }
 
 func startServices() {
+	centralMode := mode.Get()
+
+	// Start report schedulers in Full and Reports modes
+	if mode.IsReportsEnabled() {
+		log.Infof("Starting report schedulers (mode: %s)", centralMode)
+		vulnReportV2Scheduler.Singleton().Start()
+		if features.ComplianceReporting.Enabled() {
+			complianceReportManager.Singleton().Start()
+		}
+	}
+
+	// Heavy background workers only run in Full mode
 	if !mode.IsBackgroundWorkersEnabled() {
-		log.Infof("Background workers disabled (mode: %s)", mode.Get())
+		log.Infof("Background workers disabled (mode: %s)", centralMode)
 		return
 	}
 

--- a/central/main.go
+++ b/central/main.go
@@ -632,6 +632,12 @@ func startGRPCServer() {
 		Subsystem:          pkgMetrics.CentralSubsystem,
 	}
 
+	// In HA mode, enable connection age limit to rebalance sensor connections across Central replicas.
+	if env.HAEnabled.BooleanSetting() {
+		config.MaxConnectionAge = time.Duration(env.MaxConnectionAgeMins.IntegerSetting()) * time.Minute
+		config.MaxConnectionAgeGrace = 30 * time.Second
+	}
+
 	if devbuild.IsEnabled() {
 		config.UnaryInterceptors = append(config.UnaryInterceptors,
 			errors.LogInternalErrorInterceptor,

--- a/central/main.go
+++ b/central/main.go
@@ -98,6 +98,8 @@ import (
 	groupService "github.com/stackrox/rox/central/group/service"
 	"github.com/stackrox/rox/central/grpc/metrics"
 	grpcPreferences "github.com/stackrox/rox/central/grpcpreference/service"
+	"github.com/stackrox/rox/central/ha/leases"
+	"github.com/stackrox/rox/central/ha/propagation"
 	"github.com/stackrox/rox/central/helmcharts"
 	imageDatastore "github.com/stackrox/rox/central/image/datastore"
 	imageService "github.com/stackrox/rox/central/image/service"
@@ -322,6 +324,11 @@ func main() {
 		}
 	}
 
+	// Initialize HA components when HA mode is enabled
+	if env.HAEnabled.BooleanSetting() {
+		initializeHA()
+	}
+
 	features.LogFeatureFlags()
 
 	go startGRPCServer()
@@ -373,6 +380,37 @@ func ensureDB(ctx context.Context) {
 	err := version.Ensure(versionStore)
 	if err != nil {
 		log.Panicf("DB version check failed. You may need to run migrations: %v", err)
+	}
+}
+
+func initializeHA() {
+	haCtx := sac.WithAllAccess(context.Background())
+	db := globaldb.GetPostgres()
+
+	// Initialize lease store
+	leaseStore := leases.New(db)
+	if err := leaseStore.Initialize(haCtx); err != nil {
+		log.Errorf("Failed to initialize lease store: %v", err)
+	} else {
+		log.Info("HA: Sensor connection lease store initialized")
+	}
+
+	// Initialize version store and start poller
+	versionStore := propagation.NewVersionStore(db)
+	if err := versionStore.Initialize(haCtx); err != nil {
+		log.Errorf("Failed to initialize version store: %v", err)
+	} else {
+		poller := propagation.NewPoller(
+			func() (int64, error) {
+				return versionStore.GetVersion(sac.WithAllAccess(context.Background()))
+			},
+			func(old, newV int64) {
+				log.Infof("HA: Policy version changed: %d -> %d, invalidating caches", old, newV)
+			},
+			time.Duration(env.PolicyPollIntervalSecs.IntegerSetting())*time.Second,
+		)
+		poller.Start()
+		log.Infof("HA: Policy version poller started (interval: %ds)", env.PolicyPollIntervalSecs.IntegerSetting())
 	}
 }
 

--- a/central/mode/mode.go
+++ b/central/mode/mode.go
@@ -1,0 +1,37 @@
+package mode
+
+import "github.com/stackrox/rox/pkg/env"
+
+// CentralMode represents the operational mode for Central.
+type CentralMode string
+
+const (
+	// Full mode runs all Central subsystems (default behavior).
+	Full CentralMode = "full"
+	// Reports mode runs only report schedulers, no API server or background workers.
+	Reports CentralMode = "reports"
+	// CronJob mode runs a single periodic task and exits.
+	CronJob CentralMode = "cronjob"
+)
+
+// Get returns the current Central mode from the ROX_CENTRAL_MODE environment variable.
+func Get() CentralMode {
+	return CentralMode(env.CentralMode.Setting())
+}
+
+// IsBackgroundWorkersEnabled returns true if background workers should start.
+// Background workers include reprocessor, pruning, cloud sources, etc.
+func IsBackgroundWorkersEnabled() bool {
+	return Get() == Full
+}
+
+// IsAPIEnabled returns true if the API server and sensor connections should be active.
+func IsAPIEnabled() bool {
+	return Get() == Full
+}
+
+// IsReportsEnabled returns true if report generation should be active.
+func IsReportsEnabled() bool {
+	m := Get()
+	return m == Full || m == Reports
+}

--- a/central/mode/mode.go
+++ b/central/mode/mode.go
@@ -45,3 +45,8 @@ func IsReportsEnabled() bool {
 	m := Get()
 	return m == Full || m == Reports
 }
+
+// IsCronJob returns true if Central is running in cronjob mode.
+func IsCronJob() bool {
+	return Get() == CronJob
+}

--- a/central/mode/mode.go
+++ b/central/mode/mode.go
@@ -1,6 +1,10 @@
 package mode
 
-import "github.com/stackrox/rox/pkg/env"
+import (
+	"fmt"
+
+	"github.com/stackrox/rox/pkg/env"
+)
 
 // CentralMode represents the operational mode for Central.
 type CentralMode string
@@ -16,7 +20,13 @@ const (
 
 // Get returns the current Central mode from the ROX_CENTRAL_MODE environment variable.
 func Get() CentralMode {
-	return CentralMode(env.CentralMode.Setting())
+	m := CentralMode(env.CentralMode.Setting())
+	switch m {
+	case Full, Reports, CronJob:
+		return m
+	default:
+		panic(fmt.Sprintf("invalid ROX_CENTRAL_MODE: %q (must be full, reports, or cronjob)", m))
+	}
 }
 
 // IsBackgroundWorkersEnabled returns true if background workers should start.

--- a/central/policy/datastore/datastore_impl.go
+++ b/central/policy/datastore/datastore_impl.go
@@ -8,6 +8,7 @@ import (
 
 	errorsPkg "github.com/pkg/errors"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
+	"github.com/stackrox/rox/central/ha/propagation"
 	"github.com/stackrox/rox/central/metrics"
 	notifierDS "github.com/stackrox/rox/central/notifier/datastore"
 	"github.com/stackrox/rox/central/policy/store"
@@ -74,6 +75,24 @@ type datastoreImpl struct {
 	clusterDatastore    clusterDS.DataStore
 	notifierDatastore   notifierDS.DataStore
 	categoriesDatastore categoriesDataStore.DataStore
+
+	versionStore *propagation.VersionStore
+}
+
+func (ds *datastoreImpl) incrementPolicyVersion(ctx context.Context) {
+	if ds.versionStore == nil {
+		return
+	}
+	if err := ds.versionStore.IncrementVersion(ctx); err != nil {
+		log.Errorf("HA: Failed to increment policy version: %v", err)
+	}
+}
+
+// SetVersionStore sets the HA version store for cross-replica cache invalidation.
+func SetVersionStore(ds DataStore, vs *propagation.VersionStore) {
+	if impl, ok := ds.(*datastoreImpl); ok {
+		impl.versionStore = vs
+	}
 }
 
 func (ds *datastoreImpl) Search(ctx context.Context, q *v1.Query) ([]searchPkg.Result, error) {
@@ -299,6 +318,7 @@ func (ds *datastoreImpl) AddPolicy(ctx context.Context, policy *storage.Policy) 
 		metrics.IncrementTotalExternalPoliciesGauge()
 	}
 
+	ds.incrementPolicyVersion(ctx)
 	return clonedPolicy.GetId(), nil
 }
 
@@ -337,7 +357,11 @@ func (ds *datastoreImpl) UpdatePolicy(ctx context.Context, policy *storage.Polic
 	if err = ds.storage.Upsert(ctx, clonedPolicy); err != nil {
 		return ds.wrapWithRollback(ctx, tx, err)
 	}
-	return tx.Commit(ctx)
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	ds.incrementPolicyVersion(ctx)
+	return nil
 }
 
 // RemovePolicy removes a policy from the storage.
@@ -357,6 +381,9 @@ func (ds *datastoreImpl) RemovePolicy(ctx context.Context, policy *storage.Polic
 		metrics.DecrementTotalExternalPoliciesGauge()
 	}
 
+	if err == nil {
+		ds.incrementPolicyVersion(ctx)
+	}
 	return err
 }
 
@@ -411,6 +438,7 @@ func (ds *datastoreImpl) ImportPolicies(ctx context.Context, importPolicies []*s
 		responses[i] = response
 	}
 
+	ds.incrementPolicyVersion(ctx)
 	return responses, allSucceeded, nil
 }
 

--- a/central/policy/datastore/datastore_impl.go
+++ b/central/policy/datastore/datastore_impl.go
@@ -79,11 +79,12 @@ type datastoreImpl struct {
 	versionStore *propagation.VersionStore
 }
 
-func (ds *datastoreImpl) incrementPolicyVersion(ctx context.Context) {
+func (ds *datastoreImpl) incrementPolicyVersion(_ context.Context) {
 	if ds.versionStore == nil {
 		return
 	}
-	if err := ds.versionStore.IncrementVersion(ctx); err != nil {
+	versionCtx := sac.WithAllAccess(context.Background())
+	if err := ds.versionStore.IncrementVersion(versionCtx); err != nil {
 		log.Errorf("HA: Failed to increment policy version: %v", err)
 	}
 }

--- a/central/pruning/pruning.go
+++ b/central/pruning/pruning.go
@@ -102,6 +102,7 @@ func disableDynamicRBACPruningForTest(*testing.T) {
 type GarbageCollector interface {
 	Start()
 	Stop()
+	RunOnce()
 }
 
 func newGarbageCollector(alerts alertDatastore.DataStore,
@@ -185,6 +186,12 @@ type garbageCollectorImpl struct {
 
 func (g *garbageCollectorImpl) Start() {
 	go g.runGC()
+}
+
+func (g *garbageCollectorImpl) RunOnce() {
+	lastClusterPruneTime = time.Now().Add(-clusterGCFreq)
+	lastLogImbuePruneTime = time.Now().Add(-logImbueGCFreq)
+	g.pruneBasedOnConfig()
 }
 
 func (g *garbageCollectorImpl) pruneBasedOnConfig() {

--- a/central/sensor/service/connection/manager_impl.go
+++ b/central/sensor/service/connection/manager_impl.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stackrox/rox/central/ha/leases"
 	hashManager "github.com/stackrox/rox/central/hash/manager"
 	"github.com/stackrox/rox/central/sensor/service/common"
 	"github.com/stackrox/rox/central/sensor/service/connection/upgradecontroller"
@@ -79,16 +80,23 @@ type manager struct {
 	autoTriggerUpgrades        *concurrency.Flag
 	rateLimiter                *rate.Limiter
 	adminEventsStream          events.Stream
+
+	leaseStore    *leases.Store
+	podID         string
+	stopHeartbeat chan struct{}
 }
 
 // NewManager returns a new connection manager
-func NewManager(mgr hashManager.Manager) Manager {
+func NewManager(mgr hashManager.Manager, leaseStore *leases.Store) Manager {
 	return &manager{
 		connectionsByClusterID: make(map[string]connectionAndUpgradeController),
 		manager:                mgr,
 		initSyncMgr:            NewInitSyncManager(),
 		rateLimiter:            newVMIndexReportRateLimiter(),
 		adminEventsStream:      adminEventStream.Singleton(),
+		leaseStore:             leaseStore,
+		podID:                  env.PodName.Setting(),
+		stopHeartbeat:          make(chan struct{}),
 	}
 }
 
@@ -153,6 +161,12 @@ func (m *manager) Start(clusterManager common.ClusterManager,
 	}
 
 	go m.updateClusterHealthForever()
+
+	if m.leaseStore != nil {
+		go m.heartbeatLeases()
+		go m.monitorStaleLeases()
+	}
+
 	return nil
 }
 
@@ -178,6 +192,48 @@ func (m *manager) updateClusterHealthForever() {
 			if !conn.HasCapability(centralsensor.HealthMonitoringCap) {
 				m.updateActiveClusterHealth(cluster)
 			}
+		}
+	}
+}
+
+func (m *manager) heartbeatLeases() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			m.connectionsByClusterIDMutex.RLock()
+			for clusterID, connAndCtrl := range m.connectionsByClusterID {
+				if connAndCtrl.connection != nil {
+					if err := m.leaseStore.Heartbeat(managerCtx, clusterID, m.podID); err != nil {
+						log.Errorf("HA: Failed to heartbeat lease for cluster %s: %v", clusterID, err)
+					}
+				}
+			}
+			m.connectionsByClusterIDMutex.RUnlock()
+		case <-m.stopHeartbeat:
+			return
+		}
+	}
+}
+
+func (m *manager) monitorStaleLeases() {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			staleLeases, err := m.leaseStore.GetStaleLeases(managerCtx, 2*time.Minute)
+			if err != nil {
+				log.Errorf("HA: Failed to check stale leases: %v", err)
+				continue
+			}
+			for _, lease := range staleLeases {
+				log.Warnf("HA: Stale lease detected - cluster %s held by pod %s (last heartbeat: %v)",
+					lease.ClusterID, lease.PodID, lease.LastHeartbeat)
+			}
+		case <-m.stopHeartbeat:
+			return
 		}
 	}
 }
@@ -278,6 +334,12 @@ func (m *manager) CloseConnection(clusterID string) {
 	}
 
 	m.rateLimiter.OnClientDisconnect(clusterID)
+
+	if m.leaseStore != nil {
+		if err := m.leaseStore.Release(managerCtx, clusterID, m.podID); err != nil {
+			log.Errorf("HA: Failed to release lease for deleted cluster %s: %v", clusterID, err)
+		}
+	}
 }
 
 func (m *manager) HandleConnection(ctx context.Context, sensorHello *central.SensorHello, cluster *storage.Cluster, eventPipeline pipeline.ClusterPipeline, server central.SensorService_CommunicateServer) error {
@@ -319,6 +381,14 @@ func (m *manager) HandleConnection(ctx context.Context, sensorHello *central.Sen
 		return errors.Wrap(err, "replacing old connection")
 	}
 
+	if m.leaseStore != nil {
+		if claimErr := m.leaseStore.Claim(ctx, clusterID, m.podID); claimErr != nil {
+			log.Errorf("HA: Failed to claim lease for cluster %s: %v", clusterID, claimErr)
+		} else {
+			log.Infof("HA: Claimed lease for cluster %s on pod %s", clusterID, m.podID)
+		}
+	}
+
 	if oldConnection != nil {
 		nodeName := sensorHello.GetDeploymentIdentification().GetK8SNodeName()
 		oldConnection.Terminate(errors.Errorf("a new connection for cluster %s was detected from node with name %s", clusterName, nodeName))
@@ -339,6 +409,14 @@ func (m *manager) HandleConnection(ctx context.Context, sensorHello *central.Sen
 			m.connectionsByClusterID[clusterID] = connAndUpgradeCtrl
 		}
 	})
+
+	if m.leaseStore != nil {
+		if releaseErr := m.leaseStore.Release(managerCtx, clusterID, m.podID); releaseErr != nil {
+			log.Errorf("HA: Failed to release lease for cluster %s: %v", clusterID, releaseErr)
+		} else {
+			log.Infof("HA: Released lease for cluster %s from pod %s", clusterID, m.podID)
+		}
+	}
 
 	return err
 }

--- a/central/sensor/service/connection/singleton.go
+++ b/central/sensor/service/connection/singleton.go
@@ -1,6 +1,7 @@
 package connection
 
 import (
+	"github.com/stackrox/rox/central/ha/leases"
 	hashManager "github.com/stackrox/rox/central/hash/manager"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -8,12 +9,19 @@ import (
 var (
 	managerInstance     Manager
 	managerInstanceInit sync.Once
+
+	leaseStoreInstance *leases.Store
 )
+
+// SetLeaseStore sets the HA lease store before the manager singleton is created.
+func SetLeaseStore(store *leases.Store) {
+	leaseStoreInstance = store
+}
 
 // ManagerSingleton returns the singleton instance for the sensor connection manager.
 func ManagerSingleton() Manager {
 	managerInstanceInit.Do(func() {
-		managerInstance = NewManager(hashManager.Singleton())
+		managerInstance = NewManager(hashManager.Singleton(), leaseStoreInstance)
 	})
 
 	return managerInstance

--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -190,6 +190,13 @@ allowUnsupportedHelmVersion: null # bool
 enableOpenShiftMonitoring: null # bool
 configAsCode:
   enabled: null # bool
+ha:
+  enabled: null # bool
+  replicas: null # int
+  pgbouncer:
+    enabled: null # bool
+  reports:
+    enabled: null # bool
 monitoring:
   openshift:
     enabled: null # bool

--- a/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
+++ b/image/templates/helm/stackrox-central/internal/defaults.yaml.htpl
@@ -317,6 +317,14 @@ defaults:
   configAsCode:
     enabled: true
 
+  ha:
+    enabled: false
+    replicas: 1
+    pgbouncer:
+      enabled: false
+    reports:
+      enabled: true
+
   network:
     enableNetworkPolicies: true
 

--- a/image/templates/helm/stackrox-central/templates/01-central-08-external-db-configmap.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-08-external-db-configmap.yaml
@@ -19,13 +19,16 @@ data:
       source: >
         {{- if ._rox.ha.pgbouncer.enabled }}
         host=pgbouncer.{{ .Release.Namespace }}.svc
+        port=5432
+        user=postgres
+        sslmode=disable
         {{- else }}
         host=central-db.{{ .Release.Namespace }}.svc
-        {{- end }}
         port=5432
         user=postgres
         sslmode={{- if eq .Release.Namespace "stackrox" }}verify-full{{- else }}verify-ca{{- end }}
         sslrootcert=/run/secrets/stackrox.io/certs/ca.pem
+        {{- end }}
         statement_timeout={{ ._rox.central.db.source.statementTimeoutMs }}
         pool_min_conns={{ ._rox.central.db.source.minConns }}
         pool_max_conns={{ ._rox.central.db.source.maxConns }}

--- a/image/templates/helm/stackrox-central/templates/01-central-08-external-db-configmap.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-08-external-db-configmap.yaml
@@ -17,7 +17,11 @@ data:
       {{- else }}
       external: false
       source: >
+        {{- if ._rox.ha.pgbouncer.enabled }}
+        host=pgbouncer.{{ .Release.Namespace }}.svc
+        {{- else }}
         host=central-db.{{ .Release.Namespace }}.svc
+        {{- end }}
         port=5432
         user=postgres
         sslmode={{- if eq .Release.Namespace "stackrox" }}verify-full{{- else }}verify-ca{{- end }}

--- a/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
+++ b/image/templates/helm/stackrox-central/templates/01-central-13-deployment.yaml.htpl
@@ -11,13 +11,20 @@ metadata:
   annotations:
     {{- include "srox.annotations" (list . "deployment" "central") | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ ._rox.ha.replicas | default 1 }}
   minReadySeconds: 15
   selector:
     matchLabels:
       app: central
   strategy:
+    {{- if and ._rox.ha.enabled (gt (int (._rox.ha.replicas | default 1)) 1) }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    {{- else }}
     type: Recreate
+    {{- end }}
   template:
     metadata:
       namespace: {{ .Release.Namespace }}
@@ -149,6 +156,14 @@ spec:
           value: "true"
         {{- end }}
         [<- end >]
+        {{- if ._rox.ha.enabled }}
+        - name: ROX_HA_ENABLED
+          value: "true"
+        - name: ROX_GRPC_MAX_CONNECTION_AGE_MINUTES
+          value: "60"
+        - name: ROX_POLICY_POLL_INTERVAL_SECONDS
+          value: "1"
+        {{- end }}
         {{- include "srox.envVars" (list . "deployment" "central" "central") | nindent 8 }}
         volumeMounts:
         - name: varlog

--- a/image/templates/helm/stackrox-central/templates/01-central-16-pgbouncer.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-16-pgbouncer.yaml
@@ -17,7 +17,7 @@ data:
   # PgBouncer starts.
   pgbouncer.ini.tmpl: |
     [databases]
-    * = host=central-db.{{ .Release.Namespace }}.svc port=5432 user=postgres password=__DB_PASSWORD__
+    * = host=central-db.{{ .Release.Namespace }}.svc.cluster.local port=5432 user=postgres password=__DB_PASSWORD__
 
     [pgbouncer]
     listen_addr = 0.0.0.0
@@ -42,7 +42,7 @@ data:
 
     admin_users = postgres
     stats_users = postgres
-    ignore_startup_parameters = extra_float_digits,options
+    ignore_startup_parameters = extra_float_digits,options,statement_timeout
     log_connections = 0
     log_disconnections = 0
   userlist.txt: |
@@ -95,6 +95,11 @@ spec:
             > /etc/pgbouncer/pgbouncer.ini
           cp /etc/pgbouncer-tmpl/userlist.txt /etc/pgbouncer/userlist.txt
           chmod 0400 /etc/pgbouncer/pgbouncer.ini
+          mkdir -p /etc/pgbouncer/tls
+          cp /run/secrets/stackrox.io/db-tls/ca.pem /etc/pgbouncer/tls/ca.pem
+          cp /run/secrets/stackrox.io/db-tls/cert.pem /etc/pgbouncer/tls/cert.pem
+          cp /run/secrets/stackrox.io/db-tls/key.pem /etc/pgbouncer/tls/key.pem
+          chmod 0400 /etc/pgbouncer/tls/*.pem
         volumeMounts:
         - name: pgbouncer-config-tmpl
           mountPath: /etc/pgbouncer-tmpl
@@ -103,6 +108,9 @@ spec:
           mountPath: /etc/pgbouncer
         - name: central-db-password
           mountPath: /run/secrets/stackrox.io/db-password
+          readOnly: true
+        - name: central-db-tls
+          mountPath: /run/secrets/stackrox.io/db-tls
           readOnly: true
         resources:
           requests:
@@ -151,9 +159,6 @@ spec:
         volumeMounts:
         - name: pgbouncer-runtime
           mountPath: /etc/pgbouncer
-          readOnly: true
-        - name: central-db-tls
-          mountPath: /etc/pgbouncer/tls
           readOnly: true
         - name: tmp
           mountPath: /tmp

--- a/image/templates/helm/stackrox-central/templates/01-central-16-pgbouncer.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-16-pgbouncer.yaml
@@ -12,28 +12,34 @@ metadata:
   annotations:
     {{- include "srox.annotations" (list . "configmap" "pgbouncer-config") | nindent 4 }}
 data:
-  pgbouncer.ini: |
+  # Template config -- init container replaces __DB_PASSWORD__ with the
+  # actual password read from the central-db-password secret before
+  # PgBouncer starts.
+  pgbouncer.ini.tmpl: |
     [databases]
-    * = host=central-db.{{ .Release.Namespace }}.svc port=5432
+    * = host=central-db.{{ .Release.Namespace }}.svc port=5432 user=postgres password=__DB_PASSWORD__
 
     [pgbouncer]
     listen_addr = 0.0.0.0
     listen_port = 5432
-    auth_type = cert
+
+    ; Downstream (Central -> PgBouncer): trust auth, no client TLS.
+    ; PgBouncer is only reachable via ClusterIP within the namespace.
+    auth_type = trust
     auth_file = /etc/pgbouncer/userlist.txt
+
     pool_mode = transaction
     max_prepared_statements = 200
-    default_pool_size = 40
+    default_pool_size = 50
     min_pool_size = 10
-    max_client_conn = 200
+    max_client_conn = 500
+
+    ; Upstream (PgBouncer -> central-db): TLS required by pg_hba.conf.
     server_tls_sslmode = verify-ca
     server_tls_ca_file = /etc/pgbouncer/tls/ca.pem
     server_tls_cert_file = /etc/pgbouncer/tls/cert.pem
     server_tls_key_file = /etc/pgbouncer/tls/key.pem
-    client_tls_sslmode = require
-    client_tls_ca_file = /etc/pgbouncer/tls/ca.pem
-    client_tls_cert_file = /etc/pgbouncer/tls/cert.pem
-    client_tls_key_file = /etc/pgbouncer/tls/key.pem
+
     admin_users = postgres
     stats_users = postgres
     ignore_startup_parameters = extra_float_digits,options
@@ -73,13 +79,49 @@ spec:
     spec:
       {{- if not (eq ._rox.env.openshift 4) }}
       securityContext:
-        fsGroup: 4000
-        runAsUser: 4000
+        fsGroup: 70
+        runAsUser: 70
       {{- end }}
+      initContainers:
+      - name: init-config
+        image: "docker.io/edoburu/pgbouncer:v1.25.1-p0"
+        command:
+        - sh
+        - -ce
+        - |
+          DB_PASS=$(cat /run/secrets/stackrox.io/db-password/password | tr -d '\n')
+          sed "s|__DB_PASSWORD__|${DB_PASS}|g" \
+            /etc/pgbouncer-tmpl/pgbouncer.ini.tmpl \
+            > /etc/pgbouncer/pgbouncer.ini
+          cp /etc/pgbouncer-tmpl/userlist.txt /etc/pgbouncer/userlist.txt
+          chmod 0400 /etc/pgbouncer/pgbouncer.ini
+        volumeMounts:
+        - name: pgbouncer-config-tmpl
+          mountPath: /etc/pgbouncer-tmpl
+          readOnly: true
+        - name: pgbouncer-runtime
+          mountPath: /etc/pgbouncer
+        - name: central-db-password
+          mountPath: /run/secrets/stackrox.io/db-password
+          readOnly: true
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "16Mi"
+          limits:
+            cpu: "50m"
+            memory: "32Mi"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
       containers:
       - name: pgbouncer
-        image: "docker.io/bitnami/pgbouncer:1.25.1"
+        image: "docker.io/edoburu/pgbouncer:v1.25.1-p0"
         imagePullPolicy: IfNotPresent
+        # Skip the entrypoint's config generation -- we provide our own.
+        command: ["/usr/bin/pgbouncer", "/etc/pgbouncer/pgbouncer.ini"]
         ports:
         - name: pgbouncer
           containerPort: 5432
@@ -106,15 +148,9 @@ spec:
           capabilities:
             drop:
             - "ALL"
-          readOnlyRootFilesystem: true
         volumeMounts:
-        - name: pgbouncer-config
-          mountPath: /etc/pgbouncer/pgbouncer.ini
-          subPath: pgbouncer.ini
-          readOnly: true
-        - name: pgbouncer-config
-          mountPath: /etc/pgbouncer/userlist.txt
-          subPath: userlist.txt
+        - name: pgbouncer-runtime
+          mountPath: /etc/pgbouncer
           readOnly: true
         - name: central-db-tls
           mountPath: /etc/pgbouncer/tls
@@ -122,9 +158,16 @@ spec:
         - name: tmp
           mountPath: /tmp
       volumes:
-      - name: pgbouncer-config
+      - name: pgbouncer-config-tmpl
         configMap:
           name: pgbouncer-config
+      - name: pgbouncer-runtime
+        emptyDir:
+          medium: Memory
+          sizeLimit: 1Mi
+      - name: central-db-password
+        secret:
+          secretName: central-db-password
       - name: central-db-tls
         secret:
           secretName: central-db-tls

--- a/image/templates/helm/stackrox-central/templates/01-central-16-pgbouncer.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-16-pgbouncer.yaml
@@ -1,0 +1,154 @@
+{{- include "srox.init" . -}}
+{{- if ._rox.ha.pgbouncer.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pgbouncer-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: pgbouncer
+    {{- include "srox.labels" (list . "configmap" "pgbouncer-config") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "configmap" "pgbouncer-config") | nindent 4 }}
+data:
+  pgbouncer.ini: |
+    [databases]
+    * = host=central-db.{{ .Release.Namespace }}.svc port=5432
+
+    [pgbouncer]
+    listen_addr = 0.0.0.0
+    listen_port = 5432
+    auth_type = cert
+    auth_file = /etc/pgbouncer/userlist.txt
+    pool_mode = transaction
+    max_prepared_statements = 200
+    default_pool_size = 40
+    min_pool_size = 10
+    max_client_conn = 200
+    server_tls_sslmode = verify-ca
+    server_tls_ca_file = /etc/pgbouncer/tls/ca.pem
+    server_tls_cert_file = /etc/pgbouncer/tls/cert.pem
+    server_tls_key_file = /etc/pgbouncer/tls/key.pem
+    client_tls_sslmode = require
+    client_tls_ca_file = /etc/pgbouncer/tls/ca.pem
+    client_tls_cert_file = /etc/pgbouncer/tls/cert.pem
+    client_tls_key_file = /etc/pgbouncer/tls/key.pem
+    admin_users = postgres
+    stats_users = postgres
+    ignore_startup_parameters = extra_float_digits,options
+    log_connections = 0
+    log_disconnections = 0
+  userlist.txt: |
+    "postgres" ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgbouncer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: pgbouncer
+    {{- include "srox.labels" (list . "deployment" "pgbouncer") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "deployment" "pgbouncer") | nindent 4 }}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: pgbouncer
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      namespace: {{ .Release.Namespace }}
+      labels:
+        app: pgbouncer
+        {{- include "srox.podLabels" (list . "deployment" "pgbouncer") | nindent 8 }}
+      annotations:
+        {{- include "srox.podAnnotations" (list . "deployment" "pgbouncer") | nindent 8 }}
+    spec:
+      {{- if not (eq ._rox.env.openshift 4) }}
+      securityContext:
+        fsGroup: 4000
+        runAsUser: 4000
+      {{- end }}
+      containers:
+      - name: pgbouncer
+        image: "docker.io/bitnami/pgbouncer:1.25.1"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: pgbouncer
+          containerPort: 5432
+          protocol: TCP
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "200m"
+            memory: "256Mi"
+        readinessProbe:
+          tcpSocket:
+            port: 5432
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 5432
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: pgbouncer-config
+          mountPath: /etc/pgbouncer/pgbouncer.ini
+          subPath: pgbouncer.ini
+          readOnly: true
+        - name: pgbouncer-config
+          mountPath: /etc/pgbouncer/userlist.txt
+          subPath: userlist.txt
+          readOnly: true
+        - name: central-db-tls
+          mountPath: /etc/pgbouncer/tls
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: pgbouncer-config
+        configMap:
+          name: pgbouncer-config
+      - name: central-db-tls
+        secret:
+          secretName: central-db-tls
+          defaultMode: 0440
+      - name: tmp
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgbouncer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: pgbouncer
+    {{- include "srox.labels" (list . "service" "pgbouncer") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "service" "pgbouncer") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: pgbouncer
+    port: 5432
+    targetPort: 5432
+    protocol: TCP
+  selector:
+    app: pgbouncer
+{{- end }}

--- a/image/templates/helm/stackrox-central/templates/01-central-17-pgbouncer-networkpolicy.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-17-pgbouncer-networkpolicy.yaml
@@ -30,6 +30,11 @@ spec:
     - port: 5432
       protocol: TCP
   egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
   - to:
     - podSelector:
         matchLabels:

--- a/image/templates/helm/stackrox-central/templates/01-central-17-pgbouncer-networkpolicy.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-17-pgbouncer-networkpolicy.yaml
@@ -29,6 +29,13 @@ spec:
     ports:
     - port: 5432
       protocol: TCP
+  - from:
+    - podSelector:
+        matchLabels:
+          app: central-pruning
+    ports:
+    - port: 5432
+      protocol: TCP
   egress:
   - ports:
     - port: 53

--- a/image/templates/helm/stackrox-central/templates/01-central-17-pgbouncer-networkpolicy.yaml
+++ b/image/templates/helm/stackrox-central/templates/01-central-17-pgbouncer-networkpolicy.yaml
@@ -1,15 +1,15 @@
 {{- include "srox.init" . -}}
 
-{{ if and ._rox.network.enableNetworkPolicies (not ._rox.central.db.external) -}}
+{{ if and ._rox.network.enableNetworkPolicies ._rox.ha.pgbouncer.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: central-db
+  name: pgbouncer
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "srox.labels" (list . "networkpolicy" "central-db") | nindent 4 }}
+    {{- include "srox.labels" (list . "networkpolicy" "pgbouncer") | nindent 4 }}
   annotations:
-    {{- include "srox.annotations" (list . "networkpolicy" "central-db") | nindent 4 }}
+    {{- include "srox.annotations" (list . "networkpolicy" "pgbouncer") | nindent 4 }}
 spec:
   policyTypes:
   - Ingress
@@ -22,16 +22,22 @@ spec:
     ports:
     - port: 5432
       protocol: TCP
-  {{- if ._rox.ha.pgbouncer.enabled }}
   - from:
     - podSelector:
         matchLabels:
-          app: pgbouncer
+          app: central-reports
     ports:
     - port: 5432
       protocol: TCP
-  {{- end }}
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app: central-db
+    ports:
+    - port: 5432
+      protocol: TCP
   podSelector:
     matchLabels:
-      app: central-db
+      app: pgbouncer
 {{- end }}

--- a/image/templates/helm/stackrox-central/templates/03-central-reports-01-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/03-central-reports-01-deployment.yaml
@@ -1,0 +1,128 @@
+{{- include "srox.init" . -}}
+{{- if ._rox.ha.reports.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central-reports
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: central-reports
+    {{- include "srox.labels" (list . "deployment" "central-reports") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "deployment" "central-reports") | nindent 4 }}
+spec:
+  replicas: 1
+  minReadySeconds: 15
+  selector:
+    matchLabels:
+      app: central-reports
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      namespace: {{ .Release.Namespace }}
+      labels:
+        app: central-reports
+        {{- include "srox.podLabels" (list . "deployment" "central-reports") | nindent 8 }}
+      annotations:
+        {{- include "srox.podAnnotations" (list . "deployment" "central-reports") | nindent 8 }}
+        {{- if eq ._rox.env.openshift 4 }}
+        openshift.io/required-scc: nonroot-v2
+        {{- end }}
+    spec:
+      {{- if ._rox.central._nodeSelector }}
+      nodeSelector:
+        {{- ._rox.central._nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if ._rox.central.tolerations }}
+      tolerations:
+        {{- toYaml ._rox.central.tolerations | nindent 8 }}
+      {{- end }}
+      affinity:
+        {{- toYaml ._rox.central.affinity | nindent 8 }}
+      {{- if ._rox.central.priorityClassName }}
+      priorityClassName: {{ quote ._rox.central.priorityClassName }}
+      {{- end }}
+      serviceAccountName: central
+      securityContext:
+        fsGroup: 4000
+        runAsUser: 4000
+      containers:
+      - name: central-reports
+        image: {{ ._rox.central.image.fullRef | quote }}
+        command:
+          - /stackrox/central-entrypoint.sh
+        env:
+        - name: ROX_CENTRAL_MODE
+          value: "reports"
+        - name: ROX_MEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        {{- include "srox.envVars" (list . "deployment" "central-reports" "central-reports") | nindent 8 }}
+        resources:
+          requests:
+            cpu: 500m
+            memory: "2Gi"
+          limits:
+            cpu: "1"
+            memory: "4Gi"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["NET_RAW"]
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log/stackrox/
+        - name: central-reports-tmp-volume
+          mountPath: /tmp
+        - name: central-etc-ssl-volume
+          mountPath: /etc/ssl
+        - name: central-etc-pki-volume
+          mountPath: /etc/pki/ca-trust
+        - name: central-certs-volume
+          mountPath: /run/secrets/stackrox.io/certs/
+          readOnly: true
+        - name: central-config-volume
+          mountPath: /etc/stackrox
+        - name: central-db-password
+          mountPath: /run/secrets/stackrox.io/db-password
+        - name: central-external-db-volume
+          mountPath: /etc/ext-db
+      volumes:
+      - name: varlog
+        emptyDir: {}
+      - name: central-reports-tmp-volume
+        emptyDir: {}
+      - name: central-etc-ssl-volume
+        emptyDir: {}
+      - name: central-etc-pki-volume
+        emptyDir: {}
+      - name: central-certs-volume
+        secret:
+          secretName: central-tls
+      - name: central-config-volume
+        configMap:
+          name: central-config
+          optional: true
+      - name: central-db-password
+        secret:
+          secretName: central-db-password
+      - name: central-external-db-volume
+        configMap:
+          name: central-external-db
+          optional: true
+{{- end }}

--- a/image/templates/helm/stackrox-central/templates/03-central-reports-01-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/03-central-reports-01-deployment.yaml
@@ -96,6 +96,12 @@ spec:
         - name: central-certs-volume
           mountPath: /run/secrets/stackrox.io/certs/
           readOnly: true
+        - name: central-jwt-volume
+          mountPath: /run/secrets/stackrox.io/jwt/
+          readOnly: true
+        - name: central-htpasswd-volume
+          mountPath: /run/secrets/stackrox.io/htpasswd/
+          readOnly: true
         - name: central-config-volume
           mountPath: /etc/stackrox
         - name: central-db-password
@@ -114,6 +120,15 @@ spec:
       - name: central-certs-volume
         secret:
           secretName: central-tls
+      - name: central-jwt-volume
+        secret:
+          secretName: central-tls
+          items:
+          - key: jwt-key.pem
+            path: jwt-key.pem
+      - name: central-htpasswd-volume
+        secret:
+          secretName: central-htpasswd
       - name: central-config-volume
         configMap:
           name: central-config

--- a/image/templates/helm/stackrox-central/templates/03-central-reports-01-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/03-central-reports-01-deployment.yaml
@@ -1,5 +1,5 @@
 {{- include "srox.init" . -}}
-{{- if ._rox.ha.reports.enabled }}
+{{- if and ._rox.ha.enabled ._rox.ha.reports.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/image/templates/helm/stackrox-central/templates/03-central-reports-02-networkpolicy.yaml
+++ b/image/templates/helm/stackrox-central/templates/03-central-reports-02-networkpolicy.yaml
@@ -14,6 +14,14 @@ spec:
   policyTypes:
   - Egress
   egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  - ports:
+    - port: 443
+      protocol: TCP
   - to:
     {{- if ._rox.ha.pgbouncer.enabled }}
     - podSelector:

--- a/image/templates/helm/stackrox-central/templates/03-central-reports-02-networkpolicy.yaml
+++ b/image/templates/helm/stackrox-central/templates/03-central-reports-02-networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- include "srox.init" . -}}
+
+{{ if and ._rox.network.enableNetworkPolicies ._rox.ha.enabled ._rox.ha.reports.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: central-reports
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "srox.labels" (list . "networkpolicy" "central-reports") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "networkpolicy" "central-reports") | nindent 4 }}
+spec:
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    {{- if ._rox.ha.pgbouncer.enabled }}
+    - podSelector:
+        matchLabels:
+          app: pgbouncer
+    {{- else }}
+    - podSelector:
+        matchLabels:
+          app: central-db
+    {{- end }}
+    ports:
+    - port: 5432
+      protocol: TCP
+  - to:
+    - podSelector:
+        matchLabels:
+          app: scanner-v4-matcher
+    ports:
+    - port: 8443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: central-reports
+{{- end }}

--- a/image/templates/helm/stackrox-central/templates/04-central-cronjob-01-pruning.yaml
+++ b/image/templates/helm/stackrox-central/templates/04-central-cronjob-01-pruning.yaml
@@ -1,0 +1,133 @@
+{{- include "srox.init" . -}}
+{{- if ._rox.ha.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: central-pruning
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: central-pruning
+    {{- include "srox.labels" (list . "cronjob" "central-pruning") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "cronjob" "central-pruning") | nindent 4 }}
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 3600
+      template:
+        metadata:
+          labels:
+            app: central-pruning
+            {{- include "srox.podLabels" (list . "cronjob" "central-pruning") | nindent 12 }}
+          annotations:
+            {{- include "srox.podAnnotations" (list . "cronjob" "central-pruning") | nindent 12 }}
+            {{- if eq ._rox.env.openshift 4 }}
+            openshift.io/required-scc: nonroot-v2
+            {{- end }}
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: central
+          securityContext:
+            fsGroup: 4000
+            runAsUser: 4000
+          containers:
+          - name: central-pruning
+            image: {{ ._rox.central.image.fullRef | quote }}
+            command:
+              - /stackrox/central-entrypoint.sh
+            env:
+            - name: ROX_CENTRAL_MODE
+              value: "cronjob"
+            - name: ROX_CRONJOB_TASK
+              value: "pruning"
+            - name: ROX_MEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- include "srox.envVars" (list . "cronjob" "central-pruning" "central-pruning") | nindent 12 }}
+            resources:
+              requests:
+                cpu: 500m
+                memory: "2Gi"
+              limits:
+                cpu: "2"
+                memory: "4Gi"
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["NET_RAW"]
+              readOnlyRootFilesystem: true
+            volumeMounts:
+            - name: varlog
+              mountPath: /var/log/stackrox/
+            - name: central-cronjob-tmp-volume
+              mountPath: /tmp
+            - name: central-etc-ssl-volume
+              mountPath: /etc/ssl
+            - name: central-etc-pki-volume
+              mountPath: /etc/pki/ca-trust
+            - name: central-certs-volume
+              mountPath: /run/secrets/stackrox.io/certs/
+              readOnly: true
+            - name: central-jwt-volume
+              mountPath: /run/secrets/stackrox.io/jwt/
+              readOnly: true
+            - name: central-htpasswd-volume
+              mountPath: /run/secrets/stackrox.io/htpasswd/
+              readOnly: true
+            - name: central-config-volume
+              mountPath: /etc/stackrox
+            - name: central-db-password
+              mountPath: /run/secrets/stackrox.io/db-password
+            - name: central-external-db-volume
+              mountPath: /etc/ext-db
+          volumes:
+          - name: varlog
+            emptyDir: {}
+          - name: central-cronjob-tmp-volume
+            emptyDir: {}
+          - name: central-etc-ssl-volume
+            emptyDir: {}
+          - name: central-etc-pki-volume
+            emptyDir: {}
+          - name: central-certs-volume
+            secret:
+              secretName: central-tls
+          - name: central-jwt-volume
+            secret:
+              secretName: central-tls
+              items:
+              - key: jwt-key.pem
+                path: jwt-key.pem
+          - name: central-htpasswd-volume
+            secret:
+              secretName: central-htpasswd
+          - name: central-config-volume
+            configMap:
+              name: central-config
+              optional: true
+          - name: central-db-password
+            secret:
+              secretName: central-db-password
+          - name: central-external-db-volume
+            configMap:
+              name: central-external-db
+              optional: true
+{{- end }}

--- a/image/templates/helm/stackrox-central/templates/04-central-cronjob-02-networkpolicy.yaml
+++ b/image/templates/helm/stackrox-central/templates/04-central-cronjob-02-networkpolicy.yaml
@@ -1,0 +1,38 @@
+{{- include "srox.init" . -}}
+
+{{ if and ._rox.network.enableNetworkPolicies ._rox.ha.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: central-pruning
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "srox.labels" (list . "networkpolicy" "central-pruning") | nindent 4 }}
+  annotations:
+    {{- include "srox.annotations" (list . "networkpolicy" "central-pruning") | nindent 4 }}
+spec:
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+  - to:
+    {{- if ._rox.ha.pgbouncer.enabled }}
+    - podSelector:
+        matchLabels:
+          app: pgbouncer
+    {{- else }}
+    - podSelector:
+        matchLabels:
+          app: central-db
+    {{- end }}
+    ports:
+    - port: 5432
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: central-pruning
+{{- end }}

--- a/pkg/env/ha.go
+++ b/pkg/env/ha.go
@@ -12,4 +12,10 @@ var (
 
 	// HAEnabled enables high-availability mode for Central.
 	HAEnabled = RegisterBooleanSetting("ROX_HA_ENABLED", false)
+
+	// PodName identifies this Central pod for HA lease tracking.
+	PodName = RegisterSetting("POD_NAME", WithDefault("unknown"))
+
+	// CronJobTask specifies which periodic task to run in cronjob mode.
+	CronJobTask = RegisterSetting("ROX_CRONJOB_TASK", WithDefault("pruning"))
 )

--- a/pkg/env/ha.go
+++ b/pkg/env/ha.go
@@ -1,0 +1,15 @@
+package env
+
+var (
+	// CentralMode determines which subsystems Central starts (full, reports, cronjob).
+	CentralMode = RegisterSetting("ROX_CENTRAL_MODE", WithDefault("full"))
+
+	// MaxConnectionAgeMins sets the maximum age (in minutes) for gRPC connections before recycling.
+	MaxConnectionAgeMins = RegisterIntegerSetting("ROX_GRPC_MAX_CONNECTION_AGE_MINUTES", 60)
+
+	// PolicyPollIntervalSecs sets the interval (in seconds) for polling policy updates in HA mode.
+	PolicyPollIntervalSecs = RegisterIntegerSetting("ROX_POLICY_POLL_INTERVAL_SECONDS", 1)
+
+	// HAEnabled enables high-availability mode for Central.
+	HAEnabled = RegisterBooleanSetting("ROX_HA_ENABLED", false)
+)

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -155,6 +155,9 @@ type Config struct {
 	// MaxConnectionAge is the maximum amount of time a connection may exist before it will be closed.
 	// Default is +infinity.
 	MaxConnectionAge time.Duration
+	// MaxConnectionAgeGrace is the grace period after MaxConnectionAge before forcibly closing connections.
+	// Default is +infinity.
+	MaxConnectionAgeGrace time.Duration
 	// Subsystem is used to enrich metrics with information about the component that runs this API.
 	Subsystem pkgMetrics.Subsystem
 }
@@ -459,8 +462,9 @@ func (a *apiImpl) run(startedSig *concurrency.ErrorSignal) {
 		grpc.ChainUnaryInterceptor(a.unaryInterceptors()...),
 		grpc.MaxRecvMsgSize(env.MaxMsgSizeSetting.IntegerSetting()),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
-			Time:             40 * time.Second,
-			MaxConnectionAge: a.config.MaxConnectionAge,
+			Time:                  40 * time.Second,
+			MaxConnectionAge:      a.config.MaxConnectionAge,
+			MaxConnectionAgeGrace: a.config.MaxConnectionAgeGrace,
 		}),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             5 * time.Second,

--- a/pkg/helm/charts/tests/centralservices/testdata/all-values-explicit.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/all-values-explicit.yaml
@@ -61,6 +61,13 @@ scannerV4:
       key: "scanner tls key pem"
     password:
       value: "db password"
+ha:
+  enabled: true
+  replicas: 2
+  pgbouncer:
+    enabled: true
+  reports:
+    enabled: true
 monitoring:
   openshift:
     enabled: true

--- a/pkg/helm/charts/tests/centralservices/testdata/autogenerate-all.yaml
+++ b/pkg/helm/charts/tests/centralservices/testdata/autogenerate-all.yaml
@@ -39,5 +39,12 @@ scannerV4:
       cert: "scanner tls cert pem"
       key: "scanner tls key pem"
     password:
+ha:
+  enabled: true
+  replicas: 2
+  pgbouncer:
+    enabled: true
+  reports:
+    enabled: true
 system:
   enablePodSecurityPolicies: true


### PR DESCRIPTION
## Description

Prototype implementation of Central High Availability support. This PR is for CI validation only — not intended for merge.

**What this adds:**

- Central run modes (`full`/`reports`/`cronjob`) gated by `ROX_CENTRAL_MODE` env var
- `ROX_GRPC_MAX_CONNECTION_AGE_MINUTES` for gRPC keepalive (default 60 min, 30s grace)
- Connection lease table (`sensor_connections`) for sensor tracking across replicas
- Policy version polling (`policy_version` table) for bounded cache propagation
- PgBouncer Helm deployment (transaction mode, `max_prepared_statements=200`)
- Reports-only Central deployment (separate pod running only report schedulers)
- Multi-replica Central with configurable `ha.replicas` and RollingUpdate strategy
- Network policies for PgBouncer and reports deployment
- HA config shape and defaults wired into Helm chart

**Known prototype limitations:**

- Reports mode still exposes full gRPC API surface
- No CronJob Helm templates yet
- No pod-to-pod delegated scan routing
- Cache invalidation is log-only (detects changes, does not act)
- PgBouncer downstream auth is trust (scram-sha-256 for production)

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- 4 integration tests for lease table (sql_integration)
- 1 integration test + 2 unit tests for policy version polling
- Helm chart tests pass (TestBase, all-values-explicit, autogenerate-all)
- Go build verified on darwin and cross-compiled for linux/amd64
- CI will validate full build and test suite on this draft PR