### PR TITLE
fix(mtls): respect cert file env vars in certwatch leaf loader

### DIFF
--- a/pkg/mtls/verifier/verify.go
+++ b/pkg/mtls/verifier/verify.go
@@ -49,8 +49,8 @@ func loadAndWatchLeafCert() {
 }
 
 func loadLeafCertFromDirectory(dir string) (*tls.Certificate, error) {
-	certFile := filepath.Join(dir, mtls.ServiceCertFileName)
-	keyFile := filepath.Join(dir, mtls.ServiceKeyFileName)
+	certFile := filepath.Join(dir, filepath.Base(mtls.CertFilePath()))
+	keyFile := filepath.Join(dir, filepath.Base(mtls.KeyFilePath()))
 
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {

--- a/pkg/mtls/verifier/verify_test.go
+++ b/pkg/mtls/verifier/verify_test.go
@@ -45,4 +45,18 @@ func TestLoadLeafCertFromDirectory(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, cert)
 	})
+
+	t.Run("respects custom filenames from env vars", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "custom-cert.pem"), issuedCert.CertPEM, 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "custom-key.pem"), issuedCert.KeyPEM, 0600))
+		t.Setenv(mtls.CertFilePathEnvName, filepath.Join(dir, "custom-cert.pem"))
+		t.Setenv(mtls.KeyFileEnvName, filepath.Join(dir, "custom-key.pem"))
+
+		cert, err := loadLeafCertFromDirectory(dir)
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+		require.NotNil(t, cert.Leaf)
+		assert.Contains(t, cert.Leaf.DNSNames, "central.stackrox.svc")
+	})
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

This PR fixes an inconsistency introduced in https://github.com/stackrox/stackrox/pull/20215, where custom certificate file names (set by the `ROX_MTLS_CERT_FILE` or `ROX_MTLS_KEY_FILE` env vars) were ignored by `certwatch`, and always used the default names even if the env var overrides were set.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

CI + unit test sufficient.
