### PR TITLE
ROX-32708: Cherry-pick TestName fix to release-4.10

### DIFF
--- a/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
+++ b/qa-tests-backend/src/test/groovy/BaseSpecification.groovy
@@ -209,7 +209,7 @@ class BaseSpecification extends Specification {
             TimeUnit.SECONDS
     )
     @Rule
-    TestName name = new TestName()
+    protected final TestName currentTestName = new TestName()
 
     @Shared
     Logger log = LoggerFactory.getLogger("test." + this.getClass().getSimpleName())
@@ -290,7 +290,7 @@ class BaseSpecification extends Specification {
         // These .puts() have to be repeated here or else the key is cleared.
         MDC.put("logFileName", this.class.getSimpleName())
         MDC.put("specification", this.class.getSimpleName())
-        log.info("Starting testcase: ${name.getMethodName()}")
+        log.info("Starting testcase: ${currentTestName.getMethodName()}")
 
         // Make sure to use or revert back to the desired central gRPC auth
         // before each test.


### PR DESCRIPTION
## Summary

Cherry-pick of 96b274f84f from master/release-4.11 to release-4.10.

Renames the `@Rule TestName` field from `name` to `currentTestName` in `BaseSpecification.groovy` to prevent naming conflicts with Spock's `#testName` placeholder used in parameterized test names.

**Root cause:** Groovy 5.0 changed closure property resolution to prefer owner fields over delegate properties. When Spock expands `#testName` in `@Unroll` annotations, a field named `name` conflicts, causing `initializationError` before tests execute. This was causing OCP 4.22 e2e test failures on release-4.10 (`PolicyConfigurationTest`, `Enforcement`).

**Context:** Found while adding OCP 4.22 testing in openshift/release PR [#79847](https://github.com/openshift/release/pull/79847). The same tests pass on release-4.11 and master (which already have this fix).

## Test plan

- [ ] `/test ocp-next-candidate-qa-e2e-tests` — verify fix resolves the initializationError

🤖 Generated with [Claude Code](https://claude.com/claude-code)