### PR TITLE
ROX-35023: cancel reports

### DIFF
--- a/central/reports/scheduler/v2/reportgenerator/mocks/report_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/mocks/report_gen.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	reportgenerator "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
@@ -41,13 +42,13 @@ func (m *MockReportGenerator) EXPECT() *MockReportGeneratorMockRecorder {
 }
 
 // ProcessReportRequest mocks base method.
-func (m *MockReportGenerator) ProcessReportRequest(req *reportgenerator.ReportRequest) {
+func (m *MockReportGenerator) ProcessReportRequest(ctx context.Context, req *reportgenerator.ReportRequest) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ProcessReportRequest", req)
+	m.ctrl.Call(m, "ProcessReportRequest", ctx, req)
 }
 
 // ProcessReportRequest indicates an expected call of ProcessReportRequest.
-func (mr *MockReportGeneratorMockRecorder) ProcessReportRequest(req any) *gomock.Call {
+func (mr *MockReportGeneratorMockRecorder) ProcessReportRequest(ctx, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessReportRequest", reflect.TypeOf((*MockReportGenerator)(nil).ProcessReportRequest), req)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessReportRequest", reflect.TypeOf((*MockReportGenerator)(nil).ProcessReportRequest), ctx, req)
 }

--- a/central/reports/scheduler/v2/reportgenerator/report_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen.go
@@ -1,6 +1,8 @@
 package reportgenerator
 
 import (
+	"context"
+
 	"github.com/graph-gophers/graphql-go"
 	blobDS "github.com/stackrox/rox/central/blob/datastore"
 	clusterDS "github.com/stackrox/rox/central/cluster/datastore"
@@ -21,7 +23,8 @@ type ReportGenerator interface {
 	// ProcessReportRequest will generate a report and send notification via the requested notification method.
 	// On success, report will be generated and notified, and report snapshot will be stored to the db.
 	// On failure, it will log any errors and store it in the report snapshot.
-	ProcessReportRequest(req *ReportRequest)
+	// The context is used for cancellation; cancelling it will abort in-flight database queries.
+	ProcessReportRequest(ctx context.Context, req *ReportRequest)
 }
 
 // New will create a new instance of the ReportGenerator

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_bench_flat_data_model_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_bench_flat_data_model_test.go
@@ -81,7 +81,7 @@ func BenchmarkFlatDataModelReportGenerator(b *testing.B) {
 
 	b.Run("GetReportDataSQF", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			reportData, err := bts.reportGenerator.getReportDataSQF(reportSnap, collection, time.Time{})
+			reportData, err := bts.reportGenerator.getReportDataSQF(bts.ctx, reportSnap, collection, time.Time{})
 			require.NoError(b, err)
 			require.Equal(b, expectedRowCount, len(reportData.CVEResponses))
 		}
@@ -260,7 +260,7 @@ func BenchmarkEntityScopeReportGenerator(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			reportData, err := reportGenerator.getReportDataSQF(reportSnap, nil, sinceStartDate)
+			reportData, err := reportGenerator.getReportDataSQF(ctx, reportSnap, nil, sinceStartDate)
 			require.NoError(b, err)
 			require.Equal(b, expectedRowCount, len(reportData.CVEResponses))
 		}
@@ -289,7 +289,7 @@ func BenchmarkEntityScopeReportGenerator(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			reportData, err := reportGenerator.getReportDataSQF(reportSnap, nil, sinceStartDate)
+			reportData, err := reportGenerator.getReportDataSQF(ctx, reportSnap, nil, sinceStartDate)
 			require.NoError(b, err)
 			require.Equal(b, expectedRowCount, len(reportData.CVEResponses))
 		}
@@ -318,7 +318,7 @@ func BenchmarkEntityScopeReportGenerator(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			reportData, err := reportGenerator.getReportDataSQF(reportSnap, nil, sinceStartDate)
+			reportData, err := reportGenerator.getReportDataSQF(ctx, reportSnap, nil, sinceStartDate)
 			require.NoError(b, err)
 			require.Equal(b, expectedRowCount, len(reportData.CVEResponses))
 		}

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -85,11 +85,13 @@ type ImageCVEInterface interface {
 	GetCveBaseInfo() *storage.CVEInfo
 }
 
-func (rg *reportGeneratorImpl) ProcessReportRequest(req *ReportRequest) {
+func (rg *reportGeneratorImpl) ProcessReportRequest(ctx context.Context, req *ReportRequest) {
+	ctx = resolvers.SetAuthorizerOverride(loaders.WithLoaderContext(sac.WithAllAccess(ctx)), allow.Anonymous())
+
 	// First do some basic validation checks on the request.
 	err := ValidateReportRequest(req)
 	if err != nil {
-		rg.logAndUpsertError(errors.Wrap(err, "Invalid report request"), req)
+		rg.logAndUpsertError(ctx, errors.Wrap(err, "Invalid report request"), req)
 		return
 	}
 
@@ -97,14 +99,14 @@ func (rg *reportGeneratorImpl) ProcessReportRequest(req *ReportRequest) {
 		if req.ReportSnapshot.GetVulnReportFilters().GetSinceLastSentScheduledReport() {
 			req.DataStartTime, err = rg.lastSuccessfulScheduledReportTime(req.ReportSnapshot)
 			if err != nil {
-				rg.logAndUpsertError(errors.Wrap(err, "Error finding last successful scheduled report time"), req)
+				rg.logAndUpsertError(ctx, errors.Wrap(err, "Error finding last successful scheduled report time"), req)
 				return
 			}
 		} else if req.ReportSnapshot.GetVulnReportFilters().GetSinceStartDate() != nil {
 			sinceStartDate := req.ReportSnapshot.GetVulnReportFilters().GetSinceStartDate()
 			req.DataStartTime, err = protocompat.ConvertTimestampToTimeOrError(sinceStartDate)
 			if err != nil {
-				rg.logAndUpsertError(errors.Wrap(err, "Error finding last successful scheduled report time"), req)
+				rg.logAndUpsertError(ctx, errors.Wrap(err, "Error finding last successful scheduled report time"), req)
 				return
 			}
 		}
@@ -113,36 +115,44 @@ func (rg *reportGeneratorImpl) ProcessReportRequest(req *ReportRequest) {
 	// Change report status to PREPARING
 	err = rg.updateReportStatus(req.ReportSnapshot, storage.ReportStatus_PREPARING)
 	if err != nil {
-		rg.logAndUpsertError(errors.Wrap(err, "Error changing report status to PREPARING"), req)
+		rg.logAndUpsertError(ctx, errors.Wrap(err, "Error changing report status to PREPARING"), req)
 		return
 	}
 
-	err = rg.generateReportAndNotify(req)
+	err = rg.generateReportAndNotify(ctx, req)
 	if err != nil {
-		rg.logAndUpsertError(err, req)
+		rg.logAndUpsertError(ctx, err, req)
 		return
 	}
 
 	if req.ReportSnapshot.GetReportStatus().GetReportNotificationMethod() == storage.ReportStatus_EMAIL {
 		err = rg.updateReportStatus(req.ReportSnapshot, storage.ReportStatus_DELIVERED)
 		if err != nil {
-			rg.logAndUpsertError(errors.Wrap(err, "Error changing report status to DELIVERED"), req)
+			rg.logAndUpsertError(ctx, errors.Wrap(err, "Error changing report status to DELIVERED"), req)
 		}
 	}
 }
 
 /* Report generation helper functions */
-func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error {
+func (rg *reportGeneratorImpl) generateReportAndNotify(ctx context.Context, req *ReportRequest) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Get the results of running the report query
 	var err error
 	var reportData *ReportData
 	if req.ReportSnapshot.GetVulnReportFilters() != nil {
-		reportData, err = rg.getReportDataSQF(req.ReportSnapshot, req.Collection, req.DataStartTime)
+		reportData, err = rg.getReportDataSQF(ctx, req.ReportSnapshot, req.Collection, req.DataStartTime)
 	}
 	if req.ReportSnapshot.GetViewBasedVulnReportFilters() != nil {
-		reportData, err = rg.getReportDataViewBased(req.ReportSnapshot)
+		reportData, err = rg.getReportDataViewBased(ctx, req.ReportSnapshot)
 	}
 	if err != nil {
+		return err
+	}
+
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 
@@ -157,13 +167,17 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 	if err != nil {
 		return errors.Wrap(err, "Error changing report status to GENERATED")
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	switch req.ReportSnapshot.GetReportStatus().GetReportNotificationMethod() {
 	case storage.ReportStatus_DOWNLOAD:
 		parentDir := req.ReportSnapshot.GetReportConfigurationId()
 		if req.ReportSnapshot.GetVulnReportFilters() == nil {
 			parentDir = "view-based-report"
 		}
-		if err = rg.saveReportData(parentDir,
+		if err = rg.saveReportData(ctx, parentDir,
 			req.ReportSnapshot.GetReportId(), zippedCSVData); err != nil {
 			return errors.Wrap(err, "error persisting blob")
 		}
@@ -227,7 +241,7 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(req *ReportRequest) error
 	return nil
 }
 
-func (rg *reportGeneratorImpl) saveReportData(configID, reportID string, data *bytes.Buffer) error {
+func (rg *reportGeneratorImpl) saveReportData(ctx context.Context, configID, reportID string, data *bytes.Buffer) error {
 	if data == nil {
 		return errors.Errorf("No data found for report config %q and id %q", configID, reportID)
 	}
@@ -239,12 +253,12 @@ func (rg *reportGeneratorImpl) saveReportData(configID, reportID string, data *b
 		ModifiedTime: protocompat.TimestampNow(),
 		Length:       int64(data.Len()),
 	}
-	return rg.blobStore.Upsert(reportGenCtx, b, data)
+	return rg.blobStore.Upsert(ctx, b, data)
 }
 
-func (rg *reportGeneratorImpl) getReportDataSQF(snap *storage.ReportSnapshot, collection *storage.ResourceCollection,
+func (rg *reportGeneratorImpl) getReportDataSQF(ctx context.Context, snap *storage.ReportSnapshot, collection *storage.ResourceCollection,
 	dataStartTime time.Time) (*ReportData, error) {
-	rQuery, err := rg.buildReportQuery(snap, collection, dataStartTime)
+	rQuery, err := rg.buildReportQuery(ctx, snap, collection, dataStartTime)
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +274,7 @@ func (rg *reportGeneratorImpl) getReportDataSQF(snap *storage.ReportSnapshot, co
 		query := search.ConjunctionQuery(rQuery.DeploymentsQuery, cveFilterQuery)
 		query.Pagination = deployedImagesQueryParts.Pagination
 		query.Selects = deployedImagesQueryParts.Selects
-		err = pgSearch.RunSelectRequestForSchemaFn[ImageCVEQueryResponse](reportGenCtx, rg.db,
+		err = pgSearch.RunSelectRequestForSchemaFn[ImageCVEQueryResponse](ctx, rg.db,
 			deployedImagesQueryParts.Schema, query, func(r *ImageCVEQueryResponse) error {
 				cveResponses = append(cveResponses, r)
 				numDeployedImageResults++
@@ -271,9 +285,13 @@ func (rg *reportGeneratorImpl) getReportDataSQF(snap *storage.ReportSnapshot, co
 		}
 	}
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	numWatchedImageResults := 0
 	if filterOnImageType(snap.GetVulnReportFilters().GetImageTypes(), storage.VulnerabilityReportFilters_WATCHED) {
-		watchedImages, err := rg.getWatchedImages()
+		watchedImages, err := rg.getWatchedImages(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -283,7 +301,7 @@ func (rg *reportGeneratorImpl) getReportDataSQF(snap *storage.ReportSnapshot, co
 				cveFilterQuery)
 			query.Pagination = watchedImagesQueryParts.Pagination
 			query.Selects = watchedImagesQueryParts.Selects
-			err := pgSearch.RunSelectRequestForSchemaFn[ImageCVEQueryResponse](reportGenCtx, rg.db,
+			err := pgSearch.RunSelectRequestForSchemaFn[ImageCVEQueryResponse](ctx, rg.db,
 				watchedImagesQueryParts.Schema, query, func(r *ImageCVEQueryResponse) error {
 					cveResponses = append(cveResponses, r)
 					numWatchedImageResults++
@@ -295,7 +313,7 @@ func (rg *reportGeneratorImpl) getReportDataSQF(snap *storage.ReportSnapshot, co
 		}
 	}
 
-	cveResponses, err = rg.withCVEReferenceLinks(cveResponses)
+	cveResponses, err = rg.withCVEReferenceLinks(ctx, cveResponses)
 	if err != nil {
 		return nil, err
 	}
@@ -307,12 +325,12 @@ func (rg *reportGeneratorImpl) getReportDataSQF(snap *storage.ReportSnapshot, co
 	}, nil
 }
 
-func (rg *reportGeneratorImpl) getReportDataViewBased(snap *storage.ReportSnapshot) (*ReportData, error) {
-	watchedImages, err := rg.getWatchedImages()
+func (rg *reportGeneratorImpl) getReportDataViewBased(ctx context.Context, snap *storage.ReportSnapshot) (*ReportData, error) {
+	watchedImages, err := rg.getWatchedImages(ctx)
 	if err != nil {
 		return nil, err
 	}
-	query, err := rg.buildReportQueryViewBased(snap, watchedImages)
+	query, err := rg.buildReportQueryViewBased(ctx, snap, watchedImages)
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +339,7 @@ func (rg *reportGeneratorImpl) getReportDataViewBased(snap *storage.ReportSnapsh
 	var cveResponses []*ImageCVEQueryResponse
 	query.DeployedImagesQuery.Pagination = deployedImagesQueryParts.Pagination
 	query.DeployedImagesQuery.Selects = deployedImagesQueryParts.Selects
-	err = pgSearch.RunSelectRequestForSchemaFn[ImageCVEQueryResponse](reportGenCtx, rg.db,
+	err = pgSearch.RunSelectRequestForSchemaFn[ImageCVEQueryResponse](ctx, rg.db,
 		deployedImagesQueryParts.Schema, query.DeployedImagesQuery, func(r *ImageCVEQueryResponse) error {
 			cveResponses = append(cveResponses, r)
 			return nil
@@ -331,12 +349,16 @@ func (rg *reportGeneratorImpl) getReportDataViewBased(snap *storage.ReportSnapsh
 	}
 	numDeployedImageResults = len(cveResponses)
 
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	numWatchedImageResults := 0
 
 	if len(watchedImages) != 0 {
 		query.WatchedImagesQuery.Pagination = watchedImagesQueryParts.Pagination
 		query.WatchedImagesQuery.Selects = watchedImagesQueryParts.Selects
-		err := pgSearch.RunSelectRequestForSchemaFn[ImageCVEQueryResponse](reportGenCtx, rg.db,
+		err := pgSearch.RunSelectRequestForSchemaFn[ImageCVEQueryResponse](ctx, rg.db,
 			watchedImagesQueryParts.Schema, query.WatchedImagesQuery, func(r *ImageCVEQueryResponse) error {
 				cveResponses = append(cveResponses, r)
 				numWatchedImageResults++
@@ -347,7 +369,7 @@ func (rg *reportGeneratorImpl) getReportDataViewBased(snap *storage.ReportSnapsh
 		}
 	}
 
-	cveResponses, err = rg.withCVEReferenceLinks(cveResponses)
+	cveResponses, err = rg.withCVEReferenceLinks(ctx, cveResponses)
 	if err != nil {
 		return nil, err
 	}
@@ -360,13 +382,13 @@ func (rg *reportGeneratorImpl) getReportDataViewBased(snap *storage.ReportSnapsh
 
 }
 
-func (rg *reportGeneratorImpl) getClustersAndNamespacesForSAC() ([]effectiveaccessscope.Cluster, []effectiveaccessscope.Namespace, error) {
-	allClusters, err := rg.clusterDatastore.GetClusters(reportGenCtx)
+func (rg *reportGeneratorImpl) getClustersAndNamespacesForSAC(ctx context.Context) ([]effectiveaccessscope.Cluster, []effectiveaccessscope.Namespace, error) {
+	allClusters, err := rg.clusterDatastore.GetClusters(ctx)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error fetching clusters to build report query")
 	}
 	sacClusters := storagetoeffectiveaccessscope.Clusters(allClusters)
-	allNamespaces, err := rg.namespaceDatastore.GetAllNamespaces(reportGenCtx)
+	allNamespaces, err := rg.namespaceDatastore.GetAllNamespaces(ctx)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "error fetching namespaces to build report query")
 	}
@@ -374,9 +396,9 @@ func (rg *reportGeneratorImpl) getClustersAndNamespacesForSAC() ([]effectiveacce
 	return sacClusters, sacNamespaces, nil
 }
 
-func (rg *reportGeneratorImpl) buildReportQueryViewBased(snap *storage.ReportSnapshot, watchedImages []string) (*common.ReportQueryViewBased, error) {
+func (rg *reportGeneratorImpl) buildReportQueryViewBased(ctx context.Context, snap *storage.ReportSnapshot, watchedImages []string) (*common.ReportQueryViewBased, error) {
 	qb := common.NewVulnReportQueryBuilderViewBased(snap.GetViewBasedVulnReportFilters())
-	allClusters, allNamespaces, err := rg.getClustersAndNamespacesForSAC()
+	allClusters, allNamespaces, err := rg.getClustersAndNamespacesForSAC(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -387,15 +409,15 @@ func (rg *reportGeneratorImpl) buildReportQueryViewBased(snap *storage.ReportSna
 	return rQuery, nil
 }
 
-func (rg *reportGeneratorImpl) buildReportQuery(snap *storage.ReportSnapshot,
+func (rg *reportGeneratorImpl) buildReportQuery(ctx context.Context, snap *storage.ReportSnapshot,
 	collection *storage.ResourceCollection, dataStartTime time.Time) (*common.ReportQuery, error) {
 	qb := common.NewVulnReportQueryBuilder(collection, snap.GetResourceScope().GetEntityScope(), snap.GetVulnReportFilters(), rg.collectionQueryResolver,
 		dataStartTime)
-	allClusters, allNamespaces, err := rg.getClustersAndNamespacesForSAC()
+	allClusters, allNamespaces, err := rg.getClustersAndNamespacesForSAC(ctx)
 	if err != nil {
 		return nil, err
 	}
-	rQuery, err := qb.BuildQuery(reportGenCtx, allClusters, allNamespaces)
+	rQuery, err := qb.BuildQuery(ctx, allClusters, allNamespaces)
 	if err != nil {
 		return nil, errors.Wrap(err, "error building report query")
 	}
@@ -444,8 +466,8 @@ func (rg *reportGeneratorImpl) lastSuccessfulScheduledReportTime(snap *storage.R
 	return completedAt, nil
 }
 
-func (rg *reportGeneratorImpl) getWatchedImages() ([]string, error) {
-	watched, err := rg.watchedImageDatastore.GetAllWatchedImages(reportGenCtx)
+func (rg *reportGeneratorImpl) getWatchedImages(ctx context.Context) ([]string, error) {
+	watched, err := rg.watchedImageDatastore.GetAllWatchedImages(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +478,7 @@ func (rg *reportGeneratorImpl) getWatchedImages() ([]string, error) {
 	return results, nil
 }
 
-func (rg *reportGeneratorImpl) withCVEReferenceLinks(imageCVEResponses []*ImageCVEQueryResponse) ([]*ImageCVEQueryResponse, error) {
+func (rg *reportGeneratorImpl) withCVEReferenceLinks(ctx context.Context, imageCVEResponses []*ImageCVEQueryResponse) ([]*ImageCVEQueryResponse, error) {
 	cveIDs := set.NewStringSet()
 	for _, res := range imageCVEResponses {
 		if res.GetCVEID() != "" {
@@ -465,7 +487,7 @@ func (rg *reportGeneratorImpl) withCVEReferenceLinks(imageCVEResponses []*ImageC
 	}
 
 	var cves []ImageCVEInterface
-	imageCVEV2, err := rg.imageCVE2Datastore.GetBatch(reportGenCtx, cveIDs.AsSlice())
+	imageCVEV2, err := rg.imageCVE2Datastore.GetBatch(ctx, cveIDs.AsSlice())
 	if err != nil {
 		return nil, err
 	}
@@ -491,16 +513,20 @@ func (rg *reportGeneratorImpl) updateReportStatus(snapshot *storage.ReportSnapsh
 	return rg.reportSnapshotStore.UpdateReportSnapshot(reportGenCtx, snapshot)
 }
 
-func (rg *reportGeneratorImpl) logAndUpsertError(reportErr error, req *ReportRequest) {
+func (rg *reportGeneratorImpl) logAndUpsertError(ctx context.Context, reportErr error, req *ReportRequest) {
 	if req.ReportSnapshot == nil || req.ReportSnapshot.GetReportStatus() == nil {
 		utils.Should(errors.New("Request does not have non-nil report snapshot with a non-nil report status"))
 		return
 	}
-	if reportErr != nil {
+	if errors.Is(context.Cause(ctx), ErrUserCancelled) {
+		log.Infof("Report for config '%s' was cancelled by user", req.ReportSnapshot.GetName())
+		req.ReportSnapshot.ReportStatus.ErrorMsg = ErrUserCancelled.Error()
+	} else if reportErr != nil {
 		log.Errorf("Error while running report for config '%s': %s", req.ReportSnapshot.GetName(), reportErr)
 		req.ReportSnapshot.ReportStatus.ErrorMsg = reportErr.Error()
 	}
 	req.ReportSnapshot.ReportStatus.CompletedAt = protocompat.TimestampNow()
+	// Use reportGenCtx for status update since the request context may be cancelled
 	err := rg.updateReportStatus(req.ReportSnapshot, storage.ReportStatus_FAILURE)
 
 	if err != nil {

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -143,10 +143,14 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(ctx context.Context, req 
 	var err error
 	var reportData *ReportData
 	if req.ReportSnapshot.GetVulnReportFilters() != nil {
+		log.Infof("Starting report query for config '%s'", req.ReportSnapshot.GetName())
 		reportData, err = rg.getReportDataSQF(ctx, req.ReportSnapshot, req.Collection, req.DataStartTime)
+		log.Infof("Report query finished for config '%s', err=%v, ctx.Err=%v", req.ReportSnapshot.GetName(), err, ctx.Err())
 	}
 	if req.ReportSnapshot.GetViewBasedVulnReportFilters() != nil {
+		log.Infof("Starting report query for config '%s'", req.ReportSnapshot.GetName())
 		reportData, err = rg.getReportDataViewBased(ctx, req.ReportSnapshot)
+		log.Infof("Report query finished for config '%s', err=%v, ctx.Err=%v", req.ReportSnapshot.GetName(), err, ctx.Err())
 	}
 	if err != nil {
 		return err

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -156,16 +156,6 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(ctx context.Context, req 
 		return err
 	}
 
-	// TODO(surakuma): Remove this sleep after manual testing of report cancellation.
-	log.Info("Sleeping 30s to allow manual cancellation testing...")
-	select {
-	case <-time.After(30 * time.Second):
-		log.Info("Sleep completed, continuing report generation")
-	case <-ctx.Done():
-		log.Infof("Context cancelled during sleep: %v", context.Cause(ctx))
-		return ctx.Err()
-	}
-
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -285,6 +275,16 @@ func (rg *reportGeneratorImpl) getReportDataSQF(ctx context.Context, snap *stora
 	numDeployedImageResults := 0
 	var cveResponses []*ImageCVEQueryResponse
 	if filterOnImageType(snap.GetVulnReportFilters().GetImageTypes(), storage.VulnerabilityReportFilters_DEPLOYED) {
+		// TODO(surakuma): Remove this sleep after manual testing of report cancellation.
+		log.Info("[SQF] Sleeping 20s before deployed images query to allow cancellation testing...")
+		select {
+		case <-time.After(20 * time.Second):
+			log.Info("[SQF] Sleep completed, executing deployed images query")
+		case <-ctx.Done():
+			log.Infof("[SQF] Context cancelled during sleep: %v", context.Cause(ctx))
+			return nil, ctx.Err()
+		}
+
 		query := search.ConjunctionQuery(rQuery.DeploymentsQuery, cveFilterQuery)
 		query.Pagination = deployedImagesQueryParts.Pagination
 		query.Selects = deployedImagesQueryParts.Selects
@@ -351,6 +351,17 @@ func (rg *reportGeneratorImpl) getReportDataViewBased(ctx context.Context, snap 
 
 	numDeployedImageResults := 0
 	var cveResponses []*ImageCVEQueryResponse
+
+	// TODO(surakuma): Remove this sleep after manual testing of report cancellation.
+	log.Info("[ViewBased] Sleeping 20s before deployed images query to allow cancellation testing...")
+	select {
+	case <-time.After(20 * time.Second):
+		log.Info("[ViewBased] Sleep completed, executing deployed images query")
+	case <-ctx.Done():
+		log.Infof("[ViewBased] Context cancelled during sleep: %v", context.Cause(ctx))
+		return nil, ctx.Err()
+	}
+
 	query.DeployedImagesQuery.Pagination = deployedImagesQueryParts.Pagination
 	query.DeployedImagesQuery.Selects = deployedImagesQueryParts.Selects
 	err = pgSearch.RunSelectRequestForSchemaFn[ImageCVEQueryResponse](ctx, rg.db,

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -143,14 +143,10 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(ctx context.Context, req 
 	var err error
 	var reportData *ReportData
 	if req.ReportSnapshot.GetVulnReportFilters() != nil {
-		log.Infof("Starting report query for config '%s'", req.ReportSnapshot.GetName())
 		reportData, err = rg.getReportDataSQF(ctx, req.ReportSnapshot, req.Collection, req.DataStartTime)
-		log.Infof("Report query finished for config '%s', err=%v, ctx.Err=%v", req.ReportSnapshot.GetName(), err, ctx.Err())
 	}
 	if req.ReportSnapshot.GetViewBasedVulnReportFilters() != nil {
-		log.Infof("Starting report query for config '%s'", req.ReportSnapshot.GetName())
 		reportData, err = rg.getReportDataViewBased(ctx, req.ReportSnapshot)
-		log.Infof("Report query finished for config '%s', err=%v, ctx.Err=%v", req.ReportSnapshot.GetName(), err, ctx.Err())
 	}
 	if err != nil {
 		return err
@@ -275,16 +271,6 @@ func (rg *reportGeneratorImpl) getReportDataSQF(ctx context.Context, snap *stora
 	numDeployedImageResults := 0
 	var cveResponses []*ImageCVEQueryResponse
 	if filterOnImageType(snap.GetVulnReportFilters().GetImageTypes(), storage.VulnerabilityReportFilters_DEPLOYED) {
-		// TODO(surakuma): Remove this sleep after manual testing of report cancellation.
-		log.Info("[SQF] Sleeping 20s before deployed images query to allow cancellation testing...")
-		select {
-		case <-time.After(20 * time.Second):
-			log.Info("[SQF] Sleep completed, executing deployed images query")
-		case <-ctx.Done():
-			log.Infof("[SQF] Context cancelled during sleep: %v", context.Cause(ctx))
-			return nil, ctx.Err()
-		}
-
 		query := search.ConjunctionQuery(rQuery.DeploymentsQuery, cveFilterQuery)
 		query.Pagination = deployedImagesQueryParts.Pagination
 		query.Selects = deployedImagesQueryParts.Selects
@@ -351,16 +337,6 @@ func (rg *reportGeneratorImpl) getReportDataViewBased(ctx context.Context, snap 
 
 	numDeployedImageResults := 0
 	var cveResponses []*ImageCVEQueryResponse
-
-	// TODO(surakuma): Remove this sleep after manual testing of report cancellation.
-	log.Info("[ViewBased] Sleeping 20s before deployed images query to allow cancellation testing...")
-	select {
-	case <-time.After(20 * time.Second):
-		log.Info("[ViewBased] Sleep completed, executing deployed images query")
-	case <-ctx.Done():
-		log.Infof("[ViewBased] Context cancelled during sleep: %v", context.Cause(ctx))
-		return nil, ctx.Err()
-	}
 
 	query.DeployedImagesQuery.Pagination = deployedImagesQueryParts.Pagination
 	query.DeployedImagesQuery.Selects = deployedImagesQueryParts.Selects

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl.go
@@ -156,6 +156,16 @@ func (rg *reportGeneratorImpl) generateReportAndNotify(ctx context.Context, req 
 		return err
 	}
 
+	// TODO(surakuma): Remove this sleep after manual testing of report cancellation.
+	log.Info("Sleeping 30s to allow manual cancellation testing...")
+	select {
+	case <-time.After(30 * time.Second):
+		log.Info("Sleep completed, continuing report generation")
+	case <-ctx.Done():
+		log.Infof("Context cancelled during sleep: %v", context.Cause(ctx))
+		return ctx.Err()
+	}
+
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl_flat_data_model_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl_flat_data_model_test.go
@@ -216,7 +216,7 @@ func (s *NewDataModelEnhancedReportingTestSuite) TestGetReportData() {
 		s.T().Run(tc.name, func(t *testing.T) {
 			reportSnap := testReportSnapshot(tc.collection.GetId(), tc.fixability, tc.severities, tc.imageTypes, tc.scopeRules)
 			// Test get data using SQF
-			reportData, err := s.reportGenerator.getReportDataSQF(reportSnap, tc.collection, time.Time{})
+			reportData, err := s.reportGenerator.getReportDataSQF(s.ctx, reportSnap, tc.collection, time.Time{})
 			s.NoError(err)
 			collected := collectVulnReportDataSQFNewDataModel(reportData.CVEResponses)
 			s.ElementsMatch(tc.expected.deploymentNames, collected.deploymentNames)
@@ -228,6 +228,22 @@ func (s *NewDataModelEnhancedReportingTestSuite) TestGetReportData() {
 		})
 	}
 
+}
+
+func (s *NewDataModelEnhancedReportingTestSuite) TestGetReportDataWithCancelledContext() {
+	collection := testCollection("col-cancel", "", "", "")
+	reportSnap := testReportSnapshot(collection.GetId(),
+		storage.VulnerabilityReportFilters_BOTH, allSeverities(),
+		[]storage.VulnerabilityReportFilters_ImageType{storage.VulnerabilityReportFilters_DEPLOYED},
+		nil)
+
+	// Cancel the context before calling getReportDataSQF to prove cancellation propagates to the DB query
+	ctx, cancel := context.WithCancel(s.ctx)
+	cancel()
+
+	_, err := s.reportGenerator.getReportDataSQF(ctx, reportSnap, collection, time.Time{})
+	s.Error(err, "Expected error when context is cancelled before DB query")
+	s.ErrorIs(err, context.Canceled)
 }
 
 func collectVulnReportDataSQFNewDataModel(cveResponses []*ImageCVEQueryResponse) *vulnReportDataNewDataModel {
@@ -607,7 +623,7 @@ func (s *NewDataModelEnhancedReportingTestSuite) TestGetReportDataWithEntityScop
 	for name, tc := range testCases {
 		s.T().Run(name, func(t *testing.T) {
 			reportSnap := testEntityScopeReportSnapshot(tc.entityScope, tc.query, tc.imageTypes, tc.scopeRules)
-			reportData, err := s.reportGenerator.getReportDataSQF(reportSnap, nil, time.Time{})
+			reportData, err := s.reportGenerator.getReportDataSQF(s.ctx, reportSnap, nil, time.Time{})
 			s.NoError(err)
 			collected := collectVulnReportDataSQFNewDataModel(reportData.CVEResponses)
 			s.ElementsMatch(tc.expected.deploymentNames, collected.deploymentNames)

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -463,7 +463,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBased() {
 			log.Infof("Running test %s", tc.name)
 			reportSnap := testViewBasedReportSnapshot(tc.query, nil)
 			// Test get data using view-based approach
-			reportData, err := s.reportGenerator.getReportDataViewBased(reportSnap)
+			reportData, err := s.reportGenerator.getReportDataViewBased(s.ctx, reportSnap)
 			s.NoError(err)
 			collected := s.collectViewBasedReportData(reportData.CVEResponses)
 			s.ElementsMatch(tc.expected.deploymentNames, collected.deploymentNames)
@@ -511,7 +511,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBasedWithInvalidQuery
 	for _, tc := range testCases {
 		s.T().Run(tc.name, func(t *testing.T) {
 			reportSnap := testViewBasedReportSnapshot(tc.query, nil)
-			reportData, err := s.reportGenerator.getReportDataViewBased(reportSnap)
+			reportData, err := s.reportGenerator.getReportDataViewBased(s.ctx, reportSnap)
 			if tc.expectErr {
 				s.Error(err)
 			} else {
@@ -582,7 +582,7 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBasedAccessScope() {
 		s.T().Run(tc.name, func(t *testing.T) {
 			reportSnap := testViewBasedReportSnapshot(tc.query, tc.scopeRules)
 			// Test get data using view-based approach
-			reportData, err := s.reportGenerator.getReportDataViewBased(reportSnap)
+			reportData, err := s.reportGenerator.getReportDataViewBased(s.ctx, reportSnap)
 			s.NoError(err)
 			collected := s.collectViewBasedReportData(reportData.CVEResponses)
 			s.ElementsMatch(tc.expected.deploymentNames, collected.deploymentNames)
@@ -594,6 +594,30 @@ func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBasedAccessScope() {
 		})
 	}
 
+}
+
+func (s *ViewBasedReportingTestSuite) TestGetReportDataViewBasedWithCancelledContext() {
+	clusters := []*storage.Cluster{
+		{Id: uuid.NewV4().String(), Name: "c1"},
+	}
+	namespaces := testNamespaces(clusters, 1)
+	deployments, images := testDeploymentsWithImages(namespaces, 1)
+	s.upsertManyImages(images)
+	s.upsertManyDeployments(deployments)
+
+	s.clusterDatastore.EXPECT().GetClusters(gomock.Any()).
+		Return(clusters, nil).AnyTimes()
+	s.namespaceDatastore.EXPECT().GetAllNamespaces(gomock.Any()).
+		Return(namespaces, nil).AnyTimes()
+
+	reportSnap := testViewBasedReportSnapshot("", nil)
+
+	ctx, cancel := context.WithCancel(s.ctx)
+	cancel()
+
+	_, err := s.reportGenerator.getReportDataViewBased(ctx, reportSnap)
+	s.Error(err, "Expected error when context is cancelled before DB query")
+	s.ErrorIs(err, context.Canceled)
 }
 
 // Helper functions

--- a/central/reports/scheduler/v2/reportgenerator/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/types.go
@@ -3,10 +3,14 @@ package reportgenerator
 import (
 	"time"
 
+	"github.com/pkg/errors"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 )
+
+// ErrUserCancelled is the cause attached to a context when a user cancels a running report.
+var ErrUserCancelled = errors.New("report cancelled by user")
 
 // ReportRequest contains information needed to generate and notify a report
 type ReportRequest struct {

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -282,29 +282,31 @@ func (s *scheduler) RemoveReportSchedule(reportConfigID string) {
 /* Functions to add/remove report jobs from queue */
 
 // CancelReportRequest cancels a report request. If the report is waiting in queue, it is removed
-// and its snapshot is deleted. If the report is already being prepared, its context is cancelled,
-// which propagates cancellation to in-flight database queries and blob store writes.
+// and its snapshot is updated to FAILURE with a cancellation message. If the report is already
+// being prepared, its context is cancelled, which propagates cancellation to in-flight database
+// queries and blob store writes.
 func (s *scheduler) CancelReportRequest(ctx context.Context, reportID string) (bool, error) {
-	removed := s.tryRemoveFromRequestQueue(reportID)
-	if removed {
-		err := s.reportSnapshotStore.DeleteReportSnapshot(ctx, reportID)
-		if err != nil {
-			return false, errors.Wrapf(err, "Error deleting report ID '%s' from storage", reportID)
+	req := s.tryRemoveFromRequestQueue(reportID)
+	if req != nil {
+		req.ReportSnapshot.ReportStatus.ErrorMsg = reportGen.ErrUserCancelled.Error()
+		req.ReportSnapshot.ReportStatus.CompletedAt = protocompat.TimestampNow()
+		req.ReportSnapshot.ReportStatus.RunState = storage.ReportStatus_FAILURE
+		if err := s.reportSnapshotStore.UpdateReportSnapshot(ctx, req.ReportSnapshot); err != nil {
+			return false, errors.Wrapf(err, "Error updating report snapshot to FAILURE for report ID '%s'", reportID)
 		}
 		return true, nil
 	}
 	return s.tryCancelRunningReport(reportID), nil
 }
 
-// Returns true if the request was successfully removed from the ReportRequests queue
-func (s *scheduler) tryRemoveFromRequestQueue(reportID string) bool {
+// Returns the removed ReportRequest if found, nil otherwise
+func (s *scheduler) tryRemoveFromRequestQueue(reportID string) *reportGen.ReportRequest {
 	s.schedulerLock.Lock()
 	defer s.schedulerLock.Unlock()
 
-	request := findAndRemoveFromQueue(s.reportRequestsQueue, func(req *reportGen.ReportRequest) bool {
+	return findAndRemoveFromQueue(s.reportRequestsQueue, func(req *reportGen.ReportRequest) bool {
 		return req.ReportSnapshot.GetReportId() == reportID
 	})
-	return request != nil
 }
 
 func (s *scheduler) CanSubmitReportRequest(user *storage.SlimUser, reportConfig *storage.ReportConfiguration) (bool, error) {

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -234,9 +234,8 @@ func (s *scheduler) removeRunningReportCancel(reportID string) {
 }
 
 func (s *scheduler) tryCancelRunningReport(reportID string) bool {
-	var cancel context.CancelCauseFunc
-	s.schedulerLock.WithLock(func() {
-		cancel = s.runningReportCancels[reportID]
+	cancel := concurrency.WithLock1(&s.schedulerLock, func() context.CancelCauseFunc {
+		return s.runningReportCancels[reportID]
 	})
 	if cancel == nil {
 		return false

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -234,10 +234,11 @@ func (s *scheduler) removeRunningReportCancel(reportID string) {
 }
 
 func (s *scheduler) tryCancelRunningReport(reportID string) bool {
-	s.schedulerLock.Lock()
-	cancel, exists := s.runningReportCancels[reportID]
-	s.schedulerLock.Unlock()
-	if !exists {
+	var cancel context.CancelCauseFunc
+	s.schedulerLock.WithLock(func() {
+		cancel = s.runningReportCancels[reportID]
+	})
+	if cancel == nil {
 		return false
 	}
 	cancel(reportGen.ErrUserCancelled)

--- a/central/reports/scheduler/v2/scheduler_impl.go
+++ b/central/reports/scheduler/v2/scheduler_impl.go
@@ -56,6 +56,9 @@ type scheduler struct {
 	readyForReports concurrency.Signal
 	// Stores config IDs for which a report is currently running. Used to make sure only one report per config runs at a time.
 	runningReportConfigs set.StringSet
+	// Stores cancel functions for running reports, keyed by report ID.
+	// Used to cancel in-flight database queries and blob store writes when a user cancels a PREPARING report.
+	runningReportCancels map[string]context.CancelCauseFunc
 	Schema               *graphql.Schema
 
 	/* Concurrency and synchronization related fields */
@@ -69,7 +72,7 @@ type scheduler struct {
 
 	// Use to synchronize access to reportConfigToEntryIDs map
 	cronJobsLock sync.Mutex
-	// Use to synchronize access to reportsQueue and runningReportConfigs
+	// Use to synchronize access to reportsQueue, runningReportConfigs, and runningReportCancels
 	schedulerLock sync.Mutex
 	// Use to lock any database tables if needed to prevent race conditions
 	dbLock sync.Mutex
@@ -110,6 +113,7 @@ func newSchedulerImpl(reportConfigDatastore reportConfigDS.DataStore, reportSnap
 		reportRequestsQueue:    list.New(),
 		readyForReports:        concurrency.NewSignal(),
 		runningReportConfigs:   set.NewStringSet(),
+		runningReportCancels:   make(map[string]context.CancelCauseFunc),
 		Schema:                 schema,
 		stopper:                concurrency.NewStopper(),
 		cron:                   cronScheduler,
@@ -202,13 +206,42 @@ func (s *scheduler) runSingleReport(req *reportGen.ReportRequest) {
 	defer s.concurrencySema.Release(1)
 	defer s.removeFromRunningReportConfigs(req.ReportSnapshot.GetReportConfigurationId())
 
-	s.reportGenerator.ProcessReportRequest(req)
+	reportID := req.ReportSnapshot.GetReportId()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	s.addRunningReportCancel(reportID, cancel)
+	defer cancel(nil)
+	defer s.removeRunningReportCancel(reportID)
+
+	s.reportGenerator.ProcessReportRequest(ctx, req)
 }
 
 func (s *scheduler) removeFromRunningReportConfigs(configID string) {
 	s.schedulerLock.Lock()
 	defer s.schedulerLock.Unlock()
 	s.runningReportConfigs.Remove(configID)
+}
+
+func (s *scheduler) addRunningReportCancel(reportID string, cancel context.CancelCauseFunc) {
+	s.schedulerLock.Lock()
+	defer s.schedulerLock.Unlock()
+	s.runningReportCancels[reportID] = cancel
+}
+
+func (s *scheduler) removeRunningReportCancel(reportID string) {
+	s.schedulerLock.Lock()
+	defer s.schedulerLock.Unlock()
+	delete(s.runningReportCancels, reportID)
+}
+
+func (s *scheduler) tryCancelRunningReport(reportID string) bool {
+	s.schedulerLock.Lock()
+	cancel, exists := s.runningReportCancels[reportID]
+	s.schedulerLock.Unlock()
+	if !exists {
+		return false
+	}
+	cancel(reportGen.ErrUserCancelled)
+	return true
 }
 
 // UpsertReportSchedule adds/updates the schedule at which reports for the given report config are executed.
@@ -248,18 +281,19 @@ func (s *scheduler) RemoveReportSchedule(reportConfigID string) {
 
 /* Functions to add/remove report jobs from queue */
 
-// CancelReportRequest cancels a report request that is still waiting in queue. A user can only cancel a report requested by them.
-// If the report is already being prepared or has completed execution, it cannot be cancelled.
+// CancelReportRequest cancels a report request. If the report is waiting in queue, it is removed
+// and its snapshot is deleted. If the report is already being prepared, its context is cancelled,
+// which propagates cancellation to in-flight database queries and blob store writes.
 func (s *scheduler) CancelReportRequest(ctx context.Context, reportID string) (bool, error) {
 	removed := s.tryRemoveFromRequestQueue(reportID)
-	if !removed {
-		return false, nil
+	if removed {
+		err := s.reportSnapshotStore.DeleteReportSnapshot(ctx, reportID)
+		if err != nil {
+			return false, errors.Wrapf(err, "Error deleting report ID '%s' from storage", reportID)
+		}
+		return true, nil
 	}
-	err := s.reportSnapshotStore.DeleteReportSnapshot(ctx, reportID)
-	if err != nil {
-		return false, errors.Wrapf(err, "Error deleting report ID '%s' from storage", reportID)
-	}
-	return true, nil
+	return s.tryCancelRunningReport(reportID), nil
 }
 
 // Returns true if the request was successfully removed from the ReportRequests queue

--- a/central/reports/scheduler/v2/scheduler_impl_test.go
+++ b/central/reports/scheduler/v2/scheduler_impl_test.go
@@ -195,6 +195,10 @@ func TestCancelRunningReportCancelsContext(t *testing.T) {
 		},
 	}
 
+	// Acquire the semaphore since runSingleReport releases it
+	err := s.concurrencySema.Acquire(context.Background(), 1)
+	assert.NoError(t, err)
+
 	go s.runSingleReport(req)
 	<-started
 
@@ -239,12 +243,16 @@ func TestCancelReportRequestCancelsRunningReport(t *testing.T) {
 		},
 	}
 
+	// Acquire the semaphore since runSingleReport releases it
+	err := s.concurrencySema.Acquire(context.Background(), 1)
+	assert.NoError(t, err)
+
 	go s.runSingleReport(req)
 	<-started
 
 	// Report is not in queue (it's running), so CancelReportRequest should cancel the running context
-	cancelled, err := s.CancelReportRequest(context.Background(), "running-report-id")
-	assert.NoError(t, err)
+	cancelled, cancelErr := s.CancelReportRequest(context.Background(), "running-report-id")
+	assert.NoError(t, cancelErr)
 	assert.True(t, cancelled)
 
 	assert.Error(t, capturedCtx.Err())

--- a/central/reports/scheduler/v2/scheduler_impl_test.go
+++ b/central/reports/scheduler/v2/scheduler_impl_test.go
@@ -1,10 +1,13 @@
 package v2
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stackrox/rox/central/reports/config/datastore/mocks"
+	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
+	reportGenMocks "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator/mocks"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -158,4 +161,106 @@ func TestQueueScheduledReportsSkipsEmptyResourceScope(t *testing.T) {
 	assert.Contains(t, s.reportConfigToEntryIDs, "config-with-entity-scope")
 	assert.NotContains(t, s.reportConfigToEntryIDs, "config-empty-scope")
 	assert.NotContains(t, s.reportConfigToEntryIDs, "config-nil-scope")
+}
+
+func TestCancelRunningReportCancelsContext(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockReportGen := reportGenMocks.NewMockReportGenerator(ctrl)
+
+	cronScheduler := cron.New()
+	cronScheduler.Start()
+	defer cronScheduler.Stop()
+
+	s := newSchedulerImpl(nil, nil, nil, nil, mockReportGen, nil, cronScheduler, nil)
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	var capturedCtx context.Context
+
+	mockReportGen.EXPECT().ProcessReportRequest(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *reportGen.ReportRequest) {
+			capturedCtx = ctx
+			close(started)
+			<-done
+		},
+	)
+
+	req := &reportGen.ReportRequest{
+		ReportSnapshot: &storage.ReportSnapshot{
+			ReportId:              "test-report-id",
+			ReportConfigurationId: "test-config-id",
+			ReportStatus: &storage.ReportStatus{
+				RunState: storage.ReportStatus_WAITING,
+			},
+		},
+	}
+
+	go s.runSingleReport(req)
+	<-started
+
+	cancelled := s.tryCancelRunningReport("test-report-id")
+	assert.True(t, cancelled)
+
+	assert.Error(t, capturedCtx.Err())
+	assert.ErrorIs(t, context.Cause(capturedCtx), reportGen.ErrUserCancelled)
+
+	close(done)
+}
+
+func TestCancelReportRequestCancelsRunningReport(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockReportGen := reportGenMocks.NewMockReportGenerator(ctrl)
+
+	cronScheduler := cron.New()
+	cronScheduler.Start()
+	defer cronScheduler.Stop()
+
+	s := newSchedulerImpl(nil, nil, nil, nil, mockReportGen, nil, cronScheduler, nil)
+
+	started := make(chan struct{})
+	done := make(chan struct{})
+	var capturedCtx context.Context
+
+	mockReportGen.EXPECT().ProcessReportRequest(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *reportGen.ReportRequest) {
+			capturedCtx = ctx
+			close(started)
+			<-done
+		},
+	)
+
+	req := &reportGen.ReportRequest{
+		ReportSnapshot: &storage.ReportSnapshot{
+			ReportId:              "running-report-id",
+			ReportConfigurationId: "test-config-id",
+			ReportStatus: &storage.ReportStatus{
+				RunState: storage.ReportStatus_WAITING,
+			},
+		},
+	}
+
+	go s.runSingleReport(req)
+	<-started
+
+	// Report is not in queue (it's running), so CancelReportRequest should cancel the running context
+	cancelled, err := s.CancelReportRequest(context.Background(), "running-report-id")
+	assert.NoError(t, err)
+	assert.True(t, cancelled)
+
+	assert.Error(t, capturedCtx.Err())
+	assert.ErrorIs(t, context.Cause(capturedCtx), reportGen.ErrUserCancelled)
+
+	close(done)
+}
+
+func TestCancelReportRequestReturnsFalseForUnknownReport(t *testing.T) {
+	cronScheduler := cron.New()
+	cronScheduler.Start()
+	defer cronScheduler.Stop()
+
+	s := newSchedulerImpl(nil, nil, nil, nil, nil, nil, cronScheduler, nil)
+
+	cancelled, err := s.CancelReportRequest(context.Background(), "nonexistent-id")
+	assert.NoError(t, err)
+	assert.False(t, cancelled)
 }

--- a/central/reports/scheduler/v2/scheduler_impl_test.go
+++ b/central/reports/scheduler/v2/scheduler_impl_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackrox/rox/central/reports/config/datastore/mocks"
 	reportGen "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator"
 	reportGenMocks "github.com/stackrox/rox/central/reports/scheduler/v2/reportgenerator/mocks"
+	snapshotMocks "github.com/stackrox/rox/central/reports/snapshot/datastore/mocks"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -271,4 +272,40 @@ func TestCancelReportRequestReturnsFalseForUnknownReport(t *testing.T) {
 	cancelled, err := s.CancelReportRequest(context.Background(), "nonexistent-id")
 	assert.NoError(t, err)
 	assert.False(t, cancelled)
+}
+
+func TestCancelReportRequestUpdatesWaitingReportToFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockSnapshotStore := snapshotMocks.NewMockDataStore(ctrl)
+
+	cronScheduler := cron.New()
+	cronScheduler.Start()
+	defer cronScheduler.Stop()
+
+	s := newSchedulerImpl(nil, mockSnapshotStore, nil, nil, nil, nil, cronScheduler, nil)
+
+	req := &reportGen.ReportRequest{
+		ReportSnapshot: &storage.ReportSnapshot{
+			ReportId:              "waiting-report-id",
+			ReportConfigurationId: "test-config-id",
+			Name:                  "test-report",
+			ReportStatus: &storage.ReportStatus{
+				RunState: storage.ReportStatus_WAITING,
+			},
+		},
+	}
+	s.reportRequestsQueue.PushBack(req)
+
+	mockSnapshotStore.EXPECT().UpdateReportSnapshot(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, snap *storage.ReportSnapshot) error {
+			assert.Equal(t, storage.ReportStatus_FAILURE, snap.GetReportStatus().GetRunState())
+			assert.Equal(t, reportGen.ErrUserCancelled.Error(), snap.GetReportStatus().GetErrorMsg())
+			assert.NotNil(t, snap.GetReportStatus().GetCompletedAt())
+			return nil
+		})
+
+	cancelled, err := s.CancelReportRequest(context.Background(), "waiting-report-id")
+	assert.NoError(t, err)
+	assert.True(t, cancelled)
+	assert.Equal(t, 0, s.reportRequestsQueue.Len())
 }

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -1118,6 +1118,24 @@ func (s *ReportServiceTestSuite) TestCancelReport() {
 				snap.ReportStatus.RunState = storage.ReportStatus_PREPARING
 				s.reportSnapshotDataStore.EXPECT().Get(gomock.Any(), reportSnapshot.GetReportId()).
 					Return(snap, true, nil).Times(1)
+				s.scheduler.EXPECT().CancelReportRequest(gomock.Any(), reportSnapshot.GetReportId()).
+					Return(true, nil).Times(1)
+			},
+			isError: false,
+		},
+		{
+			desc: "Report in PREPARING state but no longer in running map",
+			req: &apiV2.ResourceByID{
+				Id: reportSnapshot.GetReportId(),
+			},
+			ctx: userContext,
+			mockGen: func() {
+				snap := reportSnapshot.CloneVT()
+				snap.ReportStatus.RunState = storage.ReportStatus_PREPARING
+				s.reportSnapshotDataStore.EXPECT().Get(gomock.Any(), reportSnapshot.GetReportId()).
+					Return(snap, true, nil).Times(1)
+				s.scheduler.EXPECT().CancelReportRequest(gomock.Any(), reportSnapshot.GetReportId()).
+					Return(false, nil).Times(1)
 			},
 			isError: true,
 		},

--- a/central/reports/validation/validate.go
+++ b/central/reports/validation/validate.go
@@ -356,12 +356,11 @@ func (v *Validator) ValidateCancelReportRequest(reportID string, requester *stor
 	}
 
 	switch snapshot.GetReportStatus().GetRunState() {
-	case storage.ReportStatus_DELIVERED, storage.ReportStatus_GENERATED, storage.ReportStatus_FAILURE:
+	case storage.ReportStatus_WAITING, storage.ReportStatus_PREPARING:
+		// valid states for cancellation — fall through
+	default:
 		return errors.Wrapf(errox.InvalidArgs, "Cannot cancel. Report job ID '%s' has already completed execution.", reportID)
-	case storage.ReportStatus_PREPARING:
-		return errors.Wrapf(errox.InvalidArgs, "Cannot cancel. Report job ID '%s' is currently being prepared.", reportID)
 	}
-
 	if requester.GetId() != snapshot.GetRequester().GetId() {
 		return errors.Wrap(errox.NotAuthorized, "Report job cannot be cancelled by a user who did not request the report.")
 	}


### PR DESCRIPTION
This PR adds cancellation of vulnerability reports in PREPARING state by adding context to scheduler and passing it to report generator for each report job. This change is implemented as part of improvement proposed in https://docs.google.com/document/d/1s7pCa8PT9pvgtzUhe3P51ZP6rzfgVrx3JYbgo0TwmeA/edit?tab=t.0. This will help customers that have report jobs stuck in endless retry loop because of resource limitation or other error.In such scenarios, the user becomes blocked, and the only available workaround is to manually delete report jobs directly from the database.This issue can be resolved by extending the existing CancelReportRequest functionality to support cancellation of jobs in the PREPARING state

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

The change was tested by adding sleep to report generator and using reporting API to create a report job for config based reports and cancel the job in PREPARING state. Verified the job was cancelled by looking at logs and error message in GET status API response
<img width="990" height="409" alt="api_del" src="https://github.com/user-attachments/assets/e27e900f-4f6f-4061-ae30-09a14bbeebc7" />
<img width="889" height="658" alt="api_run" src="https://github.com/user-attachments/assets/e479b179-7828-4dfb-a752-0791b8754985" />
<img width="1029" height="670" alt="rep_status" src="https://github.com/user-attachments/assets/14c28cbe-de6a-4662-a2f0-57ae840984f8" />
<img width="1324" height="89" alt="Screenshot 2026-06-04 at 10 20 36 AM" src="https://github.com/user-attachments/assets/1bb9a73d-cfb0-44d5-a9c4-a231dd12c31a" />
