### PR TITLE
ROX-34816: fix missing timestamps in report ZIP entries

### DIFF
--- a/central/complianceoperator/v2/report/manager/format/formatter.go
+++ b/central/complianceoperator/v2/report/manager/format/formatter.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/complianceoperator/v2/report"
@@ -150,8 +151,25 @@ func getFileName(format string, clusterName string, timestamp *timestamppb.Times
 	return fmt.Sprintf(format, fmt.Sprintf("%s_%d-%d-%d", clusterName, year, month, day))
 }
 
+type timestampedZipWriter struct {
+	w *zip.Writer
+}
+
+func (t *timestampedZipWriter) Create(name string) (io.Writer, error) {
+	header := &zip.FileHeader{
+		Name:     name,
+		Method:   zip.Deflate,
+		Modified: time.Now(),
+	}
+	return t.w.CreateHeader(header)
+}
+
+func (t *timestampedZipWriter) Close() error {
+	return t.w.Close()
+}
+
 func createNewZipWriter(buf *bytes.Buffer) ZipWriter {
-	return zip.NewWriter(buf)
+	return &timestampedZipWriter{w: zip.NewWriter(buf)}
 }
 
 func createNewCSVWriter(header csv.Header, sort bool) CSVWriter {

--- a/central/complianceoperator/v2/report/manager/format/formatter_test.go
+++ b/central/complianceoperator/v2/report/manager/format/formatter_test.go
@@ -1,15 +1,19 @@
 package format
 
 import (
+	"archive/zip"
 	"bytes"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/complianceoperator/v2/report"
 	"github.com/stackrox/rox/central/complianceoperator/v2/report/manager/format/mocks"
 	"github.com/stackrox/rox/pkg/csv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -19,6 +23,24 @@ const (
 	clusterID1 = "cluster-1"
 	clusterID2 = "cluster-2"
 )
+
+func TestTimestampedZipWriter_SetsModifiedTimestamp(t *testing.T) {
+	var buf bytes.Buffer
+	before := time.Now().Add(-time.Minute)
+	zw := createNewZipWriter(&buf)
+
+	w, err := zw.Create("test.csv")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("data"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	reader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	require.Len(t, reader.File, 1)
+	assert.False(t, reader.File[0].Modified.IsZero(), "ZIP entry Modified timestamp should not be zero")
+	assert.True(t, reader.File[0].Modified.After(before), "ZIP entry Modified timestamp should be recent")
+}
 
 func TestComplianceReportingFormatter(t *testing.T) {
 	suite.Run(t, new(ComplianceReportingFormatterSuite))

--- a/central/reports/common/report_formatter.go
+++ b/central/reports/common/report_formatter.go
@@ -171,7 +171,13 @@ func Format(deployedImagesResults []DeployedImagesResult, watchedImagesResults [
 
 	var zipBuf bytes.Buffer
 	zipWriter := zip.NewWriter(&zipBuf)
-	zipFile, err := zipWriter.Create(makeFileName(configName, time.Now()))
+	now := time.Now()
+	header := &zip.FileHeader{
+		Name:     makeFileName(configName, now),
+		Method:   zip.Deflate,
+		Modified: now,
+	}
+	zipFile, err := zipWriter.CreateHeader(header)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create a zip file of the vuln report")
 	}

--- a/central/reports/common/report_formatter_test.go
+++ b/central/reports/common/report_formatter_test.go
@@ -1,11 +1,14 @@
 package common
 
 import (
+	"archive/zip"
+	"bytes"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_replaceUnsafeRunes(t *testing.T) {
@@ -23,6 +26,18 @@ func Test_replaceUnsafeRunes(t *testing.T) {
 			assert.Equal(t, expected, builder.String())
 		})
 	}
+}
+
+func TestFormat_ZipEntryHasModifiedTimestamp(t *testing.T) {
+	before := time.Now().Add(-time.Minute)
+	result, err := Format(nil, nil, "test", false)
+	require.NoError(t, err)
+
+	reader, err := zip.NewReader(bytes.NewReader(result.ZippedCsv.Bytes()), int64(result.ZippedCsv.Len()))
+	require.NoError(t, err)
+	require.Len(t, reader.File, 1)
+	assert.False(t, reader.File[0].Modified.IsZero(), "ZIP entry Modified timestamp should not be zero")
+	assert.True(t, reader.File[0].Modified.After(before), "ZIP entry Modified timestamp should be recent")
 }
 
 func Test_makeFileName(t *testing.T) {

--- a/central/reports/scheduler/v2/reportgenerator/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/csv_gen.go
@@ -82,8 +82,14 @@ func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string) (*byt
 		truncatedName = configName[0:80] + "..."
 	}
 
-	reportName := fmt.Sprintf("RHACS_Vulnerability_Report_%s_%s.csv", truncatedName, time.Now().Format("02_January_2006"))
-	zipFile, err := zipWriter.Create(reportName)
+	now := time.Now()
+	reportName := fmt.Sprintf("RHACS_Vulnerability_Report_%s_%s.csv", truncatedName, now.Format("02_January_2006"))
+	header := &zip.FileHeader{
+		Name:     reportName,
+		Method:   zip.Deflate,
+		Modified: now,
+	}
+	zipFile, err := zipWriter.CreateHeader(header)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to create the zip file for report config '%s'", configName)
 	}

--- a/central/reports/scheduler/v2/reportgenerator/csv_gen_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/csv_gen_test.go
@@ -1,0 +1,23 @@
+package reportgenerator
+
+import (
+	"archive/zip"
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateCSV_ZipEntryHasModifiedTimestamp(t *testing.T) {
+	before := time.Now().Add(-time.Minute)
+	buf, err := GenerateCSV(nil, "test")
+	require.NoError(t, err)
+
+	reader, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	require.Len(t, reader.File, 1)
+	assert.False(t, reader.File[0].Modified.IsZero(), "ZIP entry Modified timestamp should not be zero")
+	assert.True(t, reader.File[0].Modified.After(before), "ZIP entry Modified timestamp should be recent")
+}


### PR DESCRIPTION
## Description

Files inside vulnerability and compliance report ZIP exports had no `Modified` timestamp in their ZIP metadata. On Linux (e.g. Fedora), this caused the file modification date to display as "11/30/79 12:00AM" — the Go `archive/zip` zero-value date. macOS masked the bug by substituting the current time when the ZIP entry timestamp is zero.

The root cause was use of `zipWriter.Create(filename)`, which does not set the `Modified` field on the ZIP file header. The fix replaces these calls with `zipWriter.CreateHeader(&zip.FileHeader{Modified: ...})`, using the same timestamp already computed for the filename. This pattern was already used correctly in `central/debug/service/zip.go` and `pkg/zip/wrapper.go`.

**Alternative considered:** For the compliance formatter, which uses a `ZipWriter` interface, adding `CreateHeader` to the interface would have required updating the mock and 14 test assertions. Instead, a `timestampedZipWriter` wrapper overrides `Create` to internally use `CreateHeader` with `time.Now()`, requiring no interface or mock changes.

Co-Authored-By: Claude Opus 4.6 [noreply@anthropic.com](mailto:noreply@anthropic.com)

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request)  is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
~- [ ] added e2e tests~
~- [ ] added regression tests~
~- [ ] added compatibility tests~
~- [ ] modified existing tests~

### How I validated my change

- Added 3 unit tests that create ZIP archives via the modified code paths and assert the `Modified` timestamp is non-zero and recent
- Verified all existing tests in the 3 affected packages continue to pass
- Code was partially generated by AI
- Deployed container image build from the PR and verified that the date was embedded in the zip file listing:

```
$ unzip -l /Users/vwilson/Downloads/AA-may26-2026-418f2636-2026-05-26T23_32_01.278086139Z.zip
Archive:  /Users/vwilson/Downloads/AA-may26-2026-418f2636-2026-05-26T23_32_01.278086139Z.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
    53256  05-26-2026 19:32   RHACS_Vulnerability_Report_AA-may26-2026-418f2636_26_May_2026.csv
---------                     -------
    53256                     1 file
```