### PR TITLE
ROX-34804: use custom audience for config-controller M2M auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 ### Technical Changes
 
-- ROX-34804: The machine access configuration for `config-controller` now validates the audience of the service account token. All audience values are allowed if other role bindings have been added to the machine access configuration.
+- ROX-34804: The machine access configuration for `config-controller` now validates the audience (`aud` claim) of the service account token. The expected audience is `central.stackrox.io`. When users have added their own role bindings to this machine access configuration, the audience check is not enforced by default to keep backwards compatibility. It is recommended to set the expected audience to `central.stackrox.io` after ensuring that all exchange tokens are being created with this audience claim.
 
 ## [4.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 ### Technical Changes
 
+- ROX-34804: The machine access configuration for `config-controller` now validates the audience of the service account token. All audience values are allowed if other role bindings have been added to the machine access configuration.
+
 ## [4.11.0]
 
 

--- a/central/auth/datastore/datastore_impl.go
+++ b/central/auth/datastore/datastore_impl.go
@@ -23,6 +23,8 @@ import (
 	"github.com/stackrox/rox/pkg/uuid"
 )
 
+const configControllerM2MAudience = "central.stackrox.io"
+
 var (
 	_ DataStore = (*datastoreImpl)(nil)
 
@@ -257,6 +259,7 @@ func newKubeM2MConfig(kubeSAIssuer string) *storage.AuthMachineToMachineConfig {
 		TokenExpirationDuration: "1h",
 		Mappings:                []*storage.AuthMachineToMachineConfig_Mapping{},
 		Issuer:                  kubeSAIssuer,
+		Audience:                configControllerM2MAudience,
 	}
 }
 
@@ -285,6 +288,13 @@ func (d *datastoreImpl) configureConfigControllerAccess(kubeSAConfig *storage.Au
 			ValueExpression: configControllerServiceAccountName,
 			Role:            "Configuration Controller",
 		})
+	}
+
+	// Only set the audience on upgraded configs when no other mappings exist.
+	// If users added their own mappings, their tokens won't carry the custom
+	// audience, so enforcing it would break their setup.
+	if kubeSAConfig.GetAudience() == "" && len(kubeSAConfig.GetMappings()) == 1 {
+		kubeSAConfig.Audience = configControllerM2MAudience
 	}
 
 	ctx := sac.WithGlobalAccessScopeChecker(context.Background(), sac.AllowFixedScopes(

--- a/central/auth/datastore/datastore_impl.go
+++ b/central/auth/datastore/datastore_impl.go
@@ -290,9 +290,10 @@ func (d *datastoreImpl) configureConfigControllerAccess(kubeSAConfig *storage.Au
 		})
 	}
 
-	// Only set the audience on upgraded configs when no other mappings exist.
-	// If users added their own mappings, their tokens won't carry the custom
-	// audience, so enforcing it would break their setup.
+	// Above we ensure that the config-controller mapping is always present.
+	// But we only set the audience on upgraded configs when the config-controller
+	// mapping is the only mapping. If users added their own mappings, their tokens
+	// may not carry the custom audience, so enforcing it could break their setup.
 	if kubeSAConfig.GetAudience() == "" && len(kubeSAConfig.GetMappings()) == 1 {
 		kubeSAConfig.Audience = configControllerM2MAudience
 	}

--- a/central/auth/datastore/datastore_impl_test.go
+++ b/central/auth/datastore/datastore_impl_test.go
@@ -163,6 +163,7 @@ func (s *datastorePostgresTestSuite) TestKubeSAM2MConfigPersistsAfterDelete() {
 		s.Equal("sub", kubeSAConfig.GetMappings()[0].GetKey())
 		s.Equal("Configuration Controller", kubeSAConfig.GetMappings()[0].GetRole())
 		s.Contains(kubeSAConfig.GetMappings()[0].GetValueExpression(), "config-controller")
+		s.Equal(configControllerM2MAudience, kubeSAConfig.GetAudience())
 	}
 
 	s.kubeSAM2MConfig(authDataStoreMutator, authDataStoreValidator)
@@ -176,6 +177,7 @@ func (s *datastorePostgresTestSuite) TestKubeSAM2MConfigPersistsAfterRestart() {
 		s.Equal("sub", kubeSAConfig.GetMappings()[0].GetKey())
 		s.Equal("Configuration Controller", kubeSAConfig.GetMappings()[0].GetRole())
 		s.Contains(kubeSAConfig.GetMappings()[0].GetValueExpression(), "config-controller")
+		s.Equal(configControllerM2MAudience, kubeSAConfig.GetAudience())
 	}
 
 	s.kubeSAM2MConfig(authDataStoreMutator, authDataStoreValidator)
@@ -223,9 +225,107 @@ func (s *datastorePostgresTestSuite) TestKubeSAM2MConfigPersistsAfterModificatio
 				s.FailNowf("Failed to find role mapping", "key=%s; role=%s; valueExpression=%s", mapping.GetKey(), mapping.GetRole(), mapping.GetValueExpression())
 			}
 		}
+		s.Equal(configControllerM2MAudience, kubeSAConfig.GetAudience())
 	}
 
 	s.kubeSAM2MConfig(authDataStoreMutator, authDataStoreValidator)
+}
+
+// TestKubeSAM2MConfigAudienceSetOnUpgradeWithSingleMapping simulates upgrading
+// from a Central version that did not set an audience on the kube SA M2M config.
+// When the config only has the config-controller mapping, the audience should be
+// backfilled on restart.
+func (s *datastorePostgresTestSuite) TestKubeSAM2MConfigAudienceSetOnUpgradeWithSingleMapping() {
+	controller := gomock.NewController(s.T())
+	defer controller.Finish()
+	authStore := store.New(s.pool.DB)
+
+	// Seed a pre-existing config without audience (simulates pre-upgrade state).
+	legacyConfig := &storage.AuthMachineToMachineConfig{
+		Id:                      uuid.NewV4().String(),
+		Type:                    storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT,
+		TokenExpirationDuration: "1h",
+		Issuer:                  testIssuer,
+		Mappings: []*storage.AuthMachineToMachineConfig_Mapping{
+			{
+				Key:             "sub",
+				ValueExpression: configControllerServiceAccountName,
+				Role:            configController,
+			},
+		},
+	}
+	s.Require().NoError(authStore.Upsert(s.ctx, legacyConfig))
+
+	// Simulate Central restart with InitializeTokenExchangers.
+	mockSet := mocks.NewMockTokenExchangerSet(controller)
+	mockSet.EXPECT().UpsertTokenExchanger(gomock.Any(), kubeSAMatcher{}).Return(nil).MinTimes(1)
+	mockSet.EXPECT().GetTokenExchanger(gomock.Any()).Return(nil, false).AnyTimes()
+
+	authDataStore := New(authStore, s.roleDataStore, mockSet)
+	s.NoError(authDataStore.InitializeTokenExchangers())
+
+	var kubeSAConfig *storage.AuthMachineToMachineConfig
+	err := authDataStore.ForEachAuthM2MConfig(s.ctx, func(obj *storage.AuthMachineToMachineConfig) error {
+		if obj.GetIssuer() == testIssuer {
+			kubeSAConfig = obj
+		}
+		return nil
+	})
+	s.NoError(err)
+	s.Require().NotNil(kubeSAConfig)
+	s.Equal(1, len(kubeSAConfig.GetMappings()))
+	s.Equal(configControllerM2MAudience, kubeSAConfig.GetAudience(), "audience should be backfilled when only the config-controller mapping exists")
+}
+
+// TestKubeSAM2MConfigAudienceNotSetOnUpgradeWithMultipleMappings simulates
+// upgrading from a Central version that did not set an audience, where the user
+// has added their own role mappings to the kube SA M2M config. The audience must
+// NOT be backfilled because the user's tokens won't carry the custom audience.
+func (s *datastorePostgresTestSuite) TestKubeSAM2MConfigAudienceNotSetOnUpgradeWithMultipleMappings() {
+	controller := gomock.NewController(s.T())
+	defer controller.Finish()
+	authStore := store.New(s.pool.DB)
+
+	// Seed a pre-existing config without audience that has an additional user mapping.
+	legacyConfig := &storage.AuthMachineToMachineConfig{
+		Id:                      uuid.NewV4().String(),
+		Type:                    storage.AuthMachineToMachineConfig_KUBE_SERVICE_ACCOUNT,
+		TokenExpirationDuration: "1h",
+		Issuer:                  testIssuer,
+		Mappings: []*storage.AuthMachineToMachineConfig_Mapping{
+			{
+				Key:             "sub",
+				ValueExpression: configControllerServiceAccountName,
+				Role:            configController,
+			},
+			{
+				Key:             "sub",
+				ValueExpression: "system:serviceaccount:my-namespace:my-service-account",
+				Role:            testRole1,
+			},
+		},
+	}
+	s.Require().NoError(authStore.Upsert(s.ctx, legacyConfig))
+
+	// Simulate Central restart with InitializeTokenExchangers.
+	mockSet := mocks.NewMockTokenExchangerSet(controller)
+	mockSet.EXPECT().UpsertTokenExchanger(gomock.Any(), kubeSAMatcher{}).Return(nil).MinTimes(1)
+	mockSet.EXPECT().GetTokenExchanger(gomock.Any()).Return(nil, false).AnyTimes()
+
+	authDataStore := New(authStore, s.roleDataStore, mockSet)
+	s.NoError(authDataStore.InitializeTokenExchangers())
+
+	var kubeSAConfig *storage.AuthMachineToMachineConfig
+	err := authDataStore.ForEachAuthM2MConfig(s.ctx, func(obj *storage.AuthMachineToMachineConfig) error {
+		if obj.GetIssuer() == testIssuer {
+			kubeSAConfig = obj
+		}
+		return nil
+	})
+	s.NoError(err)
+	s.Require().NotNil(kubeSAConfig)
+	s.Equal(2, len(kubeSAConfig.GetMappings()))
+	s.Empty(kubeSAConfig.GetAudience(), "audience must not be set when user-defined mappings exist")
 }
 
 func (s *datastorePostgresTestSuite) TestAddFKConstraint() {

--- a/config-controller/pkg/client/client.go
+++ b/config-controller/pkg/client/client.go
@@ -52,7 +52,7 @@ func (c *perRPCCreds) RequireTransportSecurity() bool {
 
 func (c *perRPCCreds) refreshToken(ctx context.Context) error {
 	log.Debug("Refreshing Central API token")
-	token, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	token, err := os.ReadFile("/var/run/secrets/stackrox.io/m2m/token")
 	if err != nil {
 		return errors.WithMessage(err, "error reading service account token file")
 	}

--- a/image/templates/helm/stackrox-central/templates/02-config-controller-02-deployment.yaml
+++ b/image/templates/helm/stackrox-central/templates/02-config-controller-02-deployment.yaml
@@ -98,6 +98,9 @@ spec:
           mountPath: /etc/ssl
         - name: etc-pki-volume
           mountPath: /etc/pki/ca-trust
+        - name: m2m
+          mountPath: /var/run/secrets/stackrox.io/m2m
+          readOnly: true
       terminationGracePeriodSeconds: 10
       volumes:
       - name: central-certs-volume
@@ -115,4 +118,11 @@ spec:
         emptyDir: {}
       - name: etc-pki-volume
         emptyDir: {}
+      - name: m2m
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: central.stackrox.io
+              expirationSeconds: 3600
+              path: token
 {{- end }}


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

The purpose of this change is preventing token replay attacks by using a customized audience for the m2m token.

The config-controller now requests a Kubernetes service account token with the audience `central.stackrox.io` via a projected volume, and Central's auto-created kube SA M2M config validates this audience. Existing configs without an audience are backfilled on startup iff no other role mappings have been defined. This is done to maintain backwards compatibility for users who have already set up custom role mappings and may not generate tokens with the required audience value.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

* Confirmed that the builtin m2m integration is upserted correctly with the expected audience:
  - for fresh Central deployments
  - when updating from a previous Central version
* Confirmed that the builtin m2m integration is NOT upserted with audience if user defined role mappings exist.
* Confirmed that the config controller still works:
  - created a `SecurityPolicy` and confirmed reconciliation
* Confirmed that the config controller does NOT work when the audience is changed in the m2m integration:
> pkg/client: 2026/06/08 10:51:12.459616 client.go:276: Warn: Initialization Error: could not exchange token: Failed to exchange token: rpc error: code = Unauthenticated desc = ID token is invalid: oidc: expected audience "fake-audience" got ["central.stackrox.io"]