### PR TITLE
fix(sensor): harden synced reconciliation input handling 

### DIFF
--- a/central/sensor/service/connection/duplicate_synced_regression_test.go
+++ b/central/sensor/service/connection/duplicate_synced_regression_test.go
@@ -1,0 +1,63 @@
+package connection
+
+import (
+	"testing"
+
+	hashManager "github.com/stackrox/rox/central/hash/manager"
+	pipelineMock "github.com/stackrox/rox/central/sensor/service/pipeline/mocks"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDuplicateSyncedEventDoesNotPanic(t *testing.T) {
+	const clusterID = "duplicate-synced-cluster"
+
+	ctrl := gomock.NewController(t)
+	mockPipeline := pipelineMock.NewMockClusterPipeline(ctrl)
+	var reconcileCalls int
+	mockPipeline.EXPECT().Reconcile(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(_ any, _ any) error {
+		reconcileCalls++
+		return nil
+	})
+
+	stopSig := concurrency.NewErrorSignal()
+	deduper := hashManager.NewDeduper(nil, clusterID)
+	deduper.StartSync()
+
+	handler := newSensorEventHandler(
+		&storage.Cluster{Id: clusterID, Name: "duplicate-synced-cluster"},
+		"regression-sensor-version",
+		mockPipeline,
+		nil,
+		&stopSig,
+		deduper,
+		NewInitSyncManager(),
+	)
+
+	msg := &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id: "duplicate-synced-regression",
+				Resource: &central.SensorEvent_Synced{
+					Synced: &central.SensorEvent_ResourcesSynced{
+						UnchangedIds: []string{
+							"Deployment:deployment-1",
+							"Pod:pod-1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	handler.addMultiplexed(t.Context(), msg)
+
+	assert.NotPanics(t, func() {
+		handler.addMultiplexed(t.Context(), msg.CloneVT())
+	})
+	assert.Equal(t, 1, reconcileCalls)
+	assert.True(t, handler.reconciliationMap.IsClosed())
+}

--- a/central/sensor/service/connection/sensorevents.go
+++ b/central/sensor/service/connection/sensorevents.go
@@ -89,6 +89,10 @@ func (s *sensorEventHandler) addMultiplexed(ctx context.Context, msg *central.Ms
 	// The occurrence of a "Synced" event from the sensor marks the conclusion
 	// of the initial synchronization process.
 	case *central.SensorEvent_Synced:
+		if s.reconciliationMap.IsClosed() {
+			log.Warnf("Ignoring duplicate reconciliation event for cluster %s (%s)", s.cluster.GetName(), s.cluster.GetId())
+			return
+		}
 		// Call the reconcile functions
 		log.Info("Receiving reconciliation event")
 

--- a/central/sensor/service/connection/synced_event_regression_test.go
+++ b/central/sensor/service/connection/synced_event_regression_test.go
@@ -1,0 +1,72 @@
+package connection
+
+import (
+	"testing"
+
+	hashManager "github.com/stackrox/rox/central/hash/manager"
+	pipelineMock "github.com/stackrox/rox/central/sensor/service/pipeline/mocks"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/set"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// Malformed unchanged_ids should be ignored rather than crashing the Synced
+// event reconciliation path. Valid entries still need to reconcile, and sync
+// bookkeeping still needs to complete.
+func TestSyncedEventMalformedUnchangedIDsDoesNotPanic(t *testing.T) {
+	const clusterID = "regression-cluster"
+
+	ctrl := gomock.NewController(t)
+	mockPipeline := pipelineMock.NewMockClusterPipeline(ctrl)
+	var reconcileCalls int
+	mockPipeline.EXPECT().Reconcile(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(_ any, _ any) error {
+		reconcileCalls++
+		return nil
+	})
+
+	stopSig := concurrency.NewErrorSignal()
+	initSyncMgr := &initSyncManager{
+		maxSensors: 1,
+		sensors:    set.NewStringSet(clusterID),
+	}
+	deduper := hashManager.NewDeduper(nil, clusterID)
+	deduper.StartSync()
+
+	handler := newSensorEventHandler(
+		&storage.Cluster{Id: clusterID, Name: "regression-cluster"},
+		"regression-sensor-version",
+		mockPipeline,
+		nil,
+		&stopSig,
+		deduper,
+		initSyncMgr,
+	)
+
+	msg := &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id: "synced-regression",
+				Resource: &central.SensorEvent_Synced{
+					Synced: &central.SensorEvent_ResourcesSynced{
+						UnchangedIds: []string{
+							"Deployment:deployment-2",
+							"definitely-not-a-deduper-key",
+							"AlertResults:alert-1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		handler.addMultiplexed(t.Context(), msg)
+	})
+	assert.Equal(t, 1, reconcileCalls)
+	assert.True(t, handler.reconciliationMap.IsClosed())
+	assert.False(t, initSyncMgr.sensors.Contains(clusterID))
+	assert.Len(t, handler.workerQueues, 0)
+}

--- a/pkg/deduperkey/key.go
+++ b/pkg/deduperkey/key.go
@@ -65,14 +65,14 @@ func (k *Key) String() string {
 // of the keys might have failed when being parsed.
 func ParseKeySlice(keys []string) ([]Key, error) {
 	errList := errorhelpers.NewErrorList("malformed key entries")
-	result := make([]Key, len(keys))
-	for i, v := range keys {
+	result := make([]Key, 0, len(keys))
+	for _, v := range keys {
 		parsedKey, err := KeyFrom(v)
 		if err != nil {
 			errList.AddError(errors.Wrapf(err, "key: %s", v))
 			continue
 		}
-		result[i] = parsedKey
+		result = append(result, parsedKey)
 	}
 	return result, errList.ToError()
 }

--- a/pkg/deduperkey/key_test.go
+++ b/pkg/deduperkey/key_test.go
@@ -131,6 +131,22 @@ func withKey(resource any, id string) Key {
 	}
 }
 
+func TestParseKeySliceSkipsMalformedEntries(t *testing.T) {
+	t.Parallel()
+
+	keys, err := ParseKeySlice([]string{
+		eventPkg.FormatKey("Deployment", fixtureconsts.Deployment1),
+		"definitely-not-a-deduper-key",
+		eventPkg.FormatKey("AlertResults", stubID),
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, []Key{
+		withKey(&central.SensorEvent_Deployment{}, fixtureconsts.Deployment1),
+		withKey(&central.SensorEvent_AlertResults{}, stubID),
+	}, keys)
+}
+
 var allSensorEventTypes []string
 
 var whitelist = []string{


### PR DESCRIPTION
## Description

Harden sensor sync reconciliation against malformed and duplicate input from the sensor side.

- Fix to bug 1: skip malformed deduper keys when parsing `Synced.unchanged_ids`
- Fix to bug 2: ignore duplicate `Synced` events after reconciliation is already closed
- Add regression coverage for both panic cases found during fuzzing

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Unit tests
