### PR TITLE
ROX-34740: Fix race condition between policy and notifier delete

### DIFF
--- a/central/detection/policy_set_impl.go
+++ b/central/detection/policy_set_impl.go
@@ -2,15 +2,20 @@ package detection
 
 import (
 	"context"
+	"errors"
 
 	policyDatastore "github.com/stackrox/rox/central/policy/datastore"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/detection"
+	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
 )
 
 var (
+	log = logging.LoggerForModule()
+
 	policyCtx = sac.WithGlobalAccessScopeChecker(context.Background(),
 		sac.AllowFixedScopes(sac.AccessModeScopeKeys(storage.Access_READ_WRITE_ACCESS),
 			sac.ResourceScopeKeys(resources.WorkflowAdministration)))
@@ -45,6 +50,13 @@ func (p *setImpl) RemoveNotifier(notifierID string) error {
 
 		err := p.policyStore.UpdatePolicy(policyCtx, policy)
 		if err != nil {
+			// Policy may have been deleted concurrently (e.g., config-controller removing a declarative policy).
+			// Update of categories will fail because of foreign key constraint.
+			if errors.Is(err, errox.ReferencedObjectNotFound) {
+				log.Warnf("Skipping notifier removal from policy %s: %v", policy.GetId(), err)
+				continue
+			}
+
 			return err
 		}
 	}

--- a/central/detection/policy_set_impl_test.go
+++ b/central/detection/policy_set_impl_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackrox/rox/pkg/booleanpolicy/fieldnames"
 	"github.com/stackrox/rox/pkg/detection"
 	"github.com/stackrox/rox/pkg/detection/mocks"
+	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/testutils"
@@ -261,4 +262,57 @@ func TestPolicySet_WithLabelProviders(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 3, policyCount, "ForEach should iterate over all policies")
+}
+
+func TestPolicySet_RemoveNotifier_ConcurrentPolicyDeletion(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	policySetMock := mocks.NewMockPolicySet(mockCtrl)
+	policyDatastoreMock := mocks2.NewMockDataStore(mockCtrl)
+
+	policySet := &setImpl{
+		PolicySet:   policySetMock,
+		policyStore: policyDatastoreMock,
+	}
+
+	policySetMock.EXPECT().GetCompiledPolicies().Return(map[string]detection.CompiledPolicy{
+		"policy1": wrapPolicy(&storage.Policy{
+			Id:        "policy1",
+			Notifiers: []string{"notifier1", "notifier2"},
+		}),
+		"deleted-policy": wrapPolicy(&storage.Policy{
+			Id:        "deleted-policy",
+			Notifiers: []string{"notifier1", "notifier2", "notifier3"},
+		}),
+		"policy3": wrapPolicy(&storage.Policy{
+			Id:        "policy3",
+			Notifiers: []string{"notifier2", "notifier3"},
+		}),
+	})
+
+	var updatedPolicies []*storage.Policy
+	policyDatastoreMock.EXPECT().UpdatePolicy(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(_ context.Context, policy *storage.Policy) error {
+		if policy.GetId() == "deleted-policy" {
+			// Test assumes that toErrox() is called and DB error is mapped.
+			return errox.ReferencedObjectNotFound
+		}
+		updatedPolicies = append(updatedPolicies, policy)
+		return nil
+	})
+
+	require.NoError(t, policySet.RemoveNotifier("notifier2"))
+
+	expectedUpdates := []*storage.Policy{
+		{
+			Id:        "policy1",
+			Notifiers: []string{"notifier1"},
+		},
+		{
+			Id:        "policy3",
+			Notifiers: []string{"notifier3"},
+		},
+	}
+
+	protoassert.ElementsMatch(t, expectedUpdates, updatedPolicies)
 }

--- a/tests/policy_as_code_test.go
+++ b/tests/policy_as_code_test.go
@@ -473,7 +473,6 @@ func (pc *PolicyAsCodeSuite) createCRAndObserveInCentral(policyCR *v1alpha1.Secu
 }
 
 func (pc *PolicyAsCodeSuite) TearDownSuite() {
-	// TODO: Don't double delete
 	for _, policy := range pc.policies {
 		pc.T().Logf("Deleting policy with name \"%s\"", policy.GetName())
 		if policy.GetSource() == storage.PolicySource_DECLARATIVE {


### PR DESCRIPTION
## Description

`RemoveNotifier` races with concurrent policy deletion. When a policy is deleted (e.g., config-controller removing a declarative policy via finalizer), the DB row is removed before the in-memory PolicySet is updated. If `RemoveNotifier` runs in that window, it finds the stale policy in the PolicySet and calls `UpdatePolicy`, which internally re-inserts `policy_category_edges` referencing the now-deleted policy row - triggering a FK violation (SQLSTATE 23503).

This caused `TestPolicyAsCode` TearDown failures (ROX-34740) and cascading `TestTLSChallenge` timeouts (ROX-33160) due to leaked cluster resources.

**Error chain**
RemoveNotifier → UpdatePolicy → SetPolicyCategoriesForPolicy → INSERT INTO policy_category_edges (PolicyId FK → deleted policy) → SQLSTATE 23503 → toErrox() → errox.ReferencedObjectNotFound

**Fix**

Handle `errox.ReferencedObjectNotFound` in `RemoveNotifier` as a no-op - if the policy was concurrently deleted, there is nothing to clean up. Log a warning and continue to the next policy.

**Note:** Removed stale `TODO` comment from test. It is not actionable.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] added unit tests

### How I validated my change

- [x] run test without code change -> **fails**
- [x] run test with code change -> **success**
- [x] run tests in CI and check them
