### PR TITLE
fix: add placeholder fields for empty GraphQL types

### DIFF
--- a/central/graphql/generator/codegen/codegen.go
+++ b/central/graphql/generator/codegen/codegen.go
@@ -124,16 +124,17 @@ func GenerateResolvers(parameters generator.TypeWalkParameters, writer io.Writer
 	typeData := typeWalk(parameters)
 	rootTemplate := template.New("codegen")
 	rootTemplate.Funcs(template.FuncMap{
-		"importedName": importedName,
-		"isEnum":       isEnum,
-		"listField":    listField,
-		"listName":     listName,
-		"lower":        lower,
-		"nonListField": func(td schemaEntry, field fieldData) bool { return !listField(td, field) },
-		"plural":       plural,
-		"translator":   translator(rootTemplate),
-		"valueType":    valueType,
-		"schemaType":   schemaType,
+		"importedName":    importedName,
+		"isEnum":          isEnum,
+		"listField":       listField,
+		"listName":        listName,
+		"lower":           lower,
+		"nonListField":    func(td schemaEntry, field fieldData) bool { return !listField(td, field) },
+		"plural":          plural,
+		"translator":      translator(rootTemplate),
+		"valueType":       valueType,
+		"hasSchemaFields": hasSchemaFields,
+		"schemaType":      schemaType,
 	})
 	for name, text := range templates {
 		thisTemplate := rootTemplate

--- a/central/graphql/generator/codegen/codegen.go.tpl
+++ b/central/graphql/generator/codegen/codegen.go.tpl
@@ -35,6 +35,9 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 {{- range $td.Data.UnionData }}
 		"{{lower .Name }}: {{ $td.Data.Name }}{{.Name}}",
 {{- end }}
+{{- if not (hasSchemaFields $td) }}
+		"_unused: Boolean",
+{{- end }}
 	}))
 {{- range $ud := $td.Data.UnionData }}
 	utils.Must(builder.AddUnionType("{{ $td.Data.Name }}{{ $ud.Name }}", []string{
@@ -143,6 +146,11 @@ func (resolver *{{lower $td.Data.Name}}Resolver) {{ $fd.Name }}(ctx context.Cont
 }
 {{end -}}
 {{end}}
+{{- if not (hasSchemaFields $td) }}
+func (resolver *{{lower $td.Data.Name}}Resolver) Unused() *bool {
+	return nil
+}
+{{end -}}
 {{- range $ud := $td.Data.UnionData}}
 type {{lower $td.Data.Name}}{{$ud.Name}}Resolver struct {
 	resolver interface{}

--- a/central/graphql/generator/codegen/schema.go
+++ b/central/graphql/generator/codegen/schema.go
@@ -71,6 +71,23 @@ func schemaType(fd fieldData) string {
 	return schemaExpand(fd.Type)
 }
 
+// hasSchemaFields reports whether the entry will produce at least one GraphQL field.
+// GraphQL spec requires every object type to define one or more fields.
+func hasSchemaFields(entry schemaEntry) bool {
+	for _, fd := range entry.Data.FieldData {
+		if schemaType(fd) != "" {
+			return true
+		}
+	}
+	return len(entry.Data.UnionData) > 0
+}
+
+// TODO(ROX-34963): Add support for []byte fields in GraphQL schema generation.
+// Proto fields of type `bytes` (Go []byte) are silently dropped because uint8
+// has no GraphQL scalar mapping, causing types like CosignSignature to appear
+// empty. A proper fix would map []byte to a String scalar (base64-encoded) and
+// update the resolver codegen to emit encoding/decoding wrappers.
+
 func schemaExpand(p reflect.Type) string {
 	switch p.Kind() {
 	case reflect.String:

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -568,6 +568,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 	}))
 	generator.RegisterProtoEnum(builder, reflect.TypeOf(storage.ContainerType(0)))
 	utils.Must(builder.AddType("CosignSignature", []string{
+		"_unused: Boolean",
 	}))
 	utils.Must(builder.AddType("DataSource", []string{
 		"id: ID!",
@@ -661,6 +662,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"name: String!",
 	}))
 	utils.Must(builder.AddType("FalsePositiveRequest", []string{
+		"_unused: Boolean",
 	}))
 	utils.Must(builder.AddInput("FalsePositiveVulnRequest", []string{
 		"comment: String",
@@ -707,6 +709,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"runs: [ComplianceRun]!",
 	}))
 	utils.Must(builder.AddType("GetPermissionsResponse", []string{
+		"_unused: Boolean",
 	}))
 	utils.Must(builder.AddType("GoogleProviderMetadata", []string{
 		"clusterName: String!",
@@ -1568,6 +1571,7 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 		"VulnerabilityRequest_Scope_Global",
 	}))
 	utils.Must(builder.AddType("VulnerabilityRequest_Scope_Global", []string{
+		"_unused: Boolean",
 	}))
 	utils.Must(builder.AddType("VulnerabilityRequest_Scope_Image", []string{
 		"registry: String!",
@@ -7039,6 +7043,10 @@ func (resolver *cosignSignatureResolver) SignaturePayload(ctx context.Context) [
 	return value
 }
 
+func (resolver *cosignSignatureResolver) Unused() *bool {
+	return nil
+}
+
 type dataSourceResolver struct {
 	ctx  context.Context
 	root *Resolver
@@ -8013,6 +8021,10 @@ func (resolver *Resolver) wrapFalsePositiveRequestsWithContext(ctx context.Conte
 	return output, nil
 }
 
+func (resolver *falsePositiveRequestResolver) Unused() *bool {
+	return nil
+}
+
 type fileAccessResolver struct {
 	ctx  context.Context
 	root *Resolver
@@ -8453,6 +8465,10 @@ func (resolver *Resolver) wrapGetPermissionsResponsesWithContext(ctx context.Con
 		output[i] = &getPermissionsResponseResolver{ctx: ctx, root: resolver, data: v}
 	}
 	return output, nil
+}
+
+func (resolver *getPermissionsResponseResolver) Unused() *bool {
+	return nil
 }
 
 type googleProviderMetadataResolver struct {
@@ -16803,6 +16819,10 @@ func (resolver *Resolver) wrapVulnerabilityRequest_Scope_GlobalsWithContext(ctx 
 		output[i] = &vulnerabilityRequest_Scope_GlobalResolver{ctx: ctx, root: resolver, data: v}
 	}
 	return output, nil
+}
+
+func (resolver *vulnerabilityRequest_Scope_GlobalResolver) Unused() *bool {
+	return nil
 }
 
 type vulnerabilityRequest_Scope_ImageResolver struct {


### PR DESCRIPTION
## Description

graphql-go v1.7.1 added strict enforcement of the GraphQL spec rule that every object type must define at least one field. Bumping from v1.5.0 to v1.10.2 (PR #20714) causes schema parsing to fail for types that end up with zero fields after codegen.

Three types are affected:
- `FalsePositiveRequest` - empty proto message
- `VulnerabilityRequest_Scope_Global` - empty proto message (oneof discriminator)
- `CosignSignature` - all 5 fields are `bytes` type, which has no GraphQL scalar mapping, so they are silently dropped

The codegen now detects empty types and injects a placeholder `_unused: Boolean` field with a nil-returning resolver.

A fourth type, `GetPermissionsResponse` is also updated. It was empty at codegen time (its only field is a map with an unsupported value type) but gets a field added at runtime via `AddExtraResolver` in `central/graphql/resolvers/roles.go`. The placeholder is harmless there - the type ends up with both `_unused` and the runtime-added field.



## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

CI is sufficient.
