### PR TITLE
fix(build): remove unnecessary -linkmode=external from go-tool.sh

### DIFF
--- a/scripts/go-tool.sh
+++ b/scripts/go-tool.sh
@@ -56,24 +56,25 @@ if [[ "$DEBUG_BUILD" != "yes" ]]; then
   ldflags+=(-s -w)
 fi
 
-if [[ "${CGO_ENABLED}" != 0 ]]; then
-  echo >&2 "CGO_ENABLED is not 0. Compiling with -linkmode=external"
-  ldflags+=('-linkmode=external')
-fi
-
 function invoke_go() {
   local tool="${1:?"invoke_go tool argument required"}"
   shift
   local args=()
-  local CGO_ENABLED
+  local extra_ldflags=()
 
   args+=("-buildvcs=false")
-  args+=(-ldflags="${ldflags[*]}")
   args+=(-tags "$(tr , ' ' <<<"$GOTAGS")")
+
   if [[ "$RACE" == "true" ]]; then
     export CGO_ENABLED=1
     args+=("-race")
+    if command -v musl-gcc &>/dev/null; then
+      export CC=musl-gcc
+      extra_ldflags+=('-linkmode=external' '-extldflags=-static')
+    fi
   fi
+
+  args+=(-ldflags="${ldflags[*]} ${extra_ldflags[*]}")
   go "$tool" "${args[@]}" "$@"
 }
 


### PR DESCRIPTION
## Description

Removes the unconditional `-linkmode=external` injection from `go-tool.sh` when `CGO_ENABLED != 0`. Go's linker auto-detects the correct linkmode for all build scenarios, making this flag redundant.

**Problem:** `go-tool.sh` adds `-linkmode=external` to every CGO-enabled build. This was originally added as a safety measure but is unnecessary — Go's auto-detection already selects the right linkmode.

**Why it's safe to remove:**

Tested empirically on Go 1.25.9 and 1.26.3 across Debian and UBI9, including the Red Hat FIPS toolchain (`go1.25.9 Red Hat 1.25.9-1.el9_7` with `GOEXPERIMENT=strictfipsruntime`):

| Build variant | No linkmode | `-linkmode=external` | NEEDED libs | Runs? |
|---|---|---|---|---|
| FIPS (Red Hat toolchain) | 5,914,752 bytes | 5,914,800 bytes | libresolv, libc | Both work |
| CGO=1 (standard Go) | 4,806,508 bytes | 4,735,264 bytes | libresolv, libc | Both work |
| Race | 8,855,054 bytes | 8,687,760 bytes | libresolv, libc | Both work |

The Red Hat compliance shim (`/usr/bin/go` wrapper in `openshift-golang-builder`) does not inject or require any linkmode flags.

**What changed:**

- Removed the `if CGO_ENABLED != 0; ldflags+=(-linkmode=external)` block
- Race builds still explicitly set `CGO_ENABLED=1` (required — `-race` errors if `CGO_ENABLED=0`)
- Added musl-gcc detection for race builds: if present, uses `-linkmode=external -extldflags=-static` for fully static binaries
- Removed `local CGO_ENABLED` declaration that was shadowing the env var export

**Affected build paths:** GHA amd64 builds, Konflux FIPS/roxctl/operator builds, local dev. All continue to produce correct dynamically-linked binaries via Go auto-detection.

Related to #20745.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

Build tooling change only — no unit tests applicable. CI build jobs exercise all affected paths.

### How I validated my change

- Built test programs on UBI9 with Red Hat FIPS Go toolchain (`brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25`) using `CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime` with no linkmode — binary builds, links correctly (libresolv + libc), and runs
- Verified on Go 1.25.9 (amd64) and Go 1.26.3 (arm64) on both Debian and UBI9
- Confirmed Red Hat compliance shim source does not inject linkmode flags
- Confirmed Go source (`cmd/link/internal/ld/config.go`) — neither race detector nor boringcrypto/FIPS force external linking; auto-detection handles both correctly