### PR TITLE
fix(ci): filter soft-deleted Quay tags in image existence check

### DIFF
--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1048,7 +1048,7 @@ check_rhacs_eng_image_exists() {
     local name="$1"
     local tag="$2"
 
-    local url="https://quay.io/api/v1/repository/rhacs-eng/$name/tag?specificTag=$tag"
+    local url="https://quay.io/api/v1/repository/rhacs-eng/$name/tag/?onlyActiveTags=true&specificTag=$tag"
     info "Checking for $name using $url"
     local check
     local extra_args=()


### PR DESCRIPTION
## Description

`check_rhacs_eng_image_exists` queries the Quay API for image tags but does not filter out soft-deleted tags. Quay retains deleted tags for 14 days (time machine feature), so deleted tags still appear in API responses and pass the existence check.

This causes `check-crd-compatibility` to treat a deleted tag as a released version, attempt to `git checkout` it, and fail because no corresponding git ref exists. Currently blocking all PR merges to master.

Problem:
check-crd-compatibility was failing. We had a mistakenly created v4.11.0 tagged image (and v4.12.0) and the crd check looks up git tags based on the quay image rhacs-eng/stackrox-operator-index tags ? So it found 4.11.0 and then failed to find that git tag:
example failure run: https://github.com/stackrox/stackrox/actions/runs/26450105239/job/77868129447
raised in chat: https://redhat-internal.slack.com/archives/CELUQKESC/p1779810171976809

Fix:
- [x] delete bad tags
- [ ] add `onlyActiveTags=true` to the Quay API query URL (for check-crd-compatibility).

### How I validated my change

Verified against live Quay API that the soft-deleted `v4.12.0` tag on `stackrox-operator-index`:
- Without `onlyActiveTags=true`: returns the tag (with `end_ts` set)
- With `onlyActiveTags=true`: returns empty `{"tags": []}`