### PR TITLE
ROX-35012: Fix V1 compliance operator startup panic and convoy

### DIFF
--- a/central/complianceoperator/manager/convoy_test.go
+++ b/central/complianceoperator/manager/convoy_test.go
@@ -1,0 +1,195 @@
+//go:build sql_integration
+
+package manager
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/stackrox/rox/central/compliance/datastore/mocks"
+	"github.com/stackrox/rox/central/compliance/framework"
+	"github.com/stackrox/rox/central/compliance/standards"
+	"github.com/stackrox/rox/central/compliance/standards/metadata"
+	checkResultsDatastore "github.com/stackrox/rox/central/complianceoperator/checkresults/datastore"
+	checkResultsStore "github.com/stackrox/rox/central/complianceoperator/checkresults/store/postgres"
+	profileDatastore "github.com/stackrox/rox/central/complianceoperator/profiles/datastore"
+	profileStore "github.com/stackrox/rox/central/complianceoperator/profiles/store/postgres"
+	rulesDatastore "github.com/stackrox/rox/central/complianceoperator/rules/datastore"
+	rulesStore "github.com/stackrox/rox/central/complianceoperator/rules/store/postgres"
+	scansDatastore "github.com/stackrox/rox/central/complianceoperator/scans/datastore"
+	scansStore "github.com/stackrox/rox/central/complianceoperator/scans/store/postgres"
+	scanSettingBindingDatastore "github.com/stackrox/rox/central/complianceoperator/scansettingbinding/datastore"
+	scanSettingBindingStore "github.com/stackrox/rox/central/complianceoperator/scansettingbinding/store/postgres"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func newManagerTB(tb testing.TB) *managerImpl {
+	tb.Helper()
+	registry, err := standards.NewRegistry(framework.RegistrySingleton(), metadata.AllStandards...)
+	require.NoError(tb, err)
+
+	db := pgtest.ForT(tb)
+	prof := profileStore.New(db)
+	ssb := scanSettingBindingStore.New(db)
+	rules := rulesStore.New(db)
+	rulesDS, err := rulesDatastore.NewDatastore(rules)
+	require.NoError(tb, err)
+	scans := scansStore.New(db)
+	scansDS := scansDatastore.NewDatastore(scans)
+	checks := checkResultsStore.New(db)
+
+	ctrl := gomock.NewController(tb)
+	compliance := mocks.NewMockDataStore(ctrl)
+
+	mgr, err := NewManager(registry, profileDatastore.NewDatastore(prof), scansDS, scanSettingBindingDatastore.NewDatastore(ssb), rulesDS, checkResultsDatastore.NewDatastore(checks), compliance)
+	require.NoError(tb, err)
+	return mgr.(*managerImpl)
+}
+
+func makeConvoyRule(clusterID, ruleName string) *storage.ComplianceOperatorRule {
+	return &storage.ComplianceOperatorRule{
+		Id:   uuid.NewV4().String(),
+		Name: fmt.Sprintf("%s-ext", ruleName),
+		Annotations: map[string]string{
+			v1alpha1.RuleIDAnnotationKey: ruleName,
+		},
+		ClusterId: clusterID,
+		Title:     fmt.Sprintf("Rule %s", ruleName),
+	}
+}
+
+func makeConvoyProfile(clusterID, profileName string, ruleNames []string) *storage.ComplianceOperatorProfile {
+	rules := make([]*storage.ComplianceOperatorProfile_Rule, len(ruleNames))
+	for i, name := range ruleNames {
+		rules[i] = &storage.ComplianceOperatorProfile_Rule{Name: name}
+	}
+	return &storage.ComplianceOperatorProfile{
+		Id:          uuid.NewV4().String(),
+		Name:        profileName,
+		ClusterId:   clusterID,
+		Description: fmt.Sprintf("Profile %s on cluster %s", profileName, clusterID),
+		Annotations: map[string]string{
+			v1alpha1.ProductTypeAnnotation: string(v1alpha1.ScanTypePlatform),
+		},
+		Rules: rules,
+	}
+}
+
+func seedProfiles(tb testing.TB, mgr *managerImpl, numClusters, profilesPerCluster int, ruleNames []string) {
+	tb.Helper()
+	for c := 0; c < numClusters; c++ {
+		for p := 0; p < profilesPerCluster; p++ {
+			profile := makeConvoyProfile(fmt.Sprintf("cluster-%d", c), fmt.Sprintf("profile-%d", p), ruleNames)
+			require.NoError(tb, mgr.AddProfile(profile))
+		}
+	}
+}
+
+// TestConcurrentAddProfileCompletesWithoutConvoy verifies that without the old
+// startup Walk competing for resources, concurrent AddProfile calls from sensor
+// reconnects complete within a reasonable deadline.
+//
+// Background: The old NewManager did a Walk of all profiles at startup, calling
+// addProfileNoLock for each — which itself did another Walk. This O(N²) pattern
+// combined with concurrent sensor AddProfile calls caused a lock convoy that
+// exhausted context deadlines and panicked Central. See the customer stack trace:
+//
+//	panic: context deadline exceeded
+//	    iterating over rows
+//	    RunCursorQueryForSchemaFn → walkByQuery → Walk →
+//	    complianceoperator/profiles/datastore.Walk →
+//	    complianceoperator/manager.NewManager
+//
+// The fix removes the startup Walk (sensors repopulate on reconnect) and
+// throttles concurrent profile/rule pipeline operations via semaphore.
+func TestConcurrentAddProfileCompletesWithoutConvoy(t *testing.T) {
+	mgr := newManagerTB(t)
+
+	ruleNames := []string{"rule-0", "rule-1", "rule-2"}
+	for _, name := range ruleNames {
+		require.NoError(t, mgr.AddRule(makeConvoyRule("seed", name)))
+	}
+
+	seedProfiles(t, mgr, 50, 10, ruleNames)
+	t.Logf("Seeded 500 profiles")
+
+	deadline := 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	sensorClusters := 20
+	var wg sync.WaitGroup
+	errs := make([]error, sensorClusters)
+	wg.Add(sensorClusters)
+
+	start := time.Now()
+	for c := 0; c < sensorClusters; c++ {
+		go func(clusterIdx int) {
+			defer wg.Done()
+			clusterID := fmt.Sprintf("reconnecting-%d", clusterIdx)
+			for p := 0; p < 10; p++ {
+				if ctx.Err() != nil {
+					errs[clusterIdx] = ctx.Err()
+					return
+				}
+				profile := makeConvoyProfile(clusterID, fmt.Sprintf("profile-%d", p), ruleNames)
+				if err := mgr.AddProfile(profile); err != nil {
+					errs[clusterIdx] = err
+					return
+				}
+			}
+		}(c)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+	t.Logf("20 clusters × 10 profiles completed in %v", elapsed)
+
+	for i, err := range errs {
+		assert.NoError(t, err, "sensor cluster %d should not error", i)
+	}
+	assert.Less(t, elapsed, deadline, "should complete well within deadline")
+}
+
+// BenchmarkAddProfileConvoy measures concurrent AddProfile throughput.
+func BenchmarkAddProfileConvoy(b *testing.B) {
+	for _, numClusters := range []int{5, 10, 20} {
+		b.Run(fmt.Sprintf("clusters_%d", numClusters), func(b *testing.B) {
+			mgr := newManagerTB(b)
+
+			ruleNames := []string{"rule-0", "rule-1", "rule-2"}
+			for _, name := range ruleNames {
+				require.NoError(b, mgr.AddRule(makeConvoyRule("seed", name)))
+			}
+
+			seedProfiles(b, mgr, 5, 10, ruleNames)
+
+			profilesPerCluster := 10
+
+			b.ResetTimer()
+			for b.Loop() {
+				var wg sync.WaitGroup
+				wg.Add(numClusters)
+				for c := 0; c < numClusters; c++ {
+					go func(clusterIdx int) {
+						defer wg.Done()
+						clusterID := fmt.Sprintf("reconnecting-%d", clusterIdx)
+						for p := 0; p < profilesPerCluster; p++ {
+							profile := makeConvoyProfile(clusterID, fmt.Sprintf("profile-%d", p), ruleNames)
+							_ = mgr.AddProfile(profile)
+						}
+					}(c)
+				}
+				wg.Wait()
+			}
+		})
+	}
+}

--- a/central/complianceoperator/manager/convoy_test.go
+++ b/central/complianceoperator/manager/convoy_test.go
@@ -5,7 +5,7 @@ package manager
 import (
 	"context"
 	"fmt"
-	"sync"
+	"github.com/stackrox/rox/pkg/sync"
 	"testing"
 	"time"
 

--- a/central/complianceoperator/manager/convoy_test.go
+++ b/central/complianceoperator/manager/convoy_test.go
@@ -5,7 +5,6 @@ package manager
 import (
 	"context"
 	"fmt"
-	"github.com/stackrox/rox/pkg/sync"
 	"testing"
 	"time"
 
@@ -26,6 +25,7 @@ import (
 	scanSettingBindingStore "github.com/stackrox/rox/central/complianceoperator/scansettingbinding/store/postgres"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/central/complianceoperator/manager/manager.go
+++ b/central/complianceoperator/manager/manager.go
@@ -80,13 +80,10 @@ func NewManager(registry *standards.Registry, profiles profileDatastore.DataStor
 		rules:               rules,
 		results:             results,
 	}
-	// Postgres retries in addProfileNoLock(...)
-	err := profiles.Walk(allAccessCtx, func(profile *storage.ComplianceOperatorProfile) error {
-		return mgr.addProfileNoLock(profile)
-	})
-	if err != nil {
-		return nil, err
-	}
+	// The registry starts empty and is populated as sensors reconnect and push
+	// profiles through AddProfile. Sensors always re-send all compliance data
+	// on reconnect (compliance types skip deduping), so the registry will be
+	// fully populated once all sensors have reconnected.
 	return mgr, nil
 }
 

--- a/central/complianceoperator/pipelines/complianceoperatorprofiles/pipeline.go
+++ b/central/complianceoperator/pipelines/complianceoperatorprofiles/pipeline.go
@@ -3,6 +3,7 @@ package complianceoperatorprofiles
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	"github.com/stackrox/rox/central/complianceoperator/manager"
 	"github.com/stackrox/rox/central/complianceoperator/profiles/datastore"
 	countMetrics "github.com/stackrox/rox/central/metrics"
@@ -12,12 +13,17 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/set"
+	"golang.org/x/sync/semaphore"
 )
 
 var (
+	log = logging.LoggerForModule()
+
 	_ pipeline.Fragment = (*pipelineImpl)(nil)
 )
 
@@ -28,15 +34,18 @@ func GetPipeline() pipeline.Fragment {
 
 // NewPipeline returns a new instance of Pipeline.
 func NewPipeline(datastore datastore.DataStore, manager manager.Manager) pipeline.Fragment {
+	maxConcurrency := int64(env.ComplianceV1MaxConcurrency.IntegerSetting())
 	return &pipelineImpl{
 		datastore: datastore,
 		manager:   manager,
+		semaphore: semaphore.NewWeighted(maxConcurrency),
 	}
 }
 
 type pipelineImpl struct {
 	datastore datastore.DataStore
 	manager   manager.Manager
+	semaphore *semaphore.Weighted
 }
 
 func (s *pipelineImpl) Capabilities() []centralsensor.CentralCapability {
@@ -69,8 +78,13 @@ func (s *pipelineImpl) Match(msg *central.MsgFromSensor) bool {
 }
 
 // Run runs the pipeline template on the input and returns the output.
-func (s *pipelineImpl) Run(_ context.Context, clusterID string, msg *central.MsgFromSensor, _ common.MessageInjector) error {
+func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.MsgFromSensor, _ common.MessageInjector) error {
 	defer countMetrics.IncrementResourceProcessedCounter(pipeline.ActionToOperation(msg.GetEvent().GetAction()), metrics.ComplianceOperatorProfile)
+
+	if err := s.acquireSemaphore(ctx); err != nil {
+		return err
+	}
+	defer s.semaphore.Release(1)
 
 	event := msg.GetEvent()
 	profile := event.GetComplianceOperatorProfile()
@@ -82,6 +96,29 @@ func (s *pipelineImpl) Run(_ context.Context, clusterID string, msg *central.Msg
 	default:
 		return s.manager.AddProfile(profile)
 	}
+}
+
+func (s *pipelineImpl) acquireSemaphore(ctx context.Context) error {
+	waitTime := env.ComplianceV1SemaphoreWaitTime.DurationSetting()
+
+	acquireCtx := ctx
+	if waitTime > 0 {
+		var cancel context.CancelFunc
+		acquireCtx, cancel = context.WithTimeout(ctx, waitTime)
+		defer cancel()
+	}
+
+	if err := s.semaphore.Acquire(acquireCtx, 1); err != nil {
+		if ctx.Err() != nil {
+			log.Debugf("Unable to acquire semaphore for compliance profile update: %v", err)
+		} else if errors.Is(err, context.DeadlineExceeded) {
+			log.Warnf("Timed out waiting to process compliance profile (waited %v): %v", waitTime, err)
+		} else {
+			log.Errorf("Unexpected error acquiring compliance profile semaphore: %v", err)
+		}
+		return err
+	}
+	return nil
 }
 
 func (s *pipelineImpl) OnFinish(_ string) {}

--- a/central/complianceoperator/pipelines/complianceoperatorprofiles/pipeline_test.go
+++ b/central/complianceoperator/pipelines/complianceoperatorprofiles/pipeline_test.go
@@ -2,17 +2,24 @@ package complianceoperatorprofiles
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	managerMocks "github.com/stackrox/rox/central/complianceoperator/manager/mocks"
 	v1ProfileMocks "github.com/stackrox/rox/central/complianceoperator/profiles/datastore/mocks"
 	"github.com/stackrox/rox/central/convert/testutils"
 	"github.com/stackrox/rox/central/sensor/service/pipeline/reconciliation"
 	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/fixtures/fixtureconsts"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
+	"golang.org/x/sync/semaphore"
 )
 
 func TestPipeline(t *testing.T) {
@@ -100,4 +107,109 @@ func (s *PipelineTestSuite) TestRunReconcileNoOp() {
 
 	err := pipeline.Reconcile(ctx, fixtureconsts.Cluster1, reconciliation.NewStoreMap())
 	s.NoError(err)
+}
+
+func TestThrottlesConcurrency(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mgr := managerMocks.NewMockManager(ctrl)
+	ds := v1ProfileMocks.NewMockDataStore(ctrl)
+
+	const maxConcurrency = 3
+	p := &pipelineImpl{
+		datastore: ds,
+		manager:   mgr,
+		semaphore: semaphore.NewWeighted(maxConcurrency),
+	}
+
+	var currentConcurrency atomic.Int32
+	var peakConcurrency atomic.Int32
+	var completed atomic.Int32
+
+	const numProfiles = 20
+
+	for i := 0; i < numProfiles; i++ {
+		profile := &storage.ComplianceOperatorProfile{
+			Id:   uuid.NewV4().String(),
+			Name: "profile",
+		}
+		mgr.EXPECT().AddProfile(gomock.Any()).Do(func(_ *storage.ComplianceOperatorProfile) {
+			cur := currentConcurrency.Add(1)
+			for {
+				peak := peakConcurrency.Load()
+				if cur <= peak {
+					break
+				}
+				if peakConcurrency.CompareAndSwap(peak, cur) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			currentConcurrency.Add(-1)
+			completed.Add(1)
+		}).Return(nil)
+
+		msg := &central.MsgFromSensor{
+			Msg: &central.MsgFromSensor_Event{
+				Event: &central.SensorEvent{
+					Id:     profile.GetId(),
+					Action: central.ResourceAction_CREATE_RESOURCE,
+					Resource: &central.SensorEvent_ComplianceOperatorProfile{
+						ComplianceOperatorProfile: profile,
+					},
+				},
+			},
+		}
+
+		go func() {
+			err := p.Run(context.Background(), "cluster-1", msg, nil)
+			assert.NoError(t, err)
+		}()
+	}
+
+	require.Eventually(t, func() bool {
+		return completed.Load() == numProfiles
+	}, 10*time.Second, 10*time.Millisecond)
+
+	assert.LessOrEqual(t, peakConcurrency.Load(), int32(maxConcurrency),
+		"peak concurrency (%d) should not exceed the semaphore limit (%d)",
+		peakConcurrency.Load(), maxConcurrency)
+	t.Logf("Peak concurrency: %d (limit: %d)", peakConcurrency.Load(), maxConcurrency)
+}
+
+func TestRespectsContextCancellation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mgr := managerMocks.NewMockManager(ctrl)
+	ds := v1ProfileMocks.NewMockDataStore(ctrl)
+
+	sem := semaphore.NewWeighted(1)
+	require.NoError(t, sem.Acquire(context.Background(), 1))
+
+	p := &pipelineImpl{
+		datastore: ds,
+		manager:   mgr,
+		semaphore: sem,
+	}
+
+	msg := &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     uuid.NewV4().String(),
+				Action: central.ResourceAction_CREATE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorProfile{
+					ComplianceOperatorProfile: &storage.ComplianceOperatorProfile{
+						Id:   uuid.NewV4().String(),
+						Name: "profile",
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := p.Run(ctx, "cluster-1", msg, nil)
+	assert.Error(t, err, "Run should return an error when context is cancelled")
+
+	sem.Release(1)
 }

--- a/central/complianceoperator/pipelines/complianceoperatorrules/pipeline.go
+++ b/central/complianceoperator/pipelines/complianceoperatorrules/pipeline.go
@@ -14,12 +14,17 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/central"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/centralsensor"
+	"github.com/stackrox/rox/pkg/env"
+	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/metrics"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/set"
+	"golang.org/x/sync/semaphore"
 )
 
 var (
+	log = logging.LoggerForModule()
+
 	_ pipeline.Fragment = (*pipelineImpl)(nil)
 )
 
@@ -30,15 +35,18 @@ func GetPipeline() pipeline.Fragment {
 
 // NewPipeline returns a new instance of Pipeline.
 func NewPipeline(datastore datastore.DataStore, manager manager.Manager) pipeline.Fragment {
+	maxConcurrency := int64(env.ComplianceV1MaxConcurrency.IntegerSetting())
 	return &pipelineImpl{
 		datastore: datastore,
 		manager:   manager,
+		semaphore: semaphore.NewWeighted(maxConcurrency),
 	}
 }
 
 type pipelineImpl struct {
 	datastore datastore.DataStore
 	manager   manager.Manager
+	semaphore *semaphore.Weighted
 }
 
 func (s *pipelineImpl) Capabilities() []centralsensor.CentralCapability {
@@ -70,8 +78,13 @@ func (s *pipelineImpl) Match(msg *central.MsgFromSensor) bool {
 }
 
 // Run runs the pipeline template on the input and returns the output.
-func (s *pipelineImpl) Run(_ context.Context, clusterID string, msg *central.MsgFromSensor, _ common.MessageInjector) error {
+func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.MsgFromSensor, _ common.MessageInjector) error {
 	defer countMetrics.IncrementResourceProcessedCounter(pipeline.ActionToOperation(msg.GetEvent().GetAction()), metrics.ComplianceOperatorRule)
+
+	if err := s.acquireSemaphore(ctx); err != nil {
+		return err
+	}
+	defer s.semaphore.Release(1)
 
 	event := msg.GetEvent()
 	rule := event.GetComplianceOperatorRule()
@@ -87,6 +100,29 @@ func (s *pipelineImpl) Run(_ context.Context, clusterID string, msg *central.Msg
 	default:
 		return s.manager.AddRule(rule)
 	}
+}
+
+func (s *pipelineImpl) acquireSemaphore(ctx context.Context) error {
+	waitTime := env.ComplianceV1SemaphoreWaitTime.DurationSetting()
+
+	acquireCtx := ctx
+	if waitTime > 0 {
+		var cancel context.CancelFunc
+		acquireCtx, cancel = context.WithTimeout(ctx, waitTime)
+		defer cancel()
+	}
+
+	if err := s.semaphore.Acquire(acquireCtx, 1); err != nil {
+		if ctx.Err() != nil {
+			log.Debugf("Unable to acquire semaphore for compliance rule update: %v", err)
+		} else if errors.Is(err, context.DeadlineExceeded) {
+			log.Warnf("Timed out waiting to process compliance rule (waited %v): %v", waitTime, err)
+		} else {
+			log.Errorf("Unexpected error acquiring compliance rule semaphore: %v", err)
+		}
+		return err
+	}
+	return nil
 }
 
 func (s *pipelineImpl) OnFinish(_ string) {}

--- a/central/complianceoperator/pipelines/complianceoperatorrules/pipeline_test.go
+++ b/central/complianceoperator/pipelines/complianceoperatorrules/pipeline_test.go
@@ -1,0 +1,124 @@
+package complianceoperatorrules
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	managerMocks "github.com/stackrox/rox/central/complianceoperator/manager/mocks"
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/sync/semaphore"
+)
+
+func makeRuleMsg(ruleID, ruleName string) *central.MsgFromSensor {
+	return &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     ruleID,
+				Action: central.ResourceAction_CREATE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorRule{
+					ComplianceOperatorRule: &storage.ComplianceOperatorRule{
+						Id:   ruleID,
+						Name: ruleName,
+						Annotations: map[string]string{
+							v1alpha1.RuleIDAnnotationKey: ruleName,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestRunCallsAddRule(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mgr := managerMocks.NewMockManager(ctrl)
+	p := &pipelineImpl{
+		manager:   mgr,
+		semaphore: semaphore.NewWeighted(5),
+	}
+
+	mgr.EXPECT().AddRule(gomock.Any()).Return(nil)
+
+	err := p.Run(context.Background(), "cluster-1", makeRuleMsg(uuid.NewV4().String(), "test-rule"), nil)
+	assert.NoError(t, err)
+}
+
+func TestThrottlesConcurrency(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mgr := managerMocks.NewMockManager(ctrl)
+
+	const maxConcurrency = 3
+	p := &pipelineImpl{
+		manager:   mgr,
+		semaphore: semaphore.NewWeighted(maxConcurrency),
+	}
+
+	var currentConcurrency atomic.Int32
+	var peakConcurrency atomic.Int32
+	var completed atomic.Int32
+
+	const numRules = 20
+
+	for i := 0; i < numRules; i++ {
+		mgr.EXPECT().AddRule(gomock.Any()).Do(func(_ *storage.ComplianceOperatorRule) {
+			cur := currentConcurrency.Add(1)
+			for {
+				peak := peakConcurrency.Load()
+				if cur <= peak {
+					break
+				}
+				if peakConcurrency.CompareAndSwap(peak, cur) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			currentConcurrency.Add(-1)
+			completed.Add(1)
+		}).Return(nil)
+
+		msg := makeRuleMsg(uuid.NewV4().String(), "test-rule")
+
+		go func() {
+			err := p.Run(context.Background(), "cluster-1", msg, nil)
+			assert.NoError(t, err)
+		}()
+	}
+
+	require.Eventually(t, func() bool {
+		return completed.Load() == numRules
+	}, 10*time.Second, 10*time.Millisecond)
+
+	assert.LessOrEqual(t, peakConcurrency.Load(), int32(maxConcurrency),
+		"peak concurrency (%d) should not exceed the semaphore limit (%d)",
+		peakConcurrency.Load(), maxConcurrency)
+	t.Logf("Peak concurrency: %d (limit: %d)", peakConcurrency.Load(), maxConcurrency)
+}
+
+func TestRespectsContextCancellation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mgr := managerMocks.NewMockManager(ctrl)
+
+	sem := semaphore.NewWeighted(1)
+	require.NoError(t, sem.Acquire(context.Background(), 1))
+
+	p := &pipelineImpl{
+		manager:   mgr,
+		semaphore: sem,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := p.Run(ctx, "cluster-1", makeRuleMsg(uuid.NewV4().String(), "test-rule"), nil)
+	assert.Error(t, err, "Run should return an error when context is cancelled")
+
+	sem.Release(1)
+}

--- a/pkg/env/compliance_v1.go
+++ b/pkg/env/compliance_v1.go
@@ -1,0 +1,15 @@
+package env
+
+import "time"
+
+var (
+	// ComplianceV1MaxConcurrency limits how many V1 compliance operator profile/rule
+	// updates can run concurrently. Each update acquires a DB connection and may Walk
+	// the profiles table, so unbounded concurrency during sensor reconnects can exhaust
+	// the connection pool.
+	ComplianceV1MaxConcurrency = RegisterIntegerSetting("ROX_COMPLIANCE_V1_MAX_CONCURRENCY", 5).WithMinimum(1).WithMaximum(30)
+
+	// ComplianceV1SemaphoreWaitTime is the maximum time a pipeline worker will wait
+	// to acquire a semaphore slot before dropping the operation.
+	ComplianceV1SemaphoreWaitTime = registerDurationSetting("ROX_COMPLIANCE_V1_SEMAPHORE_WAIT_TIME", 2*time.Minute, WithDurationZeroAllowed())
+)


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Central panics on startup with "context deadline exceeded / iterating
over rows" when many clusters reconnect simultaneously. Root cause:
NewManager did a Walk of all compliance profiles at startup, calling
addProfileNoLock for each — which itself did another full Walk. This
O(N²) pattern combined with concurrent sensor AddProfile calls created
a lock convoy on registryLock that exhausted the cursor timeout.

Fix:
- Remove the startup Walk in NewManager. Sensors always re-send all
  compliance operator data on reconnect (V1 compliance types skip
  deduping), so the registry populates naturally.
- Throttle concurrent profile and rule pipeline operations via semaphore
  (default 5, configurable via ROX_COMPLIANCE_V1_MAX_CONCURRENCY) to
  prevent DB connection pool exhaustion during mass sensor reconnects.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Added unit tests and benchmarks.  Fired up a cluster and ensured that the in memory map is correctly populated as profiles are added by exercising the deprecated UI which is the only place that needs/uses the in memory map.