### PR TITLE
ROX-34804: validate aud claim in M2M OIDC token exchange

### DIFF
--- a/central/auth/m2m/generic_token_verifier.go
+++ b/central/auth/m2m/generic_token_verifier.go
@@ -14,7 +14,10 @@ type genericTokenVerifier struct {
 var _ tokenVerifier = (*genericTokenVerifier)(nil)
 
 func (g *genericTokenVerifier) VerifyIDToken(ctx context.Context, rawIDToken string) (*IDToken, error) {
-	// Skip the client id check unless the user has configured the expected audience claim.
+	// When an expected audience is configured, validate the token's aud claim via the go-oidc
+	// ClientID check. Otherwise skip it for backward compatibility: a single client ID cannot
+	// cover all cases (e.g. GitHub Actions tokens use per-repository audience values), and the
+	// audience may still be verified indirectly through claim mappings.
 	oidcConfig := &oidc.Config{SkipClientIDCheck: true}
 	if g.audience != "" {
 		oidcConfig.ClientID = g.audience

--- a/central/auth/m2m/generic_token_verifier.go
+++ b/central/auth/m2m/generic_token_verifier.go
@@ -8,21 +8,19 @@ import (
 
 type genericTokenVerifier struct {
 	provider *oidc.Provider
+	audience string
 }
 
 var _ tokenVerifier = (*genericTokenVerifier)(nil)
 
 func (g *genericTokenVerifier) VerifyIDToken(ctx context.Context, rawIDToken string) (*IDToken, error) {
-	verifier := g.provider.Verifier(&oidc.Config{
-		// We currently provide no config to expose the client ID that's associated with the ID token.
-		// The reason for this is the following:
-		// - A magnitude of client IDs would have to be configured (i.e. in the case of GitHub actions, this would be
-		// all repository URLs including their potential customizations).
-		// - Client IDs (i.e. the "sub" claim) _may_ be part for the mappings within the
-		// config. So, essentially the client ID check is deferred to a latter point, as the mappings _may_ be used
-		// for mapping, but it currently isn't a requirement.
-		SkipClientIDCheck: true,
-	})
+	// Skip the client id check unless the user has configured the expected audience claim.
+	oidcConfig := &oidc.Config{SkipClientIDCheck: true}
+	if g.audience != "" {
+		oidcConfig.ClientID = g.audience
+		oidcConfig.SkipClientIDCheck = false
+	}
+	verifier := g.provider.Verifier(oidcConfig)
 
 	token, err := verifier.Verify(ctx, rawIDToken)
 	if err != nil {

--- a/central/auth/m2m/generic_token_verifier_test.go
+++ b/central/auth/m2m/generic_token_verifier_test.go
@@ -18,20 +18,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_genericTokenVerifier_VerifyIDToken(t *testing.T) {
-	// Generate RSA key pair for signing.
+func newTestOIDCServer(t *testing.T) (*httptest.Server, *rsa.PrivateKey, string) {
+	t.Helper()
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 	publicKey := &privateKey.PublicKey
-
 	keyID := "test-key-id"
 
-	// Create a mock OIDC server.
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
-	defer server.Close()
+	t.Cleanup(server.Close)
 
-	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
 		discovery := map[string]any{
 			"issuer":                                server.URL,
 			"authorization_endpoint":                server.URL + "/auth",
@@ -40,16 +38,15 @@ func Test_genericTokenVerifier_VerifyIDToken(t *testing.T) {
 			"id_token_signing_alg_values_supported": []string{"RS256"},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		err := json.NewEncoder(w).Encode(discovery)
-		require.NoError(t, err)
+		if err := json.NewEncoder(w).Encode(discovery); err != nil {
+			t.Errorf("encoding discovery document: %v", err)
+			return
+		}
 	})
 
-	// JWKS endpoint with real RSA public key.
-	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
-		// Convert RSA public key to JWK format
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
 		nBytes := publicKey.N.Bytes()
 		eBytes := big.NewInt(int64(publicKey.E)).Bytes()
-
 		jwks := map[string]any{
 			"keys": []map[string]any{
 				{
@@ -63,21 +60,33 @@ func Test_genericTokenVerifier_VerifyIDToken(t *testing.T) {
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		err := json.NewEncoder(w).Encode(jwks)
-		require.NoError(t, err)
+		if err := json.NewEncoder(w).Encode(jwks); err != nil {
+			t.Errorf("encoding JWKS: %v", err)
+			return
+		}
 	})
 
-	// Create real OIDC provider pointing to our mock server.
+	return server, privateKey, keyID
+}
+
+func signToken(t *testing.T, privateKey *rsa.PrivateKey, keyID string, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = keyID
+	tokenString, err := token.SignedString(privateKey)
+	require.NoError(t, err)
+	return tokenString
+}
+
+func Test_genericTokenVerifier_VerifyIDToken(t *testing.T) {
+	server, privateKey, keyID := newTestOIDCServer(t)
+
 	ctx := context.Background()
 	provider, err := oidc.NewProvider(ctx, server.URL)
 	require.NoError(t, err)
 
-	// Create verifier with real provider.
-	verifier := &genericTokenVerifier{provider: provider}
-
-	// Create a valid JWT token.
 	now := time.Now()
-	claims := jwt.MapClaims{
+	tokenString := signToken(t, privateKey, keyID, jwt.MapClaims{
 		"iss":   server.URL,
 		"sub":   "test-subject",
 		"aud":   []string{"test-audience"},
@@ -85,34 +94,97 @@ func Test_genericTokenVerifier_VerifyIDToken(t *testing.T) {
 		"iat":   now.Unix(),
 		"email": "test@example.com",
 		"name":  "Test User",
-	}
+	})
 
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-	token.Header["kid"] = keyID
+	verifier := &genericTokenVerifier{provider: provider}
 
-	tokenString, err := token.SignedString(privateKey)
-	require.NoError(t, err)
-
-	// Test with valid token.
 	idToken, err := verifier.VerifyIDToken(ctx, tokenString)
-
-	// Should succeed.
 	require.NoError(t, err)
 	require.NotNil(t, idToken)
 	assert.Equal(t, "test-subject", idToken.Subject)
 	assert.Equal(t, []string{"test-audience"}, idToken.Audience)
 
-	// Test claims extraction.
 	var extractedClaims map[string]any
 	err = idToken.Claims(&extractedClaims)
 	require.NoError(t, err)
 	assert.Equal(t, "test@example.com", extractedClaims["email"])
 	assert.Equal(t, "Test User", extractedClaims["name"])
 
-	// Test with invalid token - should fail JWT parsing/verification.
 	idToken, err = verifier.VerifyIDToken(ctx, "invalid.jwt.token")
 	assert.Nil(t, idToken)
 	assert.Error(t, err)
 	assert.NotContains(t, err.Error(), "404")
 	assert.NotContains(t, err.Error(), "connection")
+}
+
+func Test_genericTokenVerifier_AudienceValidation(t *testing.T) {
+	server, privateKey, keyID := newTestOIDCServer(t)
+
+	ctx := context.Background()
+	provider, err := oidc.NewProvider(ctx, server.URL)
+	require.NoError(t, err)
+
+	now := time.Now()
+	baseClaims := func(aud any) jwt.MapClaims {
+		claims := jwt.MapClaims{
+			"iss": server.URL,
+			"sub": "test-subject",
+			"exp": now.Add(time.Hour).Unix(),
+			"iat": now.Unix(),
+		}
+		if aud != nil {
+			claims["aud"] = aud
+		}
+		return claims
+	}
+
+	testCases := map[string]struct {
+		audience      string
+		tokenAudience any
+		expectError   bool
+	}{
+		"matching audience passes": {
+			audience:      "my-client-id",
+			tokenAudience: "my-client-id",
+		},
+		"matching audience in array passes": {
+			audience:      "my-client-id",
+			tokenAudience: []string{"other-client", "my-client-id"},
+		},
+		"non-matching audience is rejected": {
+			audience:      "my-client-id",
+			tokenAudience: "wrong-audience",
+			expectError:   true,
+		},
+		"non-matching audience array is rejected": {
+			audience:      "my-client-id",
+			tokenAudience: []string{"wrong-audience", "another-wrong"},
+			expectError:   true,
+		},
+		"empty audience config skips check": {
+			audience:      "",
+			tokenAudience: "any-audience-value",
+		},
+		"token without aud claim is rejected when audience is configured": {
+			audience:      "my-client-id",
+			tokenAudience: nil,
+			expectError:   true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			verifier := &genericTokenVerifier{provider: provider, audience: tc.audience}
+			tokenString := signToken(t, privateKey, keyID, baseClaims(tc.tokenAudience))
+
+			idToken, err := verifier.VerifyIDToken(ctx, tokenString)
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, idToken)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, idToken)
+			}
+		})
+	}
 }

--- a/central/auth/m2m/token_verifier.go
+++ b/central/auth/m2m/token_verifier.go
@@ -40,5 +40,5 @@ func tokenVerifierFromConfig(ctx context.Context, config *storage.AuthMachineToM
 		return nil, errors.Wrapf(err, "creating OIDC provider for issuer %q", config.GetIssuer())
 	}
 
-	return &genericTokenVerifier{provider: provider}, nil
+	return &genericTokenVerifier{provider: provider, audience: config.GetAudience()}, nil
 }

--- a/central/convert/storagetov1/auth_m2m_config.go
+++ b/central/convert/storagetov1/auth_m2m_config.go
@@ -23,6 +23,7 @@ func AuthM2MConfig(config *storage.AuthMachineToMachineConfig) *v1.AuthMachineTo
 		TokenExpirationDuration: config.GetTokenExpirationDuration(),
 		Mappings:                convertMappings(config.GetMappings()),
 		Issuer:                  config.GetIssuer(),
+		Audience:                config.GetAudience(),
 		Traits:                  Traits(config.GetTraits()),
 	}
 

--- a/central/convert/v1tostorage/auth_m2m_config.go
+++ b/central/convert/v1tostorage/auth_m2m_config.go
@@ -13,6 +13,7 @@ func AuthM2MConfig(config *v1.AuthMachineToMachineConfig) *storage.AuthMachineTo
 		TokenExpirationDuration: config.GetTokenExpirationDuration(),
 		Mappings:                convertMappings(config.GetMappings()),
 		Issuer:                  config.GetIssuer(),
+		Audience:                config.GetAudience(),
 		Traits:                  Traits(config.GetTraits()),
 	}
 

--- a/generated/api/v1/auth_service.pb.go
+++ b/generated/api/v1/auth_service.pb.go
@@ -285,8 +285,13 @@ type AuthMachineToMachineConfig struct {
 	//
 	// Issuer is a unique key, therefore there may be at most one GITHUB_ACTIONS config, and each
 	// GENERIC config must have a distinct issuer.
-	Issuer        string  `protobuf:"bytes,5,opt,name=issuer,proto3" json:"issuer,omitempty"`
-	Traits        *Traits `protobuf:"bytes,6,opt,name=traits,proto3" json:"traits,omitempty"`
+	Issuer string  `protobuf:"bytes,5,opt,name=issuer,proto3" json:"issuer,omitempty"`
+	Traits *Traits `protobuf:"bytes,6,opt,name=traits,proto3" json:"traits,omitempty"`
+	// The expected audience (aud claim) of the ID token.
+	// When set, the OIDC token verifier validates that the token's aud claim contains this value,
+	// rejecting tokens intended for other recipients (RFC 7519 Section 4.1.3).
+	// When empty, the audience check is skipped for backward compatibility.
+	Audience      string `protobuf:"bytes,7,opt,name=audience,proto3" json:"audience,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -361,6 +366,13 @@ func (x *AuthMachineToMachineConfig) GetTraits() *Traits {
 		return x.Traits
 	}
 	return nil
+}
+
+func (x *AuthMachineToMachineConfig) GetAudience() string {
+	if x != nil {
+		return x.Audience
+	}
+	return ""
 }
 
 type ListAuthMachineToMachineConfigResponse struct {
@@ -760,7 +772,7 @@ const file_api_v1_auth_service_proto_rawDesc = "" +
 	"\tuser_info\x18\x06 \x01(\v2\x11.storage.UserInfoR\buserInfo\x12:\n" +
 	"\x0fuser_attributes\x18\a \x03(\v2\x11.v1.UserAttributeR\x0euserAttributes\x12\x1b\n" +
 	"\tidp_token\x18\b \x01(\tR\bidpTokenB\x04\n" +
-	"\x02id\"\xc0\x03\n" +
+	"\x02id\"\xdc\x03\n" +
 	"\x1aAuthMachineToMachineConfig\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x127\n" +
 	"\x04type\x18\x02 \x01(\x0e2#.v1.AuthMachineToMachineConfig.TypeR\x04type\x12:\n" +
@@ -768,7 +780,8 @@ const file_api_v1_auth_service_proto_rawDesc = "" +
 	"\bmappings\x18\x04 \x03(\v2&.v1.AuthMachineToMachineConfig.MappingR\bmappings\x12\x16\n" +
 	"\x06issuer\x18\x05 \x01(\tR\x06issuer\x12\"\n" +
 	"\x06traits\x18\x06 \x01(\v2\n" +
-	".v1.TraitsR\x06traits\x1aZ\n" +
+	".v1.TraitsR\x06traits\x12\x1a\n" +
+	"\baudience\x18\a \x01(\tR\baudience\x1aZ\n" +
 	"\aMapping\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
 	"\x10value_expression\x18\x02 \x01(\tR\x0fvalueExpression\x12\x12\n" +

--- a/generated/api/v1/auth_service.swagger.json
+++ b/generated/api/v1/auth_service.swagger.json
@@ -285,6 +285,10 @@
             },
             "traits": {
               "$ref": "#/definitions/v1Traits"
+            },
+            "audience": {
+              "type": "string",
+              "description": "The expected audience (aud claim) of the ID token.\nWhen set, the OIDC token verifier validates that the token's aud claim contains this value,\nrejecting tokens intended for other recipients (RFC 7519 Section 4.1.3).\nWhen empty, the audience check is skipped for backward compatibility."
             }
           },
           "description": "AuthMachineToMachineConfig determines rules for exchanging an identity token from a third party with\na Central access token. The M2M stands for machine to machine, as this is the intended use-case\nfor the config."
@@ -587,6 +591,10 @@
         },
         "traits": {
           "$ref": "#/definitions/v1Traits"
+        },
+        "audience": {
+          "type": "string",
+          "description": "The expected audience (aud claim) of the ID token.\nWhen set, the OIDC token verifier validates that the token's aud claim contains this value,\nrejecting tokens intended for other recipients (RFC 7519 Section 4.1.3).\nWhen empty, the audience check is skipped for backward compatibility."
         }
       },
       "description": "AuthMachineToMachineConfig determines rules for exchanging an identity token from a third party with\na Central access token. The M2M stands for machine to machine, as this is the intended use-case\nfor the config."

--- a/generated/api/v1/auth_service_vtproto.pb.go
+++ b/generated/api/v1/auth_service_vtproto.pb.go
@@ -143,6 +143,7 @@ func (m *AuthMachineToMachineConfig) CloneVT() *AuthMachineToMachineConfig {
 	r.TokenExpirationDuration = m.TokenExpirationDuration
 	r.Issuer = m.Issuer
 	r.Traits = m.Traits.CloneVT()
+	r.Audience = m.Audience
 	if rhs := m.Mappings; rhs != nil {
 		tmpContainer := make([]*AuthMachineToMachineConfig_Mapping, len(rhs))
 		for k, v := range rhs {
@@ -491,6 +492,9 @@ func (this *AuthMachineToMachineConfig) EqualVT(that *AuthMachineToMachineConfig
 		return false
 	}
 	if !this.Traits.EqualVT(that.Traits) {
+		return false
+	}
+	if this.Audience != that.Audience {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -953,6 +957,13 @@ func (m *AuthMachineToMachineConfig) MarshalToSizedBufferVT(dAtA []byte) (int, e
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Audience) > 0 {
+		i -= len(m.Audience)
+		copy(dAtA[i:], m.Audience)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Audience)))
+		i--
+		dAtA[i] = 0x3a
 	}
 	if m.Traits != nil {
 		size, err := m.Traits.MarshalToSizedBufferVT(dAtA[:i])
@@ -1454,6 +1465,10 @@ func (m *AuthMachineToMachineConfig) SizeVT() (n int) {
 	}
 	if m.Traits != nil {
 		l = m.Traits.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Audience)
+	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -2397,6 +2412,38 @@ func (m *AuthMachineToMachineConfig) UnmarshalVT(dAtA []byte) error {
 			if err := m.Traits.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Audience", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Audience = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -3900,6 +3947,42 @@ func (m *AuthMachineToMachineConfig) UnmarshalVTUnsafe(dAtA []byte) error {
 			if err := m.Traits.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Audience", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Audience = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/generated/storage/auth_machine_to_machine.pb.go
+++ b/generated/storage/auth_machine_to_machine.pb.go
@@ -73,7 +73,7 @@ func (AuthMachineToMachineConfig_Type) EnumDescriptor() ([]byte, []int) {
 // AuthMachineToMachineConfig is the storage representation of auth machine to machine configs in Central.
 //
 // Refer to v1.AuthMachineToMachineConfig for a more detailed doc.
-// Next tag: 7.
+// Next tag: 8.
 type AuthMachineToMachineConfig struct {
 	state                   protoimpl.MessageState                `protogen:"open.v1"`
 	Id                      string                                `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk,type(uuid)"` // @gotags: sql:"pk,type(uuid)"
@@ -82,8 +82,13 @@ type AuthMachineToMachineConfig struct {
 	Mappings                []*AuthMachineToMachineConfig_Mapping `protobuf:"bytes,4,rep,name=mappings,proto3" json:"mappings,omitempty"`
 	// The issuer is related to an ID token's issuer.
 	// Spec: https://openid.net/specs/openid-connect-core-1_0.html#IDToken.
-	Issuer        string  `protobuf:"bytes,5,opt,name=issuer,proto3" json:"issuer,omitempty" sql:"unique"` // @gotags: sql:"unique"
-	Traits        *Traits `protobuf:"bytes,6,opt,name=traits,proto3" json:"traits,omitempty"`
+	Issuer string  `protobuf:"bytes,5,opt,name=issuer,proto3" json:"issuer,omitempty" sql:"unique"` // @gotags: sql:"unique"
+	Traits *Traits `protobuf:"bytes,6,opt,name=traits,proto3" json:"traits,omitempty"`
+	// The expected audience (aud claim) of the ID token.
+	// When set, the OIDC token verifier validates that the token's aud
+	// claim contains this value. When empty, the audience check is skipped
+	// for backward compatibility.
+	Audience      string `protobuf:"bytes,7,opt,name=audience,proto3" json:"audience,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -160,6 +165,13 @@ func (x *AuthMachineToMachineConfig) GetTraits() *Traits {
 	return nil
 }
 
+func (x *AuthMachineToMachineConfig) GetAudience() string {
+	if x != nil {
+		return x.Audience
+	}
+	return ""
+}
+
 type AuthMachineToMachineConfig_Mapping struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	Key             string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
@@ -224,14 +236,15 @@ var File_storage_auth_machine_to_machine_proto protoreflect.FileDescriptor
 
 const file_storage_auth_machine_to_machine_proto_rawDesc = "" +
 	"\n" +
-	"%storage/auth_machine_to_machine.proto\x12\astorage\x1a\x14storage/traits.proto\"\xcf\x03\n" +
+	"%storage/auth_machine_to_machine.proto\x12\astorage\x1a\x14storage/traits.proto\"\xeb\x03\n" +
 	"\x1aAuthMachineToMachineConfig\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12<\n" +
 	"\x04type\x18\x02 \x01(\x0e2(.storage.AuthMachineToMachineConfig.TypeR\x04type\x12:\n" +
 	"\x19token_expiration_duration\x18\x03 \x01(\tR\x17tokenExpirationDuration\x12G\n" +
 	"\bmappings\x18\x04 \x03(\v2+.storage.AuthMachineToMachineConfig.MappingR\bmappings\x12\x16\n" +
 	"\x06issuer\x18\x05 \x01(\tR\x06issuer\x12'\n" +
-	"\x06traits\x18\x06 \x01(\v2\x0f.storage.TraitsR\x06traits\x1aZ\n" +
+	"\x06traits\x18\x06 \x01(\v2\x0f.storage.TraitsR\x06traits\x12\x1a\n" +
+	"\baudience\x18\a \x01(\tR\baudience\x1aZ\n" +
 	"\aMapping\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
 	"\x10value_expression\x18\x02 \x01(\tR\x0fvalueExpression\x12\x12\n" +

--- a/generated/storage/auth_machine_to_machine_vtproto.pb.go
+++ b/generated/storage/auth_machine_to_machine_vtproto.pb.go
@@ -49,6 +49,7 @@ func (m *AuthMachineToMachineConfig) CloneVT() *AuthMachineToMachineConfig {
 	r.TokenExpirationDuration = m.TokenExpirationDuration
 	r.Issuer = m.Issuer
 	r.Traits = m.Traits.CloneVT()
+	r.Audience = m.Audience
 	if rhs := m.Mappings; rhs != nil {
 		tmpContainer := make([]*AuthMachineToMachineConfig_Mapping, len(rhs))
 		for k, v := range rhs {
@@ -128,6 +129,9 @@ func (this *AuthMachineToMachineConfig) EqualVT(that *AuthMachineToMachineConfig
 		return false
 	}
 	if !this.Traits.EqualVT(that.Traits) {
+		return false
+	}
+	if this.Audience != that.Audience {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -223,6 +227,13 @@ func (m *AuthMachineToMachineConfig) MarshalToSizedBufferVT(dAtA []byte) (int, e
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Audience) > 0 {
+		i -= len(m.Audience)
+		copy(dAtA[i:], m.Audience)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Audience)))
+		i--
+		dAtA[i] = 0x3a
 	}
 	if m.Traits != nil {
 		size, err := m.Traits.MarshalToSizedBufferVT(dAtA[:i])
@@ -326,6 +337,10 @@ func (m *AuthMachineToMachineConfig) SizeVT() (n int) {
 	}
 	if m.Traits != nil {
 		l = m.Traits.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Audience)
+	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -692,6 +707,38 @@ func (m *AuthMachineToMachineConfig) UnmarshalVT(dAtA []byte) error {
 			if err := m.Traits.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Audience", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Audience = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -1099,6 +1146,42 @@ func (m *AuthMachineToMachineConfig) UnmarshalVTUnsafe(dAtA []byte) error {
 			if err := m.Traits.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Audience", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.Audience = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/declarativeconfig/auth_machine_to_machine.go
+++ b/pkg/declarativeconfig/auth_machine_to_machine.go
@@ -24,6 +24,7 @@ type AuthMachineToMachineConfig struct {
 	TokenExpirationDuration string                         `yaml:"tokenExpirationDuration,omitempty"`
 	Mappings                []MachineToMachineRoleMapping  `yaml:"mappings,omitempty"`
 	Issuer                  string                         `yaml:"issuer,omitempty"`
+	Audience                string                         `yaml:"audience,omitempty"`
 }
 
 // AuthMachineToMachineConfigType is representation of storage.AuthMachineToMachineConfig_Type

--- a/pkg/declarativeconfig/transform/auth_machine_to_machine.go
+++ b/pkg/declarativeconfig/transform/auth_machine_to_machine.go
@@ -42,6 +42,7 @@ func (t authMachineToMachineConfigTransform) Transform(
 		TokenExpirationDuration: authM2MConfig.TokenExpirationDuration,
 		Mappings:                mappings,
 		Issuer:                  authM2MConfig.Issuer,
+		Audience:                authM2MConfig.Audience,
 		Traits:                  &storage.Traits{Origin: storage.Traits_DECLARATIVE},
 	}
 

--- a/proto/api/v1/auth_service.proto
+++ b/proto/api/v1/auth_service.proto
@@ -85,6 +85,12 @@ message AuthMachineToMachineConfig {
   string issuer = 5;
 
   Traits traits = 6;
+
+  // The expected audience (aud claim) of the ID token.
+  // When set, the OIDC token verifier validates that the token's aud claim contains this value,
+  // rejecting tokens intended for other recipients (RFC 7519 Section 4.1.3).
+  // When empty, the audience check is skipped for backward compatibility.
+  string audience = 7;
 }
 
 message ListAuthMachineToMachineConfigResponse {

--- a/proto/storage/auth_machine_to_machine.proto
+++ b/proto/storage/auth_machine_to_machine.proto
@@ -10,7 +10,7 @@ option java_package = "io.stackrox.proto.storage";
 // AuthMachineToMachineConfig is the storage representation of auth machine to machine configs in Central.
 //
 // Refer to v1.AuthMachineToMachineConfig for a more detailed doc.
-// Next tag: 7.
+// Next tag: 8.
 message AuthMachineToMachineConfig {
   string id = 1; // @gotags: sql:"pk,type(uuid)"
 
@@ -35,4 +35,10 @@ message AuthMachineToMachineConfig {
   string issuer = 5; // @gotags: sql:"unique"
 
   Traits traits = 6;
+
+  // The expected audience (aud claim) of the ID token.
+  // When set, the OIDC token verifier validates that the token's aud
+  // claim contains this value. When empty, the audience check is skipped
+  // for backward compatibility.
+  string audience = 7;
 }

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -1172,6 +1172,11 @@
                 "id": 6,
                 "name": "traits",
                 "type": "Traits"
+              },
+              {
+                "id": 7,
+                "name": "audience",
+                "type": "string"
               }
             ],
             "messages": [

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -46,6 +46,7 @@ export type MachineAccessConfig = {
         role: string;
     }[];
     issuer: string;
+    audience: string;
 };
 
 export const validationSchema = yup.object().shape({
@@ -66,6 +67,7 @@ export const validationSchema = yup.object().shape({
 
 export const defaultValues: MachineAccessConfig = {
     issuer: '',
+    audience: '',
     mappings: [],
     tokenExpirationDuration: '',
     type: 'GENERIC',
@@ -171,6 +173,28 @@ function MachineAccessIntegrationForm({
                                 onBlur={handleBlur}
                                 isDisabled={!isEditable || values.type === 'GITHUB_ACTIONS'}
                             />
+                        </FormLabelGroup>
+                        <FormLabelGroup
+                            label="Audience"
+                            fieldId="audience"
+                            touched={touched}
+                            errors={errors}
+                        >
+                            <TextInput
+                                type="text"
+                                id="audience"
+                                value={values.audience}
+                                onChange={(event, value) => onChange(value, event)}
+                                onBlur={handleBlur}
+                                isDisabled={!isEditable}
+                            />
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem>
+                                        Expected audience (aud) claim of the identity token. Leave blank to accept any audience.
+                                    </HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
                         </FormLabelGroup>
                         <FormLabelGroup
                             isRequired

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/MachineAccessIntegrationForm.tsx
@@ -191,7 +191,8 @@ function MachineAccessIntegrationForm({
                             <FormHelperText>
                                 <HelperText>
                                     <HelperTextItem>
-                                        Expected audience (aud) claim of the identity token. Leave blank to accept any audience.
+                                        Expected audience (aud) claim of the identity token. Leave
+                                        blank to accept any audience.
                                     </HelperTextItem>
                                 </HelperText>
                             </FormHelperText>

--- a/ui/apps/platform/src/services/MachineAccessService.ts
+++ b/ui/apps/platform/src/services/MachineAccessService.ts
@@ -15,6 +15,7 @@ export type AuthMachineToMachineConfig = {
     tokenExpirationDuration: string;
     type: MachineConfigType;
     issuer: string;
+    audience: string;
     mappings: MachineConfigMapping[];
     traits?: Traits;
 };


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The M2M token verifier unconditionally set SkipClientIDCheck=true, accepting any ID token from a configured issuer regardless of its intended audience. This is a confused-deputy vulnerability per RFC 7519 Section 4.1.3: an attacker with a valid token from the same issuer but intended for a different service could exchange it for a Central access token.

Add an optional `audience` field to AuthMachineToMachineConfig. When set, the OIDC verifier validates that the token's aud claim contains the expected value. When empty, the check is skipped for backward compatibility with existing configs.

<img width="1206" height="738" alt="SCR-20260605-ljvt" src="https://github.com/user-attachments/assets/40c6668d-bd13-4e42-9f2e-39a5c4718a0c" />

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Using Azure applications to generate tokens with custom audience:

```
$ APP_NAME="CentralAPI"
$ APP_ID=$(az ad app create --display-name "$APP_NAME" --query appId -o tsv)
$ OBJECT_ID=$(az ad app show --id "$APP_ID" --query id -o tsv)
$ CLI_CLIENT_ID="04b07795-8ddb-461a-bbee-02f9e1bf7b46"
$ SCOPE_ID=$(uuidgen)

$ PAYLOAD_STEP1=$(cat <<EOF
{
  "identifierUris": ["api://$APP_ID"],
  "api": {
    "oauth2PermissionScopes": [
      {
        "adminConsentDescription": "Access Central API",
        "adminConsentDisplayName": "Access Central API",
        "id": "$SCOPE_ID",
        "isEnabled": true,
        "type": "User",
        "userConsentDescription": "Access Central API",
        "userConsentDisplayName": "Access Central API",
        "value": "access_as_user"
      }
    ]
  }
}
EOF
)

# Expose API scope
az rest --method PATCH \
  --uri "https://graph.microsoft.com/v1.0/applications/$OBJECT_ID" \
  --headers '{"Content-Type":"application/json"}' \
  --body "$PAYLOAD_STEP1"


PAYLOAD_STEP2=$(cat <<EOF
{
  "api": {
    "preAuthorizedApplications": [
      {
        "appId": "$CLI_CLIENT_ID",
        "delegatedPermissionIds": ["$SCOPE_ID"]
      }
    ]
  }
}
EOF
)

# Pre-authorizing the Azure CLI
az rest --method PATCH \
  --uri "https://graph.microsoft.com/v1.0/applications/$OBJECT_ID" \
  --headers '{"Content-Type":"application/json"}' \
  --body "$PAYLOAD_STEP2"
```

We can now request tokens with
```
$ az account get-access-token --scope "api://$APP_ID/access_as_user"
```

which yields a jwt token like

```
{
  "aud": "api://cd5aeeb5-73d9-4bc5-bf3f-232cfad90fa8", # <-- this is our Azure app id
  "iss": "https://sts.windows.net/6aec22ae-2b26-45bd-b17f-d60e89828e89/",
  ...
}
```

Now test `roxctl central machine-to-machine exchange`:

1. When audience is set and matches:
```
$ roxctl central machine-to-machine exchange --token=(az account get-access-token --scope "api://cd5aeeb5-73d9-4bc5-bf3f-232cfad90fa8/access_as_user"| jq .accessToken --raw-output) --insecure-skip-tls-verify

INFO:	Successfully persisted the authentication information for central central-stackrox.apps.sh-05-26-1.ocp.infra.rox.systems:443.
You can now use the exchanged short-lived access token for all other commands!

Note that in case the token is expired, you have to run "roxctl central machine-to-machine exchange" again.
```

2. When audience is set and does not match:
```
$ roxctl central machine-to-machine exchange --token=(az account get-access-token --scope "api://cd5aeeb5-73d9-4bc5-bf3f-232cfad90fa8/access_as_user"| jq .accessToken --raw-output) --insecure-skip-tls-verify

ERROR:	exchange request failed: expected status code 200, but received 401. Response Body: {"code":16,"message":"ID token is invalid: oidc: expectedaudience \"api://cd5aeeb5-73d9-4bc5-bf3f-232cfad90fa8xxx\" got [\"api://cd5aeeb5-73d9-4bc5-bf3f-232cfad90fa8\"]","details":[],"error":"ID token is invalid: oidc: expected audience \"api://cd5aeeb5-73d9-4bc5-bf3f-232cfad90fa8xxx\" got [\"api://cd5aeeb5-73d9-4bc5-bf3f-232cfad90fa8\"]"}
```
3. When audience is not set and does not match:
```
$ roxctl central machine-to-machine exchange --token=(az account get-access-token --scope "api://cd5aeeb5-73d9-4bc5-bf3f-232cfad90fa8/access_as_user"| jq .accessToken --raw-output) --insecure-skip-tls-verify

INFO:	Successfully persisted the authentication information for central central-stackrox.apps.sh-05-26-1.ocp.infra.rox.systems:443.
You can now use the exchanged short-lived access token for all other commands!

Note that in case the token is expired, you have to run "roxctl central machine-to-machine exchange" again.
```