### PR TITLE
ROX-34875: fix init container e2e tests on release builds

### DIFF
--- a/tests/init_container_test.go
+++ b/tests/init_container_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e
+//go:build test_e2e && !release
 
 package tests
 


### PR DESCRIPTION
## Description

Fixes ROX-34875. The init container e2e tests (added in #20367) fail in nightly CI because the `SetupSuite` check used `os.Getenv("ROX_INIT_CONTAINER_SUPPORT")` to decide whether to skip. The `ci_export` in `lib.sh` sets this env var to `"true"` in the test runner shell, so the tests always run — even on release/nightly builds where the deployed Central and Sensor don't actually have the feature enabled (release builds exclude `feature-flag-values.yaml` from the Helm chart, and `roxctl` skips env-var-based feature flag injection).

This changes `SetupSuite` to query Central's feature flag API instead. On dev builds, the feature is enabled on Central/Sensor via `feature-flag-values.yaml` and the tests run. On release builds, the feature is off and the tests correctly skip.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Traced the deployment path: nightly Prow builds use `GOTAGS=release`, which causes `feature-flag-values.yaml` to be excluded from the Sensor Helm chart and `roxctl` to skip env-var feature flag injection
- Confirmed `ci_export ROX_INIT_CONTAINER_SUPPORT "true"` only affects the test runner process, not the deployed components on release builds
- The API-based check correctly reflects the actual Central state regardless of build type
