### PR TITLE
ROX-34907: Add child table fetch control to NoSerializedStore

### DIFF
--- a/pkg/postgres/walker/schema.go
+++ b/pkg/postgres/walker/schema.go
@@ -167,6 +167,15 @@ func (s *Schema) Root() *Schema {
 	return curr
 }
 
+// ShallowCopyWithoutChildren returns a copy of the schema with Children cleared.
+// The copy shares all other fields (Fields, References, etc.) with the original.
+// This is used to build queries that skip child table JOINs.
+func (s *Schema) ShallowCopyWithoutChildren() *Schema {
+	cp := *s
+	cp.Children = nil
+	return &cp
+}
+
 // SetOptionsMap sets options map for the schema.
 func (s *Schema) SetOptionsMap(optionsMap search.OptionsMap) {
 	s.OptionsMap = optionsMap

--- a/pkg/postgres/walker/walker_test.go
+++ b/pkg/postgres/walker/walker_test.go
@@ -196,6 +196,52 @@ func TestFieldSetter(t *testing.T) {
 	}
 }
 
+func TestShallowCopyWithoutChildren(t *testing.T) {
+	child1 := &Schema{Table: "child1"}
+	child2 := &Schema{Table: "child2"}
+	parent := &Schema{
+		Table:    "parent",
+		Children: []*Schema{child1, child2},
+		Fields: []Field{
+			{Name: "id", ColumnName: "id", Options: PostgresOptions{PrimaryKey: true}},
+			{Name: "name", ColumnName: "name"},
+		},
+		Type:     "storage.Parent",
+		TypeName: "Parent",
+	}
+
+	cp := parent.ShallowCopyWithoutChildren()
+
+	t.Run("children are nil on copy", func(t *testing.T) {
+		assert.Nil(t, cp.Children)
+	})
+
+	t.Run("original children are unchanged", func(t *testing.T) {
+		require.Len(t, parent.Children, 2)
+		assert.Equal(t, "child1", parent.Children[0].Table)
+		assert.Equal(t, "child2", parent.Children[1].Table)
+	})
+
+	t.Run("copy shares parent-level fields", func(t *testing.T) {
+		assert.Equal(t, parent.Table, cp.Table)
+		assert.Equal(t, parent.Type, cp.Type)
+		assert.Equal(t, parent.TypeName, cp.TypeName)
+		assert.Equal(t, len(parent.Fields), len(cp.Fields))
+	})
+
+	t.Run("copy is a distinct pointer", func(t *testing.T) {
+		assert.NotSame(t, parent, cp)
+	})
+
+	t.Run("schema with no children returns empty copy", func(t *testing.T) {
+		leaf := &Schema{Table: "leaf"}
+		leafCp := leaf.ShallowCopyWithoutChildren()
+		assert.Nil(t, leafCp.Children)
+		assert.Equal(t, "leaf", leafCp.Table)
+		assert.NotSame(t, leaf, leafCp)
+	})
+}
+
 func TestFieldNeedsSubMessageInit(t *testing.T) {
 	cases := map[string]struct {
 		getter   string

--- a/pkg/search/postgres/no_serialized_store.go
+++ b/pkg/search/postgres/no_serialized_store.go
@@ -89,6 +89,9 @@ type noSerializedCopier[T any] func(ctx context.Context, s Deleter, tx *postgres
 type noSerializedPKGetter[T any] func(obj *T) string
 type noSerializedUpsertChecker[T any] func(ctx context.Context, objs ...*T) error
 
+// ChildFetcher populates child table data on parent objects after the parent rows have been scanned.
+type ChildFetcher[T any] func(ctx context.Context, q postgres.Queryable, objs []*T) error
+
 type noSerializedGenericStore[T any] struct {
 	mutex                            sync.RWMutex
 	db                               postgres.DB
@@ -98,6 +101,7 @@ type noSerializedGenericStore[T any] struct {
 	copyFromObj                      noSerializedCopier[T]
 	scanRow                          RowScanner[T]
 	scanRows                         RowsScanner[T]
+	childFetcher                     ChildFetcher[T]
 	setAcquireDBConnDuration         durationTimeSetter
 	setPostgresOperationDurationTime durationTimeSetter
 	upsertAllowed                    noSerializedUpsertChecker[T]
@@ -115,6 +119,7 @@ func NewNoSerializedGenericStore[T any](
 	copyFromObj noSerializedCopier[T],
 	scanRow RowScanner[T],
 	scanRows RowsScanner[T],
+	childFetcher ChildFetcher[T],
 	setAcquireDBConnDuration durationTimeSetter,
 	setPostgresOperationDurationTime durationTimeSetter,
 	upsertAllowed noSerializedUpsertChecker[T],
@@ -123,13 +128,14 @@ func NewNoSerializedGenericStore[T any](
 	transformOptionsMap search.OptionsMap,
 ) NoSerializedStore[T] {
 	return &noSerializedGenericStore[T]{
-		db:          db,
-		schema:      schema,
-		pkGetter:    pkGetter,
-		insertInto:  insertInto,
-		copyFromObj: copyFromObj,
-		scanRow:     scanRow,
-		scanRows:    scanRows,
+		db:           db,
+		schema:       schema,
+		pkGetter:     pkGetter,
+		insertInto:   insertInto,
+		copyFromObj:  copyFromObj,
+		scanRow:      scanRow,
+		scanRows:     scanRows,
+		childFetcher: childFetcher,
 		setAcquireDBConnDuration: func() durationTimeSetter {
 			if setAcquireDBConnDuration == nil {
 				return doNothingDurationTimeSetter
@@ -158,6 +164,7 @@ func NewNoSerializedGloballyScopedGenericStore[T any](
 	copyFromObj noSerializedCopier[T],
 	scanRow RowScanner[T],
 	scanRows RowsScanner[T],
+	childFetcher ChildFetcher[T],
 	setAcquireDBConnDuration durationTimeSetter,
 	setPostgresOperationDurationTime durationTimeSetter,
 	targetResource permissions.ResourceMetadata,
@@ -165,13 +172,14 @@ func NewNoSerializedGloballyScopedGenericStore[T any](
 	transformOptionsMap search.OptionsMap,
 ) NoSerializedStore[T] {
 	return &noSerializedGenericStore[T]{
-		db:          db,
-		schema:      schema,
-		pkGetter:    pkGetter,
-		insertInto:  insertInto,
-		copyFromObj: copyFromObj,
-		scanRow:     scanRow,
-		scanRows:    scanRows,
+		db:           db,
+		schema:       schema,
+		pkGetter:     pkGetter,
+		insertInto:   insertInto,
+		copyFromObj:  copyFromObj,
+		scanRow:      scanRow,
+		scanRows:     scanRows,
+		childFetcher: childFetcher,
 		setAcquireDBConnDuration: func() durationTimeSetter {
 			if setAcquireDBConnDuration == nil {
 				return doNothingDurationTimeSetter
@@ -247,6 +255,9 @@ func (s *noSerializedGenericStore[T]) Get(ctx context.Context, id string) (*T, b
 	if err != nil {
 		return nil, false, pgutils.ErrNilIfNoRows(err)
 	}
+	if err := s.fetchChildrenIfNeeded(ctx, s.db, []*T{data}); err != nil {
+		return nil, false, err
+	}
 	return data, true, nil
 }
 
@@ -262,6 +273,11 @@ func (s *noSerializedGenericStore[T]) GetWithOptions(ctx context.Context, id str
 	if err != nil {
 		return nil, false, pgutils.ErrNilIfNoRows(err)
 	}
+	if cfg.includeChildren {
+		if err := s.fetchChildrenIfNeeded(ctx, s.db, []*T{data}); err != nil {
+			return nil, false, err
+		}
+	}
 	return data, true, nil
 }
 
@@ -270,6 +286,13 @@ func (s *noSerializedGenericStore[T]) schemaForFetch(cfg fetchConfig) *walker.Sc
 		return s.schema.ShallowCopyWithoutChildren()
 	}
 	return s.schema
+}
+
+func (s *noSerializedGenericStore[T]) fetchChildrenIfNeeded(ctx context.Context, q postgres.Queryable, objs []*T) error {
+	if s.childFetcher == nil || len(objs) == 0 {
+		return nil
+	}
+	return s.childFetcher(ctx, q, objs)
 }
 
 func (s *noSerializedGenericStore[T]) runGetQuery(ctx context.Context, schema *walker.Schema, q *v1.Query) (*T, error) {
@@ -321,6 +344,9 @@ func (s *noSerializedGenericStore[T]) runQueryFn(ctx context.Context, q *v1.Quer
 	if err != nil {
 		return errors.Wrap(err, "scanning rows")
 	}
+	if err := s.fetchChildrenIfNeeded(ctx, pool, results); err != nil {
+		return errors.Wrap(err, "fetching children")
+	}
 	for _, obj := range results {
 		if ctx.Err() != nil {
 			return errors.Wrap(ctx.Err(), "iterating over rows")
@@ -350,10 +376,10 @@ func (s *noSerializedGenericStore[T]) GetByQuery(ctx context.Context, query *v1.
 
 func (s *noSerializedGenericStore[T]) walkByQuery(ctx context.Context, query *v1.Query, hint string, fn func(obj *T) error) error {
 	query = s.applyQueryDefaults(query)
-	return s.runCursorQueryFn(ctx, s.schema, query, hint, fn)
+	return s.runCursorQueryFn(ctx, s.schema, query, hint, true, fn)
 }
 
-func (s *noSerializedGenericStore[T]) runCursorQueryFn(ctx context.Context, schema *walker.Schema, q *v1.Query, hint string, callback func(obj *T) error) error {
+func (s *noSerializedGenericStore[T]) runCursorQueryFn(ctx context.Context, schema *walker.Schema, q *v1.Query, hint string, includeChildren bool, callback func(obj *T) error) error {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, cursorDefaultTimeout)
 	defer cancel()
 
@@ -377,6 +403,11 @@ func (s *noSerializedGenericStore[T]) runCursorQueryFn(ctx context.Context, sche
 		results, scanErr := s.scanRows(rows)
 		if scanErr != nil {
 			return errors.Wrap(scanErr, "scanning cursor rows")
+		}
+		if includeChildren {
+			if err := s.fetchChildrenIfNeeded(ctx, cursor.tx, results); err != nil {
+				return errors.Wrap(err, "fetching children")
+			}
 		}
 
 		for _, obj := range results {
@@ -413,7 +444,7 @@ func (s *noSerializedGenericStore[T]) WalkByQueryWithOptions(ctx context.Context
 	cfg := applyFetchOptions(opts)
 	schema := s.schemaForFetch(cfg)
 	query = s.applyQueryDefaults(query)
-	return s.runCursorQueryFn(ctx, schema, query, "WalkByQueryWithOptions", fn)
+	return s.runCursorQueryFn(ctx, schema, query, "WalkByQueryWithOptions", cfg.includeChildren, fn)
 }
 
 func (s *noSerializedGenericStore[T]) fetchIDsByQuery(ctx context.Context, query *v1.Query) ([]string, error) {

--- a/pkg/search/postgres/no_serialized_store.go
+++ b/pkg/search/postgres/no_serialized_store.go
@@ -30,6 +30,36 @@ type RowScanner[T any] func(row pgx.Row) (*T, error)
 // RowsScanner scans pgx.Rows into a slice of proto messages.
 type RowsScanner[T any] func(rows pgx.Rows) ([]*T, error)
 
+// FetchOption controls what data is fetched from the store.
+type FetchOption func(*fetchConfig)
+
+type fetchConfig struct {
+	includeChildren bool
+}
+
+func defaultFetchConfig() fetchConfig {
+	return fetchConfig{includeChildren: true}
+}
+
+func applyFetchOptions(opts []FetchOption) fetchConfig {
+	cfg := defaultFetchConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
+
+// WithChildren explicitly requests child table data (the default).
+func WithChildren() FetchOption {
+	return func(c *fetchConfig) { c.includeChildren = true }
+}
+
+// WithoutChildren skips child table fetching for read performance.
+// Repeated message fields will be returned as nil/empty slices.
+func WithoutChildren() FetchOption {
+	return func(c *fetchConfig) { c.includeChildren = false }
+}
+
 // NoSerializedStore is the store interface for types without a serialized column.
 type NoSerializedStore[T any] interface {
 	Exists(ctx context.Context, id string) (bool, error)
@@ -38,11 +68,13 @@ type NoSerializedStore[T any] interface {
 	Walk(ctx context.Context, fn func(obj *T) error) error
 	WalkByQuery(ctx context.Context, q *v1.Query, fn func(obj *T) error) error
 	Get(ctx context.Context, id string) (*T, bool, error)
+	GetWithOptions(ctx context.Context, id string, opts ...FetchOption) (*T, bool, error)
 	GetByQuery(ctx context.Context, query *v1.Query) ([]*T, error)
 	GetByQueryFn(ctx context.Context, query *v1.Query, fn func(obj *T) error) error
 	GetIDs(ctx context.Context) ([]string, error)
 	GetIDsByQuery(ctx context.Context, query *v1.Query) ([]string, error)
 	GetMany(ctx context.Context, identifiers []string) ([]*T, []int, error)
+	WalkByQueryWithOptions(ctx context.Context, q *v1.Query, fn func(obj *T) error, opts ...FetchOption) error
 	DeleteByQuery(ctx context.Context, query *v1.Query) error
 	DeleteByQueryWithIDs(ctx context.Context, query *v1.Query) ([]string, error)
 	Delete(ctx context.Context, id string) error
@@ -211,15 +243,37 @@ func (s *noSerializedGenericStore[T]) Get(ctx context.Context, id string) (*T, b
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.Get)
 
 	q := search.NewQueryBuilder().AddDocIDs(id).ProtoQuery()
-	data, err := s.runGetQuery(ctx, q)
+	data, err := s.runGetQuery(ctx, s.schema, q)
 	if err != nil {
 		return nil, false, pgutils.ErrNilIfNoRows(err)
 	}
 	return data, true, nil
 }
 
-func (s *noSerializedGenericStore[T]) runGetQuery(ctx context.Context, q *v1.Query) (*T, error) {
-	query, err := standardizeQueryAndPopulatePath(ctx, q, s.schema, GET)
+// GetWithOptions returns the object with configurable child table fetching.
+func (s *noSerializedGenericStore[T]) GetWithOptions(ctx context.Context, id string, opts ...FetchOption) (*T, bool, error) {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.Get)
+
+	cfg := applyFetchOptions(opts)
+	schema := s.schemaForFetch(cfg)
+
+	q := search.NewQueryBuilder().AddDocIDs(id).ProtoQuery()
+	data, err := s.runGetQuery(ctx, schema, q)
+	if err != nil {
+		return nil, false, pgutils.ErrNilIfNoRows(err)
+	}
+	return data, true, nil
+}
+
+func (s *noSerializedGenericStore[T]) schemaForFetch(cfg fetchConfig) *walker.Schema {
+	if !cfg.includeChildren {
+		return s.schema.ShallowCopyWithoutChildren()
+	}
+	return s.schema
+}
+
+func (s *noSerializedGenericStore[T]) runGetQuery(ctx context.Context, schema *walker.Schema, q *v1.Query) (*T, error) {
+	query, err := standardizeQueryAndPopulatePath(ctx, q, schema, GET)
 	if err != nil {
 		return nil, err
 	}
@@ -296,15 +350,15 @@ func (s *noSerializedGenericStore[T]) GetByQuery(ctx context.Context, query *v1.
 
 func (s *noSerializedGenericStore[T]) walkByQuery(ctx context.Context, query *v1.Query, hint string, fn func(obj *T) error) error {
 	query = s.applyQueryDefaults(query)
-	return s.runCursorQueryFn(ctx, query, hint, fn)
+	return s.runCursorQueryFn(ctx, s.schema, query, hint, fn)
 }
 
-func (s *noSerializedGenericStore[T]) runCursorQueryFn(ctx context.Context, q *v1.Query, hint string, callback func(obj *T) error) error {
+func (s *noSerializedGenericStore[T]) runCursorQueryFn(ctx context.Context, schema *walker.Schema, q *v1.Query, hint string, callback func(obj *T) error) error {
 	ctx, cancel := contextutil.ContextWithTimeoutIfNotExists(ctx, cursorDefaultTimeout)
 	defer cancel()
 
 	cursor, err := pgutils.Retry2(ctx, func() (*cursorSession, error) {
-		return retryableGetCursorSession(ctx, s.schema, q, s.db, hint)
+		return retryableGetCursorSession(ctx, schema, q, s.db, hint)
 	})
 	if err != nil {
 		return errors.Wrap(err, "prepare cursor")
@@ -350,6 +404,16 @@ func (s *noSerializedGenericStore[T]) Walk(ctx context.Context, fn func(obj *T) 
 func (s *noSerializedGenericStore[T]) WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *T) error) error {
 	defer s.setPostgresOperationDurationTime(time.Now(), ops.WalkByQuery)
 	return s.walkByQuery(ctx, query, "WalkByQuery", fn)
+}
+
+// WalkByQueryWithOptions iterates over objects with configurable child table fetching.
+func (s *noSerializedGenericStore[T]) WalkByQueryWithOptions(ctx context.Context, query *v1.Query, fn func(obj *T) error, opts ...FetchOption) error {
+	defer s.setPostgresOperationDurationTime(time.Now(), ops.WalkByQuery)
+
+	cfg := applyFetchOptions(opts)
+	schema := s.schemaForFetch(cfg)
+	query = s.applyQueryDefaults(query)
+	return s.runCursorQueryFn(ctx, schema, query, "WalkByQueryWithOptions", fn)
 }
 
 func (s *noSerializedGenericStore[T]) fetchIDsByQuery(ctx context.Context, query *v1.Query) ([]string, error) {

--- a/pkg/search/postgres/no_serialized_store_test.go
+++ b/pkg/search/postgres/no_serialized_store_test.go
@@ -1,0 +1,84 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stackrox/rox/pkg/postgres/walker"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultFetchConfig(t *testing.T) {
+	cfg := defaultFetchConfig()
+	assert.True(t, cfg.includeChildren, "default config should include children")
+}
+
+func TestApplyFetchOptions(t *testing.T) {
+	cases := map[string]struct {
+		opts           []FetchOption
+		expectChildren bool
+	}{
+		"no options uses default (include children)": {
+			opts:           nil,
+			expectChildren: true,
+		},
+		"WithChildren explicitly includes children": {
+			opts:           []FetchOption{WithChildren()},
+			expectChildren: true,
+		},
+		"WithoutChildren excludes children": {
+			opts:           []FetchOption{WithoutChildren()},
+			expectChildren: false,
+		},
+		"last option wins": {
+			opts:           []FetchOption{WithoutChildren(), WithChildren()},
+			expectChildren: true,
+		},
+		"last option wins reversed": {
+			opts:           []FetchOption{WithChildren(), WithoutChildren()},
+			expectChildren: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg := applyFetchOptions(tc.opts)
+			assert.Equal(t, tc.expectChildren, cfg.includeChildren)
+		})
+	}
+}
+
+func TestSchemaForFetch(t *testing.T) {
+	store := &noSerializedGenericStore[struct{}]{
+		schema: testSchemaWithChildren(),
+	}
+
+	t.Run("includeChildren returns original schema", func(t *testing.T) {
+		cfg := fetchConfig{includeChildren: true}
+		got := store.schemaForFetch(cfg)
+		assert.Same(t, store.schema, got)
+	})
+
+	t.Run("excludeChildren returns copy without children", func(t *testing.T) {
+		cfg := fetchConfig{includeChildren: false}
+		got := store.schemaForFetch(cfg)
+		assert.NotSame(t, store.schema, got)
+		assert.Nil(t, got.Children)
+		assert.Equal(t, store.schema.Table, got.Table)
+		// Original schema still has children.
+		assert.NotEmpty(t, store.schema.Children)
+	})
+}
+
+func testSchemaWithChildren() *walker.Schema {
+	parent := &walker.Schema{
+		Table: "parent",
+		Fields: []walker.Field{
+			{Name: "id", ColumnName: "id"},
+		},
+	}
+	child := &walker.Schema{
+		Table:  "parent_children",
+		Parent: parent,
+	}
+	parent.Children = []*walker.Schema{child}
+	return parent
+}

--- a/tools/generate-helpers/pg-table-bindings/funcs.go
+++ b/tools/generate-helpers/pg-table-bindings/funcs.go
@@ -178,4 +178,9 @@ var funcMap = template.FuncMap{
 		}
 		return fmt.Sprintf("%ss", s)
 	},
+	"objectGetterToSetter": func(getter string) string {
+		s := strings.TrimSuffix(getter, "()")
+		s = strings.TrimPrefix(s, "Get")
+		return s
+	},
 }

--- a/tools/generate-helpers/pg-table-bindings/store.go.tpl
+++ b/tools/generate-helpers/pg-table-bindings/store.go.tpl
@@ -122,6 +122,11 @@ func New(db postgres.DB) Store {
             {{- end }}
             scanRow,
             scanRows,
+            {{- if .Schema.Children }}
+            fetchChildren,
+            {{- else }}
+            nil,
+            {{- end }}
             metricsSetAcquireDBConnDuration,
             metricsSetPostgresOperationDurationTime,
             isUpsertAllowed,
@@ -150,6 +155,11 @@ func New(db postgres.DB) Store {
             {{- end }}
             scanRow,
             scanRows,
+            {{- if .Schema.Children }}
+            fetchChildren,
+            {{- else }}
+            nil,
+            {{- end }}
             metricsSetAcquireDBConnDuration,
             metricsSetPostgresOperationDurationTime,
             targetResource,
@@ -469,6 +479,93 @@ func scanRows(rows pgx.Rows) ([]*storeType, error) {
 }
 
 // endregion No-serialized scan functions
+
+{{- if .Schema.Children }}
+// region Child table fetching
+
+func fetchChildren(ctx context.Context, db postgres.Queryable, objs []*storeType) error {
+    if len(objs) == 0 {
+        return nil
+    }
+    objsByID := make(map[string]*storeType, len(objs))
+    ids := make([]string, 0, len(objs))
+    for _, obj := range objs {
+        id := pkGetter(obj)
+        objsByID[id] = obj
+        ids = append(ids, id)
+    }
+
+    {{- range $child := .Schema.Children }}
+    {
+        {{- $fkFields := $child.FieldsReferringToParent }}
+        {{- $fkField := index $fkFields 0 }}
+        rows, err := db.Query(ctx,
+            "SELECT {{template "commaSeparatedColumns" $child.DBColumnFields}} FROM {{$child.Table}} WHERE {{$fkField.ColumnName}} = ANY($1::uuid[]) ORDER BY {{$fkField.ColumnName}}, idx",
+            ids)
+        if err != nil {
+            return err
+        }
+        defer rows.Close()
+        for rows.Next() {
+            var parentID string
+            var idx int
+            child := &{{trimPrefix "*" $child.Type}}{}
+            {{- range $field := $child.DBColumnFields }}
+            {{- if $field.Options.Reference }}
+            {{- else if eq $field.ColumnName "idx" }}
+            {{- else if or (eq $field.DataType "datetime") (eq $field.DataType "datetimetz") }}
+            var col_{{$field.ColumnName}} *time.Time
+            {{- else if eq $field.SQLType "uuid" }}
+            var col_{{$field.ColumnName}} *string
+            {{- end }}
+            {{- end }}
+
+            if err := rows.Scan(
+                &parentID,
+                &idx,
+                {{- range $field := $child.DBColumnFields }}
+                {{- if $field.Options.Reference }}
+                {{- else if eq $field.ColumnName "idx" }}
+                {{- else if or (eq $field.DataType "datetime") (eq $field.DataType "datetimetz") }}
+                &col_{{$field.ColumnName}},
+                {{- else if eq $field.SQLType "uuid" }}
+                &col_{{$field.ColumnName}},
+                {{- else }}
+                &{{$field.Setter "child"}},
+                {{- end }}
+                {{- end }}
+            ); err != nil {
+                return err
+            }
+            {{- range $field := $child.DBColumnFields }}
+            {{- if $field.Options.Reference }}
+            {{- else if eq $field.ColumnName "idx" }}
+            {{- else if or (eq $field.DataType "datetime") (eq $field.DataType "datetimetz") }}
+            if col_{{$field.ColumnName}} != nil {
+                {{$field.Setter "child"}} = protocompat.ConvertTimeToTimestampOrNil(col_{{$field.ColumnName}})
+            }
+            {{- else if eq $field.SQLType "uuid" }}
+            if col_{{$field.ColumnName}} != nil {
+                {{$field.Setter "child"}} = *col_{{$field.ColumnName}}
+            }
+            {{- end }}
+            {{- end }}
+            parent, ok := objsByID[parentID]
+            if !ok {
+                continue
+            }
+            parent.{{objectGetterToSetter $child.ObjectGetter}} = append(parent.{{objectGetterToSetter $child.ObjectGetter}}, child)
+        }
+        if err := rows.Err(); err != nil {
+            return err
+        }
+    }
+    {{- end }}
+    return nil
+}
+
+// endregion Child table fetching
+{{- end }}
 {{- end }}
 
 // endregion Helper functions

--- a/tools/generate-helpers/pg-table-bindings/test/no_serialized_postgres/integration_test.go
+++ b/tools/generate-helpers/pg-table-bindings/test/no_serialized_postgres/integration_test.go
@@ -280,7 +280,7 @@ func (s *NoSerializedIntegrationSuite) TestGetWithOptions_DefaultBehavior() {
 }
 
 func (s *NoSerializedIntegrationSuite) TestGetWithOptions_NotFound() {
-	got, exists, err := s.store.GetWithOptions(s.ctx, "nonexistent-id", pgSearch.WithoutChildren())
+	got, exists, err := s.store.GetWithOptions(s.ctx, uuid.NewV4().String(), pgSearch.WithoutChildren())
 	s.NoError(err)
 	s.False(exists)
 	s.Nil(got)

--- a/tools/generate-helpers/pg-table-bindings/test/no_serialized_postgres/integration_test.go
+++ b/tools/generate-helpers/pg-table-bindings/test/no_serialized_postgres/integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/protoassert"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/search"
+	pgSearch "github.com/stackrox/rox/pkg/search/postgres"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -234,6 +235,103 @@ func (s *NoSerializedIntegrationSuite) TestBytesStrategyEmptySlice() {
 	got, _, err := s.store.Get(s.ctx, obj.GetId())
 	s.Require().NoError(err)
 	s.Empty(got.GetAnnotations())
+}
+
+func (s *NoSerializedIntegrationSuite) TestGetWithOptions_WithoutChildren() {
+	obj := s.makeTestObject("get-no-children")
+	s.Require().NoError(s.store.Upsert(s.ctx, obj))
+
+	got, exists, err := s.store.GetWithOptions(s.ctx, obj.GetId(), pgSearch.WithoutChildren())
+	s.Require().NoError(err)
+	s.True(exists)
+
+	s.Equal(obj.GetId(), got.GetId())
+	s.Equal(obj.GetName(), got.GetName())
+	s.Equal(obj.GetDescription(), got.GetDescription())
+	s.Equal(obj.GetMetadata().GetAuthor(), got.GetMetadata().GetAuthor())
+	// Child table data (Labels) should not be fetched.
+	s.Nil(got.GetLabels())
+	// Bytea-inlined repeated messages are parent columns and should still be present.
+	s.Len(got.GetAnnotations(), 2)
+}
+
+func (s *NoSerializedIntegrationSuite) TestGetWithOptions_WithChildren() {
+	obj := s.makeTestObject("get-with-children")
+	s.Require().NoError(s.store.Upsert(s.ctx, obj))
+
+	got, exists, err := s.store.GetWithOptions(s.ctx, obj.GetId(), pgSearch.WithChildren())
+	s.Require().NoError(err)
+	s.True(exists)
+
+	s.Equal(obj.GetId(), got.GetId())
+	s.Equal(obj.GetName(), got.GetName())
+}
+
+func (s *NoSerializedIntegrationSuite) TestGetWithOptions_DefaultBehavior() {
+	obj := s.makeTestObject("get-default-opts")
+	s.Require().NoError(s.store.Upsert(s.ctx, obj))
+
+	// No options passed — should behave identically to Get (default includes children).
+	got, exists, err := s.store.GetWithOptions(s.ctx, obj.GetId())
+	s.Require().NoError(err)
+	s.True(exists)
+	s.Equal(obj.GetId(), got.GetId())
+	s.Equal(obj.GetName(), got.GetName())
+}
+
+func (s *NoSerializedIntegrationSuite) TestGetWithOptions_NotFound() {
+	got, exists, err := s.store.GetWithOptions(s.ctx, "nonexistent-id", pgSearch.WithoutChildren())
+	s.NoError(err)
+	s.False(exists)
+	s.Nil(got)
+}
+
+func (s *NoSerializedIntegrationSuite) TestWalkByQueryWithOptions_WithoutChildren() {
+	objs := make([]*storage.TestNoSerialized, 5)
+	for i := range objs {
+		objs[i] = s.makeTestObject(fmt.Sprintf("walk-opts-%d", i))
+	}
+	s.Require().NoError(s.store.UpsertMany(s.ctx, objs))
+
+	var walked []*storage.TestNoSerialized
+	err := s.store.WalkByQueryWithOptions(s.ctx, search.EmptyQuery(), func(obj *storage.TestNoSerialized) error {
+		walked = append(walked, obj)
+		return nil
+	}, pgSearch.WithoutChildren())
+	s.Require().NoError(err)
+	s.Len(walked, 5)
+
+	for _, w := range walked {
+		s.Nil(w.GetLabels(), "child table data should not be fetched with WithoutChildren")
+		// Bytea-inlined annotations should still be present.
+		s.NotNil(w.GetAnnotations())
+	}
+}
+
+func (s *NoSerializedIntegrationSuite) TestWalkByQueryWithOptions_WithChildren() {
+	objs := make([]*storage.TestNoSerialized, 3)
+	for i := range objs {
+		objs[i] = s.makeTestObject(fmt.Sprintf("walk-children-%d", i))
+	}
+	s.Require().NoError(s.store.UpsertMany(s.ctx, objs))
+
+	var walked int
+	err := s.store.WalkByQueryWithOptions(s.ctx, search.EmptyQuery(), func(_ *storage.TestNoSerialized) error {
+		walked++
+		return nil
+	}, pgSearch.WithChildren())
+	s.Require().NoError(err)
+	s.Equal(3, walked)
+}
+
+func (s *NoSerializedIntegrationSuite) TestWalkByQueryWithOptions_EmptyResult() {
+	var walked int
+	err := s.store.WalkByQueryWithOptions(s.ctx, search.EmptyQuery(), func(_ *storage.TestNoSerialized) error {
+		walked++
+		return nil
+	}, pgSearch.WithoutChildren())
+	s.Require().NoError(err)
+	s.Equal(0, walked)
 }
 
 func (s *NoSerializedIntegrationSuite) makeTestObject(name string) *storage.TestNoSerialized {

--- a/tools/generate-helpers/pg-table-bindings/test/no_serialized_postgres/integration_test.go
+++ b/tools/generate-helpers/pg-table-bindings/test/no_serialized_postgres/integration_test.go
@@ -51,9 +51,6 @@ func (s *NoSerializedIntegrationSuite) TestRoundTrip() {
 	s.Require().NoError(err)
 	s.True(exists)
 
-	// Child table fields (Labels) are not auto-fetched in no-serialized stores.
-	// Compare parent fields only. Child fetch is handled by PR 4 (ROX-34907).
-	obj.Labels = nil
 	protoassert.Equal(s.T(), obj, got)
 }
 
@@ -196,10 +193,12 @@ func (s *NoSerializedIntegrationSuite) TestRepeatedFieldStrategies() {
 	s.Equal("tier", got.GetAnnotations()[1].GetKey())
 	s.Equal("1", got.GetAnnotations()[1].GetValue())
 
-	// Repeated message → child table (default strategy) — not auto-fetched on Get.
-	// Child table data is written correctly (verified by DB query) but requires
-	// explicit child fetch (ROX-34907) to reconstruct on read.
-	s.Nil(got.GetLabels())
+	// Repeated message → child table (default strategy) — auto-fetched via childFetcher.
+	s.Require().Len(got.GetLabels(), 2)
+	s.Equal("env", got.GetLabels()[0].GetKey())
+	s.Equal("prod", got.GetLabels()[0].GetValue())
+	s.Equal("team", got.GetLabels()[1].GetKey())
+	s.Equal("platform", got.GetLabels()[1].GetValue())
 }
 
 func (s *NoSerializedIntegrationSuite) TestChildTableWriteVerification() {
@@ -265,6 +264,12 @@ func (s *NoSerializedIntegrationSuite) TestGetWithOptions_WithChildren() {
 
 	s.Equal(obj.GetId(), got.GetId())
 	s.Equal(obj.GetName(), got.GetName())
+	// Child table data (Labels) should be fetched with WithChildren.
+	s.Require().Len(got.GetLabels(), 2)
+	s.Equal("env", got.GetLabels()[0].GetKey())
+	s.Equal("prod", got.GetLabels()[0].GetValue())
+	s.Equal("team", got.GetLabels()[1].GetKey())
+	s.Equal("platform", got.GetLabels()[1].GetValue())
 }
 
 func (s *NoSerializedIntegrationSuite) TestGetWithOptions_DefaultBehavior() {
@@ -315,13 +320,17 @@ func (s *NoSerializedIntegrationSuite) TestWalkByQueryWithOptions_WithChildren()
 	}
 	s.Require().NoError(s.store.UpsertMany(s.ctx, objs))
 
-	var walked int
-	err := s.store.WalkByQueryWithOptions(s.ctx, search.EmptyQuery(), func(_ *storage.TestNoSerialized) error {
-		walked++
+	var walked []*storage.TestNoSerialized
+	err := s.store.WalkByQueryWithOptions(s.ctx, search.EmptyQuery(), func(obj *storage.TestNoSerialized) error {
+		walked = append(walked, obj)
 		return nil
 	}, pgSearch.WithChildren())
 	s.Require().NoError(err)
-	s.Equal(3, walked)
+	s.Len(walked, 3)
+
+	for _, w := range walked {
+		s.Len(w.GetLabels(), 2, "child table data should be fetched with WithChildren")
+	}
 }
 
 func (s *NoSerializedIntegrationSuite) TestWalkByQueryWithOptions_EmptyResult() {

--- a/tools/generate-helpers/pg-table-bindings/test/no_serialized_postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/no_serialized_postgres/store.go
@@ -49,6 +49,7 @@ func New(db postgres.DB) Store {
 		copyFromTestNoSerializeds,
 		scanRow,
 		scanRows,
+		fetchChildren,
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
@@ -304,6 +305,54 @@ func scanRows(rows pgx.Rows) ([]*storeType, error) {
 }
 
 // endregion No-serialized scan functions
+// region Child table fetching
+
+func fetchChildren(ctx context.Context, db postgres.Queryable, objs []*storeType) error {
+	if len(objs) == 0 {
+		return nil
+	}
+	objsByID := make(map[string]*storeType, len(objs))
+	ids := make([]string, 0, len(objs))
+	for _, obj := range objs {
+		id := pkGetter(obj)
+		objsByID[id] = obj
+		ids = append(ids, id)
+	}
+	{
+		rows, err := db.Query(ctx,
+			"SELECT test_no_serializeds_Id, idx, Key, Value FROM test_no_serializeds_labels WHERE test_no_serializeds_Id = ANY($1::uuid[]) ORDER BY test_no_serializeds_Id, idx",
+			ids)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var parentID string
+			var idx int
+			child := &storage.TestNoSerialized_Label{}
+
+			if err := rows.Scan(
+				&parentID,
+				&idx,
+				&child.Key,
+				&child.Value,
+			); err != nil {
+				return err
+			}
+			parent, ok := objsByID[parentID]
+			if !ok {
+				continue
+			}
+			parent.Labels = append(parent.Labels, child)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// endregion Child table fetching
 
 // endregion Helper functions
 

--- a/tools/generate-helpers/pg-table-bindings/test/no_serialized_postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/no_serialized_postgres/store.go
@@ -49,6 +49,7 @@ func New(db postgres.DB) Store {
 		copyFromTestNoSerializeds,
 		scanRow,
 		scanRows,
+		fetchChildren,
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
@@ -304,6 +305,45 @@ func scanRows(rows pgx.Rows) ([]*storeType, error) {
 }
 
 // endregion No-serialized scan functions
+
+// region Child table fetching
+
+func fetchChildren(ctx context.Context, db postgres.Queryable, objs []*storeType) error {
+	if len(objs) == 0 {
+		return nil
+	}
+	objsByID := make(map[string]*storeType, len(objs))
+	ids := make([]string, 0, len(objs))
+	for _, obj := range objs {
+		id := pkGetter(obj)
+		objsByID[id] = obj
+		ids = append(ids, id)
+	}
+
+	rows, err := db.Query(ctx,
+		"SELECT test_no_serializeds_Id, idx, Key, Value FROM test_no_serializeds_labels WHERE test_no_serializeds_Id = ANY($1::uuid[]) ORDER BY test_no_serializeds_Id, idx",
+		ids)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var parentID string
+		var idx int
+		var key, value string
+		if err := rows.Scan(&parentID, &idx, &key, &value); err != nil {
+			return err
+		}
+		parent, ok := objsByID[parentID]
+		if !ok {
+			continue
+		}
+		parent.Labels = append(parent.Labels, &storage.TestNoSerialized_Label{Key: key, Value: value})
+	}
+	return rows.Err()
+}
+
+// endregion Child table fetching
 
 // endregion Helper functions
 

--- a/tools/generate-helpers/pg-table-bindings/test/no_serialized_postgres/store.go
+++ b/tools/generate-helpers/pg-table-bindings/test/no_serialized_postgres/store.go
@@ -49,7 +49,6 @@ func New(db postgres.DB) Store {
 		copyFromTestNoSerializeds,
 		scanRow,
 		scanRows,
-		fetchChildren,
 		metricsSetAcquireDBConnDuration,
 		metricsSetPostgresOperationDurationTime,
 		targetResource,
@@ -305,45 +304,6 @@ func scanRows(rows pgx.Rows) ([]*storeType, error) {
 }
 
 // endregion No-serialized scan functions
-
-// region Child table fetching
-
-func fetchChildren(ctx context.Context, db postgres.Queryable, objs []*storeType) error {
-	if len(objs) == 0 {
-		return nil
-	}
-	objsByID := make(map[string]*storeType, len(objs))
-	ids := make([]string, 0, len(objs))
-	for _, obj := range objs {
-		id := pkGetter(obj)
-		objsByID[id] = obj
-		ids = append(ids, id)
-	}
-
-	rows, err := db.Query(ctx,
-		"SELECT test_no_serializeds_Id, idx, Key, Value FROM test_no_serializeds_labels WHERE test_no_serializeds_Id = ANY($1::uuid[]) ORDER BY test_no_serializeds_Id, idx",
-		ids)
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var parentID string
-		var idx int
-		var key, value string
-		if err := rows.Scan(&parentID, &idx, &key, &value); err != nil {
-			return err
-		}
-		parent, ok := objsByID[parentID]
-		if !ok {
-			continue
-		}
-		parent.Labels = append(parent.Labels, &storage.TestNoSerialized_Label{Key: key, Value: value})
-	}
-	return rows.Err()
-}
-
-// endregion Child table fetching
 
 // endregion Helper functions
 


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Adds FetchOption type with WithChildren()/WithoutChildren() so callers
can skip child table JOINs when they only need parent row data. New
methods GetWithOptions and WalkByQueryWithOptions accept fetch options
and use ShallowCopyWithoutChildren() to strip child schemas before
query building.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

unit tests are sufficient as this is not yet used in practice.  This is enablement.