### PR TITLE
ROX-33431: Bump Konflux tasks memory to avoid OOMs / 4.9

### DIFF
--- a/.tekton/central-db-build.yaml
+++ b/.tekton/central-db-build.yaml
@@ -67,15 +67,23 @@ spec:
     name: basic-component-pipeline
 
   taskRunSpecs:
+  # The following are overrides to default step resources to prevent occasional or deterministic OOM kills.
   - pipelineTaskName: build-source-image
     stepSpecs:
-    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
     - name: build
       computeResources:
         limits:
           memory: 3Gi
         requests:
           memory: 3Gi
+  - pipelineTaskName: rpms-signature-scan
+    stepSpecs:
+    - name: rpms-signature-scan
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-central-db-4-9

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -71,21 +71,32 @@ spec:
     name: main-pipeline
 
   taskRunSpecs:
+  # The following are overrides to default step resources to prevent occasional or deterministic OOM kills.
   - pipelineTaskName: prefetch-dependencies
+    podTemplate: &go-memlimit
+      env:
+      - name: GOMEMLIMIT
+        value: 2500MiB
     stepSpecs:
-    # Limit CPU for Go dependencies prefetch, as it tends to be OOM-killed when it gets lots of it without OOTB limit.
     - name: prefetch-dependencies
       computeResources:
         limits:
+          memory: 5Gi
+        requests:
+          memory: 5Gi
+    - name: create-trusted-artifact
+      computeResources: &ta-resources
+        limits:
           cpu: 2
+          memory: 5Gi
         requests:
           cpu: 2
-  # For all sbom-syft-generate steps:
-  # Memory is increased for the syft command to succeed. Otherwise, there's an error like this in log and container
-  # exits with 137 (OOMKilled):
-  # /tekton/scripts/script-2-h7nll: line 7:    33 Killed                  syft dir:$(cat /shared/container_path) --output cyclonedx-json=/var/workdir/sbom-image.json
+          memory: 5Gi
   - pipelineTaskName: build-images
+    podTemplate: *go-memlimit
     stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
     - name: sbom-syft-generate
       computeResources:
         limits:
@@ -93,14 +104,31 @@ spec:
         requests:
           memory: 3Gi
   - pipelineTaskName: build-source-image
+    podTemplate: *go-memlimit
     stepSpecs:
-    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
     - name: build
       computeResources:
         limits:
           memory: 3Gi
         requests:
           memory: 3Gi
+  - pipelineTaskName: sast-shell-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-unicode-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-snyk-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-main-4-9

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -66,24 +66,58 @@ spec:
     name: basic-component-pipeline
 
   taskRunSpecs:
+  # The following are overrides to default step resources to prevent occasional or deterministic OOM kills.
   - pipelineTaskName: prefetch-dependencies
+    podTemplate: &go-memlimit
+      env:
+      - name: GOMEMLIMIT
+        value: 2500MiB
     stepSpecs:
-    # Limit CPU for Go dependencies prefetch, as it tends to be OOM-killed when it gets lots of it without OOTB limit.
     - name: prefetch-dependencies
       computeResources:
         limits:
+          memory: 5Gi
+        requests:
+          memory: 5Gi
+    - name: create-trusted-artifact
+      computeResources: &ta-resources
+        limits:
           cpu: 2
+          memory: 5Gi
         requests:
           cpu: 2
-  - pipelineTaskName: build-source-image
+          memory: 5Gi
+  - pipelineTaskName: build-images
+    podTemplate: *go-memlimit
     stepSpecs:
-    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: build-source-image
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
     - name: build
       computeResources:
         limits:
           memory: 3Gi
         requests:
           memory: 3Gi
+  - pipelineTaskName: sast-shell-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-unicode-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-snyk-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator-4-9

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -67,15 +67,58 @@ spec:
     name: operator-bundle-pipeline
 
   taskRunSpecs:
-  - pipelineTaskName: build-source-image
+  # The following are overrides to default step resources to prevent occasional or deterministic OOM kills.
+  - pipelineTaskName: prefetch-dependencies
+    podTemplate: &go-memlimit
+      env:
+      - name: GOMEMLIMIT
+        value: 2500MiB
     stepSpecs:
-    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
+    - name: prefetch-dependencies
+      computeResources:
+        limits:
+          memory: 5Gi
+        requests:
+          memory: 5Gi
+    - name: create-trusted-artifact
+      computeResources: &ta-resources
+        limits:
+          cpu: 2
+          memory: 5Gi
+        requests:
+          cpu: 2
+          memory: 5Gi
+  - pipelineTaskName: build-container
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: build-source-image
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
     - name: build
       computeResources:
         limits:
           memory: 3Gi
         requests:
           memory: 3Gi
+  - pipelineTaskName: sast-shell-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-unicode-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-snyk-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator-bundle-4-9

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -66,24 +66,58 @@ spec:
     name: basic-component-pipeline
 
   taskRunSpecs:
+  # The following are overrides to default step resources to prevent occasional or deterministic OOM kills.
   - pipelineTaskName: prefetch-dependencies
+    podTemplate: &go-memlimit
+      env:
+      - name: GOMEMLIMIT
+        value: 2500MiB
     stepSpecs:
-    # Limit CPU for Go dependencies prefetch, as it tends to be OOM-killed when it gets lots of it without OOTB limit.
     - name: prefetch-dependencies
       computeResources:
         limits:
+          memory: 5Gi
+        requests:
+          memory: 5Gi
+    - name: create-trusted-artifact
+      computeResources: &ta-resources
+        limits:
           cpu: 2
+          memory: 5Gi
         requests:
           cpu: 2
-  - pipelineTaskName: build-source-image
+          memory: 5Gi
+  - pipelineTaskName: build-images
+    podTemplate: *go-memlimit
     stepSpecs:
-    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: build-source-image
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
     - name: build
       computeResources:
         limits:
           memory: 3Gi
         requests:
           memory: 3Gi
+  - pipelineTaskName: sast-shell-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-unicode-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-snyk-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-roxctl-4-9

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -66,24 +66,58 @@ spec:
     name: scanner-v4-pipeline
 
   taskRunSpecs:
+  # The following are overrides to default step resources to prevent occasional or deterministic OOM kills.
   - pipelineTaskName: prefetch-dependencies
+    podTemplate: &go-memlimit
+      env:
+      - name: GOMEMLIMIT
+        value: 2500MiB
     stepSpecs:
-    # Limit CPU for Go dependencies prefetch, as it tends to be OOM-killed when it gets lots of it without OOTB limit.
     - name: prefetch-dependencies
       computeResources:
         limits:
+          memory: 5Gi
+        requests:
+          memory: 5Gi
+    - name: create-trusted-artifact
+      computeResources: &ta-resources
+        limits:
           cpu: 2
+          memory: 5Gi
         requests:
           cpu: 2
-  - pipelineTaskName: build-source-image
+          memory: 5Gi
+  - pipelineTaskName: build-images
+    podTemplate: *go-memlimit
     stepSpecs:
-    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: build-source-image
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
     - name: build
       computeResources:
         limits:
           memory: 3Gi
         requests:
           memory: 3Gi
+  - pipelineTaskName: sast-shell-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-unicode-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
+  - pipelineTaskName: sast-snyk-check
+    podTemplate: *go-memlimit
+    stepSpecs:
+    - name: use-trusted-artifact
+      computeResources: *ta-resources
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-scanner-v4-4-9

--- a/.tekton/scanner-v4-db-build.yaml
+++ b/.tekton/scanner-v4-db-build.yaml
@@ -67,15 +67,23 @@ spec:
     name: basic-component-pipeline
 
   taskRunSpecs:
+  # The following are overrides to default step resources to prevent occasional or deterministic OOM kills.
   - pipelineTaskName: build-source-image
     stepSpecs:
-    # Bump memory for source image build because the one with defaults tends to get sometimes OOM-killed.
     - name: build
       computeResources:
         limits:
           memory: 3Gi
         requests:
           memory: 3Gi
+  - pipelineTaskName: rpms-signature-scan
+    stepSpecs:
+    - name: rpms-signature-scan
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
 
   taskRunTemplate:
     serviceAccountName: build-pipeline-scanner-v4-db-4-9


### PR DESCRIPTION
## Description

Same as https://github.com/stackrox/stackrox/pull/20655 but applied to `release-4.9` branch.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

Just by looking at Konflux CI.