### PR TITLE
ROX-34951: add skip_container_types field to EvaluationFilter proto

### DIFF
--- a/generated/api/v1/alert_service.swagger.json
+++ b/generated/api/v1/alert_service.swagger.json
@@ -1182,6 +1182,14 @@
       },
       "title": "Next tag: 13"
     },
+    "storageContainerType": {
+      "type": "string",
+      "enum": [
+        "REGULAR",
+        "INIT"
+      ],
+      "default": "REGULAR"
+    },
     "storageEnforcementAction": {
       "type": "string",
       "enum": [
@@ -1199,6 +1207,14 @@
     },
     "storageEvaluationFilter": {
       "type": "object",
+      "properties": {
+        "skipContainerTypes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/storageContainerType"
+          }
+        }
+      },
       "description": "EvaluationFilter pre-filters which entities a policy evaluates."
     },
     "storageEventSource": {

--- a/generated/api/v1/detection_service.swagger.json
+++ b/generated/api/v1/detection_service.swagger.json
@@ -1005,6 +1005,14 @@
     },
     "storageEvaluationFilter": {
       "type": "object",
+      "properties": {
+        "skipContainerTypes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/storageContainerType"
+          }
+        }
+      },
       "description": "EvaluationFilter pre-filters which entities a policy evaluates."
     },
     "storageEventSource": {

--- a/generated/api/v1/policy_service.swagger.json
+++ b/generated/api/v1/policy_service.swagger.json
@@ -846,6 +846,14 @@
       ],
       "default": "OR"
     },
+    "storageContainerType": {
+      "type": "string",
+      "enum": [
+        "REGULAR",
+        "INIT"
+      ],
+      "default": "REGULAR"
+    },
     "storageEnforcementAction": {
       "type": "string",
       "enum": [
@@ -863,6 +871,14 @@
     },
     "storageEvaluationFilter": {
       "type": "object",
+      "properties": {
+        "skipContainerTypes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/storageContainerType"
+          }
+        }
+      },
       "description": "EvaluationFilter pre-filters which entities a policy evaluates."
     },
     "storageEventSource": {

--- a/generated/storage/policy.pb.go
+++ b/generated/storage/policy.pb.go
@@ -1007,9 +1007,10 @@ func (x *ListPolicy) GetEvaluationFilter() *EvaluationFilter {
 
 // EvaluationFilter pre-filters which entities a policy evaluates.
 type EvaluationFilter struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	SkipContainerTypes []ContainerType        `protobuf:"varint,1,rep,packed,name=skip_container_types,json=skipContainerTypes,proto3,enum=storage.ContainerType" json:"skip_container_types,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *EvaluationFilter) Reset() {
@@ -1040,6 +1041,13 @@ func (x *EvaluationFilter) ProtoReflect() protoreflect.Message {
 // Deprecated: Use EvaluationFilter.ProtoReflect.Descriptor instead.
 func (*EvaluationFilter) Descriptor() ([]byte, []int) {
 	return file_storage_policy_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *EvaluationFilter) GetSkipContainerTypes() []ContainerType {
+	if x != nil {
+		return x.SkipContainerTypes
+	}
+	return nil
 }
 
 type Exclusion struct {
@@ -1352,7 +1360,7 @@ var File_storage_policy_proto protoreflect.FileDescriptor
 
 const file_storage_policy_proto_rawDesc = "" +
 	"\n" +
-	"\x14storage/policy.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x13storage/image.proto\x1a\x13storage/scope.proto\"\xfc\t\n" +
+	"\x14storage/policy.proto\x12\astorage\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x18storage/deployment.proto\x1a\x13storage/image.proto\x1a\x13storage/scope.proto\"\xfc\t\n" +
 	"\x06Policy\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
@@ -1420,8 +1428,9 @@ const file_storage_policy_proto_rawDesc = "" +
 	"is_default\x18\n" +
 	" \x01(\bR\tisDefault\x12-\n" +
 	"\x06source\x18\v \x01(\x0e2\x15.storage.PolicySourceR\x06source\x12F\n" +
-	"\x11evaluation_filter\x18\f \x01(\v2\x19.storage.EvaluationFilterR\x10evaluationFilter\"\x12\n" +
-	"\x10EvaluationFilter\"\xf5\x02\n" +
+	"\x11evaluation_filter\x18\f \x01(\v2\x19.storage.EvaluationFilterR\x10evaluationFilter\"\\\n" +
+	"\x10EvaluationFilter\x12H\n" +
+	"\x14skip_container_types\x18\x01 \x03(\x0e2\x16.storage.ContainerTypeR\x12skipContainerTypes\"\xf5\x02\n" +
 	"\tExclusion\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12=\n" +
 	"\n" +
@@ -1522,7 +1531,8 @@ var file_storage_policy_proto_goTypes = []any{
 	(*Exclusion_Image)(nil),           // 19: storage.Exclusion.Image
 	(*Scope)(nil),                     // 20: storage.Scope
 	(*timestamppb.Timestamp)(nil),     // 21: google.protobuf.Timestamp
-	(*ImageName)(nil),                 // 22: storage.ImageName
+	(ContainerType)(0),                // 22: storage.ContainerType
+	(*ImageName)(nil),                 // 23: storage.ImageName
 }
 var file_storage_policy_proto_depIdxs = []int32{
 	5,  // 0: storage.Policy.lifecycle_stages:type_name -> storage.LifecycleStage
@@ -1546,17 +1556,18 @@ var file_storage_policy_proto_depIdxs = []int32{
 	1,  // 18: storage.ListPolicy.event_source:type_name -> storage.EventSource
 	0,  // 19: storage.ListPolicy.source:type_name -> storage.PolicySource
 	13, // 20: storage.ListPolicy.evaluation_filter:type_name -> storage.EvaluationFilter
-	18, // 21: storage.Exclusion.deployment:type_name -> storage.Exclusion.Deployment
-	19, // 22: storage.Exclusion.image:type_name -> storage.Exclusion.Image
-	21, // 23: storage.Exclusion.expiration:type_name -> google.protobuf.Timestamp
-	7,  // 24: storage.ExportPoliciesResponse.policies:type_name -> storage.Policy
-	22, // 25: storage.Exclusion.Container.image_name:type_name -> storage.ImageName
-	20, // 26: storage.Exclusion.Deployment.scope:type_name -> storage.Scope
-	27, // [27:27] is the sub-list for method output_type
-	27, // [27:27] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	22, // 21: storage.EvaluationFilter.skip_container_types:type_name -> storage.ContainerType
+	18, // 22: storage.Exclusion.deployment:type_name -> storage.Exclusion.Deployment
+	19, // 23: storage.Exclusion.image:type_name -> storage.Exclusion.Image
+	21, // 24: storage.Exclusion.expiration:type_name -> google.protobuf.Timestamp
+	7,  // 25: storage.ExportPoliciesResponse.policies:type_name -> storage.Policy
+	23, // 26: storage.Exclusion.Container.image_name:type_name -> storage.ImageName
+	20, // 27: storage.Exclusion.Deployment.scope:type_name -> storage.Scope
+	28, // [28:28] is the sub-list for method output_type
+	28, // [28:28] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_storage_policy_proto_init() }
@@ -1564,6 +1575,7 @@ func file_storage_policy_proto_init() {
 	if File_storage_policy_proto != nil {
 		return
 	}
+	file_storage_deployment_proto_init()
 	file_storage_image_proto_init()
 	file_storage_scope_proto_init()
 	type x struct{}

--- a/generated/storage/policy_vtproto.pb.go
+++ b/generated/storage/policy_vtproto.pb.go
@@ -257,6 +257,11 @@ func (m *EvaluationFilter) CloneVT() *EvaluationFilter {
 		return (*EvaluationFilter)(nil)
 	}
 	r := new(EvaluationFilter)
+	if rhs := m.SkipContainerTypes; rhs != nil {
+		tmpContainer := make([]ContainerType, len(rhs))
+		copy(tmpContainer, rhs)
+		r.SkipContainerTypes = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -764,6 +769,15 @@ func (this *EvaluationFilter) EqualVT(that *EvaluationFilter) bool {
 		return true
 	} else if this == nil || that == nil {
 		return false
+	}
+	if len(this.SkipContainerTypes) != len(that.SkipContainerTypes) {
+		return false
+	}
+	for i, vx := range this.SkipContainerTypes {
+		vy := that.SkipContainerTypes[i]
+		if vx != vy {
+			return false
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -1626,6 +1640,27 @@ func (m *EvaluationFilter) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.SkipContainerTypes) > 0 {
+		var pksize2 int
+		for _, num := range m.SkipContainerTypes {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num1 := range m.SkipContainerTypes {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0xa
+	}
 	return len(dAtA) - i, nil
 }
 
@@ -2161,6 +2196,13 @@ func (m *EvaluationFilter) SizeVT() (n int) {
 	}
 	var l int
 	_ = l
+	if len(m.SkipContainerTypes) > 0 {
+		l = 0
+		for _, e := range m.SkipContainerTypes {
+			l += protohelpers.SizeOfVarint(uint64(e))
+		}
+		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -4129,6 +4171,75 @@ func (m *EvaluationFilter) UnmarshalVT(dAtA []byte) error {
 			return fmt.Errorf("proto: EvaluationFilter: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		case 1:
+			if wireType == 0 {
+				var v ContainerType
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= ContainerType(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.SkipContainerTypes = append(m.SkipContainerTypes, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.SkipContainerTypes) == 0 {
+					m.SkipContainerTypes = make([]ContainerType, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v ContainerType
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= ContainerType(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.SkipContainerTypes = append(m.SkipContainerTypes, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field SkipContainerTypes", wireType)
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -6668,6 +6779,75 @@ func (m *EvaluationFilter) UnmarshalVTUnsafe(dAtA []byte) error {
 			return fmt.Errorf("proto: EvaluationFilter: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		case 1:
+			if wireType == 0 {
+				var v ContainerType
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= ContainerType(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.SkipContainerTypes = append(m.SkipContainerTypes, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.SkipContainerTypes) == 0 {
+					m.SkipContainerTypes = make([]ContainerType, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v ContainerType
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= ContainerType(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.SkipContainerTypes = append(m.SkipContainerTypes, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field SkipContainerTypes", wireType)
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/proto/storage/policy.proto
+++ b/proto/storage/policy.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package storage;
 
 import "google/protobuf/timestamp.proto";
+import "storage/deployment.proto";
 import "storage/image.proto";
 import "storage/scope.proto";
 
@@ -178,7 +179,9 @@ enum Comparator {
 }
 
 // EvaluationFilter pre-filters which entities a policy evaluates.
-message EvaluationFilter {}
+message EvaluationFilter {
+  repeated ContainerType skip_container_types = 1;
+}
 
 message Exclusion {
   string name = 1; // @gotags: crYaml:",omitempty"

--- a/proto/storage/proto.lock
+++ b/proto/storage/proto.lock
@@ -14087,7 +14087,15 @@
             ]
           },
           {
-            "name": "EvaluationFilter"
+            "name": "EvaluationFilter",
+            "fields": [
+              {
+                "id": 1,
+                "name": "skip_container_types",
+                "type": "ContainerType",
+                "is_repeated": true
+              }
+            ]
           },
           {
             "name": "Exclusion",
@@ -14169,6 +14177,9 @@
         "imports": [
           {
             "path": "google/protobuf/timestamp.proto"
+          },
+          {
+            "path": "storage/deployment.proto"
           },
           {
             "path": "storage/image.proto"


### PR DESCRIPTION
## Description

Adds `skip_container_types` field to the `EvaluationFilter` meessage in `policy.proto`, reusing the existing `ContainerType` enum from `deployment.proto`. This allows policies to specify which container types to skip during evaluation (e.g. skip init containers).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change