### PR TITLE
ROX-34779: skip deleting old results on scan config timeout

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -608,9 +608,6 @@ func (m *managerImpl) handleReadyScanConfig() {
 		concurrency.WithLock(&m.watchingScanConfigsLock, func() {
 			delete(m.watchingScanConfigs, scanConfigWatcherResult.WatcherID)
 		})
-		if err := watcher.DeleteOldResultsFromMissingScans(m.automaticReportingCtx, scanConfigWatcherResult, m.profileDataStore, m.scanDataStore, m.checkResultDataStore); err != nil {
-			log.Errorf("unable to delete old CheckResults: %v", err)
-		}
 		m.generateReportsFromWatcherResults(scanConfigWatcherResult)
 	}
 }

--- a/central/complianceoperator/v2/report/manager/results/results_aggregator.go
+++ b/central/complianceoperator/v2/report/manager/results/results_aggregator.go
@@ -109,14 +109,13 @@ func (g *Aggregator) getReportDataForCluster(ctx context.Context, scanConfigID, 
 			// this cluster). Exclude all results to avoid including stale data
 			// from a previous scan cycle in the report.
 			return ret, statuses, nil
-		} else {
-			allScansSet := set.NewStringSet(successfulScanNames...)
-			failedScansSet := set.NewStringSet()
-			for _, scan := range clusterData.FailedInfo.FailedScans {
-				failedScansSet.Add(scan.GetScanName())
-			}
-			successfulScanNames = allScansSet.Difference(failedScansSet).AsSlice()
 		}
+		allScansSet := set.NewStringSet(successfulScanNames...)
+		failedScansSet := set.NewStringSet()
+		for _, scan := range clusterData.FailedInfo.FailedScans {
+			failedScansSet.Add(scan.GetScanName())
+		}
+		successfulScanNames = allScansSet.Difference(failedScansSet).AsSlice()
 	}
 	scanConfigQuery := search.NewQueryBuilder().
 		AddExactMatches(search.ComplianceOperatorScanConfig, scanConfigID).

--- a/central/complianceoperator/v2/report/manager/results/results_aggregator.go
+++ b/central/complianceoperator/v2/report/manager/results/results_aggregator.go
@@ -103,12 +103,20 @@ func (g *Aggregator) getReportDataForCluster(ctx context.Context, scanConfigID, 
 	}
 	successfulScanNames := clusterData.ScanNames
 	if clusterData.FailedInfo != nil {
-		allScansSet := set.NewStringSet(successfulScanNames...)
-		failedScansSet := set.NewStringSet()
-		for _, scan := range clusterData.FailedInfo.FailedScans {
-			failedScansSet.Add(scan.GetScanName())
+		if len(clusterData.FailedInfo.FailedScans) == 0 {
+			// The entire cluster failed to report (e.g. sensor disconnected,
+			// scan config watcher timed out without receiving any results from
+			// this cluster). Exclude all results to avoid including stale data
+			// from a previous scan cycle in the report.
+			return ret, statuses, nil
+		} else {
+			allScansSet := set.NewStringSet(successfulScanNames...)
+			failedScansSet := set.NewStringSet()
+			for _, scan := range clusterData.FailedInfo.FailedScans {
+				failedScansSet.Add(scan.GetScanName())
+			}
+			successfulScanNames = allScansSet.Difference(failedScansSet).AsSlice()
 		}
-		successfulScanNames = allScansSet.Difference(failedScansSet).AsSlice()
 	}
 	scanConfigQuery := search.NewQueryBuilder().
 		AddExactMatches(search.ComplianceOperatorScanConfig, scanConfigID).

--- a/central/complianceoperator/v2/report/manager/results/results_aggregator_test.go
+++ b/central/complianceoperator/v2/report/manager/results/results_aggregator_test.go
@@ -53,6 +53,7 @@ type getReportDataTestCase struct {
 	numFailedChecksPerCluster int
 	numMixedChecksPerCluster  int
 	numFailedClusters         int
+	numFullyFailedClusters    int
 	expectedWalkByErr         error
 }
 
@@ -73,6 +74,14 @@ func (s *ComplianceResultsAggregatorSuite) Test_GetReportDataResultsGeneration()
 			numMixedChecksPerCluster:  3,
 			numFailedClusters:         1,
 		},
+		"generate report data with fully failed cluster excludes stale results": {
+			numClusters:               2,
+			numProfiles:               2,
+			numPassedChecksPerCluster: 2,
+			numFailedChecksPerCluster: 1,
+			numMixedChecksPerCluster:  3,
+			numFullyFailedClusters:    1,
+		},
 		"generate report walk by error": {
 			numClusters:       3,
 			numProfiles:       4,
@@ -82,9 +91,11 @@ func (s *ComplianceResultsAggregatorSuite) Test_GetReportDataResultsGeneration()
 	for tname, tcase := range cases {
 		s.Run(tname, func() {
 			ctx := context.Background()
-			req := getRequest(ctx, tcase.numClusters, tcase.numProfiles, tcase.numFailedClusters)
+			req := getRequest(ctx, tcase.numClusters, tcase.numProfiles, tcase.numFailedClusters, tcase.numFullyFailedClusters)
+			// Fully-failed clusters (empty FailedScans) return early without calling WalkByQuery
+			walkByTimes := tcase.numClusters + tcase.numFailedClusters
 			s.checkResultsDS.EXPECT().WalkByQuery(gomock.Eq(ctx), gomock.Any(), gomock.Any()).
-				Times(tcase.numClusters + tcase.numFailedClusters).
+				Times(walkByTimes).
 				DoAndReturn(fakeWalkByResponse(
 					req.ClusterData,
 					tcase.expectedWalkByErr,
@@ -517,7 +528,7 @@ func (s *ComplianceResultsAggregatorSuite) SetupTest() {
 	s.aggregator = NewAggregator(s.checkResultsDS, s.scanDS, s.profileDS, s.remediationDS, s.ruleDS)
 }
 
-func getRequest(ctx context.Context, numClusters, numProfiles, numFailedClusters int) *report.Request {
+func getRequest(ctx context.Context, numClusters, numProfiles, numFailedClusters, numFullyFailedClusters int) *report.Request {
 	ret := &report.Request{
 		Ctx:          ctx,
 		ScanConfigID: scanConfigID,
@@ -525,7 +536,8 @@ func getRequest(ctx context.Context, numClusters, numProfiles, numFailedClusters
 		Profiles:     getNames("profile", numProfiles),
 	}
 	clusterData := make(map[string]*report.ClusterData)
-	for i := 0; i < numClusters+numFailedClusters; i++ {
+	totalExtra := numFailedClusters + numFullyFailedClusters
+	for i := 0; i < numClusters+totalExtra; i++ {
 		id := fmt.Sprintf("cluster-%d", i)
 		var profileNames []string
 		for j := range numProfiles {
@@ -559,6 +571,22 @@ func getRequest(ctx context.Context, numClusters, numProfiles, numFailedClusters
 			clusterData[id].FailedInfo = failedInfo
 		}
 		ret.NumFailedClusters = numFailedClusters
+	}
+	// Fully-failed clusters: FailedInfo set but FailedScans empty (e.g. sensor
+	// disconnected, cluster never reported). Results aggregator should skip these
+	// entirely to avoid including stale data.
+	if numFullyFailedClusters > 0 {
+		offset := numClusters + numFailedClusters
+		for i := offset; i < offset+numFullyFailedClusters; i++ {
+			id := fmt.Sprintf("cluster-%d", i)
+			ret.ClusterIDs = append(ret.ClusterIDs, id)
+			clusterData[id].FailedInfo = &report.FailedCluster{
+				ClusterId:   id,
+				ClusterName: id,
+				Reasons:     []string{"cluster did not report any results"},
+			}
+		}
+		ret.NumFailedClusters += numFullyFailedClusters
 	}
 	ret.ClusterData = clusterData
 	return ret
@@ -597,7 +625,7 @@ func getRowFromCluster(check, clusterID string) *report.ResultRow {
 }
 
 func assertResults(t *testing.T, tcase getReportDataTestCase, res *report.Results) {
-	assert.Equal(t, tcase.numClusters+tcase.numFailedClusters, res.Clusters)
+	assert.Equal(t, tcase.numClusters+tcase.numFailedClusters+tcase.numFullyFailedClusters, res.Clusters)
 	assert.Equal(t, tcase.numProfiles, len(res.Profiles))
 	if tcase.expectedWalkByErr != nil {
 		assert.Equal(t, 0, res.TotalPass)

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher.go
@@ -3,10 +3,8 @@ package watcher
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/pkg/errors"
-	resultsDataStore "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore"
 	profileDatastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore"
 	snapshotDataStore "github.com/stackrox/rox/central/complianceoperator/v2/report/datastore"
 	scanConfigurationDS "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
@@ -29,47 +27,6 @@ var (
 // GetScanConfigFromScan returns the ScanConfiguration associated with the given scan
 func GetScanConfigFromScan(ctx context.Context, scan *storage.ComplianceOperatorScanV2, scanConfigDS scanConfigurationDS.DataStore) (*storage.ComplianceOperatorScanConfigurationV2, error) {
 	return scanConfigDS.GetScanConfigurationByName(ctx, scan.GetScanConfigName())
-}
-
-func DeleteOldResultsFromMissingScans(ctx context.Context, results *ScanConfigWatcherResults, profileDataStore profileDatastore.DataStore, scanDataStore scanDataStore.DataStore, resultsDataStore resultsDataStore.DataStore) error {
-	if results == nil {
-		return errors.New("unable to delete old CheckResults from an nil ScanConfigWatcherResults")
-	}
-	scans, err := GetScansFromScanConfiguration(ctx, results.ScanConfig, profileDataStore, scanDataStore)
-	if err != nil {
-		return err
-	}
-	for _, scanResults := range results.ScanResults {
-		scans.Remove(fmt.Sprintf("%s:%s", scanResults.Scan.GetClusterId(), scanResults.Scan.GetId()))
-	}
-	if scans.Cardinality() == 0 {
-		return nil
-	}
-	log.Warnf("Deleting old check results from %d scans that did not report results for scan config %s (missing: %v)",
-		scans.Cardinality(), results.ScanConfig.GetScanConfigName(), scans.AsSlice())
-	errList := errorhelpers.NewErrorList("delete old CheckResults from missing scans")
-	for scanWatcherID := range scans {
-		parts := strings.Split(scanWatcherID, ":")
-		if len(parts) != 2 {
-			errList.AddError(errors.Errorf("unable to parse ScanID from %q", scanWatcherID))
-			continue
-		}
-		scan, found, err := scanDataStore.GetScan(ctx, parts[1])
-		if err != nil {
-			errList.AddError(err)
-			continue
-		}
-		if !found {
-			errList.AddError(errors.Errorf("unable to find Scan with ID %q", parts[1]))
-			continue
-		}
-		log.Warnf("Deleting all check results for missing scan %s (scanRefId: %s, cluster: %s)",
-			scan.GetScanName(), scan.GetScanRefId(), parts[0])
-		if err := resultsDataStore.DeleteOldResults(ctx, scan.GetLastStartedTime(), scan.GetScanRefId(), true); err != nil {
-			errList.AddError(err)
-		}
-	}
-	return errList.ToError()
 }
 
 // ScanConfigWatcher determines if a ScanConfiguration has running scans or has completed

--- a/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
+++ b/central/complianceoperator/v2/report/manager/watcher/scanconfigwatcher_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	checkResultsMocks "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore/mocks"
 	profileDatastore "github.com/stackrox/rox/central/complianceoperator/v2/profiles/datastore/mocks"
 	snapshotMocks "github.com/stackrox/rox/central/complianceoperator/v2/report/datastore/mocks"
 	scanMocks "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore/mocks"
@@ -18,7 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type scanConfigTestEvent func(*testing.T, ScanConfigWatcher)
@@ -376,102 +374,4 @@ func TestScanConfigWatcherGetScans(t *testing.T) {
 
 	scans = scanConfigWatcher.GetScans()
 	require.Len(t, scans, 2)
-}
-
-func TestDeleteOldResultsFromMissingScans(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	checkDS := checkResultsMocks.NewMockDataStore(ctrl)
-	profileDS := profileDatastore.NewMockDataStore(ctrl)
-	scanDS := scanMocks.NewMockDataStore(ctrl)
-	timeNow := timestamppb.Now()
-	scanID := "scan-id"
-	scanRefID := "ref-id"
-	t.Run("nil results should return an error", func(tt *testing.T) {
-		assert.Error(tt, DeleteOldResultsFromMissingScans(context.Background(), nil, profileDS, scanDS, checkDS))
-	})
-	t.Run("error retrieving profiles should return an error", func(tt *testing.T) {
-		results := &ScanConfigWatcherResults{
-			ScanConfig: &storage.ComplianceOperatorScanConfigurationV2{},
-		}
-		profileDS.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorProfileV2{}, errors.New("some error"))
-		assert.Error(tt, DeleteOldResultsFromMissingScans(context.Background(), results, profileDS, scanDS, checkDS))
-	})
-	t.Run("error retrieving scans set should return an error", func(tt *testing.T) {
-		results := &ScanConfigWatcherResults{
-			ScanConfig: &storage.ComplianceOperatorScanConfigurationV2{},
-		}
-		profileDS.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorProfileV2{
-			{},
-		}, nil)
-		scanDS.EXPECT().SearchScans(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorScanV2{}, errors.New("some error"))
-		assert.Error(tt, DeleteOldResultsFromMissingScans(context.Background(), results, profileDS, scanDS, checkDS))
-	})
-	t.Run("error retrieving scan should return an error", func(tt *testing.T) {
-		results := &ScanConfigWatcherResults{
-			ScanConfig: &storage.ComplianceOperatorScanConfigurationV2{},
-		}
-		profileDS.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorProfileV2{
-			{},
-		}, nil)
-		scanDS.EXPECT().SearchScans(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorScanV2{
-			{
-				Id: scanID,
-			},
-		}, nil)
-		scanDS.EXPECT().GetScan(gomock.Any(), gomock.Eq(scanID)).Times(1).Return(&storage.ComplianceOperatorScanV2{}, false, errors.New("some error"))
-		assert.Error(tt, DeleteOldResultsFromMissingScans(context.Background(), results, profileDS, scanDS, checkDS))
-	})
-	t.Run("scan not found should return an error", func(tt *testing.T) {
-		results := &ScanConfigWatcherResults{
-			ScanConfig: &storage.ComplianceOperatorScanConfigurationV2{},
-		}
-		profileDS.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorProfileV2{
-			{},
-		}, nil)
-		scanDS.EXPECT().SearchScans(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorScanV2{
-			{
-				Id: scanID,
-			},
-		}, nil)
-		scanDS.EXPECT().GetScan(gomock.Any(), gomock.Eq(scanID)).Times(1).Return(&storage.ComplianceOperatorScanV2{}, false, nil)
-		assert.Error(tt, DeleteOldResultsFromMissingScans(context.Background(), results, profileDS, scanDS, checkDS))
-	})
-	t.Run("delete old results error should return an error", func(tt *testing.T) {
-		results := &ScanConfigWatcherResults{
-			ScanConfig: &storage.ComplianceOperatorScanConfigurationV2{},
-		}
-		profileDS.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorProfileV2{
-			{},
-		}, nil)
-		scanDS.EXPECT().SearchScans(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorScanV2{
-			{
-				Id: scanID,
-			},
-		}, nil)
-		scanDS.EXPECT().GetScan(gomock.Any(), gomock.Eq(scanID)).Times(1).Return(&storage.ComplianceOperatorScanV2{
-			ScanRefId:       scanRefID,
-			LastStartedTime: timeNow,
-		}, true, nil)
-		checkDS.EXPECT().DeleteOldResults(gomock.Any(), gomock.Eq(timeNow), gomock.Eq(scanRefID), gomock.Eq(true)).Times(1).Return(errors.New("some error"))
-		assert.Error(tt, DeleteOldResultsFromMissingScans(context.Background(), results, profileDS, scanDS, checkDS))
-	})
-	t.Run("delete old results", func(tt *testing.T) {
-		results := &ScanConfigWatcherResults{
-			ScanConfig: &storage.ComplianceOperatorScanConfigurationV2{},
-		}
-		profileDS.EXPECT().SearchProfiles(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorProfileV2{
-			{},
-		}, nil)
-		scanDS.EXPECT().SearchScans(gomock.Any(), gomock.Any()).Times(1).Return([]*storage.ComplianceOperatorScanV2{
-			{
-				Id: scanID,
-			},
-		}, nil)
-		scanDS.EXPECT().GetScan(gomock.Any(), gomock.Eq(scanID)).Times(1).Return(&storage.ComplianceOperatorScanV2{
-			ScanRefId:       scanRefID,
-			LastStartedTime: timeNow,
-		}, true, nil)
-		checkDS.EXPECT().DeleteOldResults(gomock.Any(), gomock.Eq(timeNow), gomock.Eq(scanRefID), gomock.Eq(true)).Times(1).Return(nil)
-		assert.NoError(tt, DeleteOldResultsFromMissingScans(context.Background(), results, profileDS, scanDS, checkDS))
-	})
 }


### PR DESCRIPTION
## Description

`DeleteOldResultsFromMissingScans` was introduced (PR #15298, ROX-29251) to maintain consistency between the compliance coverage dashboard and reports: if a cluster did not report results during a scan cycle, its old results were deleted so the dashboard would not show stale data that contradicts the report (which marks the cluster as failed).

The function only has effect on timeout/error paths (on success, all scans reported and there are nothing to clean up by construction). On those paths, deletion causes clusters to vanish from the dashboard — the exact outcome it was meant to prevent. Evidence from ROX-34779: central logs show a ScanConfigWatcher timeout (21/27 scans reported), after which `DeleteOldResultsFromMissingScans` deleted all check results for the 2 clusters that did not report in time. CO must-gathers confirm scans completed successfully on those clusters — the data existed, ACS deleted it.

**This PR removes the deletion and accepts a controlled inconsistency:**

- **Commit 1:** Remove `DeleteOldResultsFromMissingScans`. Old results are preserved in the DB. The dashboard shows last-known-good data rather than nothing — clusters stay visible.
- **Commit 2:** Prevent stale data from leaking into reports. When a cluster failed entirely (`FailedInfo` set, `FailedScans` empty), the results aggregator skips it. Reports show the cluster as failed without including stale results.

This means the dashboard may show stale results for a cluster that reports mark as failed — a deliberate trade-off. Clusters disappearing from the dashboard is a worse outcome than showing slightly stale data, and there is planned effort to add staleness indicators to the UI (ROX-35712).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Unit tests pass
- Verified in-cluster: disconnected a sensor mid-scan and let the scan config watcher time out. The disconnected cluster's check results stayed in the database (no deletion), and the generated report correctly excluded that cluster's stale results (empty per-cluster CSV with just the failure reason) while the healthy cluster's report was unaffected
- New test case covers the fully-failed cluster path (FailedScans empty → early return, no stale results in report)
- Call count assertion: `WalkByQuery` `Times` excludes fully-failed clusters — if the aggregator called it for one, the mock would fail