### PR TITLE
ROX-34908: add --no-serialized flag and walker infrastructure

### DIFF
--- a/pkg/postgres/pgutils/messagebytes.go
+++ b/pkg/postgres/pgutils/messagebytes.go
@@ -1,0 +1,69 @@
+package pgutils
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// MarshalRepeatedMessages marshals a slice of proto messages into a single []byte.
+// Each message is length-delimited: varint(len) + marshaled bytes.
+func MarshalRepeatedMessages[T interface{ MarshalVT() ([]byte, error) }](msgs []T) ([]byte, error) {
+	if len(msgs) == 0 {
+		return nil, nil
+	}
+	var buf []byte
+	for _, msg := range msgs {
+		data, err := msg.MarshalVT()
+		if err != nil {
+			return nil, err
+		}
+		buf = protowire.AppendVarint(buf, uint64(len(data)))
+		buf = append(buf, data...)
+	}
+	return buf, nil
+}
+
+// MustMarshalRepeatedMessages is like MarshalRepeatedMessages but panics on error.
+func MustMarshalRepeatedMessages[T interface{ MarshalVT() ([]byte, error) }](msgs []T) []byte {
+	data, err := MarshalRepeatedMessages(msgs)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal repeated messages: %v", err))
+	}
+	return data
+}
+
+// UnmarshalRepeatedMessages unmarshals a []byte (produced by MarshalRepeatedMessages)
+// back into a slice of proto messages. The newFn creates a new empty message instance.
+func UnmarshalRepeatedMessages[T interface{ UnmarshalVT([]byte) error }](data []byte, newFn func() T) ([]T, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var msgs []T
+	for len(data) > 0 {
+		size, n := protowire.ConsumeVarint(data)
+		if n < 0 {
+			return nil, fmt.Errorf("messagebytes: invalid varint at offset %d", len(data))
+		}
+		data = data[n:]
+		if uint64(len(data)) < size {
+			return nil, fmt.Errorf("messagebytes: truncated message, need %d bytes but only %d remain", size, len(data))
+		}
+		msg := newFn()
+		if err := msg.UnmarshalVT(data[:size]); err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, msg)
+		data = data[size:]
+	}
+	return msgs, nil
+}
+
+// MustUnmarshalRepeatedMessages is like UnmarshalRepeatedMessages but panics on error.
+func MustUnmarshalRepeatedMessages[T interface{ UnmarshalVT([]byte) error }](data []byte, newFn func() T) []T {
+	msgs, err := UnmarshalRepeatedMessages(data, newFn)
+	if err != nil {
+		panic(fmt.Sprintf("failed to unmarshal repeated messages: %v", err))
+	}
+	return msgs
+}

--- a/pkg/postgres/pgutils/messagebytes_test.go
+++ b/pkg/postgres/pgutils/messagebytes_test.go
@@ -1,0 +1,89 @@
+package pgutils
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalUnmarshalRepeatedMessages_RoundTrip(t *testing.T) {
+	msgs := []*storage.ProcessSignal_LineageInfo{
+		{ParentUid: 1, ParentExecFilePath: "/usr/bin/bash"},
+		{ParentUid: 2, ParentExecFilePath: "/usr/bin/python"},
+		{ParentUid: 3, ParentExecFilePath: "/bin/sh"},
+	}
+
+	data, err := MarshalRepeatedMessages(msgs)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+
+	got, err := UnmarshalRepeatedMessages(data, func() *storage.ProcessSignal_LineageInfo {
+		return &storage.ProcessSignal_LineageInfo{}
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	for i, msg := range msgs {
+		assert.Equal(t, msg.GetParentUid(), got[i].GetParentUid())
+		assert.Equal(t, msg.GetParentExecFilePath(), got[i].GetParentExecFilePath())
+	}
+}
+
+func TestMarshalUnmarshalRepeatedMessages_Empty(t *testing.T) {
+	data, err := MarshalRepeatedMessages[*storage.ProcessSignal_LineageInfo](nil)
+	require.NoError(t, err)
+	assert.Nil(t, data)
+
+	got, err := UnmarshalRepeatedMessages(nil, func() *storage.ProcessSignal_LineageInfo {
+		return &storage.ProcessSignal_LineageInfo{}
+	})
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestMarshalUnmarshalRepeatedMessages_SingleElement(t *testing.T) {
+	msgs := []*storage.ProcessSignal_LineageInfo{
+		{ParentUid: 42, ParentExecFilePath: "/only/one"},
+	}
+
+	data, err := MarshalRepeatedMessages(msgs)
+	require.NoError(t, err)
+
+	got, err := UnmarshalRepeatedMessages(data, func() *storage.ProcessSignal_LineageInfo {
+		return &storage.ProcessSignal_LineageInfo{}
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, uint32(42), got[0].GetParentUid())
+}
+
+func TestUnmarshalRepeatedMessages_Truncated(t *testing.T) {
+	msgs := []*storage.ProcessSignal_LineageInfo{
+		{ParentUid: 1, ParentExecFilePath: "/usr/bin/bash"},
+	}
+
+	data, err := MarshalRepeatedMessages(msgs)
+	require.NoError(t, err)
+
+	// Truncate the data
+	_, err = UnmarshalRepeatedMessages(data[:len(data)-2], func() *storage.ProcessSignal_LineageInfo {
+		return &storage.ProcessSignal_LineageInfo{}
+	})
+	assert.Error(t, err)
+}
+
+func TestMustMarshalRepeatedMessages(t *testing.T) {
+	msgs := []*storage.ProcessSignal_LineageInfo{
+		{ParentUid: 1},
+	}
+	data := MustMarshalRepeatedMessages(msgs)
+	assert.NotEmpty(t, data)
+
+	got := MustUnmarshalRepeatedMessages(data, func() *storage.ProcessSignal_LineageInfo {
+		return &storage.ProcessSignal_LineageInfo{}
+	})
+	require.Len(t, got, 1)
+	assert.Equal(t, uint32(1), got[0].GetParentUid())
+}

--- a/pkg/postgres/types.go
+++ b/pkg/postgres/types.go
@@ -7,21 +7,22 @@ type DataType string
 
 // Defines all the internal types derived from the struct fields
 const (
-	Bytes       DataType = "bytes"
-	Bool        DataType = "bool"
-	Numeric     DataType = "numeric"
-	String      DataType = "string"
-	DateTime    DataType = "datetime"
-	Map         DataType = "map"
-	Enum        DataType = "enum"
-	StringArray DataType = "stringarray"
-	EnumArray   DataType = "enumarray"
-	Integer     DataType = "integer"
-	IntArray    DataType = "intarray"
-	BigInteger  DataType = "biginteger"
-	UUID        DataType = "uuid"
-	CIDR        DataType = "cidr"
-	DateTimeTZ  DataType = "datetimetz"
+	Bytes        DataType = "bytes"
+	Bool         DataType = "bool"
+	Numeric      DataType = "numeric"
+	String       DataType = "string"
+	DateTime     DataType = "datetime"
+	Map          DataType = "map"
+	Enum         DataType = "enum"
+	StringArray  DataType = "stringarray"
+	EnumArray    DataType = "enumarray"
+	Integer      DataType = "integer"
+	IntArray     DataType = "intarray"
+	BigInteger   DataType = "biginteger"
+	UUID         DataType = "uuid"
+	CIDR         DataType = "cidr"
+	DateTimeTZ   DataType = "datetimetz"
+	MessageBytes DataType = "messagebytes"
 )
 
 var (
@@ -54,7 +55,7 @@ func DataTypeToSQLType(dataType DataType) string {
 		sqlType = "text[]"
 	case EnumArray, IntArray:
 		sqlType = "int[]"
-	case Bytes:
+	case Bytes, MessageBytes:
 		sqlType = "bytea"
 	case CIDR:
 		sqlType = "cidr"

--- a/pkg/postgres/walker/schema.go
+++ b/pkg/postgres/walker/schema.go
@@ -89,6 +89,22 @@ type SchemaRelationship struct {
 	CycleReference bool
 }
 
+// InlinedSubMessage records a sub-message field that was flattened into the parent schema's columns.
+// Only populated when NoSerialized is true. Used by store template code generation.
+type InlinedSubMessage struct {
+	FieldName    string
+	TypeName     string
+	GetterPrefix string
+}
+
+// InlinedRepeatedMessage records a repeated message field stored as a bytea column
+// instead of a child table. Only populated when NoSerialized is true.
+type InlinedRepeatedMessage struct {
+	ColumnName  string
+	ElementType string
+	SetterPath  string
+}
+
 // ThisSchemaColumnNames generates the sequence of column names for this schema
 func (s *SchemaRelationship) ThisSchemaColumnNames() []string {
 	var seq []string
@@ -141,6 +157,27 @@ type Schema struct {
 	SearchScope map[v1.SearchCategory]struct{}
 
 	ScopingResource permissions.ResourceMetadata
+
+	// NoSerialized indicates that this schema should not have a serialized
+	// bytea column. All proto fields become DB columns, and reads reconstruct
+	// the proto from columns instead of unmarshaling a blob.
+	NoSerialized bool
+
+	// InlinedSubMessages tracks sub-message fields that were flattened into
+	// this schema's columns. Only populated when NoSerialized is true.
+	InlinedSubMessages []InlinedSubMessage
+
+	// InlinedRepeatedMessages tracks repeated message fields stored as bytea
+	// columns instead of child tables. Only populated when NoSerialized is true.
+	InlinedRepeatedMessages []InlinedRepeatedMessage
+}
+
+// Root returns the root schema by walking up the Parent chain.
+func (s *Schema) Root() *Schema {
+	for s.Parent != nil {
+		s = s.Parent
+	}
+	return s
 }
 
 // TableFieldsGroup is the group of table fields. A slice of this struct can be used where the table order is essential,
@@ -505,6 +542,12 @@ type ObjectGetter struct {
 	value    string
 }
 
+// IsVariable returns whether this ObjectGetter refers to a local variable.
+func (o ObjectGetter) IsVariable() bool { return o.variable }
+
+// Value returns the raw getter path value.
+func (o ObjectGetter) Value() string { return o.value }
+
 // Field is the representation of a struct field in Postgres
 type Field struct {
 	Schema *Schema
@@ -527,6 +570,10 @@ type Field struct {
 	DerivedSearchFields []DerivedSearchField
 	// Derived indicates whether the search field (if valid search field) is derived from other search field.
 	Derived bool
+
+	// MessageBytesElemType is set for MessageBytes fields: the Go type of the
+	// repeated message element (e.g., "storage.ProcessSignal_LineageInfo").
+	MessageBytesElemType string
 }
 
 // DerivedSearchField represents a search field that's derived.
@@ -548,5 +595,8 @@ func (f Field) Getter(prefix string) string {
 
 // Include returns if the field should be included in the schema
 func (f Field) Include() bool {
+	if f.Schema != nil && f.Schema.Root().NoSerialized {
+		return true
+	}
 	return f.Options.PrimaryKey || f.Options.Unique || f.Search.Enabled || f.ColumnName == "serialized" || f.Options.Reference != nil
 }

--- a/pkg/postgres/walker/walker.go
+++ b/pkg/postgres/walker/walker.go
@@ -54,6 +54,9 @@ func (c walkerContext) childContext(name string, searchDisabled bool, opts Postg
 }
 
 func removeTablesWithNoSearchableFields(schema *Schema) (shouldInclude bool) {
+	if schema.Root().NoSerialized {
+		return true
+	}
 	includedChildren := schema.Children[:0]
 	for _, child := range schema.Children {
 		if shouldIncludeChild := removeTablesWithNoSearchableFields(child); shouldIncludeChild {
@@ -76,7 +79,9 @@ func removeTablesWithNoSearchableFields(schema *Schema) (shouldInclude bool) {
 
 func addCommonFields(s *Schema, parentPrimaryKeys ...Field) {
 	if len(parentPrimaryKeys) == 0 {
-		s.Fields = append(s.Fields, getSerializedField(s))
+		if !s.NoSerialized {
+			s.Fields = append(s.Fields, getSerializedField(s))
+		}
 	} else {
 		// Collect additional fields separately so we can put them in front of the field list
 		// (since these are primary keys, that is cleaner).
@@ -136,12 +141,24 @@ func postProcessSchema(s *Schema) {
 	addCommonFields(s)
 }
 
+// WalkOption is a functional option for Walk.
+type WalkOption func(*Schema)
+
+// WithNoSerialized returns a WalkOption that sets NoSerialized on the schema,
+// causing all proto fields to become DB columns with no serialized bytea blob.
+func WithNoSerialized() WalkOption {
+	return func(s *Schema) { s.NoSerialized = true }
+}
+
 // Walk iterates over the obj and creates a search.Map object from the found struct tags
-func Walk(obj reflect.Type, table string) *Schema {
+func Walk(obj reflect.Type, table string, opts ...WalkOption) *Schema {
 	schema := &Schema{
 		Table:    table,
 		Type:     obj.String(),
 		TypeName: obj.Elem().Name(),
+	}
+	for _, opt := range opts {
+		opt(schema)
 	}
 	handleStruct(walkerContext{}, schema, obj.Elem())
 
@@ -395,6 +412,13 @@ func handleStruct(ctx walkerContext, schema *Schema, original reflect.Type) {
 				schema.AddFieldWithType(field, dt, opts)
 				continue
 			}
+			if schema.Root().NoSerialized {
+				schema.InlinedSubMessages = append(schema.InlinedSubMessages, InlinedSubMessage{
+					FieldName:    structField.Name,
+					TypeName:     structField.Type.Elem().String(),
+					GetterPrefix: ctx.Getter(structField.Name),
+				})
+			}
 			handleStruct(ctx.childContext(field.Name, searchOpts.Ignored, opts), schema, structField.Type.Elem())
 		case reflect.Slice:
 			elemType := structField.Type.Elem()
@@ -412,6 +436,21 @@ func handleStruct(ctx walkerContext, schema *Schema, original reflect.Type) {
 				} else {
 					schema.AddFieldWithType(field, postgres.IntArray, opts)
 				}
+				continue
+			}
+
+			// NoSerialized: inline repeated messages without searchable fields as MessageBytes bytea
+			if schema.Root().NoSerialized && !hasSearchableFields(elemType.Elem()) {
+				field.DataType = postgres.MessageBytes
+				field.SQLType = postgres.DataTypeToSQLType(postgres.MessageBytes)
+				field.ModelType = "[]byte"
+				field.MessageBytesElemType = elemType.Elem().String()
+				schema.AddFieldWithType(field, postgres.MessageBytes, opts)
+				schema.InlinedRepeatedMessages = append(schema.InlinedRepeatedMessages, InlinedRepeatedMessage{
+					ColumnName:  field.ColumnName,
+					ElementType: elemType.Elem().String(),
+					SetterPath:  getterToSetterPath(ctx.Getter(field.Name)),
+				})
 				continue
 			}
 
@@ -468,4 +507,30 @@ func handleStruct(ctx walkerContext, schema *Schema, original reflect.Type) {
 			panic(fmt.Sprintf("Type %s for field %s is not currently handled", original.Kind(), field.Name))
 		}
 	}
+}
+
+func hasSearchableFields(t reflect.Type) bool {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if protoreflect.IsInternalGeneratorField(f) {
+			continue
+		}
+		if tag := f.Tag.Get("search"); tag != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func getterToSetterPath(getter string) string {
+	parts := strings.Split(getter, ".")
+	var result []string
+	for _, p := range parts {
+		p = strings.TrimPrefix(p, "Get")
+		p = strings.TrimSuffix(p, "()")
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return strings.Join(result, ".")
 }

--- a/tools/generate-helpers/pg-table-bindings/main.go
+++ b/tools/generate-helpers/pg-table-bindings/main.go
@@ -117,6 +117,10 @@ type properties struct {
 
 	// Generates helper functions to create/destroy tables and store
 	GenerateDataModelHelpers bool
+
+	// NoSerialized indicates that the store should not use a serialized bytea column.
+	// All proto fields become DB columns, reads reconstruct the proto from columns.
+	NoSerialized bool
 }
 
 type parsedReference struct {
@@ -158,6 +162,7 @@ func main() {
 	c.Flags().BoolVar(&props.ConversionFuncs, "conversion-funcs", false, "indicates that we should generate conversion functions between protobuf types to/from Gorm model")
 
 	c.Flags().BoolVar(&props.GenerateDataModelHelpers, "generate-data-model-helpers", false, "if true, generates CreateTableAndNewStore and Destroy functions")
+	c.Flags().BoolVar(&props.NoSerialized, "no-serialized", false, "generate store without serialized bytea column; all proto fields become DB columns")
 	c.RunE = func(*cobra.Command, []string) error {
 		typ := stringutils.OrDefault(props.RegisteredType, props.Type)
 		fmt.Println(readable.Time(time.Now()), "Generating for", typ)
@@ -169,7 +174,11 @@ func main() {
 		if props.Table == "" {
 			props.Table = pgutils.NamingStrategy.TableName(trimmedType)
 		}
-		schema := walker.Walk(mt, props.Table)
+		var walkOpts []walker.WalkOption
+		if props.NoSerialized {
+			walkOpts = append(walkOpts, walker.WithNoSerialized())
+		}
+		schema := walker.Walk(mt, props.Table, walkOpts...)
 		if schema.NoPrimaryKey() && !props.SingletonStore {
 			log.Fatal("No primary key defined, please check relevant proto file and ensure a primary key is specified using the \"sql:\"pk\"\" tag")
 		}
@@ -247,6 +256,7 @@ func main() {
 			"Singleton":            props.SingletonStore,
 
 			"GenerateDataModelHelpers": props.GenerateDataModelHelpers,
+			"NoSerialized":             props.NoSerialized,
 		}
 
 		if err := common.RenderFile(templateMap, schemaTemplate, getSchemaFileName(props.SchemaDirectory, schema.Table)); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/schema.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/schema.go.tpl
@@ -52,9 +52,9 @@ var (
         if schema != nil {
             return schema
         }
-        schema = walker.Walk(reflect.TypeOf(({{.Schema.Type}})(nil)), "{{.Schema.Table}}")
+        schema = walker.Walk(reflect.TypeOf(({{.Schema.Type}})(nil)), "{{.Schema.Table}}"{{if .NoSerialized}}, walker.WithNoSerialized(){{end}})
         {{- else}}
-        schema := walker.Walk(reflect.TypeOf(({{.Schema.Type}})(nil)), "{{.Schema.Table}}")
+        schema := walker.Walk(reflect.TypeOf(({{.Schema.Type}})(nil)), "{{.Schema.Table}}"{{if .NoSerialized}}, walker.WithNoSerialized(){{end}})
         {{- end}}
 
         {{- if gt (len .References) 0 }}


### PR DESCRIPTION
Schema walker, types, and CLI foundation for serialized-free store
generation. No existing stores are affected — the --no-serialized
flag is opt-in per entity via gen.go directives.

Walker changes: WalkOption functional options, WithNoSerialized()
option, all-fields-as-columns mode, MessageBytes inlining for
repeated messages without searchable fields, sub-message tracking.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
