### PR TITLE
ROX-30838: Fix flaky compliance report manager tests

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -3,8 +3,6 @@ package manager
 import (
 	"context"
 	"fmt"
-	"slices"
-	"strings"
 	"testing"
 	"time"
 
@@ -19,7 +17,6 @@ import (
 	scanMocks "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore/mocks"
 	bindingsDS "github.com/stackrox/rox/central/complianceoperator/v2/scansettingbindings/datastore/mocks"
 	suiteDS "github.com/stackrox/rox/central/complianceoperator/v2/suites/datastore/mocks"
-	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/env"
@@ -28,12 +25,10 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authn/mocks"
 	"github.com/stackrox/rox/pkg/protocompat"
 	"github.com/stackrox/rox/pkg/sac"
-	"github.com/stackrox/rox/pkg/search"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type ManagerTestSuite struct {
@@ -92,194 +87,236 @@ func (m *ManagerTestSuite) TearDownTest() {
 
 func (m *ManagerTestSuite) TestHandleReportRequest() {
 	m.T().Setenv(env.ReportExecutionMaxConcurrency.EnvVar(), "1")
-	identity := mocks.NewMockIdentity(m.mockCtrl)
-	identity.EXPECT().UID().AnyTimes().Return("user-id")
-	identity.EXPECT().FullName().AnyTimes().Return("user-name")
-	identity.EXPECT().FriendlyName().AnyTimes().Return("user-friendly-name")
-	m.scanConfigDataStore.EXPECT().GetScanConfigClusterStatus(gomock.Any(), newGetScanConfigClusterStatusMatcher(getTestScanConfig())).AnyTimes().Return(getTestClusterStatusFromScanConfig(getTestScanConfig()), nil)
-	m.suiteDataStore.EXPECT().GetSuites(gomock.Any(), newGetSuitesMatcher(getTestScanConfig())).AnyTimes()
-	m.bindingsDataStore.EXPECT().GetScanSettingBindings(gomock.Any(), newGetBindingMatcher(getTestScanConfig())).AnyTimes()
-	ctx := authn.ContextWithIdentity(context.Background(), identity, m.T())
 
-	m.Run("Successful report, no watchers running", func() {
-		manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
-		manager.Start()
-		scanConfig := getTestScanConfig()
-		wg := concurrency.NewWaitGroup(1)
-		m.snapshotDataStore.EXPECT().UpsertSnapshot(gomock.Any(), gomock.Any()).Times(1).
-			Return(nil)
-		m.reportGen.EXPECT().ProcessReportRequest(gomock.Any()).Times(1).
-			DoAndReturn(func(_ any) error {
-				wg.Add(-1)
-				return nil
-			})
-		m.snapshotDataStore.EXPECT().
-			GetLastSnapshotFromScanConfig(gomock.Any(), gomock.Eq(scanConfig.GetId())).
+	scanConfig := getTestScanConfig()
+
+	newIdentityCtx := func() context.Context {
+		identity := mocks.NewMockIdentity(m.mockCtrl)
+		identity.EXPECT().UID().AnyTimes().Return("user-id")
+		identity.EXPECT().FullName().AnyTimes().Return("user-name")
+		identity.EXPECT().FriendlyName().AnyTimes().Return("user-friendly-name")
+		return authn.ContextWithIdentity(context.Background(), identity, m.T())
+	}
+
+	setupReportDataMocks := func() {
+		m.scanConfigDataStore.EXPECT().GetScanConfigClusterStatus(gomock.Any(), gomock.Eq(scanConfig.GetId())).
+			Times(1).Return(getTestClusterStatusFromScanConfig(scanConfig), nil)
+		m.suiteDataStore.EXPECT().GetSuites(gomock.Any(), gomock.Any()).Times(1).Return(nil, nil)
+		m.bindingsDataStore.EXPECT().GetScanSettingBindings(gomock.Any(), gomock.Any()).
+			Times(len(scanConfig.GetClusters())).Return(nil, nil)
+	}
+
+	m.Run("No watcher running", func() {
+		setupReportDataMocks()
+		m.snapshotDataStore.EXPECT().UpsertSnapshot(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+		m.snapshotDataStore.EXPECT().GetLastSnapshotFromScanConfig(gomock.Any(), gomock.Eq(scanConfig.GetId())).
 			Times(1).Return(nil, nil)
-		m.scanDataStore.EXPECT().
-			SearchScans(gomock.Any(), gomock.Any()).
+		m.scanDataStore.EXPECT().SearchScans(gomock.Any(), gomock.Any()).
 			Times(len(scanConfig.GetClusters())).
 			Return(getScans(len(scanConfig.GetProfiles())), nil)
-		err := manager.SubmitReportRequest(ctx, getTestScanConfig(), storage.ComplianceOperatorReportStatus_EMAIL)
-		m.Require().NoError(err)
-		handleWaitGroup(m.T(), &wg, 10*time.Millisecond, "report generation")
-	})
+		m.reportGen.EXPECT().ProcessReportRequest(gomock.Any()).Times(1).Return(nil)
 
-	m.Run("Error in the database", func() {
-		manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
-		manager.Start()
-		wg := concurrency.NewWaitGroup(1)
-		m.snapshotDataStore.EXPECT().UpsertSnapshot(gomock.Any(), gomock.Any()).Times(1).
-			DoAndReturn(func(_, _ any) error {
-				wg.Add(-1)
-				return errors.New("some error")
-			})
-		err := manager.SubmitReportRequest(ctx, getTestScanConfig(), storage.ComplianceOperatorReportStatus_EMAIL)
-		m.Require().NoError(err)
-		handleWaitGroup(m.T(), &wg, 10*time.Millisecond, "storage error")
-	})
-
-	m.Run("Successful report, with watcher running", func() {
-		m.T().Skip("ROX-30838: Enable again")
-		manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
-		manager.Start()
-		wg := concurrency.NewWaitGroup(2)
-		now := protocompat.TimestampNow()
-		scanConfig := getTestScanConfig()
-		scans := getTestScansFromScanConfig(scanConfig, now)
-		scan := getTestScan(scans[0].GetId(), scanConfig.GetScanConfigName(), scans[0].GetClusterId(), now, true)
-		// Setup EXPECT calls
-		calls := m.setupExpectCallsFromScanConfig(scanConfig, now)
-		calls = append(calls, m.setupExpectCallsFromFinishScan(scan, scanConfig, now)...)
-		gomock.InOrder(calls...)
-		// Expect upsert Snapshot in the SubmitReportRequest call
-		calls = []any{
-			m.snapshotDataStore.EXPECT().
-				UpsertSnapshot(gomock.Any(), gomock.Any()).
-				Times(1).Return(nil),
+		mgr := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+		impl := mgr.(*managerImpl)
+		req := &reportRequest{
+			scanConfig:         scanConfig,
+			ctx:                newIdentityCtx(),
+			notificationMethod: storage.ComplianceOperatorReportStatus_EMAIL,
 		}
-		calls = append(calls, m.setupExpectCallsFromFinishAllScans(scanConfig, scans[1:], now, 2)...)
-		calls = append(calls, m.reportGen.EXPECT().
-			ProcessReportRequest(gomock.Any()).
-			Times(2).
-			DoAndReturn(func(_ any) error {
-				wg.Add(-1)
-				return nil
-			}))
-		gomock.InAnyOrder(calls)
-
-		// Push the Resources
-		m.pushScansAndResults(manager, scanConfig, now)
-		m.finishFirstScan(manager, scan, scanConfig)
-
-		m.Eventually(func() bool {
-			managerImp, ok := manager.(*managerImpl)
-			m.Require().True(ok)
-			return concurrency.WithLock1[bool](&managerImp.watchingScanConfigsLock, func() bool {
-				return len(managerImp.watchingScanConfigs) > 0
-			})
-		}, 100*time.Millisecond, 10*time.Millisecond)
-
-		err := manager.SubmitReportRequest(ctx, scanConfig, storage.ComplianceOperatorReportStatus_EMAIL)
+		generated, err := impl.handleReportRequest(req)
 		m.Require().NoError(err)
-
-		m.Eventually(func() bool {
-			managerImp, ok := manager.(*managerImpl)
-			m.Require().True(ok)
-			return concurrency.WithLock1[bool](&managerImp.mu, func() bool {
-				return len(managerImp.runningReportConfigs) > 0
-			})
-		}, 100*time.Millisecond, 10*time.Millisecond)
-
-		time.Sleep(100 * time.Millisecond)
-
-		m.finishScans(manager, scans[1:])
-
-		m.Eventually(func() bool {
-			managerImp, ok := manager.(*managerImpl)
-			m.Require().True(ok)
-			return concurrency.WithLock1[bool](&managerImp.watchingScanConfigsLock, func() bool {
-				return len(managerImp.watchingScanConfigs) == 0
-			})
-		}, 100*time.Millisecond, 10*time.Millisecond)
-		handleWaitGroup(m.T(), &wg, 500*time.Millisecond, "reports to be generated")
+		m.Assert().True(generated)
+		m.Assert().NotEmpty(req.snapshotID)
 	})
 
+	m.Run("Upsert snapshot error", func() {
+		setupReportDataMocks()
+		m.snapshotDataStore.EXPECT().UpsertSnapshot(gomock.Any(), gomock.Any()).Times(1).
+			Return(errors.New("db error"))
+
+		mgr := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+		impl := mgr.(*managerImpl)
+		req := &reportRequest{
+			scanConfig:         scanConfig,
+			ctx:                newIdentityCtx(),
+			notificationMethod: storage.ComplianceOperatorReportStatus_EMAIL,
+		}
+		generated, err := impl.handleReportRequest(req)
+		m.Require().Error(err)
+		m.Assert().False(generated)
+		m.Assert().Contains(err.Error(), "unable to upsert snapshot")
+	})
+
+	m.Run("Watcher running, subscribes and defers report", func() {
+		setupReportDataMocks()
+		stubWatcher := &stubScanConfigWatcher{}
+		m.snapshotDataStore.EXPECT().UpsertSnapshot(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
+		mgr := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+		impl := mgr.(*managerImpl)
+		concurrency.WithLock(&impl.watchingScanConfigsLock, func() {
+			impl.watchingScanConfigs[scanConfig.GetId()] = stubWatcher
+		})
+
+		req := &reportRequest{
+			scanConfig:         scanConfig,
+			ctx:                newIdentityCtx(),
+			notificationMethod: storage.ComplianceOperatorReportStatus_EMAIL,
+		}
+		generated, err := impl.handleReportRequest(req)
+		m.Require().NoError(err)
+		m.Assert().False(generated, "report should be deferred when watcher is running")
+		m.Assert().Len(stubWatcher.subscribedSnapshots, 1)
+		m.Assert().Equal(storage.ComplianceOperatorReportStatus_WAITING, stubWatcher.subscribedSnapshots[0].GetReportStatus().GetRunState())
+	})
+
+	m.Run("Missing identity returns error", func() {
+		mgr := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+		impl := mgr.(*managerImpl)
+		req := &reportRequest{
+			scanConfig:         scanConfig,
+			ctx:                context.Background(),
+			notificationMethod: storage.ComplianceOperatorReportStatus_EMAIL,
+		}
+		generated, err := impl.handleReportRequest(req)
+		m.Require().Error(err)
+		m.Assert().False(generated)
+		m.Assert().Contains(err.Error(), "could not determine user identity")
+	})
 }
 
-func (m *ManagerTestSuite) TestFailedReportWithWatcherRunningAndNoNotifiers() {
+func (m *ManagerTestSuite) TestGenerateReportFromWatcherResults() {
 	m.T().Setenv(env.ReportExecutionMaxConcurrency.EnvVar(), "1")
-	identity := mocks.NewMockIdentity(m.mockCtrl)
-	identity.EXPECT().UID().AnyTimes().Return("user-id")
-	identity.EXPECT().FullName().AnyTimes().Return("user-name")
-	identity.EXPECT().FriendlyName().AnyTimes().Return("user-friendly-name")
-	m.scanConfigDataStore.EXPECT().GetScanConfigClusterStatus(gomock.Any(), newGetScanConfigClusterStatusMatcher(getTestScanConfig())).AnyTimes().Return(getTestClusterStatusFromScanConfig(getTestScanConfig()), nil)
-	m.suiteDataStore.EXPECT().GetSuites(gomock.Any(), newGetSuitesMatcher(getTestScanConfig())).AnyTimes()
-	m.bindingsDataStore.EXPECT().GetScanSettingBindings(gomock.Any(), newGetBindingMatcher(getTestScanConfig())).AnyTimes()
-	ctx := authn.ContextWithIdentity(context.Background(), identity, m.T())
-
-	// Set the timeouts to 2 so the scan watchers timeout fast
-	m.T().Setenv(env.ComplianceScanWatcherTimeout.EnvVar(), "2s")
-	// The scan config watcher should not timeout, if it does then the test is broken.
-	// We still set it to 20s to not have the test hagging for 10 minutes before the timeout.
-	m.T().Setenv(env.ComplianceScanScheduleWatcherTimeout.EnvVar(), "20s")
-
-	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
-	manager.Start()
-	now := protocompat.TimestampNow()
 	scanConfig := getTestScanConfig()
-	scanConfig.Notifiers = nil
-	scans := getTestScansFromScanConfig(scanConfig, now)
-	scan := getTestScan(scans[0].GetId(), scanConfig.GetScanConfigName(), scans[0].GetClusterId(), now, true)
-	wg := concurrency.NewWaitGroup(1)
-	// Setup EXPECT calls
-	calls := m.setupExpectCallsFromScanConfig(scanConfig, now)
-	calls = append(calls, m.setupExpectCallsFromFinishScan(scan, scanConfig, now)...)
-	gomock.InOrder(calls...)
-	calls = []any{
-		m.snapshotDataStore.EXPECT().
-			UpsertSnapshot(gomock.Any(), gomock.Any()).
-			Times(1).Return(nil),
+
+	setupReportDataMocks := func() {
+		m.scanConfigDataStore.EXPECT().GetScanConfigClusterStatus(gomock.Any(), gomock.Eq(scanConfig.GetId())).
+			Times(1).Return(getTestClusterStatusFromScanConfig(scanConfig), nil)
+		m.suiteDataStore.EXPECT().GetSuites(gomock.Any(), gomock.Any()).Times(1).Return(nil, nil)
+		m.bindingsDataStore.EXPECT().GetScanSettingBindings(gomock.Any(), gomock.Any()).
+			Times(len(scanConfig.GetClusters())).Return(nil, nil)
 	}
-	calls = append(calls, m.setupExpectCallsFromFailAllScans(scanConfig, scans[1:], now, 1)...)
-	calls = append(calls, m.reportGen.EXPECT().
-		ProcessReportRequest(gomock.Any()).
-		Times(1).
-		DoAndReturn(func(_ any) error {
-			wg.Add(-1)
-			return nil
-		}),
-	)
-	gomock.InAnyOrder(calls)
 
-	// Push the resources
-	m.pushScansAndResults(manager, scanConfig, now)
-	m.finishFirstScan(manager, scan, scanConfig)
-	// The rest of the scan should time out after 1s
-	m.Eventually(func() bool {
-		managerImp, ok := manager.(*managerImpl)
-		m.Require().True(ok)
-		return concurrency.WithLock1[bool](&managerImp.watchingScanConfigsLock, func() bool {
-			return len(managerImp.watchingScanConfigs) > 0
-		})
-	}, 100*time.Millisecond, 10*time.Millisecond)
+	m.Run("Successful report generation", func() {
+		setupReportDataMocks()
+		m.complianceIntegrationDataStore.EXPECT().
+			GetComplianceIntegrationByCluster(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
+		m.scanDataStore.EXPECT().SearchScans(gomock.Any(), gomock.Any()).
+			Times(len(scanConfig.GetClusters())).
+			Return(getScans(len(scanConfig.GetProfiles())), nil)
+		done := make(chan struct{})
+		m.reportGen.EXPECT().ProcessReportRequest(gomock.Any()).Times(1).
+			DoAndReturn(func(_ any) error {
+				close(done)
+				return nil
+			})
 
-	m.Require().NoError(manager.SubmitReportRequest(ctx, scanConfig, storage.ComplianceOperatorReportStatus_DOWNLOAD))
+		mgr := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+		impl := mgr.(*managerImpl)
+		result := &watcher.ScanConfigWatcherResults{
+			WatcherID:  scanConfig.GetId(),
+			ScanConfig: scanConfig,
+			ScanResults: map[string]*watcher.ScanWatcherResults{
+				"cluster-1:scan-1": {Scan: &storage.ComplianceOperatorScanV2{Id: "scan-1", ClusterId: "cluster-1"}},
+				"cluster-2:scan-2": {Scan: &storage.ComplianceOperatorScanV2{Id: "scan-2", ClusterId: "cluster-2"}},
+			},
+		}
+		snapshot := &storage.ComplianceOperatorReportSnapshotV2{
+			ReportId: "report-1",
+			ReportStatus: &storage.ComplianceOperatorReportStatus{
+				ReportNotificationMethod: storage.ComplianceOperatorReportStatus_EMAIL,
+			},
+		}
+		err := impl.generateSingleReportFromWatcherResults(result, snapshot)
+		m.Require().NoError(err)
+		m.Assert().Equal(storage.ComplianceOperatorReportStatus_PREPARING, snapshot.GetReportStatus().GetRunState())
 
-	managerImp, ok := manager.(*managerImpl)
-	m.Require().True(ok)
-	m.Eventually(func() bool {
-		return concurrency.WithLock1[bool](&managerImp.watchingScanConfigsLock, func() bool {
-			return len(managerImp.watchingScanConfigs) == 0
-		})
-	}, 10*time.Second, 10*time.Millisecond)
-	// The runningReportConfigs should be empty at this point
-	m.Eventually(func() bool {
-		return concurrency.WithLock1[bool](&managerImp.mu, func() bool {
-			return len(managerImp.runningReportConfigs) == 0
-		})
-	}, 5*time.Second, 100*time.Millisecond)
-	handleWaitGroup(m.T(), &wg, 500*time.Millisecond, "reports to be generated")
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			m.FailNow("timeout waiting for ProcessReportRequest")
+		}
+	})
+
+	m.Run("Report generation with failed clusters", func() {
+		setupReportDataMocks()
+		m.complianceIntegrationDataStore.EXPECT().
+			GetComplianceIntegrationByCluster(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
+		m.scanDataStore.EXPECT().SearchScans(gomock.Any(), gomock.Any()).
+			Times(len(scanConfig.GetClusters())).
+			Return(getScans(len(scanConfig.GetProfiles())), nil)
+		m.snapshotDataStore.EXPECT().UpsertSnapshot(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+		done := make(chan struct{})
+		m.reportGen.EXPECT().ProcessReportRequest(gomock.Any()).Times(1).
+			DoAndReturn(func(_ any) error {
+				close(done)
+				return nil
+			})
+
+		mgr := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+		impl := mgr.(*managerImpl)
+		result := &watcher.ScanConfigWatcherResults{
+			WatcherID:  scanConfig.GetId(),
+			ScanConfig: scanConfig,
+			Error:      watcher.ErrScanConfigTimeout,
+			ScanResults: map[string]*watcher.ScanWatcherResults{
+				"cluster-1:scan-1": {
+					Scan:  &storage.ComplianceOperatorScanV2{Id: "scan-1", ClusterId: "cluster-1"},
+					Error: watcher.ErrScanTimeout,
+				},
+			},
+		}
+		snapshot := &storage.ComplianceOperatorReportSnapshotV2{
+			ReportId: "report-1",
+			ReportStatus: &storage.ComplianceOperatorReportStatus{
+				ReportNotificationMethod: storage.ComplianceOperatorReportStatus_EMAIL,
+			},
+		}
+		err := impl.generateSingleReportFromWatcherResults(result, snapshot)
+		m.Require().NoError(err)
+		m.Assert().Equal(storage.ComplianceOperatorReportStatus_PREPARING, snapshot.GetReportStatus().GetRunState())
+		m.Assert().NotEmpty(snapshot.GetReportStatus().GetErrorMsg())
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			m.FailNow("timeout waiting for ProcessReportRequest")
+		}
+	})
+}
+
+func (m *ManagerTestSuite) TestCreateAutomaticSnapshotAndSubscribe() {
+	scanConfig := getTestScanConfig()
+
+	m.Run("No notifiers returns error", func() {
+		noNotifierConfig := getTestScanConfig()
+		noNotifierConfig.Notifiers = nil
+
+		mgr := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+		impl := mgr.(*managerImpl)
+		stubWatcher := &stubScanConfigWatcher{}
+		err := impl.createAutomaticSnapshotAndSubscribe(m.ctx, noNotifierConfig, stubWatcher)
+		m.Require().Error(err)
+		m.Assert().Len(stubWatcher.subscribedSnapshots, 0)
+	})
+
+	m.Run("With notifiers subscribes and upserts snapshot", func() {
+		m.scanConfigDataStore.EXPECT().GetScanConfigClusterStatus(gomock.Any(), gomock.Eq(scanConfig.GetId())).
+			Times(1).Return(getTestClusterStatusFromScanConfig(scanConfig), nil)
+		m.suiteDataStore.EXPECT().GetSuites(gomock.Any(), gomock.Any()).Times(1).Return(nil, nil)
+		m.bindingsDataStore.EXPECT().GetScanSettingBindings(gomock.Any(), gomock.Any()).
+			Times(len(scanConfig.GetClusters())).Return(nil, nil)
+		m.snapshotDataStore.EXPECT().UpsertSnapshot(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
+		mgr := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+		impl := mgr.(*managerImpl)
+		stubWatcher := &stubScanConfigWatcher{}
+		err := impl.createAutomaticSnapshotAndSubscribe(m.ctx, scanConfig, stubWatcher)
+		m.Require().NoError(err)
+		m.Assert().Len(stubWatcher.subscribedSnapshots, 1)
+		m.Assert().Equal(storage.ComplianceOperatorReportStatus_WAITING, stubWatcher.subscribedSnapshots[0].GetReportStatus().GetRunState())
+		m.Assert().Equal(storage.ComplianceOperatorReportStatus_SCHEDULED, stubWatcher.subscribedSnapshots[0].GetReportStatus().GetReportRequestType())
+	})
 }
 
 func (m *ManagerTestSuite) TestHandleReadyScanDeleteOldResultsGate() {
@@ -364,6 +401,7 @@ func (m *ManagerTestSuite) TestHandleReadyScanDeleteOldResultsGate() {
 
 			manager := New(scanConfigDS, scanDS, profileDS, snapshotDS, integrationDS, suiteStore, bindingsStore, checkResultDS, generator)
 			manager.Start()
+			defer manager.Stop()
 			managerImp := manager.(*managerImpl)
 
 			result := &watcher.ScanWatcherResults{
@@ -388,7 +426,6 @@ func (m *ManagerTestSuite) TestHandleReadyScanDeleteOldResultsGate() {
 				m.FailNow("timeout waiting for handleReadyScan to process the result")
 			}
 
-			manager.Stop()
 			ctrl.Finish()
 		})
 	}
@@ -438,6 +475,7 @@ func (m *ManagerTestSuite) TestHandleScanRemove() {
 	managerImplementation, ok := manager.(*managerImpl)
 	require.True(m.T(), ok)
 	manager.Start()
+	defer manager.Stop()
 
 	scanID := "scan-1"
 	scan := &storage.ComplianceOperatorScanV2{
@@ -617,216 +655,6 @@ func getTestScanConfig() *storage.ComplianceOperatorScanConfigurationV2 {
 	}
 }
 
-func (m *ManagerTestSuite) pushScansAndResults(manager Manager, sc *storage.ComplianceOperatorScanConfigurationV2, timestamp *protocompat.Timestamp) {
-	ctx := context.Background()
-	for _, cluster := range sc.GetClusters() {
-		for _, profile := range sc.GetProfiles() {
-			scan := getTestScan(profile.GetProfileName(), sc.GetScanConfigName(), cluster.GetClusterId(), timestamp, false)
-			result := getTestResult(scan, timestamp)
-			err := manager.HandleScan(ctx, scan)
-			require.NoError(m.T(), err)
-			err = manager.HandleResult(ctx, result)
-			require.NoError(m.T(), err)
-		}
-	}
-}
-
-func (m *ManagerTestSuite) finishFirstScan(manager Manager, scan *storage.ComplianceOperatorScanV2, sc *storage.ComplianceOperatorScanConfigurationV2) {
-	ctx := context.Background()
-	err := manager.HandleScan(ctx, scan)
-	require.NoError(m.T(), err)
-}
-
-func (m *ManagerTestSuite) finishScans(manager Manager, scans []*storage.ComplianceOperatorScanV2) {
-	ctx := context.Background()
-	managerImp, ok := manager.(*managerImpl)
-	m.Require().True(ok)
-	numScanWatchers := concurrency.WithLock1[int](&managerImp.watchingScansLock, func() int {
-		return len(managerImp.watchingScans)
-	})
-	for _, scan := range scans {
-		require.NoError(m.T(), manager.HandleScan(ctx, scan))
-		m.Eventually(func() bool {
-			return concurrency.WithLock1[bool](&managerImp.watchingScansLock, func() bool {
-				return len(managerImp.watchingScans) == numScanWatchers-1
-			})
-		}, 100*time.Millisecond, 10*time.Millisecond)
-		numScanWatchers--
-	}
-}
-
-func getTestScansFromScanConfig(sc *storage.ComplianceOperatorScanConfigurationV2, timestamp *protocompat.Timestamp) []*storage.ComplianceOperatorScanV2 {
-	var ret []*storage.ComplianceOperatorScanV2
-	for _, cluster := range sc.GetClusters() {
-		for _, profile := range sc.GetProfiles() {
-			ret = append(ret, getTestScan(profile.GetProfileName(), sc.GetScanConfigName(), cluster.GetClusterId(), timestamp, true))
-		}
-	}
-	return ret
-}
-
-func (m *ManagerTestSuite) setupExpectCallsFromScanConfig(sc *storage.ComplianceOperatorScanConfigurationV2, timestamp *protocompat.Timestamp) []any {
-	var expectedCalls []any
-	for _, cluster := range sc.GetClusters() {
-		for _, profile := range sc.GetProfiles() {
-			scan := getTestScan(profile.GetProfileName(), sc.GetScanConfigName(), cluster.GetClusterId(), timestamp, false)
-			calls := []any{
-				m.scanConfigDataStore.EXPECT().
-					GetScanConfigurations(gomock.Any(), gomock.Any()).
-					Times(1).
-					Return([]*storage.ComplianceOperatorScanConfigurationV2{sc}, nil),
-				m.snapshotDataStore.EXPECT().
-					SearchSnapshots(gomock.Any(), gomock.Any()).
-					Times(1).
-					Return([]*storage.ComplianceOperatorReportSnapshotV2{}, nil),
-				m.scanDataStore.EXPECT().SearchScans(gomock.Any(), gomock.Any()).
-					Times(1).Return([]*storage.ComplianceOperatorScanV2{scan}, nil),
-				m.scanConfigDataStore.EXPECT().
-					GetScanConfigurations(gomock.Any(), gomock.Any()).
-					Times(1).
-					Return([]*storage.ComplianceOperatorScanConfigurationV2{getTestScanConfig()}, nil),
-				m.snapshotDataStore.EXPECT().
-					SearchSnapshots(gomock.Any(), gomock.Any()).
-					Times(1).
-					Return([]*storage.ComplianceOperatorReportSnapshotV2{}, nil),
-			}
-			expectedCalls = append(expectedCalls, calls...)
-		}
-	}
-	return expectedCalls
-}
-
-func (m *ManagerTestSuite) setupExpectCallsFromFinishAllScans(sc *storage.ComplianceOperatorScanConfigurationV2, scans []*storage.ComplianceOperatorScanV2, timestamp *timestamppb.Timestamp, numSnapshots int) []any {
-	var expectedCalls []any
-	for _, scan := range scans {
-		calls := []any{
-			m.scanConfigDataStore.EXPECT().
-				GetScanConfigurations(gomock.Any(), gomock.Any()).
-				Times(1).
-				Return([]*storage.ComplianceOperatorScanConfigurationV2{sc}, nil),
-			m.snapshotDataStore.EXPECT().
-				SearchSnapshots(gomock.Any(), gomock.Any()).
-				Times(1).
-				Return([]*storage.ComplianceOperatorReportSnapshotV2{}, nil),
-			m.checkResultDataStore.EXPECT().
-				DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(false)).
-				Times(1).Return(nil),
-			m.scanConfigDataStore.EXPECT().
-				GetScanConfigurationByName(gomock.Any(), gomock.Eq(sc.GetScanConfigName())).
-				Times(1).Return(sc, nil),
-			m.snapshotDataStore.EXPECT().
-				UpsertSnapshot(gomock.Any(), gomock.Any()).
-				Times(numSnapshots).
-				Return(nil),
-		}
-		expectedCalls = append(expectedCalls, calls...)
-	}
-	allScans := getTestScansFromScanConfig(sc, timestamp)
-	calls := []any{
-		// Delete Old Results of Missing Clusters
-		m.profileDataStore.EXPECT().
-			SearchProfiles(gomock.Any(), gomock.Any()).
-			Times(1).
-			Return([]*storage.ComplianceOperatorProfileV2{{}}, nil),
-		m.scanDataStore.EXPECT().
-			SearchScans(gomock.Any(), gomock.Any()).
-			Times(1).Return(allScans, nil),
-		m.scanDataStore.EXPECT().
-			SearchScans(gomock.Any(), gomock.Any()).
-			Times(len(sc.GetClusters())*numSnapshots).
-			Return(scans, nil),
-	}
-	expectedCalls = append(expectedCalls, calls...)
-	return expectedCalls
-}
-
-func (m *ManagerTestSuite) setupExpectCallsFromFailAllScans(sc *storage.ComplianceOperatorScanConfigurationV2, scans []*storage.ComplianceOperatorScanV2, timestamp *timestamppb.Timestamp, numSnapshots int) []any {
-	var expectedCalls []any
-	for range scans {
-		calls := []any{
-			m.scanConfigDataStore.EXPECT().
-				GetScanConfigurationByName(gomock.Any(), gomock.Eq(sc.GetScanConfigName())).
-				Times(1).Return(sc, nil),
-			m.snapshotDataStore.EXPECT().
-				UpsertSnapshot(gomock.Any(), gomock.Any()).
-				Times(numSnapshots).Return(nil),
-		}
-		expectedCalls = append(expectedCalls, calls...)
-	}
-	allScans := getTestScansFromScanConfig(sc, timestamp)
-	calls := []any{
-		// Delete Old Results of Missing Clusters
-		m.profileDataStore.EXPECT().
-			SearchProfiles(gomock.Any(), gomock.Any()).
-			Times(1).
-			Return([]*storage.ComplianceOperatorProfileV2{{}}, nil),
-		m.scanDataStore.EXPECT().
-			SearchScans(gomock.Any(), gomock.Any()).
-			Times(1).Return(allScans, nil),
-		// Validate Results
-		m.complianceIntegrationDataStore.EXPECT().
-			GetComplianceIntegrationByCluster(gomock.Any(), gomock.Any()).
-			Times(len(scans)).Return(nil, nil),
-		// Upsert Snapshots
-		m.snapshotDataStore.EXPECT().
-			UpsertSnapshot(gomock.Any(), gomock.Cond[*storage.ComplianceOperatorReportSnapshotV2](func(target *storage.ComplianceOperatorReportSnapshotV2) bool {
-				return target.GetReportStatus().GetRunState() == storage.ComplianceOperatorReportStatus_PREPARING
-
-			})).
-			Times(numSnapshots).Return(nil),
-		// GetClusterData
-		m.scanDataStore.EXPECT().
-			SearchScans(gomock.Any(), gomock.Any()).
-			Times(len(sc.GetClusters())*numSnapshots).
-			Return(scans, nil),
-	}
-	expectedCalls = append(expectedCalls, calls...)
-	return expectedCalls
-}
-
-func (m *ManagerTestSuite) setupExpectCallsFromFinishScan(scan *storage.ComplianceOperatorScanV2, sc *storage.ComplianceOperatorScanConfigurationV2, timestamp *timestamppb.Timestamp) []any {
-	scans := getTestScansFromScanConfig(sc, timestamp)
-	calls := []any{
-		m.scanConfigDataStore.EXPECT().
-			GetScanConfigurations(gomock.Any(), gomock.Any()).
-			Times(1).
-			Return([]*storage.ComplianceOperatorScanConfigurationV2{sc}, nil),
-		m.snapshotDataStore.EXPECT().
-			SearchSnapshots(gomock.Any(), gomock.Any()).
-			Times(1).
-			Return([]*storage.ComplianceOperatorReportSnapshotV2{}, nil),
-		m.checkResultDataStore.EXPECT().
-			DeleteOldResults(gomock.Any(), gomock.Eq(scan.GetLastStartedTime()), gomock.Eq(scan.GetScanRefId()), gomock.Eq(false)).
-			Times(1).Return(nil),
-		m.scanConfigDataStore.EXPECT().
-			GetScanConfigurationByName(gomock.Any(), gomock.Eq(sc.GetScanConfigName())).
-			Times(1).Return(sc, nil),
-		m.snapshotDataStore.EXPECT().
-			SearchSnapshots(gomock.Any(), gomock.Any()).
-			Times(1).Return(nil, nil),
-	}
-	if sc.GetNotifiers() != nil {
-		calls = append(calls, m.snapshotDataStore.EXPECT().
-			UpsertSnapshot(gomock.Any(), gomock.Any()).
-			Times(1).Return(nil))
-	}
-	calls = append(calls, []any{
-		m.profileDataStore.EXPECT().
-			SearchProfiles(gomock.Any(), gomock.Any()).
-			Times(1).
-			Return([]*storage.ComplianceOperatorProfileV2{{}}, nil),
-		m.scanDataStore.EXPECT().
-			SearchScans(gomock.Any(), gomock.Any()).
-			Times(1).Return(scans, nil),
-	}...)
-	if sc.GetNotifiers() != nil {
-		calls = append(calls, m.snapshotDataStore.EXPECT().
-			UpsertSnapshot(gomock.Any(), gomock.Any()).
-			Times(1).Return(nil))
-	}
-	return calls
-}
-
 func getTestClusterStatusFromScanConfig(sc *storage.ComplianceOperatorScanConfigurationV2) []*storage.ComplianceOperatorClusterScanConfigStatus {
 	ret := make([]*storage.ComplianceOperatorClusterScanConfigStatus, 0, len(sc.GetClusters()))
 	for _, c := range sc.GetClusters() {
@@ -836,39 +664,6 @@ func getTestClusterStatusFromScanConfig(sc *storage.ComplianceOperatorScanConfig
 		})
 	}
 	return ret
-}
-
-func getTestScan(scan, scanConfigName, cluster string, timestamp *timestamppb.Timestamp, done bool) *storage.ComplianceOperatorScanV2 {
-	ret := &storage.ComplianceOperatorScanV2{
-		Id:              scan,
-		ClusterId:       cluster,
-		LastStartedTime: timestamp,
-		ScanConfigName:  scanConfigName,
-	}
-	if done {
-		ret.Annotations = map[string]string{
-			watcher.CheckCountAnnotationKey: "1",
-		}
-	}
-	return ret
-}
-
-func getTestResult(scan *storage.ComplianceOperatorScanV2, timestamp *protocompat.Timestamp) *storage.ComplianceOperatorCheckResultV2 {
-	return &storage.ComplianceOperatorCheckResultV2{
-		ScanRefId: scan.GetScanRefId(),
-		Annotations: map[string]string{
-			watcher.LastScannedAnnotationKey: timestamp.AsTime().Format(time.RFC3339Nano),
-		},
-	}
-}
-
-func handleWaitGroup(t *testing.T, wg *concurrency.WaitGroup, timeout time.Duration, msg string) {
-	select {
-	case <-time.After(timeout):
-		t.Errorf("timeout waiting for %s", msg)
-		t.Fail()
-	case <-wg.Done():
-	}
 }
 
 func getScans(numProfiles int) []*storage.ComplianceOperatorScanV2 {
@@ -882,111 +677,25 @@ func getScans(numProfiles int) []*storage.ComplianceOperatorScanV2 {
 	return ret
 }
 
-func newGetScanConfigClusterStatusMatcher(sc *storage.ComplianceOperatorScanConfigurationV2) *getScanConfigClusterStatusMatcher {
-	return &getScanConfigClusterStatusMatcher{
-		scanConfigID: sc.GetId(),
-	}
+type stubScanConfigWatcher struct {
+	subscribedSnapshots []*storage.ComplianceOperatorReportSnapshotV2
+	scans               []*storage.ComplianceOperatorReportSnapshotV2_Scan
 }
 
-type getScanConfigClusterStatusMatcher struct {
-	scanConfigID string
-	error        string
+func (s *stubScanConfigWatcher) PushScanResults(_ *watcher.ScanWatcherResults) error { return nil }
+
+func (s *stubScanConfigWatcher) Subscribe(snapshot *storage.ComplianceOperatorReportSnapshotV2) error {
+	s.subscribedSnapshots = append(s.subscribedSnapshots, snapshot)
+	return nil
 }
 
-func (m *getScanConfigClusterStatusMatcher) Matches(target interface{}) bool {
-	scanConfigID, ok := target.(string)
-	if !ok {
-		m.error = "target is not of type string"
-		return false
-	}
-	m.error = fmt.Sprintf("expected field scan configuration ID %q", m.scanConfigID)
-	return m.scanConfigID == scanConfigID
+func (s *stubScanConfigWatcher) GetScans() []*storage.ComplianceOperatorReportSnapshotV2_Scan {
+	return s.scans
 }
 
-func (m *getScanConfigClusterStatusMatcher) String() string {
-	return m.error
-}
+func (s *stubScanConfigWatcher) Stop() {}
 
-func newGetSuitesMatcher(sc *storage.ComplianceOperatorScanConfigurationV2) *getSuitesMatcher {
-	return &getSuitesMatcher{
-		suiteName: sc.GetScanConfigName(),
-	}
-}
-
-type getSuitesMatcher struct {
-	suiteName string
-	error     string
-}
-
-func (m *getSuitesMatcher) Matches(target interface{}) bool {
-	query, ok := target.(*v1.Query)
-	if !ok {
-		m.error = "target is not of type *v1.Query"
-		return false
-	}
-	m.error = fmt.Sprintf("expected field suite name %q", m.suiteName)
-	field := query.GetBaseQuery().GetMatchFieldQuery().GetField()
-	if field != search.ComplianceOperatorSuiteName.String() {
-		m.error = fmt.Sprintf("unexpected query field %s", field)
-		return false
-	}
-	value := strings.ReplaceAll(query.GetBaseQuery().GetMatchFieldQuery().GetValue(), "\"", "")
-	return value == m.suiteName
-}
-
-func (m *getSuitesMatcher) String() string {
-	return m.error
-}
-
-func newGetBindingMatcher(sc *storage.ComplianceOperatorScanConfigurationV2) *getBindingMatcher {
-	return &getBindingMatcher{
-		scanConfigName: sc.GetScanConfigName(),
-		clusters: func() []string {
-			ret := make([]string, 0, len(sc.GetClusters()))
-			for _, c := range sc.GetClusters() {
-				ret = append(ret, c.GetClusterId())
-			}
-			return ret
-		}(),
-	}
-}
-
-type getBindingMatcher struct {
-	scanConfigName string
-	clusters       []string
-	error          string
-}
-
-func (m *getBindingMatcher) Matches(target interface{}) bool {
-	query, ok := target.(*v1.Query)
-	if !ok {
-		m.error = "target is not of type *v1.Query"
-		return false
-	}
-	m.error = fmt.Sprintf("expected fields scan configuration name %q and clusters %v", m.scanConfigName, m.clusters)
-	scanConfigFound := false
-	clustersFound := false
-	for _, q := range query.GetConjunction().GetQueries() {
-		field := q.GetBaseQuery().GetMatchFieldQuery().GetField()
-		switch field {
-		case search.ComplianceOperatorScanConfigName.String():
-			value := strings.ReplaceAll(q.GetBaseQuery().GetMatchFieldQuery().GetValue(), "\"", "")
-			if value == m.scanConfigName {
-				scanConfigFound = true
-			}
-		case search.ClusterID.String():
-			value := strings.ReplaceAll(q.GetBaseQuery().GetMatchFieldQuery().GetValue(), "\"", "")
-			if slices.Contains(m.clusters, value) {
-				clustersFound = true
-			}
-		default:
-			m.error = fmt.Sprintf("unexpected query field %s", field)
-			return false
-		}
-	}
-	return scanConfigFound && clustersFound
-}
-
-func (m *getBindingMatcher) String() string {
-	return m.error
+func (s *stubScanConfigWatcher) Finished() concurrency.ReadOnlySignal {
+	sig := concurrency.NewSignal()
+	return &sig
 }

--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -697,5 +697,6 @@ func (s *stubScanConfigWatcher) Stop() {}
 
 func (s *stubScanConfigWatcher) Finished() concurrency.ReadOnlySignal {
 	sig := concurrency.NewSignal()
+	sig.Signal()
 	return &sig
 }


### PR DESCRIPTION
## Description

Rewrites flaky tests in `central/complianceoperator/v2/report/manager/manager_test.go` that were racing goroutines against mock expectations.

**Root cause:** `TestHandleReportRequest` and `TestFailedReportWithWatcherRunningAndNoNotifiers` called `manager.Start()` (spawning 4 goroutines), then used `gomock.InOrder`/`InAnyOrder` chains of 30-40 expectations with `time.Sleep(100ms)` for synchronization. Under CI load, goroutine scheduling varied, exhausting mock expectations.

**Fix:** Call internal methods (`handleReportRequest`, `generateSingleReportFromWatcherResults`, `createAutomaticSnapshotAndSubscribe`) directly — no `Start()`, no goroutines, no timing. The watcher subsystem is already tested in `watcher/scanwatcher_test.go` and `watcher/scanconfigwatcher_test.go`.

**Changes:**
- Rewrote `TestHandleReportRequest` as 4 synchronous subtests (no watcher, upsert error, watcher running, missing identity)
- Replaced `TestFailedReportWithWatcherRunningAndNoNotifiers` with `TestGenerateReportFromWatcherResults` and `TestCreateAutomaticSnapshotAndSubscribe`
- Added `defer manager.Stop()` to `TestHandleReadyScanDeleteOldResultsGate` and `TestHandleScanRemove`
- Removed ~290 lines of dead helpers and custom matchers
- Un-skipped the ROX-30838 "watcher running" scenario

**Net result:** 993 → 702 lines, 0 skipped tests, 0 `time.Sleep`, 0 `gomock.InOrder`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- `go test -race -count=100 -timeout=300s -run TestHandleReportRequest` — 0 failures
- `go test -race -count=100 -timeout=300s -run '(TestGenerateReportFromWatcherResults|TestCreateAutomaticSnapshotAndSubscribe)'` — 0 failures
- `go test -race -count=10 -timeout=120s ./central/complianceoperator/v2/report/manager/` — full suite, 0 failures