### PR TITLE
ROX-33431: Bump resources again to prevent OOM kills

### DIFF
--- a/.tekton/central-db-build.yaml
+++ b/.tekton/central-db-build.yaml
@@ -73,8 +73,10 @@ spec:
     - name: build
       computeResources:
         limits:
+          cpu: 1
           memory: 3Gi
         requests:
+          cpu: 1
           memory: 3Gi
   - pipelineTaskName: rpms-signature-scan
     stepSpecs:

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -81,9 +81,9 @@ spec:
     - name: prefetch-dependencies
       computeResources:
         limits:
-          memory: 5Gi
+          memory: 6Gi
         requests:
-          memory: 5Gi
+          memory: 6Gi
     - name: create-trusted-artifact
       computeResources: &ta-resources
         limits:

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -111,8 +111,10 @@ spec:
     - name: build
       computeResources:
         limits:
+          cpu: 1
           memory: 3Gi
         requests:
+          cpu: 1
           memory: 3Gi
   - pipelineTaskName: sast-shell-check
     podTemplate: *go-memlimit

--- a/.tekton/main-build.yaml
+++ b/.tekton/main-build.yaml
@@ -88,10 +88,10 @@ spec:
       computeResources: &ta-resources
         limits:
           cpu: 2
-          memory: 5Gi
+          memory: 7Gi
         requests:
           cpu: 2
-          memory: 5Gi
+          memory: 7Gi
   - pipelineTaskName: build-images
     podTemplate: *go-memlimit
     stepSpecs:

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -87,10 +87,10 @@ spec:
       computeResources: &ta-resources
         limits:
           cpu: 2
-          memory: 5Gi
+          memory: 7Gi
         requests:
           cpu: 2
-          memory: 5Gi
+          memory: 7Gi
   - pipelineTaskName: build-images
     podTemplate: *go-memlimit
     stepSpecs:

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -80,9 +80,9 @@ spec:
     - name: prefetch-dependencies
       computeResources:
         limits:
-          memory: 5Gi
+          memory: 6Gi
         requests:
-          memory: 5Gi
+          memory: 6Gi
     - name: create-trusted-artifact
       computeResources: &ta-resources
         limits:

--- a/.tekton/operator-build.yaml
+++ b/.tekton/operator-build.yaml
@@ -104,8 +104,10 @@ spec:
     - name: build
       computeResources:
         limits:
+          cpu: 1
           memory: 3Gi
         requests:
+          cpu: 1
           memory: 3Gi
   - pipelineTaskName: sast-shell-check
     podTemplate: *go-memlimit

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -84,10 +84,10 @@ spec:
       computeResources: &ta-resources
         limits:
           cpu: 2
-          memory: 5Gi
+          memory: 7Gi
         requests:
           cpu: 2
-          memory: 5Gi
+          memory: 7Gi
   - pipelineTaskName: build-container
     podTemplate: *go-memlimit
     stepSpecs:

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -77,9 +77,9 @@ spec:
     - name: prefetch-dependencies
       computeResources:
         limits:
-          memory: 5Gi
+          memory: 6Gi
         requests:
-          memory: 5Gi
+          memory: 6Gi
     - name: create-trusted-artifact
       computeResources: &ta-resources
         limits:

--- a/.tekton/operator-bundle-build.yaml
+++ b/.tekton/operator-bundle-build.yaml
@@ -101,8 +101,10 @@ spec:
     - name: build
       computeResources:
         limits:
+          cpu: 1
           memory: 3Gi
         requests:
+          cpu: 1
           memory: 3Gi
   - pipelineTaskName: sast-shell-check
     podTemplate: *go-memlimit

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -87,10 +87,10 @@ spec:
       computeResources: &ta-resources
         limits:
           cpu: 2
-          memory: 5Gi
+          memory: 7Gi
         requests:
           cpu: 2
-          memory: 5Gi
+          memory: 7Gi
   - pipelineTaskName: build-images
     podTemplate: *go-memlimit
     stepSpecs:

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -80,9 +80,9 @@ spec:
     - name: prefetch-dependencies
       computeResources:
         limits:
-          memory: 5Gi
+          memory: 6Gi
         requests:
-          memory: 5Gi
+          memory: 6Gi
     - name: create-trusted-artifact
       computeResources: &ta-resources
         limits:

--- a/.tekton/roxctl-build.yaml
+++ b/.tekton/roxctl-build.yaml
@@ -104,8 +104,10 @@ spec:
     - name: build
       computeResources:
         limits:
+          cpu: 1
           memory: 3Gi
         requests:
+          cpu: 1
           memory: 3Gi
   - pipelineTaskName: sast-shell-check
     podTemplate: *go-memlimit

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -87,10 +87,10 @@ spec:
       computeResources: &ta-resources
         limits:
           cpu: 2
-          memory: 5Gi
+          memory: 7Gi
         requests:
           cpu: 2
-          memory: 5Gi
+          memory: 7Gi
   - pipelineTaskName: build-images
     podTemplate: *go-memlimit
     stepSpecs:

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -80,9 +80,9 @@ spec:
     - name: prefetch-dependencies
       computeResources:
         limits:
-          memory: 5Gi
+          memory: 6Gi
         requests:
-          memory: 5Gi
+          memory: 6Gi
     - name: create-trusted-artifact
       computeResources: &ta-resources
         limits:

--- a/.tekton/scanner-v4-build.yaml
+++ b/.tekton/scanner-v4-build.yaml
@@ -104,8 +104,10 @@ spec:
     - name: build
       computeResources:
         limits:
+          cpu: 1
           memory: 3Gi
         requests:
+          cpu: 1
           memory: 3Gi
   - pipelineTaskName: sast-shell-check
     podTemplate: *go-memlimit

--- a/.tekton/scanner-v4-db-build.yaml
+++ b/.tekton/scanner-v4-db-build.yaml
@@ -73,8 +73,10 @@ spec:
     - name: build
       computeResources:
         limits:
+          cpu: 1
           memory: 3Gi
         requests:
+          cpu: 1
           memory: 3Gi
   - pipelineTaskName: rpms-signature-scan
     stepSpecs:


### PR DESCRIPTION
## Description

Follows up on https://github.com/stackrox/stackrox/pull/20655 with findings from OOM dashboard. See https://redhat-internal.slack.com/archives/C081BAM590Q/p1780296820165749

Note that I had to manually pull some info from pods to determine for which branch they ran. That's how I narrowed the set of failures to look at.

It's best to review this PR per commits because I shared info in the commit message in each.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

Only CI. Will run a few times.