### PR TITLE
ROX-34818: fix race condition in TestRelay_UMHInteraction

### DIFF
--- a/compliance/virtualmachines/relay/relay_test.go
+++ b/compliance/virtualmachines/relay/relay_test.go
@@ -322,10 +322,9 @@ func (s *relayTestSuite) TestRelay_RateLimiting() {
 // TestRelay_UMHInteraction verifies the relay observes UMH signals and marks ACKs.
 func (s *relayTestSuite) TestRelay_UMHInteraction() {
 	done := concurrency.NewSignal()
+
 	mockIndexReportSender := &mockIndexReportSender{
-		failOnIndex:   -1,
-		done:          &done,
-		expectedCount: 1,
+		failOnIndex: -1,
 	}
 
 	mockIndexReportStream := &mockIndexReportStream{
@@ -336,6 +335,9 @@ func (s *relayTestSuite) TestRelay_UMHInteraction() {
 
 	umh := &mockUMH{
 		retryCh: make(chan string, 1),
+		onObserveSendingCb: func(_ string) {
+			done.Signal()
+		},
 	}
 
 	relay := New(mockIndexReportStream, mockIndexReportSender, umh, noThrottlingReportsPerMinute, testStaleAckThreshold)
@@ -348,14 +350,12 @@ func (s *relayTestSuite) TestRelay_UMHInteraction() {
 		errChan <- relay.Run(ctx)
 	}()
 
-	// Wait for the report to be sent.
 	select {
 	case <-done.Done():
 	case <-time.After(time.Second):
-		s.Fail("timeout waiting for report send")
+		s.Fail("timeout waiting for ObserveSending")
 	}
 
-	// Verify ObserveSending recorded the VSOCK ID.
 	var sends []string
 	concurrency.WithLock(&umh.mu, func() {
 		sends = append(sends, umh.sends...)
@@ -640,12 +640,13 @@ func (m *mockIndexReportSender) Send(_ context.Context, vmReport *v1.VMReport) e
 
 // mockUMH is a mock UnconfirmedMessageHandler for testing
 type mockUMH struct {
-	mu      sync.Mutex
-	acks    []string
-	nacks   []string
-	sends   []string
-	retryCh chan string
-	onACKCb func(resourceID string)
+	mu                 sync.Mutex
+	acks               []string
+	nacks              []string
+	sends              []string
+	retryCh            chan string
+	onACKCb            func(resourceID string)
+	onObserveSendingCb func(resourceID string)
 }
 
 func (m *mockUMH) HandleACK(resourceID string) {
@@ -666,9 +667,14 @@ func (m *mockUMH) HandleNACK(resourceID string) {
 }
 
 func (m *mockUMH) ObserveSending(resourceID string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.sends = append(m.sends, resourceID)
+	var cb func(resourceID string)
+	concurrency.WithLock(&m.mu, func() {
+		m.sends = append(m.sends, resourceID)
+		cb = m.onObserveSendingCb
+	})
+	if cb != nil {
+		cb(resourceID)
+	}
 }
 
 func (m *mockUMH) RetryCommand() <-chan string {

--- a/compliance/virtualmachines/relay/relay_test.go
+++ b/compliance/virtualmachines/relay/relay_test.go
@@ -667,14 +667,12 @@ func (m *mockUMH) HandleNACK(resourceID string) {
 }
 
 func (m *mockUMH) ObserveSending(resourceID string) {
-	var cb func(resourceID string)
 	concurrency.WithLock(&m.mu, func() {
 		m.sends = append(m.sends, resourceID)
-		cb = m.onObserveSendingCb
+		if m.onObserveSendingCb != nil {
+			m.onObserveSendingCb(resourceID)
+		}
 	})
-	if cb != nil {
-		cb(resourceID)
-	}
 }
 
 func (m *mockUMH) RetryCommand() <-chan string {


### PR DESCRIPTION
## Description

fix(relay): fix race condition in TestRelay_UMHInteraction

The test was signaling completion when Send() finished, but ObserveSending()
runs AFTER Send() returns (relay.go:183-188). This caused intermittent failures
where the test read umh.sends before ObserveSending() appended the VSOCK ID.

Fix: Move synchronization to ObserveSending callback. The test now waits for
the actual event it asserts on, eliminating the race. Follows the existing
onACKCb pattern already used by mockUMH.HandleACK().

ROX-34818: github.com/stackrox/rox/compliance/virtualmachines/relay / TestRelay FAILED

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI