### PR TITLE
feat(sensor): add sensor-bench profiling harness

### DIFF
--- a/sensor/debugger/k8s/k8sclient.go
+++ b/sensor/debugger/k8s/k8sclient.go
@@ -32,6 +32,11 @@ func MakeFakeClient() *ClientSet {
 	}
 }
 
+// SetDynamic sets the dynamic client on the ClientSet.
+func (c *ClientSet) SetDynamic(d dynamic.Interface) {
+	c.dynamic = d
+}
+
 // MakeFakeClientFromRest creates a k8s client from rest.Config
 func MakeFakeClientFromRest(restConfig *rest.Config) *ClientSet {
 	client, err := kubernetes.NewForConfig(restConfig)

--- a/tools/sensor-bench/collector.go
+++ b/tools/sensor-bench/collector.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+const (
+	pprofBaseURL = "http://127.0.0.1:6060"
+	metricsURL   = "http://localhost:9090/metrics"
+)
+
+type RunMetadata struct {
+	Config    *Config   `json:"config"`
+	StartTime time.Time `json:"startTime"`
+	EndTime   time.Time `json:"endTime"`
+	Duration  string    `json:"duration"`
+}
+
+func collectProfiles(outputDir string) error {
+	profiles := map[string]string{
+		"heap.pb.gz":      pprofBaseURL + "/debug/heap",
+		"goroutine.pb.gz": pprofBaseURL + "/debug/goroutine",
+	}
+	for filename, url := range profiles {
+		if err := downloadToFile(url, filepath.Join(outputDir, filename)); err != nil {
+			return fmt.Errorf("collecting %s: %w", filename, err)
+		}
+	}
+	return nil
+}
+
+func collectMetrics(outputDir string) error {
+	resp, err := http.Get(metricsURL)
+	if err != nil {
+		return fmt.Errorf("fetching metrics: %w", err)
+	}
+	defer resp.Body.Close()
+
+	dec := expfmt.NewDecoder(resp.Body, expfmt.NewFormat(expfmt.TypeTextPlain))
+	families := make(map[string]*dto.MetricFamily)
+	for {
+		var mf dto.MetricFamily
+		if err := dec.Decode(&mf); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("decoding metrics: %w", err)
+		}
+		families[mf.GetName()] = &mf
+	}
+
+	flat := flattenMetrics(families)
+
+	data, err := json.MarshalIndent(flat, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling metrics: %w", err)
+	}
+
+	return os.WriteFile(filepath.Join(outputDir, "metrics.json"), data, 0644)
+}
+
+func writeRunMetadata(outputDir string, cfg *Config, start, end time.Time) error {
+	meta := RunMetadata{
+		Config:    cfg,
+		StartTime: start,
+		EndTime:   end,
+		Duration:  end.Sub(start).String(),
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling run metadata: %w", err)
+	}
+	return os.WriteFile(filepath.Join(outputDir, "run.json"), data, 0644)
+}
+
+func downloadToFile(url, path string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+type MetricValue struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels,omitempty"`
+	Value  float64           `json:"value"`
+}
+
+func flattenMetrics(families map[string]*dto.MetricFamily) []MetricValue {
+	var result []MetricValue
+	for name, family := range families {
+		for _, m := range family.GetMetric() {
+			labels := make(map[string]string)
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+
+			var value float64
+			switch family.GetType() {
+			case dto.MetricType_COUNTER:
+				value = m.GetCounter().GetValue()
+			case dto.MetricType_GAUGE:
+				value = m.GetGauge().GetValue()
+			case dto.MetricType_SUMMARY:
+				value = m.GetSummary().GetSampleSum()
+			case dto.MetricType_HISTOGRAM:
+				value = m.GetHistogram().GetSampleSum()
+			case dto.MetricType_UNTYPED:
+				value = m.GetUntyped().GetValue()
+			}
+
+			result = append(result, MetricValue{
+				Name:   name,
+				Labels: labels,
+				Value:  value,
+			})
+		}
+	}
+	return result
+}

--- a/tools/sensor-bench/completion.go
+++ b/tools/sensor-bench/completion.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/concurrency"
+	centralDebug "github.com/stackrox/rox/sensor/debugger/central"
+)
+
+type Condition interface {
+	Check(msg *central.MsgFromSensor)
+	Met() bool
+	String() string
+}
+
+type CompletionChecker struct {
+	conditions []Condition
+	Done       concurrency.Signal
+}
+
+func NewCompletionChecker(cfg *Config, fakeCentral *centralDebug.FakeService) (*CompletionChecker, error) {
+	cc := &CompletionChecker{
+		Done: concurrency.NewSignal(),
+	}
+
+	for _, condCfg := range cfg.Completion.Conditions {
+		cond, err := buildCondition(condCfg)
+		if err != nil {
+			return nil, err
+		}
+		cc.conditions = append(cc.conditions, cond)
+	}
+
+	fakeCentral.OnMessage(func(msg *central.MsgFromSensor) {
+		for _, c := range cc.conditions {
+			c.Check(msg)
+		}
+		if cc.allMet() {
+			cc.Done.Signal()
+		}
+	})
+
+	return cc, nil
+}
+
+func (cc *CompletionChecker) allMet() bool {
+	for _, c := range cc.conditions {
+		if !c.Met() {
+			return false
+		}
+	}
+	return true
+}
+
+func buildCondition(cfg ConditionConfig) (Condition, error) {
+	switch cfg.Type {
+	case "deploymentCount":
+		return &deploymentCountCondition{target: cfg.Count}, nil
+	case "deploymentField":
+		return newDeploymentFieldCondition(cfg)
+	default:
+		return nil, fmt.Errorf("unknown condition type: %s", cfg.Type)
+	}
+}
+
+type deploymentCountCondition struct {
+	target int
+	seen   int
+}
+
+func (c *deploymentCountCondition) Check(msg *central.MsgFromSensor) {
+	if msg.GetEvent().GetDeployment() != nil {
+		c.seen++
+	}
+}
+
+func (c *deploymentCountCondition) Met() bool {
+	return c.seen >= c.target
+}
+
+func (c *deploymentCountCondition) String() string {
+	return fmt.Sprintf("deploymentCount: %d/%d", c.seen, c.target)
+}
+
+type deploymentFieldCondition struct {
+	field   string
+	value   string
+	target  int
+	matched int
+}
+
+func newDeploymentFieldCondition(cfg ConditionConfig) (*deploymentFieldCondition, error) {
+	switch cfg.Field {
+	case "permissionLevel", "exposure":
+	default:
+		return nil, fmt.Errorf("unsupported deployment field: %s", cfg.Field)
+	}
+	return &deploymentFieldCondition{
+		field:  cfg.Field,
+		value:  cfg.Value,
+		target: cfg.Count,
+	}, nil
+}
+
+func (c *deploymentFieldCondition) Check(msg *central.MsgFromSensor) {
+	dep := msg.GetEvent().GetDeployment()
+	if dep == nil {
+		return
+	}
+	if c.matches(dep) {
+		c.matched++
+	}
+}
+
+func (c *deploymentFieldCondition) matches(dep *storage.Deployment) bool {
+	switch c.field {
+	case "permissionLevel":
+		return strings.EqualFold(dep.GetServiceAccountPermissionLevel().String(), c.value)
+	case "exposure":
+		for _, port := range dep.GetPorts() {
+			if strings.EqualFold(port.GetExposure().String(), c.value) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+func (c *deploymentFieldCondition) Met() bool {
+	return c.matched >= c.target
+}
+
+func (c *deploymentFieldCondition) String() string {
+	return fmt.Sprintf("deploymentField(%s=%s): %d/%d", c.field, c.value, c.matched, c.target)
+}

--- a/tools/sensor-bench/config.go
+++ b/tools/sensor-bench/config.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"go.yaml.in/yaml/v3"
+)
+
+type Config struct {
+	Workload   WorkloadConfig   `yaml:"workload"`
+	Policies   PoliciesConfig   `yaml:"policies"`
+	Completion CompletionConfig `yaml:"completion"`
+}
+
+type WorkloadConfig struct {
+	Namespaces   int               `yaml:"namespaces"`
+	Deployments  DeploymentConfig  `yaml:"deployments"`
+	Roles        RoleConfig        `yaml:"roles"`
+	RoleBindings RoleBindingConfig `yaml:"roleBindings"`
+	Services     ServiceConfig     `yaml:"services"`
+}
+
+type DeploymentConfig struct {
+	Count          int    `yaml:"count"`
+	Containers     int    `yaml:"containers"`
+	Image          string `yaml:"image"`
+	ServiceAccount string `yaml:"serviceAccount"`
+}
+
+type RoleConfig struct {
+	Count       int      `yaml:"count"`
+	ClusterWide bool     `yaml:"clusterWide"`
+	Verbs       []string `yaml:"verbs"`
+}
+
+type RoleBindingConfig struct {
+	Count int `yaml:"count"`
+}
+
+type ServiceConfig struct {
+	Count int    `yaml:"count"`
+	Type  string `yaml:"type"`
+}
+
+type PoliciesConfig struct {
+	UseDefaults bool `yaml:"useDefaults"`
+}
+
+type CompletionConfig struct {
+	Timeout    time.Duration     `yaml:"timeout"`
+	Conditions []ConditionConfig `yaml:"conditions"`
+}
+
+type ConditionConfig struct {
+	Type  string `yaml:"type"`
+	Field string `yaml:"field"`
+	Value string `yaml:"value"`
+	Count int    `yaml:"count"`
+}
+
+func loadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+	cfg := &Config{}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+	applyDefaults(cfg)
+	if err := validate(cfg); err != nil {
+		return nil, fmt.Errorf("validating config: %w", err)
+	}
+	return cfg, nil
+}
+
+func applyDefaults(cfg *Config) {
+	if cfg.Workload.Namespaces == 0 {
+		cfg.Workload.Namespaces = 1
+	}
+	if cfg.Workload.Deployments.Containers == 0 {
+		cfg.Workload.Deployments.Containers = 1
+	}
+	if cfg.Workload.Deployments.Image == "" {
+		cfg.Workload.Deployments.Image = "nginx:1.25"
+	}
+	if cfg.Workload.Deployments.ServiceAccount == "" {
+		cfg.Workload.Deployments.ServiceAccount = "default"
+	}
+	if len(cfg.Workload.Roles.Verbs) == 0 {
+		cfg.Workload.Roles.Verbs = []string{"get", "list"}
+	}
+	if cfg.Workload.Services.Type == "" {
+		cfg.Workload.Services.Type = "ClusterIP"
+	}
+	if cfg.Completion.Timeout == 0 {
+		cfg.Completion.Timeout = 120 * time.Second
+	}
+}
+
+func validate(cfg *Config) error {
+	if cfg.Workload.Deployments.Count == 0 {
+		return fmt.Errorf("workload.deployments.count must be > 0")
+	}
+	switch cfg.Workload.Services.Type {
+	case "ClusterIP", "NodePort", "LoadBalancer":
+	default:
+		return fmt.Errorf("invalid service type %q: must be ClusterIP, NodePort, or LoadBalancer", cfg.Workload.Services.Type)
+	}
+	if len(cfg.Completion.Conditions) == 0 {
+		return fmt.Errorf("at least one completion condition is required")
+	}
+	for i, c := range cfg.Completion.Conditions {
+		switch c.Type {
+		case "deploymentCount", "deploymentField":
+		default:
+			return fmt.Errorf("condition[%d]: unknown type %q", i, c.Type)
+		}
+		if c.Count <= 0 {
+			return fmt.Errorf("condition[%d]: count must be > 0", i)
+		}
+		if c.Type == "deploymentField" && c.Field == "" {
+			return fmt.Errorf("condition[%d]: deploymentField requires a field name", i)
+		}
+	}
+	return nil
+}

--- a/tools/sensor-bench/harness.go
+++ b/tools/sensor-bench/harness.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/defaults/policies"
+	"github.com/stackrox/rox/pkg/metrics"
+	"github.com/stackrox/rox/pkg/utils"
+	"github.com/stackrox/rox/sensor/common/clusterid"
+	sensorCommon "github.com/stackrox/rox/sensor/common/sensor"
+	centralDebug "github.com/stackrox/rox/sensor/debugger/central"
+	"github.com/stackrox/rox/sensor/debugger/k8s"
+	"github.com/stackrox/rox/sensor/debugger/message"
+	sensorKit "github.com/stackrox/rox/sensor/kubernetes/sensor"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakeDynamic "k8s.io/client-go/dynamic/fake"
+)
+
+type Harness struct {
+	FakeCentral *centralDebug.FakeService
+	FakeClient  *k8s.ClientSet
+
+	sensorInstance *sensorCommon.Sensor
+	grpcServer     *grpc.Server
+	listener       *bufconn.Listener
+}
+
+func NewHarness(cfg *Config) (*Harness, error) {
+	if err := setupCertEnv(); err != nil {
+		return nil, fmt.Errorf("setting up cert env: %w", err)
+	}
+
+	os.Setenv("ROX_METRICS_PORT", ":9090")
+	os.Setenv("ROX_ENABLE_SECURE_METRICS", "false")
+
+	policyList, err := loadPolicies(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("loading policies: %w", err)
+	}
+
+	clusterID := "00000000-0000-4000-A000-000000000000"
+	fakeCentral := centralDebug.MakeFakeCentralWithInitialMessages(
+		message.SensorHello(clusterID),
+		message.ClusterConfig(),
+		message.PolicySync(policyList),
+		message.BaselineSync([]*storage.ProcessBaseline{}),
+		message.NetworkBaselineSync([]*storage.NetworkBaseline{}),
+	)
+
+	fakeClient := k8s.MakeFakeClient()
+	scheme := runtime.NewScheme()
+	apiextv1.AddToScheme(scheme)
+	fakeClient.SetDynamic(fakeDynamic.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}: "CustomResourceDefinitionList",
+		},
+	))
+
+	conn, grpcServer, listener := createGRPCConnection(fakeCentral)
+	connFactory := centralDebug.MakeFakeConnectionFactory(conn)
+
+	s, err := sensorKit.CreateSensor(sensorKit.ConfigWithDefaults().
+		WithK8sClient(fakeClient).
+		WithLocalSensor(true).
+		WithCentralConnectionFactory(connFactory).
+		WithClusterIDHandler(clusterid.NewHandler()))
+	if err != nil {
+		grpcServer.Stop()
+		return nil, fmt.Errorf("creating sensor: %w", err)
+	}
+
+	metrics.NewServer(metrics.SensorSubsystem, metrics.NewTLSConfigurerFromEnv()).RunForever()
+
+	go s.Start()
+	fakeCentral.ConnectionStarted.Wait()
+
+	return &Harness{
+		FakeCentral:    fakeCentral,
+		FakeClient:     fakeClient,
+		sensorInstance: s,
+		grpcServer:     grpcServer,
+		listener:       listener,
+	}, nil
+}
+
+func (h *Harness) Stop() {
+	h.FakeCentral.KillSwitch.Signal()
+	h.sensorInstance.Stop()
+	h.grpcServer.Stop()
+	utils.IgnoreError(h.listener.Close)
+}
+
+func createGRPCConnection(fakeCentral *centralDebug.FakeService) (*grpc.ClientConn, *grpc.Server, *bufconn.Listener) {
+	buffer := 1024 * 1024
+	listener := bufconn.Listen(buffer)
+
+	server := grpc.NewServer()
+	central.RegisterSensorServiceServer(server, fakeCentral)
+
+	go func() {
+		utils.IgnoreError(func() error {
+			return server.Serve(listener)
+		})
+	}()
+
+	//nolint:staticcheck // DialContext eagerly connects, which is needed for the fake connection factory
+	conn, err := grpc.DialContext(context.Background(), "",
+		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("failed to dial bufconn: %v", err))
+	}
+
+	return conn, server, listener
+}
+
+func setupCertEnv() error {
+	certsDir := filepath.Join("tools", "local-sensor", "certs")
+	if _, err := os.Stat(filepath.Join(certsDir, "cert.pem")); err != nil {
+		return fmt.Errorf("certs not found at %s: run from the repo root", certsDir)
+	}
+	os.Setenv("ROX_MTLS_CERT_FILE", filepath.Join(certsDir, "cert.pem"))
+	os.Setenv("ROX_MTLS_KEY_FILE", filepath.Join(certsDir, "key.pem"))
+	os.Setenv("ROX_MTLS_CA_FILE", filepath.Join(certsDir, "caCert.pem"))
+	os.Setenv("ROX_MTLS_CA_KEY_FILE", filepath.Join(certsDir, "caKey.pem"))
+	return nil
+}
+
+func loadPolicies(cfg *Config) ([]*storage.Policy, error) {
+	if !cfg.Policies.UseDefaults {
+		return []*storage.Policy{}, nil
+	}
+	policyList, err := policies.DefaultPolicies()
+	if err != nil {
+		return nil, fmt.Errorf("loading default policies: %w", err)
+	}
+	return policyList, nil
+}

--- a/tools/sensor-bench/main.go
+++ b/tools/sensor-bench/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"time"
+)
+
+func main() {
+	configPath := flag.String("config", "", "path to scenario YAML config (required)")
+	outputDir := flag.String("output", "", "output directory for profiles and metrics (required)")
+	cpuProfileSecs := flag.Int("cpu-profile-seconds", 0, "CPU profile duration in seconds (0 to use wall-clock of scenario)")
+	flag.Parse()
+
+	if *configPath == "" || *outputDir == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		log.Fatalf("Loading config: %v", err)
+	}
+
+	if err := os.MkdirAll(*outputDir, 0755); err != nil {
+		log.Fatalf("Creating output dir: %v", err)
+	}
+
+	log.Println("Starting sensor harness...")
+	harness, err := NewHarness(cfg)
+	if err != nil {
+		log.Fatalf("Creating harness: %v", err)
+	}
+	defer harness.Stop()
+
+	log.Println("Setting up completion checker...")
+	checker, err := NewCompletionChecker(cfg, harness.FakeCentral)
+	if err != nil {
+		log.Fatalf("Creating completion checker: %v", err)
+	}
+
+	// Wait briefly for sensor to fully initialize (metrics/pprof servers)
+	time.Sleep(1 * time.Second)
+
+	cpuFile, err := os.Create(filepath.Join(*outputDir, "cpu.pb.gz"))
+	if err != nil {
+		log.Fatalf("Creating CPU profile file: %v", err)
+	}
+	if err := pprof.StartCPUProfile(cpuFile); err != nil {
+		log.Fatalf("Starting CPU profile: %v", err)
+	}
+
+	log.Printf("Injecting workload: %d deployments, %d roles, %d services across %d namespaces...",
+		cfg.Workload.Deployments.Count,
+		cfg.Workload.Roles.Count,
+		cfg.Workload.Services.Count,
+		cfg.Workload.Namespaces)
+
+	startTime := time.Now()
+	if err := RunScenario(context.Background(), harness, cfg); err != nil {
+		log.Fatalf("Running scenario: %v", err)
+	}
+	log.Println("Injection complete. Waiting for completion conditions...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.Completion.Timeout)
+	defer cancel()
+
+	select {
+	case <-checker.Done.Done():
+		log.Println("All completion conditions met.")
+	case <-ctx.Done():
+		log.Println("WARNING: timeout reached before all conditions were met")
+		for _, c := range checker.conditions {
+			log.Printf("  %s", c)
+		}
+	}
+	endTime := time.Now()
+
+	if *cpuProfileSecs > 0 {
+		log.Printf("Collecting CPU profile for %d additional seconds...", *cpuProfileSecs)
+		time.Sleep(time.Duration(*cpuProfileSecs) * time.Second)
+	}
+	pprof.StopCPUProfile()
+	cpuFile.Close()
+
+	log.Println("Collecting profiles and metrics...")
+	if err := collectProfiles(*outputDir); err != nil {
+		log.Printf("WARNING: collecting profiles: %v", err)
+	}
+	if err := collectMetrics(*outputDir); err != nil {
+		log.Printf("WARNING: collecting metrics: %v", err)
+	}
+	if err := writeRunMetadata(*outputDir, cfg, startTime, endTime); err != nil {
+		log.Printf("WARNING: writing run metadata: %v", err)
+	}
+
+	log.Printf("Done. Results in %s (wall time: %s)", *outputDir, endTime.Sub(startTime))
+}
+
+func printConditionStatus(checker *CompletionChecker) {
+	for _, c := range checker.conditions {
+		fmt.Printf("  %s\n", c)
+	}
+}

--- a/tools/sensor-bench/scenario.go
+++ b/tools/sensor-bench/scenario.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"runtime/pprof"
+
+	"github.com/stackrox/rox/sensor/debugger/k8s"
+	v1 "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
+
+func randString(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+func RunScenario(ctx context.Context, h *Harness, cfg *Config) error {
+	labels := pprof.Labels("component", "bench-harness")
+	pprof.Do(ctx, labels, func(ctx context.Context) {
+		injectWorkload(ctx, h.FakeClient, cfg)
+	})
+	return nil
+}
+
+func injectWorkload(ctx context.Context, client *k8s.ClientSet, cfg *Config) {
+	w := cfg.Workload
+
+	namespaces := make([]string, w.Namespaces)
+	for i := range namespaces {
+		namespaces[i] = fmt.Sprintf("bench-ns-%d", i)
+		createNamespace(client, namespaces[i])
+	}
+
+	roleNames := make([]string, w.Roles.Count)
+	for i := range w.Roles.Count {
+		ns := namespaces[i%len(namespaces)]
+		roleName := fmt.Sprintf("role-%d", i)
+		roleNames[i] = roleName
+		if w.Roles.ClusterWide {
+			createClusterRole(client, roleName, w.Roles.Verbs)
+		} else {
+			createRole(client, ns, roleName, w.Roles.Verbs)
+		}
+	}
+
+	for i := range w.RoleBindings.Count {
+		ns := namespaces[i%len(namespaces)]
+		bindingName := fmt.Sprintf("binding-%d", i)
+		roleName := roleNames[i%len(roleNames)]
+		sa := serviceAccountFor(w.Deployments.ServiceAccount, i)
+		if w.Roles.ClusterWide {
+			createClusterRoleBinding(client, bindingName, roleName, ns, sa)
+		} else {
+			createRoleBinding(client, ns, bindingName, roleName, sa)
+		}
+	}
+
+	for i := range w.Services.Count {
+		ns := namespaces[i%len(namespaces)]
+		serviceName := fmt.Sprintf("svc-%d", i)
+		appLabel := fmt.Sprintf("app-%d", i)
+		createService(client, ns, serviceName, appLabel, w.Services.Type)
+	}
+
+	for i := range w.Deployments.Count {
+		ns := namespaces[i%len(namespaces)]
+		deploymentName := fmt.Sprintf("deploy-%d", i)
+		appLabel := fmt.Sprintf("app-%d", i)
+		sa := serviceAccountFor(w.Deployments.ServiceAccount, i)
+		createDeployment(client, ns, deploymentName, appLabel, sa, w.Deployments.Image, w.Deployments.Containers)
+	}
+}
+
+func serviceAccountFor(saConfig string, index int) string {
+	if saConfig == "random" {
+		return fmt.Sprintf("sa-%s", randString(5))
+	}
+	return saConfig
+}
+
+func createNamespace(client *k8s.ClientSet, name string) {
+	_, err := client.Kubernetes().CoreV1().Namespaces().Create(context.Background(), &core.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		panic(fmt.Sprintf("creating namespace %s: %v", name, err))
+	}
+}
+
+func createRole(client *k8s.ClientSet, namespace, name string, verbs []string) {
+	_, err := client.Kubernetes().RbacV1().Roles(namespace).Create(context.Background(), &rbac.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Rules: []rbac.PolicyRule{{
+			Verbs:     verbs,
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+		}},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		panic(fmt.Sprintf("creating role %s/%s: %v", namespace, name, err))
+	}
+}
+
+func createClusterRole(client *k8s.ClientSet, name string, verbs []string) {
+	_, err := client.Kubernetes().RbacV1().ClusterRoles().Create(context.Background(), &rbac.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Rules: []rbac.PolicyRule{{
+			Verbs:     verbs,
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+		}},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		panic(fmt.Sprintf("creating cluster role %s: %v", name, err))
+	}
+}
+
+func createRoleBinding(client *k8s.ClientSet, namespace, name, roleName, serviceAccount string) {
+	_, err := client.Kubernetes().RbacV1().RoleBindings(namespace).Create(context.Background(), &rbac.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Subjects: []rbac.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      serviceAccount,
+			Namespace: namespace,
+		}},
+		RoleRef: rbac.RoleRef{Kind: "Role", Name: roleName, APIGroup: "rbac.authorization.k8s.io"},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		panic(fmt.Sprintf("creating role binding %s/%s: %v", namespace, name, err))
+	}
+}
+
+func createClusterRoleBinding(client *k8s.ClientSet, name, roleName, namespace, serviceAccount string) {
+	_, err := client.Kubernetes().RbacV1().ClusterRoleBindings().Create(context.Background(), &rbac.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Subjects: []rbac.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      serviceAccount,
+			Namespace: namespace,
+		}},
+		RoleRef: rbac.RoleRef{Kind: "ClusterRole", Name: roleName, APIGroup: "rbac.authorization.k8s.io"},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		panic(fmt.Sprintf("creating cluster role binding %s: %v", name, err))
+	}
+}
+
+func createService(client *k8s.ClientSet, namespace, name, appLabel, svcType string) {
+	serviceType := core.ServiceTypeClusterIP
+	switch svcType {
+	case "NodePort":
+		serviceType = core.ServiceTypeNodePort
+	case "LoadBalancer":
+		serviceType = core.ServiceTypeLoadBalancer
+	}
+	_, err := client.Kubernetes().CoreV1().Services(namespace).Create(context.Background(), &core.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: core.ServiceSpec{
+			Ports: []core.ServicePort{{
+				Name:       "http",
+				Protocol:   "TCP",
+				Port:       80,
+				TargetPort: intstr.IntOrString{IntVal: 8080},
+			}},
+			Selector: map[string]string{"app": appLabel},
+			Type:     serviceType,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		panic(fmt.Sprintf("creating service %s/%s: %v", namespace, name, err))
+	}
+}
+
+func createDeployment(client *k8s.ClientSet, namespace, name, appLabel, serviceAccount, image string, numContainers int) {
+	containers := make([]core.Container, numContainers)
+	for i := range containers {
+		containers[i] = core.Container{
+			Name:  fmt.Sprintf("container-%d", i),
+			Image: image,
+		}
+	}
+
+	_, err := client.Kubernetes().AppsV1().Deployments(namespace).Create(context.Background(), &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": appLabel},
+		},
+		Spec: v1.DeploymentSpec{
+			Template: core.PodTemplateSpec{
+				Spec: core.PodSpec{
+					Containers:         containers,
+					ServiceAccountName: serviceAccount,
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		panic(fmt.Sprintf("creating deployment %s/%s: %v", namespace, name, err))
+	}
+}

--- a/tools/sensor-bench/testdata/small.yaml
+++ b/tools/sensor-bench/testdata/small.yaml
@@ -1,0 +1,25 @@
+workload:
+  namespaces: 2
+  deployments:
+    count: 50
+    containers: 1
+    image: "nginx:1.25"
+    serviceAccount: "default"
+  roles:
+    count: 10
+    clusterWide: false
+    verbs: ["get", "list"]
+  roleBindings:
+    count: 10
+  services:
+    count: 10
+    type: "ClusterIP"
+
+policies:
+  useDefaults: true
+
+completion:
+  timeout: 60s
+  conditions:
+    - type: deploymentCount
+      count: 50


### PR DESCRIPTION
## Description

Standalone Go tool (`tools/sensor-bench`) that runs sensor with YAML-configurable workloads, waits for configurable completion conditions, and collects pprof profiles + Prometheus metrics at a consistent point in execution. Designed for reproducible performance regression detection.

**Key design decisions:**
- Runs sensor in-process using the existing `sensor/debugger` test infrastructure (fake central, fake K8s client) rather than requiring a real cluster
- Injection goroutines are wrapped with `pprof.Labels("component", "bench-harness")` so they can be filtered out during CPU profile analysis — the fake event generation is not cheap and would otherwise pollute profiles
- Completion conditions are configurable (deployment count, deployment field matching for permission level / exposure) and extensible
- Output format (pprof `.pb.gz` + `metrics.json` + `run.json`) is compatible with `go tool pprof` and the existing profiler-cli

**Usage:**
```
go run ./tools/sensor-bench   --config=tools/sensor-bench/testdata/small.yaml   --output=./run-001
```

**Follow-up work:** image scan mocking, alert count conditions, more complex scenarios.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

This is a developer-only benchmarking tool under `tools/`. No automated tests added — validated by running the tool manually.

### How I validated my change

Ran the tool with a test config (50 deployments, 10 roles, 10 services, default policies):

```
go run ./tools/sensor-bench --config=tools/sensor-bench/testdata/small.yaml --output=/tmp/sensor-bench-test
```

Verified:
- Sensor starts, connects to fake central, processes all events
- All 50 deployment events reach fake central (completion condition met)
- Output directory contains valid `cpu.pb.gz`, `heap.pb.gz`, `goroutine.pb.gz`, `metrics.json`, `run.json`
- Profiles open correctly with `go tool pprof`
- pprof labels (`component=bench-harness`) are present in CPU profile for filtering