### PR TITLE
perf(ci): broader GOCACHE fallback for go.mod changes

### DIFF
--- a/.github/actions/cache-go-dependencies/action.yaml
+++ b/.github/actions/cache-go-dependencies/action.yaml
@@ -33,7 +33,9 @@ runs:
       with:
         path: ${{ steps.cache-paths.outputs.GOCACHE }}
         key: go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-${{ steps.cache-paths.outputs.GOMOD_HASH }}-${{ steps.cache-paths.outputs.TAG }}
-        restore-keys: go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-${{ steps.cache-paths.outputs.GOMOD_HASH }}-
+        restore-keys: |
+          go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-${{ steps.cache-paths.outputs.GOMOD_HASH }}-
+          go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-
 
     - name: Cache Go Build (restore)
       if: ${{ !(inputs.save == 'true' && (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)) }}
@@ -41,7 +43,9 @@ runs:
       with:
         path: ${{ steps.cache-paths.outputs.GOCACHE }}
         key: go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-${{ steps.cache-paths.outputs.GOMOD_HASH }}-${{ steps.cache-paths.outputs.TAG }}
-        restore-keys: go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-${{ steps.cache-paths.outputs.GOMOD_HASH }}-
+        restore-keys: |
+          go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-${{ steps.cache-paths.outputs.GOMOD_HASH }}-
+          go-build-v2-${{ github.job }}${{ steps.cache-paths.outputs.KEY_SUFFIX }}-${{ steps.cache-paths.outputs.GOARCH }}-
 
     - name: Mark GOCACHE entries for stale detection
       run: |


### PR DESCRIPTION
## Description

When `go.mod` changes on master (dependency bumps), PRs get a full cache miss until master saves a new cache with the updated gomod hash. This gap was observed to be 20+ minutes, during which every PR builds fully cold (~30 min).

Adds a broader restore key fallback that drops the gomod hash, so PRs fall back to the most recent cache from any gomod version instead of building from scratch.

**Restore key order:**
1. Exact: `job + gotags + arch + gomod_hash + commit_sha`
2. Same gomod: `job + gotags + arch + gomod_hash` (existing)
3. **Any gomod: `job + gotags + arch` (new fallback)**

The existing GOCACHE trimming mechanism (backdate entries to year 2000, mark accessed as fresh, trim stale after build) self-cleans entries from the old gomod hash on the first run.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready

### How I validated my change

Observed cache miss on PR #20844 at 11:17 UTC when master had not yet saved a cache with the new gomod hash. Master saved at 11:37 UTC. Subsequent PRs at 14:27 UTC hit the cache via prefix restore. This broader fallback would have given the 11:17 PR a warm (stale) cache instead of a 30+ minute cold build.