### PR TITLE
ROX-34929: Dedupe Scanner V4 Packages and Vulns

### DIFF
--- a/pkg/features/list.go
+++ b/pkg/features/list.go
@@ -194,4 +194,7 @@ var (
 
 	// ScannerV4RedHatVEXNotAffected enables filtering image vulnerabilities using Red Hat VEX known_not_affected assertions.
 	ScannerV4RedHatVEXNotAffected = registerFeature("Scanner V4 will filter image vulnerabilities using Red Hat VEX known_not_affected assertions", "ROX_SCANNER_V4_RED_HAT_VEX_NOT_AFFECTED")
+
+	// ScannerV4Dedupe de-duplicates packages and vulnerabilities from appearing in scan results.
+	ScannerV4Dedupe = registerFeature("Deduplicate packages and vulnerabilities found in Scanner V4 results.", "ROX_SCANNER_V4_DEDUPE")
 )

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -699,10 +699,10 @@ func compareFixVersions(a, b, pkgFixedBy string) int {
 
 // applyFixFields overwrites fix-related fields on dst from src.
 func applyFixFields(dst, src *storage.EmbeddedVulnerability) {
-	dst.Advisory = src.Advisory
-	dst.Datasource = src.Datasource
-	dst.FixAvailableTimestamp = src.FixAvailableTimestamp
-	dst.SetFixedBy = src.SetFixedBy
+	dst.Advisory = src.GetAdvisory()
+	dst.Datasource = src.GetDatasource()
+	dst.FixAvailableTimestamp = src.GetFixAvailableTimestamp()
+	dst.SetFixedBy = src.GetSetFixedBy()
 }
 
 // compareNumericSegments compares two strings by extracting their numeric
@@ -737,15 +737,15 @@ func mergeScoringFields(dst, src *storage.EmbeddedVulnerability) {
 		return
 	}
 
-	dst.Summary = src.Summary
-	dst.Severity = src.Severity
-	dst.CvssV2 = src.CvssV2
-	dst.CvssV3 = src.CvssV3
-	dst.Cvss = src.Cvss
-	dst.ScoreVersion = src.ScoreVersion
-	dst.CvssMetrics = src.CvssMetrics
-	dst.NvdCvss = src.NvdCvss
-	dst.Link = src.Link
-	dst.PublishedOn = src.PublishedOn
-	dst.Epss = src.Epss
+	dst.Summary = src.GetSummary()
+	dst.Severity = src.GetSeverity()
+	dst.CvssV2 = src.GetCvssV2()
+	dst.CvssV3 = src.GetCvssV3()
+	dst.Cvss = src.GetCvss()
+	dst.ScoreVersion = src.GetScoreVersion()
+	dst.CvssMetrics = src.GetCvssMetrics()
+	dst.NvdCvss = src.GetNvdCvss()
+	dst.Link = src.GetLink()
+	dst.PublishedOn = src.GetPublishedOn()
+	dst.Epss = src.GetEpss()
 }

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -651,12 +651,12 @@ func notes(report *v4.VulnerabilityReport) []storage.ImageScan_Note {
 }
 
 // mergeFixFields overwrites fix-related fields on dst when src has more
-// recent or more complete fix data. Priority: later advisory, has fix over
+// recent or more complete fix data. Priority: later fix date, has fix over
 // doesn't, matches package-level fix version, higher version by numeric
 // comparison.
 func mergeFixFields(dst, src *storage.EmbeddedVulnerability, pkgFixedByVersion string) {
 	c := cmp.Or(
-		compareAdvisories(src.GetAdvisory(), dst.GetAdvisory()),
+		protocompat.CompareTimestamps(src.GetFixAvailableTimestamp(), dst.GetFixAvailableTimestamp()),
 		compareFixVersions(src.GetFixedBy(), dst.GetFixedBy(), pkgFixedByVersion),
 	)
 	if c > 0 {
@@ -751,19 +751,4 @@ func mergeScoringFields(dst, src *storage.EmbeddedVulnerability) {
 	dst.Link = src.Link
 	dst.PublishedOn = src.PublishedOn
 	dst.Epss = src.Epss
-}
-
-// compareAdvisories compares two advisories by their numeric segments.
-// Nil is less than non-nil.
-func compareAdvisories(a, b *storage.Advisory) int {
-	if a == nil && b == nil {
-		return 0
-	}
-	if a == nil {
-		return -1
-	}
-	if b == nil {
-		return 1
-	}
-	return compareNumericSegments(a.GetName(), b.GetName())
 }

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -699,12 +699,11 @@ func applyFixFields(dst *storage.EmbeddedVulnerability, src *v4.VulnerabilityRep
 	dst.Advisory = srcAdv
 	dst.Datasource = vulnDataSource(src, envOS)
 	dst.FixAvailableTimestamp = src.GetFixedDate()
+	dst.SetFixedBy = nil
 	if fix := src.GetFixedInVersion(); fix != "" {
 		dst.SetFixedBy = &storage.EmbeddedVulnerability_FixedBy{
 			FixedBy: fix,
 		}
-	} else {
-		dst.SetFixedBy = nil
 	}
 }
 

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -1,7 +1,11 @@
 package scannerv4
 
 import (
+	"cmp"
 	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
 	"strings"
 
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
@@ -21,6 +25,9 @@ import (
 // IMPORTANT: This delimiter was chosen because it does not appear in any known
 // Claircore or StackRox updater names.
 const vulnDataSourceDelimiter = "::"
+
+// digitSegment matches contiguous runs of digits for numeric segment comparisons.
+var digitSegment = regexp.MustCompile(`\d+`)
 
 func imageScan(metadata *storage.ImageMetadata, report *v4.VulnerabilityReport, scannerVersion string) *storage.ImageScan {
 	layerSHAToIndex := clair.BuildSHAToIndexMap(metadata)
@@ -48,8 +55,37 @@ func componentsWithLayerMap(metadata *storage.ImageMetadata, report *v4.Vulnerab
 			pkgs[pkg.GetId()] = pkg
 		}
 	}
+	// Filter out non-binary packages that should not become user-facing components:
+	// - "ancestry" packages carry VEX suppression metadata only.
+	// - "source" packages already referenced by a binary are redundant since the
+	//   binary's vulnerability findings are a superset of its source's.
+	// Unreferenced source packages are kept defensively.
+	dedupe := features.ScannerV4Dedupe.Enabled()
+	var referencedSourceIDs set.StringSet
+	if dedupe {
+		referencedSourceIDs = set.NewStringSet()
+		for _, pkg := range pkgs {
+			if pkg.GetKind() != "binary" {
+				continue
+			}
+			if srcID := pkg.GetSource().GetId(); srcID != "" {
+				referencedSourceIDs.Add(srcID)
+			}
+		}
+	}
+
 	components := make([]*storage.EmbeddedImageScanComponent, 0, len(pkgs))
 	for id, pkg := range pkgs {
+		if dedupe {
+			switch pkg.GetKind() {
+			case "ancestry":
+				continue
+			case "source":
+				if referencedSourceIDs.Contains(id) {
+					continue
+				}
+			}
+		}
 		vulnIDs := report.GetPackageVulnerabilities()[id].GetValues()
 
 		var (
@@ -67,7 +103,7 @@ func componentsWithLayerMap(metadata *storage.ImageMetadata, report *v4.Vulnerab
 			Name:         pkg.GetName(),
 			Version:      pkg.GetVersion(),
 			Architecture: pkg.GetArch(),
-			Vulns:        vulnerabilities(report.GetVulnerabilities(), vulnIDs, envOS(env, report)),
+			Vulns:        vulnerabilities(report.GetVulnerabilities(), vulnIDs, envOS(env, report), pkg.GetFixedInVersion()),
 			FixedBy:      pkg.GetFixedInVersion(),
 			Source:       source,
 			Location:     location,
@@ -177,13 +213,20 @@ func layerIndex(layerSHAToIndex map[string]int32, env *v4.Environment) *storage.
 	}
 }
 
-func vulnerabilities(vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerability, ids []string, envOS string) []*storage.EmbeddedVulnerability {
+func vulnerabilities(vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerability, ids []string, envOS string, pkgFixedByVersion string) []*storage.EmbeddedVulnerability {
 	if len(vulnerabilities) == 0 || len(ids) == 0 {
 		return nil
 	}
 
+	dedupe := features.ScannerV4Dedupe.Enabled()
+
 	vulns := make([]*storage.EmbeddedVulnerability, 0, len(ids))
 	uniqueVulns := set.NewStringSet()
+	var cveNameToIdx map[string]int
+	if dedupe {
+		cveNameToIdx = make(map[string]int, len(ids))
+	}
+
 	for _, id := range ids {
 		if !uniqueVulns.Add(id) {
 			// Already saw this vulnerability, so ignore it.
@@ -196,36 +239,54 @@ func vulnerabilities(vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerab
 			continue
 		}
 
-		// TODO(ROX-20355): Populate last modified once the API is available.
-		vuln := &storage.EmbeddedVulnerability{
-			Cve:      ccVuln.GetName(),
-			Advisory: advisory(ccVuln.GetAdvisory()),
-			Summary:  ccVuln.GetDescription(),
-			// TODO(ROX-26547)
-			// The link field will be overwritten if preferred CVSS source is available
-			Link:        link(ccVuln.GetLink()),
-			PublishedOn: ccVuln.GetIssued(),
-			// LastModified: ,
-			VulnerabilityType:     storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
-			Severity:              normalizedSeverity(ccVuln.GetNormalizedSeverity()),
-			Epss:                  epss(ccVuln.GetEpssMetrics()),
-			FixAvailableTimestamp: ccVuln.GetFixedDate(),
-			Datasource:            vulnDataSource(ccVuln, envOS),
-		}
-		if err := setScoresAndScoreVersions(vuln, ccVuln.GetCvssMetrics()); err != nil {
-			utils.Should(err)
-		}
-		maybeOverwriteSeverity(vuln)
-		if ccVuln.GetFixedInVersion() != "" {
-			vuln.SetFixedBy = &storage.EmbeddedVulnerability_FixedBy{
-				FixedBy: ccVuln.GetFixedInVersion(),
+		name := ccVuln.GetName()
+
+		// Multiple Scanner V4 vulns from different sources can share the
+		// same CVE identifier. Merge duplicates into a single entry.
+		if dedupe && name != "" {
+			if idx, exists := cveNameToIdx[name]; exists {
+				mergeFixFields(vulns[idx], ccVuln, envOS, pkgFixedByVersion)
+				mergeScoringFields(vulns[idx], ccVuln)
+				continue
 			}
+			cveNameToIdx[name] = len(vulns)
 		}
 
-		vulns = append(vulns, vuln)
+		vulns = append(vulns, buildEmbeddedVulnerability(ccVuln, envOS))
 	}
 
 	return vulns
+}
+
+// buildEmbeddedVulnerability converts a single v4 vulnerability into its
+// storage representation, populating all fields from the v4 source.
+func buildEmbeddedVulnerability(ccVuln *v4.VulnerabilityReport_Vulnerability, envOS string) *storage.EmbeddedVulnerability {
+	// TODO(ROX-20355): Populate last modified once the API is available.
+	vuln := &storage.EmbeddedVulnerability{
+		Cve:      ccVuln.GetName(),
+		Advisory: advisory(ccVuln.GetAdvisory()),
+		Summary:  ccVuln.GetDescription(),
+		// TODO(ROX-26547)
+		// The link field will be overwritten if preferred CVSS source is available
+		Link:        link(ccVuln.GetLink()),
+		PublishedOn: ccVuln.GetIssued(),
+		// LastModified: ,
+		VulnerabilityType:     storage.EmbeddedVulnerability_IMAGE_VULNERABILITY,
+		Severity:              normalizedSeverity(ccVuln.GetNormalizedSeverity()),
+		Epss:                  epss(ccVuln.GetEpssMetrics()),
+		FixAvailableTimestamp: ccVuln.GetFixedDate(),
+		Datasource:            vulnDataSource(ccVuln, envOS),
+	}
+	if err := setScoresAndScoreVersions(vuln, ccVuln.GetCvssMetrics()); err != nil {
+		utils.Should(err)
+	}
+	maybeOverwriteSeverity(vuln)
+	if ccVuln.GetFixedInVersion() != "" {
+		vuln.SetFixedBy = &storage.EmbeddedVulnerability_FixedBy{
+			FixedBy: ccVuln.GetFixedInVersion(),
+		}
+	}
+	return vuln
 }
 
 // vulnDataSource builds a string that uniquely identifies a vulnerability's datasource.
@@ -586,4 +647,144 @@ func notes(report *v4.VulnerabilityReport) []storage.ImageScan_Note {
 	}
 
 	return notes
+}
+
+// mergeFixFields overwrites fix-related fields on dst when src has more
+// recent or more complete fix data. Priority: later advisory, has fix over
+// doesn't, matches package-level fix version, higher version by numeric
+// comparison.
+func mergeFixFields(dst *storage.EmbeddedVulnerability, src *v4.VulnerabilityReport_Vulnerability, envOS, pkgFixedByVersion string) {
+	srcAdv := advisory(src.GetAdvisory())
+	c := cmp.Or(
+		compareAdvisories(srcAdv, dst.GetAdvisory()),
+		compareFixVersions(src.GetFixedInVersion(), dst.GetFixedBy(), pkgFixedByVersion),
+	)
+	if c > 0 {
+		applyFixFields(dst, src, srcAdv, envOS)
+	}
+}
+
+// compareFixVersions returns positive when a represents a more complete or
+// higher fix version than b. Priority: having a fix over not, matching
+// pkgFixedBy, higher version by numeric comparison.
+func compareFixVersions(a, b, pkgFixedBy string) int {
+	aHasFix, bHasFix := a != "", b != ""
+	if aHasFix != bHasFix {
+		if aHasFix {
+			return 1
+		}
+		return -1
+	}
+	if !aHasFix {
+		return 0
+	}
+	if pkgFixedBy != "" && (a == pkgFixedBy) != (b == pkgFixedBy) {
+		if a == pkgFixedBy {
+			return 1
+		}
+		return -1
+	}
+	// Reaching here means both have a fix, neither matches pkgFixedBy (or it
+	// is empty), and the versions disagree. This is rare — it requires two
+	// sources to report different fix versions for the same CVE. Use a
+	// deterministic numeric comparison so the result is stable across runs.
+	if a != b {
+		return compareNumericSegments(a, b)
+	}
+	return 0
+}
+
+// applyFixFields overwrites fix-related fields on dst from src.
+func applyFixFields(dst *storage.EmbeddedVulnerability, src *v4.VulnerabilityReport_Vulnerability, srcAdv *storage.Advisory, envOS string) {
+	dst.Advisory = srcAdv
+	dst.Datasource = vulnDataSource(src, envOS)
+	dst.FixAvailableTimestamp = src.GetFixedDate()
+	if fix := src.GetFixedInVersion(); fix != "" {
+		dst.SetFixedBy = &storage.EmbeddedVulnerability_FixedBy{
+			FixedBy: fix,
+		}
+	} else {
+		dst.SetFixedBy = nil
+	}
+}
+
+// compareNumericSegments compares two strings by extracting their numeric
+// segments and comparing left-to-right, falling back to lexicographic order.
+func compareNumericSegments(a, b string) int {
+	if c := slices.Compare(splitVersionNumbers(a), splitVersionNumbers(b)); c != 0 {
+		return c
+	}
+	return cmp.Compare(a, b)
+}
+
+func splitVersionNumbers(v string) []int {
+	matches := digitSegment.FindAllString(v, -1)
+	nums := make([]int, 0, len(matches))
+	for _, m := range matches {
+		n, _ := strconv.Atoi(m)
+		nums = append(nums, n)
+	}
+	return nums
+}
+
+// mergeScoringFields overwrites scoring-related fields on dst when src has more
+// complete or higher-severity scoring data. Priority: more CVSS metrics, higher
+// severity, higher CVSS base score.
+func mergeScoringFields(dst *storage.EmbeddedVulnerability, src *v4.VulnerabilityReport_Vulnerability) {
+	c := cmp.Or(
+		cmp.Compare(len(src.GetCvssMetrics()), len(dst.GetCvssMetrics())),
+		cmp.Compare(normalizedSeverity(src.GetNormalizedSeverity()), dst.GetSeverity()),
+		cmp.Compare(v4BaseScore(src.GetCvssMetrics()), dst.GetCvss()),
+	)
+	if c <= 0 {
+		return
+	}
+
+	dst.Summary = src.GetDescription()
+	dst.Severity = normalizedSeverity(src.GetNormalizedSeverity())
+	dst.CvssV2 = nil
+	dst.CvssV3 = nil
+	dst.Cvss = 0
+	dst.ScoreVersion = 0
+	dst.CvssMetrics = nil
+	dst.NvdCvss = 0
+	dst.Link = link(src.GetLink())
+	dst.PublishedOn = src.GetIssued()
+	if err := setScoresAndScoreVersions(dst, src.GetCvssMetrics()); err != nil {
+		utils.Should(err)
+	}
+	maybeOverwriteSeverity(dst)
+	dst.Epss = epss(src.GetEpssMetrics())
+}
+
+// compareAdvisories compares two advisories by their numeric segments.
+// Nil is less than non-nil.
+func compareAdvisories(a, b *storage.Advisory) int {
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil {
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+	return compareNumericSegments(a.GetName(), b.GetName())
+}
+
+// v4BaseScore returns the base score from the preferred CVSS metric entry.
+// The preferred entry is always at index 0 — this ordering is guaranteed by
+// the mapper that builds the v4 proto (see baseScore in mappers.go).
+func v4BaseScore(metrics []*v4.VulnerabilityReport_Vulnerability_CVSS) float32 {
+	if len(metrics) == 0 {
+		return 0
+	}
+	m := metrics[0]
+	if v3 := m.GetV3(); v3 != nil {
+		return v3.GetBaseScore()
+	}
+	if v2 := m.GetV2(); v2 != nil {
+		return v2.GetBaseScore()
+	}
+	return 0
 }

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -55,10 +55,7 @@ func componentsWithLayerMap(metadata *storage.ImageMetadata, report *v4.Vulnerab
 			pkgs[pkg.GetId()] = pkg
 		}
 	}
-	// Filter out non-binary packages that should not become user-facing components:
-	// - "ancestry" packages carry VEX suppression metadata only.
-	// - "source" packages already referenced by a binary are redundant since the
-	//   binary's vulnerability findings are a superset of its source's.
+	// Filter out packages that should not become user-facing components.
 	// Unreferenced source packages are kept defensively.
 	dedupe := features.ScannerV4Dedupe.Enabled()
 	var referencedSourceIDs set.StringSet

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -245,8 +245,9 @@ func vulnerabilities(vulnerabilities map[string]*v4.VulnerabilityReport_Vulnerab
 		// same CVE identifier. Merge duplicates into a single entry.
 		if dedupe && name != "" {
 			if idx, exists := cveNameToIdx[name]; exists {
-				mergeFixFields(vulns[idx], ccVuln, envOS, pkgFixedByVersion)
-				mergeScoringFields(vulns[idx], ccVuln)
+				candidate := buildEmbeddedVulnerability(ccVuln, envOS)
+				mergeFixFields(vulns[idx], candidate, pkgFixedByVersion)
+				mergeScoringFields(vulns[idx], candidate)
 				continue
 			}
 			cveNameToIdx[name] = len(vulns)
@@ -653,14 +654,13 @@ func notes(report *v4.VulnerabilityReport) []storage.ImageScan_Note {
 // recent or more complete fix data. Priority: later advisory, has fix over
 // doesn't, matches package-level fix version, higher version by numeric
 // comparison.
-func mergeFixFields(dst *storage.EmbeddedVulnerability, src *v4.VulnerabilityReport_Vulnerability, envOS, pkgFixedByVersion string) {
-	srcAdv := advisory(src.GetAdvisory())
+func mergeFixFields(dst, src *storage.EmbeddedVulnerability, pkgFixedByVersion string) {
 	c := cmp.Or(
-		compareAdvisories(srcAdv, dst.GetAdvisory()),
-		compareFixVersions(src.GetFixedInVersion(), dst.GetFixedBy(), pkgFixedByVersion),
+		compareAdvisories(src.GetAdvisory(), dst.GetAdvisory()),
+		compareFixVersions(src.GetFixedBy(), dst.GetFixedBy(), pkgFixedByVersion),
 	)
 	if c > 0 {
-		applyFixFields(dst, src, srcAdv, envOS)
+		applyFixFields(dst, src)
 	}
 }
 
@@ -695,16 +695,11 @@ func compareFixVersions(a, b, pkgFixedBy string) int {
 }
 
 // applyFixFields overwrites fix-related fields on dst from src.
-func applyFixFields(dst *storage.EmbeddedVulnerability, src *v4.VulnerabilityReport_Vulnerability, srcAdv *storage.Advisory, envOS string) {
-	dst.Advisory = srcAdv
-	dst.Datasource = vulnDataSource(src, envOS)
-	dst.FixAvailableTimestamp = src.GetFixedDate()
-	dst.SetFixedBy = nil
-	if fix := src.GetFixedInVersion(); fix != "" {
-		dst.SetFixedBy = &storage.EmbeddedVulnerability_FixedBy{
-			FixedBy: fix,
-		}
-	}
+func applyFixFields(dst, src *storage.EmbeddedVulnerability) {
+	dst.Advisory = src.Advisory
+	dst.Datasource = src.Datasource
+	dst.FixAvailableTimestamp = src.FixAvailableTimestamp
+	dst.SetFixedBy = src.SetFixedBy
 }
 
 // compareNumericSegments compares two strings by extracting their numeric
@@ -729,31 +724,27 @@ func splitVersionNumbers(v string) []int {
 // mergeScoringFields overwrites scoring-related fields on dst when src has more
 // complete or higher-severity scoring data. Priority: more CVSS metrics, higher
 // severity, higher CVSS base score.
-func mergeScoringFields(dst *storage.EmbeddedVulnerability, src *v4.VulnerabilityReport_Vulnerability) {
+func mergeScoringFields(dst, src *storage.EmbeddedVulnerability) {
 	c := cmp.Or(
 		cmp.Compare(len(src.GetCvssMetrics()), len(dst.GetCvssMetrics())),
-		cmp.Compare(normalizedSeverity(src.GetNormalizedSeverity()), dst.GetSeverity()),
-		cmp.Compare(v4BaseScore(src.GetCvssMetrics()), dst.GetCvss()),
+		cmp.Compare(src.GetSeverity(), dst.GetSeverity()),
+		cmp.Compare(src.GetCvss(), dst.GetCvss()),
 	)
 	if c <= 0 {
 		return
 	}
 
-	dst.Summary = src.GetDescription()
-	dst.Severity = normalizedSeverity(src.GetNormalizedSeverity())
-	dst.CvssV2 = nil
-	dst.CvssV3 = nil
-	dst.Cvss = 0
-	dst.ScoreVersion = 0
-	dst.CvssMetrics = nil
-	dst.NvdCvss = 0
-	dst.Link = link(src.GetLink())
-	dst.PublishedOn = src.GetIssued()
-	if err := setScoresAndScoreVersions(dst, src.GetCvssMetrics()); err != nil {
-		utils.Should(err)
-	}
-	maybeOverwriteSeverity(dst)
-	dst.Epss = epss(src.GetEpssMetrics())
+	dst.Summary = src.Summary
+	dst.Severity = src.Severity
+	dst.CvssV2 = src.CvssV2
+	dst.CvssV3 = src.CvssV3
+	dst.Cvss = src.Cvss
+	dst.ScoreVersion = src.ScoreVersion
+	dst.CvssMetrics = src.CvssMetrics
+	dst.NvdCvss = src.NvdCvss
+	dst.Link = src.Link
+	dst.PublishedOn = src.PublishedOn
+	dst.Epss = src.Epss
 }
 
 // compareAdvisories compares two advisories by their numeric segments.
@@ -769,21 +760,4 @@ func compareAdvisories(a, b *storage.Advisory) int {
 		return 1
 	}
 	return compareNumericSegments(a.GetName(), b.GetName())
-}
-
-// v4BaseScore returns the base score from the preferred CVSS metric entry.
-// The preferred entry is always at index 0 — this ordering is guaranteed by
-// the mapper that builds the v4 proto (see baseScore in mappers.go).
-func v4BaseScore(metrics []*v4.VulnerabilityReport_Vulnerability_CVSS) float32 {
-	if len(metrics) == 0 {
-		return 0
-	}
-	m := metrics[0]
-	if v3 := m.GetV3(); v3 != nil {
-		return v3.GetBaseScore()
-	}
-	if v2 := m.GetV2(); v2 != nil {
-		return v2.GetBaseScore()
-	}
-	return 0
 }

--- a/pkg/scanners/scannerv4/convert.go
+++ b/pkg/scanners/scannerv4/convert.go
@@ -689,7 +689,13 @@ func compareFixVersions(a, b, pkgFixedBy string) int {
 	// sources to report different fix versions for the same CVE. Use a
 	// deterministic numeric comparison so the result is stable across runs.
 	if a != b {
-		return compareNumericSegments(a, b)
+		c := compareNumericSegments(a, b)
+		winner := a
+		if c < 0 {
+			winner = b
+		}
+		log.Debugf("fix version mismatch during dedup: %q vs %q, picking %q via numeric comparison", a, b, winner)
+		return c
 	}
 	return 0
 }

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -8,8 +8,10 @@ import (
 	v4 "github.com/stackrox/rox/generated/internalapi/scanner/v4"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/clair"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/protocompat"
+	"github.com/stackrox/rox/pkg/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -313,6 +315,7 @@ func TestConvert(t *testing.T) {
 func TestComponents(t *testing.T) {
 	testcases := []struct {
 		name     string
+		dedupe   bool
 		metadata *storage.ImageMetadata
 		report   *v4.VulnerabilityReport
 		expected []*storage.EmbeddedImageScanComponent
@@ -555,9 +558,220 @@ func TestComponents(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "RHCC source+binary+ancestry kept without dedupe feature flag",
+			dedupe: false,
+			metadata: &storage.ImageMetadata{
+				V1: &storage.V1Metadata{Digest: "d"},
+			},
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"src-1": {
+							Id:      "src-1",
+							Name:    "ubi9/ubi-micro",
+							Version: "1779858857",
+							Kind:    "source",
+						},
+						"bin-1": {
+							Id:      "bin-1",
+							Name:    "ubi9/ubi-micro",
+							Version: "1779858857",
+							Kind:    "binary",
+							Source:  &v4.Package{Id: "src-1", Name: "ubi9/ubi-micro", Kind: "source"},
+						},
+						"anc-1": {
+							Id:      "anc-1",
+							Name:    "ubi9/ubi-micro",
+							Version: "1779858857",
+							Kind:    "ancestry",
+							Source:  &v4.Package{Id: "src-1", Name: "ubi9/ubi-micro", Kind: "source"},
+						},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1": {Environments: []*v4.Environment{{PackageDb: "root/buildinfo/labels.json"}}},
+						"src-1": {Environments: []*v4.Environment{{PackageDb: "root/buildinfo/labels.json"}}},
+						"anc-1": {Environments: []*v4.Environment{{PackageDb: "root/buildinfo/labels.json"}}},
+					},
+				},
+			},
+			expected: []*storage.EmbeddedImageScanComponent{
+				{
+					Name:     "ubi9/ubi-micro",
+					Version:  "1779858857",
+					Source:   storage.SourceType_OS,
+					Location: "root/buildinfo/labels.json",
+				},
+				{
+					Name:     "ubi9/ubi-micro",
+					Version:  "1779858857",
+					Source:   storage.SourceType_OS,
+					Location: "root/buildinfo/labels.json",
+				},
+				{
+					Name:     "ubi9/ubi-micro",
+					Version:  "1779858857",
+					Source:   storage.SourceType_OS,
+					Location: "root/buildinfo/labels.json",
+				},
+			},
+		},
+		{
+			name:   "RHCC source+binary+ancestry only keeps binary",
+			dedupe: true,
+			metadata: &storage.ImageMetadata{
+				V1: &storage.V1Metadata{Digest: "d"},
+			},
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"src-1": {
+							Id:      "src-1",
+							Name:    "ubi9/ubi-micro",
+							Version: "1779858857",
+							Kind:    "source",
+						},
+						"bin-1": {
+							Id:      "bin-1",
+							Name:    "ubi9/ubi-micro",
+							Version: "1779858857",
+							Kind:    "binary",
+							Source:  &v4.Package{Id: "src-1", Name: "ubi9/ubi-micro", Kind: "source"},
+						},
+						"anc-1": {
+							Id:      "anc-1",
+							Name:    "ubi9/ubi-micro",
+							Version: "1779858857",
+							Kind:    "ancestry",
+							Source:  &v4.Package{Id: "src-1", Name: "ubi9/ubi-micro", Kind: "source"},
+						},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1": {Environments: []*v4.Environment{{PackageDb: "root/buildinfo/labels.json"}}},
+						"src-1": {Environments: []*v4.Environment{{PackageDb: "root/buildinfo/labels.json"}}},
+						"anc-1": {Environments: []*v4.Environment{{PackageDb: "root/buildinfo/labels.json"}}},
+					},
+				},
+			},
+			expected: []*storage.EmbeddedImageScanComponent{
+				{
+					Name:     "ubi9/ubi-micro",
+					Version:  "1779858857",
+					Source:   storage.SourceType_OS,
+					Location: "root/buildinfo/labels.json",
+				},
+			},
+		},
+		{
+			name:   "source with different name from binary is still filtered",
+			dedupe: true,
+			metadata: &storage.ImageMetadata{
+				V1: &storage.V1Metadata{Digest: "d"},
+			},
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"src-1": {
+							Id:      "src-1",
+							Name:    "rhel-els-container",
+							Version: "9.4-847",
+							Kind:    "source",
+						},
+						"bin-1": {
+							Id:      "bin-1",
+							Name:    "rhel-els",
+							Version: "9.4-847",
+							Kind:    "binary",
+							Source:  &v4.Package{Id: "src-1", Name: "rhel-els-container", Kind: "source"},
+						},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"bin-1": {Environments: []*v4.Environment{{PackageDb: "root/buildinfo/Dockerfile-rhel-els"}}},
+						"src-1": {Environments: []*v4.Environment{{PackageDb: "root/buildinfo/Dockerfile-rhel-els"}}},
+					},
+				},
+			},
+			expected: []*storage.EmbeddedImageScanComponent{
+				{
+					Name:     "rhel-els",
+					Version:  "9.4-847",
+					Source:   storage.SourceType_OS,
+					Location: "root/buildinfo/Dockerfile-rhel-els",
+				},
+			},
+		},
+		{
+			name:   "source+ancestry without binary retains source",
+			dedupe: true,
+			metadata: &storage.ImageMetadata{
+				V1: &storage.V1Metadata{Digest: "d"},
+			},
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"src-1": {
+							Id:      "src-1",
+							Name:    "ubi9/ubi-micro",
+							Version: "1779858857",
+							Kind:    "source",
+						},
+						"anc-1": {
+							Id:      "anc-1",
+							Name:    "ubi9/ubi-micro",
+							Version: "1779858857",
+							Kind:    "ancestry",
+							Source:  &v4.Package{Id: "src-1", Name: "ubi9/ubi-micro", Kind: "source"},
+						},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"src-1": {Environments: []*v4.Environment{{PackageDb: "root/buildinfo/labels.json"}}},
+						"anc-1": {Environments: []*v4.Environment{{PackageDb: "root/buildinfo/labels.json"}}},
+					},
+				},
+			},
+			expected: []*storage.EmbeddedImageScanComponent{
+				{
+					Name:     "ubi9/ubi-micro",
+					Version:  "1779858857",
+					Source:   storage.SourceType_OS,
+					Location: "root/buildinfo/labels.json",
+				},
+			},
+		},
+		{
+			name:   "standalone source package not referenced by binary is kept",
+			dedupe: true,
+			metadata: &storage.ImageMetadata{
+				V1: &storage.V1Metadata{Digest: "d"},
+			},
+			report: &v4.VulnerabilityReport{
+				Contents: &v4.Contents{
+					Packages: map[string]*v4.Package{
+						"src-1": {
+							Id:      "src-1",
+							Name:    "standalone-src",
+							Version: "1.0",
+							Kind:    "source",
+						},
+					},
+					Environments: map[string]*v4.Environment_List{
+						"src-1": {Environments: []*v4.Environment{{PackageDb: "sqlite:var/lib/rpm"}}},
+					},
+				},
+			},
+			expected: []*storage.EmbeddedImageScanComponent{
+				{
+					Name:     "standalone-src",
+					Version:  "1.0",
+					Source:   storage.SourceType_OS,
+					Location: "var/lib/rpm",
+				},
+			},
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			testutils.MustUpdateFeature(t, features.ScannerV4Dedupe, tc.dedupe)
 			got := componentsWithLayerMap(tc.metadata, tc.report, clair.BuildSHAToIndexMap(tc.metadata))
 			protoassert.SlicesEqual(t, tc.expected, got, fmt.Sprintf("expected: %+#v\ngot: %+#v", tc.expected, got))
 		})
@@ -2030,6 +2244,372 @@ func TestVulnDataSource(t *testing.T) {
 		t.Run(testcase.expected, func(t *testing.T) {
 			name := vulnDataSource(testcase.ccVuln, testcase.os)
 			assert.Equal(t, testcase.expected, name)
+		})
+	}
+}
+
+func TestVulnerabilities_DedupByCVEName(t *testing.T) {
+	testutils.MustUpdateFeature(t, features.ScannerV4Dedupe, true)
+
+	t.Run("duplicate CVEs are merged with highest severity", func(t *testing.T) {
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {
+				Id: "a", Name: "CVE-2024-1", Description: "short",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_LOW,
+				FixedInVersion:     "1.0.0",
+			},
+			"b": {
+				Id: "b", Name: "CVE-2024-1", Description: "a much longer description",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_CRITICAL,
+				FixedInVersion:     "2.0.0",
+			},
+		}
+		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "")
+		require.Len(t, got, 1)
+		assert.Equal(t, "CVE-2024-1", got[0].GetCve())
+		// Fix primary is "b" (higher fix version by best-effort comparison): fix fields from "b".
+		assert.Equal(t, "2.0.0", got[0].GetFixedBy())
+		// Advisories are the same (both nil), so summary comes from scoring
+		// primary ("b" — higher severity).
+		assert.Equal(t, "a much longer description", got[0].GetSummary())
+		assert.Equal(t, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, got[0].GetSeverity())
+	})
+
+	t.Run("RHSA merge: newer advisory wins fix fields, same scoring", func(t *testing.T) {
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {
+				Id: "a", Name: "CVE-2024-8176", Description: "stack overflow in libexpat",
+				Advisory:           &v4.VulnerabilityReport_Advisory{Name: "RHSA-2025:3531", Link: "https://access.redhat.com/errata/RHSA-2025:3531"},
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+				FixedInVersion:     "0:2.5.0-3.el9_5.3",
+				Link:               "https://access.redhat.com/security/cve/CVE-2024-8176",
+				CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
+					{
+						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_RED_HAT,
+						Url:    "https://access.redhat.com/security/cve/CVE-2024-8176",
+						V3:     &v4.VulnerabilityReport_Vulnerability_CVSS_V3{BaseScore: 7.5, Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"},
+					},
+				},
+			},
+			"b": {
+				Id: "b", Name: "CVE-2024-8176", Description: "stack overflow in libexpat",
+				Advisory:           &v4.VulnerabilityReport_Advisory{Name: "RHSA-2025:7444", Link: "https://access.redhat.com/errata/RHSA-2025:7444"},
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+				FixedInVersion:     "0:2.5.0-5.el9_6",
+				Link:               "https://access.redhat.com/security/cve/CVE-2024-8176",
+				CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
+					{
+						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_RED_HAT,
+						Url:    "https://access.redhat.com/security/cve/CVE-2024-8176",
+						V3:     &v4.VulnerabilityReport_Vulnerability_CVSS_V3{BaseScore: 7.5, Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"},
+					},
+				},
+			},
+		}
+		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "")
+		require.Len(t, got, 1)
+		assert.Equal(t, "CVE-2024-8176", got[0].GetCve())
+		assert.Equal(t, "RHSA-2025:7444", got[0].GetAdvisory().GetName())
+		assert.Equal(t, "0:2.5.0-5.el9_6", got[0].GetFixedBy())
+	})
+
+	t.Run("no advisory: more CVSS metrics wins scoring", func(t *testing.T) {
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {
+				Id: "a", Name: "CVE-2026-33997", Description: "Off-by-one error",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+				Link:               "https://osv.dev/vulnerability/GHSA-pxq6-2prw-chj9",
+				CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
+					{
+						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_OSV,
+						Url:    "https://osv.dev/vulnerability/GHSA-pxq6-2prw-chj9",
+						V3:     &v4.VulnerabilityReport_Vulnerability_CVSS_V3{BaseScore: 6.8, Vector: "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N"},
+					},
+					{
+						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
+						Url:    "https://nvd.nist.gov/vuln/detail/CVE-2026-33997",
+						V3:     &v4.VulnerabilityReport_Vulnerability_CVSS_V3{BaseScore: 8.1, Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N"},
+					},
+				},
+			},
+			"b": {
+				Id: "b", Name: "CVE-2026-33997", Description: "Off-by-one error in github.com/docker/docker",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
+				Link:               "https://nvd.nist.gov/vuln/detail/CVE-2026-33997",
+				CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
+					{
+						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
+						Url:    "https://nvd.nist.gov/vuln/detail/CVE-2026-33997",
+						V3:     &v4.VulnerabilityReport_Vulnerability_CVSS_V3{BaseScore: 8.1, Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N"},
+					},
+				},
+			},
+		}
+		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "")
+		require.Len(t, got, 1)
+		assert.Equal(t, "CVE-2026-33997", got[0].GetCve())
+		// A wins scoring (2 metrics > 1): summary, severity from A.
+		assert.Equal(t, "Off-by-one error", got[0].GetSummary())
+		assert.Len(t, got[0].GetCvssMetrics(), 2)
+	})
+
+	t.Run("no advisory: entry with fix wins over entry without", func(t *testing.T) {
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {
+				Id: "a", Name: "CVE-2026-34040", Description: "AuthZ plugin bypass",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
+				FixedInVersion:     "29.3.1",
+				Link:               "https://osv.dev/vulnerability/GHSA-x744-4wpc-v9h2",
+				CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
+					{
+						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_OSV,
+						Url:    "https://osv.dev/vulnerability/GHSA-x744-4wpc-v9h2",
+						V3:     &v4.VulnerabilityReport_Vulnerability_CVSS_V3{BaseScore: 8.8, Vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"},
+					},
+					{
+						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
+						Url:    "https://nvd.nist.gov/vuln/detail/CVE-2026-34040",
+						V3:     &v4.VulnerabilityReport_Vulnerability_CVSS_V3{BaseScore: 7.8, Vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"},
+					},
+				},
+			},
+			"b": {
+				Id: "b", Name: "CVE-2026-34040", Description: "AuthZ plugin bypass in github.com/docker/docker",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
+				Link:               "https://nvd.nist.gov/vuln/detail/CVE-2026-34040",
+				CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
+					{
+						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
+						Url:    "https://nvd.nist.gov/vuln/detail/CVE-2026-34040",
+						V3:     &v4.VulnerabilityReport_Vulnerability_CVSS_V3{BaseScore: 7.8, Vector: "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"},
+					},
+				},
+			},
+		}
+		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "")
+		require.Len(t, got, 1)
+		assert.Equal(t, "CVE-2026-34040", got[0].GetCve())
+		assert.Equal(t, "29.3.1", got[0].GetFixedBy())
+		// A wins scoring (2 metrics > 1).
+		assert.Equal(t, "AuthZ plugin bypass", got[0].GetSummary())
+		assert.Len(t, got[0].GetCvssMetrics(), 2)
+	})
+
+	t.Run("no advisory: same metric count and severity, higher CVSS base score wins", func(t *testing.T) {
+		// Same number of CVSS metrics, same severity — the higher base
+		// score breaks the tie and its scoring fields are selected.
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {
+				Id: "a", Name: "CVE-2024-9999", Description: "lower score entry",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
+				FixedInVersion:     "1.0.0",
+				Link:               "https://example.com/low",
+				CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
+					{
+						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
+						Url:    "https://nvd.nist.gov/vuln/detail/CVE-2024-9999",
+						V3:     &v4.VulnerabilityReport_Vulnerability_CVSS_V3{BaseScore: 5.9, Vector: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"},
+					},
+				},
+			},
+			"b": {
+				Id: "b", Name: "CVE-2024-9999", Description: "higher score entry",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_IMPORTANT,
+				FixedInVersion:     "1.0.0",
+				Link:               "https://example.com/high",
+				CvssMetrics: []*v4.VulnerabilityReport_Vulnerability_CVSS{
+					{
+						Source: v4.VulnerabilityReport_Vulnerability_CVSS_SOURCE_NVD,
+						Url:    "https://nvd.nist.gov/vuln/detail/CVE-2024-9999",
+						V3:     &v4.VulnerabilityReport_Vulnerability_CVSS_V3{BaseScore: 7.5, Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"},
+					},
+				},
+			},
+		}
+		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "")
+		require.Len(t, got, 1)
+		assert.Equal(t, "CVE-2024-9999", got[0].GetCve())
+		// B wins scoring (higher base score: 7.5 > 5.9).
+		assert.Equal(t, "higher score entry", got[0].GetSummary())
+		assert.InDelta(t, 7.5, got[0].GetCvss(), 0.01)
+	})
+
+	t.Run("duplicate RHSA names are deduped", func(t *testing.T) {
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {Id: "a", Name: "RHSA-2024:100"},
+			"b": {Id: "b", Name: "RHSA-2024:100"},
+		}
+		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "")
+		assert.Len(t, got, 1)
+	})
+
+	t.Run("no duplicates passes through", func(t *testing.T) {
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {Id: "a", Name: "CVE-2024-1"},
+			"b": {Id: "b", Name: "CVE-2024-2"},
+		}
+		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "")
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("feature flag off disables dedupe", func(t *testing.T) {
+		testutils.MustUpdateFeature(t, features.ScannerV4Dedupe, false)
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {Id: "a", Name: "CVE-2024-1"},
+			"b": {Id: "b", Name: "CVE-2024-1"},
+		}
+		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "")
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("higher fix version wins when all else equal", func(t *testing.T) {
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {
+				Id: "a", Name: "CVE-2024-1",
+				FixedInVersion: "1.2.3",
+			},
+			"b": {
+				Id: "b", Name: "CVE-2024-1",
+				FixedInVersion: "1.2.5",
+			},
+		}
+		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "")
+		require.Len(t, got, 1)
+		assert.Equal(t, "1.2.5", got[0].GetFixedBy())
+	})
+
+	t.Run("three duplicates merge rolling", func(t *testing.T) {
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {
+				Id: "a", Name: "CVE-2024-1",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_LOW,
+				FixedInVersion:     "1.0.0",
+			},
+			"b": {
+				Id: "b", Name: "CVE-2024-1",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_CRITICAL,
+				FixedInVersion:     "2.0.0",
+			},
+			"c": {
+				Id: "c", Name: "CVE-2024-1",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_MODERATE,
+				FixedInVersion:     "3.0.0",
+			},
+		}
+		got := vulnerabilities(vulnMap, []string{"a", "b", "c"}, "", "")
+		require.Len(t, got, 1)
+		// Scoring: "b" wins (CRITICAL > MODERATE > LOW).
+		assert.Equal(t, storage.VulnerabilitySeverity_CRITICAL_VULNERABILITY_SEVERITY, got[0].GetSeverity())
+		// Fix: "c" wins (3.0.0 > 2.0.0 > 1.0.0 by best-effort compare).
+		assert.Equal(t, "3.0.0", got[0].GetFixedBy())
+	})
+
+	t.Run("equal scoring keeps first-seen", func(t *testing.T) {
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {
+				Id: "a", Name: "CVE-2024-1", Description: "first",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_LOW,
+			},
+			"b": {
+				Id: "b", Name: "CVE-2024-1", Description: "second",
+				NormalizedSeverity: v4.VulnerabilityReport_Vulnerability_SEVERITY_LOW,
+			},
+		}
+		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "")
+		require.Len(t, got, 1)
+		// Equal scoring — first-seen ("a") keeps its summary.
+		assert.Equal(t, "first", got[0].GetSummary())
+	})
+
+	t.Run("dst fix matches pkgFixedBy, src fix does not", func(t *testing.T) {
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {
+				Id: "a", Name: "CVE-2024-1",
+				FixedInVersion: "2.0.0",
+			},
+			"b": {
+				Id: "b", Name: "CVE-2024-1",
+				FixedInVersion: "1.5.0",
+			},
+		}
+		// "a" matches pkgFixedBy, "b" does not — "a" keeps its fix.
+		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "2.0.0")
+		require.Len(t, got, 1)
+		assert.Equal(t, "2.0.0", got[0].GetFixedBy())
+	})
+
+	t.Run("advisory wins with no fix version", func(t *testing.T) {
+		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
+			"a": {
+				Id: "a", Name: "CVE-2024-1",
+				Advisory:       &v4.VulnerabilityReport_Advisory{Name: "RHSA-2024:100"},
+				FixedInVersion: "1.0.0",
+			},
+			"b": {
+				Id: "b", Name: "CVE-2024-1",
+				Advisory: &v4.VulnerabilityReport_Advisory{Name: "RHSA-2024:200"},
+			},
+		}
+		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "")
+		require.Len(t, got, 1)
+		// "b" wins on advisory — fix version is empty from "b".
+		assert.Equal(t, "RHSA-2024:200", got[0].GetAdvisory().GetName())
+		assert.Equal(t, "", got[0].GetFixedBy())
+	})
+}
+
+func TestCompareAdvisories(t *testing.T) {
+	testcases := map[string]struct {
+		a, b     *storage.Advisory
+		expected int
+	}{
+		"both nil":                    {nil, nil, 0},
+		"a nil":                       {nil, &storage.Advisory{Name: "RHSA-2024:100"}, -1},
+		"b nil":                       {&storage.Advisory{Name: "RHSA-2024:100"}, nil, 1},
+		"same":                        {&storage.Advisory{Name: "RHSA-2024:100"}, &storage.Advisory{Name: "RHSA-2024:100"}, 0},
+		"same year different number":  {&storage.Advisory{Name: "RHSA-2024:100"}, &storage.Advisory{Name: "RHSA-2024:200"}, -1},
+		"same year numeric not lex":   {&storage.Advisory{Name: "RHSA-2024:100"}, &storage.Advisory{Name: "RHSA-2024:90"}, 1},
+		"different years":             {&storage.Advisory{Name: "RHSA-2023:500"}, &storage.Advisory{Name: "RHSA-2024:100"}, -1},
+		"parseable year over not":     {&storage.Advisory{Name: "RHSA-2024:100"}, &storage.Advisory{Name: "some-advisory"}, 1},
+		"neither parseable lex order": {&storage.Advisory{Name: "AAA-advisory"}, &storage.Advisory{Name: "ZZZ-advisory"}, -1},
+	}
+	for name, tt := range testcases {
+		t.Run(name, func(t *testing.T) {
+			got := compareAdvisories(tt.a, tt.b)
+			assert.Equal(t, tt.expected, got)
+			reverse := compareAdvisories(tt.b, tt.a)
+			assert.Equal(t, -tt.expected, reverse)
+		})
+	}
+}
+
+func TestCompareNumericSegments(t *testing.T) {
+	testcases := map[string]struct {
+		a, b     string
+		expected int
+	}{
+		"equal":                            {"1.2.3", "1.2.3", 0},
+		"semver less":                      {"1.2.3", "1.2.5", -1},
+		"semver greater":                   {"2.0.0", "1.9.9", 1},
+		"major differs":                    {"1.0.0", "2.0.0", -1},
+		"rpm style":                        {"0:1.2.3-4.el8", "0:1.2.3-5.el8", -1},
+		"rpm epoch differs":                {"0:1.2.3-4.el8", "1:1.2.3-4.el8", -1},
+		"longer version wins":              {"1.2.3", "1.2.3.1", -1},
+		"shorter version loses":            {"1.2.3.1", "1.2.3", 1},
+		"debian style":                     {"1.2.3-4ubuntu5", "1.2.3-4ubuntu6", -1},
+		"same numeric diff suffix":         {"1.2.3-alpha", "1.2.3-beta", -1},
+		"more segments but smaller values": {"0.0.0.0.1", "1.0.0", -1},
+		"fewer segments but larger values": {"2.0", "1.9.9.9.9", 1},
+		"empty equal":                      {"", "", 0},
+	}
+	for name, tt := range testcases {
+		t.Run(name, func(t *testing.T) {
+			got := compareNumericSegments(tt.a, tt.b)
+			assert.Equal(t, tt.expected, got)
+			if tt.expected != 0 {
+				reverse := compareNumericSegments(tt.b, tt.a)
+				assert.Equal(t, -tt.expected, reverse)
+			}
 		})
 	}
 }

--- a/pkg/scanners/scannerv4/convert_test.go
+++ b/pkg/scanners/scannerv4/convert_test.go
@@ -2538,49 +2538,28 @@ func TestVulnerabilities_DedupByCVEName(t *testing.T) {
 		assert.Equal(t, "2.0.0", got[0].GetFixedBy())
 	})
 
-	t.Run("advisory wins with no fix version", func(t *testing.T) {
+	t.Run("later fix date wins with no fix version", func(t *testing.T) {
+		earlier := protocompat.GetProtoTimestampFromSeconds(1700000000)
+		later := protocompat.GetProtoTimestampFromSeconds(1710000000)
 		vulnMap := map[string]*v4.VulnerabilityReport_Vulnerability{
 			"a": {
 				Id: "a", Name: "CVE-2024-1",
 				Advisory:       &v4.VulnerabilityReport_Advisory{Name: "RHSA-2024:100"},
 				FixedInVersion: "1.0.0",
+				FixedDate:      earlier,
 			},
 			"b": {
 				Id: "b", Name: "CVE-2024-1",
-				Advisory: &v4.VulnerabilityReport_Advisory{Name: "RHSA-2024:200"},
+				Advisory:  &v4.VulnerabilityReport_Advisory{Name: "RHSA-2024:200"},
+				FixedDate: later,
 			},
 		}
 		got := vulnerabilities(vulnMap, []string{"a", "b"}, "", "")
 		require.Len(t, got, 1)
-		// "b" wins on advisory — fix version is empty from "b".
+		// "b" wins on fix date — fix version is empty from "b".
 		assert.Equal(t, "RHSA-2024:200", got[0].GetAdvisory().GetName())
 		assert.Equal(t, "", got[0].GetFixedBy())
 	})
-}
-
-func TestCompareAdvisories(t *testing.T) {
-	testcases := map[string]struct {
-		a, b     *storage.Advisory
-		expected int
-	}{
-		"both nil":                    {nil, nil, 0},
-		"a nil":                       {nil, &storage.Advisory{Name: "RHSA-2024:100"}, -1},
-		"b nil":                       {&storage.Advisory{Name: "RHSA-2024:100"}, nil, 1},
-		"same":                        {&storage.Advisory{Name: "RHSA-2024:100"}, &storage.Advisory{Name: "RHSA-2024:100"}, 0},
-		"same year different number":  {&storage.Advisory{Name: "RHSA-2024:100"}, &storage.Advisory{Name: "RHSA-2024:200"}, -1},
-		"same year numeric not lex":   {&storage.Advisory{Name: "RHSA-2024:100"}, &storage.Advisory{Name: "RHSA-2024:90"}, 1},
-		"different years":             {&storage.Advisory{Name: "RHSA-2023:500"}, &storage.Advisory{Name: "RHSA-2024:100"}, -1},
-		"parseable year over not":     {&storage.Advisory{Name: "RHSA-2024:100"}, &storage.Advisory{Name: "some-advisory"}, 1},
-		"neither parseable lex order": {&storage.Advisory{Name: "AAA-advisory"}, &storage.Advisory{Name: "ZZZ-advisory"}, -1},
-	}
-	for name, tt := range testcases {
-		t.Run(name, func(t *testing.T) {
-			got := compareAdvisories(tt.a, tt.b)
-			assert.Equal(t, tt.expected, got)
-			reverse := compareAdvisories(tt.b, tt.a)
-			assert.Equal(t, -tt.expected, reverse)
-		})
-	}
 }
 
 func TestCompareNumericSegments(t *testing.T) {

--- a/pkg/scanners/scannerv4/vm_convert.go
+++ b/pkg/scanners/scannerv4/vm_convert.go
@@ -82,7 +82,7 @@ func toVirtualMachineScanComponentVulnerabilities(
 	vulnerabilitiesByID map[string]*v4.VulnerabilityReport_Vulnerability,
 	vulnerabilityIDs []string,
 ) []*storage.VirtualMachineVulnerability {
-	embeddedVulns := vulnerabilities(vulnerabilitiesByID, vulnerabilityIDs, "")
+	embeddedVulns := vulnerabilities(vulnerabilitiesByID, vulnerabilityIDs, "", "")
 	result := make([]*storage.VirtualMachineVulnerability, 0, len(embeddedVulns))
 	for _, vuln := range embeddedVulns {
 		resultVuln := &storage.VirtualMachineVulnerability{


### PR DESCRIPTION
## Description

Adds logic to dedupe packages and vulnerabilities in Scanner V4 results.

The deduping logic is disabled by default because it will be backported, to enable set `ROX_SCANNER_V4_DEDUPE: true`. 

### Deduping scenarios addressed

1. Duplicate RHCC packages (one per `kind`: `source`, `binary`, `ancestry`)
   - Only one is needed.
2. Duplicate vulns where only the advisory (RHSA) differs.
   - A single CVE may be fixed by multiple RHSA's, each RHSA would yield a 'duplicate' - now only the 'latest' is kept.
3. Different perspectives for the same vuln (ie: GHSA vs. GO, PYSEC vs. GHSA, etc.)
   - Logic added to pick the most complete / actionable entry

### Placement
Originally the logic was added to `mappers.go`, was later moved to `convert.go` as it was more readable and allowed for a 'rolling' approach when modifying the vuln details. In `mappers.go`, as vulns were combined new 'synthetic' vulns had to be created and added to the `vulnerabilities` map to not break other packages that may not reference the same set of duplicates (unnecessary complexity).

### Logic
Comparing by `severity` or `CVSS` was not enough, OSV/Red Hat have priority over NVD and in various scenarios the 'lower severity' needed to be top level.

To address known duplicate scenarios and keep data actionable, fields were grouped as 'fix' related and 'scoring' related (loose), the grouped fields are kept together such that the 'fix' info may come from duplicate A and the scoring from duplicate B.


| Scoring fields | Fix fields |
|---|---|
| cvss | advisory |
| cvssV2 | fixed by |
| cvssV3 | fix avail timestamp |
| scoreVersion | |
| link | |
| published\_on | |
| last\_modified | |
| severity | |
| summary | |

<details>
<summary><b>Deduping examples from real images</b></summary>

#### Scenario 1: Duplicate RHSAs — same CVE, different advisories

**Image:** `registry.redhat.io/compliance/openshift-compliance-openscap-rhel8@sha256:b64926c3cd92381b31f31f28ca01f05c52bc0fbbc581941ba6f0da5b3b142d36`
**Package:** `expat 2.5.0-3.el9_5.1` (rpm)

**Scoring:** equal — both have identical CVSS, severity, and summary.
**Fix:** B wins — newer advisory, newer fixed-by version, later fix timestamp.

| Field | Dupe A | Dupe B | Winner |
|---|---|---|---|
| CVE | CVE-2024-8176 | CVE-2024-8176 | — |
| Advisory | RHSA-2025:3531 | RHSA-2025:7444 | **B** (newer) |
| Fixed by | `0:2.5.0-3.el9_5.3` | `0:2.5.0-5.el9_6` | **B** (newer) |
| Fix timestamp | 2025-04-02 | 2025-05-13 | **B** (newer) |
| CVSS / severity | 7.5 / MODERATE | 7.5 / MODERATE | equal |

---

#### Scenario 2: Different perspectives — different CVSS scores

**Image:** `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:29e3563d5fc11a54ffbf7b28694f1cc3975a72e24035fca4afa44d7937e932c7`
**Package:** `github.com/docker/docker v27.5.1+incompatible` (Go binary)

**Scoring:** A wins — has 2 CVSS metric sources vs 1.
**Fix:** equal — neither has an advisory or fix version.

| Field | Dupe A | Dupe B | Winner |
|---|---|---|---|
| CVE | CVE-2026-33997 | CVE-2026-33997 | — |
| CVSS | 6.8 | 8.1 | **A** (more sources) |
| CVSS vector | `AV:N/AC:H/...` | `AV:N/AC:L/...` | **A** |
| Severity | MODERATE | IMPORTANT | **A** |
| Link | osv.dev | nvd.nist.gov | **A** |
| Published | 2026-03-27 | 2026-04-02 | **A** (earlier) |
| CVSS metrics | 2 sources | 1 source | **A** |

---

#### Scenario 3: Different perspectives — one has fix version

**Same image as Scenario 2**
**Package:** `github.com/docker/docker v27.5.1+incompatible` (Go binary)

**Scoring:** A wins — higher CVSS (8.8 vs 7.8), 2 metric sources vs 1.
**Fix:** A wins — has fix version `29.3.1`; B has none.

| Field | Dupe A | Dupe B | Winner |
|---|---|---|---|
| CVE | CVE-2026-34040 | CVE-2026-34040 | — |
| CVSS | 8.8 | 7.8 | **A** |
| Fixed by | `29.3.1` | empty | **A** |
| Severity | IMPORTANT | IMPORTANT | equal |
| Link | osv.dev | nvd.nist.gov | **A** |
| CVSS metrics | 2 sources | 1 source | **A** |

---

#### Scenario 4: Different perspectives — one has no scoring at all

**Same image as Scenario 2**
**Package:** `github.com/go-jose/go-jose/v3 v3.0.4` (Go binary)

**Scoring:** A wins — has CVSS, severity, and metric source; B has none.
**Fix:** equal — both have `3.0.5` as the fix version.

| Field | Dupe A | Dupe B | Winner |
|---|---|---|---|
| CVE | CVE-2026-34986 | CVE-2026-34986 | — |
| CVSS | 7.5 | empty | **A** |
| CVSS v3 | full vector | empty | **A** |
| Severity | IMPORTANT | UNKNOWN | **A** |
| Fixed by | `3.0.5` | `3.0.5` | equal |
| CVSS metrics | 1 source | empty | **A** |

---

#### Scenario 5: Different perspectives — different CVSS severity

**Same image as Scenario 2**
**Package:** `setuptools 53.0.0` (Python)

**Scoring:** A wins — higher CVSS (7.5 vs 5.9), 2 metric sources vs 1.
**Fix:** equal — both have `65.5.1` as the fix version.

| Field | Dupe A | Dupe B | Winner |
|---|---|---|---|
| CVE | CVE-2022-40897 | CVE-2022-40897 | — |
| CVSS | 7.5 | 5.9 | **A** |
| CVSS vector | `AV:N/AC:L/...` | `AV:N/AC:H/...` | **A** |
| Severity | IMPORTANT | MODERATE | **A** |
| Link | osv.dev | nvd.nist.gov | **A** |
| Fixed by | `65.5.1` | `65.5.1` | equal |
| CVSS metrics | 2 sources | 1 source | **A** |

</details>


## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] modified existing tests

### How I validated my change

unit tests + CI + manually

Using a custom dupe detector and two different infra clusters, one with the fix the other without, analyzed each active image for duplicates.

The cluster without the fix:

```
Summary
  Images scanned:          96
  Total components:        26758
  Total CVE entries:       7656
  Duplicate CVEs:          436
  Identical components:    370

  If duplicates removed (estimate):
    CVEs:        7656 -> 7220  (5.7% reduction)
    Components:  26758 -> 26388  (1.4% reduction)
```



```
Summary
  Images scanned:          96
  Total components:        26387
  Total CVE entries:       7220
  Duplicate CVEs:          0
  Identical components:    0
```