### PR TITLE
fix: deduplicate CVEs by name in central scanner v4 conversion layer

### DIFF
--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -178,11 +178,13 @@ func vulnerabilities(vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerab
 		return nil
 	}
 
-	vulns := make([]*storage.EmbeddedVulnerability, 0, len(ids))
-	uniqueVulns := set.NewStringSet()
+	// Deduplicate by CVE name, keeping the entry with the highest severity.
+	// Multiple advisory sources (e.g., GHSA + Go vulndb, OVAL + CSAF) can
+	// produce separate entries that resolve to the same CVE name.
+	vulnByCVE := make(map[string]*storage.EmbeddedVulnerability, len(ids))
+	seenIDs := set.NewStringSet()
 	for _, id := range ids {
-		if !uniqueVulns.Add(id) {
-			// Already saw this vulnerability, so ignore it.
+		if !seenIDs.Add(id) {
 			continue
 		}
 
@@ -218,9 +220,20 @@ func vulnerabilities(vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerab
 			}
 		}
 
-		vulns = append(vulns, vuln)
+		if existing, ok := vulnByCVE[vuln.GetCve()]; ok {
+			if vuln.GetSeverity() > existing.GetSeverity() ||
+				(vuln.GetSeverity() == existing.GetSeverity() && vuln.GetCvss() > existing.GetCvss()) {
+				vulnByCVE[vuln.GetCve()] = vuln
+			}
+			continue
+		}
+		vulnByCVE[vuln.GetCve()] = vuln
 	}
 
+	vulns := make([]*storage.EmbeddedVulnerability, 0, len(vulnByCVE))
+	for _, vuln := range vulnByCVE {
+		vulns = append(vulns, vuln)
+	}
 	return vulns
 }
 

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -15,6 +15,85 @@ import (
 
 const scannerVersion = "indexer=4.8.3"
 
+func TestVulnerabilitiesDedup(t *testing.T) {
+	tests := map[string]struct {
+		vulns    map[string]*v4.VulnerabilityReport_Vulnerability
+		ids      []string
+		expected int
+		wantSev  storage.VulnerabilitySeverity
+	}{
+		"alias duplicates are deduplicated by CVE name": {
+			vulns: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"ghsa-1": {
+					Name:               "CVE-2026-33186",
+					Description:        "from GHSA",
+					Link:               "https://nvd.nist.gov/vuln/detail/CVE-2026-33186",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_CRITICAL,
+				},
+				"go-1": {
+					Name:               "CVE-2026-33186",
+					Description:        "from Go vulndb",
+					Link:               "https://osv.dev/vulnerability/CVE-2026-33186",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_UNSPECIFIED,
+				},
+			},
+			ids:      []string{"ghsa-1", "go-1"},
+			expected: 1,
+			wantSev:  storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY,
+		},
+		"different CVEs are not deduplicated": {
+			vulns: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"v1": {
+					Name:               "CVE-2026-0001",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
+				},
+				"v2": {
+					Name:               "CVE-2026-0002",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+				},
+			},
+			ids:      []string{"v1", "v2"},
+			expected: 2,
+		},
+		"same ClairCore ID is deduplicated": {
+			vulns: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"v1": {
+					Name:               "CVE-2026-99999",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
+				},
+			},
+			ids:      []string{"v1", "v1"},
+			expected: 1,
+		},
+		"keeps higher severity on duplicate": {
+			vulns: map[string]*v4.VulnerabilityReport_Vulnerability{
+				"oval-1": {
+					Name:               "CVE-2025-14087",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+				},
+				"csaf-1": {
+					Name:               "CVE-2025-14087",
+					NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
+				},
+			},
+			ids:      []string{"oval-1", "csaf-1"},
+			expected: 1,
+			wantSev:  storage.VulnerabilitySeverity_IMPORTANT_VULNERABILITY_SEVERITY,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := vulnerabilities(tt.vulns, tt.ids, "")
+			assert.Len(t, result, tt.expected)
+			if tt.expected == 1 && tt.wantSev != 0 {
+				assert.Equal(t, tt.wantSev, result[0].GetSeverity(),
+					"should keep the entry with higher severity")
+			}
+		})
+	}
+}
+
 func TestNoPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
 		imageScan(nil, nil, "")


### PR DESCRIPTION
When multiple advisory sources (GHSA + Go vulndb, OVAL + CSAF) produce
separate entries that resolve to the same CVE name, central now keeps
only the entry with the highest severity. Covers images, VMs, and SBOMs.

Alternative to the scanner-side fix in dedupeVulns. Both can coexist
as defense in depth.

Partially generated by AI

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
