### PR TITLE
ROX-34425: improve process timestamp use with checkpoint windows

### DIFF
--- a/central/splunk/violations.go
+++ b/central/splunk/violations.go
@@ -37,6 +37,13 @@ const (
 	// detected but not yet seen in the database. Ten seconds were chosen based on our understanding how quickly
 	// violations are persisted.
 	eventualConsistencyMargin = 10 * time.Second
+
+	// maxProcessDetectionDelay is the maximum expected delay between when a process runs (signal time) and when
+	// the resulting alert is stored in Central's database. The full pipeline is: sensor detection -> transmission
+	// to central -> enrichment -> database storage. In CI environments this delay has been observed at 50+ seconds.
+	// This constant bounds the fallback recovery window for process violations whose signal time has already been
+	// passed by the checkpoint but whose alert was recently stored.
+	maxProcessDetectionDelay = 2 * time.Minute
 )
 
 var (
@@ -210,8 +217,11 @@ func extractViolations(alert *storage.Alert, fromTime time.Time, toTime time.Tim
 			seenViolations = true
 
 			violationTime := getProcessViolationTime(alert, procIndicator)
-			if violationTime == nil || violationTime.Compare(fromTime) <= 0 ||
-				violationTime.Compare(toTime) > 0 {
+			if violationTime == nil {
+				continue
+			}
+			if !isTimeInWindow(violationTime, fromTime, toTime) &&
+				!isProcessViolationRecoverableViaAlertTime(violationTime, alert, fromTime, toTime) {
 				continue
 			}
 
@@ -305,6 +315,25 @@ func generateViolationID(alertID string, v *storage.Alert_Violation) (string, er
 	// In the end we just need IDs with uniqueness so this should be good enough.
 	alertUUID = uuid.NewV5(alertUUID, alertID)
 	return uuid.NewV5(alertUUID, hex.Dump(data)).String(), nil
+}
+
+func isTimeInWindow(t *time.Time, fromTime, toTime time.Time) bool {
+	return t != nil && t.Compare(fromTime) > 0 && t.Compare(toTime) <= 0
+}
+
+// isProcessViolationRecoverableViaAlertTime returns true when a process violation's signal time has
+// fallen behind the checkpoint window but the alert was recently stored (alert.Time is within the
+// window). This handles the race where the pipeline delay between process execution and alert
+// storage exceeds the checkpoint advancement rate.
+func isProcessViolationRecoverableViaAlertTime(signalTime *time.Time, alert *storage.Alert, fromTime, toTime time.Time) bool {
+	alertTime := protocompat.ConvertTimestampToTimeOrNil(alert.GetTime())
+	if alertTime == nil {
+		return false
+	}
+	if !isTimeInWindow(alertTime, fromTime, toTime) {
+		return false
+	}
+	return signalTime.After(alertTime.Add(-maxProcessDetectionDelay))
 }
 
 func getProcessViolationTime(fromAlert *storage.Alert, fromProcIndicator *storage.ProcessIndicator) *time.Time {

--- a/central/splunk/violations_test.go
+++ b/central/splunk/violations_test.go
@@ -1343,6 +1343,57 @@ func (s *violationsTestSuite) TestCheckpointTimestampFiltering() {
 	}
 }
 
+func (s *violationsTestSuite) makeDelayedProcessAlert(signalTime, alertTime string) *storage.Alert {
+	alert := s.processAlert.CloneVT()
+	alert.ProcessViolation.Processes = alert.GetProcessViolation().GetProcesses()[:1]
+	alert.ProcessViolation.Processes[0].Signal.Time = makeTimestamp(signalTime)
+	alert.Time = makeTimestamp(alertTime)
+	return alert
+}
+
+func (s *violationsTestSuite) TestProcessViolationDelayedStorage() {
+	// Signal time is 50 seconds before alert time, simulating the pipeline delay
+	// from sensor -> central -> enrichment -> storage.
+	alert := s.makeDelayedProcessAlert("2021-02-01T17:15:00Z", "2021-02-01T17:15:50Z")
+
+	// Checkpoint window: 17:15:30 to 17:16:00
+	// Signal time (17:15:00) is before fromTime (17:15:30) — would normally be excluded.
+	// Alert time (17:15:50) is within [fromTime, toTime] — fallback should include it.
+	vs := s.getViolations(s.prepare().
+		setCheckpoint("2021-02-01T17:15:30Z__2021-02-01T17:16:00Z").
+		setAlerts(alert).runRequestAndGetBody())
+	s.Len(vs, 1)
+	// The reported violation time should still be the signal time, not alert time.
+	s.Equal("2021-02-01T17:15:00Z", s.extr(vs[0], ".violationInfo.violationTime"))
+}
+
+func (s *violationsTestSuite) TestProcessViolationTooOldSignalNotRecovered() {
+	// Signal time is more than maxProcessDetectionDelay (2 min) before alert time.
+	alert := s.makeDelayedProcessAlert("2021-02-01T17:12:00Z", "2021-02-01T17:15:50Z")
+
+	// Checkpoint window includes alert time but signal time is >2 min before alert time.
+	vs := s.getViolations(s.prepare().
+		setCheckpoint("2021-02-01T17:15:30Z__2021-02-01T17:16:00Z").
+		setAlerts(alert).runRequestAndGetBody())
+	s.Len(vs, 0)
+}
+
+func (s *violationsTestSuite) TestProcessViolationDelayedStorageNoDuplicates() {
+	alert := s.makeDelayedProcessAlert("2021-02-01T17:15:00Z", "2021-02-01T17:15:50Z")
+
+	// First window: should include the violation via fallback.
+	vs1 := s.getViolations(s.prepare().
+		setCheckpoint("2021-02-01T17:15:30Z__2021-02-01T17:16:00Z").
+		setAlerts(alert).runRequestAndGetBody())
+	s.Len(vs1, 1)
+
+	// Second window: checkpoint advances, should NOT include again.
+	vs2 := s.getViolations(s.prepare().
+		setCheckpoint("2021-02-01T17:16:00Z__2021-02-01T17:16:30Z").
+		setAlerts(alert).runRequestAndGetBody())
+	s.Len(vs2, 0)
+}
+
 func (s *violationsTestSuite) TestCheckpointFromAlertIDFiltering() {
 	smallerID, biggerID := s.processAlert.GetId(), s.k8sAlert.GetId()
 	if smallerID > biggerID {


### PR DESCRIPTION
## Description

For the checkpoint window, process timestamp is used (the point at which the process was executed) and not the alert timestamp (the point at which the violation was stored) which means that if the latency between execution and storage is long enough, we can miss process violations that fall outside the checkpoint window but the alert they caused exists within the window.

This adds a window delay to account for this latency whereby process violations will be included if their alert is within the window or their process timestamp is within a given delay (two minutes) of the window.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

This should fix the intermittent e2e test flake, so some gratuitous CI test repetitions should be enough to verify this fix.
