### PR TITLE
fix(scanner): harden malformed CPE validation

### DIFF
--- a/scanner/services/validators/validators.go
+++ b/scanner/services/validators/validators.go
@@ -154,6 +154,17 @@ func validateContents(contents *v4.Contents) error {
 	return nil
 }
 
+func validateCPEString(raw string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("cpe parser panicked: %v", r)
+		}
+	}()
+
+	_, err = cpe.Unbind(raw)
+	return err
+}
+
 func validateMap[T hasIDAndCPE](m map[string]T, fieldName string, validateF func(T) error) error {
 	for k, v := range m {
 		if reflect.ValueOf(v).IsZero() {
@@ -162,8 +173,7 @@ func validateMap[T hasIDAndCPE](m map[string]T, fieldName string, validateF func
 		if v.GetId() == "" {
 			return fmt.Errorf("%s element %q: ID is empty", fieldName, k)
 		}
-		_, err := cpe.Unbind(v.GetCpe())
-		if err != nil {
+		if err := validateCPEString(v.GetCpe()); err != nil {
 			return fmt.Errorf("%s element %q: invalid CPE: %w", fieldName, k, err)
 		}
 		if err := validateF(v); err != nil {
@@ -182,8 +192,7 @@ func validateList[T hasIDAndCPE](l []T, fieldName string, validateF func(T) erro
 		if o.GetId() == "" {
 			return fmt.Errorf("%s element #%d: Id is empty", fieldName, n)
 		}
-		_, err := cpe.Unbind(o.GetCpe())
-		if err != nil {
+		if err := validateCPEString(o.GetCpe()); err != nil {
 			return fmt.Errorf("%s element #%d (id: %q): invalid CPE: %w", fieldName, n, o.GetId(), err)
 		}
 		if err := validateF(o); err != nil {

--- a/scanner/services/validators/validators_test.go
+++ b/scanner/services/validators/validators_test.go
@@ -260,6 +260,25 @@ func Test_validateGetVulnerabilitiesRequest(t *testing.T) {
 	}
 }
 
+func TestValidateGetVulnerabilitiesRequest_MalformedRepositoryCPEDoesNotPanic(t *testing.T) {
+	req := &v4.GetVulnerabilitiesRequest{
+		HashId: "/v4/containerimage/foobar",
+		Contents: &v4.Contents{
+			Repositories: map[string]*v4.Repository{
+				"repo": {
+					Id:  "repo",
+					Cpe: "cpe:2.3:0:000000:00:0:0:0:0:0:0:0:0:0",
+				},
+			},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		err := ValidateGetVulnerabilitiesRequest(req)
+		assert.ErrorContains(t, err, `Contents.Repositories element "repo": invalid CPE`)
+	})
+}
+
 func Test_validateScanSBOMRequest(t *testing.T) {
 	tests := map[string]struct {
 		req     *v4.ScanSBOMRequest


### PR DESCRIPTION
## Description

Harden scanner request validation so malformed CPE input cannot crash the matcher validation path.

- wrap CPE parsing used by request validation so parser panics are reported as invalid input
- add a regression test for the malformed repository CPE found by fuzzing
- verify the saved fuzz reproducer no longer crashes

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Unit tests

