### PR TITLE
ROX-34813: Fix race condition

### DIFF
--- a/sensor/tests/connection/runtime/runtime_test.go
+++ b/sensor/tests/connection/runtime/runtime_test.go
@@ -52,8 +52,10 @@ func Test_SensorIntermediateRuntimeEvents(t *testing.T) {
 
 	var fakeCollector *collector.FakeCollector
 	if !helper.UseRealCollector.BooleanSetting() {
-		fakeCollector = collector.NewFakeCollector(collector.WithDefaultConfig().WithCertsPath(config.CertFilePath))
-		require.NoError(t, fakeCollector.Start())
+		require.Eventually(t, func() bool {
+			fakeCollector = collector.NewFakeCollector(collector.WithDefaultConfig().WithCertsPath(config.CertFilePath))
+			return fakeCollector.Start() == nil
+		}, 30*time.Second, time.Second, "fake collector failed to connect to sensor gRPC server")
 	}
 
 	c.RunTest(t, helper.WithTestCase(func(t *testing.T, testContext *helper.TestContext, _ map[string]k8s.Object) {


### PR DESCRIPTION
## Description

We are getting the following failure in tests:
```
  rpc error: code = Unavailable desc = connection error:
    "transport: Error while dialing: dial tcp [::1]:8443: connect: connection refused"
```

**Root cause:** Race condition between sensor's gRPC server startup and `FakeCollector` connection attempt.

- On line `50`, `helper.NewContextWithConfig` starts the sensor and waits for its connection to fake central - but not for the sensor's public gRPC server on `:8443` to be listening.
- The gRPC server binds the port in a separate goroutine that may still be running when `NewContextWithConfig` returns.
- On line 55-56, the test immediately creates a `FakeCollector` and connects to `localhost:8443`, which fails if the port isn't bound yet.

**Reproduction:** Injecting `time.Sleep(2s)` in `pkg/grpc/server.go -> run()` method before `endpointCfg.instantiate()` (which calls `net.Listen`) deterministically reproduces the failure - identical to CI.

**Fix:** Wrap `FakeCollector` creation and startup in `require.Eventually` with a 30-second timeout and 1-second retry interval, allowing the test to wait for the sensor's gRPC endpoint to become available.

**Note:** We are not able to wrap only `fakeCollector.Start()` in `require.Eventually` because it could leak some goroutines that could read from the same channels created by `newFakeNetworkFlowManager`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] Let run test in CI
- [x] Run test locally with the `time.Sleep(2s)` still injected in `server.go`, the test was re-run and passed. The retry logic successfully waited for the gRPC server to start listening before connecting.
