### PR TITLE
ci: add AI-powered review comment fixer GitHub Action [hackathon]

### DIFF
--- a/.github/workflows/ai-fixxxer.yaml
+++ b/.github/workflows/ai-fixxxer.yaml
@@ -1,0 +1,250 @@
+name: AI PR Fixxxer
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  ai_fixxx_bulk:
+    name: Run AI Fixxxer (bulk)
+    if: >-
+      github.event_name == 'issue_comment'
+      && github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/ai-fixxx')
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: React with eyes
+      run: |
+        gh api \
+          repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+          -f content=eyes
+      env:
+        GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+    - name: Fetch PR metadata
+      id: pr-metadata
+      run: |
+        pr_json=$(gh api "${{ github.event.issue.pull_request.url }}")
+        pr_head_repo=$(echo "$pr_json" | jq -r '.head.repo.full_name')
+
+        if [ "$pr_head_repo" != "${{ github.repository }}" ]; then
+          echo "::error::PR is from a fork ($pr_head_repo). Cannot push back — aborting."
+          exit 1
+        fi
+
+        branch=$(echo "$pr_json" | jq -r '.head.ref')
+        pr_number=$(echo "$pr_json" | jq -r '.number')
+
+        if [ -z "$branch" ] || [ "$branch" = "null" ]; then
+          echo "::error::Failed to detect source branch."
+          exit 1
+        fi
+
+        echo "branch=$branch" >> "$GITHUB_OUTPUT"
+        echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ steps.pr-metadata.outputs.branch }}
+        fetch-depth: 0
+        token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+    - name: Configure git
+      run: |
+        git config --global user.name "AI Fixxxer"
+        git config --global user.email "rhacs-bot@redhat.com"
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Install Claude Code
+      run: npm install -g @anthropic-ai/claude-code
+
+    - name: Authenticate gcloud
+      run: |
+        cat > $HOME/gcp-key.json <<'EOF'
+        ${{ secrets.AI_FIXXX_SA_KEY }}
+        EOF
+        gcloud auth activate-service-account \
+          "${{ secrets.AI_FIXXX_SA_EMAIL }}" \
+          --key-file=$HOME/gcp-key.json
+
+    - name: Run AI Fixxxer
+      id: ai-fixxx
+      run: |
+        chmod +x scripts/ai-fixxxer.sh
+        bash scripts/ai-fixxxer.sh
+      env:
+        GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+        CLAUDE_CODE_USE_VERTEX: "1"
+        CLOUD_ML_REGION: us-east5
+        ANTHROPIC_VERTEX_PROJECT_ID: itpc-gcp-hcm-pe-eng-claude
+        GOOGLE_APPLICATION_CREDENTIALS: /home/runner/gcp-key.json
+        PR_NUMBER: ${{ steps.pr-metadata.outputs.pr_number }}
+        REPO: ${{ github.repository }}
+
+    - name: Cleanup credentials
+      if: always()
+      run: rm -f "$HOME/gcp-key.json"
+
+    - name: Push changes
+      run: |
+        if [ -n "$(git log origin/${{ steps.pr-metadata.outputs.branch }}..HEAD --oneline)" ]; then
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin HEAD:${{ steps.pr-metadata.outputs.branch }}
+          echo "pushed=true" >> "$GITHUB_ENV"
+        else
+          echo "No new commits to push."
+          echo "pushed=false" >> "$GITHUB_ENV"
+        fi
+      env:
+        PUSH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+    - name: React with rocket on success
+      if: success()
+      run: |
+        gh api \
+          repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+          -f content=rocket
+      env:
+        GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+    - name: React with confused on failure
+      if: failure()
+      run: |
+        gh api \
+          repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+          -f content=confused
+      env:
+        GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+  ai_fixxx_single:
+    name: Run AI Fixxxer (single comment)
+    if: >-
+      github.event_name == 'pull_request_review_comment'
+      && github.event.comment.in_reply_to_id != 0
+      && startsWith(github.event.comment.body, '/ai-fixxx')
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: React with eyes
+      run: |
+        gh api \
+          repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.id }}/reactions \
+          -f content=eyes
+      env:
+        GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: metadata
+      run: |
+        echo "branch=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+        echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+        echo "parent_comment_id=${{ github.event.comment.in_reply_to_id }}" >> "$GITHUB_OUTPUT"
+
+        raw_body="${{ github.event.comment.body }}"
+        instructions="${raw_body#/ai-fixxx}"
+        instructions="$(echo "$instructions" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+        {
+          echo "user_instructions<<INSTRUCTIONS_EOF"
+          echo "$instructions"
+          echo "INSTRUCTIONS_EOF"
+        } >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+    - name: Check fork
+      run: |
+        if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+          echo "::error::PR is from a fork. Cannot push back — aborting."
+          exit 1
+        fi
+
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ steps.metadata.outputs.branch }}
+        fetch-depth: 0
+        token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+    - name: Configure git
+      run: |
+        git config --global user.name "AI Fixxxer"
+        git config --global user.email "rhacs-bot@redhat.com"
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Install Claude Code
+      run: npm install -g @anthropic-ai/claude-code
+
+    - name: Authenticate gcloud
+      run: |
+        cat > $HOME/gcp-key.json <<'EOF'
+        ${{ secrets.AI_FIXXX_SA_KEY }}
+        EOF
+        gcloud auth activate-service-account \
+          "${{ secrets.AI_FIXXX_SA_EMAIL }}" \
+          --key-file=$HOME/gcp-key.json
+
+    - name: Run AI Fixxxer
+      id: ai-fixxx
+      run: |
+        chmod +x scripts/ai-fixxxer.sh
+        bash scripts/ai-fixxxer.sh
+      env:
+        GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+        CLAUDE_CODE_USE_VERTEX: "1"
+        CLOUD_ML_REGION: us-east5
+        ANTHROPIC_VERTEX_PROJECT_ID: itpc-gcp-hcm-pe-eng-claude
+        GOOGLE_APPLICATION_CREDENTIALS: /home/runner/gcp-key.json
+        PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+        REPO: ${{ github.repository }}
+        SINGLE_COMMENT_ID: ${{ steps.metadata.outputs.parent_comment_id }}
+        USER_INSTRUCTIONS: ${{ steps.metadata.outputs.user_instructions }}
+
+    - name: Cleanup credentials
+      if: always()
+      run: rm -f "$HOME/gcp-key.json"
+
+    - name: Push changes
+      run: |
+        if [ -n "$(git log origin/${{ steps.metadata.outputs.branch }}..HEAD --oneline)" ]; then
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin HEAD:${{ steps.metadata.outputs.branch }}
+          echo "pushed=true" >> "$GITHUB_ENV"
+        else
+          echo "No new commits to push."
+          echo "pushed=false" >> "$GITHUB_ENV"
+        fi
+      env:
+        PUSH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+    - name: React with rocket on success
+      if: success()
+      run: |
+        gh api \
+          repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.id }}/reactions \
+          -f content=rocket
+      env:
+        GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
+
+    - name: React with confused on failure
+      if: failure()
+      run: |
+        gh api \
+          repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.id }}/reactions \
+          -f content=confused
+      env:
+        GH_TOKEN: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/ai-fixxxer.yaml
+++ b/.github/workflows/ai-fixxxer.yaml
@@ -19,6 +19,9 @@ jobs:
       && github.event.issue.pull_request
       && startsWith(github.event.comment.body, '/ai-fixxx')
     runs-on: ubuntu-latest
+    concurrency:
+      group: ai-fixxxer-bulk-${{ github.event.issue.number }}
+      cancel-in-progress: true
     steps:
 
     - name: React with eyes
@@ -68,7 +71,17 @@ jobs:
       with:
         node-version: 20
 
+    - name: Cache Claude Code
+      id: cache-claude
+      uses: actions/cache@v4
+      with:
+        path: |
+          /usr/local/lib/node_modules/@anthropic-ai
+          /usr/local/bin/claude
+        key: claude-code-v1
+
     - name: Install Claude Code
+      if: steps.cache-claude.outputs.cache-hit != 'true'
       run: npm install -g @anthropic-ai/claude-code
 
     - name: Authenticate gcloud
@@ -136,6 +149,9 @@ jobs:
       && github.event.comment.in_reply_to_id != 0
       && startsWith(github.event.comment.body, '/ai-fixxx')
     runs-on: ubuntu-latest
+    concurrency:
+      group: ai-fixxxer-single-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     steps:
 
     - name: React with eyes
@@ -186,7 +202,17 @@ jobs:
       with:
         node-version: 20
 
+    - name: Cache Claude Code
+      id: cache-claude
+      uses: actions/cache@v4
+      with:
+        path: |
+          /usr/local/lib/node_modules/@anthropic-ai
+          /usr/local/bin/claude
+        key: claude-code-v1
+
     - name: Install Claude Code
+      if: steps.cache-claude.outputs.cache-hit != 'true'
       run: npm install -g @anthropic-ai/claude-code
 
     - name: Authenticate gcloud

--- a/scripts/ai-fixxxer.sh
+++ b/scripts/ai-fixxxer.sh
@@ -1,0 +1,359 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${REPO:?REPO is required}"
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+MANIFEST="/tmp/ai-fixxxer-results.json"
+
+post_reply() {
+    local cid="$1"
+    local body="$2"
+    jq -n --arg b "$body" '{"body": $b}' > /tmp/reply_payload.json
+    local http_code
+    http_code=$(curl -s -o /tmp/reply_response.json -w "%{http_code}" \
+        -X POST "https://api.github.com/repos/${REPO}/pulls/${PR_NUMBER}/comments/${cid}/replies" \
+        -H "Authorization: Bearer ${GH_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Content-Type: application/json" \
+        -d @/tmp/reply_payload.json)
+    if [ "${http_code}" = "201" ]; then
+        echo "Replied to comment ${cid}"
+    else
+        echo "Failed to reply to comment ${cid} (HTTP ${http_code})"
+    fi
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# Single-comment mode: address one specific review comment
+# ──────────────────────────────────────────────────────────────────────
+if [ -n "${SINGLE_COMMENT_ID:-}" ]; then
+    echo "AI Fixxxer: Single-comment mode for comment ${SINGLE_COMMENT_ID} on PR #${PR_NUMBER}"
+
+    comment_json=$(gh api "repos/${REPO}/pulls/comments/${SINGLE_COMMENT_ID}")
+    structured_comment=$(echo "$comment_json" | jq '{
+        id: .id,
+        file: .path,
+        line: (.original_line // .line),
+        body: .body,
+        diff_hunk: .diff_hunk
+    }')
+
+    echo "Target comment:"
+    echo "$structured_comment" | jq -c '{id, file, line}'
+
+    echo "Fetching PR diff..."
+    diff=$(gh pr diff "$PR_NUMBER" --repo "$REPO")
+
+    USER_INSTRUCTIONS="${USER_INSTRUCTIONS:-}"
+
+    if [ -n "$USER_INSTRUCTIONS" ]; then
+        PROMPT=$(cat <<'PROMPT_HEREDOC'
+You are AI Fixxxer, an automated code-fix agent. You are given a single review comment from a pull request, the full PR diff for context, and explicit instructions from the user.
+
+The user has replied to this review comment with /ai-fixxx and provided specific instructions. You MUST follow the user's instructions. Do not skip complex changes — the user explicitly asked for this.
+
+## User instructions
+PROMPT_HEREDOC
+)
+        PROMPT="${PROMPT}
+${USER_INSTRUCTIONS}
+
+## Rules
+- Apply the fix or change as instructed.
+- Make ONE git commit with message \`ai-fixxxer: <short description>\`.
+- Make targeted changes — do what the user asked, nothing more.
+- Do NOT introduce new issues.
+
+## After processing
+Write a JSON manifest file to /tmp/ai-fixxxer-results.json containing a single-element array:
+
+If you made a fix:
+[{\"comment_id\": <id>, \"action\": \"fix\", \"description\": \"<what you changed>\"}]
+
+If you cannot apply the change (e.g. the request is impossible or would break things):
+[{\"comment_id\": <id>, \"action\": \"skip\", \"reason\": \"<why you cannot do this>\"}]
+
+The manifest MUST be valid JSON.
+
+## Review comment:
+${structured_comment}
+
+## Full PR diff:
+${diff}
+
+Now read the file mentioned in the review comment, apply the requested change, commit it, and write the manifest to /tmp/ai-fixxxer-results.json."
+    else
+        PROMPT=$(cat <<'PROMPT_HEREDOC'
+You are AI Fixxxer, an automated code-fix agent. You are given a single review comment from a pull request and the full PR diff for context.
+
+The user has replied to this review comment with /ai-fixxx (no additional instructions). Use your judgment:
+
+- If the comment points to an obvious, unambiguous issue (typo, unused variable, unused import, unhandled error, missing nil check, etc.), fix it.
+- If the comment asks for something too complex (refactoring, architectural changes, adding tests), skip it and explain why.
+- If the comment's feedback is factually wrong or the code is already correct, reject it and explain why.
+
+## Rules for fixes
+- Make ONE git commit with message `ai-fixxxer: <short description>`.
+- Make minimal, targeted changes — only what the review comment asks for.
+- Do NOT introduce new issues.
+
+## After processing
+Write a JSON manifest file to /tmp/ai-fixxxer-results.json containing a single-element array:
+
+For fix:
+[{"comment_id": <id>, "action": "fix", "description": "<what you changed>"}]
+
+For skip:
+[{"comment_id": <id>, "action": "skip", "reason": "<why this needs human attention>"}]
+
+For reject:
+[{"comment_id": <id>, "action": "reject", "reason": "<why the feedback is incorrect>"}]
+
+The manifest MUST be valid JSON.
+
+PROMPT_HEREDOC
+)
+        PROMPT="${PROMPT}
+
+## Review comment:
+${structured_comment}
+
+## Full PR diff:
+${diff}
+
+Now read the file mentioned in the review comment, triage the comment, apply a fix if appropriate, and write the manifest to /tmp/ai-fixxxer-results.json."
+    fi
+
+    echo "Running Claude Code (single-comment mode)..."
+    if timeout 10m claude -p --dangerously-skip-permissions "$PROMPT"; then
+        echo "Claude Code finished successfully"
+    else
+        exit_code=$?
+        echo "Claude Code exited with code: $exit_code"
+    fi
+
+    if [ ! -f "$MANIFEST" ]; then
+        echo "WARNING: Claude did not produce a manifest file."
+        post_reply "$SINGLE_COMMENT_ID" "**AI Fixxxer** ran but could not produce results. Check the [workflow run](https://github.com/${REPO}/actions) for details."
+        exit 0
+    fi
+
+    echo "Manifest contents:"
+    cat "$MANIFEST"
+
+    if ! jq empty "$MANIFEST" 2>/dev/null; then
+        echo "WARNING: Manifest is not valid JSON."
+        post_reply "$SINGLE_COMMENT_ID" "**AI Fixxxer** ran but produced an invalid results manifest. Check the [workflow run](https://github.com/${REPO}/actions) for details."
+        exit 0
+    fi
+
+    entry=$(jq -r '.[0]' "$MANIFEST")
+    action=$(echo "$entry" | jq -r '.action')
+    comment_id=$(echo "$entry" | jq -r '.comment_id')
+
+    case "$action" in
+        fix)
+            description=$(echo "$entry" | jq -r '.description')
+            sha=$(git rev-parse --short HEAD 2>/dev/null || true)
+            if [ -n "$sha" ]; then
+                post_reply "$SINGLE_COMMENT_ID" "Fixed in ${sha}: ${description}"
+            else
+                post_reply "$SINGLE_COMMENT_ID" "Fixed: ${description}"
+            fi
+            ;;
+        skip)
+            reason=$(echo "$entry" | jq -r '.reason')
+            post_reply "$SINGLE_COMMENT_ID" "**Skipped**: ${reason}"
+            ;;
+        reject)
+            reason=$(echo "$entry" | jq -r '.reason')
+            post_reply "$SINGLE_COMMENT_ID" "**Not addressed**: ${reason}"
+            ;;
+        *)
+            echo "Unknown action: $action"
+            post_reply "$SINGLE_COMMENT_ID" "**AI Fixxxer** processed the comment but returned an unexpected result. Check the [workflow run](https://github.com/${REPO}/actions) for details."
+            ;;
+    esac
+
+    echo "AI Fixxxer (single-comment mode) complete."
+    exit 0
+fi
+
+# ──────────────────────────────────────────────────────────────────────
+# Bulk mode: process all review comments on the PR
+# ──────────────────────────────────────────────────────────────────────
+echo "AI Fixxxer: Processing PR #${PR_NUMBER} in ${REPO}"
+
+# 1. Fetch all review comments on the PR (exclude replies)
+echo "Fetching review comments..."
+reviews=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --paginate)
+
+structured_reviews=$(echo "$reviews" | jq '[.[] | select(.in_reply_to_id == null) | {
+    id: .id,
+    file: .path,
+    line: (.original_line // .line),
+    body: .body,
+    diff_hunk: .diff_hunk
+}]')
+
+comment_count=$(echo "$structured_reviews" | jq 'length')
+echo "Found ${comment_count} review comment(s) (excluding replies)"
+
+if [ "$comment_count" -eq 0 ]; then
+    echo "No review comments found. Nothing to fix."
+    exit 0
+fi
+
+echo "$structured_reviews" | jq -c '.[] | {id, file, line}'
+
+# 2. Fetch the PR diff for context
+echo "Fetching PR diff..."
+diff=$(gh pr diff "$PR_NUMBER" --repo "$REPO")
+
+# 3. Build prompt for Claude
+PROMPT=$(cat <<'PROMPT_HEREDOC'
+You are AI Fixxxer, an automated code-fix agent. You are given review comments from a pull request and the full PR diff for context.
+
+Your job is to triage each review comment into one of three categories and act accordingly:
+
+**fix** — The comment points to an obvious, unambiguous issue (typo, unused variable, unused import, unhandled error, missing nil check, etc.). Make the code change.
+**skip** — The comment asks for something too complex for an automated tool: refactoring, architectural changes, adding tests, design decisions. Don't touch the code.
+**reject** — The comment's feedback is factually wrong or the code is already correct. Don't touch the code.
+
+## Rules for fixes
+- Make ONE git commit per fix. Do NOT batch multiple fixes into one commit.
+- For each fix: edit the file, then run `git add <specific-files>` and `git commit -m "ai-fixxxer: <short description>"`.
+- Make minimal, targeted changes — only what the review comment asks for.
+- Do NOT introduce new issues.
+
+## Rules for skip and reject
+- Do NOT modify any code.
+
+## After processing ALL comments
+Write a JSON manifest file to /tmp/ai-fixxxer-results.json containing an array of objects, one per review comment:
+
+For fix actions:
+{"comment_id": <id>, "action": "fix", "description": "<what you changed>"}
+
+For skip actions:
+{"comment_id": <id>, "action": "skip", "reason": "<why this needs human attention>"}
+
+For reject actions:
+{"comment_id": <id>, "action": "reject", "reason": "<why the feedback is incorrect>"}
+
+The manifest MUST be valid JSON. Write it using a heredoc or echo command. Every comment must appear in the manifest.
+
+PROMPT_HEREDOC
+)
+
+PROMPT="${PROMPT}
+
+## Review comments (JSON array with id, file, line, body, diff_hunk):
+${structured_reviews}
+
+## Full PR diff:
+${diff}
+
+Now read the files mentioned in the review comments, triage each comment, apply fixes (one commit each), and write the manifest to /tmp/ai-fixxxer-results.json."
+
+# 4. Run Claude Code
+echo "Running Claude Code..."
+if timeout 10m claude -p --dangerously-skip-permissions "$PROMPT"; then
+    echo "Claude Code finished successfully"
+else
+    exit_code=$?
+    echo "Claude Code exited with code: $exit_code"
+fi
+
+# 5. Check for manifest
+if [ ! -f "$MANIFEST" ]; then
+    echo "WARNING: Claude did not produce a manifest file."
+    gh pr comment "$PR_NUMBER" --repo "$REPO" \
+        --body "**AI Fixxxer** ran but did not produce a results manifest. Check the [workflow run](https://github.com/${REPO}/actions) for details."
+    exit 0
+fi
+
+echo "Manifest contents:"
+cat "$MANIFEST"
+
+if ! jq empty "$MANIFEST" 2>/dev/null; then
+    echo "WARNING: Manifest is not valid JSON."
+    gh pr comment "$PR_NUMBER" --repo "$REPO" \
+        --body "**AI Fixxxer** ran but produced an invalid results manifest. Check the [workflow run](https://github.com/${REPO}/actions) for details."
+    exit 0
+fi
+
+# 6. Collect commit SHAs for fix actions
+fix_commits=$(git log --oneline --format="%H %s" | grep "^.\{40\} ai-fixxxer:" || true)
+
+# 7. Post replies to each review comment
+total=$(jq 'length' "$MANIFEST")
+fixed=0
+skipped=0
+rejected=0
+fix_lines=""
+skip_lines=""
+reject_lines=""
+
+for i in $(seq 0 $((total - 1))); do
+    entry=$(jq -r ".[$i]" "$MANIFEST")
+    comment_id=$(echo "$entry" | jq -r '.comment_id')
+    action=$(echo "$entry" | jq -r '.action')
+
+    case "$action" in
+        fix)
+            description=$(echo "$entry" | jq -r '.description')
+            sha=$(echo "$fix_commits" | grep -i "$(echo "$description" | head -c 30)" | head -1 | awk '{print $1}' || true)
+            if [ -z "$sha" ]; then
+                sha=$(echo "$fix_commits" | sed -n "$((fixed + 1))p" | awk '{print $1}' || true)
+            fi
+            short_sha="${sha:0:7}"
+
+            if [ -n "$sha" ]; then
+                reply_body="Fixed in ${short_sha}: ${description}"
+            else
+                reply_body="Fixed: ${description}"
+            fi
+
+            post_reply "$comment_id" "$reply_body"
+
+            fixed=$((fixed + 1))
+            fix_lines="${fix_lines}\n- ${description}"
+            ;;
+        skip)
+            reason=$(echo "$entry" | jq -r '.reason')
+            skipped=$((skipped + 1))
+            skip_lines="${skip_lines}\n- ${reason}"
+            ;;
+        reject)
+            reason=$(echo "$entry" | jq -r '.reason')
+            rejected=$((rejected + 1))
+            reject_lines="${reject_lines}\n- ${reason}"
+            ;;
+        *)
+            echo "Unknown action: $action for comment $comment_id"
+            ;;
+    esac
+done
+
+# 8. Post summary comment
+summary="**AI Fixxxer** processed ${total} review comment(s):"
+
+if [ "$fixed" -gt 0 ]; then
+    summary="${summary}\n\n**Fixed (${fixed}):**$(echo -e "$fix_lines")"
+fi
+
+if [ "$skipped" -gt 0 ]; then
+    summary="${summary}\n\n**Skipped (${skipped})** — needs human attention:$(echo -e "$skip_lines")"
+fi
+
+if [ "$rejected" -gt 0 ]; then
+    summary="${summary}\n\n**Not addressed (${rejected})** — feedback appears incorrect:$(echo -e "$reject_lines")"
+fi
+
+gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$(echo -e "$summary")"
+
+echo "AI Fixxxer complete: ${fixed} fixed, ${skipped} skipped, ${rejected} rejected"

--- a/scripts/ai-fixxxer.sh
+++ b/scripts/ai-fixxxer.sh
@@ -30,36 +30,83 @@ post_reply() {
 # Single-comment mode: address one specific review comment
 # ──────────────────────────────────────────────────────────────────────
 if [ -n "${SINGLE_COMMENT_ID:-}" ]; then
-    echo "AI Fixxxer: Single-comment mode for comment ${SINGLE_COMMENT_ID} on PR #${PR_NUMBER}"
+    echo "AI Fixxxer: Single-comment mode triggered for comment ${SINGLE_COMMENT_ID} on PR #${PR_NUMBER}"
 
-    comment_json=$(gh api "repos/${REPO}/pulls/comments/${SINGLE_COMMENT_ID}")
-    structured_comment=$(echo "$comment_json" | jq '{
+    # --- Debounce: wait for more /ai-fixxx replies to accumulate ---
+    echo "Debouncing for 30 seconds..."
+    sleep 30
+
+    # Fetch ALL comments on the PR (top-level and replies)
+    echo "Fetching all PR comments..."
+    all_comments=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --paginate)
+
+    # Find /ai-fixxx reply comments and their parent IDs
+    # Then check which parent comments already have an AI Fixxxer response
+    # (a sibling reply starting with "Fixed", "**Skipped**", "**Not addressed**", or "**AI Fixxxer**")
+    pending=$(echo "$all_comments" | jq '
+      # All /ai-fixxx reply comments (have in_reply_to_id set)
+      [.[] | select(.in_reply_to_id != null and (.body | startswith("/ai-fixxx")))] as $requests |
+      # Parent IDs that already have a bot response
+      [.[] | select(
+        .in_reply_to_id != null and (
+          (.body | startswith("Fixed ")) or
+          (.body | startswith("**Skipped**")) or
+          (.body | startswith("**Not addressed**")) or
+          (.body | startswith("**AI Fixxxer**"))
+        )
+      ) | .in_reply_to_id] as $addressed |
+      # Keep only requests whose parent is NOT yet addressed
+      [$requests[] | select(.in_reply_to_id as $pid | $addressed | index($pid) | not)]
+    ')
+
+    pending_count=$(echo "$pending" | jq 'length')
+    echo "Found ${pending_count} pending /ai-fixxx request(s)"
+
+    if [ "$pending_count" -eq 0 ]; then
+        echo "All /ai-fixxx requests on this PR already addressed. Skipping."
+        exit 0
+    fi
+
+    # Build array of parent comments to process, with per-comment user instructions
+    parent_ids=$(echo "$pending" | jq '[.[].in_reply_to_id] | unique')
+    structured_comments=$(echo "$all_comments" | jq --argjson pids "$parent_ids" '
+      [.[] | select(.id as $id | $pids | index($id)) | {
         id: .id,
         file: .path,
         line: (.original_line // .line),
         body: .body,
         diff_hunk: .diff_hunk
-    }')
+      }]
+    ')
 
-    echo "Target comment:"
-    echo "$structured_comment" | jq -c '{id, file, line}'
+    # Build instructions map: parent_id -> user instructions (text after /ai-fixxx, trimmed)
+    instructions_json=$(echo "$pending" | jq '
+      [.[] | {
+        parent_id: .in_reply_to_id,
+        instructions: (.body | sub("^/ai-fixxx[[:space:]]*"; ""))
+      }]
+    ')
 
+    echo "Comments to process:"
+    echo "$structured_comments" | jq -c '.[] | {id, file, line}'
+
+    # Fetch the PR diff for context
     echo "Fetching PR diff..."
     diff=$(gh pr diff "$PR_NUMBER" --repo "$REPO")
 
-    USER_INSTRUCTIONS="${USER_INSTRUCTIONS:-}"
+    # Build prompt
+    if [ "$pending_count" -eq 1 ]; then
+        # Single pending comment — use focused single-comment prompt
+        comment_data=$(echo "$structured_comments" | jq '.[0]')
+        user_instr=$(echo "$instructions_json" | jq -r '.[0].instructions')
 
-    if [ -n "$USER_INSTRUCTIONS" ]; then
-        PROMPT=$(cat <<'PROMPT_HEREDOC'
-You are AI Fixxxer, an automated code-fix agent. You are given a single review comment from a pull request, the full PR diff for context, and explicit instructions from the user.
+        if [ -n "$user_instr" ] && [ "$user_instr" != "null" ] && [ "$user_instr" != "" ]; then
+            PROMPT="You are AI Fixxxer, an automated code-fix agent. You are given a single review comment from a pull request, the full PR diff for context, and explicit instructions from the user.
 
 The user has replied to this review comment with /ai-fixxx and provided specific instructions. You MUST follow the user's instructions. Do not skip complex changes — the user explicitly asked for this.
 
 ## User instructions
-PROMPT_HEREDOC
-)
-        PROMPT="${PROMPT}
-${USER_INSTRUCTIONS}
+${user_instr}
 
 ## Rules
 - Apply the fix or change as instructed.
@@ -79,15 +126,14 @@ If you cannot apply the change (e.g. the request is impossible or would break th
 The manifest MUST be valid JSON.
 
 ## Review comment:
-${structured_comment}
+${comment_data}
 
 ## Full PR diff:
 ${diff}
 
 Now read the file mentioned in the review comment, apply the requested change, commit it, and write the manifest to /tmp/ai-fixxxer-results.json."
-    else
-        PROMPT=$(cat <<'PROMPT_HEREDOC'
-You are AI Fixxxer, an automated code-fix agent. You are given a single review comment from a pull request and the full PR diff for context.
+        else
+            PROMPT="You are AI Fixxxer, an automated code-fix agent. You are given a single review comment from a pull request and the full PR diff for context.
 
 The user has replied to this review comment with /ai-fixxx (no additional instructions). Use your judgment:
 
@@ -96,7 +142,7 @@ The user has replied to this review comment with /ai-fixxx (no additional instru
 - If the comment's feedback is factually wrong or the code is already correct, reject it and explain why.
 
 ## Rules for fixes
-- Make ONE git commit with message `ai-fixxxer: <short description>`.
+- Make ONE git commit with message \`ai-fixxxer: <short description>\`.
 - Make minimal, targeted changes — only what the review comment asks for.
 - Do NOT introduce new issues.
 
@@ -104,30 +150,78 @@ The user has replied to this review comment with /ai-fixxx (no additional instru
 Write a JSON manifest file to /tmp/ai-fixxxer-results.json containing a single-element array:
 
 For fix:
-[{"comment_id": <id>, "action": "fix", "description": "<what you changed>"}]
+[{\"comment_id\": <id>, \"action\": \"fix\", \"description\": \"<what you changed>\"}]
 
 For skip:
-[{"comment_id": <id>, "action": "skip", "reason": "<why this needs human attention>"}]
+[{\"comment_id\": <id>, \"action\": \"skip\", \"reason\": \"<why this needs human attention>\"}]
 
 For reject:
-[{"comment_id": <id>, "action": "reject", "reason": "<why the feedback is incorrect>"}]
+[{\"comment_id\": <id>, \"action\": \"reject\", \"reason\": \"<why the feedback is incorrect>\"}]
 
 The manifest MUST be valid JSON.
 
-PROMPT_HEREDOC
-)
-        PROMPT="${PROMPT}
-
 ## Review comment:
-${structured_comment}
+${comment_data}
 
 ## Full PR diff:
 ${diff}
 
 Now read the file mentioned in the review comment, triage the comment, apply a fix if appropriate, and write the manifest to /tmp/ai-fixxxer-results.json."
+        fi
+    else
+        # Multiple pending comments — build a multi-comment prompt
+        # Include per-comment instructions where provided
+        comments_section=""
+        for i in $(seq 0 $((pending_count - 1))); do
+            cdata=$(echo "$structured_comments" | jq ".[$i]")
+            cid=$(echo "$cdata" | jq -r '.id')
+            cfile=$(echo "$cdata" | jq -r '.file')
+            cline=$(echo "$cdata" | jq -r '.line')
+            cbody=$(echo "$cdata" | jq -r '.body')
+            cdiff=$(echo "$cdata" | jq -r '.diff_hunk')
+            cinstr=$(echo "$instructions_json" | jq -r --argjson cid "$cid" '.[] | select(.parent_id == $cid) | .instructions // empty')
+
+            comments_section="${comments_section}
+### Comment ID: ${cid}
+File: ${cfile}, Line: ${cline}
+Review feedback: ${cbody}
+User instructions: ${cinstr:-"(none)"}
+Diff hunk:
+\`\`\`
+${cdiff}
+\`\`\`
+"
+        done
+
+        PROMPT="You are AI Fixxxer, an automated code-fix agent. Process each review comment below independently.
+
+For each comment:
+- If user instructions are provided, follow them. Do not skip complex changes when the user explicitly asked for them.
+- If no user instructions, use your judgment: fix obvious issues (typos, unused vars, unhandled errors), skip complex requests (refactoring, tests), reject wrong feedback.
+- Make ONE git commit per fix with message \`ai-fixxxer: <short description>\`.
+- Make minimal, targeted changes.
+- Do NOT introduce new issues.
+
+## After processing ALL comments
+Write a JSON manifest to /tmp/ai-fixxxer-results.json — array with one entry per comment:
+
+For fix: {\"comment_id\": <id>, \"action\": \"fix\", \"description\": \"<what you changed>\"}
+For skip: {\"comment_id\": <id>, \"action\": \"skip\", \"reason\": \"<why>\"}
+For reject: {\"comment_id\": <id>, \"action\": \"reject\", \"reason\": \"<why>\"}
+
+The manifest MUST be valid JSON. Every comment must appear.
+
+## Comments to process:
+${comments_section}
+
+## Full PR diff:
+${diff}
+
+Now read the files mentioned in the review comments, process each one, and write the manifest to /tmp/ai-fixxxer-results.json."
     fi
 
-    echo "Running Claude Code (single-comment mode)..."
+    # Run Claude Code
+    echo "Running Claude Code (single-comment mode, ${pending_count} comment(s))..."
     if timeout 10m claude -p --dangerously-skip-permissions "$PROMPT"; then
         echo "Claude Code finished successfully"
     else
@@ -135,9 +229,14 @@ Now read the file mentioned in the review comment, triage the comment, apply a f
         echo "Claude Code exited with code: $exit_code"
     fi
 
+    # Check for manifest
     if [ ! -f "$MANIFEST" ]; then
         echo "WARNING: Claude did not produce a manifest file."
-        post_reply "$SINGLE_COMMENT_ID" "**AI Fixxxer** ran but could not produce results. Check the [workflow run](https://github.com/${REPO}/actions) for details."
+        # Reply to each pending parent comment
+        for i in $(seq 0 $((pending_count - 1))); do
+            pid=$(echo "$parent_ids" | jq -r ".[$i]")
+            post_reply "$pid" "**AI Fixxxer** ran but could not produce results. Check the [workflow run](https://github.com/${REPO}/actions) for details."
+        done
         exit 0
     fi
 
@@ -146,39 +245,46 @@ Now read the file mentioned in the review comment, triage the comment, apply a f
 
     if ! jq empty "$MANIFEST" 2>/dev/null; then
         echo "WARNING: Manifest is not valid JSON."
-        post_reply "$SINGLE_COMMENT_ID" "**AI Fixxxer** ran but produced an invalid results manifest. Check the [workflow run](https://github.com/${REPO}/actions) for details."
+        for i in $(seq 0 $((pending_count - 1))); do
+            pid=$(echo "$parent_ids" | jq -r ".[$i]")
+            post_reply "$pid" "**AI Fixxxer** ran but produced an invalid manifest. Check the [workflow run](https://github.com/${REPO}/actions) for details."
+        done
         exit 0
     fi
 
-    entry=$(jq -r '.[0]' "$MANIFEST")
-    action=$(echo "$entry" | jq -r '.action')
-    comment_id=$(echo "$entry" | jq -r '.comment_id')
+    # Process manifest entries and post replies
+    manifest_count=$(jq 'length' "$MANIFEST")
+    for i in $(seq 0 $((manifest_count - 1))); do
+        entry=$(jq -r ".[$i]" "$MANIFEST")
+        comment_id=$(echo "$entry" | jq -r '.comment_id')
+        action=$(echo "$entry" | jq -r '.action')
 
-    case "$action" in
-        fix)
-            description=$(echo "$entry" | jq -r '.description')
-            sha=$(git rev-parse --short HEAD 2>/dev/null || true)
-            if [ -n "$sha" ]; then
-                post_reply "$SINGLE_COMMENT_ID" "Fixed in ${sha}: ${description}"
-            else
-                post_reply "$SINGLE_COMMENT_ID" "Fixed: ${description}"
-            fi
-            ;;
-        skip)
-            reason=$(echo "$entry" | jq -r '.reason')
-            post_reply "$SINGLE_COMMENT_ID" "**Skipped**: ${reason}"
-            ;;
-        reject)
-            reason=$(echo "$entry" | jq -r '.reason')
-            post_reply "$SINGLE_COMMENT_ID" "**Not addressed**: ${reason}"
-            ;;
-        *)
-            echo "Unknown action: $action"
-            post_reply "$SINGLE_COMMENT_ID" "**AI Fixxxer** processed the comment but returned an unexpected result. Check the [workflow run](https://github.com/${REPO}/actions) for details."
-            ;;
-    esac
+        case "$action" in
+            fix)
+                description=$(echo "$entry" | jq -r '.description')
+                sha=$(git rev-parse --short HEAD 2>/dev/null || true)
+                if [ -n "$sha" ]; then
+                    post_reply "$comment_id" "Fixed in ${sha}: ${description}"
+                else
+                    post_reply "$comment_id" "Fixed: ${description}"
+                fi
+                ;;
+            skip)
+                reason=$(echo "$entry" | jq -r '.reason')
+                post_reply "$comment_id" "**Skipped**: ${reason}"
+                ;;
+            reject)
+                reason=$(echo "$entry" | jq -r '.reason')
+                post_reply "$comment_id" "**Not addressed**: ${reason}"
+                ;;
+            *)
+                echo "Unknown action: $action for comment $comment_id"
+                post_reply "$comment_id" "**AI Fixxxer** processed the comment but returned an unexpected result. Check the [workflow run](https://github.com/${REPO}/actions) for details."
+                ;;
+        esac
+    done
 
-    echo "AI Fixxxer (single-comment mode) complete."
+    echo "AI Fixxxer (single-comment mode) complete: processed ${manifest_count} comment(s)."
     exit 0
 fi
 


### PR DESCRIPTION
## Description

Adds **AI Fixxxer**, a GitHub Action that uses Claude Code to automatically address PR review comments. Triggered by `/ai-fixxx` commands, it reads review feedback, triages each comment, applies fixes where appropriate, and replies inline with results.

### Two modes of operation

- **Bulk mode** (`ai_fixxx_bulk`) — triggered by posting `/ai-fixxx` as a top-level PR comment (`issue_comment` event). Processes all review comments on the PR in one pass. Each comment is triaged as fix (obvious issues), skip (too complex), or reject (incorrect feedback). Fixes get one commit each; a summary comment is posted at the end.
- **Single-comment mode** (`ai_fixxx_single`) — triggered by replying `/ai-fixxx` to a specific review comment (`pull_request_review_comment` event). Optionally accepts user instructions in the reply (e.g. `/ai-fixxx use filepath.Join instead`). Includes 30-second debounce to batch rapid `/ai-fixxx` replies into a single Claude invocation, with dedup against already-addressed comments.

### Workflow features

- **Concurrency groups** — scoped per-PR. Bulk mode cancels in-progress runs on re-trigger; single-comment mode queues runs (debounce handles dedup).
- **npm install caching** — Claude Code global install is cached via `actions/cache@v4`.
- **Fork detection** — aborts if the PR is from a fork (cannot push back).
- **Reactions** — adds 👀 on trigger, 🚀 on success, 😕 on failure.

### Files added

- `.github/workflows/ai-fixxxer.yaml` — workflow definition with both jobs
- `scripts/ai-fixxxer.sh` — script with bulk and single-comment logic, prompt construction, manifest parsing, and inline reply posting

## User-facing documentation

- [x] CHANGELOG.md update is not needed (internal tooling)
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: internal developer tooling, not gated by feature flag

### How I validated my change

- YAML validated with `python3 -c "import yaml; yaml.safe_load(open(...))"`
- Shell validated with `bash -n scripts/ai-fixxxer.sh`
- End-to-end tested on fork (guzalv/stackrox) with demo PRs exercising both bulk and single-comment modes