### PR TITLE
ROX-34626: Migrate detector audit log pipeline to PubSub

### DIFF
--- a/sensor/common/compliance/service.go
+++ b/sensor/common/compliance/service.go
@@ -36,7 +36,7 @@ type Service interface {
 
 // NewService returns the ComplianceServiceServer API for Sensor to use, outputs any received ComplianceReturns
 // to the input channel.
-func NewService(orchestrator orchestrator.Orchestrator, auditEventsInput chan *sensor.AuditEvents, auditLogCollectionManager AuditLogCollectionManager, complianceC <-chan common.MessageToComplianceWithAddress) Service {
+func NewService(orchestrator orchestrator.Orchestrator, auditEventsInput chan *sensor.AuditEvents, auditLogCollectionManager AuditLogCollectionManager, complianceC <-chan common.MessageToComplianceWithAddress, pubSubDispatcher common.PubSubDispatcher) Service {
 	offlineMode := &atomic.Bool{}
 	offlineMode.Store(true)
 	return &serviceImpl{
@@ -47,6 +47,7 @@ func NewService(orchestrator orchestrator.Orchestrator, auditEventsInput chan *s
 		orchestrator:              orchestrator,
 		auditEvents:               auditEventsInput,
 		auditLogCollectionManager: auditLogCollectionManager,
+		pubSubDispatcher:          pubSubDispatcher,
 		connectionManager:         newConnectionManager(),
 		offlineMode:               offlineMode,
 		stopper:                   set.NewSet[concurrency.Stopper](),

--- a/sensor/common/compliance/service_impl.go
+++ b/sensor/common/compliance/service_impl.go
@@ -13,12 +13,15 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
 	"github.com/stackrox/rox/pkg/concurrency"
+	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/grpc/authz/idcheck"
 	"github.com/stackrox/rox/pkg/k8sutil"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/sensor/common"
 	"github.com/stackrox/rox/sensor/common/compliance/index"
+	detectorEvents "github.com/stackrox/rox/sensor/common/detector/events"
 	"github.com/stackrox/rox/sensor/common/message"
 	"github.com/stackrox/rox/sensor/common/orchestrator"
 	"github.com/stackrox/rox/sensor/common/unimplemented"
@@ -42,6 +45,7 @@ type serviceImpl struct {
 	orchestrator orchestrator.Orchestrator
 
 	connectionManager *connectionManager
+	pubSubDispatcher  common.PubSubDispatcher
 
 	offlineMode *atomic.Bool
 	stopperLock sync.Mutex
@@ -247,7 +251,13 @@ func (s *serviceImpl) Communicate(server sensor.ComplianceService_CommunicateSer
 			if s.offlineMode.Load() {
 				continue
 			}
-			s.auditEvents <- t.AuditEvents
+			if features.SensorInternalPubSub.Enabled() && s.pubSubDispatcher != nil {
+				if err := s.pubSubDispatcher.Publish(&detectorEvents.AuditLogEvent{AuditEvents: t.AuditEvents}); err != nil {
+					logging.GetRateLimitedLogger().ErrorL("audit-log-publish", "Failed to publish audit log event: %v", err)
+				}
+			} else {
+				s.auditEvents <- t.AuditEvents
+			}
 			s.auditLogCollectionManager.AuditMessagesChan() <- msg
 		case *sensor.MsgFromCompliance_NodeInventory:
 			s.nodeInventories <- t.NodeInventory

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -243,14 +243,22 @@ func (d *detectorImpl) Start() error {
 		); err != nil {
 			return errors.Wrap(err, "failed to register detector file access consumer")
 		}
+		if err := d.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.DetectorAuditLogConsumer,
+			pubsub.DetectorAuditLogTopic,
+			pubsub.DetectorAuditLogLane,
+			d.handleAuditLogEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register detector audit log consumer")
+		}
 	}
 
 	go d.runDetector()
-	go d.runAuditLogEventDetector()
 	go d.serializeDeployTimeOutput()
 	go d.processDeployment()
 
 	if !d.pubSubEnabled() {
+		go d.runAuditLogEventDetector()
 		go d.processIndicator()
 		go d.processAlertsForFlowOnEntity()
 		go d.processFileAccess()
@@ -336,7 +344,9 @@ func (d *detectorImpl) Stop() {
 	d.enricher.stop()
 
 	_ = d.detectorStopper.Client().Stopped().Wait()
-	_ = d.auditStopper.Client().Stopped().Wait()
+	if !d.pubSubEnabled() {
+		_ = d.auditStopper.Client().Stopped().Wait()
+	}
 	_ = d.serializerStopper.Client().Stopped().Wait()
 }
 
@@ -509,6 +519,50 @@ func (d *detectorImpl) runDetector() {
 	}
 }
 
+func (d *detectorImpl) detectAndAlertForAuditLog(auditEvents *sensor.AuditEvents) {
+	alerts := d.unifiedDetector.DetectAuditLogEvents(auditEvents)
+	if len(alerts) == 0 {
+		// No need to process runtime alerts that have no violations
+		return
+	}
+
+	// Force update the audit log status since alerts were detected
+	// This is required because if sensor were to restart right after this alert, it's possible that
+	// the saved state is prior to this the event that generated this alert (because the updater updates on a timer)
+	// To avoid duplicate alerts force the state to be updated
+	// This is non-blocking as the updates happen on another goroutine
+	d.auditLogUpdater.ForceUpdate()
+
+	sort.Slice(alerts, func(i, j int) bool {
+		return alerts[i].GetPolicy().GetId() < alerts[j].GetPolicy().GetId()
+	})
+
+	msg := &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Action: central.ResourceAction_CREATE_RESOURCE,
+				Resource: &central.SensorEvent_AlertResults{
+					AlertResults: &central.AlertResults{
+						Source: central.AlertResults_AUDIT_EVENT,
+						Alerts: alerts,
+						Stage:  storage.LifecycleStage_RUNTIME,
+					},
+				},
+			},
+		},
+	}
+
+	// These messages are coming from compliance, and since compliance supports offline mode as well
+	// it should be ok to leave these messages without expiration.
+	expiringMessage := message.New(msg)
+
+	select {
+	case <-d.auditStopper.Flow().StopRequested():
+	case <-d.serializerStopper.Flow().StopRequested():
+	case d.output <- expiringMessage:
+	}
+}
+
 func (d *detectorImpl) runAuditLogEventDetector() {
 	defer d.auditStopper.Flow().ReportStopped()
 	for {
@@ -516,51 +570,18 @@ func (d *detectorImpl) runAuditLogEventDetector() {
 		case <-d.auditStopper.Flow().StopRequested():
 			return
 		case auditEvents := <-d.auditEventsChan:
-			alerts := d.unifiedDetector.DetectAuditLogEvents(auditEvents)
-			if len(alerts) == 0 {
-				// No need to process runtime alerts that have no violations
-				continue
-			}
-
-			// Force update the audit log status since alerts were detected
-			// This is required because if sensor were to restart right after this alert, it's possible that
-			// the saved state is prior to this the event that generated this alert (because the updater updates on a timer)
-			// To avoid duplicate alerts force the state to be updated
-			// This is non-blocking as the updates happen on another goroutine
-			d.auditLogUpdater.ForceUpdate()
-
-			sort.Slice(alerts, func(i, j int) bool {
-				return alerts[i].GetPolicy().GetId() < alerts[j].GetPolicy().GetId()
-			})
-
-			msg := &central.MsgFromSensor{
-				Msg: &central.MsgFromSensor_Event{
-					Event: &central.SensorEvent{
-						Action: central.ResourceAction_CREATE_RESOURCE,
-						Resource: &central.SensorEvent_AlertResults{
-							AlertResults: &central.AlertResults{
-								Source: central.AlertResults_AUDIT_EVENT,
-								Alerts: alerts,
-								Stage:  storage.LifecycleStage_RUNTIME,
-							},
-						},
-					},
-				},
-			}
-
-			// These messages are coming from compliance, and since compliance supports offline mode as well
-			// it should be ok to leave these messages without expiration.
-			expiringMessage := message.New(msg)
-
-			select {
-			case <-d.auditStopper.Flow().StopRequested():
-				return
-			case <-d.serializerStopper.Flow().StopRequested():
-				return
-			case d.output <- expiringMessage:
-			}
+			d.detectAndAlertForAuditLog(auditEvents)
 		}
 	}
+}
+
+func (d *detectorImpl) handleAuditLogEvent(event pubsub.Event) error {
+	auditEvent, ok := event.(*detectorEvents.AuditLogEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	d.detectAndAlertForAuditLog(auditEvent.AuditEvents)
+	return nil
 }
 
 func (d *detectorImpl) markDeploymentForProcessing(id string) {

--- a/sensor/common/detector/detector_audit_log_bench_test.go
+++ b/sensor/common/detector/detector_audit_log_bench_test.go
@@ -1,0 +1,51 @@
+package detector
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	detectorEvents "github.com/stackrox/rox/sensor/common/detector/events"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkAuditLogPipeline_SteadyState measures steady-state end-to-end
+// latency per audit log event through the full pipeline (detect → output),
+// comparing the legacy channel path with the PubSub path.
+func BenchmarkAuditLogPipeline_SteadyState(b *testing.B) {
+	for _, pubSubEnabled := range []bool{false, true} {
+		b.Run(fmt.Sprintf("pubsub=%t", pubSubEnabled), func(b *testing.B) {
+			b.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
+
+			d := createBenchDetector(b, pubSubEnabled)
+			require.NoError(b, d.Start())
+			b.Cleanup(d.Stop)
+
+			events := &sensor.AuditEvents{
+				Events: []*storage.KubernetesEvent{
+					{
+						Id: "event-1",
+						Object: &storage.KubernetesEvent_Object{
+							Name:      "test-secret",
+							Resource:  storage.KubernetesEvent_Object_SECRETS,
+							ClusterId: "cluster-1",
+							Namespace: "default",
+						},
+						ApiVerb: storage.KubernetesEvent_CREATE,
+					},
+				},
+			}
+
+			for b.Loop() {
+				if pubSubEnabled {
+					_ = d.pubSubDispatcher.Publish(&detectorEvents.AuditLogEvent{AuditEvents: events})
+				} else {
+					d.auditEventsChan <- events
+				}
+				<-d.output
+			}
+		})
+	}
+}

--- a/sensor/common/detector/detector_audit_log_test.go
+++ b/sensor/common/detector/detector_audit_log_test.go
@@ -1,0 +1,101 @@
+package detector
+
+import (
+	"fmt"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	detectorEvents "github.com/stackrox/rox/sensor/common/detector/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestAuditEvents() *sensor.AuditEvents {
+	return &sensor.AuditEvents{
+		Events: []*storage.KubernetesEvent{
+			{
+				Id: "event-1",
+				Object: &storage.KubernetesEvent_Object{
+					Name:      "test-secret",
+					Resource:  storage.KubernetesEvent_Object_SECRETS,
+					ClusterId: "cluster-1",
+					Namespace: "default",
+				},
+				ApiVerb: storage.KubernetesEvent_CREATE,
+			},
+		},
+	}
+}
+
+// sendAuditEvent sends an audit event through the appropriate path:
+// in PubSub mode, publishes directly to the dispatcher (like the compliance
+// service would); in legacy mode, writes to the auditEventsChan.
+func sendAuditEvent(d *detectorImpl, pubSubEnabled bool, events *sensor.AuditEvents) {
+	if pubSubEnabled {
+		_ = d.pubSubDispatcher.Publish(&detectorEvents.AuditLogEvent{AuditEvents: events})
+	} else {
+		d.auditEventsChan <- events
+	}
+}
+
+func TestAuditLogPipeline(t *testing.T) {
+	tests := map[string]struct {
+		setupDetector func(*detectorImpl)
+		expectOutput  bool
+	}{
+		"audit event with alerts reaches output": {
+			setupDetector: func(d *detectorImpl) {
+				d.unifiedDetector = &fakeUnifiedDetector{
+					alerts: []*storage.Alert{{
+						Id:     "alert-1",
+						Policy: &storage.Policy{Id: "policy-1"},
+					}},
+				}
+			},
+			expectOutput: true,
+		},
+		"audit event with no alerts produces no output": {
+			expectOutput: false,
+		},
+	}
+
+	for _, pubSubEnabled := range []bool{false, true} {
+		for name, tc := range tests {
+			t.Run(fmt.Sprintf("%s/pubsub=%t", name, pubSubEnabled), func(t *testing.T) {
+				t.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
+
+				synctest.Test(t, func(t *testing.T) {
+					d, _, _, _ := createTestDetector(t, pubSubEnabled)
+					if tc.setupDetector != nil {
+						tc.setupDetector(d)
+					}
+
+					require.NoError(t, d.Start())
+					defer d.Stop()
+
+					sendAuditEvent(d, pubSubEnabled, newTestAuditEvents())
+					synctest.Wait()
+
+					if tc.expectOutput {
+						select {
+						case msg := <-d.output:
+							require.NotNil(t, msg)
+							assert.NotEmpty(t, msg.GetEvent().GetAlertResults().GetAlerts())
+						default:
+							t.Fatal("expected output but none available")
+						}
+					} else {
+						select {
+						case msg := <-d.output:
+							t.Fatalf("expected no output but got: %v", msg)
+						default:
+						}
+					}
+				})
+			})
+		}
+	}
+}

--- a/sensor/common/detector/detector_audit_log_test.go
+++ b/sensor/common/detector/detector_audit_log_test.go
@@ -33,9 +33,10 @@ func newTestAuditEvents() *sensor.AuditEvents {
 // sendAuditEvent sends an audit event through the appropriate path:
 // in PubSub mode, publishes directly to the dispatcher (like the compliance
 // service would); in legacy mode, writes to the auditEventsChan.
-func sendAuditEvent(d *detectorImpl, pubSubEnabled bool, events *sensor.AuditEvents) {
+func sendAuditEvent(t *testing.T, d *detectorImpl, pubSubEnabled bool, events *sensor.AuditEvents) {
+	t.Helper()
 	if pubSubEnabled {
-		_ = d.pubSubDispatcher.Publish(&detectorEvents.AuditLogEvent{AuditEvents: events})
+		require.NoError(t, d.pubSubDispatcher.Publish(&detectorEvents.AuditLogEvent{AuditEvents: events}))
 	} else {
 		d.auditEventsChan <- events
 	}
@@ -76,7 +77,7 @@ func TestAuditLogPipeline(t *testing.T) {
 					require.NoError(t, d.Start())
 					defer d.Stop()
 
-					sendAuditEvent(d, pubSubEnabled, newTestAuditEvents())
+					sendAuditEvent(t, d, pubSubEnabled, newTestAuditEvents())
 					synctest.Wait()
 
 					if tc.expectOutput {

--- a/sensor/common/detector/detector_helpers_test.go
+++ b/sensor/common/detector/detector_helpers_test.go
@@ -22,6 +22,7 @@ import (
 	pubsubDispatcher "github.com/stackrox/rox/sensor/common/pubsub/dispatcher"
 	"github.com/stackrox/rox/sensor/common/pubsub/lane"
 	mockStore "github.com/stackrox/rox/sensor/common/store/mocks"
+	"github.com/stackrox/rox/sensor/common/updater"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -75,6 +76,7 @@ func createTestDetectorWithBufferSize(tb testing.TB, pubSubEnabled bool, bufferS
 		baselineEval:              baseline.NewBaselineEvaluator(),
 		networkbaselineEval:       networkBaselineEval.NewNetworkBaselineEvaluator(),
 		enforcer:                  &fakeEnforcer{},
+		auditLogUpdater:           &fakeAuditLogUpdater{},
 		deduper:                   newDeduper(),
 		detectorStopper:           detectorStopper,
 		auditStopper:              concurrency.NewStopper(),
@@ -111,6 +113,7 @@ func createTestDetectorWithBufferSize(tb testing.TB, pubSubEnabled bool, bufferS
 						),
 					),
 				),
+				lane.NewBlockingLane(pubsub.DetectorAuditLogLane),
 			},
 		))
 		require.NoError(tb, err)
@@ -191,3 +194,19 @@ func (f *fakeEnforcer) ProcessMessage(_ context.Context, _ *central.MsgToSensor)
 }
 func (f *fakeEnforcer) ProcessAlertResults(_ central.ResourceAction, _ storage.LifecycleStage, _ *central.AlertResults) {
 }
+
+type fakeAuditLogUpdater struct{}
+
+func (f *fakeAuditLogUpdater) Start() error                                   { return nil }
+func (f *fakeAuditLogUpdater) Stop()                                          {}
+func (f *fakeAuditLogUpdater) Notify(_ common.SensorComponentEvent)           {}
+func (f *fakeAuditLogUpdater) Capabilities() []centralsensor.SensorCapability { return nil }
+func (f *fakeAuditLogUpdater) Name() string                                   { return "fake-updater" }
+func (f *fakeAuditLogUpdater) ResponsesC() <-chan *message.ExpiringMessage    { return nil }
+func (f *fakeAuditLogUpdater) Accepts(_ *central.MsgToSensor) bool            { return false }
+func (f *fakeAuditLogUpdater) ProcessMessage(_ context.Context, _ *central.MsgToSensor) error {
+	return nil
+}
+func (f *fakeAuditLogUpdater) ForceUpdate() {}
+
+var _ updater.Component = (*fakeAuditLogUpdater)(nil)

--- a/sensor/common/detector/events/audit_log.go
+++ b/sensor/common/detector/events/audit_log.go
@@ -1,0 +1,19 @@
+package events
+
+import (
+	"github.com/stackrox/rox/generated/internalapi/sensor"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+)
+
+// AuditLogEvent holds audit log events for detection.
+type AuditLogEvent struct {
+	AuditEvents *sensor.AuditEvents
+}
+
+func (e *AuditLogEvent) Topic() pubsub.Topic {
+	return pubsub.DetectorAuditLogTopic
+}
+
+func (e *AuditLogEvent) Lane() pubsub.LaneID {
+	return pubsub.DetectorAuditLogLane
+}

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -12,6 +12,7 @@ const (
 	DetectorProcessIndicatorConsumer
 	DetectorNetworkFlowConsumer
 	DetectorFileAccessConsumer
+	DetectorAuditLogConsumer
 )
 
 var (
@@ -25,6 +26,7 @@ var (
 		DetectorProcessIndicatorConsumer:    "DetectorProcessIndicator",
 		DetectorNetworkFlowConsumer:         "DetectorNetworkFlow",
 		DetectorFileAccessConsumer:          "DetectorFileAccess",
+		DetectorAuditLogConsumer:            "DetectorAuditLog",
 	}
 )
 

--- a/sensor/common/pubsub/laneid.go
+++ b/sensor/common/pubsub/laneid.go
@@ -11,6 +11,7 @@ const (
 	DetectorProcessIndicatorLane
 	DetectorNetworkFlowLane
 	DetectorFileAccessLane
+	DetectorAuditLogLane
 )
 
 var (
@@ -23,6 +24,7 @@ var (
 		DetectorProcessIndicatorLane:   "DetectorProcessIndicator",
 		DetectorNetworkFlowLane:        "DetectorNetworkFlow",
 		DetectorFileAccessLane:         "DetectorFileAccess",
+		DetectorAuditLogLane:           "DetectorAuditLog",
 	}
 )
 

--- a/sensor/common/pubsub/topic.go
+++ b/sensor/common/pubsub/topic.go
@@ -11,6 +11,7 @@ const (
 	DetectorProcessIndicatorTopic
 	DetectorNetworkFlowTopic
 	DetectorFileAccessTopic
+	DetectorAuditLogTopic
 )
 
 var (
@@ -23,6 +24,7 @@ var (
 		DetectorProcessIndicatorTopic:   "DetectorProcessIndicator",
 		DetectorNetworkFlowTopic:        "DetectorNetworkFlow",
 		DetectorFileAccessTopic:         "DetectorFileAccess",
+		DetectorAuditLogTopic:           "DetectorAuditLog",
 	}
 )
 

--- a/sensor/kubernetes/sensor/pubsub.go
+++ b/sensor/kubernetes/sensor/pubsub.go
@@ -42,6 +42,7 @@ func buildPubSubDispatcher() (common.PubSubDispatcher, error) {
 			buildConcurrentLane(pubsub.DetectorProcessIndicatorLane, env.DetectorProcessIndicatorBufferSize),
 			buildConcurrentLane(pubsub.DetectorNetworkFlowLane, env.DetectorNetworkFlowBufferSize),
 			buildConcurrentLane(pubsub.DetectorFileAccessLane, env.DetectorFileAccessBufferSize),
+			lane.NewBlockingLane(pubsub.DetectorAuditLogLane),
 		},
 	))
 	if err != nil {

--- a/sensor/kubernetes/sensor/sensor.go
+++ b/sensor/kubernetes/sensor/sensor.go
@@ -128,7 +128,7 @@ func CreateSensor(cfg *CreateOptions) (*sensor.Sensor, error) {
 	o := orchestrator.New(cfg.k8sClient.Kubernetes())
 	complianceMultiplexer := compliance.NewMultiplexer()
 	// TODO(ROX-16931): Turn auditLogEventsInput and auditLogCollectionManager into ComplianceComponents if possible
-	complianceService := compliance.NewService(o, auditLogEventsInput, auditLogCollectionManager, complianceMultiplexer.ComplianceC())
+	complianceService := compliance.NewService(o, auditLogEventsInput, auditLogCollectionManager, complianceMultiplexer.ComplianceC(), internalMessageDispatcher)
 
 	configHandler := config.NewCommandHandler(admCtrlSettingsMgr, deploymentIdentification, helmManagedConfig, auditLogCollectionManager)
 	enforcer, err := enforcer.New(cfg.k8sClient)


### PR DESCRIPTION
## Description

Migrate the detector audit log events pipeline to the internal PubSub system, gated by ROX_SENSOR_PUBSUB. Builds on the FA pipeline migration.

- Add DetectorAuditLogTopic, DetectorAuditLogLane, DetectorAuditLogConsumer to PubSub constants
- Add AuditLogEvent in detector/events/ implementing pubsub.Event
- Register a BlockingLane (no drop/pause needed for this pipeline)
- In PubSub mode, the compliance service publishes directly to PubSub instead of writing to auditEventsChan; the detector only registers a consumer
- Refactor shared detection logic into detectAndAlertForAuditLog used by both paths
- Stop() skips waiting on auditStopper in PubSub mode since no audit goroutine runs

### Benchmark results

| Path | ns/op | B/op | allocs/op |
|------|-------|------|-----------|
| Legacy | ~1,129 | 368 | 7 |
| PubSub | ~6,993 | 600 | 11 |

~5.9us absolute overhead, 4 extra allocations. The legacy path is extremely fast (just a channel send), so the percentage is high but the absolute cost is the same ~6us PubSub machinery overhead seen across all pipelines.

## User-facing documentation

- [x] CHANGELOG.md is updated OR update is not needed
- [x] documentation PR is created and is linked above OR is not needed

## Testing and quality

- [x] the change is production ready: gated by ROX_SENSOR_PUBSUB feature flag
- [x] CI results are inspected

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- All existing detector and compliance tests pass with both PubSub enabled and disabled
- New audit log tests cover: with alerts, no alerts (both PubSub and legacy)
- Benchmark confirms stable overhead