### PR TITLE
hack: add clair-adapter service

### DIFF
--- a/clair-adapter/Dockerfile
+++ b/clair-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/clair-adapter/Dockerfile
+++ b/clair-adapter/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.24 AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /clair-adapter ./clair-adapter/cmd/clair-adapter/
+
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /clair-adapter /usr/local/bin/clair-adapter
+USER 65534:65534
+ENTRYPOINT ["clair-adapter"]

--- a/clair-adapter/README.md
+++ b/clair-adapter/README.md
@@ -1,0 +1,112 @@
+# Clair Adapter
+
+The clair-adapter is a Go service that replaces Scanner V4 by delegating container image indexing and vulnerability matching to [upstream Clair](https://github.com/quay/clair) while preserving the Scanner V4 gRPC API. Central and Sensor connect to it using the same protos, making it a drop-in replacement.
+
+Unlike Scanner V4 (which embeds ClairCore as a Go library), the adapter calls Clair over HTTP for indexing/matching and imports StackRox vulnerability data directly into Clair's PostgreSQL database.
+
+## Architecture
+
+```
+Central/Sensor ──gRPC (mTLS)──> Clair Adapter ──HTTP──> Upstream Clair
+                                     │                       │
+                                     │                       v
+                                     │               Clair PostgreSQL
+                                     │                  (shared)
+                                     │
+                                     ├── Fetches vuln bundles from Central
+                                     ├── Imports vulns directly into Clair's DB
+                                     └── Queries NVD/EPSS enrichments from DB
+```
+
+### Ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 8443 | gRPC     | Scanner V4 API (Central/Sensor connections) |
+| 9443 | HTTPS    | Health checks (`/healthz/live`, `/healthz/ready`) |
+| 9444 | HTTP     | Vulnerability bundle server (diagnostic) |
+
+## Quick Start
+
+Prerequisites: a running Kubernetes cluster with StackRox deployed via `deploy/deploy-local.sh`.
+
+```bash
+# Build and deploy everything (Clair DB, Clair, adapter)
+BUILD_IMAGE=true ./clair-adapter/deploy/deploy-clair-adapter.sh
+```
+
+The deploy script handles:
+- Building the adapter container image
+- Generating a combined TLS certificate for both scanner-v4-indexer and scanner-v4-matcher identities
+- Scaling down Scanner V4 and patching its services to route to the adapter
+- Deploying Clair PostgreSQL, upstream Clair, and the adapter
+- Detecting config changes and restarting Clair when needed
+- Comparing image SHAs to avoid unnecessary adapter restarts
+
+## Configuration
+
+The adapter is configured via a YAML file (passed with `-config`):
+
+```yaml
+clair_url: "http://clair.stackrox.svc:8080"
+clair_db_connstring: "host=clair-db.stackrox.svc port=5432 user=clair dbname=clair sslmode=disable"
+grpc_listen_addr: "0.0.0.0:8443"
+http_listen_addr: "0.0.0.0:9443"
+updater_listen_addr: "0.0.0.0:9444"
+vulnerabilities_url: "https://central.stackrox.svc/api/extensions/scannerdefinitions?version=dev"
+certs_dir: "/run/secrets/stackrox.io/certs"
+indexer:
+  enable: true
+matcher:
+  enable: true
+```
+
+| Field | Description |
+|-------|-------------|
+| `clair_url` | Upstream Clair HTTP endpoint |
+| `clair_db_connstring` | Clair's PostgreSQL connection string (for direct vuln/enrichment import) |
+| `vulnerabilities_url` | Where to fetch vulnerability bundles (Central's endpoint or definitions.stackrox.io) |
+| `certs_dir` | Path to StackRox mTLS certificates (ca.pem, cert.pem, key.pem) |
+
+## Vulnerability Data Pipeline
+
+The adapter controls the full vulnerability data pipeline:
+
+1. **Fetch**: Downloads StackRox vulnerability bundles from Central (`/api/extensions/scannerdefinitions`)
+2. **Import**: Streams bundles from disk through zstd decompression and JSONL parsing, then inserts vulnerabilities and enrichments directly into Clair's PostgreSQL using ClairCore's `MatcherStore`
+3. **Match**: When Central requests a vulnerability scan, the adapter queries Clair's matcher API
+4. **Enrich**: Queries NVD (CVSS scores) and EPSS (exploit probabilities) directly from the enrichment tables, bypassing Clair's enrichment pipeline which lacks the StackRox enricher plugins
+
+See [docs/vulnerability-data-pipeline.md](docs/vulnerability-data-pipeline.md) for details.
+
+## Package Structure
+
+| Package | Purpose |
+|---------|---------|
+| `cmd/clair-adapter` | Entrypoint, wires all components |
+| `clairclient` | HTTP client for upstream Clair's indexer/matcher APIs |
+| `config` | YAML configuration loading |
+| `enricher` | Enrichment pipeline (CSAF, NVD, EPSS, fixedby) |
+| `healthz` | HTTP health check handlers |
+| `indexer` | Container image indexing via Clair |
+| `mappers` | Converts between Clair types and Scanner V4 protos |
+| `matcher` | Vulnerability matching with enrichment injection |
+| `services` | gRPC service implementations (IndexerService, MatcherService) |
+| `updater` | Vulnerability bundle fetching, unpacking, and HTTP serving |
+| `vulnimporter` | Direct PostgreSQL import of vulnerabilities and enrichment queries |
+
+## mTLS
+
+The adapter uses a single TLS certificate with dual identity to serve both Scanner V4 Indexer and Matcher roles:
+
+- **CN**: `SCANNER_V4_INDEXER_SERVICE: Scanner V4 Indexer` (passes Central's CN check for indexer connections)
+- **OU**: `SCANNER_V4_MATCHER_SERVICE` (passes Central's OU fallback check for matcher connections)
+- **SANs**: `scanner-v4-indexer.stackrox.svc`, `scanner-v4-matcher.stackrox.svc` (plus `.svc.cluster.local` variants)
+
+The deploy script generates this certificate automatically from the StackRox CA in the `central-tls` secret.
+
+## Further Documentation
+
+- [Local E2E Testing Guide](docs/local-testing.md)
+- [Feature Status & Scanner V4 Gap Analysis](docs/feature-status.md)
+- [Vulnerability Data Pipeline](docs/vulnerability-data-pipeline.md)

--- a/clair-adapter/clairclient/client.go
+++ b/clair-adapter/clairclient/client.go
@@ -1,0 +1,268 @@
+package clairclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+)
+
+// ErrNotFound is returned when a resource is not found (HTTP 404).
+var ErrNotFound = errors.New("not found")
+
+// Client is an HTTP client for interacting with the Clair API.
+type Client struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+}
+
+// ClientOption configures the Client.
+type ClientOption func(*Client)
+
+// WithHTTPClient sets the HTTP client to use for requests.
+// If not provided, http.DefaultClient is used.
+func WithHTTPClient(hc *http.Client) ClientOption {
+	return func(c *Client) {
+		c.httpClient = hc
+	}
+}
+
+// NewClient creates a new Clair API client with the given base URL.
+// Options can be provided to customize the client behavior.
+func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL: %w", err)
+	}
+
+	c := &Client{
+		baseURL:    u,
+		httpClient: http.DefaultClient,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c, nil
+}
+
+// CreateIndexReport submits a manifest for indexing and returns the index report.
+// This corresponds to POST /indexer/api/v1/index_report.
+// Expects HTTP 201 Created on success.
+func (c *Client) CreateIndexReport(ctx context.Context, manifest Manifest) (*IndexReport, error) {
+	reqURL := c.buildURL("/indexer/api/v1/index_report")
+
+	body, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, c.handleError(resp)
+	}
+
+	var report IndexReport
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
+		return nil, fmt.Errorf("failed to decode index report: %w", err)
+	}
+
+	return &report, nil
+}
+
+// GetIndexReport retrieves an index report by manifest digest.
+// This corresponds to GET /indexer/api/v1/index_report/{digest}.
+// Returns ErrNotFound if the report does not exist (HTTP 404).
+func (c *Client) GetIndexReport(ctx context.Context, digest string) (*IndexReport, error) {
+	reqURL := c.buildURL("/indexer/api/v1/index_report/" + digest)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.handleError(resp)
+	}
+
+	var report IndexReport
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
+		return nil, fmt.Errorf("failed to decode index report: %w", err)
+	}
+
+	return &report, nil
+}
+
+// GetVulnerabilityReport retrieves a vulnerability report by manifest digest.
+// This corresponds to GET /matcher/api/v1/vulnerability_report/{digest}.
+// Accepts both HTTP 200 OK and HTTP 201 Created as success.
+// Returns ErrNotFound if the report does not exist (HTTP 404).
+func (c *Client) GetVulnerabilityReport(ctx context.Context, digest string) (*VulnerabilityReport, error) {
+	reqURL := c.buildURL("/matcher/api/v1/vulnerability_report/" + digest)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return nil, c.handleError(resp)
+	}
+
+	var report VulnerabilityReport
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
+		return nil, fmt.Errorf("failed to decode vulnerability report: %w", err)
+	}
+
+	return &report, nil
+}
+
+// DeleteIndexReport deletes an index report by manifest digest.
+// This corresponds to DELETE /indexer/api/v1/index_report/{digest}.
+// Expects HTTP 204 No Content on success.
+func (c *Client) DeleteIndexReport(ctx context.Context, digest string) error {
+	reqURL := c.buildURL("/indexer/api/v1/index_report/" + digest)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return c.handleError(resp)
+	}
+
+	return nil
+}
+
+// GetIndexState retrieves the current state of the indexer.
+// This corresponds to GET /indexer/api/v1/index_state.
+func (c *Client) GetIndexState(ctx context.Context) (*IndexState, error) {
+	reqURL := c.buildURL("/indexer/api/v1/index_state")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.handleError(resp)
+	}
+
+	var state IndexState
+	if err := json.NewDecoder(resp.Body).Decode(&state); err != nil {
+		return nil, fmt.Errorf("failed to decode index state: %w", err)
+	}
+
+	return &state, nil
+}
+
+// GetUpdateOperations retrieves the latest update operations from the matcher.
+// This corresponds to GET /matcher/api/v1/internal/update_operation?latest=true.
+func (c *Client) GetUpdateOperations(ctx context.Context) (map[string][]UpdateOperation, error) {
+	reqURL := c.buildURL("/matcher/api/v1/internal/update_operation")
+
+	// Add query parameter for latest operations
+	u, err := url.Parse(reqURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("latest", "true")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.handleError(resp)
+	}
+
+	var operations map[string][]UpdateOperation
+	if err := json.NewDecoder(resp.Body).Decode(&operations); err != nil {
+		return nil, fmt.Errorf("failed to decode update operations: %w", err)
+	}
+
+	return operations, nil
+}
+
+// buildURL constructs a full URL by joining the base URL with the given path.
+func (c *Client) buildURL(urlPath string) string {
+	u := *c.baseURL
+	u.Path = path.Join(u.Path, urlPath)
+	return u.String()
+}
+
+// handleError reads the response body (up to 4096 bytes) and returns a formatted error.
+func (c *Client) handleError(resp *http.Response) error {
+	const maxErrorBytes = 4096
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBytes))
+	return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+}
+
+// DigestFromHashID extracts a Clair-compatible digest from a StackRox hash ID.
+// StackRox uses "/v4/containerimage/sha256:abc..." but Clair expects "sha256:abc...".
+func DigestFromHashID(hashID string) string {
+	if i := strings.LastIndex(hashID, "sha256:"); i > 0 {
+		return hashID[i:]
+	}
+	return hashID
+}

--- a/clair-adapter/clairclient/client_test.go
+++ b/clair-adapter/clairclient/client_test.go
@@ -1,0 +1,362 @@
+package clairclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_CreateIndexReport(t *testing.T) {
+	ctx := t.Context()
+	expectedManifest := Manifest{
+		Hash: "sha256:abc123",
+		Layers: []Layer{
+			{
+				Hash: "sha256:layer1",
+				URI:  "https://example.com/layer1",
+				Headers: map[string][]string{
+					"Authorization": {"Bearer token"},
+				},
+			},
+		},
+	}
+
+	expectedReport := &IndexReport{
+		ManifestHash: "sha256:abc123",
+		State:        "IndexFinished",
+		Success:      true,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/indexer/api/v1/index_report", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var receivedManifest Manifest
+		err := json.NewDecoder(r.Body).Decode(&receivedManifest)
+		require.NoError(t, err)
+		assert.Equal(t, expectedManifest, receivedManifest)
+
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(expectedReport))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	report, err := client.CreateIndexReport(ctx, expectedManifest)
+	require.NoError(t, err)
+	assert.Equal(t, expectedReport, report)
+}
+
+func TestClient_GetIndexReport(t *testing.T) {
+	ctx := t.Context()
+	digest := "sha256:abc123"
+
+	expectedReport := &IndexReport{
+		ManifestHash: digest,
+		State:        "IndexFinished",
+		Success:      true,
+		Packages: map[string]Package{
+			"1": {
+				ID:      "1",
+				Name:    "curl",
+				Version: "7.68.0",
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/indexer/api/v1/index_report/"+digest, r.URL.Path)
+
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(expectedReport))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	report, err := client.GetIndexReport(ctx, digest)
+	require.NoError(t, err)
+	assert.Equal(t, expectedReport, report)
+}
+
+func TestClient_GetIndexReport_NotFound(t *testing.T) {
+	ctx := t.Context()
+	digest := "sha256:nonexistent"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/indexer/api/v1/index_report/"+digest, r.URL.Path)
+
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("index report not found"))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	report, err := client.GetIndexReport(ctx, digest)
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, report)
+}
+
+func TestClient_GetVulnerabilityReport(t *testing.T) {
+	ctx := t.Context()
+	digest := "sha256:abc123"
+
+	expectedReport := &VulnerabilityReport{
+		ManifestHash: digest,
+		State:        "Matched",
+		Success:      true,
+		Vulnerabilities: map[string]Vulnerability{
+			"CVE-2021-1234": {
+				ID:          "CVE-2021-1234",
+				Name:        "CVE-2021-1234",
+				Description: "A vulnerability",
+				Severity:    "High",
+				Issued:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		PackageVulnerabilities: map[string][]string{
+			"1": {"CVE-2021-1234"},
+		},
+	}
+
+	tests := map[string]struct {
+		statusCode int
+	}{
+		"200 OK": {
+			statusCode: http.StatusOK,
+		},
+		"201 Created": {
+			statusCode: http.StatusCreated,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/matcher/api/v1/vulnerability_report/"+digest, r.URL.Path)
+
+				w.WriteHeader(tc.statusCode)
+				require.NoError(t, json.NewEncoder(w).Encode(expectedReport))
+			}))
+			defer server.Close()
+
+			client, err := NewClient(server.URL)
+			require.NoError(t, err)
+
+			report, err := client.GetVulnerabilityReport(ctx, digest)
+			require.NoError(t, err)
+			assert.Equal(t, expectedReport, report)
+		})
+	}
+}
+
+func TestClient_DeleteIndexReport(t *testing.T) {
+	ctx := t.Context()
+	digest := "sha256:abc123"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/indexer/api/v1/index_report/"+digest, r.URL.Path)
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	err = client.DeleteIndexReport(ctx, digest)
+	require.NoError(t, err)
+}
+
+func TestClient_GetIndexState(t *testing.T) {
+	ctx := t.Context()
+
+	expectedState := &IndexState{
+		State: "IndexFinished",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/indexer/api/v1/index_state", r.URL.Path)
+
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(expectedState))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	state, err := client.GetIndexState(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, expectedState, state)
+}
+
+func TestClient_GetUpdateOperations(t *testing.T) {
+	ctx := t.Context()
+
+	expectedOps := map[string][]UpdateOperation{
+		"alpine": {
+			{
+				Ref:     "v3.15",
+				Updater: "alpine",
+				Date:    time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		"debian": {
+			{
+				Ref:     "bullseye",
+				Updater: "debian",
+				Date:    time.Date(2021, 11, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/matcher/api/v1/internal/update_operation", r.URL.Path)
+		assert.Equal(t, "true", r.URL.Query().Get("latest"))
+
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(expectedOps))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	ops, err := client.GetUpdateOperations(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, expectedOps, ops)
+}
+
+func TestClient_WithHTTPClient(t *testing.T) {
+	ctx := t.Context()
+
+	customClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(&IndexState{State: "test"}))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, WithHTTPClient(customClient))
+	require.NoError(t, err)
+	assert.Same(t, customClient, client.httpClient)
+
+	_, err = client.GetIndexState(ctx)
+	require.NoError(t, err)
+}
+
+func TestClient_ErrorHandling(t *testing.T) {
+	ctx := t.Context()
+
+	tests := map[string]struct {
+		statusCode   int
+		responseBody string
+		expectedErr  string
+	}{
+		"400 Bad Request": {
+			statusCode:   http.StatusBadRequest,
+			responseBody: "invalid manifest format",
+			expectedErr:  "HTTP 400: invalid manifest format",
+		},
+		"500 Internal Server Error": {
+			statusCode:   http.StatusInternalServerError,
+			responseBody: "database connection failed",
+			expectedErr:  "HTTP 500: database connection failed",
+		},
+		"503 Service Unavailable": {
+			statusCode:   http.StatusServiceUnavailable,
+			responseBody: "service temporarily unavailable",
+			expectedErr:  "HTTP 503: service temporarily unavailable",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.responseBody))
+			}))
+			defer server.Close()
+
+			client, err := NewClient(server.URL)
+			require.NoError(t, err)
+
+			manifest := Manifest{Hash: "sha256:test"}
+			_, err = client.CreateIndexReport(ctx, manifest)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expectedErr)
+		})
+	}
+}
+
+func TestClient_LargeErrorBody(t *testing.T) {
+	ctx := t.Context()
+
+	// Create error body larger than 4096 bytes
+	largeError := make([]byte, 5000)
+	for i := range largeError {
+		largeError[i] = 'x'
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(largeError)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	_, err = client.GetIndexState(ctx)
+	require.Error(t, err)
+	// Error message should be truncated to 4096 bytes
+	assert.LessOrEqual(t, len(err.Error()), 4096+50) // Account for "HTTP 500: " prefix
+}
+
+func TestClient_NewClient_InvalidURL(t *testing.T) {
+	_, err := NewClient("://invalid-url")
+	require.Error(t, err)
+}
+
+func TestClient_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Delay response to allow context cancellation
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	require.NoError(t, err)
+
+	// Cancel context before request completes
+	cancel()
+
+	_, err = client.GetIndexState(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context canceled")
+}

--- a/clair-adapter/clairclient/types.go
+++ b/clair-adapter/clairclient/types.go
@@ -1,0 +1,125 @@
+package clairclient
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Manifest represents the request body for POST /indexer/api/v1/index_report.
+type Manifest struct {
+	Hash   string  `json:"hash"`
+	Layers []Layer `json:"layers"`
+}
+
+// Layer represents an individual container layer.
+type Layer struct {
+	Hash    string              `json:"hash"`
+	URI     string              `json:"uri"`
+	Headers map[string][]string `json:"headers,omitempty"`
+}
+
+// IndexReport represents the response from indexer endpoints.
+type IndexReport struct {
+	ManifestHash  string                   `json:"manifest_hash"`
+	State         string                   `json:"state"`
+	Success       bool                     `json:"success"`
+	Err           string                   `json:"err"`
+	Packages      map[string]Package       `json:"packages"`
+	Distributions map[string]Distribution  `json:"distributions"`
+	Repositories  map[string]Repository    `json:"repository"`
+	Environments  map[string][]Environment `json:"environments"`
+}
+
+// VulnerabilityReport represents the response from matcher endpoint.
+type VulnerabilityReport struct {
+	ManifestHash           string                       `json:"manifest_hash"`
+	State                  string                       `json:"state"`
+	Success                bool                         `json:"success"`
+	Err                    string                       `json:"err"`
+	Packages               map[string]Package           `json:"packages"`
+	Distributions          map[string]Distribution      `json:"distributions"`
+	Repositories           map[string]Repository        `json:"repository"`
+	Environments           map[string][]Environment     `json:"environments"`
+	Vulnerabilities        map[string]Vulnerability     `json:"vulnerabilities"`
+	PackageVulnerabilities map[string][]string          `json:"package_vulnerabilities"`
+	Enrichments            map[string][]json.RawMessage `json:"enrichments"`
+}
+
+// Package represents a package found in a container image.
+type Package struct {
+	ID                string            `json:"id"`
+	Name              string            `json:"name"`
+	Version           string            `json:"version"`
+	Kind              string            `json:"kind"`
+	Arch              string            `json:"arch"`
+	Source            *Package          `json:"source,omitzero"`
+	Module            string            `json:"module,omitzero"`
+	CPE               string            `json:"cpe,omitzero"`
+	PackageDB         string            `json:"package_db,omitzero"`
+	RepositoryHint    string            `json:"repository_hint,omitzero"`
+	NormalizedVersion NormalizedVersion `json:"normalized_version,omitzero"`
+}
+
+// NormalizedVersion represents a parsed and normalized package version.
+type NormalizedVersion struct {
+	Kind string `json:"kind"`
+	V    []int  `json:"V"`
+}
+
+// Distribution represents a Linux distribution.
+type Distribution struct {
+	ID              string `json:"id"`
+	DID             string `json:"did"`
+	Name            string `json:"name"`
+	Version         string `json:"version"`
+	VersionCodeName string `json:"version_code_name"`
+	VersionID       string `json:"version_id"`
+	Arch            string `json:"arch"`
+	CPE             string `json:"cpe"`
+	PrettyName      string `json:"pretty_name"`
+}
+
+// Repository represents a package repository.
+type Repository struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Key  string `json:"key"`
+	URI  string `json:"uri"`
+	CPE  string `json:"cpe"`
+}
+
+// Environment represents the environment where a package was found.
+type Environment struct {
+	PackageDB      string   `json:"package_db"`
+	IntroducedIn   string   `json:"introduced_in"`
+	DistributionID string   `json:"distribution_id,omitzero"`
+	RepositoryIDs  []string `json:"repository_ids,omitzero"`
+}
+
+// Vulnerability represents a security vulnerability.
+type Vulnerability struct {
+	ID                 string        `json:"id"`
+	Name               string        `json:"name"`
+	Description        string        `json:"description"`
+	Issued             time.Time     `json:"issued"`
+	Links              string        `json:"links"`
+	Severity           string        `json:"severity"`
+	NormalizedSeverity string        `json:"normalized_severity"`
+	FixedInVersion     string        `json:"fixed_in_version"`
+	Package            *Package      `json:"package,omitzero"`
+	Distribution       *Distribution `json:"distribution,omitzero"`
+	Repository         *Repository   `json:"repository,omitzero"`
+	Updater            string        `json:"updater"`
+}
+
+// IndexState represents the state of an index operation.
+type IndexState struct {
+	State string `json:"state"`
+}
+
+// UpdateOperation represents a vulnerability database update operation.
+type UpdateOperation struct {
+	Ref     string    `json:"ref"`
+	Updater string    `json:"updater"`
+	Date    time.Time `json:"date"`
+}

--- a/clair-adapter/clairclient/types.go
+++ b/clair-adapter/clairclient/types.go
@@ -2,6 +2,8 @@ package clairclient
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -61,9 +63,43 @@ type Package struct {
 }
 
 // NormalizedVersion represents a parsed and normalized package version.
+// Clair returns this as a string like "dpkg:0:1.19.7" which we parse into Kind + V fields.
 type NormalizedVersion struct {
 	Kind string `json:"kind"`
 	V    []int  `json:"V"`
+}
+
+// UnmarshalJSON handles Clair's string format for normalized_version.
+func (nv *NormalizedVersion) UnmarshalJSON(data []byte) error {
+	// Try string format first (Clair API returns this)
+	var s string
+	if json.Unmarshal(data, &s) == nil && s != "" {
+		return nv.parseString(s)
+	}
+	// Fallback to struct format
+	type alias NormalizedVersion
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*nv = NormalizedVersion(a)
+	return nil
+}
+
+func (nv *NormalizedVersion) parseString(s string) error {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+	nv.Kind = parts[0]
+	for _, seg := range strings.Split(parts[1], ".") {
+		v, err := strconv.Atoi(seg)
+		if err != nil {
+			v = 0
+		}
+		nv.V = append(nv.V, v)
+	}
+	return nil
 }
 
 // Distribution represents a Linux distribution.

--- a/clair-adapter/clairclient/types_test.go
+++ b/clair-adapter/clairclient/types_test.go
@@ -1,0 +1,223 @@
+package clairclient
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManifest_JSONRoundTrip(t *testing.T) {
+	manifest := Manifest{
+		Hash: "sha256:abc123",
+		Layers: []Layer{
+			{
+				Hash: "sha256:layer1",
+				URI:  "https://registry.io/v2/repo/blobs/sha256:layer1",
+			},
+			{
+				Hash: "sha256:layer2",
+				URI:  "https://registry.io/v2/repo/blobs/sha256:layer2",
+				Headers: map[string][]string{
+					"Authorization": {"Bearer token123"},
+					"Accept":        {"application/vnd.docker.distribution.manifest.v2+json"},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	var decoded Manifest
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, manifest.Hash, decoded.Hash)
+	assert.Len(t, decoded.Layers, 2)
+	assert.Equal(t, manifest.Layers[0].Hash, decoded.Layers[0].Hash)
+	assert.Equal(t, manifest.Layers[0].URI, decoded.Layers[0].URI)
+	assert.Nil(t, decoded.Layers[0].Headers)
+	assert.Equal(t, manifest.Layers[1].Headers, decoded.Layers[1].Headers)
+}
+
+func TestIndexReport_Unmarshal(t *testing.T) {
+	jsonData := `{
+		"manifest_hash": "sha256:abc123",
+		"state": "IndexFinished",
+		"success": true,
+		"err": "",
+		"packages": {
+			"pkg1": {
+				"id": "pkg1",
+				"name": "openssl",
+				"version": "1.1.1k",
+				"kind": "binary",
+				"arch": "amd64",
+				"module": "openssl-libs",
+				"cpe": "cpe:/a:openssl:openssl:1.1.1k",
+				"package_db": "var/lib/dpkg/status",
+				"repository_hint": "debian",
+				"normalized_version": {
+					"kind": "dpkg",
+					"V": [0, 1, 1, 1, 107]
+				}
+			}
+		},
+		"distributions": {
+			"dist1": {
+				"id": "dist1",
+				"did": "debian",
+				"name": "Debian GNU/Linux",
+				"version": "11",
+				"version_code_name": "bullseye",
+				"version_id": "11",
+				"arch": "amd64",
+				"cpe": "cpe:/o:debian:debian_linux:11",
+				"pretty_name": "Debian GNU/Linux 11 (bullseye)"
+			}
+		},
+		"repository": {
+			"repo1": {
+				"id": "repo1",
+				"name": "debian-main",
+				"key": "debian",
+				"uri": "http://deb.debian.org/debian",
+				"cpe": "cpe:/o:debian:debian_linux:11"
+			}
+		},
+		"environments": {
+			"env1": [
+				{
+					"package_db": "var/lib/dpkg/status",
+					"introduced_in": "sha256:layer1",
+					"distribution_id": "dist1",
+					"repository_ids": ["repo1"]
+				}
+			]
+		}
+	}`
+
+	var report IndexReport
+	err := json.Unmarshal([]byte(jsonData), &report)
+	require.NoError(t, err)
+
+	assert.Equal(t, "sha256:abc123", report.ManifestHash)
+	assert.Equal(t, "IndexFinished", report.State)
+	assert.True(t, report.Success)
+	assert.Empty(t, report.Err)
+
+	require.Contains(t, report.Packages, "pkg1")
+	pkg := report.Packages["pkg1"]
+	assert.Equal(t, "openssl", pkg.Name)
+	assert.Equal(t, "1.1.1k", pkg.Version)
+	assert.Equal(t, "binary", pkg.Kind)
+	assert.Equal(t, "amd64", pkg.Arch)
+	assert.Equal(t, "dpkg", pkg.NormalizedVersion.Kind)
+	assert.Equal(t, []int{0, 1, 1, 1, 107}, pkg.NormalizedVersion.V)
+
+	require.Contains(t, report.Distributions, "dist1")
+	dist := report.Distributions["dist1"]
+	assert.Equal(t, "Debian GNU/Linux", dist.Name)
+	assert.Equal(t, "bullseye", dist.VersionCodeName)
+
+	require.Contains(t, report.Repositories, "repo1")
+	repo := report.Repositories["repo1"]
+	assert.Equal(t, "debian-main", repo.Name)
+	assert.Equal(t, "http://deb.debian.org/debian", repo.URI)
+
+	require.Contains(t, report.Environments, "env1")
+	require.Len(t, report.Environments["env1"], 1)
+	env := report.Environments["env1"][0]
+	assert.Equal(t, "sha256:layer1", env.IntroducedIn)
+	assert.Equal(t, "dist1", env.DistributionID)
+	assert.Equal(t, []string{"repo1"}, env.RepositoryIDs)
+}
+
+func TestVulnerabilityReport_Unmarshal(t *testing.T) {
+	issued := time.Date(2021, 5, 1, 0, 0, 0, 0, time.UTC)
+	jsonData := `{
+		"manifest_hash": "sha256:abc123",
+		"state": "IndexFinished",
+		"success": true,
+		"err": "",
+		"packages": {
+			"pkg1": {
+				"id": "pkg1",
+				"name": "openssl",
+				"version": "1.1.1k"
+			}
+		},
+		"distributions": {
+			"dist1": {
+				"id": "dist1",
+				"name": "Debian"
+			}
+		},
+		"repository": {
+			"repo1": {
+				"id": "repo1",
+				"name": "debian-main"
+			}
+		},
+		"environments": {
+			"env1": [
+				{
+					"package_db": "var/lib/dpkg/status",
+					"introduced_in": "sha256:layer1"
+				}
+			]
+		},
+		"vulnerabilities": {
+			"vuln1": {
+				"id": "CVE-2021-3450",
+				"name": "CVE-2021-3450",
+				"description": "OpenSSL TLS vulnerability",
+				"issued": "2021-05-01T00:00:00Z",
+				"links": "https://nvd.nist.gov/vuln/detail/CVE-2021-3450",
+				"severity": "High",
+				"normalized_severity": "High",
+				"fixed_in_version": "1.1.1l",
+				"updater": "debian-updater"
+			}
+		},
+		"package_vulnerabilities": {
+			"pkg1": ["vuln1"]
+		},
+		"enrichments": {
+			"vuln1": [
+				{"source": "nvd", "score": 7.4}
+			]
+		}
+	}`
+
+	var report VulnerabilityReport
+	err := json.Unmarshal([]byte(jsonData), &report)
+	require.NoError(t, err)
+
+	assert.Equal(t, "sha256:abc123", report.ManifestHash)
+	assert.True(t, report.Success)
+
+	require.Contains(t, report.Packages, "pkg1")
+	assert.Equal(t, "openssl", report.Packages["pkg1"].Name)
+
+	require.Contains(t, report.Distributions, "dist1")
+	require.Contains(t, report.Repositories, "repo1")
+	require.Contains(t, report.Environments, "env1")
+
+	require.Contains(t, report.Vulnerabilities, "vuln1")
+	vuln := report.Vulnerabilities["vuln1"]
+	assert.Equal(t, "CVE-2021-3450", vuln.ID)
+	assert.Equal(t, "OpenSSL TLS vulnerability", vuln.Description)
+	assert.Equal(t, issued, vuln.Issued)
+	assert.Equal(t, "High", vuln.Severity)
+	assert.Equal(t, "1.1.1l", vuln.FixedInVersion)
+
+	require.Contains(t, report.PackageVulnerabilities, "pkg1")
+	assert.Equal(t, []string{"vuln1"}, report.PackageVulnerabilities["pkg1"])
+
+	require.Contains(t, report.Enrichments, "vuln1")
+	require.Len(t, report.Enrichments["vuln1"], 1)
+}

--- a/clair-adapter/cmd/clair-adapter/main.go
+++ b/clair-adapter/cmd/clair-adapter/main.go
@@ -21,6 +21,7 @@ import (
 	matcherpkg "github.com/stackrox/rox/clair-adapter/matcher"
 	"github.com/stackrox/rox/clair-adapter/services"
 	"github.com/stackrox/rox/clair-adapter/updater"
+	"github.com/stackrox/rox/clair-adapter/vulnimporter"
 	pkggrpc "github.com/stackrox/rox/pkg/grpc"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	authnservice "github.com/stackrox/rox/pkg/grpc/authn/service"
@@ -49,14 +50,14 @@ func run(configPath string) error {
 
 	slog.Info("starting clair-adapter",
 		"clair_url", cfg.ClairURL,
+		"clair_db", cfg.ClairDBConnString != "",
 		"grpc_addr", cfg.GRPCListenAddr,
 		"http_addr", cfg.HTTPListenAddr,
-		"updater_addr", cfg.UpdaterListenAddr,
 		"vuln_url", cfg.VulnerabilitiesURL,
 		"certs_dir", cfg.CertsDir,
 	)
 
-	// Configure mTLS certificate paths if CertsDir is set
+	// Configure mTLS certificate paths if CertsDir is set.
 	if cfg.CertsDir != "" {
 		os.Setenv(mtls.CAFileEnvName, filepath.Join(cfg.CertsDir, mtls.CACertFileName))
 		os.Setenv(mtls.CertFilePathEnvName, filepath.Join(cfg.CertsDir, mtls.ServiceCertFileName))
@@ -72,9 +73,36 @@ func run(configPath string) error {
 		return fmt.Errorf("creating clair client: %w", err)
 	}
 
-	// Updater: fetch vulnerability data and serve to Clair
+	// Set up vulnerability bundle importer if Clair DB connection is configured.
+	var imp *vulnimporter.Importer
+	if cfg.ClairDBConnString != "" {
+		slog.Info("connecting to Clair database for direct vulnerability import")
+		store, err := vulnimporter.NewMatcherStore(ctx, cfg.ClairDBConnString)
+		if err != nil {
+			return fmt.Errorf("creating Clair matcher store: %w", err)
+		}
+		// Pass adapter's MatcherMetadataStore if available (nil is safe).
+		imp = vulnimporter.NewImporter(store, nil)
+	}
+
+	// Configure HTTP client for fetching vulnerability bundles.
+	// Use mTLS if certs are available (for Central's definitions endpoint).
+	var fetcherOpts []updater.FetcherOption
+	if cfg.CertsDir != "" {
+		mtlsClient, err := updater.NewMTLSHTTPClient()
+		if err != nil {
+			slog.WarnContext(ctx, "failed to create mTLS HTTP client, using default", "error", err)
+		} else {
+			fetcherOpts = append(fetcherOpts, updater.WithHTTPClient(mtlsClient))
+		}
+	}
+	if imp != nil {
+		fetcherOpts = append(fetcherOpts, updater.WithImporter(imp))
+	}
+
+	// Updater: fetch vulnerability data, serve to Clair, and import into Clair's DB.
 	updaterServer := updater.NewServer()
-	fetcher := updater.NewFetcher(updaterServer, []string{cfg.VulnerabilitiesURL})
+	fetcher := updater.NewFetcher(updaterServer, []string{cfg.VulnerabilitiesURL}, fetcherOpts...)
 	go func() {
 		slog.Info("starting vulnerability data fetcher")
 		if err := fetcher.Start(ctx); err != nil && ctx.Err() == nil {
@@ -82,6 +110,7 @@ func run(configPath string) error {
 		}
 	}()
 
+	// Keep the updater HTTP server as a diagnostic endpoint.
 	updaterHTTPServer := &http.Server{
 		Addr:    cfg.UpdaterListenAddr,
 		Handler: updaterServer,
@@ -93,23 +122,23 @@ func run(configPath string) error {
 		}
 	}()
 
-	// Enrichment pipeline
+	// Enrichment pipeline.
 	csafEnricher := csafpkg.NewEnricher()
 	enricherPipeline := enricher.NewPipeline(enricher.WithCSAFEnricher(csafEnricher))
 
-	// Indexer
+	// Indexer.
 	var idx idxpkg.Indexer
 	if cfg.Indexer.Enable {
 		idx = idxpkg.NewLocalIndexer(clairClient, nil)
 	}
 
-	// Matcher
+	// Matcher.
 	var mtch matcherpkg.Matcher
 	if cfg.Matcher.Enable {
 		mtch = matcherpkg.NewLocalMatcher(clairClient, enricherPipeline, nil)
 	}
 
-	// Health handler with readiness check
+	// Health handler.
 	readinessFunc := func() bool {
 		hctx, hcancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer hcancel()
@@ -118,13 +147,13 @@ func run(configPath string) error {
 	}
 	healthHandler := healthz.NewHandler(readinessFunc)
 
-	// Identity extractor for mTLS client certificates
+	// Identity extractor for mTLS client certificates.
 	identityExtractor, err := authnservice.NewExtractor()
 	if err != nil {
 		return fmt.Errorf("creating identity extractor: %w", err)
 	}
 
-	// Build gRPC API with mTLS support
+	// gRPC API with mTLS.
 	grpcAPI := pkggrpc.NewAPI(pkggrpc.Config{
 		CustomRoutes:       healthHandler.CustomRoutes(),
 		IdentityExtractors: []authn.IdentityExtractor{identityExtractor},
@@ -134,7 +163,6 @@ func run(configPath string) error {
 		},
 	})
 
-	// Register API services
 	var apiServices []pkggrpc.APIService
 	if idx != nil {
 		apiServices = append(apiServices, services.NewIndexerService(idx))
@@ -144,7 +172,6 @@ func run(configPath string) error {
 	}
 	grpcAPI.Register(apiServices...)
 
-	// Start gRPC API
 	startSig := grpcAPI.Start()
 	select {
 	case <-startSig.Done():
@@ -158,7 +185,6 @@ func run(configPath string) error {
 		return fmt.Errorf("timeout waiting for gRPC API to start")
 	}
 
-	// Wait for shutdown signal
 	<-ctx.Done()
 	slog.Info("shutting down gracefully")
 

--- a/clair-adapter/cmd/clair-adapter/main.go
+++ b/clair-adapter/cmd/clair-adapter/main.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stackrox/rox/clair-adapter/services"
 	"github.com/stackrox/rox/clair-adapter/updater"
 	pkggrpc "github.com/stackrox/rox/pkg/grpc"
+	"github.com/stackrox/rox/pkg/grpc/authn"
+	authnservice "github.com/stackrox/rox/pkg/grpc/authn/service"
 	"github.com/stackrox/rox/pkg/mtls"
 	"github.com/stackrox/rox/pkg/mtls/verifier"
 )
@@ -116,9 +118,16 @@ func run(configPath string) error {
 	}
 	healthHandler := healthz.NewHandler(readinessFunc)
 
+	// Identity extractor for mTLS client certificates
+	identityExtractor, err := authnservice.NewExtractor()
+	if err != nil {
+		return fmt.Errorf("creating identity extractor: %w", err)
+	}
+
 	// Build gRPC API with mTLS support
 	grpcAPI := pkggrpc.NewAPI(pkggrpc.Config{
-		CustomRoutes: healthHandler.CustomRoutes(),
+		CustomRoutes:       healthHandler.CustomRoutes(),
+		IdentityExtractors: []authn.IdentityExtractor{identityExtractor},
 		Endpoints: []*pkggrpc.EndpointConfig{
 			{ListenEndpoint: cfg.GRPCListenAddr, TLS: verifier.NonCA{}, ServeGRPC: true, ServeHTTP: false},
 			{ListenEndpoint: cfg.HTTPListenAddr, TLS: verifier.NonCA{}, ServeGRPC: false, ServeHTTP: true},

--- a/clair-adapter/cmd/clair-adapter/main.go
+++ b/clair-adapter/cmd/clair-adapter/main.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	"github.com/stackrox/rox/clair-adapter/config"
+	"github.com/stackrox/rox/clair-adapter/enricher"
+	csafpkg "github.com/stackrox/rox/clair-adapter/enricher/csaf"
+	"github.com/stackrox/rox/clair-adapter/healthz"
+	idxpkg "github.com/stackrox/rox/clair-adapter/indexer"
+	matcherpkg "github.com/stackrox/rox/clair-adapter/matcher"
+	"github.com/stackrox/rox/clair-adapter/services"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+)
+
+func main() {
+	configPath := flag.String("config", "", "path to config file")
+	flag.Parse()
+	if err := run(*configPath); err != nil {
+		slog.Error("fatal", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(configPath string) error {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	// Set up logging
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: cfg.LogLevel,
+	})))
+
+	slog.Info("starting clair-adapter",
+		"clair_url", cfg.ClairURL,
+		"grpc_addr", cfg.GRPCListenAddr,
+		"http_addr", cfg.HTTPListenAddr,
+		"indexer_enabled", cfg.Indexer.Enable,
+		"matcher_enabled", cfg.Matcher.Enable,
+	)
+
+	// Create Clair client
+	clairClient, err := clairclient.NewClient(cfg.ClairURL)
+	if err != nil {
+		return fmt.Errorf("creating clair client: %w", err)
+	}
+
+	// Create CSAF enricher + pipeline
+	csafEnricher := csafpkg.NewEnricher()
+	enricherPipeline := enricher.NewPipeline(csafEnricher)
+
+	// Create indexer (nil metadataStore for now — DB init is future plan)
+	var idx *idxpkg.Indexer
+	if cfg.Indexer.Enable {
+		idx = idxpkg.NewIndexer(clairClient, nil)
+	}
+
+	// Create matcher (nil metadataStore)
+	var mtch *matcherpkg.Matcher
+	if cfg.Matcher.Enable {
+		mtch = matcherpkg.NewMatcher(clairClient, nil, enricherPipeline)
+	}
+
+	// Create gRPC server
+	grpcServer := grpc.NewServer()
+	if idx != nil {
+		indexService := services.NewIndexerService(idx)
+		v4.RegisterIndexerServiceServer(grpcServer, indexService)
+	}
+	if mtch != nil {
+		matchService := services.NewMatcherService(mtch)
+		v4.RegisterMatcherServiceServer(grpcServer, matchService)
+	}
+	reflection.Register(grpcServer)
+
+	// Create health HTTP server
+	isReady := func() bool {
+		// Ping Clair to verify connectivity
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		return clairClient.IndexState(ctx) != nil
+	}
+	healthHandler := healthz.NewHandler(isReady)
+	httpServer := &http.Server{
+		Addr:    cfg.HTTPListenAddr,
+		Handler: healthHandler,
+	}
+
+	// Start gRPC server
+	grpcListener, err := net.Listen("tcp", cfg.GRPCListenAddr)
+	if err != nil {
+		return fmt.Errorf("creating grpc listener: %w", err)
+	}
+	go func() {
+		slog.Info("grpc server listening", "addr", cfg.GRPCListenAddr)
+		if err := grpcServer.Serve(grpcListener); err != nil {
+			slog.Error("grpc server failed", "error", err)
+		}
+	}()
+
+	// Start HTTP health server
+	go func() {
+		slog.Info("http health server listening", "addr", cfg.HTTPListenAddr)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("http server failed", "error", err)
+		}
+	}()
+
+	// Wait for signal
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	<-sigCh
+
+	slog.Info("shutting down gracefully")
+
+	// Graceful shutdown
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	grpcServer.GracefulStop()
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		slog.Error("http server shutdown failed", "error", err)
+	}
+
+	slog.Info("shutdown complete")
+	return nil
+}

--- a/clair-adapter/cmd/clair-adapter/main.go
+++ b/clair-adapter/cmd/clair-adapter/main.go
@@ -20,6 +20,7 @@ import (
 	idxpkg "github.com/stackrox/rox/clair-adapter/indexer"
 	matcherpkg "github.com/stackrox/rox/clair-adapter/matcher"
 	"github.com/stackrox/rox/clair-adapter/services"
+	"github.com/stackrox/rox/clair-adapter/updater"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -40,7 +41,6 @@ func run(configPath string) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	// Set up logging
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: cfg.LogLevel,
 	})))
@@ -49,93 +49,104 @@ func run(configPath string) error {
 		"clair_url", cfg.ClairURL,
 		"grpc_addr", cfg.GRPCListenAddr,
 		"http_addr", cfg.HTTPListenAddr,
-		"indexer_enabled", cfg.Indexer.Enable,
-		"matcher_enabled", cfg.Matcher.Enable,
+		"updater_addr", cfg.UpdaterListenAddr,
+		"vuln_url", cfg.VulnerabilitiesURL,
 	)
 
-	// Create Clair client
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
 	clairClient, err := clairclient.NewClient(cfg.ClairURL)
 	if err != nil {
 		return fmt.Errorf("creating clair client: %w", err)
 	}
 
-	// Create CSAF enricher + pipeline
+	// Updater: fetch vulnerability data and serve to Clair
+	updaterServer := updater.NewServer()
+	fetcher := updater.NewFetcher(updaterServer, []string{cfg.VulnerabilitiesURL})
+	go func() {
+		slog.Info("starting vulnerability data fetcher")
+		if err := fetcher.Start(ctx); err != nil && ctx.Err() == nil {
+			slog.Error("vulnerability fetcher failed", "error", err)
+		}
+	}()
+
+	updaterHTTPServer := &http.Server{
+		Addr:    cfg.UpdaterListenAddr,
+		Handler: updaterServer,
+	}
+	go func() {
+		slog.Info("updater HTTP server listening", "addr", cfg.UpdaterListenAddr)
+		if err := updaterHTTPServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("updater HTTP server failed", "error", err)
+		}
+	}()
+
+	// Enrichment pipeline
 	csafEnricher := csafpkg.NewEnricher()
 	enricherPipeline := enricher.NewPipeline(enricher.WithCSAFEnricher(csafEnricher))
 
-	// Create indexer (nil metadataStore for now — DB init is future plan)
+	// Indexer
 	var idx idxpkg.Indexer
 	if cfg.Indexer.Enable {
 		idx = idxpkg.NewLocalIndexer(clairClient, nil)
 	}
 
-	// Create matcher (nil metadataStore)
+	// Matcher
 	var mtch matcherpkg.Matcher
 	if cfg.Matcher.Enable {
 		mtch = matcherpkg.NewLocalMatcher(clairClient, enricherPipeline, nil)
 	}
 
-	// Create gRPC server
+	// gRPC server
 	grpcServer := grpc.NewServer()
 	if idx != nil {
-		indexService := services.NewIndexerService(idx)
-		v4.RegisterIndexerServer(grpcServer, indexService)
+		v4.RegisterIndexerServer(grpcServer, services.NewIndexerService(idx))
 	}
 	if mtch != nil {
-		matchService := services.NewMatcherService(mtch)
-		v4.RegisterMatcherServer(grpcServer, matchService)
+		v4.RegisterMatcherServer(grpcServer, services.NewMatcherService(mtch))
 	}
 	reflection.Register(grpcServer)
 
-	// Create health HTTP server
-	isReady := func() bool {
-		// Ping Clair to verify connectivity
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		_, err := clairClient.GetIndexState(ctx)
-		return err == nil
-	}
-	healthHandler := healthz.NewHandler(isReady)
-	httpServer := &http.Server{
-		Addr:    cfg.HTTPListenAddr,
-		Handler: healthHandler,
-	}
-
-	// Start gRPC server
-	grpcListener, err := net.Listen("tcp", cfg.GRPCListenAddr)
+	grpcLis, err := net.Listen("tcp", cfg.GRPCListenAddr)
 	if err != nil {
 		return fmt.Errorf("creating grpc listener: %w", err)
 	}
 	go func() {
-		slog.Info("grpc server listening", "addr", cfg.GRPCListenAddr)
-		if err := grpcServer.Serve(grpcListener); err != nil {
-			slog.Error("grpc server failed", "error", err)
+		slog.Info("gRPC server listening", "addr", cfg.GRPCListenAddr)
+		if err := grpcServer.Serve(grpcLis); err != nil {
+			slog.Error("gRPC server failed", "error", err)
 		}
 	}()
 
-	// Start HTTP health server
+	// Health server
+	healthHandler := healthz.NewHandler(func() bool {
+		hctx, hcancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer hcancel()
+		_, err := clairClient.GetIndexState(hctx)
+		return err == nil
+	})
+	httpServer := &http.Server{
+		Addr:    cfg.HTTPListenAddr,
+		Handler: healthHandler,
+	}
 	go func() {
-		slog.Info("http health server listening", "addr", cfg.HTTPListenAddr)
+		slog.Info("health HTTP server listening", "addr", cfg.HTTPListenAddr)
 		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("http server failed", "error", err)
+			slog.Error("health HTTP server failed", "error", err)
 		}
 	}()
 
-	// Wait for signal
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
-	<-sigCh
-
+	// Wait for shutdown signal
+	<-ctx.Done()
 	slog.Info("shutting down gracefully")
 
-	// Graceful shutdown
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
 
 	grpcServer.GracefulStop()
-	if err := httpServer.Shutdown(shutdownCtx); err != nil {
-		slog.Error("http server shutdown failed", "error", err)
-	}
+	httpServer.Shutdown(shutdownCtx)
+	updaterHTTPServer.Shutdown(shutdownCtx)
 
 	slog.Info("shutdown complete")
 	return nil

--- a/clair-adapter/cmd/clair-adapter/main.go
+++ b/clair-adapter/cmd/clair-adapter/main.go
@@ -5,10 +5,10 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -21,9 +21,9 @@ import (
 	matcherpkg "github.com/stackrox/rox/clair-adapter/matcher"
 	"github.com/stackrox/rox/clair-adapter/services"
 	"github.com/stackrox/rox/clair-adapter/updater"
-	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
+	pkggrpc "github.com/stackrox/rox/pkg/grpc"
+	"github.com/stackrox/rox/pkg/mtls"
+	"github.com/stackrox/rox/pkg/mtls/verifier"
 )
 
 func main() {
@@ -51,7 +51,16 @@ func run(configPath string) error {
 		"http_addr", cfg.HTTPListenAddr,
 		"updater_addr", cfg.UpdaterListenAddr,
 		"vuln_url", cfg.VulnerabilitiesURL,
+		"certs_dir", cfg.CertsDir,
 	)
+
+	// Configure mTLS certificate paths if CertsDir is set
+	if cfg.CertsDir != "" {
+		os.Setenv(mtls.CAFileEnvName, filepath.Join(cfg.CertsDir, mtls.CACertFileName))
+		os.Setenv(mtls.CertFilePathEnvName, filepath.Join(cfg.CertsDir, mtls.ServiceCertFileName))
+		os.Setenv(mtls.KeyFileEnvName, filepath.Join(cfg.CertsDir, mtls.ServiceKeyFileName))
+		slog.Info("mTLS configured", "certs_dir", cfg.CertsDir)
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -98,44 +107,47 @@ func run(configPath string) error {
 		mtch = matcherpkg.NewLocalMatcher(clairClient, enricherPipeline, nil)
 	}
 
-	// gRPC server
-	grpcServer := grpc.NewServer()
-	if idx != nil {
-		v4.RegisterIndexerServer(grpcServer, services.NewIndexerService(idx))
-	}
-	if mtch != nil {
-		v4.RegisterMatcherServer(grpcServer, services.NewMatcherService(mtch))
-	}
-	reflection.Register(grpcServer)
-
-	grpcLis, err := net.Listen("tcp", cfg.GRPCListenAddr)
-	if err != nil {
-		return fmt.Errorf("creating grpc listener: %w", err)
-	}
-	go func() {
-		slog.Info("gRPC server listening", "addr", cfg.GRPCListenAddr)
-		if err := grpcServer.Serve(grpcLis); err != nil {
-			slog.Error("gRPC server failed", "error", err)
-		}
-	}()
-
-	// Health server
-	healthHandler := healthz.NewHandler(func() bool {
+	// Health handler with readiness check
+	readinessFunc := func() bool {
 		hctx, hcancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer hcancel()
 		_, err := clairClient.GetIndexState(hctx)
 		return err == nil
-	})
-	httpServer := &http.Server{
-		Addr:    cfg.HTTPListenAddr,
-		Handler: healthHandler,
 	}
-	go func() {
-		slog.Info("health HTTP server listening", "addr", cfg.HTTPListenAddr)
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("health HTTP server failed", "error", err)
+	healthHandler := healthz.NewHandler(readinessFunc)
+
+	// Build gRPC API with mTLS support
+	grpcAPI := pkggrpc.NewAPI(pkggrpc.Config{
+		CustomRoutes: healthHandler.CustomRoutes(),
+		Endpoints: []*pkggrpc.EndpointConfig{
+			{ListenEndpoint: cfg.GRPCListenAddr, TLS: verifier.NonCA{}, ServeGRPC: true, ServeHTTP: false},
+			{ListenEndpoint: cfg.HTTPListenAddr, TLS: verifier.NonCA{}, ServeGRPC: false, ServeHTTP: true},
+		},
+	})
+
+	// Register API services
+	var apiServices []pkggrpc.APIService
+	if idx != nil {
+		apiServices = append(apiServices, services.NewIndexerService(idx))
+	}
+	if mtch != nil {
+		apiServices = append(apiServices, services.NewMatcherService(mtch))
+	}
+	grpcAPI.Register(apiServices...)
+
+	// Start gRPC API
+	startSig := grpcAPI.Start()
+	select {
+	case <-startSig.Done():
+		if err := startSig.Err(); err != nil {
+			return fmt.Errorf("failed to start gRPC API: %w", err)
 		}
-	}()
+		slog.Info("gRPC API started", "grpc_addr", cfg.GRPCListenAddr, "http_addr", cfg.HTTPListenAddr)
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(10 * time.Second):
+		return fmt.Errorf("timeout waiting for gRPC API to start")
+	}
 
 	// Wait for shutdown signal
 	<-ctx.Done()
@@ -144,8 +156,7 @@ func run(configPath string) error {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
 
-	grpcServer.GracefulStop()
-	httpServer.Shutdown(shutdownCtx)
+	grpcAPI.Stop()
 	updaterHTTPServer.Shutdown(shutdownCtx)
 
 	slog.Info("shutdown complete")

--- a/clair-adapter/cmd/clair-adapter/main.go
+++ b/clair-adapter/cmd/clair-adapter/main.go
@@ -61,29 +61,29 @@ func run(configPath string) error {
 
 	// Create CSAF enricher + pipeline
 	csafEnricher := csafpkg.NewEnricher()
-	enricherPipeline := enricher.NewPipeline(csafEnricher)
+	enricherPipeline := enricher.NewPipeline(enricher.WithCSAFEnricher(csafEnricher))
 
 	// Create indexer (nil metadataStore for now — DB init is future plan)
-	var idx *idxpkg.Indexer
+	var idx idxpkg.Indexer
 	if cfg.Indexer.Enable {
-		idx = idxpkg.NewIndexer(clairClient, nil)
+		idx = idxpkg.NewLocalIndexer(clairClient, nil)
 	}
 
 	// Create matcher (nil metadataStore)
-	var mtch *matcherpkg.Matcher
+	var mtch matcherpkg.Matcher
 	if cfg.Matcher.Enable {
-		mtch = matcherpkg.NewMatcher(clairClient, nil, enricherPipeline)
+		mtch = matcherpkg.NewLocalMatcher(clairClient, enricherPipeline, nil)
 	}
 
 	// Create gRPC server
 	grpcServer := grpc.NewServer()
 	if idx != nil {
 		indexService := services.NewIndexerService(idx)
-		v4.RegisterIndexerServiceServer(grpcServer, indexService)
+		v4.RegisterIndexerServer(grpcServer, indexService)
 	}
 	if mtch != nil {
 		matchService := services.NewMatcherService(mtch)
-		v4.RegisterMatcherServiceServer(grpcServer, matchService)
+		v4.RegisterMatcherServer(grpcServer, matchService)
 	}
 	reflection.Register(grpcServer)
 
@@ -92,7 +92,8 @@ func run(configPath string) error {
 		// Ping Clair to verify connectivity
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
-		return clairClient.IndexState(ctx) != nil
+		_, err := clairClient.GetIndexState(ctx)
+		return err == nil
 	}
 	healthHandler := healthz.NewHandler(isReady)
 	httpServer := &http.Server{

--- a/clair-adapter/cmd/clair-adapter/main.go
+++ b/clair-adapter/cmd/clair-adapter/main.go
@@ -73,16 +73,17 @@ func run(configPath string) error {
 		return fmt.Errorf("creating clair client: %w", err)
 	}
 
-	// Set up vulnerability bundle importer if Clair DB connection is configured.
+	// Set up vulnerability bundle importer and enrichment fetcher if Clair DB is configured.
 	var imp *vulnimporter.Importer
+	var enrichFetcher *vulnimporter.EnrichmentFetcher
 	if cfg.ClairDBConnString != "" {
 		slog.Info("connecting to Clair database for direct vulnerability import")
-		store, err := vulnimporter.NewMatcherStore(ctx, cfg.ClairDBConnString)
+		store, pool, err := vulnimporter.NewMatcherStoreAndPool(ctx, cfg.ClairDBConnString)
 		if err != nil {
 			return fmt.Errorf("creating Clair matcher store: %w", err)
 		}
-		// Pass adapter's MatcherMetadataStore if available (nil is safe).
 		imp = vulnimporter.NewImporter(store, nil)
+		enrichFetcher = vulnimporter.NewEnrichmentFetcher(pool)
 	}
 
 	// Configure HTTP client for fetching vulnerability bundles.
@@ -135,7 +136,11 @@ func run(configPath string) error {
 	// Matcher.
 	var mtch matcherpkg.Matcher
 	if cfg.Matcher.Enable {
-		mtch = matcherpkg.NewLocalMatcher(clairClient, enricherPipeline, nil)
+		var matcherOpts []matcherpkg.LocalMatcherOption
+		if enrichFetcher != nil {
+			matcherOpts = append(matcherOpts, matcherpkg.WithEnrichmentFetcher(enrichFetcher))
+		}
+		mtch = matcherpkg.NewLocalMatcher(clairClient, enricherPipeline, nil, matcherOpts...)
 	}
 
 	// Health handler.

--- a/clair-adapter/config/config.go
+++ b/clair-adapter/config/config.go
@@ -10,6 +10,7 @@ import (
 
 type Config struct {
 	ClairURL           string        `yaml:"clair_url"`
+	ClairDBConnString  string        `yaml:"clair_db_connstring"`
 	GRPCListenAddr     string        `yaml:"grpc_listen_addr"`
 	HTTPListenAddr     string        `yaml:"http_listen_addr"`
 	UpdaterListenAddr  string        `yaml:"updater_listen_addr"`

--- a/clair-adapter/config/config.go
+++ b/clair-adapter/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	HTTPListenAddr     string        `yaml:"http_listen_addr"`
 	UpdaterListenAddr  string        `yaml:"updater_listen_addr"`
 	VulnerabilitiesURL string        `yaml:"vulnerabilities_url"`
+	CertsDir           string        `yaml:"certs_dir"`
 	Indexer            IndexerConfig `yaml:"indexer"`
 	Matcher            MatcherConfig `yaml:"matcher"`
 	LogLevel           slog.Level    `yaml:"log_level"`

--- a/clair-adapter/config/config.go
+++ b/clair-adapter/config/config.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	ClairURL       string        `yaml:"clair_url"`
+	GRPCListenAddr string        `yaml:"grpc_listen_addr"`
+	HTTPListenAddr string        `yaml:"http_listen_addr"`
+	Indexer        IndexerConfig `yaml:"indexer"`
+	Matcher        MatcherConfig `yaml:"matcher"`
+	LogLevel       slog.Level    `yaml:"log_level"`
+}
+
+type IndexerConfig struct {
+	Database DatabaseConfig `yaml:"database"`
+	Enable   bool           `yaml:"enable"`
+}
+
+type MatcherConfig struct {
+	Database DatabaseConfig `yaml:"database"`
+	Enable   bool           `yaml:"enable"`
+}
+
+type DatabaseConfig struct {
+	ConnString string `yaml:"conn_string"`
+}
+
+func Defaults() *Config {
+	return &Config{
+		ClairURL:       "http://localhost:8080",
+		GRPCListenAddr: ":8443",
+		HTTPListenAddr: ":9443",
+		Indexer:        IndexerConfig{Enable: true},
+		Matcher:        MatcherConfig{Enable: true},
+		LogLevel:       slog.LevelInfo,
+	}
+}
+
+func Load(path string) (*Config, error) {
+	cfg := Defaults()
+	if path == "" {
+		return cfg, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+	return cfg, nil
+}

--- a/clair-adapter/config/config.go
+++ b/clair-adapter/config/config.go
@@ -9,12 +9,14 @@ import (
 )
 
 type Config struct {
-	ClairURL       string        `yaml:"clair_url"`
-	GRPCListenAddr string        `yaml:"grpc_listen_addr"`
-	HTTPListenAddr string        `yaml:"http_listen_addr"`
-	Indexer        IndexerConfig `yaml:"indexer"`
-	Matcher        MatcherConfig `yaml:"matcher"`
-	LogLevel       slog.Level    `yaml:"log_level"`
+	ClairURL           string        `yaml:"clair_url"`
+	GRPCListenAddr     string        `yaml:"grpc_listen_addr"`
+	HTTPListenAddr     string        `yaml:"http_listen_addr"`
+	UpdaterListenAddr  string        `yaml:"updater_listen_addr"`
+	VulnerabilitiesURL string        `yaml:"vulnerabilities_url"`
+	Indexer            IndexerConfig `yaml:"indexer"`
+	Matcher            MatcherConfig `yaml:"matcher"`
+	LogLevel           slog.Level    `yaml:"log_level"`
 }
 
 type IndexerConfig struct {
@@ -33,12 +35,14 @@ type DatabaseConfig struct {
 
 func Defaults() *Config {
 	return &Config{
-		ClairURL:       "http://localhost:8080",
-		GRPCListenAddr: ":8443",
-		HTTPListenAddr: ":9443",
-		Indexer:        IndexerConfig{Enable: true},
-		Matcher:        MatcherConfig{Enable: true},
-		LogLevel:       slog.LevelInfo,
+		ClairURL:           "http://localhost:8080",
+		GRPCListenAddr:     ":8443",
+		HTTPListenAddr:     ":9443",
+		UpdaterListenAddr:  ":9444",
+		VulnerabilitiesURL: "https://definitions.stackrox.io/v4/vulnerability-bundles/dev/vulnerabilities.zip",
+		Indexer:            IndexerConfig{Enable: true},
+		Matcher:            MatcherConfig{Enable: true},
+		LogLevel:           slog.LevelInfo,
 	}
 }
 

--- a/clair-adapter/datastore/postgres/connect.go
+++ b/clair-adapter/datastore/postgres/connect.go
@@ -1,0 +1,66 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	maxRetries      = 30
+	retryInterval   = 10 * time.Second
+	initialConnWait = 5 * time.Second
+)
+
+// Connect establishes a connection pool to PostgreSQL with retry logic.
+// It sets the application_name runtime parameter and verifies connectivity with a ping.
+func Connect(ctx context.Context, connString string, applicationName string) (*pgxpool.Pool, error) {
+	config, err := pgxpool.ParseConfig(connString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse connection string: %w", err)
+	}
+
+	// Set application name for connection tracking
+	config.ConnConfig.RuntimeParams["application_name"] = applicationName
+
+	var pool *pgxpool.Pool
+	var lastErr error
+
+	// Allow initial connection delay
+	time.Sleep(initialConnWait)
+
+	for attempt := range maxRetries {
+		pool, err = pgxpool.NewWithConfig(ctx, config)
+		if err != nil {
+			lastErr = fmt.Errorf("attempt %d failed to create pool: %w", attempt+1, err)
+			slog.Warn("Failed to create connection pool", "attempt", attempt+1, "error", err)
+
+			if attempt < maxRetries-1 {
+				time.Sleep(retryInterval)
+			}
+			continue
+		}
+
+		// Verify connection with ping
+		if err := pool.Ping(ctx); err != nil {
+			pool.Close()
+			lastErr = fmt.Errorf("attempt %d failed to ping database: %w", attempt+1, err)
+			slog.Warn("Failed to ping database", "attempt", attempt+1, "error", err)
+
+			if attempt < maxRetries-1 {
+				time.Sleep(retryInterval)
+			}
+			continue
+		}
+
+		slog.Info("Successfully connected to PostgreSQL",
+			"attempt", attempt+1,
+			"application_name", applicationName)
+		return pool, nil
+	}
+
+	return nil, fmt.Errorf("failed to connect after %d attempts: %w", maxRetries, lastErr)
+}

--- a/clair-adapter/datastore/postgres/indexer_metadata_store.go
+++ b/clair-adapter/datastore/postgres/indexer_metadata_store.go
@@ -1,0 +1,101 @@
+package postgres
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stackrox/rox/clair-adapter/datastore"
+)
+
+//go:embed migrations/indexer/01-init.sql
+var indexerInitSchema string
+
+// indexerMetadataStore implements datastore.IndexerMetadataStore for PostgreSQL.
+type indexerMetadataStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewIndexerMetadataStore creates a new IndexerMetadataStore and initializes the schema.
+func NewIndexerMetadataStore(ctx context.Context, pool *pgxpool.Pool) (datastore.IndexerMetadataStore, error) {
+	store := &indexerMetadataStore{pool: pool}
+
+	// Initialize schema
+	if _, err := pool.Exec(ctx, indexerInitSchema); err != nil {
+		return nil, fmt.Errorf("failed to initialize indexer metadata schema: %w", err)
+	}
+
+	return store, nil
+}
+
+// StoreManifest records or updates a manifest with its expiration time.
+func (s *indexerMetadataStore) StoreManifest(ctx context.Context, manifestID string, expiration time.Time) error {
+	query := `
+		INSERT INTO manifest_metadata (manifest_id, expiration)
+		VALUES ($1, $2)
+		ON CONFLICT (manifest_id)
+		DO UPDATE SET expiration = EXCLUDED.expiration
+	`
+
+	_, err := s.pool.Exec(ctx, query, manifestID, expiration)
+	if err != nil {
+		return fmt.Errorf("failed to store manifest metadata: %w", err)
+	}
+
+	return nil
+}
+
+// ManifestExists checks if a manifest is present in the metadata store.
+func (s *indexerMetadataStore) ManifestExists(ctx context.Context, manifestID string) (bool, error) {
+	query := `SELECT EXISTS(SELECT 1 FROM manifest_metadata WHERE manifest_id = $1)`
+
+	var exists bool
+	err := s.pool.QueryRow(ctx, query, manifestID).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to check manifest existence: %w", err)
+	}
+
+	return exists, nil
+}
+
+// GCManifests deletes up to limit expired manifests older than the given expiration time.
+// Returns the list of deleted manifest IDs.
+func (s *indexerMetadataStore) GCManifests(ctx context.Context, expiration time.Time, limit int) ([]string, error) {
+	query := `
+		DELETE FROM manifest_metadata
+		WHERE manifest_id IN (
+			SELECT manifest_id
+			FROM manifest_metadata
+			WHERE expiration < $1
+			ORDER BY expiration
+			LIMIT $2
+		)
+		RETURNING manifest_id
+	`
+
+	rows, err := s.pool.Query(ctx, query, expiration, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to garbage collect manifests: %w", err)
+	}
+	defer rows.Close()
+
+	var deletedIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("failed to scan deleted manifest ID: %w", err)
+		}
+		deletedIDs = append(deletedIDs, id)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating deleted manifest IDs: %w", err)
+	}
+
+	return deletedIDs, nil
+}
+
+var _ datastore.IndexerMetadataStore = (*indexerMetadataStore)(nil)

--- a/clair-adapter/datastore/postgres/matcher_metadata_store.go
+++ b/clair-adapter/datastore/postgres/matcher_metadata_store.go
@@ -1,0 +1,77 @@
+package postgres
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/stackrox/rox/clair-adapter/datastore"
+)
+
+//go:embed migrations/matcher/01-init.sql
+var matcherInitSchema string
+
+//go:embed migrations/matcher/02-update-timestamp.sql
+var matcherTimestampMigration string
+
+// matcherMetadataStore implements datastore.MatcherMetadataStore for PostgreSQL.
+type matcherMetadataStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewMatcherMetadataStore creates a new MatcherMetadataStore and initializes the schema.
+func NewMatcherMetadataStore(ctx context.Context, pool *pgxpool.Pool) (datastore.MatcherMetadataStore, error) {
+	store := &matcherMetadataStore{pool: pool}
+
+	// Initialize schema - run both migrations in order
+	if _, err := pool.Exec(ctx, matcherInitSchema); err != nil {
+		return nil, fmt.Errorf("failed to initialize matcher metadata schema: %w", err)
+	}
+
+	if _, err := pool.Exec(ctx, matcherTimestampMigration); err != nil {
+		return nil, fmt.Errorf("failed to apply matcher timestamp migration: %w", err)
+	}
+
+	return store, nil
+}
+
+// GetLastVulnerabilityUpdate returns the earliest vulnerability update timestamp across all bundles.
+// Returns zero time if no updates have been recorded.
+func (s *matcherMetadataStore) GetLastVulnerabilityUpdate(ctx context.Context) (time.Time, error) {
+	query := `SELECT COALESCE(MIN(update_timestamp), to_timestamp(0)) FROM last_vuln_update`
+
+	var lastUpdate time.Time
+	err := s.pool.QueryRow(ctx, query).Scan(&lastUpdate)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to get last vulnerability update: %w", err)
+	}
+
+	return lastUpdate, nil
+}
+
+// SetLastVulnerabilityUpdate records the update timestamp for a specific vulnerability bundle.
+func (s *matcherMetadataStore) SetLastVulnerabilityUpdate(ctx context.Context, bundle string, lastUpdate time.Time) error {
+	query := `
+		INSERT INTO last_vuln_update (key, timestamp, update_timestamp)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (key)
+		DO UPDATE SET
+			timestamp = EXCLUDED.timestamp,
+			update_timestamp = EXCLUDED.update_timestamp
+	`
+
+	// Store both text timestamp for backwards compatibility and proper timestamp column
+	timestampText := lastUpdate.Format(time.RFC3339)
+
+	_, err := s.pool.Exec(ctx, query, bundle, timestampText, lastUpdate)
+	if err != nil {
+		return fmt.Errorf("failed to set last vulnerability update: %w", err)
+	}
+
+	return nil
+}
+
+var _ datastore.MatcherMetadataStore = (*matcherMetadataStore)(nil)

--- a/clair-adapter/datastore/postgres/migrations/indexer/01-init.sql
+++ b/clair-adapter/datastore/postgres/migrations/indexer/01-init.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS manifest_metadata (
+    manifest_id TEXT PRIMARY KEY,
+    expiration  TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS manifest_metadata_expiration_idx ON manifest_metadata(expiration);

--- a/clair-adapter/datastore/postgres/migrations/indexer/02-external-index-report.sql
+++ b/clair-adapter/datastore/postgres/migrations/indexer/02-external-index-report.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS external_index_report (
+    hash_id TEXT PRIMARY KEY,
+    indexer_version TEXT NOT NULL,
+    index_report JSONB NOT NULL,
+    expiration TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS external_index_report_expiration_idx ON external_index_report(expiration);

--- a/clair-adapter/datastore/postgres/migrations/matcher/01-init.sql
+++ b/clair-adapter/datastore/postgres/migrations/matcher/01-init.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS last_vuln_update (
+    key       VARCHAR(128) PRIMARY KEY,
+    timestamp TEXT
+);

--- a/clair-adapter/datastore/postgres/migrations/matcher/02-update-timestamp.sql
+++ b/clair-adapter/datastore/postgres/migrations/matcher/02-update-timestamp.sql
@@ -1,0 +1,2 @@
+ALTER TABLE last_vuln_update
+    ADD COLUMN IF NOT EXISTS update_timestamp TIMESTAMP DEFAULT to_timestamp(0) NOT NULL;

--- a/clair-adapter/datastore/types.go
+++ b/clair-adapter/datastore/types.go
@@ -1,0 +1,29 @@
+package datastore
+
+import (
+	"context"
+	"time"
+)
+
+// IndexerMetadataStore manages manifest lifecycle tracking in the indexer database.
+type IndexerMetadataStore interface {
+	// StoreManifest records or updates a manifest with its expiration time.
+	StoreManifest(ctx context.Context, manifestID string, expiration time.Time) error
+
+	// ManifestExists checks if a manifest is present in the metadata store.
+	ManifestExists(ctx context.Context, manifestID string) (bool, error)
+
+	// GCManifests deletes up to limit expired manifests older than the given expiration time.
+	// Returns the list of deleted manifest IDs.
+	GCManifests(ctx context.Context, expiration time.Time, limit int) ([]string, error)
+}
+
+// MatcherMetadataStore manages vulnerability update tracking in the matcher database.
+type MatcherMetadataStore interface {
+	// GetLastVulnerabilityUpdate returns the earliest vulnerability update timestamp across all bundles.
+	// Returns zero time if no updates have been recorded.
+	GetLastVulnerabilityUpdate(ctx context.Context) (time.Time, error)
+
+	// SetLastVulnerabilityUpdate records the update timestamp for a specific vulnerability bundle.
+	SetLastVulnerabilityUpdate(ctx context.Context, bundle string, lastUpdate time.Time) error
+}

--- a/clair-adapter/deploy/deploy-clair-adapter.sh
+++ b/clair-adapter/deploy/deploy-clair-adapter.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+#
+# Deploy Clair + Clair Adapter to a local Kubernetes cluster.
+#
+# Compatible with the StackRox deploy-local.sh workflow:
+#   1. Run ./deploy/deploy-local.sh first (with or without ROX_SCANNER_V4=false)
+#   2. Run this script to deploy Clair + Adapter alongside StackRox
+#
+# Environment variables:
+#   NAMESPACE              - Kubernetes namespace (default: stackrox)
+#   CLAIR_ADAPTER_IMAGE    - Adapter container image (default: clair-adapter:dev)
+#   CLAIR_IMAGE            - Upstream Clair image (default: quay.io/projectquay/clair:4.7.4)
+#   CLAIR_DB_IMAGE         - Clair PostgreSQL image (default: docker.io/library/postgres:15)
+#   VULN_URL               - Vulnerability definitions URL (default: definitions.stackrox.io)
+#   SCALE_DOWN_SCANNER_V4  - Scale down Scanner V4 if running (default: true)
+#   BUILD_IMAGE            - Build adapter image before deploying (default: false)
+#   CLUSTER_TYPE           - kind, minikube, or docker-desktop (auto-detected)
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${DIR}/../.." && pwd)"
+
+# Configuration with defaults
+NAMESPACE="${NAMESPACE:-stackrox}"
+CLAIR_ADAPTER_IMAGE="${CLAIR_ADAPTER_IMAGE:-clair-adapter:dev}"
+CLAIR_IMAGE="${CLAIR_IMAGE:-quay.io/projectquay/clair:4.7.4}"
+CLAIR_DB_IMAGE="${CLAIR_DB_IMAGE:-docker.io/library/postgres:15}"
+VULN_URL="${VULN_URL:-https://definitions.stackrox.io/v4/vulnerability-bundles/dev/vulnerabilities.zip}"
+SCALE_DOWN_SCANNER_V4="${SCALE_DOWN_SCANNER_V4:-true}"
+BUILD_IMAGE="${BUILD_IMAGE:-false}"
+
+# Auto-detect cluster type
+detect_cluster_type() {
+    if kubectl config current-context 2>/dev/null | grep -q "kind-"; then
+        echo "kind"
+    elif kubectl config current-context 2>/dev/null | grep -q "minikube"; then
+        echo "minikube"
+    else
+        echo "docker-desktop"
+    fi
+}
+CLUSTER_TYPE="${CLUSTER_TYPE:-$(detect_cluster_type)}"
+
+echo "=== Clair Adapter Deployment ==="
+echo "  Namespace:       ${NAMESPACE}"
+echo "  Adapter image:   ${CLAIR_ADAPTER_IMAGE}"
+echo "  Clair image:     ${CLAIR_IMAGE}"
+echo "  Cluster type:    ${CLUSTER_TYPE}"
+echo "  Vuln URL:        ${VULN_URL}"
+echo ""
+
+# Step 0: Optionally build the adapter image
+if [[ "${BUILD_IMAGE}" == "true" ]]; then
+    echo "--- Building clair-adapter image ---"
+    docker build -t "${CLAIR_ADAPTER_IMAGE}" -f "${DIR}/../Dockerfile" "${REPO_ROOT}"
+fi
+
+# Step 1: Load image into cluster if needed
+echo "--- Loading adapter image into cluster ---"
+case "${CLUSTER_TYPE}" in
+    kind)
+        kind load docker-image "${CLAIR_ADAPTER_IMAGE}" 2>/dev/null || echo "  (image may already be loaded or kind not in use)"
+        ;;
+    minikube)
+        minikube image load "${CLAIR_ADAPTER_IMAGE}" 2>/dev/null || echo "  (image may already be loaded)"
+        ;;
+    docker-desktop)
+        echo "  Docker Desktop: image is available locally"
+        ;;
+esac
+
+# Step 2: Create namespace if needed
+kubectl create namespace "${NAMESPACE}" 2>/dev/null || true
+
+# Step 3: Scale down Scanner V4 if running
+if [[ "${SCALE_DOWN_SCANNER_V4}" == "true" ]]; then
+    echo "--- Scaling down Scanner V4 (if present) ---"
+    kubectl scale deploy scanner-v4-indexer scanner-v4-matcher -n "${NAMESPACE}" --replicas=0 2>/dev/null || true
+fi
+
+# Step 4: Deploy Clair PostgreSQL
+echo "--- Deploying Clair PostgreSQL ---"
+kubectl apply -n "${NAMESPACE}" -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clair-db
+  labels:
+    app: clair-db
+    app.kubernetes.io/component: clair-db
+    app.kubernetes.io/part-of: clair-adapter
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: clair-db
+  template:
+    metadata:
+      labels:
+        app: clair-db
+    spec:
+      containers:
+      - name: postgres
+        image: ${CLAIR_DB_IMAGE}
+        env:
+        - name: POSTGRES_USER
+          value: clair
+        - name: POSTGRES_DB
+          value: clair
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: trust
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        ports:
+        - containerPort: 5432
+          protocol: TCP
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+        resources:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+          limits:
+            cpu: "1"
+            memory: 1Gi
+        readinessProbe:
+          exec:
+            command: ["pg_isready", "-U", "clair"]
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      volumes:
+      - name: data
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clair-db
+  labels:
+    app: clair-db
+    app.kubernetes.io/part-of: clair-adapter
+spec:
+  selector:
+    app: clair-db
+  ports:
+  - port: 5432
+    targetPort: 5432
+    protocol: TCP
+EOF
+
+# Step 5: Deploy Clair config and service
+echo "--- Deploying upstream Clair ---"
+kubectl apply -n "${NAMESPACE}" -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clair-config
+  labels:
+    app.kubernetes.io/part-of: clair-adapter
+data:
+  config.yaml: |
+    http_listen_addr: 0.0.0.0:8080
+    introspection_addr: 0.0.0.0:8089
+    log_level: info
+    indexer:
+      connstring: host=clair-db.${NAMESPACE}.svc port=5432 user=clair dbname=clair sslmode=disable
+      scanlock_retry: 10
+      layer_scan_concurrency: 5
+      migrations: true
+    matcher:
+      connstring: host=clair-db.${NAMESPACE}.svc port=5432 user=clair dbname=clair sslmode=disable
+      migrations: true
+    notifier:
+      connstring: host=clair-db.${NAMESPACE}.svc port=5432 user=clair dbname=clair sslmode=disable
+      migrations: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clair
+  labels:
+    app: clair
+    app.kubernetes.io/component: clair
+    app.kubernetes.io/part-of: clair-adapter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clair
+  template:
+    metadata:
+      labels:
+        app: clair
+    spec:
+      containers:
+      - name: clair
+        image: ${CLAIR_IMAGE}
+        args:
+        - "-conf"
+        - "/etc/clair/config.yaml"
+        - "-mode"
+        - "combo"
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 8089
+          name: introspection
+          protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /etc/clair
+        resources:
+          requests:
+            cpu: 200m
+            memory: 1Gi
+          limits:
+            cpu: "2"
+            memory: 4Gi
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8089
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8089
+          initialDelaySeconds: 60
+          periodSeconds: 30
+      volumes:
+      - name: config
+        configMap:
+          name: clair-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clair
+  labels:
+    app: clair
+    app.kubernetes.io/part-of: clair-adapter
+spec:
+  selector:
+    app: clair
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: http
+    protocol: TCP
+  - port: 8089
+    targetPort: 8089
+    name: introspection
+    protocol: TCP
+EOF
+
+# Step 6: Deploy Clair Adapter
+echo "--- Deploying Clair Adapter ---"
+kubectl apply -n "${NAMESPACE}" -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clair-adapter-config
+  labels:
+    app.kubernetes.io/part-of: clair-adapter
+data:
+  config.yaml: |
+    clair_url: "http://clair.${NAMESPACE}.svc:8080"
+    grpc_listen_addr: "0.0.0.0:8443"
+    http_listen_addr: "0.0.0.0:9443"
+    updater_listen_addr: "0.0.0.0:9444"
+    vulnerabilities_url: "${VULN_URL}"
+    indexer:
+      enable: true
+    matcher:
+      enable: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clair-adapter
+  labels:
+    app: clair-adapter
+    app.kubernetes.io/component: clair-adapter
+    app.kubernetes.io/part-of: clair-adapter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clair-adapter
+  template:
+    metadata:
+      labels:
+        app: clair-adapter
+    spec:
+      containers:
+      - name: clair-adapter
+        image: ${CLAIR_ADAPTER_IMAGE}
+        imagePullPolicy: IfNotPresent
+        args:
+        - "-config"
+        - "/etc/clair-adapter/config.yaml"
+        ports:
+        - containerPort: 8443
+          name: grpc
+          protocol: TCP
+        - containerPort: 9443
+          name: health
+          protocol: TCP
+        - containerPort: 9444
+          name: updater
+          protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /etc/clair-adapter
+        resources:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+          limits:
+            cpu: "1"
+            memory: 2Gi
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 9443
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthz/live
+            port: 9443
+          initialDelaySeconds: 5
+          periodSeconds: 15
+      volumes:
+      - name: config
+        configMap:
+          name: clair-adapter-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clair-adapter
+  labels:
+    app: clair-adapter
+    app.kubernetes.io/part-of: clair-adapter
+spec:
+  selector:
+    app: clair-adapter
+  ports:
+  - port: 8443
+    targetPort: 8443
+    name: grpc
+    protocol: TCP
+  - port: 9443
+    targetPort: 9443
+    name: health
+    protocol: TCP
+  - port: 9444
+    targetPort: 9444
+    name: updater
+    protocol: TCP
+EOF
+
+# Step 7: Wait for deployments
+echo ""
+echo "--- Waiting for pods to be ready ---"
+kubectl rollout status deploy/clair-db -n "${NAMESPACE}" --timeout=120s
+echo "  clair-db: ready"
+kubectl rollout status deploy/clair -n "${NAMESPACE}" --timeout=180s
+echo "  clair: ready"
+kubectl rollout status deploy/clair-adapter -n "${NAMESPACE}" --timeout=120s
+echo "  clair-adapter: ready"
+
+# Step 8: Print status and next steps
+echo ""
+echo "=== Deployment Complete ==="
+echo ""
+kubectl get pods -n "${NAMESPACE}" -l app.kubernetes.io/part-of=clair-adapter -o wide
+echo ""
+echo "--- Quick Test ---"
+echo ""
+echo "  # Port-forward gRPC (for grpcurl):"
+echo "  kubectl port-forward -n ${NAMESPACE} svc/clair-adapter 8443:8443"
+echo ""
+echo "  # List services:"
+echo "  grpcurl -plaintext localhost:8443 list"
+echo ""
+echo "  # Index an image:"
+echo "  grpcurl -plaintext localhost:8443 scanner.v4.Indexer/CreateIndexReport \\"
+echo "    -d '{\"hash_id\": \"/v4/containerimage/sha256:test1\", \"container_image\": {\"url\": \"https://docker.io/library/alpine:3.18\"}}'"
+echo ""
+echo "  # Get vulnerabilities:"
+echo "  grpcurl -plaintext localhost:8443 scanner.v4.Matcher/GetVulnerabilities \\"
+echo "    -d '{\"hash_id\": \"/v4/containerimage/sha256:test1\"}'"
+echo ""
+echo "  # Check adapter health:"
+echo "  kubectl port-forward -n ${NAMESPACE} svc/clair-adapter 9443:9443"
+echo "  curl http://localhost:9443/healthz/ready"
+echo ""
+echo "  # View logs:"
+echo "  kubectl logs -n ${NAMESPACE} deploy/clair-adapter -f"
+echo ""
+
+# Step 9: If StackRox Central is running, show integration instructions
+if kubectl get deploy/central -n "${NAMESPACE}" &>/dev/null; then
+    echo "--- StackRox Central Detected ---"
+    echo ""
+    echo "  Scanner V4 has been scaled down. To test with Central:"
+    echo ""
+    echo "  Note: Full Central integration requires mTLS (not yet implemented)."
+    echo "  For now, test via grpcurl directly against the adapter."
+    echo ""
+fi

--- a/clair-adapter/deploy/deploy-clair-adapter.sh
+++ b/clair-adapter/deploy/deploy-clair-adapter.sh
@@ -77,6 +77,67 @@ kubectl create namespace "${NAMESPACE}" 2>/dev/null || true
 if [[ "${SCALE_DOWN_SCANNER_V4}" == "true" ]]; then
     echo "--- Scaling down Scanner V4 (if present) ---"
     kubectl scale deploy scanner-v4-indexer scanner-v4-matcher -n "${NAMESPACE}" --replicas=0 2>/dev/null || true
+
+    echo "--- Patching Scanner V4 services to route to clair-adapter ---"
+    for svc in scanner-v4-indexer scanner-v4-matcher; do
+        kubectl patch svc "${svc}" -n "${NAMESPACE}" --type=json \
+            -p '[{"op":"replace","path":"/spec/selector","value":{"app":"clair-adapter"}}]' 2>/dev/null || true
+    done
+fi
+
+# Step 3b: Generate combined TLS cert for the adapter
+# The adapter needs a cert valid for both scanner-v4-indexer and scanner-v4-matcher
+# DNS names so Central can connect to it as either service.
+if kubectl get secret central-tls -n "${NAMESPACE}" &>/dev/null; then
+    echo "--- Generating clair-adapter TLS certificate ---"
+    CERT_TMPDIR="$(mktemp -d)"
+    trap 'rm -rf "${CERT_TMPDIR}"' EXIT
+
+    kubectl get secret central-tls -n "${NAMESPACE}" -o jsonpath='{.data.ca\.pem}' | base64 -d > "${CERT_TMPDIR}/ca.pem"
+    kubectl get secret central-tls -n "${NAMESPACE}" -o jsonpath='{.data.ca-key\.pem}' | base64 -d > "${CERT_TMPDIR}/ca-key.pem"
+
+    openssl genrsa -out "${CERT_TMPDIR}/key.pem" 2048 2>/dev/null
+
+    cat > "${CERT_TMPDIR}/csr.conf" <<CSREOF
+[req]
+default_bits = 2048
+prompt = no
+distinguished_name = dn
+req_extensions = v3_req
+
+[dn]
+CN = SCANNER_V4_INDEXER_SERVICE: Scanner V4 Indexer
+OU = SCANNER_V4_MATCHER_SERVICE
+
+[v3_req]
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+basicConstraints = critical, CA:FALSE
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = scanner-v4-indexer.${NAMESPACE}
+DNS.2 = scanner-v4-indexer.${NAMESPACE}.svc
+DNS.3 = scanner-v4-indexer.${NAMESPACE}.svc.cluster.local
+DNS.4 = scanner-v4-matcher.${NAMESPACE}
+DNS.5 = scanner-v4-matcher.${NAMESPACE}.svc
+DNS.6 = scanner-v4-matcher.${NAMESPACE}.svc.cluster.local
+CSREOF
+
+    openssl req -new -key "${CERT_TMPDIR}/key.pem" -out "${CERT_TMPDIR}/csr.pem" -config "${CERT_TMPDIR}/csr.conf" 2>/dev/null
+    openssl x509 -req -in "${CERT_TMPDIR}/csr.pem" \
+        -CA "${CERT_TMPDIR}/ca.pem" -CAkey "${CERT_TMPDIR}/ca-key.pem" -CAcreateserial \
+        -out "${CERT_TMPDIR}/cert.pem" -days 365 \
+        -extensions v3_req -extfile "${CERT_TMPDIR}/csr.conf" 2>/dev/null
+
+    kubectl create secret generic clair-adapter-tls -n "${NAMESPACE}" \
+        --from-file=ca.pem="${CERT_TMPDIR}/ca.pem" \
+        --from-file=cert.pem="${CERT_TMPDIR}/cert.pem" \
+        --from-file=key.pem="${CERT_TMPDIR}/key.pem" \
+        --dry-run=client -o yaml | kubectl apply -f - 2>/dev/null
+    echo "  clair-adapter-tls secret created"
+else
+    echo "  WARNING: central-tls secret not found, skipping TLS cert generation"
 fi
 
 # Step 4: Deploy Clair PostgreSQL
@@ -154,6 +215,31 @@ EOF
 
 # Step 5: Deploy Clair config and service
 echo "--- Deploying upstream Clair ---"
+
+# Capture desired config to detect changes
+CLAIR_CONFIG_DESIRED="$(cat <<CFGEOF
+http_listen_addr: 0.0.0.0:8080
+introspection_addr: 0.0.0.0:8089
+log_level: info
+indexer:
+  connstring: host=clair-db.${NAMESPACE}.svc port=5432 user=clair dbname=clair sslmode=disable
+  scanlock_retry: 10
+  layer_scan_concurrency: 5
+  migrations: true
+matcher:
+  connstring: host=clair-db.${NAMESPACE}.svc port=5432 user=clair dbname=clair sslmode=disable
+  migrations: true
+notifier:
+  connstring: host=clair-db.${NAMESPACE}.svc port=5432 user=clair dbname=clair sslmode=disable
+  migrations: true
+CFGEOF
+)"
+CLAIR_CONFIG_CURRENT="$(kubectl get configmap clair-config -n "${NAMESPACE}" -o jsonpath='{.data.config\.yaml}' 2>/dev/null)"
+CLAIR_CONFIG_CHANGED=false
+if [[ "${CLAIR_CONFIG_DESIRED}" != "${CLAIR_CONFIG_CURRENT}" ]]; then
+    CLAIR_CONFIG_CHANGED=true
+fi
+
 kubectl apply -n "${NAMESPACE}" -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
@@ -163,20 +249,7 @@ metadata:
     app.kubernetes.io/part-of: clair-adapter
 data:
   config.yaml: |
-    http_listen_addr: 0.0.0.0:8080
-    introspection_addr: 0.0.0.0:8089
-    log_level: info
-    indexer:
-      connstring: host=clair-db.${NAMESPACE}.svc port=5432 user=clair dbname=clair sslmode=disable
-      scanlock_retry: 10
-      layer_scan_concurrency: 5
-      migrations: true
-    matcher:
-      connstring: host=clair-db.${NAMESPACE}.svc port=5432 user=clair dbname=clair sslmode=disable
-      migrations: true
-    notifier:
-      connstring: host=clair-db.${NAMESPACE}.svc port=5432 user=clair dbname=clair sslmode=disable
-      migrations: true
+$(echo "${CLAIR_CONFIG_DESIRED}" | sed 's/^/    /')
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -227,12 +300,15 @@ spec:
             port: 8089
           initialDelaySeconds: 30
           periodSeconds: 10
+          timeoutSeconds: 5
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8089
-          initialDelaySeconds: 60
+          initialDelaySeconds: 120
           periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 5
       volumes:
       - name: config
         configMap:
@@ -258,6 +334,11 @@ spec:
     name: introspection
     protocol: TCP
 EOF
+
+if [[ "${CLAIR_CONFIG_CHANGED}" == "true" ]]; then
+    echo "  Clair config changed, restarting deployment"
+    kubectl rollout restart deploy/clair -n "${NAMESPACE}" 2>/dev/null || true
+fi
 
 # Step 6: Deploy Clair Adapter
 echo "--- Deploying Clair Adapter ---"
@@ -324,20 +405,22 @@ spec:
         resources:
           requests:
             cpu: 200m
-            memory: 512Mi
+            memory: 1Gi
           limits:
-            cpu: "1"
-            memory: 2Gi
+            cpu: "2"
+            memory: 4Gi
         readinessProbe:
           httpGet:
             path: /healthz/ready
             port: 9443
+            scheme: HTTPS
           initialDelaySeconds: 10
           periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /healthz/live
             port: 9443
+            scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 15
       volumes:
@@ -346,7 +429,7 @@ spec:
           name: clair-adapter-config
       - name: tls-volume
         secret:
-          secretName: scanner-v4-matcher-tls
+          secretName: clair-adapter-tls
           optional: true
 ---
 apiVersion: v1
@@ -374,7 +457,15 @@ spec:
     protocol: TCP
 EOF
 
-# Step 7: Wait for deployments
+# Step 7: Restart adapter if the local image differs from what the pod is running
+BUILT_IMAGE_ID="$(docker inspect --format='{{.Id}}' "${CLAIR_ADAPTER_IMAGE}" 2>/dev/null)"
+RUNNING_IMAGE_ID="$(kubectl get pods -n "${NAMESPACE}" -l app=clair-adapter -o jsonpath='{.items[0].status.containerStatuses[0].imageID}' 2>/dev/null)"
+if [[ -n "${BUILT_IMAGE_ID}" && "${RUNNING_IMAGE_ID}" != *"${BUILT_IMAGE_ID}"* ]]; then
+    echo "--- Restarting clair-adapter (image changed) ---"
+    kubectl rollout restart deploy/clair-adapter -n "${NAMESPACE}" 2>/dev/null || true
+fi
+
+# Step 8: Wait for deployments
 echo ""
 echo "--- Waiting for pods to be ready ---"
 kubectl rollout status deploy/clair-db -n "${NAMESPACE}" --timeout=120s

--- a/clair-adapter/deploy/deploy-clair-adapter.sh
+++ b/clair-adapter/deploy/deploy-clair-adapter.sh
@@ -318,6 +318,9 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/clair-adapter
+        - name: tls-volume
+          mountPath: /run/secrets/stackrox.io/certs/
+          readOnly: true
         resources:
           requests:
             cpu: 200m
@@ -341,6 +344,10 @@ spec:
       - name: config
         configMap:
           name: clair-adapter-config
+      - name: tls-volume
+        secret:
+          secretName: scanner-v4-matcher-tls
+          optional: true
 ---
 apiVersion: v1
 kind: Service

--- a/clair-adapter/deploy/deploy-clair-adapter.sh
+++ b/clair-adapter/deploy/deploy-clair-adapter.sh
@@ -26,9 +26,17 @@ NAMESPACE="${NAMESPACE:-stackrox}"
 CLAIR_ADAPTER_IMAGE="${CLAIR_ADAPTER_IMAGE:-clair-adapter:dev}"
 CLAIR_IMAGE="${CLAIR_IMAGE:-quay.io/projectquay/clair:4.7.4}"
 CLAIR_DB_IMAGE="${CLAIR_DB_IMAGE:-docker.io/library/postgres:15}"
-VULN_URL="${VULN_URL:-https://definitions.stackrox.io/v4/vulnerability-bundles/dev/vulnerabilities.zip}"
 SCALE_DOWN_SCANNER_V4="${SCALE_DOWN_SCANNER_V4:-true}"
 BUILD_IMAGE="${BUILD_IMAGE:-false}"
+
+# Default VULN_URL: use Central's endpoint if Central is deployed, otherwise fall back to public CDN
+if [[ -z "${VULN_URL:-}" ]]; then
+    if kubectl get svc central -n "${NAMESPACE}" &>/dev/null; then
+        VULN_URL="https://central.${NAMESPACE}.svc/api/extensions/scannerdefinitions?version=dev"
+    else
+        VULN_URL="https://definitions.stackrox.io/v4/vulnerability-bundles/dev/vulnerabilities.zip"
+    fi
+fi
 
 # Auto-detect cluster type
 detect_cluster_type() {
@@ -352,10 +360,12 @@ metadata:
 data:
   config.yaml: |
     clair_url: "http://clair.${NAMESPACE}.svc:8080"
+    clair_db_connstring: "host=clair-db.${NAMESPACE}.svc port=5432 user=clair dbname=clair sslmode=disable"
     grpc_listen_addr: "0.0.0.0:8443"
     http_listen_addr: "0.0.0.0:9443"
     updater_listen_addr: "0.0.0.0:9444"
     vulnerabilities_url: "${VULN_URL}"
+    certs_dir: "/run/secrets/stackrox.io/certs"
     indexer:
       enable: true
     matcher:

--- a/clair-adapter/docs/feature-status.md
+++ b/clair-adapter/docs/feature-status.md
@@ -1,0 +1,134 @@
+# Clair Adapter: Feature Status & Scanner V4 Gap Analysis
+
+## What the Clair Adapter Is
+
+The clair-adapter is a Go service that replaces Scanner V4 by delegating container image indexing and vulnerability matching to upstream Clair while preserving the Scanner V4 gRPC API. Central and Sensor connect to it using the same protos — it's a drop-in replacement.
+
+Unlike Scanner V4 (which embeds ClairCore as a Go library), the adapter calls Clair over HTTP and applies StackRox-specific enrichments in-process.
+
+## Current Features
+
+### gRPC API (6 of 10 RPCs implemented)
+
+| RPC                         | Status          | Notes                                                  |
+|-----------------------------|-----------------|--------------------------------------------------------|
+| `CreateIndexReport`         | Implemented     | Fetches image manifest from registry, submits to Clair |
+| `GetIndexReport`            | Implemented     | Retrieves from Clair                                   |
+| `GetOrCreateIndexReport`    | Implemented     | Get-then-create logic                                  |
+| `HasIndexReport`            | Implemented     | Existence check via Clair                              |
+| `GetVulnerabilities`        | Implemented     | Fetches from Clair, applies in-process enrichments     |
+| `GetMetadata`               | Implemented     | Returns last vulnerability update time                 |
+| `StoreIndexReport`          | Not implemented | Returns Unimplemented                                  |
+| `GetRepositoryToCPEMapping` | Not implemented | Returns Unimplemented                                  |
+| `GetSBOM`                   | Not implemented | Returns Unimplemented                                  |
+| `ScanSBOM`                  | Not implemented | Returns Unimplemented                                  |
+
+### Indexer
+
+- **Registry interaction**: Fetches image manifests from container registries using `go-containerregistry`. Handles basic auth, insecure TLS skip, layer URI construction with auth headers for Clair.
+- **Manifest metadata tracking**: Optional PostgreSQL store for tracking indexed manifests with TTL-based expiration.
+- **Manifest GC**: Background garbage collector that deletes expired manifests from both the adapter database and Clair (via `DeleteIndexReport`). Configurable interval and throttle.
+
+### Matcher
+
+- **Vulnerability reports**: Fetches from Clair's HTTP API, returns enriched results.
+- **Last vulnerability update**: Queries Clair's update operations endpoint or adapter's metadata store.
+
+### In-Process Enrichment Pipeline
+
+After receiving Clair's vulnerability report, the adapter applies these enrichments before returning results to Central:
+
+| Enricher                  | Status                          | Notes                                                           |
+|---------------------------|---------------------------------|-----------------------------------------------------------------|
+| EPSS                      | Extracted from Clair's response | Clair provides natively                                         |
+| NVD CVSS                  | Extracted from Clair's response | Clair provides natively                                         |
+| CSAF (Red Hat advisories) | In-process                      | Matches RHSA/RHBA/RHEA names to advisory data                   |
+| Fixed-by version          | In-process                      | Computes max fixed version per package (string comparison)      |
+| Manual severity           | Parser implemented              | YAML parser for overrides; not yet wired to enrichment pipeline |
+
+### Updater Pipeline
+
+- **Online mode**: Fetches `vulnerabilities.zip` from `definitions.stackrox.io`, unpacks into per-bundle files.
+- **Air-gapped mode**: Unpacks uploaded bundles from the same ZIP format.
+- **HTTP server**: Serves vulnerability data at `/updater/{name}` and `/enricher/{name}` endpoints. Supports `ETag`/`If-None-Match` for conditional fetching. Clair is configured to poll these endpoints.
+- **Periodic fetching**: Runs on configurable interval (default 5 minutes) with `If-Modified-Since` support.
+
+### Infrastructure
+
+- **mTLS**: Uses StackRox's `pkg/grpc` framework with `verifier.NonCA{}`. Loads certificates from `/run/secrets/stackrox.io/certs/` or configurable `certs_dir`. Compatible with Scanner V4's certificate chain.
+- **Health endpoints**: `/healthz/live` (always 200), `/healthz/ready` (checks Clair connectivity). Served via `pkg/grpc` custom routes.
+- **Configuration**: YAML-based with defaults. Fields: `clair_url`, `grpc_listen_addr`, `http_listen_addr`, `updater_listen_addr`, `vulnerabilities_url`, `certs_dir`, `indexer.enable`, `matcher.enable`, `log_level`.
+- **Database**: PostgreSQL with connection retry (30 attempts). Tables for manifest metadata and vulnerability update tracking. SQL migration files included.
+- **Deployment**: Dockerfile (UBI9 micro), `deploy-clair-adapter.sh` script for local k8s (auto-detects kind/minikube/Docker Desktop, deploys Clair DB + Clair + adapter).
+- **Feature flag**: `ROX_CLAIR_ADAPTER` in `pkg/features/list.go`.
+
+### Mappers
+
+- **Index report**: Clair JSON `IndexReport` → `v4.IndexReport` proto (packages, distributions, repositories, environments).
+- **Vulnerability report**: Clair JSON `VulnerabilityReport` → `v4.VulnerabilityReport` proto with enrichment integration (CVSS metrics, EPSS, CSAF, severity mapping, fixed-by).
+- **Enrichment extraction**: Parses Clair's `enrichments` map for NVD, EPSS, CSAF, and fixed-by data.
+- **Severity normalization**: Maps Clair severity strings to proto enum values.
+
+### Test Coverage
+
+164 tests across 16 packages. All unit tests use `httptest` mocks — no running Clair or PostgreSQL required.
+
+---
+
+## Remaining Gaps vs Scanner V4
+
+### High Priority (blocks key workflows)
+
+| Feature                           | Impact                                                                                                                                       | Effort Estimate                                                                                                                     |
+|-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| **StoreIndexReport RPC**          | Central-initiated scans store external index reports for later matching. Without this, delegated scanning workflows don't work.              | Medium — port `ExternalIndexStore` from `scanner/datastore/postgres/external_index_store.go`, add version comparison logic.         |
+| **GetRepositoryToCPEMapping RPC** | Sensor uses this to map RHEL repositories to CPEs for accurate vulnerability matching. Without it, RHEL vulnerability detection is degraded. | Medium — port `RepositoryToCPEFetcher` from `scanner/indexer/repositorytocpefetcher.go`, add HTTP caching with `If-Modified-Since`. |
+| **GetSBOM RPC**                   | Returns an SPDX 2.3 JSON SBOM for an indexed image. Required for SBOM export features.                                                       | Large — requires porting `scanner/sbom/` (SBOM encoder, SPDX format support). ClairCore SBOM library is a retained dependency.      |
+| **ScanSBOM RPC**                  | Accepts an SBOM and returns a vulnerability report. Required for SBOM-based scanning.                                                        | Large — requires porting SBOM decoder (`scanner/sbom/`), PURL registry, repo-to-CPE transform.                                      |
+
+### Medium Priority (reduces quality or operational capability)
+
+| Feature                        | Impact                                                                                                                                          | Effort Estimate                                                                                                  |
+|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| **Distributed GC locks**       | Without distributed locks, multiple adapter replicas could GC simultaneously. Safe for single-replica but needed for HA.                        | Medium — port `ctxlock` usage from `scanner/indexer/manifest/manager.go`.                                        |
+| **Remote indexer support**     | Scanner V4 can run indexer and matcher on separate pods. The adapter always runs both in one process.                                           | Medium — port `scanner/indexer/remote.go`, add `IndexerAddr` config.                                             |
+| **Advanced fixed-by enricher** | Current implementation uses string comparison. Scanner V4 uses per-ecosystem version comparison (semver, Go semver, URL-encoded versions).      | Medium — port version comparison from `scanner/enricher/fixedby/fixedby.go` with matcher/version type detection. |
+| **Readiness strategies**       | Scanner V4 supports `database` (ready when DB connected) and `vulnerability` (ready when vulns loaded). Adapter only checks Clair connectivity. | Small — add config field and logic.                                                                              |
+| **Distribution notes**         | Scanner V4 adds `NOTE_OS_UNKNOWN` and `NOTE_OS_UNSUPPORTED` to vulnerability reports. Adapter doesn't.                                          | Small — port from `scanner/services/matcher.go`.                                                                 |
+| **Transport mux**              | Scanner V4 routes mTLS traffic differently for Central vs Sensor endpoints. Adapter uses a single transport.                                    | Small — port from `scanner/internal/httputil/transport_mux.go`.                                                  |
+
+### Low Priority (advanced/operational features)
+
+| Feature                            | Impact                                                                                                                            | Effort Estimate                                                                            |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| **RC bundle support**              | Try release-candidate vulnerability bundles before GA. Only matters for pre-release testing.                                      | Small — add `EnableRCVulnBundle` config, URL resolution logic.                             |
+| **Bundle allowlist**               | Restrict which vulnerability bundles are imported (e.g., only "alpine", "rhel-vex"). Reduces DB size.                             | Small — add config field, filter in updater.                                               |
+| **Export functionality**           | Generate vulnerability bundles for distribution. Used in bundle production pipeline, not at runtime.                              | Medium — port `scanner/updater/export.go`.                                                 |
+| **Proxy configuration**            | Dynamic proxy config with file watching. Adapter uses Go's default proxy env vars.                                                | Small — port `ProxyConfig` from scanner config.                                            |
+| **Manifest migration**             | One-time migration for pre-metadata manifests during upgrades. Only needed for Scanner V4 → adapter upgrades.                     | Small — port from `scanner/indexer/manifest/manager.go`.                                   |
+| **Versioned scanner tracking**     | Tracks which scanner versions indexed a manifest, detects obsolete scans. Used for re-indexing decisions.                         | Medium — port from `scanner/indexer/indexer.go`.                                           |
+| **NVD/EPSS enricher data serving** | Currently Clair provides these natively. If Clair's native enrichers are insufficient, the adapter would need to serve this data. | Medium — only needed if Clair's built-in enrichers don't match Scanner V4's output format. |
+
+---
+
+## What's Identical
+
+These aspects are fully at parity with Scanner V4:
+
+- **gRPC proto contracts** — same `proto/internalapi/scanner/v4/` protos, Central/Sensor need zero changes
+- **mTLS** — uses same `pkg/grpc` framework, same certificate paths, same CA chain
+- **Vulnerability report format** — same proto fields, same severity enum, same CVSS metric structure
+- **Index report format** — same proto fields for packages, distributions, repositories, environments
+- **Feature flag pattern** — follows existing `pkg/features/` conventions
+- **Deployment model** — separate service alongside Central, same port conventions (8443 gRPC, 9443 HTTP)
+
+## Architecture Differences (by design, not gaps)
+
+| Aspect                   | Scanner V4                                | Clair Adapter                                             |
+|--------------------------|-------------------------------------------|-----------------------------------------------------------|
+| **Vulnerability engine** | ClairCore embedded as Go library          | Upstream Clair as separate HTTP service                   |
+| **Enrichment**           | ClairCore enricher framework (in-DB)      | Hybrid: Clair-native + in-process pipeline                |
+| **Vulnerability data**   | Loaded directly into ClairCore's DB       | Adapter fetches and serves to Clair via HTTP              |
+| **Database**             | Single PostgreSQL (shared with ClairCore) | Two databases: adapter's (metadata) + Clair's (vuln data) |
+| **Clair dependency**     | ClairCore Go library (compile-time)       | Clair HTTP API (runtime)                                  |
+| **Upgrade path**         | ClairCore version locked at compile time  | Clair version independently upgradeable                   |

--- a/clair-adapter/docs/feature-status.md
+++ b/clair-adapter/docs/feature-status.md
@@ -4,7 +4,7 @@
 
 The clair-adapter is a Go service that replaces Scanner V4 by delegating container image indexing and vulnerability matching to upstream Clair while preserving the Scanner V4 gRPC API. Central and Sensor connect to it using the same protos — it's a drop-in replacement.
 
-Unlike Scanner V4 (which embeds ClairCore as a Go library), the adapter calls Clair over HTTP and applies StackRox-specific enrichments in-process.
+Unlike Scanner V4 (which embeds ClairCore as a Go library), the adapter calls Clair over HTTP for indexing/matching and imports vulnerability data directly into Clair's PostgreSQL database.
 
 ## Current Features
 
@@ -23,6 +23,12 @@ Unlike Scanner V4 (which embeds ClairCore as a Go library), the adapter calls Cl
 | `GetSBOM`                   | Not implemented | Returns Unimplemented                                  |
 | `ScanSBOM`                  | Not implemented | Returns Unimplemented                                  |
 
+### gRPC Security
+
+- **Per-RPC authorization**: `indexerAuth` and `matcherAuth` rules matching Scanner V4's access control (Central+Sensor for indexer create/get, Central-only for store, Matcher-only for CPE mapping, Central-only for all matcher RPCs).
+- **Identity extraction**: mTLS client certificate identity via `pkg/grpc/authn/service.NewExtractor()`.
+- **Hash ID normalization**: Strips `/v4/containerimage/` prefix from StackRox hash IDs before calling Clair API.
+
 ### Indexer
 
 - **Registry interaction**: Fetches image manifests from container registries using `go-containerregistry`. Handles basic auth, insecure TLS skip, layer URI construction with auth headers for Clair.
@@ -32,7 +38,7 @@ Unlike Scanner V4 (which embeds ClairCore as a Go library), the adapter calls Cl
 ### Matcher
 
 - **Vulnerability reports**: Fetches from Clair's HTTP API, returns enriched results.
-- **Last vulnerability update**: Queries Clair's update operations endpoint or adapter's metadata store.
+- **Last vulnerability update**: Queries adapter's metadata store (updated per-bundle after each import) or Clair's update operations endpoint as fallback.
 
 ### In-Process Enrichment Pipeline
 
@@ -40,27 +46,32 @@ After receiving Clair's vulnerability report, the adapter applies these enrichme
 
 | Enricher                  | Status                          | Notes                                                           |
 |---------------------------|---------------------------------|-----------------------------------------------------------------|
-| EPSS                      | Extracted from Clair's response | Clair provides natively                                         |
-| NVD CVSS                  | Extracted from Clair's response | Clair provides natively                                         |
+| EPSS                      | Extracted from Clair's response | Clair provides natively via imported data                       |
+| NVD CVSS                  | Extracted from Clair's response | Clair provides natively via imported data                       |
 | CSAF (Red Hat advisories) | In-process                      | Matches RHSA/RHBA/RHEA names to advisory data                   |
 | Fixed-by version          | In-process                      | Computes max fixed version per package (string comparison)      |
 | Manual severity           | Parser implemented              | YAML parser for overrides; not yet wired to enrichment pipeline |
 
-### Updater Pipeline
+### Vulnerability Data Pipeline
 
-- **Online mode**: Fetches `vulnerabilities.zip` from `definitions.stackrox.io`, unpacks into per-bundle files.
-- **Air-gapped mode**: Unpacks uploaded bundles from the same ZIP format.
-- **HTTP server**: Serves vulnerability data at `/updater/{name}` and `/enricher/{name}` endpoints. Supports `ETag`/`If-None-Match` for conditional fetching. Clair is configured to poll these endpoints.
-- **Periodic fetching**: Runs on configurable interval (default 5 minutes) with `If-Modified-Since` support.
+The adapter controls Clair's vulnerability data entirely — Clair's built-in updaters are disabled.
+
+- **Direct DB import**: Fetches StackRox vulnerability bundles (zstd-compressed JSONL), decompresses, and imports directly into Clair's PostgreSQL via ClairCore's `datastore.MatcherStore` (`UpdateVulnerabilitiesIter`, `UpdateEnrichmentsIter`). Reuses `scanner/updater/jsonblob.Iterate()` for parsing.
+- **Fingerprint dedup**: Skips unchanged bundles by comparing update operation fingerprints.
+- **Central integration**: When deployed with StackRox, fetches bundles from Central's definitions endpoint (`/api/extensions/scannerdefinitions?version=...`) using mTLS. Falls back to `definitions.stackrox.io` CDN when Central is unavailable.
+- **Schema readiness**: Waits for Clair's database schema (polls for `update_operation` table) before importing, handling the case where the adapter starts before Clair.
+- **HTTP diagnostic server**: Keeps the updater HTTP server (`:9444`) as a diagnostic endpoint for inspecting loaded bundles, but Clair no longer polls it.
 
 ### Infrastructure
 
-- **mTLS**: Uses StackRox's `pkg/grpc` framework with `verifier.NonCA{}`. Loads certificates from `/run/secrets/stackrox.io/certs/` or configurable `certs_dir`. Compatible with Scanner V4's certificate chain.
-- **Health endpoints**: `/healthz/live` (always 200), `/healthz/ready` (checks Clair connectivity). Served via `pkg/grpc` custom routes.
-- **Configuration**: YAML-based with defaults. Fields: `clair_url`, `grpc_listen_addr`, `http_listen_addr`, `updater_listen_addr`, `vulnerabilities_url`, `certs_dir`, `indexer.enable`, `matcher.enable`, `log_level`.
+- **mTLS**: Uses StackRox's `pkg/grpc` framework with `verifier.NonCA{}`. Loads certificates from `/run/secrets/stackrox.io/certs/` or configurable `certs_dir`. Compatible with Scanner V4's certificate chain. The deploy script generates a `clair-adapter-tls` secret with SANs for both `scanner-v4-indexer` and `scanner-v4-matcher` DNS names.
+- **mTLS HTTP client**: Fetcher uses `pkg/mtls.CACertPEM()` and `mtls.LeafCertificateFromFile()` to authenticate to Central's definitions endpoint.
+- **Health endpoints**: `/healthz/live` (always 200), `/healthz/ready` (checks Clair connectivity). Served via `pkg/grpc` custom routes over HTTPS.
+- **Configuration**: YAML-based with defaults. Fields: `clair_url`, `clair_db_connstring`, `grpc_listen_addr`, `http_listen_addr`, `updater_listen_addr`, `vulnerabilities_url`, `certs_dir`, `indexer.enable`, `matcher.enable`, `log_level`.
 - **Database**: PostgreSQL with connection retry (30 attempts). Tables for manifest metadata and vulnerability update tracking. SQL migration files included.
-- **Deployment**: Dockerfile (UBI9 micro), `deploy-clair-adapter.sh` script for local k8s (auto-detects kind/minikube/Docker Desktop, deploys Clair DB + Clair + adapter).
+- **Deployment**: Dockerfile (UBI9 micro), `deploy-clair-adapter.sh` script for local k8s. The script auto-detects kind/minikube/Docker Desktop, generates TLS certs from Central's CA, patches Scanner V4 services to route to the adapter, and auto-detects Central for the vulnerability data URL.
 - **Feature flag**: `ROX_CLAIR_ADAPTER` in `pkg/features/list.go`.
+- **NormalizedVersion parsing**: Custom `UnmarshalJSON` handles Clair's string format (e.g., `"dpkg:0:1.19.7"`) in addition to the struct format.
 
 ### Mappers
 
@@ -68,10 +79,6 @@ After receiving Clair's vulnerability report, the adapter applies these enrichme
 - **Vulnerability report**: Clair JSON `VulnerabilityReport` → `v4.VulnerabilityReport` proto with enrichment integration (CVSS metrics, EPSS, CSAF, severity mapping, fixed-by).
 - **Enrichment extraction**: Parses Clair's `enrichments` map for NVD, EPSS, CSAF, and fixed-by data.
 - **Severity normalization**: Maps Clair severity strings to proto enum values.
-
-### Test Coverage
-
-164 tests across 16 packages. All unit tests use `httptest` mocks — no running Clair or PostgreSQL required.
 
 ---
 
@@ -117,18 +124,20 @@ These aspects are fully at parity with Scanner V4:
 
 - **gRPC proto contracts** — same `proto/internalapi/scanner/v4/` protos, Central/Sensor need zero changes
 - **mTLS** — uses same `pkg/grpc` framework, same certificate paths, same CA chain
+- **Per-RPC authorization** — same access control rules as Scanner V4 (Central, Sensor, Matcher identity checks)
 - **Vulnerability report format** — same proto fields, same severity enum, same CVSS metric structure
 - **Index report format** — same proto fields for packages, distributions, repositories, environments
+- **Vulnerability data pipeline** — same bundle format, same JSONL parsing, same fingerprint-based dedup
 - **Feature flag pattern** — follows existing `pkg/features/` conventions
 - **Deployment model** — separate service alongside Central, same port conventions (8443 gRPC, 9443 HTTP)
 
 ## Architecture Differences (by design, not gaps)
 
-| Aspect                   | Scanner V4                                | Clair Adapter                                             |
-|--------------------------|-------------------------------------------|-----------------------------------------------------------|
-| **Vulnerability engine** | ClairCore embedded as Go library          | Upstream Clair as separate HTTP service                   |
-| **Enrichment**           | ClairCore enricher framework (in-DB)      | Hybrid: Clair-native + in-process pipeline                |
-| **Vulnerability data**   | Loaded directly into ClairCore's DB       | Adapter fetches and serves to Clair via HTTP              |
-| **Database**             | Single PostgreSQL (shared with ClairCore) | Two databases: adapter's (metadata) + Clair's (vuln data) |
-| **Clair dependency**     | ClairCore Go library (compile-time)       | Clair HTTP API (runtime)                                  |
-| **Upgrade path**         | ClairCore version locked at compile time  | Clair version independently upgradeable                   |
+| Aspect                   | Scanner V4                                       | Clair Adapter                                                     |
+|--------------------------|--------------------------------------------------|-------------------------------------------------------------------|
+| **Vulnerability engine** | ClairCore embedded as Go library                 | Upstream Clair as separate HTTP service                           |
+| **Enrichment**           | ClairCore enricher framework (in-DB, in-process) | Hybrid: data imported into Clair DB + in-process pipeline         |
+| **Vulnerability data**   | Loaded directly into ClairCore's DB via library  | Adapter imports into Clair's DB via ClairCore datastore interface |
+| **Database**             | Single PostgreSQL (shared with ClairCore)        | Two databases: adapter's (metadata) + Clair's (vuln data)         |
+| **Clair dependency**     | ClairCore Go library (compile-time)              | Clair HTTP API (runtime) + ClairCore datastore (compile-time)     |
+| **Upgrade path**         | ClairCore version locked at compile time         | Clair version independently upgradeable                           |

--- a/clair-adapter/docs/local-testing.md
+++ b/clair-adapter/docs/local-testing.md
@@ -1,0 +1,193 @@
+# Clair Adapter: Local E2E Testing Guide
+
+## Overview
+
+This guide covers testing the clair-adapter end-to-end on a local Kubernetes cluster. The adapter replaces Scanner V4 by delegating to upstream Clair for indexing and vulnerability matching, while applying StackRox-specific enrichments in-process.
+
+## Prerequisites
+
+- Local Kubernetes cluster (Docker Desktop, minikube, or kind)
+- `kubectl` configured for your cluster
+- `docker` CLI for building images
+- `grpcurl` for gRPC testing (`brew install grpcurl`)
+- Go 1.24+ for building the adapter binary
+
+## Architecture
+
+```
+Central ──gRPC──▶ Clair Adapter ──HTTP──▶ Upstream Clair
+                       │                       │
+                       │                       ▼
+                       │               Clair PostgreSQL
+                       │
+                       ▼
+               Adapter PostgreSQL
+               (manifest metadata)
+```
+
+The adapter:
+- Listens on `:8443` (gRPC) for Central/Sensor connections
+- Listens on `:9443` (HTTP) for health checks
+- Listens on `:9444` (HTTP) for serving vulnerability data to Clair
+- Fetches vulnerability data from `definitions.stackrox.io` and serves it to Clair
+- Fetches container image manifests from registries and submits to Clair for indexing
+- Applies CSAF, fixed-by, and manual severity enrichments in-process
+
+## Quick Start
+
+### 1. Build the adapter image
+
+```bash
+cd /Users/blugo/dev/stackrox/stackrox/scanner-adapter
+
+# Build the container image
+docker build -t clair-adapter:dev -f clair-adapter/Dockerfile .
+
+# Load into your cluster
+# For kind:
+kind load docker-image clair-adapter:dev
+# For minikube:
+minikube image load clair-adapter:dev
+# For Docker Desktop: image is already available
+```
+
+### 2. Deploy Clair + Adapter
+
+```bash
+# Deploy everything (Clair DB, Clair, Adapter DB, Adapter)
+./clair-adapter/deploy/deploy-clair-adapter.sh
+
+# Wait for pods
+kubectl get pods -n stackrox -w
+```
+
+### 3. Verify
+
+```bash
+# Check health
+kubectl port-forward -n stackrox svc/clair-adapter 9443:9443 &
+curl http://localhost:9443/healthz/live    # Should return 200
+curl http://localhost:9443/healthz/ready   # 200 when Clair is up
+
+# Check updater is serving data
+kubectl port-forward -n stackrox svc/clair-adapter 9444:9444 &
+curl -s -o /dev/null -w "%{http_code}" http://localhost:9444/updater/alpine
+# Should return 200 (or 404 if bundles haven't been fetched yet)
+```
+
+### 4. Test with grpcurl
+
+```bash
+kubectl port-forward -n stackrox svc/clair-adapter 8443:8443 &
+
+# List available services
+grpcurl -plaintext localhost:8443 list
+
+# Check if an index report exists (expect not found)
+grpcurl -plaintext localhost:8443 scanner.v4.Indexer/HasIndexReport \
+  -d '{"hash_id": "sha256:nonexistent"}'
+
+# Index a real image
+grpcurl -plaintext localhost:8443 scanner.v4.Indexer/CreateIndexReport \
+  -d '{
+    "hash_id": "/v4/containerimage/sha256:test123",
+    "container_image": {
+      "url": "https://docker.io/library/alpine:3.18"
+    }
+  }'
+
+# Get vulnerabilities for the indexed image
+grpcurl -plaintext localhost:8443 scanner.v4.Matcher/GetVulnerabilities \
+  -d '{"hash_id": "/v4/containerimage/sha256:test123"}'
+
+# Get vulnerability metadata (last update time)
+grpcurl -plaintext localhost:8443 scanner.v4.Matcher/GetMetadata
+```
+
+## Testing with StackRox Central
+
+### Option A: Deploy StackRox first, then swap scanner
+
+```bash
+# 1. Deploy StackRox normally
+./deploy/deploy-local.sh
+
+# 2. Deploy Clair + Adapter alongside
+./clair-adapter/deploy/deploy-clair-adapter.sh
+
+# 3. Scale down Scanner V4
+kubectl scale deploy scanner-v4-indexer scanner-v4-matcher -n stackrox --replicas=0
+
+# 4. Point Central at the adapter (no mTLS — only works for basic testing)
+# Central expects the scanner endpoint via internal config.
+# For a quick test, port-forward and use roxctl:
+kubectl port-forward -n stackrox svc/central 8000:443 &
+roxctl -e localhost:8000 -p <admin-password> image scan --image docker.io/library/alpine:3.18
+```
+
+### Option B: Deploy with Scanner V4 disabled
+
+```bash
+# Deploy StackRox without Scanner V4
+export ROX_SCANNER_V4=false
+./deploy/deploy-local.sh
+
+# Then deploy Clair + Adapter
+./clair-adapter/deploy/deploy-clair-adapter.sh
+```
+
+Note: Central won't automatically connect to the adapter in this mode because it expects Scanner V4's mTLS certificates and service discovery. Full Central integration requires Helm chart changes (future work).
+
+## Troubleshooting
+
+### Check adapter logs
+```bash
+kubectl logs -n stackrox deploy/clair-adapter -f
+```
+
+### Check Clair logs
+```bash
+kubectl logs -n stackrox deploy/clair -f
+```
+
+### Adapter not ready
+The adapter's readiness check pings Clair's index state endpoint. If Clair isn't up yet, the adapter will report not ready. Check Clair DB connectivity:
+```bash
+kubectl logs -n stackrox deploy/clair-db
+kubectl logs -n stackrox deploy/clair
+```
+
+### Vulnerability data not available
+The adapter fetches vulnerability bundles from `definitions.stackrox.io`. Check:
+```bash
+# Verify fetcher is running
+kubectl logs -n stackrox deploy/clair-adapter | grep -i "fetch\|vuln\|bundle"
+
+# Check if the updater server has data
+kubectl port-forward -n stackrox svc/clair-adapter 9444:9444 &
+curl -v http://localhost:9444/updater/alpine
+```
+
+### Image indexing fails
+Registry authentication issues are the most common cause. Check:
+```bash
+kubectl logs -n stackrox deploy/clair-adapter | grep -i "registry\|layer\|index"
+kubectl logs -n stackrox deploy/clair | grep -i "index\|layer\|fetch"
+```
+
+## Current Limitations
+
+- **No mTLS**: The adapter doesn't implement mTLS yet, so Central can't connect to it in a standard StackRox deployment without additional configuration.
+- **No SBOM**: `GetSBOM` and `ScanSBOM` RPCs return Unimplemented.
+- **No Helm chart**: The adapter is deployed via raw manifests, not integrated into StackRox's Helm charts.
+- **Clair updaters disabled**: Vulnerability data depends entirely on the adapter's fetcher downloading from `definitions.stackrox.io`.
+
+## Cleanup
+
+```bash
+# Remove Clair + Adapter
+kubectl delete deploy clair-adapter clair clair-db clair-adapter-db -n stackrox
+kubectl delete svc clair-adapter clair clair-db clair-adapter-db -n stackrox
+kubectl delete configmap clair-config clair-adapter-config -n stackrox
+kubectl delete pvc clair-db-data clair-adapter-db-data -n stackrox 2>/dev/null
+```

--- a/clair-adapter/docs/local-testing.md
+++ b/clair-adapter/docs/local-testing.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide covers testing the clair-adapter end-to-end on a local Kubernetes cluster. The adapter replaces Scanner V4 by delegating to upstream Clair for indexing and vulnerability matching, while applying StackRox-specific enrichments in-process.
+This guide covers testing the clair-adapter end-to-end on a local Kubernetes cluster. The adapter replaces Scanner V4 by delegating to upstream Clair for indexing and vulnerability matching, importing vulnerability data directly into Clair's database, and applying StackRox-specific enrichments in-process.
 
 ## Prerequisites
 
@@ -10,26 +10,32 @@ This guide covers testing the clair-adapter end-to-end on a local Kubernetes clu
 - `kubectl` configured for your cluster
 - `docker` CLI for building images
 - `grpcurl` for gRPC testing (`brew install grpcurl`)
-- Go 1.24+ for building the adapter binary
+- Go 1.25+ for building the adapter binary
 
 ## Architecture
 
 ```
-Central ──gRPC──▶ Clair Adapter ──HTTP──▶ Upstream Clair
-                       │                       │
-                       │                       ▼
-                       │               Clair PostgreSQL
-                       │
-                       ▼
-               Adapter PostgreSQL
-               (manifest metadata)
+                    gRPC (mTLS)
+Central/Sensor ────────────────▶ Clair Adapter ──HTTP──▶ Upstream Clair
+                                      │                       │
+                                      │                       ▼
+                              mTLS    │               Clair PostgreSQL
+                       ┌──────────────┘                    ▲
+                       ▼                                   │
+                    Central                         Direct DB import
+             /api/extensions/                     (ClairCore datastore)
+            scannerdefinitions                         │
+                       │                               │
+                       ▼                               │
+               vulnerabilities.zip ──── unpack ────────┘
 ```
 
 The adapter:
-- Listens on `:8443` (gRPC) for Central/Sensor connections
-- Listens on `:9443` (HTTP) for health checks
-- Listens on `:9444` (HTTP) for serving vulnerability data to Clair
-- Fetches vulnerability data from `definitions.stackrox.io` and serves it to Clair
+- Listens on `:8443` (gRPC, mTLS) for Central/Sensor connections
+- Listens on `:9443` (HTTPS) for health checks
+- Listens on `:9444` (HTTP) for diagnostic updater endpoint
+- Fetches vulnerability bundles from Central (or `definitions.stackrox.io` fallback)
+- Imports vulnerability data directly into Clair's PostgreSQL
 - Fetches container image manifests from registries and submits to Clair for indexing
 - Applies CSAF, fixed-by, and manual severity enrichments in-process
 
@@ -51,41 +57,53 @@ minikube image load clair-adapter:dev
 # For Docker Desktop: image is already available
 ```
 
-### 2. Deploy Clair + Adapter
+### 2. Deploy StackRox + Clair Adapter
+
+The recommended flow deploys StackRox first, then deploys the adapter alongside it:
 
 ```bash
-# Deploy everything (Clair DB, Clair, Adapter DB, Adapter)
-./clair-adapter/deploy/deploy-clair-adapter.sh
+# 1. Deploy StackRox normally
+./deploy/deploy-local.sh
 
-# Wait for pods
-kubectl get pods -n stackrox -w
+# 2. Deploy Clair + Adapter (auto-detects Central, generates TLS certs, patches services)
+BUILD_IMAGE=true ./clair-adapter/deploy/deploy-clair-adapter.sh
+
+# The script will:
+# - Build the adapter image
+# - Scale down Scanner V4
+# - Patch scanner-v4-indexer/matcher services to route to the adapter
+# - Generate a TLS cert signed by Central's CA with Scanner V4 DNS SANs
+# - Deploy Clair DB + Clair + Adapter
+# - Configure the adapter to fetch vuln data from Central
+# - Wait for all pods to be ready
 ```
 
 ### 3. Verify
 
 ```bash
-# Check health
-kubectl port-forward -n stackrox svc/clair-adapter 9443:9443 &
-curl http://localhost:9443/healthz/live    # Should return 200
-curl http://localhost:9443/healthz/ready   # 200 when Clair is up
+# Check pods are running
+kubectl get pods -n stackrox -l app.kubernetes.io/part-of=clair-adapter
 
-# Check updater is serving data
-kubectl port-forward -n stackrox svc/clair-adapter 9444:9444 &
-curl -s -o /dev/null -w "%{http_code}" http://localhost:9444/updater/alpine
-# Should return 200 (or 404 if bundles haven't been fetched yet)
+# Check adapter logs for successful bundle import
+kubectl logs -n stackrox deploy/clair-adapter | grep -i "imported\|import"
+
+# Test via Central UI or roxctl
+kubectl port-forward -n stackrox svc/central 8000:443 &
+roxctl -e localhost:8000 -p <admin-password> image scan --image docker.io/library/alpine:3.18
 ```
 
-### 4. Test with grpcurl
+### 4. Test with grpcurl (without StackRox)
+
+If testing without StackRox deployed, the adapter runs without mTLS:
 
 ```bash
+# Deploy without StackRox (uses definitions.stackrox.io CDN for vuln data)
+SCALE_DOWN_SCANNER_V4=false ./clair-adapter/deploy/deploy-clair-adapter.sh
+
 kubectl port-forward -n stackrox svc/clair-adapter 8443:8443 &
 
 # List available services
 grpcurl -plaintext localhost:8443 list
-
-# Check if an index report exists (expect not found)
-grpcurl -plaintext localhost:8443 scanner.v4.Indexer/HasIndexReport \
-  -d '{"hash_id": "sha256:nonexistent"}'
 
 # Index a real image
 grpcurl -plaintext localhost:8443 scanner.v4.Indexer/CreateIndexReport \
@@ -104,39 +122,51 @@ grpcurl -plaintext localhost:8443 scanner.v4.Matcher/GetVulnerabilities \
 grpcurl -plaintext localhost:8443 scanner.v4.Matcher/GetMetadata
 ```
 
-## Testing with StackRox Central
-
-### Option A: Deploy StackRox first, then swap scanner
+When deployed with StackRox, mTLS is required. Use grpcurl with certs:
 
 ```bash
-# 1. Deploy StackRox normally
-./deploy/deploy-local.sh
+# Extract certs from the adapter's TLS secret
+kubectl get secret clair-adapter-tls -n stackrox -o jsonpath='{.data.ca\.pem}' | base64 -d > /tmp/ca.pem
+kubectl get secret clair-adapter-tls -n stackrox -o jsonpath='{.data.cert\.pem}' | base64 -d > /tmp/cert.pem
+kubectl get secret clair-adapter-tls -n stackrox -o jsonpath='{.data.key\.pem}' | base64 -d > /tmp/key.pem
 
-# 2. Deploy Clair + Adapter alongside
-./clair-adapter/deploy/deploy-clair-adapter.sh
+kubectl port-forward -n stackrox svc/clair-adapter 8443:8443 &
 
-# 3. Scale down Scanner V4
-kubectl scale deploy scanner-v4-indexer scanner-v4-matcher -n stackrox --replicas=0
-
-# 4. Point Central at the adapter (no mTLS — only works for basic testing)
-# Central expects the scanner endpoint via internal config.
-# For a quick test, port-forward and use roxctl:
-kubectl port-forward -n stackrox svc/central 8000:443 &
-roxctl -e localhost:8000 -p <admin-password> image scan --image docker.io/library/alpine:3.18
+grpcurl -cacert /tmp/ca.pem -cert /tmp/cert.pem -key /tmp/key.pem \
+  localhost:8443 scanner.v4.Indexer/HasIndexReport \
+  -d '{"hash_id": "/v4/containerimage/sha256:test"}'
 ```
 
-### Option B: Deploy with Scanner V4 disabled
+## Configuration
 
-```bash
-# Deploy StackRox without Scanner V4
-export ROX_SCANNER_V4=false
-./deploy/deploy-local.sh
+The adapter is configured via YAML. Key fields:
 
-# Then deploy Clair + Adapter
-./clair-adapter/deploy/deploy-clair-adapter.sh
-```
+| Field                  | Default                          | Description                                         |
+|------------------------|----------------------------------|-----------------------------------------------------|
+| `clair_url`            | `http://localhost:8080`          | Upstream Clair HTTP endpoint                        |
+| `clair_db_connstring`  | (empty)                          | Clair's PostgreSQL connection string for direct import |
+| `grpc_listen_addr`     | `:8443`                          | gRPC endpoint (mTLS)                                |
+| `http_listen_addr`     | `:9443`                          | Health/HTTP endpoint (HTTPS)                        |
+| `updater_listen_addr`  | `:9444`                          | Diagnostic updater HTTP endpoint                    |
+| `vulnerabilities_url`  | Central's endpoint or CDN        | Where to fetch vulnerability bundles                |
+| `certs_dir`            | `/run/secrets/stackrox.io/certs` | mTLS certificate directory                          |
+| `indexer.enable`       | `true`                           | Enable indexer service                              |
+| `matcher.enable`       | `true`                           | Enable matcher service                              |
 
-Note: Central won't automatically connect to the adapter in this mode because it expects Scanner V4's mTLS certificates and service discovery. Full Central integration requires Helm chart changes (future work).
+## How the Deploy Script Works
+
+`clair-adapter/deploy/deploy-clair-adapter.sh` does the following:
+
+1. **Optionally builds** the adapter image (`BUILD_IMAGE=true`)
+2. **Loads image** into cluster (kind/minikube/Docker Desktop auto-detected)
+3. **Scales down Scanner V4** indexer and matcher deployments
+4. **Patches Scanner V4 services** — changes `scanner-v4-indexer` and `scanner-v4-matcher` service selectors to route to the adapter pod, so Central connects to the adapter at the same DNS names
+5. **Generates TLS certificate** — extracts CA from `central-tls` secret, creates a cert with SANs for both `scanner-v4-indexer` and `scanner-v4-matcher` DNS names, stores as `clair-adapter-tls` secret
+6. **Deploys Clair DB** — PostgreSQL 15 with trust auth
+7. **Deploys upstream Clair** — combo mode, native updaters disabled
+8. **Deploys clair-adapter** — configured with Clair URL, Clair DB connection, Central vuln URL, TLS certs
+9. **Detects image changes** — restarts adapter if the local image differs from what's running
+10. **Waits for readiness** — all three deployments must be ready
 
 ## Troubleshooting
 
@@ -157,37 +187,52 @@ kubectl logs -n stackrox deploy/clair-db
 kubectl logs -n stackrox deploy/clair
 ```
 
-### Vulnerability data not available
-The adapter fetches vulnerability bundles from `definitions.stackrox.io`. Check:
+### No vulnerabilities returned
+The adapter imports vulnerability data directly into Clair's PostgreSQL. Check:
 ```bash
-# Verify fetcher is running
-kubectl logs -n stackrox deploy/clair-adapter | grep -i "fetch\|vuln\|bundle"
+# Look for successful import messages
+kubectl logs -n stackrox deploy/clair-adapter | grep -i "imported"
 
-# Check if the updater server has data
-kubectl port-forward -n stackrox svc/clair-adapter 9444:9444 &
-curl -v http://localhost:9444/updater/alpine
+# Verify Clair's DB has vulnerability data
+kubectl exec -n stackrox deploy/clair-db -- psql -U clair -c "SELECT count(*) FROM vuln"
+```
+
+If the adapter fetches from Central, verify Central is serving definitions:
+```bash
+kubectl logs -n stackrox deploy/central | grep -i "scannerdefinitions"
 ```
 
 ### Image indexing fails
-Registry authentication issues are the most common cause. Check:
+Registry authentication issues are the most common cause:
 ```bash
 kubectl logs -n stackrox deploy/clair-adapter | grep -i "registry\|layer\|index"
 kubectl logs -n stackrox deploy/clair | grep -i "index\|layer\|fetch"
 ```
 
+### mTLS connection failures
+```bash
+# Verify the TLS secret exists and has the right SANs
+kubectl get secret clair-adapter-tls -n stackrox
+openssl x509 -in <(kubectl get secret clair-adapter-tls -n stackrox -o jsonpath='{.data.cert\.pem}' | base64 -d) -text -noout | grep DNS
+```
+
 ## Current Limitations
 
-- **No mTLS**: The adapter doesn't implement mTLS yet, so Central can't connect to it in a standard StackRox deployment without additional configuration.
 - **No SBOM**: `GetSBOM` and `ScanSBOM` RPCs return Unimplemented.
 - **No Helm chart**: The adapter is deployed via raw manifests, not integrated into StackRox's Helm charts.
-- **Clair updaters disabled**: Vulnerability data depends entirely on the adapter's fetcher downloading from `definitions.stackrox.io`.
+- **No StoreIndexReport**: Delegated scanning workflows that store external index reports are not yet supported.
+- **Simple fixed-by**: Uses string comparison instead of per-ecosystem version comparison.
 
 ## Cleanup
 
 ```bash
 # Remove Clair + Adapter
-kubectl delete deploy clair-adapter clair clair-db clair-adapter-db -n stackrox
-kubectl delete svc clair-adapter clair clair-db clair-adapter-db -n stackrox
+kubectl delete deploy clair-adapter clair clair-db -n stackrox
+kubectl delete svc clair-adapter clair clair-db -n stackrox
 kubectl delete configmap clair-config clair-adapter-config -n stackrox
-kubectl delete pvc clair-db-data clair-adapter-db-data -n stackrox 2>/dev/null
+kubectl delete secret clair-adapter-tls -n stackrox 2>/dev/null
+
+# Restore Scanner V4 services (if you patched them)
+kubectl scale deploy scanner-v4-indexer scanner-v4-matcher -n stackrox --replicas=1
+# You may also need to restore the original service selectors
 ```

--- a/clair-adapter/docs/vulnerability-data-pipeline.md
+++ b/clair-adapter/docs/vulnerability-data-pipeline.md
@@ -1,0 +1,225 @@
+# Vulnerability Data Pipeline: Implementation Details & Caveats
+
+## Overview
+
+The clair-adapter controls all vulnerability data that Clair uses for matching. Clair's native updaters are disabled. The adapter fetches StackRox vulnerability bundles, imports them directly into Clair's PostgreSQL database, and Clair reads from its own database when performing vulnerability matching.
+
+This is the same bundle format and data flow that Scanner V4 uses, but the import mechanism differs: Scanner V4 calls ClairCore as an embedded Go library, while the adapter connects to Clair's PostgreSQL externally via the ClairCore `datastore.MatcherStore` interface.
+
+## Data Flow
+
+```
+Central (or definitions.stackrox.io CDN)
+    │
+    │  HTTPS (mTLS when Central, plain when CDN)
+    ▼
+Fetcher (clair-adapter/updater/fetcher.go)
+    │  Downloads vulnerabilities.zip
+    │  Sends If-Modified-Since to skip unchanged data
+    ▼
+UnpackBundle (clair-adapter/updater/bundle.go)
+    │  Extracts ZIP into []BundleData
+    │  Each entry: name + zstd-compressed JSONL + SHA256 fingerprint
+    ▼
+Importer (clair-adapter/vulnimporter/importer.go)
+    │  For each bundle:
+    │    1. Decompress zstd
+    │    2. Parse JSONL via jsonblob.Iterate()
+    │    3. Check fingerprint (skip if unchanged)
+    │    4. Call store.UpdateVulnerabilitiesIter() or UpdateEnrichmentsIter()
+    │    5. Record timestamp in adapter's metadata store
+    ▼
+Clair PostgreSQL
+    │  vuln, update_operation, uo_vuln tables populated
+    ▼
+Clair Matcher (queried via HTTP by the adapter)
+    │  Returns VulnerabilityReport with matched vulns + enrichments
+    ▼
+Adapter in-process enrichment
+    │  Applies CSAF, fixed-by, manual severity
+    ▼
+Central/Sensor (gRPC response)
+```
+
+## Bundle Format
+
+The vulnerability bundle is a ZIP file containing multiple zstd-compressed JSONL files:
+
+```
+vulnerabilities.zip
+├── alpine.json.zst
+├── aws.json.zst
+├── debian.json.zst
+├── epss.json.zst
+├── manual.json.zst
+├── nvd.json.zst
+├── oracle.json.zst
+├── photon.json.zst
+├── rhel-vex.json.zst
+├── stackrox-rhel-csaf.json.zst
+├── suse.json.zst
+└── ubuntu.json.zst
+```
+
+Each `.json.zst` file is a zstd-compressed stream of newline-delimited JSON. Each line represents either a vulnerability record or an enrichment record, grouped by `UpdateOperation` (identified by a UUID reference and updater name).
+
+The format is defined in `scanner/updater/jsonblob/jsonblob.go` and is a fork of ClairCore's jsonblob format with support for individual record iteration.
+
+## Bundle Sources
+
+### Online Mode (with Central)
+
+When deployed alongside StackRox Central, the adapter fetches bundles from Central's scanner definitions endpoint:
+
+```
+https://central.<namespace>.svc/api/extensions/scannerdefinitions?version=<version>
+```
+
+This requires mTLS authentication. The adapter uses the same certificates mounted at `/run/secrets/stackrox.io/certs/` to authenticate as a Scanner V4 service identity. Central's authorizer accepts Scanner V4 identities for this endpoint.
+
+The deploy script auto-detects Central and configures this URL automatically.
+
+### Online Mode (without Central)
+
+When Central is not available, the adapter falls back to the public CDN:
+
+```
+https://definitions.stackrox.io/v4/vulnerability-bundles/<version>/vulnerabilities.zip
+```
+
+No authentication required. The version defaults to `dev` for non-release builds.
+
+### Air-Gapped Mode
+
+In air-gapped environments, Central receives offline definition bundles uploaded by an administrator. Central then serves them at the same `/api/extensions/scannerdefinitions` endpoint. The adapter fetches from this endpoint as in online mode — the distinction is transparent to the adapter.
+
+## Import Mechanism
+
+### How It Works
+
+The importer (`vulnimporter/importer.go`) writes directly to Clair's PostgreSQL using ClairCore's `datastore.MatcherStore` interface. This is the same interface that ClairCore uses internally when Clair runs its own updaters.
+
+Key operations:
+- `store.UpdateVulnerabilitiesIter()` — inserts vulnerabilities and creates an `update_operation` record
+- `store.UpdateEnrichmentsIter()` — inserts enrichment data (EPSS scores, NVD CVSS, etc.)
+- `store.GetUpdateOperations()` — checks fingerprints to skip unchanged bundles
+
+### Connection to Clair's Database
+
+The adapter connects to Clair's PostgreSQL via `clair_db_connstring` config. It does NOT run migrations (`doMigration: false`) — Clair manages its own schema.
+
+The store initialization waits for Clair's schema to be ready by polling for the `update_operation` table (up to 30 attempts, 5 seconds apart). This handles the startup ordering case where the adapter starts before Clair has completed its migrations.
+
+### Fingerprint-Based Deduplication
+
+Each `UpdateOperation` in the JSONL stream has a fingerprint. Before importing, the importer checks if an operation with the same fingerprint already exists for that updater. If so, the bundle is skipped. This prevents redundant imports when the fetcher runs on its periodic schedule but the data hasn't changed.
+
+## Caveats & Known Differences from Scanner V4
+
+### 1. No Distributed Locking
+
+Scanner V4 uses `ctxlock.Locker` (PostgreSQL advisory locks) to prevent multiple Scanner V4 instances from importing the same bundle simultaneously. The adapter does not implement distributed locking.
+
+**Impact**: Safe for single-replica deployments. In HA setups with multiple adapter replicas, two replicas could import the same bundle concurrently. ClairCore's `UpdateVulnerabilitiesIter` is transactional, so this won't corrupt data, but it wastes resources.
+
+**Mitigation**: Run a single adapter replica for now. Distributed locking is a documented gap.
+
+### 2. No Per-Bundle Timestamp Dedup
+
+Scanner V4's `updateBundle()` (line 464-508) uses a two-phase timestamp check:
+1. Calls `metadataStore.GetOrSetLastVulnerabilityUpdate()` to get/create a per-bundle timestamp
+2. Compares the bundle's ZIP archive modification time against the stored timestamp
+3. Skips the bundle if the stored timestamp is >= the archive time
+
+The adapter relies solely on fingerprint-based dedup within the JSONL stream (via `GetUpdateOperations` + fingerprint comparison). It does not compare ZIP modification times against stored timestamps.
+
+**Impact**: The adapter may re-import bundles that Scanner V4 would skip when the fingerprint changes but the content is effectively the same. In practice, fingerprint dedup catches most cases.
+
+### 3. No Bundle Allowlist Filtering
+
+Scanner V4 supports `VulnBundleAllowlist` config to restrict which bundles are imported (e.g., only `["alpine", "rhel-vex"]`). The adapter imports all bundles in the ZIP.
+
+**Impact**: All vulnerability data is imported, which uses more database space but ensures complete coverage. Add allowlist support if selective import is needed.
+
+### 4. No GC After Import
+
+Scanner V4 runs `metadataStore.GCVulnerabilityUpdates()` after each import cycle to clean up updaters that were deleted from the bundle (line 449). It also runs periodic `store.GC()` to remove old update operations beyond the retention limit.
+
+The adapter does not run post-import GC. Over time, old update operations accumulate in Clair's database.
+
+**Impact**: Database size grows unbounded for update_operation and uo_vuln tables. Clair's own internal GC may handle some of this, but it's disabled when updaters are disabled.
+
+**Mitigation**: Periodically run `store.GC(ctx, keepN)` or add a GC loop to the adapter. This is a documented gap.
+
+### 5. No Known Distributions Tracking
+
+After importing, Scanner V4 calls `distManager.update(ctx)` to refresh the list of known Linux distributions from the database. This is used for `GetKnownDistributions()` and for generating `NOTE_OS_UNKNOWN` / `NOTE_OS_UNSUPPORTED` notes on vulnerability reports.
+
+The adapter does not track known distributions.
+
+**Impact**: Vulnerability reports don't include OS support notes. Not a data correctness issue, but reduces diagnostic information.
+
+### 6. No Retry on Fetch Failure
+
+Scanner V4's `fetchFromURL()` (line 578) implements exponential backoff retry for dial errors (12 attempts, 10-second delays). The adapter's fetcher tries each URL once per cycle.
+
+**Impact**: Transient network failures cause the entire fetch cycle to fail. The periodic ticker (default 5 minutes) provides implicit retry, but there's a 5-minute gap before the next attempt.
+
+### 7. ZIP Modification Time Not Used
+
+Scanner V4 parses the `Last-Modified` HTTP header into a `time.Time` and uses it as the authoritative timestamp for the bundle. This timestamp is stored per-bundle and used for subsequent dedup (see caveat #2).
+
+The adapter stores `Last-Modified` as a raw string for `If-Modified-Since` conditional requests, but does not parse it into a timestamp for per-bundle dedup.
+
+### 8. mTLS Client Cert Loading
+
+The adapter's mTLS HTTP client (`NewMTLSHTTPClient`) loads certificates once at startup. Scanner V4's transport uses `mtls.LeafCertificateFromFile()` which is called per-request and supports hot-reload when certificates rotate.
+
+**Impact**: If certificates are rotated while the adapter is running, the HTTP client continues using the old certificates until the adapter is restarted. The gRPC server (via `pkg/grpc`) handles cert rotation correctly — this only affects the outbound HTTP client to Central.
+
+### 9. ClairCore Version Coupling
+
+The adapter imports `github.com/quay/claircore/datastore/postgres` to initialize the matcher store. This creates a compile-time dependency on a specific ClairCore version. If the Clair instance runs a different ClairCore version with schema changes, the import could fail or behave unexpectedly.
+
+**Mitigation**: Pin the adapter's ClairCore dependency to match the deployed Clair version. Bump both together.
+
+## Configuration Reference
+
+| Field                    | Required | Default                        | Description                                        |
+|--------------------------|----------|--------------------------------|----------------------------------------------------|
+| `clair_db_connstring`    | Yes*     | (empty)                        | PostgreSQL connection string for Clair's database  |
+| `vulnerabilities_url`    | No       | Auto-detected (Central or CDN) | URL to fetch vulnerability bundles from            |
+| `certs_dir`              | No       | `/run/secrets/stackrox.io/certs` | mTLS certificates for Central authentication     |
+| `updater_listen_addr`    | No       | `:9444`                        | Diagnostic HTTP server for inspecting bundles      |
+
+*If `clair_db_connstring` is empty, the importer is disabled and vulnerability data is not imported. Clair will have no vulnerability data unless its own updaters are enabled.
+
+## Monitoring
+
+### Successful Import
+
+Look for log lines:
+
+```
+{"level":"INFO","msg":"importing update","updater":"RHEL8-rhel-8","kind":"vulnerability","bundle":"rhel-vex.json.zst"}
+{"level":"INFO","msg":"update imported","updater":"RHEL8-rhel-8","kind":"vulnerability","ref":"<uuid>","count":12345,"bundle":"rhel-vex.json.zst"}
+```
+
+### Fingerprint Skip
+
+```
+{"level":"INFO","msg":"fingerprint match, skipping","updater":"alpine-community-v3.18-main"}
+```
+
+### Fetch Failure
+
+```
+{"level":"ERROR","msg":"fetch cycle failed","error":"all URLs failed, last error: ..."}
+```
+
+### Verifying Data in Clair's DB
+
+```bash
+kubectl exec -n stackrox deploy/clair-db -- psql -U clair -c "SELECT updater, count(*) FROM vuln GROUP BY updater ORDER BY count DESC LIMIT 10"
+kubectl exec -n stackrox deploy/clair-db -- psql -U clair -c "SELECT updater, date FROM update_operation ORDER BY date DESC LIMIT 10"
+```

--- a/clair-adapter/enricher/csaf/csaf.go
+++ b/clair-adapter/enricher/csaf/csaf.go
@@ -1,0 +1,91 @@
+package csaf
+
+import (
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+)
+
+// Advisory represents a CSAF security advisory.
+type Advisory struct {
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	ReleaseDate time.Time `json:"release_date"`
+	Severity    string    `json:"severity"`
+	CVSSv3      CVSSScore `json:"cvssv3"`
+	CVSSv2      CVSSScore `json:"cvssv2"`
+}
+
+// CVSSScore represents a CVSS score with its vector string.
+type CVSSScore struct {
+	BaseScore float64 `json:"base_score"`
+	Vector    string  `json:"vector"`
+}
+
+// Enricher enriches vulnerability reports with CSAF advisory data.
+type Enricher struct {
+	mu         sync.RWMutex
+	advisories map[string]*Advisory
+}
+
+// Option configures an Enricher.
+type Option func(*Enricher)
+
+// NewEnricher creates a new CSAF enricher.
+func NewEnricher(opts ...Option) *Enricher {
+	e := &Enricher{
+		advisories: make(map[string]*Advisory),
+	}
+
+	for _, opt := range opts {
+		opt(e)
+	}
+
+	return e
+}
+
+// WithStaticAdvisories configures the enricher with a static set of advisories.
+func WithStaticAdvisories(advisories map[string]*Advisory) Option {
+	return func(e *Enricher) {
+		e.advisories = advisories
+	}
+}
+
+// SetAdvisories updates the advisories map used for enrichment.
+// Thread-safe for concurrent use.
+func (e *Enricher) SetAdvisories(advisories map[string]*Advisory) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.advisories = advisories
+}
+
+// rhsaPattern matches RHSA, RHBA, and RHEA advisory identifiers.
+var rhsaPattern = regexp.MustCompile(`(RH[SBE]A-\d{4}:\d+)`)
+
+// Enrich extracts RHSA/RHBA/RHEA names from vulnerability names and looks them up
+// in the advisories map. Returns map[vulnID]*Advisory.
+func (e *Enricher) Enrich(vr *clairclient.VulnerabilityReport) (map[string]*Advisory, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	result := make(map[string]*Advisory)
+
+	for vulnID, vuln := range vr.Vulnerabilities {
+		// Extract advisory name from vulnerability name
+		matches := rhsaPattern.FindStringSubmatch(vuln.Name)
+		if len(matches) < 2 {
+			continue
+		}
+
+		advisoryName := matches[1]
+
+		// Look up advisory
+		if advisory, exists := e.advisories[advisoryName]; exists {
+			result[vulnID] = advisory
+		}
+	}
+
+	return result, nil
+}

--- a/clair-adapter/enricher/csaf/csaf_test.go
+++ b/clair-adapter/enricher/csaf/csaf_test.go
@@ -1,0 +1,200 @@
+package csaf
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnrich(t *testing.T) {
+	releaseDate := time.Date(2023, 5, 15, 0, 0, 0, 0, time.UTC)
+
+	advisory := &Advisory{
+		Name:        "RHSA-2023:1234",
+		Description: "bash security update",
+		ReleaseDate: releaseDate,
+		Severity:    "Important",
+		CVSSv3: CVSSScore{
+			BaseScore: 7.5,
+			Vector:    "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+		},
+		CVSSv2: CVSSScore{
+			BaseScore: 5.0,
+			Vector:    "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+		},
+	}
+
+	tests := map[string]struct {
+		vr       *clairclient.VulnerabilityReport
+		enricher *Enricher
+		expected map[string]*Advisory
+	}{
+		"vuln with RHSA in name matches advisory": {
+			vr: &clairclient.VulnerabilityReport{
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {
+						ID:   "vuln1",
+						Name: "RHSA-2023:1234: bash update",
+					},
+				},
+			},
+			enricher: NewEnricher(WithStaticAdvisories(map[string]*Advisory{
+				"RHSA-2023:1234": advisory,
+			})),
+			expected: map[string]*Advisory{
+				"vuln1": advisory,
+			},
+		},
+		"RHBA advisory matches": {
+			vr: &clairclient.VulnerabilityReport{
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {
+						ID:   "vuln1",
+						Name: "RHBA-2023:5678: bug fix update",
+					},
+				},
+			},
+			enricher: NewEnricher(WithStaticAdvisories(map[string]*Advisory{
+				"RHBA-2023:5678": {Name: "RHBA-2023:5678", Description: "Bug fix"},
+			})),
+			expected: map[string]*Advisory{
+				"vuln1": {Name: "RHBA-2023:5678", Description: "Bug fix"},
+			},
+		},
+		"RHEA advisory matches": {
+			vr: &clairclient.VulnerabilityReport{
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {
+						ID:   "vuln1",
+						Name: "RHEA-2023:9999: enhancement advisory",
+					},
+				},
+			},
+			enricher: NewEnricher(WithStaticAdvisories(map[string]*Advisory{
+				"RHEA-2023:9999": {Name: "RHEA-2023:9999", Description: "Enhancement"},
+			})),
+			expected: map[string]*Advisory{
+				"vuln1": {Name: "RHEA-2023:9999", Description: "Enhancement"},
+			},
+		},
+		"multiple vulns with advisories": {
+			vr: &clairclient.VulnerabilityReport{
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {ID: "vuln1", Name: "RHSA-2023:1111: update 1"},
+					"vuln2": {ID: "vuln2", Name: "RHSA-2023:2222: update 2"},
+				},
+			},
+			enricher: NewEnricher(WithStaticAdvisories(map[string]*Advisory{
+				"RHSA-2023:1111": {Name: "RHSA-2023:1111"},
+				"RHSA-2023:2222": {Name: "RHSA-2023:2222"},
+			})),
+			expected: map[string]*Advisory{
+				"vuln1": {Name: "RHSA-2023:1111"},
+				"vuln2": {Name: "RHSA-2023:2222"},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := tc.enricher.Enrich(tc.vr)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEnrich_NoMatch(t *testing.T) {
+	tests := map[string]struct {
+		vr       *clairclient.VulnerabilityReport
+		enricher *Enricher
+		expected map[string]*Advisory
+	}{
+		"CVE-only vuln name with no advisory": {
+			vr: &clairclient.VulnerabilityReport{
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {
+						ID:   "vuln1",
+						Name: "CVE-2023-1234",
+					},
+				},
+			},
+			enricher: NewEnricher(WithStaticAdvisories(map[string]*Advisory{
+				"RHSA-2023:1234": {Name: "RHSA-2023:1234"},
+			})),
+			expected: map[string]*Advisory{},
+		},
+		"RHSA in name but not in advisories": {
+			vr: &clairclient.VulnerabilityReport{
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {
+						ID:   "vuln1",
+						Name: "RHSA-2023:9999: unknown advisory",
+					},
+				},
+			},
+			enricher: NewEnricher(WithStaticAdvisories(map[string]*Advisory{
+				"RHSA-2023:1234": {Name: "RHSA-2023:1234"},
+			})),
+			expected: map[string]*Advisory{},
+		},
+		"empty advisories map": {
+			vr: &clairclient.VulnerabilityReport{
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {ID: "vuln1", Name: "RHSA-2023:1234: test"},
+				},
+			},
+			enricher: NewEnricher(),
+			expected: map[string]*Advisory{},
+		},
+		"empty vulnerability report": {
+			vr:       &clairclient.VulnerabilityReport{},
+			enricher: NewEnricher(),
+			expected: map[string]*Advisory{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := tc.enricher.Enrich(tc.vr)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestSetAdvisories(t *testing.T) {
+	enricher := NewEnricher()
+
+	// Initially empty
+	vr := &clairclient.VulnerabilityReport{
+		Vulnerabilities: map[string]clairclient.Vulnerability{
+			"vuln1": {ID: "vuln1", Name: "RHSA-2023:1234: test"},
+		},
+	}
+
+	result, err := enricher.Enrich(vr)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+
+	// Set advisories
+	advisories := map[string]*Advisory{
+		"RHSA-2023:1234": {Name: "RHSA-2023:1234", Description: "Test advisory"},
+	}
+	enricher.SetAdvisories(advisories)
+
+	// Now should find advisory
+	result, err = enricher.Enrich(vr)
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "Test advisory", result["vuln1"].Description)
+
+	// Update advisories
+	enricher.SetAdvisories(map[string]*Advisory{})
+	result, err = enricher.Enrich(vr)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}

--- a/clair-adapter/enricher/fixedby/fixedby.go
+++ b/clair-adapter/enricher/fixedby/fixedby.go
@@ -1,0 +1,35 @@
+package fixedby
+
+import (
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+)
+
+// Enrich computes fixed-by version per package from a VulnerabilityReport.
+// For each package, find the maximum FixedInVersion across all its vulnerabilities.
+// Returns map[packageID]fixedVersion. Empty FixedInVersion is skipped.
+func Enrich(vr *clairclient.VulnerabilityReport) (map[string]string, error) {
+	result := make(map[string]string)
+
+	for pkgID, vulnIDs := range vr.PackageVulnerabilities {
+		var maxVersion string
+
+		for _, vulnID := range vulnIDs {
+			vuln, exists := vr.Vulnerabilities[vulnID]
+			if !exists || vuln.FixedInVersion == "" {
+				continue
+			}
+
+			// Find the maximum fixed version (simple string comparison)
+			// In a real implementation, this would use proper version comparison
+			if maxVersion == "" || vuln.FixedInVersion > maxVersion {
+				maxVersion = vuln.FixedInVersion
+			}
+		}
+
+		if maxVersion != "" {
+			result[pkgID] = maxVersion
+		}
+	}
+
+	return result, nil
+}

--- a/clair-adapter/enricher/fixedby/fixedby_test.go
+++ b/clair-adapter/enricher/fixedby/fixedby_test.go
@@ -1,0 +1,131 @@
+package fixedby
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnrich(t *testing.T) {
+	tests := map[string]struct {
+		vr       *clairclient.VulnerabilityReport
+		expected map[string]string
+	}{
+		"two vulns with different fixed versions for one package": {
+			vr: &clairclient.VulnerabilityReport{
+				Packages: map[string]clairclient.Package{
+					"pkg1": {ID: "pkg1", Name: "bash", Version: "5.0"},
+				},
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {ID: "vuln1", FixedInVersion: "5.2"},
+					"vuln2": {ID: "vuln2", FixedInVersion: "5.3"},
+				},
+				PackageVulnerabilities: map[string][]string{
+					"pkg1": {"vuln1", "vuln2"},
+				},
+			},
+			expected: map[string]string{
+				"pkg1": "5.3",
+			},
+		},
+		"multiple packages with different fixed versions": {
+			vr: &clairclient.VulnerabilityReport{
+				Packages: map[string]clairclient.Package{
+					"pkg1": {ID: "pkg1", Name: "bash"},
+					"pkg2": {ID: "pkg2", Name: "curl"},
+				},
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {ID: "vuln1", FixedInVersion: "5.2"},
+					"vuln2": {ID: "vuln2", FixedInVersion: "5.3"},
+					"vuln3": {ID: "vuln3", FixedInVersion: "7.1"},
+				},
+				PackageVulnerabilities: map[string][]string{
+					"pkg1": {"vuln1", "vuln2"},
+					"pkg2": {"vuln3"},
+				},
+			},
+			expected: map[string]string{
+				"pkg1": "5.3",
+				"pkg2": "7.1",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := Enrich(tc.vr)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEnrich_NoFixedVersion(t *testing.T) {
+	tests := map[string]struct {
+		vr       *clairclient.VulnerabilityReport
+		expected map[string]string
+	}{
+		"vuln with empty fixed version": {
+			vr: &clairclient.VulnerabilityReport{
+				Packages: map[string]clairclient.Package{
+					"pkg1": {ID: "pkg1", Name: "bash"},
+				},
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {ID: "vuln1", FixedInVersion: ""},
+				},
+				PackageVulnerabilities: map[string][]string{
+					"pkg1": {"vuln1"},
+				},
+			},
+			expected: map[string]string{},
+		},
+		"all vulns without fixed version": {
+			vr: &clairclient.VulnerabilityReport{
+				Packages: map[string]clairclient.Package{
+					"pkg1": {ID: "pkg1"},
+					"pkg2": {ID: "pkg2"},
+				},
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {ID: "vuln1", FixedInVersion: ""},
+					"vuln2": {ID: "vuln2", FixedInVersion: ""},
+				},
+				PackageVulnerabilities: map[string][]string{
+					"pkg1": {"vuln1"},
+					"pkg2": {"vuln2"},
+				},
+			},
+			expected: map[string]string{},
+		},
+		"mixed fixed and unfixed vulns": {
+			vr: &clairclient.VulnerabilityReport{
+				Packages: map[string]clairclient.Package{
+					"pkg1": {ID: "pkg1"},
+				},
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {ID: "vuln1", FixedInVersion: ""},
+					"vuln2": {ID: "vuln2", FixedInVersion: "5.3"},
+				},
+				PackageVulnerabilities: map[string][]string{
+					"pkg1": {"vuln1", "vuln2"},
+				},
+			},
+			expected: map[string]string{
+				"pkg1": "5.3",
+			},
+		},
+		"empty report": {
+			vr:       &clairclient.VulnerabilityReport{},
+			expected: map[string]string{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := Enrich(tc.vr)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/clair-adapter/enricher/manual/manual.go
+++ b/clair-adapter/enricher/manual/manual.go
@@ -1,0 +1,39 @@
+package manual
+
+import (
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+// VulnerabilityOverride represents a manual override for vulnerability metadata.
+type VulnerabilityOverride struct {
+	Name               string `yaml:"Name"`
+	Description        string `yaml:"Description,omitempty"`
+	Severity           string `yaml:"Severity,omitempty"`
+	NormalizedSeverity string `yaml:"NormalizedSeverity,omitempty"`
+	FixedInVersion     string `yaml:"FixedInVersion,omitempty"`
+	Links              string `yaml:"Links,omitempty"`
+}
+
+// overridesDocument is the wrapper structure for the YAML document.
+type overridesDocument struct {
+	Vulnerabilities []VulnerabilityOverride `yaml:"vulnerabilities"`
+}
+
+// ParseOverrides parses YAML data containing vulnerability overrides.
+// Expected format:
+//
+//	vulnerabilities:
+//	  - Name: CVE-2023-9999
+//	    Severity: Critical
+//	    NormalizedSeverity: Critical
+//	    FixedInVersion: "1.0.1"
+func ParseOverrides(data []byte) ([]VulnerabilityOverride, error) {
+	var doc overridesDocument
+
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, errors.Wrap(err, "failed to parse vulnerability overrides YAML")
+	}
+
+	return doc.Vulnerabilities, nil
+}

--- a/clair-adapter/enricher/manual/manual_test.go
+++ b/clair-adapter/enricher/manual/manual_test.go
@@ -1,0 +1,141 @@
+package manual
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOverrides(t *testing.T) {
+	tests := map[string]struct {
+		yaml     string
+		expected []VulnerabilityOverride
+		wantErr  bool
+	}{
+		"single vulnerability override": {
+			yaml: `vulnerabilities:
+  - Name: CVE-2023-9999
+    Severity: Critical
+    NormalizedSeverity: Critical
+    FixedInVersion: "1.0.1"
+`,
+			expected: []VulnerabilityOverride{
+				{
+					Name:               "CVE-2023-9999",
+					Severity:           "Critical",
+					NormalizedSeverity: "Critical",
+					FixedInVersion:     "1.0.1",
+				},
+			},
+		},
+		"multiple vulnerability overrides": {
+			yaml: `vulnerabilities:
+  - Name: CVE-2023-1111
+    Description: First vulnerability
+    Severity: High
+    NormalizedSeverity: Important
+    FixedInVersion: "2.0.0"
+    Links: https://example.com/cve-2023-1111
+  - Name: CVE-2023-2222
+    Description: Second vulnerability
+    Severity: Medium
+    NormalizedSeverity: Moderate
+    FixedInVersion: "3.1.0"
+`,
+			expected: []VulnerabilityOverride{
+				{
+					Name:               "CVE-2023-1111",
+					Description:        "First vulnerability",
+					Severity:           "High",
+					NormalizedSeverity: "Important",
+					FixedInVersion:     "2.0.0",
+					Links:              "https://example.com/cve-2023-1111",
+				},
+				{
+					Name:               "CVE-2023-2222",
+					Description:        "Second vulnerability",
+					Severity:           "Medium",
+					NormalizedSeverity: "Moderate",
+					FixedInVersion:     "3.1.0",
+				},
+			},
+		},
+		"partial fields": {
+			yaml: `vulnerabilities:
+  - Name: CVE-2023-3333
+    Severity: Low
+`,
+			expected: []VulnerabilityOverride{
+				{
+					Name:     "CVE-2023-3333",
+					Severity: "Low",
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := ParseOverrides([]byte(tc.yaml))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestParseOverrides_Empty(t *testing.T) {
+	tests := map[string]struct {
+		yaml     string
+		expected []VulnerabilityOverride
+	}{
+		"empty vulnerabilities list": {
+			yaml:     `vulnerabilities: []`,
+			expected: []VulnerabilityOverride{},
+		},
+		"no vulnerabilities key": {
+			yaml:     ``,
+			expected: nil,
+		},
+		"empty document": {
+			yaml:     `{}`,
+			expected: nil,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := ParseOverrides([]byte(tc.yaml))
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestParseOverrides_InvalidYAML(t *testing.T) {
+	tests := map[string]struct {
+		yaml string
+	}{
+		"invalid YAML syntax": {
+			yaml: `vulnerabilities:
+  - Name: CVE-2023-9999
+    Severity: Critical
+  invalid line without indentation
+`,
+		},
+		"malformed structure": {
+			yaml: `vulnerabilities: "not a list"`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseOverrides([]byte(tc.yaml))
+			require.Error(t, err)
+		})
+	}
+}

--- a/clair-adapter/enricher/pipeline.go
+++ b/clair-adapter/enricher/pipeline.go
@@ -1,0 +1,84 @@
+package enricher
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	"github.com/stackrox/rox/clair-adapter/enricher/csaf"
+	"github.com/stackrox/rox/clair-adapter/enricher/fixedby"
+	"github.com/stackrox/rox/clair-adapter/mappers"
+)
+
+// EnrichmentResult contains all enrichment data extracted from a vulnerability report.
+type EnrichmentResult struct {
+	NVDVulns       map[string]map[string]*mappers.NVDItem
+	EPSSItems      map[string]map[string]*mappers.EPSSItem
+	CSAFAdvisories map[string]*csaf.Advisory
+	PkgFixedBy     map[string]string
+}
+
+// Pipeline orchestrates the enrichment process for vulnerability reports.
+type Pipeline struct {
+	csafEnricher *csaf.Enricher
+}
+
+// PipelineOption configures a Pipeline.
+type PipelineOption func(*Pipeline)
+
+// NewPipeline creates a new enrichment pipeline.
+func NewPipeline(opts ...PipelineOption) *Pipeline {
+	p := &Pipeline{}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
+}
+
+// WithCSAFEnricher configures the pipeline with a CSAF enricher.
+func WithCSAFEnricher(e *csaf.Enricher) PipelineOption {
+	return func(p *Pipeline) {
+		p.csafEnricher = e
+	}
+}
+
+// Enrich processes a vulnerability report through all enrichment stages.
+// Returns combined enrichment data from all sources.
+func (p *Pipeline) Enrich(ctx context.Context, vr *clairclient.VulnerabilityReport) (*EnrichmentResult, error) {
+	result := &EnrichmentResult{}
+
+	// Extract NVD vulnerability data
+	nvdVulns, err := mappers.ExtractNVDVulnerabilities(vr.Enrichments)
+	if err != nil {
+		return nil, err
+	}
+	result.NVDVulns = nvdVulns
+
+	// Extract EPSS data
+	epssItems, err := mappers.ExtractEPSS(vr.Enrichments)
+	if err != nil {
+		return nil, err
+	}
+	result.EPSSItems = epssItems
+
+	// Compute package fixed-by versions
+	pkgFixedBy, err := fixedby.Enrich(vr)
+	if err != nil {
+		return nil, err
+	}
+	result.PkgFixedBy = pkgFixedBy
+
+	// Apply CSAF enrichment if configured (best-effort)
+	if p.csafEnricher != nil {
+		csafAdvisories, err := p.csafEnricher.Enrich(vr)
+		if err != nil {
+			slog.WarnContext(ctx, "CSAF enrichment failed, continuing without it", "error", err)
+		} else {
+			result.CSAFAdvisories = csafAdvisories
+		}
+	}
+
+	return result, nil
+}

--- a/clair-adapter/enricher/pipeline_test.go
+++ b/clair-adapter/enricher/pipeline_test.go
@@ -1,0 +1,209 @@
+package enricher
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	"github.com/stackrox/rox/clair-adapter/enricher/csaf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipeline_Enrich(t *testing.T) {
+	tests := map[string]struct {
+		vr       *clairclient.VulnerabilityReport
+		pipeline *Pipeline
+		validate func(t *testing.T, result *EnrichmentResult, err error)
+	}{
+		"vuln with fixed version populates PkgFixedBy": {
+			vr: &clairclient.VulnerabilityReport{
+				Packages: map[string]clairclient.Package{
+					"pkg1": {ID: "pkg1", Name: "bash", Version: "5.0"},
+				},
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {ID: "vuln1", FixedInVersion: "5.2"},
+				},
+				PackageVulnerabilities: map[string][]string{
+					"pkg1": {"vuln1"},
+				},
+			},
+			pipeline: NewPipeline(),
+			validate: func(t *testing.T, result *EnrichmentResult, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, map[string]string{"pkg1": "5.2"}, result.PkgFixedBy)
+			},
+		},
+		"NVD enrichment data is extracted": {
+			vr: &clairclient.VulnerabilityReport{
+				Enrichments: map[string][]json.RawMessage{
+					"message/vnd.clair.map.vulnerability; enricher=clair.cvss": {
+						json.RawMessage(`{"CVE-2023-1234": [{"cve": "CVE-2023-1234", "cvss": [{"version": "3.1", "score": 7.5, "vector": "CVSS:3.1/AV:N/AC:L"}]}]}`),
+					},
+				},
+			},
+			pipeline: NewPipeline(),
+			validate: func(t *testing.T, result *EnrichmentResult, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, result.NVDVulns)
+				assert.Len(t, result.NVDVulns, 1)
+				for _, nvdMap := range result.NVDVulns {
+					assert.Contains(t, nvdMap, "CVE-2023-1234")
+					assert.Equal(t, 7.5, nvdMap["CVE-2023-1234"].CVSSv3.BaseScore)
+				}
+			},
+		},
+		"EPSS enrichment data is extracted": {
+			vr: &clairclient.VulnerabilityReport{
+				Enrichments: map[string][]json.RawMessage{
+					"message/vnd.clair.map.enrichment; enricher=clair.epss": {
+						json.RawMessage(`{"CVE-2023-1234": [{"cve": "CVE-2023-1234", "epss": {"model_version": "v2023.03.01", "date": "2023-05-15", "probability": 0.00123, "percentile": 0.45678}}]}`),
+					},
+				},
+			},
+			pipeline: NewPipeline(),
+			validate: func(t *testing.T, result *EnrichmentResult, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, result.EPSSItems)
+				assert.Len(t, result.EPSSItems, 1)
+				for _, epssMap := range result.EPSSItems {
+					assert.Contains(t, epssMap, "CVE-2023-1234")
+					assert.Equal(t, 0.00123, epssMap["CVE-2023-1234"].Probability)
+				}
+			},
+		},
+		"CSAF enrichment when enricher provided": {
+			vr: &clairclient.VulnerabilityReport{
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {ID: "vuln1", Name: "RHSA-2023:1234: bash update"},
+				},
+			},
+			pipeline: NewPipeline(WithCSAFEnricher(csaf.NewEnricher(csaf.WithStaticAdvisories(map[string]*csaf.Advisory{
+				"RHSA-2023:1234": {
+					Name:        "RHSA-2023:1234",
+					Description: "bash security update",
+					Severity:    "Important",
+				},
+			})))),
+			validate: func(t *testing.T, result *EnrichmentResult, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, result.CSAFAdvisories)
+				assert.Len(t, result.CSAFAdvisories, 1)
+				assert.Contains(t, result.CSAFAdvisories, "vuln1")
+				assert.Equal(t, "bash security update", result.CSAFAdvisories["vuln1"].Description)
+			},
+		},
+		"no CSAF enrichment when enricher not provided": {
+			vr: &clairclient.VulnerabilityReport{
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {ID: "vuln1", Name: "RHSA-2023:1234: bash update"},
+				},
+			},
+			pipeline: NewPipeline(),
+			validate: func(t *testing.T, result *EnrichmentResult, err error) {
+				require.NoError(t, err)
+				assert.Empty(t, result.CSAFAdvisories)
+			},
+		},
+		"all enrichments combined": {
+			vr: &clairclient.VulnerabilityReport{
+				Packages: map[string]clairclient.Package{
+					"pkg1": {ID: "pkg1"},
+				},
+				Vulnerabilities: map[string]clairclient.Vulnerability{
+					"vuln1": {ID: "vuln1", Name: "RHSA-2023:1234: test", FixedInVersion: "1.0"},
+				},
+				PackageVulnerabilities: map[string][]string{
+					"pkg1": {"vuln1"},
+				},
+				Enrichments: map[string][]json.RawMessage{
+					"message/vnd.clair.map.vulnerability; enricher=clair.cvss": {
+						json.RawMessage(`{"CVE-2023-1234": [{"cve": "CVE-2023-1234", "cvss": [{"version": "3.1", "score": 7.5, "vector": "CVSS:3.1/AV:N/AC:L"}]}]}`),
+					},
+					"message/vnd.clair.map.enrichment; enricher=clair.epss": {
+						json.RawMessage(`{"CVE-2023-1234": [{"cve": "CVE-2023-1234", "epss": {"model_version": "v2023.03.01", "date": "2023-05-15", "probability": 0.001, "percentile": 0.45}}]}`),
+					},
+				},
+			},
+			pipeline: NewPipeline(WithCSAFEnricher(csaf.NewEnricher(csaf.WithStaticAdvisories(map[string]*csaf.Advisory{
+				"RHSA-2023:1234": {Name: "RHSA-2023:1234", Description: "test"},
+			})))),
+			validate: func(t *testing.T, result *EnrichmentResult, err error) {
+				require.NoError(t, err)
+				assert.NotEmpty(t, result.NVDVulns)
+				assert.NotEmpty(t, result.EPSSItems)
+				assert.NotEmpty(t, result.PkgFixedBy)
+				assert.NotEmpty(t, result.CSAFAdvisories)
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			result, err := tc.pipeline.Enrich(ctx, tc.vr)
+			tc.validate(t, result, err)
+		})
+	}
+}
+
+func TestPipeline_Enrich_Empty(t *testing.T) {
+	tests := map[string]struct {
+		vr       *clairclient.VulnerabilityReport
+		pipeline *Pipeline
+	}{
+		"empty report": {
+			vr:       &clairclient.VulnerabilityReport{},
+			pipeline: NewPipeline(),
+		},
+		"no enrichments": {
+			vr: &clairclient.VulnerabilityReport{
+				Packages: map[string]clairclient.Package{
+					"pkg1": {ID: "pkg1"},
+				},
+			},
+			pipeline: NewPipeline(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			result, err := tc.pipeline.Enrich(ctx, tc.vr)
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Empty(t, result.NVDVulns)
+			assert.Empty(t, result.EPSSItems)
+			assert.Empty(t, result.PkgFixedBy)
+			assert.Empty(t, result.CSAFAdvisories)
+		})
+	}
+}
+
+func TestPipeline_WithCSAFEnricher(t *testing.T) {
+	releaseDate := time.Date(2023, 5, 15, 0, 0, 0, 0, time.UTC)
+
+	csafEnricher := csaf.NewEnricher(csaf.WithStaticAdvisories(map[string]*csaf.Advisory{
+		"RHSA-2023:1234": {
+			Name:        "RHSA-2023:1234",
+			Description: "security update",
+			ReleaseDate: releaseDate,
+			Severity:    "Important",
+		},
+	}))
+
+	pipeline := NewPipeline(WithCSAFEnricher(csafEnricher))
+
+	vr := &clairclient.VulnerabilityReport{
+		Vulnerabilities: map[string]clairclient.Vulnerability{
+			"vuln1": {ID: "vuln1", Name: "RHSA-2023:1234: test"},
+		},
+	}
+
+	ctx := t.Context()
+	result, err := pipeline.Enrich(ctx, vr)
+	require.NoError(t, err)
+	require.Len(t, result.CSAFAdvisories, 1)
+	assert.Equal(t, "security update", result.CSAFAdvisories["vuln1"].Description)
+}

--- a/clair-adapter/healthz/healthz.go
+++ b/clair-adapter/healthz/healthz.go
@@ -1,0 +1,38 @@
+package healthz
+
+import (
+	"net/http"
+)
+
+// Handler provides liveness and readiness health check endpoints.
+type Handler struct {
+	isReady func() bool
+}
+
+// NewHandler creates a new health check handler.
+// isReady is called to determine readiness status; nil means always ready.
+func NewHandler(isReady func() bool) *Handler {
+	return &Handler{isReady: isReady}
+}
+
+// ServeHTTP implements http.Handler for health check routes.
+// Supports:
+// - /healthz/live - always returns 200 OK
+// - /healthz/ready - returns 200 OK if ready, 503 Service Unavailable otherwise
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/healthz/live":
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	case "/healthz/ready":
+		if h.isReady == nil || h.isReady() {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("Ready"))
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("Not Ready"))
+		}
+	default:
+		http.NotFound(w, r)
+	}
+}

--- a/clair-adapter/healthz/healthz.go
+++ b/clair-adapter/healthz/healthz.go
@@ -2,6 +2,9 @@ package healthz
 
 import (
 	"net/http"
+
+	"github.com/stackrox/rox/pkg/grpc/authz/allow"
+	"github.com/stackrox/rox/pkg/grpc/routes"
 )
 
 // Handler provides liveness and readiness health check endpoints.
@@ -22,17 +25,43 @@ func NewHandler(isReady func() bool) *Handler {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case "/healthz/live":
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("OK"))
+		h.live(w, r)
 	case "/healthz/ready":
-		if h.isReady == nil || h.isReady() {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("Ready"))
-		} else {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte("Not Ready"))
-		}
+		h.ready(w, r)
 	default:
 		http.NotFound(w, r)
+	}
+}
+
+func (h *Handler) live(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("OK"))
+}
+
+func (h *Handler) ready(w http.ResponseWriter, _ *http.Request) {
+	if h.isReady == nil || h.isReady() {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Ready"))
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("Not Ready"))
+	}
+}
+
+// CustomRoutes returns the health check routes for pkg/grpc.API integration.
+func (h *Handler) CustomRoutes() []routes.CustomRoute {
+	return []routes.CustomRoute{
+		{
+			Route:         "/healthz/live",
+			Authorizer:    allow.Anonymous(),
+			ServerHandler: http.HandlerFunc(h.live),
+			Compression:   false,
+		},
+		{
+			Route:         "/healthz/ready",
+			Authorizer:    allow.Anonymous(),
+			ServerHandler: http.HandlerFunc(h.ready),
+			Compression:   false,
+		},
 	}
 }

--- a/clair-adapter/indexer/indexer.go
+++ b/clair-adapter/indexer/indexer.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -50,34 +51,58 @@ func WithInsecureSkipTLSVerify(skip bool) Option {
 	}
 }
 
+// layerFetcher is a function that fetches layer descriptors from a registry.
+type layerFetcher func(ctx context.Context, imageURL string, opts indexOpts) ([]clairclient.Layer, error)
+
 // localIndexer implements the Indexer interface using a Clair HTTP client.
 type localIndexer struct {
 	clair         *clairclient.Client
 	metadataStore datastore.IndexerMetadataStore // may be nil
+	fetchLayers   layerFetcher                   // defaults to fetchManifestLayers
+}
+
+// LocalIndexerOption configures a localIndexer.
+type LocalIndexerOption func(*localIndexer)
+
+// WithLayerFetcher overrides the default layer fetcher (used for testing).
+func WithLayerFetcher(fetcher layerFetcher) LocalIndexerOption {
+	return func(l *localIndexer) {
+		l.fetchLayers = fetcher
+	}
 }
 
 // NewLocalIndexer creates a new indexer that delegates to a Clair HTTP client.
 // The metadataStore parameter is optional (may be nil) and is used to track manifest lifecycle.
-func NewLocalIndexer(clair *clairclient.Client, metadataStore datastore.IndexerMetadataStore) Indexer {
-	return &localIndexer{
+func NewLocalIndexer(clair *clairclient.Client, metadataStore datastore.IndexerMetadataStore, opts ...LocalIndexerOption) Indexer {
+	idx := &localIndexer{
 		clair:         clair,
 		metadataStore: metadataStore,
+		fetchLayers:   fetchManifestLayers,
 	}
+	for _, opt := range opts {
+		opt(idx)
+	}
+	return idx
 }
 
 // IndexContainerImage indexes a container image by submitting a manifest to Clair.
-// Currently, layers are left empty as full registry interaction is planned for the future.
 func (l *localIndexer) IndexContainerImage(ctx context.Context, hashID, imageURL string, opts ...Option) (*clairclient.IndexReport, error) {
-	// Apply options (currently not used in manifest construction, reserved for future registry integration)
+	// Apply options
 	var options indexOpts
 	for _, opt := range opts {
 		opt(&options)
 	}
 
-	// Build manifest with empty layers (full registry interaction is a future plan)
+	// Fetch manifest layers from registry
+	layers, err := l.fetchLayers(ctx, imageURL, options)
+	if err != nil {
+		return nil, fmt.Errorf("fetching manifest layers: %w", err)
+	}
+
+	// Build manifest for Clair
 	manifest := clairclient.Manifest{
 		Hash:   hashID,
-		Layers: []clairclient.Layer{},
+		Layers: layers,
 	}
 
 	// Submit to Clair for indexing

--- a/clair-adapter/indexer/indexer.go
+++ b/clair-adapter/indexer/indexer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/stackrox/rox/clair-adapter/clairclient"
@@ -101,7 +101,7 @@ func (l *localIndexer) IndexContainerImage(ctx context.Context, hashID, imageURL
 
 	// Build manifest for Clair
 	manifest := clairclient.Manifest{
-		Hash:   hashID,
+		Hash:   clairclient.DigestFromHashID(hashID),
 		Layers: layers,
 	}
 
@@ -117,7 +117,7 @@ func (l *localIndexer) IndexContainerImage(ctx context.Context, hashID, imageURL
 		expiration := time.Now().Add(24 * time.Hour)
 		if err := l.metadataStore.StoreManifest(ctx, hashID, expiration); err != nil {
 			// Log warning but don't fail the operation
-			log.Printf("warning: failed to store manifest metadata for %s: %v", hashID, err)
+			slog.WarnContext(ctx, "failed to store manifest metadata", "manifest_id", hashID, "error", err)
 		}
 	}
 
@@ -127,7 +127,7 @@ func (l *localIndexer) IndexContainerImage(ctx context.Context, hashID, imageURL
 // GetIndexReport retrieves an index report from Clair by manifest hash.
 // Returns (report, true, nil) if found, (nil, false, nil) if not found.
 func (l *localIndexer) GetIndexReport(ctx context.Context, hashID string) (*clairclient.IndexReport, bool, error) {
-	report, err := l.clair.GetIndexReport(ctx, hashID)
+	report, err := l.clair.GetIndexReport(ctx, clairclient.DigestFromHashID(hashID))
 	if err != nil {
 		if errors.Is(err, clairclient.ErrNotFound) {
 			return nil, false, nil
@@ -140,7 +140,7 @@ func (l *localIndexer) GetIndexReport(ctx context.Context, hashID string) (*clai
 
 // HasIndexReport checks if an index report exists in Clair.
 func (l *localIndexer) HasIndexReport(ctx context.Context, hashID string) (bool, error) {
-	_, err := l.clair.GetIndexReport(ctx, hashID)
+	_, err := l.clair.GetIndexReport(ctx, clairclient.DigestFromHashID(hashID))
 	if err != nil {
 		if errors.Is(err, clairclient.ErrNotFound) {
 			return false, nil

--- a/clair-adapter/indexer/indexer.go
+++ b/clair-adapter/indexer/indexer.go
@@ -1,0 +1,127 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	"github.com/stackrox/rox/clair-adapter/datastore"
+)
+
+// Indexer provides container image indexing operations.
+type Indexer interface {
+	// IndexContainerImage indexes a container image and returns the index report.
+	// hashID is the manifest hash (digest) and imageURL is the container image reference.
+	// Options can be provided for registry authentication.
+	IndexContainerImage(ctx context.Context, hashID, imageURL string, opts ...Option) (*clairclient.IndexReport, error)
+
+	// GetIndexReport retrieves an existing index report by manifest hash.
+	// Returns (report, true, nil) if found, (nil, false, nil) if not found, or (nil, false, err) on error.
+	GetIndexReport(ctx context.Context, hashID string) (*clairclient.IndexReport, bool, error)
+
+	// HasIndexReport checks if an index report exists for the given manifest hash.
+	HasIndexReport(ctx context.Context, hashID string) (bool, error)
+}
+
+// Option configures indexing behavior.
+type Option func(*indexOpts)
+
+// indexOpts holds indexing options.
+type indexOpts struct {
+	username              string
+	password              string
+	insecureSkipTLSVerify bool
+}
+
+// WithBasicAuth configures basic authentication credentials for registry access.
+func WithBasicAuth(username, password string) Option {
+	return func(opts *indexOpts) {
+		opts.username = username
+		opts.password = password
+	}
+}
+
+// WithInsecureSkipTLSVerify configures whether to skip TLS verification for registry access.
+func WithInsecureSkipTLSVerify(skip bool) Option {
+	return func(opts *indexOpts) {
+		opts.insecureSkipTLSVerify = skip
+	}
+}
+
+// localIndexer implements the Indexer interface using a Clair HTTP client.
+type localIndexer struct {
+	clair         *clairclient.Client
+	metadataStore datastore.IndexerMetadataStore // may be nil
+}
+
+// NewLocalIndexer creates a new indexer that delegates to a Clair HTTP client.
+// The metadataStore parameter is optional (may be nil) and is used to track manifest lifecycle.
+func NewLocalIndexer(clair *clairclient.Client, metadataStore datastore.IndexerMetadataStore) Indexer {
+	return &localIndexer{
+		clair:         clair,
+		metadataStore: metadataStore,
+	}
+}
+
+// IndexContainerImage indexes a container image by submitting a manifest to Clair.
+// Currently, layers are left empty as full registry interaction is planned for the future.
+func (l *localIndexer) IndexContainerImage(ctx context.Context, hashID, imageURL string, opts ...Option) (*clairclient.IndexReport, error) {
+	// Apply options (currently not used in manifest construction, reserved for future registry integration)
+	var options indexOpts
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	// Build manifest with empty layers (full registry interaction is a future plan)
+	manifest := clairclient.Manifest{
+		Hash:   hashID,
+		Layers: []clairclient.Layer{},
+	}
+
+	// Submit to Clair for indexing
+	report, err := l.clair.CreateIndexReport(ctx, manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store manifest metadata if metadata store is configured
+	if l.metadataStore != nil {
+		// Set expiration to 24 hours from now
+		expiration := time.Now().Add(24 * time.Hour)
+		if err := l.metadataStore.StoreManifest(ctx, hashID, expiration); err != nil {
+			// Log warning but don't fail the operation
+			log.Printf("warning: failed to store manifest metadata for %s: %v", hashID, err)
+		}
+	}
+
+	return report, nil
+}
+
+// GetIndexReport retrieves an index report from Clair by manifest hash.
+// Returns (report, true, nil) if found, (nil, false, nil) if not found.
+func (l *localIndexer) GetIndexReport(ctx context.Context, hashID string) (*clairclient.IndexReport, bool, error) {
+	report, err := l.clair.GetIndexReport(ctx, hashID)
+	if err != nil {
+		if errors.Is(err, clairclient.ErrNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+
+	return report, true, nil
+}
+
+// HasIndexReport checks if an index report exists in Clair.
+func (l *localIndexer) HasIndexReport(ctx context.Context, hashID string) (bool, error) {
+	_, err := l.clair.GetIndexReport(ctx, hashID)
+	if err != nil {
+		if errors.Is(err, clairclient.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}

--- a/clair-adapter/indexer/indexer_test.go
+++ b/clair-adapter/indexer/indexer_test.go
@@ -53,7 +53,7 @@ func TestIndexer_IndexContainerImage(t *testing.T) {
 				err := json.NewDecoder(r.Body).Decode(&manifest)
 				require.NoError(t, err)
 				assert.Equal(t, tc.hashID, manifest.Hash)
-				assert.Empty(t, manifest.Layers) // Layers are empty for now
+				assert.Empty(t, manifest.Layers) // Stub fetcher returns empty layers
 
 				w.WriteHeader(tc.mockStatus)
 				if tc.mockResponse != nil {
@@ -63,11 +63,16 @@ func TestIndexer_IndexContainerImage(t *testing.T) {
 			}))
 			defer server.Close()
 
-			// Create client and indexer
+			// Create client and indexer with stub layer fetcher
 			client, err := clairclient.NewClient(server.URL)
 			require.NoError(t, err)
 
-			indexer := NewLocalIndexer(client, nil)
+			// Stub fetcher that returns empty layers
+			stubFetcher := func(ctx context.Context, imageURL string, opts indexOpts) ([]clairclient.Layer, error) {
+				return []clairclient.Layer{}, nil
+			}
+
+			indexer := NewLocalIndexer(client, nil, WithLayerFetcher(stubFetcher))
 
 			// Execute test
 			ctx := context.Background()
@@ -108,7 +113,12 @@ func TestIndexer_IndexContainerImage_WithMetadataStore(t *testing.T) {
 		stored: make(map[string]time.Time),
 	}
 
-	indexer := NewLocalIndexer(client, mockStore)
+	// Stub fetcher that returns empty layers
+	stubFetcher := func(ctx context.Context, imageURL string, opts indexOpts) ([]clairclient.Layer, error) {
+		return []clairclient.Layer{}, nil
+	}
+
+	indexer := NewLocalIndexer(client, mockStore, WithLayerFetcher(stubFetcher))
 
 	ctx := context.Background()
 	report, err := indexer.IndexContainerImage(ctx, "sha256:stored123", "registry.io/image:v1")
@@ -255,7 +265,12 @@ func TestIndexer_WithOptions(t *testing.T) {
 	client, err := clairclient.NewClient(server.URL)
 	require.NoError(t, err)
 
-	indexer := NewLocalIndexer(client, nil)
+	// Stub fetcher that returns empty layers
+	stubFetcher := func(ctx context.Context, imageURL string, opts indexOpts) ([]clairclient.Layer, error) {
+		return []clairclient.Layer{}, nil
+	}
+
+	indexer := NewLocalIndexer(client, nil, WithLayerFetcher(stubFetcher))
 
 	ctx := context.Background()
 	_, err = indexer.IndexContainerImage(

--- a/clair-adapter/indexer/indexer_test.go
+++ b/clair-adapter/indexer/indexer_test.go
@@ -1,0 +1,289 @@
+package indexer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexer_IndexContainerImage(t *testing.T) {
+	tests := map[string]struct {
+		hashID       string
+		imageURL     string
+		mockResponse *clairclient.IndexReport
+		mockStatus   int
+		expectError  bool
+	}{
+		"successful indexing": {
+			hashID:   "sha256:abc123",
+			imageURL: "registry.io/image:tag",
+			mockResponse: &clairclient.IndexReport{
+				ManifestHash: "sha256:abc123",
+				State:        "IndexFinished",
+				Success:      true,
+				Packages:     map[string]clairclient.Package{},
+			},
+			mockStatus:  http.StatusCreated,
+			expectError: false,
+		},
+		"clair returns error": {
+			hashID:      "sha256:def456",
+			imageURL:    "registry.io/image:tag",
+			mockStatus:  http.StatusInternalServerError,
+			expectError: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Create mock Clair server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/indexer/api/v1/index_report", r.URL.Path)
+
+				// Verify request body
+				var manifest clairclient.Manifest
+				err := json.NewDecoder(r.Body).Decode(&manifest)
+				require.NoError(t, err)
+				assert.Equal(t, tc.hashID, manifest.Hash)
+				assert.Empty(t, manifest.Layers) // Layers are empty for now
+
+				w.WriteHeader(tc.mockStatus)
+				if tc.mockResponse != nil {
+					err := json.NewEncoder(w).Encode(tc.mockResponse)
+					require.NoError(t, err)
+				}
+			}))
+			defer server.Close()
+
+			// Create client and indexer
+			client, err := clairclient.NewClient(server.URL)
+			require.NoError(t, err)
+
+			indexer := NewLocalIndexer(client, nil)
+
+			// Execute test
+			ctx := context.Background()
+			report, err := indexer.IndexContainerImage(ctx, tc.hashID, tc.imageURL)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, report)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, report)
+				assert.Equal(t, tc.hashID, report.ManifestHash)
+				assert.True(t, report.Success)
+			}
+		})
+	}
+}
+
+func TestIndexer_IndexContainerImage_WithMetadataStore(t *testing.T) {
+	mockReport := &clairclient.IndexReport{
+		ManifestHash: "sha256:stored123",
+		State:        "IndexFinished",
+		Success:      true,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		err := json.NewEncoder(w).Encode(mockReport)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client, err := clairclient.NewClient(server.URL)
+	require.NoError(t, err)
+
+	// Mock metadata store
+	mockStore := &mockIndexerMetadataStore{
+		stored: make(map[string]time.Time),
+	}
+
+	indexer := NewLocalIndexer(client, mockStore)
+
+	ctx := context.Background()
+	report, err := indexer.IndexContainerImage(ctx, "sha256:stored123", "registry.io/image:v1")
+
+	require.NoError(t, err)
+	assert.NotNil(t, report)
+
+	// Verify metadata was stored
+	assert.Contains(t, mockStore.stored, "sha256:stored123")
+	assert.True(t, mockStore.stored["sha256:stored123"].After(time.Now()))
+}
+
+func TestIndexer_GetIndexReport(t *testing.T) {
+	tests := map[string]struct {
+		hashID       string
+		mockResponse *clairclient.IndexReport
+		mockStatus   int
+		expectFound  bool
+		expectError  bool
+	}{
+		"report found": {
+			hashID: "sha256:exists",
+			mockResponse: &clairclient.IndexReport{
+				ManifestHash: "sha256:exists",
+				State:        "IndexFinished",
+				Success:      true,
+			},
+			mockStatus:  http.StatusOK,
+			expectFound: true,
+		},
+		"report not found": {
+			hashID:      "sha256:notfound",
+			mockStatus:  http.StatusNotFound,
+			expectFound: false,
+		},
+		"server error": {
+			hashID:      "sha256:error",
+			mockStatus:  http.StatusInternalServerError,
+			expectError: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, tc.hashID)
+
+				w.WriteHeader(tc.mockStatus)
+				if tc.mockResponse != nil {
+					err := json.NewEncoder(w).Encode(tc.mockResponse)
+					require.NoError(t, err)
+				}
+			}))
+			defer server.Close()
+
+			client, err := clairclient.NewClient(server.URL)
+			require.NoError(t, err)
+
+			indexer := NewLocalIndexer(client, nil)
+
+			ctx := context.Background()
+			report, found, err := indexer.GetIndexReport(ctx, tc.hashID)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectFound, found)
+				if tc.expectFound {
+					assert.NotNil(t, report)
+					assert.Equal(t, tc.hashID, report.ManifestHash)
+				} else {
+					assert.Nil(t, report)
+				}
+			}
+		})
+	}
+}
+
+func TestIndexer_HasIndexReport(t *testing.T) {
+	tests := map[string]struct {
+		hashID      string
+		mockStatus  int
+		expectFound bool
+		expectError bool
+	}{
+		"report exists": {
+			hashID:      "sha256:exists",
+			mockStatus:  http.StatusOK,
+			expectFound: true,
+		},
+		"report does not exist": {
+			hashID:      "sha256:notfound",
+			mockStatus:  http.StatusNotFound,
+			expectFound: false,
+		},
+		"server error": {
+			hashID:      "sha256:error",
+			mockStatus:  http.StatusInternalServerError,
+			expectError: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.mockStatus)
+				if tc.mockStatus == http.StatusOK {
+					report := &clairclient.IndexReport{ManifestHash: tc.hashID}
+					err := json.NewEncoder(w).Encode(report)
+					require.NoError(t, err)
+				}
+			}))
+			defer server.Close()
+
+			client, err := clairclient.NewClient(server.URL)
+			require.NoError(t, err)
+
+			indexer := NewLocalIndexer(client, nil)
+
+			ctx := context.Background()
+			exists, err := indexer.HasIndexReport(ctx, tc.hashID)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectFound, exists)
+			}
+		})
+	}
+}
+
+func TestIndexer_WithOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		report := &clairclient.IndexReport{ManifestHash: "sha256:test"}
+		err := json.NewEncoder(w).Encode(report)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client, err := clairclient.NewClient(server.URL)
+	require.NoError(t, err)
+
+	indexer := NewLocalIndexer(client, nil)
+
+	ctx := context.Background()
+	_, err = indexer.IndexContainerImage(
+		ctx,
+		"sha256:test",
+		"registry.io/image:v1",
+		WithBasicAuth("user", "pass"),
+		WithInsecureSkipTLSVerify(true),
+	)
+
+	require.NoError(t, err)
+}
+
+// mockIndexerMetadataStore is a simple in-memory implementation for testing
+type mockIndexerMetadataStore struct {
+	stored map[string]time.Time
+}
+
+func (m *mockIndexerMetadataStore) StoreManifest(ctx context.Context, manifestID string, expiration time.Time) error {
+	m.stored[manifestID] = expiration
+	return nil
+}
+
+func (m *mockIndexerMetadataStore) ManifestExists(ctx context.Context, manifestID string) (bool, error) {
+	_, exists := m.stored[manifestID]
+	return exists, nil
+}
+
+func (m *mockIndexerMetadataStore) GCManifests(ctx context.Context, expiration time.Time, limit int) ([]string, error) {
+	return nil, nil
+}

--- a/clair-adapter/indexer/manifest/manager.go
+++ b/clair-adapter/indexer/manifest/manager.go
@@ -1,0 +1,128 @@
+package manifest
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/stackrox/rox/clair-adapter/datastore"
+)
+
+// ClairClient defines the interface for interacting with Clair's indexer API.
+type ClairClient interface {
+	DeleteIndexReport(ctx context.Context, digest string) error
+}
+
+// Manager garbage-collects expired manifests from both the adapter database and Clair.
+type Manager struct {
+	metadataStore datastore.IndexerMetadataStore
+	clair         ClairClient
+	gcInterval    time.Duration
+	gcThrottle    int
+	cancel        context.CancelFunc
+}
+
+// ManagerOption configures the Manager.
+type ManagerOption func(*Manager)
+
+// WithGCInterval sets the interval between garbage collection cycles.
+// Default is 1 hour.
+func WithGCInterval(d time.Duration) ManagerOption {
+	return func(m *Manager) {
+		m.gcInterval = d
+	}
+}
+
+// WithGCThrottle sets the maximum number of manifests to garbage collect per cycle.
+// Default is 100.
+func WithGCThrottle(n int) ManagerOption {
+	return func(m *Manager) {
+		m.gcThrottle = n
+	}
+}
+
+// NewManager creates a new manifest garbage collection manager.
+func NewManager(metadataStore datastore.IndexerMetadataStore, clair ClairClient, opts ...ManagerOption) *Manager {
+	m := &Manager{
+		metadataStore: metadataStore,
+		clair:         clair,
+		gcInterval:    time.Hour,
+		gcThrottle:    100,
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+// StartGC starts the garbage collection loop and blocks until the context is canceled.
+// It runs GC immediately on start, then runs at the configured interval.
+func (m *Manager) StartGC(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	m.cancel = cancel
+	defer cancel()
+
+	// Run GC immediately on start
+	if err := m.runGC(ctx); err != nil {
+		slog.ErrorContext(ctx, "Initial GC failed", "error", err)
+	}
+
+	ticker := time.NewTicker(m.gcInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := m.runGC(ctx); err != nil {
+				slog.ErrorContext(ctx, "GC cycle failed", "error", err)
+			}
+		}
+	}
+}
+
+// StopGC stops the garbage collection loop.
+func (m *Manager) StopGC() {
+	if m.cancel != nil {
+		m.cancel()
+	}
+}
+
+// runGC performs a single garbage collection cycle.
+func (m *Manager) runGC(ctx context.Context) error {
+	now := time.Now()
+
+	// Get expired manifest IDs
+	expiredIDs, err := m.metadataStore.GCManifests(ctx, now, m.gcThrottle)
+	if err != nil {
+		return fmt.Errorf("failed to get expired manifests: %w", err)
+	}
+
+	if len(expiredIDs) == 0 {
+		return nil
+	}
+
+	slog.InfoContext(ctx, "Starting GC cycle", "expired_count", len(expiredIDs))
+
+	// Delete each manifest from Clair
+	deletedCount := 0
+	for _, manifestID := range expiredIDs {
+		if err := m.clair.DeleteIndexReport(ctx, manifestID); err != nil {
+			slog.WarnContext(ctx, "Failed to delete index report from Clair",
+				"manifest_id", manifestID,
+				"error", err)
+			continue
+		}
+		deletedCount++
+	}
+
+	slog.InfoContext(ctx, "GC cycle completed",
+		"deleted", deletedCount,
+		"failed", len(expiredIDs)-deletedCount)
+
+	return nil
+}

--- a/clair-adapter/indexer/manifest/manager_test.go
+++ b/clair-adapter/indexer/manifest/manager_test.go
@@ -1,0 +1,208 @@
+package manifest
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MockMetadataStore implements a mock for datastore.IndexerMetadataStore.
+type MockMetadataStore struct {
+	GCManifestsFunc func(ctx context.Context, expiration time.Time, limit int) ([]string, error)
+}
+
+func (m *MockMetadataStore) StoreManifest(ctx context.Context, manifestID string, expiration time.Time) error {
+	return nil
+}
+
+func (m *MockMetadataStore) ManifestExists(ctx context.Context, manifestID string) (bool, error) {
+	return false, nil
+}
+
+func (m *MockMetadataStore) GCManifests(ctx context.Context, expiration time.Time, limit int) ([]string, error) {
+	if m.GCManifestsFunc != nil {
+		return m.GCManifestsFunc(ctx, expiration, limit)
+	}
+	return nil, nil
+}
+
+// MockClairClient implements a mock for clairclient.Client.
+type MockClairClient struct {
+	DeleteIndexReportFunc func(ctx context.Context, digest string) error
+}
+
+func (m *MockClairClient) DeleteIndexReport(ctx context.Context, digest string) error {
+	if m.DeleteIndexReportFunc != nil {
+		return m.DeleteIndexReportFunc(ctx, digest)
+	}
+	return nil
+}
+
+func TestManager_GC(t *testing.T) {
+	tests := map[string]struct {
+		expiredManifests []string
+		gcError          error
+		deleteErrors     map[string]error
+		wantDeleteCalls  []string
+	}{
+		"no expired manifests": {
+			expiredManifests: nil,
+			wantDeleteCalls:  nil,
+		},
+		"single expired manifest": {
+			expiredManifests: []string{"sha256:abc123"},
+			wantDeleteCalls:  []string{"sha256:abc123"},
+		},
+		"multiple expired manifests": {
+			expiredManifests: []string{"sha256:abc123", "sha256:def456", "sha256:ghi789"},
+			wantDeleteCalls:  []string{"sha256:abc123", "sha256:def456", "sha256:ghi789"},
+		},
+		"GC error returns error": {
+			gcError:         errors.New("database error"),
+			wantDeleteCalls: nil,
+		},
+		"delete error continues to next manifest": {
+			expiredManifests: []string{"sha256:abc123", "sha256:def456", "sha256:ghi789"},
+			deleteErrors: map[string]error{
+				"sha256:def456": errors.New("delete failed"),
+			},
+			wantDeleteCalls: []string{"sha256:abc123", "sha256:def456", "sha256:ghi789"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+
+			var deleteCalls []string
+			mockStore := &MockMetadataStore{
+				GCManifestsFunc: func(ctx context.Context, expiration time.Time, limit int) ([]string, error) {
+					if tt.gcError != nil {
+						return nil, tt.gcError
+					}
+					assert.Equal(t, 100, limit, "expected default GC throttle")
+					return tt.expiredManifests, nil
+				},
+			}
+
+			mockClair := &MockClairClient{
+				DeleteIndexReportFunc: func(ctx context.Context, digest string) error {
+					deleteCalls = append(deleteCalls, digest)
+					if tt.deleteErrors != nil {
+						if err, ok := tt.deleteErrors[digest]; ok {
+							return err
+						}
+					}
+					return nil
+				},
+			}
+
+			m := NewManager(mockStore, mockClair)
+
+			err := m.runGC(ctx)
+
+			if tt.gcError != nil {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to get expired manifests")
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantDeleteCalls, deleteCalls)
+		})
+	}
+}
+
+func TestManager_Options(t *testing.T) {
+	mockStore := &MockMetadataStore{}
+	mockClair := &MockClairClient{}
+
+	t.Run("default options", func(t *testing.T) {
+		m := NewManager(mockStore, mockClair)
+		assert.Equal(t, time.Hour, m.gcInterval)
+		assert.Equal(t, 100, m.gcThrottle)
+	})
+
+	t.Run("custom GC interval", func(t *testing.T) {
+		m := NewManager(mockStore, mockClair, WithGCInterval(30*time.Minute))
+		assert.Equal(t, 30*time.Minute, m.gcInterval)
+	})
+
+	t.Run("custom GC throttle", func(t *testing.T) {
+		m := NewManager(mockStore, mockClair, WithGCThrottle(50))
+		assert.Equal(t, 50, m.gcThrottle)
+	})
+}
+
+func TestManager_StartStopGC(t *testing.T) {
+	ctx := t.Context()
+
+	gcCount := 0
+	mockStore := &MockMetadataStore{
+		GCManifestsFunc: func(ctx context.Context, expiration time.Time, limit int) ([]string, error) {
+			gcCount++
+			return nil, nil
+		},
+	}
+	mockClair := &MockClairClient{}
+
+	// Use a very short interval for testing
+	m := NewManager(mockStore, mockClair, WithGCInterval(10*time.Millisecond))
+
+	// Start GC in background
+	gcCtx, cancel := context.WithCancel(ctx)
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- m.StartGC(gcCtx)
+	}()
+
+	// Wait for at least 2 GC cycles
+	time.Sleep(25 * time.Millisecond)
+
+	// Stop GC
+	m.StopGC()
+	cancel()
+
+	// Wait for GC to finish
+	err := <-errChan
+	require.NoError(t, err)
+
+	// Should have run GC at least twice (immediate + at least one interval)
+	assert.GreaterOrEqual(t, gcCount, 2)
+}
+
+func TestManager_StartGC_ContextCancellation(t *testing.T) {
+	ctx := t.Context()
+
+	mockStore := &MockMetadataStore{
+		GCManifestsFunc: func(ctx context.Context, expiration time.Time, limit int) ([]string, error) {
+			return nil, nil
+		},
+	}
+	mockClair := &MockClairClient{}
+
+	m := NewManager(mockStore, mockClair, WithGCInterval(time.Hour))
+
+	// Create a context that we'll cancel immediately
+	gcCtx, cancel := context.WithCancel(ctx)
+
+	// Start GC
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- m.StartGC(gcCtx)
+	}()
+
+	// Give it time to start and run first GC
+	time.Sleep(10 * time.Millisecond)
+
+	// Cancel context
+	cancel()
+
+	// Wait for GC to finish
+	err := <-errChan
+	require.NoError(t, err)
+}

--- a/clair-adapter/indexer/registry.go
+++ b/clair-adapter/indexer/registry.go
@@ -1,0 +1,166 @@
+package indexer
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+)
+
+// fetchManifestLayers fetches an image manifest from a container registry
+// and returns layer descriptors suitable for Clair's indexing API.
+func fetchManifestLayers(ctx context.Context, imageURL string, opts indexOpts) ([]clairclient.Layer, error) {
+	// 1. Parse image reference
+	ref, err := parseImageRef(imageURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Build auth option
+	var auth authn.Authenticator = authn.Anonymous
+	if opts.username != "" {
+		auth = &authn.Basic{Username: opts.username, Password: opts.password}
+	}
+
+	// 3. Fetch image descriptor to get layer list
+	desc, err := remote.Get(ref, remote.WithAuth(auth), remote.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("fetching image descriptor: %w", err)
+	}
+
+	img, err := desc.Image()
+	if err != nil {
+		return nil, fmt.Errorf("getting image from descriptor: %w", err)
+	}
+
+	imgLayers, err := img.Layers()
+	if err != nil {
+		return nil, fmt.Errorf("getting image layers: %w", err)
+	}
+
+	// 4. Build authenticated HTTP client for layer URI construction
+	httpClient, err := buildLayerHTTPClient(ctx, ref, auth, opts.insecureSkipTLSVerify)
+	if err != nil {
+		return nil, fmt.Errorf("building layer HTTP client: %w", err)
+	}
+
+	// 5. Construct layer descriptors for Clair
+	var layers []clairclient.Layer
+	for _, layer := range imgLayers {
+		digest, err := layer.Digest()
+		if err != nil {
+			return nil, fmt.Errorf("getting layer digest: %w", err)
+		}
+
+		layerURI, headers, err := buildLayerURI(ctx, httpClient, ref, digest.String())
+		if err != nil {
+			return nil, fmt.Errorf("building layer URI for %s: %w", digest, err)
+		}
+
+		layers = append(layers, clairclient.Layer{
+			Hash:    digest.String(),
+			URI:     layerURI,
+			Headers: headers,
+		})
+	}
+
+	return layers, nil
+}
+
+// parseImageRef parses a container image URL into a name.Reference.
+// Accepts formats: "docker.io/library/bash:5.1", "https://registry.example.com/repo:tag"
+func parseImageRef(imageURL string) (name.Reference, error) {
+	// Strip scheme if present
+	u := imageURL
+	if strings.HasPrefix(u, "https://") || strings.HasPrefix(u, "http://") {
+		parsed, err := url.Parse(u)
+		if err != nil {
+			return nil, fmt.Errorf("parsing URL: %w", err)
+		}
+		u = parsed.Host + parsed.Path
+	}
+
+	ref, err := name.ParseReference(u)
+	if err != nil {
+		return nil, fmt.Errorf("parsing image reference %q: %w", u, err)
+	}
+	return ref, nil
+}
+
+// buildLayerHTTPClient creates an HTTP client with registry authentication.
+func buildLayerHTTPClient(ctx context.Context, ref name.Reference, auth authn.Authenticator, insecure bool) (*http.Client, error) {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("unexpected default transport type %T", http.DefaultTransport)
+	}
+	tr := base.Clone()
+	if insecure {
+		if tr.TLSClientConfig == nil {
+			tr.TLSClientConfig = &tls.Config{}
+		}
+		tr.TLSClientConfig.InsecureSkipVerify = true
+	}
+
+	// Add retry wrapper
+	var roundTripper http.RoundTripper = transport.NewRetry(tr)
+
+	// Add authentication transport (handles registry challenge-response)
+	repo := ref.Context()
+	roundTripper, err := transport.NewWithContext(ctx, repo.Registry, auth, roundTripper, []string{repo.Scope(transport.PullScope)})
+	if err != nil {
+		return nil, fmt.Errorf("creating auth transport: %w", err)
+	}
+
+	return &http.Client{Transport: roundTripper}, nil
+}
+
+// buildLayerURI constructs the blob URI for a layer and captures auth headers.
+// It sends a partial-content request to the registry to trigger auth challenge-response,
+// then returns the final URI and headers that Clair can use to fetch the layer.
+func buildLayerURI(ctx context.Context, httpClient *http.Client, ref name.Reference, layerDigest string) (string, map[string][]string, error) {
+	repo := ref.Context()
+	registryURL := url.URL{
+		Scheme: repo.Scheme(),
+		Host:   repo.RegistryStr(),
+	}
+
+	imgPath := strings.TrimPrefix(repo.RepositoryStr(), repo.RegistryStr())
+	blobPath := path.Join("/", "v2", imgPath, "blobs", layerDigest)
+	registryURL.Path = blobPath
+
+	// Send a partial-content request to trigger auth and get final URI
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, registryURL.String(), nil)
+	if err != nil {
+		return "", nil, err
+	}
+	req.Header.Set("Range", "bytes=0-0")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", nil, fmt.Errorf("probing layer: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// The actual request (after redirects) has the auth headers we need
+	finalReq := resp.Request
+	headers := make(map[string][]string)
+	for k, v := range finalReq.Header {
+		// Copy auth-related headers, skip noise
+		if k == "Authorization" || k == "Accept" {
+			headers[k] = v
+		}
+	}
+
+	// Remove Range header — we want Clair to fetch the full layer
+	// Use the final URL (after any redirects)
+	return finalReq.URL.String(), headers, nil
+}

--- a/clair-adapter/indexer/registry_test.go
+++ b/clair-adapter/indexer/registry_test.go
@@ -1,0 +1,44 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseImageRef(t *testing.T) {
+	tests := map[string]struct {
+		input   string
+		wantErr bool
+	}{
+		"docker hub with tag": {
+			input: "docker.io/library/bash:5.1",
+		},
+		"with https scheme": {
+			input: "https://registry.example.com/repo/image:tag",
+		},
+		"with http scheme": {
+			input: "http://registry.example.com/repo/image:tag",
+		},
+		"digest reference": {
+			input: "docker.io/library/bash@sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abcd",
+		},
+		"empty": {
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ref, err := parseImageRef(tc.input)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, ref)
+		})
+	}
+}

--- a/clair-adapter/mappers/enrichment.go
+++ b/clair-adapter/mappers/enrichment.go
@@ -1,0 +1,252 @@
+package mappers
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// NVDItem represents NVD vulnerability data with CVSS scores.
+type NVDItem struct {
+	CVSSv2 *CVSSScore
+	CVSSv3 *CVSSScore
+}
+
+// CVSSScore represents a CVSS score with its vector string.
+type CVSSScore struct {
+	BaseScore float64
+	Vector    string
+}
+
+// EPSSItem represents EPSS (Exploit Prediction Scoring System) data.
+type EPSSItem struct {
+	ModelVersion string
+	Date         string
+	Probability  float64
+	Percentile   float64
+}
+
+// CSAFAdvisory represents a CSAF advisory from RHEL.
+type CSAFAdvisory struct {
+	Name        string
+	Description string
+	ReleaseDate time.Time
+	Severity    string
+	CVSSv3      CVSSScore
+	CVSSv2      CVSSScore
+}
+
+// ExtractNVDVulnerabilities extracts NVD vulnerability data from enrichments.
+// Returns a map of enrichment key -> CVE ID -> NVD data.
+func ExtractNVDVulnerabilities(enrichments map[string][]json.RawMessage) (map[string]map[string]*NVDItem, error) {
+	result := make(map[string]map[string]*NVDItem)
+
+	for key, messages := range enrichments {
+		if !strings.HasPrefix(key, "message/vnd.clair.map.vulnerability") {
+			continue
+		}
+
+		cveMap := make(map[string]*NVDItem)
+		for _, msg := range messages {
+			// Parse the message as a map of CVE ID -> array of NVD entries
+			var vulnMap map[string][]struct {
+				CVE  string `json:"cve"`
+				CVSS []struct {
+					Version string  `json:"version"`
+					Score   float64 `json:"score"`
+					Vector  string  `json:"vector"`
+				} `json:"cvss"`
+			}
+
+			if err := json.Unmarshal(msg, &vulnMap); err != nil {
+				return nil, errors.Wrap(err, "failed to unmarshal NVD vulnerability data")
+			}
+
+			for cveID, entries := range vulnMap {
+				if len(entries) == 0 {
+					continue
+				}
+
+				// Take the first entry for this CVE
+				entry := entries[0]
+				nvdItem := &NVDItem{}
+
+				// Process CVSS scores
+				for _, cvss := range entry.CVSS {
+					score := &CVSSScore{
+						BaseScore: cvss.Score,
+						Vector:    cvss.Vector,
+					}
+
+					// Determine version by checking first character
+					if len(cvss.Version) > 0 {
+						if cvss.Version[0] == '2' {
+							nvdItem.CVSSv2 = score
+						} else if cvss.Version[0] == '3' {
+							nvdItem.CVSSv3 = score
+						}
+					}
+				}
+
+				cveMap[cveID] = nvdItem
+			}
+		}
+
+		if len(cveMap) > 0 {
+			result[key] = cveMap
+		}
+	}
+
+	return result, nil
+}
+
+// ExtractEPSS extracts EPSS data from enrichments.
+// Returns a map of enrichment key -> CVE ID -> EPSS data.
+func ExtractEPSS(enrichments map[string][]json.RawMessage) (map[string]map[string]*EPSSItem, error) {
+	result := make(map[string]map[string]*EPSSItem)
+
+	for key, messages := range enrichments {
+		if !strings.HasPrefix(key, "message/vnd.clair.map.enrichment") {
+			continue
+		}
+
+		cveMap := make(map[string]*EPSSItem)
+		for _, msg := range messages {
+			// Parse the message as a map of CVE ID -> array of EPSS entries
+			var epssMap map[string][]struct {
+				CVE  string `json:"cve"`
+				EPSS struct {
+					ModelVersion string  `json:"model_version"`
+					Date         string  `json:"date"`
+					Probability  float64 `json:"probability"`
+					Percentile   float64 `json:"percentile"`
+				} `json:"epss"`
+			}
+
+			if err := json.Unmarshal(msg, &epssMap); err != nil {
+				return nil, errors.Wrap(err, "failed to unmarshal EPSS data")
+			}
+
+			for cveID, entries := range epssMap {
+				if len(entries) == 0 {
+					continue
+				}
+
+				// Take the first entry for this CVE
+				entry := entries[0]
+				epssItem := &EPSSItem{
+					ModelVersion: entry.EPSS.ModelVersion,
+					Date:         entry.EPSS.Date,
+					Probability:  entry.EPSS.Probability,
+					Percentile:   entry.EPSS.Percentile,
+				}
+
+				cveMap[cveID] = epssItem
+			}
+		}
+
+		if len(cveMap) > 0 {
+			result[key] = cveMap
+		}
+	}
+
+	return result, nil
+}
+
+// ExtractCSAFAdvisories extracts CSAF advisory data from enrichments.
+// Returns a map of CVE ID -> CSAF advisory (first advisory per CVE).
+func ExtractCSAFAdvisories(enrichments map[string][]json.RawMessage) (map[string]*CSAFAdvisory, error) {
+	const csafKey = "message/vnd.stackrox.scannerv4.map.csaf; enricher=stackrox.rhel-csaf"
+
+	result := make(map[string]*CSAFAdvisory)
+
+	messages, exists := enrichments[csafKey]
+	if !exists {
+		return result, nil
+	}
+
+	for _, msg := range messages {
+		// Parse the message as a map of CVE ID -> array of advisories
+		var advisoryMap map[string][]struct {
+			Name        string    `json:"name"`
+			Description string    `json:"description"`
+			Released    time.Time `json:"released"`
+			Severity    string    `json:"severity"`
+			CVSSv3      *struct {
+				BaseScore float64 `json:"base_score"`
+				Vector    string  `json:"vector"`
+			} `json:"cvss_v3,omitzero"`
+			CVSSv2 *struct {
+				BaseScore float64 `json:"base_score"`
+				Vector    string  `json:"vector"`
+			} `json:"cvss_v2,omitzero"`
+		}
+
+		if err := json.Unmarshal(msg, &advisoryMap); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal CSAF advisory data")
+		}
+
+		for cveID, advisories := range advisoryMap {
+			if len(advisories) == 0 {
+				continue
+			}
+
+			// Take the first advisory for this CVE
+			adv := advisories[0]
+			csafAdv := &CSAFAdvisory{
+				Name:        adv.Name,
+				Description: adv.Description,
+				ReleaseDate: adv.Released,
+				Severity:    adv.Severity,
+			}
+
+			if adv.CVSSv3 != nil {
+				csafAdv.CVSSv3 = CVSSScore{
+					BaseScore: adv.CVSSv3.BaseScore,
+					Vector:    adv.CVSSv3.Vector,
+				}
+			}
+
+			if adv.CVSSv2 != nil {
+				csafAdv.CVSSv2 = CVSSScore{
+					BaseScore: adv.CVSSv2.BaseScore,
+					Vector:    adv.CVSSv2.Vector,
+				}
+			}
+
+			result[cveID] = csafAdv
+		}
+	}
+
+	return result, nil
+}
+
+// ExtractPkgFixedBy extracts package fixed-by version mappings from enrichments.
+// Returns a map of package ID -> fixed version.
+func ExtractPkgFixedBy(enrichments map[string][]json.RawMessage) (map[string]string, error) {
+	const fixedByKey = "message/vnd.stackrox.scannerv4.fixedby; enricher=fixedby"
+
+	result := make(map[string]string)
+
+	messages, exists := enrichments[fixedByKey]
+	if !exists {
+		return result, nil
+	}
+
+	for _, msg := range messages {
+		// Parse the message as a map of package ID -> fixed version
+		var pkgMap map[string]string
+
+		if err := json.Unmarshal(msg, &pkgMap); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal package fixed-by data")
+		}
+
+		for pkgID, fixedVersion := range pkgMap {
+			result[pkgID] = fixedVersion
+		}
+	}
+
+	return result, nil
+}

--- a/clair-adapter/mappers/enrichment_test.go
+++ b/clair-adapter/mappers/enrichment_test.go
@@ -1,0 +1,282 @@
+package mappers
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractNVDVulnerabilities(t *testing.T) {
+	enrichments := map[string][]json.RawMessage{
+		"message/vnd.clair.map.vulnerability; enricher=nvd": {
+			json.RawMessage(`{
+				"CVE-2021-1234": [{
+					"cve": "CVE-2021-1234",
+					"cvss": [{
+						"version": "3.1",
+						"score": 7.5,
+						"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+					}]
+				}]
+			}`),
+			json.RawMessage(`{
+				"CVE-2021-5678": [{
+					"cve": "CVE-2021-5678",
+					"cvss": [{
+						"version": "2.0",
+						"score": 5.0,
+						"vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+					}, {
+						"version": "3.1",
+						"score": 9.8,
+						"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+					}]
+				}]
+			}`),
+		},
+		"message/vnd.clair.map.vulnerability; enricher=other": {
+			json.RawMessage(`{
+				"CVE-2022-9999": [{
+					"cve": "CVE-2022-9999",
+					"cvss": [{
+						"version": "3.0",
+						"score": 4.3,
+						"vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+					}]
+				}]
+			}`),
+		},
+	}
+
+	result, err := ExtractNVDVulnerabilities(enrichments)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Check CVE-2021-1234 with only CVSSv3
+	nvd1234 := result["message/vnd.clair.map.vulnerability; enricher=nvd"]["CVE-2021-1234"]
+	require.NotNil(t, nvd1234)
+	assert.Nil(t, nvd1234.CVSSv2)
+	require.NotNil(t, nvd1234.CVSSv3)
+	assert.Equal(t, 7.5, nvd1234.CVSSv3.BaseScore)
+	assert.Equal(t, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", nvd1234.CVSSv3.Vector)
+
+	// Check CVE-2021-5678 with both CVSSv2 and CVSSv3
+	nvd5678 := result["message/vnd.clair.map.vulnerability; enricher=nvd"]["CVE-2021-5678"]
+	require.NotNil(t, nvd5678)
+	require.NotNil(t, nvd5678.CVSSv2)
+	assert.Equal(t, 5.0, nvd5678.CVSSv2.BaseScore)
+	assert.Equal(t, "AV:N/AC:L/Au:N/C:N/I:N/A:P", nvd5678.CVSSv2.Vector)
+	require.NotNil(t, nvd5678.CVSSv3)
+	assert.Equal(t, 9.8, nvd5678.CVSSv3.BaseScore)
+	assert.Equal(t, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", nvd5678.CVSSv3.Vector)
+
+	// Check CVE-2022-9999 from other enricher
+	nvd9999 := result["message/vnd.clair.map.vulnerability; enricher=other"]["CVE-2022-9999"]
+	require.NotNil(t, nvd9999)
+	assert.Nil(t, nvd9999.CVSSv2)
+	require.NotNil(t, nvd9999.CVSSv3)
+	assert.Equal(t, 4.3, nvd9999.CVSSv3.BaseScore)
+	assert.Equal(t, "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N", nvd9999.CVSSv3.Vector)
+}
+
+func TestExtractNVDVulnerabilities_NoEnrichments(t *testing.T) {
+	testCases := map[string]struct {
+		input    map[string][]json.RawMessage
+		expected map[string]map[string]*NVDItem
+	}{
+		"nil input": {
+			input:    nil,
+			expected: map[string]map[string]*NVDItem{},
+		},
+		"empty input": {
+			input:    map[string][]json.RawMessage{},
+			expected: map[string]map[string]*NVDItem{},
+		},
+		"no matching keys": {
+			input: map[string][]json.RawMessage{
+				"other/key": {json.RawMessage(`{}`)},
+			},
+			expected: map[string]map[string]*NVDItem{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result, err := ExtractNVDVulnerabilities(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestExtractEPSS(t *testing.T) {
+	enrichments := map[string][]json.RawMessage{
+		"message/vnd.clair.map.enrichment; enricher=epss": {
+			json.RawMessage(`{
+				"CVE-2021-1234": [{
+					"cve": "CVE-2021-1234",
+					"epss": {
+						"model_version": "v2023.03.01",
+						"date": "2023-03-15",
+						"probability": 0.75432,
+						"percentile": 0.92156
+					}
+				}]
+			}`),
+			json.RawMessage(`{
+				"CVE-2021-5678": [{
+					"cve": "CVE-2021-5678",
+					"epss": {
+						"model_version": "v2023.03.01",
+						"date": "2023-03-15",
+						"probability": 0.00123,
+						"percentile": 0.12345
+					}
+				}]
+			}`),
+		},
+	}
+
+	result, err := ExtractEPSS(enrichments)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Check CVE-2021-1234
+	epss1234 := result["message/vnd.clair.map.enrichment; enricher=epss"]["CVE-2021-1234"]
+	require.NotNil(t, epss1234)
+	assert.Equal(t, "v2023.03.01", epss1234.ModelVersion)
+	assert.Equal(t, "2023-03-15", epss1234.Date)
+	assert.Equal(t, 0.75432, epss1234.Probability)
+	assert.Equal(t, 0.92156, epss1234.Percentile)
+
+	// Check CVE-2021-5678
+	epss5678 := result["message/vnd.clair.map.enrichment; enricher=epss"]["CVE-2021-5678"]
+	require.NotNil(t, epss5678)
+	assert.Equal(t, "v2023.03.01", epss5678.ModelVersion)
+	assert.Equal(t, "2023-03-15", epss5678.Date)
+	assert.Equal(t, 0.00123, epss5678.Probability)
+	assert.Equal(t, 0.12345, epss5678.Percentile)
+}
+
+func TestExtractCSAFAdvisories(t *testing.T) {
+	enrichments := map[string][]json.RawMessage{
+		"message/vnd.stackrox.scannerv4.map.csaf; enricher=stackrox.rhel-csaf": {
+			json.RawMessage(`{
+				"CVE-2021-1234": [{
+					"name": "RHSA-2021:1234",
+					"description": "Important security update for package",
+					"released": "2021-04-15T00:00:00Z",
+					"severity": "Important",
+					"cvss_v3": {
+						"base_score": 7.5,
+						"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+					}
+				}]
+			}`),
+			json.RawMessage(`{
+				"CVE-2021-5678": [{
+					"name": "RHSA-2021:5678",
+					"description": "Critical security update for library",
+					"released": "2021-12-01T00:00:00Z",
+					"severity": "Critical",
+					"cvss_v3": {
+						"base_score": 9.8,
+						"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+					},
+					"cvss_v2": {
+						"base_score": 10.0,
+						"vector": "AV:N/AC:L/Au:N/C:C/I:C/A:C"
+					}
+				}, {
+					"name": "RHSA-2021:5679",
+					"description": "Another advisory (should be ignored)",
+					"released": "2021-12-02T00:00:00Z",
+					"severity": "Moderate"
+				}]
+			}`),
+		},
+	}
+
+	result, err := ExtractCSAFAdvisories(enrichments)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Check CVE-2021-1234 - first advisory taken
+	advisory1234 := result["CVE-2021-1234"]
+	require.NotNil(t, advisory1234)
+	assert.Equal(t, "RHSA-2021:1234", advisory1234.Name)
+	assert.Equal(t, "Important security update for package", advisory1234.Description)
+	assert.Equal(t, "Important", advisory1234.Severity)
+	expectedDate1 := time.Date(2021, 4, 15, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, expectedDate1, advisory1234.ReleaseDate)
+	assert.Equal(t, 7.5, advisory1234.CVSSv3.BaseScore)
+	assert.Equal(t, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", advisory1234.CVSSv3.Vector)
+	assert.Equal(t, 0.0, advisory1234.CVSSv2.BaseScore)
+	assert.Equal(t, "", advisory1234.CVSSv2.Vector)
+
+	// Check CVE-2021-5678 - first advisory taken, second ignored
+	advisory5678 := result["CVE-2021-5678"]
+	require.NotNil(t, advisory5678)
+	assert.Equal(t, "RHSA-2021:5678", advisory5678.Name)
+	assert.Equal(t, "Critical security update for library", advisory5678.Description)
+	assert.Equal(t, "Critical", advisory5678.Severity)
+	expectedDate2 := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, expectedDate2, advisory5678.ReleaseDate)
+	assert.Equal(t, 9.8, advisory5678.CVSSv3.BaseScore)
+	assert.Equal(t, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", advisory5678.CVSSv3.Vector)
+	assert.Equal(t, 10.0, advisory5678.CVSSv2.BaseScore)
+	assert.Equal(t, "AV:N/AC:L/Au:N/C:C/I:C/A:C", advisory5678.CVSSv2.Vector)
+}
+
+func TestExtractPkgFixedBy(t *testing.T) {
+	enrichments := map[string][]json.RawMessage{
+		"message/vnd.stackrox.scannerv4.fixedby; enricher=fixedby": {
+			json.RawMessage(`{
+				"pkg:1": "1.2.3-4.el8",
+				"pkg:2": "2.0.0",
+				"pkg:3": ""
+			}`),
+		},
+	}
+
+	result, err := ExtractPkgFixedBy(enrichments)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "1.2.3-4.el8", result["pkg:1"])
+	assert.Equal(t, "2.0.0", result["pkg:2"])
+	assert.Equal(t, "", result["pkg:3"])
+}
+
+func TestExtractPkgFixedBy_NoEnrichments(t *testing.T) {
+	testCases := map[string]struct {
+		input    map[string][]json.RawMessage
+		expected map[string]string
+	}{
+		"nil input": {
+			input:    nil,
+			expected: map[string]string{},
+		},
+		"empty input": {
+			input:    map[string][]json.RawMessage{},
+			expected: map[string]string{},
+		},
+		"no matching key": {
+			input: map[string][]json.RawMessage{
+				"other/key": {json.RawMessage(`{"pkg:1": "1.0.0"}`)},
+			},
+			expected: map[string]string{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result, err := ExtractPkgFixedBy(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/clair-adapter/mappers/index_report.go
+++ b/clair-adapter/mappers/index_report.go
@@ -1,0 +1,149 @@
+package mappers
+
+import (
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+)
+
+// ToProtoIndexReport converts a Clair IndexReport to the Scanner V4 proto format.
+func ToProtoIndexReport(ir *clairclient.IndexReport) (*v4.IndexReport, error) {
+	contents, err := toProtoContents(
+		ir.Packages,
+		ir.Distributions,
+		ir.Repositories,
+		ir.Environments,
+		nil, // pkgFixedBy is nil for index reports
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v4.IndexReport{
+		HashId:   ir.ManifestHash,
+		State:    ir.State,
+		Success:  ir.Success,
+		Err:      ir.Err,
+		Contents: contents,
+	}, nil
+}
+
+// toProtoContents converts Clair content maps to proto Contents.
+// This is shared between index and vulnerability report mappers.
+// pkgFixedBy maps package ID to fixed-in version (nil for index reports).
+func toProtoContents(
+	packages map[string]clairclient.Package,
+	distributions map[string]clairclient.Distribution,
+	repositories map[string]clairclient.Repository,
+	environments map[string][]clairclient.Environment,
+	pkgFixedBy map[string]string,
+) (*v4.Contents, error) {
+	contents := &v4.Contents{
+		Packages:      make(map[string]*v4.Package),
+		Distributions: make(map[string]*v4.Distribution),
+		Repositories:  make(map[string]*v4.Repository),
+		Environments:  make(map[string]*v4.Environment_List),
+	}
+
+	// Convert packages
+	for id, pkg := range packages {
+		var fixedIn string
+		if pkgFixedBy != nil {
+			fixedIn = pkgFixedBy[id]
+		}
+		contents.Packages[id] = toProtoPackage(pkg, fixedIn)
+	}
+
+	// Convert distributions
+	for id, dist := range distributions {
+		contents.Distributions[id] = toProtoDistribution(dist)
+	}
+
+	// Convert repositories
+	for id, repo := range repositories {
+		contents.Repositories[id] = toProtoRepository(repo)
+	}
+
+	// Convert environments
+	for id, envList := range environments {
+		protoEnvList := &v4.Environment_List{
+			Environments: make([]*v4.Environment, 0, len(envList)),
+		}
+		for _, env := range envList {
+			protoEnvList.Environments = append(protoEnvList.Environments, toProtoEnvironment(env))
+		}
+		contents.Environments[id] = protoEnvList
+	}
+
+	return contents, nil
+}
+
+// toProtoPackage converts a Clair Package to proto Package.
+// Handles recursive Source field and int to int32 conversion for NormalizedVersion.
+func toProtoPackage(pkg clairclient.Package, fixedInVersion string) *v4.Package {
+	protoPkg := &v4.Package{
+		Id:             pkg.ID,
+		Name:           pkg.Name,
+		Version:        pkg.Version,
+		Kind:           pkg.Kind,
+		Arch:           pkg.Arch,
+		Module:         pkg.Module,
+		Cpe:            pkg.CPE,
+		PackageDb:      pkg.PackageDB,
+		RepositoryHint: pkg.RepositoryHint,
+		FixedInVersion: fixedInVersion,
+	}
+
+	// Handle recursive source package
+	if pkg.Source != nil {
+		protoPkg.Source = toProtoPackage(*pkg.Source, "")
+	}
+
+	// Convert NormalizedVersion (int -> int32)
+	if pkg.NormalizedVersion.Kind != "" || len(pkg.NormalizedVersion.V) > 0 {
+		protoPkg.NormalizedVersion = &v4.NormalizedVersion{
+			Kind: pkg.NormalizedVersion.Kind,
+			V:    make([]int32, len(pkg.NormalizedVersion.V)),
+		}
+		for i, v := range pkg.NormalizedVersion.V {
+			protoPkg.NormalizedVersion.V[i] = int32(v)
+		}
+	}
+
+	return protoPkg
+}
+
+// toProtoDistribution converts a Clair Distribution to proto Distribution.
+func toProtoDistribution(dist clairclient.Distribution) *v4.Distribution {
+	return &v4.Distribution{
+		Id:              dist.ID,
+		Did:             dist.DID,
+		Name:            dist.Name,
+		Version:         dist.Version,
+		VersionCodeName: dist.VersionCodeName,
+		VersionId:       dist.VersionID,
+		Arch:            dist.Arch,
+		Cpe:             dist.CPE,
+		PrettyName:      dist.PrettyName,
+	}
+}
+
+// toProtoRepository converts a Clair Repository to proto Repository.
+func toProtoRepository(repo clairclient.Repository) *v4.Repository {
+	return &v4.Repository{
+		Id:   repo.ID,
+		Name: repo.Name,
+		Key:  repo.Key,
+		Uri:  repo.URI,
+		Cpe:  repo.CPE,
+	}
+}
+
+// toProtoEnvironment converts a Clair Environment to proto Environment.
+func toProtoEnvironment(env clairclient.Environment) *v4.Environment {
+	return &v4.Environment{
+		PackageDb:      env.PackageDB,
+		IntroducedIn:   env.IntroducedIn,
+		DistributionId: env.DistributionID,
+		RepositoryIds:  env.RepositoryIDs,
+	}
+}

--- a/clair-adapter/mappers/index_report_test.go
+++ b/clair-adapter/mappers/index_report_test.go
@@ -1,0 +1,195 @@
+package mappers
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToProtoIndexReport(t *testing.T) {
+	clairReport := &clairclient.IndexReport{
+		ManifestHash: "sha256:abc123",
+		State:        "IndexFinished",
+		Success:      true,
+		Err:          "",
+		Packages: map[string]clairclient.Package{
+			"pkg1": {
+				ID:      "pkg1",
+				Name:    "curl",
+				Version: "7.68.0-1ubuntu2.4",
+				Kind:    "binary",
+				Arch:    "amd64",
+				Source: &clairclient.Package{
+					ID:      "src1",
+					Name:    "curl",
+					Version: "7.68.0-1ubuntu2.4",
+					Kind:    "source",
+				},
+				Module:         "",
+				CPE:            "cpe:2.3:a:haxx:curl:7.68.0:*:*:*:*:*:*:*",
+				PackageDB:      "var/lib/dpkg/status",
+				RepositoryHint: "ubuntu",
+				NormalizedVersion: clairclient.NormalizedVersion{
+					Kind: "deb",
+					V:    []int{7, 68, 0, 1},
+				},
+			},
+		},
+		Distributions: map[string]clairclient.Distribution{
+			"dist1": {
+				ID:              "dist1",
+				DID:             "ubuntu",
+				Name:            "Ubuntu",
+				Version:         "20.04",
+				VersionCodeName: "focal",
+				VersionID:       "20.04",
+				Arch:            "amd64",
+				CPE:             "cpe:/o:canonical:ubuntu_linux:20.04",
+				PrettyName:      "Ubuntu 20.04 LTS",
+			},
+		},
+		Repositories: map[string]clairclient.Repository{
+			"repo1": {
+				ID:   "repo1",
+				Name: "Ubuntu 20.04",
+				Key:  "ubuntu-key",
+				URI:  "http://archive.ubuntu.com/ubuntu",
+				CPE:  "cpe:/o:canonical:ubuntu_linux:20.04",
+			},
+		},
+		Environments: map[string][]clairclient.Environment{
+			"pkg1": {
+				{
+					PackageDB:      "var/lib/dpkg/status",
+					IntroducedIn:   "sha256:layer1",
+					DistributionID: "dist1",
+					RepositoryIDs:  []string{"repo1"},
+				},
+			},
+		},
+	}
+
+	protoReport, err := ToProtoIndexReport(clairReport)
+	require.NoError(t, err)
+	require.NotNil(t, protoReport)
+
+	// Verify top-level fields
+	assert.Equal(t, "sha256:abc123", protoReport.HashId)
+	assert.Equal(t, "IndexFinished", protoReport.State)
+	assert.True(t, protoReport.Success)
+	assert.Empty(t, protoReport.Err)
+
+	// Verify contents exist
+	require.NotNil(t, protoReport.Contents)
+
+	// Verify package mapping
+	require.Len(t, protoReport.Contents.Packages, 1)
+	pkg, ok := protoReport.Contents.Packages["pkg1"]
+	require.True(t, ok)
+	assert.Equal(t, "pkg1", pkg.Id)
+	assert.Equal(t, "curl", pkg.Name)
+	assert.Equal(t, "7.68.0-1ubuntu2.4", pkg.Version)
+	assert.Equal(t, "binary", pkg.Kind)
+	assert.Equal(t, "amd64", pkg.Arch)
+	assert.Equal(t, "cpe:2.3:a:haxx:curl:7.68.0:*:*:*:*:*:*:*", pkg.Cpe)
+	assert.Equal(t, "var/lib/dpkg/status", pkg.PackageDb)
+	assert.Equal(t, "ubuntu", pkg.RepositoryHint)
+	assert.Empty(t, pkg.FixedInVersion) // Should be empty for index reports
+
+	// Verify source package
+	require.NotNil(t, pkg.Source)
+	assert.Equal(t, "src1", pkg.Source.Id)
+	assert.Equal(t, "curl", pkg.Source.Name)
+	assert.Equal(t, "source", pkg.Source.Kind)
+
+	// Verify normalized version (int -> int32 conversion)
+	require.NotNil(t, pkg.NormalizedVersion)
+	assert.Equal(t, "deb", pkg.NormalizedVersion.Kind)
+	assert.Equal(t, []int32{7, 68, 0, 1}, pkg.NormalizedVersion.V)
+
+	// Verify distribution mapping
+	require.Len(t, protoReport.Contents.Distributions, 1)
+	dist, ok := protoReport.Contents.Distributions["dist1"]
+	require.True(t, ok)
+	assert.Equal(t, "dist1", dist.Id)
+	assert.Equal(t, "ubuntu", dist.Did)
+	assert.Equal(t, "Ubuntu", dist.Name)
+	assert.Equal(t, "20.04", dist.Version)
+	assert.Equal(t, "focal", dist.VersionCodeName)
+	assert.Equal(t, "20.04", dist.VersionId)
+	assert.Equal(t, "amd64", dist.Arch)
+	assert.Equal(t, "cpe:/o:canonical:ubuntu_linux:20.04", dist.Cpe)
+	assert.Equal(t, "Ubuntu 20.04 LTS", dist.PrettyName)
+
+	// Verify repository mapping
+	require.Len(t, protoReport.Contents.Repositories, 1)
+	repo, ok := protoReport.Contents.Repositories["repo1"]
+	require.True(t, ok)
+	assert.Equal(t, "repo1", repo.Id)
+	assert.Equal(t, "Ubuntu 20.04", repo.Name)
+	assert.Equal(t, "ubuntu-key", repo.Key)
+	assert.Equal(t, "http://archive.ubuntu.com/ubuntu", repo.Uri)
+	assert.Equal(t, "cpe:/o:canonical:ubuntu_linux:20.04", repo.Cpe)
+
+	// Verify environment mapping
+	require.Len(t, protoReport.Contents.Environments, 1)
+	envList, ok := protoReport.Contents.Environments["pkg1"]
+	require.True(t, ok)
+	require.NotNil(t, envList)
+	require.Len(t, envList.Environments, 1)
+	env := envList.Environments[0]
+	assert.Equal(t, "var/lib/dpkg/status", env.PackageDb)
+	assert.Equal(t, "sha256:layer1", env.IntroducedIn)
+	assert.Equal(t, "dist1", env.DistributionId)
+	assert.Equal(t, []string{"repo1"}, env.RepositoryIds)
+}
+
+func TestToProtoIndexReport_EmptyReport(t *testing.T) {
+	clairReport := &clairclient.IndexReport{
+		ManifestHash:  "sha256:empty",
+		State:         "IndexFinished",
+		Success:       true,
+		Packages:      map[string]clairclient.Package{},
+		Distributions: map[string]clairclient.Distribution{},
+		Repositories:  map[string]clairclient.Repository{},
+		Environments:  map[string][]clairclient.Environment{},
+	}
+
+	protoReport, err := ToProtoIndexReport(clairReport)
+	require.NoError(t, err)
+	require.NotNil(t, protoReport)
+
+	assert.Equal(t, "sha256:empty", protoReport.HashId)
+	assert.Equal(t, "IndexFinished", protoReport.State)
+	assert.True(t, protoReport.Success)
+
+	// Verify empty contents don't cause panics
+	require.NotNil(t, protoReport.Contents)
+	assert.Empty(t, protoReport.Contents.Packages)
+	assert.Empty(t, protoReport.Contents.Distributions)
+	assert.Empty(t, protoReport.Contents.Repositories)
+	assert.Empty(t, protoReport.Contents.Environments)
+}
+
+func TestToProtoIndexReport_FailedReport(t *testing.T) {
+	clairReport := &clairclient.IndexReport{
+		ManifestHash: "sha256:failed",
+		State:        "IndexError",
+		Success:      false,
+		Err:          "failed to index layer: connection timeout",
+	}
+
+	protoReport, err := ToProtoIndexReport(clairReport)
+	require.NoError(t, err)
+	require.NotNil(t, protoReport)
+
+	assert.Equal(t, "sha256:failed", protoReport.HashId)
+	assert.Equal(t, "IndexError", protoReport.State)
+	assert.False(t, protoReport.Success)
+	assert.Equal(t, "failed to index layer: connection timeout", protoReport.Err)
+
+	// Contents should still be created even for failed reports
+	require.NotNil(t, protoReport.Contents)
+}

--- a/clair-adapter/mappers/vulnerability_report.go
+++ b/clair-adapter/mappers/vulnerability_report.go
@@ -1,0 +1,212 @@
+package mappers
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var cveIDRegex = regexp.MustCompile(`CVE-\d{4}-\d+`)
+
+// ToProtoVulnerabilityReport converts a Clair VulnerabilityReport to the Scanner V4 proto format.
+// It extracts enrichments and integrates them into the vulnerability data.
+func ToProtoVulnerabilityReport(ctx context.Context, vr *clairclient.VulnerabilityReport) (*v4.VulnerabilityReport, error) {
+	// Extract enrichments
+	nvdVulns, err := ExtractNVDVulnerabilities(vr.Enrichments)
+	if err != nil {
+		return nil, err
+	}
+
+	epssItems, err := ExtractEPSS(vr.Enrichments)
+	if err != nil {
+		return nil, err
+	}
+
+	csafAdvisories, err := ExtractCSAFAdvisories(vr.Enrichments)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgFixedBy, err := ExtractPkgFixedBy(vr.Enrichments)
+	if err != nil {
+		return nil, err
+	}
+
+	return ToProtoVulnerabilityReportWithEnrichments(ctx, vr, nvdVulns, epssItems, csafAdvisories, pkgFixedBy)
+}
+
+// ToProtoVulnerabilityReportWithEnrichments converts a Clair VulnerabilityReport to the Scanner V4 proto format
+// using pre-computed enrichments. This is useful for the MatcherService which may cache enrichments.
+func ToProtoVulnerabilityReportWithEnrichments(
+	ctx context.Context,
+	vr *clairclient.VulnerabilityReport,
+	nvdVulns map[string]map[string]*NVDItem,
+	epssItems map[string]map[string]*EPSSItem,
+	csafAdvisories map[string]*CSAFAdvisory,
+	pkgFixedBy map[string]string,
+) (*v4.VulnerabilityReport, error) {
+	// Build contents with fixed-by versions
+	contents, err := toProtoContents(
+		vr.Packages,
+		vr.Distributions,
+		vr.Repositories,
+		vr.Environments,
+		pkgFixedBy,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map vulnerabilities
+	protoVulns := make(map[string]*v4.VulnerabilityReport_Vulnerability)
+	for id, vuln := range vr.Vulnerabilities {
+		protoVulns[id] = toProtoVulnerability(vuln, nvdVulns, epssItems, csafAdvisories, pkgFixedBy)
+	}
+
+	// Map package vulnerabilities
+	protoPkgVulns := make(map[string]*v4.StringList)
+	for pkgID, vulnIDs := range vr.PackageVulnerabilities {
+		protoPkgVulns[pkgID] = &v4.StringList{
+			Values: vulnIDs,
+		}
+	}
+
+	return &v4.VulnerabilityReport{
+		HashId:                 vr.ManifestHash,
+		Vulnerabilities:        protoVulns,
+		PackageVulnerabilities: protoPkgVulns,
+		Contents:               contents,
+	}, nil
+}
+
+// toProtoVulnerability converts a Clair Vulnerability to proto with enrichment data.
+func toProtoVulnerability(
+	vuln clairclient.Vulnerability,
+	nvdVulns map[string]map[string]*NVDItem,
+	epssItems map[string]map[string]*EPSSItem,
+	csafAdvisories map[string]*CSAFAdvisory,
+	pkgFixedBy map[string]string,
+) *v4.VulnerabilityReport_Vulnerability {
+	// Extract CVE ID from vulnerability name
+	cveID := cveIDRegex.FindString(vuln.Name)
+
+	// Start with base vulnerability data
+	protoVuln := &v4.VulnerabilityReport_Vulnerability{
+		Id:                 vuln.ID,
+		Name:               vuln.Name,
+		Description:        vuln.Description,
+		Issued:             timestamppb.New(vuln.Issued),
+		Link:               vuln.Links,
+		Severity:           vuln.Severity,
+		NormalizedSeverity: mapSeverity(vuln.NormalizedSeverity),
+		FixedInVersion:     vuln.FixedInVersion,
+		Updater:            vuln.Updater,
+	}
+
+	// Set package, distribution, and repository IDs if present
+	if vuln.Package != nil {
+		protoVuln.PackageId = vuln.Package.ID
+	}
+	if vuln.Distribution != nil {
+		protoVuln.DistributionId = vuln.Distribution.ID
+	}
+	if vuln.Repository != nil {
+		protoVuln.RepositoryId = vuln.Repository.ID
+	}
+
+	// If we have a CVE ID, apply enrichments
+	if cveID != "" {
+		// Check for CSAF advisory (Red Hat data) - this takes precedence
+		if csafAdv := csafAdvisories[cveID]; csafAdv != nil {
+			// Override with CSAF data
+			protoVuln.Description = csafAdv.Description
+			protoVuln.NormalizedSeverity = mapSeverity(csafAdv.Severity)
+			protoVuln.Issued = timestamppb.New(csafAdv.ReleaseDate)
+			protoVuln.Advisory = &v4.VulnerabilityReport_Advisory{
+				Name: csafAdv.Name,
+			}
+
+			// Add Red Hat CVSS metrics from CSAF
+			rhCVSS := &v4.VulnerabilityReport_Vulnerability_CVSS{
+				Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_RED_HAT,
+			}
+			if csafAdv.CVSSv3.BaseScore > 0 {
+				rhCVSS.V3 = &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+					BaseScore: float32(csafAdv.CVSSv3.BaseScore),
+					Vector:    csafAdv.CVSSv3.Vector,
+				}
+			}
+			if csafAdv.CVSSv2.BaseScore > 0 {
+				rhCVSS.V2 = &v4.VulnerabilityReport_Vulnerability_CVSS_V2{
+					BaseScore: float32(csafAdv.CVSSv2.BaseScore),
+					Vector:    csafAdv.CVSSv2.Vector,
+				}
+			}
+			protoVuln.CvssMetrics = append(protoVuln.CvssMetrics, rhCVSS)
+		}
+
+		// Add NVD CVSS metrics
+		for _, nvdMap := range nvdVulns {
+			if nvdItem := nvdMap[cveID]; nvdItem != nil {
+				nvdCVSS := &v4.VulnerabilityReport_Vulnerability_CVSS{
+					Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
+				}
+				if nvdItem.CVSSv3 != nil {
+					nvdCVSS.V3 = &v4.VulnerabilityReport_Vulnerability_CVSS_V3{
+						BaseScore: float32(nvdItem.CVSSv3.BaseScore),
+						Vector:    nvdItem.CVSSv3.Vector,
+					}
+				}
+				if nvdItem.CVSSv2 != nil {
+					nvdCVSS.V2 = &v4.VulnerabilityReport_Vulnerability_CVSS_V2{
+						BaseScore: float32(nvdItem.CVSSv2.BaseScore),
+						Vector:    nvdItem.CVSSv2.Vector,
+					}
+				}
+				protoVuln.CvssMetrics = append(protoVuln.CvssMetrics, nvdCVSS)
+				break // Take first NVD match
+			}
+		}
+
+		// Add EPSS metrics
+		for _, epssMap := range epssItems {
+			if epss := epssMap[cveID]; epss != nil {
+				protoVuln.EpssMetrics = &v4.VulnerabilityReport_Vulnerability_EPSS{
+					ModelVersion: epss.ModelVersion,
+					Date:         epss.Date,
+					Probability:  float32(epss.Probability),
+					Percentile:   float32(epss.Percentile),
+				}
+				break // Take first EPSS match
+			}
+		}
+	}
+
+	// Override fixed version with enrichment data if available
+	if vuln.Package != nil {
+		if fixedVersion := pkgFixedBy[vuln.Package.ID]; fixedVersion != "" {
+			protoVuln.FixedInVersion = fixedVersion
+		}
+	}
+
+	return protoVuln
+}
+
+// mapSeverity converts a severity string to the proto enum.
+func mapSeverity(s string) v4.VulnerabilityReport_Vulnerability_Severity {
+	switch s {
+	case "low", "negligible":
+		return v4.VulnerabilityReport_Vulnerability_SEVERITY_LOW
+	case "medium", "moderate":
+		return v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE
+	case "high", "important":
+		return v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT
+	case "critical", "defcon1":
+		return v4.VulnerabilityReport_Vulnerability_SEVERITY_CRITICAL
+	default:
+		return v4.VulnerabilityReport_Vulnerability_SEVERITY_UNSPECIFIED
+	}
+}

--- a/clair-adapter/mappers/vulnerability_report_test.go
+++ b/clair-adapter/mappers/vulnerability_report_test.go
@@ -1,0 +1,354 @@
+package mappers
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestMapSeverity(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected v4.VulnerabilityReport_Vulnerability_Severity
+	}{
+		"low":         {"low", v4.VulnerabilityReport_Vulnerability_SEVERITY_LOW},
+		"negligible":  {"negligible", v4.VulnerabilityReport_Vulnerability_SEVERITY_LOW},
+		"medium":      {"medium", v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE},
+		"moderate":    {"moderate", v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE},
+		"high":        {"high", v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT},
+		"important":   {"important", v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT},
+		"critical":    {"critical", v4.VulnerabilityReport_Vulnerability_SEVERITY_CRITICAL},
+		"defcon1":     {"defcon1", v4.VulnerabilityReport_Vulnerability_SEVERITY_CRITICAL},
+		"unknown":     {"unknown", v4.VulnerabilityReport_Vulnerability_SEVERITY_UNSPECIFIED},
+		"empty":       {"", v4.VulnerabilityReport_Vulnerability_SEVERITY_UNSPECIFIED},
+		"unspecified": {"unspecified", v4.VulnerabilityReport_Vulnerability_SEVERITY_UNSPECIFIED},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := mapSeverity(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestToProtoVulnerabilityReport_Empty(t *testing.T) {
+	ctx := t.Context()
+	vr := &clairclient.VulnerabilityReport{
+		ManifestHash:           "test-hash",
+		State:                  "IndexFinished",
+		Success:                true,
+		Err:                    "",
+		Packages:               make(map[string]clairclient.Package),
+		Distributions:          make(map[string]clairclient.Distribution),
+		Repositories:           make(map[string]clairclient.Repository),
+		Environments:           make(map[string][]clairclient.Environment),
+		Vulnerabilities:        make(map[string]clairclient.Vulnerability),
+		PackageVulnerabilities: make(map[string][]string),
+		Enrichments:            make(map[string][]json.RawMessage),
+	}
+
+	result, err := ToProtoVulnerabilityReport(ctx, vr)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "test-hash", result.HashId)
+	assert.Empty(t, result.Vulnerabilities)
+	assert.Empty(t, result.PackageVulnerabilities)
+	assert.NotNil(t, result.Contents)
+}
+
+func TestToProtoVulnerabilityReport_Basic(t *testing.T) {
+	ctx := t.Context()
+	issued := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	vr := &clairclient.VulnerabilityReport{
+		ManifestHash: "test-hash",
+		State:        "IndexFinished",
+		Success:      true,
+		Packages: map[string]clairclient.Package{
+			"pkg1": {
+				ID:      "pkg1",
+				Name:    "libssl",
+				Version: "1.0.0",
+			},
+		},
+		Distributions: map[string]clairclient.Distribution{
+			"dist1": {
+				ID:   "dist1",
+				Name: "ubuntu",
+			},
+		},
+		Repositories: make(map[string]clairclient.Repository),
+		Environments: make(map[string][]clairclient.Environment),
+		Vulnerabilities: map[string]clairclient.Vulnerability{
+			"vuln1": {
+				ID:                 "vuln1",
+				Name:               "CVE-2024-1234",
+				Description:        "Test vulnerability",
+				Issued:             issued,
+				Links:              "https://example.com",
+				Severity:           "high",
+				NormalizedSeverity: "high",
+				FixedInVersion:     "1.0.1",
+				Updater:            "ubuntu-updater",
+				Package: &clairclient.Package{
+					ID: "pkg1",
+				},
+				Distribution: &clairclient.Distribution{
+					ID: "dist1",
+				},
+			},
+		},
+		PackageVulnerabilities: map[string][]string{
+			"pkg1": {"vuln1"},
+		},
+		Enrichments: make(map[string][]json.RawMessage),
+	}
+
+	result, err := ToProtoVulnerabilityReport(ctx, vr)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+
+	// Check basic fields
+	assert.Equal(t, "test-hash", result.HashId)
+	assert.Len(t, result.Vulnerabilities, 1)
+	assert.Len(t, result.PackageVulnerabilities, 1)
+
+	// Check vulnerability mapping
+	vuln := result.Vulnerabilities["vuln1"]
+	require.NotNil(t, vuln)
+	assert.Equal(t, "vuln1", vuln.Id)
+	assert.Equal(t, "CVE-2024-1234", vuln.Name)
+	assert.Equal(t, "Test vulnerability", vuln.Description)
+	assert.Equal(t, "1.0.1", vuln.FixedInVersion)
+	assert.Equal(t, v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT, vuln.NormalizedSeverity)
+	assert.Equal(t, "ubuntu-updater", vuln.Updater)
+	assert.Equal(t, "https://example.com", vuln.Link)
+	assert.Equal(t, timestamppb.New(issued), vuln.Issued)
+	assert.Equal(t, "pkg1", vuln.PackageId)
+	assert.Equal(t, "dist1", vuln.DistributionId)
+
+	// Check package vulnerabilities
+	pkgVulns := result.PackageVulnerabilities["pkg1"]
+	require.NotNil(t, pkgVulns)
+	assert.Equal(t, []string{"vuln1"}, pkgVulns.Values)
+}
+
+func TestToProtoVulnerabilityReport_WithEnrichments(t *testing.T) {
+	ctx := t.Context()
+	issued := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	csafReleased := time.Date(2024, 1, 20, 0, 0, 0, 0, time.UTC)
+
+	vr := &clairclient.VulnerabilityReport{
+		ManifestHash: "test-hash",
+		State:        "IndexFinished",
+		Success:      true,
+		Packages: map[string]clairclient.Package{
+			"pkg1": {
+				ID:      "pkg1",
+				Name:    "libssl",
+				Version: "1.0.0",
+			},
+		},
+		Distributions: map[string]clairclient.Distribution{
+			"dist1": {
+				ID:   "dist1",
+				Name: "rhel",
+			},
+		},
+		Repositories: make(map[string]clairclient.Repository),
+		Environments: make(map[string][]clairclient.Environment),
+		Vulnerabilities: map[string]clairclient.Vulnerability{
+			"vuln1": {
+				ID:                 "vuln1",
+				Name:               "CVE-2024-5678",
+				Description:        "Original description",
+				Issued:             issued,
+				Links:              "https://example.com",
+				Severity:           "medium",
+				NormalizedSeverity: "medium",
+				FixedInVersion:     "1.0.1",
+				Updater:            "rhel-updater",
+				Package: &clairclient.Package{
+					ID: "pkg1",
+				},
+				Distribution: &clairclient.Distribution{
+					ID: "dist1",
+				},
+			},
+		},
+		PackageVulnerabilities: map[string][]string{
+			"pkg1": {"vuln1"},
+		},
+		Enrichments: make(map[string][]json.RawMessage),
+	}
+
+	// Pre-computed enrichments
+	nvdVulns := map[string]map[string]*NVDItem{
+		"key1": {
+			"CVE-2024-5678": {
+				CVSSv2: &CVSSScore{
+					BaseScore: 5.0,
+					Vector:    "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+				},
+				CVSSv3: &CVSSScore{
+					BaseScore: 7.5,
+					Vector:    "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+				},
+			},
+		},
+	}
+
+	epssItems := map[string]map[string]*EPSSItem{
+		"key1": {
+			"CVE-2024-5678": {
+				ModelVersion: "v2023.03.01",
+				Date:         "2024-01-20",
+				Probability:  0.00234,
+				Percentile:   0.45678,
+			},
+		},
+	}
+
+	csafAdvisories := map[string]*CSAFAdvisory{
+		"CVE-2024-5678": {
+			Name:        "RHSA-2024:0123",
+			Description: "CSAF description override",
+			ReleaseDate: csafReleased,
+			Severity:    "important",
+			CVSSv3: CVSSScore{
+				BaseScore: 8.1,
+				Vector:    "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+			},
+			CVSSv2: CVSSScore{
+				BaseScore: 6.8,
+				Vector:    "AV:N/AC:M/Au:N/C:P/I:P/A:P",
+			},
+		},
+	}
+
+	pkgFixedBy := map[string]string{
+		"pkg1": "1.0.2",
+	}
+
+	result, err := ToProtoVulnerabilityReportWithEnrichments(
+		ctx,
+		vr,
+		nvdVulns,
+		epssItems,
+		csafAdvisories,
+		pkgFixedBy,
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+
+	// Check vulnerability with enrichments
+	vuln := result.Vulnerabilities["vuln1"]
+	require.NotNil(t, vuln)
+
+	// Check CSAF advisory override
+	assert.Equal(t, "CSAF description override", vuln.Description)
+	assert.Equal(t, v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT, vuln.NormalizedSeverity)
+	assert.Equal(t, timestamppb.New(csafReleased), vuln.Issued)
+	require.NotNil(t, vuln.Advisory)
+	assert.Equal(t, "RHSA-2024:0123", vuln.Advisory.Name)
+
+	// Check CVSS metrics (Red Hat from CSAF should be first)
+	require.Len(t, vuln.CvssMetrics, 2)
+
+	// First should be Red Hat from CSAF
+	rhCVSS := vuln.CvssMetrics[0]
+	assert.Equal(t, v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_RED_HAT, rhCVSS.Source)
+	require.NotNil(t, rhCVSS.V3)
+	assert.InDelta(t, 8.1, rhCVSS.V3.BaseScore, 0.01)
+	assert.Equal(t, "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H", rhCVSS.V3.Vector)
+	require.NotNil(t, rhCVSS.V2)
+	assert.InDelta(t, 6.8, rhCVSS.V2.BaseScore, 0.01)
+
+	// Second should be NVD
+	nvdCVSS := vuln.CvssMetrics[1]
+	assert.Equal(t, v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD, nvdCVSS.Source)
+	require.NotNil(t, nvdCVSS.V3)
+	assert.InDelta(t, 7.5, nvdCVSS.V3.BaseScore, 0.01)
+	require.NotNil(t, nvdCVSS.V2)
+	assert.InDelta(t, 5.0, nvdCVSS.V2.BaseScore, 0.01)
+
+	// Check EPSS metrics
+	require.NotNil(t, vuln.EpssMetrics)
+	assert.Equal(t, "v2023.03.01", vuln.EpssMetrics.ModelVersion)
+	assert.Equal(t, "2024-01-20", vuln.EpssMetrics.Date)
+	assert.InDelta(t, 0.00234, vuln.EpssMetrics.Probability, 0.00001)
+	assert.InDelta(t, 0.45678, vuln.EpssMetrics.Percentile, 0.00001)
+
+	// Check fixed-in version from package enrichment
+	assert.Equal(t, "1.0.2", vuln.FixedInVersion)
+
+	// Check contents has fixed-by version
+	require.NotNil(t, result.Contents)
+	pkg := result.Contents.Packages["pkg1"]
+	require.NotNil(t, pkg)
+	assert.Equal(t, "1.0.2", pkg.FixedInVersion)
+}
+
+func TestToProtoVulnerabilityReportWithEnrichments_NoCVE(t *testing.T) {
+	ctx := t.Context()
+	issued := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	vr := &clairclient.VulnerabilityReport{
+		ManifestHash: "test-hash",
+		State:        "IndexFinished",
+		Success:      true,
+		Packages: map[string]clairclient.Package{
+			"pkg1": {
+				ID:      "pkg1",
+				Name:    "libssl",
+				Version: "1.0.0",
+			},
+		},
+		Distributions: make(map[string]clairclient.Distribution),
+		Repositories:  make(map[string]clairclient.Repository),
+		Environments:  make(map[string][]clairclient.Environment),
+		Vulnerabilities: map[string]clairclient.Vulnerability{
+			"vuln1": {
+				ID:                 "vuln1",
+				Name:               "GHSA-1234-5678-9012",
+				Description:        "GitHub advisory",
+				Issued:             issued,
+				Severity:           "high",
+				NormalizedSeverity: "high",
+				FixedInVersion:     "1.0.1",
+				Updater:            "github-updater",
+			},
+		},
+		PackageVulnerabilities: map[string][]string{
+			"pkg1": {"vuln1"},
+		},
+		Enrichments: make(map[string][]json.RawMessage),
+	}
+
+	result, err := ToProtoVulnerabilityReportWithEnrichments(
+		ctx,
+		vr,
+		make(map[string]map[string]*NVDItem),
+		make(map[string]map[string]*EPSSItem),
+		make(map[string]*CSAFAdvisory),
+		make(map[string]string),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+
+	// Should still map the vulnerability without enrichments
+	vuln := result.Vulnerabilities["vuln1"]
+	require.NotNil(t, vuln)
+	assert.Equal(t, "GHSA-1234-5678-9012", vuln.Name)
+	assert.Equal(t, v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT, vuln.NormalizedSeverity)
+	assert.Nil(t, vuln.Advisory)
+	assert.Empty(t, vuln.CvssMetrics)
+	assert.Nil(t, vuln.EpssMetrics)
+}

--- a/clair-adapter/matcher/matcher.go
+++ b/clair-adapter/matcher/matcher.go
@@ -2,20 +2,17 @@ package matcher
 
 import (
 	"context"
-	"strings"
+	"regexp"
 	"time"
 
 	"github.com/stackrox/rox/clair-adapter/clairclient"
 	"github.com/stackrox/rox/clair-adapter/datastore"
 	"github.com/stackrox/rox/clair-adapter/enricher"
+	"github.com/stackrox/rox/clair-adapter/mappers"
+	"github.com/stackrox/rox/clair-adapter/vulnimporter"
 )
 
-func clairDigest(hashID string) string {
-	if i := strings.LastIndex(hashID, "sha256:"); i > 0 {
-		return hashID[i:]
-	}
-	return hashID
-}
+var cvePattern = regexp.MustCompile(`CVE-\d{4}-\d+`)
 
 // Matcher provides vulnerability matching operations.
 type Matcher interface {
@@ -29,37 +26,78 @@ type Matcher interface {
 
 // localMatcher implements the Matcher interface using a Clair HTTP client.
 type localMatcher struct {
-	clair         *clairclient.Client
-	pipeline      *enricher.Pipeline
-	metadataStore datastore.MatcherMetadataStore // may be nil
+	clair             *clairclient.Client
+	pipeline          *enricher.Pipeline
+	enrichmentFetcher *vulnimporter.EnrichmentFetcher // may be nil
+	metadataStore     datastore.MatcherMetadataStore  // may be nil
 }
 
 // NewLocalMatcher creates a new matcher that delegates to a Clair HTTP client
 // and enriches results using the provided enrichment pipeline.
 // The metadataStore parameter is optional (may be nil) and is used to track vulnerability updates.
-func NewLocalMatcher(clair *clairclient.Client, pipeline *enricher.Pipeline, metadataStore datastore.MatcherMetadataStore) Matcher {
-	return &localMatcher{
+func NewLocalMatcher(clair *clairclient.Client, pipeline *enricher.Pipeline, metadataStore datastore.MatcherMetadataStore, opts ...LocalMatcherOption) Matcher {
+	m := &localMatcher{
 		clair:         clair,
 		pipeline:      pipeline,
 		metadataStore: metadataStore,
 	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// LocalMatcherOption configures a localMatcher.
+type LocalMatcherOption func(*localMatcher)
+
+// WithEnrichmentFetcher configures direct DB enrichment fetching.
+func WithEnrichmentFetcher(f *vulnimporter.EnrichmentFetcher) LocalMatcherOption {
+	return func(m *localMatcher) { m.enrichmentFetcher = f }
 }
 
 // GetVulnerabilities retrieves and enriches vulnerability data for a container image.
 func (l *localMatcher) GetVulnerabilities(ctx context.Context, hashID string) (*clairclient.VulnerabilityReport, *enricher.EnrichmentResult, error) {
-	// Get vulnerability report from Clair
-	report, err := l.clair.GetVulnerabilityReport(ctx, clairDigest(hashID))
+	report, err := l.clair.GetVulnerabilityReport(ctx, clairclient.DigestFromHashID(hashID))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// Enrich the report using the pipeline
-	enrichmentResult, err := l.pipeline.Enrich(report)
+	enrichmentResult, err := l.pipeline.Enrich(ctx, report)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// Clair doesn't return enrichment data (NVD/EPSS) because it doesn't have
+	// the StackRox enricher plugins. Fetch directly from the DB if available.
+	if l.enrichmentFetcher != nil {
+		cves := extractCVEs(report)
+		if len(cves) > 0 {
+			nvd := l.enrichmentFetcher.FetchNVD(ctx, cves)
+			if len(nvd) > 0 {
+				enrichmentResult.NVDVulns = map[string]map[string]*mappers.NVDItem{"db": nvd}
+			}
+			epss := l.enrichmentFetcher.FetchEPSS(ctx, cves)
+			if len(epss) > 0 {
+				enrichmentResult.EPSSItems = map[string]map[string]*mappers.EPSSItem{"db": epss}
+			}
+		}
 	}
 
 	return report, enrichmentResult, nil
+}
+
+func extractCVEs(report *clairclient.VulnerabilityReport) []string {
+	seen := make(map[string]struct{})
+	for _, v := range report.Vulnerabilities {
+		for _, m := range cvePattern.FindAllString(v.Name, -1) {
+			seen[m] = struct{}{}
+		}
+	}
+	cves := make([]string, 0, len(seen))
+	for cve := range seen {
+		cves = append(cves, cve)
+	}
+	return cves
 }
 
 // GetLastVulnerabilityUpdate returns the most recent vulnerability database update timestamp.

--- a/clair-adapter/matcher/matcher.go
+++ b/clair-adapter/matcher/matcher.go
@@ -2,12 +2,20 @@ package matcher
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/stackrox/rox/clair-adapter/clairclient"
 	"github.com/stackrox/rox/clair-adapter/datastore"
 	"github.com/stackrox/rox/clair-adapter/enricher"
 )
+
+func clairDigest(hashID string) string {
+	if i := strings.LastIndex(hashID, "sha256:"); i > 0 {
+		return hashID[i:]
+	}
+	return hashID
+}
 
 // Matcher provides vulnerability matching operations.
 type Matcher interface {
@@ -40,7 +48,7 @@ func NewLocalMatcher(clair *clairclient.Client, pipeline *enricher.Pipeline, met
 // GetVulnerabilities retrieves and enriches vulnerability data for a container image.
 func (l *localMatcher) GetVulnerabilities(ctx context.Context, hashID string) (*clairclient.VulnerabilityReport, *enricher.EnrichmentResult, error) {
 	// Get vulnerability report from Clair
-	report, err := l.clair.GetVulnerabilityReport(ctx, hashID)
+	report, err := l.clair.GetVulnerabilityReport(ctx, clairDigest(hashID))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/clair-adapter/matcher/matcher.go
+++ b/clair-adapter/matcher/matcher.go
@@ -1,0 +1,82 @@
+package matcher
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	"github.com/stackrox/rox/clair-adapter/datastore"
+	"github.com/stackrox/rox/clair-adapter/enricher"
+)
+
+// Matcher provides vulnerability matching operations.
+type Matcher interface {
+	// GetVulnerabilities retrieves vulnerabilities for a container image by manifest hash.
+	// Returns the raw vulnerability report from Clair and the enrichment result.
+	GetVulnerabilities(ctx context.Context, hashID string) (*clairclient.VulnerabilityReport, *enricher.EnrichmentResult, error)
+
+	// GetLastVulnerabilityUpdate returns the timestamp of the most recent vulnerability database update.
+	GetLastVulnerabilityUpdate(ctx context.Context) (time.Time, error)
+}
+
+// localMatcher implements the Matcher interface using a Clair HTTP client.
+type localMatcher struct {
+	clair         *clairclient.Client
+	pipeline      *enricher.Pipeline
+	metadataStore datastore.MatcherMetadataStore // may be nil
+}
+
+// NewLocalMatcher creates a new matcher that delegates to a Clair HTTP client
+// and enriches results using the provided enrichment pipeline.
+// The metadataStore parameter is optional (may be nil) and is used to track vulnerability updates.
+func NewLocalMatcher(clair *clairclient.Client, pipeline *enricher.Pipeline, metadataStore datastore.MatcherMetadataStore) Matcher {
+	return &localMatcher{
+		clair:         clair,
+		pipeline:      pipeline,
+		metadataStore: metadataStore,
+	}
+}
+
+// GetVulnerabilities retrieves and enriches vulnerability data for a container image.
+func (l *localMatcher) GetVulnerabilities(ctx context.Context, hashID string) (*clairclient.VulnerabilityReport, *enricher.EnrichmentResult, error) {
+	// Get vulnerability report from Clair
+	report, err := l.clair.GetVulnerabilityReport(ctx, hashID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Enrich the report using the pipeline
+	enrichmentResult, err := l.pipeline.Enrich(report)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return report, enrichmentResult, nil
+}
+
+// GetLastVulnerabilityUpdate returns the most recent vulnerability database update timestamp.
+// If a metadata store is configured, it is used. Otherwise, Clair's update operations are queried.
+func (l *localMatcher) GetLastVulnerabilityUpdate(ctx context.Context) (time.Time, error) {
+	// Use metadata store if available
+	if l.metadataStore != nil {
+		return l.metadataStore.GetLastVulnerabilityUpdate(ctx)
+	}
+
+	// Otherwise, query Clair for update operations
+	operations, err := l.clair.GetUpdateOperations(ctx)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	// Find the latest date across all operations
+	var latest time.Time
+	for _, ops := range operations {
+		for _, op := range ops {
+			if op.Date.After(latest) {
+				latest = op.Date
+			}
+		}
+	}
+
+	return latest, nil
+}

--- a/clair-adapter/matcher/matcher_test.go
+++ b/clair-adapter/matcher/matcher_test.go
@@ -1,0 +1,257 @@
+package matcher
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	"github.com/stackrox/rox/clair-adapter/enricher"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatcher_GetVulnerabilities(t *testing.T) {
+	mockVuln := clairclient.Vulnerability{
+		ID:             "CVE-2024-1234",
+		Name:           "Test Vulnerability",
+		Severity:       "High",
+		FixedInVersion: "1.2.3",
+		Package: &clairclient.Package{
+			ID:      "pkg1",
+			Name:    "testpkg",
+			Version: "1.0.0",
+		},
+	}
+
+	mockReport := &clairclient.VulnerabilityReport{
+		ManifestHash: "sha256:test123",
+		State:        "MatchFinished",
+		Success:      true,
+		Packages: map[string]clairclient.Package{
+			"pkg1": {
+				ID:      "pkg1",
+				Name:    "testpkg",
+				Version: "1.0.0",
+			},
+		},
+		Vulnerabilities: map[string]clairclient.Vulnerability{
+			"CVE-2024-1234": mockVuln,
+		},
+		PackageVulnerabilities: map[string][]string{
+			"pkg1": {"CVE-2024-1234"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "vulnerability_report")
+
+		w.WriteHeader(http.StatusCreated)
+		err := json.NewEncoder(w).Encode(mockReport)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client, err := clairclient.NewClient(server.URL)
+	require.NoError(t, err)
+
+	pipeline := enricher.NewPipeline()
+	matcher := NewLocalMatcher(client, pipeline, nil)
+
+	ctx := context.Background()
+	report, enrichmentResult, err := matcher.GetVulnerabilities(ctx, "sha256:test123")
+
+	require.NoError(t, err)
+	assert.NotNil(t, report)
+	assert.NotNil(t, enrichmentResult)
+
+	// Verify report content
+	assert.Equal(t, "sha256:test123", report.ManifestHash)
+	assert.True(t, report.Success)
+	assert.Contains(t, report.Vulnerabilities, "CVE-2024-1234")
+
+	// Verify enrichment result has PkgFixedBy populated
+	assert.NotNil(t, enrichmentResult.PkgFixedBy)
+	assert.Contains(t, enrichmentResult.PkgFixedBy, "pkg1")
+	assert.Equal(t, "1.2.3", enrichmentResult.PkgFixedBy["pkg1"])
+}
+
+func TestMatcher_GetVulnerabilities_MultipleVulns(t *testing.T) {
+	mockReport := &clairclient.VulnerabilityReport{
+		ManifestHash: "sha256:multi",
+		State:        "MatchFinished",
+		Success:      true,
+		Packages: map[string]clairclient.Package{
+			"pkg1": {ID: "pkg1", Name: "pkg1", Version: "1.0"},
+			"pkg2": {ID: "pkg2", Name: "pkg2", Version: "2.0"},
+		},
+		Vulnerabilities: map[string]clairclient.Vulnerability{
+			"CVE-2024-0001": {
+				ID:             "CVE-2024-0001",
+				FixedInVersion: "1.1.0",
+				Package:        &clairclient.Package{ID: "pkg1"},
+			},
+			"CVE-2024-0002": {
+				ID:             "CVE-2024-0002",
+				FixedInVersion: "2.1.0",
+				Package:        &clairclient.Package{ID: "pkg2"},
+			},
+		},
+		PackageVulnerabilities: map[string][]string{
+			"pkg1": {"CVE-2024-0001"},
+			"pkg2": {"CVE-2024-0002"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(mockReport)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client, err := clairclient.NewClient(server.URL)
+	require.NoError(t, err)
+
+	pipeline := enricher.NewPipeline()
+	matcher := NewLocalMatcher(client, pipeline, nil)
+
+	ctx := context.Background()
+	_, enrichmentResult, err := matcher.GetVulnerabilities(ctx, "sha256:multi")
+
+	require.NoError(t, err)
+	assert.NotNil(t, enrichmentResult)
+	assert.Len(t, enrichmentResult.PkgFixedBy, 2)
+	assert.Equal(t, "1.1.0", enrichmentResult.PkgFixedBy["pkg1"])
+	assert.Equal(t, "2.1.0", enrichmentResult.PkgFixedBy["pkg2"])
+}
+
+func TestMatcher_GetLastVulnerabilityUpdate(t *testing.T) {
+	now := time.Now()
+	oldDate := now.Add(-48 * time.Hour)
+	recentDate := now.Add(-1 * time.Hour)
+
+	mockOperations := map[string][]clairclient.UpdateOperation{
+		"updater1": {
+			{
+				Ref:     "ref1",
+				Updater: "updater1",
+				Date:    oldDate,
+			},
+		},
+		"updater2": {
+			{
+				Ref:     "ref2",
+				Updater: "updater2",
+				Date:    recentDate,
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "update_operation")
+		assert.Equal(t, "true", r.URL.Query().Get("latest"))
+
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(mockOperations)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client, err := clairclient.NewClient(server.URL)
+	require.NoError(t, err)
+
+	pipeline := enricher.NewPipeline()
+	matcher := NewLocalMatcher(client, pipeline, nil)
+
+	ctx := context.Background()
+	lastUpdate, err := matcher.GetLastVulnerabilityUpdate(ctx)
+
+	require.NoError(t, err)
+	// Should return the most recent date
+	assert.True(t, lastUpdate.After(oldDate))
+	assert.WithinDuration(t, recentDate, lastUpdate, time.Second)
+}
+
+func TestMatcher_GetLastVulnerabilityUpdate_WithMetadataStore(t *testing.T) {
+	expectedTime := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	mockStore := &mockMatcherMetadataStore{
+		lastUpdate: expectedTime,
+	}
+
+	// Don't need a real server since we won't hit it
+	client, err := clairclient.NewClient("http://localhost:9999")
+	require.NoError(t, err)
+
+	pipeline := enricher.NewPipeline()
+	matcher := NewLocalMatcher(client, pipeline, mockStore)
+
+	ctx := context.Background()
+	lastUpdate, err := matcher.GetLastVulnerabilityUpdate(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedTime, lastUpdate)
+}
+
+func TestMatcher_GetLastVulnerabilityUpdate_EmptyOperations(t *testing.T) {
+	mockOperations := map[string][]clairclient.UpdateOperation{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(w).Encode(mockOperations)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client, err := clairclient.NewClient(server.URL)
+	require.NoError(t, err)
+
+	pipeline := enricher.NewPipeline()
+	matcher := NewLocalMatcher(client, pipeline, nil)
+
+	ctx := context.Background()
+	lastUpdate, err := matcher.GetLastVulnerabilityUpdate(ctx)
+
+	require.NoError(t, err)
+	assert.True(t, lastUpdate.IsZero())
+}
+
+func TestMatcher_GetVulnerabilities_ErrorFromClair(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client, err := clairclient.NewClient(server.URL)
+	require.NoError(t, err)
+
+	pipeline := enricher.NewPipeline()
+	matcher := NewLocalMatcher(client, pipeline, nil)
+
+	ctx := context.Background()
+	report, enrichmentResult, err := matcher.GetVulnerabilities(ctx, "sha256:error")
+
+	assert.Error(t, err)
+	assert.Nil(t, report)
+	assert.Nil(t, enrichmentResult)
+}
+
+// mockMatcherMetadataStore is a simple in-memory implementation for testing
+type mockMatcherMetadataStore struct {
+	lastUpdate time.Time
+}
+
+func (m *mockMatcherMetadataStore) GetLastVulnerabilityUpdate(ctx context.Context) (time.Time, error) {
+	return m.lastUpdate, nil
+}
+
+func (m *mockMatcherMetadataStore) SetLastVulnerabilityUpdate(ctx context.Context, bundle string, lastUpdate time.Time) error {
+	m.lastUpdate = lastUpdate
+	return nil
+}

--- a/clair-adapter/services/indexer.go
+++ b/clair-adapter/services/indexer.go
@@ -128,7 +128,7 @@ func (s *IndexerService) HasIndexReport(ctx context.Context, req *v4.HasIndexRep
 }
 
 // StoreIndexReport is not implemented.
-func (s *IndexerService) StoreIndexReport(ctx context.Context, req *v4.StoreIndexReportRequest) (*v4.IndexReport, error) {
+func (s *IndexerService) StoreIndexReport(ctx context.Context, req *v4.StoreIndexReportRequest) (*v4.StoreIndexReportResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "StoreIndexReport is not implemented")
 }
 

--- a/clair-adapter/services/indexer.go
+++ b/clair-adapter/services/indexer.go
@@ -2,34 +2,58 @@ package services
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/pkg/errors"
 	"github.com/stackrox/rox/clair-adapter/indexer"
 	"github.com/stackrox/rox/clair-adapter/mappers"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stackrox/rox/pkg/grpc/authz"
+	"github.com/stackrox/rox/pkg/grpc/authz/idcheck"
+	"github.com/stackrox/rox/pkg/grpc/authz/or"
+	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-// IndexerService implements the Scanner V4 IndexerServer interface.
-type IndexerService struct {
+var indexerAuth = perrpc.FromMap(map[authz.Authorizer][]string{
+	or.Or(idcheck.CentralOnly(), idcheck.SensorsOnly(), idcheck.ScannerV4MatcherOnly()): {
+		v4.Indexer_GetIndexReport_FullMethodName,
+		v4.Indexer_HasIndexReport_FullMethodName,
+	},
+	or.Or(idcheck.CentralOnly(), idcheck.SensorsOnly()): {
+		v4.Indexer_CreateIndexReport_FullMethodName,
+		v4.Indexer_GetOrCreateIndexReport_FullMethodName,
+	},
+	or.Or(idcheck.CentralOnly()): {
+		v4.Indexer_StoreIndexReport_FullMethodName,
+	},
+	or.Or(idcheck.ScannerV4MatcherOnly()): {
+		v4.Indexer_GetRepositoryToCPEMapping_FullMethodName,
+	},
+})
+
+// indexerService implements the Scanner V4 IndexerServer interface.
+type indexerService struct {
 	v4.UnimplementedIndexerServer
 	idx indexer.Indexer
 }
 
-// NewIndexerService creates a new IndexerService with the given indexer.
-func NewIndexerService(idx indexer.Indexer) *IndexerService {
-	return &IndexerService{
+// NewIndexerService creates a new indexerService with the given indexer.
+func NewIndexerService(idx indexer.Indexer) *indexerService {
+	return &indexerService{
 		idx: idx,
 	}
 }
 
 // CreateIndexReport creates an index report for the specified container image.
-func (s *IndexerService) CreateIndexReport(ctx context.Context, req *v4.CreateIndexReportRequest) (*v4.IndexReport, error) {
+func (s *indexerService) CreateIndexReport(ctx context.Context, req *v4.CreateIndexReportRequest) (*v4.IndexReport, error) {
+	slog.InfoContext(ctx, "CreateIndexReport called", "hash_id", req.GetHashId())
+
 	img := req.GetContainerImage()
 	if img == nil {
+		slog.ErrorContext(ctx, "CreateIndexReport failed: container image is required")
 		return nil, status.Error(codes.InvalidArgument, "container image is required")
 	}
 
@@ -45,45 +69,56 @@ func (s *IndexerService) CreateIndexReport(ctx context.Context, req *v4.CreateIn
 	// Index the container image
 	ir, err := s.idx.IndexContainerImage(ctx, req.GetHashId(), img.GetUrl(), opts...)
 	if err != nil {
-		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to index container image").Error())
+		slog.ErrorContext(ctx, "Failed to index container image", "error", err, "hash_id", req.GetHashId())
+		return nil, status.Errorf(codes.Internal, "failed to index container image: %v", err)
 	}
 
 	// Convert to proto format
 	protoReport, err := mappers.ToProtoIndexReport(ir)
 	if err != nil {
-		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to convert index report").Error())
+		slog.ErrorContext(ctx, "Failed to convert index report", "error", err, "hash_id", req.GetHashId())
+		return nil, status.Errorf(codes.Internal, "failed to convert index report: %v", err)
 	}
 
 	// Set the hash ID from the request
 	protoReport.HashId = req.GetHashId()
 
+	slog.InfoContext(ctx, "CreateIndexReport completed", "hash_id", req.GetHashId())
 	return protoReport, nil
 }
 
 // GetIndexReport retrieves an existing index report by manifest hash.
-func (s *IndexerService) GetIndexReport(ctx context.Context, req *v4.GetIndexReportRequest) (*v4.IndexReport, error) {
+func (s *indexerService) GetIndexReport(ctx context.Context, req *v4.GetIndexReportRequest) (*v4.IndexReport, error) {
+	slog.InfoContext(ctx, "GetIndexReport called", "hash_id", req.GetHashId())
+
 	ir, found, err := s.idx.GetIndexReport(ctx, req.GetHashId())
 	if err != nil {
-		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to get index report").Error())
+		slog.ErrorContext(ctx, "Failed to get index report", "error", err, "hash_id", req.GetHashId())
+		return nil, status.Errorf(codes.Internal, "failed to get index report: %v", err)
 	}
 	if !found {
+		slog.InfoContext(ctx, "Index report not found", "hash_id", req.GetHashId())
 		return nil, status.Error(codes.NotFound, "index report not found")
 	}
 
 	// Convert to proto format
 	protoReport, err := mappers.ToProtoIndexReport(ir)
 	if err != nil {
-		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to convert index report").Error())
+		slog.ErrorContext(ctx, "Failed to convert index report", "error", err, "hash_id", req.GetHashId())
+		return nil, status.Errorf(codes.Internal, "failed to convert index report: %v", err)
 	}
 
 	// Set the hash ID from the request
 	protoReport.HashId = req.GetHashId()
 
+	slog.InfoContext(ctx, "GetIndexReport completed", "hash_id", req.GetHashId())
 	return protoReport, nil
 }
 
 // GetOrCreateIndexReport retrieves an existing index report or creates a new one.
-func (s *IndexerService) GetOrCreateIndexReport(ctx context.Context, req *v4.GetOrCreateIndexReportRequest) (*v4.IndexReport, error) {
+func (s *indexerService) GetOrCreateIndexReport(ctx context.Context, req *v4.GetOrCreateIndexReportRequest) (*v4.IndexReport, error) {
+	slog.InfoContext(ctx, "GetOrCreateIndexReport called", "hash_id", req.GetHashId())
+
 	// Try to get existing report first
 	getReq := &v4.GetIndexReportRequest{
 		HashId: req.GetHashId(),
@@ -92,6 +127,7 @@ func (s *IndexerService) GetOrCreateIndexReport(ctx context.Context, req *v4.Get
 	report, err := s.GetIndexReport(ctx, getReq)
 	if err == nil {
 		// Found existing report
+		slog.InfoContext(ctx, "GetOrCreateIndexReport completed (found existing)", "hash_id", req.GetHashId())
 		return report, nil
 	}
 
@@ -99,10 +135,12 @@ func (s *IndexerService) GetOrCreateIndexReport(ctx context.Context, req *v4.Get
 	st := status.Convert(err)
 	if st.Code() != codes.NotFound {
 		// Some other error occurred
+		slog.ErrorContext(ctx, "GetOrCreateIndexReport failed", "error", err, "hash_id", req.GetHashId())
 		return nil, err
 	}
 
 	// Report not found, create it
+	slog.InfoContext(ctx, "Index report not found, creating new one", "hash_id", req.GetHashId())
 	createReq := &v4.CreateIndexReportRequest{
 		HashId: req.GetHashId(),
 	}
@@ -118,33 +156,44 @@ func (s *IndexerService) GetOrCreateIndexReport(ctx context.Context, req *v4.Get
 }
 
 // HasIndexReport checks if an index report exists for the given manifest hash.
-func (s *IndexerService) HasIndexReport(ctx context.Context, req *v4.HasIndexReportRequest) (*v4.HasIndexReportResponse, error) {
+func (s *indexerService) HasIndexReport(ctx context.Context, req *v4.HasIndexReportRequest) (*v4.HasIndexReportResponse, error) {
+	slog.InfoContext(ctx, "HasIndexReport called", "hash_id", req.GetHashId())
+
 	exists, err := s.idx.HasIndexReport(ctx, req.GetHashId())
 	if err != nil {
-		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to check index report").Error())
+		slog.ErrorContext(ctx, "Failed to check index report", "error", err, "hash_id", req.GetHashId())
+		return nil, status.Errorf(codes.Internal, "failed to check index report: %v", err)
 	}
 
+	slog.InfoContext(ctx, "HasIndexReport completed", "hash_id", req.GetHashId(), "exists", exists)
 	return &v4.HasIndexReportResponse{
 		Exists: exists,
 	}, nil
 }
 
 // StoreIndexReport is not implemented.
-func (s *IndexerService) StoreIndexReport(ctx context.Context, req *v4.StoreIndexReportRequest) (*v4.StoreIndexReportResponse, error) {
+func (s *indexerService) StoreIndexReport(ctx context.Context, req *v4.StoreIndexReportRequest) (*v4.StoreIndexReportResponse, error) {
+	slog.InfoContext(ctx, "StoreIndexReport called (not implemented)")
 	return nil, status.Error(codes.Unimplemented, "StoreIndexReport is not implemented")
 }
 
 // GetRepositoryToCPEMapping is not implemented.
-func (s *IndexerService) GetRepositoryToCPEMapping(ctx context.Context, req *v4.GetRepositoryToCPEMappingRequest) (*v4.GetRepositoryToCPEMappingResponse, error) {
+func (s *indexerService) GetRepositoryToCPEMapping(ctx context.Context, req *v4.GetRepositoryToCPEMappingRequest) (*v4.GetRepositoryToCPEMappingResponse, error) {
+	slog.InfoContext(ctx, "GetRepositoryToCPEMapping called (not implemented)")
 	return nil, status.Error(codes.Unimplemented, "GetRepositoryToCPEMapping is not implemented")
 }
 
-// RegisterServiceServer registers the IndexerService with the gRPC server.
-func (s *IndexerService) RegisterServiceServer(grpcServer *grpc.Server) {
+// AuthFuncOverride specifies the auth criteria for this API.
+func (s *indexerService) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	return ctx, indexerAuth.Authorized(ctx, fullMethodName)
+}
+
+// RegisterServiceServer registers the indexerService with the gRPC server.
+func (s *indexerService) RegisterServiceServer(grpcServer *grpc.Server) {
 	v4.RegisterIndexerServer(grpcServer, s)
 }
 
-// RegisterServiceHandler is a no-op for IndexerService (no HTTP gateway needed).
-func (s *IndexerService) RegisterServiceHandler(_ context.Context, _ *runtime.ServeMux, _ *grpc.ClientConn) error {
+// RegisterServiceHandler is a no-op for indexerService (no HTTP gateway needed).
+func (s *indexerService) RegisterServiceHandler(_ context.Context, _ *runtime.ServeMux, _ *grpc.ClientConn) error {
 	return nil
 }

--- a/clair-adapter/services/indexer.go
+++ b/clair-adapter/services/indexer.go
@@ -3,10 +3,12 @@ package services
 import (
 	"context"
 
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/clair-adapter/indexer"
 	"github.com/stackrox/rox/clair-adapter/mappers"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -135,4 +137,14 @@ func (s *IndexerService) StoreIndexReport(ctx context.Context, req *v4.StoreInde
 // GetRepositoryToCPEMapping is not implemented.
 func (s *IndexerService) GetRepositoryToCPEMapping(ctx context.Context, req *v4.GetRepositoryToCPEMappingRequest) (*v4.GetRepositoryToCPEMappingResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "GetRepositoryToCPEMapping is not implemented")
+}
+
+// RegisterServiceServer registers the IndexerService with the gRPC server.
+func (s *IndexerService) RegisterServiceServer(grpcServer *grpc.Server) {
+	v4.RegisterIndexerServer(grpcServer, s)
+}
+
+// RegisterServiceHandler is a no-op for IndexerService (no HTTP gateway needed).
+func (s *IndexerService) RegisterServiceHandler(_ context.Context, _ *runtime.ServeMux, _ *grpc.ClientConn) error {
+	return nil
 }

--- a/clair-adapter/services/indexer.go
+++ b/clair-adapter/services/indexer.go
@@ -1,0 +1,138 @@
+package services
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/clair-adapter/indexer"
+	"github.com/stackrox/rox/clair-adapter/mappers"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IndexerService implements the Scanner V4 IndexerServer interface.
+type IndexerService struct {
+	v4.UnimplementedIndexerServer
+	idx indexer.Indexer
+}
+
+// NewIndexerService creates a new IndexerService with the given indexer.
+func NewIndexerService(idx indexer.Indexer) *IndexerService {
+	return &IndexerService{
+		idx: idx,
+	}
+}
+
+// CreateIndexReport creates an index report for the specified container image.
+func (s *IndexerService) CreateIndexReport(ctx context.Context, req *v4.CreateIndexReportRequest) (*v4.IndexReport, error) {
+	img := req.GetContainerImage()
+	if img == nil {
+		return nil, status.Error(codes.InvalidArgument, "container image is required")
+	}
+
+	// Build indexer options from image credentials
+	var opts []indexer.Option
+	if img.GetUsername() != "" || img.GetPassword() != "" {
+		opts = append(opts, indexer.WithBasicAuth(img.GetUsername(), img.GetPassword()))
+	}
+	if img.GetInsecureSkipTlsVerify() {
+		opts = append(opts, indexer.WithInsecureSkipTLSVerify(img.GetInsecureSkipTlsVerify()))
+	}
+
+	// Index the container image
+	ir, err := s.idx.IndexContainerImage(ctx, req.GetHashId(), img.GetUrl(), opts...)
+	if err != nil {
+		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to index container image").Error())
+	}
+
+	// Convert to proto format
+	protoReport, err := mappers.ToProtoIndexReport(ir)
+	if err != nil {
+		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to convert index report").Error())
+	}
+
+	// Set the hash ID from the request
+	protoReport.HashId = req.GetHashId()
+
+	return protoReport, nil
+}
+
+// GetIndexReport retrieves an existing index report by manifest hash.
+func (s *IndexerService) GetIndexReport(ctx context.Context, req *v4.GetIndexReportRequest) (*v4.IndexReport, error) {
+	ir, found, err := s.idx.GetIndexReport(ctx, req.GetHashId())
+	if err != nil {
+		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to get index report").Error())
+	}
+	if !found {
+		return nil, status.Error(codes.NotFound, "index report not found")
+	}
+
+	// Convert to proto format
+	protoReport, err := mappers.ToProtoIndexReport(ir)
+	if err != nil {
+		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to convert index report").Error())
+	}
+
+	// Set the hash ID from the request
+	protoReport.HashId = req.GetHashId()
+
+	return protoReport, nil
+}
+
+// GetOrCreateIndexReport retrieves an existing index report or creates a new one.
+func (s *IndexerService) GetOrCreateIndexReport(ctx context.Context, req *v4.GetOrCreateIndexReportRequest) (*v4.IndexReport, error) {
+	// Try to get existing report first
+	getReq := &v4.GetIndexReportRequest{
+		HashId: req.GetHashId(),
+	}
+
+	report, err := s.GetIndexReport(ctx, getReq)
+	if err == nil {
+		// Found existing report
+		return report, nil
+	}
+
+	// Check if error was NotFound
+	st := status.Convert(err)
+	if st.Code() != codes.NotFound {
+		// Some other error occurred
+		return nil, err
+	}
+
+	// Report not found, create it
+	createReq := &v4.CreateIndexReportRequest{
+		HashId: req.GetHashId(),
+	}
+
+	// Copy the resource locator
+	if img := req.GetContainerImage(); img != nil {
+		createReq.ResourceLocator = &v4.CreateIndexReportRequest_ContainerImage{
+			ContainerImage: img,
+		}
+	}
+
+	return s.CreateIndexReport(ctx, createReq)
+}
+
+// HasIndexReport checks if an index report exists for the given manifest hash.
+func (s *IndexerService) HasIndexReport(ctx context.Context, req *v4.HasIndexReportRequest) (*v4.HasIndexReportResponse, error) {
+	exists, err := s.idx.HasIndexReport(ctx, req.GetHashId())
+	if err != nil {
+		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to check index report").Error())
+	}
+
+	return &v4.HasIndexReportResponse{
+		Exists: exists,
+	}, nil
+}
+
+// StoreIndexReport is not implemented.
+func (s *IndexerService) StoreIndexReport(ctx context.Context, req *v4.StoreIndexReportRequest) (*v4.IndexReport, error) {
+	return nil, status.Error(codes.Unimplemented, "StoreIndexReport is not implemented")
+}
+
+// GetRepositoryToCPEMapping is not implemented.
+func (s *IndexerService) GetRepositoryToCPEMapping(ctx context.Context, req *v4.GetRepositoryToCPEMappingRequest) (*v4.GetRepositoryToCPEMappingResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "GetRepositoryToCPEMapping is not implemented")
+}

--- a/clair-adapter/services/indexer_test.go
+++ b/clair-adapter/services/indexer_test.go
@@ -16,8 +16,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// newTestIndexerService creates a test IndexerService backed by a mock Clair server.
-func newTestIndexerService(t *testing.T, handler http.Handler) *IndexerService {
+// newTestIndexerService creates a test indexerService backed by a mock Clair server.
+func newTestIndexerService(t *testing.T, handler http.Handler) *indexerService {
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 

--- a/clair-adapter/services/indexer_test.go
+++ b/clair-adapter/services/indexer_test.go
@@ -1,0 +1,221 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	"github.com/stackrox/rox/clair-adapter/indexer"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// newTestIndexerService creates a test IndexerService backed by a mock Clair server.
+func newTestIndexerService(t *testing.T, handler http.Handler) *IndexerService {
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	c, err := clairclient.NewClient(srv.URL)
+	require.NoError(t, err)
+
+	idx := indexer.NewLocalIndexer(c, nil)
+	return NewIndexerService(idx)
+}
+
+func TestCreateIndexReport_Success(t *testing.T) {
+	const hashID = "sha256:abc123"
+	const imageURL = "docker.io/library/alpine:3.18"
+
+	// Mock Clair server that returns a successful index report
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/indexer/api/v1/index_report" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		// Return a simple index report
+		report := &clairclient.IndexReport{
+			ManifestHash: hashID,
+			State:        "IndexFinished",
+			Packages: map[string]clairclient.Package{
+				"1": {
+					ID:      "1",
+					Name:    "alpine-baselayout",
+					Version: "3.4.3-r1",
+					Kind:    "binary",
+				},
+			},
+			Environments: map[string][]clairclient.Environment{
+				"1": {
+					{
+						PackageDB: "lib/apk/db/installed",
+					},
+				},
+			},
+		}
+
+		w.WriteHeader(http.StatusCreated) // Clair returns 201 for CreateIndexReport
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(report)
+	})
+
+	svc := newTestIndexerService(t, handler)
+
+	req := &v4.CreateIndexReportRequest{
+		HashId: hashID,
+		ResourceLocator: &v4.CreateIndexReportRequest_ContainerImage{
+			ContainerImage: &v4.ContainerImageLocator{
+				Url: imageURL,
+			},
+		},
+	}
+
+	resp, err := svc.CreateIndexReport(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, hashID, resp.GetHashId())
+	assert.Equal(t, "IndexFinished", resp.GetState())
+	assert.Len(t, resp.GetContents().GetPackages(), 1)
+}
+
+func TestCreateIndexReport_NilContainerImage(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not call Clair")
+	})
+
+	svc := newTestIndexerService(t, handler)
+
+	req := &v4.CreateIndexReportRequest{
+		HashId:          "sha256:abc123",
+		ResourceLocator: nil, // nil resource locator
+	}
+
+	resp, err := svc.CreateIndexReport(context.Background(), req)
+	require.Error(t, err)
+	assert.Nil(t, resp)
+
+	// Check for InvalidArgument status
+	st := status.Convert(err)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestGetIndexReport_Success(t *testing.T) {
+	const hashID = "sha256:abc123"
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/indexer/api/v1/index_report/"+hashID {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		report := &clairclient.IndexReport{
+			ManifestHash: hashID,
+			State:        "IndexFinished",
+			Packages: map[string]clairclient.Package{
+				"1": {
+					ID:      "1",
+					Name:    "test-package",
+					Version: "1.0.0",
+					Kind:    "binary",
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(report)
+	})
+
+	svc := newTestIndexerService(t, handler)
+
+	req := &v4.GetIndexReportRequest{
+		HashId: hashID,
+	}
+
+	resp, err := svc.GetIndexReport(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, hashID, resp.GetHashId())
+	assert.Equal(t, "IndexFinished", resp.GetState())
+}
+
+func TestGetIndexReport_NotFound(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{
+			"code":    "404",
+			"message": "index report not found",
+		})
+	})
+
+	svc := newTestIndexerService(t, handler)
+
+	req := &v4.GetIndexReportRequest{
+		HashId: "sha256:nonexistent",
+	}
+
+	resp, err := svc.GetIndexReport(context.Background(), req)
+	require.Error(t, err)
+	assert.Nil(t, resp)
+
+	// Check for NotFound status
+	st := status.Convert(err)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestHasIndexReport_Exists(t *testing.T) {
+	const hashID = "sha256:abc123"
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/indexer/api/v1/index_report/"+hashID {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		// Return minimal report to indicate it exists
+		report := &clairclient.IndexReport{
+			ManifestHash: hashID,
+			State:        "IndexFinished",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(report)
+	})
+
+	svc := newTestIndexerService(t, handler)
+
+	req := &v4.HasIndexReportRequest{
+		HashId: hashID,
+	}
+
+	resp, err := svc.HasIndexReport(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.GetExists())
+}
+
+func TestHasIndexReport_NotExists(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{
+			"code":    "404",
+			"message": "index report not found",
+		})
+	})
+
+	svc := newTestIndexerService(t, handler)
+
+	req := &v4.HasIndexReportRequest{
+		HashId: "sha256:nonexistent",
+	}
+
+	resp, err := svc.HasIndexReport(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.False(t, resp.GetExists())
+}

--- a/clair-adapter/services/matcher.go
+++ b/clair-adapter/services/matcher.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"strings"
 
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/clair-adapter/enricher/csaf"
 	"github.com/stackrox/rox/clair-adapter/mappers"
 	"github.com/stackrox/rox/clair-adapter/matcher"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -78,6 +80,16 @@ func (s *MatcherService) GetSBOM(ctx context.Context, req *v4.GetSBOMRequest) (*
 // ScanSBOM is not implemented.
 func (s *MatcherService) ScanSBOM(ctx context.Context, req *v4.ScanSBOMRequest) (*v4.ScanSBOMResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "ScanSBOM is not implemented")
+}
+
+// RegisterServiceServer registers the MatcherService with the gRPC server.
+func (s *MatcherService) RegisterServiceServer(grpcServer *grpc.Server) {
+	v4.RegisterMatcherServer(grpcServer, s)
+}
+
+// RegisterServiceHandler is a no-op for MatcherService (no HTTP gateway needed).
+func (s *MatcherService) RegisterServiceHandler(_ context.Context, _ *runtime.ServeMux, _ *grpc.ClientConn) error {
+	return nil
 }
 
 // convertCSAFAdvisories converts from enricher/csaf.Advisory to mappers.CSAFAdvisory.

--- a/clair-adapter/services/matcher.go
+++ b/clair-adapter/services/matcher.go
@@ -2,14 +2,18 @@ package services
 
 import (
 	"context"
-	"strings"
+	"errors"
+	"log/slog"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/pkg/errors"
+	"github.com/stackrox/rox/clair-adapter/clairclient"
 	"github.com/stackrox/rox/clair-adapter/enricher/csaf"
 	"github.com/stackrox/rox/clair-adapter/mappers"
 	"github.com/stackrox/rox/clair-adapter/matcher"
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stackrox/rox/pkg/grpc/authz"
+	"github.com/stackrox/rox/pkg/grpc/authz/idcheck"
+	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -17,28 +21,41 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// MatcherService implements the Scanner V4 MatcherServer interface.
-type MatcherService struct {
+var matcherAuth = perrpc.FromMap(map[authz.Authorizer][]string{
+	idcheck.CentralOnly(): {
+		v4.Matcher_GetVulnerabilities_FullMethodName,
+		v4.Matcher_GetMetadata_FullMethodName,
+		v4.Matcher_GetSBOM_FullMethodName,
+		v4.Matcher_ScanSBOM_FullMethodName,
+	},
+})
+
+// matcherService implements the Scanner V4 MatcherServer interface.
+type matcherService struct {
 	v4.UnimplementedMatcherServer
 	m matcher.Matcher
 }
 
-// NewMatcherService creates a new MatcherService with the given matcher.
-func NewMatcherService(m matcher.Matcher) *MatcherService {
-	return &MatcherService{
+// NewMatcherService creates a new matcherService with the given matcher.
+func NewMatcherService(m matcher.Matcher) *matcherService {
+	return &matcherService{
 		m: m,
 	}
 }
 
 // GetVulnerabilities retrieves vulnerability information for a previously indexed manifest.
-func (s *MatcherService) GetVulnerabilities(ctx context.Context, req *v4.GetVulnerabilitiesRequest) (*v4.VulnerabilityReport, error) {
+func (s *matcherService) GetVulnerabilities(ctx context.Context, req *v4.GetVulnerabilitiesRequest) (*v4.VulnerabilityReport, error) {
+	slog.InfoContext(ctx, "GetVulnerabilities called", "hash_id", req.GetHashId())
+
 	vr, enrichResult, err := s.m.GetVulnerabilities(ctx, req.GetHashId())
 	if err != nil {
-		// Check if it's a "not found" error from Clair client (HTTP 404)
-		if strings.Contains(err.Error(), "HTTP 404") {
+		// Check if it's a "not found" error from Clair client
+		if errors.Is(err, clairclient.ErrNotFound) {
+			slog.InfoContext(ctx, "Vulnerability report not found", "hash_id", req.GetHashId())
 			return nil, status.Error(codes.NotFound, "vulnerability report not found")
 		}
-		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to get vulnerabilities").Error())
+		slog.ErrorContext(ctx, "Failed to get vulnerabilities", "error", err, "hash_id", req.GetHashId())
+		return nil, status.Errorf(codes.Internal, "failed to get vulnerabilities: %v", err)
 	}
 
 	// Convert CSAF advisories from enricher format to mapper format
@@ -54,41 +71,54 @@ func (s *MatcherService) GetVulnerabilities(ctx context.Context, req *v4.GetVuln
 		enrichResult.PkgFixedBy,
 	)
 	if err != nil {
-		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to convert vulnerability report").Error())
+		slog.ErrorContext(ctx, "Failed to convert vulnerability report", "error", err, "hash_id", req.GetHashId())
+		return nil, status.Errorf(codes.Internal, "failed to convert vulnerability report: %v", err)
 	}
 
+	slog.InfoContext(ctx, "GetVulnerabilities completed", "hash_id", req.GetHashId())
 	return protoReport, nil
 }
 
 // GetMetadata returns metadata about the vulnerability database, including the last update time.
-func (s *MatcherService) GetMetadata(ctx context.Context, _ *emptypb.Empty) (*v4.Metadata, error) {
+func (s *matcherService) GetMetadata(ctx context.Context, _ *emptypb.Empty) (*v4.Metadata, error) {
+	slog.InfoContext(ctx, "GetMetadata called")
+
 	ts, err := s.m.GetLastVulnerabilityUpdate(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to get metadata").Error())
+		slog.ErrorContext(ctx, "Failed to get metadata", "error", err)
+		return nil, status.Errorf(codes.Internal, "failed to get metadata: %v", err)
 	}
 
+	slog.InfoContext(ctx, "GetMetadata completed", "last_vulnerability_update", ts)
 	return &v4.Metadata{
 		LastVulnerabilityUpdate: timestamppb.New(ts),
 	}, nil
 }
 
 // GetSBOM is not implemented.
-func (s *MatcherService) GetSBOM(ctx context.Context, req *v4.GetSBOMRequest) (*v4.GetSBOMResponse, error) {
+func (s *matcherService) GetSBOM(ctx context.Context, req *v4.GetSBOMRequest) (*v4.GetSBOMResponse, error) {
+	slog.InfoContext(ctx, "GetSBOM called (not implemented)")
 	return nil, status.Error(codes.Unimplemented, "GetSBOM is not implemented")
 }
 
 // ScanSBOM is not implemented.
-func (s *MatcherService) ScanSBOM(ctx context.Context, req *v4.ScanSBOMRequest) (*v4.ScanSBOMResponse, error) {
+func (s *matcherService) ScanSBOM(ctx context.Context, req *v4.ScanSBOMRequest) (*v4.ScanSBOMResponse, error) {
+	slog.InfoContext(ctx, "ScanSBOM called (not implemented)")
 	return nil, status.Error(codes.Unimplemented, "ScanSBOM is not implemented")
 }
 
-// RegisterServiceServer registers the MatcherService with the gRPC server.
-func (s *MatcherService) RegisterServiceServer(grpcServer *grpc.Server) {
+// AuthFuncOverride specifies the auth criteria for this API.
+func (s *matcherService) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {
+	return ctx, matcherAuth.Authorized(ctx, fullMethodName)
+}
+
+// RegisterServiceServer registers the matcherService with the gRPC server.
+func (s *matcherService) RegisterServiceServer(grpcServer *grpc.Server) {
 	v4.RegisterMatcherServer(grpcServer, s)
 }
 
-// RegisterServiceHandler is a no-op for MatcherService (no HTTP gateway needed).
-func (s *MatcherService) RegisterServiceHandler(_ context.Context, _ *runtime.ServeMux, _ *grpc.ClientConn) error {
+// RegisterServiceHandler is a no-op for matcherService (no HTTP gateway needed).
+func (s *matcherService) RegisterServiceHandler(_ context.Context, _ *runtime.ServeMux, _ *grpc.ClientConn) error {
 	return nil
 }
 

--- a/clair-adapter/services/matcher.go
+++ b/clair-adapter/services/matcher.go
@@ -1,0 +1,108 @@
+package services
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/stackrox/rox/clair-adapter/enricher/csaf"
+	"github.com/stackrox/rox/clair-adapter/mappers"
+	"github.com/stackrox/rox/clair-adapter/matcher"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// MatcherService implements the Scanner V4 MatcherServer interface.
+type MatcherService struct {
+	v4.UnimplementedMatcherServer
+	m matcher.Matcher
+}
+
+// NewMatcherService creates a new MatcherService with the given matcher.
+func NewMatcherService(m matcher.Matcher) *MatcherService {
+	return &MatcherService{
+		m: m,
+	}
+}
+
+// GetVulnerabilities retrieves vulnerability information for a previously indexed manifest.
+func (s *MatcherService) GetVulnerabilities(ctx context.Context, req *v4.GetVulnerabilitiesRequest) (*v4.VulnerabilityReport, error) {
+	vr, enrichResult, err := s.m.GetVulnerabilities(ctx, req.GetHashId())
+	if err != nil {
+		// Check if it's a "not found" error from Clair client (HTTP 404)
+		if strings.Contains(err.Error(), "HTTP 404") {
+			return nil, status.Error(codes.NotFound, "vulnerability report not found")
+		}
+		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to get vulnerabilities").Error())
+	}
+
+	// Convert CSAF advisories from enricher format to mapper format
+	mappersCSAF := convertCSAFAdvisories(enrichResult.CSAFAdvisories)
+
+	// Convert to proto format with enrichments
+	protoReport, err := mappers.ToProtoVulnerabilityReportWithEnrichments(
+		ctx,
+		vr,
+		enrichResult.NVDVulns,
+		enrichResult.EPSSItems,
+		mappersCSAF,
+		enrichResult.PkgFixedBy,
+	)
+	if err != nil {
+		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to convert vulnerability report").Error())
+	}
+
+	return protoReport, nil
+}
+
+// GetMetadata returns metadata about the vulnerability database, including the last update time.
+func (s *MatcherService) GetMetadata(ctx context.Context, _ *emptypb.Empty) (*v4.Metadata, error) {
+	ts, err := s.m.GetLastVulnerabilityUpdate(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, errors.Wrap(err, "failed to get metadata").Error())
+	}
+
+	return &v4.Metadata{
+		LastVulnerabilityUpdate: timestamppb.New(ts),
+	}, nil
+}
+
+// GetSBOM is not implemented.
+func (s *MatcherService) GetSBOM(ctx context.Context, req *v4.GetSBOMRequest) (*v4.GetSBOMResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "GetSBOM is not implemented")
+}
+
+// ScanSBOM is not implemented.
+func (s *MatcherService) ScanSBOM(ctx context.Context, req *v4.ScanSBOMRequest) (*v4.ScanSBOMResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "ScanSBOM is not implemented")
+}
+
+// convertCSAFAdvisories converts from enricher/csaf.Advisory to mappers.CSAFAdvisory.
+func convertCSAFAdvisories(csafAdvisories map[string]*csaf.Advisory) map[string]*mappers.CSAFAdvisory {
+	if csafAdvisories == nil {
+		return nil
+	}
+
+	result := make(map[string]*mappers.CSAFAdvisory, len(csafAdvisories))
+	for cveID, advisory := range csafAdvisories {
+		result[cveID] = &mappers.CSAFAdvisory{
+			Name:        advisory.Name,
+			Description: advisory.Description,
+			ReleaseDate: advisory.ReleaseDate,
+			Severity:    advisory.Severity,
+			CVSSv3: mappers.CVSSScore{
+				BaseScore: advisory.CVSSv3.BaseScore,
+				Vector:    advisory.CVSSv3.Vector,
+			},
+			CVSSv2: mappers.CVSSScore{
+				BaseScore: advisory.CVSSv2.BaseScore,
+				Vector:    advisory.CVSSv2.Vector,
+			},
+		}
+	}
+
+	return result
+}

--- a/clair-adapter/services/matcher_test.go
+++ b/clair-adapter/services/matcher_test.go
@@ -1,0 +1,147 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stackrox/rox/clair-adapter/clairclient"
+	"github.com/stackrox/rox/clair-adapter/enricher"
+	"github.com/stackrox/rox/clair-adapter/matcher"
+	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// newTestMatcherService creates a test MatcherService backed by a mock Clair server.
+func newTestMatcherService(t *testing.T, handler http.Handler) *MatcherService {
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	c, err := clairclient.NewClient(srv.URL)
+	require.NoError(t, err)
+
+	pipeline := enricher.NewPipeline()
+	m := matcher.NewLocalMatcher(c, pipeline, nil)
+	return NewMatcherService(m)
+}
+
+func TestGetVulnerabilities_Success(t *testing.T) {
+	const hashID = "sha256:abc123"
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/matcher/api/v1/vulnerability_report/"+hashID {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		// Return a vulnerability report with a vulnerability
+		report := &clairclient.VulnerabilityReport{
+			ManifestHash: hashID,
+			Vulnerabilities: map[string]clairclient.Vulnerability{
+				"vuln-1": {
+					ID:                 "vuln-1",
+					Name:               "CVE-2023-1234",
+					Description:        "A test vulnerability",
+					Severity:           "high",
+					NormalizedSeverity: "high",
+					FixedInVersion:     "1.2.3",
+					Links:              "https://example.com/cve-2023-1234",
+					Issued:             time.Date(2023, 1, 15, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			PackageVulnerabilities: map[string][]string{
+				"pkg-1": {"vuln-1"},
+			},
+			Packages: map[string]clairclient.Package{
+				"pkg-1": {
+					ID:      "pkg-1",
+					Name:    "test-package",
+					Version: "1.0.0",
+					Kind:    "binary",
+				},
+			},
+			Enrichments: map[string][]json.RawMessage{},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(report)
+	})
+
+	svc := newTestMatcherService(t, handler)
+
+	req := &v4.GetVulnerabilitiesRequest{
+		HashId: hashID,
+	}
+
+	resp, err := svc.GetVulnerabilities(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, hashID, resp.GetHashId())
+	assert.Len(t, resp.GetVulnerabilities(), 1)
+	assert.Contains(t, resp.GetVulnerabilities(), "vuln-1")
+}
+
+func TestGetVulnerabilities_NotFound(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{
+			"code":    "404",
+			"message": "vulnerability report not found",
+		})
+	})
+
+	svc := newTestMatcherService(t, handler)
+
+	req := &v4.GetVulnerabilitiesRequest{
+		HashId: "sha256:nonexistent",
+	}
+
+	resp, err := svc.GetVulnerabilities(context.Background(), req)
+	require.Error(t, err)
+	assert.Nil(t, resp)
+
+	// Check for NotFound status
+	st := status.Convert(err)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestGetMetadata_Success(t *testing.T) {
+	lastUpdate := time.Date(2023, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/matcher/api/v1/internal/update_operation" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		// Return update operations
+		updateOps := map[string][]clairclient.UpdateOperation{
+			"updater-1": {
+				{
+					Updater: "updater-1",
+					Date:    lastUpdate,
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(updateOps)
+	})
+
+	svc := newTestMatcherService(t, handler)
+
+	resp, err := svc.GetMetadata(context.Background(), &emptypb.Empty{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Check timestamp matches
+	assert.NotNil(t, resp.GetLastVulnerabilityUpdate())
+	assert.Equal(t, lastUpdate.Unix(), resp.GetLastVulnerabilityUpdate().GetSeconds())
+}

--- a/clair-adapter/services/matcher_test.go
+++ b/clair-adapter/services/matcher_test.go
@@ -19,8 +19,8 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-// newTestMatcherService creates a test MatcherService backed by a mock Clair server.
-func newTestMatcherService(t *testing.T, handler http.Handler) *MatcherService {
+// newTestMatcherService creates a test matcherService backed by a mock Clair server.
+func newTestMatcherService(t *testing.T, handler http.Handler) *matcherService {
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 

--- a/clair-adapter/updater/bundle.go
+++ b/clair-adapter/updater/bundle.go
@@ -1,0 +1,76 @@
+package updater
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// UnpackBundle opens a vulnerabilities.zip and returns the contained bundles.
+// Each file in the ZIP (e.g., "alpine.json.zst") becomes a BundleData entry.
+func UnpackBundle(zipPath string) ([]*BundleData, error) {
+	f, err := os.Open(zipPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open ZIP file: %w", err)
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat ZIP file: %w", err)
+	}
+
+	return UnpackBundleFromReader(f, stat.Size())
+}
+
+// UnpackBundleFromReader reads a ZIP from an io.ReaderAt.
+func UnpackBundleFromReader(r io.ReaderAt, size int64) ([]*BundleData, error) {
+	zipReader, err := zip.NewReader(r, size)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ZIP reader: %w", err)
+	}
+
+	var bundles []*BundleData
+
+	for _, file := range zipReader.File {
+		// Skip directories
+		if file.FileInfo().IsDir() {
+			continue
+		}
+
+		// Open file
+		rc, err := file.Open()
+		if err != nil {
+			return nil, fmt.Errorf("failed to open file %s in ZIP: %w", file.Name, err)
+		}
+
+		// Read content
+		data, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s in ZIP: %w", file.Name, err)
+		}
+
+		// Compute SHA256 fingerprint
+		hash := sha256.Sum256(data)
+		fingerprint := hex.EncodeToString(hash[:])
+
+		// Extract name (remove .zst extension)
+		name := file.Name
+		name = strings.TrimSuffix(name, ".zst")
+		name = filepath.Base(name) // Get just the filename, not directory
+
+		bundles = append(bundles, &BundleData{
+			Name:        name,
+			Data:        data,
+			Fingerprint: fingerprint,
+		})
+	}
+
+	return bundles, nil
+}

--- a/clair-adapter/updater/bundle_test.go
+++ b/clair-adapter/updater/bundle_test.go
@@ -1,0 +1,170 @@
+package updater
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnpackBundle(t *testing.T) {
+	ctx := t.Context()
+	_ = ctx
+
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "vulnerabilities.zip")
+
+	// Create test data
+	alpineData := []byte("alpine vulnerability data")
+	nvdData := []byte("nvd vulnerability data")
+
+	// Create a ZIP file with test bundles
+	zipFile, err := os.Create(zipPath)
+	require.NoError(t, err)
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+
+	// Add alpine bundle
+	alpineWriter, err := zipWriter.Create("alpine.json.zst")
+	require.NoError(t, err)
+	_, err = alpineWriter.Write(alpineData)
+	require.NoError(t, err)
+
+	// Add nvd bundle
+	nvdWriter, err := zipWriter.Create("nvd.json.zst")
+	require.NoError(t, err)
+	_, err = nvdWriter.Write(nvdData)
+	require.NoError(t, err)
+
+	require.NoError(t, zipWriter.Close())
+	require.NoError(t, zipFile.Close())
+
+	// Unpack the bundle
+	bundles, err := UnpackBundle(zipPath)
+	require.NoError(t, err)
+	require.Len(t, bundles, 2)
+
+	// Verify bundles
+	bundleMap := make(map[string]*BundleData)
+	for _, bundle := range bundles {
+		bundleMap[bundle.Name] = bundle
+	}
+
+	// Check alpine bundle
+	alpine, ok := bundleMap["alpine.json"]
+	require.True(t, ok, "alpine bundle not found")
+	assert.Equal(t, alpineData, alpine.Data)
+
+	// Verify fingerprint is correct SHA256
+	expectedFingerprint := sha256.Sum256(alpineData)
+	assert.Equal(t, hex.EncodeToString(expectedFingerprint[:]), alpine.Fingerprint)
+
+	// Check nvd bundle
+	nvd, ok := bundleMap["nvd.json"]
+	require.True(t, ok, "nvd bundle not found")
+	assert.Equal(t, nvdData, nvd.Data)
+
+	expectedFingerprint = sha256.Sum256(nvdData)
+	assert.Equal(t, hex.EncodeToString(expectedFingerprint[:]), nvd.Fingerprint)
+}
+
+func TestUnpackBundleFromReader(t *testing.T) {
+	// Create test data
+	alpineData := []byte("alpine vulnerability data")
+	nvdData := []byte("nvd vulnerability data")
+
+	// Create a ZIP in memory
+	var buf bytes.Buffer
+	zipWriter := zip.NewWriter(&buf)
+
+	// Add alpine bundle
+	alpineWriter, err := zipWriter.Create("alpine.json.zst")
+	require.NoError(t, err)
+	_, err = alpineWriter.Write(alpineData)
+	require.NoError(t, err)
+
+	// Add nvd bundle
+	nvdWriter, err := zipWriter.Create("nvd.json.zst")
+	require.NoError(t, err)
+	_, err = nvdWriter.Write(nvdData)
+	require.NoError(t, err)
+
+	require.NoError(t, zipWriter.Close())
+
+	// Unpack from reader
+	reader := bytes.NewReader(buf.Bytes())
+	bundles, err := UnpackBundleFromReader(reader, int64(buf.Len()))
+	require.NoError(t, err)
+	require.Len(t, bundles, 2)
+
+	// Verify bundles
+	bundleMap := make(map[string]*BundleData)
+	for _, bundle := range bundles {
+		bundleMap[bundle.Name] = bundle
+	}
+
+	assert.Contains(t, bundleMap, "alpine.json")
+	assert.Contains(t, bundleMap, "nvd.json")
+}
+
+func TestUnpackBundle_EmptyZip(t *testing.T) {
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "empty.zip")
+
+	// Create an empty ZIP
+	zipFile, err := os.Create(zipPath)
+	require.NoError(t, err)
+	zipWriter := zip.NewWriter(zipFile)
+	require.NoError(t, zipWriter.Close())
+	require.NoError(t, zipFile.Close())
+
+	// Unpack should succeed but return empty slice
+	bundles, err := UnpackBundle(zipPath)
+	require.NoError(t, err)
+	assert.Empty(t, bundles)
+}
+
+func TestUnpackBundle_NonExistentFile(t *testing.T) {
+	bundles, err := UnpackBundle("/nonexistent/path/vulnerabilities.zip")
+	require.Error(t, err)
+	assert.Nil(t, bundles)
+}
+
+func TestUnpackBundle_IgnoresDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "vulnerabilities.zip")
+
+	// Create a ZIP with a directory
+	zipFile, err := os.Create(zipPath)
+	require.NoError(t, err)
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+
+	// Add a directory entry
+	_, err = zipWriter.Create("subdir/")
+	require.NoError(t, err)
+
+	// Add a file
+	fileWriter, err := zipWriter.Create("alpine.json.zst")
+	require.NoError(t, err)
+	_, err = fileWriter.Write([]byte("data"))
+	require.NoError(t, err)
+
+	require.NoError(t, zipWriter.Close())
+	require.NoError(t, zipFile.Close())
+
+	// Unpack should only return the file, not the directory
+	bundles, err := UnpackBundle(zipPath)
+	require.NoError(t, err)
+	require.Len(t, bundles, 1)
+	assert.Equal(t, "alpine.json", bundles[0].Name)
+}

--- a/clair-adapter/updater/fetcher.go
+++ b/clair-adapter/updater/fetcher.go
@@ -1,0 +1,172 @@
+package updater
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Fetcher fetches vulnerability data from URLs in online mode.
+type Fetcher struct {
+	server       *Server
+	client       *http.Client
+	urls         []string      // candidate URLs, tried in order
+	interval     time.Duration // default 5 minutes
+	lastModified string        // for If-Modified-Since header
+}
+
+// FetcherOption configures the Fetcher.
+type FetcherOption func(*Fetcher)
+
+// WithFetchInterval sets the interval between fetch cycles.
+// Default is 5 minutes.
+func WithFetchInterval(d time.Duration) FetcherOption {
+	return func(f *Fetcher) {
+		f.interval = d
+	}
+}
+
+// WithHTTPClient sets the HTTP client to use for requests.
+// Default is http.DefaultClient.
+func WithHTTPClient(c *http.Client) FetcherOption {
+	return func(f *Fetcher) {
+		f.client = c
+	}
+}
+
+// NewFetcher creates a new vulnerability data fetcher.
+func NewFetcher(server *Server, urls []string, opts ...FetcherOption) *Fetcher {
+	f := &Fetcher{
+		server:   server,
+		client:   http.DefaultClient,
+		urls:     urls,
+		interval: 5 * time.Minute,
+	}
+
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	return f
+}
+
+// Start starts the fetch loop and blocks until the context is canceled.
+// It fetches immediately on start, then runs at the configured interval.
+func (f *Fetcher) Start(ctx context.Context) error {
+	// Fetch immediately on start
+	if err := f.FetchOnce(ctx); err != nil {
+		slog.ErrorContext(ctx, "Initial fetch failed", "error", err)
+	}
+
+	ticker := time.NewTicker(f.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := f.FetchOnce(ctx); err != nil {
+				slog.ErrorContext(ctx, "Fetch cycle failed", "error", err)
+			}
+		}
+	}
+}
+
+// FetchOnce performs a single fetch cycle.
+func (f *Fetcher) FetchOnce(ctx context.Context) error {
+	if len(f.urls) == 0 {
+		return fmt.Errorf("no URLs configured")
+	}
+
+	var lastErr error
+
+	// Try each URL in order
+	for _, url := range f.urls {
+		slog.InfoContext(ctx, "Fetching vulnerability data", "url", url)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to create request: %w", err)
+			continue
+		}
+
+		// Add If-Modified-Since header if we have a last modified time
+		if f.lastModified != "" {
+			req.Header.Set("If-Modified-Since", f.lastModified)
+		}
+
+		resp, err := f.client.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("request failed: %w", err)
+			continue
+		}
+
+		switch resp.StatusCode {
+		case http.StatusNotModified:
+			resp.Body.Close()
+			slog.InfoContext(ctx, "Vulnerability data not modified")
+			return nil
+
+		case http.StatusOK:
+			// Download to temporary file
+			tmpFile, err := os.CreateTemp("", "vulnerabilities-*.zip")
+			if err != nil {
+				resp.Body.Close()
+				lastErr = fmt.Errorf("failed to create temp file: %w", err)
+				continue
+			}
+			tmpPath := tmpFile.Name()
+
+			// Copy response to temp file
+			_, err = io.Copy(tmpFile, resp.Body)
+			resp.Body.Close()
+			tmpFile.Close()
+
+			if err != nil {
+				os.Remove(tmpPath)
+				lastErr = fmt.Errorf("failed to download file: %w", err)
+				continue
+			}
+
+			// Unpack bundles
+			bundles, err := UnpackBundle(tmpPath)
+			os.Remove(tmpPath)
+
+			if err != nil {
+				lastErr = fmt.Errorf("failed to unpack bundle: %w", err)
+				continue
+			}
+
+			// Update server with new bundles
+			f.server.SetBundles(bundles)
+
+			// Update last modified time from response header
+			if lastMod := resp.Header.Get("Last-Modified"); lastMod != "" {
+				f.lastModified = lastMod
+			}
+
+			slog.InfoContext(ctx, "Successfully fetched and loaded vulnerability data",
+				"bundles", len(bundles),
+				"url", url)
+			return nil
+
+		case http.StatusNotFound:
+			resp.Body.Close()
+			lastErr = fmt.Errorf("URL not found: %s", url)
+			continue
+
+		default:
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			resp.Body.Close()
+			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+			continue
+		}
+	}
+
+	return fmt.Errorf("all URLs failed, last error: %w", lastErr)
+}

--- a/clair-adapter/updater/fetcher.go
+++ b/clair-adapter/updater/fetcher.go
@@ -2,40 +2,49 @@ package updater
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/stackrox/rox/pkg/mtls"
 )
+
+// BundleImporter imports vulnerability bundles from a ZIP file on disk.
+type BundleImporter interface {
+	ImportFromZip(ctx context.Context, zipPath string) error
+}
 
 // Fetcher fetches vulnerability data from URLs in online mode.
 type Fetcher struct {
 	server       *Server
+	importer     BundleImporter
 	client       *http.Client
-	urls         []string      // candidate URLs, tried in order
-	interval     time.Duration // default 5 minutes
-	lastModified string        // for If-Modified-Since header
+	urls         []string
+	interval     time.Duration
+	lastModified string
 }
 
 // FetcherOption configures the Fetcher.
 type FetcherOption func(*Fetcher)
 
 // WithFetchInterval sets the interval between fetch cycles.
-// Default is 5 minutes.
 func WithFetchInterval(d time.Duration) FetcherOption {
-	return func(f *Fetcher) {
-		f.interval = d
-	}
+	return func(f *Fetcher) { f.interval = d }
 }
 
 // WithHTTPClient sets the HTTP client to use for requests.
-// Default is http.DefaultClient.
 func WithHTTPClient(c *http.Client) FetcherOption {
-	return func(f *Fetcher) {
-		f.client = c
-	}
+	return func(f *Fetcher) { f.client = c }
+}
+
+// WithImporter sets the bundle importer called after successful fetch.
+func WithImporter(imp BundleImporter) FetcherOption {
+	return func(f *Fetcher) { f.importer = imp }
 }
 
 // NewFetcher creates a new vulnerability data fetcher.
@@ -46,20 +55,16 @@ func NewFetcher(server *Server, urls []string, opts ...FetcherOption) *Fetcher {
 		urls:     urls,
 		interval: 5 * time.Minute,
 	}
-
 	for _, opt := range opts {
 		opt(f)
 	}
-
 	return f
 }
 
 // Start starts the fetch loop and blocks until the context is canceled.
-// It fetches immediately on start, then runs at the configured interval.
 func (f *Fetcher) Start(ctx context.Context) error {
-	// Fetch immediately on start
 	if err := f.FetchOnce(ctx); err != nil {
-		slog.ErrorContext(ctx, "Initial fetch failed", "error", err)
+		slog.ErrorContext(ctx, "initial fetch failed", "error", err)
 	}
 
 	ticker := time.NewTicker(f.interval)
@@ -71,7 +76,7 @@ func (f *Fetcher) Start(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			if err := f.FetchOnce(ctx); err != nil {
-				slog.ErrorContext(ctx, "Fetch cycle failed", "error", err)
+				slog.ErrorContext(ctx, "fetch cycle failed", "error", err)
 			}
 		}
 	}
@@ -85,17 +90,14 @@ func (f *Fetcher) FetchOnce(ctx context.Context) error {
 
 	var lastErr error
 
-	// Try each URL in order
 	for _, url := range f.urls {
-		slog.InfoContext(ctx, "Fetching vulnerability data", "url", url)
+		slog.InfoContext(ctx, "fetching vulnerability data", "url", url)
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
-			lastErr = fmt.Errorf("failed to create request: %w", err)
+			lastErr = fmt.Errorf("creating request: %w", err)
 			continue
 		}
-
-		// Add If-Modified-Since header if we have a last modified time
 		if f.lastModified != "" {
 			req.Header.Set("If-Modified-Since", f.lastModified)
 		}
@@ -109,50 +111,50 @@ func (f *Fetcher) FetchOnce(ctx context.Context) error {
 		switch resp.StatusCode {
 		case http.StatusNotModified:
 			resp.Body.Close()
-			slog.InfoContext(ctx, "Vulnerability data not modified")
+			slog.InfoContext(ctx, "vulnerability data not modified")
 			return nil
 
 		case http.StatusOK:
-			// Download to temporary file
 			tmpFile, err := os.CreateTemp("", "vulnerabilities-*.zip")
 			if err != nil {
 				resp.Body.Close()
-				lastErr = fmt.Errorf("failed to create temp file: %w", err)
+				lastErr = fmt.Errorf("creating temp file: %w", err)
 				continue
 			}
 			tmpPath := tmpFile.Name()
 
-			// Copy response to temp file
 			_, err = io.Copy(tmpFile, resp.Body)
 			resp.Body.Close()
 			tmpFile.Close()
-
 			if err != nil {
 				os.Remove(tmpPath)
-				lastErr = fmt.Errorf("failed to download file: %w", err)
+				lastErr = fmt.Errorf("downloading: %w", err)
 				continue
 			}
 
-			// Unpack bundles
+			// Import into Clair's DB by streaming from the ZIP on disk.
+			if f.importer != nil {
+				if err := f.importer.ImportFromZip(ctx, tmpPath); err != nil {
+					slog.ErrorContext(ctx, "failed to import bundles into Clair DB", "error", err)
+				}
+			}
+
+			// Unpack bundles into memory for the HTTP server.
 			bundles, err := UnpackBundle(tmpPath)
 			os.Remove(tmpPath)
-
 			if err != nil {
-				lastErr = fmt.Errorf("failed to unpack bundle: %w", err)
+				lastErr = fmt.Errorf("unpacking bundle: %w", err)
 				continue
 			}
 
-			// Update server with new bundles
 			f.server.SetBundles(bundles)
 
-			// Update last modified time from response header
 			if lastMod := resp.Header.Get("Last-Modified"); lastMod != "" {
 				f.lastModified = lastMod
 			}
 
-			slog.InfoContext(ctx, "Successfully fetched and loaded vulnerability data",
-				"bundles", len(bundles),
-				"url", url)
+			slog.InfoContext(ctx, "vulnerability data loaded",
+				"bundles", len(bundles), "url", url, "imported", f.importer != nil)
 			return nil
 
 		case http.StatusNotFound:
@@ -169,4 +171,32 @@ func (f *Fetcher) FetchOnce(ctx context.Context) error {
 	}
 
 	return fmt.Errorf("all URLs failed, last error: %w", lastErr)
+}
+
+// NewMTLSHTTPClient creates an HTTP client configured with StackRox mTLS
+// certificates for authenticating to Central.
+func NewMTLSHTTPClient() (*http.Client, error) {
+	caPEM, err := mtls.CACertPEM()
+	if err != nil {
+		return nil, fmt.Errorf("loading CA certificate: %w", err)
+	}
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("failed to add CA certificate to pool")
+	}
+
+	cert, err := mtls.LeafCertificateFromFile()
+	if err != nil {
+		return nil, fmt.Errorf("loading client certificate: %w", err)
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:      certPool,
+				Certificates: []tls.Certificate{cert},
+			},
+		},
+		Timeout: 5 * time.Minute,
+	}, nil
 }

--- a/clair-adapter/updater/fetcher_test.go
+++ b/clair-adapter/updater/fetcher_test.go
@@ -1,0 +1,268 @@
+package updater
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestZip(t *testing.T, files map[string][]byte) []byte {
+	var buf bytes.Buffer
+	zipWriter := zip.NewWriter(&buf)
+
+	for name, data := range files {
+		writer, err := zipWriter.Create(name)
+		require.NoError(t, err)
+		_, err = writer.Write(data)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, zipWriter.Close())
+	return buf.Bytes()
+}
+
+func TestFetcher_FetchOnce(t *testing.T) {
+	zipData := createTestZip(t, map[string][]byte{
+		"alpine.json.zst": []byte("alpine data"),
+		"nvd.json.zst":    []byte("nvd data"),
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 GMT")
+		w.WriteHeader(http.StatusOK)
+		w.Write(zipData)
+	}))
+	defer server.Close()
+
+	updateServer := NewServer()
+	fetcher := NewFetcher(updateServer, []string{server.URL})
+
+	ctx := t.Context()
+	err := fetcher.FetchOnce(ctx)
+	require.NoError(t, err)
+
+	// Verify bundles were loaded into server
+	req := httptest.NewRequest(http.MethodGet, "/updater/alpine.json", nil)
+	rec := httptest.NewRecorder()
+	updateServer.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []byte("alpine data"), rec.Body.Bytes())
+
+	// Verify lastModified was set
+	assert.Equal(t, "Mon, 02 Jan 2006 15:04:05 GMT", fetcher.lastModified)
+}
+
+func TestFetcher_FetchOnce_NotModified(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Mon, 02 Jan 2006 15:04:05 GMT", r.Header.Get("If-Modified-Since"))
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer server.Close()
+
+	updateServer := NewServer()
+	fetcher := NewFetcher(updateServer, []string{server.URL})
+	fetcher.lastModified = "Mon, 02 Jan 2006 15:04:05 GMT"
+
+	ctx := t.Context()
+	err := fetcher.FetchOnce(ctx)
+	require.NoError(t, err)
+}
+
+func TestFetcher_FetchOnce_FallbackToNextURL(t *testing.T) {
+	zipData := createTestZip(t, map[string][]byte{
+		"alpine.json.zst": []byte("alpine data"),
+	})
+
+	// First server returns 404
+	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server1.Close()
+
+	// Second server returns data
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 GMT")
+		w.WriteHeader(http.StatusOK)
+		w.Write(zipData)
+	}))
+	defer server2.Close()
+
+	updateServer := NewServer()
+	fetcher := NewFetcher(updateServer, []string{server1.URL, server2.URL})
+
+	ctx := t.Context()
+	err := fetcher.FetchOnce(ctx)
+	require.NoError(t, err)
+
+	// Verify bundles were loaded from second server
+	req := httptest.NewRequest(http.MethodGet, "/updater/alpine.json", nil)
+	rec := httptest.NewRecorder()
+	updateServer.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestFetcher_FetchOnce_AllURLsFail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	updateServer := NewServer()
+	fetcher := NewFetcher(updateServer, []string{server.URL})
+
+	ctx := t.Context()
+	err := fetcher.FetchOnce(ctx)
+	require.Error(t, err)
+}
+
+func TestFetcher_Start(t *testing.T) {
+	fetchCount := 0
+	zipData := createTestZip(t, map[string][]byte{
+		"alpine.json.zst": []byte("alpine data"),
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount++
+		w.Header().Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 GMT")
+		w.WriteHeader(http.StatusOK)
+		w.Write(zipData)
+	}))
+	defer server.Close()
+
+	updateServer := NewServer()
+	fetcher := NewFetcher(updateServer, []string{server.URL}, WithFetchInterval(10*time.Millisecond))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// Start fetcher in background
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- fetcher.Start(ctx)
+	}()
+
+	// Wait for at least 2 fetch cycles
+	time.Sleep(25 * time.Millisecond)
+
+	// Stop fetcher
+	cancel()
+
+	// Wait for fetcher to finish
+	err := <-errChan
+	require.NoError(t, err)
+
+	// Should have fetched at least twice (immediate + at least one interval)
+	assert.GreaterOrEqual(t, fetchCount, 2)
+}
+
+func TestFetcher_Options(t *testing.T) {
+	updateServer := NewServer()
+
+	t.Run("default options", func(t *testing.T) {
+		f := NewFetcher(updateServer, []string{"http://example.com"})
+		assert.Equal(t, 5*time.Minute, f.interval)
+		assert.NotNil(t, f.client)
+	})
+
+	t.Run("custom interval", func(t *testing.T) {
+		f := NewFetcher(updateServer, []string{"http://example.com"}, WithFetchInterval(10*time.Minute))
+		assert.Equal(t, 10*time.Minute, f.interval)
+	})
+
+	t.Run("custom HTTP client", func(t *testing.T) {
+		customClient := &http.Client{Timeout: 30 * time.Second}
+		f := NewFetcher(updateServer, []string{"http://example.com"}, WithHTTPClient(customClient))
+		assert.Equal(t, customClient, f.client)
+	})
+}
+
+func TestFetcher_FetchOnce_InvalidZip(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("not a zip file"))
+	}))
+	defer server.Close()
+
+	updateServer := NewServer()
+	fetcher := NewFetcher(updateServer, []string{server.URL})
+
+	ctx := t.Context()
+	err := fetcher.FetchOnce(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unpack bundle")
+}
+
+func TestFetcher_FetchOnce_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Slow response
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	updateServer := NewServer()
+	fetcher := NewFetcher(updateServer, []string{server.URL})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // Cancel immediately
+
+	err := fetcher.FetchOnce(ctx)
+	require.Error(t, err)
+}
+
+func TestFetcher_FetchOnce_EmptyURLs(t *testing.T) {
+	updateServer := NewServer()
+	fetcher := NewFetcher(updateServer, []string{})
+
+	ctx := t.Context()
+	err := fetcher.FetchOnce(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no URLs configured")
+}
+
+func TestFetcher_FetchOnce_LastModifiedPersists(t *testing.T) {
+	requestCount := 0
+	zipData := createTestZip(t, map[string][]byte{
+		"alpine.json.zst": []byte("alpine data"),
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			// First request: return data
+			w.Header().Set("Last-Modified", "Mon, 02 Jan 2006 15:04:05 GMT")
+			w.WriteHeader(http.StatusOK)
+			w.Write(zipData)
+		} else {
+			// Subsequent requests: check If-Modified-Since header
+			assert.Equal(t, "Mon, 02 Jan 2006 15:04:05 GMT", r.Header.Get("If-Modified-Since"))
+			w.WriteHeader(http.StatusNotModified)
+		}
+	}))
+	defer server.Close()
+
+	updateServer := NewServer()
+	fetcher := NewFetcher(updateServer, []string{server.URL})
+
+	ctx := t.Context()
+
+	// First fetch
+	err := fetcher.FetchOnce(ctx)
+	require.NoError(t, err)
+
+	// Second fetch should send If-Modified-Since
+	err = fetcher.FetchOnce(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, requestCount)
+}

--- a/clair-adapter/updater/fetcher_test.go
+++ b/clair-adapter/updater/fetcher_test.go
@@ -199,7 +199,7 @@ func TestFetcher_FetchOnce_InvalidZip(t *testing.T) {
 	ctx := t.Context()
 	err := fetcher.FetchOnce(ctx)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to unpack bundle")
+	assert.Contains(t, err.Error(), "unpacking bundle")
 }
 
 func TestFetcher_FetchOnce_ContextCancellation(t *testing.T) {

--- a/clair-adapter/updater/server.go
+++ b/clair-adapter/updater/server.go
@@ -1,0 +1,82 @@
+package updater
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// Server serves vulnerability data to Clair.
+// Each bundle is served at its own endpoint (/updater/{name} or /enricher/{name}).
+type Server struct {
+	mu      sync.RWMutex
+	bundles map[string]*BundleData // keyed by bundle name
+	mux     *http.ServeMux
+}
+
+// NewServer creates a new updater HTTP server.
+func NewServer() *Server {
+	s := &Server{
+		bundles: make(map[string]*BundleData),
+		mux:     http.NewServeMux(),
+	}
+
+	// Register catch-all handler
+	s.mux.HandleFunc("/", s.handleBundle)
+
+	return s
+}
+
+// SetBundles atomically updates the available bundles.
+func (s *Server) SetBundles(bundles []*BundleData) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Clear existing bundles
+	clear(s.bundles)
+
+	// Add new bundles
+	for _, bundle := range bundles {
+		s.bundles[bundle.Name] = bundle
+	}
+}
+
+// ServeHTTP implements http.Handler.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+// handleBundle handles requests for vulnerability bundles.
+func (s *Server) handleBundle(w http.ResponseWriter, r *http.Request) {
+	// Parse path: /updater/{name} or /enricher/{name}
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/"), "/")
+	if len(parts) != 2 || (parts[0] != "updater" && parts[0] != "enricher") {
+		http.NotFound(w, r)
+		return
+	}
+
+	bundleName := parts[1]
+
+	s.mu.RLock()
+	bundle, ok := s.bundles[bundleName]
+	s.mu.RUnlock()
+
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Check If-None-Match for conditional GET
+	if r.Header.Get("If-None-Match") == bundle.Fingerprint {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	// Set headers
+	w.Header().Set("ETag", bundle.Fingerprint)
+	w.Header().Set("Content-Type", "application/zstd")
+
+	// Write data
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(bundle.Data)
+}

--- a/clair-adapter/updater/server_test.go
+++ b/clair-adapter/updater/server_test.go
@@ -1,0 +1,145 @@
+package updater
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer_ServeBundleData(t *testing.T) {
+	s := NewServer()
+
+	bundles := []*BundleData{
+		{
+			Name:        "alpine",
+			Data:        []byte("compressed alpine data"),
+			Fingerprint: "abc123",
+		},
+		{
+			Name:        "nvd",
+			Data:        []byte("compressed nvd data"),
+			Fingerprint: "def456",
+		},
+	}
+
+	s.SetBundles(bundles)
+
+	tests := map[string]struct {
+		path           string
+		wantStatusCode int
+		wantData       []byte
+		wantETag       string
+	}{
+		"get updater bundle": {
+			path:           "/updater/alpine",
+			wantStatusCode: http.StatusOK,
+			wantData:       []byte("compressed alpine data"),
+			wantETag:       "abc123",
+		},
+		"get enricher bundle": {
+			path:           "/enricher/nvd",
+			wantStatusCode: http.StatusOK,
+			wantData:       []byte("compressed nvd data"),
+			wantETag:       "def456",
+		},
+		"not found": {
+			path:           "/updater/unknown",
+			wantStatusCode: http.StatusNotFound,
+		},
+		"invalid path": {
+			path:           "/invalid/path",
+			wantStatusCode: http.StatusNotFound,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+
+			s.ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.wantStatusCode, rec.Code)
+
+			if tt.wantStatusCode == http.StatusOK {
+				assert.Equal(t, tt.wantData, rec.Body.Bytes())
+				assert.Equal(t, tt.wantETag, rec.Header().Get("ETag"))
+				assert.Equal(t, "application/zstd", rec.Header().Get("Content-Type"))
+			}
+		})
+	}
+}
+
+func TestServer_NotModified(t *testing.T) {
+	s := NewServer()
+
+	s.SetBundles([]*BundleData{
+		{
+			Name:        "alpine",
+			Data:        []byte("compressed alpine data"),
+			Fingerprint: "abc123",
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/updater/alpine", nil)
+	req.Header.Set("If-None-Match", "abc123")
+	rec := httptest.NewRecorder()
+
+	s.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotModified, rec.Code)
+	assert.Empty(t, rec.Body.Bytes())
+}
+
+func TestServer_NotFound(t *testing.T) {
+	s := NewServer()
+
+	s.SetBundles([]*BundleData{
+		{
+			Name:        "alpine",
+			Data:        []byte("compressed alpine data"),
+			Fingerprint: "abc123",
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/updater/unknown", nil)
+	rec := httptest.NewRecorder()
+
+	s.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestServer_SetBundles_UpdatesExisting(t *testing.T) {
+	s := NewServer()
+
+	// Set initial bundles
+	s.SetBundles([]*BundleData{
+		{
+			Name:        "alpine",
+			Data:        []byte("old data"),
+			Fingerprint: "old",
+		},
+	})
+
+	// Update with new bundles
+	s.SetBundles([]*BundleData{
+		{
+			Name:        "alpine",
+			Data:        []byte("new data"),
+			Fingerprint: "new",
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/updater/alpine", nil)
+	rec := httptest.NewRecorder()
+
+	s.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []byte("new data"), rec.Body.Bytes())
+	assert.Equal(t, "new", rec.Header().Get("ETag"))
+}

--- a/clair-adapter/updater/types.go
+++ b/clair-adapter/updater/types.go
@@ -1,0 +1,8 @@
+package updater
+
+// BundleData represents unpacked vulnerability data ready to serve to Clair.
+type BundleData struct {
+	Name        string // e.g., "alpine", "nvd", "rhel-vex"
+	Data        []byte // Raw content (zstd-compressed JSON)
+	Fingerprint string // ETag/fingerprint for conditional serving
+}

--- a/clair-adapter/vulnimporter/enrichment.go
+++ b/clair-adapter/vulnimporter/enrichment.go
@@ -1,0 +1,142 @@
+package vulnimporter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stackrox/rox/clair-adapter/mappers"
+)
+
+// EnrichmentFetcher queries Clair's enrichment table directly
+// to retrieve NVD and EPSS data for a set of CVE IDs.
+type EnrichmentFetcher struct {
+	pool *pgxpool.Pool
+}
+
+func NewEnrichmentFetcher(pool *pgxpool.Pool) *EnrichmentFetcher {
+	return &EnrichmentFetcher{pool: pool}
+}
+
+type enrichmentRow struct {
+	Tags []string
+	Data json.RawMessage
+}
+
+const enrichmentQuery = `
+SELECT e.tags, e.data
+FROM enrichment e
+JOIN uo_enrich ue ON ue.enrich = e.id
+JOIN latest_update_operations l ON l.id = ue.uo
+WHERE l.updater = $1
+  AND l.kind = 'enrichment'
+  AND e.tags && $2::text[];`
+
+func (f *EnrichmentFetcher) fetchRows(ctx context.Context, updater string, cves []string) ([]enrichmentRow, error) {
+	rows, err := f.pool.Query(ctx, enrichmentQuery, updater, cves)
+	if err != nil {
+		return nil, fmt.Errorf("querying enrichment for %s: %w", updater, err)
+	}
+	defer rows.Close()
+
+	var result []enrichmentRow
+	for rows.Next() {
+		var r enrichmentRow
+		if err := rows.Scan(&r.Tags, &r.Data); err != nil {
+			return nil, fmt.Errorf("scanning enrichment row: %w", err)
+		}
+		result = append(result, r)
+	}
+	return result, rows.Err()
+}
+
+// nvdData matches the JSON stored in the enrichment table by the StackRox NVD enricher.
+type nvdData struct {
+	ID      string `json:"id"`
+	Metrics struct {
+		CvssMetricV2  []cvssMetric `json:"cvssMetricV2"`
+		CvssMetricV31 []cvssMetric `json:"cvssMetricV31"`
+		CvssMetricV30 []cvssMetric `json:"cvssMetricV30"`
+		CvssMetricV40 []cvssMetric `json:"cvssMetricV40"`
+	} `json:"metrics"`
+}
+
+type cvssMetric struct {
+	CvssData struct {
+		Version      string  `json:"version"`
+		BaseScore    float64 `json:"baseScore"`
+		VectorString string  `json:"vectorString"`
+	} `json:"cvssData"`
+}
+
+// FetchNVD queries the enrichment table for NVD data matching the given CVE IDs.
+func (f *EnrichmentFetcher) FetchNVD(ctx context.Context, cves []string) map[string]*mappers.NVDItem {
+	if len(cves) == 0 {
+		return nil
+	}
+	rows, err := f.fetchRows(ctx, "nvd", cves)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to fetch NVD enrichments", "error", err)
+		return nil
+	}
+	result := make(map[string]*mappers.NVDItem, len(rows))
+	for _, r := range rows {
+		var d nvdData
+		if err := json.Unmarshal(r.Data, &d); err != nil {
+			continue
+		}
+		item := &mappers.NVDItem{}
+		if len(d.Metrics.CvssMetricV31) > 0 {
+			m := d.Metrics.CvssMetricV31[0]
+			item.CVSSv3 = &mappers.CVSSScore{BaseScore: m.CvssData.BaseScore, Vector: m.CvssData.VectorString}
+		} else if len(d.Metrics.CvssMetricV30) > 0 {
+			m := d.Metrics.CvssMetricV30[0]
+			item.CVSSv3 = &mappers.CVSSScore{BaseScore: m.CvssData.BaseScore, Vector: m.CvssData.VectorString}
+		}
+		if len(d.Metrics.CvssMetricV2) > 0 {
+			m := d.Metrics.CvssMetricV2[0]
+			item.CVSSv2 = &mappers.CVSSScore{BaseScore: m.CvssData.BaseScore, Vector: m.CvssData.VectorString}
+		}
+		result[d.ID] = item
+	}
+	slog.DebugContext(ctx, "fetched NVD enrichments", "requested", len(cves), "found", len(result))
+	return result
+}
+
+// epssData matches the JSON stored in the enrichment table by the EPSS enricher.
+type epssData struct {
+	CVE          string  `json:"cve"`
+	ModelVersion string  `json:"modelVersion"`
+	Date         string  `json:"date"`
+	EPSS         float64 `json:"epss"`
+	Percentile   float64 `json:"percentile"`
+}
+
+// FetchEPSS queries the enrichment table for EPSS data matching the given CVE IDs.
+func (f *EnrichmentFetcher) FetchEPSS(ctx context.Context, cves []string) map[string]*mappers.EPSSItem {
+	if len(cves) == 0 {
+		return nil
+	}
+	rows, err := f.fetchRows(ctx, "clair.epss", cves)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to fetch EPSS enrichments", "error", err)
+		return nil
+	}
+	result := make(map[string]*mappers.EPSSItem, len(rows))
+	for _, r := range rows {
+		var d epssData
+		if err := json.Unmarshal(r.Data, &d); err != nil {
+			continue
+		}
+		result[d.CVE] = &mappers.EPSSItem{
+			ModelVersion: d.ModelVersion,
+			Date:         d.Date,
+			Probability:  d.EPSS,
+			Percentile:   d.Percentile,
+		}
+	}
+	slog.DebugContext(ctx, "fetched EPSS enrichments", "requested", len(cves), "found", len(result))
+	return result
+}

--- a/clair-adapter/vulnimporter/importer.go
+++ b/clair-adapter/vulnimporter/importer.go
@@ -1,0 +1,160 @@
+package vulnimporter
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/klauspost/compress/zstd"
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/datastore"
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/stackrox/rox/scanner/updater/jsonblob"
+)
+
+// Importer imports StackRox vulnerability bundles directly into Clair's database.
+type Importer struct {
+	store         datastore.MatcherStore
+	metadataStore MetadataStore
+}
+
+// MetadataStore tracks vulnerability update timestamps.
+type MetadataStore interface {
+	SetLastVulnerabilityUpdate(ctx context.Context, bundle string, lastUpdate time.Time) error
+}
+
+// NewImporter creates an importer that writes to the given Clair matcher store.
+// metadataStore is optional; if provided, it records import timestamps per bundle.
+func NewImporter(store datastore.MatcherStore, metadataStore MetadataStore) *Importer {
+	return &Importer{store: store, metadataStore: metadataStore}
+}
+
+// ImportFromZip streams vulnerability bundles from a ZIP file on disk into Clair's database.
+// Each entry in the ZIP is a zstd-compressed JSONL file that is streamed through
+// decompression and parsing without buffering the full contents in memory.
+func (imp *Importer) ImportFromZip(ctx context.Context, zipPath string) error {
+	f, err := os.Open(zipPath)
+	if err != nil {
+		return fmt.Errorf("opening zip: %w", err)
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat zip: %w", err)
+	}
+
+	zr, err := zip.NewReader(f, stat.Size())
+	if err != nil {
+		return fmt.Errorf("reading zip: %w", err)
+	}
+
+	for _, zf := range zr.File {
+		if zf.FileInfo().IsDir() {
+			continue
+		}
+		if err := imp.importZipEntry(ctx, zf); err != nil {
+			slog.ErrorContext(ctx, "failed to import bundle", "bundle", zf.Name, "error", err)
+			continue
+		}
+	}
+	return nil
+}
+
+func (imp *Importer) importZipEntry(ctx context.Context, zf *zip.File) error {
+	rc, err := zf.Open()
+	if err != nil {
+		return fmt.Errorf("opening entry %s: %w", zf.Name, err)
+	}
+	defer rc.Close()
+
+	dec, err := zstd.NewReader(rc)
+	if err != nil {
+		return fmt.Errorf("creating zstd reader for %s: %w", zf.Name, err)
+	}
+	defer dec.Close()
+
+	return imp.importFromReader(ctx, dec, zf.Name)
+}
+
+// importFromReader is the core import logic, closely following
+// scanner/matcher/updater/vuln/updater.go:Import() (lines 209-271).
+func (imp *Importer) importFromReader(ctx context.Context, r io.Reader, bundleName string) (err error) {
+	iter, iterErr := jsonblob.Iterate(r)
+
+	iter(func(op *driver.UpdateOperation, it jsonblob.RecordIter) bool {
+		// Check fingerprint to skip unchanged data.
+		var ops map[string][]driver.UpdateOperation
+		ops, err = imp.store.GetUpdateOperations(ctx, op.Kind, op.Updater)
+		if err != nil {
+			return false
+		}
+		for _, o := range ops[op.Updater] {
+			if o.Fingerprint == op.Fingerprint {
+				slog.InfoContext(ctx, "fingerprint match, skipping", "updater", op.Updater)
+				return true
+			}
+		}
+
+		slog.InfoContext(ctx, "importing update", "updater", op.Updater, "kind", string(op.Kind), "bundle", bundleName)
+		var ref uuid.UUID
+		count := 0
+
+		switch op.Kind {
+		case driver.VulnerabilityKind:
+			ref, err = imp.store.UpdateVulnerabilitiesIter(ctx, op.Updater, op.Fingerprint, func(yield func(*claircore.Vulnerability, error) bool) {
+				it(func(v *claircore.Vulnerability, _ *driver.EnrichmentRecord) bool {
+					count++
+					return yield(v, nil)
+				})
+				if err := iterErr(); err != nil {
+					yield(nil, err)
+				}
+			})
+		case driver.EnrichmentKind:
+			ref, err = imp.store.UpdateEnrichmentsIter(ctx, op.Updater, op.Fingerprint, func(yield func(*driver.EnrichmentRecord, error) bool) {
+				it(func(_ *claircore.Vulnerability, e *driver.EnrichmentRecord) bool {
+					count++
+					return yield(e, nil)
+				})
+				if err := iterErr(); err != nil {
+					yield(nil, err)
+				}
+			})
+		default:
+			slog.WarnContext(ctx, "unknown kind, skipping", "kind", string(op.Kind))
+		}
+
+		if err != nil {
+			err = fmt.Errorf("updating %s: %w", op.Kind, err)
+			return false
+		}
+
+		slog.InfoContext(ctx, "update imported",
+			"updater", op.Updater,
+			"kind", string(op.Kind),
+			"ref", ref.String(),
+			"count", count,
+			"bundle", bundleName,
+		)
+
+		// Record import timestamp for this bundle.
+		if imp.metadataStore != nil {
+			if storeErr := imp.metadataStore.SetLastVulnerabilityUpdate(ctx, op.Updater, time.Now()); storeErr != nil {
+				slog.WarnContext(ctx, "failed to record import timestamp", "updater", op.Updater, "error", storeErr)
+			}
+		}
+
+		return true
+	})
+
+	if err := iterErr(); err != nil {
+		return fmt.Errorf("iterating bundle %s: %w", bundleName, err)
+	}
+	return err
+}

--- a/clair-adapter/vulnimporter/store.go
+++ b/clair-adapter/vulnimporter/store.go
@@ -11,16 +11,16 @@ import (
 	ccpostgres "github.com/quay/claircore/datastore/postgres"
 )
 
-// NewMatcherStore connects to Clair's PostgreSQL and returns a MatcherStore
-// suitable for importing vulnerability data directly.
+// NewMatcherStoreAndPool connects to Clair's PostgreSQL and returns both
+// a MatcherStore for importing data and the underlying pgxpool.Pool for
+// direct queries (e.g., enrichment fetching).
 //
 // doMigration is false because Clair manages its own schema migrations.
-// If Clair hasn't started yet and tables don't exist, this will retry
-// until the context is canceled or the connection succeeds.
-func NewMatcherStore(ctx context.Context, connString string) (datastore.MatcherStore, error) {
+// Retries connection and waits for schema to be ready.
+func NewMatcherStoreAndPool(ctx context.Context, connString string) (datastore.MatcherStore, *pgxpool.Pool, error) {
 	cfg, err := pgxpool.ParseConfig(connString)
 	if err != nil {
-		return nil, fmt.Errorf("parsing Clair DB connection string: %w", err)
+		return nil, nil, fmt.Errorf("parsing Clair DB connection string: %w", err)
 	}
 	cfg.ConnConfig.RuntimeParams["application_name"] = "clair-adapter-importer"
 
@@ -36,15 +36,14 @@ func NewMatcherStore(ctx context.Context, connString string) (datastore.MatcherS
 		slog.WarnContext(ctx, "waiting for Clair database", "attempt", attempt, "error", err)
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		case <-time.After(10 * time.Second):
 		}
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Clair database after 30 attempts: %w", err)
+		return nil, nil, fmt.Errorf("failed to connect to Clair database after 30 attempts: %w", err)
 	}
 
-	// Wait for Clair's tables to exist (Clair runs migrations on startup).
 	for attempt := 1; attempt <= 30; attempt++ {
 		var exists bool
 		err = pool.QueryRow(ctx,
@@ -56,7 +55,7 @@ func NewMatcherStore(ctx context.Context, connString string) (datastore.MatcherS
 		select {
 		case <-ctx.Done():
 			pool.Close()
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		case <-time.After(5 * time.Second):
 		}
 	}
@@ -64,8 +63,8 @@ func NewMatcherStore(ctx context.Context, connString string) (datastore.MatcherS
 	store, err := ccpostgres.InitPostgresMatcherStore(ctx, pool, false)
 	if err != nil {
 		pool.Close()
-		return nil, fmt.Errorf("initializing Clair matcher store: %w", err)
+		return nil, nil, fmt.Errorf("initializing Clair matcher store: %w", err)
 	}
 
-	return store, nil
+	return store, pool, nil
 }

--- a/clair-adapter/vulnimporter/store.go
+++ b/clair-adapter/vulnimporter/store.go
@@ -1,0 +1,71 @@
+package vulnimporter
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/quay/claircore/datastore"
+	ccpostgres "github.com/quay/claircore/datastore/postgres"
+)
+
+// NewMatcherStore connects to Clair's PostgreSQL and returns a MatcherStore
+// suitable for importing vulnerability data directly.
+//
+// doMigration is false because Clair manages its own schema migrations.
+// If Clair hasn't started yet and tables don't exist, this will retry
+// until the context is canceled or the connection succeeds.
+func NewMatcherStore(ctx context.Context, connString string) (datastore.MatcherStore, error) {
+	cfg, err := pgxpool.ParseConfig(connString)
+	if err != nil {
+		return nil, fmt.Errorf("parsing Clair DB connection string: %w", err)
+	}
+	cfg.ConnConfig.RuntimeParams["application_name"] = "clair-adapter-importer"
+
+	var pool *pgxpool.Pool
+	for attempt := 1; attempt <= 30; attempt++ {
+		pool, err = pgxpool.NewWithConfig(ctx, cfg)
+		if err == nil {
+			if err = pool.Ping(ctx); err == nil {
+				break
+			}
+			pool.Close()
+		}
+		slog.WarnContext(ctx, "waiting for Clair database", "attempt", attempt, "error", err)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(10 * time.Second):
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Clair database after 30 attempts: %w", err)
+	}
+
+	// Wait for Clair's tables to exist (Clair runs migrations on startup).
+	for attempt := 1; attempt <= 30; attempt++ {
+		var exists bool
+		err = pool.QueryRow(ctx,
+			`SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'update_operation')`).Scan(&exists)
+		if err == nil && exists {
+			break
+		}
+		slog.WarnContext(ctx, "waiting for Clair schema (update_operation table)", "attempt", attempt)
+		select {
+		case <-ctx.Done():
+			pool.Close()
+			return nil, ctx.Err()
+		case <-time.After(5 * time.Second):
+		}
+	}
+
+	store, err := ccpostgres.InitPostgresMatcherStore(ctx, pool, false)
+	if err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("initializing Clair matcher store: %w", err)
+	}
+
+	return store, nil
+}

--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -181,6 +181,11 @@ var (
 	// This must be set in Scanner V4 Indexer to have any effect.
 	ScannerV4MavenSearch = registerFeature("Enables Scanner V4 to reach out to ROX_SCANNER_V4_MAVEN_SEARCH_URL for additional information about Java packages", "ROX_SCANNER_V4_MAVEN_SEARCH")
 
+	// ClairAdapter enables the Clair adapter as a drop-in replacement for Scanner V4.
+	// When enabled, Central and Sensor connect to the Clair adapter (which proxies to upstream Clair)
+	// instead of Scanner V4.
+	ClairAdapter = registerFeature("Use upstream Clair via the Clair adapter instead of Scanner V4", "ROX_CLAIR_ADAPTER")
+
 	VirtualMachines = registerFeature("Enables virtual machine management", "ROX_VIRTUAL_MACHINES")
 
 	// ScannerV4StoreExternalIndexReports enables storing index reports from delegated scans to Central's Scanner V4 Indexer.


### PR DESCRIPTION
## Description

Add the clair-adapter, a Go service that replaces Scanner V4 by delegating
container image indexing and vulnerability matching to upstream Clair while
preserving the Scanner V4 gRPC API. Central and Sensor connect to it using
the same protos, making it a drop-in replacement.

Unlike Scanner V4 (which embeds ClairCore as a Go library), the adapter
calls Clair over HTTP for indexing/matching and imports StackRox
vulnerability data directly into Clair's PostgreSQL database.

### Why

Scanner V4 tightly couples StackRox to a vendored ClairCore, making
upgrades, security patches, and feature additions slow and painful.
By delegating to upstream Clair, the adapter decouples the two
projects: Clair can be upgraded independently, and the adapter only
needs to maintain the mapping layer between Scanner V4 protos and
Clair's HTTP API.

### What

- **Clair HTTP client** wrapping Clair's indexer and matcher REST APIs
- **Proto mappers** converting between Clair JSON types and Scanner V4 protobuf (index reports, vulnerability
reports, enrichments)
- **Enrichment pipeline** with in-process CSAF, NVD, EPSS, and fixed-by enrichers (Clair lacks StackRox-specific
enricher plugins, so these run inside the adapter)
- **gRPC services** implementing `IndexerServer` and `MatcherServer` with per-RPC authorization matching Scanner
V4's access control model
- **Vulnerability data pipeline**: fetches StackRox vuln bundles from Central, unpacks them, and imports
vulnerabilities + enrichments directly into Clair's PostgreSQL via ClairCore's `MatcherStore`
- **Registry interaction** for fetching image manifests/layers with auth transport and retry
- **Manifest GC manager** for lifecycle tracking
- **mTLS** using `pkg/grpc` framework with dual-identity certificates (indexer + matcher)
- **Feature flag** `ClairAdapter` gating all functionality
- **Deploy script** for local development (builds image, generates TLS certs, patches Scanner V4 services to
route to the adapter)
- Documentation: README, feature status/gap analysis, local testing guide, vulnerability pipeline docs

### Alternatives considered

- **Forking ClairCore**: Would let us stay in-process but means maintaining a fork indefinitely. The whole point
is to stop doing that.
- **Sidecar pattern**: Running Clair as a sidecar next to Scanner V4. Rejected because it doesn't simplify the
data pipeline or remove the ClairCore dependency.

### Limitations

4 of 10 Scanner V4 RPCs are not implemented (`StoreIndexReport`, `GetRepositoryToCPEMapping`, `GetSBOM`,
`ScanSBOM`); they return `Unimplemented`. These are not used in the primary scan flow.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
