### PR TITLE
ROX-27600, ROX-27170, ROX-25991: Add a retry for `oc login` on OSD

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1881,22 +1881,11 @@ setup_automation_flavor_e2e_cluster() {
         source "${SHARED_DIR}/dotenv"
         # OSD API server certificates may not be fully propagated right after
         # cluster creation, causing transient x509 errors (ROX-27600).
-        local max_login_attempts=5
-        local login_delay=30
-        for attempt in $(seq 1 "$max_login_attempts"); do
-            if oc login "$CLUSTER_API_ENDPOINT" \
-                    --username "$CLUSTER_USERNAME" \
-                    --password "$CLUSTER_PASSWORD" \
-                    --insecure-skip-tls-verify=true; then
-                info "OSD login succeeded on attempt ${attempt}"
-                break
-            fi
-            if [[ "$attempt" -eq "$max_login_attempts" ]]; then
-                die "Failed to log in to OSD cluster after ${max_login_attempts} attempts"
-            fi
-            warn "OSD login attempt ${attempt}/${max_login_attempts} failed, retrying in ${login_delay}s..."
-            sleep "$login_delay"
-        done
+        retry 5 true oc login "$CLUSTER_API_ENDPOINT" \
+                --username "$CLUSTER_USERNAME" \
+                --password "$CLUSTER_PASSWORD" \
+                --insecure-skip-tls-verify=true \
+            || die "Failed to log in to OSD cluster"
     fi
 
     # Export console credentials for OCP UI e2e tests (Cypress browser login)

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1879,10 +1879,24 @@ setup_automation_flavor_e2e_cluster() {
     if [[ "$ci_job" =~ ^osd ]]; then
         info "Logging in to an OSD cluster"
         source "${SHARED_DIR}/dotenv"
-        oc login "$CLUSTER_API_ENDPOINT" \
-                --username "$CLUSTER_USERNAME" \
-                --password "$CLUSTER_PASSWORD" \
-                --insecure-skip-tls-verify=true
+        # OSD API server certificates may not be fully propagated right after
+        # cluster creation, causing transient x509 errors (ROX-27600).
+        local max_login_attempts=5
+        local login_delay=30
+        for attempt in $(seq 1 "$max_login_attempts"); do
+            if oc login "$CLUSTER_API_ENDPOINT" \
+                    --username "$CLUSTER_USERNAME" \
+                    --password "$CLUSTER_PASSWORD" \
+                    --insecure-skip-tls-verify=true; then
+                info "OSD login succeeded on attempt ${attempt}"
+                break
+            fi
+            if [[ "$attempt" -eq "$max_login_attempts" ]]; then
+                die "Failed to log in to OSD cluster after ${max_login_attempts} attempts"
+            fi
+            warn "OSD login attempt ${attempt}/${max_login_attempts} failed, retrying in ${login_delay}s..."
+            sleep "$login_delay"
+        done
     fi
 
     # Export console credentials for OCP UI e2e tests (Cypress browser login)

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -1881,7 +1881,8 @@ setup_automation_flavor_e2e_cluster() {
         source "${SHARED_DIR}/dotenv"
         # OSD API server certificates may not be fully propagated right after
         # cluster creation, causing transient x509 errors (ROX-27600).
-        retry 5 true oc login "$CLUSTER_API_ENDPOINT" \
+        retry 5 true \
+            oc login "$CLUSTER_API_ENDPOINT" \
                 --username "$CLUSTER_USERNAME" \
                 --password "$CLUSTER_PASSWORD" \
                 --insecure-skip-tls-verify=true \


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Attempt to fix the issue with OSD cluster login. Despite `--insecure-skip-tls-verify=true` being passed, `oc login` still fails with an x509 error. Why this happens is *unclear* but maybe a simple retry help if the problem is the cert propagation delay after cluster creation.

A better way would be to check for cluster health including certificate propagation before even attempting the login but I'm not sure how to do this for OSD, so `oc login` acts as a readiness command here.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Next nightlies will test this.
