### PR TITLE
ROX-34855: Filter empty scope

### DIFF
--- a/central/detection/lifecycle/singleton.go
+++ b/central/detection/lifecycle/singleton.go
@@ -45,7 +45,7 @@ func initialize() {
 	log.Infof("Injecting %d policies into detectors.", len(policies))
 	for _, policy := range policies {
 		err = manager.UpsertPolicy(policy)
-		utils.Should(errors.Wrap(err, "could not inject policy"))
+		log.Error(errors.Wrap(err, "could not inject policy"))
 	}
 	log.Info("Done injecting policies.")
 

--- a/central/detection/lifecycle/singleton.go
+++ b/central/detection/lifecycle/singleton.go
@@ -45,7 +45,7 @@ func initialize() {
 	log.Infof("Injecting %d policies into detectors.", len(policies))
 	for _, policy := range policies {
 		err = manager.UpsertPolicy(policy)
-		log.Error(errors.Wrap(err, "could not inject policy"))
+		utils.Should(errors.Wrap(err, "could not inject policy"))
 	}
 	log.Info("Done injecting policies.")
 

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -185,7 +185,7 @@ func (s *serviceImpl) ListReportConfigurations(ctx context.Context, query *apiV2
 	// This scenario can happen after downgrade from a future release(4.11 and above) with more resource scope to 4.10.
 	filteredQ = search.ConjunctionQuery(
 		filteredQ,
-		search.NewQueryBuilder().AddExactMatches(search.CollectionID, "").ProtoQuery())
+		search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery())
 
 	// Fill in pagination.
 	paginated.FillPaginationV2(filteredQ, query.GetPagination(), maxPaginationLimit)

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -181,6 +181,11 @@ func (s *serviceImpl) ListReportConfigurations(ctx context.Context, query *apiV2
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 	filteredQ := common.WithoutV1ReportConfigs(parsedQuery)
+	// This filter removes report configs with empty collection.
+	// This scenario can happen after downgrade from a future release(4.11 and above) with more resource scope to 4.10.
+	filteredQ = search.ConjunctionQuery(
+		filteredQ,
+		search.NewQueryBuilder().AddExactMatches(search.CollectionID, "").ProtoQuery())
 
 	// Fill in pagination.
 	paginated.FillPaginationV2(filteredQ, query.GetPagination(), maxPaginationLimit)


### PR DESCRIPTION
This PR filters out resource scope with empty collection ID from List Report Config API in 4.10. This is done in case someone downgrades from a future release with new scoping methods(like entity scope in 4.11) to a 4.10.x version which can cause UI crash because of new scoping method. ResourceScope will unmarshal as empty scope( as seen in testing) after downgrade and no new jobs will  be scheduled in this case given the scheduler validation in 4.10

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Tested this change manually by deploying 4.11 RC ACS . creating two report config - one with entity scope and other with collection. Downgraded to 4.10.3-4-gb10ca40c7d and verified that collection config shows up in UI and user can download reports. Entity scope config does not show up in UI