### PR TITLE
chore(ui-hackathon): replace hardcoded route paths with imports

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginLimited.js
+++ b/ui/apps/platform/eslint-plugins/pluginLimited.js
@@ -672,6 +672,42 @@ const rules = {
             };
         },
     },
+
+    'no-hardcoded-route-paths': {
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    "Route paths must use constants from 'routePaths' instead of hardcoded '/main/...' strings",
+            },
+            schema: [],
+        },
+        create(context) {
+            const routePathPattern = /\/main\//;
+
+            return {
+                Literal(node) {
+                    if (typeof node.value === 'string' && routePathPattern.test(node.value)) {
+                        context.report({
+                            node,
+                            message:
+                                "Import route paths from 'routePaths' instead of hardcoding '/main/...' strings.",
+                        });
+                    }
+                },
+                TemplateLiteral(node) {
+                    const firstQuasi = node.quasis[0];
+                    if (firstQuasi && routePathPattern.test(firstQuasi.value.raw)) {
+                        context.report({
+                            node,
+                            message:
+                                "Import route paths from 'routePaths' instead of hardcoding '/main/...' strings.",
+                        });
+                    }
+                },
+            };
+        },
+    },
 };
 
 // Use limited as key of pluginLimited in eslint.config.js file.

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -1163,6 +1163,16 @@ module.exports = [
         },
     },
     {
+        files: ['src/**/*.{js,jsx,ts,tsx}'],
+        ignores: ['src/**/*.test.*', 'src/**/*.cy.*'],
+        plugins: {
+            limited: pluginLimited,
+        },
+        rules: {
+            'limited/no-hardcoded-route-paths': 'error',
+        },
+    },
+    {
         files: ['*.js', 'tailwind-plugins/*.js'], // non-product files
 
         languageOptions: {

--- a/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AuthProviders/AuthProviderForm.tsx
@@ -34,6 +34,7 @@ import SelectSingle from 'Components/SelectSingle'; // TODO import from where?
 import TraitsOriginLabel from 'Components/TraitsOriginLabel';
 import { selectors } from 'reducers';
 import { actions as authActions } from 'reducers/auth';
+import { accessControlBasePath } from 'routePaths';
 import type { Role } from 'services/RolesService';
 import { getIsAuthProviderImmutable } from 'services/AuthService';
 import type { AuthProvider, AuthProviderInfo, Group } from 'services/AuthService';
@@ -337,7 +338,7 @@ function AuthProviderForm({
                                 <ToolbarGroup variant="action-group">
                                     <ToolbarItem>
                                         <Link
-                                            to="/main/access-control/auth-providers"
+                                            to={`${accessControlBasePath}/auth-providers`}
                                             aria-current="page"
                                             className="pf-v6-u-font-size-sm"
                                         >

--- a/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
+++ b/ui/apps/platform/src/Containers/Administration/Events/AdministrationEventsTable.tsx
@@ -11,6 +11,7 @@ import {
 } from 'services/AdministrationEventsService';
 import type { AdministrationEvent } from 'services/AdministrationEventsService';
 import type { SearchFilter } from 'types/search';
+import { administrationEventsBasePath } from 'routePaths';
 
 import { getLevelIcon, getLevelText } from './AdministrationEvent';
 import AdministrationEventHintMessage from './AdministrationEventHintMessage';
@@ -55,7 +56,9 @@ function AdministrationEventsTable({
                         <Tbody key={id} isExpanded>
                             <Tr style={{ borderBottom: 'none' }}>
                                 <Td dataLabel="Domain" modifier="nowrap">
-                                    <Link to={`/main/administration-events/${id}`}>{domain}</Link>
+                                    <Link to={`${administrationEventsBasePath}/${id}`}>
+                                        {domain}
+                                    </Link>
                                 </Td>
                                 <Td dataLabel="Resource type" modifier="nowrap">
                                     {resourceType}

--- a/ui/apps/platform/src/Containers/Login/LoginPage.jsx
+++ b/ui/apps/platform/src/Containers/Login/LoginPage.jsx
@@ -17,6 +17,7 @@ import ReduxPasswordField from 'Components/forms/ReduxPasswordField';
 import Labeled from 'Components/Labeled';
 import CollapsibleAnimatedDiv from 'Components/animations/CollapsibleAnimatedDiv';
 import BrandLogo from 'Components/PatternFly/BrandLogo';
+import { dashboardPath } from 'routePaths';
 import { loginWithBasicAuth } from 'services/AuthService';
 import { parseAndDecodeFragment } from 'utils/parseAndDecodeFragment';
 
@@ -246,7 +247,7 @@ class LoginPage extends Component {
                 <div className="p-8 w-full text-center">
                     <Link
                         className="p-3 px-6 rounded-sm bg-primary-600 hover:bg-primary-700 text-base-100 text-center no-underline"
-                        to="/main/dashboard"
+                        to={dashboardPath}
                     >
                         Go to Dashboard
                     </Link>

--- a/ui/apps/platform/src/utils/URLGenerator.js
+++ b/ui/apps/platform/src/utils/URLGenerator.js
@@ -4,10 +4,13 @@ import { generatePath } from 'react-router-dom-v5-compat';
 import pageTypes from 'constants/pageTypes';
 import { pagingParams, searchParams, sortParams } from 'constants/searchParams';
 import useCases from 'constants/useCaseTypes';
+
 import {
     clustersBasePath,
     clustersPathWithParam,
+    configManagementPath,
     policiesPath,
+    policyManagementBasePath,
     riskWorkloadPath,
     riskWorkloadsBasePath,
     secretsPath,
@@ -35,13 +38,13 @@ const legacyPathMap = {
     },
     [useCases.SECRET]: {
         [pageTypes.ENTITY]: secretsPath,
-        [pageTypes.LIST]: '/main/configmanagement/secrets',
-        [pageTypes.DASHBOARD]: '/main/configmanagement/secrets',
+        [pageTypes.LIST]: `${configManagementPath}/secrets`,
+        [pageTypes.DASHBOARD]: `${configManagementPath}/secrets`,
     },
     [useCases.POLICY]: {
         [pageTypes.ENTITY]: policiesPath,
-        [pageTypes.LIST]: '/main/policies',
-        [pageTypes.DASHBOARD]: '/main/policies',
+        [pageTypes.LIST]: policyManagementBasePath,
+        [pageTypes.DASHBOARD]: policyManagementBasePath,
     },
 };
 function generateURL(workflowState) {

--- a/ui/apps/platform/src/utils/URLService.js
+++ b/ui/apps/platform/src/utils/URLService.js
@@ -9,7 +9,9 @@ import configMgmtEntityRelationship from 'Containers/ConfigManagement/entityTabR
 import Raven from 'raven-js';
 
 import {
+    configManagementPath,
     policiesPath,
+    policyManagementBasePath,
     riskWorkloadPath,
     riskWorkloadsBasePath,
     secretsPath,
@@ -97,13 +99,13 @@ function getPath(urlParams) {
         },
         [useCases.SECRET]: {
             [pageTypes.ENTITY]: secretsPath,
-            [pageTypes.LIST]: '/main/configmanagement/secrets',
-            [pageTypes.DASHBOARD]: '/main/configmanagement/secrets',
+            [pageTypes.LIST]: `${configManagementPath}/secrets`,
+            [pageTypes.DASHBOARD]: `${configManagementPath}/secrets`,
         },
         [useCases.POLICY]: {
             [pageTypes.ENTITY]: policiesPath,
-            [pageTypes.LIST]: '/main/policies',
-            [pageTypes.DASHBOARD]: '/main/policies',
+            [pageTypes.LIST]: policyManagementBasePath,
+            [pageTypes.DASHBOARD]: policyManagementBasePath,
         },
     };
 


### PR DESCRIPTION
## Description

Replace hardcoded `/main/` path strings in 5 source files with imports from `routePaths.ts`. Add a custom ESLint rule (`no-hardcoded-route-paths`) to prevent future hardcoded paths in source files (excludes unit and component test files).

## Context

This was a prerequisite for some hackathon work that attempts to deterministically detect what cypress tests are affected by a given code change. It is somewhat useful regardless of if we pursue that work, hence a separate PR.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Verified lint rule catches hardcoded `/main/` paths in source files
- Verified lint rule does not apply to `*.test.*` and `*.cy.*` files
- CI
- Manual testing of affected legacy ConfigMgmt/Vulnerabilities pages