### PR TITLE
fix: skip SAR checks for resources that do not exist in the cluster

### DIFF
--- a/sensor/common/centralproxy/authorizer.go
+++ b/sensor/common/centralproxy/authorizer.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authv1 "k8s.io/api/authorization/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -64,6 +65,68 @@ func (r k8sResource) String() string {
 	return fmt.Sprintf("%s.%s", r.Resource, r.Group)
 }
 
+// groupVersion returns the API group version string used by the Discovery API.
+// Core resources (empty group) map to "v1", all others to "group/v1".
+func (r k8sResource) groupVersion() string {
+	if r.Group == "" {
+		return "v1"
+	}
+	return r.Group + "/v1"
+}
+
+// filterAvailableResources queries the Discovery API to determine which resources
+// actually exist in the cluster and returns only those. Resources whose API group
+// is not found are excluded. On transient Discovery errors, resources are kept
+// to avoid silently skipping authorization checks (fail-open).
+func filterAvailableResources(client kubernetes.Interface, resources []k8sResource) []k8sResource {
+	type groupResult struct {
+		resources []string
+		available bool
+	}
+	discovered := make(map[string]groupResult)
+
+	for _, r := range resources {
+		gv := r.groupVersion()
+		if _, checked := discovered[gv]; checked {
+			continue
+		}
+
+		resourceList, err := client.Discovery().ServerResourcesForGroupVersion(gv)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.Infof("API group %q not available in cluster, skipping authorization checks for its resources", gv)
+				discovered[gv] = groupResult{available: false}
+				continue
+			}
+			log.Warnf("Failed to discover resources for API group %q, keeping authorization checks (fail-open): %v", gv, err)
+			discovered[gv] = groupResult{available: true}
+			continue
+		}
+
+		names := make([]string, 0, len(resourceList.APIResources))
+		for _, apiRes := range resourceList.APIResources {
+			names = append(names, apiRes.Name)
+		}
+		discovered[gv] = groupResult{resources: names, available: true}
+	}
+
+	var filtered []k8sResource
+	for _, r := range resources {
+		gv := r.groupVersion()
+		result := discovered[gv]
+		if !result.available {
+			log.Infof("Skipping authorization check for %s (API group %q not available)", r, gv)
+			continue
+		}
+		if result.resources != nil && !slices.Contains(result.resources, r.Resource) {
+			log.Infof("Skipping authorization check for %s (resource not found in API group %q)", r, gv)
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	return filtered
+}
+
 // k8sAuthorizer verifies that a bearer token has the required Kubernetes permissions.
 // It validates tokens using TokenReview and checks permissions using SubjectAccessReview.
 // The user is authorized if they have get and list permissions to all deployment-like
@@ -80,9 +143,28 @@ type k8sAuthorizer struct {
 	authzGroup *coalescer.Coalescer[authzResult]
 }
 
+// allResourcesToCheck is the full list of deployment-like resources that the authorizer
+// checks permissions for. At construction time, this list is filtered to only include
+// resources that actually exist in the cluster.
+var allResourcesToCheck = []k8sResource{
+	{Resource: "pods", Group: ""},
+	{Resource: "replicationcontrollers", Group: ""},
+	{Resource: "daemonsets", Group: "apps"},
+	{Resource: "deployments", Group: "apps"},
+	{Resource: "replicasets", Group: "apps"},
+	{Resource: "statefulsets", Group: "apps"},
+	{Resource: "cronjobs", Group: "batch"},
+	{Resource: "jobs", Group: "batch"},
+	{Resource: "deploymentconfigs", Group: "apps.openshift.io"},
+}
+
 // newK8sAuthorizer creates a new Kubernetes-based authorizer with TokenReview and
-// SubjectAccessReview caching.
+// SubjectAccessReview caching. It queries the cluster's Discovery API to determine
+// which resources exist and only checks permissions for those.
 func newK8sAuthorizer(client kubernetes.Interface) *k8sAuthorizer {
+	available := filterAvailableResources(client, allResourcesToCheck)
+	log.Infof("Authorizer will check permissions for %d resources: %v", len(available), available)
+
 	return &k8sAuthorizer{
 		client:           client,
 		tokenCache:       expiringcache.NewExpiringCache[string, *authenticationv1.UserInfo](defaultCacheTTL),
@@ -90,17 +172,7 @@ func newK8sAuthorizer(client kubernetes.Interface) *k8sAuthorizer {
 		verbsToCheck:     []string{"get", "list"},
 		tokenReviewGroup: coalescer.New[*authenticationv1.UserInfo](),
 		authzGroup:       coalescer.New[authzResult](),
-		resourcesToCheck: []k8sResource{
-			{Resource: "pods", Group: ""},
-			{Resource: "replicationcontrollers", Group: ""},
-			{Resource: "daemonsets", Group: "apps"},
-			{Resource: "deployments", Group: "apps"},
-			{Resource: "replicasets", Group: "apps"},
-			{Resource: "statefulsets", Group: "apps"},
-			{Resource: "cronjobs", Group: "batch"},
-			{Resource: "jobs", Group: "batch"},
-			{Resource: "deploymentconfigs", Group: "apps.openshift.io"},
-		},
+		resourcesToCheck: available,
 	}
 }
 

--- a/sensor/common/centralproxy/authorizer_test.go
+++ b/sensor/common/centralproxy/authorizer_test.go
@@ -14,13 +14,16 @@ import (
 	"github.com/stretchr/testify/require"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	k8sTesting "k8s.io/client-go/testing"
 )
 
 func TestK8sAuthorizer_MissingToken(t *testing.T) {
 	fakeClient := fake.NewClientset()
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -34,6 +37,7 @@ func TestK8sAuthorizer_MissingToken(t *testing.T) {
 
 func TestK8sAuthorizer_InvalidToken(t *testing.T) {
 	fakeClient := fake.NewClientset()
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -57,6 +61,7 @@ func TestK8sAuthorizer_TokenAuthenticationFailed(t *testing.T) {
 		}, nil
 	})
 
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -76,6 +81,7 @@ func TestK8sAuthorizer_TokenReviewAPIError(t *testing.T) {
 		return true, nil, errors.New("API server unavailable")
 	})
 
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -101,6 +107,7 @@ func TestK8sAuthorizer_TokenReviewStatusError(t *testing.T) {
 		}, nil
 	})
 
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -125,6 +132,7 @@ func TestK8sAuthorizer_AllPermissionsGranted_Namespace(t *testing.T) {
 		}, nil
 	})
 
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	userInfo := &authenticationv1.UserInfo{
@@ -152,6 +160,7 @@ func TestK8sAuthorizer_AllPermissionsGranted_ClusterWide(t *testing.T) {
 		}, nil
 	})
 
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	userInfo := &authenticationv1.UserInfo{
@@ -186,6 +195,7 @@ func TestK8sAuthorizer_MissingPermission_Namespace(t *testing.T) {
 		}, nil
 	})
 
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	userInfo := &authenticationv1.UserInfo{
@@ -221,6 +231,7 @@ func TestK8sAuthorizer_MissingPermission_ClusterWide(t *testing.T) {
 		}, nil
 	})
 
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	userInfo := &authenticationv1.UserInfo{
@@ -247,6 +258,7 @@ func TestK8sAuthorizer_SubjectAccessReviewError(t *testing.T) {
 		return true, nil, errors.New("API server unavailable")
 	})
 
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	userInfo := &authenticationv1.UserInfo{
@@ -276,6 +288,7 @@ func TestK8sAuthorizer_SubjectAccessReviewEvaluationError(t *testing.T) {
 		}, nil
 	})
 
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	userInfo := &authenticationv1.UserInfo{
@@ -301,12 +314,12 @@ func TestK8sAuthorizer_SubjectAccessReviewEvaluationError(t *testing.T) {
 func TestK8sAuthorizer_CachingBehavior(t *testing.T) {
 	fakeClient := fake.NewClientset()
 
-	sarCallCount := 0
-	tokenReviewCallCount := 0
+	var sarCallCount atomic.Int32
+	var tokenReviewCallCount atomic.Int32
 
 	// Mock TokenReview
 	fakeClient.PrependReactor("create", "tokenreviews", func(action k8sTesting.Action) (bool, runtime.Object, error) {
-		tokenReviewCallCount++
+		tokenReviewCallCount.Add(1)
 		return true, &authenticationv1.TokenReview{
 			Status: authenticationv1.TokenReviewStatus{
 				Authenticated: true,
@@ -321,7 +334,7 @@ func TestK8sAuthorizer_CachingBehavior(t *testing.T) {
 
 	// Mock SubjectAccessReview - allow all and count calls
 	fakeClient.PrependReactor("create", "subjectaccessreviews", func(action k8sTesting.Action) (bool, runtime.Object, error) {
-		sarCallCount++
+		sarCallCount.Add(1)
 		return true, &authv1.SubjectAccessReview{
 			Status: authv1.SubjectAccessReviewStatus{
 				Allowed: true,
@@ -329,6 +342,7 @@ func TestK8sAuthorizer_CachingBehavior(t *testing.T) {
 		}, nil
 	})
 
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -341,11 +355,11 @@ func TestK8sAuthorizer_CachingBehavior(t *testing.T) {
 	err = authorizer.authorize(context.Background(), userInfo, req)
 	assert.NoError(t, err)
 
-	firstSARCallCount := sarCallCount
-	firstTokenReviewCallCount := tokenReviewCallCount
+	firstSARCallCount := sarCallCount.Load()
+	firstTokenReviewCallCount := tokenReviewCallCount.Load()
 
 	// Verify we made at least one SAR call on first authorization
-	assert.Greater(t, firstSARCallCount, 0, "First authorization should perform at least one SAR call")
+	assert.Greater(t, firstSARCallCount, int32(0), "First authorization should perform at least one SAR call")
 
 	// Second request with same token and namespace - should use cache
 	userInfo, err = authorizer.authenticate(context.Background(), req)
@@ -354,19 +368,19 @@ func TestK8sAuthorizer_CachingBehavior(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Both SAR and TokenReview calls should NOT increase (all cached)
-	assert.Equal(t, firstSARCallCount, sarCallCount, "Second authorization should use cached SAR results")
-	assert.Equal(t, firstTokenReviewCallCount, tokenReviewCallCount, "TokenReview should use cached results")
+	assert.Equal(t, firstSARCallCount, sarCallCount.Load(), "Second authorization should use cached SAR results")
+	assert.Equal(t, firstTokenReviewCallCount, tokenReviewCallCount.Load(), "TokenReview should use cached results")
 }
 
 func TestK8sAuthorizer_CachingBehavior_Denied(t *testing.T) {
 	fakeClient := fake.NewClientset()
 
-	sarCallCount := 0
-	tokenReviewCallCount := 0
+	var sarCallCount atomic.Int32
+	var tokenReviewCallCount atomic.Int32
 
 	// Mock TokenReview
 	fakeClient.PrependReactor("create", "tokenreviews", func(action k8sTesting.Action) (bool, runtime.Object, error) {
-		tokenReviewCallCount++
+		tokenReviewCallCount.Add(1)
 		return true, &authenticationv1.TokenReview{
 			Status: authenticationv1.TokenReviewStatus{
 				Authenticated: true,
@@ -381,7 +395,7 @@ func TestK8sAuthorizer_CachingBehavior_Denied(t *testing.T) {
 
 	// Mock SubjectAccessReview - deny all
 	fakeClient.PrependReactor("create", "subjectaccessreviews", func(action k8sTesting.Action) (bool, runtime.Object, error) {
-		sarCallCount++
+		sarCallCount.Add(1)
 		return true, &authv1.SubjectAccessReview{
 			Status: authv1.SubjectAccessReviewStatus{
 				Allowed: false,
@@ -389,6 +403,7 @@ func TestK8sAuthorizer_CachingBehavior_Denied(t *testing.T) {
 		}, nil
 	})
 
+	registerAllResources(fakeClient)
 	authorizer := newK8sAuthorizer(fakeClient)
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -402,11 +417,11 @@ func TestK8sAuthorizer_CachingBehavior_Denied(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "lacks")
 
-	firstSARCallCount := sarCallCount
-	firstTokenReviewCallCount := tokenReviewCallCount
+	firstSARCallCount := sarCallCount.Load()
+	firstTokenReviewCallCount := tokenReviewCallCount.Load()
 
 	// Verify we made at least one SAR call on first authorization
-	assert.Greater(t, firstSARCallCount, 0, "First authorization should perform at least one SAR call")
+	assert.Greater(t, firstSARCallCount, int32(0), "First authorization should perform at least one SAR call")
 
 	// Second request with same token and namespace - should use cached denial
 	userInfo, err = authorizer.authenticate(context.Background(), req)
@@ -416,8 +431,8 @@ func TestK8sAuthorizer_CachingBehavior_Denied(t *testing.T) {
 	assert.Contains(t, err.Error(), "lacks")
 
 	// Both SAR and TokenReview calls should NOT increase (all cached)
-	assert.Equal(t, firstSARCallCount, sarCallCount, "Second authorization should use cached SAR denial results")
-	assert.Equal(t, firstTokenReviewCallCount, tokenReviewCallCount, "TokenReview should use cached results")
+	assert.Equal(t, firstSARCallCount, sarCallCount.Load(), "Second authorization should use cached SAR denial results")
+	assert.Equal(t, firstTokenReviewCallCount, tokenReviewCallCount.Load(), "TokenReview should use cached results")
 }
 
 func TestK8sAuthorizer_TokenReviewCaching(t *testing.T) {
@@ -439,6 +454,7 @@ func TestK8sAuthorizer_TokenReviewCaching(t *testing.T) {
 			}, nil
 		})
 
+		registerAllResources(fakeClient)
 		authorizer := newK8sAuthorizer(fakeClient)
 
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -469,6 +485,7 @@ func TestK8sAuthorizer_TokenReviewCaching(t *testing.T) {
 			}, nil
 		})
 
+		registerAllResources(fakeClient)
 		authorizer := newK8sAuthorizer(fakeClient)
 
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
@@ -514,6 +531,7 @@ func TestK8sAuthorizer_TokenReviewCoalescing(t *testing.T) {
 			}, nil
 		})
 
+		registerAllResources(fakeClient)
 		authorizer := newK8sAuthorizer(fakeClient)
 
 		const numGoroutines = 10
@@ -575,6 +593,7 @@ func TestK8sAuthorizer_AuthorizationCoalescing(t *testing.T) {
 		})
 
 		// Create authorizer with only one resource to check for simpler test
+		registerAllResources(fakeClient)
 		authorizer := newK8sAuthorizer(fakeClient)
 		authorizer.verbsToCheck = []string{"get"}
 		authorizer.resourcesToCheck = []k8sResource{
@@ -644,6 +663,7 @@ func TestK8sAuthorizer_AuthorizationCoalescing(t *testing.T) {
 		})
 
 		// Create authorizer with only one resource to check for simpler test
+		registerAllResources(fakeClient)
 		authorizer := newK8sAuthorizer(fakeClient)
 		authorizer.verbsToCheck = []string{"get"}
 		authorizer.resourcesToCheck = []k8sResource{
@@ -714,6 +734,7 @@ func TestK8sAuthorizer_AuthorizationCoalescing(t *testing.T) {
 		})
 
 		// Create authorizer with only one resource to check for simpler test
+		registerAllResources(fakeClient)
 		authorizer := newK8sAuthorizer(fakeClient)
 		authorizer.verbsToCheck = []string{"get"}
 		authorizer.resourcesToCheck = []k8sResource{
@@ -747,5 +768,196 @@ func TestK8sAuthorizer_AuthorizationCoalescing(t *testing.T) {
 
 		// We should have observed at least one more SAR call, proving errors were not cached
 		assert.Greater(t, sarCallCount.Load(), firstCallCount, "transient errors must not be cached")
+	})
+}
+
+func TestFilterAvailableResources(t *testing.T) {
+	t.Run("missing API group is filtered out", func(t *testing.T) {
+		fakeClient := fake.NewClientset()
+		fd := fakeClient.Discovery().(*fakediscovery.FakeDiscovery)
+		fd.Resources = []*metav1.APIResourceList{
+			{
+				GroupVersion: "v1",
+				APIResources: []metav1.APIResource{
+					{Name: "pods"},
+					{Name: "replicationcontrollers"},
+				},
+			},
+			{
+				GroupVersion: "apps/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "daemonsets"},
+					{Name: "deployments"},
+					{Name: "replicasets"},
+					{Name: "statefulsets"},
+				},
+			},
+			{
+				GroupVersion: "batch/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "cronjobs"},
+					{Name: "jobs"},
+				},
+			},
+			// apps.openshift.io/v1 is intentionally missing.
+		}
+
+		result := filterAvailableResources(fakeClient, allResourcesToCheck)
+
+		assert.Len(t, result, 8, "expected 8 resources (all except deploymentconfigs)")
+		for _, r := range result {
+			assert.NotEqual(t, "deploymentconfigs", r.Resource,
+				"deploymentconfigs should be filtered out when apps.openshift.io is missing")
+		}
+	})
+
+	t.Run("all groups present retains all resources", func(t *testing.T) {
+		fakeClient := fake.NewClientset()
+		registerAllResources(fakeClient)
+
+		result := filterAvailableResources(fakeClient, allResourcesToCheck)
+
+		assert.Len(t, result, len(allResourcesToCheck),
+			"all resources should be retained when all API groups are available")
+	})
+
+	t.Run("missing individual resource within existing group is filtered out", func(t *testing.T) {
+		fakeClient := fake.NewClientset()
+		fd := fakeClient.Discovery().(*fakediscovery.FakeDiscovery)
+		fd.Resources = []*metav1.APIResourceList{
+			{
+				GroupVersion: "v1",
+				APIResources: []metav1.APIResource{
+					{Name: "pods"},
+					// replicationcontrollers intentionally missing.
+				},
+			},
+			{
+				GroupVersion: "apps/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "daemonsets"},
+					{Name: "deployments"},
+					{Name: "replicasets"},
+					{Name: "statefulsets"},
+				},
+			},
+			{
+				GroupVersion: "batch/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "cronjobs"},
+					{Name: "jobs"},
+				},
+			},
+			{
+				GroupVersion: "apps.openshift.io/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "deploymentconfigs"},
+				},
+			},
+		}
+
+		result := filterAvailableResources(fakeClient, allResourcesToCheck)
+
+		assert.Len(t, result, 8, "expected 8 resources (all except replicationcontrollers)")
+		for _, r := range result {
+			assert.NotEqual(t, "replicationcontrollers", r.Resource,
+				"replicationcontrollers should be filtered out when not in discovery response")
+		}
+	})
+
+	t.Run("transient discovery error keeps resources (fail-open)", func(t *testing.T) {
+		fakeClient := fake.NewClientset()
+		fd := fakeClient.Discovery().(*fakediscovery.FakeDiscovery)
+		fd.Resources = []*metav1.APIResourceList{
+			{
+				GroupVersion: "v1",
+				APIResources: []metav1.APIResource{
+					{Name: "pods"},
+					{Name: "replicationcontrollers"},
+				},
+			},
+		}
+
+		client := &transientDiscoveryClient{
+			Interface: fakeClient,
+			disc: &transientDiscovery{
+				FakeDiscovery:   fd,
+				transientGroups: map[string]bool{"apps/v1": true},
+			},
+		}
+
+		resources := []k8sResource{
+			{Resource: "pods", Group: ""},
+			{Resource: "deployments", Group: "apps"},
+		}
+
+		result := filterAvailableResources(client, resources)
+
+		assert.Len(t, result, 2, "both resources should be retained when discovery error is transient (fail-open)")
+		assert.Equal(t, "pods", result[0].Resource)
+		assert.Equal(t, "deployments", result[1].Resource)
+	})
+
+	t.Run("authorizer with missing group skips SAR for those resources", func(t *testing.T) {
+		fakeClient := fake.NewClientset()
+		fd := fakeClient.Discovery().(*fakediscovery.FakeDiscovery)
+		fd.Resources = []*metav1.APIResourceList{
+			{
+				GroupVersion: "v1",
+				APIResources: []metav1.APIResource{
+					{Name: "pods"},
+					{Name: "replicationcontrollers"},
+				},
+			},
+			{
+				GroupVersion: "apps/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "daemonsets"},
+					{Name: "deployments"},
+					{Name: "replicasets"},
+					{Name: "statefulsets"},
+				},
+			},
+			{
+				GroupVersion: "batch/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "cronjobs"},
+					{Name: "jobs"},
+				},
+			},
+			// No apps.openshift.io/v1: DeploymentConfig not available.
+		}
+
+		var sarResources []string
+		var sarMu sync.Mutex
+		fakeClient.PrependReactor("create", "subjectaccessreviews", func(action k8sTesting.Action) (bool, runtime.Object, error) {
+			createAction := action.(k8sTesting.CreateAction)
+			sar := createAction.GetObject().(*authv1.SubjectAccessReview)
+			sarMu.Lock()
+			sarResources = append(sarResources, sar.Spec.ResourceAttributes.Resource)
+			sarMu.Unlock()
+			return true, &authv1.SubjectAccessReview{
+				Status: authv1.SubjectAccessReviewStatus{Allowed: true},
+			}, nil
+		})
+
+		authorizer := newK8sAuthorizer(fakeClient)
+
+		userInfo := &authenticationv1.UserInfo{
+			Username: "test-user",
+			UID:      "test-uid",
+			Groups:   []string{"test-group"},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.Header.Set(stackroxNamespaceHeader, "test-namespace")
+
+		err := authorizer.authorize(context.Background(), userInfo, req)
+		assert.NoError(t, err)
+
+		assert.NotContains(t, sarResources, "deploymentconfigs",
+			"SAR should not be checked for deploymentconfigs when the API group is unavailable")
+		assert.Contains(t, sarResources, "pods", "SAR should still check core resources")
+		assert.Contains(t, sarResources, "deployments", "SAR should still check apps resources")
 	})
 }

--- a/sensor/common/centralproxy/testutils.go
+++ b/sensor/common/centralproxy/testutils.go
@@ -18,7 +18,11 @@ import (
 	"github.com/stretchr/testify/require"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	k8sTesting "k8s.io/client-go/testing"
 )
@@ -93,10 +97,29 @@ func newTestHandlerWithTransportError(t *testing.T, baseURL *url.URL, authorizer
 	}
 }
 
+// registerAllResources configures the fake client's Discovery API to report all resources
+// from allResourcesToCheck as available. This ensures that filterAvailableResources
+// retains all resources during authorizer construction in tests.
+func registerAllResources(fakeClient *fake.Clientset) {
+	resourcesByGV := make(map[string][]metav1.APIResource)
+	for _, r := range allResourcesToCheck {
+		gv := r.groupVersion()
+		resourcesByGV[gv] = append(resourcesByGV[gv], metav1.APIResource{Name: r.Resource})
+	}
+	fd := fakeClient.Discovery().(*fakediscovery.FakeDiscovery)
+	for gv, resources := range resourcesByGV {
+		fd.Resources = append(fd.Resources, &metav1.APIResourceList{
+			GroupVersion: gv,
+			APIResources: resources,
+		})
+	}
+}
+
 // newAllowingAuthorizer creates a k8sAuthorizer with a fake client that allows all authorization requests.
 func newAllowingAuthorizer(t testing.TB) *k8sAuthorizer {
 	t.Helper()
 	fakeClient := fake.NewClientset()
+	registerAllResources(fakeClient)
 
 	// Mock TokenReview to return authenticated
 	fakeClient.PrependReactor("create", "tokenreviews", func(action k8sTesting.Action) (bool, runtime.Object, error) {
@@ -127,6 +150,7 @@ func newAllowingAuthorizer(t testing.TB) *k8sAuthorizer {
 func newDenyingAuthorizer(t testing.TB) *k8sAuthorizer {
 	t.Helper()
 	fakeClient := fake.NewClientset()
+	registerAllResources(fakeClient)
 
 	// Mock TokenReview to return authenticated
 	fakeClient.PrependReactor("create", "tokenreviews", func(action k8sTesting.Action) (bool, runtime.Object, error) {
@@ -157,6 +181,7 @@ func newDenyingAuthorizer(t testing.TB) *k8sAuthorizer {
 func newUnauthenticatedAuthorizer(t testing.TB) *k8sAuthorizer {
 	t.Helper()
 	fakeClient := fake.NewClientset()
+	registerAllResources(fakeClient)
 
 	// Mock TokenReview to return unauthenticated (invalid token)
 	fakeClient.PrependReactor("create", "tokenreviews", func(action k8sTesting.Action) (bool, runtime.Object, error) {
@@ -234,4 +259,34 @@ func (f *proxyTestFixture) serveHTTP(t *testing.T, method, path string, headers 
 	w := httptest.NewRecorder()
 	f.handler.ServeHTTP(w, req)
 	return w
+}
+
+// transientDiscoveryClient wraps a kubernetes.Interface to inject transient
+// discovery errors for specific API group versions via a custom Discovery
+// implementation.
+type transientDiscoveryClient struct {
+	kubernetes.Interface
+	disc discovery.DiscoveryInterface
+}
+
+func (c *transientDiscoveryClient) Discovery() discovery.DiscoveryInterface {
+	return c.disc
+}
+
+// transientDiscovery wraps FakeDiscovery and returns transient (non-NotFound)
+// errors for the specified group versions.
+type transientDiscovery struct {
+	*fakediscovery.FakeDiscovery
+	transientGroups map[string]bool
+}
+
+func (d *transientDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	if d.transientGroups[groupVersion] {
+		return nil, errors.New("transient API server error")
+	}
+	res, err := d.FakeDiscovery.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		return nil, errors.Wrap(err, "discovering resources")
+	}
+	return res, nil
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The centralproxy authorizer checked permissions for a hardcoded list of resources including deploymentconfigs.apps.openshift.io. On OCP clusters without DeploymentConfig capability, users without wildcard RBAC for that API group were denied access for a resource that does not exist.

Query the Discovery API at authorizer construction time to filter the resource list to only those actually available. Missing API groups are skipped; transient discovery errors keep the resources (fail-open) to avoid silently bypassing authorization.

Before:

Users with restricted permissions could run into situations where SubjectAccessReviews are denied for resources which do not exist in the cluster.

<img width="1222" height="600" alt="SCR-20260602-ouxs" src="https://github.com/user-attachments/assets/dc7c6b77-809a-4ee3-80e0-2cddb3297ac7" />

After:

Only resources which actually exist in the cluster are checked for access.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

* Created an OCP cluster without `DeploymentConfig` capability.
* Check sensor logs
```
common/centralproxy: 2026/06/02 14:06:43.234932 authorizer.go:97: Info: API group "apps.openshift.io/v1" not available in cluster, skipping authorization checks for its resources
common/centralproxy: 2026/06/02 14:06:43.235094 authorizer.go:118: Info: Skipping authorization check for deploymentconfigs.apps.openshift.io (API group "apps.openshift.io/v1" not available)
common/centralproxy: 2026/06/02 14:06:43.235381 authorizer.go:166: Info: Authorizer will check permissions for 8 resources: [pods.core replicationcontrollers.core daemonsets.apps deployments.apps replicasets.apps statefulsets.apps cronjobs.batch jobs.batch]
```
* Confirm that console plugin renders correctly when scoped to a namespace where the user does not have `*` permissions.