### PR TITLE
experiment: UI-only change to verify Go tests skip

### DIFF
--- a/.github/workflows/unit-tests-go-passthrough.yaml
+++ b/.github/workflows/unit-tests-go-passthrough.yaml
@@ -17,43 +17,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          {
-            echo "## Go tests skipped — UI-only PR"
-            echo ""
-            echo "This is a passthrough job. No Go tests were run because this PR only changes \`ui/\` files."
-            echo ""
-            echo "GitHub required checks must report pass/fail/skip and cannot be left pending"
-            echo "when a workflow is skipped by path filters. This job exists solely to satisfy"
-            echo "the required check."
-          } >> "$GITHUB_STEP_SUMMARY"
+          echo "## Go tests skipped — UI-only PR" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "This is a passthrough job. No Go tests were run because this PR only changes \`ui/\` files." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "GitHub required checks must report pass/fail/skip and cannot be left pending" >> "$GITHUB_STEP_SUMMARY"
+          echo "when a workflow is skipped by path filters. This job exists solely to satisfy" >> "$GITHUB_STEP_SUMMARY"
+          echo "the required check." >> "$GITHUB_STEP_SUMMARY"
 
   go-postgres:
     name: go-postgres (GOTAGS="", 15)
     runs-on: ubuntu-latest
     steps:
       - run: |
-          {
-            echo "## Go postgres tests skipped — UI-only PR"
-            echo ""
-            echo "This is a passthrough job. See \`go (GOTAGS=\"\")\` summary for details."
-          } >> "$GITHUB_STEP_SUMMARY"
+          echo "## Go postgres tests skipped — UI-only PR" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "This is a passthrough job. See \`go (GOTAGS=\"\")\` summary for details." >> "$GITHUB_STEP_SUMMARY"
 
   go-bench:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          {
-            echo "## Go bench tests skipped — UI-only PR"
-            echo ""
-            echo "This is a passthrough job. See \`go (GOTAGS=\"\")\` summary for details."
-          } >> "$GITHUB_STEP_SUMMARY"
+          echo "## Go bench tests skipped — UI-only PR" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "This is a passthrough job. See \`go (GOTAGS=\"\")\` summary for details." >> "$GITHUB_STEP_SUMMARY"
 
   local-roxctl-tests:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          {
-            echo "## roxctl tests skipped — UI-only PR"
-            echo ""
-            echo "This is a passthrough job. See \`go (GOTAGS=\"\")\` summary for details."
-          } >> "$GITHUB_STEP_SUMMARY"
+          echo "## roxctl tests skipped — UI-only PR" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "This is a passthrough job. See \`go (GOTAGS=\"\")\` summary for details." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/unit-tests-go-passthrough.yaml
+++ b/.github/workflows/unit-tests-go-passthrough.yaml
@@ -17,35 +17,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "## Go tests skipped — UI-only PR" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "This is a passthrough job. No Go tests were run because this PR only changes \`ui/\` files." >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "GitHub required checks must report pass/fail/skip and cannot be left pending" >> "$GITHUB_STEP_SUMMARY"
-          echo "when a workflow is skipped by path filters. This job exists solely to satisfy" >> "$GITHUB_STEP_SUMMARY"
-          echo "the required check." >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Go tests skipped — UI-only PR"
+            echo ""
+            echo "This is a passthrough job. No Go tests were run because this PR only changes \`ui/\` files."
+            echo ""
+            echo "GitHub required checks must report pass/fail/skip and cannot be left pending"
+            echo "when a workflow is skipped by path filters. This job exists solely to satisfy"
+            echo "the required check."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   go-postgres:
     name: go-postgres (GOTAGS="", 15)
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "## Go postgres tests skipped — UI-only PR" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "This is a passthrough job. See \`go (GOTAGS=\"\")\` summary for details." >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Go postgres tests skipped — UI-only PR"
+            echo ""
+            echo "This is a passthrough job. See \`go (GOTAGS=\"\")\` summary for details."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   go-bench:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "## Go bench tests skipped — UI-only PR" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "This is a passthrough job. See \`go (GOTAGS=\"\")\` summary for details." >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Go bench tests skipped — UI-only PR"
+            echo ""
+            echo "This is a passthrough job. See \`go (GOTAGS=\"\")\` summary for details."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   local-roxctl-tests:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "## roxctl tests skipped — UI-only PR" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "This is a passthrough job. See \`go (GOTAGS=\"\")\` summary for details." >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## roxctl tests skipped — UI-only PR"
+            echo ""
+            echo "This is a passthrough job. See \`go (GOTAGS=\"\")\` summary for details."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/unit-tests-ui-passthrough.yaml
+++ b/.github/workflows/unit-tests-ui-passthrough.yaml
@@ -11,4 +11,11 @@ jobs:
   ui:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Skipped — no UI changes"
+      - run: |
+          echo "## UI tests skipped — no UI changes" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "This is a passthrough job. No UI tests were run because this PR does not change \`ui/\` files." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "GitHub required checks must report pass/fail/skip and cannot be left pending" >> "$GITHUB_STEP_SUMMARY"
+          echo "when a workflow is skipped by path filters. This job exists solely to satisfy" >> "$GITHUB_STEP_SUMMARY"
+          echo "the required check." >> "$GITHUB_STEP_SUMMARY"

--- a/ui/apps/platform/src/constants/accessControl.ts
+++ b/ui/apps/platform/src/constants/accessControl.ts
@@ -80,3 +80,4 @@ export const resourceRemovalReleaseVersions = new Map<ResourceName, string>([]);
 export const replacedResourceMapping = new Map<ResourceName, string>([]);
 
 export const deprecatedResourceRowStyle = { backgroundColor: 'rgb(255,250,205)' };
+// UI-only change to test Go test skipping


### PR DESCRIPTION
## Experiment

Stacked on #20737. This PR touches only `ui/` to verify that:

1. **UI Unit Tests** workflow triggers (paths match `ui/**`)
2. **Unit Tests** workflow does NOT trigger (paths-ignore `ui/**`)
3. Go passthrough jobs report success (satisfying required checks)

If this works, UI-only PRs save ~30 minutes of Go test compute.

Do not merge — experiment only.