### PR TITLE
ROX-34779: fix scan watcher race on sensor reconnection

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stackrox/rox/pkg/queue"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
-	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/timestamp"
@@ -40,6 +39,12 @@ import (
 var (
 	log         = logging.LoggerForModule()
 	maxRequests = 100
+
+	// completedScansTTL is how long a completed scan ID stays in the
+	// completedScans map. It only needs to cover the window between watcher
+	// completion and snapshot persistence in the DB; after that,
+	// GetWatcherIDFromScan's DB query serves as the durable backstop.
+	completedScansTTL = 5 * time.Minute
 )
 
 type reportRequest struct {
@@ -81,9 +86,12 @@ type managerImpl struct {
 	watchingScans map[string]watcher.ScanWatcher
 	// watchingScansStartTime records when a given watcher was started (for the metrics)
 	watchingScansStartTime map[string]time.Time
-	// completedScans tracks watcher IDs that have already completed, preventing
-	// duplicate watcher creation when late scan events arrive after completion.
-	completedScans set.StringSet
+	// completedScans tracks recently completed scan watcher IDs with their
+	// completion time. Entries expire after completedScansTTL. This prevents
+	// duplicate watcher creation in the brief window between watcher completion
+	// and snapshot persistence, without permanently blocking future scan cycles
+	// that reuse the same K8s UID.
+	completedScans map[string]time.Time
 	// readyQueue holds the scan that are ready to be reported
 	readyQueue *queue.Queue[*watcher.ScanWatcherResults]
 
@@ -127,7 +135,7 @@ func New(scanConfigDS scanConfigurationDS.DataStore,
 		automaticReportingCtx:  sac.WithAllAccess(context.Background()),
 		watchingScans:          make(map[string]watcher.ScanWatcher),
 		watchingScansStartTime: make(map[string]time.Time),
-		completedScans:         set.NewStringSet(),
+		completedScans:         make(map[string]time.Time),
 		readyQueue:             queue.NewQueue[*watcher.ScanWatcherResults](),
 		watchingScanConfigs:    make(map[string]watcher.ScanConfigWatcher),
 		scanConfigReadyQueue:   queue.NewQueue[*watcher.ScanConfigWatcherResults](),
@@ -201,6 +209,7 @@ func (m *managerImpl) Stop() {
 		}
 		m.watchingScans = make(map[string]watcher.ScanWatcher)
 		m.watchingScansStartTime = make(map[string]time.Time)
+		m.completedScans = make(map[string]time.Time)
 	})
 	concurrency.WithLock(&m.watchingScanConfigsLock, func() {
 		for _, scanConfigWatcher := range m.watchingScanConfigs {
@@ -425,6 +434,7 @@ func (m *managerImpl) HandleScanRemove(scanID string) error {
 		if scanWatcher, found := m.watchingScans[id]; found {
 			scanWatcher.Stop(watcher.ErrScanRemoved)
 		}
+		delete(m.completedScans, id)
 	})
 	return nil
 }
@@ -432,12 +442,22 @@ func (m *managerImpl) HandleScanRemove(scanID string) error {
 func (m *managerImpl) getWatcher(sensorCtx context.Context, id string) watcher.ScanWatcher {
 	var scanWatcher watcher.ScanWatcher
 	concurrency.WithLock(&m.watchingScansLock, func() {
+		// Lazily purge expired entries from completedScans.
+		now := time.Now()
+		for k, completedAt := range m.completedScans {
+			if now.Sub(completedAt) >= completedScansTTL {
+				delete(m.completedScans, k)
+			}
+		}
+
 		var found bool
-		if scanWatcher, found = m.watchingScans[id]; !found && !m.completedScans.Contains(id) {
-			scanWatcher = watcher.NewScanWatcher(m.automaticReportingCtx, sensorCtx, id, m.readyQueue)
-			m.watchingScans[id] = scanWatcher
-			m.watchingScansStartTime[id] = time.Now()
-			m.updateMaxNumScansRunningInParallelNoLock()
+		if scanWatcher, found = m.watchingScans[id]; !found {
+			if _, recentlyCompleted := m.completedScans[id]; !recentlyCompleted {
+				scanWatcher = watcher.NewScanWatcher(m.automaticReportingCtx, sensorCtx, id, m.readyQueue)
+				m.watchingScans[id] = scanWatcher
+				m.watchingScansStartTime[id] = time.Now()
+				m.updateMaxNumScansRunningInParallelNoLock()
+			}
 		}
 	})
 	return scanWatcher
@@ -480,7 +500,7 @@ func (m *managerImpl) handleReadyScan() {
 	for scanWatcherResult := range m.readyQueue.Seq(m.stopper.LowLevel().GetStopRequestSignal()) {
 		concurrency.WithLock(&m.watchingScansLock, func() {
 			delete(m.watchingScans, scanWatcherResult.WatcherID)
-			m.completedScans.Add(scanWatcherResult.WatcherID)
+			m.completedScans[scanWatcherResult.WatcherID] = time.Now()
 
 			m.maxScansInParallel.Store(int32(len(m.watchingScans)))
 			timeActive := time.Since(m.watchingScansStartTime[scanWatcherResult.WatcherID])

--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stackrox/rox/pkg/queue"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/stringutils"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/timestamp"
@@ -80,6 +81,9 @@ type managerImpl struct {
 	watchingScans map[string]watcher.ScanWatcher
 	// watchingScansStartTime records when a given watcher was started (for the metrics)
 	watchingScansStartTime map[string]time.Time
+	// completedScans tracks watcher IDs that have already completed, preventing
+	// duplicate watcher creation when late scan events arrive after completion.
+	completedScans set.StringSet
 	// readyQueue holds the scan that are ready to be reported
 	readyQueue *queue.Queue[*watcher.ScanWatcherResults]
 
@@ -123,6 +127,7 @@ func New(scanConfigDS scanConfigurationDS.DataStore,
 		automaticReportingCtx:  sac.WithAllAccess(context.Background()),
 		watchingScans:          make(map[string]watcher.ScanWatcher),
 		watchingScansStartTime: make(map[string]time.Time),
+		completedScans:         set.NewStringSet(),
 		readyQueue:             queue.NewQueue[*watcher.ScanWatcherResults](),
 		watchingScanConfigs:    make(map[string]watcher.ScanConfigWatcher),
 		scanConfigReadyQueue:   queue.NewQueue[*watcher.ScanConfigWatcherResults](),
@@ -370,11 +375,7 @@ func (m *managerImpl) HandleScan(sensorCtx context.Context, scan *storage.Compli
 		}
 		return err
 	}
-	numChecks, err := watcher.GetExpectedNumChecks(scan)
-	if err != nil {
-		log.Warnf("Failed to get expected number of checks from annotations for %s: %v", scan.GetScanName(), err)
-	}
-	w := m.getWatcher(sensorCtx, id, numChecks)
+	w := m.getWatcher(sensorCtx, id)
 	if w != nil {
 		return w.PushScan(scan)
 	}
@@ -428,16 +429,11 @@ func (m *managerImpl) HandleScanRemove(scanID string) error {
 	return nil
 }
 
-func (m *managerImpl) getWatcher(sensorCtx context.Context, id string, numChecks int) watcher.ScanWatcher {
+func (m *managerImpl) getWatcher(sensorCtx context.Context, id string) watcher.ScanWatcher {
 	var scanWatcher watcher.ScanWatcher
 	concurrency.WithLock(&m.watchingScansLock, func() {
 		var found bool
-		// The check for `numChecks == 0` is here to prevent starting a watcher twice per scan.
-		// It may happen that additional status updates (e.g., state) from CO arrive
-		// after the watcher is removed from the watchingScans (i.e., we have all the checks).
-		// Not checking that would cause a new watcher to be created here and in some circumstances
-		// (when no e-mail is provided for notification), the watcher would time-out and delete the data from DB.
-		if scanWatcher, found = m.watchingScans[id]; !found && numChecks == 0 {
+		if scanWatcher, found = m.watchingScans[id]; !found && !m.completedScans.Contains(id) {
 			scanWatcher = watcher.NewScanWatcher(m.automaticReportingCtx, sensorCtx, id, m.readyQueue)
 			m.watchingScans[id] = scanWatcher
 			m.watchingScansStartTime[id] = time.Now()
@@ -468,7 +464,7 @@ func (m *managerImpl) HandleResult(sensorCtx context.Context, result *storage.Co
 		}
 		return err
 	}
-	w := m.getWatcher(sensorCtx, id, 0)
+	w := m.getWatcher(sensorCtx, id)
 	if w != nil {
 		return w.PushCheckResult(result)
 	}
@@ -484,6 +480,7 @@ func (m *managerImpl) handleReadyScan() {
 	for scanWatcherResult := range m.readyQueue.Seq(m.stopper.LowLevel().GetStopRequestSignal()) {
 		concurrency.WithLock(&m.watchingScansLock, func() {
 			delete(m.watchingScans, scanWatcherResult.WatcherID)
+			m.completedScans.Add(scanWatcherResult.WatcherID)
 
 			m.maxScansInParallel.Store(int32(len(m.watchingScans)))
 			timeActive := time.Since(m.watchingScansStartTime[scanWatcherResult.WatcherID])

--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -433,6 +433,188 @@ func (m *ManagerTestSuite) TestHandleScan() {
 	})
 }
 
+func (m *ManagerTestSuite) TestCompletedScansBlocksWatcherWithinTTL() {
+	m.scanConfigDataStore.EXPECT().GetScanConfigurations(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorScanConfigurationV2{{Id: "scan-config-id"}}, nil)
+	m.snapshotDataStore.EXPECT().SearchSnapshots(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorReportSnapshotV2{}, nil)
+
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+	impl := manager.(*managerImpl)
+
+	scan := &storage.ComplianceOperatorScanV2{
+		Id:              "scan-id",
+		ClusterId:       "cluster-id",
+		LastStartedTime: protocompat.TimestampNow(),
+	}
+
+	// Create and verify the first watcher exists.
+	err := manager.HandleScan(context.Background(), scan)
+	m.Require().NoError(err)
+	id, err := watcher.GetWatcherIDFromScan(context.Background(), scan, m.snapshotDataStore, m.scanConfigDataStore, nil)
+	m.Require().NoError(err)
+
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		m.Require().Contains(impl.watchingScans, id)
+	})
+
+	// Simulate watcher completion: remove from watchingScans, add to completedScans.
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		w := impl.watchingScans[id]
+		w.Stop(nil)
+		<-w.Finished().Done()
+		delete(impl.watchingScans, id)
+		impl.completedScans[id] = time.Now()
+	})
+
+	// Attempting to create a watcher for the same ID should be blocked.
+	err = manager.HandleScan(context.Background(), scan)
+	m.Require().NoError(err)
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		_, found := impl.watchingScans[id]
+		m.Assert().False(found, "watcher should NOT be created while completedScans entry is within TTL")
+	})
+}
+
+func (m *ManagerTestSuite) TestCompletedScansAllowsWatcherAfterTTL() {
+	m.scanConfigDataStore.EXPECT().GetScanConfigurations(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorScanConfigurationV2{{Id: "scan-config-id"}}, nil)
+	m.snapshotDataStore.EXPECT().SearchSnapshots(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorReportSnapshotV2{}, nil)
+
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+	impl := manager.(*managerImpl)
+
+	scan := &storage.ComplianceOperatorScanV2{
+		Id:              "scan-id",
+		ClusterId:       "cluster-id",
+		LastStartedTime: protocompat.TimestampNow(),
+	}
+
+	id, err := watcher.GetWatcherIDFromScan(context.Background(), scan, m.snapshotDataStore, m.scanConfigDataStore, nil)
+	m.Require().NoError(err)
+
+	// Simulate a completion entry that is already expired.
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		impl.completedScans[id] = time.Now().Add(-completedScansTTL - time.Second)
+	})
+
+	// A new watcher should be created because the entry has expired.
+	err = manager.HandleScan(context.Background(), scan)
+	m.Require().NoError(err)
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		w, found := impl.watchingScans[id]
+		m.Assert().True(found, "watcher should be created after completedScans entry expires")
+		m.Assert().NotNil(w)
+		// Clean up watcher
+		w.Stop(nil)
+		<-w.Finished().Done()
+		delete(impl.watchingScans, id)
+	})
+}
+
+// TestScanWatcherLifecycleAcrossCycles verifies that a scan watcher is created
+// for a second scan cycle that reuses the same scan K8s UID, after the first
+// cycle's watcher completes and the completedScans TTL expires. This is the
+// exact scenario that the completedScans TTL guards against: the Compliance
+// Operator reuses ComplianceScan objects (same UID) across cycles, and without
+// TTL-bounded expiry the completedScans set would permanently block all
+// subsequent cycles.
+func (m *ManagerTestSuite) TestScanWatcherLifecycleAcrossCycles() {
+	m.scanConfigDataStore.EXPECT().GetScanConfigurations(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorScanConfigurationV2{{Id: "scan-config-id"}}, nil)
+	m.snapshotDataStore.EXPECT().SearchSnapshots(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorReportSnapshotV2{}, nil)
+
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+	impl := manager.(*managerImpl)
+
+	scanID := "ocp4-cis-uid-abc"
+	clusterID := "cluster-1"
+	scan := &storage.ComplianceOperatorScanV2{
+		Id:              scanID,
+		ClusterId:       clusterID,
+		LastStartedTime: protocompat.TimestampNow(),
+		ScanConfigName:  "test-scan",
+	}
+	watcherID := fmt.Sprintf("%s:%s", clusterID, scanID)
+
+	// --- Cycle 1: Create watcher, push scan, simulate completion ---
+
+	m.Require().NoError(manager.HandleScan(context.Background(), scan))
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		w, found := impl.watchingScans[watcherID]
+		m.Require().True(found, "cycle 1: watcher must be created")
+		m.Require().NotNil(w)
+	})
+
+	// Simulate the watcher completing: stop it, remove from watchingScans,
+	// add to completedScans — this mirrors what handleReadyScan does.
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		w := impl.watchingScans[watcherID]
+		w.Stop(nil)
+		<-w.Finished().Done()
+		delete(impl.watchingScans, watcherID)
+		impl.completedScans[watcherID] = time.Now()
+	})
+
+	// Verify the watcher is blocked immediately after completion.
+	m.Require().NoError(manager.HandleScan(context.Background(), scan))
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		_, found := impl.watchingScans[watcherID]
+		m.Assert().False(found, "watcher should be blocked by completedScans within TTL")
+	})
+
+	// --- Cycle 2: Same UID, after TTL expires ---
+
+	// Simulate TTL expiry by backdating the completedScans entry.
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		impl.completedScans[watcherID] = time.Now().Add(-completedScansTTL - time.Second)
+	})
+
+	// The same scan UID should now be allowed to create a new watcher.
+	m.Require().NoError(manager.HandleScan(context.Background(), scan))
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		w, found := impl.watchingScans[watcherID]
+		m.Assert().True(found, "cycle 2: watcher must be created after TTL expires")
+		m.Assert().NotNil(w)
+		// Verify the expired entry was cleaned up.
+		_, stillInCompleted := impl.completedScans[watcherID]
+		m.Assert().False(stillInCompleted, "expired entry should be purged by lazy cleanup")
+		// Clean up
+		w.Stop(nil)
+		<-w.Finished().Done()
+		delete(impl.watchingScans, watcherID)
+	})
+}
+
+func (m *ManagerTestSuite) TestHandleScanRemoveCleanupCompletedScans() {
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+	impl := manager.(*managerImpl)
+
+	scan := &storage.ComplianceOperatorScanV2{
+		Id:              "scan-1",
+		ClusterId:       "cluster-id",
+		LastStartedTime: protocompat.TimestampNow(),
+	}
+	id := fmt.Sprintf("%s:%s", scan.GetClusterId(), scan.GetId())
+
+	// Seed a completedScans entry.
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		impl.completedScans[id] = time.Now()
+	})
+
+	m.scanDataStore.EXPECT().GetScan(gomock.Any(), gomock.Any()).Times(1).Return(scan, true, nil)
+
+	err := manager.HandleScanRemove("scan-1")
+	m.Require().NoError(err)
+
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		_, found := impl.completedScans[id]
+		m.Assert().False(found, "HandleScanRemove should clear completedScans entry")
+	})
+}
+
 func (m *ManagerTestSuite) TestHandleScanRemove() {
 	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
 	managerImplementation, ok := manager.(*managerImpl)


### PR DESCRIPTION
## Description

**Problem:** On sensor reconnection, scan events arrive in their final DONE state with the `check-count` annotation already set. The `getWatcher()` guard `!found && numChecks == 0` refused to create a watcher when `numChecks > 0`, silently dropping the scan event. Check results processed on a separate goroutine then created a watcher with `totalChecks=0`, which could never complete and always timed out.

This is the root cause of compliance scan watcher timeouts that lead to clusters disappearing from the compliance coverage dashboard. Reproduced on a real cluster and confirmed in customer diagnostic logs.

**Root cause:** `getWatcher()` at `manager_impl.go` uses `numChecks == 0` as a proxy for "this is the first event for this scan." On sensor reconnection, the first event is a completed scan with the annotation already present (`numChecks > 0`), so the guard rejects it. The scan and result pipelines run on separate worker queues with no ordering guarantee, creating a race condition.

**Fix:** Replace the `numChecks == 0` guard with a TTL-bounded `completedScans` map (`map[string]time.Time`, 5-minute TTL). This preserves the original intent (no duplicate watchers after completion) while allowing initial watcher creation regardless of annotation state. The TTL prevents the map from permanently blocking future scan cycles — the Compliance Operator reuses ComplianceScan K8s objects (same UID) across cycles, so a permanent set would silently break all reporting after the first cycle.

**Why TTL-bounded, not permanent:** `GetWatcherIDFromScan`'s DB snapshot query is the durable backstop. The `completedScans` map only needs to cover the brief window (~seconds) between watcher completion and snapshot persistence.

**Alternative considered:** Removing the guard entirely. Rejected because the snapshot write is not instantaneous — a brief window exists where a duplicate watcher could be created before the snapshot lands in the DB.

**Stacked on:** logging improvements in earlier commits on this branch.

### Cluster verification (2026-06-12, ga-ocp4-cron)

**Before (master `4.12.x-164-ga76806e189`):** Trigger scan, wait for completion, restart sensor. Central logs:
```
Timeout waiting for the scan ...45fce3f6... to finish. Received 48/0 check results
Timeout waiting for the scan ...c75a2da8... to finish. Received 12/0 check results
```
Pattern: `N/0` — check results arrived but `totalChecks` was never set.

**After (patched binary with TTL-bounded completedScans):** Same scenario. Central logs:
```
Scan config repro-test completed with 1 scans, 0 reports, error: <nil>
```
Zero timeout errors. Scan watcher completed successfully after sensor reconnection.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- 4 new unit tests covering TTL-bounded completedScans behavior:
  - `TestCompletedScansBlocksWatcherWithinTTL` — watcher blocked within TTL
  - `TestCompletedScansAllowsWatcherAfterTTL` — watcher allowed after TTL expires
  - `TestScanWatcherLifecycleAcrossCycles` — full two-cycle test with same UID
  - `TestHandleScanRemoveCleanupCompletedScans` — HandleScanRemove clears entries
- All 15 existing tests pass (1 pre-existing skip: ROX-30838)
- Verified on ga-ocp4-cron cluster (see above): before/after sensor reconnection