### PR TITLE
ROX-34988: Add no-TabContent-hidden and another in pluginPatternFly

### DIFF
--- a/ui/apps/platform/eslint-plugins/pluginPatternFly.js
+++ b/ui/apps/platform/eslint-plugins/pluginPatternFly.js
@@ -362,6 +362,72 @@ const rules = {
             };
         },
     },
+    'no-Tab-tabContentId-without-children': {
+        // Tab element needs tabContentId prop only if it has separate content in TabContent element.
+        // Tab-empty-contentId is the opposite rule in pluginAccessibility.js file.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Omit tabContentId prop of Tab element that has children',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (node.name?.name === 'Tab') {
+                        const ancestors = context.sourceCode.getAncestors(node);
+                        if (
+                            ancestors.length >= 1 &&
+                            Array.isArray(ancestors[ancestors.length - 1].children) &&
+                            ancestors[ancestors.length - 1].children.length !== 0
+                        ) {
+                            if (
+                                node.attributes.some(
+                                    (attribute) => attribute.name?.name === 'tabContentId'
+                                )
+                            ) {
+                                context.report({
+                                    node,
+                                    message:
+                                        'Omit tabContentId prop of Tab element that has children',
+                                });
+                            }
+                        }
+                    }
+                },
+            };
+        },
+    },
+    'no-TabContent-hidden': {
+        // Do not use implicit conditional rendering via hidden prop.
+        // Because non-active tab might request data that user never sees.
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Replace hidden prop of TabContent element with explicit conditional rendering',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXOpeningElement(node) {
+                    if (node.name?.name === 'TabContent') {
+                        if (
+                            node.attributes.some((attribute) => attribute.name?.name === 'hidden')
+                        ) {
+                            context.report({
+                                node,
+                                message:
+                                    'Replace hidden prop of TabContent element with explicit conditional rendering',
+                            });
+                        }
+                    }
+                },
+            };
+        },
+    },
     'no-Td-data-label': {
         // Although Td element renders prop as data-label attribute,
         // require dataLabel prop to simplify other lint rules.

--- a/ui/apps/platform/src/Containers/AccessControl/AccessScopes/LabelInclusion.tsx
+++ b/ui/apps/platform/src/Containers/AccessControl/AccessScopes/LabelInclusion.tsx
@@ -62,34 +62,30 @@ function LabelInclusion({
                     }
                 />
             </Tabs>
-            <TabContent
-                eventKey="clusterLabelSelectors"
-                id="clusterLabelSelectors"
-                hidden={activeKeyTab !== 'clusterLabelSelectors'}
-            >
-                <LabelSelectorCards
-                    labelSelectors={clusterLabelSelectors}
-                    labelSelectorsKey="clusterLabelSelectors"
-                    hasAction={hasAction}
-                    labelSelectorsEditingState={labelSelectorsEditingState}
-                    setLabelSelectorsEditingState={setLabelSelectorsEditingState}
-                    handleLabelSelectorsChange={handleLabelSelectorsChange}
-                />
-            </TabContent>
-            <TabContent
-                eventKey="namespaceLabelSelectors"
-                id="namespaceLabelSelectors"
-                hidden={activeKeyTab !== 'namespaceLabelSelectors'}
-            >
-                <LabelSelectorCards
-                    labelSelectors={namespaceLabelSelectors}
-                    labelSelectorsKey="namespaceLabelSelectors"
-                    hasAction={hasAction}
-                    labelSelectorsEditingState={labelSelectorsEditingState}
-                    setLabelSelectorsEditingState={setLabelSelectorsEditingState}
-                    handleLabelSelectorsChange={handleLabelSelectorsChange}
-                />
-            </TabContent>
+            {activeKeyTab === 'clusterLabelSelectors' && (
+                <TabContent eventKey="clusterLabelSelectors" id="clusterLabelSelectors">
+                    <LabelSelectorCards
+                        labelSelectors={clusterLabelSelectors}
+                        labelSelectorsKey="clusterLabelSelectors"
+                        hasAction={hasAction}
+                        labelSelectorsEditingState={labelSelectorsEditingState}
+                        setLabelSelectorsEditingState={setLabelSelectorsEditingState}
+                        handleLabelSelectorsChange={handleLabelSelectorsChange}
+                    />
+                </TabContent>
+            )}
+            {activeKeyTab === 'namespaceLabelSelectors' && (
+                <TabContent eventKey="namespaceLabelSelectors" id="namespaceLabelSelectors">
+                    <LabelSelectorCards
+                        labelSelectors={namespaceLabelSelectors}
+                        labelSelectorsKey="namespaceLabelSelectors"
+                        hasAction={hasAction}
+                        labelSelectorsEditingState={labelSelectorsEditingState}
+                        setLabelSelectorsEditingState={setLabelSelectorsEditingState}
+                        handleLabelSelectorsChange={handleLabelSelectorsChange}
+                    />
+                </TabContent>
+            )}
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterModal.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterModal.tsx
@@ -67,11 +67,12 @@ function SecureClusterModal({ isModalOpen, setIsModalOpen }): ReactElement {
                     </Tabs>
                     <Divider component="div" />
                 </FlexItem>
-                {activeKey === 'Operator' ? (
+                {activeKey === 'Operator' && (
                     <TabContent id={idOperator}>
                         <SecureClusterUsingOperator headingLevel={headingLevel} />
                     </TabContent>
-                ) : (
+                )}
+                {activeKey === 'Helm' && (
                     <TabContent id={idHelm}>
                         <SecureClusterUsingHelmChart headingLevel={headingLevel} />
                     </TabContent>

--- a/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/ClusterRegistrationSecrets/SecureClusterPage.tsx
@@ -50,11 +50,7 @@ function SecureClusterPage(): ReactElement {
                     mountOnEnter
                     unmountOnExit
                 >
-                    <Tab
-                        eventKey={operatorTab}
-                        title={<TabTitleText>{operatorTab}</TabTitleText>}
-                        tabContentId={operatorTab}
-                    >
+                    <Tab eventKey={operatorTab} title={<TabTitleText>{operatorTab}</TabTitleText>}>
                         <PageSection>
                             <SecureClusterUsingOperator headingLevel={headingLevel} />
                         </PageSection>
@@ -62,7 +58,6 @@ function SecureClusterPage(): ReactElement {
                     <Tab
                         eventKey={helmChartTab}
                         title={<TabTitleText>Helm chart (deprecated)</TabTitleText>}
-                        tabContentId={helmChartTab}
                     >
                         <PageSection>
                             <SecureClusterUsingHelmChart headingLevel={headingLevel} />

--- a/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Clusters/InitBundles/SecureClusterPage.tsx
@@ -50,11 +50,7 @@ function SecureClusterPage(): ReactElement {
                     mountOnEnter
                     unmountOnExit
                 >
-                    <Tab
-                        eventKey={operatorTab}
-                        title={<TabTitleText>{operatorTab}</TabTitleText>}
-                        tabContentId={operatorTab}
-                    >
+                    <Tab eventKey={operatorTab} title={<TabTitleText>{operatorTab}</TabTitleText>}>
                         <PageSection>
                             <SecureClusterUsingOperator headingLevel={headingLevel} />
                         </PageSection>
@@ -62,7 +58,6 @@ function SecureClusterPage(): ReactElement {
                     <Tab
                         eventKey={helmChartTab}
                         title={<TabTitleText>Helm chart (deprecated)</TabTitleText>}
-                        tabContentId={helmChartTab}
                     >
                         <PageSection>
                             <SecureClusterUsingHelmChart headingLevel={headingLevel} />

--- a/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/IntegrationsTabPage.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationTiles/IntegrationsTabPage.tsx
@@ -54,7 +54,6 @@ function IntegrationsTabPage({
                                     {integrationSourceTitleMap[sourceEnabled]}
                                 </TabTitleText>
                             }
-                            tabContentId={sourceEnabled}
                         >
                             <PageSection>{children}</PageSection>
                         </Tab>

--- a/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/deployment/DeploymentSideBar.tsx
@@ -226,68 +226,60 @@ function DeploymentSideBar({
                         </Tabs>
                     </StackItem>
                     <StackItem isFilled style={{ overflow: 'auto' }}>
-                        <TabContent
-                            eventKey={'DETAILS'}
-                            id={'DETAILS'}
-                            hidden={activeTab !== 'DETAILS'}
-                        >
-                            {deployment && (
-                                <DeploymentDetails
-                                    deployment={deployment}
-                                    deploymentId={deploymentId}
-                                    edgeState={edgeState}
-                                    edges={edges}
-                                    listenPorts={listenPorts}
-                                    networkPolicyState={networkPolicyState}
-                                    nodes={nodes}
-                                />
-                            )}
-                        </TabContent>
-                        {hasReadAccessForDeploymentTab(hasReadAccess, 'FLOWS') && (
-                            <TabContent
-                                eventKey={'FLOWS'}
-                                id={'FLOWS'}
-                                hidden={activeTab !== 'FLOWS'}
-                            >
-                                {activeTab === 'FLOWS' && (
-                                    <DeploymentFlows
+                        {activeTab === 'DETAILS' && (
+                            <TabContent eventKey={'DETAILS'} id={'DETAILS'}>
+                                {deployment && (
+                                    <DeploymentDetails
+                                        deployment={deployment}
                                         deploymentId={deploymentId}
                                         edgeState={edgeState}
                                         edges={edges}
+                                        listenPorts={listenPorts}
+                                        networkPolicyState={networkPolicyState}
                                         nodes={nodes}
-                                        onNodeSelect={onNodeSelect}
                                     />
                                 )}
                             </TabContent>
                         )}
-                        {hasReadAccessForDeploymentTab(hasReadAccess, 'BASELINE') && (
-                            <TabContent
-                                eventKey={'BASELINE'}
-                                id={'BASELINE'}
-                                hidden={activeTab !== 'BASELINE'}
-                                className="pf-v6-u-h-100"
-                            >
-                                {activeTab === 'BASELINE' && (
-                                    <DeploymentBaseline
-                                        deployment={deployment}
-                                        deploymentId={deploymentId}
-                                        onNodeSelect={onNodeSelect}
+                        {hasReadAccessForDeploymentTab(hasReadAccess, 'FLOWS') &&
+                            activeTab === 'FLOWS' && (
+                                <TabContent eventKey={'FLOWS'} id={'FLOWS'}>
+                                    {activeTab === 'FLOWS' && (
+                                        <DeploymentFlows
+                                            deploymentId={deploymentId}
+                                            edgeState={edgeState}
+                                            edges={edges}
+                                            nodes={nodes}
+                                            onNodeSelect={onNodeSelect}
+                                        />
+                                    )}
+                                </TabContent>
+                            )}
+                        {hasReadAccessForDeploymentTab(hasReadAccess, 'BASELINE') &&
+                            activeTab === 'BASELINE' && (
+                                <TabContent
+                                    eventKey={'BASELINE'}
+                                    id={'BASELINE'}
+                                    className="pf-v6-u-h-100"
+                                >
+                                    {activeTab === 'BASELINE' && (
+                                        <DeploymentBaseline
+                                            deployment={deployment}
+                                            deploymentId={deploymentId}
+                                            onNodeSelect={onNodeSelect}
+                                        />
+                                    )}
+                                </TabContent>
+                            )}
+                        {hasReadAccessForDeploymentTab(hasReadAccess, 'NETWORK_POLICIES') &&
+                            activeTab === 'NETWORK_POLICIES' && (
+                                <TabContent eventKey={'NETWORK_POLICIES'} id="NETWORK_POLICIES">
+                                    <NetworkPolicies
+                                        entityName={deployment.name}
+                                        policyIds={deploymentPolicyIds}
                                     />
-                                )}
-                            </TabContent>
-                        )}
-                        {hasReadAccessForDeploymentTab(hasReadAccess, 'NETWORK_POLICIES') && (
-                            <TabContent
-                                eventKey={'NETWORK_POLICIES'}
-                                id="NETWORK_POLICIES"
-                                hidden={activeTab !== 'NETWORK_POLICIES'}
-                            >
-                                <NetworkPolicies
-                                    entityName={deployment.name}
-                                    policyIds={deploymentPolicyIds}
-                                />
-                            </TabContent>
-                        )}
+                                </TabContent>
+                            )}
                     </StackItem>
                 </>
             )}

--- a/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/namespace/NamespaceSideBar.tsx
@@ -118,24 +118,26 @@ function NamespaceSideBar({
                 </Tabs>
             </StackItem>
             <StackItem isFilled style={{ overflow: 'auto' }}>
-                <TabContent
-                    eventKey="DEPLOYMENTS"
-                    id="DEPLOYMENTS"
-                    hidden={activeTab !== 'DEPLOYMENTS'}
-                >
-                    <NamespaceDeployments deployments={deployments} onNodeSelect={onNodeSelect} />
-                </TabContent>
-                <TabContent
-                    eventKey="NETWORK_POLICIES"
-                    id="NETWORK_POLICIES"
-                    hidden={activeTab !== 'NETWORK_POLICIES'}
-                    className="pf-v6-u-h-100"
-                >
-                    <NetworkPolicies
-                        entityName={namespaceNode?.label || ''}
-                        policyIds={uniqueNamespacePolicyIds}
-                    />
-                </TabContent>
+                {activeTab === 'DEPLOYMENTS' && (
+                    <TabContent eventKey="DEPLOYMENTS" id="DEPLOYMENTS">
+                        <NamespaceDeployments
+                            deployments={deployments}
+                            onNodeSelect={onNodeSelect}
+                        />
+                    </TabContent>
+                )}
+                {activeTab === 'NETWORK_POLICIES' && (
+                    <TabContent
+                        eventKey="NETWORK_POLICIES"
+                        id="NETWORK_POLICIES"
+                        className="pf-v6-u-h-100"
+                    >
+                        <NetworkPolicies
+                            entityName={namespaceNode?.label || ''}
+                            policyIds={uniqueNamespacePolicyIds}
+                        />
+                    </TabContent>
+                )}
             </StackItem>
         </Stack>
     );

--- a/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
+++ b/ui/apps/platform/src/Containers/NetworkGraph/simulation/NetworkPolicySimulatorSidePanel.tsx
@@ -443,89 +443,88 @@ function NetworkPolicySimulatorSidePanel({
                 </Tabs>
             </StackItem>
             <StackItem isFilled style={{ overflow: 'auto' }}>
-                <TabContent
-                    eventKey={tabs.SIMULATE_NETWORK_POLICIES}
-                    id="Simulate_network_policies"
-                    hidden={activeKeyTab !== tabs.SIMULATE_NETWORK_POLICIES}
-                >
-                    <div className="pf-v6-u-p-lg pf-v6-u-h-100">
-                        <Stack hasGutter>
-                            <StackItem>
-                                <Stack hasGutter>
-                                    <StackItem>
-                                        <Title headingLevel="h3">
-                                            Generate network policies from the traffic
-                                        </Title>
-                                    </StackItem>
-                                    <StackItem>
-                                        <Content component="p">
-                                            Generate a set of recommended network policies based on
-                                            your cluster&apos;s traffic. Only deployments that are
-                                            part of the current scope will be included in generated
-                                            policies.
-                                        </Content>
-                                    </StackItem>
-                                    <StackItem>
-                                        <Checkbox
-                                            label="Exclude ports & protocols"
-                                            isChecked={isExcludingPortsAndProtocols}
-                                            onChange={(_event, val) =>
-                                                setIsExcludingPortsAndProtocols(val)
-                                            }
-                                            id="controlled-check-1"
-                                            name="check1"
-                                        />
-                                    </StackItem>
-                                    <StackItem>
-                                        <Button
-                                            variant="secondary"
-                                            onClick={generateNetworkPolicies}
-                                        >
-                                            Generate and simulate network policies
-                                        </Button>
-                                    </StackItem>
-                                </Stack>
-                            </StackItem>
-                            <StackItem>
-                                <Divider component="div" />
-                            </StackItem>
-                            <StackItem>
-                                <Stack hasGutter>
-                                    <StackItem>
-                                        <Title headingLevel="h3">
-                                            Upload a network policy YAML
-                                        </Title>
-                                    </StackItem>
-                                    <StackItem>
-                                        <Content component="p">
-                                            Upload your network policies to quickly preview your
-                                            environment under different policy configurations and
-                                            time windows. When ready, apply the network policies
-                                            directly or share them with your team.
-                                        </Content>
-                                    </StackItem>
-                                    <StackItem>
-                                        <UploadYAMLButton
-                                            onFileInputChange={handleFileInputChange}
-                                        />
-                                    </StackItem>
-                                </Stack>
-                            </StackItem>
-                        </Stack>
-                    </div>
-                </TabContent>
-                <TabContent
-                    eventKey={tabs.VIEW_ACTIVE_YAMLS}
-                    id="View_active_YAMLS"
-                    hidden={activeKeyTab !== tabs.VIEW_ACTIVE_YAMLS}
-                >
-                    <ViewActiveYAMLs
-                        networkPolicies={currentNetworkPolicies ?? []}
-                        generateNetworkPolicies={generateNetworkPolicies}
-                        undoNetworkPolicies={undoNetworkPolicies}
-                        onFileInputChange={handleFileInputChange}
-                    />
-                </TabContent>
+                {activeKeyTab === tabs.SIMULATE_NETWORK_POLICIES && (
+                    <TabContent
+                        eventKey={tabs.SIMULATE_NETWORK_POLICIES}
+                        id="Simulate_network_policies"
+                    >
+                        <div className="pf-v6-u-p-lg pf-v6-u-h-100">
+                            <Stack hasGutter>
+                                <StackItem>
+                                    <Stack hasGutter>
+                                        <StackItem>
+                                            <Title headingLevel="h3">
+                                                Generate network policies from the traffic
+                                            </Title>
+                                        </StackItem>
+                                        <StackItem>
+                                            <Content component="p">
+                                                Generate a set of recommended network policies based
+                                                on your cluster&apos;s traffic. Only deployments
+                                                that are part of the current scope will be included
+                                                in generated policies.
+                                            </Content>
+                                        </StackItem>
+                                        <StackItem>
+                                            <Checkbox
+                                                label="Exclude ports & protocols"
+                                                isChecked={isExcludingPortsAndProtocols}
+                                                onChange={(_event, val) =>
+                                                    setIsExcludingPortsAndProtocols(val)
+                                                }
+                                                id="controlled-check-1"
+                                                name="check1"
+                                            />
+                                        </StackItem>
+                                        <StackItem>
+                                            <Button
+                                                variant="secondary"
+                                                onClick={generateNetworkPolicies}
+                                            >
+                                                Generate and simulate network policies
+                                            </Button>
+                                        </StackItem>
+                                    </Stack>
+                                </StackItem>
+                                <StackItem>
+                                    <Divider component="div" />
+                                </StackItem>
+                                <StackItem>
+                                    <Stack hasGutter>
+                                        <StackItem>
+                                            <Title headingLevel="h3">
+                                                Upload a network policy YAML
+                                            </Title>
+                                        </StackItem>
+                                        <StackItem>
+                                            <Content component="p">
+                                                Upload your network policies to quickly preview your
+                                                environment under different policy configurations
+                                                and time windows. When ready, apply the network
+                                                policies directly or share them with your team.
+                                            </Content>
+                                        </StackItem>
+                                        <StackItem>
+                                            <UploadYAMLButton
+                                                onFileInputChange={handleFileInputChange}
+                                            />
+                                        </StackItem>
+                                    </Stack>
+                                </StackItem>
+                            </Stack>
+                        </div>
+                    </TabContent>
+                )}
+                {activeKeyTab === tabs.VIEW_ACTIVE_YAMLS && (
+                    <TabContent eventKey={tabs.VIEW_ACTIVE_YAMLS} id="View_active_YAMLS">
+                        <ViewActiveYAMLs
+                            networkPolicies={currentNetworkPolicies ?? []}
+                            generateNetworkPolicies={generateNetworkPolicies}
+                            undoNetworkPolicies={undoNetworkPolicies}
+                            onFileInputChange={handleFileInputChange}
+                        />
+                    </TabContent>
+                )}
             </StackItem>
         </Stack>
     );

--- a/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/NodeCves/Node/NodePage.tsx
@@ -25,9 +25,6 @@ import type { NodeMetadata } from './NodePageHeader';
 import NodePageVulnerabilities from './NodePageVulnerabilities';
 import NodePageDetails from './NodePageDetails';
 
-const idDetails = 'NodePageDetails';
-const idVulnerabilities = 'NodePageVulnerabilities';
-
 const nodeCveOverviewPath = getOverviewPagePath('Node', {
     entityTab: 'Node',
 });
@@ -95,18 +92,10 @@ function NodePage() {
                             mountOnEnter
                             unmountOnExit
                         >
-                            <Tab
-                                eventKey={vulnTabKey}
-                                tabContentId={idVulnerabilities}
-                                title={vulnTabKey}
-                            >
+                            <Tab eventKey={vulnTabKey} title={vulnTabKey}>
                                 <NodePageVulnerabilities nodeId={nodeId} />
                             </Tab>
-                            <Tab
-                                eventKey={detailTabKey}
-                                tabContentId={idDetails}
-                                title={detailTabKey}
-                            >
+                            <Tab eventKey={detailTabKey} title={detailTabKey}>
                                 <NodePageDetails nodeId={nodeId} />
                             </Tab>
                         </Tabs>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/PlatformCves/Cluster/ClusterPage.tsx
@@ -25,9 +25,6 @@ import type { ClusterMetadata } from './ClusterPageHeader';
 import ClusterPageDetails from './ClusterPageDetails';
 import ClusterPageVulnerabilities from './ClusterPageVulnerabilities';
 
-const idDetails = 'ClusterPageDetails';
-const idVulnerabilities = 'ClusterPageVulnerabilities';
-
 const platformCvesClusterOverviewPath = getOverviewPagePath('Platform', {
     entityTab: 'Cluster',
 });
@@ -100,18 +97,10 @@ function ClusterPage() {
                             mountOnEnter
                             unmountOnExit
                         >
-                            <Tab
-                                eventKey={vulnTabKey}
-                                tabContentId={idVulnerabilities}
-                                title={vulnTabKey}
-                            >
+                            <Tab eventKey={vulnTabKey} title={vulnTabKey}>
                                 <ClusterPageVulnerabilities clusterId={clusterId} />
                             </Tab>
-                            <Tab
-                                eventKey={detailTabKey}
-                                tabContentId={idDetails}
-                                title={detailTabKey}
-                            >
+                            <Tab eventKey={detailTabKey} title={detailTabKey}>
                                 <ClusterPageDetails clusterId={clusterId} />
                             </Tab>
                         </Tabs>

--- a/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionRequestForm.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/components/ExceptionRequestModal/ExceptionRequestForm.tsx
@@ -112,50 +112,47 @@ function ExceptionRequestForm({
                     <Tab eventKey="options" title="Options" tabContentId="options" />
                     <Tab eventKey="cves" title="CVE selections" tabContentId="cves" />
                 </Tabs>
-                <TabContent
-                    id="options"
-                    className="pf-v6-u-flex-1"
-                    hidden={activeKeyTab !== 'options'}
-                >
-                    <Flex
-                        direction={{ default: 'column' }}
-                        spaceItems={{ default: 'spaceItemsLg' }}
-                    >
-                        <Content component="p">{formHeaderText}</Content>
-                        {showExpiryField && <ExpiryField formik={formik} />}
-                        {showScopeField && (
-                            <ExceptionScopeField
-                                fieldId="scope"
-                                label="Scope"
-                                formik={formik}
-                                scopeContext={scopeContext}
-                            />
-                        )}
-                        <FormGroup fieldId="comment" label={commentFieldLabel} isRequired>
-                            <TextArea
-                                id="comment"
-                                name="comment"
-                                isRequired
-                                onBlur={handleBlur('comment')}
-                                onChange={(_event, value) => setFieldValue('comment', value)}
-                                validated={touched.comment && errors.comment ? 'error' : 'default'}
-                            />
-                        </FormGroup>
-                    </Flex>
-                </TabContent>
-                <TabContent
-                    id="cves"
-                    className="pf-v6-u-flex-1"
-                    hidden={activeKeyTab !== 'cves'}
-                    style={{ overflowY: 'auto' }}
-                >
-                    <CveSelections
-                        cves={cves}
-                        selectedCVEIds={formik.values.cves}
-                        onAdd={onAddCVE}
-                        onRemove={onRemoveCVE}
-                    />
-                </TabContent>
+                {activeKeyTab === 'options' && (
+                    <TabContent id="options" className="pf-v6-u-flex-1">
+                        <Flex
+                            direction={{ default: 'column' }}
+                            spaceItems={{ default: 'spaceItemsLg' }}
+                        >
+                            <Content component="p">{formHeaderText}</Content>
+                            {showExpiryField && <ExpiryField formik={formik} />}
+                            {showScopeField && (
+                                <ExceptionScopeField
+                                    fieldId="scope"
+                                    label="Scope"
+                                    formik={formik}
+                                    scopeContext={scopeContext}
+                                />
+                            )}
+                            <FormGroup fieldId="comment" label={commentFieldLabel} isRequired>
+                                <TextArea
+                                    id="comment"
+                                    name="comment"
+                                    isRequired
+                                    onBlur={handleBlur('comment')}
+                                    onChange={(_event, value) => setFieldValue('comment', value)}
+                                    validated={
+                                        touched.comment && errors.comment ? 'error' : 'default'
+                                    }
+                                />
+                            </FormGroup>
+                        </Flex>
+                    </TabContent>
+                )}
+                {activeKeyTab === 'cves' && (
+                    <TabContent id="cves" className="pf-v6-u-flex-1" style={{ overflowY: 'auto' }}>
+                        <CveSelections
+                            cves={cves}
+                            selectedCVEIds={formik.values.cves}
+                            onAdd={onAddCVE}
+                            onRemove={onRemoveCVE}
+                        />
+                    </TabContent>
+                )}
                 <Flex>
                     <Button
                         isLoading={isSubmitting}


### PR DESCRIPTION
## Description

**Review**: Hide space because of indentation changes

### Problem

From time to time in testing, I have noticed more requests than I expected. I suspected that non-active tabs made some of them.

For example, requests for **Network policy** tab of namespace side panel.

Although conditional rendering of tabs for **role permissions** is as complete as we are aware to prevent 403 Forbidden status for responses, requests for tab content that some users might never view seems like a self-inflicted **scale problem**.

### Analysis

Find in Files `<TabContent` has 18 results in 8 files.
* LabelInclusion.tsx has `eventKey`, `id`, and `hidden` props
* SecureClusterModel.tsx has explicit conditional rendering via ternary expression and `id` prop
* DeploymentSideBar.tsx has some hybrid **outer** explicit conditional rendering for role permissions and some **inner** for data, except for **Network policies** tab, and has `eventKey`, `id`, and `hidden` props
* NamespaceSideBar.tsx has `eventKey`, `id`, and `hidden` props
* NetworkPolicySimulatorSidePanel.tsx has `eventKey`, `id`, and `hidden` props
* ExceptionRequestForm.tsx does not have `eventKey` but does have `id` and `hidden` props
* ExceptionRequestDetailsPage.tsx has `id` prop for the only `TabContent` element
* VirtualMachinePage.tsx has explicit conditional rendering and `id` prop

### Solution

Thank you, **David Vail** for suggesting that presence of `hidden` prop is the cue for indirect conditional rendering.

Use typescript-eslint playground to see that `name.name` is relevant property of `JSXAttribute` and for `JSXIdentifier` nodes that are descendants of `JSXOpeningElement` node.

https://typescript-eslint.io/play/#ts=5.9.3&showAST=es&fileType=.tsx

1. Edit pluginPatternFly.js file to add `no-TabContent-hidden` rule.

2. Replace `hidden` prop with explicit conditional rendering.

    Thank you, **Brad** for pattern to follow:

    https://github.com/stackrox/stackrox/blob/master/ui/apps/platform/src/Containers/Vulnerabilities/VirtualMachineCves/VirtualMachine/VirtualMachinePage.tsx

3. Replace unique ternary with normal parallel conditional and pattern.

### Bonus problem, analysis, and solution

Thank you, **Linda** for question about props are for accessibility.

1. During (attempted) testing of `SecureClusterModal` element, I fell into the corresponding **page** elements, which had accessibility issue:

    > ARIA attributes must conform to valid values

    https://dequeuniversity.com/rules/axe/4.11/aria-valid-attr-value

    Because tab content is **not** separate, `tabContentId` prop renders `aria-controls` attribute which refers to an `id` attribute that does not exist!

2. Add `no-Tab-tabContentId-with-children` rule.

    > child id for case in which a `TabContent` section is defined outside of a `Tabs` component

    https://www.patternfly.org/components/tabs/#tab

3. Delete irrelevant `tabContentId` props.

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is GA
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added lint rules
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.

    See presence of errors before and absence of errors after changes to component files.

3. `npm run start` in ui/apps/platform folder with staging demo as central.

    See presence of accessibility issues in **Bonus** section before and absence after changes to component files.