### PR TITLE
ROX-33329: Refactor test to avoid race condition

### DIFF
--- a/pkg/secretinformer/informer_test.go
+++ b/pkg/secretinformer/informer_test.go
@@ -22,14 +22,15 @@ const (
 
 func TestSecretInformer(t *testing.T) {
 	cases := map[string]struct {
-		setupFn             func(k8sClient *fake.Clientset) error
+		preCreateSecret     bool
+		setupFn             func(t *testing.T, k8sClient *fake.Clientset)
 		expectedOnAddCnt    int
 		expectedOnUpdateCnt int
 		expectedOnDeleteCnt int
 		expectedData        string
 	}{
 		"secret added": {
-			setupFn: func(k8sClient *fake.Clientset) error {
+			setupFn: func(t *testing.T, k8sClient *fake.Clientset) {
 				_, err := k8sClient.CoreV1().Secrets(namespace).Create(
 					context.Background(),
 					&v1.Secret{
@@ -40,13 +41,13 @@ func TestSecretInformer(t *testing.T) {
 					},
 					metav1.CreateOptions{},
 				)
-				return err
+				require.NoError(t, err)
 			},
 			expectedOnAddCnt: 1,
 			expectedData:     secretData,
 		},
 		"secret updated": {
-			setupFn: func(k8sClient *fake.Clientset) error {
+			setupFn: func(t *testing.T, k8sClient *fake.Clientset) {
 				_, err := k8sClient.CoreV1().Secrets(namespace).Create(
 					context.Background(),
 					&v1.Secret{
@@ -57,9 +58,7 @@ func TestSecretInformer(t *testing.T) {
 					},
 					metav1.CreateOptions{},
 				)
-				if err != nil {
-					return err
-				}
+				require.NoError(t, err)
 				_, err = k8sClient.CoreV1().Secrets(namespace).Update(
 					context.Background(),
 					&v1.Secret{
@@ -70,14 +69,35 @@ func TestSecretInformer(t *testing.T) {
 					},
 					metav1.UpdateOptions{},
 				)
-				return err
+				require.NoError(t, err)
 			},
 			expectedOnAddCnt:    1,
 			expectedOnUpdateCnt: 1,
 			expectedData:        secretData,
 		},
 		"secret deleted": {
-			setupFn: func(k8sClient *fake.Clientset) error {
+			preCreateSecret: true,
+			setupFn: func(t *testing.T, k8sClient *fake.Clientset) {
+				err := k8sClient.CoreV1().Secrets(namespace).Delete(
+					context.Background(), secretName, metav1.DeleteOptions{},
+				)
+				require.NoError(t, err)
+			},
+			expectedOnAddCnt:    1,
+			expectedOnDeleteCnt: 1,
+			expectedData:        secretData,
+		},
+		"no secret": {
+			setupFn: func(_ *testing.T, _ *fake.Clientset) {},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			var onAddCnt, onUpdateCnt, onDeleteCnt atomic.Int32
+
+			k8sClient := fake.NewClientset()
+			if c.preCreateSecret {
 				_, err := k8sClient.CoreV1().Secrets(namespace).Create(
 					context.Background(),
 					&v1.Secret{
@@ -88,30 +108,9 @@ func TestSecretInformer(t *testing.T) {
 					},
 					metav1.CreateOptions{},
 				)
-				if err != nil {
-					return err
-				}
-				err = k8sClient.CoreV1().Secrets(namespace).Delete(
-					context.Background(), secretName, metav1.DeleteOptions{},
-				)
-				return err
-			},
-			expectedOnAddCnt:    1,
-			expectedOnDeleteCnt: 1,
-			expectedData:        secretData,
-		},
-		"no secret": {
-			setupFn: func(k8sClient *fake.Clientset) error {
-				return nil
-			},
-		},
-	}
+				require.NoError(t, err)
+			}
 
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			var onAddCnt, onUpdateCnt, onDeleteCnt atomic.Int32
-
-			k8sClient := fake.NewClientset()
 			informer := NewSecretInformer(
 				namespace,
 				secretName,
@@ -133,13 +132,20 @@ func TestSecretInformer(t *testing.T) {
 			defer informer.Stop()
 			require.Eventually(t, informer.HasSynced, 30*time.Second, 100*time.Millisecond)
 
-			require.NoError(t, c.setupFn(k8sClient))
+			if c.preCreateSecret {
+				require.Eventually(t, func() bool {
+					return onAddCnt.Load() > 0
+				}, 30*time.Second, 50*time.Millisecond,
+					"add callback not invoked for pre-created secret")
+			}
+
+			c.setupFn(t, k8sClient)
 
 			assert.Eventually(t, func() bool {
 				return onAddCnt.Load() == int32(c.expectedOnAddCnt) &&
 					onUpdateCnt.Load() == int32(c.expectedOnUpdateCnt) &&
 					onDeleteCnt.Load() == int32(c.expectedOnDeleteCnt)
-			}, 10*time.Second, 50*time.Millisecond,
+			}, 30*time.Second, 50*time.Millisecond,
 				"callbacks not invoked as expected (add: %d/%d, update: %d/%d, delete: %d/%d)",
 				onAddCnt.Load(), c.expectedOnAddCnt, onUpdateCnt.Load(), c.expectedOnUpdateCnt,
 				onDeleteCnt.Load(), c.expectedOnDeleteCnt)


### PR DESCRIPTION
## Description

**Root Cause:** The test created a Kubernetes secret and immediately deleted it, then expected the informer's asynchronous event handler to process both the add and delete watch events within 10 seconds. Under CI CPU load, the informer's goroutines were starved and never processed either event.

**Fix (2 changes):**
1. Structural fix: Pre-create the secret before starting the informer for the `secret_deleted` case. The add event is now delivered during the initial list sync (guaranteed by `HasSynced()`), and only the delete goes through the watch path. This eliminates the create-delete race entirely.
2. Timeout hardening: Increased `assert.Eventually` timeout from 10s to 30s across all subtests to handle goroutine scheduling delays under load.

**Verification:** 200 consecutive runs with -race under 8 CPU stress processes on 4 cores -- 0 failures (vs 2-3 failures before the fix).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] Run test in CI (https://github.com/stackrox/stackrox/actions/runs/27146822643/job/80126768766)
- [x] Reproduce locally with VM load (8 CPU stress processes on 4 cores)
- [x] Run tests with the same load on VM
