### PR TITLE
ROX-34880: Refactor resolver to use PubSub

### DIFF
--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -16,6 +16,7 @@ const (
 	DetectorDeploymentConsumer
 	DetectorScanResultConsumer
 	DetectorDeployAlertOutputConsumer
+	OutputQueueConsumer
 )
 
 var (
@@ -33,6 +34,7 @@ var (
 		DetectorDeploymentConsumer:          "DetectorDeployment",
 		DetectorScanResultConsumer:          "DetectorScanResult",
 		DetectorDeployAlertOutputConsumer:   "DetectorDeployAlertOutput",
+		OutputQueueConsumer:                 "OutputQueue",
 	}
 )
 

--- a/sensor/common/pubsub/lane/blocking.go
+++ b/sensor/common/pubsub/lane/blocking.go
@@ -69,11 +69,14 @@ type blockingLane struct {
 }
 
 func (l *blockingLane) Publish(event pubsub.Event) error {
+	// Capture topic before writing to the channel: once the event is on
+	// the channel a consumer goroutine may mutate it via SetTopicAndLane.
+	topic := event.Topic()
 	if err := l.ch.Write(event); err != nil {
-		metrics.RecordPublishOperation(l.id, event.Topic(), metrics.PublishError)
+		metrics.RecordPublishOperation(l.id, topic, metrics.PublishError)
 		return errors.Wrap(pubsubErrors.NewPublishOnStoppedLaneErr(l.id), "unable to publish event")
 	}
-	metrics.RecordPublishOperation(l.id, event.Topic(), metrics.Published)
+	metrics.RecordPublishOperation(l.id, topic, metrics.Published)
 	metrics.SetQueueSize(l.id, l.ch.Len())
 	return nil
 }

--- a/sensor/common/pubsub/lane/concurrent.go
+++ b/sensor/common/pubsub/lane/concurrent.go
@@ -67,11 +67,14 @@ type concurrentLane struct {
 }
 
 func (l *concurrentLane) Publish(event pubsub.Event) error {
+	// Capture topic before writing to the channel: once the event is on
+	// the channel a consumer goroutine may mutate it via SetTopicAndLane.
+	topic := event.Topic()
 	if err := l.ch.Write(event); err != nil {
-		metrics.RecordPublishOperation(l.id, event.Topic(), metrics.PublishError)
+		metrics.RecordPublishOperation(l.id, topic, metrics.PublishError)
 		return errors.Wrap(pubsubErrors.NewPublishOnStoppedLaneErr(l.id), "unable to publish event")
 	}
-	metrics.RecordPublishOperation(l.id, event.Topic(), metrics.Published)
+	metrics.RecordPublishOperation(l.id, topic, metrics.Published)
 	metrics.SetQueueSize(l.id, l.ch.Len())
 	return nil
 }

--- a/sensor/common/pubsub/laneid.go
+++ b/sensor/common/pubsub/laneid.go
@@ -15,6 +15,7 @@ const (
 	DetectorDeploymentLane
 	DetectorScanResultLane
 	DetectorDeployAlertOutputLane
+	ResolvedResourceEventLane
 )
 
 var (
@@ -31,6 +32,7 @@ var (
 		DetectorDeploymentLane:         "DetectorDeployment",
 		DetectorScanResultLane:         "DetectorScanResult",
 		DetectorDeployAlertOutputLane:  "DetectorDeployAlertOutput",
+		ResolvedResourceEventLane:      "ResolvedResourceEvent",
 	}
 )
 

--- a/sensor/common/pubsub/topic.go
+++ b/sensor/common/pubsub/topic.go
@@ -15,6 +15,7 @@ const (
 	DetectorDeploymentTopic
 	DetectorScanResultTopic
 	DetectorDeployAlertOutputTopic
+	ResolvedResourceEventTopic
 )
 
 var (
@@ -31,6 +32,7 @@ var (
 		DetectorDeploymentTopic:         "DetectorDeployment",
 		DetectorScanResultTopic:         "DetectorScanResult",
 		DetectorDeployAlertOutputTopic:  "DetectorDeployAlertOutput",
+		ResolvedResourceEventTopic:      "ResolvedResourceEvent",
 	}
 )
 

--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -99,13 +99,6 @@ func (e *ResourceEvent) Lane() pubsub.LaneID {
 	return *e.lane
 }
 
-// SetTopicAndLane overwrites the topic and lane on the event, used by the resolver
-// before re-publishing a resolved event to the output queue via PubSub.
-func (e *ResourceEvent) SetTopicAndLane(topic pubsub.Topic, lane pubsub.LaneID) {
-	e.topic = &topic
-	e.lane = &lane
-}
-
 // AddSensorEvent appends central sensor events to be bundled with this resource event.
 func (e *ResourceEvent) AddSensorEvent(event ...*central.SensorEvent) *ResourceEvent {
 	e.ForwardMessages = append(e.ForwardMessages, event...)

--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -65,8 +65,9 @@ type ResourceEvent struct {
 	// Context contains a context that determines if the message is still valid.
 	Context context.Context
 
-	topic *pubsub.Topic
-	lane  *pubsub.LaneID
+	topic           pubsub.Topic
+	lane            pubsub.LaneID
+	topicAndLaneSet bool
 }
 
 // NewEvent creates a resource event with preset sensor event messages.
@@ -80,29 +81,31 @@ func NewEventWithTopicAndLane(topic pubsub.Topic, lane pubsub.LaneID, msg ...*ce
 	return &ResourceEvent{
 		ForwardMessages: msg,
 		Context:         context.Background(),
-		topic:           &topic,
-		lane:            &lane,
+		topic:           topic,
+		lane:            lane,
+		topicAndLaneSet: true,
 	}
 }
 
 // SetTopicAndLane sets the topic and lane on an existing event, avoiding a new allocation.
 func (e *ResourceEvent) SetTopicAndLane(topic pubsub.Topic, lane pubsub.LaneID) {
-	e.topic = &topic
-	e.lane = &lane
+	e.topic = topic
+	e.lane = lane
+	e.topicAndLaneSet = true
 }
 
 func (e *ResourceEvent) Topic() pubsub.Topic {
-	if e.topic == nil {
+	if !e.topicAndLaneSet {
 		return pubsub.KubernetesDispatcherEventTopic
 	}
-	return *e.topic
+	return e.topic
 }
 
 func (e *ResourceEvent) Lane() pubsub.LaneID {
-	if e.lane == nil {
+	if !e.topicAndLaneSet {
 		return pubsub.KubernetesDispatcherEventLane
 	}
-	return *e.lane
+	return e.lane
 }
 
 // AddSensorEvent appends central sensor events to be bundled with this resource event.

--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -99,6 +99,13 @@ func (e *ResourceEvent) Lane() pubsub.LaneID {
 	return *e.lane
 }
 
+// SetTopicAndLane overwrites the topic and lane on the event, used by the resolver
+// before re-publishing a resolved event to the output queue via PubSub.
+func (e *ResourceEvent) SetTopicAndLane(topic pubsub.Topic, lane pubsub.LaneID) {
+	e.topic = &topic
+	e.lane = &lane
+}
+
 // AddSensorEvent appends central sensor events to be bundled with this resource event.
 func (e *ResourceEvent) AddSensorEvent(event ...*central.SensorEvent) *ResourceEvent {
 	e.ForwardMessages = append(e.ForwardMessages, event...)

--- a/sensor/kubernetes/eventpipeline/component/message.go
+++ b/sensor/kubernetes/eventpipeline/component/message.go
@@ -85,6 +85,12 @@ func NewEventWithTopicAndLane(topic pubsub.Topic, lane pubsub.LaneID, msg ...*ce
 	}
 }
 
+// SetTopicAndLane sets the topic and lane on an existing event, avoiding a new allocation.
+func (e *ResourceEvent) SetTopicAndLane(topic pubsub.Topic, lane pubsub.LaneID) {
+	e.topic = &topic
+	e.lane = &lane
+}
+
 func (e *ResourceEvent) Topic() pubsub.Topic {
 	if e.topic == nil {
 		return pubsub.KubernetesDispatcherEventTopic

--- a/sensor/kubernetes/eventpipeline/output/output.go
+++ b/sensor/kubernetes/eventpipeline/output/output.go
@@ -1,14 +1,21 @@
 package output
 
 import (
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
 
+type pubSubRegister interface {
+	RegisterConsumerToLane(pubsub.ConsumerID, pubsub.Topic, pubsub.LaneID, pubsub.EventCallback) error
+}
+
 // New instantiates an output Queue component.
-func New(detector detector.Detector, queueSize int) component.OutputQueue {
+func New(detector detector.Detector, queueSize int, dispatcher pubSubRegister) (component.OutputQueue, error) {
 	ch := make(chan *component.ResourceEvent, queueSize)
 	forwardQueue := make(chan *message.ExpiringMessage, queueSize)
 	outputQueue := &outputQueueImpl{
@@ -17,5 +24,13 @@ func New(detector detector.Detector, queueSize int) component.OutputQueue {
 		forwardQueue: forwardQueue,
 		stopper:      concurrency.NewStopper(),
 	}
-	return outputQueue
+	if features.SensorInternalPubSub.Enabled() {
+		if dispatcher == nil {
+			return nil, errors.Errorf("pubsub dispatcher is nil and the feature flag %q is enabled", features.SensorInternalPubSub.EnvVar())
+		}
+		if err := dispatcher.RegisterConsumerToLane(pubsub.OutputQueueConsumer, pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane, outputQueue.ProcessResourceEvent); err != nil {
+			return nil, errors.Wrapf(err, "unable to register output queue as consumer of topic %q in lane %q", pubsub.ResolvedResourceEventTopic.String(), pubsub.ResolvedResourceEventLane.String())
+		}
+	}
+	return outputQueue, nil
 }

--- a/sensor/kubernetes/eventpipeline/output/output_bench_test.go
+++ b/sensor/kubernetes/eventpipeline/output/output_bench_test.go
@@ -1,0 +1,122 @@
+package output
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common/detector/mocks"
+	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
+	"go.uber.org/mock/gomock"
+)
+
+func benchOutputQueue(b *testing.B, pubsubEnabled bool, makeEvent func() *component.ResourceEvent) {
+	b.Helper()
+	b.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubsubEnabled))
+
+	ctrl := gomock.NewController(b)
+	det := mocks.NewMockDetector(ctrl)
+	det.EXPECT().ReprocessDeployments(gomock.Any()).AnyTimes()
+	det.EXPECT().ProcessDeployment(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	var disp *fakeDispatcher
+	var reg pubSubRegister
+	if pubsubEnabled {
+		disp = &fakeDispatcher{}
+		reg = disp
+	}
+	q, err := New(det, 1024, reg)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := q.Start(); err != nil {
+		b.Fatal(err)
+	}
+
+	stopDrain := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ch := q.ResponsesC()
+		for {
+			select {
+			case <-ch:
+			case <-stopDrain:
+				return
+			}
+		}
+	}()
+	b.Cleanup(func() {
+		q.Stop()
+		close(stopDrain)
+		<-done
+	})
+
+	b.ResetTimer()
+	for b.Loop() {
+		event := makeEvent()
+		if pubsubEnabled {
+			if err := disp.callback(event); err != nil {
+				b.Fatal(err)
+			}
+		} else {
+			q.Send(event)
+		}
+	}
+}
+
+func BenchmarkOutputQueue_SingleForward(b *testing.B) {
+	makeEvent := func() *component.ResourceEvent {
+		return &component.ResourceEvent{
+			Context:         context.Background(),
+			ForwardMessages: []*central.SensorEvent{{Id: "a"}},
+		}
+	}
+	for _, pubsubEnabled := range []bool{false, true} {
+		b.Run(fmt.Sprintf("pubsub=%t", pubsubEnabled), func(b *testing.B) {
+			benchOutputQueue(b, pubsubEnabled, makeEvent)
+		})
+	}
+}
+
+func BenchmarkOutputQueue_MultipleForward(b *testing.B) {
+	makeEvent := func() *component.ResourceEvent {
+		return &component.ResourceEvent{
+			Context: context.Background(),
+			ForwardMessages: []*central.SensorEvent{
+				{Id: "a"},
+				{Id: "b"},
+				{Id: "c"},
+			},
+		}
+	}
+	for _, pubsubEnabled := range []bool{false, true} {
+		b.Run(fmt.Sprintf("pubsub=%t", pubsubEnabled), func(b *testing.B) {
+			benchOutputQueue(b, pubsubEnabled, makeEvent)
+		})
+	}
+}
+
+func BenchmarkOutputQueue_WithDetector(b *testing.B) {
+	makeEvent := func() *component.ResourceEvent {
+		return &component.ResourceEvent{
+			Context:              context.Background(),
+			ForwardMessages:      []*central.SensorEvent{{Id: "a"}},
+			ReprocessDeployments: []string{"dep-a", "dep-b"},
+			DetectorMessages: []component.DeploytimeDetectionRequest{
+				{
+					Object: &storage.Deployment{Id: "dep-c"},
+					Action: central.ResourceAction_CREATE_RESOURCE,
+				},
+			},
+		}
+	}
+	for _, pubsubEnabled := range []bool{false, true} {
+		b.Run(fmt.Sprintf("pubsub=%t", pubsubEnabled), func(b *testing.B) {
+			benchOutputQueue(b, pubsubEnabled, makeEvent)
+		})
+	}
+}

--- a/sensor/kubernetes/eventpipeline/output/output_bench_test.go
+++ b/sensor/kubernetes/eventpipeline/output/output_bench_test.go
@@ -9,11 +9,14 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/sensor/common/detector/mocks"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"go.uber.org/mock/gomock"
 )
 
-func benchOutputQueue(b *testing.B, pubsubEnabled bool, makeEvent func() *component.ResourceEvent) {
+func benchOutputQueue(b *testing.B, pubsubEnabled bool, forwardCount int, makeEvent func() *component.ResourceEvent) {
 	b.Helper()
 	b.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubsubEnabled))
 
@@ -22,12 +25,20 @@ func benchOutputQueue(b *testing.B, pubsubEnabled bool, makeEvent func() *compon
 	det.EXPECT().ReprocessDeployments(gomock.Any()).AnyTimes()
 	det.EXPECT().ProcessDeployment(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	var disp *fakeDispatcher
+	var disp testDispatcher
 	var reg pubSubRegister
 	if pubsubEnabled {
-		disp = &fakeDispatcher{}
-		reg = disp
+		d, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.ResolvedResourceEventLane),
+		}))
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Cleanup(d.Stop)
+		disp = d
+		reg = d
 	}
+
 	q, err := New(det, 1024, reg)
 	if err != nil {
 		b.Fatal(err)
@@ -35,35 +46,21 @@ func benchOutputQueue(b *testing.B, pubsubEnabled bool, makeEvent func() *compon
 	if err := q.Start(); err != nil {
 		b.Fatal(err)
 	}
-
-	stopDrain := make(chan struct{})
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		ch := q.ResponsesC()
-		for {
-			select {
-			case <-ch:
-			case <-stopDrain:
-				return
-			}
-		}
-	}()
-	b.Cleanup(func() {
-		q.Stop()
-		close(stopDrain)
-		<-done
-	})
+	b.Cleanup(q.Stop)
 
 	b.ResetTimer()
 	for b.Loop() {
 		event := makeEvent()
 		if pubsubEnabled {
-			if err := disp.callback(event); err != nil {
+			event.SetTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
+			if err := disp.Publish(event); err != nil {
 				b.Fatal(err)
 			}
 		} else {
 			q.Send(event)
+		}
+		for range forwardCount {
+			<-q.ResponsesC()
 		}
 	}
 }
@@ -77,7 +74,7 @@ func BenchmarkOutputQueue_SingleForward(b *testing.B) {
 	}
 	for _, pubsubEnabled := range []bool{false, true} {
 		b.Run(fmt.Sprintf("pubsub=%t", pubsubEnabled), func(b *testing.B) {
-			benchOutputQueue(b, pubsubEnabled, makeEvent)
+			benchOutputQueue(b, pubsubEnabled, 1, makeEvent)
 		})
 	}
 }
@@ -95,7 +92,7 @@ func BenchmarkOutputQueue_MultipleForward(b *testing.B) {
 	}
 	for _, pubsubEnabled := range []bool{false, true} {
 		b.Run(fmt.Sprintf("pubsub=%t", pubsubEnabled), func(b *testing.B) {
-			benchOutputQueue(b, pubsubEnabled, makeEvent)
+			benchOutputQueue(b, pubsubEnabled, 3, makeEvent)
 		})
 	}
 }
@@ -116,7 +113,7 @@ func BenchmarkOutputQueue_WithDetector(b *testing.B) {
 	}
 	for _, pubsubEnabled := range []bool{false, true} {
 		b.Run(fmt.Sprintf("pubsub=%t", pubsubEnabled), func(b *testing.B) {
-			benchOutputQueue(b, pubsubEnabled, makeEvent)
+			benchOutputQueue(b, pubsubEnabled, 1, makeEvent)
 		})
 	}
 }

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -72,7 +72,7 @@ func (q *outputQueueImpl) ProcessResourceEvent(event pubsub.Event) error {
 	return nil
 }
 
-func (q *outputQueueImpl) processMsg(msg *component.ResourceEvent) (stopped bool) {
+func (q *outputQueueImpl) processMsg(msg *component.ResourceEvent) bool {
 	if msg.Context == nil {
 		msg.Context = context.Background()
 	}
@@ -82,7 +82,7 @@ func (q *outputQueueImpl) processMsg(msg *component.ResourceEvent) (stopped bool
 			select {
 			case q.forwardQueue <- expiringMessage:
 			case <-q.stopper.Flow().StopRequested():
-				return true
+				return false
 			}
 		}
 	}
@@ -92,7 +92,7 @@ func (q *outputQueueImpl) processMsg(msg *component.ResourceEvent) (stopped bool
 	for _, detectorRequest := range msg.DetectorMessages {
 		q.detector.ProcessDeployment(msg.Context, detectorRequest.Object, detectorRequest.Action)
 	}
-	return false
+	return true
 }
 
 func wrapSensorEvent(update *central.SensorEvent) *central.MsgFromSensor {
@@ -115,7 +115,7 @@ func (q *outputQueueImpl) runOutputQueue() {
 			if !more {
 				return
 			}
-			if q.processMsg(msg) {
+			if !q.processMsg(msg) {
 				return
 			}
 			metrics.DecOutputChannelSize()

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -3,11 +3,14 @@ package output
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/sensor/common/detector"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/metrics"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
 
@@ -32,18 +35,56 @@ func (q *outputQueueImpl) ResponsesC() <-chan *message.ExpiringMessage {
 
 // Start the outputQueueImpl component
 func (q *outputQueueImpl) Start() error {
-	go q.runOutputQueue()
+	if !features.SensorInternalPubSub.Enabled() {
+		go q.runOutputQueue()
+	}
 	return nil
 }
 
 // Stop the outputQueueImpl component
 func (q *outputQueueImpl) Stop() {
+	if features.SensorInternalPubSub.Enabled() {
+		// No goroutine was started; signal stopped so the Wait below returns immediately.
+		q.stopper.Flow().ReportStopped()
+	}
 	if !q.stopper.Client().Stopped().IsDone() {
 		defer func() {
 			_ = q.stopper.Client().Stopped().Wait()
 		}()
 	}
 	q.stopper.Client().Stop()
+}
+
+// ProcessResourceEvent is the PubSub callback invoked by the dispatcher when a resolved
+// resource event is published by the resolver (ResolvedResourceEventTopic).
+func (q *outputQueueImpl) ProcessResourceEvent(event pubsub.Event) error {
+	select {
+	case <-q.stopper.Flow().StopRequested():
+		return nil
+	default:
+	}
+	msg, ok := event.(*component.ResourceEvent)
+	if !ok {
+		return errors.New("unable to convert event to *component.ResourceEvent")
+	}
+	if msg.Context == nil {
+		msg.Context = context.Background()
+	}
+	for _, resourceUpdates := range msg.ForwardMessages {
+		expiringMessage := message.NewExpiring(msg.Context, wrapSensorEvent(resourceUpdates))
+		if !expiringMessage.IsExpired() {
+			select {
+			case q.forwardQueue <- expiringMessage:
+			case <-q.stopper.Flow().StopRequested():
+				return nil
+			}
+		}
+	}
+	q.detector.ReprocessDeployments(msg.ReprocessDeployments...)
+	for _, detectorRequest := range msg.DetectorMessages {
+		q.detector.ProcessDeployment(msg.Context, detectorRequest.Object, detectorRequest.Action)
+	}
+	return nil
 }
 
 func wrapSensorEvent(update *central.SensorEvent) *central.MsgFromSensor {

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -45,7 +45,7 @@ func (q *outputQueueImpl) Start() error {
 func (q *outputQueueImpl) Stop() {
 	if features.SensorInternalPubSub.Enabled() {
 		// No goroutine was started; signal stopped so the Wait below returns immediately.
-		// TODO(ROX-34880): Remove stopper usage once ResponsesC is migrated to PubSub.
+		// TODO(ROX-35054): Remove stopper usage once ResponsesC is migrated to PubSub.
 		q.stopper.Flow().ReportStopped()
 	}
 	if !q.stopper.Client().Stopped().IsDone() {

--- a/sensor/kubernetes/eventpipeline/output/output_impl.go
+++ b/sensor/kubernetes/eventpipeline/output/output_impl.go
@@ -45,6 +45,7 @@ func (q *outputQueueImpl) Start() error {
 func (q *outputQueueImpl) Stop() {
 	if features.SensorInternalPubSub.Enabled() {
 		// No goroutine was started; signal stopped so the Wait below returns immediately.
+		// TODO(ROX-34880): Remove stopper usage once ResponsesC is migrated to PubSub.
 		q.stopper.Flow().ReportStopped()
 	}
 	if !q.stopper.Client().Stopped().IsDone() {
@@ -67,6 +68,11 @@ func (q *outputQueueImpl) ProcessResourceEvent(event pubsub.Event) error {
 	if !ok {
 		return errors.New("unable to convert event to *component.ResourceEvent")
 	}
+	q.processMsg(msg)
+	return nil
+}
+
+func (q *outputQueueImpl) processMsg(msg *component.ResourceEvent) (stopped bool) {
 	if msg.Context == nil {
 		msg.Context = context.Background()
 	}
@@ -76,15 +82,17 @@ func (q *outputQueueImpl) ProcessResourceEvent(event pubsub.Event) error {
 			select {
 			case q.forwardQueue <- expiringMessage:
 			case <-q.stopper.Flow().StopRequested():
-				return nil
+				return true
 			}
 		}
 	}
+	// The order here is important. We rely on ReprocessDeployments being called
+	// before ProcessDeployment to remove the deployments from the deduper.
 	q.detector.ReprocessDeployments(msg.ReprocessDeployments...)
 	for _, detectorRequest := range msg.DetectorMessages {
 		q.detector.ProcessDeployment(msg.Context, detectorRequest.Object, detectorRequest.Action)
 	}
-	return nil
+	return false
 }
 
 func wrapSensorEvent(update *central.SensorEvent) *central.MsgFromSensor {
@@ -107,26 +115,8 @@ func (q *outputQueueImpl) runOutputQueue() {
 			if !more {
 				return
 			}
-
-			if msg.Context == nil {
-				msg.Context = context.Background()
-			}
-
-			for _, resourceUpdates := range msg.ForwardMessages {
-				expiringMessage := message.NewExpiring(msg.Context, wrapSensorEvent(resourceUpdates))
-				if !expiringMessage.IsExpired() {
-					select {
-					case q.forwardQueue <- expiringMessage:
-					case <-q.stopper.Flow().StopRequested():
-						return
-					}
-				}
-			}
-
-			// The order here is important. We rely on the ReprocessDeployment being called before ProcessDeployment to remove the deployments from the deduper.
-			q.detector.ReprocessDeployments(msg.ReprocessDeployments...)
-			for _, detectorRequest := range msg.DetectorMessages {
-				q.detector.ProcessDeployment(msg.Context, detectorRequest.Object, detectorRequest.Action)
+			if q.processMsg(msg) {
+				return
 			}
 			metrics.DecOutputChannelSize()
 		}

--- a/sensor/kubernetes/eventpipeline/output/output_test.go
+++ b/sensor/kubernetes/eventpipeline/output/output_test.go
@@ -12,8 +12,11 @@ import (
 	"github.com/stackrox/rox/sensor/common/detector/mocks"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/pubsub"
+	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
+	"github.com/stackrox/rox/sensor/common/pubsub/lane"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -21,23 +24,20 @@ const (
 	waitTimeout = 100 * time.Millisecond
 )
 
-// fakeDispatcher captures the EventCallback registered by New() so tests can
-// invoke it directly, simulating what the real PubSub dispatcher would do.
-type fakeDispatcher struct {
-	callback pubsub.EventCallback
-}
-
-func (f *fakeDispatcher) RegisterConsumerToLane(_ pubsub.ConsumerID, _ pubsub.Topic, _ pubsub.LaneID, cb pubsub.EventCallback) error {
-	f.callback = cb
-	return nil
+// testDispatcher extends pubSubRegister with Publish and Stop so tests can
+// send events through the real dispatcher machinery.
+type testDispatcher interface {
+	pubSubRegister
+	Publish(pubsub.Event) error
+	Stop()
 }
 
 // outputTestEnv bundles the output queue, its dispatcher (if pubsub), and a
 // helper to send events through the correct path.
 type outputTestEnv struct {
-	queue      component.OutputQueue
-	dispatcher *fakeDispatcher
-	pubsub     bool
+	queue    component.OutputQueue
+	pubsub   bool
+	dispatch testDispatcher
 }
 
 func newOutputTestEnv(t *testing.T, det *mocks.MockDetector, pubsubEnabled bool, queueSize int) *outputTestEnv {
@@ -45,12 +45,17 @@ func newOutputTestEnv(t *testing.T, det *mocks.MockDetector, pubsubEnabled bool,
 	t.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubsubEnabled))
 
 	env := &outputTestEnv{pubsub: pubsubEnabled}
-	var disp pubSubRegister
+	var reg pubSubRegister
 	if pubsubEnabled {
-		env.dispatcher = &fakeDispatcher{}
-		disp = env.dispatcher
+		d, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+			lane.NewBlockingLane(pubsub.ResolvedResourceEventLane),
+		}))
+		require.NoError(t, err)
+		t.Cleanup(d.Stop)
+		env.dispatch = d
+		reg = d
 	}
-	q, err := New(det, queueSize, disp)
+	q, err := New(det, queueSize, reg)
 	assert.NoError(t, err)
 	env.queue = q
 	return env
@@ -59,7 +64,8 @@ func newOutputTestEnv(t *testing.T, det *mocks.MockDetector, pubsubEnabled bool,
 func (e *outputTestEnv) send(t *testing.T, event *component.ResourceEvent) {
 	t.Helper()
 	if e.pubsub {
-		assert.NoError(t, e.dispatcher.callback(event))
+		event.SetTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
+		assert.NoError(t, e.dispatch.Publish(event))
 	} else {
 		e.queue.Send(event)
 	}
@@ -230,13 +236,19 @@ func Test_ProcessResourceEvent_WrongType(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	det := mocks.NewMockDetector(ctrl)
 
-	disp := &fakeDispatcher{}
-	q, err := New(det, 10, disp)
+	d, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+		lane.NewBlockingLane(pubsub.ResolvedResourceEventLane),
+	}))
+	require.NoError(t, err)
+	t.Cleanup(d.Stop)
+
+	q, err := New(det, 10, d)
 	assert.NoError(t, err)
 	assert.NoError(t, q.Start())
 	defer q.Stop()
 
-	err = disp.callback(&wrongTypeEvent{})
+	impl := q.(*outputQueueImpl)
+	err = impl.ProcessResourceEvent(&wrongTypeEvent{})
 	assert.ErrorContains(t, err, "unable to convert event to *component.ResourceEvent")
 }
 
@@ -245,16 +257,22 @@ func Test_ProcessResourceEvent_StopRequested(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	det := mocks.NewMockDetector(ctrl)
 
-	disp := &fakeDispatcher{}
-	q, err := New(det, 10, disp)
+	d, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs([]pubsub.LaneConfig{
+		lane.NewBlockingLane(pubsub.ResolvedResourceEventLane),
+	}))
+	require.NoError(t, err)
+	t.Cleanup(d.Stop)
+
+	q, err := New(det, 10, d)
 	assert.NoError(t, err)
 	assert.NoError(t, q.Start())
 	q.Stop()
 
-	err = disp.callback(&component.ResourceEvent{
+	event := &component.ResourceEvent{
 		Context:         context.Background(),
 		ForwardMessages: []*central.SensorEvent{{Id: "x"}},
-	})
-	assert.NoError(t, err)
+	}
+	event.SetTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
+	assert.NoError(t, d.Publish(event))
 	shouldNotForwardMessage(t, q.ResponsesC())
 }

--- a/sensor/kubernetes/eventpipeline/output/output_test.go
+++ b/sensor/kubernetes/eventpipeline/output/output_test.go
@@ -185,11 +185,14 @@ func Test_OutputQueue_DetectorCalls(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			det := mocks.NewMockDetector(ctrl)
 			det.EXPECT().ReprocessDeployments("dep-a", "dep-b")
+			done := make(chan struct{})
 			det.EXPECT().ProcessDeployment(
 				gomock.Any(),
 				gomock.Any(),
 				gomock.Eq(central.ResourceAction_CREATE_RESOURCE),
-			)
+			).Do(func(context.Context, *storage.Deployment, central.ResourceAction) {
+				close(done)
+			})
 
 			env := newOutputTestEnv(t, det, pubsubEnabled, 10)
 			assert.NoError(t, env.queue.Start())
@@ -205,6 +208,12 @@ func Test_OutputQueue_DetectorCalls(t *testing.T) {
 					},
 				},
 			})
+
+			select {
+			case <-done:
+			case <-time.After(waitTimeout):
+				t.Fatal("timed out waiting for detector calls")
+			}
 		})
 	}
 }

--- a/sensor/kubernetes/eventpipeline/output/output_test.go
+++ b/sensor/kubernetes/eventpipeline/output/output_test.go
@@ -34,9 +34,13 @@ func shouldNotForwardMessage(t *testing.T, ch <-chan *message.ExpiringMessage) {
 }
 
 func Test_OutputQueue_ExpiringMessages(t *testing.T) {
+	// This test exercises the legacy channel-based output queue path.
+	// Disable the feature flag so New does not require a pubsub dispatcher.
+	t.Setenv("ROX_SENSOR_PUBSUB", "false")
 	ctrl := gomock.NewController(t)
 	detector := mocks.NewMockDetector(ctrl)
-	q := New(detector, 10)
+	q, err := New(detector, 10, nil)
+	assert.NoError(t, err)
 
 	assert.NoError(t, q.Start())
 	defer q.Stop()

--- a/sensor/kubernetes/eventpipeline/output/output_test.go
+++ b/sensor/kubernetes/eventpipeline/output/output_test.go
@@ -6,8 +6,11 @@ import (
 	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/sensor/common/detector/mocks"
 	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -82,4 +85,117 @@ func Test_OutputQueue_ExpiringMessages(t *testing.T) {
 			tc.assertion(t, q.ResponsesC())
 		})
 	}
+}
+
+// wrongTypeEvent satisfies pubsub.Event but is not *component.ResourceEvent,
+// used to exercise the type-assertion guard in ProcessResourceEvent.
+type wrongTypeEvent struct{}
+
+func (w *wrongTypeEvent) Topic() pubsub.Topic { return pubsub.ResolvedResourceEventTopic }
+func (w *wrongTypeEvent) Lane() pubsub.LaneID { return pubsub.ResolvedResourceEventLane }
+
+func Test_ProcessResourceEvent_WrongType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	q := &outputQueueImpl{
+		innerQueue:   make(chan *component.ResourceEvent, 1),
+		forwardQueue: make(chan *message.ExpiringMessage, 1),
+		detector:     mocks.NewMockDetector(ctrl),
+		stopper:      concurrency.NewStopper(),
+	}
+	err := q.ProcessResourceEvent(&wrongTypeEvent{})
+	assert.ErrorContains(t, err, "unable to convert event to *component.ResourceEvent")
+}
+
+func Test_ProcessResourceEvent_StopRequested(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	// No detector expectations: the stop guard fires before any processing.
+	q := &outputQueueImpl{
+		innerQueue:   make(chan *component.ResourceEvent, 1),
+		forwardQueue: make(chan *message.ExpiringMessage, 1),
+		detector:     mocks.NewMockDetector(ctrl),
+		stopper:      concurrency.NewStopper(),
+	}
+	q.stopper.Client().Stop()
+	err := q.ProcessResourceEvent(&component.ResourceEvent{
+		Context:         context.Background(),
+		ForwardMessages: []*central.SensorEvent{{Id: "x"}},
+	})
+	assert.NoError(t, err)
+	shouldNotForwardMessage(t, q.ResponsesC())
+}
+
+func Test_ProcessResourceEvent_ForwardMessages(t *testing.T) {
+	expiredCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	testCases := map[string]struct {
+		message   *component.ResourceEvent
+		assertion func(*testing.T, <-chan *message.ExpiringMessage)
+	}{
+		"nil context treated as Background": {
+			message: &component.ResourceEvent{
+				Context:         nil,
+				ForwardMessages: []*central.SensorEvent{{Id: "a"}},
+			},
+			assertion: shouldForwardMessage,
+		},
+		"non-expired message is forwarded": {
+			message: &component.ResourceEvent{
+				Context:         context.Background(),
+				ForwardMessages: []*central.SensorEvent{{Id: "a"}},
+			},
+			assertion: shouldForwardMessage,
+		},
+		"expired message is not forwarded": {
+			message: &component.ResourceEvent{
+				Context:         expiredCtx,
+				ForwardMessages: []*central.SensorEvent{{Id: "a"}},
+			},
+			assertion: shouldNotForwardMessage,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			det := mocks.NewMockDetector(ctrl)
+			det.EXPECT().ReprocessDeployments(gomock.Eq([]string{}))
+			q := &outputQueueImpl{
+				innerQueue:   make(chan *component.ResourceEvent, 1),
+				forwardQueue: make(chan *message.ExpiringMessage, 10),
+				detector:     det,
+				stopper:      concurrency.NewStopper(),
+			}
+			assert.NoError(t, q.ProcessResourceEvent(tc.message))
+			tc.assertion(t, q.ResponsesC())
+		})
+	}
+}
+
+func Test_ProcessResourceEvent_DetectorCalls(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	det := mocks.NewMockDetector(ctrl)
+	det.EXPECT().ReprocessDeployments("dep-a", "dep-b")
+	det.EXPECT().ProcessDeployment(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Eq(central.ResourceAction_CREATE_RESOURCE),
+	)
+
+	q := &outputQueueImpl{
+		innerQueue:   make(chan *component.ResourceEvent, 1),
+		forwardQueue: make(chan *message.ExpiringMessage, 10),
+		detector:     det,
+		stopper:      concurrency.NewStopper(),
+	}
+	assert.NoError(t, q.ProcessResourceEvent(&component.ResourceEvent{
+		Context:              context.Background(),
+		ReprocessDeployments: []string{"dep-a", "dep-b"},
+		DetectorMessages: []component.DeploytimeDetectionRequest{
+			{
+				Object: &storage.Deployment{Id: "dep-c"},
+				Action: central.ResourceAction_CREATE_RESOURCE,
+			},
+		},
+	}))
 }

--- a/sensor/kubernetes/eventpipeline/output/output_test.go
+++ b/sensor/kubernetes/eventpipeline/output/output_test.go
@@ -2,12 +2,13 @@ package output
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/sensor/common/detector/mocks"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/pubsub"
@@ -19,6 +20,50 @@ import (
 const (
 	waitTimeout = 100 * time.Millisecond
 )
+
+// fakeDispatcher captures the EventCallback registered by New() so tests can
+// invoke it directly, simulating what the real PubSub dispatcher would do.
+type fakeDispatcher struct {
+	callback pubsub.EventCallback
+}
+
+func (f *fakeDispatcher) RegisterConsumerToLane(_ pubsub.ConsumerID, _ pubsub.Topic, _ pubsub.LaneID, cb pubsub.EventCallback) error {
+	f.callback = cb
+	return nil
+}
+
+// outputTestEnv bundles the output queue, its dispatcher (if pubsub), and a
+// helper to send events through the correct path.
+type outputTestEnv struct {
+	queue      component.OutputQueue
+	dispatcher *fakeDispatcher
+	pubsub     bool
+}
+
+func newOutputTestEnv(t *testing.T, det *mocks.MockDetector, pubsubEnabled bool, queueSize int) *outputTestEnv {
+	t.Helper()
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubsubEnabled))
+
+	env := &outputTestEnv{pubsub: pubsubEnabled}
+	var disp pubSubRegister
+	if pubsubEnabled {
+		env.dispatcher = &fakeDispatcher{}
+		disp = env.dispatcher
+	}
+	q, err := New(det, queueSize, disp)
+	assert.NoError(t, err)
+	env.queue = q
+	return env
+}
+
+func (e *outputTestEnv) send(t *testing.T, event *component.ResourceEvent) {
+	t.Helper()
+	if e.pubsub {
+		assert.NoError(t, e.dispatcher.callback(event))
+	} else {
+		e.queue.Send(event)
+	}
+}
 
 func shouldForwardMessage(t *testing.T, ch <-chan *message.ExpiringMessage) {
 	select {
@@ -37,17 +82,6 @@ func shouldNotForwardMessage(t *testing.T, ch <-chan *message.ExpiringMessage) {
 }
 
 func Test_OutputQueue_ExpiringMessages(t *testing.T) {
-	// This test exercises the legacy channel-based output queue path.
-	// Disable the feature flag so New does not require a pubsub dispatcher.
-	t.Setenv("ROX_SENSOR_PUBSUB", "false")
-	ctrl := gomock.NewController(t)
-	detector := mocks.NewMockDetector(ctrl)
-	q, err := New(detector, 10, nil)
-	assert.NoError(t, err)
-
-	assert.NoError(t, q.Start())
-	defer q.Stop()
-
 	expiredContext, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -78,53 +112,25 @@ func Test_OutputQueue_ExpiringMessages(t *testing.T) {
 		},
 	}
 
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			detector.EXPECT().ReprocessDeployments(gomock.Eq([]string{}))
-			q.Send(tc.message)
-			tc.assertion(t, q.ResponsesC())
-		})
+	for _, pubsubEnabled := range []bool{false, true} {
+		for name, tc := range testCases {
+			t.Run(fmt.Sprintf("%s/pubsub=%t", name, pubsubEnabled), func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				det := mocks.NewMockDetector(ctrl)
+				det.EXPECT().ReprocessDeployments(gomock.Eq([]string{}))
+
+				env := newOutputTestEnv(t, det, pubsubEnabled, 10)
+				assert.NoError(t, env.queue.Start())
+				defer env.queue.Stop()
+
+				env.send(t, tc.message)
+				tc.assertion(t, env.queue.ResponsesC())
+			})
+		}
 	}
 }
 
-// wrongTypeEvent satisfies pubsub.Event but is not *component.ResourceEvent,
-// used to exercise the type-assertion guard in ProcessResourceEvent.
-type wrongTypeEvent struct{}
-
-func (w *wrongTypeEvent) Topic() pubsub.Topic { return pubsub.ResolvedResourceEventTopic }
-func (w *wrongTypeEvent) Lane() pubsub.LaneID { return pubsub.ResolvedResourceEventLane }
-
-func Test_ProcessResourceEvent_WrongType(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	q := &outputQueueImpl{
-		innerQueue:   make(chan *component.ResourceEvent, 1),
-		forwardQueue: make(chan *message.ExpiringMessage, 1),
-		detector:     mocks.NewMockDetector(ctrl),
-		stopper:      concurrency.NewStopper(),
-	}
-	err := q.ProcessResourceEvent(&wrongTypeEvent{})
-	assert.ErrorContains(t, err, "unable to convert event to *component.ResourceEvent")
-}
-
-func Test_ProcessResourceEvent_StopRequested(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	// No detector expectations: the stop guard fires before any processing.
-	q := &outputQueueImpl{
-		innerQueue:   make(chan *component.ResourceEvent, 1),
-		forwardQueue: make(chan *message.ExpiringMessage, 1),
-		detector:     mocks.NewMockDetector(ctrl),
-		stopper:      concurrency.NewStopper(),
-	}
-	q.stopper.Client().Stop()
-	err := q.ProcessResourceEvent(&component.ResourceEvent{
-		Context:         context.Background(),
-		ForwardMessages: []*central.SensorEvent{{Id: "x"}},
-	})
-	assert.NoError(t, err)
-	shouldNotForwardMessage(t, q.ResponsesC())
-}
-
-func Test_ProcessResourceEvent_ForwardMessages(t *testing.T) {
+func Test_OutputQueue_ForwardMessages(t *testing.T) {
 	expiredCtx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -155,47 +161,91 @@ func Test_ProcessResourceEvent_ForwardMessages(t *testing.T) {
 		},
 	}
 
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
+	for _, pubsubEnabled := range []bool{false, true} {
+		for name, tc := range testCases {
+			t.Run(fmt.Sprintf("%s/pubsub=%t", name, pubsubEnabled), func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				det := mocks.NewMockDetector(ctrl)
+				det.EXPECT().ReprocessDeployments(gomock.Eq([]string{}))
+
+				env := newOutputTestEnv(t, det, pubsubEnabled, 10)
+				assert.NoError(t, env.queue.Start())
+				defer env.queue.Stop()
+
+				env.send(t, tc.message)
+				tc.assertion(t, env.queue.ResponsesC())
+			})
+		}
+	}
+}
+
+func Test_OutputQueue_DetectorCalls(t *testing.T) {
+	for _, pubsubEnabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("pubsub=%t", pubsubEnabled), func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			det := mocks.NewMockDetector(ctrl)
-			det.EXPECT().ReprocessDeployments(gomock.Eq([]string{}))
-			q := &outputQueueImpl{
-				innerQueue:   make(chan *component.ResourceEvent, 1),
-				forwardQueue: make(chan *message.ExpiringMessage, 10),
-				detector:     det,
-				stopper:      concurrency.NewStopper(),
-			}
-			assert.NoError(t, q.ProcessResourceEvent(tc.message))
-			tc.assertion(t, q.ResponsesC())
+			det.EXPECT().ReprocessDeployments("dep-a", "dep-b")
+			det.EXPECT().ProcessDeployment(
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Eq(central.ResourceAction_CREATE_RESOURCE),
+			)
+
+			env := newOutputTestEnv(t, det, pubsubEnabled, 10)
+			assert.NoError(t, env.queue.Start())
+			defer env.queue.Stop()
+
+			env.send(t, &component.ResourceEvent{
+				Context:              context.Background(),
+				ReprocessDeployments: []string{"dep-a", "dep-b"},
+				DetectorMessages: []component.DeploytimeDetectionRequest{
+					{
+						Object: &storage.Deployment{Id: "dep-c"},
+						Action: central.ResourceAction_CREATE_RESOURCE,
+					},
+				},
+			})
 		})
 	}
 }
 
-func Test_ProcessResourceEvent_DetectorCalls(t *testing.T) {
+// wrongTypeEvent satisfies pubsub.Event but is not *component.ResourceEvent,
+// used to exercise the type-assertion guard in ProcessResourceEvent.
+type wrongTypeEvent struct{}
+
+func (w *wrongTypeEvent) Topic() pubsub.Topic { return pubsub.ResolvedResourceEventTopic }
+func (w *wrongTypeEvent) Lane() pubsub.LaneID { return pubsub.ResolvedResourceEventLane }
+
+func Test_ProcessResourceEvent_WrongType(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
 	ctrl := gomock.NewController(t)
 	det := mocks.NewMockDetector(ctrl)
-	det.EXPECT().ReprocessDeployments("dep-a", "dep-b")
-	det.EXPECT().ProcessDeployment(
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Eq(central.ResourceAction_CREATE_RESOURCE),
-	)
 
-	q := &outputQueueImpl{
-		innerQueue:   make(chan *component.ResourceEvent, 1),
-		forwardQueue: make(chan *message.ExpiringMessage, 10),
-		detector:     det,
-		stopper:      concurrency.NewStopper(),
-	}
-	assert.NoError(t, q.ProcessResourceEvent(&component.ResourceEvent{
-		Context:              context.Background(),
-		ReprocessDeployments: []string{"dep-a", "dep-b"},
-		DetectorMessages: []component.DeploytimeDetectionRequest{
-			{
-				Object: &storage.Deployment{Id: "dep-c"},
-				Action: central.ResourceAction_CREATE_RESOURCE,
-			},
-		},
-	}))
+	disp := &fakeDispatcher{}
+	q, err := New(det, 10, disp)
+	assert.NoError(t, err)
+	assert.NoError(t, q.Start())
+	defer q.Stop()
+
+	err = disp.callback(&wrongTypeEvent{})
+	assert.ErrorContains(t, err, "unable to convert event to *component.ResourceEvent")
+}
+
+func Test_ProcessResourceEvent_StopRequested(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+	ctrl := gomock.NewController(t)
+	det := mocks.NewMockDetector(ctrl)
+
+	disp := &fakeDispatcher{}
+	q, err := New(det, 10, disp)
+	assert.NoError(t, err)
+	assert.NoError(t, q.Start())
+	q.Stop()
+
+	err = disp.callback(&component.ResourceEvent{
+		Context:         context.Background(),
+		ForwardMessages: []*central.SensorEvent{{Id: "x"}},
+	})
+	assert.NoError(t, err)
+	shouldNotForwardMessage(t, q.ResponsesC())
 }

--- a/sensor/kubernetes/eventpipeline/pipeline.go
+++ b/sensor/kubernetes/eventpipeline/pipeline.go
@@ -47,9 +47,12 @@ func New(clusterID clusterIDWaiter,
 	pubSub *internalmessage.MessageSubscriber,
 	pubSubDispatcher component.PubSubDispatcher,
 ) (common.SensorComponent, error) {
-	outputQueue := output.New(detector, queueSize)
 	if features.SensorInternalPubSub.Enabled() && pubSubDispatcher == nil {
 		return nil, errors.Errorf("unable to initialize the event pipeline. %q is enabled but the PubSubDispatcher is `nil`", features.SensorInternalPubSub.EnvVar())
+	}
+	outputQueue, err := output.New(detector, queueSize, pubSubDispatcher)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to initialize the output queue")
 	}
 	depResolver, err := resolver.New(outputQueue, storeProvider, queueSize, pubSubDispatcher)
 	if err != nil {

--- a/sensor/kubernetes/eventpipeline/resolver/resolver.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver.go
@@ -11,12 +11,13 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/eventpipeline/component"
 )
 
-type pubSubRegister interface {
+type pubSubDispatcher interface {
 	RegisterConsumerToLane(pubsub.ConsumerID, pubsub.Topic, pubsub.LaneID, pubsub.EventCallback) error
+	Publish(pubsub.Event) error
 }
 
 // New instantiates a Resolver component.
-func New(outputQueue component.OutputQueue, provider store.Provider, queueSize int, pubsubDispatcher pubSubRegister) (component.Resolver, error) {
+func New(outputQueue component.OutputQueue, provider store.Provider, queueSize int, dispatcher pubSubDispatcher) (component.Resolver, error) {
 	res := &resolverImpl{
 		outputQueue:           outputQueue,
 		innerQueue:            make(chan *component.ResourceEvent, queueSize),
@@ -26,15 +27,16 @@ func New(outputQueue component.OutputQueue, provider store.Provider, queueSize i
 		deploymentRefQueue:    nil,
 	}
 	if features.SensorInternalPubSub.Enabled() {
-		if pubsubDispatcher == nil {
+		if dispatcher == nil {
 			return nil, errors.Errorf("pubsub dispatcher is null and the feature flag %q is enabled", features.SensorInternalPubSub.EnvVar())
 		}
-		if err := pubsubDispatcher.RegisterConsumerToLane(pubsub.ResolverConsumer, pubsub.KubernetesDispatcherEventTopic, pubsub.KubernetesDispatcherEventLane, res.ProcessResourceEvent); err != nil {
+		if err := dispatcher.RegisterConsumerToLane(pubsub.ResolverConsumer, pubsub.KubernetesDispatcherEventTopic, pubsub.KubernetesDispatcherEventLane, res.ProcessResourceEvent); err != nil {
 			return nil, errors.Wrapf(err, "unable to register resolver as consumer of topic %q in lane %q", pubsub.KubernetesDispatcherEventTopic.String(), pubsub.KubernetesDispatcherEventLane.String())
 		}
-		if err := pubsubDispatcher.RegisterConsumerToLane(pubsub.ResolverConsumer, pubsub.FromCentralResolverEventTopic, pubsub.FromCentralResolverEventLane, res.ProcessResourceEvent); err != nil {
+		if err := dispatcher.RegisterConsumerToLane(pubsub.ResolverConsumer, pubsub.FromCentralResolverEventTopic, pubsub.FromCentralResolverEventLane, res.ProcessResourceEvent); err != nil {
 			return nil, errors.Wrapf(err, "unable to register resolver as consumer of topic %q in lane %q", pubsub.FromCentralResolverEventTopic.String(), pubsub.FromCentralResolverEventLane.String())
 		}
+		res.pubsubDispatcher = dispatcher
 	}
 	if features.SensorAggregateDeploymentReferenceOptimization.Enabled() {
 		res.deploymentRefQueue = dedupingqueue.NewDedupingQueue[string](

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_bench_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_bench_test.go
@@ -70,14 +70,6 @@ func dispatchEvent(b *testing.B, event *component.ResourceEvent, resolver compon
 	res.Send(event)
 }
 
-// benchmarkProcessDeploymentReferences runs the resolver benchmark using the
-// currently active feature flag value for SensorInternalPubSub.
-//
-// To compare legacy vs pubsub with benchstat:
-//
-//	ROX_SENSOR_PUBSUB=false go test -run='^$' -bench=BenchmarkProcess -benchmem -count=10 ./sensor/kubernetes/eventpipeline/resolver/ > bench_legacy.txt
-//	ROX_SENSOR_PUBSUB=true  go test -run='^$' -bench=BenchmarkProcess -benchmem -count=10 ./sensor/kubernetes/eventpipeline/resolver/ > bench_pubsub.txt
-//	benchstat bench_legacy.txt bench_pubsub.txt
 func benchmarkProcessDeploymentReferences(b *testing.B, randomIDs bool) {
 	pubsubEnabled := features.SensorInternalPubSub.Enabled()
 	for _, bc := range cases {
@@ -102,11 +94,21 @@ func benchmarkProcessDeploymentReferences(b *testing.B, randomIDs bool) {
 }
 
 func BenchmarkProcessDeploymentReferences(b *testing.B) {
-	benchmarkProcessDeploymentReferences(b, false)
+	for _, pubsubEnabled := range []bool{false, true} {
+		b.Run(fmt.Sprintf("pubsub=%t", pubsubEnabled), func(b *testing.B) {
+			b.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubsubEnabled))
+			benchmarkProcessDeploymentReferences(b, false)
+		})
+	}
 }
 
 func BenchmarkProcessRandomDeploymentReferences(b *testing.B) {
-	benchmarkProcessDeploymentReferences(b, true)
+	for _, pubsubEnabled := range []bool{false, true} {
+		b.Run(fmt.Sprintf("pubsub=%t", pubsubEnabled), func(b *testing.B) {
+			b.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubsubEnabled))
+			benchmarkProcessDeploymentReferences(b, true)
+		})
+	}
 }
 
 func setupResolver(b *testing.B) {

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_bench_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_bench_test.go
@@ -70,6 +70,10 @@ func dispatchEvent(b *testing.B, event *component.ResourceEvent, resolver compon
 	res.Send(event)
 }
 
+// benchmarkProcessDeploymentReferences benchmarks resolver-internal processing only:
+// deployment reference resolution, store lookups, and the deduping queue. The output
+// queue consumer (ProcessResourceEvent / buffered lane) is NOT exercised here; see
+// the output package benchmarks (output_bench_test.go) for that coverage.
 func benchmarkProcessDeploymentReferences(b *testing.B, randomIDs bool) {
 	pubsubEnabled := features.SensorInternalPubSub.Enabled()
 	for _, bc := range cases {
@@ -79,10 +83,11 @@ func benchmarkProcessDeploymentReferences(b *testing.B, randomIDs bool) {
 			setupResolver(b)
 			b.Cleanup(func() { res.Stop() })
 
+			rng := rand.New(rand.NewSource(42))
 			for b.Loop() {
 				b.StopTimer()
 				doneSignal.Reset()
-				events := createEvents(randomIDs, bc.numEvents, bc.numDeployments)
+				events := createEvents(rng, randomIDs, bc.numEvents, bc.numDeployments)
 				b.StartTimer()
 				for _, event := range events {
 					dispatchEvent(b, event, res, pubsubEnabled)
@@ -190,7 +195,7 @@ func setupMocks(b *testing.B, doneSignal *concurrency.Signal, pubsubEnabled bool
 	})
 }
 
-func createEvents(randomIDs bool, numEvents, numDeploymentRefs int) []*component.ResourceEvent {
+func createEvents(rng *rand.Rand, randomIDs bool, numEvents, numDeploymentRefs int) []*component.ResourceEvent {
 	ret := make([]*component.ResourceEvent, numEvents+1)
 	var ids []string
 	if !randomIDs {
@@ -199,7 +204,7 @@ func createEvents(randomIDs bool, numEvents, numDeploymentRefs int) []*component
 	for i := 0; i < numEvents; i++ {
 		var event component.ResourceEvent
 		if randomIDs {
-			ids = createRandomIds(numDeploymentRefs)
+			ids = createRandomIds(rng, numDeploymentRefs)
 		}
 		event.AddDeploymentReference(resolver.ResolveDeploymentIds(ids...))
 		ret[i] = &event
@@ -221,18 +226,18 @@ func createIds(n int) []string {
 
 const charset = "abcdef0123456789"
 
-func randStringWithLength(n int) string {
+func randStringWithLength(rng *rand.Rand, n int) string {
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))]
+		b[i] = charset[rng.Intn(len(charset))]
 	}
 	return string(b)
 }
 
-func createRandomIds(n int) []string {
+func createRandomIds(rng *rand.Rand, n int) []string {
 	ret := make([]string, n)
 	for i := 0; i < n; i++ {
-		ret[i] = randStringWithLength(10)
+		ret[i] = randStringWithLength(rng, 10)
 	}
 	return ret
 }

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_bench_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_bench_test.go
@@ -84,21 +84,18 @@ func benchmarkProcessDeploymentReferences(b *testing.B, randomIDs bool) {
 		b.Run(fmt.Sprintf("events=%d/deployments=%d", bc.numEvents, bc.numDeployments), func(b *testing.B) {
 			doneSignal := concurrency.NewSignal()
 			setupMocks(b, &doneSignal, pubsubEnabled)
+			setupResolver(b)
+			b.Cleanup(func() { res.Stop() })
 
 			for b.Loop() {
 				b.StopTimer()
 				doneSignal.Reset()
 				events := createEvents(randomIDs, bc.numEvents, bc.numDeployments)
-				setupResolver(b)
 				b.StartTimer()
 				for _, event := range events {
 					dispatchEvent(b, event, res, pubsubEnabled)
 				}
 				doneSignal.Wait()
-				b.StopTimer()
-				res.Stop()
-				// b.Loop() requires the timer to be running when called.
-				b.StartTimer()
 			}
 		})
 	}

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_bench_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_bench_test.go
@@ -70,54 +70,46 @@ func dispatchEvent(b *testing.B, event *component.ResourceEvent, resolver compon
 	res.Send(event)
 }
 
-func BenchmarkProcessDeploymentReferences(b *testing.B) {
-	for _, value := range []bool{true, false} {
-		b.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", value))
-		for _, bc := range cases {
-			b.Run(fmt.Sprintf("Benchmark with %d events and %d deployments per event and %q is %t", bc.numEvents, bc.numDeployments, features.SensorInternalPubSub.EnvVar(), value), func(b *testing.B) {
-				for b.Loop() {
-					b.StopTimer()
-					doneSignal := concurrency.NewSignal()
-					setupMocks(b, &doneSignal, value)
-					events := createEvents(false, bc.numEvents, bc.numDeployments)
-					setupResolver(b)
-					b.StartTimer()
-					for _, event := range events {
-						dispatchEvent(b, event, res, value)
-					}
-					doneSignal.Wait()
-					b.StopTimer()
-					res.Stop()
-					b.StartTimer()
+// benchmarkProcessDeploymentReferences runs the resolver benchmark using the
+// currently active feature flag value for SensorInternalPubSub.
+//
+// To compare legacy vs pubsub with benchstat:
+//
+//	ROX_SENSOR_PUBSUB=false go test -run='^$' -bench=BenchmarkProcess -benchmem -count=10 ./sensor/kubernetes/eventpipeline/resolver/ > bench_legacy.txt
+//	ROX_SENSOR_PUBSUB=true  go test -run='^$' -bench=BenchmarkProcess -benchmem -count=10 ./sensor/kubernetes/eventpipeline/resolver/ > bench_pubsub.txt
+//	benchstat bench_legacy.txt bench_pubsub.txt
+func benchmarkProcessDeploymentReferences(b *testing.B, randomIDs bool) {
+	pubsubEnabled := features.SensorInternalPubSub.Enabled()
+	for _, bc := range cases {
+		b.Run(fmt.Sprintf("events=%d/deployments=%d", bc.numEvents, bc.numDeployments), func(b *testing.B) {
+			doneSignal := concurrency.NewSignal()
+			setupMocks(b, &doneSignal, pubsubEnabled)
+
+			for b.Loop() {
+				b.StopTimer()
+				doneSignal.Reset()
+				events := createEvents(randomIDs, bc.numEvents, bc.numDeployments)
+				setupResolver(b)
+				b.StartTimer()
+				for _, event := range events {
+					dispatchEvent(b, event, res, pubsubEnabled)
 				}
-			})
-		}
+				doneSignal.Wait()
+				b.StopTimer()
+				res.Stop()
+				// b.Loop() requires the timer to be running when called.
+				b.StartTimer()
+			}
+		})
 	}
 }
 
+func BenchmarkProcessDeploymentReferences(b *testing.B) {
+	benchmarkProcessDeploymentReferences(b, false)
+}
+
 func BenchmarkProcessRandomDeploymentReferences(b *testing.B) {
-	for _, value := range []bool{true, false} {
-		b.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", value))
-		for _, bc := range cases {
-			b.Run(fmt.Sprintf("Benchmark with %d events and %d random deployments per event and %q is %t", bc.numEvents, bc.numDeployments, features.SensorInternalPubSub.EnvVar(), value), func(b *testing.B) {
-				for b.Loop() {
-					b.StopTimer()
-					doneSignal := concurrency.NewSignal()
-					setupMocks(b, &doneSignal, value)
-					events := createEvents(true, bc.numEvents, bc.numDeployments)
-					setupResolver(b)
-					b.StartTimer()
-					for _, event := range events {
-						dispatchEvent(b, event, res, value)
-					}
-					doneSignal.Wait()
-					b.StopTimer()
-					res.Stop()
-					b.StartTimer()
-				}
-			})
-		}
-	}
+	benchmarkProcessDeploymentReferences(b, true)
 }
 
 func setupResolver(b *testing.B) {
@@ -148,7 +140,7 @@ func setupMocks(b *testing.B, doneSignal *concurrency.Signal, pubsubEnabled bool
 	mockPubSubDispatcher = mocksComponent.NewMockPubSubDispatcher(mockCtrl)
 	// Set up the EXPECT
 	if pubsubEnabled {
-		mockPubSubDispatcher.EXPECT().RegisterConsumerToLane(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(nil)
+		mockPubSubDispatcher.EXPECT().RegisterConsumerToLane(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 		mockPubSubDispatcher.EXPECT().Publish(gomock.Any()).AnyTimes().DoAndReturn(func(event pubsub.Event) error {
 			resourceEvent, ok := event.(*component.ResourceEvent)
 			if !ok {

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_bench_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_bench_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/service"
 	"github.com/stackrox/rox/sensor/common/store"
 	mocksStore "github.com/stackrox/rox/sensor/common/store/mocks"
@@ -87,6 +88,7 @@ func BenchmarkProcessDeploymentReferences(b *testing.B) {
 					doneSignal.Wait()
 					b.StopTimer()
 					res.Stop()
+					b.StartTimer()
 				}
 			})
 		}
@@ -111,6 +113,7 @@ func BenchmarkProcessRandomDeploymentReferences(b *testing.B) {
 					doneSignal.Wait()
 					b.StopTimer()
 					res.Stop()
+					b.StartTimer()
 				}
 			})
 		}
@@ -146,6 +149,18 @@ func setupMocks(b *testing.B, doneSignal *concurrency.Signal, pubsubEnabled bool
 	// Set up the EXPECT
 	if pubsubEnabled {
 		mockPubSubDispatcher.EXPECT().RegisterConsumerToLane(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(nil)
+		mockPubSubDispatcher.EXPECT().Publish(gomock.Any()).AnyTimes().DoAndReturn(func(event pubsub.Event) error {
+			resourceEvent, ok := event.(*component.ResourceEvent)
+			if !ok {
+				return nil
+			}
+			for _, m := range resourceEvent.ForwardMessages {
+				if m.GetDeployment().GetId() == lastDeploymentID {
+					doneSignal.Signal()
+				}
+			}
+			return nil
+		})
 	}
 	mockOutput.EXPECT().Send(gomock.Any()).AnyTimes().DoAndReturn(func(resourceEvent *component.ResourceEvent) {
 		for _, m := range resourceEvent.ForwardMessages {

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -266,10 +266,8 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 	}
 
 	if features.SensorInternalPubSub.Enabled() {
-		forwardMsg := component.NewEventWithTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
-		forwardMsg.Context = msg.Context
-		forwardMsg.MergeResourceEvent(msg)
-		if err := r.pubsubDispatcher.Publish(forwardMsg); err != nil {
+		msg.SetTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
+		if err := r.pubsubDispatcher.Publish(msg); err != nil {
 			log.Errorf("failed to publish resolved resource event to output queue: %v", err)
 		}
 		return

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -60,6 +60,8 @@ type resolverImpl struct {
 	pullAndResolveStopped concurrency.Signal
 
 	deploymentRefQueue *dedupingqueue.DedupingQueue[string]
+
+	pubsubDispatcher pubSubDispatcher
 }
 
 // Start the resolverImpl component
@@ -198,6 +200,13 @@ func (r *resolverImpl) resolveAndSend(ref *deploymentRef) {
 	msg.DeploymentTiming = ref.deploymentTiming
 	resolved := r.resolveDeployment(msg, ref)
 	if resolved || len(msg.ReprocessDeployments) > 0 {
+		if features.SensorInternalPubSub.Enabled() {
+			msg.SetTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
+			if err := r.pubsubDispatcher.Publish(msg); err != nil {
+				log.Errorf("failed to publish resolved resource event to output queue: %v", err)
+			}
+			return
+		}
 		r.outputQueue.Send(msg)
 	}
 }
@@ -257,6 +266,13 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 
 	}
 
+	if features.SensorInternalPubSub.Enabled() {
+		msg.SetTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
+		if err := r.pubsubDispatcher.Publish(msg); err != nil {
+			log.Errorf("failed to publish resolved resource event to output queue: %v", err)
+		}
+		return
+	}
 	r.outputQueue.Send(msg)
 }
 

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_impl.go
@@ -195,13 +195,12 @@ func (r *resolverImpl) resolveDeployment(msg *component.ResourceEvent, ref *depl
 // resolveAndSend resolves a single deployment ref and sends the resulting event
 // to the output queue if the deployment was resolved or if reprocess data was added.
 func (r *resolverImpl) resolveAndSend(ref *deploymentRef) {
-	msg := component.NewEvent()
+	msg := component.NewEventWithTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
 	msg.Context = ref.context
 	msg.DeploymentTiming = ref.deploymentTiming
 	resolved := r.resolveDeployment(msg, ref)
 	if resolved || len(msg.ReprocessDeployments) > 0 {
 		if features.SensorInternalPubSub.Enabled() {
-			msg.SetTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
 			if err := r.pubsubDispatcher.Publish(msg); err != nil {
 				log.Errorf("failed to publish resolved resource event to output queue: %v", err)
 			}
@@ -267,8 +266,10 @@ func (r *resolverImpl) processMessage(msg *component.ResourceEvent) {
 	}
 
 	if features.SensorInternalPubSub.Enabled() {
-		msg.SetTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
-		if err := r.pubsubDispatcher.Publish(msg); err != nil {
+		forwardMsg := component.NewEventWithTopicAndLane(pubsub.ResolvedResourceEventTopic, pubsub.ResolvedResourceEventLane)
+		forwardMsg.Context = msg.Context
+		forwardMsg.MergeResourceEvent(msg)
+		if err := r.pubsubDispatcher.Publish(forwardMsg); err != nil {
 			log.Errorf("failed to publish resolved resource event to output queue: %v", err)
 		}
 		return

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_race_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_race_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/testutils/goleak"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/service"
 	"github.com/stackrox/rox/sensor/common/store"
 	mocksStore "github.com/stackrox/rox/sensor/common/store/mocks"
@@ -32,15 +33,16 @@ type raceTestEnv struct {
 	t        *testing.T
 	resolver *resolverImpl
 
-	mockDeploymentStore *mocksStore.MockDeploymentStore
-	mockRBACStore       *mocksStore.MockRBACStore
-	mockServiceStore    *mocksStore.MockServiceStore
-	mockEndpointManager *mocksStore.MockEndpointManager
+	mockDeploymentStore  *mocksStore.MockDeploymentStore
+	mockRBACStore        *mocksStore.MockRBACStore
+	mockServiceStore     *mocksStore.MockServiceStore
+	mockEndpointManager  *mocksStore.MockEndpointManager
+	mockPubSubDispatcher *mocks.MockPubSubDispatcher
 
 	sentEvents []*component.ResourceEvent
 }
 
-func newRaceTestEnv(t *testing.T) *raceTestEnv {
+func newRaceTestEnv(t *testing.T, pubSubEnabled bool) *raceTestEnv {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 
@@ -57,10 +59,6 @@ func newRaceTestEnv(t *testing.T) *raceTestEnv {
 		mockServiceStore:    svcStore,
 		mockEndpointManager: endpointMgr,
 	}
-
-	mockOutput.EXPECT().Send(gomock.Any()).AnyTimes().Do(func(event *component.ResourceEvent) {
-		env.sentEvents = append(env.sentEvents, event)
-	})
 
 	var queue *dedupingqueue.DedupingQueue[string]
 	if features.SensorAggregateDeploymentReferenceOptimization.Enabled() {
@@ -80,6 +78,22 @@ func newRaceTestEnv(t *testing.T) *raceTestEnv {
 		deploymentRefQueue:    queue,
 	}
 
+	if pubSubEnabled {
+		dispatcher := mocks.NewMockPubSubDispatcher(ctrl)
+		dispatcher.EXPECT().Publish(gomock.Any()).AnyTimes().DoAndReturn(func(event pubsub.Event) error {
+			if e, ok := event.(*component.ResourceEvent); ok {
+				env.sentEvents = append(env.sentEvents, e)
+			}
+			return nil
+		})
+		env.mockPubSubDispatcher = dispatcher
+		env.resolver.pubsubDispatcher = dispatcher
+	} else {
+		mockOutput.EXPECT().Send(gomock.Any()).AnyTimes().Do(func(event *component.ResourceEvent) {
+			env.sentEvents = append(env.sentEvents, event)
+		})
+	}
+
 	return env
 }
 
@@ -92,10 +106,6 @@ type raceTestCase struct {
 }
 
 func TestResolverRaceScenarios(t *testing.T) {
-	// This test directly constructs resolverImpl without a pubsubDispatcher and exercises
-	// the legacy channel-based path. Disable the feature flag so processMessage does not
-	// attempt to publish via a nil dispatcher.
-	t.Setenv(features.SensorInternalPubSub.EnvVar(), "false")
 	defer goleak.AssertNoGoroutineLeaks(t)
 
 	cases := map[string]raceTestCase{
@@ -305,16 +315,19 @@ func TestResolverRaceScenarios(t *testing.T) {
 			ffStates = append(ffStates, false)
 		}
 		for _, ffEnabled := range ffStates {
-			t.Run(fmt.Sprintf("%s/ff=%t", name, ffEnabled), func(t *testing.T) {
-				synctest.Test(t, func(t *testing.T) {
-					t.Setenv(features.SensorAggregateDeploymentReferenceOptimization.EnvVar(),
-						fmt.Sprintf("%t", ffEnabled))
-					env := newRaceTestEnv(t)
-					for _, step := range tc.steps {
-						step(env)
-					}
+			for _, pubSubEnabled := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/ff=%t/pubsub=%t", name, ffEnabled, pubSubEnabled), func(t *testing.T) {
+					synctest.Test(t, func(t *testing.T) {
+						t.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
+						t.Setenv(features.SensorAggregateDeploymentReferenceOptimization.EnvVar(),
+							fmt.Sprintf("%t", ffEnabled))
+						env := newRaceTestEnv(t, pubSubEnabled)
+						for _, step := range tc.steps {
+							step(env)
+						}
+					})
 				})
-			})
+			}
 		}
 	}
 }

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_race_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_race_test.go
@@ -92,6 +92,10 @@ type raceTestCase struct {
 }
 
 func TestResolverRaceScenarios(t *testing.T) {
+	// This test directly constructs resolverImpl without a pubsubDispatcher and exercises
+	// the legacy channel-based path. Disable the feature flag so processMessage does not
+	// attempt to publish via a nil dispatcher.
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "false")
 	defer goleak.AssertNoGoroutineLeaks(t)
 
 	cases := map[string]raceTestCase{

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -560,7 +560,7 @@ func (s *resolverSuite) Test_ToEvent_InitContainerFiltering() {
 // wg.Done() is called once per expected invocation.
 func (s *resolverSuite) expectOutputSend(pubSubEnabled bool, matcher gomock.Matcher, times int, wg *sync.WaitGroup) {
 	if pubSubEnabled {
-		s.mockPubSubDispatcher.EXPECT().Publish(gomock.Any()).Times(times).Return(nil).
+		s.mockPubSubDispatcher.EXPECT().Publish(matcher).Times(times).Return(nil).
 			Do(func(_ interface{}) { wg.Done() })
 	} else {
 		s.mockOutput.EXPECT().Send(matcher).Times(times).

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -98,9 +98,7 @@ func (s *resolverSuite) Test_MessageSentToOutput() {
 			messageReceived := sync.WaitGroup{}
 			messageReceived.Add(1)
 
-			s.mockOutput.EXPECT().Send(gomock.Any()).Times(1).Do(func(arg0 interface{}) {
-				defer messageReceived.Done()
-			})
+			s.expectOutputSend(pubSubEnabled, gomock.Any(), 1, &messageReceived)
 			event := &component.ResourceEvent{
 				ForwardMessages: []*central.SensorEvent{
 					{
@@ -157,9 +155,7 @@ func (s *resolverSuite) Test_Send_DeploymentWithRBACs() {
 					acceptableNumberOfMismatches: 1,
 				}
 
-				s.mockOutput.EXPECT().Send(&expectedDeployment).Times(2).Do(func(arg0 interface{}) {
-					defer messageReceived.Done()
-				})
+				s.expectOutputSend(pubSubEnabled, &expectedDeployment, 2, &messageReceived)
 
 				event := &component.ResourceEvent{
 					DeploymentReferences: []component.DeploymentReference{
@@ -205,9 +201,7 @@ func (s *resolverSuite) Test_Send_DeploymentsWithServiceExposure() {
 				acceptableNumberOfMismatches: 1,
 			}
 
-			s.mockOutput.EXPECT().Send(&expectedDeployment).Times(2).Do(func(arg0 interface{}) {
-				defer messageReceived.Done()
-			})
+			s.expectOutputSend(pubSubEnabled, &expectedDeployment, 2, &messageReceived)
 
 			event := &component.ResourceEvent{
 				DeploymentReferences: []component.DeploymentReference{
@@ -240,9 +234,7 @@ func (s *resolverSuite) Test_Send_MultipleDeploymentRefs() {
 			s.givenPermissionLevelForDeployment("4321", storage.PermissionLevel_ELEVATED_IN_NAMESPACE)
 			s.givenPermissionLevelForDeployment("6543", storage.PermissionLevel_ELEVATED_CLUSTER_WIDE)
 
-			s.mockOutput.EXPECT().Send(&messageCounterMatcher{numEvents: []int{0, 1, 1, 1}}).Times(4).Do(func(arg0 interface{}) {
-				defer messageReceived.Done()
-			})
+			s.expectOutputSend(pubSubEnabled, &messageCounterMatcher{numEvents: []int{0, 1, 1, 1}}, 4, &messageReceived)
 
 			event := &component.ResourceEvent{
 				DeploymentReferences: []component.DeploymentReference{
@@ -278,16 +270,10 @@ func (s *resolverSuite) Test_Send_ResourceAction() {
 					messageReceived.Add(2)
 
 					s.givenPermissionLevelForDeployment("1234", storage.PermissionLevel_NONE)
-					s.mockOutput.EXPECT()
-
-					s.mockOutput.EXPECT().Send(
-						&resourceActionMatcher{
-							resourceAction:               action,
-							acceptableNumberOfMismatches: 1,
-						},
-					).Times(2).Do(func(arg0 interface{}) {
-						defer messageReceived.Done()
-					})
+					s.expectOutputSend(pubSubEnabled, &resourceActionMatcher{
+						resourceAction:               action,
+						acceptableNumberOfMismatches: 1,
+					}, 2, &messageReceived)
 
 					event := &component.ResourceEvent{
 						DeploymentReferences: []component.DeploymentReference{
@@ -319,9 +305,7 @@ func (s *resolverSuite) Test_Send_BuildDeploymentWithDependenciesError() {
 
 			s.givenBuildDependenciesError("1234", &waitForEvents)
 
-			s.mockOutput.EXPECT().Send(&messageCounterMatcher{numEvents: []int{0}}).Times(1).Do(func(arg0 interface{}) {
-				defer waitForEvents.Done()
-			})
+			s.expectOutputSend(pubSubEnabled, &messageCounterMatcher{numEvents: []int{0}}, 1, &waitForEvents)
 
 			event := &component.ResourceEvent{
 				DeploymentReferences: []component.DeploymentReference{
@@ -355,9 +339,7 @@ func (s *resolverSuite) Test_Send_DeploymentNotFound() {
 			s.mockRBACStore.EXPECT().GetPermissionLevelForDeployment(gomock.Any()).Times(0)
 			s.mockDeploymentStore.EXPECT().BuildDeploymentWithDependencies(gomock.Any(), gomock.Any()).Times(0)
 
-			s.mockOutput.EXPECT().Send(&messageCounterMatcher{numEvents: []int{0}}).Times(1).Do(func(arg0 interface{}) {
-				defer waitForEvents.Done()
-			})
+			s.expectOutputSend(pubSubEnabled, &messageCounterMatcher{numEvents: []int{0}}, 1, &waitForEvents)
 
 			event := &component.ResourceEvent{
 				DeploymentReferences: []component.DeploymentReference{
@@ -393,9 +375,7 @@ func (s *resolverSuite) Test_Send_DetectorReference() {
 				},
 			}
 
-			s.mockOutput.EXPECT().Send(&detectionObjectMatcher{expected: detectionObject}).Times(1).Do(func(arg0 interface{}) {
-				defer messageReceived.Done()
-			})
+			s.expectOutputSend(pubSubEnabled, &detectionObjectMatcher{expected: detectionObject}, 1, &messageReceived)
 
 			event := &component.ResourceEvent{
 				DetectorMessages: detectionObject,
@@ -467,9 +447,7 @@ func (s *resolverSuite) Test_Send_ForwardedMessagesAreSent() {
 
 				s.givenAnyDeploymentProcessedNTimes(testCase.expectedDeploymentProcessed)
 
-				s.mockOutput.EXPECT().Send(&messageCounterMatcher{numEvents: testCase.expectedEvents}).Times(len(testCase.expectedEvents)).Do(func(arg0 interface{}) {
-					defer messageReceived.Done()
-				})
+				s.expectOutputSend(pubSubEnabled, &messageCounterMatcher{numEvents: testCase.expectedEvents}, len(testCase.expectedEvents), &messageReceived)
 
 				event := &component.ResourceEvent{
 					ForwardMessages: testCase.forwardedMessages,
@@ -516,13 +494,11 @@ func (s *resolverSuite) Test_Send_SkipDedupingBehavior() {
 
 				s.givenPermissionLevelForDeployment("1234", storage.PermissionLevel_NONE)
 
-				s.mockOutput.EXPECT().Send(&deploymentMatcher{
+				s.expectOutputSend(pubSubEnabled, &deploymentMatcher{
 					id:                           "1234",
 					permissionLevel:              storage.PermissionLevel_NONE,
 					acceptableNumberOfMismatches: tc.expectedSends - 1,
-				}).Times(tc.expectedSends).Do(func(arg0 interface{}) {
-					defer messageReceived.Done()
-				})
+				}, tc.expectedSends, &messageReceived)
 
 				event := &component.ResourceEvent{
 					DeploymentReferences: []component.DeploymentReference{
@@ -576,6 +552,19 @@ func (s *resolverSuite) Test_ToEvent_InitContainerFiltering() {
 				s.Assert().Equal(name, dep.GetContainers()[i].GetName())
 			}
 		})
+	}
+}
+
+// expectOutputSend sets up mock expectations for the resolver's output path.
+// In pubsub mode the resolver publishes to the dispatcher; in legacy mode it calls Send.
+// wg.Done() is called once per expected invocation.
+func (s *resolverSuite) expectOutputSend(pubSubEnabled bool, matcher gomock.Matcher, times int, wg *sync.WaitGroup) {
+	if pubSubEnabled {
+		s.mockPubSubDispatcher.EXPECT().Publish(gomock.Any()).Times(times).Return(nil).
+			Do(func(_ interface{}) { wg.Done() })
+	} else {
+		s.mockOutput.EXPECT().Send(matcher).Times(times).
+			Do(func(_ interface{}) { wg.Done() })
 	}
 }
 

--- a/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
+++ b/sensor/kubernetes/eventpipeline/resolver/resolver_test.go
@@ -78,6 +78,11 @@ func (s *resolverSuite) newResolver(pubsubEnabled bool) component.Resolver {
 	return resolver
 }
 
+func (s *resolverSuite) startResolver(resolver component.Resolver) {
+	s.Require().NoError(resolver.Start())
+	s.T().Cleanup(resolver.Stop)
+}
+
 func (s *resolverSuite) dispatchEvent(event *component.ResourceEvent, resolver component.Resolver, pubSubEnabled bool) {
 	if pubSubEnabled {
 		err := resolver.ProcessResourceEvent(event)
@@ -92,8 +97,7 @@ func (s *resolverSuite) Test_MessageSentToOutput() {
 		s.Run(fmt.Sprintf("with %s %t", features.SensorInternalPubSub.EnvVar(), pubSubEnabled), func() {
 			s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
 			resolver := s.newResolver(pubSubEnabled)
-			err := resolver.Start()
-			s.NoError(err)
+			s.startResolver(resolver)
 
 			messageReceived := sync.WaitGroup{}
 			messageReceived.Add(1)
@@ -120,8 +124,7 @@ func (s *resolverSuite) Test_Send_DeploymentWithRBACs() {
 	for _, pubSubEnabled := range []bool{true, false} {
 		s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
 		resolver := s.newResolver(pubSubEnabled)
-		err := resolver.Start()
-		s.NoError(err)
+		s.startResolver(resolver)
 
 		testCases := map[string]struct {
 			deploymentID    string
@@ -178,8 +181,7 @@ func (s *resolverSuite) Test_Send_DeploymentsWithServiceExposure() {
 		s.Run(fmt.Sprintf("with %s %t", features.SensorInternalPubSub.EnvVar(), pubSubEnabled), func() {
 			s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
 			resolver := s.newResolver(pubSubEnabled)
-			err := resolver.Start()
-			s.NoError(err)
+			s.startResolver(resolver)
 
 			messageReceived := sync.WaitGroup{}
 			messageReceived.Add(2)
@@ -224,8 +226,7 @@ func (s *resolverSuite) Test_Send_MultipleDeploymentRefs() {
 		s.Run(fmt.Sprintf("with %s %t", features.SensorInternalPubSub.EnvVar(), pubSubEnabled), func() {
 			s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
 			resolver := s.newResolver(pubSubEnabled)
-			err := resolver.Start()
-			s.NoError(err)
+			s.startResolver(resolver)
 
 			messageReceived := sync.WaitGroup{}
 			messageReceived.Add(4)
@@ -261,8 +262,7 @@ func (s *resolverSuite) Test_Send_ResourceAction() {
 		s.Run(fmt.Sprintf("with %s %t", features.SensorInternalPubSub.EnvVar(), pubSubEnabled), func() {
 			s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
 			resolver := s.newResolver(pubSubEnabled)
-			err := resolver.Start()
-			s.NoError(err)
+			s.startResolver(resolver)
 
 			for _, action := range []central.ResourceAction{central.ResourceAction_CREATE_RESOURCE, central.ResourceAction_UPDATE_RESOURCE} {
 				s.Run(fmt.Sprintf("ResourceAction: %s", action), func() {
@@ -297,8 +297,7 @@ func (s *resolverSuite) Test_Send_BuildDeploymentWithDependenciesError() {
 		s.Run(fmt.Sprintf("with %s %t", features.SensorInternalPubSub.EnvVar(), pubSubEnabled), func() {
 			s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
 			resolver := s.newResolver(pubSubEnabled)
-			err := resolver.Start()
-			s.NoError(err)
+			s.startResolver(resolver)
 
 			waitForEvents := sync.WaitGroup{}
 			waitForEvents.Add(2)
@@ -327,8 +326,7 @@ func (s *resolverSuite) Test_Send_DeploymentNotFound() {
 		s.Run(fmt.Sprintf("with %s %t", features.SensorInternalPubSub.EnvVar(), pubSubEnabled), func() {
 			s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
 			resolver := s.newResolver(pubSubEnabled)
-			err := resolver.Start()
-			s.NoError(err)
+			s.startResolver(resolver)
 
 			waitForEvents := sync.WaitGroup{}
 			waitForEvents.Add(2)
@@ -362,8 +360,7 @@ func (s *resolverSuite) Test_Send_DetectorReference() {
 		s.Run(fmt.Sprintf("with %s %t", features.SensorInternalPubSub.EnvVar(), pubSubEnabled), func() {
 			s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
 			resolver := s.newResolver(pubSubEnabled)
-			err := resolver.Start()
-			s.NoError(err)
+			s.startResolver(resolver)
 
 			messageReceived := sync.WaitGroup{}
 			messageReceived.Add(1)
@@ -391,8 +388,7 @@ func (s *resolverSuite) Test_Send_ForwardedMessagesAreSent() {
 	for _, pubSubEnabled := range []bool{true, false} {
 		s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
 		resolver := s.newResolver(pubSubEnabled)
-		err := resolver.Start()
-		s.NoError(err)
+		s.startResolver(resolver)
 
 		// There are two types of resource events that will be written to the output queue.
 		// 1) Resource events that were processed at the handlers level. E.g.: Pod events,
@@ -486,8 +482,7 @@ func (s *resolverSuite) Test_Send_SkipDedupingBehavior() {
 			s.Run(fmt.Sprintf("%s with %s %t", name, features.SensorInternalPubSub.EnvVar(), pubSubEnabled), func() {
 				s.T().Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
 				resolver := s.newResolver(pubSubEnabled)
-				err := resolver.Start()
-				s.NoError(err)
+				s.startResolver(resolver)
 
 				messageReceived := sync.WaitGroup{}
 				messageReceived.Add(tc.expectedSends)

--- a/sensor/kubernetes/sensor/pubsub.go
+++ b/sensor/kubernetes/sensor/pubsub.go
@@ -39,6 +39,7 @@ func buildPubSubDispatcher() (common.PubSubDispatcher, error) {
 			lane.NewBlockingLane(pubsub.FromCentralResolverEventLane),
 			lane.NewBlockingLane(pubsub.EnrichedProcessIndicatorLane),
 			lane.NewBlockingLane(pubsub.UnenrichedProcessIndicatorLane),
+			lane.NewBlockingLane(pubsub.ResolvedResourceEventLane),
 			buildConcurrentLane(pubsub.DetectorProcessIndicatorLane, env.DetectorProcessIndicatorBufferSize),
 			buildConcurrentLane(pubsub.DetectorNetworkFlowLane, env.DetectorNetworkFlowBufferSize),
 			buildConcurrentLane(pubsub.DetectorFileAccessLane, env.DetectorFileAccessBufferSize),

--- a/sensor/kubernetes/sensor/pubsub.go
+++ b/sensor/kubernetes/sensor/pubsub.go
@@ -32,14 +32,14 @@ func buildConcurrentLane(id pubsub.LaneID, bufferEnv *env.IntegerSetting) pubsub
 	)
 }
 
-func buildPubSubDispatcher() (common.PubSubDispatcher, error) {
+func buildPubSubDispatcher(eventPipelineQueueSize int) (common.PubSubDispatcher, error) {
 	dispatcher, err := pubsubDispatcher.NewDispatcher(pubsubDispatcher.WithLaneConfigs(
 		[]pubsub.LaneConfig{
 			lane.NewBlockingLane(pubsub.KubernetesDispatcherEventLane),
 			lane.NewBlockingLane(pubsub.FromCentralResolverEventLane),
 			lane.NewBlockingLane(pubsub.EnrichedProcessIndicatorLane),
 			lane.NewBlockingLane(pubsub.UnenrichedProcessIndicatorLane),
-			lane.NewBlockingLane(pubsub.ResolvedResourceEventLane),
+			lane.NewBlockingLane(pubsub.ResolvedResourceEventLane, lane.WithBlockingLaneSize(eventPipelineQueueSize)),
 			buildConcurrentLane(pubsub.DetectorProcessIndicatorLane, env.DetectorProcessIndicatorBufferSize),
 			buildConcurrentLane(pubsub.DetectorNetworkFlowLane, env.DetectorNetworkFlowBufferSize),
 			buildConcurrentLane(pubsub.DetectorFileAccessLane, env.DetectorFileAccessBufferSize),

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -73,7 +73,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	if features.SensorInternalPubSub.Enabled() {
 		log.Info("Internal PubSub system enabled")
 		var err error
-		internalMessageDispatcher, err = buildPubSubDispatcher()
+		internalMessageDispatcher, err = buildPubSubDispatcher(cfg.eventPipelineQueueSize)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

Migrates the resolver and output queue to use the PubSub system, as specified in ROX-34880.

- Resolver's `Send()` calls are replaced with `pubsubDispatcher.Publish()` on both `processMessage` and `resolveAndSend` paths.
- Output queue's `runOutputQueue()` loop is replaced with a `ProcessResourceEvent` PubSub callback, registered at construction time.
- New PubSub constants: `ResolvedResourceEventTopic`, `ResolvedResourceEventLane`, `OutputQueueConsumer`.
- `SetTopicAndLane()` helper added to `ResourceEvent` for use by the resolver before publishing.
- All changes are gated behind the `ROX_SENSOR_PUBSUB` feature flag — the legacy path is fully preserved when the flag is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Unit tests added for `ProcessResourceEvent` covering: wrong event type, stop-requested early exit, nil context, expired/non-expired messages, and detector calls.
- Race tests extended to cover both `pubsub=true` and `pubsub=false` flag states across all existing scenarios.
- `go test -race ./sensor/kubernetes/eventpipeline/...` passes clean.