### PR TITLE
ROX-34424: Hot reload TLS certs in Sensor

### DIFF
--- a/pkg/clientconn/client.go
+++ b/pkg/clientconn/client.go
@@ -293,11 +293,11 @@ func OptionsForEndpoint(endpoint string, extraConnOpts ...ConnectionOption) (Opt
 	}
 
 	if connOpts.useServiceCertToken {
-		leafCert, err := mtls.LeafCertificateFromFile()
-		if err != nil {
-			return Options{}, errors.Wrap(err, "loading client certificate")
+		cert := verifier.WatchedLeafCert()
+		if cert == nil {
+			return Options{}, errors.New("no leaf certificate available for service cert token")
 		}
-		clientConnOpts.PerRPCCreds = servicecerttoken.NewServiceCertClientCreds(&leafCert)
+		clientConnOpts.PerRPCCreds = servicecerttoken.NewServiceCertClientCreds(cert)
 	}
 
 	clientConnOpts.MaxMsgRecvSize = connOpts.maxMsgRecvSize

--- a/pkg/clientconn/client.go
+++ b/pkg/clientconn/client.go
@@ -120,15 +120,15 @@ func TLSConfig(server mtls.Subject, opts TLSConfigOptions) (*tls.Config, error) 
 
 	if opts.UseClientCert != DontUseClientCert {
 		conf.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-			cert, err := mtls.LeafCertificateFromFile()
-			if err != nil {
+			cert := verifier.WatchedLeafCert()
+			if cert == nil {
 				if opts.UseClientCert == MustUseClientCert {
-					return nil, err
+					return nil, errors.New("no leaf certificate available")
 				}
-				log.Warnf("Failed to load client certificate for TLS connection: %v", err)
+				log.Warn("No leaf certificate available for TLS connection")
 				return &tls.Certificate{}, nil
 			}
-			return &cert, nil
+			return cert, nil
 		}
 	}
 

--- a/pkg/clientconn/client_test.go
+++ b/pkg/clientconn/client_test.go
@@ -1,6 +1,7 @@
 package clientconn
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -11,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/mtls"
@@ -176,8 +178,9 @@ func (t *ClientTestSuite) TestGetClientCertificate_ReloadsFromDisk() {
 	cert2 := testutils.IssueSelfSignedCert(t.T(), "second-cert")
 	writeCertToFiles(t.T(), certDir, &cert2)
 
-	got2, err := conf.GetClientCertificate(nil)
-	t.Require().NoError(err)
-	t.Equal(cert2.Certificate[0], got2.Certificate[0], "GetClientCertificate should return the new cert after files changed")
-	t.NotEqual(got1.Certificate[0], got2.Certificate[0], "Certs should differ after rotation")
+	t.Require().Eventually(func() bool {
+		got, err := conf.GetClientCertificate(nil)
+		return err == nil && len(got.Certificate) > 0 &&
+			bytes.Equal(got.Certificate[0], cert2.Certificate[0])
+	}, 30*time.Second, 200*time.Millisecond, "expected rotated cert to be picked up by certwatch")
 }

--- a/pkg/mtls/README.md
+++ b/pkg/mtls/README.md
@@ -1,5 +1,7 @@
 # TLS certificates in StackRox
 
+This document covers **StackRox internal CA mTLS** only.
+
 ## Architecture
 
 - StackRox uses mTLS for most inter-service communication. Service type is extracted
@@ -37,7 +39,7 @@
 - Legacy manual cert download (UI/API): `central/certgen/` — generates YAML files for users to `kubectl apply`
 - CA rotation logic: `operator/internal/central/carotation/rotation.go`
 - Operator TLS reconciliation: `operator/internal/central/extensions/reconcile_tls.go`
-- Sensor cert init (one-time copy at startup): `sensor/kubernetes/certinit/init_tls_certs.go`
+- Sensor cert init (copy at startup, watch `certs-new` for updates): `sensor/kubernetes/certinit/init_tls_certs.go`
 - Sensor cert refresh (TLS challenge + CA bundle): `sensor/kubernetes/certrefresh/`
 - Postgres DB cert reload (Central DB, Scanner V4 DB): `image/postgres/scripts/cert-watcher.sh`, `image/templates/helm/shared/templates/_cert-watcher.tpl`
 
@@ -52,8 +54,6 @@
 The following certificates are currently known to be cached at start-up and not reloaded:
 
 - CA material (`CACert()`, `SecondaryCACert()`, `CAForSigning()`, etc.) in `pkg/mtls/crypto.go`: `sync.Once`, never refreshed. Intentional — the Operator restarts all pods on CA change.
-
-- Sensor: all certs are effectively cached because `certinit` copies them to an emptyDir at startup. Client certs are also cached at construction (`centralclient.NewClient`, `StartProxyServer`, scanner client).
 
 ## Certificate management — who manages what
 

--- a/pkg/mtls/verifier/verify.go
+++ b/pkg/mtls/verifier/verify.go
@@ -94,6 +94,16 @@ func addSecondaryCACertIfExists(certPool *x509.CertPool) {
 	}
 }
 
+// WatchedLeafCert returns the current in-memory leaf certificate maintained by
+// certwatch. The certificate is loaded from disk on startup and updated
+// atomically whenever the cert files change, with validation on each reload
+// (invalid certificates are rejected, preserving the previous valid cert).
+// Returns nil if no certificate has been loaded yet.
+func WatchedLeafCert() *tls.Certificate {
+	loadAndWatchLeafCert()
+	return leafCert.Load()
+}
+
 // TLSConfig initializes a server configuration that requires client TLS
 // authentication based on a single certificate in the filesystem.
 // The returned config uses GetConfigForClient to serve the latest cert

--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -81,11 +81,11 @@ func NewClient(endpoint string) (*Client, error) {
 	tlsConf := &tls.Config{
 		InsecureSkipVerify: true,
 		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
-			cert, err := mtls.LeafCertificateFromFile()
-			if err != nil {
-				return nil, errors.Wrap(err, "obtaining client certificate")
+			cert := verifier.WatchedLeafCert()
+			if cert == nil {
+				return nil, errors.New("no leaf certificate available")
 			}
-			return &cert, nil
+			return cert, nil
 		},
 	}
 	httpClient := &http.Client{

--- a/sensor/common/centralclient/client.go
+++ b/sensor/common/centralclient/client.go
@@ -78,14 +78,14 @@ func NewClient(endpoint string) (*Client, error) {
 	// Moreover, authentication requirements can be tightened in future and thus having an older version
 	// of Sensor authenticating itself will enable backward compatibility with newer Centrals. This has
 	// indeed happened in the past when `/v1/metadata` became authenticated.
-	clientCert, err := mtls.LeafCertificateFromFile()
-	if err != nil {
-		return nil, errors.Wrap(err, "obtaining client certificate")
-	}
 	tlsConf := &tls.Config{
 		InsecureSkipVerify: true,
-		Certificates: []tls.Certificate{
-			clientCert,
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			cert, err := mtls.LeafCertificateFromFile()
+			if err != nil {
+				return nil, errors.Wrap(err, "obtaining client certificate")
+			}
+			return &cert, nil
 		},
 	}
 	httpClient := &http.Client{

--- a/sensor/common/centralclient/client_test.go
+++ b/sensor/common/centralclient/client_test.go
@@ -1,6 +1,7 @@
 package centralclient
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -15,6 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/initca"
@@ -573,10 +575,11 @@ func (t *ClientTestSuite) TestNewClient_GetClientCertificateReloadsFromDisk() {
 	cert2 := testutils.IssueSelfSignedCert(t.T(), "second-sensor-cert")
 	writeLeafCertToFiles(t.T(), t.clientCertDir, cert2)
 
-	got2, err := transport.TLSClientConfig.GetClientCertificate(nil)
-	t.Require().NoError(err)
-	t.Equal(cert2.Certificate[0], got2.Certificate[0])
-	t.NotEqual(got1.Certificate[0], got2.Certificate[0])
+	t.Require().Eventually(func() bool {
+		got, err := transport.TLSClientConfig.GetClientCertificate(nil)
+		return err == nil && len(got.Certificate) > 0 &&
+			bytes.Equal(got.Certificate[0], cert2.Certificate[0])
+	}, 30*time.Second, 200*time.Millisecond, "expected rotated cert to be picked up by certwatch")
 }
 
 func (t *ClientTestSuite) TestNewClientReplacesProtocols() {

--- a/sensor/common/centralclient/client_test.go
+++ b/sensor/common/centralclient/client_test.go
@@ -3,9 +3,11 @@ package centralclient
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"embed"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -23,6 +25,8 @@ import (
 	"github.com/stackrox/rox/pkg/cryptoutils"
 	"github.com/stackrox/rox/pkg/cryptoutils/mocks"
 	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stackrox/rox/pkg/testutils"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 )
@@ -539,6 +543,40 @@ func (t *ClientTestSuite) TestExtractCentralCAsFromTrustInfo() {
 			}
 		})
 	}
+}
+
+func writeLeafCertToFiles(tb testing.TB, certDir string, cert tls.Certificate) {
+	tb.Helper()
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+	require.NoError(tb, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+	require.NoError(tb, os.WriteFile(filepath.Join(certDir, "cert.pem"), certPEM, 0600))
+	require.NoError(tb, os.WriteFile(filepath.Join(certDir, "key.pem"), keyPEM, 0600))
+}
+
+func (t *ClientTestSuite) TestNewClient_GetClientCertificateReloadsFromDisk() {
+	cert1 := testutils.IssueSelfSignedCert(t.T(), "first-sensor-cert")
+	writeLeafCertToFiles(t.T(), t.clientCertDir, cert1)
+
+	c, err := NewClient(endpoint)
+	t.Require().NoError(err)
+
+	transport, ok := c.httpClient.Transport.(*http.Transport)
+	t.Require().True(ok)
+	t.Require().NotNil(transport.TLSClientConfig.GetClientCertificate)
+
+	got1, err := transport.TLSClientConfig.GetClientCertificate(nil)
+	t.Require().NoError(err)
+	t.Equal(cert1.Certificate[0], got1.Certificate[0])
+
+	cert2 := testutils.IssueSelfSignedCert(t.T(), "second-sensor-cert")
+	writeLeafCertToFiles(t.T(), t.clientCertDir, cert2)
+
+	got2, err := transport.TLSClientConfig.GetClientCertificate(nil)
+	t.Require().NoError(err)
+	t.Equal(cert2.Certificate[0], got2.Certificate[0])
+	t.NotEqual(got1.Certificate[0], got2.Certificate[0])
 }
 
 func (t *ClientTestSuite) TestNewClientReplacesProtocols() {

--- a/sensor/kubernetes/certinit/init_tls_certs.go
+++ b/sensor/kubernetes/certinit/init_tls_certs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/fileutils"
+	"github.com/stackrox/rox/pkg/k8scfgwatch"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/mtls"
 )
@@ -25,7 +26,10 @@ var (
 	newSourceDir    = env.RegisterSetting("ROX_CERTS_NEW_DIR", env.WithDefault("/run/secrets/stackrox.io/certs-new/")).Setting()
 )
 
-const timeout = 5 * time.Minute
+const (
+	timeout       = 5 * time.Minute
+	watchInterval = 5 * time.Second
+)
 
 // Run sets up TLS certificates by copying them from new or legacy source directories
 // to mtls.CertsPrefix. New certificates (from the tls-cert-sensor secret) have precedence
@@ -63,7 +67,52 @@ func Run() error {
 		return errors.Wrap(err, "cannot copy files")
 	}
 
+	if newCertsExist {
+		startCertsNewWatcher(realDest)
+	}
 	return nil
+}
+
+// startCertsNewWatcher polls certs-new (tls-cert-sensor secret mount) and copies updates into the
+// working cert directory. Legacy certs are only used for initial registration; ongoing refresh
+// always updates certs-new.
+func startCertsNewWatcher(destDir string) {
+	handler := &certsNewSyncHandler{destDir: destDir}
+	watchOpts := k8scfgwatch.Options{
+		Interval: watchInterval,
+		Force:    true,
+	}
+	if err := k8scfgwatch.WatchConfigMountDir(context.Background(), newSourceDir, k8scfgwatch.DeduplicateWatchErrors(handler), watchOpts); err != nil {
+		log.Warnf("Failed to start TLS cert sync watcher on %q: %v", newSourceDir, err)
+	}
+}
+
+type certsNewSyncHandler struct {
+	destDir string
+}
+
+func (h *certsNewSyncHandler) OnChange(dir string) (interface{}, error) {
+	return findFiles(dir)
+}
+
+func (h *certsNewSyncHandler) OnStableUpdate(val interface{}, err error) {
+	if err != nil {
+		log.Errorf("Error reading TLS certificates from %q for sync to %q: %v", newSourceDir, h.destDir, err)
+		return
+	}
+	files, ok := val.([]string)
+	if !ok || len(files) == 0 {
+		return
+	}
+	if err := copyFiles(files, h.destDir); err != nil {
+		log.Errorf("Syncing TLS certificates from %q to %q: %v", newSourceDir, h.destDir, err)
+		return
+	}
+	log.Infof("Synced TLS certificates from %q to %q", newSourceDir, h.destDir)
+}
+
+func (h *certsNewSyncHandler) OnWatchError(err error) {
+	log.Warnf("TLS cert sync watcher error for %q: %v", newSourceDir, err)
 }
 
 func copyFiles(files []string, destDir string) error {

--- a/sensor/kubernetes/certinit/init_tls_certs.go
+++ b/sensor/kubernetes/certinit/init_tls_certs.go
@@ -104,6 +104,9 @@ func (h *certsNewSyncHandler) OnStableUpdate(val interface{}, err error) {
 	if !ok || len(files) == 0 {
 		return
 	}
+	// copyFiles is not atomic (files are written sequentially), but TLS consumers
+	// read from the certwatch in-memory cert (updated atomically after validation),
+	// not directly from these files. See verifier.WatchedLeafCert().
 	if err := copyFiles(files, h.destDir); err != nil {
 		log.Errorf("Syncing TLS certificates from %q to %q: %v", newSourceDir, h.destDir, err)
 		return

--- a/sensor/kubernetes/certinit/init_tls_certs_test.go
+++ b/sensor/kubernetes/certinit/init_tls_certs_test.go
@@ -182,6 +182,40 @@ func (s *initTLSCertsSuite) TestRun() {
 	})
 }
 
+func (s *initTLSCertsSuite) TestCertsNewSyncHandler() {
+	s.createDirs()
+	s.createFiles(newSourceDir, 3, "cert", "v1")
+
+	handler := &certsNewSyncHandler{destDir: destinationDir}
+	files, err := handler.OnChange(newSourceDir)
+	s.Require().NoError(err)
+	handler.OnStableUpdate(files, nil)
+
+	destFiles, err := os.ReadDir(destinationDir)
+	s.Require().NoError(err)
+	s.Len(destFiles, 3)
+	for _, f := range destFiles {
+		content, err := os.ReadFile(filepath.Join(destinationDir, f.Name()))
+		s.Require().NoError(err)
+		s.Equal("v1", string(content))
+	}
+
+	for i := 0; i < 3; i++ {
+		err := os.WriteFile(filepath.Join(newSourceDir, fmt.Sprintf("cert%d", i)), []byte("v2"), 0600)
+		s.Require().NoError(err)
+	}
+
+	files, err = handler.OnChange(newSourceDir)
+	s.Require().NoError(err)
+	handler.OnStableUpdate(files, nil)
+
+	for _, f := range destFiles {
+		content, err := os.ReadFile(filepath.Join(destinationDir, f.Name()))
+		s.Require().NoError(err)
+		s.Equal("v2", string(content), "expected file %q to be updated", f.Name())
+	}
+}
+
 func (s *initTLSCertsSuite) createDirs() {
 	legacySourceDir = s.T().TempDir()
 	newSourceDir = s.T().TempDir()


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

#### Context
The `certinit` package allows Sensor to choose at startup between the legacy init bundle certs (`sentor-tls`) and the new certs obtained via CRS or cert refresh (`tls-cert-sensor`). This is to provide backwards to compatibility with init bundles. At startup, Sensor copies the certificates into the into the `/run/secrets/stackrox.io/certs/` emptyDir.

This means however that any changes to `tls-cert-sensor` are only detected after a pod restart. This PR enables Sensor to pick up renewed internal mTLS leaf certificates without a need for restarting the pod.

#### Changes
- **`certinit`**: After the initial copy, poll `certs-new` and re-copy all cert files into certificates dir when the mount changes.
- **`centralclient`**: Use `GetClientCertificate` to read the leaf cert from disk on each TLS handshake instead of caching it at client construction.

To prevent races when certs are updated, client certificates are now cached in memory by `certwatcher`, re-using the mechanism already used by servers. This has implications outside of Sensor:
* client certs are now cached for services (previously they were reloaded from disk on each new TLS handshake)
* if the service certs are replaced with invalid certs, they will not be loaded and cached 

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Deployed a Central and a Secured Cluster CR in the `stackrox` namespace, and initialized the Secured Cluster using an init bundle.

The logs prove that refreshed certificates are re-loaded immediately by Sensor. Previously a pod restart would have been necessary to switch from the `sensor-tls` to the `tls-cert-sensor` secret:

  | Time | Event | Detail |
  |---|---|---|
  | 10:06:45 | Sensor starts with init bundle (legacy) cert | `SerialNumber: 809395110481134603`, wildcard subject `00000000-0000-0000-0000-000000000000` |
  | 10:06:45 | Connects to Central | `"First connection from cluster my-cluster using a sensor service certificate"` |
  | 10:06:50 | certrefresh creates `tls-cert-sensor` | Central issues cluster-specific certs |
  | 10:07:55 | certinit watcher syncs `certs-new/` → `certs/` | `"Synced TLS certificates from certs-new to certs"` |
  | 10:07:55 | certwatch loads new cert | `SerialNumber: 5295796196214010808`, cluster-specific subject `17c1d203-f12a-40b3-8670-65fa448409e4` |
  | 10:09:39 | Central manually restarted, Sensor reconnects | `"Cleared init artifact ID (8324e245-...) of newly created cluster my-cluster"` - proves cluster-specific cert was used |
  
  There were no restarts of the Sensor pod during this test.