### PR TITLE
ROX-34908: Add --no-serialized flag to walker and pg-table-bindings

### DIFF
--- a/pkg/postgres/types.go
+++ b/pkg/postgres/types.go
@@ -7,21 +7,22 @@ type DataType string
 
 // Defines all the internal types derived from the struct fields
 const (
-	Bytes       DataType = "bytes"
-	Bool        DataType = "bool"
-	Numeric     DataType = "numeric"
-	String      DataType = "string"
-	DateTime    DataType = "datetime"
-	Map         DataType = "map"
-	Enum        DataType = "enum"
-	StringArray DataType = "stringarray"
-	EnumArray   DataType = "enumarray"
-	Integer     DataType = "integer"
-	IntArray    DataType = "intarray"
-	BigInteger  DataType = "biginteger"
-	UUID        DataType = "uuid"
-	CIDR        DataType = "cidr"
-	DateTimeTZ  DataType = "datetimetz"
+	Bytes        DataType = "bytes"
+	Bool         DataType = "bool"
+	Numeric      DataType = "numeric"
+	String       DataType = "string"
+	DateTime     DataType = "datetime"
+	Map          DataType = "map"
+	Enum         DataType = "enum"
+	StringArray  DataType = "stringarray"
+	EnumArray    DataType = "enumarray"
+	Integer      DataType = "integer"
+	IntArray     DataType = "intarray"
+	BigInteger   DataType = "biginteger"
+	UUID         DataType = "uuid"
+	CIDR         DataType = "cidr"
+	DateTimeTZ   DataType = "datetimetz"
+	MessageBytes DataType = "messagebytes"
 )
 
 var (
@@ -54,7 +55,7 @@ func DataTypeToSQLType(dataType DataType) string {
 		sqlType = "text[]"
 	case EnumArray, IntArray:
 		sqlType = "int[]"
-	case Bytes:
+	case Bytes, MessageBytes:
 		sqlType = "bytea"
 	case CIDR:
 		sqlType = "cidr"

--- a/pkg/postgres/walker/schema.go
+++ b/pkg/postgres/walker/schema.go
@@ -470,6 +470,10 @@ type PostgresOptions struct {
 	// IgnoreChildIndexes is an option used to tell the walker that
 	// index options of children of this field should be ignored.
 	IgnoreChildIndexes bool
+
+	// RepeatedStrategy overrides how a repeated message field is stored.
+	// Valid values: "" (default, child table), "bytea" (inline as MessageBytes).
+	RepeatedStrategy string
 }
 
 type foreignKeyRef struct {
@@ -564,5 +568,5 @@ func (f Field) Include() bool {
 	if f.Schema != nil && f.Schema.Root().NoSerialized {
 		return f.ColumnName != "serialized"
 	}
-	return f.Options.PrimaryKey || f.Options.Unique || f.Search.Enabled || f.ColumnName == "serialized" || f.Options.Reference != nil
+	return f.Options.PrimaryKey || f.Options.Unique || f.Search.Enabled || f.ColumnName == "serialized" || f.Options.Reference != nil || f.Options.RepeatedStrategy != ""
 }

--- a/pkg/postgres/walker/schema.go
+++ b/pkg/postgres/walker/schema.go
@@ -141,12 +141,25 @@ type Schema struct {
 	SearchScope map[v1.SearchCategory]struct{}
 
 	ScopingResource permissions.ResourceMetadata
+
+	// NoSerialized indicates this schema should not include a serialized bytea column.
+	// When true, all proto fields are stored as individual DB columns.
+	NoSerialized bool
 }
 
 // TableFieldsGroup is the group of table fields. A slice of this struct can be used where the table order is essential,
 type TableFieldsGroup struct {
 	Table  string
 	Fields []Field
+}
+
+// Root returns the root schema (the one with no parent).
+func (s *Schema) Root() *Schema {
+	curr := s
+	for curr.Parent != nil {
+		curr = curr.Parent
+	}
+	return curr
 }
 
 // SetOptionsMap sets options map for the schema.
@@ -548,5 +561,8 @@ func (f Field) Getter(prefix string) string {
 
 // Include returns if the field should be included in the schema
 func (f Field) Include() bool {
+	if f.Schema != nil && f.Schema.Root().NoSerialized {
+		return f.ColumnName != "serialized"
+	}
 	return f.Options.PrimaryKey || f.Options.Unique || f.Search.Enabled || f.ColumnName == "serialized" || f.Options.Reference != nil
 }

--- a/pkg/postgres/walker/walker.go
+++ b/pkg/postgres/walker/walker.go
@@ -75,7 +75,7 @@ func removeTablesWithNoSearchableFields(schema *Schema) (shouldInclude bool) {
 }
 
 func addCommonFields(s *Schema, parentPrimaryKeys ...Field) {
-	if len(parentPrimaryKeys) == 0 {
+	if len(parentPrimaryKeys) == 0 && !s.NoSerialized {
 		s.Fields = append(s.Fields, getSerializedField(s))
 	} else {
 		// Collect additional fields separately so we can put them in front of the field list
@@ -136,13 +136,29 @@ func postProcessSchema(s *Schema) {
 	addCommonFields(s)
 }
 
+// WalkOption configures schema generation.
+type WalkOption func(*Schema)
+
+// WithNoSerialized produces a schema without a serialized bytea column.
+// All proto fields become individual DB columns.
+func WithNoSerialized() WalkOption {
+	return func(s *Schema) {
+		s.NoSerialized = true
+	}
+}
+
 // Walk iterates over the obj and creates a search.Map object from the found struct tags
-func Walk(obj reflect.Type, table string) *Schema {
+func Walk(obj reflect.Type, table string, opts ...WalkOption) *Schema {
 	schema := &Schema{
 		Table:    table,
 		Type:     obj.String(),
 		TypeName: obj.Elem().Name(),
 	}
+
+	for _, opt := range opts {
+		opt(schema)
+	}
+
 	handleStruct(walkerContext{}, schema, obj.Elem())
 
 	// Post-process schema

--- a/pkg/postgres/walker/walker.go
+++ b/pkg/postgres/walker/walker.go
@@ -439,9 +439,14 @@ func handleStruct(ctx walkerContext, schema *Schema, original reflect.Type) {
 				continue
 			}
 
-			if opts.RepeatedStrategy == "bytea" {
+			switch opts.RepeatedStrategy {
+			case "bytea":
 				schema.AddFieldWithType(field, postgres.MessageBytes, opts)
 				continue
+			case "child_table", "":
+				// Default behavior: create a child table.
+			default:
+				log.Errorf("field %s.%s has unsupported strategy(%s), valid values are: bytea, child_table", original.Name(), structField.Name, opts.RepeatedStrategy)
 			}
 
 			childSchema := &Schema{

--- a/pkg/postgres/walker/walker.go
+++ b/pkg/postgres/walker/walker.go
@@ -295,6 +295,8 @@ func getPostgresOptions(tag string, topLevel bool, ignorePK, ignoreUnique, ignor
 		case strings.HasPrefix(field, "type"):
 			typeName := field[strings.Index(field, "(")+1 : strings.Index(field, ")")]
 			opts.ColumnType = typeName
+		case strings.HasPrefix(field, "strategy"):
+			opts.RepeatedStrategy = field[strings.Index(field, "(")+1 : strings.Index(field, ")")]
 		case field == "":
 		default:
 			// ignore for just right now
@@ -428,6 +430,11 @@ func handleStruct(ctx walkerContext, schema *Schema, original reflect.Type) {
 				} else {
 					schema.AddFieldWithType(field, postgres.IntArray, opts)
 				}
+				continue
+			}
+
+			if opts.RepeatedStrategy == "bytea" {
+				schema.AddFieldWithType(field, postgres.MessageBytes, opts)
 				continue
 			}
 

--- a/pkg/postgres/walker/walker.go
+++ b/pkg/postgres/walker/walker.go
@@ -75,8 +75,11 @@ func removeTablesWithNoSearchableFields(schema *Schema) (shouldInclude bool) {
 }
 
 func addCommonFields(s *Schema, parentPrimaryKeys ...Field) {
-	if len(parentPrimaryKeys) == 0 && !s.NoSerialized {
-		s.Fields = append(s.Fields, getSerializedField(s))
+	if len(parentPrimaryKeys) == 0 {
+		// Root table: add serialized field unless NoSerialized is set.
+		if !s.NoSerialized {
+			s.Fields = append(s.Fields, getSerializedField(s))
+		}
 	} else {
 		// Collect additional fields separately so we can put them in front of the field list
 		// (since these are primary keys, that is cleaner).
@@ -378,6 +381,9 @@ func handleStruct(ctx walkerContext, schema *Schema, original reflect.Type) {
 		}
 		opts := getPostgresOptions(structField.Tag.Get("sql"), schema.Parent == nil, ctx.ignorePK, ctx.ignoreUnique, ctx.ignoreFKs, ctx.ignoreIndex)
 		if opts.Ignored {
+			if schema.Root().NoSerialized {
+				log.Panicf("field %s.%s has sql:\"-\" which is incompatible with --no-serialized", original.Name(), structField.Name)
+			}
 			continue
 		}
 		searchOpts, derivedFields := getSearchOptions(ctx, structField.Tag.Get("search"))

--- a/pkg/postgres/walker/walker_test.go
+++ b/pkg/postgres/walker/walker_test.go
@@ -81,6 +81,10 @@ func TestFieldIncludeNoSerialized(t *testing.T) {
 			field:    Field{Schema: normalSchema, ColumnName: "name", Name: "name"},
 			expected: false,
 		},
+		"normal: RepeatedStrategy field included": {
+			field:    Field{Schema: normalSchema, ColumnName: "data", Options: PostgresOptions{RepeatedStrategy: "bytea"}},
+			expected: true,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/postgres/walker/walker_test.go
+++ b/pkg/postgres/walker/walker_test.go
@@ -17,6 +17,12 @@ type TestChildMessage struct {
 	Value string `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty" search:"Test Child Value"`
 }
 
+type TestStorageWithIgnoredField struct {
+	ID      string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk,type(uuid)"`
+	Name    string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Ignored string `protobuf:"bytes,3,opt,name=ignored,proto3" json:"ignored,omitempty" sql:"-"`
+}
+
 type TestStorageWithRepeatedStrategy struct {
 	ID      string              `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk,type(uuid)"`
 	Inlined []*TestChildMessage `protobuf:"bytes,2,rep,name=inlined,proto3" json:"inlined,omitempty" sql:"strategy(bytea)"`
@@ -136,4 +142,11 @@ func TestRepeatedFieldStrategy(t *testing.T) {
 				"strategy(bytea) field should not create a child table")
 		}
 	})
+}
+
+func TestNoSerializedRejectsSqlIgnored(t *testing.T) {
+	mt := reflect.TypeOf(&TestStorageWithIgnoredField{})
+	assert.Panics(t, func() {
+		Walk(mt, "test_table", WithNoSerialized())
+	}, "Walk with NoSerialized should fatal on sql:\"-\" fields")
 }

--- a/pkg/postgres/walker/walker_test.go
+++ b/pkg/postgres/walker/walker_test.go
@@ -4,12 +4,23 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type TestStorageType struct {
 	ID string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk,id,type(uuid)"`
+}
+
+type TestChildMessage struct {
+	Value string `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty" search:"Test Child Value"`
+}
+
+type TestStorageWithRepeatedStrategy struct {
+	ID      string              `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk,type(uuid)"`
+	Inlined []*TestChildMessage `protobuf:"bytes,2,rep,name=inlined,proto3" json:"inlined,omitempty" sql:"strategy(bytea)"`
+	AsChild []*TestChildMessage `protobuf:"bytes,3,rep,name=as_child,proto3" json:"as_child,omitempty"`
 }
 
 // One can specify a custom SQL type for the structure field
@@ -94,6 +105,35 @@ func TestWalkWithNoSerialized(t *testing.T) {
 		for _, f := range schema.DBColumnFields() {
 			assert.NotEqual(t, "serialized", f.ColumnName,
 				"no-serialized schema should not have serialized in DBColumnFields")
+		}
+	})
+}
+
+func TestRepeatedFieldStrategy(t *testing.T) {
+	mt := reflect.TypeOf(&TestStorageWithRepeatedStrategy{})
+	schema := Walk(mt, "test_strategy")
+
+	t.Run("strategy(bytea) inlines as MessageBytes column", func(t *testing.T) {
+		var found bool
+		for _, f := range schema.Fields {
+			if f.Name == "Inlined" {
+				found = true
+				assert.Equal(t, postgres.MessageBytes, f.DataType)
+				assert.Equal(t, "bytea", f.SQLType)
+			}
+		}
+		assert.True(t, found, "Inlined field should exist as a column")
+	})
+
+	t.Run("default strategy creates child table", func(t *testing.T) {
+		require.Len(t, schema.Children, 1)
+		assert.Contains(t, schema.Children[0].Table, "as_child")
+	})
+
+	t.Run("inlined field is not a child table", func(t *testing.T) {
+		for _, child := range schema.Children {
+			assert.NotContains(t, child.Table, "inlined",
+				"strategy(bytea) field should not create a child table")
 		}
 	})
 }

--- a/pkg/postgres/walker/walker_test.go
+++ b/pkg/postgres/walker/walker_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type TestStorageType struct {
@@ -23,4 +24,76 @@ func TestClusterGetter(t *testing.T) {
 	}
 
 	assert.Equal(t, IDField.SQLType, "uuid")
+}
+
+func TestSchemaRoot(t *testing.T) {
+	grandparent := &Schema{Table: "grandparent"}
+	parent := &Schema{Table: "parent", Parent: grandparent}
+	child := &Schema{Table: "child", Parent: parent}
+
+	assert.Equal(t, grandparent, grandparent.Root())
+	assert.Equal(t, grandparent, parent.Root())
+	assert.Equal(t, grandparent, child.Root())
+}
+
+func TestFieldIncludeNoSerialized(t *testing.T) {
+	noSerSchema := &Schema{NoSerialized: true}
+	normalSchema := &Schema{NoSerialized: false}
+
+	cases := map[string]struct {
+		field    Field
+		expected bool
+	}{
+		"no-serialized: serialized column excluded": {
+			field:    Field{Schema: noSerSchema, ColumnName: "serialized"},
+			expected: false,
+		},
+		"no-serialized: regular field included": {
+			field:    Field{Schema: noSerSchema, ColumnName: "name", Name: "name"},
+			expected: true,
+		},
+		"no-serialized: PK included": {
+			field:    Field{Schema: noSerSchema, ColumnName: "id", Options: PostgresOptions{PrimaryKey: true}},
+			expected: true,
+		},
+		"normal: serialized column included": {
+			field:    Field{Schema: normalSchema, ColumnName: "serialized"},
+			expected: true,
+		},
+		"normal: regular field excluded without PK/search/ref": {
+			field:    Field{Schema: normalSchema, ColumnName: "name", Name: "name"},
+			expected: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.field.Include())
+		})
+	}
+}
+
+func TestWalkWithNoSerialized(t *testing.T) {
+	mt := reflect.TypeOf(&TestStorageType{})
+	require.NotNil(t, mt)
+
+	t.Run("default walk includes serialized", func(t *testing.T) {
+		schema := Walk(mt, "test_table")
+		var hasSerialized bool
+		for _, f := range schema.Fields {
+			if f.ColumnName == "serialized" {
+				hasSerialized = true
+			}
+		}
+		assert.True(t, hasSerialized, "default walk should include serialized field")
+		assert.False(t, schema.NoSerialized)
+	})
+
+	t.Run("WithNoSerialized excludes serialized from DBColumnFields", func(t *testing.T) {
+		schema := Walk(mt, "test_table", WithNoSerialized())
+		assert.True(t, schema.NoSerialized)
+		for _, f := range schema.DBColumnFields() {
+			assert.NotEqual(t, "serialized", f.ColumnName,
+				"no-serialized schema should not have serialized in DBColumnFields")
+		}
+	})
 }

--- a/pkg/postgres/walker/walker_test.go
+++ b/pkg/postgres/walker/walker_test.go
@@ -29,6 +29,11 @@ type TestStorageWithRepeatedStrategy struct {
 	AsChild []*TestChildMessage `protobuf:"bytes,3,rep,name=as_child,proto3" json:"as_child,omitempty"`
 }
 
+type TestStorageWithExplicitChildTable struct {
+	ID      string              `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk,type(uuid)"`
+	AsChild []*TestChildMessage `protobuf:"bytes,2,rep,name=as_child,proto3" json:"as_child,omitempty" sql:"strategy(child_table)"`
+}
+
 // One can specify a custom SQL type for the structure field
 func TestClusterGetter(t *testing.T) {
 	IDField := Field{SQLType: ""}
@@ -153,4 +158,12 @@ func TestNoSerializedRejectsSqlIgnored(t *testing.T) {
 	assert.Panics(t, func() {
 		Walk(mt, "test_table", WithNoSerialized())
 	}, "Walk with NoSerialized should fatal on sql:\"-\" fields")
+}
+
+func TestExplicitChildTableStrategy(t *testing.T) {
+	mt := reflect.TypeOf(&TestStorageWithExplicitChildTable{})
+	schema := Walk(mt, "test_explicit_child")
+
+	require.Len(t, schema.Children, 1)
+	assert.Contains(t, schema.Children[0].Table, "as_child")
 }

--- a/tools/generate-helpers/pg-table-bindings/main.go
+++ b/tools/generate-helpers/pg-table-bindings/main.go
@@ -117,6 +117,10 @@ type properties struct {
 
 	// Generates helper functions to create/destroy tables and store
 	GenerateDataModelHelpers bool
+
+	// NoSerialized indicates the store should not use a serialized bytea column.
+	// All proto fields become individual DB columns.
+	NoSerialized bool
 }
 
 type parsedReference struct {
@@ -158,6 +162,7 @@ func main() {
 	c.Flags().BoolVar(&props.ConversionFuncs, "conversion-funcs", false, "indicates that we should generate conversion functions between protobuf types to/from Gorm model")
 
 	c.Flags().BoolVar(&props.GenerateDataModelHelpers, "generate-data-model-helpers", false, "if true, generates CreateTableAndNewStore and Destroy functions")
+	c.Flags().BoolVar(&props.NoSerialized, "no-serialized", false, "if true, all proto fields become individual DB columns with no serialized bytea blob")
 	c.RunE = func(*cobra.Command, []string) error {
 		typ := stringutils.OrDefault(props.RegisteredType, props.Type)
 		fmt.Println(readable.Time(time.Now()), "Generating for", typ)
@@ -169,7 +174,11 @@ func main() {
 		if props.Table == "" {
 			props.Table = pgutils.NamingStrategy.TableName(trimmedType)
 		}
-		schema := walker.Walk(mt, props.Table)
+		var walkOpts []walker.WalkOption
+		if props.NoSerialized {
+			walkOpts = append(walkOpts, walker.WithNoSerialized())
+		}
+		schema := walker.Walk(mt, props.Table, walkOpts...)
 		if schema.NoPrimaryKey() && !props.SingletonStore {
 			log.Fatal("No primary key defined, please check relevant proto file and ensure a primary key is specified using the \"sql:\"pk\"\" tag")
 		}
@@ -247,6 +256,7 @@ func main() {
 			"Singleton":            props.SingletonStore,
 
 			"GenerateDataModelHelpers": props.GenerateDataModelHelpers,
+			"NoSerialized":             props.NoSerialized,
 		}
 
 		if err := common.RenderFile(templateMap, schemaTemplate, getSchemaFileName(props.SchemaDirectory, schema.Table)); err != nil {

--- a/tools/generate-helpers/pg-table-bindings/schema.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/schema.go.tpl
@@ -52,9 +52,9 @@ var (
         if schema != nil {
             return schema
         }
-        schema = walker.Walk(reflect.TypeOf(({{.Schema.Type}})(nil)), "{{.Schema.Table}}")
+        schema = walker.Walk(reflect.TypeOf(({{.Schema.Type}})(nil)), "{{.Schema.Table}}"{{- if .NoSerialized }}, walker.WithNoSerialized(){{- end }})
         {{- else}}
-        schema := walker.Walk(reflect.TypeOf(({{.Schema.Type}})(nil)), "{{.Schema.Table}}")
+        schema := walker.Walk(reflect.TypeOf(({{.Schema.Type}})(nil)), "{{.Schema.Table}}"{{- if .NoSerialized }}, walker.WithNoSerialized(){{- end }})
         {{- end}}
 
         {{- if gt (len .References) 0 }}


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Walker gains WalkOption/WithNoSerialized() to produce schemas where all
proto fields become individual DB columns with no serialized bytea blob.
Field.Include() returns true for all fields in this mode. The
pg-table-bindings generator accepts --no-serialized and passes it through
to the walker and templates. Also adds MessageBytes DataType for future
use with inlined repeated messages.

This is the foundational PR — no stores use the flag yet. The store
templates, search integration, and test proto follow in subsequent PRs.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Unit test and the rest of the stack.