### PR TITLE
ROX-34828: Improve doLookupEndpoint

### DIFF
--- a/sensor/common/clusterentities/store_endpoints.go
+++ b/sensor/common/clusterentities/store_endpoints.go
@@ -418,11 +418,14 @@ type Map[T any] interface {
 	~map[EndpointTargetInfo]T
 }
 
-func doLookupEndpoint[M Map[T], T any](ep net.NumericEndpoint, src map[net.NumericEndpoint]map[string]M) (results []LookupResult) {
-	for deploymentID, targetInfoSet := range src[ep] {
+func doLookupEndpoint[M Map[T], T any](ep net.NumericEndpoint, src map[net.NumericEndpoint]map[string]M) []LookupResult {
+	deploymentsMap := src[ep]
+	results := make([]LookupResult, 0, len(deploymentsMap))
+	for deploymentID, targetInfoSet := range deploymentsMap {
 		result := LookupResult{
 			Entity:         networkgraph.EntityForDeployment(deploymentID),
-			ContainerPorts: make([]uint16, 0),
+			ContainerPorts: make([]uint16, 0, len(targetInfoSet)),
+			PortNames:      make([]string, 0, len(targetInfoSet)),
 		}
 		for tgtInfo := range targetInfoSet {
 			result.ContainerPorts = append(result.ContainerPorts, tgtInfo.ContainerPort)

--- a/sensor/common/clusterentities/store_endpoints_lookup_bench_test.go
+++ b/sensor/common/clusterentities/store_endpoints_lookup_bench_test.go
@@ -1,0 +1,69 @@
+package clusterentities
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/net"
+	"github.com/stackrox/rox/pkg/networkgraph"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+func doLookupEndpointOld[M Map[T], T any](ep net.NumericEndpoint, src map[net.NumericEndpoint]map[string]M) (results []LookupResult) {
+	for deploymentID, targetInfoSet := range src[ep] {
+		result := LookupResult{
+			Entity:         networkgraph.EntityForDeployment(deploymentID),
+			ContainerPorts: make([]uint16, 0),
+		}
+		for tgtInfo := range targetInfoSet {
+			result.ContainerPorts = append(result.ContainerPorts, tgtInfo.ContainerPort)
+			if tgtInfo.PortName != "" {
+				result.PortNames = append(result.PortNames, tgtInfo.PortName)
+			}
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+func buildLookupBenchData(numDeployments, targetsPerDeployment int) (net.NumericEndpoint, map[net.NumericEndpoint]map[string]set.Set[EndpointTargetInfo]) {
+	ep := buildEndpoint("10.0.0.1", 8080)
+	deploymentsMap := make(map[string]set.Set[EndpointTargetInfo], numDeployments)
+	for d := range numDeployments {
+		etiSet := make(set.Set[EndpointTargetInfo], targetsPerDeployment)
+		for t := range targetsPerDeployment {
+			etiSet.Add(EndpointTargetInfo{
+				ContainerPort: uint16(8080 + t),
+				PortName:      fmt.Sprintf("port-%d", t),
+			})
+		}
+		deploymentsMap[fmt.Sprintf("depl-%d", d)] = etiSet
+	}
+	src := map[net.NumericEndpoint]map[string]set.Set[EndpointTargetInfo]{ep: deploymentsMap}
+	return ep, src
+}
+
+func BenchmarkDoLookupEndpoint(b *testing.B) {
+	deploymentCounts := []int{1, 10, 50, 100}
+	targetCounts := []int{1, 4, 8}
+
+	for _, numDeployments := range deploymentCounts {
+		for _, targetsPerDeployment := range targetCounts {
+			name := fmt.Sprintf("%ddepl_%dtargets", numDeployments, targetsPerDeployment)
+			ep, src := buildLookupBenchData(numDeployments, targetsPerDeployment)
+
+			b.Run("old/"+name, func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					doLookupEndpointOld(ep, src)
+				}
+			})
+			b.Run("new/"+name, func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					doLookupEndpoint(ep, src)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

`doLookupEndpoint` creates slices without specifying the capacity. However, in each case we either know how large the slice will be, or have a good idea how large it will be. This PR sets the capacities for the slices in `doLookupEndpoint`. Benchmark tests are also added. The results are shown below.

```
| Scenario             |  Old ns/op |  New ns/op | Speedup |   Old B/op |   New B/op | Old allocs | New allocs |
| ---                  |        --- |        --- |     --- |        --- |        --- |        --- |        --- |
| 1depl_1targets       |      267.9 |      221.8 |     17% |        136 |        130 |          3 |          3 |
| 1depl_4targets       |      378.2 |      267.7 |     29% |        232 |        184 |          5 |          3 |
| 1depl_8targets       |      482.4 |      298.3 |     38% |        376 |        256 |          7 |          3 |
| 10depl_1targets      |     2144.8 |     1285.0 |     40% |       3664 |       1332 |         25 |         21 |
| 10depl_4targets      |     3270.6 |     1704.6 |     48% |       4624 |       1872 |         45 |         21 |
| 10depl_8targets      |     4336.6 |     2049.2 |     53% |       6064 |       2592 |         65 |         21 |
| 50depl_1targets      |     9690.0 |     5721.4 |     41% |      16912 |       6276 |        107 |        101 |
| 50depl_4targets      |    15738.2 |     8198.6 |     48% |      21712 |       8976 |        207 |        101 |
| 50depl_8targets      |    21282.0 |     9773.8 |     54% |      28912 |      12576 |        307 |        101 |
| 100depl_1targets     |    20629.4 |    11879.4 |     42% |      34496 |      12680 |        208 |        201 |
| 100depl_4targets     |    31636.6 |    15909.4 |     50% |      44096 |      18080 |        408 |        201 |
| 100depl_8targets     |    41844.4 |    19261.2 |     54% |      58496 |      25280 |        608 |        201 |
| 1000depl_1targets    |   184014.2 |   122022.8 |     34% |     260896 |     124496 |       2011 |       2001 |
| 1000depl_4targets    |   288747.4 |   165182.2 |     43% |     356897 |     178496 |       4011 |       2001 |
| 1000depl_8targets    |   385399.4 |   195132.8 |     49% |     500897 |     250496 |       6011 |       2001 |
```

Note that the test cases with 1000 deployments were removed after creating the PR description to save time.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Benchmark testing was done. See above.
