### PR TITLE
chore(pg): optimize GetLimit preallocation logic

### DIFF
--- a/pkg/search/paginated/paginated.go
+++ b/pkg/search/paginated/paginated.go
@@ -1,8 +1,6 @@
 package paginated
 
 import (
-	"math"
-
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	v2 "github.com/stackrox/rox/generated/api/v2"
 	"github.com/stackrox/rox/pkg/search"
@@ -168,7 +166,7 @@ func PaginateSlice[T any](offset, limit int, slice []T) []T {
 
 // GetLimit returns pagination limit or a value if it's unlimited
 func GetLimit(paginationLimit int32, whenUnlimited int32) int32 {
-	if paginationLimit <= 0 || paginationLimit == math.MaxInt32 {
+	if paginationLimit <= 0 || paginationLimit > whenUnlimited {
 		return whenUnlimited
 	}
 	return paginationLimit

--- a/pkg/search/paginated/paginated_test.go
+++ b/pkg/search/paginated/paginated_test.go
@@ -44,9 +44,9 @@ func (s *paginationTestSuite) TestGetLimit() {
 		math.MinInt32:     whenUnlimited,
 		-1:                whenUnlimited,
 		1:                 1,
-		math.MaxInt32 - 1: math.MaxInt32 - 1,
+		math.MaxInt32 - 1: whenUnlimited,
 		whenUnlimited:     whenUnlimited,
-		whenUnlimited + 1: whenUnlimited + 1,
+		whenUnlimited + 1: whenUnlimited,
 		whenUnlimited - 1: whenUnlimited - 1,
 	} {
 		s.T().Run(fmt.Sprintf("%d %d", given, expected), func(t *testing.T) {


### PR DESCRIPTION
## Description

 Simplified GetLimit() function to use whenUnlimited parameter as the upper bound for slice capacity preallocation, improving code clarity and reducing memory overhead.

- #15129

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI