### PR TITLE
feat(tls): configurable Secured Cluster certificate validity

### DIFF
--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -315,6 +315,8 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"type: CVE_CVEType!",
 	}))
 	utils.Must(builder.AddType("ClusterCertExpiryStatus", []string{
+		"lastRefreshTime: Time",
+		"lastRefreshedCertExpiry: Time",
 		"sensorCertExpiry: Time",
 		"sensorCertNotBefore: Time",
 	}))
@@ -4445,6 +4447,16 @@ func (resolver *Resolver) wrapClusterCertExpiryStatusesWithContext(ctx context.C
 		output[i] = &clusterCertExpiryStatusResolver{ctx: ctx, root: resolver, data: v}
 	}
 	return output, nil
+}
+
+func (resolver *clusterCertExpiryStatusResolver) LastRefreshTime(ctx context.Context) (*graphql.Time, error) {
+	value := resolver.data.GetLastRefreshTime()
+	return protocompat.ConvertTimestampToGraphqlTimeOrError(value)
+}
+
+func (resolver *clusterCertExpiryStatusResolver) LastRefreshedCertExpiry(ctx context.Context) (*graphql.Time, error) {
+	value := resolver.data.GetLastRefreshedCertExpiry()
+	return protocompat.ConvertTimestampToGraphqlTimeOrError(value)
 }
 
 func (resolver *clusterCertExpiryStatusResolver) SensorCertExpiry(ctx context.Context) (*graphql.Time, error) {

--- a/central/securedclustercertgen/certificates.go
+++ b/central/securedclustercertgen/certificates.go
@@ -2,6 +2,7 @@ package securedclustercertgen
 
 import (
 	"os"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -37,12 +38,13 @@ type certIssuerImpl struct {
 	signingCA                mtls.CA
 	secondaryCA              mtls.CA
 	sensorSupportsCARotation bool
+	requestedValidity        time.Duration
 }
 
 // IssueSecuredClusterCerts issues certificates for all the services of a secured cluster (including local scanner).
 // It loads the CAs from disk and selects which CA to use for signing  based on Sensor capabilities
 // and the optional Sensor CA fingerprint.
-func IssueSecuredClusterCerts(namespace, clusterID string, sensorSupportsCARotation bool, sensorCAFingerprint string) (*storage.TypedServiceCertificateSet, error) {
+func IssueSecuredClusterCerts(namespace, clusterID string, sensorSupportsCARotation bool, sensorCAFingerprint string, requestedValidity time.Duration) (*storage.TypedServiceCertificateSet, error) {
 	primaryCA, err := mtls.CAForSigning()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not load CA for signing")
@@ -55,7 +57,7 @@ func IssueSecuredClusterCerts(namespace, clusterID string, sensorSupportsCARotat
 		}
 	}
 
-	return IssueSecuredClusterCertsWithCAs(namespace, clusterID, sensorSupportsCARotation, primaryCA, secondaryCA, sensorCAFingerprint)
+	return IssueSecuredClusterCertsWithCAs(namespace, clusterID, sensorSupportsCARotation, primaryCA, secondaryCA, sensorCAFingerprint, requestedValidity)
 }
 
 // IssueSecuredClusterCertsWithCAs issues certificates for all the services of a secured cluster (including local scanner),
@@ -68,6 +70,7 @@ func IssueSecuredClusterCertsWithCAs(
 	primaryCA mtls.CA,
 	secondaryCA mtls.CA,
 	sensorCAFingerprint string,
+	requestedValidity time.Duration,
 ) (*storage.TypedServiceCertificateSet, error) {
 	if primaryCA == nil {
 		return nil, errors.New("primary CA is required")
@@ -92,6 +95,7 @@ func IssueSecuredClusterCertsWithCAs(
 		signingCA:                primaryCA,
 		secondaryCA:              secondaryCA,
 		sensorSupportsCARotation: sensorSupportsCARotation,
+		requestedValidity:        requestedValidity,
 	}
 
 	return certIssuer.issueCertificates(namespace, clusterID)
@@ -191,6 +195,9 @@ func (c *certIssuerImpl) generateServiceCertMap(serviceType storage.ServiceType,
 	subject := mtls.NewSubject(clusterID, serviceType)
 	issueOpts := []mtls.IssueCertOption{
 		mtls.WithNamespace(namespace),
+	}
+	if c.requestedValidity > 0 {
+		issueOpts = append(issueOpts, mtls.WithValidityNotAfter(time.Now().Add(c.requestedValidity)))
 	}
 	if err := certgen.IssueServiceCert(fileMap, c.signingCA, subject, "", issueOpts...); err != nil {
 		return nil, errors.Wrap(err, "error generating service certificate")

--- a/central/securedclustercertgen/certificates_test.go
+++ b/central/securedclustercertgen/certificates_test.go
@@ -204,7 +204,7 @@ func (s *securedClusterCertGenSuite) TestSecuredClusterCertificateGenerationCust
 	s.Require().NoError(err)
 
 	expectedNotAfter := time.Now().Add(requestedValidity)
-	s.InDelta(float64(expectedNotAfter.Unix()), float64(cert.NotAfter.Unix()), float64(2*time.Minute), "cert NotAfter should match requested validity")
+	s.InDelta(float64(expectedNotAfter.Unix()), float64(cert.NotAfter.Unix()), float64((2 * time.Minute).Seconds()), "cert NotAfter should match requested validity")
 }
 
 func (s *securedClusterCertGenSuite) TestServiceIssueLocalScannerCerts() {

--- a/central/securedclustercertgen/certificates_test.go
+++ b/central/securedclustercertgen/certificates_test.go
@@ -187,6 +187,26 @@ func (s *securedClusterCertGenSuite) TestSecuredClusterCertificateGeneration() {
 	}
 }
 
+func (s *securedClusterCertGenSuite) TestSecuredClusterCertificateGenerationCustomValidity() {
+	requestedValidity := 45 * 24 * time.Hour
+	ca, err := mtls.CAForSigning()
+	s.Require().NoError(err)
+
+	certIssuer := certIssuerImpl{
+		serviceTypes:             set.NewFrozenSet(storage.ServiceType_SENSOR_SERVICE),
+		signingCA:                ca,
+		sensorSupportsCARotation: false,
+		requestedValidity:        requestedValidity,
+	}
+	certMap, err := certIssuer.generateServiceCertMap(storage.ServiceType_SENSOR_SERVICE, namespace, clusterID)
+	s.Require().NoError(err)
+	cert, err := helpers.ParseCertificatePEM(certMap["cert.pem"])
+	s.Require().NoError(err)
+
+	expectedNotAfter := time.Now().Add(requestedValidity)
+	s.InDelta(float64(expectedNotAfter.Unix()), float64(cert.NotAfter.Unix()), float64(2*time.Minute), "cert NotAfter should match requested validity")
+}
+
 func (s *securedClusterCertGenSuite) TestServiceIssueLocalScannerCerts() {
 	getServiceTypes := func() set.FrozenSet[string] {
 		serviceTypes := scannerV2ServiceTypes
@@ -281,7 +301,7 @@ func (s *securedClusterCertGenSuite) TestServiceIssueSecuredClusterCerts() {
 
 	for tcName, tc := range testCases {
 		s.Run(tcName, func() {
-			certs, err := IssueSecuredClusterCerts(tc.namespace, tc.clusterID, false, "")
+			certs, err := IssueSecuredClusterCerts(tc.namespace, tc.clusterID, false, "", 0)
 			if tc.shouldFail {
 				s.Require().Error(err)
 				return
@@ -436,7 +456,7 @@ func (s *securedClusterCARotationSuite) TestIssueSecuredClusterCertsWithCAs() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			certs, err := IssueSecuredClusterCertsWithCAs(namespace, clusterID, tc.sensorSupportsCARotation, tc.primaryCA, tc.secondaryCA, tc.sensorCAFingerprint)
+			certs, err := IssueSecuredClusterCertsWithCAs(namespace, clusterID, tc.sensorSupportsCARotation, tc.primaryCA, tc.secondaryCA, tc.sensorCAFingerprint, 0)
 			s.Require().NoError(err)
 			s.Require().NotNil(certs)
 			s.Require().NotEmpty(certs.GetCaPem())
@@ -518,7 +538,7 @@ func (s *securedClusterCARotationSuite) TestBuildCABundle() {
 }
 
 func (s *securedClusterCARotationSuite) TestServiceCertificateGeneration() {
-	certs, err := IssueSecuredClusterCertsWithCAs(namespace, clusterID, true, s.primaryCA, s.secondaryCA, "")
+	certs, err := IssueSecuredClusterCertsWithCAs(namespace, clusterID, true, s.primaryCA, s.secondaryCA, "", 0)
 	s.Require().NoError(err)
 	s.Require().NotNil(certs)
 
@@ -545,18 +565,18 @@ func (s *securedClusterCARotationSuite) TestServiceCertificateGeneration() {
 
 func (s *securedClusterCARotationSuite) TestErrorHandling() {
 	s.Run("empty namespace", func() {
-		_, err := IssueSecuredClusterCertsWithCAs("", clusterID, true, s.primaryCA, s.secondaryCA, "")
+		_, err := IssueSecuredClusterCertsWithCAs("", clusterID, true, s.primaryCA, s.secondaryCA, "", 0)
 		s.Error(err)
 		s.Contains(err.Error(), "namespace is required")
 	})
 
 	s.Run("empty cluster ID", func() {
-		_, err := IssueSecuredClusterCertsWithCAs(namespace, "", true, s.primaryCA, s.secondaryCA, "")
+		_, err := IssueSecuredClusterCertsWithCAs(namespace, "", true, s.primaryCA, s.secondaryCA, "", 0)
 		s.Error(err)
 	})
 
 	s.Run("nil primary CA", func() {
-		_, err := IssueSecuredClusterCertsWithCAs(namespace, clusterID, true, nil, s.secondaryCA, "")
+		_, err := IssueSecuredClusterCertsWithCAs(namespace, clusterID, true, nil, s.secondaryCA, "", 0)
 		s.Error(err)
 		s.Contains(err.Error(), "primary CA is required")
 	})

--- a/central/securedclustercertgen/sensor_cert.go
+++ b/central/securedclustercertgen/sensor_cert.go
@@ -1,0 +1,51 @@
+package securedclustercertgen
+
+import (
+	"crypto/x509"
+	"time"
+
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/generated/storage"
+)
+
+// SensorCertificateValidity returns NotBefore and NotAfter for the Sensor service certificate in the set.
+func SensorCertificateValidity(certificates *storage.TypedServiceCertificateSet) (notBefore, notAfter time.Time, err error) {
+	if certificates == nil {
+		return time.Time{}, time.Time{}, errors.New("certificates set is nil")
+	}
+	for _, typedCert := range certificates.GetServiceCerts() {
+		if typedCert.GetServiceType() != storage.ServiceType_SENSOR_SERVICE {
+			continue
+		}
+		certPEM := typedCert.GetCert().GetCertPem()
+		if len(certPEM) == 0 {
+			return time.Time{}, time.Time{}, errors.New("sensor certificate PEM is empty")
+		}
+		cert, parseErr := helpers.ParseCertificatePEM(certPEM)
+		if parseErr != nil {
+			return time.Time{}, time.Time{}, errors.Wrap(parseErr, "parsing sensor certificate")
+		}
+		return cert.NotBefore, cert.NotAfter, nil
+	}
+	return time.Time{}, time.Time{}, errors.New("sensor certificate not found in certificate set")
+}
+
+// ParseCertificateNotAfter parses NotAfter from a PEM-encoded certificate.
+func ParseCertificateNotAfter(certPEM []byte) (time.Time, error) {
+	cert, err := helpers.ParseCertificatePEM(certPEM)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return cert.NotAfter, nil
+}
+
+// ParseCertificateValidity parses NotBefore and NotAfter from a PEM-encoded certificate.
+func ParseCertificateValidity(certPEM []byte) (notBefore, notAfter time.Time, err error) {
+	var cert *x509.Certificate
+	cert, err = helpers.ParseCertificatePEM(certPEM)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	return cert.NotBefore, cert.NotAfter, nil
+}

--- a/central/securedclustercertgen/validity.go
+++ b/central/securedclustercertgen/validity.go
@@ -10,7 +10,9 @@ import (
 
 const (
 	// minRequestedCertValidity is the absolute floor for requested certificate validity.
-	minRequestedCertValidity = 5 * time.Minute
+	// Must be greater than the 1h clock-skew grace period used when setting notBefore,
+	// otherwise the refresher would see a near-zero or negative window and loop immediately.
+	minRequestedCertValidity = 2 * time.Hour
 )
 
 // ClampRequestedValidity validates and clamps the requested certificate validity duration.

--- a/central/securedclustercertgen/validity.go
+++ b/central/securedclustercertgen/validity.go
@@ -1,0 +1,37 @@
+package securedclustercertgen
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/pkg/mtls"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+const (
+	// minRequestedCertValidity is the absolute floor for requested certificate validity.
+	minRequestedCertValidity = 5 * time.Minute
+)
+
+// ClampRequestedValidity validates and clamps the requested certificate validity duration.
+// When requested is nil or zero, returns zero duration (caller should use default 1-year signing profile).
+func ClampRequestedValidity(requested *durationpb.Duration) (time.Duration, error) {
+	if requested == nil {
+		return 0, nil
+	}
+	d := requested.AsDuration()
+	if d == 0 {
+		return 0, nil
+	}
+	if d < 0 {
+		return 0, errors.New("requested validity must not be negative")
+	}
+	if d < minRequestedCertValidity {
+		return 0, errors.Errorf("requested validity %s is below the minimum %s", d, minRequestedCertValidity)
+	}
+	maxValidity := mtls.CertLifetime()
+	if d > maxValidity {
+		d = maxValidity
+	}
+	return d, nil
+}

--- a/central/securedclustercertgen/validity_test.go
+++ b/central/securedclustercertgen/validity_test.go
@@ -36,6 +36,14 @@ func TestClampRequestedValidity(t *testing.T) {
 			requested: durationpb.New(time.Minute),
 			wantErr:   "below the minimum",
 		},
+		"just below minimum": {
+			requested: durationpb.New(2*time.Hour - time.Second),
+			wantErr:   "below the minimum",
+		},
+		"exactly minimum": {
+			requested: durationpb.New(2 * time.Hour),
+			want:      2 * time.Hour,
+		},
 		"negative": {
 			requested: durationpb.New(-time.Hour),
 			wantErr:   "must not be negative",

--- a/central/securedclustercertgen/validity_test.go
+++ b/central/securedclustercertgen/validity_test.go
@@ -1,0 +1,56 @@
+package securedclustercertgen
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestClampRequestedValidity(t *testing.T) {
+	cases := map[string]struct {
+		requested *durationpb.Duration
+		want      time.Duration
+		wantErr   string
+	}{
+		"nil": {
+			requested: nil,
+			want:      0,
+		},
+		"zero": {
+			requested: durationpb.New(0),
+			want:      0,
+		},
+		"45 days": {
+			requested: durationpb.New(45 * 24 * time.Hour),
+			want:      45 * 24 * time.Hour,
+		},
+		"above max clamped": {
+			requested: durationpb.New(2 * 365 * 24 * time.Hour),
+			want:      mtls.CertLifetime(),
+		},
+		"below minimum": {
+			requested: durationpb.New(time.Minute),
+			wantErr:   "below the minimum",
+		},
+		"negative": {
+			requested: durationpb.New(-time.Hour),
+			wantErr:   "must not be negative",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ClampRequestedValidity(tc.requested)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/central/sensor/service/common/manager.go
+++ b/central/sensor/service/common/manager.go
@@ -11,6 +11,7 @@ import (
 type ClusterManager interface {
 	UpdateClusterUpgradeStatus(ctx context.Context, clusterID string, status *storage.ClusterUpgradeStatus) error
 	UpdateClusterHealth(ctx context.Context, id string, status *storage.ClusterHealthStatus) error
+	UpdateClusterCertExpiryStatus(ctx context.Context, id string, status *storage.ClusterCertExpiryStatus) error
 	UpdateSensorDeploymentIdentification(ctx context.Context, clusterID string, identification *storage.SensorDeploymentIdentification) error
 	GetCluster(ctx context.Context, id string) (*storage.Cluster, bool, error)
 	GetClusters(ctx context.Context) ([]*storage.Cluster, error)

--- a/central/sensor/service/common/mocks/manager.go
+++ b/central/sensor/service/common/mocks/manager.go
@@ -73,6 +73,20 @@ func (mr *MockClusterManagerMockRecorder) GetClusters(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusters", reflect.TypeOf((*MockClusterManager)(nil).GetClusters), ctx)
 }
 
+// UpdateClusterCertExpiryStatus mocks base method.
+func (m *MockClusterManager) UpdateClusterCertExpiryStatus(ctx context.Context, id string, status *storage.ClusterCertExpiryStatus) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateClusterCertExpiryStatus", ctx, id, status)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateClusterCertExpiryStatus indicates an expected call of UpdateClusterCertExpiryStatus.
+func (mr *MockClusterManagerMockRecorder) UpdateClusterCertExpiryStatus(ctx, id, status any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterCertExpiryStatus", reflect.TypeOf((*MockClusterManager)(nil).UpdateClusterCertExpiryStatus), ctx, id, status)
+}
+
 // UpdateClusterHealth mocks base method.
 func (m *MockClusterManager) UpdateClusterHealth(ctx context.Context, id string, status *storage.ClusterHealthStatus) error {
 	m.ctrl.T.Helper()

--- a/central/sensor/service/connection/connection_impl.go
+++ b/central/sensor/service/connection/connection_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/pkg/errors"
 	compScanSetting "github.com/stackrox/rox/central/complianceoperator/v2/scanconfigurations/datastore"
@@ -34,6 +35,7 @@ import (
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/protoconv/schedule"
 	"github.com/stackrox/rox/pkg/rate"
 	"github.com/stackrox/rox/pkg/reflectutils"
@@ -460,12 +462,25 @@ func (c *sensorConnection) processIssueSecuredClusterCertsRequest(ctx context.Co
 		var certificates *storage.TypedServiceCertificateSet
 		sensorSupportsRotation := c.capabilities.Contains(centralsensor.SensorCARotationSupported)
 		caFingerprint := request.GetCaFingerprint()
-		certificates, err = securedclustercertgen.IssueSecuredClusterCerts(namespace, clusterID, sensorSupportsRotation, caFingerprint)
-		response = &central.IssueSecuredClusterCertsResponse{
-			RequestId: requestID,
-			Response: &central.IssueSecuredClusterCertsResponse_Certificates{
-				Certificates: certificates,
-			},
+		requestedValidity, validityErr := securedclustercertgen.ClampRequestedValidity(request.GetRequestedValidity())
+		if validityErr != nil {
+			err = validityErr
+		} else {
+			certificates, err = securedclustercertgen.IssueSecuredClusterCerts(
+				namespace, clusterID, sensorSupportsRotation, caFingerprint, requestedValidity)
+			if err == nil && c.clusterMgr != nil {
+				if updateErr := c.updateCertRefreshMetadata(ctx, certificates); updateErr != nil {
+					log.Warnf("Failed to update cert refresh metadata for cluster %s: %v", clusterID, updateErr)
+				}
+			}
+		}
+		if err == nil {
+			response = &central.IssueSecuredClusterCertsResponse{
+				RequestId: requestID,
+				Response: &central.IssueSecuredClusterCertsResponse_Certificates{
+					Certificates: certificates,
+				},
+			}
 		}
 	}
 	if err != nil {
@@ -485,6 +500,43 @@ func (c *sensorConnection) processIssueSecuredClusterCertsRequest(ctx context.Co
 		return errors.Wrap(err, errMsg)
 	}
 	return nil
+}
+
+func (c *sensorConnection) updateCertRefreshMetadata(ctx context.Context, certificates *storage.TypedServiceCertificateSet) error {
+	_, notAfter, err := securedclustercertgen.SensorCertificateValidity(certificates)
+	if err != nil {
+		return err
+	}
+
+	cluster, exists, err := c.clusterMgr.GetCluster(ctx, c.clusterID)
+	if err != nil {
+		return errors.Wrap(err, "getting cluster for cert refresh metadata update")
+	}
+	if !exists {
+		return errors.New("cluster not found for cert refresh metadata update")
+	}
+
+	expiryStatus := cluster.GetStatus().GetCertExpiryStatus()
+	if expiryStatus == nil {
+		expiryStatus = &storage.ClusterCertExpiryStatus{}
+	} else {
+		expiryStatus = expiryStatus.CloneVT()
+	}
+
+	refreshTime := time.Now().UTC()
+	refreshTimestamp, err := protocompat.ConvertTimeToTimestampOrError(refreshTime)
+	if err != nil {
+		return errors.Wrap(err, "converting refresh time to timestamp")
+	}
+	refreshedCertExpiryTimestamp, err := protocompat.ConvertTimeToTimestampOrError(notAfter)
+	if err != nil {
+		return errors.Wrap(err, "converting refreshed cert expiry to timestamp")
+	}
+
+	expiryStatus.LastRefreshTime = refreshTimestamp
+	expiryStatus.LastRefreshedCertExpiry = refreshedCertExpiryTimestamp
+
+	return c.clusterMgr.UpdateClusterCertExpiryStatus(ctx, c.clusterID, expiryStatus)
 }
 
 // getPolicySyncMsg fetches stored policies and prepares them for delivery to sensor.

--- a/central/sensor/service/service_impl.go
+++ b/central/sensor/service/service_impl.go
@@ -174,8 +174,13 @@ func (s *serviceImpl) Communicate(server central.SensorService_CommunicateServer
 
 		if err := safe.RunE(func() error {
 			sensorNamespace := sensorHello.GetDeploymentIdentification().GetAppNamespace()
+			requestedValidity, err := securedclustercertgen.ClampRequestedValidity(sensorHello.GetRequestedCertValidity())
+			if err != nil {
+				log.Warnf("Sensor for cluster %s requested invalid cert validity: %v; using default", cluster.GetName(), err)
+				requestedValidity = 0
+			}
 			certificateSet, err := securedclustercertgen.IssueSecuredClusterCerts(
-				sensorNamespace, clusterID, isCARotationSupported(sensorHello), "", 0)
+				sensorNamespace, clusterID, isCARotationSupported(sensorHello), "", requestedValidity)
 			if err != nil {
 				return errors.Wrapf(err, "issuing a certificate bundle for cluster %s", cluster.GetName())
 			}

--- a/central/sensor/service/service_impl.go
+++ b/central/sensor/service/service_impl.go
@@ -175,7 +175,7 @@ func (s *serviceImpl) Communicate(server central.SensorService_CommunicateServer
 		if err := safe.RunE(func() error {
 			sensorNamespace := sensorHello.GetDeploymentIdentification().GetAppNamespace()
 			certificateSet, err := securedclustercertgen.IssueSecuredClusterCerts(
-				sensorNamespace, clusterID, isCARotationSupported(sensorHello), "")
+				sensorNamespace, clusterID, isCARotationSupported(sensorHello), "", 0)
 			if err != nil {
 				return errors.Wrapf(err, "issuing a certificate bundle for cluster %s", cluster.GetName())
 			}

--- a/generated/api/v1/cluster_service.swagger.json
+++ b/generated/api/v1/cluster_service.swagger.json
@@ -624,6 +624,16 @@
         "sensorCertNotBefore": {
           "type": "string",
           "format": "date-time"
+        },
+        "lastRefreshTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last successful cert issuance by Central for this cluster."
+        },
+        "lastRefreshedCertExpiry": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiry of the certs issued in the last refresh."
         }
       }
     },

--- a/generated/internalapi/central/hello.pb.go
+++ b/generated/internalapi/central/hello.pb.go
@@ -10,6 +10,7 @@ import (
 	storage "github.com/stackrox/rox/generated/storage"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -151,8 +152,11 @@ type SensorHello struct {
 	SensorState SensorHello_SensorState `protobuf:"varint,6,opt,name=sensor_state,json=sensorState,proto3,enum=central.SensorHello_SensorState" json:"sensor_state,omitempty"`
 	// request_deduper_state is a request to central to communicate its deduper state.
 	RequestDeduperState bool `protobuf:"varint,7,opt,name=request_deduper_state,json=requestDeduperState,proto3" json:"request_deduper_state,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// requested_cert_validity is the desired validity duration for certificates issued
+	// by Central during the initial connection handshake. When unset, Central uses the default 1-year profile.
+	RequestedCertValidity *durationpb.Duration `protobuf:"bytes,8,opt,name=requested_cert_validity,json=requestedCertValidity,proto3" json:"requested_cert_validity,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *SensorHello) Reset() {
@@ -232,6 +236,13 @@ func (x *SensorHello) GetRequestDeduperState() bool {
 		return x.RequestDeduperState
 	}
 	return false
+}
+
+func (x *SensorHello) GetRequestedCertValidity() *durationpb.Duration {
+	if x != nil {
+		return x.RequestedCertValidity
+	}
+	return nil
 }
 
 type CentralHello struct {
@@ -330,14 +341,14 @@ var File_internalapi_central_hello_proto protoreflect.FileDescriptor
 
 const file_internalapi_central_hello_proto_rawDesc = "" +
 	"\n" +
-	"\x1finternalapi/central/hello.proto\x12\acentral\x1a\x15storage/cluster.proto\"\xdb\x01\n" +
+	"\x1finternalapi/central/hello.proto\x12\acentral\x1a\x1egoogle/protobuf/duration.proto\x1a\x15storage/cluster.proto\"\xdb\x01\n" +
 	"\x15HelmManagedConfigInit\x12E\n" +
 	"\x0ecluster_config\x18\x01 \x01(\v2\x1e.storage.CompleteClusterConfigR\rclusterConfig\x12!\n" +
 	"\fcluster_name\x18\x02 \x01(\tR\vclusterName\x12\x1d\n" +
 	"\n" +
 	"cluster_id\x18\x03 \x01(\tR\tclusterId\x123\n" +
 	"\n" +
-	"managed_by\x18\x05 \x01(\x0e2\x14.storage.ManagerTypeR\tmanagedByJ\x04\b\x04\x10\x05\"\xef\x03\n" +
+	"managed_by\x18\x05 \x01(\x0e2\x14.storage.ManagerTypeR\tmanagedByJ\x04\b\x04\x10\x05\"\xc2\x04\n" +
 	"\vSensorHello\x12%\n" +
 	"\x0esensor_version\x18\x01 \x01(\tR\rsensorVersion\x12\"\n" +
 	"\fcapabilities\x18\x02 \x03(\tR\fcapabilities\x12d\n" +
@@ -345,7 +356,8 @@ const file_internalapi_central_hello_proto_rawDesc = "" +
 	"\x18helm_managed_config_init\x18\x03 \x01(\v2\x1e.central.HelmManagedConfigInitR\x15helmManagedConfigInit\x12%\n" +
 	"\x0epolicy_version\x18\x04 \x01(\tR\rpolicyVersion\x12C\n" +
 	"\fsensor_state\x18\x06 \x01(\x0e2 .central.SensorHello.SensorStateR\vsensorState\x122\n" +
-	"\x15request_deduper_state\x18\a \x01(\bR\x13requestDeduperState\"6\n" +
+	"\x15request_deduper_state\x18\a \x01(\bR\x13requestDeduperState\x12Q\n" +
+	"\x17requested_cert_validity\x18\b \x01(\v2\x19.google.protobuf.DurationR\x15requestedCertValidity\"6\n" +
 	"\vSensorState\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
 	"\aSTARTUP\x10\x01\x12\r\n" +
@@ -388,6 +400,7 @@ var file_internalapi_central_hello_proto_goTypes = []any{
 	(*storage.CompleteClusterConfig)(nil),          // 5: storage.CompleteClusterConfig
 	(storage.ManagerType)(0),                       // 6: storage.ManagerType
 	(*storage.SensorDeploymentIdentification)(nil), // 7: storage.SensorDeploymentIdentification
+	(*durationpb.Duration)(nil),                    // 8: google.protobuf.Duration
 }
 var file_internalapi_central_hello_proto_depIdxs = []int32{
 	5, // 0: central.HelmManagedConfigInit.cluster_config:type_name -> storage.CompleteClusterConfig
@@ -395,12 +408,13 @@ var file_internalapi_central_hello_proto_depIdxs = []int32{
 	7, // 2: central.SensorHello.deployment_identification:type_name -> storage.SensorDeploymentIdentification
 	1, // 3: central.SensorHello.helm_managed_config_init:type_name -> central.HelmManagedConfigInit
 	0, // 4: central.SensorHello.sensor_state:type_name -> central.SensorHello.SensorState
-	4, // 5: central.CentralHello.cert_bundle:type_name -> central.CentralHello.CertBundleEntry
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	8, // 5: central.SensorHello.requested_cert_validity:type_name -> google.protobuf.Duration
+	4, // 6: central.CentralHello.cert_bundle:type_name -> central.CentralHello.CertBundleEntry
+	7, // [7:7] is the sub-list for method output_type
+	7, // [7:7] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_internalapi_central_hello_proto_init() }

--- a/generated/internalapi/central/hello_vtproto.pb.go
+++ b/generated/internalapi/central/hello_vtproto.pb.go
@@ -7,9 +7,11 @@ package central
 import (
 	fmt "fmt"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
+	durationpb1 "github.com/planetscale/vtprotobuf/types/known/durationpb"
 	storage "github.com/stackrox/rox/generated/storage"
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	io "io"
 	unsafe "unsafe"
 )
@@ -59,6 +61,7 @@ func (m *SensorHello) CloneVT() *SensorHello {
 	r.PolicyVersion = m.PolicyVersion
 	r.SensorState = m.SensorState
 	r.RequestDeduperState = m.RequestDeduperState
+	r.RequestedCertValidity = (*durationpb.Duration)((*durationpb1.Duration)(m.RequestedCertValidity).CloneVT())
 	if rhs := m.Capabilities; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -192,6 +195,9 @@ func (this *SensorHello) EqualVT(that *SensorHello) bool {
 		return false
 	}
 	if this.RequestDeduperState != that.RequestDeduperState {
+		return false
+	}
+	if !(*durationpb1.Duration)(this.RequestedCertValidity).EqualVT((*durationpb1.Duration)(that.RequestedCertValidity)) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -365,6 +371,16 @@ func (m *SensorHello) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.RequestedCertValidity != nil {
+		size, err := (*durationpb1.Duration)(m.RequestedCertValidity).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x42
 	}
 	if m.RequestDeduperState {
 		i--
@@ -613,6 +629,10 @@ func (m *SensorHello) SizeVT() (n int) {
 	}
 	if m.RequestDeduperState {
 		n += 2
+	}
+	if m.RequestedCertValidity != nil {
+		l = (*durationpb1.Duration)(m.RequestedCertValidity).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -1084,6 +1104,42 @@ func (m *SensorHello) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.RequestDeduperState = bool(v != 0)
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequestedCertValidity", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RequestedCertValidity == nil {
+				m.RequestedCertValidity = &durationpb.Duration{}
+			}
+			if err := (*durationpb1.Duration)(m.RequestedCertValidity).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -1894,6 +1950,42 @@ func (m *SensorHello) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 			}
 			m.RequestDeduperState = bool(v != 0)
+		case 8:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequestedCertValidity", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RequestedCertValidity == nil {
+				m.RequestedCertValidity = &durationpb.Duration{}
+			}
+			if err := (*durationpb1.Duration)(m.RequestedCertValidity).UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/generated/internalapi/central/secured_cluster_cert_refresh.pb.go
+++ b/generated/internalapi/central/secured_cluster_cert_refresh.pb.go
@@ -10,6 +10,7 @@ import (
 	storage "github.com/stackrox/rox/generated/storage"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -71,8 +72,10 @@ type IssueSecuredClusterCertsRequest struct {
 	RequestId string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
 	// Optional: hex-encoded SHA-512_256 fingerprint of the Sensor's currently trusted CA
 	CaFingerprint string `protobuf:"bytes,2,opt,name=ca_fingerprint,json=caFingerprint,proto3" json:"ca_fingerprint,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Optional: requested validity duration for issued certificates. When unset, Central uses the default 1-year profile.
+	RequestedValidity *durationpb.Duration `protobuf:"bytes,3,opt,name=requested_validity,json=requestedValidity,proto3" json:"requested_validity,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *IssueSecuredClusterCertsRequest) Reset() {
@@ -117,6 +120,13 @@ func (x *IssueSecuredClusterCertsRequest) GetCaFingerprint() string {
 		return x.CaFingerprint
 	}
 	return ""
+}
+
+func (x *IssueSecuredClusterCertsRequest) GetRequestedValidity() *durationpb.Duration {
+	if x != nil {
+		return x.RequestedValidity
+	}
+	return nil
 }
 
 type IssueSecuredClusterCertsResponse struct {
@@ -213,13 +223,14 @@ var File_internalapi_central_secured_cluster_cert_refresh_proto protoreflect.Fil
 
 const file_internalapi_central_secured_cluster_cert_refresh_proto_rawDesc = "" +
 	"\n" +
-	"6internalapi/central/secured_cluster_cert_refresh.proto\x12\acentral\x1a\x1estorage/service_identity.proto\"9\n" +
+	"6internalapi/central/secured_cluster_cert_refresh.proto\x12\acentral\x1a\x1egoogle/protobuf/duration.proto\x1a\x1estorage/service_identity.proto\"9\n" +
 	"\x1dSecuredClusterCertsIssueError\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage\"g\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\"\xb1\x01\n" +
 	"\x1fIssueSecuredClusterCertsRequest\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12%\n" +
-	"\x0eca_fingerprint\x18\x02 \x01(\tR\rcaFingerprint\"\xd8\x01\n" +
+	"\x0eca_fingerprint\x18\x02 \x01(\tR\rcaFingerprint\x12H\n" +
+	"\x12requested_validity\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x11requestedValidity\"\xd8\x01\n" +
 	" IssueSecuredClusterCertsResponse\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12I\n" +
@@ -245,16 +256,18 @@ var file_internalapi_central_secured_cluster_cert_refresh_proto_goTypes = []any{
 	(*SecuredClusterCertsIssueError)(nil),      // 0: central.SecuredClusterCertsIssueError
 	(*IssueSecuredClusterCertsRequest)(nil),    // 1: central.IssueSecuredClusterCertsRequest
 	(*IssueSecuredClusterCertsResponse)(nil),   // 2: central.IssueSecuredClusterCertsResponse
-	(*storage.TypedServiceCertificateSet)(nil), // 3: storage.TypedServiceCertificateSet
+	(*durationpb.Duration)(nil),                // 3: google.protobuf.Duration
+	(*storage.TypedServiceCertificateSet)(nil), // 4: storage.TypedServiceCertificateSet
 }
 var file_internalapi_central_secured_cluster_cert_refresh_proto_depIdxs = []int32{
-	3, // 0: central.IssueSecuredClusterCertsResponse.certificates:type_name -> storage.TypedServiceCertificateSet
-	0, // 1: central.IssueSecuredClusterCertsResponse.error:type_name -> central.SecuredClusterCertsIssueError
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	3, // 0: central.IssueSecuredClusterCertsRequest.requested_validity:type_name -> google.protobuf.Duration
+	4, // 1: central.IssueSecuredClusterCertsResponse.certificates:type_name -> storage.TypedServiceCertificateSet
+	0, // 2: central.IssueSecuredClusterCertsResponse.error:type_name -> central.SecuredClusterCertsIssueError
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_internalapi_central_secured_cluster_cert_refresh_proto_init() }

--- a/generated/internalapi/central/secured_cluster_cert_refresh_vtproto.pb.go
+++ b/generated/internalapi/central/secured_cluster_cert_refresh_vtproto.pb.go
@@ -7,9 +7,11 @@ package central
 import (
 	fmt "fmt"
 	protohelpers "github.com/planetscale/vtprotobuf/protohelpers"
+	durationpb1 "github.com/planetscale/vtprotobuf/types/known/durationpb"
 	storage "github.com/stackrox/rox/generated/storage"
 	proto "google.golang.org/protobuf/proto"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	io "io"
 	unsafe "unsafe"
 )
@@ -45,6 +47,7 @@ func (m *IssueSecuredClusterCertsRequest) CloneVT() *IssueSecuredClusterCertsReq
 	r := new(IssueSecuredClusterCertsRequest)
 	r.RequestId = m.RequestId
 	r.CaFingerprint = m.CaFingerprint
+	r.RequestedValidity = (*durationpb.Duration)((*durationpb1.Duration)(m.RequestedValidity).CloneVT())
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -133,6 +136,9 @@ func (this *IssueSecuredClusterCertsRequest) EqualVT(that *IssueSecuredClusterCe
 		return false
 	}
 	if this.CaFingerprint != that.CaFingerprint {
+		return false
+	}
+	if !(*durationpb1.Duration)(this.RequestedValidity).EqualVT((*durationpb1.Duration)(that.RequestedValidity)) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -302,6 +308,16 @@ func (m *IssueSecuredClusterCertsRequest) MarshalToSizedBufferVT(dAtA []byte) (i
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.RequestedValidity != nil {
+		size, err := (*durationpb1.Duration)(m.RequestedValidity).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if len(m.CaFingerprint) > 0 {
 		i -= len(m.CaFingerprint)
 		copy(dAtA[i:], m.CaFingerprint)
@@ -452,6 +468,10 @@ func (m *IssueSecuredClusterCertsRequest) SizeVT() (n int) {
 	}
 	l = len(m.CaFingerprint)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.RequestedValidity != nil {
+		l = (*durationpb1.Duration)(m.RequestedValidity).SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -684,6 +704,42 @@ func (m *IssueSecuredClusterCertsRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.CaFingerprint = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequestedValidity", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RequestedValidity == nil {
+				m.RequestedValidity = &durationpb.Duration{}
+			}
+			if err := (*durationpb1.Duration)(m.RequestedValidity).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -1075,6 +1131,42 @@ func (m *IssueSecuredClusterCertsRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
 			}
 			m.CaFingerprint = stringValue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RequestedValidity", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.RequestedValidity == nil {
+				m.RequestedValidity = &durationpb.Duration{}
+			}
+			if err := (*durationpb1.Duration)(m.RequestedValidity).UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/internalapi/central/v1/token_service.pb.go
+++ b/generated/internalapi/central/v1/token_service.pb.go
@@ -319,8 +319,8 @@ var file_internalapi_central_v1_token_service_proto_enumTypes = make([]protoimpl
 var file_internalapi_central_v1_token_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internalapi_central_v1_token_service_proto_goTypes = []any{
 	(Access)(0), // 0: central.v1.Access
-	(*GenerateTokenForPermissionsAndScopeRequest)(nil), // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
-	(*ClusterScope)(nil), // 2: central.v1.ClusterScope
+	(*GenerateTokenForPermissionsAndScopeRequest)(nil),  // 1: central.v1.GenerateTokenForPermissionsAndScopeRequest
+	(*ClusterScope)(nil),                                // 2: central.v1.ClusterScope
 	(*GenerateTokenForPermissionsAndScopeResponse)(nil), // 3: central.v1.GenerateTokenForPermissionsAndScopeResponse
 	nil,                         // 4: central.v1.GenerateTokenForPermissionsAndScopeRequest.PermissionsEntry
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration

--- a/generated/storage/cluster.pb.go
+++ b/generated/storage/cluster.pb.go
@@ -1701,8 +1701,12 @@ type ClusterCertExpiryStatus struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	SensorCertExpiry    *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=sensor_cert_expiry,json=sensorCertExpiry,proto3" json:"sensor_cert_expiry,omitempty"`
 	SensorCertNotBefore *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=sensor_cert_not_before,json=sensorCertNotBefore,proto3" json:"sensor_cert_not_before,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Timestamp of the last successful cert issuance by Central for this cluster.
+	LastRefreshTime *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=last_refresh_time,json=lastRefreshTime,proto3" json:"last_refresh_time,omitempty"`
+	// Expiry of the certs issued in the last refresh.
+	LastRefreshedCertExpiry *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=last_refreshed_cert_expiry,json=lastRefreshedCertExpiry,proto3" json:"last_refreshed_cert_expiry,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *ClusterCertExpiryStatus) Reset() {
@@ -1745,6 +1749,20 @@ func (x *ClusterCertExpiryStatus) GetSensorCertExpiry() *timestamppb.Timestamp {
 func (x *ClusterCertExpiryStatus) GetSensorCertNotBefore() *timestamppb.Timestamp {
 	if x != nil {
 		return x.SensorCertNotBefore
+	}
+	return nil
+}
+
+func (x *ClusterCertExpiryStatus) GetLastRefreshTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastRefreshTime
+	}
+	return nil
+}
+
+func (x *ClusterCertExpiryStatus) GetLastRefreshedCertExpiry() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastRefreshedCertExpiry
 	}
 	return nil
 }
@@ -2870,10 +2888,12 @@ const file_storage_cluster_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.storage.AuditLogFileStateR\x05value:\x028\x01J\x04\b\x06\x10\aJ\x04\b\b\x10\tJ\x04\b\t\x10\n" +
 	"J\x04\b\n" +
-	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rJ\x04\b\x0e\x10\x0f\"\xb4\x01\n" +
+	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rJ\x04\b\x0e\x10\x0f\"\xd5\x02\n" +
 	"\x17ClusterCertExpiryStatus\x12H\n" +
 	"\x12sensor_cert_expiry\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x10sensorCertExpiry\x12O\n" +
-	"\x16sensor_cert_not_before\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x13sensorCertNotBefore\"\xbc\x03\n" +
+	"\x16sensor_cert_not_before\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x13sensorCertNotBefore\x12F\n" +
+	"\x11last_refresh_time\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x0flastRefreshTime\x12W\n" +
+	"\x1alast_refreshed_cert_expiry\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x17lastRefreshedCertExpiry\"\xbc\x03\n" +
 	"\rClusterStatus\x12%\n" +
 	"\x0esensor_version\x18\x01 \x01(\tR\rsensorVersion\x12R\n" +
 	"\x17DEPRECATED_last_contact\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x15DEPRECATEDLastContact\x12F\n" +
@@ -3069,34 +3089,36 @@ var file_storage_cluster_proto_depIdxs = []int32{
 	2,  // 25: storage.Cluster.managed_by:type_name -> storage.ManagerType
 	36, // 26: storage.ClusterCertExpiryStatus.sensor_cert_expiry:type_name -> google.protobuf.Timestamp
 	36, // 27: storage.ClusterCertExpiryStatus.sensor_cert_not_before:type_name -> google.protobuf.Timestamp
-	36, // 28: storage.ClusterStatus.DEPRECATED_last_contact:type_name -> google.protobuf.Timestamp
-	12, // 29: storage.ClusterStatus.provider_metadata:type_name -> storage.ProviderMetadata
-	13, // 30: storage.ClusterStatus.orchestrator_metadata:type_name -> storage.OrchestratorMetadata
-	24, // 31: storage.ClusterStatus.upgrade_status:type_name -> storage.ClusterUpgradeStatus
-	22, // 32: storage.ClusterStatus.cert_expiry_status:type_name -> storage.ClusterCertExpiryStatus
-	4,  // 33: storage.ClusterUpgradeStatus.upgradability:type_name -> storage.ClusterUpgradeStatus.Upgradability
-	35, // 34: storage.ClusterUpgradeStatus.most_recent_process:type_name -> storage.ClusterUpgradeStatus.UpgradeProcessStatus
-	6,  // 35: storage.UpgradeProgress.upgrade_state:type_name -> storage.UpgradeProgress.UpgradeState
-	36, // 36: storage.UpgradeProgress.since:type_name -> google.protobuf.Timestamp
-	36, // 37: storage.AuditLogFileState.collect_logs_since:type_name -> google.protobuf.Timestamp
-	28, // 38: storage.ClusterHealthStatus.collector_health_info:type_name -> storage.CollectorHealthInfo
-	29, // 39: storage.ClusterHealthStatus.admission_control_health_info:type_name -> storage.AdmissionControlHealthInfo
-	30, // 40: storage.ClusterHealthStatus.scanner_health_info:type_name -> storage.ScannerHealthInfo
-	7,  // 41: storage.ClusterHealthStatus.sensor_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	7,  // 42: storage.ClusterHealthStatus.collector_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	7,  // 43: storage.ClusterHealthStatus.overall_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	7,  // 44: storage.ClusterHealthStatus.admission_control_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	7,  // 45: storage.ClusterHealthStatus.scanner_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
-	36, // 46: storage.ClusterHealthStatus.last_contact:type_name -> google.protobuf.Timestamp
-	26, // 47: storage.Cluster.AuditLogStateEntry.value:type_name -> storage.AuditLogFileState
-	36, // 48: storage.ClusterUpgradeStatus.UpgradeProcessStatus.initiated_at:type_name -> google.protobuf.Timestamp
-	25, // 49: storage.ClusterUpgradeStatus.UpgradeProcessStatus.progress:type_name -> storage.UpgradeProgress
-	5,  // 50: storage.ClusterUpgradeStatus.UpgradeProcessStatus.type:type_name -> storage.ClusterUpgradeStatus.UpgradeProcessStatus.UpgradeProcessType
-	51, // [51:51] is the sub-list for method output_type
-	51, // [51:51] is the sub-list for method input_type
-	51, // [51:51] is the sub-list for extension type_name
-	51, // [51:51] is the sub-list for extension extendee
-	0,  // [0:51] is the sub-list for field type_name
+	36, // 28: storage.ClusterCertExpiryStatus.last_refresh_time:type_name -> google.protobuf.Timestamp
+	36, // 29: storage.ClusterCertExpiryStatus.last_refreshed_cert_expiry:type_name -> google.protobuf.Timestamp
+	36, // 30: storage.ClusterStatus.DEPRECATED_last_contact:type_name -> google.protobuf.Timestamp
+	12, // 31: storage.ClusterStatus.provider_metadata:type_name -> storage.ProviderMetadata
+	13, // 32: storage.ClusterStatus.orchestrator_metadata:type_name -> storage.OrchestratorMetadata
+	24, // 33: storage.ClusterStatus.upgrade_status:type_name -> storage.ClusterUpgradeStatus
+	22, // 34: storage.ClusterStatus.cert_expiry_status:type_name -> storage.ClusterCertExpiryStatus
+	4,  // 35: storage.ClusterUpgradeStatus.upgradability:type_name -> storage.ClusterUpgradeStatus.Upgradability
+	35, // 36: storage.ClusterUpgradeStatus.most_recent_process:type_name -> storage.ClusterUpgradeStatus.UpgradeProcessStatus
+	6,  // 37: storage.UpgradeProgress.upgrade_state:type_name -> storage.UpgradeProgress.UpgradeState
+	36, // 38: storage.UpgradeProgress.since:type_name -> google.protobuf.Timestamp
+	36, // 39: storage.AuditLogFileState.collect_logs_since:type_name -> google.protobuf.Timestamp
+	28, // 40: storage.ClusterHealthStatus.collector_health_info:type_name -> storage.CollectorHealthInfo
+	29, // 41: storage.ClusterHealthStatus.admission_control_health_info:type_name -> storage.AdmissionControlHealthInfo
+	30, // 42: storage.ClusterHealthStatus.scanner_health_info:type_name -> storage.ScannerHealthInfo
+	7,  // 43: storage.ClusterHealthStatus.sensor_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	7,  // 44: storage.ClusterHealthStatus.collector_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	7,  // 45: storage.ClusterHealthStatus.overall_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	7,  // 46: storage.ClusterHealthStatus.admission_control_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	7,  // 47: storage.ClusterHealthStatus.scanner_health_status:type_name -> storage.ClusterHealthStatus.HealthStatusLabel
+	36, // 48: storage.ClusterHealthStatus.last_contact:type_name -> google.protobuf.Timestamp
+	26, // 49: storage.Cluster.AuditLogStateEntry.value:type_name -> storage.AuditLogFileState
+	36, // 50: storage.ClusterUpgradeStatus.UpgradeProcessStatus.initiated_at:type_name -> google.protobuf.Timestamp
+	25, // 51: storage.ClusterUpgradeStatus.UpgradeProcessStatus.progress:type_name -> storage.UpgradeProgress
+	5,  // 52: storage.ClusterUpgradeStatus.UpgradeProcessStatus.type:type_name -> storage.ClusterUpgradeStatus.UpgradeProcessStatus.UpgradeProcessType
+	53, // [53:53] is the sub-list for method output_type
+	53, // [53:53] is the sub-list for method input_type
+	53, // [53:53] is the sub-list for extension type_name
+	53, // [53:53] is the sub-list for extension extendee
+	0,  // [0:53] is the sub-list for field type_name
 }
 
 func init() { file_storage_cluster_proto_init() }

--- a/generated/storage/cluster_vtproto.pb.go
+++ b/generated/storage/cluster_vtproto.pb.go
@@ -416,6 +416,8 @@ func (m *ClusterCertExpiryStatus) CloneVT() *ClusterCertExpiryStatus {
 	r := new(ClusterCertExpiryStatus)
 	r.SensorCertExpiry = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.SensorCertExpiry).CloneVT())
 	r.SensorCertNotBefore = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.SensorCertNotBefore).CloneVT())
+	r.LastRefreshTime = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.LastRefreshTime).CloneVT())
+	r.LastRefreshedCertExpiry = (*timestamppb.Timestamp)((*timestamppb1.Timestamp)(m.LastRefreshedCertExpiry).CloneVT())
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1383,6 +1385,12 @@ func (this *ClusterCertExpiryStatus) EqualVT(that *ClusterCertExpiryStatus) bool
 		return false
 	}
 	if !(*timestamppb1.Timestamp)(this.SensorCertNotBefore).EqualVT((*timestamppb1.Timestamp)(that.SensorCertNotBefore)) {
+		return false
+	}
+	if !(*timestamppb1.Timestamp)(this.LastRefreshTime).EqualVT((*timestamppb1.Timestamp)(that.LastRefreshTime)) {
+		return false
+	}
+	if !(*timestamppb1.Timestamp)(this.LastRefreshedCertExpiry).EqualVT((*timestamppb1.Timestamp)(that.LastRefreshedCertExpiry)) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -3245,6 +3253,26 @@ func (m *ClusterCertExpiryStatus) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.LastRefreshedCertExpiry != nil {
+		size, err := (*timestamppb1.Timestamp)(m.LastRefreshedCertExpiry).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.LastRefreshTime != nil {
+		size, err := (*timestamppb1.Timestamp)(m.LastRefreshTime).MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if m.SensorCertNotBefore != nil {
 		size, err := (*timestamppb1.Timestamp)(m.SensorCertNotBefore).MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -4556,6 +4584,14 @@ func (m *ClusterCertExpiryStatus) SizeVT() (n int) {
 	}
 	if m.SensorCertNotBefore != nil {
 		l = (*timestamppb1.Timestamp)(m.SensorCertNotBefore).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.LastRefreshTime != nil {
+		l = (*timestamppb1.Timestamp)(m.LastRefreshTime).SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.LastRefreshedCertExpiry != nil {
+		l = (*timestamppb1.Timestamp)(m.LastRefreshedCertExpiry).SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -8305,6 +8341,78 @@ func (m *ClusterCertExpiryStatus) UnmarshalVT(dAtA []byte) error {
 				m.SensorCertNotBefore = &timestamppb.Timestamp{}
 			}
 			if err := (*timestamppb1.Timestamp)(m.SensorCertNotBefore).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastRefreshTime", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LastRefreshTime == nil {
+				m.LastRefreshTime = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.LastRefreshTime).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastRefreshedCertExpiry", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LastRefreshedCertExpiry == nil {
+				m.LastRefreshedCertExpiry = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.LastRefreshedCertExpiry).UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -13594,6 +13702,78 @@ func (m *ClusterCertExpiryStatus) UnmarshalVTUnsafe(dAtA []byte) error {
 				m.SensorCertNotBefore = &timestamppb.Timestamp{}
 			}
 			if err := (*timestamppb1.Timestamp)(m.SensorCertNotBefore).UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastRefreshTime", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LastRefreshTime == nil {
+				m.LastRefreshTime = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.LastRefreshTime).UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LastRefreshedCertExpiry", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.LastRefreshedCertExpiry == nil {
+				m.LastRefreshedCertExpiry = &timestamppb.Timestamp{}
+			}
+			if err := (*timestamppb1.Timestamp)(m.LastRefreshedCertExpiry).UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -8,6 +8,7 @@ createUpgraderServiceAccount: null # string
 helmManaged: null
 createSecrets: null
 additionalCAs: null # [obj]
+certRefreshValidity: null # [str]
 imagePullSecrets:
   username: null # string
   password: null # string

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -8,7 +8,7 @@ createUpgraderServiceAccount: null # string
 helmManaged: null
 createSecrets: null
 additionalCAs: null # [obj]
-certRefreshValidity: null # [str]
+certRefreshValidity: null # str
 imagePullSecrets:
   username: null # string
   password: null # string

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -8,7 +8,7 @@ createUpgraderServiceAccount: null # string
 helmManaged: null
 createSecrets: null
 additionalCAs: null # [obj]
-certRefreshValidity: null # str
+serviceCertValidity: null # str
 imagePullSecrets:
   username: null # string
   password: null # string

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -125,9 +125,9 @@ spec:
         - name: ROX_CERTS_NEW_DIR
           value: /run/secrets/stackrox.io/certs-new/
         {{- end }}
-        {{- if ._rox.certRefreshValidity }}
-        - name: ROX_SENSOR_CERT_REQUESTED_VALIDITY
-          value: {{ quote ._rox.certRefreshValidity }}
+        {{- if ._rox.serviceCertValidity }}
+        - name: ROX_SENSOR_SERVICE_CERT_VALIDITY
+          value: {{ quote ._rox.serviceCertValidity }}
         {{- end }}
         {{- include "srox.envVars" (list . "deployment" "sensor" "sensor") | nindent 8 }}
         volumeMounts:
@@ -246,9 +246,9 @@ spec:
         - name: ROX_ENABLE_SECURE_METRICS
           value: "true"
         {{- end }}
-        {{- if ._rox.certRefreshValidity }}
-        - name: ROX_SENSOR_CERT_REQUESTED_VALIDITY
-          value: {{ quote ._rox.certRefreshValidity }}
+        {{- if ._rox.serviceCertValidity }}
+        - name: ROX_SENSOR_SERVICE_CERT_VALIDITY
+          value: {{ quote ._rox.serviceCertValidity }}
         {{- end }}
         {{- include "srox.envVars" (list . "deployment" "sensor" "sensor") | nindent 8 }}
         volumeMounts:

--- a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl
@@ -125,6 +125,10 @@ spec:
         - name: ROX_CERTS_NEW_DIR
           value: /run/secrets/stackrox.io/certs-new/
         {{- end }}
+        {{- if ._rox.certRefreshValidity }}
+        - name: ROX_SENSOR_CERT_REQUESTED_VALIDITY
+          value: {{ quote ._rox.certRefreshValidity }}
+        {{- end }}
         {{- include "srox.envVars" (list . "deployment" "sensor" "sensor") | nindent 8 }}
         volumeMounts:
         - name: sensor-etc-ssl-volume
@@ -241,6 +245,10 @@ spec:
         {{- if ._rox.monitoring.openshift.enabled }}
         - name: ROX_ENABLE_SECURE_METRICS
           value: "true"
+        {{- end }}
+        {{- if ._rox.certRefreshValidity }}
+        - name: ROX_SENSOR_CERT_REQUESTED_VALIDITY
+          value: {{ quote ._rox.certRefreshValidity }}
         {{- end }}
         {{- include "srox.envVars" (list . "deployment" "sensor" "sensor") | nindent 8 }}
         volumeMounts:

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -47,9 +47,9 @@
 ##       -----END CERTIFICATE-----
 #additionalCAs: null
 #
-## Requested validity duration for automatically refreshed service certificates (e.g. "1080h" for 45 days).
-## When unset, Sensor uses the Operator default (8760h). Central caps at 1 year and enforces a 5-minute floor.
-#certRefreshValidity: null
+## Validity duration for service certificates issued to secured cluster components (e.g. "1080h" for 45 days).
+## When unset, the Operator default (8760h) is used. Central caps at 1 year and enforces a 5-minute floor.
+#serviceCertValidity: null
 #
 # Specify `true` to create the `sensor-upgrader` account. By default, the StackRox Kubernetes
 # Security Platform creates a service account called `sensor-upgrader` in each secured cluster.

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -47,6 +47,10 @@
 ##       -----END CERTIFICATE-----
 #additionalCAs: null
 #
+## Requested validity duration for automatically refreshed service certificates (e.g. "1080h" for 45 days).
+## When unset, Sensor uses the Operator default (8760h). Central caps at 1 year and enforces a 5-minute floor.
+#certRefreshValidity: null
+#
 # Specify `true` to create the `sensor-upgrader` account. By default, the StackRox Kubernetes
 # Security Platform creates a service account called `sensor-upgrader` in each secured cluster.
 # This account is highly privileged but is only used during upgrades. If you don’t create this

--- a/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
+++ b/image/templates/helm/stackrox-secured-cluster/values-public.yaml.example
@@ -48,7 +48,7 @@
 #additionalCAs: null
 #
 ## Validity duration for service certificates issued to secured cluster components (e.g. "1080h" for 45 days).
-## When unset, the Operator default (8760h) is used. Central caps at 1 year and enforces a 5-minute floor.
+## When unset, the Operator default (8760h) is used. Central caps at 1 year and enforces a 2-hour minimum.
 #serviceCertValidity: null
 #
 # Specify `true` to create the `sensor-upgrader` account. By default, the StackRox Kubernetes

--- a/operator/api/v1alpha1/common_types.go
+++ b/operator/api/v1alpha1/common_types.go
@@ -158,10 +158,10 @@ type TLSConfig struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Additional CAs"
 	AdditionalCAs []AdditionalCA `json:"additionalCAs,omitempty"`
 
-	// Requested validity duration for automatically refreshed service certificates.
+	// Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
 	// The default is: 8760h.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Certificate Refresh Validity"
-	CertRefreshValidity *metav1.Duration `json:"certRefreshValidity,omitempty"`
+	CertRefreshValidity *string `json:"certRefreshValidity,omitempty"`
 }
 
 // LocalSecretReference is a reference to a secret within the same namespace.

--- a/operator/api/v1alpha1/common_types.go
+++ b/operator/api/v1alpha1/common_types.go
@@ -157,6 +157,11 @@ type TLSConfig struct {
 	// Allows you to specify additional trusted Root CAs.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Additional CAs"
 	AdditionalCAs []AdditionalCA `json:"additionalCAs,omitempty"`
+
+	// Requested validity duration for automatically refreshed service certificates.
+	// The default is: 8760h.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Certificate Refresh Validity"
+	CertRefreshValidity *metav1.Duration `json:"certRefreshValidity,omitempty"`
 }
 
 // LocalSecretReference is a reference to a secret within the same namespace.

--- a/operator/api/v1alpha1/common_types.go
+++ b/operator/api/v1alpha1/common_types.go
@@ -152,8 +152,8 @@ type AdditionalCA struct {
 	Content string `json:"content"`
 }
 
-// DefaultCertRefreshValidity is the default value for CertRefreshValidity (1 year).
-const DefaultCertRefreshValidity = "8760h"
+// DefaultServiceCertValidity is the default value for ServiceCertValidity (1 year).
+const DefaultServiceCertValidity = "8760h"
 
 // TLSConfig defines common TLS-related settings for all components.
 type TLSConfig struct {
@@ -161,11 +161,11 @@ type TLSConfig struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Additional CAs"
 	AdditionalCAs []AdditionalCA `json:"additionalCAs,omitempty"`
 
-	// Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+	// Validity duration for service certificates issued to secured cluster components (e.g. "8760h").
 	// The default is: 8760h.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Certificate Refresh Validity"
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Service Certificate Validity"
 	// +kubebuilder:validation:Pattern=`^(\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+$`
-	CertRefreshValidity *string `json:"certRefreshValidity,omitempty"`
+	ServiceCertValidity *string `json:"serviceCertValidity,omitempty"`
 }
 
 // LocalSecretReference is a reference to a secret within the same namespace.

--- a/operator/api/v1alpha1/common_types.go
+++ b/operator/api/v1alpha1/common_types.go
@@ -152,6 +152,9 @@ type AdditionalCA struct {
 	Content string `json:"content"`
 }
 
+// DefaultCertRefreshValidity is the default value for CertRefreshValidity (1 year).
+const DefaultCertRefreshValidity = "8760h"
+
 // TLSConfig defines common TLS-related settings for all components.
 type TLSConfig struct {
 	// Allows you to specify additional trusted Root CAs.
@@ -161,6 +164,7 @@ type TLSConfig struct {
 	// Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
 	// The default is: 8760h.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Certificate Refresh Validity"
+	// +kubebuilder:validation:Pattern=`^(\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+$`
 	CertRefreshValidity *string `json:"certRefreshValidity,omitempty"`
 }
 

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,6 @@ package v1alpha1
 
 import (
 	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -1887,7 +1886,7 @@ func (in *TLSConfig) DeepCopyInto(out *TLSConfig) {
 	}
 	if in.CertRefreshValidity != nil {
 		in, out := &in.CertRefreshValidity, &out.CertRefreshValidity
-		*out = new(metav1.Duration)
+		*out = new(string)
 		**out = **in
 	}
 }

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -1884,8 +1884,8 @@ func (in *TLSConfig) DeepCopyInto(out *TLSConfig) {
 		*out = make([]AdditionalCA, len(*in))
 		copy(*out, *in)
 	}
-	if in.CertRefreshValidity != nil {
-		in, out := &in.CertRefreshValidity, &out.CertRefreshValidity
+	if in.ServiceCertValidity != nil {
+		in, out := &in.ServiceCertValidity, &out.ServiceCertValidity
 		*out = new(string)
 		**out = **in
 	}

--- a/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1alpha1
 
 import (
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -1883,6 +1884,11 @@ func (in *TLSConfig) DeepCopyInto(out *TLSConfig) {
 		in, out := &in.AdditionalCAs, &out.AdditionalCAs
 		*out = make([]AdditionalCA, len(*in))
 		copy(*out, *in)
+	}
+	if in.CertRefreshValidity != nil {
+		in, out := &in.CertRefreshValidity, &out.CertRefreshValidity
+		*out = new(metav1.Duration)
+		**out = **in
 	}
 }
 

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -2073,6 +2073,11 @@ spec:
                       - name
                       type: object
                     type: array
+                  certRefreshValidity:
+                    description: |-
+                      Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+                      The default is: 8760h.
+                    type: string
                 type: object
             type: object
           status:

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -2077,6 +2077,7 @@ spec:
                     description: |-
                       Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
                       The default is: 8760h.
+                    pattern: ^(\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+$
                     type: string
                 type: object
             type: object

--- a/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_centrals.yaml
@@ -2073,9 +2073,9 @@ spec:
                       - name
                       type: object
                     type: array
-                  certRefreshValidity:
+                  serviceCertValidity:
                     description: |-
-                      Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+                      Validity duration for service certificates issued to secured cluster components (e.g. "8760h").
                       The default is: 8760h.
                     pattern: ^(\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+$
                     type: string

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -1886,6 +1886,7 @@ spec:
                     description: |-
                       Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
                       The default is: 8760h.
+                    pattern: ^(\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+$
                     type: string
                 type: object
             required:

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -1882,9 +1882,9 @@ spec:
                       - name
                       type: object
                     type: array
-                  certRefreshValidity:
+                  serviceCertValidity:
                     description: |-
-                      Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+                      Validity duration for service certificates issued to secured cluster components (e.g. "8760h").
                       The default is: 8760h.
                     pattern: ^(\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+$
                     type: string

--- a/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
+++ b/operator/bundle/manifests/platform.stackrox.io_securedclusters.yaml
@@ -1882,6 +1882,11 @@ spec:
                       - name
                       type: object
                     type: array
+                  certRefreshValidity:
+                    description: |-
+                      Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+                      The default is: 8760h.
+                    type: string
                 type: object
             required:
             - clusterName

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -905,6 +905,11 @@ spec:
           - description: Allows you to specify additional trusted Root CAs.
             displayName: Additional CAs
             path: tls.additionalCAs
+          - description: |-
+              Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+              The default is: 8760h.
+            displayName: Certificate Refresh Validity
+            path: tls.certRefreshValidity
         statusDescriptors:
           - description: Info stores information on how to obtain the admin password.
             displayName: Admin Credentials Info
@@ -1557,6 +1562,11 @@ spec:
           - description: Allows you to specify additional trusted Root CAs.
             displayName: Additional CAs
             path: tls.additionalCAs
+          - description: |-
+              Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+              The default is: 8760h.
+            displayName: Certificate Refresh Validity
+            path: tls.certRefreshValidity
         statusDescriptors:
           - description: The deployed version of the product.
             displayName: Product Version

--- a/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/rhacs-operator.clusterserviceversion.yaml
@@ -906,10 +906,10 @@ spec:
             displayName: Additional CAs
             path: tls.additionalCAs
           - description: |-
-              Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+              Validity duration for service certificates issued to secured cluster components (e.g. "8760h").
               The default is: 8760h.
-            displayName: Certificate Refresh Validity
-            path: tls.certRefreshValidity
+            displayName: Service Certificate Validity
+            path: tls.serviceCertValidity
         statusDescriptors:
           - description: Info stores information on how to obtain the admin password.
             displayName: Admin Credentials Info
@@ -1563,10 +1563,10 @@ spec:
             displayName: Additional CAs
             path: tls.additionalCAs
           - description: |-
-              Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+              Validity duration for service certificates issued to secured cluster components (e.g. "8760h").
               The default is: 8760h.
-            displayName: Certificate Refresh Validity
-            path: tls.certRefreshValidity
+            displayName: Service Certificate Validity
+            path: tls.serviceCertValidity
         statusDescriptors:
           - description: The deployed version of the product.
             displayName: Product Version

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -2076,6 +2076,7 @@ spec:
                     description: |-
                       Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
                       The default is: 8760h.
+                    pattern: ^(\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+$
                     type: string
                 type: object
             type: object

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -2072,9 +2072,9 @@ spec:
                       - name
                       type: object
                     type: array
-                  certRefreshValidity:
+                  serviceCertValidity:
                     description: |-
-                      Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+                      Validity duration for service certificates issued to secured cluster components (e.g. "8760h").
                       The default is: 8760h.
                     pattern: ^(\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+$
                     type: string

--- a/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_centrals.yaml
@@ -2072,6 +2072,11 @@ spec:
                       - name
                       type: object
                     type: array
+                  certRefreshValidity:
+                    description: |-
+                      Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+                      The default is: 8760h.
+                    type: string
                 type: object
             type: object
           status:

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -1881,6 +1881,11 @@ spec:
                       - name
                       type: object
                     type: array
+                  certRefreshValidity:
+                    description: |-
+                      Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+                      The default is: 8760h.
+                    type: string
                 type: object
             required:
             - clusterName

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -1881,9 +1881,9 @@ spec:
                       - name
                       type: object
                     type: array
-                  certRefreshValidity:
+                  serviceCertValidity:
                     description: |-
-                      Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+                      Validity duration for service certificates issued to secured cluster components (e.g. "8760h").
                       The default is: 8760h.
                     pattern: ^(\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+$
                     type: string

--- a/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
+++ b/operator/config/crd/bases/platform.stackrox.io_securedclusters.yaml
@@ -1885,6 +1885,7 @@ spec:
                     description: |-
                       Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
                       The default is: 8760h.
+                    pattern: ^(\d+(\.\d+)?(ns|us|µs|ms|s|m|h))+$
                     type: string
                 type: object
             required:

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -892,6 +892,11 @@ spec:
       - description: Allows you to specify additional trusted Root CAs.
         displayName: Additional CAs
         path: tls.additionalCAs
+      - description: |-
+          Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+          The default is: 8760h.
+        displayName: Certificate Refresh Validity
+        path: tls.certRefreshValidity
       statusDescriptors:
       - description: Info stores information on how to obtain the admin password.
         displayName: Admin Credentials Info
@@ -1563,6 +1568,11 @@ spec:
       - description: Allows you to specify additional trusted Root CAs.
         displayName: Additional CAs
         path: tls.additionalCAs
+      - description: |-
+          Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+          The default is: 8760h.
+        displayName: Certificate Refresh Validity
+        path: tls.certRefreshValidity
       statusDescriptors:
       - description: The deployed version of the product.
         displayName: Product Version

--- a/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/rhacs-operator.clusterserviceversion.yaml
@@ -893,10 +893,10 @@ spec:
         displayName: Additional CAs
         path: tls.additionalCAs
       - description: |-
-          Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+          Validity duration for service certificates issued to secured cluster components (e.g. "8760h").
           The default is: 8760h.
-        displayName: Certificate Refresh Validity
-        path: tls.certRefreshValidity
+        displayName: Service Certificate Validity
+        path: tls.serviceCertValidity
       statusDescriptors:
       - description: Info stores information on how to obtain the admin password.
         displayName: Admin Credentials Info
@@ -1569,10 +1569,10 @@ spec:
         displayName: Additional CAs
         path: tls.additionalCAs
       - description: |-
-          Requested validity duration for automatically refreshed service certificates (e.g. "8760h").
+          Validity duration for service certificates issued to secured cluster components (e.g. "8760h").
           The default is: 8760h.
-        displayName: Certificate Refresh Validity
-        path: tls.certRefreshValidity
+        displayName: Service Certificate Validity
+        path: tls.serviceCertValidity
       statusDescriptors:
       - description: The deployed version of the product.
         displayName: Product Version

--- a/operator/internal/central/defaults/static.go
+++ b/operator/internal/central/defaults/static.go
@@ -92,7 +92,7 @@ var staticDefaults = platform.CentralSpec{
 		ComponentPolicy: ptr.To(platform.ConfigAsCodeComponentEnabled),
 	},
 	TLS: &platform.TLSConfig{
-		CertRefreshValidity: ptr.To(platform.DefaultCertRefreshValidity),
+		ServiceCertValidity: ptr.To(platform.DefaultServiceCertValidity),
 	},
 	Customize: &platform.CustomizeSpec{
 		DeploymentDefaults: &platform.DeploymentDefaultsSpec{

--- a/operator/internal/central/defaults/static.go
+++ b/operator/internal/central/defaults/static.go
@@ -92,7 +92,7 @@ var staticDefaults = platform.CentralSpec{
 		ComponentPolicy: ptr.To(platform.ConfigAsCodeComponentEnabled),
 	},
 	TLS: &platform.TLSConfig{
-		CertRefreshValidity: ptr.To("8760h"),
+		CertRefreshValidity: ptr.To(platform.DefaultCertRefreshValidity),
 	},
 	Customize: &platform.CustomizeSpec{
 		DeploymentDefaults: &platform.DeploymentDefaultsSpec{

--- a/operator/internal/central/defaults/static.go
+++ b/operator/internal/central/defaults/static.go
@@ -91,6 +91,9 @@ var staticDefaults = platform.CentralSpec{
 	ConfigAsCode: &platform.ConfigAsCodeSpec{
 		ComponentPolicy: ptr.To(platform.ConfigAsCodeComponentEnabled),
 	},
+	TLS: &platform.TLSConfig{
+		CertRefreshValidity: ptr.To("8760h"),
+	},
 	Customize: &platform.CustomizeSpec{
 		DeploymentDefaults: &platform.DeploymentDefaultsSpec{
 			PinToNodes: ptr.To(platform.PinToNodesNone),

--- a/operator/internal/securedcluster/defaults/static.go
+++ b/operator/internal/securedcluster/defaults/static.go
@@ -3,10 +3,12 @@ package defaults
 import (
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/go-logr/logr"
 	platform "github.com/stackrox/rox/operator/api/v1alpha1"
 	"github.com/stackrox/rox/operator/internal/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -76,6 +78,9 @@ var staticDefaults = platform.SecuredClusterSpec{
 	ProcessIndicators: &platform.ProcessIndicatorsSpec{
 		Persistence:        platform.ProcessIndicatorConfigEnabled.Pointer(),
 		ExcludeOpenshiftNs: platform.ProcessIndicatorConfigDisabled.Pointer(),
+	},
+	TLS: &platform.TLSConfig{
+		CertRefreshValidity: &metav1.Duration{Duration: 365 * 24 * time.Hour},
 	},
 }
 

--- a/operator/internal/securedcluster/defaults/static.go
+++ b/operator/internal/securedcluster/defaults/static.go
@@ -3,12 +3,10 @@ package defaults
 import (
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/go-logr/logr"
 	platform "github.com/stackrox/rox/operator/api/v1alpha1"
 	"github.com/stackrox/rox/operator/internal/common"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -80,7 +78,7 @@ var staticDefaults = platform.SecuredClusterSpec{
 		ExcludeOpenshiftNs: platform.ProcessIndicatorConfigDisabled.Pointer(),
 	},
 	TLS: &platform.TLSConfig{
-		CertRefreshValidity: &metav1.Duration{Duration: 365 * 24 * time.Hour},
+		CertRefreshValidity: ptr.To("8760h"),
 	},
 }
 

--- a/operator/internal/securedcluster/defaults/static.go
+++ b/operator/internal/securedcluster/defaults/static.go
@@ -78,7 +78,7 @@ var staticDefaults = platform.SecuredClusterSpec{
 		ExcludeOpenshiftNs: platform.ProcessIndicatorConfigDisabled.Pointer(),
 	},
 	TLS: &platform.TLSConfig{
-		CertRefreshValidity: ptr.To(platform.DefaultCertRefreshValidity),
+		ServiceCertValidity: ptr.To(platform.DefaultServiceCertValidity),
 	},
 }
 

--- a/operator/internal/securedcluster/defaults/static.go
+++ b/operator/internal/securedcluster/defaults/static.go
@@ -78,7 +78,7 @@ var staticDefaults = platform.SecuredClusterSpec{
 		ExcludeOpenshiftNs: platform.ProcessIndicatorConfigDisabled.Pointer(),
 	},
 	TLS: &platform.TLSConfig{
-		CertRefreshValidity: ptr.To("8760h"),
+		CertRefreshValidity: ptr.To(platform.DefaultCertRefreshValidity),
 	},
 }
 

--- a/operator/internal/values/translation/translation.go
+++ b/operator/internal/values/translation/translation.go
@@ -103,17 +103,28 @@ func GetImagePullSecrets(imagePullSecrets []platform.LocalSecretReference) *Valu
 	return &res
 }
 
-// GetTLSConfigValues converts platform.TLSConfig to a *ValuesBuilder with an "additionalCAs" field.
+// GetTLSConfigValues converts platform.TLSConfig to a *ValuesBuilder.
 func GetTLSConfigValues(tls *platform.TLSConfig) *ValuesBuilder {
-	if tls == nil || len(tls.AdditionalCAs) == 0 {
+	if tls == nil {
 		return nil
 	}
-	cas := NewValuesBuilder()
-	for _, ca := range tls.AdditionalCAs {
-		cas.SetStringValue(ca.Name, ca.Content)
-	}
 	res := NewValuesBuilder()
-	res.AddChild("additionalCAs", &cas)
+	hasValues := false
+	if len(tls.AdditionalCAs) > 0 {
+		hasValues = true
+		cas := NewValuesBuilder()
+		for _, ca := range tls.AdditionalCAs {
+			cas.SetStringValue(ca.Name, ca.Content)
+		}
+		res.AddChild("additionalCAs", &cas)
+	}
+	if tls.CertRefreshValidity != nil && tls.CertRefreshValidity.Duration > 0 {
+		hasValues = true
+		res.SetStringValue("certRefreshValidity", tls.CertRefreshValidity.Duration.String())
+	}
+	if !hasValues {
+		return nil
+	}
 	return &res
 }
 

--- a/operator/internal/values/translation/translation.go
+++ b/operator/internal/values/translation/translation.go
@@ -118,9 +118,9 @@ func GetTLSConfigValues(tls *platform.TLSConfig) *ValuesBuilder {
 		}
 		res.AddChild("additionalCAs", &cas)
 	}
-	if tls.CertRefreshValidity != nil && tls.CertRefreshValidity.Duration > 0 {
+	if tls.CertRefreshValidity != nil && *tls.CertRefreshValidity != "" {
 		hasValues = true
-		res.SetStringValue("certRefreshValidity", tls.CertRefreshValidity.Duration.String())
+		res.SetStringValue("certRefreshValidity", *tls.CertRefreshValidity)
 	}
 	if !hasValues {
 		return nil

--- a/operator/internal/values/translation/translation.go
+++ b/operator/internal/values/translation/translation.go
@@ -118,9 +118,9 @@ func GetTLSConfigValues(tls *platform.TLSConfig) *ValuesBuilder {
 		}
 		res.AddChild("additionalCAs", &cas)
 	}
-	if tls.CertRefreshValidity != nil && *tls.CertRefreshValidity != "" {
+	if tls.ServiceCertValidity != nil && *tls.ServiceCertValidity != "" {
 		hasValues = true
-		res.SetStringValue("certRefreshValidity", *tls.CertRefreshValidity)
+		res.SetStringValue("serviceCertValidity", *tls.ServiceCertValidity)
 	}
 	if !hasValues {
 		return nil

--- a/operator/internal/values/translation/translation_test.go
+++ b/operator/internal/values/translation/translation_test.go
@@ -3,7 +3,6 @@ package translation
 import (
 	"context"
 	"testing"
-	"time"
 
 	platform "github.com/stackrox/rox/operator/api/v1alpha1"
 	"github.com/stackrox/rox/operator/internal/utils"
@@ -181,10 +180,10 @@ func TestGetTLSConfigValues(t *testing.T) {
 		},
 		"cert-refresh-validity": {
 			tls: &platform.TLSConfig{
-				CertRefreshValidity: &v1.Duration{Duration: 45 * 24 * time.Hour},
+				CertRefreshValidity: pointers.String("1080h0m0s"),
 			},
 			want: chartutil.Values{
-				"certRefreshValidity": (45 * 24 * time.Hour).String(),
+				"certRefreshValidity": "1080h0m0s",
 			},
 		},
 	}

--- a/operator/internal/values/translation/translation_test.go
+++ b/operator/internal/values/translation/translation_test.go
@@ -3,6 +3,7 @@ package translation
 import (
 	"context"
 	"testing"
+	"time"
 
 	platform "github.com/stackrox/rox/operator/api/v1alpha1"
 	"github.com/stackrox/rox/operator/internal/utils"
@@ -176,6 +177,14 @@ func TestGetTLSConfigValues(t *testing.T) {
 					"ca1-name": "ca1-content",
 					"ca2-name": "ca2-content",
 				},
+			},
+		},
+		"cert-refresh-validity": {
+			tls: &platform.TLSConfig{
+				CertRefreshValidity: &v1.Duration{Duration: 45 * 24 * time.Hour},
+			},
+			want: chartutil.Values{
+				"certRefreshValidity": (45 * 24 * time.Hour).String(),
 			},
 		},
 	}

--- a/operator/internal/values/translation/translation_test.go
+++ b/operator/internal/values/translation/translation_test.go
@@ -178,12 +178,12 @@ func TestGetTLSConfigValues(t *testing.T) {
 				},
 			},
 		},
-		"cert-refresh-validity": {
+		"service-cert-validity": {
 			tls: &platform.TLSConfig{
-				CertRefreshValidity: pointers.String("1080h0m0s"),
+				ServiceCertValidity: pointers.String("1080h0m0s"),
 			},
 			want: chartutil.Values{
-				"certRefreshValidity": "1080h0m0s",
+				"serviceCertValidity": "1080h0m0s",
 			},
 		},
 	}

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -143,6 +143,10 @@ var (
 	// ignored (unless debug logging is enabled). Set to 0 to log every tick at Info level.
 	ClusterEntitiesSlowRecordTickLogThreshold = registerDurationSetting("ROX_CLUSTER_ENTITIES_SLOW_RECORD_TICK_LOG_THRESHOLD", 5*time.Second, WithDurationZeroAllowed())
 
+	// SensorCertRequestedValidity is the validity duration requested when refreshing secured cluster certificates.
+	// When unset or zero, Central uses the default 1-year signing profile.
+	SensorCertRequestedValidity = registerDurationSetting("ROX_SENSOR_CERT_REQUESTED_VALIDITY", 0, WithDurationZeroAllowed())
+
 	// NetworkFlowBatching enables batching of network flow updates to smooth out data spikes.
 	NetworkFlowBatching = RegisterBooleanSetting("ROX_NETFLOW_BATCHING", false)
 	// NetworkFlowCacheLimiting enables limiting the network flow cache size to prevent memory issues.

--- a/pkg/env/sensor.go
+++ b/pkg/env/sensor.go
@@ -143,9 +143,9 @@ var (
 	// ignored (unless debug logging is enabled). Set to 0 to log every tick at Info level.
 	ClusterEntitiesSlowRecordTickLogThreshold = registerDurationSetting("ROX_CLUSTER_ENTITIES_SLOW_RECORD_TICK_LOG_THRESHOLD", 5*time.Second, WithDurationZeroAllowed())
 
-	// SensorCertRequestedValidity is the validity duration requested when refreshing secured cluster certificates.
+	// SensorServiceCertValidity is the desired validity duration for service certificates issued to secured cluster components.
 	// When unset or zero, Central uses the default 1-year signing profile.
-	SensorCertRequestedValidity = registerDurationSetting("ROX_SENSOR_CERT_REQUESTED_VALIDITY", 0, WithDurationZeroAllowed())
+	SensorServiceCertValidity = registerDurationSetting("ROX_SENSOR_SERVICE_CERT_VALIDITY", 0, WithDurationZeroAllowed())
 
 	// NetworkFlowBatching enables batching of network flow updates to smooth out data spikes.
 	NetworkFlowBatching = RegisterBooleanSetting("ROX_NETFLOW_BATCHING", false)

--- a/pkg/mtls/crypto.go
+++ b/pkg/mtls/crypto.go
@@ -78,6 +78,11 @@ const (
 	crsProfileDefaultValidityPeriod = 24 * time.Hour
 )
 
+// CertLifetime is the maximum validity duration for standard leaf certificates.
+func CertLifetime() time.Duration {
+	return certLifetime
+}
+
 var (
 	log = logging.LoggerForModule()
 

--- a/proto/internalapi/central/hello.proto
+++ b/proto/internalapi/central/hello.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package central;
 
+import "google/protobuf/duration.proto";
 import "storage/cluster.proto";
 
 option go_package = "./internalapi/central;central";
@@ -36,6 +37,10 @@ message SensorHello {
 
   // request_deduper_state is a request to central to communicate its deduper state.
   bool request_deduper_state = 7;
+
+  // requested_cert_validity is the desired validity duration for certificates issued
+  // by Central during the initial connection handshake. When unset, Central uses the default 1-year profile.
+  google.protobuf.Duration requested_cert_validity = 8;
 }
 
 message CentralHello {

--- a/proto/internalapi/central/secured_cluster_cert_refresh.proto
+++ b/proto/internalapi/central/secured_cluster_cert_refresh.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package central;
 
+import "google/protobuf/duration.proto";
 import "storage/service_identity.proto";
 
 option go_package = "./internalapi/central;central";
@@ -14,6 +15,8 @@ message IssueSecuredClusterCertsRequest {
   string request_id = 1;
   // Optional: hex-encoded SHA-512_256 fingerprint of the Sensor's currently trusted CA
   string ca_fingerprint = 2;
+  // Optional: requested validity duration for issued certificates. When unset, Central uses the default 1-year profile.
+  google.protobuf.Duration requested_validity = 3;
 }
 
 message IssueSecuredClusterCertsResponse {

--- a/proto/storage/cluster.proto
+++ b/proto/storage/cluster.proto
@@ -221,6 +221,10 @@ enum ManagerType {
 message ClusterCertExpiryStatus {
   google.protobuf.Timestamp sensor_cert_expiry = 1;
   google.protobuf.Timestamp sensor_cert_not_before = 2;
+  // Timestamp of the last successful cert issuance by Central for this cluster.
+  google.protobuf.Timestamp last_refresh_time = 3;
+  // Expiry of the certs issued in the last refresh.
+  google.protobuf.Timestamp last_refreshed_cert_expiry = 4;
 }
 
 message ClusterStatus {

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -2585,6 +2585,16 @@
                 "id": 2,
                 "name": "sensor_cert_not_before",
                 "type": "google.protobuf.Timestamp"
+              },
+              {
+                "id": 3,
+                "name": "last_refresh_time",
+                "type": "google.protobuf.Timestamp"
+              },
+              {
+                "id": 4,
+                "name": "last_refreshed_cert_expiry",
+                "type": "google.protobuf.Timestamp"
               }
             ]
           },

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -150,7 +150,7 @@ func (s *centralCommunicationImpl) sendEvents(client central.SensorServiceClient
 		SensorState:              s.getSensorState(),
 		RequestDeduperState:      s.clientReconcile,
 	}
-	if requestedValidity := env.SensorCertRequestedValidity.DurationSetting(); requestedValidity > 0 {
+	if requestedValidity := env.SensorServiceCertValidity.DurationSetting(); requestedValidity > 0 {
 		sensorHello.RequestedCertValidity = durationpb.New(requestedValidity)
 	}
 

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/deduperkey"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sliceutils"
@@ -32,6 +33,7 @@ import (
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // sensor implements the Sensor interface by sending inputs to central,
@@ -147,6 +149,9 @@ func (s *centralCommunicationImpl) sendEvents(client central.SensorServiceClient
 		DeploymentIdentification: configHandler.GetDeploymentIdentification(),
 		SensorState:              s.getSensorState(),
 		RequestDeduperState:      s.clientReconcile,
+	}
+	if requestedValidity := env.SensorCertRequestedValidity.DurationSetting(); requestedValidity > 0 {
+		sensorHello.RequestedCertValidity = durationpb.New(requestedValidity)
 	}
 
 	capsSet := set.NewSet[centralsensor.SensorCapability]()

--- a/sensor/kubernetes/certrefresh/env.go
+++ b/sensor/kubernetes/certrefresh/env.go
@@ -1,6 +1,8 @@
 package certrefresh
 
 import (
+	"time"
+
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/sensor/common/installmethod"
 )
@@ -14,6 +16,11 @@ var sensorCARotationOperatorEnabled = env.RegisterBooleanSetting("ROX_SENSOR_CA_
 // When enabled, Helm-managed Sensors will advertise the SensorCARotationSupported capability to Central,
 // causing Central to issue Secured Cluster certificates signed by the newer CA during CA rotation.
 var sensorCARotationHelmEnabled = env.RegisterBooleanSetting("ROX_SENSOR_CA_ROTATION_HELM_ENABLED", false)
+
+// SensorCertRequestedValidity returns the configured certificate validity request duration.
+func SensorCertRequestedValidity() time.Duration {
+	return env.SensorCertRequestedValidity.DurationSetting()
+}
 
 // SensorCARotationEnabled returns whether CA rotation capabilities should be enabled for this Sensor,
 // based on the installation method and corresponding environment variable settings.

--- a/sensor/kubernetes/certrefresh/env.go
+++ b/sensor/kubernetes/certrefresh/env.go
@@ -17,9 +17,9 @@ var sensorCARotationOperatorEnabled = env.RegisterBooleanSetting("ROX_SENSOR_CA_
 // causing Central to issue Secured Cluster certificates signed by the newer CA during CA rotation.
 var sensorCARotationHelmEnabled = env.RegisterBooleanSetting("ROX_SENSOR_CA_ROTATION_HELM_ENABLED", false)
 
-// SensorCertRequestedValidity returns the configured certificate validity request duration.
-func SensorCertRequestedValidity() time.Duration {
-	return env.SensorCertRequestedValidity.DurationSetting()
+// SensorServiceCertValidity returns the configured service certificate validity duration.
+func SensorServiceCertValidity() time.Duration {
+	return env.SensorServiceCertValidity.DurationSetting()
 }
 
 // SensorCARotationEnabled returns whether CA rotation capabilities should be enabled for this Sensor,

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
@@ -80,7 +80,7 @@ func newSecuredClusterMsgFromSensor(requestID string) *central.MsgFromSensor {
 		RequestId:     requestID,
 		CaFingerprint: currentSensorCAFingerprint(),
 	}
-	if requestedValidity := SensorCertRequestedValidity(); requestedValidity > 0 {
+	if requestedValidity := SensorServiceCertValidity(); requestedValidity > 0 {
 		request.RequestedValidity = durationpb.New(requestedValidity)
 	}
 	return &central.MsgFromSensor{

--- a/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
+++ b/sensor/kubernetes/certrefresh/securedcluster_tls_issuer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/certrepo"
 	"github.com/stackrox/rox/sensor/kubernetes/certrefresh/securedcluster"
+	"google.golang.org/protobuf/types/known/durationpb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -75,12 +76,16 @@ func NewSecuredClusterTLSIssuer(
 }
 
 func newSecuredClusterMsgFromSensor(requestID string) *central.MsgFromSensor {
+	request := &central.IssueSecuredClusterCertsRequest{
+		RequestId:     requestID,
+		CaFingerprint: currentSensorCAFingerprint(),
+	}
+	if requestedValidity := SensorCertRequestedValidity(); requestedValidity > 0 {
+		request.RequestedValidity = durationpb.New(requestedValidity)
+	}
 	return &central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_IssueSecuredClusterCertsRequest{
-			IssueSecuredClusterCertsRequest: &central.IssueSecuredClusterCertsRequest{
-				RequestId:     requestID,
-				CaFingerprint: currentSensorCAFingerprint(),
-			},
+			IssueSecuredClusterCertsRequest: request,
 		},
 	}
 }

--- a/sensor/kubernetes/crs/crs.go
+++ b/sensor/kubernetes/crs/crs.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stackrox/rox/sensor/kubernetes/helm"
 	"github.com/stackrox/rox/sensor/kubernetes/sensor"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
@@ -304,10 +305,14 @@ func prepareSensorHelloMessage(ctx context.Context, k8sClient kubernetes.Interfa
 		return nil, errors.Wrap(err, "assembling Helm configuration")
 	}
 
-	return &central.SensorHello{
+	hello := &central.SensorHello{
 		SensorVersion:            version.GetMainVersion(),
 		PolicyVersion:            policyversion.CurrentVersion().String(),
 		DeploymentIdentification: deploymentIdentification,
 		HelmManagedConfigInit:    helmManagedConfigInit,
-	}, nil
+	}
+	if requestedValidity := env.SensorServiceCertValidity.DurationSetting(); requestedValidity > 0 {
+		hello.RequestedCertValidity = durationpb.New(requestedValidity)
+	}
+	return hello, nil
 }

--- a/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
+++ b/ui/apps/platform/cypress/integration/systemHealth/clusters.test.js
@@ -196,9 +196,9 @@ describe('System Health Clusters with fixture', () => {
         const cardTitle = 'Credential expiration';
         const nthRow = 1; // Clusters
 
-        cy.get(getTableCellContainsSelector(cardTitle, nthRow, '\u2265 30 days', 4));
-        cy.get(getTableCellContainsSelector(cardTitle, nthRow, '< 7 days', 1));
-        cy.get(getTableCellContainsSelector(cardTitle, nthRow, '< 30 days', 1));
+        cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Healthy', 4));
+        cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Unhealthy', 1));
+        cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Degraded', 1));
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Unavailable', 0));
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Uninitialized', 1));
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Total', 7));
@@ -305,9 +305,9 @@ describe('System Health Clusters subset 3', () => {
         const cardTitle = 'Credential expiration';
         const nthRow = 1; // Clusters
 
-        cy.get(getTableCellContainsSelector(cardTitle, nthRow, '\u2265 30 days', 2));
-        cy.get(getTableCellContainsSelector(cardTitle, nthRow, '< 7 days', 0));
-        cy.get(getTableCellContainsSelector(cardTitle, nthRow, '< 30 days', 1));
+        cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Healthy', 2));
+        cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Unhealthy', 0));
+        cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Degraded', 1));
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Unavailable', 0));
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Uninitialized', 0));
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Total', 3));
@@ -399,9 +399,9 @@ describe('System Health Clusters subset 1 Uninitialized', () => {
         const cardTitle = 'Credential expiration';
         const nthRow = 1; // Clusters
 
-        cy.get(getTableCellContainsSelector(cardTitle, nthRow, '\u2265 30 days', 0));
-        cy.get(getTableCellContainsSelector(cardTitle, nthRow, '< 7 days', 0));
-        cy.get(getTableCellContainsSelector(cardTitle, nthRow, '< 30 days', 0));
+        cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Healthy', 0));
+        cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Unhealthy', 0));
+        cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Degraded', 0));
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Unavailable', 0));
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Uninitialized', 1));
         cy.get(getTableCellContainsSelector(cardTitle, nthRow, 'Total', 1));

--- a/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/Components/CredentialExpiration.tsx
@@ -30,7 +30,8 @@ function CredentialExpiration({
         return <HealthStatusNotApplicable testId={testId} />;
     }
 
-    const { sensorCertExpiry } = certExpiryStatus;
+    const { sensorCertExpiry, sensorCertNotBefore, lastRefreshTime, lastRefreshedCertExpiry } =
+        certExpiryStatus;
     const currentDatetime = new Date();
 
     // Adapt health status categories to certificate expiration.
@@ -38,23 +39,32 @@ function CredentialExpiration({
     const { Icon, fgColor } = healthStatusStylesLegacy[healthStatus];
     const icon = <Icon className="h-4 w-4" />;
 
+    // When a refresh has occurred after the current connection was established, show the
+    // refreshed cert's expiry instead of the (potentially stale) connection cert expiry.
+    const refreshedAfterConnection =
+        lastRefreshedCertExpiry &&
+        lastRefreshTime &&
+        sensorCertNotBefore &&
+        new Date(sensorCertNotBefore) < new Date(lastRefreshTime);
+    const displayedExpiry = refreshedAfterConnection ? lastRefreshedCertExpiry : sensorCertExpiry;
+
     // Order arguments according to date-fns@2 convention:
-    // If sensorCertExpiry > currentDateTime: in X units
-    // If sensorCertExpiry <= currentDateTime: X units ago
+    // If expiry > currentDateTime: in X units
+    // If expiry <= currentDateTime: X units ago
     const distanceElement = (
         <span className="whitespace-nowrap">
-            {getDistanceStrictAsPhrase(sensorCertExpiry, currentDatetime)}
+            {getDistanceStrictAsPhrase(displayedExpiry, currentDatetime)}
         </span>
     );
 
     let expirationElement = <></>;
-    const diffInDays = differenceInDays(sensorCertExpiry, currentDatetime);
+    const diffInDays = differenceInDays(displayedExpiry, currentDatetime);
     if (healthStatus === 'HEALTHY') {
         let tooltipText: string;
         if (diffInDays === 0) {
-            tooltipText = `Expiration time: ${getTime(sensorCertExpiry)}`;
+            tooltipText = `Expiration time: ${getTime(displayedExpiry)}`;
         } else {
-            tooltipText = `Expiration date: ${getDate(sensorCertExpiry)}`;
+            tooltipText = `Expiration date: ${getDate(displayedExpiry)}`;
         }
         // A tooltip displays expiration date or time
         expirationElement = (
@@ -70,8 +80,8 @@ function CredentialExpiration({
                 {distanceElement}{' '}
                 <span className="whitespace-nowrap">{`on ${
                     diffInDays > 0 && diffInDays < 7
-                        ? getDayOfWeek(sensorCertExpiry)
-                        : getDate(sensorCertExpiry)
+                        ? getDayOfWeek(displayedExpiry)
+                        : getDate(displayedExpiry)
                 }`}</span>
             </div>
         );

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -716,7 +716,7 @@ describe('cluster helpers', () => {
                     lastRefreshTime: '2022-06-01T00:00:00Z',
                     lastRefreshedCertExpiry: '2022-07-10T00:00:00Z',
                 },
-                new Date('2022-07-05T00:00:00Z')
+                new Date('2022-07-08T00:00:00Z')
             );
 
             expect(status).toBe('DEGRADED');

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.test.js
@@ -695,6 +695,32 @@ describe('cluster helpers', () => {
 
             expect(status).toBe('UNHEALTHY');
         });
+        it('should return HEALTHY when connection cert is stale but refresh issued healthy certs', () => {
+            const status = getCredentialExpirationStatus(
+                {
+                    sensorCertNotBefore: '2022-01-01T00:00:00Z',
+                    sensorCertExpiry: '2022-02-01T00:00:00Z',
+                    lastRefreshTime: '2022-06-01T00:00:00Z',
+                    lastRefreshedCertExpiry: '2022-08-01T00:00:00Z',
+                },
+                new Date('2022-07-01T00:00:00Z')
+            );
+
+            expect(status).toBe('HEALTHY');
+        });
+        it('should return DEGRADED when last refreshed cert is nearing expiry', () => {
+            const status = getCredentialExpirationStatus(
+                {
+                    sensorCertNotBefore: '2022-01-01T00:00:00Z',
+                    sensorCertExpiry: '2022-12-31T23:59:59Z',
+                    lastRefreshTime: '2022-06-01T00:00:00Z',
+                    lastRefreshedCertExpiry: '2022-07-10T00:00:00Z',
+                },
+                new Date('2022-07-05T00:00:00Z')
+            );
+
+            expect(status).toBe('DEGRADED');
+        });
         it('should return UNHEALTHY when the short lived cert expired', () => {
             const status = getCredentialExpirationStatus(
                 {

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -1,4 +1,4 @@
-import { differenceInDays, differenceInMinutes } from 'date-fns';
+import { differenceInMinutes } from 'date-fns';
 import get from 'lodash/get';
 import { DownloadCloud } from 'react-feather';
 import {
@@ -21,7 +21,7 @@ import type {
 import { getDate, getDistanceStrict } from 'utils/dateUtils';
 
 import { healthStatusLabels } from './cluster.constants';
-import type { CertExpiryStatus } from './clusterTypes';
+import type { CertExpiryStatus, SensorHealthStatus } from './clusterTypes';
 
 export const runtimeOptions = [
     {
@@ -321,26 +321,33 @@ export function formatCloudProvider(providerMetadata: ClusterProviderMetadata) {
     return 'Not available';
 }
 
-const shortLivedCertMaxDays = 14;
-
-const longLivedCertThresholds = {
-    thresholdDegradedMinutes: 7 * 24 * 60, // Unhealthy if less than a week before expiry
-    thresholdHealthyMinutes: 30 * 24 * 60, // Degraded if less than a month before expiry
+type CertExpirationThresholds = {
+    thresholdDegradedMinutes: number;
+    thresholdHealthyMinutes: number;
 };
 
-const shortLivedCertThresholds = {
-    thresholdDegradedMinutes: 15, // Unhealthy if less than 15 minutes before expiry
-    thresholdHealthyMinutes: 59, // Degraded if less than an hour before expiry
-};
-
-const resolveThresholds = (expiryStatus: CertExpiryStatus) => {
-    const certDurationDays = differenceInDays(
+const resolveThresholds = (expiryStatus: CertExpiryStatus): CertExpirationThresholds => {
+    const certDurationMinutes = differenceInMinutes(
         expiryStatus.sensorCertExpiry,
         expiryStatus.sensorCertNotBefore
     );
-    return certDurationDays <= shortLivedCertMaxDays
-        ? shortLivedCertThresholds
-        : longLivedCertThresholds;
+    return {
+        thresholdDegradedMinutes: Math.max(15, Math.round(certDurationMinutes * 0.02)),
+        thresholdHealthyMinutes: Math.max(59, Math.round(certDurationMinutes * 0.08)),
+    };
+};
+
+const healthFromRemainingMinutes = (
+    remainingMinutes: number,
+    thresholds: CertExpirationThresholds
+): SensorHealthStatus => {
+    if (remainingMinutes < thresholds.thresholdDegradedMinutes) {
+        return 'UNHEALTHY';
+    }
+    if (remainingMinutes < thresholds.thresholdHealthyMinutes) {
+        return 'DEGRADED';
+    }
+    return 'HEALTHY';
 };
 
 /*
@@ -363,17 +370,33 @@ export const getCredentialExpirationStatus = (
     sensorCertExpiryStatus: CertExpiryStatus,
     currentDatetime
 ) => {
-    const { sensorCertExpiry } = sensorCertExpiryStatus;
-    const diffInMinutes = differenceInMinutes(sensorCertExpiry, currentDatetime);
-    const { thresholdDegradedMinutes, thresholdHealthyMinutes } =
-        resolveThresholds(sensorCertExpiryStatus);
+    const thresholds = resolveThresholds(sensorCertExpiryStatus);
 
-    if (diffInMinutes < thresholdDegradedMinutes) {
-        return 'UNHEALTHY';
+    if (sensorCertExpiryStatus.lastRefreshedCertExpiry) {
+        const refreshedRemainingMinutes = differenceInMinutes(
+            sensorCertExpiryStatus.lastRefreshedCertExpiry,
+            currentDatetime
+        );
+        const refreshedHealth = healthFromRemainingMinutes(
+            refreshedRemainingMinutes,
+            thresholds
+        );
+        if (refreshedHealth !== 'HEALTHY') {
+            return refreshedHealth;
+        }
     }
 
-    if (diffInMinutes < thresholdHealthyMinutes) {
-        return 'DEGRADED';
+    const connectionRemainingMinutes = differenceInMinutes(
+        sensorCertExpiryStatus.sensorCertExpiry,
+        currentDatetime
+    );
+    const connectionEstablishedAfterLastRefresh =
+        !sensorCertExpiryStatus.lastRefreshTime ||
+        new Date(sensorCertExpiryStatus.sensorCertNotBefore) >=
+            new Date(sensorCertExpiryStatus.lastRefreshTime);
+
+    if (connectionEstablishedAfterLastRefresh) {
+        return healthFromRemainingMinutes(connectionRemainingMinutes, thresholds);
     }
 
     return 'HEALTHY';

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -377,10 +377,7 @@ export const getCredentialExpirationStatus = (
     sensorCertExpiryStatus: CertExpiryStatus,
     currentDatetime
 ) => {
-    if (
-        sensorCertExpiryStatus.lastRefreshedCertExpiry &&
-        sensorCertExpiryStatus.lastRefreshTime
-    ) {
+    if (sensorCertExpiryStatus.lastRefreshedCertExpiry && sensorCertExpiryStatus.lastRefreshTime) {
         const refreshedDurationMinutes = differenceInMinutes(
             sensorCertExpiryStatus.lastRefreshedCertExpiry,
             sensorCertExpiryStatus.lastRefreshTime

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -403,6 +403,7 @@ export const getCredentialExpirationStatus = (
     );
     const connectionEstablishedAfterLastRefresh =
         !sensorCertExpiryStatus.lastRefreshTime ||
+        !sensorCertExpiryStatus.sensorCertNotBefore ||
         new Date(sensorCertExpiryStatus.sensorCertNotBefore) >=
             new Date(sensorCertExpiryStatus.lastRefreshTime);
 

--- a/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/cluster.helpers.tsx
@@ -326,15 +326,22 @@ type CertExpirationThresholds = {
     thresholdHealthyMinutes: number;
 };
 
+const defaultCertDurationMinutes = 365 * 24 * 60;
+
+const computeThresholds = (durationMinutes: number): CertExpirationThresholds => ({
+    thresholdDegradedMinutes: Math.max(15, Math.round(durationMinutes * 0.02)),
+    thresholdHealthyMinutes: Math.max(59, Math.round(durationMinutes * 0.08)),
+});
+
 const resolveThresholds = (expiryStatus: CertExpiryStatus): CertExpirationThresholds => {
+    if (!expiryStatus.sensorCertNotBefore) {
+        return computeThresholds(defaultCertDurationMinutes);
+    }
     const certDurationMinutes = differenceInMinutes(
         expiryStatus.sensorCertExpiry,
         expiryStatus.sensorCertNotBefore
     );
-    return {
-        thresholdDegradedMinutes: Math.max(15, Math.round(certDurationMinutes * 0.02)),
-        thresholdHealthyMinutes: Math.max(59, Math.round(certDurationMinutes * 0.08)),
-    };
+    return computeThresholds(certDurationMinutes);
 };
 
 const healthFromRemainingMinutes = (
@@ -370,22 +377,29 @@ export const getCredentialExpirationStatus = (
     sensorCertExpiryStatus: CertExpiryStatus,
     currentDatetime
 ) => {
-    const thresholds = resolveThresholds(sensorCertExpiryStatus);
-
-    if (sensorCertExpiryStatus.lastRefreshedCertExpiry) {
+    if (
+        sensorCertExpiryStatus.lastRefreshedCertExpiry &&
+        sensorCertExpiryStatus.lastRefreshTime
+    ) {
+        const refreshedDurationMinutes = differenceInMinutes(
+            sensorCertExpiryStatus.lastRefreshedCertExpiry,
+            sensorCertExpiryStatus.lastRefreshTime
+        );
+        const refreshedThresholds = computeThresholds(refreshedDurationMinutes);
         const refreshedRemainingMinutes = differenceInMinutes(
             sensorCertExpiryStatus.lastRefreshedCertExpiry,
             currentDatetime
         );
         const refreshedHealth = healthFromRemainingMinutes(
             refreshedRemainingMinutes,
-            thresholds
+            refreshedThresholds
         );
         if (refreshedHealth !== 'HEALTHY') {
             return refreshedHealth;
         }
     }
 
+    const thresholds = resolveThresholds(sensorCertExpiryStatus);
     const connectionRemainingMinutes = differenceInMinutes(
         sensorCertExpiryStatus.sensorCertExpiry,
         currentDatetime

--- a/ui/apps/platform/src/Containers/Clusters/clusterTypes.ts
+++ b/ui/apps/platform/src/Containers/Clusters/clusterTypes.ts
@@ -70,6 +70,8 @@ export type CentralEnv = {
 export type CertExpiryStatus = {
     sensorCertExpiry: string; // ISO 8601
     sensorCertNotBefore: string; // ISO 8601
+    lastRefreshTime?: string; // ISO 8601
+    lastRefreshedCertExpiry?: string; // ISO 8601
 };
 
 export type ClusterStatus = {

--- a/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
+++ b/ui/apps/platform/src/Containers/SystemHealth/ClustersHealth/CredentialExpirationCard.tsx
@@ -16,9 +16,9 @@ import {
     TheadClustersHealth,
 } from './ClustersHealthTable';
 
-const dataLabelHealthy = '\u2265 30 days'; // greater than or equal to
-const dataLabelUnhealthy = '< 7 days';
-const dataLabelDegraded = '< 30 days';
+const dataLabelHealthy = 'Healthy';
+const dataLabelUnhealthy = 'Unhealthy';
+const dataLabelDegraded = 'Degraded';
 
 export type CredentialExpirationCardProps = {
     clusters: Cluster[];

--- a/ui/apps/platform/src/types/cluster.proto.ts
+++ b/ui/apps/platform/src/types/cluster.proto.ts
@@ -155,6 +155,9 @@ export type ClusterManagerType =
 
 export type ClusterCertExpiryStatus = {
     sensorCertExpiry: string; // ISO 8601 date string
+    sensorCertNotBefore?: string; // ISO 8601 date string
+    lastRefreshTime?: string; // ISO 8601 date string
+    lastRefreshedCertExpiry?: string; // ISO 8601 date string
 };
 
 export type ClusterStatus = {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Introduces configurable validity duration for mTLS service certificates issued to Secured
Cluster components (Sensor, Admission Control, Collector, Scanner). Previously certificates
were always issued with a fixed 1-year lifetime; this PR allows users to opt in to shorter
durations for improved security posture.

### How it works

- A new `spec.tls.serviceCertValidity` field on the `SecuredCluster` CRD (and `Central` CRD,
  which shares `TLSConfig`) controls the desired certificate lifetime (e.g. `"1080h"` for
  45 days, `"2h"` for testing). Default remains `8760h` (1 year) to preserve existing
  behaviour.
- The Operator translates the CRD field into the `ROX_SENSOR_SERVICE_CERT_VALIDITY`
  environment variable on the Sensor deployment.
- Sensor reads this env var and includes `requested_cert_validity` in both the initial
  `SensorHello` handshake message **and** subsequent `IssueSecuredClusterCertsRequest`
  refresh messages.
- Central validates and clamps the requested duration (minimum 2h, maximum 1 year) before
  issuing certificates, so neither Sensor nor the CRS init container can bypass the server-
  side policy.
- After each successful issuance Central stores `last_refresh_time` and
  `last_refreshed_cert_expiry` on the cluster's `CertExpiryStatus`. The UI uses these to
  correctly show the current certificate health even when the gRPC connection has outlived
  the original connection-time certificate.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

- Deployed Central + Secured Cluster on GKE with `serviceCertValidity: "2h"`.
- Confirmed the initial CRS-issued certificate had a 2h validity (notAfter = issuance + 2h).
- Observed Sensor rotating certificates every ~30 minutes over a 60-hour weekend run with
  no disconnections, no errors, and no pod restarts. Certificate serial numbers changed on
  each rotation, confirming hot-reload via `certwatch` worked end-to-end.
- Verified all 7 service types (Sensor, Admission Control, Collector, Scanner, Scanner DB,
  Scanner V4 Indexer, Scanner V4 DB) rotated successfully in each cycle.
- Confirmed the UI shows the correct (refreshed) certificate expiry and a green health
  status after the connection cert expired.
- Unit tests added for `ClampRequestedValidity` (boundary cases: nil, zero, exact minimum,
  just below minimum, valid range, above maximum, negative).
