### PR TITLE
perf(sensor): preallocate slices in LookupByNetAddr

### DIFF
--- a/sensor/common/clusterentities/store_ips.go
+++ b/sensor/common/clusterentities/store_ips.go
@@ -122,21 +122,25 @@ func (e *podIPsStore) purgeDeploymentNoLock(deploymentID string) {
 func (e *podIPsStore) LookupByNetAddr(ip net.IPAddress, port uint16) (results, historical []LookupResult) {
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()
-	for deploymentID := range e.ipMap[ip] {
-		result := LookupResult{
-			Entity:         networkgraph.EntityForDeployment(deploymentID),
-			ContainerPorts: []uint16{port},
+	if currentSet := e.ipMap[ip]; len(currentSet) > 0 {
+		results = make([]LookupResult, 0, len(currentSet))
+		for deploymentID := range currentSet {
+			results = append(results, LookupResult{
+				Entity:         networkgraph.EntityForDeployment(deploymentID),
+				ContainerPorts: []uint16{port},
+			})
 		}
-		results = append(results, result)
 	}
 	// if there is a match in the map, then there is no need to search in history,
 	// as it may contain data about different past deployment using this address
-	for histDeploymentID := range e.historicalIPs[ip] {
-		result := LookupResult{
-			Entity:         networkgraph.EntityForDeployment(histDeploymentID),
-			ContainerPorts: []uint16{port},
+	if histSet := e.historicalIPs[ip]; len(histSet) > 0 {
+		historical = make([]LookupResult, 0, len(histSet))
+		for histDeploymentID := range histSet {
+			historical = append(historical, LookupResult{
+				Entity:         networkgraph.EntityForDeployment(histDeploymentID),
+				ContainerPorts: []uint16{port},
+			})
 		}
-		historical = append(historical, result)
 	}
 	return results, historical
 }

--- a/sensor/common/clusterentities/store_ips_bench_test.go
+++ b/sensor/common/clusterentities/store_ips_bench_test.go
@@ -1,0 +1,104 @@
+package clusterentities
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/net"
+	"github.com/stackrox/rox/pkg/set"
+)
+
+func buildIPsStore(numDeployments int, withHistory bool) (*podIPsStore, net.IPAddress) {
+	var memSize uint16
+	if withHistory {
+		memSize = 5
+	}
+	store := newPodIPsStoreWithMemory(memSize)
+
+	lookupIP := net.ParseIP(fmt.Sprintf("10.0.%d.%d", (0/256)%256, 0%256))
+
+	for i := range numDeployments {
+		ip := net.ParseIP(fmt.Sprintf("10.0.%d.%d", (i/256)%256, i%256))
+		deploymentID := fmt.Sprintf("deploy-%d", i)
+		deplSet := store.ipMap[ip]
+		deplSet.Add(deploymentID)
+		store.ipMap[ip] = deplSet
+		store.reverseIPMap[deploymentID] = set.NewFrozenSet(ip)
+
+		if withHistory {
+			histIP := net.ParseIP(fmt.Sprintf("10.1.%d.%d", (i/256)%256, i%256))
+			if _, ok := store.historicalIPs[histIP]; !ok {
+				store.historicalIPs[histIP] = make(map[string]*entityStatus)
+			}
+			store.historicalIPs[histIP][deploymentID] = newHistoricalEntity(memSize)
+		}
+	}
+
+	return store, lookupIP
+}
+
+func buildIPsStoreShared(numDeployments int, withHistory bool) (*podIPsStore, net.IPAddress) {
+	var memSize uint16
+	if withHistory {
+		memSize = 5
+	}
+	store := newPodIPsStoreWithMemory(memSize)
+
+	sharedIP := net.ParseIP("10.0.0.1")
+	for i := range numDeployments {
+		deploymentID := fmt.Sprintf("deploy-%d", i)
+		deplSet := store.ipMap[sharedIP]
+		deplSet.Add(deploymentID)
+		store.ipMap[sharedIP] = deplSet
+		store.reverseIPMap[deploymentID] = set.NewFrozenSet(sharedIP)
+	}
+
+	if withHistory {
+		histIP := net.ParseIP("10.1.0.1")
+		store.historicalIPs[histIP] = make(map[string]*entityStatus)
+		for i := range numDeployments {
+			store.historicalIPs[histIP][fmt.Sprintf("hist-deploy-%d", i)] = newHistoricalEntity(memSize)
+		}
+	}
+
+	return store, sharedIP
+}
+
+func BenchmarkLookupByNetAddr(b *testing.B) {
+	deploymentCounts := []int{1, 4, 10, 50, 100}
+
+	for _, n := range deploymentCounts {
+		store, ip := buildIPsStoreShared(n, false)
+		b.Run(fmt.Sprintf("%ddepl_current", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				store.LookupByNetAddr(ip, 8080)
+			}
+		})
+	}
+
+	for _, n := range deploymentCounts {
+		_, lookupIP := buildIPsStoreShared(n, true)
+		store, _ := buildIPsStoreShared(n, true)
+		histIP := net.ParseIP("10.1.0.1")
+		_ = lookupIP
+		b.Run(fmt.Sprintf("%ddepl_historical", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				store.LookupByNetAddr(histIP, 8080)
+			}
+		})
+	}
+
+	for _, n := range deploymentCounts {
+		store, ip := buildIPsStoreShared(n, true)
+		histIP := net.ParseIP("10.1.0.1")
+		_ = histIP
+		b.Run(fmt.Sprintf("%ddepl_both", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				store.LookupByNetAddr(ip, 8080)
+			}
+		})
+	}
+}

--- a/sensor/common/clusterentities/store_ips_bench_test.go
+++ b/sensor/common/clusterentities/store_ips_bench_test.go
@@ -25,10 +25,11 @@ func buildIPsStoreShared(numDeployments int, withHistory bool) (*podIPsStore, ne
 	}
 
 	if withHistory {
-		histIP := net.ParseIP("10.1.0.1")
-		store.historicalIPs[histIP] = make(map[string]*entityStatus)
-		for i := range numDeployments {
-			store.historicalIPs[histIP][fmt.Sprintf("hist-deploy-%d", i)] = newHistoricalEntity(memSize)
+		for _, ip := range []net.IPAddress{sharedIP, net.ParseIP("10.1.0.1")} {
+			store.historicalIPs[ip] = make(map[string]*entityStatus)
+			for i := range numDeployments {
+				store.historicalIPs[ip][fmt.Sprintf("hist-deploy-%d", i)] = newHistoricalEntity(memSize)
+			}
 		}
 	}
 

--- a/sensor/common/clusterentities/store_ips_bench_test.go
+++ b/sensor/common/clusterentities/store_ips_bench_test.go
@@ -8,35 +8,6 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 )
 
-func buildIPsStore(numDeployments int, withHistory bool) (*podIPsStore, net.IPAddress) {
-	var memSize uint16
-	if withHistory {
-		memSize = 5
-	}
-	store := newPodIPsStoreWithMemory(memSize)
-
-	lookupIP := net.ParseIP(fmt.Sprintf("10.0.%d.%d", (0/256)%256, 0%256))
-
-	for i := range numDeployments {
-		ip := net.ParseIP(fmt.Sprintf("10.0.%d.%d", (i/256)%256, i%256))
-		deploymentID := fmt.Sprintf("deploy-%d", i)
-		deplSet := store.ipMap[ip]
-		deplSet.Add(deploymentID)
-		store.ipMap[ip] = deplSet
-		store.reverseIPMap[deploymentID] = set.NewFrozenSet(ip)
-
-		if withHistory {
-			histIP := net.ParseIP(fmt.Sprintf("10.1.%d.%d", (i/256)%256, i%256))
-			if _, ok := store.historicalIPs[histIP]; !ok {
-				store.historicalIPs[histIP] = make(map[string]*entityStatus)
-			}
-			store.historicalIPs[histIP][deploymentID] = newHistoricalEntity(memSize)
-		}
-	}
-
-	return store, lookupIP
-}
-
 func buildIPsStoreShared(numDeployments int, withHistory bool) (*podIPsStore, net.IPAddress) {
 	var memSize uint16
 	if withHistory {
@@ -78,10 +49,8 @@ func BenchmarkLookupByNetAddr(b *testing.B) {
 	}
 
 	for _, n := range deploymentCounts {
-		_, lookupIP := buildIPsStoreShared(n, true)
 		store, _ := buildIPsStoreShared(n, true)
 		histIP := net.ParseIP("10.1.0.1")
-		_ = lookupIP
 		b.Run(fmt.Sprintf("%ddepl_historical", n), func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
@@ -92,9 +61,7 @@ func BenchmarkLookupByNetAddr(b *testing.B) {
 
 	for _, n := range deploymentCounts {
 		store, ip := buildIPsStoreShared(n, true)
-		histIP := net.ParseIP("10.1.0.1")
-		_ = histIP
-		b.Run(fmt.Sprintf("%ddepl_both", n), func(b *testing.B) {
+		b.Run(fmt.Sprintf("%ddepl_current_with_history", n), func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
 				store.LookupByNetAddr(ip, 8080)


### PR DESCRIPTION
## Description

`LookupByNetAddr` builds `results` and `historical` slices by appending in a loop over maps of known size, but never preallocates capacity. This causes repeated grow-copy reallocations that scale quadratically with the number of deployments sharing an IP.

This PR preallocates both slices with the exact map size, eliminating all intermediate allocations. The pattern mirrors the optimization applied to `doLookupEndpoint` in #20795.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Ran benchmark tests locally (`BenchmarkLookupByNetAddr`, 6 iterations, Apple M3 Pro) before and after the change, compared with `benchstat`. Full raw results below.

#### benchstat 
```
goos: darwin
goarch: arm64
pkg: github.com/stackrox/rox/sensor/common/clusterentities
cpu: Apple M3 Pro
                                                │ /tmp/bench-master.txt │       /tmp/bench-current.txt        │
                                                │        sec/op         │    sec/op     vs base               │
LookupByNetAddr/1depl_current-12                           151.5n ±  3%   136.1n ±  5%  -10.19% (p=0.002 n=6)
LookupByNetAddr/4depl_current-12                           324.4n ±  5%   206.5n ±  2%  -36.37% (p=0.002 n=6)
LookupByNetAddr/10depl_current-12                          778.8n ±  2%   384.8n ±  2%  -50.59% (p=0.002 n=6)
LookupByNetAddr/50depl_current-12                          2.742µ ±  7%   1.333µ ±  1%  -51.40% (p=0.002 n=6)
LookupByNetAddr/100depl_current-12                         4.923µ ±  8%   2.466µ ±  4%  -49.92% (p=0.002 n=6)
LookupByNetAddr/1depl_historical-12                        151.4n ± 23%   144.6n ±  5%        ~ (p=0.065 n=6)
LookupByNetAddr/4depl_historical-12                        320.3n ±  5%   240.5n ± 16%  -24.91% (p=0.002 n=6)
LookupByNetAddr/10depl_historical-12                       773.5n ±  3%   375.9n ±  2%  -51.41% (p=0.002 n=6)
LookupByNetAddr/50depl_historical-12                       2.641µ ±  2%   1.329µ ±  1%  -49.69% (p=0.002 n=6)
LookupByNetAddr/100depl_historical-12                      4.924µ ± 10%   2.454µ ±  4%  -50.16% (p=0.002 n=6)
LookupByNetAddr/1depl_current_with_history-12              212.7n ±  4%   203.6n ±  4%   -4.23% (p=0.009 n=6)
LookupByNetAddr/4depl_current_with_history-12              535.4n ±  5%   361.0n ±  8%  -32.57% (p=0.002 n=6)
LookupByNetAddr/10depl_current_with_history-12            1455.5n ±  5%   695.6n ±  2%  -52.21% (p=0.002 n=6)
LookupByNetAddr/50depl_current_with_history-12             5.379µ ±  6%   2.650µ ±  2%  -50.74% (p=0.002 n=6)
LookupByNetAddr/100depl_current_with_history-12            9.978µ ± 21%   4.923µ ±  1%  -50.66% (p=0.002 n=6)
geomean                                                    1.055µ         631.3n        -40.18%

                                                │ /tmp/bench-master.txt │        /tmp/bench-current.txt         │
                                                │         B/op          │     B/op      vs base                 │
LookupByNetAddr/1depl_current-12                             114.0 ± 0%     114.0 ± 0%        ~ (p=1.000 n=6) ¹
LookupByNetAddr/4depl_current-12                             744.0 ± 0%     424.0 ± 0%  -43.01% (p=0.002 n=6)
LookupByNetAddr/10depl_current-12                          3.363Ki ± 0%   1.145Ki ± 0%  -65.97% (p=0.002 n=6)
LookupByNetAddr/50depl_current-12                         15.441Ki ± 0%   5.348Ki ± 0%  -65.37% (p=0.002 n=6)
LookupByNetAddr/100depl_current-12                         31.54Ki ± 0%   10.82Ki ± 0%  -65.69% (p=0.002 n=6)
LookupByNetAddr/1depl_historical-12                          114.0 ± 0%     114.0 ± 0%        ~ (p=1.000 n=6) ¹
LookupByNetAddr/4depl_historical-12                          744.0 ± 0%     424.0 ± 0%  -43.01% (p=0.002 n=6)
LookupByNetAddr/10depl_historical-12                       3.363Ki ± 0%   1.145Ki ± 0%  -65.97% (p=0.002 n=6)
LookupByNetAddr/50depl_historical-12                      15.441Ki ± 0%   5.348Ki ± 0%  -65.37% (p=0.002 n=6)
LookupByNetAddr/100depl_historical-12                      31.54Ki ± 0%   10.82Ki ± 0%  -65.69% (p=0.002 n=6)
LookupByNetAddr/1depl_current_with_history-12                228.0 ± 0%     228.0 ± 0%        ~ (p=1.000 n=6) ¹
LookupByNetAddr/4depl_current_with_history-12               1488.0 ± 0%     848.0 ± 0%  -43.01% (p=0.002 n=6)
LookupByNetAddr/10depl_current_with_history-12             6.727Ki ± 0%   2.289Ki ± 0%  -65.97% (p=0.002 n=6)
LookupByNetAddr/50depl_current_with_history-12             30.88Ki ± 0%   10.70Ki ± 0%  -65.37% (p=0.002 n=6)
LookupByNetAddr/100depl_current_with_history-12            63.08Ki ± 0%   21.64Ki ± 0%  -65.69% (p=0.002 n=6)
geomean                                                    3.348Ki        1.575Ki       -52.96%
¹ all samples are equal

                                                │ /tmp/bench-master.txt │       /tmp/bench-current.txt        │
                                                │       allocs/op       │ allocs/op   vs base                 │
LookupByNetAddr/1depl_current-12                             2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=6) ¹
LookupByNetAddr/4depl_current-12                             7.000 ± 0%   5.000 ± 0%  -28.57% (p=0.002 n=6)
LookupByNetAddr/10depl_current-12                            15.00 ± 0%   11.00 ± 0%  -26.67% (p=0.002 n=6)
LookupByNetAddr/50depl_current-12                            57.00 ± 0%   51.00 ± 0%  -10.53% (p=0.002 n=6)
LookupByNetAddr/100depl_current-12                           108.0 ± 0%   101.0 ± 0%   -6.48% (p=0.002 n=6)
LookupByNetAddr/1depl_historical-12                          2.000 ± 0%   2.000 ± 0%        ~ (p=1.000 n=6) ¹
LookupByNetAddr/4depl_historical-12                          7.000 ± 0%   5.000 ± 0%  -28.57% (p=0.002 n=6)
LookupByNetAddr/10depl_historical-12                         15.00 ± 0%   11.00 ± 0%  -26.67% (p=0.002 n=6)
LookupByNetAddr/50depl_historical-12                         57.00 ± 0%   51.00 ± 0%  -10.53% (p=0.002 n=6)
LookupByNetAddr/100depl_historical-12                        108.0 ± 0%   101.0 ± 0%   -6.48% (p=0.002 n=6)
LookupByNetAddr/1depl_current_with_history-12                4.000 ± 0%   4.000 ± 0%        ~ (p=1.000 n=6) ¹
LookupByNetAddr/4depl_current_with_history-12                14.00 ± 0%   10.00 ± 0%  -28.57% (p=0.002 n=6)
LookupByNetAddr/10depl_current_with_history-12               30.00 ± 0%   22.00 ± 0%  -26.67% (p=0.002 n=6)
LookupByNetAddr/50depl_current_with_history-12               114.0 ± 0%   102.0 ± 0%  -10.53% (p=0.002 n=6)
LookupByNetAddr/100depl_current_with_history-12              216.0 ± 0%   202.0 ± 0%   -6.48% (p=0.002 n=6)
geomean                                                      21.02        17.82       -15.21%
¹ all samples are equal
```
AI-Assisted: cursor, ~70% generated, user reviewed logic