### PR TITLE
ROX-32912: Bump ClairCore with VEX and RHCC fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.69.0
-	github.com/quay/claircore v1.5.53-0.20260609230952-c99d6521c52a
+	github.com/quay/claircore v1.5.53-0.20260623202659-e6cd4c8e9962
 	github.com/quay/claircore/toolkit v1.6.1
 	github.com/quay/zlog/v2 v2.1.1
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319

--- a/go.sum
+++ b/go.sum
@@ -1288,8 +1288,8 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
-github.com/quay/claircore v1.5.53-0.20260609230952-c99d6521c52a h1:en8ZHSkuYIKfj3QuWnjdk2xkh5NLNVoyWZtXT/8N14A=
-github.com/quay/claircore v1.5.53-0.20260609230952-c99d6521c52a/go.mod h1:K0Z581W9ag2yK+pGsGdChiVLL6QOD1vdllALt0JzgWU=
+github.com/quay/claircore v1.5.53-0.20260623202659-e6cd4c8e9962 h1:boYeLNO7qfRfmIJ6RGrIw5zIDFhR1781iMGqUQfNqUs=
+github.com/quay/claircore v1.5.53-0.20260623202659-e6cd4c8e9962/go.mod h1:Tru7zL45XO2Q/j5vPmIM6750/X332bAhum7i3OlUpHI=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=
 github.com/quay/claircore/toolkit v1.6.1 h1:a3X1v28n5bo05T94cBlaoPU8xYCErRGPM3l6AlmYWj4=
 github.com/quay/claircore/toolkit v1.6.1/go.mod h1:dTzlp1pgNchc+CN73HJiG9+e0ygU54QPt397eXnGGo4=


### PR DESCRIPTION
## Description

Bumps ClairCore to upstream [`e6cd4c8e`](https://github.com/quay/claircore/commit/e6cd4c8e9962c95116db457fd553f90f87d2f2b5), which includes the following fixes since the version currently on master:

- **claircore: add JSON marshaling for Alias type** ([PR #1896](https://github.com/quay/claircore/pull/1896)) — `unique.Handle[string]` does not implement `json.Marshaler`, causing `Alias.Space` to serialize as `{}` instead of the actual namespace value. This breaks vulnerability bundle serialization via jsonblob. Adds `MarshalJSON` and `UnmarshalJSON` to preserve Space values through JSON round-trips.

- **datastore/postgres: populate Aliases and Self when retrieving vulnerabilities** ([PR #1896](https://github.com/quay/claircore/pull/1896)) — When the matcher retrieves vulnerabilities from the database, the `Aliases` and `Self` fields on each `claircore.Vulnerability` were not populated. This means the `VulnerabilityReport` returned by Scanner V4 contained empty alias lists, preventing Central from cross-referencing VEX `known_not_affected` assertions with actual vulnerability findings.

- **rhcc: account for incorrectly double-quoted labels.json values** — The Red Hat build system was writing labels.json files with double-quoted values, causing false negatives during RHCC matching.

- **vex: only check vendor_fix remediations** — RHSA links were being lost for vulnerabilities where the productID had multiple remediations and a non-vendor_fix one (without a URL) was winning.

- **acceptance: add VEX parser option to include the productID** — Adds a parser option for test contexts.

- **chore: add clair-maintainers to CODEOWNERS**

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Validated end-to-end on a GKE cluster by deploying StackRox with 3 Scanner V4 matcher replicas and verifying two things: that concurrent vulnerability bundle loading works despite alias table deadlocks, and that VEX `known_not_affected` filtering correctly suppresses false positives through both the Scanner V4 and Central APIs.

#### Prerequisites

Create a GKE cluster (e.g., via `infractl create gke-default`). Ensure `docker login` credentials exist for `quay.io` (to pull StackRox images) and `registry.redhat.io` (to scan the test image). Build `scannerctl` from the stackrox repo with `make -C scanner bin/scannerctl`.

#### Step 1: Deploy StackRox with 3 matcher replicas

Deploy using the Helm path (`OUTPUT_FORMAT=helm`) so that `ROX_CENTRAL_EXTRA_HELM_VALUES_FILE` is applied during `helm upgrade --install`. This sets the vulnerability bundle URL and feature flag as environment variables on the matcher and Central deployments at install time, before any pod starts. The Helm values file configures:

- 3 matcher replicas with autoscaling disabled (`scannerV4.matcher.replicas: 3`)
- The custom vulnerability bundle URL via `SCANNER_V4_MATCHER_VULNERABILITIES_URL`
- The VEX feature flag via `ROX_SCANNER_V4_RED_HAT_VEX_NOT_AFFECTED=true` on Central

Export `REGISTRY_USERNAME` and `REGISTRY_PASSWORD` from `~/.docker/config.json` before running the deploy script, because `deploy/k8s/central-deploy/central/scripts/docker-auth.sh` looks up `https://quay.io` in docker config but `docker login quay.io` stores credentials under `quay.io` (no scheme). The env var path bypasses this mismatch.

After deploy, verify the scanner image tag matches the CI build and all 3 matcher replicas are running.

#### Step 2: Monitor concurrent bundle import

The 3 matcher replicas import the 244 MB vulnerability bundle concurrently. Each bundle within the ZIP is protected by a PostgreSQL advisory lock, so only one replica imports a given bundle at a time, but different bundles import in parallel across replicas. This concurrent access to the shared alias table triggers deadlocks (`ERROR: deadlock detected (SQLSTATE 40P01)`) on `rhel-vex.json.zst`, the known issue from [ClairCore PR #1891](https://github.com/quay/claircore/pull/1891).

Monitor the matcher logs for completion. A replica is done when its `"completed update"` log count exceeds its `"errors encountered during updater run"` count. When a deadlock kills a bundle import, the updater finishes its cycle with an error, then retries the failed bundle on the next cycle. All 13 bundles eventually import despite deadlocks. Import time depends on storage class: HDD (`standard-rwo`) took 37–103 minutes per replica; SSD (`premium-rwo`) is significantly faster.

After all replicas complete, validate the database state by querying the Scanner V4 DB:

```sql
SELECT count(*) FROM last_vuln_update;                                              -- expect 13 bundles
SELECT count(*) FROM vuln WHERE package_kind='ancestry' AND not_vulnerable=true;    -- expect ~238k records
SELECT count(*) FROM alias;                                                         -- expect ~534k records
SELECT not_vulnerable FROM vuln WHERE name='CVE-2024-24786' AND package_name LIKE '%mta%' AND package_kind='ancestry'; -- expect 't'
```

#### Step 3: Validate VEX assertions via Scanner V4 API

Scan `registry.redhat.io/mta/mta-rhel8-operator@sha256:1719cafe5b15c44bb1bb207bce1cc2a6ee7c1b097901d8fab61912ce298f40dd` using `scannerctl` through port-forwarded gRPC connections to the indexer (port 8444) and matcher (port 8445). This image reports CVE-2024-24786 for `google.golang.org/protobuf@v1.29.1`, but Red Hat's VEX data marks the container as `known_not_affected` for that CVE.

Verify in the raw `VulnerabilityReport`:

- `package_not_vulnerable` contains entries (62 in this run), confirming VEX assertions are present
- CVE-2024-24786 exists from the `rhel-vex` updater with 4 aliases: `CVE:2024-24786`, `GO:2024-2611`, `RHBZ:2268046`, and the Red Hat security URL
- A corresponding finding from `osv/go` shares common aliases (`CVE:2024-24786`, `GO:2024-2611`) with the VEX assertion, confirming the cross-reference works
- The CVE is referenced in `package_not_vulnerable` for the MTA ancestry package

#### Step 4: Validate VEX filtering via Central API

Scan the same image through Central's REST API (`POST /v1/images/scan` with `force: true`), toggling the `ROX_SCANNER_V4_RED_HAT_VEX_NOT_AFFECTED` feature flag between scans. Each toggle requires restarting Central (`kubectl set env deployment/central`).

| Flag state | Total vulns | CVE-2024-24786 |
|-----------|-------------|----------------|
| ON | 1,598 | Suppressed |
| OFF | 1,603 (+5) | Present in `google.golang.org/protobuf@v1.29.1` |
| ON (re-verify) | 1,598 | Suppressed |

The +5 delta when the flag is off confirms that VEX filtering suppresses 5 vulnerabilities that would otherwise appear as false positives. The re-verify pass confirms the filtering is deterministic.