### PR TITLE
fix: build only host architecture for local roxctl tests

### DIFF
--- a/tests/roxctl/bats-tests/helpers.bash
+++ b/tests/roxctl/bats-tests/helpers.bash
@@ -55,9 +55,10 @@ delete-outdated-binaries() {
 roxctl-development-cmd() {
   if [[ ! -x "${tmp_roxctl}/roxctl-dev" ]]; then
     _uname="$(luname)"
+    _goarch="$(go env GOARCH)"
     mkdir -p "$tmp_roxctl"
-    make -s "roxctl-${_uname}" GOTAGS='' 2>&3
-    mv "bin/${_uname}_amd64/roxctl" "${tmp_roxctl}/roxctl-dev"
+    make -s "roxctl_${_uname}-${_goarch}" GOTAGS='' 2>&3
+    mv "bin/${_uname}_${_goarch}/roxctl" "${tmp_roxctl}/roxctl-dev"
   fi
   echo "${tmp_roxctl}/roxctl-dev"
 }
@@ -71,9 +72,10 @@ roxctl-development() {
 roxctl-release-cmd() {
   if [[ ! -x "${tmp_roxctl}/roxctl-release" ]]; then
     _uname="$(luname)"
+    _goarch="$(go env GOARCH)"
     mkdir -p "$tmp_roxctl"
-    make -s "roxctl-${_uname}" GOTAGS='release' 2>&3
-    mv "bin/${_uname}_amd64/roxctl" "${tmp_roxctl}/roxctl-release"
+    make -s "roxctl_${_uname}-${_goarch}" GOTAGS='release' 2>&3
+    mv "bin/${_uname}_${_goarch}/roxctl" "${tmp_roxctl}/roxctl-release"
   fi
   echo "${tmp_roxctl}/roxctl-release"
 }


### PR DESCRIPTION
## Description

Previously, local roxctl tests built all 4 Linux architectures (amd64, arm64, ppc64le, s390x) even though only the host arch was needed, wasting significant build time.

Changed helpers.bash to:
- Use `roxctl_${os}-${arch}` target instead of `roxctl-${os}`
- Detect host GOARCH with `go env GOARCH`
- Build only the binary needed for the current platform

This reduces local test build time by ~75% (4 builds → 1 build).

Co-Authored-By: AI Assistant
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI
only one arch build:
https://github.com/stackrox/stackrox/actions/runs/26527551167/job/78135189284?pr=20832#step:7:229