### PR TITLE
ROX-34909, ROX-34910, ROX-34911: Store and search for no-serialized

### DIFF
--- a/pkg/postgres/pgutils/messagebytes.go
+++ b/pkg/postgres/pgutils/messagebytes.go
@@ -27,6 +27,15 @@ func MarshalRepeatedMessages[T proto.Message](msgs []T) ([]byte, error) {
 	return buf, nil
 }
 
+// MustMarshalRepeatedMessages is like MarshalRepeatedMessages but panics on error.
+func MustMarshalRepeatedMessages[T proto.Message](msgs []T) []byte {
+	data, err := MarshalRepeatedMessages(msgs)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
 // UnmarshalRepeatedMessages deserializes a bytea produced by MarshalRepeatedMessages
 // back into a slice of proto messages.
 func UnmarshalRepeatedMessages[T proto.Message](data []byte, newMsg func() T) ([]T, error) {

--- a/pkg/postgres/pgutils/messagebytes.go
+++ b/pkg/postgres/pgutils/messagebytes.go
@@ -1,0 +1,54 @@
+package pgutils
+
+import (
+	"encoding/binary"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+)
+
+// MarshalRepeatedMessages serializes a slice of proto messages into a single bytea.
+// Format: [4-byte big-endian length][message bytes] repeated. Returns nil for empty/nil slices.
+func MarshalRepeatedMessages[T proto.Message](msgs []T) ([]byte, error) {
+	if len(msgs) == 0 {
+		return nil, nil
+	}
+	var buf []byte
+	for _, msg := range msgs {
+		data, err := proto.Marshal(msg)
+		if err != nil {
+			return nil, errors.Wrap(err, "marshaling repeated message")
+		}
+		lenBuf := make([]byte, 4)
+		binary.BigEndian.PutUint32(lenBuf, uint32(len(data)))
+		buf = append(buf, lenBuf...)
+		buf = append(buf, data...)
+	}
+	return buf, nil
+}
+
+// UnmarshalRepeatedMessages deserializes a bytea produced by MarshalRepeatedMessages
+// back into a slice of proto messages.
+func UnmarshalRepeatedMessages[T proto.Message](data []byte, newMsg func() T) ([]T, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var msgs []T
+	for len(data) > 0 {
+		if len(data) < 4 {
+			return nil, errors.New("messagebytes: truncated length prefix")
+		}
+		length := binary.BigEndian.Uint32(data[:4])
+		data = data[4:]
+		if uint32(len(data)) < length {
+			return nil, errors.New("messagebytes: truncated message data")
+		}
+		msg := newMsg()
+		if err := proto.Unmarshal(data[:length], msg); err != nil {
+			return nil, errors.Wrap(err, "unmarshaling repeated message")
+		}
+		msgs = append(msgs, msg)
+		data = data[length:]
+	}
+	return msgs, nil
+}

--- a/pkg/postgres/pgutils/messagebytes_test.go
+++ b/pkg/postgres/pgutils/messagebytes_test.go
@@ -1,0 +1,71 @@
+package pgutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestMarshalUnmarshalRepeatedMessages(t *testing.T) {
+	cases := map[string]struct {
+		input []*wrapperspb.StringValue
+	}{
+		"nil slice":   {input: nil},
+		"empty slice": {input: []*wrapperspb.StringValue{}},
+		"single message": {
+			input: []*wrapperspb.StringValue{wrapperspb.String("hello")},
+		},
+		"multiple messages": {
+			input: []*wrapperspb.StringValue{
+				wrapperspb.String("foo"),
+				wrapperspb.String("bar"),
+				wrapperspb.String("baz"),
+			},
+		},
+		"message with empty string": {
+			input: []*wrapperspb.StringValue{wrapperspb.String("")},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			data, err := MarshalRepeatedMessages(tc.input)
+			require.NoError(t, err)
+
+			result, err := UnmarshalRepeatedMessages(data, func() *wrapperspb.StringValue {
+				return &wrapperspb.StringValue{}
+			})
+			require.NoError(t, err)
+
+			if len(tc.input) == 0 {
+				assert.Empty(t, result)
+			} else {
+				require.Len(t, result, len(tc.input))
+				for i, msg := range result {
+					assert.Equal(t, tc.input[i].GetValue(), msg.GetValue())
+				}
+			}
+		})
+	}
+}
+
+func TestUnmarshalRepeatedMessagesTruncated(t *testing.T) {
+	msgs := []*wrapperspb.StringValue{wrapperspb.String("test")}
+	data, err := MarshalRepeatedMessages(msgs)
+	require.NoError(t, err)
+
+	t.Run("truncated length", func(t *testing.T) {
+		_, err := UnmarshalRepeatedMessages(data[:2], func() *wrapperspb.StringValue {
+			return &wrapperspb.StringValue{}
+		})
+		assert.ErrorContains(t, err, "truncated length prefix")
+	})
+
+	t.Run("truncated data", func(t *testing.T) {
+		_, err := UnmarshalRepeatedMessages(data[:5], func() *wrapperspb.StringValue {
+			return &wrapperspb.StringValue{}
+		})
+		assert.ErrorContains(t, err, "truncated message data")
+	})
+}

--- a/pkg/postgres/walker/schema.go
+++ b/pkg/postgres/walker/schema.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/auth/permissions"
@@ -561,6 +562,48 @@ func (f Field) Getter(prefix string) string {
 		return value
 	}
 	return prefix + "." + value
+}
+
+// Setter returns the settable field path for assignment, e.g. "Id" or "Signal.Name".
+// Converts getter chain "GetFoo().GetBar()" → "Foo.Bar".
+func (f Field) Setter(prefix string) string {
+	if f.ObjectGetter.variable {
+		return f.ObjectGetter.value
+	}
+	return prefix + "." + getterToSetter(f.ObjectGetter.value)
+}
+
+// NeedsSubMessageInit returns the prefix chain of sub-messages that must be initialized
+// before setting this field. Returns empty string for top-level fields.
+// E.g., for getter "GetSignal().GetName()", returns "Signal" — the caller must
+// ensure obj.Signal is non-nil before setting obj.Signal.Name.
+func (f Field) NeedsSubMessageInit(prefix string) string {
+	parts := strings.Split(f.ObjectGetter.value, ".")
+	if len(parts) <= 1 {
+		return ""
+	}
+	// Build init chain for all but the last part
+	var initParts []string
+	for _, p := range parts[:len(parts)-1] {
+		initParts = append(initParts, getterPartToField(p))
+	}
+	return prefix + "." + strings.Join(initParts, ".")
+}
+
+// getterPartToField converts "GetFoo()" → "Foo".
+func getterPartToField(part string) string {
+	part = strings.TrimSuffix(part, "()")
+	part = strings.TrimPrefix(part, "Get")
+	return part
+}
+
+// getterToSetter converts "GetFoo().GetBar()" → "Foo.Bar".
+func getterToSetter(getter string) string {
+	parts := strings.Split(getter, ".")
+	for i, p := range parts {
+		parts[i] = getterPartToField(p)
+	}
+	return strings.Join(parts, ".")
 }
 
 // Include returns if the field should be included in the schema

--- a/pkg/postgres/walker/schema.go
+++ b/pkg/postgres/walker/schema.go
@@ -146,6 +146,10 @@ type Schema struct {
 	// NoSerialized indicates this schema should not include a serialized bytea column.
 	// When true, all proto fields are stored as individual DB columns.
 	NoSerialized bool
+
+	// SubMessages maps setter paths (e.g., "Metadata") to Go type strings (e.g., "storage.TestNoSerialized_Metadata")
+	// for sub-messages that need initialization before scanning individual columns.
+	SubMessages map[string]string
 }
 
 // TableFieldsGroup is the group of table fields. A slice of this struct can be used where the table order is essential,

--- a/pkg/postgres/walker/walker.go
+++ b/pkg/postgres/walker/walker.go
@@ -81,20 +81,11 @@ func addCommonFields(s *Schema, parentPrimaryKeys ...Field) {
 			s.Fields = append(s.Fields, getSerializedField(s))
 		}
 	} else {
-		// Collect additional fields separately so we can put them in front of the field list
-		// (since these are primary keys, that is cleaner).
+		// Child table: add parent FK fields and idx column.
 		var additionalFields []Field
-		// Child tables represent tables that are stored in an array inside the parent.
-		// Rows in the child table do not have an id of their own.
-		// Instead, they are identified by their parent's primary key, and an index column (which
-		// represents the index of this specific child among the parent's children).
 		for _, parentPrimaryKey := range parentPrimaryKeys {
 			var columnNameInChild string
 			var columnNameInChildForCodeVariables string
-			// If a column in a child table references a column "X" in the parent table, we
-			// name the column in the child "parent_table_name_X".
-			// We keep this name even in the grandchild, and do not continuously add prefixes in front.
-			// This is accomplished by only prefixing the table name if the column is not already a reference.
 			if parentPrimaryKey.Options.Reference == nil {
 				columnNameInChild = fmt.Sprintf("%s_%s", parentPrimaryKey.Schema.Table, parentPrimaryKey.ColumnName)
 			} else {
@@ -135,7 +126,11 @@ func addCommonFields(s *Schema, parentPrimaryKeys ...Field) {
 }
 
 func postProcessSchema(s *Schema) {
-	removeTablesWithNoSearchableFields(s)
+	// NoSerialized schemas need all child tables since there's no serialized blob
+	// to fall back on — the child table IS the data for repeated message fields.
+	if !s.NoSerialized {
+		removeTablesWithNoSearchableFields(s)
+	}
 	addCommonFields(s)
 }
 
@@ -418,6 +413,13 @@ func handleStruct(ctx walkerContext, schema *Schema, original reflect.Type) {
 				}
 				schema.AddFieldWithType(field, dt, opts)
 				continue
+			}
+			if schema.NoSerialized {
+				setterPath := getterToSetter(ctx.Getter(field.Name))
+				if schema.SubMessages == nil {
+					schema.SubMessages = make(map[string]string)
+				}
+				schema.SubMessages[setterPath] = structField.Type.Elem().String()
 			}
 			handleStruct(ctx.childContext(field.Name, searchOpts.Ignored, opts), schema, structField.Type.Elem())
 		case reflect.Slice:

--- a/pkg/postgres/walker/walker_test.go
+++ b/pkg/postgres/walker/walker_test.go
@@ -167,3 +167,57 @@ func TestExplicitChildTableStrategy(t *testing.T) {
 	require.Len(t, schema.Children, 1)
 	assert.Contains(t, schema.Children[0].Table, "as_child")
 }
+
+func TestFieldSetter(t *testing.T) {
+	cases := map[string]struct {
+		getter   string
+		variable bool
+		expected string
+	}{
+		"top-level field": {
+			getter:   "GetId()",
+			expected: "obj.Id",
+		},
+		"nested field": {
+			getter:   "GetSignal().GetName()",
+			expected: "obj.Signal.Name",
+		},
+		"variable field": {
+			getter:   "parentId",
+			variable: true,
+			expected: "parentId",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := Field{ObjectGetter: ObjectGetter{value: tc.getter, variable: tc.variable}}
+			assert.Equal(t, tc.expected, f.Setter("obj"))
+		})
+	}
+}
+
+func TestFieldNeedsSubMessageInit(t *testing.T) {
+	cases := map[string]struct {
+		getter   string
+		expected string
+	}{
+		"top-level field needs no init": {
+			getter:   "GetId()",
+			expected: "",
+		},
+		"nested field needs init": {
+			getter:   "GetSignal().GetName()",
+			expected: "obj.Signal",
+		},
+		"deeply nested": {
+			getter:   "GetA().GetB().GetC()",
+			expected: "obj.A.B",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			f := Field{ObjectGetter: ObjectGetter{value: tc.getter}}
+			assert.Equal(t, tc.expected, f.NeedsSubMessageInit("obj"))
+		})
+	}
+}

--- a/pkg/search/postgres/common.go
+++ b/pkg/search/postgres/common.go
@@ -225,6 +225,13 @@ func (q *query) getPortionBeforeFromClause() string {
 		}
 		return fmt.Sprintf("select count(%s)", countOn)
 	case GET:
+		if q.Schema.NoSerialized {
+			var colPaths []string
+			for _, f := range q.Schema.DBColumnFields() {
+				colPaths = append(colPaths, qualifyColumn(q.Schema.Table, f.ColumnName, ""))
+			}
+			return "select " + strings.Join(colPaths, ", ")
+		}
 		// For GET queries with joins, we use GROUP BY for distinctness, so no need for DISTINCT ON
 		return fmt.Sprintf("select %s.serialized", q.From)
 	case SEARCH:
@@ -329,10 +336,20 @@ func (q *query) AsSQL() string {
 			}
 		}
 
-		// Add serialized column to GROUP BY (required since we're selecting it)
-		serializedPath := fmt.Sprintf("%s.serialized", q.From)
-		if groupByFields.Add(serializedPath) {
-			groupByParts = append(groupByParts, serializedPath)
+		if q.Schema.NoSerialized {
+			// Add all selected columns to GROUP BY
+			for _, f := range q.Schema.DBColumnFields() {
+				colPath := qualifyColumn(q.Schema.Table, f.ColumnName, "")
+				if groupByFields.Add(colPath) {
+					groupByParts = append(groupByParts, colPath)
+				}
+			}
+		} else {
+			// Add serialized column to GROUP BY (required since we're selecting it)
+			serializedPath := fmt.Sprintf("%s.serialized", q.From)
+			if groupByFields.Add(serializedPath) {
+				groupByParts = append(groupByParts, serializedPath)
+			}
 		}
 
 		// Add ordering fields from the primary table to GROUP BY (they're identical for same PK)

--- a/pkg/search/postgres/no_serialized_store.go
+++ b/pkg/search/postgres/no_serialized_store.go
@@ -1,0 +1,595 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/pkg/errors"
+	v1 "github.com/stackrox/rox/generated/api/v1"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/auth/permissions"
+	"github.com/stackrox/rox/pkg/contextutil"
+	ops "github.com/stackrox/rox/pkg/metrics"
+	"github.com/stackrox/rox/pkg/postgres"
+	"github.com/stackrox/rox/pkg/postgres/pgutils"
+	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/paginated"
+	"github.com/stackrox/rox/pkg/search/sortfields"
+	"github.com/stackrox/rox/pkg/sync"
+	"github.com/stackrox/rox/pkg/utils"
+)
+
+// RowScanner scans a single pgx.Row into a proto message.
+type RowScanner[T any] func(row pgx.Row) (*T, error)
+
+// RowsScanner scans pgx.Rows into a slice of proto messages.
+type RowsScanner[T any] func(rows pgx.Rows) ([]*T, error)
+
+// NoSerializedStore is the store interface for types without a serialized column.
+type NoSerializedStore[T any] interface {
+	Exists(ctx context.Context, id string) (bool, error)
+	Count(ctx context.Context, q *v1.Query) (int, error)
+	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
+	Walk(ctx context.Context, fn func(obj *T) error) error
+	WalkByQuery(ctx context.Context, q *v1.Query, fn func(obj *T) error) error
+	Get(ctx context.Context, id string) (*T, bool, error)
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*T, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *T) error) error
+	GetIDs(ctx context.Context) ([]string, error)
+	GetIDsByQuery(ctx context.Context, query *v1.Query) ([]string, error)
+	GetMany(ctx context.Context, identifiers []string) ([]*T, []int, error)
+	DeleteByQuery(ctx context.Context, query *v1.Query) error
+	DeleteByQueryWithIDs(ctx context.Context, query *v1.Query) ([]string, error)
+	Delete(ctx context.Context, id string) error
+	DeleteMany(ctx context.Context, identifiers []string) error
+	PruneMany(ctx context.Context, identifiers []string) error
+	Upsert(ctx context.Context, obj *T) error
+	UpsertMany(ctx context.Context, objs []*T) error
+}
+
+type noSerializedInserter[T any] func(batch *pgx.Batch, obj *T) error
+type noSerializedCopier[T any] func(ctx context.Context, s Deleter, tx *postgres.Tx, objs ...*T) error
+type noSerializedPKGetter[T any] func(obj *T) string
+type noSerializedUpsertChecker[T any] func(ctx context.Context, objs ...*T) error
+
+type noSerializedGenericStore[T any] struct {
+	mutex                            sync.RWMutex
+	db                               postgres.DB
+	schema                           *walker.Schema
+	pkGetter                         noSerializedPKGetter[T]
+	insertInto                       noSerializedInserter[T]
+	copyFromObj                      noSerializedCopier[T]
+	scanRow                          RowScanner[T]
+	scanRows                         RowsScanner[T]
+	setAcquireDBConnDuration         durationTimeSetter
+	setPostgresOperationDurationTime durationTimeSetter
+	upsertAllowed                    noSerializedUpsertChecker[T]
+	targetResource                   permissions.ResourceMetadata
+	defaultSort                      *v1.QuerySortOption
+	transformOptionsMap              search.OptionsMap
+}
+
+// NewNoSerializedGenericStore returns a new store for resources without a serialized column.
+func NewNoSerializedGenericStore[T any](
+	db postgres.DB,
+	schema *walker.Schema,
+	pkGetter noSerializedPKGetter[T],
+	insertInto noSerializedInserter[T],
+	copyFromObj noSerializedCopier[T],
+	scanRow RowScanner[T],
+	scanRows RowsScanner[T],
+	setAcquireDBConnDuration durationTimeSetter,
+	setPostgresOperationDurationTime durationTimeSetter,
+	upsertAllowed noSerializedUpsertChecker[T],
+	targetResource permissions.ResourceMetadata,
+	defaultSort *v1.QuerySortOption,
+	transformOptionsMap search.OptionsMap,
+) NoSerializedStore[T] {
+	return &noSerializedGenericStore[T]{
+		db:          db,
+		schema:      schema,
+		pkGetter:    pkGetter,
+		insertInto:  insertInto,
+		copyFromObj: copyFromObj,
+		scanRow:     scanRow,
+		scanRows:    scanRows,
+		setAcquireDBConnDuration: func() durationTimeSetter {
+			if setAcquireDBConnDuration == nil {
+				return doNothingDurationTimeSetter
+			}
+			return setAcquireDBConnDuration
+		}(),
+		setPostgresOperationDurationTime: func() durationTimeSetter {
+			if setPostgresOperationDurationTime == nil {
+				return doNothingDurationTimeSetter
+			}
+			return setPostgresOperationDurationTime
+		}(),
+		upsertAllowed:       upsertAllowed,
+		targetResource:      targetResource,
+		defaultSort:         defaultSort,
+		transformOptionsMap: transformOptionsMap,
+	}
+}
+
+// NewNoSerializedGloballyScopedGenericStore returns a new store for globally-scoped resources without a serialized column.
+func NewNoSerializedGloballyScopedGenericStore[T any](
+	db postgres.DB,
+	schema *walker.Schema,
+	pkGetter noSerializedPKGetter[T],
+	insertInto noSerializedInserter[T],
+	copyFromObj noSerializedCopier[T],
+	scanRow RowScanner[T],
+	scanRows RowsScanner[T],
+	setAcquireDBConnDuration durationTimeSetter,
+	setPostgresOperationDurationTime durationTimeSetter,
+	targetResource permissions.ResourceMetadata,
+	defaultSort *v1.QuerySortOption,
+	transformOptionsMap search.OptionsMap,
+) NoSerializedStore[T] {
+	return &noSerializedGenericStore[T]{
+		db:          db,
+		schema:      schema,
+		pkGetter:    pkGetter,
+		insertInto:  insertInto,
+		copyFromObj: copyFromObj,
+		scanRow:     scanRow,
+		scanRows:    scanRows,
+		setAcquireDBConnDuration: func() durationTimeSetter {
+			if setAcquireDBConnDuration == nil {
+				return doNothingDurationTimeSetter
+			}
+			return setAcquireDBConnDuration
+		}(),
+		setPostgresOperationDurationTime: func() durationTimeSetter {
+			if setPostgresOperationDurationTime == nil {
+				return doNothingDurationTimeSetter
+			}
+			return setPostgresOperationDurationTime
+		}(),
+		upsertAllowed:       noSerializedGloballyScopedUpsertChecker[T](targetResource),
+		targetResource:      targetResource,
+		defaultSort:         defaultSort,
+		transformOptionsMap: transformOptionsMap,
+	}
+}
+
+func noSerializedGloballyScopedUpsertChecker[T any](targetResource permissions.ResourceMetadata) noSerializedUpsertChecker[T] {
+	return func(ctx context.Context, objs ...*T) error {
+		scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_READ_WRITE_ACCESS).Resource(targetResource)
+		if !scopeChecker.IsAllowed() {
+			return sac.ErrResourceAccessDenied
+		}
+		return nil
+	}
+}
+
+func (s *noSerializedGenericStore[T]) applyQueryDefaults(q *v1.Query) *v1.Query {
+	if s.transformOptionsMap != nil {
+		q = sortfields.TransformSortOptions(q, s.transformOptionsMap)
+	}
+	if s.defaultSort == nil {
+		return q
+	}
+	if q.GetPagination() == nil {
+		q.Pagination = &v1.QueryPagination{}
+	}
+	if len(q.GetPagination().GetSortOptions()) == 0 {
+		q.Pagination.SortOptions = []*v1.QuerySortOption{s.defaultSort}
+	}
+	return q
+}
+
+// Exists tells whether the ID exists in the store.
+func (s *noSerializedGenericStore[T]) Exists(ctx context.Context, id string) (bool, error) {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.Exists)
+	q := search.NewQueryBuilder().AddDocIDs(id).ProtoQuery()
+	count, err := RunCountRequestForSchema(ctx, s.schema, q, s.db)
+	return count > 0, err
+}
+
+// Count returns the number of objects in the store.
+func (s *noSerializedGenericStore[T]) Count(ctx context.Context, q *v1.Query) (int, error) {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.Count)
+	return RunCountRequestForSchema(ctx, s.schema, q, s.db)
+}
+
+// Search executes a search query against the store.
+func (s *noSerializedGenericStore[T]) Search(ctx context.Context, q *v1.Query) ([]search.Result, error) {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.Search)
+	q = s.applyQueryDefaults(q)
+	return RunSearchRequestForSchema(ctx, s.schema, q, s.db)
+}
+
+// Get returns the object, if it exists from the store.
+func (s *noSerializedGenericStore[T]) Get(ctx context.Context, id string) (*T, bool, error) {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.Get)
+
+	q := search.NewQueryBuilder().AddDocIDs(id).ProtoQuery()
+	data, err := s.runGetQuery(ctx, q)
+	if err != nil {
+		return nil, false, pgutils.ErrNilIfNoRows(err)
+	}
+	return data, true, nil
+}
+
+func (s *noSerializedGenericStore[T]) runGetQuery(ctx context.Context, q *v1.Query) (*T, error) {
+	query, err := standardizeQueryAndPopulatePath(ctx, q, s.schema, GET)
+	if err != nil {
+		return nil, err
+	}
+	if query == nil {
+		return nil, emptyQueryErr
+	}
+
+	var pool postgres.Queryable
+	pool = s.db
+	if tx, parentTxExists := postgres.TxFromContext(ctx); parentTxExists {
+		pool = tx
+	}
+
+	return pgutils.Retry2(ctx, func() (*T, error) {
+		row := tracedQueryRow(ctx, pool, query.AsSQL(), query.Data...)
+		return s.scanRow(row)
+	})
+}
+
+// GetByQueryFn iterates over all objects scoped by the query and applies the closure.
+func (s *noSerializedGenericStore[T]) GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *T) error) error {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetByQuery)
+	query = s.applyQueryDefaults(query)
+	return s.runQueryFn(ctx, query, fn)
+}
+
+func (s *noSerializedGenericStore[T]) runQueryFn(ctx context.Context, q *v1.Query, callback func(obj *T) error) error {
+	var pool postgres.Queryable
+	pool = s.db
+	if tx, parentTxExists := postgres.TxFromContext(ctx); parentTxExists {
+		pool = tx
+	}
+
+	rows, err := pgutils.Retry2(ctx, func() (*tracedRows, error) {
+		return retryableGetRows(ctx, s.schema, q, pool)
+	})
+	if err != nil {
+		return err
+	}
+	if rows == nil {
+		return nil
+	}
+
+	results, err := s.scanRows(rows)
+	if err != nil {
+		return errors.Wrap(err, "scanning rows")
+	}
+	for _, obj := range results {
+		if ctx.Err() != nil {
+			return errors.Wrap(ctx.Err(), "iterating over rows")
+		}
+		if err := callback(obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetByQuery returns the objects from the store matching the query.
+func (s *noSerializedGenericStore[T]) GetByQuery(ctx context.Context, query *v1.Query) ([]*T, error) {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetByQuery)
+	query = s.applyQueryDefaults(query)
+
+	rows := make([]*T, 0, paginated.GetLimit(query.GetPagination().GetLimit(), batchAfter))
+	err := s.runQueryFn(ctx, query, func(obj *T) error {
+		rows = append(rows, obj)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return rows[0:len(rows):len(rows)], nil
+}
+
+func (s *noSerializedGenericStore[T]) walkByQuery(ctx context.Context, query *v1.Query, hint string, fn func(obj *T) error) error {
+	query = s.applyQueryDefaults(query)
+	return s.runCursorQueryFn(ctx, query, hint, fn)
+}
+
+func (s *noSerializedGenericStore[T]) runCursorQueryFn(ctx context.Context, q *v1.Query, hint string, callback func(obj *T) error) error {
+	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, cursorDefaultTimeout)
+	defer cancel()
+
+	cursor, err := pgutils.Retry2(ctx, func() (*cursorSession, error) {
+		return retryableGetCursorSession(ctx, s.schema, q, s.db, hint)
+	})
+	if err != nil {
+		return errors.Wrap(err, "prepare cursor")
+	}
+	if cursor == nil {
+		return nil
+	}
+	defer cursor.close()
+
+	for {
+		rows, err := cursor.tx.Query(ctx, fmt.Sprintf("FETCH %d FROM %s", cursorBatchSize, cursor.id))
+		if err != nil {
+			return errors.Wrap(err, "advancing in cursor")
+		}
+
+		results, scanErr := s.scanRows(rows)
+		if scanErr != nil {
+			return errors.Wrap(scanErr, "scanning cursor rows")
+		}
+
+		for _, obj := range results {
+			if ctx.Err() != nil {
+				return errors.Wrap(ctx.Err(), "iterating over rows")
+			}
+			if err := callback(obj); err != nil {
+				return errors.Wrap(err, "processing rows")
+			}
+		}
+
+		if len(results) != cursorBatchSize {
+			return ctx.Err()
+		}
+	}
+}
+
+// Walk iterates over all the objects in the store and applies the closure.
+func (s *noSerializedGenericStore[T]) Walk(ctx context.Context, fn func(obj *T) error) error {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.Walk)
+	return s.walkByQuery(ctx, search.EmptyQuery(), "Walk", fn)
+}
+
+// WalkByQuery iterates over all the objects scoped by the query and applies the closure.
+func (s *noSerializedGenericStore[T]) WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *T) error) error {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.WalkByQuery)
+	return s.walkByQuery(ctx, query, "WalkByQuery", fn)
+}
+
+func (s *noSerializedGenericStore[T]) fetchIDsByQuery(ctx context.Context, query *v1.Query) ([]string, error) {
+	result, err := RunSearchRequestForSchema(ctx, s.schema, query, s.db)
+	if err != nil {
+		return nil, err
+	}
+	identifiers := make([]string, 0, len(result))
+	for _, entry := range result {
+		identifiers = append(identifiers, entry.ID)
+	}
+	return identifiers, nil
+}
+
+// GetIDs returns all the IDs for the store.
+func (s *noSerializedGenericStore[T]) GetIDs(ctx context.Context) ([]string, error) {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetAll)
+	return s.fetchIDsByQuery(ctx, search.EmptyQuery())
+}
+
+// GetIDsByQuery returns the IDs for the store matching the query.
+func (s *noSerializedGenericStore[T]) GetIDsByQuery(ctx context.Context, query *v1.Query) ([]string, error) {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetByQuery)
+	return s.fetchIDsByQuery(ctx, s.applyQueryDefaults(query))
+}
+
+// GetMany returns the objects specified by the IDs from the store as well as the index in the missing indices slice.
+func (s *noSerializedGenericStore[T]) GetMany(ctx context.Context, identifiers []string) ([]*T, []int, error) {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.GetMany)
+
+	if len(identifiers) == 0 {
+		return nil, nil, nil
+	}
+
+	q := search.NewQueryBuilder().AddDocIDs(identifiers...).ProtoQuery()
+
+	resultsByID := make(map[string]*T, len(identifiers))
+	err := s.runQueryFn(ctx, q, func(msg *T) error {
+		resultsByID[s.pkGetter(msg)] = msg
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	missingIndices := make([]int, 0, len(identifiers)-len(resultsByID))
+	elems := make([]*T, 0, len(resultsByID))
+	for i, identifier := range identifiers {
+		if result, ok := resultsByID[identifier]; !ok {
+			missingIndices = append(missingIndices, i)
+		} else {
+			elems = append(elems, result)
+		}
+	}
+	return elems, missingIndices, nil
+}
+
+// DeleteByQuery removes the objects from the store based on the passed query.
+func (s *noSerializedGenericStore[T]) DeleteByQuery(ctx context.Context, query *v1.Query) error {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.Remove)
+	return RunDeleteRequestForSchema(ctx, s.schema, query, s.db)
+}
+
+// DeleteByQueryWithIDs removes the objects from the store based on the passed query returning deleted IDs.
+func (s *noSerializedGenericStore[T]) DeleteByQueryWithIDs(ctx context.Context, query *v1.Query) ([]string, error) {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.Remove)
+	return RunDeleteRequestReturningIDsForSchema(ctx, s.schema, query, s.db)
+}
+
+// Delete removes the object associated to the specified ID from the store.
+func (s *noSerializedGenericStore[T]) Delete(ctx context.Context, id string) error {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.Remove)
+	q := search.NewQueryBuilder().AddDocIDs(id).ProtoQuery()
+	return RunDeleteRequestForSchema(ctx, s.schema, q, s.db)
+}
+
+// DeleteMany removes the objects associated to the specified IDs from the store within a transaction.
+func (s *noSerializedGenericStore[T]) DeleteMany(ctx context.Context, identifiers []string) error {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.RemoveMany)
+
+	var err error
+	var tx *postgres.Tx
+	if !postgres.HasTxInContext(ctx) {
+		tx, err = s.db.Begin(ctx)
+		if err != nil {
+			return errors.Wrap(err, "could not create transaction for deletes")
+		}
+		ctx = postgres.ContextWithTx(ctx, tx)
+	}
+
+	if err := s.deleteMany(ctx, identifiers, deleteBatchSize, false); err != nil {
+		if tx != nil {
+			if rollbackErr := tx.Rollback(ctx); rollbackErr != nil {
+				return errors.Wrapf(err, "unable to delete records and rollback failed: %v", rollbackErr)
+			}
+		}
+		return err
+	}
+
+	if tx != nil {
+		return tx.Commit(ctx)
+	}
+	return nil
+}
+
+// PruneMany removes the objects associated to the specified IDs from the store outside a transaction.
+func (s *noSerializedGenericStore[T]) PruneMany(ctx context.Context, identifiers []string) error {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.Prune)
+	return s.deleteMany(ctx, identifiers, pruneBatchSize, true)
+}
+
+func (s *noSerializedGenericStore[T]) deleteMany(ctx context.Context, identifiers []string, initialBatchSize int, continueOnError bool) error {
+	deletedCount := 0
+	numberToDelete := len(identifiers)
+
+	if initialBatchSize <= 0 {
+		return errors.New("batch size must be greater than 0")
+	}
+
+	for identifierBatch := range slices.Chunk(identifiers, initialBatchSize) {
+		q := search.NewQueryBuilder().AddDocIDs(identifierBatch...).ProtoQuery()
+		if err := RunDeleteRequestForSchema(ctx, s.schema, q, s.db); err != nil {
+			if !continueOnError {
+				return errors.Wrap(err, "unable to delete the records")
+			}
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				break
+			}
+			log.Errorf("unable to prune the records: %v", err)
+		}
+		deletedCount = deletedCount + len(identifierBatch)
+		log.Debugf("deleted batch of %d records", len(identifierBatch))
+	}
+	log.Debugf("successfully deleted %d of %d records", deletedCount, numberToDelete)
+	return nil
+}
+
+// Upsert saves the current state of an object in storage.
+func (s *noSerializedGenericStore[T]) Upsert(ctx context.Context, obj *T) error {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.Upsert)
+	if err := s.upsertAllowed(ctx, obj); err != nil {
+		return err
+	}
+	return pgutils.Retry(ctx, func() error {
+		return s.upsert(ctx, obj)
+	})
+}
+
+// UpsertMany saves the state of multiple objects in the storage.
+func (s *noSerializedGenericStore[T]) UpsertMany(ctx context.Context, objs []*T) error {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.UpdateMany)
+	if err := s.upsertAllowed(ctx, objs...); err != nil {
+		return err
+	}
+	return pgutils.Retry(ctx, func() error {
+		if len(objs) < batchAfter || s.copyFromObj == nil {
+			s.mutex.RLock()
+			defer s.mutex.RUnlock()
+			return s.upsert(ctx, objs...)
+		}
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
+		return s.copyFrom(ctx, objs...)
+	})
+}
+
+func (s *noSerializedGenericStore[T]) acquireConn(ctx context.Context, op ops.Op) (*postgres.Conn, error) {
+	defer s.setAcquireDBConnDuration(time.Now(), op)
+	conn, err := s.db.Acquire(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not acquire connection")
+	}
+	return conn, nil
+}
+
+func (s *noSerializedGenericStore[T]) upsert(ctx context.Context, objs ...*T) error {
+	if s.insertInto == nil {
+		return utils.ShouldErr(errInvalidOperation)
+	}
+
+	batch := &pgx.Batch{}
+	for _, obj := range objs {
+		if err := s.insertInto(batch, obj); err != nil {
+			return errors.Wrap(err, "error on insertInto")
+		}
+	}
+
+	if tx, parentTxExists := postgres.TxFromContext(ctx); parentTxExists {
+		batchResults := postgres.BatchResultsFromPgx(tx.SendBatch(ctx, batch))
+		if err := batchResults.Close(); err != nil {
+			return errors.Wrap(err, "closing batch on transaction")
+		}
+		return nil
+	}
+
+	conn, err := s.acquireConn(ctx, ops.Upsert)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+
+	batchResults := conn.SendBatch(ctx, batch)
+	if err := batchResults.Close(); err != nil {
+		return errors.Wrap(err, "closing batch")
+	}
+	return nil
+}
+
+func (s *noSerializedGenericStore[T]) copyFrom(ctx context.Context, objs ...*T) error {
+	if s.copyFromObj == nil {
+		return utils.ShouldErr(errInvalidOperation)
+	}
+
+	tx, parentTxExists := postgres.TxFromContext(ctx)
+	if !parentTxExists {
+		conn, err := s.acquireConn(ctx, ops.UpsertAll)
+		if err != nil {
+			return err
+		}
+		defer conn.Release()
+		var txErr error
+		tx, ctx, txErr = conn.Begin(ctx)
+		if txErr != nil {
+			return errors.Wrap(txErr, "could not begin transaction")
+		}
+	}
+
+	if err := s.copyFromObj(ctx, s, tx, objs...); err != nil {
+		if !parentTxExists {
+			if rollbackErr := tx.Rollback(ctx); rollbackErr != nil {
+				return errors.Wrap(rollbackErr, "could not rollback transaction")
+			}
+		}
+		return errors.Wrap(err, "copy from objects failed")
+	}
+
+	if !parentTxExists {
+		if err := tx.Commit(ctx); err != nil {
+			return errors.Wrap(err, "could not commit transaction")
+		}
+	}
+	return nil
+}

--- a/tools/generate-helpers/pg-table-bindings/funcs.go
+++ b/tools/generate-helpers/pg-table-bindings/funcs.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 	"unicode"
 
+	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/protoutils"
@@ -132,6 +133,10 @@ func arr(els ...any) []any {
 	return els
 }
 
+func isMessageBytes(f walker.Field) bool {
+	return f.DataType == postgres.MessageBytes
+}
+
 var funcMap = template.FuncMap{
 	"arr":                          arr,
 	"lowerCamelCase":               lowerCamelCase,
@@ -141,6 +146,7 @@ var funcMap = template.FuncMap{
 	"concatWith":                   concatWith,
 	"searchFieldNameInOtherSchema": searchFieldNameInOtherSchema,
 	"isSacScoping":                 isSacScoping,
+	"isMessageBytes":               isMessageBytes,
 	"dict":                         dict,
 	"pluralType": func(s string) string {
 		if s[len(s)-1] == 'y' {

--- a/tools/generate-helpers/pg-table-bindings/funcs.go
+++ b/tools/generate-helpers/pg-table-bindings/funcs.go
@@ -137,6 +137,27 @@ func isMessageBytes(f walker.Field) bool {
 	return f.DataType == postgres.MessageBytes
 }
 
+type subMsgInit struct {
+	SetterPath string
+	GoType     string
+}
+
+func subMessageInits(schema *walker.Schema) []subMsgInit {
+	var inits []subMsgInit
+	for path, typ := range schema.SubMessages {
+		inits = append(inits, subMsgInit{SetterPath: "obj." + path, GoType: typ})
+	}
+	return inits
+}
+
+func messageBytesElemType(f walker.Field) string {
+	t := f.Type
+	if strings.HasPrefix(t, "[]") {
+		return t[2:]
+	}
+	return t
+}
+
 var funcMap = template.FuncMap{
 	"arr":                          arr,
 	"lowerCamelCase":               lowerCamelCase,
@@ -147,6 +168,9 @@ var funcMap = template.FuncMap{
 	"searchFieldNameInOtherSchema": searchFieldNameInOtherSchema,
 	"isSacScoping":                 isSacScoping,
 	"isMessageBytes":               isMessageBytes,
+	"messageBytesElemType":         messageBytesElemType,
+	"subMessageInits":              subMessageInits,
+	"trimPrefix":                   func(prefix, s string) string { return strings.TrimPrefix(s, prefix) },
 	"dict":                         dict,
 	"pluralType": func(s string) string {
 		if s[len(s)-1] == 'y' {

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -53,6 +53,10 @@ type (
     callback  = func(obj *storeType) error
 )
 
+{{- if .NoSerialized }}
+// Store is the interface to interact with the storage for {{ .Type }}
+type Store = pgSearch.NoSerializedStore[storeType]
+{{- else }}
 // Store is the interface to interact with the storage for {{ .Type }}
 type Store interface {
 {{- if not .JoinTable }}
@@ -86,6 +90,7 @@ type Store interface {
     GetAllFromCacheForSAC() []*storeType
 {{- end }}
 }
+{{- end }}
 
 {{ define "defineScopeChecker" }}scopeChecker := sac.GlobalAccessScopeChecker(ctx).AccessMode(storage.Access_{{ . }}_ACCESS).Resource(targetResource){{ end }}
 
@@ -103,6 +108,64 @@ type Store interface {
 
 // New returns a new Store instance using the provided sql instance.
 func New(db postgres.DB) Store {
+    {{- if .NoSerialized }}
+    {{- if .Obj.IsDirectlyScoped }}
+    return pgSearch.NewNoSerializedGenericStore[storeType](
+            db,
+            schema,
+            pkGetter,
+            {{ template "insertFunctionName" .Schema }},
+            {{- if not .NoCopyFrom }}
+            {{ template "copyFunctionName" .Schema }},
+            {{- else }}
+            nil,
+            {{- end }}
+            scanRow,
+            scanRows,
+            metricsSetAcquireDBConnDuration,
+            metricsSetPostgresOperationDurationTime,
+            isUpsertAllowed,
+            targetResource,
+            {{- if .DefaultSortStore }}
+            pgSearch.GetDefaultSort({{.DefaultSort}}, {{.ReverseDefaultSort}}),
+            {{- else }}
+            nil,
+            {{- end }}
+            {{- if .DefaultTransform }}
+            pkgSchema.{{.TransformSortOptions}},
+            {{- else }}
+            nil,
+            {{- end }}
+    )
+    {{- else }}
+    return pgSearch.NewNoSerializedGloballyScopedGenericStore[storeType](
+            db,
+            schema,
+            pkGetter,
+            {{ template "insertFunctionName" .Schema }},
+            {{- if not .NoCopyFrom }}
+            {{ template "copyFunctionName" .Schema }},
+            {{- else }}
+            nil,
+            {{- end }}
+            scanRow,
+            scanRows,
+            metricsSetAcquireDBConnDuration,
+            metricsSetPostgresOperationDurationTime,
+            targetResource,
+            {{- if .DefaultSortStore }}
+            pgSearch.GetDefaultSort({{.DefaultSort}}, {{.ReverseDefaultSort}}),
+            {{- else }}
+            nil,
+            {{- end }}
+            {{- if .DefaultTransform }}
+            pkgSchema.{{.TransformSortOptions}},
+            {{- else }}
+            nil,
+            {{- end }}
+    )
+    {{- end }}
+    {{- else }}
     {{ if .CachedStore -}}
     // Use of {{ template "storeCreator" . }} can be dangerous with high cardinality stores,
     // and be the source of memory pressure. Think twice about the need for in-memory caching
@@ -143,6 +206,7 @@ func New(db postgres.DB) Store {
             nil,
             {{- end }}
     )
+    {{- end }}
 }
 
 // region Helper functions
@@ -213,7 +277,7 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
 {{- define "insertObject"}}
 {{- $schema := .schema }}
 func {{ template "insertFunctionName" $schema }}(batch *pgx.Batch, obj {{$schema.Type}}{{ range $field := $schema.FieldsDeterminedByParent }}, {{$field.Name}} {{$field.Type}}{{end}}) error {
-    {{if not $schema.Parent }}
+    {{if and (not $schema.Parent) (not $schema.NoSerialized) }}
     serialized, marshalErr := obj.MarshalVT()
     if marshalErr != nil {
         return marshalErr
@@ -290,7 +354,7 @@ func {{ template "copyFunctionName" $schema }}(ctx context.Context, s pgSearch.D
         obj := objs[idx]
         idx++
 
-        {{if not $schema.Parent }}
+        {{if and (not $schema.Parent) (not $schema.NoSerialized) }}
         serialized, marshalErr := obj.MarshalVT()
         if marshalErr != nil {
             return nil, marshalErr
@@ -324,6 +388,72 @@ func {{ template "copyFunctionName" $schema }}(ctx context.Context, s pgSearch.D
 {{- if not .NoCopyFrom }}
 {{ template "copyObject" dict "schema" .Schema }}
 {{- end }}
+{{- end }}
+
+{{- if .NoSerialized }}
+// region No-serialized scan functions
+
+func scanRow(row pgx.Row) (*storeType, error) {
+    var obj storeType
+
+    // Declare intermediate scan variables for types needing conversion
+    {{- range $field := .Schema.DBColumnFields }}
+    {{- if or (eq $field.DataType "datetime") (eq $field.DataType "datetimetz") }}
+    var col_{{$field.ColumnName}} *time.Time
+    {{- else if eq $field.SQLType "uuid" }}
+    var col_{{$field.ColumnName}} *string
+    {{- else if eq $field.SQLType "cidr" }}
+    var col_{{$field.ColumnName}} *string
+    {{- else if isMessageBytes $field }}
+    var col_{{$field.ColumnName}} []byte
+    {{- end }}
+    {{- end }}
+
+    if err := row.Scan(
+        {{- range $field := .Schema.DBColumnFields }}
+        {{- if or (eq $field.DataType "datetime") (eq $field.DataType "datetimetz") }}
+        &col_{{$field.ColumnName}},
+        {{- else if eq $field.SQLType "uuid" }}
+        &col_{{$field.ColumnName}},
+        {{- else if eq $field.SQLType "cidr" }}
+        &col_{{$field.ColumnName}},
+        {{- else if isMessageBytes $field }}
+        &col_{{$field.ColumnName}},
+        {{- else }}
+        &{{$field.Setter "obj"}},
+        {{- end }}
+        {{- end }}
+    ); err != nil {
+        return nil, err
+    }
+
+    // Post-scan conversions
+    {{- range $field := .Schema.DBColumnFields }}
+    {{- if or (eq $field.DataType "datetime") (eq $field.DataType "datetimetz") }}
+    if col_{{$field.ColumnName}} != nil {
+        {{$field.Setter "obj"}} = protocompat.ConvertTimeToTimestampOrNil(col_{{$field.ColumnName}})
+    }
+    {{- else if eq $field.SQLType "uuid" }}
+    if col_{{$field.ColumnName}} != nil {
+        {{$field.Setter "obj"}} = *col_{{$field.ColumnName}}
+    }
+    {{- else if eq $field.SQLType "cidr" }}
+    if col_{{$field.ColumnName}} != nil {
+        {{$field.Setter "obj"}} = *col_{{$field.ColumnName}}
+    }
+    {{- end }}
+    {{- end }}
+
+    return &obj, nil
+}
+
+func scanRows(rows pgx.Rows) ([]*storeType, error) {
+    return pgx.CollectRows(rows, func(r pgx.CollectableRow) (*storeType, error) {
+        return scanRow(r)
+    })
+}
+
+// endregion No-serialized scan functions
 {{- end }}
 
 // endregion Helper functions

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -269,6 +269,8 @@ func isUpsertAllowed(ctx context.Context, objs ...*storeType) error {
         pgutils.EmptyOrMap({{$field.Getter "obj"}}),
     {{- else if and (eq $field.DataType "string") ($field.Options.Reference) ($field.Options.Reference.Nullable) }}
         pgutils.NilOrString({{$field.Getter "obj"}}),
+    {{- else if isMessageBytes $field }}
+        pgutils.MustMarshalRepeatedMessages({{$field.Getter "obj"}}),
     {{- else }}
         {{$field.Getter "obj"}},{{end}}
 {{- end}}
@@ -394,7 +396,12 @@ func {{ template "copyFunctionName" $schema }}(ctx context.Context, s pgSearch.D
 // region No-serialized scan functions
 
 func scanRow(row pgx.Row) (*storeType, error) {
-    var obj storeType
+    obj := &storeType{}
+
+    // Initialize sub-messages before scanning
+    {{- range $init := subMessageInits .Schema }}
+    {{$init.SetterPath}} = &{{$init.GoType}}{}
+    {{- end }}
 
     // Declare intermediate scan variables for types needing conversion
     {{- range $field := .Schema.DBColumnFields }}
@@ -441,10 +448,18 @@ func scanRow(row pgx.Row) (*storeType, error) {
     if col_{{$field.ColumnName}} != nil {
         {{$field.Setter "obj"}} = *col_{{$field.ColumnName}}
     }
+    {{- else if isMessageBytes $field }}
+    if col_{{$field.ColumnName}} != nil {
+        unmarshaled, unmarshalErr := pgutils.UnmarshalRepeatedMessages(col_{{$field.ColumnName}}, func() {{messageBytesElemType $field}} { return new({{messageBytesElemType $field | trimPrefix "*"}}) })
+        if unmarshalErr != nil {
+            return nil, unmarshalErr
+        }
+        {{$field.Setter "obj"}} = unmarshaled
+    }
     {{- end }}
     {{- end }}
 
-    return &obj, nil
+    return obj, nil
 }
 
 func scanRows(rows pgx.Rows) ([]*storeType, error) {


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Adds NoSerializedStore[T] — a generic store that reconstructs proto
objects from individual DB columns instead of deserializing a bytea blob.
Includes scanner-based Get/Walk/Query paths, column-based GET query
generation in the search framework, and template changes for both
write path (skip MarshalVT) and read path (scanRow/scanRows generation).

Key components:
- NoSerializedStore[T] in pkg/search/postgres with scanner injection
- GET query and GROUP BY changes in common.go for column-based select
- messagebytes utility for inlining repeated proto messages as bytea
- store.go.tpl: conditional MarshalVT, scanRow/scanRows, constructor
- Field.Setter() and NeedsSubMessageInit() for scan target generation
- isMessageBytes template helper

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

unit tests and the rest of the stack.