### PR TITLE
chore(sensor): remove legacy node-scanning compat metrics

### DIFF
--- a/deploy/charts/monitoring/dashboards/node-inventory.json
+++ b/deploy/charts/monitoring/dashboards/node-inventory.json
@@ -187,15 +187,15 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rox_sensor_node_inventories_received_total{job=\"sensor\"}",
+          "expr": "rox_sensor_node_scan_processed_total{job=\"sensor\"}",
           "interval": "",
-          "legendFormat": "{{exported_node_name}}",
+          "legendFormat": "{{node_name}}",
           "refId": "A"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Received Node Inventories per Node",
+      "title": "Processed Node Scans per Node",
       "type": "stat"
     },
     {

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -400,7 +400,6 @@ func (c *nodeInventoryHandlerImpl) sendNodeInventory(toC chan<- *message.Expirin
 			},
 		},
 	}):
-		metrics.ObserveReceivedNodeInventory(inventory) // keeping for compatibility with 4.6. Remove in 4.8
 		metrics.ObserveNodeScan(inventory.GetNodeName(), metrics.NodeScanTypeNodeInventory, metrics.NodeScanOperationSendToCentral)
 	}
 }
@@ -423,7 +422,6 @@ func (c *nodeInventoryHandlerImpl) sendNodeIndex(toC chan<- *message.ExpiringMes
 	default:
 		defer func() {
 			log.Debugf("Sent IndexReport to Central")
-			metrics.ObserveReceivedNodeIndex(indexWrap.NodeName) // keeping for compatibility with 4.6. Remove in 4.8
 			metrics.ObserveNodeScan(indexWrap.NodeName, metrics.NodeScanTypeNodeIndex, metrics.NodeScanOperationSendToCentral)
 		}()
 		irWrapperFunc := noop

--- a/sensor/common/detector/metrics/metrics.go
+++ b/sensor/common/detector/metrics/metrics.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stackrox/rox/generated/internalapi/central"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
@@ -143,8 +142,6 @@ var (
 			// Number of selector terms on the network policy that triggered the metric update
 			"numSelectors",
 		})
-	// processedNodeScan is a metric meant to replace and provide extra context on
-	// receivedNodeInventory and receivedNodeIndex
 	processedNodeScan = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.SensorSubsystem.String(),
@@ -156,26 +153,6 @@ var (
 			"node_name",
 			"type",
 			"operation",
-		})
-	receivedNodeInventory = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.SensorSubsystem.String(),
-		Name:      "node_inventories_received_total",
-		Help:      "Total number of Node Inventories received by this Sensor",
-	},
-		[]string{
-			// Name of the node sending an inventory
-			"node_name",
-		})
-	receivedNodeIndex = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.SensorSubsystem.String(),
-		Name:      "node_indexes_received_total",
-		Help:      "Total number of Node Indexes received by this Sensor",
-	},
-		[]string{
-			// Name of the node sending an inventory
-			"node_name",
 		})
 	processedNodeScanningAck = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
@@ -390,20 +367,6 @@ func ObserveNodeScan(nodeName string, typ NodeScanType, op NodeScanOperation) {
 	}).Inc()
 }
 
-// ObserveReceivedNodeInventory observes the metric.
-func ObserveReceivedNodeInventory(inventory *storage.NodeInventory) {
-	receivedNodeInventory.With(prometheus.Labels{
-		"node_name": inventory.GetNodeName(),
-	}).Inc()
-}
-
-// ObserveReceivedNodeIndex observes the metric.
-func ObserveReceivedNodeIndex(nodeName string) {
-	receivedNodeIndex.With(prometheus.Labels{
-		"node_name": nodeName,
-	}).Inc()
-}
-
 // ObserveNodeScanningAck records (in Sensor) the instance of Central sending (N)Ack to Sensor
 func ObserveNodeScanningAck(nodeName, ackType, messageType string, op AckOperation, reason AckReason, origin AckOrigin) {
 	processedNodeScanningAck.With(prometheus.Labels{
@@ -592,8 +555,6 @@ func init() {
 		networkPoliciesStored,
 		networkPoliciesStoreEvents,
 		processedNodeScan,
-		receivedNodeInventory,
-		receivedNodeIndex,
 		processedNodeScanningAck,
 		DetectorNetworkFlowQueueOperations,
 		DetectorProcessIndicatorQueueOperations,


### PR DESCRIPTION
## Description

Remove the legacy `receivedNodeInventory` (`node_inventories_received_total`) and `receivedNodeIndex` (`node_indexes_received_total`) Prometheus counters from Sensor. These were kept for backward compatibility with Central 4.6 and explicitly marked "Remove in 4.8". The replacement metric `processedNodeScan` (`node_scan_processed_total`) has been emitting on the same code paths since its introduction and provides additional context via `type` and `operation` labels.

Changes:
- Remove `ObserveReceivedNodeInventory` and `ObserveReceivedNodeIndex` call sites from `node_inventory_handler_impl.go`
- Remove the metric definitions, helper functions, and Prometheus registration from `sensor/common/detector/metrics/metrics.go`
- Remove the now-unused `generated/storage` import
- Update the Grafana node-inventory dashboard panel to query `node_scan_processed_total` instead of the removed `node_inventories_received_total`

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

No test changes needed — no existing tests referenced the removed helpers, and the replacement metric (`ObserveNodeScan`) is unchanged.

### How I validated my change

- CI
- Grep'd the entire repo for all references to the removed metric names (`ObserveReceivedNodeInventory`, `ObserveReceivedNodeIndex`, `node_inventories_received_total`, `node_indexes_received_total`) — no remaining consumers outside the removed code and the updated dashboard
