### PR TITLE
fix: limit body reader in centralproxy transport

### DIFF
--- a/pkg/centralproxy/allowed_paths.go
+++ b/pkg/centralproxy/allowed_paths.go
@@ -10,6 +10,10 @@ import "github.com/stackrox/rox/pkg/set"
 //   - Entries ending with "/" are treated as prefixes: any request path
 //     starting with that prefix is allowed.
 //   - Entries without a trailing "/" require an exact match.
+//
+// IMPORTANT: The proxy buffers request bodies in memory for retry support.
+// When adding new paths, ensure the endpoints do not expect request bodies
+// exceeding the buffer limit.
 var AllowedProxyPaths = set.NewFrozenStringSet(
 	"/api/graphql",
 	"/static/ocp-plugin/",

--- a/sensor/common/centralproxy/transport.go
+++ b/sensor/common/centralproxy/transport.go
@@ -39,6 +39,11 @@ const (
 	// This ensures that token requests don't hang indefinitely when all callers have cancelled.
 	tokenRequestTimeout = 30 * time.Second
 
+	// maxRequestBodySize is the maximum size of a proxied request body that will
+	// be buffered for retry. 32 MiB is generous for the query/filter payloads
+	// this proxy handles while still guarding against memory exhaustion.
+	maxRequestBodySize = 32 << 20
+
 	// FullClusterAccessScope is the namespace scope value that indicates full cluster access.
 	FullClusterAccessScope = "*"
 )
@@ -123,10 +128,14 @@ func (t *scopedTokenTransport) RoundTrip(req *http.Request) (*http.Response, err
 	// Buffer the request body upfront so we can replay it on retry.
 	var bodyBytes []byte
 	if req.Body != nil && req.Body != http.NoBody {
+		defer utils.IgnoreError(req.Body.Close)
 		var err error
-		bodyBytes, err = io.ReadAll(req.Body)
+		bodyBytes, err = io.ReadAll(io.LimitReader(req.Body, maxRequestBodySize+1))
 		if err != nil {
 			return nil, errors.Wrap(err, "reading request body")
+		}
+		if len(bodyBytes) > maxRequestBodySize {
+			return nil, errors.Errorf("request body exceeds maximum allowed size of %d bytes", maxRequestBodySize)
 		}
 		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	}

--- a/sensor/common/centralproxy/transport_test.go
+++ b/sensor/common/centralproxy/transport_test.go
@@ -789,6 +789,56 @@ func TestScopedTokenTransport_RetryWithRequestBody(t *testing.T) {
 	})
 }
 
+func TestScopedTokenTransport_RequestBodySizeLimit(t *testing.T) {
+	tests := map[string]struct {
+		bodySize  int
+		wantError bool
+	}{
+		"body within limit is accepted":     {bodySize: 64, wantError: false},
+		"body exactly at limit is accepted": {bodySize: maxRequestBodySize, wantError: false},
+		"body exceeding limit is rejected":  {bodySize: maxRequestBodySize + 1, wantError: true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			fakeClient := &fakeTokenServiceClient{
+				response: &centralv1.GenerateTokenForPermissionsAndScopeResponse{
+					Token: "test-token",
+				},
+			}
+
+			mockBase := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				if tt.wantError {
+					t.Fatal("base transport should not be called for oversized body")
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+				}, nil
+			})
+
+			transport := &scopedTokenTransport{
+				base:          mockBase,
+				tokenProvider: newTestTokenProvider(fakeClient, "test-cluster-id"),
+			}
+
+			body := strings.NewReader(strings.Repeat("x", tt.bodySize))
+			req := httptest.NewRequest(http.MethodPost, "/v1/alerts", body)
+			resp, err := transport.RoundTrip(req)
+
+			if tt.wantError {
+				assert.Error(t, err)
+				assert.Nil(t, resp)
+				assert.Contains(t, err.Error(), "maximum allowed size")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+			}
+		})
+	}
+}
+
 // trackingReadCloser wraps an io.ReadCloser and tracks read/close operations.
 type trackingReadCloser struct {
 	io.ReadCloser


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR addresses unbounded use of `io.ReadAll`, which got flagged in other code parts as a potential security issue.

It adds a 32 MiB size limit to request bodies buffered by the `centralproxy` transport to prevent unbounded memory consumption. The transport buffers request bodies to enable retries, but previously had no size limit.

The 32 MiB threshold is generous for the query/filter payloads this proxy handles (alerts, network flows, compliance data) while protecting against memory exhaustion if misconfigured clients send unexpectedly large requests.

Requests exceeding the limit are rejected with a clear error before reaching the base transport.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

see added tests