### PR TITLE
ROX-15383: switch to ANY() array parameter for large value sets

### DIFF
--- a/pkg/env/postgres_query.go
+++ b/pkg/env/postgres_query.go
@@ -1,0 +1,9 @@
+package env
+
+var (
+	// PostgresParameterThreshold controls when the search framework switches
+	// from IN ($1, $2, ...) to = ANY($1::type[]) for exact-match disjunctions.
+	// Values below this threshold use IN for better plan quality; values at or
+	// above use ANY to avoid the 65535 parameter limit.
+	PostgresParameterThreshold = RegisterIntegerSetting("ROX_POSTGRES_PARAMETER_THRESHOLD", 100)
+)

--- a/pkg/search/parser.go
+++ b/pkg/search/parser.go
@@ -1,14 +1,11 @@
 package search
 
 import (
-	"runtime/debug"
 	"strings"
 
-	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
-	"github.com/stackrox/rox/pkg/utils"
 )
 
 var (
@@ -162,10 +159,12 @@ func parsePair(pair string, allowEmpty bool) (key string, values string, valid b
 }
 
 func queryFromFieldValues(field string, values []string, highlight bool) *v1.Query {
-	// A SQL query can have no more than 65535 parameters.
+	// Large value sets are handled by combineDisjunction which switches from
+	// IN ($1,$2,...) to = ANY($1::text[]) when the count exceeds the configured
+	// threshold (ROX_POSTGRES_PARAMETER_THRESHOLD). Log for visibility but do
+	// not panic — the query will execute correctly.
 	if len(values) > MaxQueryParameters {
-		debug.PrintStack()
-		utils.Should(errors.Errorf("UNEXPECTED: too many parameters %d for a query.  No more than %d parameters allowed in single query", len(values), MaxQueryParameters))
+		log.Warnf("Large parameter set (%d values) for field %q exceeds SQL limit of %d; query will use ANY() array parameter", len(values), field, MaxQueryParameters)
 	}
 	queries := make([]*v1.Query, 0, len(values))
 	for _, value := range values {

--- a/pkg/search/parser_test.go
+++ b/pkg/search/parser_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stackrox/rox/pkg/buildinfo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -223,23 +222,14 @@ func TestValueAndModifierFromString(t *testing.T) {
 }
 
 func TestQueryFromFieldValuesMaxParametersExceeded(t *testing.T) {
-	// Create a slice of values that exceeds MaxQueryParameters
-	// MaxQueryParameters is math.MaxUint16 (65535), so we create 65536 values
+	// Large value sets no longer panic — combineDisjunction handles them
+	// by switching to = ANY($1::text[]) when the count exceeds the threshold.
 	excessiveValues := make([]string, MaxQueryParameters+1)
 	for i := 0; i < len(excessiveValues); i++ {
 		excessiveValues[i] = fmt.Sprintf("value%d", i)
 	}
 
-	// On dev builds, utils.Should panics; on release builds, it logs and returns.
-	if !buildinfo.ReleaseBuild {
-		// Verify that queryFromFieldValues panics when given too many parameters on dev builds
-		require.Panics(t, func() {
-			queryFromFieldValues("test-field", excessiveValues, false)
-		}, "Expected queryFromFieldValues to panic when exceeding MaxQueryParameters on dev builds")
-	} else {
-		// On release builds, queryFromFieldValues should not panic
-		require.NotPanics(t, func() {
-			queryFromFieldValues("test-field", excessiveValues, false)
-		}, "Expected queryFromFieldValues to not panic on release builds")
-	}
+	require.NotPanics(t, func() {
+		queryFromFieldValues("test-field", excessiveValues, false)
+	}, "queryFromFieldValues should not panic for large value sets")
 }

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -600,9 +600,10 @@ func combineDisjunction(entries []*pgsearch.QueryEntry) *pgsearch.QueryEntry {
 	// to avoid the 65535 parameter limit. For small sets, use IN ($1, $2, ...)
 	// for better plan quality since the planner can inspect individual values.
 	if len(values) >= env.PostgresParameterThreshold.IntegerSetting() {
-		// Detect column type from the first value to pick the right array cast.
+		// Detect column type from the original entry value (before string conversion)
+		// to pick the right array cast.
 		cast := "::text[]"
-		if _, isUUID := values[0].(pkgUUID.UUID); isUUID {
+		if _, isUUID := entries[0].Where.Values[0].(pkgUUID.UUID); isUUID {
 			cast = "::uuid[]"
 		}
 		stringValues := make([]string, len(values))

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/stringutils"
 	pkgUtils "github.com/stackrox/rox/pkg/utils"
+	pkgUUID "github.com/stackrox/rox/pkg/uuid"
 )
 
 var (
@@ -595,17 +596,22 @@ func combineDisjunction(entries []*pgsearch.QueryEntry) *pgsearch.QueryEntry {
 	where := seenQueries.GetArbitraryElem()
 	where = strings.TrimSuffix(where, exactQuerySuffix)
 
-	// For large value sets, use = ANY($1::text[]) with a single array parameter
+	// For large value sets, use = ANY($1::type[]) with a single array parameter
 	// to avoid the 65535 parameter limit. For small sets, use IN ($1, $2, ...)
 	// for better plan quality since the planner can inspect individual values.
 	if len(values) >= env.PostgresParameterThreshold.IntegerSetting() {
+		// Detect column type from the first value to pick the right array cast.
+		cast := "::text[]"
+		if _, isUUID := values[0].(pkgUUID.UUID); isUUID {
+			cast = "::uuid[]"
+		}
 		stringValues := make([]string, len(values))
 		for i, v := range values {
 			stringValues[i] = fmt.Sprintf("%s", v)
 		}
 		return &pgsearch.QueryEntry{
 			Where: pgsearch.WhereClause{
-				Query:  fmt.Sprintf("%s = ANY($$::text[])", where),
+				Query:  fmt.Sprintf("%s = ANY($$%s)", where, cast),
 				Values: []interface{}{stringValues},
 			},
 			SelectedFields: entries[0].SelectedFields,

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/stringutils"
 	pkgUtils "github.com/stackrox/rox/pkg/utils"
-	pkgUUID "github.com/stackrox/rox/pkg/uuid"
 )
 
 var (
@@ -596,24 +595,20 @@ func combineDisjunction(entries []*pgsearch.QueryEntry) *pgsearch.QueryEntry {
 	where := seenQueries.GetArbitraryElem()
 	where = strings.TrimSuffix(where, exactQuerySuffix)
 
-	// For large value sets, use = ANY($1::type[]) with a single array parameter
+	// For large value sets, use = ANY($$) with a single array parameter
 	// to avoid the 65535 parameter limit. For small sets, use IN ($1, $2, ...)
 	// for better plan quality since the planner can inspect individual values.
+	// pgx infers the array type from the element type ([]uuid.UUID → uuid[],
+	// []string → text[], etc.) so no explicit cast is needed.
 	if len(values) >= env.PostgresParameterThreshold.IntegerSetting() {
-		// Detect column type from the original entry value (before string conversion)
-		// to pick the right array cast.
-		cast := "::text[]"
-		if _, isUUID := entries[0].Where.Values[0].(pkgUUID.UUID); isUUID {
-			cast = "::uuid[]"
-		}
-		stringValues := make([]string, len(values))
-		for i, v := range values {
-			stringValues[i] = fmt.Sprintf("%s", v)
+		originalValues := make([]interface{}, len(entries))
+		for i, entry := range entries {
+			originalValues[i] = entry.Where.Values[0]
 		}
 		return &pgsearch.QueryEntry{
 			Where: pgsearch.WhereClause{
-				Query:  fmt.Sprintf("%s = ANY($$%s)", where, cast),
-				Values: []interface{}{stringValues},
+				Query:  fmt.Sprintf("%s = ANY($$)", where),
+				Values: []interface{}{originalValues},
 			},
 			SelectedFields: entries[0].SelectedFields,
 			GroupBy:        nil,

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -595,6 +595,24 @@ func combineDisjunction(entries []*pgsearch.QueryEntry) *pgsearch.QueryEntry {
 	where := seenQueries.GetArbitraryElem()
 	where = strings.TrimSuffix(where, exactQuerySuffix)
 
+	// For large value sets, use = ANY($1::text[]) with a single array parameter
+	// to avoid the 65535 parameter limit. For small sets, use IN ($1, $2, ...)
+	// for better plan quality since the planner can inspect individual values.
+	if len(values) >= env.PostgresParameterThreshold.IntegerSetting() {
+		stringValues := make([]string, len(values))
+		for i, v := range values {
+			stringValues[i] = fmt.Sprintf("%s", v)
+		}
+		return &pgsearch.QueryEntry{
+			Where: pgsearch.WhereClause{
+				Query:  fmt.Sprintf("%s = ANY($$::text[])", where),
+				Values: []interface{}{stringValues},
+			},
+			SelectedFields: entries[0].SelectedFields,
+			GroupBy:        nil,
+		}
+	}
+
 	return &pgsearch.QueryEntry{
 		Where: pgsearch.WhereClause{
 			Query:  fmt.Sprintf("%s IN (%s$$)", where, strings.Join(make([]string, len(entries)), "$$, ")),

--- a/pkg/search/postgres/common_pg_test.go
+++ b/pkg/search/postgres/common_pg_test.go
@@ -5,6 +5,7 @@ package postgres_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
 	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
+	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stackrox/rox/tools/generate-helpers/pg-table-bindings/multitest/postgres"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -184,4 +186,38 @@ func TestRunDistinctCountForSchema(t *testing.T) {
 	count, err = pgSearch.RunDistinctCountForSchema(ctx, testDB.DB, schema.TestStructsSchema, q, search.TestKey)
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
+}
+
+func TestLargeParameterSetUsesANY(t *testing.T) {
+	ctx := sac.WithAllAccess(context.Background())
+	testDB := pgtest.ForT(t)
+
+	store := postgres.New(testDB.DB)
+
+	// Insert 10 test structs with known keys.
+	knownKeys := make([]string, 10)
+	for i := range knownKeys {
+		key := uuid.NewV4().String()
+		knownKeys[i] = key
+		require.NoError(t, store.Upsert(ctx, &storage.TestStruct{
+			Key1:    key,
+			Key2:    fmt.Sprintf("key2-%d", i),
+			String_: fmt.Sprintf("value-%d", i),
+		}))
+	}
+
+	// Build a query with 70K+ values for the same field.
+	// The first 10 are the known keys, the rest are random UUIDs that won't match.
+	values := make([]string, 70_001)
+	copy(values, knownKeys)
+	for i := 10; i < len(values); i++ {
+		values[i] = uuid.NewV4().String()
+	}
+
+	// This would fail with "too many parameters" if IN were used (65535 limit).
+	// With ANY it uses a single array parameter.
+	q := search.NewQueryBuilder().AddExactMatches(search.TestKey, values...).ProtoQuery()
+	results, err := store.Search(ctx, q)
+	require.NoError(t, err)
+	assert.Len(t, results, 10, "should find all 10 inserted structs")
 }

--- a/pkg/search/postgres/common_test.go
+++ b/pkg/search/postgres/common_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stackrox/rox/pkg/search/scoped"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -1440,6 +1441,67 @@ func TestCombineQueryEntries_PostTransformComposition(t *testing.T) {
 				got := result.SelectedFields[0].PostTransform(nil).([]string)
 				assert.ElementsMatch(t, tc.expectedTransform, got)
 			}
+		})
+	}
+}
+
+func TestCombineDisjunctionANYThreshold(t *testing.T) {
+	t.Setenv("ROX_POSTGRES_PARAMETER_THRESHOLD", "3")
+
+	for _, c := range []struct {
+		desc          string
+		q             *v1.Query
+		schema        *walker.Schema
+		queryType     QueryType
+		expectedWhere string
+		expectedData  []interface{}
+		expectedSQL   string
+	}{
+		{
+			desc:          "below threshold uses IN",
+			q:             search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "A", "B").ProtoQuery(),
+			schema:        deploymentBaseSchema,
+			queryType:     SEARCH,
+			expectedWhere: "deployments.Name IN ($$, $$)",
+			expectedData:  []interface{}{"A", "B"},
+		},
+		{
+			desc:          "at threshold uses ANY",
+			q:             search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "A", "B", "C").ProtoQuery(),
+			schema:        deploymentBaseSchema,
+			queryType:     SEARCH,
+			expectedWhere: "deployments.Name = ANY($$)",
+			expectedData:  []interface{}{[]interface{}{"A", "B", "C"}},
+		},
+		{
+			desc:          "above threshold uses ANY",
+			q:             search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "A", "B", "C", "D").ProtoQuery(),
+			schema:        deploymentBaseSchema,
+			queryType:     SEARCH,
+			expectedWhere: "deployments.Name = ANY($$)",
+			expectedData:  []interface{}{[]interface{}{"A", "B", "C", "D"}},
+		},
+		{
+			desc:         "ANY full SQL in count query",
+			q:            search.NewQueryBuilder().AddExactMatches(search.DeploymentName, "X", "Y", "Z").ProtoQuery(),
+			schema:       deploymentBaseSchema,
+			queryType:    COUNT,
+			expectedSQL:  "select count(*) from deployments where deployments.Name = ANY($1)",
+			expectedData: []interface{}{[]interface{}{"X", "Y", "Z"}},
+		},
+	} {
+		t.Run(c.desc, func(t *testing.T) {
+			ctx := sac.WithAllAccess(context.Background())
+			actual, err := standardizeQueryAndPopulatePath(ctx, c.q, c.schema, c.queryType)
+			require.NoError(t, err)
+
+			if c.expectedWhere != "" {
+				assert.Equal(t, c.expectedWhere, actual.Where)
+			}
+			if c.expectedSQL != "" {
+				assert.Equal(t, c.expectedSQL, actual.AsSQL())
+			}
+			assert.Equal(t, c.expectedData, actual.Data)
 		})
 	}
 }

--- a/pkg/search/postgres/query/test/uuid_query_test.go
+++ b/pkg/search/postgres/query/test/uuid_query_test.go
@@ -34,6 +34,59 @@ func (s *UUIDTestSuite) SetupTest() {
 	s.ctx = sac.WithAllAccess(context.Background())
 }
 
+// TestLargeUUIDParameterSetUsesANY verifies that queries with more values than
+// PostgresParameterThreshold work correctly on UUID-typed columns. The ANY($$)
+// path relies on pgx inferring uuid[] from the element types; this test catches
+// regressions where the wrong type is inferred and PostgreSQL rejects the query.
+func (s *UUIDTestSuite) TestLargeUUIDParameterSetUsesANY() {
+	const matchCount = 10
+	const totalValues = 101 // > default threshold of 100, triggers ANY path
+
+	// Insert structs with known UUID keys and known optional_uuid values.
+	objs := make([]*storage.TestSingleUUIDKeyStruct, matchCount)
+	knownKeys := make([]string, matchCount)
+	knownOptionalUUIDs := make([]string, matchCount)
+	for i := range objs {
+		key := uuid.NewV4().String()
+		optUUID := uuid.NewV4().String()
+		knownKeys[i] = key
+		knownOptionalUUIDs[i] = optUUID
+		objs[i] = &storage.TestSingleUUIDKeyStruct{
+			Key:          key,
+			Name:         uuid.NewV4().String(),
+			OptionalUuid: optUUID,
+		}
+	}
+	s.Require().NoError(s.store.UpsertMany(s.ctx, objs))
+
+	// Build value lists: known values first, padded with non-matching UUIDs.
+	keyValues := make([]string, totalValues)
+	copy(keyValues, knownKeys)
+	for i := matchCount; i < totalValues; i++ {
+		keyValues[i] = uuid.NewV4().String()
+	}
+
+	optUUIDValues := make([]string, totalValues)
+	copy(optUUIDValues, knownOptionalUUIDs)
+	for i := matchCount; i < totalValues; i++ {
+		optUUIDValues[i] = uuid.NewV4().String()
+	}
+
+	s.Run("uuid primary key column", func() {
+		q := search.NewQueryBuilder().AddExactMatches(search.TestKey, keyValues...).ProtoQuery()
+		results, err := s.store.Search(s.ctx, q)
+		s.Require().NoError(err)
+		s.Len(results, matchCount)
+	})
+
+	s.Run("uuid non-pk column", func() {
+		q := search.NewQueryBuilder().AddExactMatches(search.TestUUID, optUUIDValues...).ProtoQuery()
+		results, err := s.store.Search(s.ctx, q)
+		s.Require().NoError(err)
+		s.Len(results, matchCount)
+	})
+}
+
 func (s *UUIDTestSuite) TestNullableUUIDQueries() {
 	// 3 objects without OptionalUuid, 3 with it set
 	objs := []*storage.TestSingleUUIDKeyStruct{


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

When a disjunction has more values than ROX_POSTGRES_PARAMETER_THRESHOLD
(default 100), combineDisjunction now generates = ANY($1::text[]) with
a single array parameter instead of IN ($1, $2, ...) with N parameters.
This avoids the 65535 parameter limit that caused panics with large
process indicator and image component queries.

Small value sets continue to use IN for better plan quality.

Partially generated by AI

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Long running cluster.  Looking particularly at `select listening_endpoints.serialized from listening_endpoints where listening_endpoints.ProcessIndicatorId`.  

  ```
┌──────────────────────┬───────────────────────────┬───────────────────────────┬────────────┐
  │       Segment        │         Baseline          │        PR cluster         │   Change   │
  ├──────────────────────┼───────────────────────────┼───────────────────────────┼────────────┤
  │ < 100 params (IN)    │       1,094 calls @ 181ms │       1,221 calls @ 115ms │          — │
  ├──────────────────────┼───────────────────────────┼───────────────────────────┼────────────┤
  │ >= 100 params        │ 10,642 calls @ 164ms (IN) │ 10,570 calls @ 95ms (ANY) │ 42% faster │
  ├──────────────────────┼───────────────────────────┼───────────────────────────┼────────────┤
  │ Overall weighted avg │                     165ms │                      97ms │ 41% faster │
  └──────────────────────┴───────────────────────────┴───────────────────────────┴────────────┘
```