### PR TITLE
chore(deps): fix go-toolset tag and ignore RHEL versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -309,6 +309,11 @@ updates:
     commit-message:
       include: scope
       prefix: chore
+    ignore:
+      # ubi9/go-toolset has both Go-based (1.x) and RHEL-based (9.x) tags.
+      # Only track Go version tags.
+      - dependency-name: "ubi9/go-toolset"
+        versions: [">= 2"]
 
   - package-ecosystem: 'docker'
     directory: 'operator/tests/controller/metrics'

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,7 @@
 ARG roxpath=/workspace/src/github.com/stackrox/rox
 ARG TARGET_ARCH=amd64
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
 
 # Build the manager binary
 ARG TARGET_ARCH

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -2,7 +2,7 @@
 ARG roxpath=/workspace/src/github.com/stackrox/rox
 ARG TARGET_ARCH=amd64
 
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:9.8 AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 # Build the manager binary
 ARG TARGET_ARCH


### PR DESCRIPTION
## Description

The `ubi9/go-toolset` image has two parallel versioning schemes: Go-based (`1.x`) and RHEL-based (`9.x`). Dependabot picked up the RHEL tag `9.8` as a version bump from Go tag `1.25` in #20713, similar to an earlier occurrence in #17740. I think it's more useful to keep the go-version-based scheme.

This PR:
- Reverts to Go versioning (`1.25`), to test that the bump to 1.26 occurs soon
- Adds a dependabot ignore rule to skip versions `>= 2`, filtering out RHEL-based tags going forward

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No test changes needed - this is a build config and CI config fix.

### How I validated my change

Verified that the `1.25` tag exists for `ubi9/go-toolset` and that the dependabot ignore rule syntax is correct per GitHub and bundler documentation.