### PR TITLE
ROX-34817: Remove UI e2e test dependence on CVE data

### DIFF
--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getCvesForDeployment.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getCvesForDeployment.json
@@ -1,0 +1,79 @@
+{
+    "data": {
+        "deployment": {
+            "imageVulnerabilityCount": 1,
+            "id": "mock-deployment-001",
+            "images": [
+                {
+                    "id": "sha256:abcxyz",
+                    "digest": "sha256:abcxyz",
+                    "name": {
+                        "registry": "docker.io",
+                        "remote": "cypress-test/image",
+                        "tag": "v0.0.1",
+                        "__typename": "ImageName"
+                    },
+                    "metadata": {
+                        "v1": {
+                            "layers": [
+                                {
+                                    "instruction": "ADD",
+                                    "value": "file:abc123 in /",
+                                    "__typename": "ImageLayer"
+                                }
+                            ],
+                            "__typename": "V1Metadata"
+                        },
+                        "__typename": "ImageMetadata"
+                    },
+                    "__typename": "Image"
+                }
+            ],
+            "imageVulnerabilities": [
+                {
+                    "vulnerabilityId": "MOCK-2023-123456#debian:11",
+                    "cve": "MOCK-2023-123456",
+                    "cveBaseInfo": {
+                        "epss": null,
+                        "__typename": "CveBaseInfo"
+                    },
+                    "operatingSystem": "debian:11",
+                    "publishedOn": "2023-10-14T02:15:00Z",
+                    "summary": "Mocked CVE for Cypress testing",
+                    "pendingExceptionCount": 0,
+                    "images": [
+                        {
+                            "imageId": "sha256:abcxyz",
+                            "imageComponents": [
+                                {
+                                    "name": "openssl",
+                                    "version": "3.0.8-r0",
+                                    "location": "",
+                                    "source": "OS",
+                                    "layerIndex": 0,
+                                    "imageVulnerabilities": [
+                                        {
+                                            "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+                                            "cvss": 7.5,
+                                            "scoreVersion": "V3",
+                                            "fixedByVersion": "3.0.8-r1",
+                                            "advisory": null,
+                                            "discoveredAtImage": "2024-03-01T17:45:32.757812569Z",
+                                            "publishedOn": "2023-03-22T17:15:00Z",
+                                            "pendingExceptionCount": 0,
+                                            "__typename": "ImageVulnerability"
+                                        }
+                                    ],
+                                    "__typename": "ImageComponent"
+                                }
+                            ],
+                            "__typename": "Image"
+                        }
+                    ],
+                    "__typename": "ImageVulnerability"
+                }
+            ],
+            "__typename": "Deployment"
+        }
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getDeploymentList.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getDeploymentList.json
@@ -1,0 +1,22 @@
+{
+    "data": {
+        "deployments": [
+            {
+                "id": "mock-deployment-001",
+                "name": "cypress-test-deployment",
+                "type": "Deployment",
+                "imageCVECountBySeverity": {
+                    "critical": { "total": 2 },
+                    "important": { "total": 0 },
+                    "moderate": { "total": 0 },
+                    "low": { "total": 0 },
+                    "unknown": { "total": 0 }
+                },
+                "clusterName": "remote",
+                "namespace": "stackrox",
+                "imageCount": 1,
+                "created": "2024-01-15T10:30:00Z"
+            }
+        ]
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getDeploymentMetadata.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getDeploymentMetadata.json
@@ -1,0 +1,13 @@
+{
+    "data": {
+        "deployment": {
+            "id": "mock-deployment-001",
+            "name": "cypress-test-deployment",
+            "namespace": "stackrox",
+            "clusterName": "remote",
+            "created": "2024-01-15T10:30:00Z",
+            "imageCount": 1,
+            "__typename": "Deployment"
+        }
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getDeploymentResources.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getDeploymentResources.json
@@ -1,0 +1,25 @@
+{
+    "data": {
+        "deployment": {
+            "id": "mock-deployment-001",
+            "imageCount": 1,
+            "images": [
+                {
+                    "id": "sha256:abcxyz",
+                    "digest": "sha256:abcxyz",
+                    "name": {
+                        "registry": "docker.io",
+                        "remote": "cypress-test/image",
+                        "tag": "v0.0.1",
+                        "__typename": "ImageName"
+                    },
+                    "deploymentCount": 1,
+                    "operatingSystem": "debian:11",
+                    "scanTime": "2024-03-01T17:45:32.757812569Z",
+                    "__typename": "Image"
+                }
+            ],
+            "__typename": "Deployment"
+        }
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getDeploymentSummaryData.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getDeploymentSummaryData.json
@@ -1,0 +1,36 @@
+{
+    "data": {
+        "deployment": {
+            "id": "mock-deployment-001",
+            "imageCVECountBySeverity": {
+                "unknown": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "low": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "moderate": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "important": {
+                    "total": 1,
+                    "fixable": 1,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "critical": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "__typename": "ResourceCountByCVESeverity"
+            },
+            "__typename": "Deployment"
+        }
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getDeploymentsForCVE.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getDeploymentsForCVE.json
@@ -1,0 +1,69 @@
+{
+    "data": {
+        "deployments": [
+            {
+                "id": "mock-deployment-001",
+                "name": "cypress-test-deployment",
+                "namespace": "stackrox",
+                "type": "Deployment",
+                "clusterName": "remote",
+                "created": "2024-01-15T10:30:00Z",
+                "unknownImageCount": 0,
+                "lowImageCount": 0,
+                "moderateImageCount": 0,
+                "importantImageCount": 1,
+                "criticalImageCount": 0,
+                "images": [
+                    {
+                        "id": "sha256:abcxyz",
+                        "digest": "sha256:abcxyz",
+                        "name": {
+                            "registry": "docker.io",
+                            "remote": "cypress-test/image",
+                            "tag": "v0.0.1",
+                            "__typename": "ImageName"
+                        },
+                        "metadata": {
+                            "v1": {
+                                "layers": [
+                                    {
+                                        "instruction": "ADD",
+                                        "value": "file:abc123 in /",
+                                        "__typename": "ImageLayer"
+                                    }
+                                ],
+                                "__typename": "V1Metadata"
+                            },
+                            "__typename": "ImageMetadata"
+                        },
+                        "imageComponents": [
+                            {
+                                "name": "openssl",
+                                "version": "3.0.8-r0",
+                                "location": "",
+                                "source": "OS",
+                                "layerIndex": 0,
+                                "imageVulnerabilities": [
+                                    {
+                                        "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+                                        "cvss": 7.5,
+                                        "scoreVersion": "V3",
+                                        "fixedByVersion": "3.0.8-r1",
+                                        "advisory": null,
+                                        "discoveredAtImage": "2024-03-01T17:45:32.757812569Z",
+                                        "publishedOn": "2023-03-22T17:15:00Z",
+                                        "pendingExceptionCount": 0,
+                                        "__typename": "ImageVulnerability"
+                                    }
+                                ],
+                                "__typename": "ImageComponent"
+                            }
+                        ],
+                        "__typename": "Image"
+                    }
+                ],
+                "__typename": "Deployment"
+            }
+        ]
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getImageCveMetadata.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getImageCveMetadata.json
@@ -1,0 +1,17 @@
+{
+    "data": {
+        "imageCVE": {
+            "cve": "MOCK-2023-123456",
+            "firstDiscoveredInSystem": "2024-03-25T14:35:43.111026Z",
+            "publishedOn": "2023-10-14T02:15:00Z",
+            "distroTuples": [
+                {
+                    "summary": "Mocked CVE for Cypress testing",
+                    "link": "",
+                    "operatingSystem": "debian:11",
+                    "cveBaseInfo": { "epss": null }
+                }
+            ]
+        }
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getImageCveSummaryData.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getImageCveSummaryData.json
@@ -1,0 +1,40 @@
+{
+    "data": {
+        "totalImageCount": 1,
+        "imageCount": 1,
+        "deploymentCount": 1,
+        "imageCVE": {
+            "cve": "MOCK-2023-123456",
+            "affectedImageCount": 1,
+            "affectedImageCountBySeverity": {
+                "unknown": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "low": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "moderate": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "important": {
+                    "total": 1,
+                    "fixable": 1,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "critical": {
+                    "total": 0,
+                    "fixable": 0,
+                    "__typename": "ResourceCountByFixability"
+                },
+                "__typename": "ResourceCountByCVESeverity"
+            },
+            "__typename": "ImageCVE"
+        }
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getImageList.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getImageList.json
@@ -1,0 +1,30 @@
+{
+    "data": {
+        "images": [
+            {
+                "id": "sha256:abcxyz",
+                "digest": "sha256:abcxyz",
+                "name": {
+                    "registry": "docker.io",
+                    "remote": "cypress-test/image",
+                    "tag": "v0.0.1",
+                    "fullName": "docker.io/cypress-test/image:v0.0.1"
+                },
+                "imageCVECountBySeverity": {
+                    "critical": { "total": 2 },
+                    "important": { "total": 0 },
+                    "moderate": { "total": 0 },
+                    "low": { "total": 0 },
+                    "unknown": { "total": 0 }
+                },
+                "operatingSystem": "debian:11",
+                "deploymentCount": 1,
+                "watchStatus": "NOT_WATCHED",
+                "metadata": { "v1": { "created": "2024-01-15T10:30:00Z" } },
+                "scanTime": "2024-06-01T12:00:00Z",
+                "scanNotes": [],
+                "notes": []
+            }
+        ]
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getImagesForCVE.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getImagesForCVE.json
@@ -1,0 +1,57 @@
+{
+    "data": {
+        "images": [
+            {
+                "id": "sha256:abcxyz",
+                "digest": "sha256:abcxyz",
+                "name": {
+                    "registry": "docker.io",
+                    "remote": "cypress-test/image",
+                    "tag": "v0.0.1",
+                    "__typename": "ImageName"
+                },
+                "metadata": {
+                    "v1": {
+                        "layers": [
+                            {
+                                "instruction": "ADD",
+                                "value": "file:abc123 in /",
+                                "__typename": "ImageLayer"
+                            }
+                        ],
+                        "__typename": "V1Metadata"
+                    },
+                    "__typename": "ImageMetadata"
+                },
+                "operatingSystem": "debian:11",
+                "watchStatus": "NOT_WATCHED",
+                "imageComponents": [
+                    {
+                        "name": "openssl",
+                        "version": "3.0.8-r0",
+                        "location": "",
+                        "source": "OS",
+                        "layerIndex": 0,
+                        "inBaseImageLayer": false,
+                        "imageVulnerabilities": [
+                            {
+                                "severity": "IMPORTANT_VULNERABILITY_SEVERITY",
+                                "fixedByVersion": "3.0.8-r1",
+                                "advisory": null,
+                                "pendingExceptionCount": 0,
+                                "discoveredAtImage": "2024-03-01T17:45:32.757812569Z",
+                                "cvss": 7.5,
+                                "scoreVersion": "V3",
+                                "nvdCvss": 0,
+                                "nvdScoreVersion": "UNKNOWN_VERSION",
+                                "__typename": "ImageVulnerability"
+                            }
+                        ],
+                        "__typename": "ImageComponent"
+                    }
+                ],
+                "__typename": "Image"
+            }
+        ]
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getNamespaceViewNamespaces.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/getNamespaceViewNamespaces.json
@@ -1,0 +1,18 @@
+{
+    "data": {
+        "namespaces": [
+            {
+                "metadata": {
+                    "id": "mock-namespace-001",
+                    "name": "stackrox",
+                    "clusterId": "mock-cluster-001",
+                    "clusterName": "remote",
+                    "labels": [],
+                    "annotations": [],
+                    "priority": 1
+                },
+                "deploymentCount": 5
+            }
+        ]
+    }
+}

--- a/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/imageWithMultipleCves.json
+++ b/ui/apps/platform/cypress/fixtures/vulnerabilities/workloadCves/imageWithMultipleCves.json
@@ -6,6 +6,7 @@
                 "registry": "docker.io",
                 "remote": "cypress-test/image",
                 "tag": "v0.0.1",
+                "fullName": "docker.io/cypress-test/image:v0.0.1",
                 "__typename": "ImageName"
             },
             "deploymentCount": 1,
@@ -22,8 +23,8 @@
                 "__typename": "DataSource"
             },
             "scanTime": "2024-12-02T13:51:19.876935617Z",
-            "scanNotes": ["OS_CVES_STALE"],
-            "notes": ["MISSING_SIGNATURE", "MISSING_SIGNATURE_VERIFICATION_DATA"],
+            "scanNotes": [],
+            "notes": [],
             "__typename": "Image"
         }
     }

--- a/ui/apps/platform/cypress/integration/exceptionConfiguration/vulnerabilitiesExceptionConfig.test.js
+++ b/ui/apps/platform/cypress/integration/exceptionConfiguration/vulnerabilitiesExceptionConfig.test.js
@@ -1,8 +1,8 @@
 import withAuth from '../../helpers/basicAuth';
+import { visit } from '../../helpers/visit';
 import {
     interactAndWaitForCveList,
     selectSingleCveForException,
-    visitWorkloadCveOverview,
 } from '../vulnerabilities/workloadCves/WorkloadCves.helpers';
 import {
     resetExceptionConfig,
@@ -109,7 +109,7 @@ describe('Vulnerabilities Exception Configuration', () => {
         // Mock the CVE list response on the Workload CVE page to prevent flakiness when no CVEs are reported
         interactAndWaitForCveList(() => {
             // Visit the Workload CVE page, open a deferral modal, and verify that the specified options are available
-            visitWorkloadCveOverview();
+            visit('/main/vulnerabilities/platform/');
             selectSingleCveForException('DEFERRAL');
             cy.get('button:contains("Options")').click();
 
@@ -136,7 +136,7 @@ describe('Vulnerabilities Exception Configuration', () => {
             cy.get('.pf-v6-c-alert:contains("The configuration was updated successfully")');
 
             // Revisit Workload CVEs and verify that the updated options are available
-            visitWorkloadCveOverview();
+            visit('/main/vulnerabilities/platform/');
             selectSingleCveForException('DEFERRAL');
             cy.get('button:contains("Options")').click();
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedDeferralsTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedDeferralsTable.test.ts
@@ -52,7 +52,9 @@ describe('Exception Management - Approved Deferrals Table', () => {
             viewCvesByObservationState('Deferred');
 
             // Verify correct CVE filter
-            cy.get('td[data-label="Request details"] a:contains("View")').click();
+            cy.get(
+                `tr:has(td[data-label="CVE"]:contains("${cveName}")) td[data-label="Request details"] a:contains("View")`
+            ).click();
             cy.get(workloadSelectors.filterLabelGroupItem('CVE', cveName));
 
             // Verify a link in the table containing the request

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedFalsePositivesTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/approvedFalsePositivesTable.test.ts
@@ -51,7 +51,9 @@ describe('Exception Management - Approved False Positives Table', () => {
                 viewCvesByObservationState('False positives');
 
                 // Verify correct CVE filter
-                cy.get('td[data-label="Request details"] a:contains("View")').click();
+                cy.get(
+                    `tr:has(td[data-label="CVE"]:contains("${cveName}")) td[data-label="Request details"] a:contains("View")`
+                ).click();
                 cy.get(workloadSelectors.filterLabelGroupItem('CVE', cveName));
 
                 // Verify a link in the table containing the request

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/deniedRequestsTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/deniedRequestsTable.test.ts
@@ -50,6 +50,9 @@ describe('Exception Management - Denied Requests Table', () => {
         denyRequest();
         visitDeniedRequestsTab();
 
+        // Sort by Requested to ensure the most recent request is the first one
+        cy.get(selectors.tableSortColumn('Requested')).click();
+
         // the false positive request should be denied
         cy.get(
             'table tr:nth(1) td[data-label="Requested action"]:contains("False positive")'

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/pendingRequestsTable.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/pendingRequestsTable.test.ts
@@ -42,6 +42,9 @@ describe('Exception Management Pending Requests Page', () => {
 
             visitPendingRequestsTab();
 
+            // Sort by Requested to ensure the most recent request is the first one
+            cy.get(selectors.tableSortColumn('Requested')).click();
+
             // the deferred request should be pending
             cy.get(
                 'table td[data-label="Requested action"]:contains("Deferred (when all fixed)")'
@@ -91,9 +94,10 @@ describe('Exception Management Pending Requests Page', () => {
                 const requestNameLink = 'table td[data-label="Request name"]';
 
                 cy.get(requestNameLink)
+                    .first()
                     .invoke('text')
                     .then((requestName) => {
-                        cy.get(requestNameLink).click();
+                        cy.get(requestNameLink).first().click();
                         cy.get(`h1:contains("${requestName}")`).should('exist');
                     });
             });
@@ -236,11 +240,13 @@ describe('Exception Management Pending Requests Page', () => {
 
             visitPendingRequestsTab();
 
-            cy.get('table td[data-label="Request name"] a').then((element) => {
-                const requestName = element.text().trim();
-                typeAndEnterCustomSearchFilterValue('Exception', 'Request Name', requestName);
-                cy.get('table td[data-label="Request name"] a').should('exist');
-            });
+            cy.get('table td[data-label="Request name"] a')
+                .first()
+                .then((element) => {
+                    const requestName = element.text().trim();
+                    typeAndEnterCustomSearchFilterValue('Exception', 'Request Name', requestName);
+                    cy.get('table td[data-label="Request name"] a').should('exist');
+                });
         });
     });
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/requestDetails.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/requestDetails.test.ts
@@ -1,4 +1,8 @@
 import withAuth from '../../../helpers/basicAuth';
+import {
+    getRouteMatcherMapForGraphQL,
+    interactAndWaitForResponses,
+} from '../../../helpers/request';
 import { cancelAllCveExceptions } from '../workloadCves/WorkloadCves.helpers';
 import { deferAndVisitRequestDetails } from './ExceptionManagement.helpers';
 import { selectors } from './ExceptionManagement.selectors';
@@ -139,14 +143,27 @@ describe('Exception Management Request Details Page', () => {
 
     it('should be able to navigate to the Workload CVEs CVE Details page by clicking on the "CVE" link', () => {
         deferAndVisitRequestDetails(deferralProps);
+
+        const routeMatcherMap = getRouteMatcherMapForGraphQL(['getImageCveMetadata']);
+        const staticResponseMap = {
+            getImageCveMetadata: {
+                fixture: 'vulnerabilities/workloadCves/getImageCveMetadata.json',
+            },
+        };
+
         cy.get('table td[data-label="CVE"] a')
             .invoke('text')
             .then((cveName) => {
-                cy.get('table td[data-label="CVE"] a').click();
+                interactAndWaitForResponses(
+                    () => {
+                        cy.get('table td[data-label="CVE"] a').click();
+                    },
+                    routeMatcherMap,
+                    staticResponseMap
+                );
                 cy.get('h1')
                     .invoke('text')
                     .then((headerText) => {
-                        // page header should be the same CVE we clicked
                         expect(headerText).to.equal(cveName);
                     });
             });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/requestDetails.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/requestDetails.test.ts
@@ -152,11 +152,12 @@ describe('Exception Management Request Details Page', () => {
         };
 
         cy.get('table td[data-label="CVE"] a')
+            .first()
             .invoke('text')
             .then((cveName) => {
                 interactAndWaitForResponses(
                     () => {
-                        cy.get('table td[data-label="CVE"] a').click();
+                        cy.get('table td[data-label="CVE"] a').first().click();
                     },
                     routeMatcherMap,
                     staticResponseMap

--- a/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/updateRequestFlow.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/exceptionManagement/updateRequestFlow.test.ts
@@ -12,6 +12,26 @@ const deferralProps = {
     scope: 'All images',
 };
 
+// Mocked affected images response to match mocked CVEs in exception request
+const mockAffectedImagesCountBody = {
+    data: {
+        imageCVEs: [
+            {
+                cve: 'MOCK-2023-123456',
+                affectedImageCount: 4,
+                distroTuples: [
+                    {
+                        summary: 'This is a MOCKED CYPRESS RESPONSE for a CVE',
+                        operatingSystem: 'debian:11',
+                        cvss: 9.8,
+                        scoreVersion: 'V3',
+                    },
+                ],
+            },
+        ],
+    },
+};
+
 describe('Exception Management Request Details Page', () => {
     withAuth();
 
@@ -24,15 +44,15 @@ describe('Exception Management Request Details Page', () => {
     });
 
     it('should be able to update a pending request', () => {
-        deferAndVisitRequestDetails(deferralProps);
-
         const newExpiry = 'When all CVEs are fixable';
         const newComment = 'Updated';
 
-        cy.intercept({ method: 'POST', url: graphql('getAffectedImagesCount') }).as(
-            'getAffectedImagesCount'
-        );
-        cy.intercept({ method: 'POST', url: graphql('getImageCVEList') }).as('getImageCVEList');
+        cy.intercept(
+            { method: 'POST', url: graphql('getAffectedImagesCount') },
+            { body: mockAffectedImagesCountBody }
+        ).as('getAffectedImagesCount');
+
+        deferAndVisitRequestDetails(deferralProps);
 
         // check values pre-update
         cy.get('dl.vulnerability-exception-request-overview')
@@ -45,7 +65,6 @@ describe('Exception Management Request Details Page', () => {
             .should('contain.text', deferralProps.comment);
 
         cy.wait('@getAffectedImagesCount');
-        cy.wait('@getImageCVEList');
 
         // update deferral
         cy.get('button:contains("Update request")').click();

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -29,9 +29,6 @@ export function getFutureDateByDays(days) {
 
 export function visitWorkloadCveOverview({ clearFiltersOnVisit = true, urlSearch = '' } = {}) {
     const routeMatcherMap = getRouteMatcherMapForGraphQL(['getImageCVEList']);
-    Object.keys(routeMatcherMap).forEach((key) => {
-        routeMatcherMap[key].times = 1;
-    });
     const staticResponseMap = {
         getImageCVEList: { fixture: 'vulnerabilities/workloadCves/getImageCVEList.json' },
     };

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/WorkloadCves.helpers.js
@@ -32,21 +32,23 @@ export function visitWorkloadCveOverview({ clearFiltersOnVisit = true, urlSearch
     Object.keys(routeMatcherMap).forEach((key) => {
         routeMatcherMap[key].times = 1;
     });
-    // With Workload CVEs split between User and Platform components, we can only reliably expect
-    // CVEs to be present for the built-in (Platform) components during CI
+    const staticResponseMap = {
+        getImageCVEList: { fixture: 'vulnerabilities/workloadCves/getImageCVEList.json' },
+    };
     const basePath = '/main/vulnerabilities/platform/';
-    visit(basePath + urlSearch, routeMatcherMap);
+    visit(basePath + urlSearch, routeMatcherMap, staticResponseMap);
 
     cy.get(`h1:contains("Platform vulnerabilities")`);
     cy.location('pathname').should('eq', basePath);
 
-    // Clear the default filters that will be applied to increase the likelihood of finding entities with
-    // CVEs. The default filters of Severity: Critical and Severity: Important make it very likely that
-    // there will be no results across entity tabs on the overview page.
     if (clearFiltersOnVisit) {
-        interactAndWaitForResponses(() => {
-            cy.get(vulnSelectors.clearFiltersButton).click();
-        }, routeMatcherMap);
+        interactAndWaitForResponses(
+            () => {
+                cy.get(vulnSelectors.clearFiltersButton).click();
+            },
+            routeMatcherMap,
+            staticResponseMap
+        );
     }
 }
 
@@ -165,12 +167,15 @@ export function cancelAllCveExceptions() {
     return cy.env(['ROX_AUTH_TOKEN']).then(({ ROX_AUTH_TOKEN }) => {
         const auth = { bearer: ROX_AUTH_TOKEN };
 
-        cy.request({ url: '/v2/vulnerability-exceptions', auth }).as('vulnExceptions');
+        cy.request({
+            url: '/v2/vulnerability-exceptions?query=Requester User Name:ui_tests',
+            auth,
+        }).as('vulnExceptions');
 
         return cy.get('@vulnExceptions').then((res) => {
             return Promise.all(
-                res.body.exceptions.map(({ id, expired, requester }) => {
-                    return requester?.name === 'ui_tests' && !expired
+                res.body.exceptions.map(({ id, expired }) => {
+                    return !expired
                         ? cy.request({
                               url: `/v2/vulnerability-exceptions/${id}/cancel`,
                               auth,
@@ -250,7 +255,7 @@ export function verifySelectedCvesInModal(cveNames) {
  * The v2 response uses `imageV2` as the root key, `ImageV2` as the typename,
  * a UUID-style `id`, and an additional `digest` field.
  */
-function toImageV2Response(v1Response) {
+export function toImageV2Response(v1Response) {
     const { image } = v1Response.data;
     return {
         data: {
@@ -265,54 +270,56 @@ function toImageV2Response(v1Response) {
 }
 
 /**
- * Visits an image single page via the workload CVE overview page and mocks the responses for the image
- * details and CVE list. We need to mock the CVE list to ensure that multiple CVEs are present for the image. We
- * also need to mock the image details to ensure Apollo does not duplicate CVE requests due to mismatched
- * image IDs.
+ * Navigates to the image list, clicks the first image, and mocks the detail page responses.
  *
- * @returns {Cypress.Chainable} - The image name
+ * Assumes the caller has already visited the workload CVE overview page and
+ * switched to the Image tab.
+ *
+ * @returns {Cypress.Chainable<string>} - The image name
  */
-export function visitImageSinglePageWithMockedResponses() {
+export function clickFirstImageWithMockedResponses() {
     const imageDetailsOpname = 'getImageDetails';
     const cveListOpname = 'getCVEsForImage';
-    const routeMatcherMapForImageCves = getRouteMatcherMapForGraphQL([
-        imageDetailsOpname,
-        cveListOpname,
-    ]);
+    const routeMatcherMap = getRouteMatcherMapForGraphQL([imageDetailsOpname, cveListOpname]);
 
-    const staticResponseMapForImageCves = {
-        [imageDetailsOpname]: {
-            fixture: 'vulnerabilities/workloadCves/imageWithMultipleCves.json',
-        },
-    };
+    return cy
+        .fixture('vulnerabilities/workloadCves/multipleCvesForImage.json')
+        .then((v1Response) => {
+            const staticResponseMap = {
+                [imageDetailsOpname]: {
+                    fixture: 'vulnerabilities/workloadCves/imageWithMultipleCves.json',
+                },
+                [cveListOpname]: hasFeatureFlag('ROX_FLATTEN_IMAGE_DATA')
+                    ? { body: toImageV2Response(v1Response) }
+                    : { body: v1Response },
+            };
 
-    // When FlattenImageData is enabled, the getCVEsForImage query uses imageV2(...)
-    // which returns data under the `imageV2` key instead of `image`.
-    if (hasFeatureFlag('ROX_FLATTEN_IMAGE_DATA')) {
-        cy.fixture('vulnerabilities/workloadCves/multipleCvesForImage.json').then((v1Response) => {
-            staticResponseMapForImageCves[cveListOpname] = { body: toImageV2Response(v1Response) };
+            return interactAndWaitForResponses(
+                () => cy.get('tbody tr td[data-label="Image"] a').first().click(),
+                routeMatcherMap,
+                staticResponseMap
+            ).then(() => {
+                return cy.get('h1').then(($h1) => {
+                    return $h1.text().replace(/(@sha256)?:.*/, '');
+                });
+            });
         });
-    } else {
-        staticResponseMapForImageCves[cveListOpname] = {
-            fixture: 'vulnerabilities/workloadCves/multipleCvesForImage.json',
-        };
-    }
+}
 
+/**
+ * Visits an image single page via the workload CVE overview page and mocks the responses for the image
+ * details and CVE list.
+ *
+ * @returns {Cypress.Chainable<string>} - The image name
+ */
+export function visitImageSinglePageWithMockedResponses() {
     visitWorkloadCveOverview();
 
-    interactAndWaitForResponses(
-        () => {
-            selectEntityTab('Image');
-            cy.get('tbody tr td[data-label="Image"] a').first().click();
-        },
-        routeMatcherMapForImageCves,
-        staticResponseMapForImageCves
-    );
-
-    return cy.get('h1').then(($h1) => {
-        // Remove the SHA and/or tag from the image name
-        return $h1.text().replace(/(@sha256)?:.*/, '');
+    interactAndWaitForImageList(() => {
+        selectEntityTab('Image');
     });
+
+    return clickFirstImageWithMockedResponses();
 }
 
 /**
@@ -471,7 +478,10 @@ export function interactAndWaitForImageList(callback) {
     const imageListOpname = 'getImageList';
     const imageListRouteMatcherMap = getRouteMatcherMapForGraphQL([imageListOpname]);
     imageListRouteMatcherMap[imageListOpname].times = 1;
-    return interactAndWaitForResponses(callback, imageListRouteMatcherMap);
+    const staticResponseMap = {
+        [imageListOpname]: { fixture: 'vulnerabilities/workloadCves/getImageList.json' },
+    };
+    return interactAndWaitForResponses(callback, imageListRouteMatcherMap, staticResponseMap);
 }
 
 /**
@@ -483,15 +493,25 @@ export function interactAndWaitForDeploymentList(callback) {
     const deploymentListOpname = 'getDeploymentList';
     const deploymentListRouteMatcherMap = getRouteMatcherMapForGraphQL([deploymentListOpname]);
     deploymentListRouteMatcherMap[deploymentListOpname].times = 1;
-    return interactAndWaitForResponses(callback, deploymentListRouteMatcherMap);
+    const staticResponseMap = {
+        [deploymentListOpname]: { fixture: 'vulnerabilities/workloadCves/getDeploymentList.json' },
+    };
+    return interactAndWaitForResponses(callback, deploymentListRouteMatcherMap, staticResponseMap);
 }
 
 export function visitNamespaceView() {
+    const routeMatcherMap = getRouteMatcherMapForGraphQL(['getNamespaceViewNamespaces']);
+    const staticResponseMap = {
+        getNamespaceViewNamespaces: {
+            fixture: 'vulnerabilities/workloadCves/getNamespaceViewNamespaces.json',
+        },
+    };
     interactAndWaitForResponses(
         () => {
             cy.get('a:contains("Namespace view")').click();
         },
-        getRouteMatcherMapForGraphQL(['getNamespaceViewNamespaces'])
+        routeMatcherMap,
+        staticResponseMap
     );
 }
 
@@ -505,4 +525,17 @@ export function assertSearchEntities(entities) {
     entities.forEach((entity) => {
         cy.get(compoundFiltersSelectors.entityMenuItem).contains(entity);
     });
+}
+
+export function mockSbomGenerationRequest() {
+    return cy.intercept('POST', '/api/v1/images/sbom', (req) =>
+        req.reply({
+            delay: 1000,
+            statusCode: 200,
+            headers: {
+                'content-disposition': 'attachment; filename="sbom.json"',
+            },
+            body: { mock: true },
+        })
+    );
 }

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/deploymentSingle.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/deploymentSingle.test.ts
@@ -1,9 +1,13 @@
 import withAuth from '../../../helpers/basicAuth';
 import { verifyColumnManagement } from '../../../helpers/tableHelpers';
+import {
+    getRouteMatcherMapForGraphQL,
+    interactAndWaitForResponses,
+} from '../../../helpers/request';
 
 import {
     applyLocalSeverityFilters,
-    selectEntityTab,
+    interactAndWaitForDeploymentList,
     visitWorkloadCveOverview,
 } from './WorkloadCves.helpers';
 import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
@@ -16,8 +20,34 @@ describe('Workload CVE Deployment Single page', () => {
     function visitFirstDeployment() {
         visitWorkloadCveOverview();
 
-        selectEntityTab('Deployment');
-        cy.get('tbody tr td[data-label="Deployment"] a').first().click();
+        interactAndWaitForDeploymentList(() => {
+            cy.get(vulnSelectors.entityTypeToggleItem('Deployment')).click();
+        });
+
+        const routeMatcherMap = getRouteMatcherMapForGraphQL([
+            'getDeploymentMetadata',
+            'getCvesForDeployment',
+            'getDeploymentSummaryData',
+        ]);
+        const staticResponseMap = {
+            getDeploymentMetadata: {
+                fixture: 'vulnerabilities/workloadCves/getDeploymentMetadata.json',
+            },
+            getCvesForDeployment: {
+                fixture: 'vulnerabilities/workloadCves/getCvesForDeployment.json',
+            },
+            getDeploymentSummaryData: {
+                fixture: 'vulnerabilities/workloadCves/getDeploymentSummaryData.json',
+            },
+        };
+
+        interactAndWaitForResponses(
+            () => {
+                cy.get('tbody tr td[data-label="Deployment"] a').first().click();
+            },
+            routeMatcherMap,
+            staticResponseMap
+        );
     }
 
     it('should contain the correct search filters in the toolbar', () => {
@@ -49,7 +79,17 @@ describe('Workload CVE Deployment Single page', () => {
         cy.get('table thead tr th').contains('First discovered');
 
         // Visit the resources tab
-        cy.get(selectors.resourcesTab).click();
+        interactAndWaitForResponses(
+            () => {
+                cy.get(selectors.resourcesTab).click();
+            },
+            getRouteMatcherMapForGraphQL(['getDeploymentResources']),
+            {
+                getDeploymentResources: {
+                    fixture: 'vulnerabilities/workloadCves/getDeploymentResources.json',
+                },
+            }
+        );
 
         cy.get(selectors.vulnerabilitiesTab).should('have.attr', 'aria-selected', 'false');
         cy.get(selectors.resourcesTab).should('have.attr', 'aria-selected', 'true');

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageCveSingle.test.js
@@ -1,13 +1,11 @@
 import withAuth from '../../../helpers/basicAuth';
 import { verifyColumnManagement } from '../../../helpers/tableHelpers';
 import {
-    applyLocalSeverityFilters,
-    selectEntityTab,
-    visitWorkloadCveOverview,
-} from './WorkloadCves.helpers';
-import { selectors } from './WorkloadCves.selectors';
-import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
-import { addAutocompleteFilter, compoundFiltersSelectors } from '../../../helpers/compoundFilters';
+    getRouteMatcherMapForGraphQL,
+    interactAndWaitForResponses,
+} from '../../../helpers/request';
+import { selectEntityTab, visitWorkloadCveOverview } from './WorkloadCves.helpers';
+import { compoundFiltersSelectors } from '../../../helpers/compoundFilters';
 
 describe('Workload CVE Image CVE Single page', () => {
     withAuth();
@@ -15,7 +13,30 @@ describe('Workload CVE Image CVE Single page', () => {
     function visitFirstCve() {
         visitWorkloadCveOverview();
 
-        cy.get('tbody tr td[data-label="CVE"] a').first().click();
+        const routeMatcherMap = getRouteMatcherMapForGraphQL([
+            'getImageCveMetadata',
+            'getImageCveSummaryData',
+            'getImagesForCVE',
+        ]);
+        const staticResponseMap = {
+            getImageCveMetadata: {
+                fixture: 'vulnerabilities/workloadCves/getImageCveMetadata.json',
+            },
+            getImageCveSummaryData: {
+                fixture: 'vulnerabilities/workloadCves/getImageCveSummaryData.json',
+            },
+            getImagesForCVE: {
+                fixture: 'vulnerabilities/workloadCves/getImagesForCVE.json',
+            },
+        };
+
+        interactAndWaitForResponses(
+            () => {
+                cy.get('tbody tr td[data-label="CVE"] a').first().click();
+            },
+            routeMatcherMap,
+            staticResponseMap
+        );
     }
 
     it('should correctly handle ImageCVE single page specific behavior', () => {
@@ -30,121 +51,6 @@ describe('Workload CVE Image CVE Single page', () => {
         cy.get(compoundFiltersSelectors.entityMenuItem).contains('Cluster');
         cy.get(compoundFiltersSelectors.entityMenuItem).contains('Namespace');
         cy.get(compoundFiltersSelectors.entityMenuToggle).click();
-    });
-
-    it('should correctly handle local filters on the images tab', () => {
-        visitFirstCve();
-
-        cy.get('table tbody tr:nth-of-type(1) td[data-label="CVE severity"]').then(
-            ([$severity]) => {
-                // Extract the severity from the first row of the table. These are values
-                // that we know should exist in the table when no filters are applied.
-                const severity = $severity.innerText;
-
-                // Apply any filter that _doesn't_ match the severity value extracted from the first row to ensure all data
-                // matching that severity is filtered out from the table. e.g. If the first row has a severity of "Critical",
-                // applying a filter of "Important" will ensure that no data in the table will match a severity of "Critical".
-                cy.get(selectors.severityDropdown).click();
-                cy.get(`${selectors.severityMenuItems} label:not(:contains("${severity}"))`)
-                    .first()
-                    .click();
-                cy.get(selectors.severityDropdown).click();
-
-                // With the negative filters applied, no data in the table should match
-                cy.get(
-                    `table tbody tr td[data-label="CVE severity"]:contains("${severity}")`
-                ).should('not.exist');
-
-                // Clear the filters
-                cy.get(vulnSelectors.clearFiltersButton).click();
-
-                // Apply the filter that _does_ match the value extracted from the first row to ensure all data
-                // in the table only contains that severity value. Since this value was pulled from the first row
-                // we know that there will be at least one entry in the table.
-                applyLocalSeverityFilters(severity);
-
-                // Ensure that table has at least one row
-                cy.get('table tbody tr');
-                // Assert that no table rows that contain a severity other than the applied
-                // filter exists. The double negative is a bit confusing, but it is an easy way to assert
-                // that Cypress retries until the assertion passes.
-                cy.get(
-                    `table tbody tr td[data-label="CVE severity"]:not(:contains("${severity}"))`
-                ).should('not.exist');
-            }
-        );
-    });
-
-    it('should correctly handle local filters on the deployments tab', () => {
-        visitFirstCve();
-        cy.get(vulnSelectors.entityTypeToggleItem('Deployment')).click();
-
-        // Wait for the loading spinner to disappear
-        cy.get('.pf-v6-c-spinner').should('not.exist');
-
-        cy.get(`${selectors.firstTableRow} td[data-label="Namespace"]`).then(([$namespace]) => {
-            const namespace = $namespace.innerText;
-
-            addAutocompleteFilter('Namespace', 'Name', `bogus-${namespace}`);
-
-            cy.get(`table tbody tr td[data-label="Namespace"]:contains("${namespace}")`).should(
-                'not.exist'
-            );
-
-            cy.get(vulnSelectors.clearFiltersButton).click();
-
-            addAutocompleteFilter('Namespace', 'Name', namespace);
-
-            cy.get(
-                `table tbody tr td[data-label="Namespace"]:not(:contains("${namespace}"))`
-            ).should('not.exist');
-        });
-    });
-
-    it('should have consistent behavior within the data table', () => {
-        visitFirstCve();
-
-        // Test that the number of components in the top level row matches the table in the expanded row
-        cy.get(`${selectors.firstTableRow} .pf-v6-c-table__toggle button`).click();
-        cy.get(`${selectors.firstTableRow} td[data-label="Affected components"]`).then(
-            ([$componentCell]) => {
-                const componentText = $componentCell.innerText;
-                const componentCount = /\d+ components?/.test(componentText)
-                    ? parseInt(componentText.replace(/ components?/, ''), 10)
-                    : 1;
-
-                cy.get(`${selectors.firstTableRow} + tr.pf-m-expanded table tbody`).should(
-                    'have.length',
-                    componentCount
-                );
-            }
-        );
-
-        // Test that the image links navigate to the correct page
-        cy.get(`${selectors.firstTableRow} td[data-label="Image"] a`).then(([$imageLink]) => {
-            // Remove newlines to avoid issues with the text not matching the link
-            const imageName = $imageLink.innerText.replace('\n', '');
-            cy.wrap($imageLink).click();
-            cy.get(`h1:contains("${imageName}")`);
-        });
-
-        // Go back to the CVE page
-        cy.go('back');
-
-        // Go to the deployment toggle tab
-        cy.get(vulnSelectors.entityTypeToggleItem('Deployment')).click();
-
-        // Test the the deployment links navigate to the correct page
-        cy.get(`${selectors.firstTableRow} td[data-label="Deployment"] a`).then(
-            ([$deploymentLink]) => {
-                const deploymentName = $deploymentLink.innerText.replace('\n', '');
-                cy.wrap($deploymentLink).click();
-                cy.get(`h1:contains("${deploymentName}")`);
-            }
-        );
-
-        // Go back to the CVE page
-        cy.go('back');
     });
 
     describe('Column management tests', () => {

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/imageSingle.test.ts
@@ -1,22 +1,19 @@
 import withAuth from '../../../helpers/basicAuth';
-import { addAutocompleteFilter, compoundFiltersSelectors } from '../../../helpers/compoundFilters';
+import { compoundFiltersSelectors } from '../../../helpers/compoundFilters';
 import { hasFeatureFlag } from '../../../helpers/features';
 import {
     getRouteMatcherMapForGraphQL,
     interactAndWaitForResponses,
     interceptAndOverrideFeatureFlags,
     interceptAndOverridePermissions,
-    interceptAndWatchRequests,
 } from '../../../helpers/request';
-import {
-    changePerPageOption,
-    sortByTableHeader,
-    verifyColumnManagement,
-} from '../../../helpers/tableHelpers';
+import { verifyColumnManagement } from '../../../helpers/tableHelpers';
 
 import { selectors as vulnSelectors } from '../vulnerabilities.selectors';
 import {
-    applyLocalSeverityFilters,
+    clickFirstImageWithMockedResponses,
+    interactAndWaitForImageList,
+    mockSbomGenerationRequest,
     selectEntityTab,
     visitWorkloadCveOverview,
 } from './WorkloadCves.helpers';
@@ -25,20 +22,17 @@ import { selectors } from './WorkloadCves.selectors';
 describe('Workload CVE Image Single page', () => {
     withAuth();
 
-    function visitFirstImage(): Promise<string> {
+    function visitFirstImage(): Cypress.Chainable<string> {
         visitWorkloadCveOverview();
 
-        selectEntityTab('Image');
+        interactAndWaitForImageList(() => {
+            selectEntityTab('Image');
+        });
 
         // Ensure the data in the table has settled
         cy.get(selectors.isUpdatingTable).should('not.exist');
 
-        return cy.get('tbody tr td[data-label="Image"] a').then(([$imageLink]) => {
-            const imageName = $imageLink.innerText.replace('\n', '');
-            cy.wrap($imageLink).click();
-            cy.get('h1').contains(imageName);
-            return Promise.resolve(imageName);
-        });
+        return clickFirstImageWithMockedResponses();
     }
 
     it('should contain the correct search filters in the toolbar', () => {
@@ -51,108 +45,6 @@ describe('Workload CVE Image Single page', () => {
         cy.get(compoundFiltersSelectors.entityMenuToggle).click();
     });
 
-    it('should display consistent data between the cards and the table test', () => {
-        visitFirstImage();
-
-        const severityCardSelector = vulnSelectors.summaryCard('CVEs by severity');
-        const statusCardSelector = vulnSelectors.summaryCard('CVEs by status');
-
-        // Verify the severity card renders all five severity levels with numeric counts
-        cy.get(
-            [
-                `${severityCardSelector} span.pf-v6-c-icon:contains("Critical") ~ p`,
-                `${severityCardSelector} span.pf-v6-c-icon:contains("Important") ~ p`,
-                `${severityCardSelector} span.pf-v6-c-icon:contains("Moderate") ~ p`,
-                `${severityCardSelector} span.pf-v6-c-icon:contains("Low") ~ p`,
-                `${severityCardSelector} span.pf-v6-c-icon:contains("Unknown") ~ p`,
-            ].join(',')
-        ).then(($severityTotals) => {
-            // All five severity levels should be rendered
-            expect($severityTotals).to.have.length(5);
-
-            const severityTotal = $severityTotals.toArray().reduce((acc, $el) => {
-                const count = acc + parseInt($el.innerText.replace(/\D/g, ''), 10);
-                return Number.isNaN(count) ? acc : count;
-            }, 0);
-
-            // Verify that the status card totals (fixable + unfixable) match the severity
-            // card totals, since both are derived from the same imageCVECountBySeverity data.
-            // Note: These sums may differ from "results found" because a single CVE can be
-            // counted under multiple severity levels when different sources assign different
-            // severities, while imageVulnerabilityCount is a deduplicated count.
-            cy.get(
-                [
-                    `${statusCardSelector} p:contains('with available fixes')`,
-                    `${statusCardSelector} p:contains("without fixes")`,
-                ].join(',')
-            ).then(($statusTotals) => {
-                const statusTotal = $statusTotals.toArray().reduce((acc, $el) => {
-                    const count = acc + parseInt($el.innerText.replace(/\D/g, ''), 10);
-                    return Number.isNaN(count) ? acc : count;
-                }, 0);
-
-                expect(statusTotal).to.equal(severityTotal);
-            });
-        });
-    });
-
-    it('should correctly apply a severity filter', () => {
-        visitFirstImage();
-        // Check that no severities are hidden by default
-        cy.get(vulnSelectors.summaryCard('CVEs by severity'))
-            .find('p')
-            .contains(new RegExp('(Critical|Important|Moderate|Low|Unknown) hidden'))
-            .should('not.exist');
-
-        const severityFilter = 'Critical';
-
-        applyLocalSeverityFilters(severityFilter);
-
-        // Check that summary card severities are hidden correctly
-        cy.get(`*:contains("Critical hidden")`).should('not.exist');
-        cy.get(`*:contains("Important hidden")`);
-        cy.get(`*:contains("Moderate hidden")`);
-        cy.get(`*:contains("Low hidden")`);
-        cy.get(`*:contains("Unknown hidden")`);
-
-        // Check that table rows are filtered
-        cy.get(selectors.filteredViewLabel);
-
-        // Ensure the table is not in a loading state
-        cy.get(selectors.isUpdatingTable).should('not.exist');
-
-        // Check that every row in the table has the correct severity
-        // Query for table rows via jQuery to avoid a Cypress error in the case where there are no rows
-        cy.get('table tbody').then(($table) => {
-            const $cells = $table.find('tr td[data-label="CVE severity"]');
-            // This tests the invariant that if a single severity filter is applied, all rows in the table
-            // will have that same severity. This check also holds if the filter removes all rows from the table.
-            $cells.each((_, $cell) => {
-                const severity = $cell.innerText;
-                expect(severity).to.equal(severityFilter);
-            });
-        });
-    });
-
-    // This test should correctly apply a CVE name filter to the CVEs table
-    it('should correctly apply CVE name filters', () => {
-        visitFirstImage();
-
-        // Get any table row and extract the CVE name from the column with the CVE data label
-        cy.get('tbody tr td[data-label="CVE"]')
-            .first()
-            .then(([$cveNameCell]) => {
-                const cveName = $cveNameCell.innerText;
-                // Enter the CVE name into the CVE filter
-                addAutocompleteFilter('CVE', 'Name', cveName);
-                // Check that the header above the table shows only one result
-                cy.get(`*:contains("1 result found")`);
-                // Check that the only row in the table has the correct CVE name
-                cy.get(`tbody tr td[data-label="CVE"]`).should('have.length', 1);
-                cy.get(`tbody tr td[data-label="CVE"]:contains("${cveName}")`);
-            });
-    });
-
     // Verifies that the data returned by the server is not duplicated due to Apollo client cache issues
     // see: https://issues.redhat.com/browse/ROX-24254
     //      https://github.com/stackrox/stackrox/pull/6156
@@ -161,7 +53,6 @@ describe('Workload CVE Image Single page', () => {
         const imageRootKey = isFlattenImageData ? 'imageV2' : 'image';
 
         const opname = 'getCVEsForImage';
-        const routeMatcherMap = getRouteMatcherMapForGraphQL([opname]);
 
         const imageData = {
             id: isFlattenImageData
@@ -295,14 +186,27 @@ describe('Workload CVE Image Single page', () => {
             },
         };
 
-        const staticResponseMap = { [opname]: { body } };
+        // Navigate to the image page manually instead of using visitFirstImage(),
+        // so we can provide our own getCVEsForImage response without alias conflicts.
+        visitWorkloadCveOverview();
+        interactAndWaitForImageList(() => {
+            selectEntityTab('Image');
+        });
+
+        const detailRouteMatcher = getRouteMatcherMapForGraphQL(['getImageDetails', opname]);
+        const detailStaticResponse = {
+            getImageDetails: {
+                fixture: 'vulnerabilities/workloadCves/imageWithMultipleCves.json',
+            },
+            [opname]: { body },
+        };
 
         interactAndWaitForResponses(
             () => {
-                visitFirstImage();
+                cy.get('tbody tr td[data-label="Image"] a').first().click();
             },
-            routeMatcherMap,
-            staticResponseMap
+            detailRouteMatcher,
+            detailStaticResponse
         );
 
         cy.get(vulnSelectors.expandRowButton).click();
@@ -314,78 +218,6 @@ describe('Workload CVE Image Single page', () => {
             cy.get(fixedInCellSelector)
                 .eq(index)
                 .contains(component.imageVulnerabilities[0].fixedByVersion);
-        });
-    });
-
-    // See case 03985920 and ROX-27344 for more details
-    it('should receive consistent CVE counts when sorting and paginating the table', () => {
-        const isFlattenImageData = hasFeatureFlag('ROX_FLATTEN_IMAGE_DATA');
-        const imageRootKey = isFlattenImageData ? 'imageV2' : 'image';
-
-        const opname = 'getCVEsForImage';
-        const routeMatcherMap = getRouteMatcherMapForGraphQL([opname]);
-
-        // Captures the initial CVE count and the initial query sent when visiting the image details page
-        // and uses these values as a basis of comparison on subsequent requests
-        function createAssertion(initialCount: number, initialQuery: string) {
-            return function (interception) {
-                expect(interception.request.body.variables.query).to.equal(initialQuery);
-                expect(
-                    interception.response.body.data[imageRootKey].imageVulnerabilityCount
-                ).to.equal(initialCount);
-            };
-        }
-
-        // Test count stability with no filters applied
-        interceptAndWatchRequests(routeMatcherMap).then(({ waitForRequests }) => {
-            visitFirstImage();
-            waitForRequests()
-                .then(({ request, response }) => ({
-                    assertCveCountsUnchanged: createAssertion(
-                        response.body.data[imageRootKey].imageVulnerabilityCount,
-                        request.body.variables.query
-                    ),
-                }))
-                .then(({ assertCveCountsUnchanged }) => {
-                    // Check the initial sort request
-                    sortByTableHeader('CVE');
-                    waitForRequests().then(assertCveCountsUnchanged);
-
-                    // Check the initial perPage change request
-                    changePerPageOption(50);
-                    waitForRequests().then(assertCveCountsUnchanged);
-
-                    // Test another sort back-and-forth
-                    sortByTableHeader('CVE severity');
-                    waitForRequests().then(assertCveCountsUnchanged);
-                    sortByTableHeader('CVE severity');
-                    waitForRequests().then(assertCveCountsUnchanged);
-                    sortByTableHeader('CVE severity');
-                    waitForRequests().then(assertCveCountsUnchanged);
-
-                    // Test changing back to the original pagination
-                    changePerPageOption(20);
-                    waitForRequests().then(assertCveCountsUnchanged);
-
-                    // Test a pagination change after returning to the default
-                    changePerPageOption(10);
-                    waitForRequests().then(assertCveCountsUnchanged);
-
-                    // Test sorting by a column already used as a sort *again*
-                    sortByTableHeader('CVE severity');
-                    waitForRequests().then(assertCveCountsUnchanged);
-
-                    // Test sorting on the only remaining untested column by rapidly changing
-                    // the column value without waiting for a response
-                    sortByTableHeader('CVSS');
-                    sortByTableHeader('CVSS');
-                    sortByTableHeader('CVSS');
-                    sortByTableHeader('CVSS');
-                    waitForRequests().then(assertCveCountsUnchanged);
-                    waitForRequests().then(assertCveCountsUnchanged);
-                    waitForRequests().then(assertCveCountsUnchanged);
-                    waitForRequests().then(assertCveCountsUnchanged);
-                });
         });
     });
 
@@ -421,11 +253,12 @@ describe('Workload CVE Image Single page', () => {
                 this.skip();
             }
 
+            mockSbomGenerationRequest();
+
             visitFirstImage().then((imageFullName) => {
                 cy.get(headerSbomModalButton).click();
                 cy.get(selectors.generateSbomModal).contains(imageFullName);
                 cy.get(generateSbomButton).click();
-                cy.get(':contains("Generating, please do not navigate away from this modal")');
                 cy.get(':contains("Software Bill of Materials (SBOM) generated successfully")');
             });
         });

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
@@ -7,6 +7,7 @@ import {
     applyLocalSeverityFilters,
     interactAndWaitForDeploymentList,
     interactAndWaitForImageList,
+    mockSbomGenerationRequest,
     selectEntityTab,
     visitWorkloadCveOverview,
 } from './WorkloadCves.helpers';
@@ -25,6 +26,7 @@ import {
     interceptAndWatchRequests,
 } from '../../../helpers/request';
 import { addCheckboxSelectFilter } from '../../../helpers/compoundFilters';
+import { visit } from '../../../helpers/visit';
 
 const visitFromMoreViewsDropdown = visitFromHorizontalNavExpandable('More Views');
 
@@ -196,7 +198,7 @@ describe('Workload CVE overview page tests', () => {
             interceptAndOverridePermissions({ Image: 'READ_ACCESS' });
 
             visitWorkloadCveOverview();
-            selectEntityTab('Image');
+            interactAndWaitForImageList(() => selectEntityTab('Image'));
             openTableRowActionMenu(selectors.firstTableRow);
 
             cy.get(rowMenuSbomModalButton).should('not.exist');
@@ -206,7 +208,7 @@ describe('Workload CVE overview page tests', () => {
             interceptAndOverrideFeatureFlags({ ROX_SCANNER_V4: false });
 
             visitWorkloadCveOverview();
-            selectEntityTab('Image');
+            interactAndWaitForImageList(() => selectEntityTab('Image'));
             openTableRowActionMenu(selectors.firstTableRow);
 
             cy.get(rowMenuSbomModalButton).should('have.attr', 'aria-disabled', 'true');
@@ -218,7 +220,8 @@ describe('Workload CVE overview page tests', () => {
             }
 
             visitWorkloadCveOverview();
-            selectEntityTab('Image');
+            interactAndWaitForImageList(() => selectEntityTab('Image'));
+            mockSbomGenerationRequest();
 
             cy.get(selectors.firstTableRow)
                 .find('td[data-label="Image"] a')
@@ -288,71 +291,68 @@ describe('Workload CVE overview page tests', () => {
         });
 
         it('should default to multi-severity sort and keep in sync with applied filters', () => {
-            interceptAndWatchRequests(getRouteMatcherMapForGraphQL(['getImageCVEList'])).then(
-                ({ waitAndYieldRequestBodyVariables }) => {
-                    visitWorkloadCveOverview({ clearFiltersOnVisit: false });
+            interceptAndWatchRequests(getRouteMatcherMapForGraphQL(['getImageCVEList']), {
+                getImageCVEList: {
+                    fixture: 'vulnerabilities/workloadCves/getImageCVEList.json',
+                },
+            }).then(({ waitAndYieldRequestBodyVariables }) => {
+                const basePath = '/main/vulnerabilities/platform/';
+                visit(basePath);
 
-                    // Check the default sort
-                    waitAndYieldRequestBodyVariables().then(
-                        expectRequestedSort([
-                            { field: 'Critical Severity Count', reversed: true },
-                            { field: 'Important Severity Count', reversed: true },
-                        ])
-                    );
+                // Check the default sort
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort([
+                        { field: 'Critical Severity Count', reversed: true },
+                        { field: 'Important Severity Count', reversed: true },
+                    ])
+                );
 
-                    // Check that adding a severity filter changes the sort
-                    applyLocalSeverityFilters('Moderate');
-                    waitAndYieldRequestBodyVariables().then(
-                        expectRequestedSort([
-                            { field: 'Critical Severity Count', reversed: true },
-                            { field: 'Important Severity Count', reversed: true },
-                            { field: 'Moderate Severity Count', reversed: true },
-                        ])
-                    );
+                // Check that adding a severity filter changes the sort
+                applyLocalSeverityFilters('Moderate');
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort([
+                        { field: 'Critical Severity Count', reversed: true },
+                        { field: 'Important Severity Count', reversed: true },
+                        { field: 'Moderate Severity Count', reversed: true },
+                    ])
+                );
 
-                    // Check that the severity sort is reversible
-                    sortByTableHeader('Images by severity');
-                    waitAndYieldRequestBodyVariables().then(
-                        expectRequestedSort([
-                            { field: 'Critical Severity Count', reversed: false },
-                            { field: 'Important Severity Count', reversed: false },
-                            { field: 'Moderate Severity Count', reversed: false },
-                        ])
-                    );
+                // Check that the severity sort is reversible
+                sortByTableHeader('Images by severity');
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort([
+                        { field: 'Critical Severity Count', reversed: false },
+                        { field: 'Important Severity Count', reversed: false },
+                        { field: 'Moderate Severity Count', reversed: false },
+                    ])
+                );
 
-                    // Check that sorting by another column works as intended
-                    sortByTableHeader('CVE');
-                    waitAndYieldRequestBodyVariables().then(
-                        expectRequestedSort({ field: 'CVE', reversed: true })
-                    );
+                // Check that sorting by another column works as intended
+                sortByTableHeader('CVE');
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort({ field: 'CVE', reversed: true })
+                );
 
-                    // Check that changing the severity filter when a non-severity sort is applied
-                    // maintains the current sort
-                    applyLocalSeverityFilters('Low');
-                    waitAndYieldRequestBodyVariables().then(
-                        expectRequestedSort({ field: 'CVE', reversed: true })
-                    );
+                // Check that changing the severity filter when a non-severity sort is applied
+                // maintains the current sort
+                applyLocalSeverityFilters('Low');
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort({ field: 'CVE', reversed: true })
+                );
 
-                    // Check that visiting via a direct link that includes a severity filter maintains
-                    // the correct sort
-                    visitWorkloadCveOverview({
-                        clearFiltersOnVisit: false,
-                        urlSearch: '?s[Severity][0]=Important',
-                    });
-                    waitAndYieldRequestBodyVariables().then(
-                        expectRequestedSort([{ field: 'Important Severity Count', reversed: true }])
-                    );
+                // Check that visiting via a direct link that includes a severity filter maintains
+                // the correct sort
+                visit(`${basePath}?s[Severity][0]=Important`);
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort([{ field: 'Important Severity Count', reversed: true }])
+                );
 
-                    // Check that visiting via a legacy link with SEVERITY (uppercase) still works
-                    visitWorkloadCveOverview({
-                        clearFiltersOnVisit: false,
-                        urlSearch: '?s[SEVERITY][0]=Important',
-                    });
-                    waitAndYieldRequestBodyVariables().then(
-                        expectRequestedSort([{ field: 'Important Severity Count', reversed: true }])
-                    );
-                }
-            );
+                // Check that visiting via a legacy link with SEVERITY (uppercase) still works
+                visit(`${basePath}?s[SEVERITY][0]=Important`);
+                waitAndYieldRequestBodyVariables().then(
+                    expectRequestedSort([{ field: 'Important Severity Count', reversed: true }])
+                );
+            });
         });
     });
 

--- a/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/workloadCves/workloadCveOverviewPage.test.ts
@@ -116,11 +116,16 @@ describe('Workload CVE overview page tests', () => {
     });
 
     it('should apply the correct baseline filters when switching between built in views using the user-workload based template', () => {
-        visitWorkloadCveOverview({ clearFiltersOnVisit: false });
+        // Direct visit without using helper since we do not care about global mocking for this test, and
+        // the mocking interferes with the granular waits used in this test
+        visit('/main/vulnerabilities/platform/');
 
         interceptAndWatchRequests(
             getRouteMatcherMapForGraphQL(['getImageCVEList', 'getImageList'])
         ).then(({ waitForRequests, waitAndYieldRequestBodyVariables }) => {
+            // Initial request
+            waitForRequests(['getImageCVEList']); // Wait for the third request after the filters have been changed to complete
+
             applyDefaultFilters(['Critical', 'Important'], ['Fixable']); // Set the default filters to none to prevent multiple requests on each page visit
             waitForRequests(['getImageCVEList']); // Wait for the third request after the filters have been changed to complete
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -149,8 +149,6 @@ function getWorkloadCveContextFromView(
         // TODO Handle user-defined views, or error
     }
 
-    baseSearchFilter['Cluster ID'] = ['-'];
-
     return {
         pageTitle,
         pageTitleDescription,

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/WorkloadCvesPage.tsx
@@ -149,6 +149,8 @@ function getWorkloadCveContextFromView(
         // TODO Handle user-defined views, or error
     }
 
+    baseSearchFilter['Cluster ID'] = ['-'];
+
     return {
         pageTitle,
         pageTitleDescription,


### PR DESCRIPTION
## Description

Mock data in vulnerabilities requests to avoid testing semi-unpredictable data and avoid scanner initialization delays.

Apologies for the large PR, but the reported diff looks more dramatic than this actually is. Many of the added lines are fixtures, many of the removed lines are obsolete tests now that we are mocking, and a good chunk of the remainder are whitespace changes.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Run specs locally and verify passing with `npm run cypress-spec -- "vulnerabilities/**/*"`. Temporarily add a `baseSearchFilter` of `Cluster ID:-` to force no vulnerability data when visiting pages and run suite again:
<img width="721" height="362" alt="image" src="https://github.com/user-attachments/assets/f0cc734a-1647-466f-87d8-52fca81f48fa" />


