### PR TITLE
perf(sensor): preallocate slice in DeploymentStore.GetAll

### DIFF
--- a/sensor/kubernetes/listener/resources/deployment_store.go
+++ b/sensor/kubernetes/listener/resources/deployment_store.go
@@ -144,7 +144,7 @@ func (ds *DeploymentStore) GetAll() []*storage.Deployment {
 	ds.lock.RLock()
 	defer ds.lock.RUnlock()
 
-	var ret []*storage.Deployment
+	ret := make([]*storage.Deployment, 0, len(ds.deployments))
 	for _, wrap := range ds.deployments {
 		if wrap != nil {
 			ret = append(ret, wrap.GetDeployment().CloneVT())

--- a/sensor/kubernetes/listener/resources/deployment_store_bench_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_bench_test.go
@@ -19,6 +19,7 @@ var (
 )
 
 const charset = "abcdef0123456789"
+const benchmarkFixtureSeed int64 = 0x5eed1234
 
 type namespaceAndSelector struct {
 	namespace string
@@ -119,6 +120,14 @@ func randStringWithLength(n int) string {
 	return string(b)
 }
 
+func randStringWithRand(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = charset[r.Intn(len(charset))]
+	}
+	return string(b)
+}
+
 func createDeploymentWrap() *deploymentWrap {
 	labels := make(map[string]string)
 	for i := 0; i < rand.Intn(10); i++ {
@@ -141,16 +150,32 @@ func createDeploymentWrap() *deploymentWrap {
 	}
 }
 
+func createSeededDeploymentWrap(i int) *deploymentWrap {
+	r := rand.New(rand.NewSource(benchmarkFixtureSeed + int64(i)))
+	labels := make(map[string]string)
+	for range r.Intn(10) {
+		labels[randStringWithRand(r, 16)] = randStringWithRand(r, 16)
+	}
+	return &deploymentWrap{
+		portConfigs: map[service.PortRef]*storage.PortConfig{},
+		Deployment: &storage.Deployment{
+			Labels:    labels,
+			PodLabels: labels,
+			Namespace: randStringWithRand(r, 16),
+			Id:        fmt.Sprintf("deployment-%04d-%s", i, randStringWithRand(r, 8)),
+			Name:      fmt.Sprintf("deployment-%04d-%s", i, randStringWithRand(r, 8)),
+		},
+	}
+}
+
 func BenchmarkGetAll(b *testing.B) {
 	for _, numDeployments := range []int{1, 10, 50, 100, 500, 1000} {
-		b.Run(fmt.Sprintf("deployments_%d", numDeployments), func(b *testing.B) {
+		b.Run(fmt.Sprintf("deployments=%d", numDeployments), func(b *testing.B) {
 			b.ReportAllocs()
-			b.StopTimer()
 			ds := newDeploymentStore()
-			for i := 0; i < numDeployments; i++ {
-				ds.addOrUpdateDeployment(createDeploymentWrap())
+			for i := range numDeployments {
+				ds.addOrUpdateDeployment(createSeededDeploymentWrap(i))
 			}
-			b.StartTimer()
 			for b.Loop() {
 				_ = ds.GetAll()
 			}

--- a/sensor/kubernetes/listener/resources/deployment_store_bench_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_bench_test.go
@@ -150,6 +150,10 @@ func createDeploymentWrap() *deploymentWrap {
 	}
 }
 
+// createSeededDeploymentWrap keeps BenchmarkGetAll reproducible across runs and
+// branches while still exercising deployment-shaped data similar to the random
+// fixture above. Using createDeploymentWrap here would change the benchmark input
+// on every run and make benchstat results harder to trust.
 func createSeededDeploymentWrap(i int) *deploymentWrap {
 	r := rand.New(rand.NewSource(benchmarkFixtureSeed + int64(i)))
 	labels := make(map[string]string)

--- a/sensor/kubernetes/listener/resources/deployment_store_bench_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_bench_test.go
@@ -141,6 +141,23 @@ func createDeploymentWrap() *deploymentWrap {
 	}
 }
 
+func BenchmarkGetAll(b *testing.B) {
+	for _, numDeployments := range []int{1, 10, 50, 100, 500, 1000} {
+		b.Run(fmt.Sprintf("deployments_%d", numDeployments), func(b *testing.B) {
+			b.ReportAllocs()
+			b.StopTimer()
+			ds := newDeploymentStore()
+			for i := 0; i < numDeployments; i++ {
+				ds.addOrUpdateDeployment(createDeploymentWrap())
+			}
+			b.StartTimer()
+			for b.Loop() {
+				_ = ds.GetAll()
+			}
+		})
+	}
+}
+
 func generateExposureInfos(numMaps, numExposureInfos int) []map[service.PortRef][]*storage.PortConfig_ExposureInfo {
 	result := make([]map[service.PortRef][]*storage.PortConfig_ExposureInfo, numMaps)
 

--- a/sensor/kubernetes/listener/resources/deployment_store_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_test.go
@@ -110,6 +110,58 @@ func (s *deploymentStoreSuite) Test_FindDeploymentIDsWithServiceAccount() {
 	}
 }
 
+func (s *deploymentStoreSuite) Test_GetAll() {
+	s.Assert().Empty(s.deploymentStore.GetAll())
+	s.namespaceStore.addNamespace(&storage.NamespaceMetadata{Name: "other-ns", Id: "2"})
+
+	wraps := []*deploymentWrap{
+		s.createDeploymentWrap(withLabels(makeDeploymentObject("d-1", "test-ns", "uuid-1"), map[string]string{
+			"app": "frontend",
+		})),
+		s.createDeploymentWrap(withLabels(makeDeploymentObject("d-2", "test-ns", "uuid-2"), map[string]string{
+			"app":  "backend",
+			"tier": "api",
+		})),
+		s.createDeploymentWrap(withLabels(makeDeploymentObject("d-3", "other-ns", "uuid-3"), map[string]string{
+			"app": "database",
+		})),
+	}
+
+	expectedByID := make(map[string]*storage.Deployment, len(wraps))
+	for _, wrap := range wraps {
+		s.deploymentStore.addOrUpdateDeployment(wrap)
+		expectedByID[wrap.GetId()] = wrap.GetDeployment().CloneVT()
+	}
+
+	got := s.deploymentStore.GetAll()
+	s.Require().Len(got, len(expectedByID))
+
+	gotByID := make(map[string]*storage.Deployment, len(got))
+	for _, deployment := range got {
+		gotByID[deployment.GetId()] = deployment
+	}
+
+	for id, expected := range expectedByID {
+		s.Require().Contains(gotByID, id)
+		protoassert.Equal(s.T(), expected, gotByID[id])
+	}
+
+	gotByID["uuid-1"].Name = "mutated-name"
+	gotByID["uuid-1"].PodLabels["mutated"] = "true"
+
+	refetched := s.deploymentStore.GetAll()
+	refetchedByID := make(map[string]*storage.Deployment, len(refetched))
+	for _, deployment := range refetched {
+		refetchedByID[deployment.GetId()] = deployment
+	}
+
+	s.Require().Contains(refetchedByID, "uuid-1")
+	s.Equal("d-1", refetchedByID["uuid-1"].GetName())
+	s.NotContains(refetchedByID["uuid-1"].GetPodLabels(), "mutated")
+	s.Equal("d-1", wraps[0].GetName())
+	s.NotContains(wraps[0].GetPodLabels(), "mutated")
+}
+
 func (s *deploymentStoreSuite) Test_BuildDeployments_CachedDependencies() {
 	s.T().Setenv(features.SensorDeploymentBuildOptimization.EnvVar(), "true")
 	defaultExposure := []map[service.PortRef][]*storage.PortConfig_ExposureInfo{

--- a/sensor/kubernetes/listener/resources/deployment_store_test.go
+++ b/sensor/kubernetes/listener/resources/deployment_store_test.go
@@ -114,52 +114,41 @@ func (s *deploymentStoreSuite) Test_GetAll() {
 	s.Assert().Empty(s.deploymentStore.GetAll())
 	s.namespaceStore.addNamespace(&storage.NamespaceMetadata{Name: "other-ns", Id: "2"})
 
-	wraps := []*deploymentWrap{
-		s.createDeploymentWrap(withLabels(makeDeploymentObject("d-1", "test-ns", "uuid-1"), map[string]string{
-			"app": "frontend",
-		})),
-		s.createDeploymentWrap(withLabels(makeDeploymentObject("d-2", "test-ns", "uuid-2"), map[string]string{
-			"app":  "backend",
-			"tier": "api",
-		})),
-		s.createDeploymentWrap(withLabels(makeDeploymentObject("d-3", "other-ns", "uuid-3"), map[string]string{
-			"app": "database",
-		})),
-	}
-
-	expectedByID := make(map[string]*storage.Deployment, len(wraps))
-	for _, wrap := range wraps {
+	expectedByID := make(map[string]*storage.Deployment)
+	addDeployment := func(name, namespace, id string, labels map[string]string) {
+		wrap := s.createDeploymentWrap(withLabels(makeDeploymentObject(name, namespace, types.UID(id)), labels))
 		s.deploymentStore.addOrUpdateDeployment(wrap)
-		expectedByID[wrap.GetId()] = wrap.GetDeployment().CloneVT()
+		expectedByID[id] = wrap.GetDeployment().CloneVT()
 	}
 
-	got := s.deploymentStore.GetAll()
+	addDeployment("d-1", "test-ns", "uuid-1", map[string]string{"app": "frontend"})
+	addDeployment("d-2", "test-ns", "uuid-2", map[string]string{"app": "backend", "tier": "api"})
+	addDeployment("d-3", "other-ns", "uuid-3", map[string]string{"app": "database"})
+
+	got := indexDeploymentsByID(s.deploymentStore.GetAll())
 	s.Require().Len(got, len(expectedByID))
 
-	gotByID := make(map[string]*storage.Deployment, len(got))
-	for _, deployment := range got {
-		gotByID[deployment.GetId()] = deployment
-	}
-
 	for id, expected := range expectedByID {
-		s.Require().Contains(gotByID, id)
-		protoassert.Equal(s.T(), expected, gotByID[id])
+		s.Require().Contains(got, id)
+		protoassert.Equal(s.T(), expected, got[id])
 	}
 
-	gotByID["uuid-1"].Name = "mutated-name"
-	gotByID["uuid-1"].PodLabels["mutated"] = "true"
+	// GetAll returns clones, so mutating the returned deployment must not affect store state.
+	got["uuid-1"].Name = "mutated-name"
+	got["uuid-1"].PodLabels["mutated"] = "true"
 
-	refetched := s.deploymentStore.GetAll()
-	refetchedByID := make(map[string]*storage.Deployment, len(refetched))
-	for _, deployment := range refetched {
-		refetchedByID[deployment.GetId()] = deployment
+	refetched := indexDeploymentsByID(s.deploymentStore.GetAll())
+	s.Require().Contains(refetched, "uuid-1")
+	s.Equal("d-1", refetched["uuid-1"].GetName())
+	s.NotContains(refetched["uuid-1"].GetPodLabels(), "mutated")
+}
+
+func indexDeploymentsByID(deployments []*storage.Deployment) map[string]*storage.Deployment {
+	indexed := make(map[string]*storage.Deployment, len(deployments))
+	for _, deployment := range deployments {
+		indexed[deployment.GetId()] = deployment
 	}
-
-	s.Require().Contains(refetchedByID, "uuid-1")
-	s.Equal("d-1", refetchedByID["uuid-1"].GetName())
-	s.NotContains(refetchedByID["uuid-1"].GetPodLabels(), "mutated")
-	s.Equal("d-1", wraps[0].GetName())
-	s.NotContains(wraps[0].GetPodLabels(), "mutated")
+	return indexed
 }
 
 func (s *deploymentStoreSuite) Test_BuildDeployments_CachedDependencies() {


### PR DESCRIPTION
## Description

`DeploymentStore.GetAll` grew its result slice from nil via `append`,
causing O(log n) heap reallocations per call. Since `len(ds.deployments)`
is a known upper bound, preallocate to eliminate the growth allocations.

This path is used by admission controller sync, resolver, and periodic
full scans — not per-event, but each call iterates and clones every
deployment in the store.

The PR also adds a `GetAll` unit test that covers empty-store behavior,
returned contents, and clone isolation, and updates `BenchmarkGetAll`
to use a reproducible seeded fixture so branch-to-branch runs compare
stable inputs.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added ut tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

Added `Test_GetAll` to cover returned contents and clone isolation.
Updated `BenchmarkGetAll` to use a deterministic seeded fixture before
running the benchmark comparison.

Ran `BenchmarkGetAll` with `-benchmem -count=10` before and after, compared with benchstat.

The per-element `CloneVT` dominates total allocations, so wall-clock time is flat,
but allocation counts drop at smaller store sizes where slice growth is a larger
fraction of total work:

```
goos: darwin
goarch: arm64
pkg: github.com/stackrox/rox/sensor/kubernetes/listener/resources
cpu: Apple M3 Pro

                      │       master        │       current       │
                      │       sec/op        │  sec/op   vs base   │
GetAll/deployments=1       531.2n ± 18%        547.9n ±  9%       ~ (p=0.669 n=10)
GetAll/deployments=10      3.463µ ±  7%        3.298µ ±  9%       ~ (p=0.218 n=10)
GetAll/deployments=50      15.46µ ±  6%        14.70µ ±  7%  -4.88% (p=0.009 n=10)
GetAll/deployments=100     30.82µ ±  8%        29.33µ ±  3%  -4.83% (p=0.002 n=10)
GetAll/deployments=500     167.6µ ±  2%        158.1µ ±  3%  -5.70% (p=0.001 n=10)
GetAll/deployments=1000    819.1µ ±  4%        785.2µ ±  1%  -4.15% (p=0.004 n=10)
geomean                    22.22µ              21.42µ       -3.58%

                      │       master        │       current       │
                      │        B/op         │   B/op    vs base   │
GetAll/deployments=1       1.039Ki ± 0%        1.039Ki ± 0%       ~ (p=1.000 n=10) ¹
GetAll/deployments=10      10.55Ki ± 0%        10.39Ki ± 0%  -1.55% (p=0.000 n=10)
GetAll/deployments=50      52.23Ki ± 0%        51.64Ki ± 0%  -1.12% (p=0.000 n=10)
GetAll/deployments=100     104.7Ki ± 0%        103.5Ki ± 0%  -1.19% (p=0.000 n=10)
GetAll/deployments=500     532.6Ki ± 0%        527.5Ki ± 0%  -0.96% (p=0.000 n=10)
GetAll/deployments=1000    1.038Mi ± 0%        1.029Mi ± 0%  -0.86% (p=0.000 n=10)
geomean                    56.90Ki             56.36Ki       -0.95%
¹ all samples are equal

                      │       master        │       current       │
                      │      allocs/op      │ allocs/op  vs base  │
GetAll/deployments=1       6.000 ± 0%          6.000 ± 0%       ~ (p=1.000 n=10) ¹
GetAll/deployments=10      55.00 ± 0%          51.00 ± 0%  -7.27% (p=0.000 n=10)
GetAll/deployments=50      261.0 ± 0%          255.0 ± 0%  -2.30% (p=0.000 n=10)
GetAll/deployments=100     520.0 ± 0%          513.0 ± 0%  -1.35% (p=0.000 n=10)
GetAll/deployments=500     2.624k ± 0%         2.615k ± 0% -0.34% (p=0.000 n=10)
GetAll/deployments=1000    5.237k ± 0%         5.227k ± 0% -0.19% (p=0.000 n=10)
geomean                    291.7               286.0       -1.94%
¹ all samples are equal
```
