### PR TITLE
ROX-30172: Fix operator-index multi platform build

### DIFF
--- a/.tekton/operator-index-build.yaml
+++ b/.tekton/operator-index-build.yaml
@@ -427,12 +427,14 @@ spec:
         value: ["$(params.extra-labels[*])"]
       - name: BUILDAH_FORMAT
         value: $(params.buildah-format)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.10@sha256:85102e448619f65a1fb7d4512660f8ec05677f99b724f1f838e1964545d7c857
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.10@sha256:41f3f361785550b378b50b8ce42870092026ae413c723c738c496a75587eff82
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Operator-index build platform build is incorrectly configured in a way that all builds actually build for `x86_64`.
Here is an example of [ppc64 platform](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/operator-index-on-push-cs5rd-build-images-2) build: 
But if check this image:
```
oc image info quay.io/rhacs-eng/stackrox-operator-index:v4.12.0-96-g40f6647d5f-fast@sha256:a1542ed5ea9f192e2d0fc1b0a2cffe55b3f8396822f7b48cb3556201d59f0f7e | grep -i arch
Arch:        amd64
Labels:      architecture=x86_64
```
The [task logs also ](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-acs-tenant/applications/acs/taskruns/operator-index-on-push-cs5rd-build-images-2/logs)says `\"architecture\"=\"x86_64\"`
The same issue with other paltforms.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

The [b4748c4](https://github.com/stackrox/stackrox/pull/20994/commits/b4748c4786aec17cc9ee220d98639c35f2a86ff8) now gives this image:

```
oc image info quay.io/rhacs-eng/stackrox-operator-index:v4.12.0-100-gb4748c4786-fast-linux-ppc64le@sha256:cf10aa71c3e3446f2de96a52f3a36bdeab5a642d0395e2e7cb7b6139f4e32992 | grep -i arch
Arch:        ppc64le
Labels:      architecture=ppc64le
```