### PR TITLE
ROX-34720: Fix AttemptedAlertsTest flake in violation count

### DIFF
--- a/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AttemptedAlertsTest.groovy
@@ -282,7 +282,7 @@ class AttemptedAlertsTest extends BaseSpecification {
         and:
         "Verify alerts"
         List<ListAlert> listAlerts = []
-        withRetry(3, 3) {
+        withRetry(5, 3) {
             listAlerts = Services.getViolationsWithTimeout(dep.name, KUBECTL_EXEC_POLICY_NAME, 60)
             assert listAlerts && listAlerts.size() == numAlerts
             assert listAlerts.get(0).getPolicy().getName() == KUBECTL_EXEC_POLICY_NAME
@@ -294,10 +294,10 @@ class AttemptedAlertsTest extends BaseSpecification {
                 // Verify admission controller enforcement action is applied.
                 assert listAlerts.get(0).getEnforcementAction() == EnforcementAction.FAIL_KUBE_REQUEST_ENFORCEMENT
             }
-        }
 
-        // Verify that the alerts are not merged.
-        assert AlertService.getViolation(listAlerts.get(0).getId()).getViolationsList().size() == numViolations
+            // Verify that the alerts are not merged.
+            assert AlertService.getViolation(listAlerts.get(0).getId()).getViolationsList().size() == numViolations
+        }
 
         where:
         "Data inputs are: "


### PR DESCRIPTION
## Description
The violation count assertion was outside the withRetry block, causing a race condition: the alert count was already satisfied from prior test iterations so withRetry passed immediately, but the new violation had not yet been processed through the Sensor->Central pipeline.

Move the assertion inside withRetry and increase retries from 3 to 5 to allow time for K8S event processing.

Fixes: ROX-34720

Partially generated by AI.



<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
