### PR TITLE
ci: Add GHA workflow for BYODB e2e test

### DIFF
--- a/.github/workflows/e2e-byodb-test.yaml
+++ b/.github/workflows/e2e-byodb-test.yaml
@@ -1,0 +1,231 @@
+name: e2e-byodb-test
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - master
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - labeled
+    - synchronize
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  wait-for-images:
+    if: >-
+      !github.event.pull_request.head.repo.fork && (
+        github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'e2e-byodb-test')
+      )
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+    - uses: ./.github/actions/handle-tagged-build
+    - name: Compute build tag
+      id: build-tag
+      run: echo "tag=${MAIN_IMAGE_TAG:-"$(make --quiet --no-print-directory tag)"}" | tee -a "$GITHUB_ENV"
+    - name: Wait for images
+      uses: stackrox/actions/release/wait-for-image@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/release/wait-for-image@v1
+      with:
+        token: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
+        image: |
+          rhacs-eng/main:${{ env.tag }}
+          rhacs-eng/central-db:${{ env.tag }}
+          rhacs-eng/scanner-v4:${{ env.tag }}
+          rhacs-eng/scanner-v4-db:${{ env.tag }}
+          rhacs-eng/collector:${{ env.tag }}
+
+  gke-byodb-test:
+    needs: [ wait-for-images ]
+    if: >-
+      !github.event.pull_request.head.repo.fork && (
+        github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'e2e-byodb-test')
+      )
+    runs-on: ubuntu-latest
+    env:
+      USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
+      GCP_SERVICE_ACCOUNT_STACKROX_CI: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+      CI_JOB_NAME: gke-byodb-test
+      ARTIFACT_DIR: ./junit-reports/
+      LOAD_BALANCER: lb
+      ORCHESTRATOR_FLAVOR: k8s
+      KUBERNETES_PROVIDER: gke
+      POSTGRES_VERSION: "17"
+      LONGTERM_LICENSE: "unused"
+      ROX_RISK_REPROCESSING_INTERVAL: "15s"
+      ROX_SENSOR_CONNECTION_RETRY_MAX_INTERVAL: "30s"
+    timeout-minutes: 120
+    steps:
+
+    - name: Checkout repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    - uses: ./.github/actions/job-preamble
+      with:
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+
+    - name: Docker login to Quay.io
+      env:
+        REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+        REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+      run: docker login -u "${REGISTRY_USERNAME}" --password-stdin quay.io <<<"${REGISTRY_PASSWORD}"
+
+    - name: Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # ratchet:google-github-actions/setup-gcloud@v3
+      with:
+        install_components: "gke-gcloud-auth-plugin,beta"
+
+    - name: Create GKE cluster
+      env:
+        MACHINE_TYPE: e2-standard-8
+        NUM_NODES: "3"
+      timeout-minutes: 20
+      run: |
+        source scripts/ci/gke.sh
+        provision_gke_cluster byodb
+        {
+          echo "CLUSTER_NAME=${CLUSTER_NAME}"
+          echo "ZONE=${ZONE}"
+          echo "KUBECONFIG=${HOME}/.kube/config"
+        } >> "$GITHUB_ENV"
+
+    - name: Wait for cluster to stabilize
+      timeout-minutes: 5
+      run: |
+        source scripts/ci/gke.sh
+        wait_for_cluster
+
+    - name: Build roxctl
+      run: |
+        make roxctl_linux-amd64
+        sudo cp bin/linux_amd64/roxctl /usr/local/bin/roxctl
+        echo "${HOME}/go/bin" >> "$GITHUB_PATH"
+
+    - name: Verify kubectl access
+      run: |
+        kubectl cluster-info
+        kubectl get nodes
+
+    - name: Create artifact directory
+      run: mkdir -p "$ARTIFACT_DIR"
+
+    - name: Run pre-test
+      shell: python
+      env:
+        QUAY_RHACS_ENG_BEARER_TOKEN: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
+        QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+        QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+        PYTHONUNBUFFERED: "1"
+      run: |
+        import sys
+        sys.path.append('.openshift-ci')
+        from pre_tests import PreSystemTests
+        PreSystemTests().run()
+
+    - name: Run BYODB test
+      env:
+        QUAY_RHACS_ENG_RO_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+        QUAY_RHACS_ENG_RO_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+        REGISTRY_USERNAME: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+        REGISTRY_PASSWORD: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_ECR_REGISTRY_REGION: ${{ secrets.AWS_ECR_REGISTRY_REGION }}
+        AWS_ECR_REGISTRY_NAME: ${{ secrets.AWS_ECR_REGISTRY_NAME }}
+        AWS_ASSUME_ROLE_ACCESS_KEY_ID: ${{ secrets.AWS_ASSUME_ROLE_ACCESS_KEY_ID }}
+        AWS_ASSUME_ROLE_SECRET_ACCESS_KEY: ${{ secrets.AWS_ASSUME_ROLE_SECRET_ACCESS_KEY }}
+        AWS_ASSUME_ROLE_ROLE_ID: ${{ secrets.AWS_ASSUME_ROLE_ROLE_ID }}
+        AWS_ASSUME_ROLE_EXTERNAL_ID: ${{ secrets.AWS_ASSUME_ROLE_EXTERNAL_ID }}
+        AWS_ASSUME_ROLE_TEST_CONDITION_ID: ${{ secrets.AWS_ASSUME_ROLE_TEST_CONDITION_ID }}
+        AZURE_REGISTRY_PASSWORD: ${{ secrets.AZURE_REGISTRY_PASSWORD }}
+        GOOGLE_CREDENTIALS_GCR_SCANNER_V2: ${{ secrets.GOOGLE_CREDENTIALS_GCR_SCANNER_V2 }}
+        GOOGLE_CREDENTIALS_GCR_NO_ACCESS_KEY_V2: ${{ secrets.GOOGLE_CREDENTIALS_GCR_NO_ACCESS_KEY_V2 }}
+        GOOGLE_ARTIFACT_REGISTRY_SERVICE_ACCOUNT_V2: ${{ secrets.GOOGLE_ARTIFACT_REGISTRY_SERVICE_ACCOUNT_V2 }}
+        QUAY_RHACS_ENG_BEARER_TOKEN: ${{ secrets.QUAY_RHACS_ENG_BEARER_TOKEN }}
+        REDHAT_USERNAME: ${{ secrets.RH_REGISTRY_USERNAME_RO }}
+        REDHAT_PASSWORD: ${{ secrets.RH_REGISTRY_PASSWORD_RO }}
+        SLACK_MAIN_WEBHOOK: ${{ secrets.SLACK_MAIN_WEBHOOK }}
+        OCM_OFFLINE_TOKEN: ${{ secrets.OCM_OFFLINE_TOKEN }}
+        CLOUD_SOURCES_TEST_OCM_CLIENT_ID: ${{ secrets.CLOUD_SOURCES_TEST_OCM_CLIENT_ID }}
+        CLOUD_SOURCES_TEST_OCM_CLIENT_SECRET: ${{ secrets.CLOUD_SOURCES_TEST_OCM_CLIENT_SECRET }}
+        BUILD_ID: ${{ github.run_id }}
+      timeout-minutes: 90
+      run: tests/byodb/run.sh /tmp/byodb-test-logs
+
+    - name: Persist env vars for post-test
+      if: failure() || github.event_name == 'push'
+      run: |
+        source tests/e2e/lib.sh
+        wait_for_api
+        echo "API_ENDPOINT=${API_ENDPOINT}" >> "$GITHUB_ENV"
+        echo "ROX_ADMIN_PASSWORD=$(cat deploy/k8s/central-deploy/password)" >> "$GITHUB_ENV"
+
+    - name: Run post-test
+      if: failure() || github.event_name == 'push'
+      shell: python
+      env:
+        PYTHONUNBUFFERED: "1"
+        ROX_USERNAME: admin
+      run: |
+        import os, sys
+        sys.path.append('.openshift-ci')
+        from post_tests import PostClusterTest
+        post = PostClusterTest(
+            collect_central_artifacts=False,
+        )
+        if os.environ.get("ORCHESTRATOR_FLAVOR") == "k8s":
+            post.openshift_namespaces = []
+        post.run(['/tmp/byodb-test-logs', '${{ env.ARTIFACT_DIR }}'])
+
+    - name: Run final-post
+      if: always()
+      shell: python
+      env:
+        PYTHONUNBUFFERED: "1"
+      run: |
+        import sys
+        sys.path.append('.openshift-ci')
+        from post_tests import FinalPost
+        FinalPost(store_qa_tests_data=False).run()
+
+    - name: Teardown GKE cluster
+      if: always()
+      run: |
+        if [[ -z "${CLUSTER_NAME:-}" ]]; then
+          echo "No cluster to teardown"
+          exit 0
+        fi
+        source scripts/ci/gke.sh
+        teardown_gke_cluster false || echo "Cluster teardown failed"
+
+    - name: Publish test summary
+      uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # ratchet:test-summary/action@v2
+      if: always()
+      with:
+        paths: ${{ env.ARTIFACT_DIR }}/**/*.xml
+        show: all
+
+    - name: Report junit failures in jira
+      if: (!cancelled())
+      id: junit2jira
+      uses: ./.github/actions/junit2jira
+      with:
+        create-jiras: ${{ github.event_name == 'push' }}
+        jira-user: ${{ secrets.JIRA_USER }}
+        jira-token: ${{ secrets.JIRA_TOKEN }}
+        gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
+        directory: ${{ env.ARTIFACT_DIR }}

--- a/.github/workflows/e2e-byodb-test.yaml
+++ b/.github/workflows/e2e-byodb-test.yaml
@@ -47,11 +47,6 @@ jobs:
 
   gke-byodb-test:
     needs: [ wait-for-images ]
-    if: >-
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-byodb-test')
-      )
     runs-on: ubuntu-latest
     env:
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -47,11 +47,6 @@ jobs:
 
   gke-db-backup-restore-test:
     needs: [ wait-for-images ]
-    if: >-
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-db-backup-restore-test')
-      )
     runs-on: ubuntu-latest
     env:
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -47,11 +47,6 @@ jobs:
 
   gke-nongroovy-e2e-tests:
     needs: [ wait-for-images ]
-    if: >-
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-nongroovy-tests')
-      )
     runs-on: ubuntu-latest
     env:
       USE_GKE_GCLOUD_AUTH_PLUGIN: "True"


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow to run the existing BYODB (Bring Your Own Database) e2e test on GKE. This test currently runs only through OpenShift CI (Prow) and this PR brings it to GHA as part of the ongoing migration effort to reduce reliance on Prow infrastructure.

The workflow provisions a GKE cluster, builds roxctl, deploys StackRox with an external PostgreSQL database using the existing `tests/byodb/run.sh` test script, and tears down the cluster on completion. It runs on pushes to master and on PRs labeled with `e2e-byodb-test`, matching the gating pattern used by other GHA e2e workflows (e.g., `e2e-db-backup-restore-test`, `e2e-nongroovy-tests`).

Key details:
- Uses the same pre/post test hooks from `.openshift-ci/` that the Prow job uses
- Waits for images to be built before running tests
- Reports JUnit results and creates Jira tickets for failures on master
- Cluster teardown runs unconditionally via `if: always()`

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added e2e tests

This PR does not add new test logic — it adds a GHA workflow to run the existing `tests/byodb/run.sh` e2e test that is already exercised through OpenShift CI.

### How I validated my change

- Reviewed the workflow YAML against existing GHA e2e workflows (`e2e-db-backup-restore-test.yaml`, `e2e-nongroovy-tests.yaml`) to ensure consistent patterns for cluster provisioning, image waiting, pre/post test hooks, and teardown
- Verified that the workflow references the same `tests/byodb/run.sh` entrypoint used by the Prow job in `.openshift-ci/ci_tests.py`
- Will validate end-to-end by applying the `e2e-byodb-test` label to this PR and inspecting the GHA run