### PR TITLE
fix(ci): prevent premature operator-index tags from breaking CRD check

### DIFF
--- a/.github/workflows/check-crd-compatibility.yaml
+++ b/.github/workflows/check-crd-compatibility.yaml
@@ -45,17 +45,19 @@ jobs:
       run: |
         make -C .crd-schema-checker
 
-    - name: Get previous released version
+    - name: Get previous release branch
       id: get_previous_released_version
       run: |
-        make -C operator bundle-post-process
-        released_version="$(make --no-print-directory -C operator replaced-version)"
+        current_branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+        released_version=$(git branch -r | grep -oE 'origin/release-[0-9]+\.[0-9]+$' | sed 's|origin/||' | grep -v "^${current_branch}$" | sort -V | tail -1)
+        echo "Current branch: $current_branch"
+        echo "Previous release branch: $released_version"
         echo "released_version=$released_version" >> "$GITHUB_OUTPUT"
 
-    - name: Checkout previous released version
+    - name: Checkout previous release branch
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         ref: ${{ steps.get_previous_released_version.outputs.released_version }}
         path: .old-stackrox
 

--- a/.github/workflows/release-ci.yaml
+++ b/.github/workflows/release-ci.yaml
@@ -5,6 +5,7 @@ on:
     - 'release-*'
     tags-ignore:
     - '*-nightly-*'
+    - '[0-9]*.[0-9]*.x'
 
 jobs:
   run-parameters:

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1048,7 +1048,7 @@ check_rhacs_eng_image_exists() {
     local name="$1"
     local tag="$2"
 
-    local url="https://quay.io/api/v1/repository/rhacs-eng/$name/tag?specificTag=$tag"
+    local url="https://quay.io/api/v1/repository/rhacs-eng/$name/tag/?onlyActiveTags=true&specificTag=$tag"
     info "Checking for $name using $url"
     local check
     local extra_args=()


### PR DESCRIPTION
## Description

Three fixes for the `check-crd-compatibility` CI failure that blocked all PR merges on 2026-05-26.

**Root cause:** `start-release.yml` pushes `N.M.x` git tags on master, which triggered `release-ci.yaml` (via broad `tags-ignore` filter), building and pushing `stackrox-operator-index:vN.M.0` images to Quay before the actual release. The CRD compatibility check used Quay image existence as a proxy for "this version is released," then tried to `git checkout` that version — which failed because no git tag existed.

**Fixes (one per commit):**
1. `scripts/ci/lib.sh`: add `onlyActiveTags=true` to Quay API query so soft-deleted tags (14-day retention) are excluded from all callers of `check_rhacs_eng_image_exists`
2. `release-ci.yaml`: add `[0-9]*.[0-9]*.x` to `tags-ignore` so version-marker tags don't trigger the release pipeline
3. `check-crd-compatibility.yaml`: replace the Quay-based version lookup with a git branch lookup (`release-N.M`), eliminating the external registry dependency entirely

**Alternatives considered:**
- Checking for the git tag instead of the Quay image — simpler than Quay but still couples to OLM version logic. The release branch approach is even simpler.
- Fixing only the `onlyActiveTags` issue — necessary but insufficient; the `.x` tag trigger would keep creating premature images on every release cut.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Verified `onlyActiveTags=true` returns empty for soft-deleted tags via Quay API
- Verified `release-N.M` branch lookup produces correct results: latest branch on master PRs, previous Y-stream on release branch PRs
- The `check-crd-compatibility` job on this PR validates itself