### PR TITLE
ROX-34879: check API availability for OpenShift informers

### DIFF
--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -26,6 +26,9 @@ const (
 	osImageDigestMirrorSetsResourceName = "imagedigestmirrorsets"
 	osImageTagMirrorSetsResourceName    = "imagetagmirrorsets"
 
+	osRouteGroupVersion  = "route.openshift.io/v1"
+	osRoutesResourceName = "routes"
+
 	osOperatorAlphaGroupVersion              = "operator.openshift.io/v1alpha1"
 	osImageContentSourcePoliciesResourceName = "imagecontentsourcepolicies"
 )

--- a/sensor/kubernetes/listener/listener_impl.go
+++ b/sensor/kubernetes/listener/listener_impl.go
@@ -29,6 +29,9 @@ const (
 	osRouteGroupVersion  = "route.openshift.io/v1"
 	osRoutesResourceName = "routes"
 
+	osAppsGroupVersion              = "apps.openshift.io/v1"
+	osDeploymentConfigsResourceName = "deploymentconfigs"
+
 	osOperatorAlphaGroupVersion              = "operator.openshift.io/v1alpha1"
 	osImageContentSourcePoliciesResourceName = "imagecontentsourcepolicies"
 )

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -138,12 +138,10 @@ func (k *listenerImpl) handleAllEvents() {
 
 	// Create informer factories for needed orchestrators.
 	var osAppsFactory osAppsExtVersions.SharedInformerFactory
-	var deploymentConfigsAvailable bool
 	if k.client.OpenshiftApps() != nil {
 		if resourceList, err := listenerUtils.ServerResourcesForGroup(k.client, osAppsGroupVersion); err != nil {
 			log.Errorf("Checking API resources for group %q: %v", osAppsGroupVersion, err)
 		} else if listenerUtils.ResourceExists(resourceList, osDeploymentConfigsResourceName, osAppsGroupVersion) {
-			deploymentConfigsAvailable = true
 			osAppsFactory = osAppsExtVersions.NewSharedInformerFactory(k.client.OpenshiftApps(), noResyncPeriod)
 			concurrency.WithLock(&k.sifLock, func() {
 				k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, osAppsFactory)
@@ -152,12 +150,10 @@ func (k *listenerImpl) handleAllEvents() {
 	}
 
 	var osRouteFactory osRouteExtVersions.SharedInformerFactory
-	var routesAvailable bool
 	if k.client.OpenshiftRoute() != nil {
 		if resourceList, err := listenerUtils.ServerResourcesForGroup(k.client, osRouteGroupVersion); err != nil {
 			log.Errorf("Checking API resources for group %q: %v", osRouteGroupVersion, err)
 		} else if listenerUtils.ResourceExists(resourceList, osRoutesResourceName, osRouteGroupVersion) {
-			routesAvailable = true
 			osRouteFactory = osRouteExtVersions.NewSharedInformerFactory(k.client.OpenshiftRoute(), noResyncPeriod)
 			concurrency.WithLock(&k.sifLock, func() {
 				k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, osRouteFactory)
@@ -427,7 +423,7 @@ func (k *listenerImpl) handleAllEvents() {
 	handle(k.context, informerNodes, sif.Core().V1().Nodes().Informer(), dispatchers.ForNodes(), k.pubSubDispatcher, k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock, informerTracker)
 	handle(k.context, informerServices, sif.Core().V1().Services().Informer(), dispatchers.ForServices(), k.pubSubDispatcher, k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock, informerTracker)
 
-	if routesAvailable {
+	if osRouteFactory != nil {
 		handle(k.context, informerRoutes, osRouteFactory.Route().V1().Routes().Informer(), dispatchers.ForOpenshiftRoutes(), k.pubSubDispatcher, k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock, informerTracker)
 	}
 
@@ -464,7 +460,7 @@ func (k *listenerImpl) handleAllEvents() {
 	} else {
 		handle(k.context, informerCronJobs, sif.Batch().V1beta1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetesPkg.CronJob), k.pubSubDispatcher, k.outputQueue, &syncingResources, wg, stopSignal, &eventLock, informerTracker)
 	}
-	if deploymentConfigsAvailable {
+	if osAppsFactory != nil {
 		handle(k.context, informerDeploymentConfigs, osAppsFactory.Apps().V1().DeploymentConfigs().Informer(), dispatchers.ForDeployments(kubernetesPkg.DeploymentConfig), k.pubSubDispatcher, k.outputQueue, &syncingResources, wg, stopSignal, &eventLock, informerTracker)
 	}
 

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -138,11 +138,17 @@ func (k *listenerImpl) handleAllEvents() {
 
 	// Create informer factories for needed orchestrators.
 	var osAppsFactory osAppsExtVersions.SharedInformerFactory
+	var deploymentConfigsAvailable bool
 	if k.client.OpenshiftApps() != nil {
-		osAppsFactory = osAppsExtVersions.NewSharedInformerFactory(k.client.OpenshiftApps(), noResyncPeriod)
-		concurrency.WithLock(&k.sifLock, func() {
-			k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, osAppsFactory)
-		})
+		if resourceList, err := listenerUtils.ServerResourcesForGroup(k.client, osAppsGroupVersion); err != nil {
+			log.Errorf("Checking API resources for group %q: %v", osAppsGroupVersion, err)
+		} else if listenerUtils.ResourceExists(resourceList, osDeploymentConfigsResourceName, osAppsGroupVersion) {
+			deploymentConfigsAvailable = true
+			osAppsFactory = osAppsExtVersions.NewSharedInformerFactory(k.client.OpenshiftApps(), noResyncPeriod)
+			concurrency.WithLock(&k.sifLock, func() {
+				k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, osAppsFactory)
+			})
+		}
 	}
 
 	var osRouteFactory osRouteExtVersions.SharedInformerFactory
@@ -458,7 +464,7 @@ func (k *listenerImpl) handleAllEvents() {
 	} else {
 		handle(k.context, informerCronJobs, sif.Batch().V1beta1().CronJobs().Informer(), dispatchers.ForDeployments(kubernetesPkg.CronJob), k.pubSubDispatcher, k.outputQueue, &syncingResources, wg, stopSignal, &eventLock, informerTracker)
 	}
-	if osAppsFactory != nil {
+	if deploymentConfigsAvailable {
 		handle(k.context, informerDeploymentConfigs, osAppsFactory.Apps().V1().DeploymentConfigs().Informer(), dispatchers.ForDeployments(kubernetesPkg.DeploymentConfig), k.pubSubDispatcher, k.outputQueue, &syncingResources, wg, stopSignal, &eventLock, informerTracker)
 	}
 

--- a/sensor/kubernetes/listener/resource_event_handler.go
+++ b/sensor/kubernetes/listener/resource_event_handler.go
@@ -146,11 +146,17 @@ func (k *listenerImpl) handleAllEvents() {
 	}
 
 	var osRouteFactory osRouteExtVersions.SharedInformerFactory
+	var routesAvailable bool
 	if k.client.OpenshiftRoute() != nil {
-		osRouteFactory = osRouteExtVersions.NewSharedInformerFactory(k.client.OpenshiftRoute(), noResyncPeriod)
-		concurrency.WithLock(&k.sifLock, func() {
-			k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, osRouteFactory)
-		})
+		if resourceList, err := listenerUtils.ServerResourcesForGroup(k.client, osRouteGroupVersion); err != nil {
+			log.Errorf("Checking API resources for group %q: %v", osRouteGroupVersion, err)
+		} else if listenerUtils.ResourceExists(resourceList, osRoutesResourceName, osRouteGroupVersion) {
+			routesAvailable = true
+			osRouteFactory = osRouteExtVersions.NewSharedInformerFactory(k.client.OpenshiftRoute(), noResyncPeriod)
+			concurrency.WithLock(&k.sifLock, func() {
+				k.sharedInformersToShutdown = append(k.sharedInformersToShutdown, osRouteFactory)
+			})
+		}
 	}
 
 	// We want creates to be treated as updates while existing objects are loaded.
@@ -415,7 +421,7 @@ func (k *listenerImpl) handleAllEvents() {
 	handle(k.context, informerNodes, sif.Core().V1().Nodes().Informer(), dispatchers.ForNodes(), k.pubSubDispatcher, k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock, informerTracker)
 	handle(k.context, informerServices, sif.Core().V1().Services().Informer(), dispatchers.ForServices(), k.pubSubDispatcher, k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock, informerTracker)
 
-	if osRouteFactory != nil {
+	if routesAvailable {
 		handle(k.context, informerRoutes, osRouteFactory.Route().V1().Routes().Informer(), dispatchers.ForOpenshiftRoutes(), k.pubSubDispatcher, k.outputQueue, &syncingResources, preTopLevelDeploymentWaitGroup, stopSignal, &eventLock, informerTracker)
 	}
 


### PR DESCRIPTION
## Description

When `ROX_OPENSHIFT_API` is enabled on a non-OpenShift cluster (or when the API is
removed), sensor creates Route and DeploymentConfig informers unconditionally. The informers
fail to list/watch the missing resources and `WaitForCacheSync` blocks indefinitely, hanging
sensor startup.

This adds API resource availability checks before creating the informers, matching the
existing pattern used for OpenShift Config resources (ClusterOperators, ImageDigestMirrorSets,
etc.).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

**GKE cluster (non-OpenShift):** Ran local-sensor with `ROX_OPENSHIFT_API=true`. Before the fix, sensor startup hung with repeated errors:

```
Failed to watch: failed to list *v1.Route: the server could not find the requested resource (get routes.route.openshift.io)
```

After the fix, sensor starts successfully and skips the unavailable informers.

**OCP cluster (regression test):** Created a DeploymentConfig, Service, and Route on an OpenShift cluster and verified sensor correctly processes all resources. The DeploymentConfig is dispatched as a `Deployment` with `type: DeploymentConfig`, and the Route correctly updates port exposure on the deployment:

1. DeploymentConfig created — port 80, no exposure:
```json
{
  "dispatcher": "v1.DeploymentConfig",
  "name": "test-dc",
  "type": "DeploymentConfig",
  "ports": [{"container_port": 80, "protocol": "TCP"}]
}
```

2. Service created — exposure level 3 (ClusterIP):
```json
{
  "dispatcher": "v1.Service",
  "name": "test-dc",
  "type": "DeploymentConfig",
  "ports": [{"container_port": 80, "protocol": "TCP", "exposure": 3,
    "exposure_infos": [{"level": 3, "service_name": "test-dc-svc"}]}]
}
```

3. Route created — exposure level 5 (Route) with external hostname:
```json
{
  "dispatcher": "v1.Route",
  "name": "test-dc",
  "type": "DeploymentConfig",
  "ports": [{"container_port": 80, "protocol": "TCP", "exposure": 5,
    "exposure_infos": [
      {"level": 3, "service_name": "test-dc-svc"},
      {"level": 5, "service_name": "test-dc-svc",
       "external_hostnames": ["test-dc-route-dc-test.apps.lvm-05-29-1.ocp.infra.rox.systems"]}
    ]}]
}
```