### PR TITLE
ROX-34147: Add setup-go to all unit test jobs to prevent version mismatch

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -58,6 +58,12 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         free-disk-space: 30
 
+    - name: Set up Go
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
       with:
@@ -147,6 +153,12 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+    - name: Set up Go
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+
     - name: Run Postgres
       run: |
         su postgres -c 'initdb -D /tmp/data'
@@ -209,6 +221,12 @@ jobs:
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
+    - name: Set up Go
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
 
     - name: Run Postgres
       run: |
@@ -354,6 +372,12 @@ jobs:
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
 
+    - name: Set up Go
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies
 
@@ -452,6 +476,12 @@ jobs:
     - uses: ./.github/actions/job-preamble
       with:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
+    - name: Set up Go
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # ratchet:actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
 
     - name: Cache Go dependencies
       uses: ./.github/actions/cache-go-dependencies


### PR DESCRIPTION
## Description

It looks like `go test` call is not working well with a toolchain and causes following errors when required go.mod version is different than one available in the container. To prevent this let's add `setup-go` to enforce installation of version declared in go.mod and not rely on toolchain at all. This will allow us to bump go version in a single commit. The nongroovy and other tests are not affected as they invoke tests differently, first build test binary and then run it. 

```yaml
# internal/goarch
compile: version "go1.25.8" does not match go tool version "go1.25.7"
# internal/unsafeheader
...
```

- https://github.com/stackrox/stackrox/pull/20824
- https://github.com/stackrox/stackrox/actions/runs/26523197168/job/78119699369?pr=20824

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI