### PR TITLE
ROX-26368: WIP autocomplete via GROUP BY for unique results

### DIFF
--- a/central/graphql/resolvers/search.go
+++ b/central/graphql/resolvers/search.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	alertDataStore "github.com/stackrox/rox/central/alert/datastore"
+	"github.com/stackrox/rox/central/globaldb"
 	"github.com/stackrox/rox/central/graphql/resolvers/inputtypes"
 	"github.com/stackrox/rox/central/graphql/resolvers/searchers"
 	"github.com/stackrox/rox/central/rbac/service"
@@ -188,7 +189,7 @@ type searchRequest struct {
 
 // SearchAutocomplete returns autocomplete responses for the given partial query.
 func (resolver *Resolver) SearchAutocomplete(ctx context.Context, args searchRequest) ([]string, error) {
-	return searchService.RunAutoComplete(ctx, args.Query, toSearchCategories(args.Categories), resolver.getAutoCompleteSearchers())
+	return searchService.RunAutoComplete(ctx, args.Query, toSearchCategories(args.Categories), resolver.getAutoCompleteSearchers(), globaldb.GetPostgres())
 }
 
 // SearchOptions gets all search options available for the listed categories

--- a/central/search/service/service.go
+++ b/central/search/service/service.go
@@ -7,6 +7,7 @@ import (
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
 	"github.com/stackrox/rox/central/compliance/aggregation"
 	deploymentDataStore "github.com/stackrox/rox/central/deployment/datastore"
+	"github.com/stackrox/rox/central/globaldb"
 	imageDataStore "github.com/stackrox/rox/central/image/datastore"
 	imageIntegrationDataStore "github.com/stackrox/rox/central/imageintegration/datastore"
 	imageV2Datastore "github.com/stackrox/rox/central/imagev2/datastore"
@@ -172,6 +173,7 @@ func (b *serviceBuilder) WithImageIntegrationStore(store imageIntegrationDataSto
 
 func (b *serviceBuilder) Build() Service {
 	s := serviceImpl{
+		db:                globaldb.GetPostgres(),
 		alerts:            b.alerts,
 		deployments:       b.deployments,
 		images:            b.images,

--- a/central/search/service/service_impl.go
+++ b/central/search/service/service_impl.go
@@ -360,8 +360,7 @@ type autocompleteValue struct {
 // values for the autocomplete field. Returns nil if the field type is not
 // suitable for GROUP BY (maps, arrays) or the category has no schema.
 //
-// When the schema has a Risk Score field, results are ordered by max(risk_score)
-// DESC so the most relevant values appear first. Otherwise, no ordering is applied.
+// Results are ordered alphabetically by the autocomplete field.
 func runGroupByAutocomplete(ctx context.Context, db postgres.DB, category v1.SearchCategory, query *v1.Query, autocompleteKey string, limit int) ([]string, error) {
 	schema := pgMapping.GetTableFromCategory(category)
 	if schema == nil {
@@ -379,16 +378,9 @@ func runGroupByAutocomplete(ctx context.Context, db postgres.DB, category v1.Sea
 	}
 	cloned.Pagination = &v1.QueryPagination{
 		Limit: int32(limit),
-	}
-
-	if _, ok := schema.OptionsMap.Get(search.RiskScore.String()); ok {
-		cloned.Pagination.SortOptions = []*v1.QuerySortOption{{
-			Field:    search.RiskScore.String(),
-			Reversed: true,
-			AggregateBy: &v1.AggregateBy{
-				AggrFunc: v1.Aggregation_MAX,
-			},
-		}}
+		SortOptions: []*v1.QuerySortOption{{
+			Field: autocompleteKey,
+		}},
 	}
 
 	var results []string

--- a/central/search/service/service_impl.go
+++ b/central/search/service/service_impl.go
@@ -359,6 +359,9 @@ type autocompleteValue struct {
 // runGroupByAutocomplete executes a GROUP BY query to get exactly `limit` unique
 // values for the autocomplete field. Returns nil if the field type is not
 // suitable for GROUP BY (maps, arrays) or the category has no schema.
+//
+// When the schema has a Risk Score field, results are ordered by max(risk_score)
+// DESC so the most relevant values appear first. Otherwise, no ordering is applied.
 func runGroupByAutocomplete(ctx context.Context, db postgres.DB, category v1.SearchCategory, query *v1.Query, autocompleteKey string, limit int) ([]string, error) {
 	schema := pgMapping.GetTableFromCategory(category)
 	if schema == nil {
@@ -376,6 +379,16 @@ func runGroupByAutocomplete(ctx context.Context, db postgres.DB, category v1.Sea
 	}
 	cloned.Pagination = &v1.QueryPagination{
 		Limit: int32(limit),
+	}
+
+	if _, ok := schema.OptionsMap.Get(search.RiskScore.String()); ok {
+		cloned.Pagination.SortOptions = []*v1.QuerySortOption{{
+			Field:    search.RiskScore.String(),
+			Reversed: true,
+			AggregateBy: &v1.AggregateBy{
+				AggrFunc: v1.Aggregation_MAX,
+			},
+		}}
 	}
 
 	var results []string

--- a/central/search/service/service_impl.go
+++ b/central/search/service/service_impl.go
@@ -43,7 +43,6 @@ import (
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 	pgMapping "github.com/stackrox/rox/pkg/search/postgres/mapping"
 	"github.com/stackrox/rox/pkg/set"
-	"github.com/stackrox/rox/pkg/utils"
 	"google.golang.org/grpc"
 )
 
@@ -226,130 +225,131 @@ func RunAutoComplete(ctx context.Context, queryString string, categories []v1.Se
 		categories = autocompleteCategories.AsSlice()
 	}
 
-	// Try the optimized GROUP BY path for scalar fields.
-	if db != nil {
-		remaining := maxAutocompleteResults
-		resultSet := set.NewStringSet()
-		var stringResults []string
+	remaining := maxAutocompleteResults
+	resultSet := set.NewStringSet()
+	var stringResults []string
 
-		for _, category := range categories {
-			if remaining <= 0 {
-				break
-			}
-			if category == v1.SearchCategory_ALERTS && !shouldProcessAlerts(query) {
-				continue
-			}
-
-			optMultiMap := categoryToOptionsMultimap[category]
-			if optMultiMap == nil {
-				continue
-			}
-			autocompleteFields := optMultiMap.GetAll(autocompleteKey)
-			if len(autocompleteFields) == 0 {
-				continue
-			}
-
-			// Only use GROUP BY for scalar fields (not maps).
-			isMap := false
-			for _, f := range autocompleteFields {
-				if f.GetType() == v1.SearchDataType_SEARCH_MAP {
-					isMap = true
-					break
-				}
-			}
-			if isMap {
-				continue
-			}
-
-			values, groupByErr := runGroupByAutocomplete(ctx, db, category, query, autocompleteKey, remaining)
-			if groupByErr != nil {
-				log.Warnf("GROUP BY autocomplete failed for category %s, falling back: %v", category, groupByErr)
-				continue
-			}
-			for _, v := range values {
-				v = handleMatch(autocompleteFields[0].GetFieldPath(), v)
-				if resultSet.Add(v) {
-					stringResults = append(stringResults, v)
-					remaining--
-				}
-			}
-		}
-		if len(stringResults) > 0 {
-			return stringResults, nil
-		}
-	}
-
-	// Fallback: search + Go-side deduplication.
-	query.Pagination = &v1.QueryPagination{
-		Limit: pagination,
-	}
-
-	var autocompleteResults []autocompleteResult
 	for _, category := range categories {
+		if remaining <= 0 {
+			break
+		}
 		if category == v1.SearchCategory_ALERTS && !shouldProcessAlerts(query) {
 			continue
-		}
-		searcher, ok := searchers[category]
-		if searcher == nil {
-			if ok {
-				utils.Should(errors.Errorf("searchers map has an entry for category %v, but the returned searcher was nil", category))
-			}
-			return nil, errors.Wrapf(errox.InvalidArgs, "Search category %q is not implemented", category.String())
 		}
 
 		optMultiMap := categoryToOptionsMultimap[category]
 		if optMultiMap == nil {
-			return nil, errors.Wrapf(errox.InvalidArgs, "Search category %q is not implemented", category.String())
+			continue
 		}
-
 		autocompleteFields := optMultiMap.GetAll(autocompleteKey)
 		if len(autocompleteFields) == 0 {
 			continue
 		}
 
-		fieldPaths := make([]string, 0, 3*len(autocompleteFields))
-		for _, field := range autocompleteFields {
-			fieldPaths = append(fieldPaths,
-				field.GetFieldPath(),
-				search.ToMapKeyPath(field.GetFieldPath()),
-				search.ToMapValuePath(field.GetFieldPath()),
-			)
+		isMap := false
+		for _, f := range autocompleteFields {
+			if f.GetType() == v1.SearchDataType_SEARCH_MAP {
+				isMap = true
+				break
+			}
 		}
 
-		results, err := searcher.Search(ctx, query)
-		if err != nil {
-			log.Errorf("failed to search category %s: %s", category.String(), err)
-			return nil, err
+		if isMap {
+			// Map fields (labels, annotations) need the search path to
+			// produce key=value pairs via Go post-processing.
+			values, err := searchAutocomplete(ctx, searchers, category, query, autocompleteFields)
+			if err != nil {
+				return nil, err
+			}
+			for _, v := range values {
+				if resultSet.Add(v) {
+					stringResults = append(stringResults, v)
+					remaining--
+				}
+			}
+			continue
 		}
-		for _, r := range results {
-			matches := trimMatches(r.Matches, fieldPaths)
-			if isMapMatch(matches) {
-				autocompleteResults = append(autocompleteResults, handleMapResults(matches, r.Score)...)
+
+		// Scalar fields use GROUP BY for guaranteed unique results.
+		// Fall back to search if GROUP BY fails (e.g., framework query generation issues).
+		if db != nil {
+			values, groupByErr := runGroupByAutocomplete(ctx, db, category, query, autocompleteKey, remaining)
+			if groupByErr == nil {
+				for _, v := range values {
+					v = handleMatch(autocompleteFields[0].GetFieldPath(), v)
+					if resultSet.Add(v) {
+						stringResults = append(stringResults, v)
+						remaining--
+					}
+				}
 				continue
 			}
+			log.Warnf("GROUP BY autocomplete failed for category %s, using search: %v", category, groupByErr)
+		}
+		values, err := searchAutocomplete(ctx, searchers, category, query, autocompleteFields)
+		if err != nil {
+			return nil, err
+		}
+		for _, v := range values {
+			if resultSet.Add(v) {
+				stringResults = append(stringResults, v)
+				remaining--
+			}
+		}
+	}
 
-			for fieldPath, match := range matches {
-				for _, v := range match {
-					value := handleMatch(fieldPath, v)
-					autocompleteResults = append(autocompleteResults, autocompleteResult{value: value, score: r.Score})
+	return stringResults, nil
+}
+
+// searchAutocomplete uses the legacy search+deduplicate path for map fields
+// where GROUP BY cannot produce key=value pairs.
+func searchAutocomplete(ctx context.Context, searchers map[v1.SearchCategory]search.Searcher, category v1.SearchCategory, query *v1.Query, autocompleteFields []*search.Field) ([]string, error) {
+	searcher := searchers[category]
+	if searcher == nil {
+		return nil, nil
+	}
+
+	searchQuery := query.CloneVT()
+	searchQuery.Pagination = &v1.QueryPagination{
+		Limit: pagination,
+	}
+
+	fieldPaths := make([]string, 0, 3*len(autocompleteFields))
+	for _, field := range autocompleteFields {
+		fieldPaths = append(fieldPaths,
+			field.GetFieldPath(),
+			search.ToMapKeyPath(field.GetFieldPath()),
+			search.ToMapValuePath(field.GetFieldPath()),
+		)
+	}
+
+	results, err := searcher.Search(ctx, searchQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := set.NewStringSet()
+	var values []string
+	for _, r := range results {
+		matches := trimMatches(r.Matches, fieldPaths)
+		if isMapMatch(matches) {
+			for _, ar := range handleMapResults(matches, 0) {
+				if seen.Add(ar.value) {
+					values = append(values, ar.value)
+				}
+			}
+			continue
+		}
+		for fieldPath, match := range matches {
+			for _, v := range match {
+				value := handleMatch(fieldPath, v)
+				if seen.Add(value) {
+					values = append(values, value)
 				}
 			}
 		}
 	}
-
-	sort.Slice(autocompleteResults, func(i, j int) bool { return autocompleteResults[i].score > autocompleteResults[j].score })
-	resultSet := set.NewStringSet()
-
-	var stringResults []string
-	for _, a := range autocompleteResults {
-		if added := resultSet.Add(a.value); added {
-			stringResults = append(stringResults, a.value)
-		}
-		if resultSet.Cardinality() == maxAutocompleteResults {
-			break
-		}
-	}
-	return stringResults, nil
+	return values, nil
 }
 
 type autocompleteValue struct {

--- a/central/search/service/service_impl.go
+++ b/central/search/service/service_impl.go
@@ -37,8 +37,11 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
+	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/search/enumregistry"
+	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
+	pgMapping "github.com/stackrox/rox/pkg/search/postgres/mapping"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/utils"
 	"google.golang.org/grpc"
@@ -138,6 +141,7 @@ var (
 type serviceImpl struct {
 	v1.UnimplementedSearchServiceServer
 
+	db                postgres.DB
 	alerts            alertDataStore.DataStore
 	deployments       deploymentDataStore.DataStore
 	images            imageDataStore.DataStore
@@ -208,19 +212,78 @@ func trimMatches(matches map[string][]string, fieldPaths []string) map[string][]
 }
 
 // RunAutoComplete runs an autocomplete request. It's a free function used by both regular search and by GraphQL.
-func RunAutoComplete(ctx context.Context, queryString string, categories []v1.SearchCategory, searchers map[v1.SearchCategory]search.Searcher) ([]string, error) {
+// When db is non-nil and the autocomplete field is a scalar type, a GROUP BY
+// query is used to return exactly maxAutocompleteResults unique values from
+// Postgres. For map/array fields or when db is nil, the existing search +
+// Go-side deduplication path is used.
+func RunAutoComplete(ctx context.Context, queryString string, categories []v1.SearchCategory, searchers map[v1.SearchCategory]search.Searcher, db postgres.DB) ([]string, error) {
 	query, autocompleteKey, err := search.ParseQueryForAutocomplete(queryString)
 	if err != nil {
 		return nil, errors.Wrapf(errox.InvalidArgs, "unable to parse query %q: %v", queryString, err)
-	}
-	// Set the max return size for the query
-	query.Pagination = &v1.QueryPagination{
-		Limit: pagination,
 	}
 
 	if len(categories) == 0 {
 		categories = autocompleteCategories.AsSlice()
 	}
+
+	// Try the optimized GROUP BY path for scalar fields.
+	if db != nil {
+		remaining := maxAutocompleteResults
+		resultSet := set.NewStringSet()
+		var stringResults []string
+
+		for _, category := range categories {
+			if remaining <= 0 {
+				break
+			}
+			if category == v1.SearchCategory_ALERTS && !shouldProcessAlerts(query) {
+				continue
+			}
+
+			optMultiMap := categoryToOptionsMultimap[category]
+			if optMultiMap == nil {
+				continue
+			}
+			autocompleteFields := optMultiMap.GetAll(autocompleteKey)
+			if len(autocompleteFields) == 0 {
+				continue
+			}
+
+			// Only use GROUP BY for scalar fields (not maps).
+			isMap := false
+			for _, f := range autocompleteFields {
+				if f.GetType() == v1.SearchDataType_SEARCH_MAP {
+					isMap = true
+					break
+				}
+			}
+			if isMap {
+				continue
+			}
+
+			values, groupByErr := runGroupByAutocomplete(ctx, db, category, query, autocompleteKey, remaining)
+			if groupByErr != nil {
+				log.Warnf("GROUP BY autocomplete failed for category %s, falling back: %v", category, groupByErr)
+				continue
+			}
+			for _, v := range values {
+				v = handleMatch(autocompleteFields[0].GetFieldPath(), v)
+				if resultSet.Add(v) {
+					stringResults = append(stringResults, v)
+					remaining--
+				}
+			}
+		}
+		if len(stringResults) > 0 {
+			return stringResults, nil
+		}
+	}
+
+	// Fallback: search + Go-side deduplication.
+	query.Pagination = &v1.QueryPagination{
+		Limit: pagination,
+	}
+
 	var autocompleteResults []autocompleteResult
 	for _, category := range categories {
 		if category == v1.SearchCategory_ALERTS && !shouldProcessAlerts(query) {
@@ -241,11 +304,9 @@ func RunAutoComplete(ctx context.Context, queryString string, categories []v1.Se
 
 		autocompleteFields := optMultiMap.GetAll(autocompleteKey)
 		if len(autocompleteFields) == 0 {
-			// Category for field to be autocompleted not applicable.
 			continue
 		}
 
-		// All the field paths to consider for the autocomplete field.
 		fieldPaths := make([]string, 0, 3*len(autocompleteFields))
 		for _, field := range autocompleteFields {
 			fieldPaths = append(fieldPaths,
@@ -262,10 +323,6 @@ func RunAutoComplete(ctx context.Context, queryString string, categories []v1.Se
 		}
 		for _, r := range results {
 			matches := trimMatches(r.Matches, fieldPaths)
-			// In postgres, we do not need to combine map key and values matches as `k=v` because it is already done by postgres searcher.
-			// With postgres, the following condition will not pass anyway.
-			//
-			// This implies that the object is a map because it has multiple values
 			if isMapMatch(matches) {
 				autocompleteResults = append(autocompleteResults, handleMapResults(matches, r.Score)...)
 				continue
@@ -295,8 +352,47 @@ func RunAutoComplete(ctx context.Context, queryString string, categories []v1.Se
 	return stringResults, nil
 }
 
+type autocompleteValue struct {
+	Value string `db:"value"`
+}
+
+// runGroupByAutocomplete executes a GROUP BY query to get exactly `limit` unique
+// values for the autocomplete field. Returns nil if the field type is not
+// suitable for GROUP BY (maps, arrays) or the category has no schema.
+func runGroupByAutocomplete(ctx context.Context, db postgres.DB, category v1.SearchCategory, query *v1.Query, autocompleteKey string, limit int) ([]string, error) {
+	schema := pgMapping.GetTableFromCategory(category)
+	if schema == nil {
+		return nil, nil
+	}
+
+	fieldLabel := search.FieldLabel(autocompleteKey)
+
+	cloned := query.CloneVT()
+	cloned.Selects = []*v1.QuerySelect{
+		search.NewQuerySelect(fieldLabel).Proto(),
+	}
+	cloned.GroupBy = &v1.QueryGroupBy{
+		Fields: []string{autocompleteKey},
+	}
+	cloned.Pagination = &v1.QueryPagination{
+		Limit: int32(limit),
+	}
+
+	var results []string
+	err := pgSearch.RunSelectRequestForSchemaFn(ctx, db, schema, cloned, func(r *autocompleteValue) error {
+		if r.Value != "" {
+			results = append(results, r.Value)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (s *serviceImpl) autocomplete(ctx context.Context, queryString string, categories []v1.SearchCategory) ([]string, error) {
-	return RunAutoComplete(ctx, queryString, categories, s.getAutocompleteSearchers())
+	return RunAutoComplete(ctx, queryString, categories, s.getAutocompleteSearchers(), s.db)
 }
 
 func (s *serviceImpl) Autocomplete(ctx context.Context, req *v1.RawSearchRequest) (*v1.AutocompleteResponse, error) {

--- a/central/search/service/service_impl_test.go
+++ b/central/search/service/service_impl_test.go
@@ -362,6 +362,7 @@ func (s *SearchOperationsTestSuite) TestAutocomplete() {
 		WithPolicyCategoryDataStore(categoryDataStoreMocks.NewMockDataStore(s.mockCtrl))
 
 	service := builder.Build().(*serviceImpl)
+	service.db = s.pool
 
 	for _, testCase := range []struct {
 		query           string
@@ -466,6 +467,7 @@ func (s *SearchOperationsTestSuite) TestAutocompleteForEnums() {
 		WithPolicyCategoryDataStore(categoriesDS)
 
 	service := builder.Build().(*serviceImpl)
+	service.db = s.pool
 
 	results, err := service.autocomplete(ctx, fmt.Sprintf("%s:", search.Severity), []v1.SearchCategory{v1.SearchCategory_POLICIES})
 	s.NoError(err)
@@ -519,6 +521,7 @@ func (s *SearchOperationsTestSuite) TestAutocompleteAuthz() {
 
 	builder = builder.WithPolicyCategoryDataStore(categoryDataStoreMocks.NewMockDataStore(s.mockCtrl))
 	service := builder.Build().(*serviceImpl)
+	service.db = s.pool
 
 	deploymentQuery := search.NewQueryBuilder().AddStrings(search.DeploymentName, deployment.GetName()).Query()
 	alertQuery := search.NewQueryBuilder().AddStrings(search.DeploymentName, alert.GetDeployment().GetName()).Query()
@@ -592,6 +595,7 @@ func (s *SearchOperationsTestSuite) TestSearchAuthz() {
 		WithPolicyCategoryDataStore(categoryDataStoreMocks.NewMockDataStore(s.mockCtrl))
 
 	service := builder.Build().(*serviceImpl)
+	service.db = s.pool
 
 	deploymentQuery := search.NewQueryBuilder().AddStrings(search.DeploymentName, deployment.GetName()).Query()
 	alertQuery := search.NewQueryBuilder().AddStrings(search.DeploymentName, alert.GetDeployment().GetName()).Query()


### PR DESCRIPTION
ROX-26368: WIP autocomplete via GROUP BY for unique results

First cut: RunAutoComplete uses GROUP BY query for scalar fields to
get exactly N unique values from Postgres instead of over-fetching
and deduplicating in Go. Falls back to existing search path for
map fields or on error.

TODO: add ORDER BY with aggregate (max/min) for sort-field ranking.

Partially generated by AI

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

ROX-26368: add ORDER BY max(risk_score) to GROUP BY autocomplete

When the schema has a Risk Score field, autocomplete results are
ordered by max(risk_score) DESC so the most relevant values appear
first. Categories without Risk Score get unsorted unique results.

Partially generated by AI

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
