### PR TITLE
ROX-30599: Return NA for missing CVSS score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 
 ### Technical Changes
 
+- ROX-30599: The internal GraphQL API now returns `null` instead of `0` for CVSS and NVD CVSS scores when a score is unavailable for a CVE. CSV vulnerability reports now display "Not Available" for these fields, consistent with EPSS score handling. While the GraphQL API is for internal use only and is not officially supported, this is a breaking schema change: the `cvss` and `nvdcvss` fields on image vulnerability types changed from non-nullable to nullable.
+
 ## [4.11.0]
 
 

--- a/central/cve/cluster/csv/handler.go
+++ b/central/cve/cluster/csv/handler.go
@@ -166,7 +166,11 @@ func ClusterCVECSVRows(c context.Context, query *v1.Query, rawQuery resolvers.Ra
 			errorList.AddError(err)
 		}
 		dataRow.Fixable = strconv.FormatBool(isFixable)
-		dataRow.CvssScore = fmt.Sprintf("%.2f (%s)", d.Cvss(ctx), d.ScoreVersion(ctx))
+		if cvss := d.Cvss(ctx); cvss != nil {
+			dataRow.CvssScore = fmt.Sprintf("%.2f (%s)", *cvss, d.ScoreVersion(ctx))
+		} else {
+			dataRow.CvssScore = "Not Available"
+		}
 		envImpact, err := d.EnvImpact(ctx)
 		if err != nil {
 			errorList.AddError(err)

--- a/central/cve/image/csv/handler.go
+++ b/central/cve/image/csv/handler.go
@@ -187,7 +187,11 @@ func ImageCVECSVRows(c context.Context, query *v1.Query, rawQuery resolvers.RawQ
 			errorList.AddError(err)
 		}
 		dataRow.Fixable = strconv.FormatBool(isFixable)
-		dataRow.CvssScore = fmt.Sprintf("%.2f (%s)", d.Cvss(ctx), d.ScoreVersion(ctx))
+		if cvss := d.Cvss(ctx); cvss != nil {
+			dataRow.CvssScore = fmt.Sprintf("%.2f (%s)", *cvss, d.ScoreVersion(ctx))
+		} else {
+			dataRow.CvssScore = "Not Available"
+		}
 		envImpact, err := d.EnvImpact(ctx)
 		if err != nil {
 			errorList.AddError(err)

--- a/central/cve/node/csv/handler.go
+++ b/central/cve/node/csv/handler.go
@@ -166,7 +166,11 @@ func NodeCVECSVRows(c context.Context, query *v1.Query, rawQuery resolvers.RawQu
 			errorList.AddError(err)
 		}
 		dataRow.Fixable = strconv.FormatBool(isFixable)
-		dataRow.CvssScore = fmt.Sprintf("%.2f (%s)", d.Cvss(ctx), d.ScoreVersion(ctx))
+		if cvss := d.Cvss(ctx); cvss != nil {
+			dataRow.CvssScore = fmt.Sprintf("%.2f (%s)", *cvss, d.ScoreVersion(ctx))
+		} else {
+			dataRow.CvssScore = "Not Available"
+		}
 		envImpact, err := d.EnvImpact(ctx)
 		if err != nil {
 			errorList.AddError(err)

--- a/central/graphql/resolvers/cluster_vulnerabilities.go
+++ b/central/graphql/resolvers/cluster_vulnerabilities.go
@@ -438,6 +438,11 @@ func (resolver *clusterCVEResolver) Suppressed(_ context.Context) bool {
 	return resolver.data.GetSnoozed()
 }
 
+func (resolver *clusterCVEResolver) Cvss(_ context.Context) *float64 {
+	v := float64(resolver.data.GetCvss())
+	return &v
+}
+
 func (resolver *clusterCVEResolver) UnusedVarSink(_ context.Context, _ RawQuery) *int32 {
 	return nil
 }

--- a/central/graphql/resolvers/common_vulnerabilities.go
+++ b/central/graphql/resolvers/common_vulnerabilities.go
@@ -16,7 +16,7 @@ var commonVulnerabilitySubResolvers = []string{
 	"createdAt: Time",
 	"cve: String!",
 	"cveBaseInfo: CVEInfo",
-	"cvss: Float!",
+	"cvss: Float",
 	"envImpact: Float!",
 	"fixedByVersion: String!",
 	"id: ID!",
@@ -43,7 +43,7 @@ type CommonVulnerabilityResolver interface {
 	CreatedAt(ctx context.Context) (*graphql.Time, error)
 	CVE(ctx context.Context) string
 	CveBaseInfo(ctx context.Context) (*cVEInfoResolver, error)
-	Cvss(ctx context.Context) float64
+	Cvss(ctx context.Context) *float64
 	EnvImpact(ctx context.Context) (float64, error)
 	FixedByVersion(ctx context.Context) (string, error)
 	Id(ctx context.Context) graphql.ID

--- a/central/graphql/resolvers/gen/main.go
+++ b/central/graphql/resolvers/gen/main.go
@@ -131,6 +131,14 @@ var (
 				ParentType: reflect.TypeOf(storage.ImageSignatureVerificationResult{}),
 				FieldName:  "VerifierName",
 			},
+			{
+				ParentType: reflect.TypeOf(storage.ClusterCVE{}),
+				FieldName:  "Cvss",
+			},
+			{
+				ParentType: reflect.TypeOf(storage.NodeCVE{}),
+				FieldName:  "Cvss",
+			},
 		},
 		InputTypes: []reflect.Type{
 			reflect.TypeOf((*inputtypes.FalsePositiveVulnRequest)(nil)),

--- a/central/graphql/resolvers/generated.go
+++ b/central/graphql/resolvers/generated.go
@@ -305,7 +305,6 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 	}))
 	utils.Must(builder.AddType("ClusterCVE", []string{
 		"cveBaseInfo: CVEInfo",
-		"cvss: Float!",
 		"id: ID!",
 		"impactScore: Float!",
 		"severity: VulnerabilitySeverity!",
@@ -1003,7 +1002,6 @@ func registerGeneratedTypes(builder generator.SchemaBuilder) {
 	}))
 	utils.Must(builder.AddType("NodeCVE", []string{
 		"cveBaseInfo: CVEInfo",
-		"cvss: Float!",
 		"id: ID!",
 		"impactScore: Float!",
 		"operatingSystem: String!",
@@ -4363,11 +4361,6 @@ func (resolver *Resolver) wrapClusterCVEsWithContext(ctx context.Context, values
 func (resolver *clusterCVEResolver) CveBaseInfo(ctx context.Context) (*cVEInfoResolver, error) {
 	value := resolver.data.GetCveBaseInfo()
 	return resolver.root.wrapCVEInfo(value, true, nil)
-}
-
-func (resolver *clusterCVEResolver) Cvss(ctx context.Context) float64 {
-	value := resolver.data.GetCvss()
-	return float64(value)
 }
 
 func (resolver *clusterCVEResolver) Id(ctx context.Context) graphql.ID {
@@ -11464,11 +11457,6 @@ func (resolver *Resolver) wrapNodeCVEsWithContext(ctx context.Context, values []
 func (resolver *nodeCVEResolver) CveBaseInfo(ctx context.Context) (*cVEInfoResolver, error) {
 	value := resolver.data.GetCveBaseInfo()
 	return resolver.root.wrapCVEInfo(value, true, nil)
-}
-
-func (resolver *nodeCVEResolver) Cvss(ctx context.Context) float64 {
-	value := resolver.data.GetCvss()
-	return float64(value)
 }
 
 func (resolver *nodeCVEResolver) Id(ctx context.Context) graphql.ID {

--- a/central/graphql/resolvers/image_vulnerabilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities.go
@@ -31,13 +31,13 @@ func init() {
 	utils.Must(schema.AddType("ImageCVEV2", []string{
 		"componentId: String!",
 		"cveBaseInfo: CVEInfo",
-		"cvss: Float!",
+		"cvss: Float",
 		"firstImageOccurrence: Time",
 		"id: ID!",
 		"imageId: String!",
 		"impactScore: Float!",
 		"nvdScoreVersion: CvssScoreVersion!",
-		"nvdcvss: Float!",
+		"nvdcvss: Float",
 		"operatingSystem: String!",
 		"severity: VulnerabilitySeverity!",
 		"state: VulnerabilityState!",
@@ -59,7 +59,7 @@ func init() {
 				"images(query: String, pagination: Pagination): [Image!]!",
 				"operatingSystem: String!",
 				"vulnerabilityState: String!",
-				"nvdCvss: Float!",
+				"nvdCvss: Float",
 				"nvdScoreVersion: String!",
 			)),
 		schema.AddQuery("imageVulnerability(id: ID): ImageVulnerability"),
@@ -86,7 +86,7 @@ type ImageVulnerabilityResolver interface {
 	Images(ctx context.Context, args PaginatedQuery) ([]ImageResolver, error)
 	OperatingSystem(ctx context.Context) string
 	VulnerabilityState(ctx context.Context) string
-	Nvdcvss(ctx context.Context) float64
+	Nvdcvss(ctx context.Context) *float64
 	NvdScoreVersion(ctx context.Context) string
 }
 

--- a/central/graphql/resolvers/image_vulnerabilities_utilities.go
+++ b/central/graphql/resolvers/image_vulnerabilities_utilities.go
@@ -58,11 +58,17 @@ func (resolver *imageCVEV2Resolver) CveBaseInfo(ctx context.Context) (*cVEInfoRe
 	return resolver.root.wrapCVEInfo(value, true, nil)
 }
 
-func (resolver *imageCVEV2Resolver) Cvss(ctx context.Context) float64 {
+func (resolver *imageCVEV2Resolver) Cvss(ctx context.Context) *float64 {
+	var v float64
 	if resolver.flatData != nil {
-		return float64(resolver.flatData.GetTopCVSS())
+		v = float64(resolver.flatData.GetTopCVSS())
+	} else {
+		v = float64(resolver.data.GetCvss())
 	}
-	return float64(resolver.data.GetCvss())
+	if v == 0.0 {
+		return nil
+	}
+	return &v
 }
 
 func (resolver *imageCVEV2Resolver) FirstImageOccurrence(ctx context.Context) (*graphql.Time, error) {
@@ -90,11 +96,17 @@ func (resolver *imageCVEV2Resolver) NvdScoreVersion(ctx context.Context) string 
 	return value.String()
 }
 
-func (resolver *imageCVEV2Resolver) Nvdcvss(ctx context.Context) float64 {
+func (resolver *imageCVEV2Resolver) Nvdcvss(ctx context.Context) *float64 {
+	var v float64
 	if resolver.flatData != nil {
-		return float64(resolver.flatData.GetTopNVDCVSS())
+		v = float64(resolver.flatData.GetTopNVDCVSS())
+	} else {
+		v = float64(resolver.data.GetNvdcvss())
 	}
-	return float64(resolver.data.GetNvdcvss())
+	if v == 0.0 {
+		return nil
+	}
+	return &v
 }
 
 func (resolver *imageCVEV2Resolver) Severity(ctx context.Context) string {

--- a/central/graphql/resolvers/image_vulnerabilities_utilities_test.go
+++ b/central/graphql/resolvers/image_vulnerabilities_utilities_test.go
@@ -10,6 +10,10 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func floatPtr(f float64) *float64 {
+	return &f
+}
+
 func TestImageCVEV2Resolver_PrefersFlatData(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
@@ -21,11 +25,16 @@ func TestImageCVEV2Resolver_PrefersFlatData(t *testing.T) {
 	flatData.EXPECT().GetTopCVSS().Return(float32(9.8)).AnyTimes()
 	flatData.EXPECT().GetTopNVDCVSS().Return(float32(9.1)).AnyTimes()
 
+	zeroFlatData := cveFlatMocks.NewMockCveFlat(ctrl)
+	zeroFlatData.EXPECT().GetSeverity().Return(&critical).AnyTimes()
+	zeroFlatData.EXPECT().GetTopCVSS().Return(float32(0.0)).AnyTimes()
+	zeroFlatData.EXPECT().GetTopNVDCVSS().Return(float32(0.0)).AnyTimes()
+
 	cases := map[string]struct {
 		resolver         *imageCVEV2Resolver
 		expectedSeverity string
-		expectedCvss     float64
-		expectedNvdCvss  float64
+		expectedCvss     *float64
+		expectedNvdCvss  *float64
 	}{
 		"with flatData, aggregated values are returned": {
 			resolver: &imageCVEV2Resolver{
@@ -37,8 +46,8 @@ func TestImageCVEV2Resolver_PrefersFlatData(t *testing.T) {
 				flatData: flatData,
 			},
 			expectedSeverity: critical.String(),
-			expectedCvss:     9.8,
-			expectedNvdCvss:  9.1,
+			expectedCvss:     floatPtr(9.8),
+			expectedNvdCvss:  floatPtr(9.1),
 		},
 		"without flatData, denormalized values are returned": {
 			resolver: &imageCVEV2Resolver{
@@ -49,8 +58,33 @@ func TestImageCVEV2Resolver_PrefersFlatData(t *testing.T) {
 				},
 			},
 			expectedSeverity: important.String(),
-			expectedCvss:     7.5,
-			expectedNvdCvss:  6.9,
+			expectedCvss:     floatPtr(7.5),
+			expectedNvdCvss:  floatPtr(6.9),
+		},
+		"zero CVSS returns nil": {
+			resolver: &imageCVEV2Resolver{
+				data: &storage.ImageCVEV2{
+					Severity: important,
+					Cvss:     0.0,
+					Nvdcvss:  0.0,
+				},
+			},
+			expectedSeverity: important.String(),
+			expectedCvss:     nil,
+			expectedNvdCvss:  nil,
+		},
+		"zero CVSS in flatData returns nil": {
+			resolver: &imageCVEV2Resolver{
+				data: &storage.ImageCVEV2{
+					Severity: important,
+					Cvss:     7.5,
+					Nvdcvss:  6.9,
+				},
+				flatData: zeroFlatData,
+			},
+			expectedSeverity: critical.String(),
+			expectedCvss:     nil,
+			expectedNvdCvss:  nil,
 		},
 	}
 
@@ -58,8 +92,18 @@ func TestImageCVEV2Resolver_PrefersFlatData(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, tc.expectedSeverity, tc.resolver.Severity(ctx))
-			assert.InDelta(t, tc.expectedCvss, tc.resolver.Cvss(ctx), 0.001)
-			assert.InDelta(t, tc.expectedNvdCvss, tc.resolver.Nvdcvss(ctx), 0.001)
+			cvss := tc.resolver.Cvss(ctx)
+			nvdCvss := tc.resolver.Nvdcvss(ctx)
+			if tc.expectedCvss == nil {
+				assert.Nil(t, cvss)
+			} else {
+				assert.InDelta(t, *tc.expectedCvss, *cvss, 0.001)
+			}
+			if tc.expectedNvdCvss == nil {
+				assert.Nil(t, nvdCvss)
+			} else {
+				assert.InDelta(t, *tc.expectedNvdCvss, *nvdCvss, 0.001)
+			}
 		})
 	}
 }

--- a/central/graphql/resolvers/node_vulnerabilities.go
+++ b/central/graphql/resolvers/node_vulnerabilities.go
@@ -478,6 +478,11 @@ func (resolver *nodeCVEResolver) SuppressExpiry(_ context.Context) (*graphql.Tim
 	return protocompat.ConvertTimestampToGraphqlTimeOrError(resolver.data.GetSnoozeExpiry())
 }
 
+func (resolver *nodeCVEResolver) Cvss(_ context.Context) *float64 {
+	v := float64(resolver.data.GetCvss())
+	return &v
+}
+
 // Suppressed returns true if the node CVE is snoozed
 func (resolver *nodeCVEResolver) Suppressed(_ context.Context) bool {
 	defer metrics.SetGraphQLOperationDurationTime(time.Now(), pkgMetrics.NodeCVEs, "Suppressed")

--- a/central/reports/scheduler/v2/reportgenerator/csv_gen.go
+++ b/central/reports/scheduler/v2/reportgenerator/csv_gen.go
@@ -41,6 +41,18 @@ func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string) (*byt
 	csvWriter := csv.NewGenericWriter(csvHeader, true)
 
 	for _, r := range cveResponses {
+		var cvssScore string
+		if r.GetCVSS() != nil {
+			cvssScore = strconv.FormatFloat(*r.GetCVSS(), 'f', 2, 64)
+		} else {
+			cvssScore = "Not Available"
+		}
+		var nvdCVSSScore string
+		if r.GetNVDCVSS() != nil {
+			nvdCVSSScore = strconv.FormatFloat(*r.GetNVDCVSS(), 'f', 2, 64)
+		} else {
+			nvdCVSSScore = "Not Available"
+		}
 		var epssScore string
 		if r.GetEPSSProbability() != nil {
 			epssScore = strconv.FormatFloat(*r.GetEPSSProbability()*100, 'f', 3, 64)
@@ -58,8 +70,8 @@ func GenerateCSV(cveResponses []*ImageCVEQueryResponse, configName string) (*byt
 			strconv.FormatBool(r.GetFixable()),
 			r.GetFixedByVersion(),
 			strings.ToTitle(stringutils.GetUpTo(r.GetSeverity().String(), "_")),
-			strconv.FormatFloat(r.GetCVSS(), 'f', 2, 64),
-			strconv.FormatFloat(r.GetNVDCVSS(), 'f', 2, 64),
+			cvssScore,
+			nvdCVSSScore,
 			epssScore,
 			r.GetDiscoveredAtImage(),
 			r.Link,

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_impl_flat_data_model_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_impl_flat_data_model_test.go
@@ -36,7 +36,7 @@ type vulnReportDataNewDataModel struct {
 	imageNames      []string
 	componentNames  []string
 	cveNames        []string
-	cvss            []float64
+	cvss            []*float64
 }
 
 func TestVulnReportingNewDataModel(t *testing.T) {
@@ -235,7 +235,7 @@ func collectVulnReportDataSQFNewDataModel(cveResponses []*ImageCVEQueryResponse)
 	imageNames := set.NewStringSet()
 	componentNames := set.NewStringSet()
 	cveNames := make([]string, 0)
-	cvss := make([]float64, 0)
+	cvss := make([]*float64, 0)
 
 	for _, res := range cveResponses {
 		if res.GetDeployment() != "" {

--- a/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
+++ b/central/reports/scheduler/v2/reportgenerator/report_gen_view_based_test.go
@@ -50,7 +50,7 @@ type viewBasedReportData struct {
 	imageNames      []string
 	componentNames  []string
 	cveNames        []string
-	cvss            []float64
+	cvss            []*float64
 }
 
 func (s *ViewBasedReportingTestSuite) SetupSuite() {
@@ -637,7 +637,7 @@ func (s *ViewBasedReportingTestSuite) collectViewBasedReportData(cveResponses []
 	imageNames := set.NewStringSet()
 	componentNames := set.NewStringSet()
 	cveNames := make([]string, 0)
-	cvss := make([]float64, 0)
+	cvss := make([]*float64, 0)
 
 	for _, res := range cveResponses {
 		if res.GetDeployment() != "" {

--- a/central/reports/scheduler/v2/reportgenerator/types.go
+++ b/central/reports/scheduler/v2/reportgenerator/types.go
@@ -125,18 +125,12 @@ func (res *ImageCVEQueryResponse) GetSeverity() storage.VulnerabilitySeverity {
 	return *res.Severity
 }
 
-func (res *ImageCVEQueryResponse) GetCVSS() float64 {
-	if res.CVSS == nil {
-		return 0.0
-	}
-	return *res.CVSS
+func (res *ImageCVEQueryResponse) GetCVSS() *float64 {
+	return res.CVSS
 }
 
-func (res *ImageCVEQueryResponse) GetNVDCVSS() float64 {
-	if res.NVDCVSS == nil {
-		return 0.0
-	}
-	return *res.NVDCVSS
+func (res *ImageCVEQueryResponse) GetNVDCVSS() *float64 {
+	return res.NVDCVSS
 }
 
 func (res *ImageCVEQueryResponse) GetEPSSProbability() *float64 {


### PR DESCRIPTION
## Description
GraphQL and CSV vulnerability reports returned `0` for CVSS and NVD CVSS scores when the value was unavailable, which
is misleading — customers can't distinguish "no score" from "score is zero." This aligns CVSS and NVD CVSS handling
with the existing EPSS pattern, which already returns null/`"Not Available"` for missing values.
**GraphQL:** `cvss` and `nvdcvss` fields changed from `Float!` to nullable `Float` on ImageCVEV2 and
ImageVulnerability types. The resolvers return `null` instead of `0` when no score is available. ClusterCVE and
NodeCVE resolvers were updated to satisfy the shared `CommonVulnerabilityResolver` interface but always return a
non-nil value (behavior unchanged for those types).
**CSV reports (v2):** `GetCVSS()` and `GetNVDCVSS()` now return `*float64`, and the CSV generator outputs `"Not
GraphQL and CSV vulnerability reports returned `0` for CVSS and NVD CVSS scores when the value was unavailable, which ismisleading — customers can't distinguish "no score" from "score is zero." This aligns CVSS and NVD CVSS handling with theexisting EPSS pattern, which already returns null/`"Not Available"`
for missing values.
**GraphQL:** `cvss` and `nvdcvss` fields changed from `Float!` to nullable `Float` on ImageCVEV2 and ImageVulnerabilitytypes. The resolvers return `null` instead of `0` when no score is available. ClusterCVE and NodeCVE resolvers wereupdated to satisfy the shared `CommonVulnerabilityResolver` interface but
always return a non-nil value (behavior unchanged for those types).
**CSV reports (v2):** `GetCVSS()` and `GetNVDCVSS()` now return `*float64`, and the CSV generator outputs `"NotAvailable"` for nil values, matching the existing EPSS handling. V1 reports are not changed (deprecated, being removedseparately).

## User-facing documentation
- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is not needed (Release Notes text suggested instead)

## Testing and quality
- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edittab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing
- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change
- Unit tests pass for both GraphQL resolvers (`TestImageCVEV2Resolver_PrefersFlatData`) and CSV report generator
- Added test cases verifying zero CVSS values return nil from both proto data and flat data paths
- Updated existing test assertions from `float64` to `*float64` to match new signatures
- `go build ./central/...` compiles cleanly