### PR TITLE
ROX-34801: reject SAML assertions with expired time conditions

### DIFF
--- a/pkg/administration/events/codes/codes.go
+++ b/pkg/administration/events/codes/codes.go
@@ -8,6 +8,9 @@ const (
 	APITokenCreated = "api-token-created"
 	APITokenExpired = "api-token-expired"
 
+	// Auth Provider codes.
+	SAMLAssertionExpired = "saml-assertion-expired"
+
 	// Backup codes.
 	GCSGeneric          = "gcs-generic"
 	S3CompatibleGeneric = "s3compatible-generic"

--- a/pkg/administration/events/domain.go
+++ b/pkg/administration/events/domain.go
@@ -12,6 +12,7 @@ const (
 var moduleToDomain = map[*regexp.Regexp]string{
 	regexp.MustCompile(`^apitoken/creation`):                                      AuthenticationDomain,
 	regexp.MustCompile(`^apitoken/expiration`):                                    AuthenticationDomain,
+	regexp.MustCompile(`^pkg/auth/authproviders/saml$`):                           AuthenticationDomain,
 	regexp.MustCompile(`(^|/)externalbackups(/|$)`):                               IntegrationDomain,
 	regexp.MustCompile(`(^|/)cloudsources(/|$)`):                                  IntegrationDomain,
 	regexp.MustCompile(`(^|/)notifiers(/|$)`):                                     IntegrationDomain,

--- a/pkg/administration/events/hints.go
+++ b/pkg/administration/events/hints.go
@@ -16,6 +16,13 @@ var (
 	// vulnerability definitions).
 	hints = map[string]map[string]map[string]string{
 		AuthenticationDomain: {
+			adminResources.AuthProvider: {
+				codes.SAMLAssertionExpired: `A SAML assertion was rejected because it is expired or not yet valid. This may indicate:
+- A replay attack using a previously captured assertion.
+- Clock skew between the identity provider and StackRox Central.
+
+Verify that the system clocks on Central and the identity provider are synchronized. If this occurs during legitimate login attempts, check the identity provider's assertion lifetime configuration.`,
+			},
 			adminResources.APIToken: {
 				codes.APITokenCreated: `An API token has been created.`,
 				codes.APITokenExpired: `An API token is about to expire. See the details on the expiration time within the event message.

--- a/pkg/administration/events/resources/resources.go
+++ b/pkg/administration/events/resources/resources.go
@@ -4,10 +4,11 @@ import "github.com/stackrox/rox/pkg/sac/resources"
 
 // Resources used in administration events.
 const (
-	APIToken    = "API Token"
-	Backup      = "Backup"
-	CloudSource = "Cloud Source"
-	Notifier    = "Notifier"
+	APIToken     = "API Token"
+	AuthProvider = "Auth Provider"
+	Backup       = "Backup"
+	CloudSource  = "Cloud Source"
+	Notifier     = "Notifier"
 )
 
 // Resources used in administration events.

--- a/pkg/auth/authproviders/saml/backend_impl.go
+++ b/pkg/auth/authproviders/saml/backend_impl.go
@@ -8,12 +8,22 @@ import (
 
 	"github.com/pkg/errors"
 	saml2 "github.com/russellhaering/gosaml2"
+	"github.com/stackrox/rox/pkg/administration/events/codes"
+	events "github.com/stackrox/rox/pkg/administration/events/option"
 	"github.com/stackrox/rox/pkg/auth/authproviders"
 	"github.com/stackrox/rox/pkg/auth/authproviders/idputil"
 	"github.com/stackrox/rox/pkg/auth/tokens"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
 	"github.com/stackrox/rox/pkg/httputil"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/stringutils"
+)
+
+var (
+	log = logging.LoggerForModule(events.EnableAdministrationEvents())
+
+	errAssertionExpired = errox.NotAuthorized.New("SAML assertion expired or not yet valid")
 )
 
 // All configuration keys the auth provider exposes within the auth provider config map.
@@ -31,11 +41,13 @@ type backendImpl struct {
 	acsURLPath string
 	sp         saml2.SAMLServiceProvider
 	id         string
+	provider   authproviders.Provider
 
 	config map[string]string
 }
 
-func (p *backendImpl) OnEnable(_ authproviders.Provider) {
+func (p *backendImpl) OnEnable(provider authproviders.Provider) {
+	p.provider = provider
 	p.factory.RegisterBackend(p)
 }
 
@@ -115,6 +127,14 @@ func (p *backendImpl) consumeSAMLResponse(samlResponse string) (*authproviders.A
 	ai, err := p.sp.RetrieveAssertionInfo(samlResponse)
 	if err != nil {
 		return nil, errors.Wrap(err, "error in saml response")
+	}
+
+	if ai.WarningInfo != nil && ai.WarningInfo.InvalidTime {
+		log.Warnw("SAML assertion expired or not yet valid, rejecting authentication.",
+			logging.ErrCode(codes.SAMLAssertionExpired),
+			logging.AuthProviderName(p.provider.Name()),
+		)
+		return nil, errAssertionExpired
 	}
 
 	var expiry time.Time

--- a/pkg/auth/authproviders/saml/backend_impl_test.go
+++ b/pkg/auth/authproviders/saml/backend_impl_test.go
@@ -1,0 +1,156 @@
+package saml
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	saml2 "github.com/russellhaering/gosaml2"
+	dsig "github.com/russellhaering/goxmldsig"
+	"github.com/stackrox/rox/pkg/auth/authproviders"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumeSAMLResponse_RejectsExpiredAssertion(t *testing.T) {
+	now := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	cases := map[string]struct {
+		conditionsNotBefore    time.Time
+		conditionsNotOnOrAfter time.Time
+		subjectNotOnOrAfter    time.Time
+		wantErr                bool
+	}{
+		"valid assertion is accepted": {
+			conditionsNotBefore:    now.Add(-5 * time.Minute),
+			conditionsNotOnOrAfter: now.Add(5 * time.Minute),
+			subjectNotOnOrAfter:    now.Add(10 * time.Minute),
+		},
+		"expired assertion is rejected": {
+			conditionsNotBefore:    now.Add(-1 * time.Hour),
+			conditionsNotOnOrAfter: now.Add(-30 * time.Minute),
+			subjectNotOnOrAfter:    now.Add(1 * time.Hour),
+			wantErr:                true,
+		},
+		"not-yet-valid assertion is rejected": {
+			conditionsNotBefore:    now.Add(30 * time.Minute),
+			conditionsNotOnOrAfter: now.Add(1 * time.Hour),
+			subjectNotOnOrAfter:    now.Add(2 * time.Hour),
+			wantErr:                true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			backend := newTestBackend(now)
+			xml := samlResponseXML(t, samlResponseParams{
+				conditionsNotBefore:    tc.conditionsNotBefore,
+				conditionsNotOnOrAfter: tc.conditionsNotOnOrAfter,
+				subjectNotOnOrAfter:    tc.subjectNotOnOrAfter,
+				audience:               testAudience,
+			})
+			encoded := base64.StdEncoding.EncodeToString([]byte(xml))
+
+			resp, err := backend.consumeSAMLResponse(encoded)
+
+			if !tc.wantErr {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			} else {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, errAssertionExpired)
+				assert.ErrorIs(t, err, errox.NotAuthorized)
+				assert.Nil(t, resp)
+			}
+		})
+	}
+}
+
+const (
+	testACSURL    = "https://stackrox.example.com/sso/providers/saml/acs"
+	testIdPIssuer = "https://idp.example.com"
+	testAudience  = "https://stackrox.example.com"
+)
+
+type samlResponseParams struct {
+	conditionsNotBefore    time.Time
+	conditionsNotOnOrAfter time.Time
+	subjectNotOnOrAfter    time.Time
+	audience               string
+}
+
+func samlResponseXML(t *testing.T, params samlResponseParams) string {
+	t.Helper()
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+    Destination="%s"
+    ID="_response_1"
+    IssueInstant="2025-01-01T00:00:00Z"
+    Version="2.0">
+  <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">%s</saml2:Issuer>
+  <saml2p:Status>
+    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </saml2p:Status>
+  <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+      ID="_assertion_1"
+      IssueInstant="2025-01-01T00:00:00Z"
+      Version="2.0">
+    <saml2:Issuer>%s</saml2:Issuer>
+    <saml2:Subject>
+      <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">attacker@evil.com</saml2:NameID>
+      <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml2:SubjectConfirmationData
+            NotOnOrAfter="%s"
+            Recipient="%s"/>
+      </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:Conditions NotBefore="%s" NotOnOrAfter="%s">
+      <saml2:AudienceRestriction>
+        <saml2:Audience>%s</saml2:Audience>
+      </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AuthnStatement AuthnInstant="2025-01-01T00:00:00Z">
+      <saml2:AuthnContext>
+        <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml2:AuthnContextClassRef>
+      </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+      <saml2:Attribute Name="email">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:type="xs:string">attacker@evil.com</saml2:AttributeValue>
+      </saml2:Attribute>
+    </saml2:AttributeStatement>
+  </saml2:Assertion>
+</saml2p:Response>`,
+		testACSURL,
+		testIdPIssuer,
+		testIdPIssuer,
+		params.subjectNotOnOrAfter.Format(time.RFC3339),
+		testACSURL,
+		params.conditionsNotBefore.Format(time.RFC3339),
+		params.conditionsNotOnOrAfter.Format(time.RFC3339),
+		params.audience,
+	)
+}
+
+type stubProvider struct {
+	authproviders.Provider
+	name string
+}
+
+func (s *stubProvider) Name() string { return s.name }
+
+func newTestBackend(now time.Time) *backendImpl {
+	return &backendImpl{
+		provider: &stubProvider{name: "test-saml-provider"},
+		sp: saml2.SAMLServiceProvider{
+			IdentityProviderIssuer:      testIdPIssuer,
+			AssertionConsumerServiceURL: testACSURL,
+			SkipSignatureValidation:     true,
+			Clock:                       dsig.NewFakeClockAt(now),
+		},
+	}
+}

--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -14,6 +14,7 @@ const (
 
 	alertIDField      = "alert_id"
 	apiTokenIDField   = "api_token_id"
+	authProviderField = "auth_provider"
 	apiTokenNameField = "api_token_name"
 	backupField       = "backup"
 	cloudSourceField  = "cloud_source"
@@ -29,6 +30,7 @@ const (
 var resourceTypeFields = map[string]string{
 	apiTokenIDField:   administrationResources.APIToken,
 	apiTokenNameField: administrationResources.APIToken,
+	authProviderField: administrationResources.AuthProvider,
 	backupField:       administrationResources.Backup,
 	cloudSourceField:  administrationResources.CloudSource,
 	clusterIDField:    administrationResources.Cluster,
@@ -95,6 +97,11 @@ func BackupName(name string) zap.Field {
 // CloudSourceName provides the cloud source name as a structured log field.
 func CloudSourceName(name string) zap.Field {
 	return String(cloudSourceField, name)
+}
+
+// AuthProviderName provides the auth provider name as a structured log field.
+func AuthProviderName(name string) zap.Field {
+	return String(authProviderField, name)
 }
 
 // NotifierName provides the notifier name as a structured log field.
@@ -183,6 +190,7 @@ func getResourceTypeField(field zap.Field) (string, bool) {
 
 func isIDField(fieldName string) bool {
 	return fieldName != apiTokenNameField &&
+		fieldName != authProviderField &&
 		fieldName != backupField &&
 		fieldName != cloudSourceField &&
 		fieldName != imageField &&


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

`gosaml2.RetrieveAssertionInfo` returns `WarningInfo.InvalidTime` when the assertion's Conditions time window has expired or is not yet valid. `consumeSAMLResponse` never checked this, silently accepting expired assertions. Reject them and emit an administration event in the Authentication domain.

Stack:
- https://github.com/stackrox/stackrox/pull/20865
- https://github.com/stackrox/stackrox/pull/20847

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Note that With Auth0, gosaml2's `Validate()` rejects the expired `SubjectConfirmation` before `VerifyAssertionConditions` runs, so you'll see the library-level rejection. Our InvalidTime check is defense-in-depth for IdPs where `Conditions.NotOnOrAfter` is tighter than `SubjectConfirmation.NotOnOrAfter`. The integration test (`TestConsumeSAMLResponse_RejectsExpiredAssertion`) is the definitive proof of that path — it sets different expiry times for each.

To specifically trigger our code path in a manual test, you'd need an IdP that lets you configure Conditions.NotOnOrAfter separately from
SubjectConfirmation.NotOnOrAfter. Auth0 doesn't support this. The integration test with SkipSignatureValidation and a fake clock is the only way to exercise it end-to-end.