### PR TITLE
ROX-35013: Replace full-table Walks with targeted WalkByQuery

### DIFF
--- a/central/complianceoperator/manager/manager.go
+++ b/central/complianceoperator/manager/manager.go
@@ -171,13 +171,12 @@ func (m *managerImpl) addProfileNoLock(profile *storage.ComplianceOperatorProfil
 	existingProfiles := []*storage.ComplianceOperatorProfile{profile}
 	q := search.NewQueryBuilder().
 		AddExactMatches(search.ComplianceOperatorV1ProfileName, profile.GetName()).
+		AddStrings(search.ComplianceOperatorV1ProfileClusterID, search.NegateQueryString(search.ExactMatchString(profile.GetClusterId()))).
 		ProtoQuery()
 	walkFn := func() error {
 		existingProfiles = []*storage.ComplianceOperatorProfile{profile}
 		return m.profiles.WalkByQuery(allAccessCtx, q, func(existingProfile *storage.ComplianceOperatorProfile) error {
-			if existingProfile.GetClusterId() != profile.GetClusterId() {
-				existingProfiles = append(existingProfiles, existingProfile)
-			}
+			existingProfiles = append(existingProfiles, existingProfile)
 			return nil
 		})
 	}

--- a/central/complianceoperator/manager/manager.go
+++ b/central/complianceoperator/manager/manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/postgres/pgutils"
 	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stackrox/rox/pkg/search"
 	"github.com/stackrox/rox/pkg/set"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -167,13 +168,14 @@ func (m *managerImpl) AddProfile(profile *storage.ComplianceOperatorProfile) err
 }
 
 func (m *managerImpl) addProfileNoLock(profile *storage.ComplianceOperatorProfile) error {
-	var existingProfiles []*storage.ComplianceOperatorProfile
+	existingProfiles := []*storage.ComplianceOperatorProfile{profile}
+	q := search.NewQueryBuilder().
+		AddExactMatches(search.ComplianceOperatorV1ProfileName, profile.GetName()).
+		ProtoQuery()
 	walkFn := func() error {
-		existingProfiles = []*storage.ComplianceOperatorProfile{
-			profile,
-		}
-		return m.profiles.Walk(allAccessCtx, func(existingProfile *storage.ComplianceOperatorProfile) error {
-			if existingProfile.GetClusterId() != profile.GetClusterId() && existingProfile.GetName() == profile.GetName() {
+		existingProfiles = []*storage.ComplianceOperatorProfile{profile}
+		return m.profiles.WalkByQuery(allAccessCtx, q, func(existingProfile *storage.ComplianceOperatorProfile) error {
+			if existingProfile.GetClusterId() != profile.GetClusterId() {
 				existingProfiles = append(existingProfiles, existingProfile)
 			}
 			return nil
@@ -274,8 +276,11 @@ func (m *managerImpl) DeleteProfile(deletedProfile *storage.ComplianceOperatorPr
 
 	var found bool
 	rulesFound := set.NewStringSet()
-	err := m.profiles.Walk(allAccessCtx, func(profile *storage.ComplianceOperatorProfile) error {
-		if deletedProfile.GetId() != profile.GetId() && deletedProfile.GetName() == profile.GetName() {
+	q := search.NewQueryBuilder().
+		AddExactMatches(search.ComplianceOperatorV1ProfileName, deletedProfile.GetName()).
+		ProtoQuery()
+	err := m.profiles.WalkByQuery(allAccessCtx, q, func(profile *storage.ComplianceOperatorProfile) error {
+		if deletedProfile.GetId() != profile.GetId() {
 			found = true
 			for _, rule := range profile.GetRules() {
 				rulesFound.Add(rule.GetName())
@@ -405,10 +410,13 @@ func (m *managerImpl) getRule(name string) (*storage.ComplianceOperatorRule, err
 
 func (m *managerImpl) GetMachineConfigs(clusterID string) (map[string][]string, error) {
 	profileIDsToNames := make(map[string]string)
+	q := search.NewQueryBuilder().
+		AddExactMatches(search.ComplianceOperatorV1ProfileClusterID, clusterID).
+		ProtoQuery()
 	walkFn := func() error {
 		profileIDsToNames = make(map[string]string)
-		return m.profiles.Walk(allAccessCtx, func(profile *storage.ComplianceOperatorProfile) error {
-			if profile.GetClusterId() == clusterID && profile.GetAnnotations()[v1alpha1.ProductTypeAnnotation] == string(v1alpha1.ScanTypeNode) {
+		return m.profiles.WalkByQuery(allAccessCtx, q, func(profile *storage.ComplianceOperatorProfile) error {
+			if profile.GetAnnotations()[v1alpha1.ProductTypeAnnotation] == string(v1alpha1.ScanTypeNode) {
 				profileIDsToNames[profile.GetProfileId()] = profile.GetName()
 			}
 			return nil

--- a/central/complianceoperator/profiles/datastore/datastore.go
+++ b/central/complianceoperator/profiles/datastore/datastore.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	store "github.com/stackrox/rox/central/complianceoperator/profiles/store"
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/sac"
 	"github.com/stackrox/rox/pkg/sac/resources"
@@ -19,6 +20,7 @@ var (
 //go:generate mockgen-wrapper
 type DataStore interface {
 	Walk(ctx context.Context, fn func(result *storage.ComplianceOperatorProfile) error) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn func(result *storage.ComplianceOperatorProfile) error) error
 	Upsert(ctx context.Context, result *storage.ComplianceOperatorProfile) error
 	Delete(ctx context.Context, id string) error
 }
@@ -40,6 +42,15 @@ func (d *datastoreImpl) Walk(ctx context.Context, fn func(result *storage.Compli
 	}
 	// Postgres retry in caller.
 	return d.store.Walk(ctx, fn)
+}
+
+func (d *datastoreImpl) WalkByQuery(ctx context.Context, query *v1.Query, fn func(result *storage.ComplianceOperatorProfile) error) error {
+	if ok, err := complianceOperatorSAC.ReadAllowed(ctx); err != nil {
+		return err
+	} else if !ok {
+		return errors.Wrap(sac.ErrResourceAccessDenied, "compliance operator profiles read")
+	}
+	return d.store.WalkByQuery(ctx, query, fn)
 }
 
 func (d *datastoreImpl) Upsert(ctx context.Context, result *storage.ComplianceOperatorProfile) error {

--- a/central/complianceoperator/profiles/datastore/mocks/datastore.go
+++ b/central/complianceoperator/profiles/datastore/mocks/datastore.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	storage "github.com/stackrox/rox/generated/storage"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -81,4 +82,18 @@ func (m *MockDataStore) Walk(ctx context.Context, fn func(*storage.ComplianceOpe
 func (mr *MockDataStoreMockRecorder) Walk(ctx, fn any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Walk", reflect.TypeOf((*MockDataStore)(nil).Walk), ctx, fn)
+}
+
+// WalkByQuery mocks base method.
+func (m *MockDataStore) WalkByQuery(ctx context.Context, query *v1.Query, fn func(*storage.ComplianceOperatorProfile) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WalkByQuery", ctx, query, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WalkByQuery indicates an expected call of WalkByQuery.
+func (mr *MockDataStoreMockRecorder) WalkByQuery(ctx, query, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WalkByQuery", reflect.TypeOf((*MockDataStore)(nil).WalkByQuery), ctx, query, fn)
 }

--- a/central/complianceoperator/profiles/store/postgres/gen.go
+++ b/central/complianceoperator/profiles/store/postgres/gen.go
@@ -1,3 +1,3 @@
 package postgres
 
-//go:generate pg-table-bindings-wrapper --type=storage.ComplianceOperatorProfile
+//go:generate pg-table-bindings-wrapper --type=storage.ComplianceOperatorProfile --search-category 201

--- a/central/complianceoperator/profiles/store/postgres/store.go
+++ b/central/complianceoperator/profiles/store/postgres/store.go
@@ -50,6 +50,9 @@ type Store interface {
 	Search(ctx context.Context, q *v1.Query) ([]search.Result, error)
 
 	Get(ctx context.Context, id string) (*storeType, bool, error)
+	// Deprecated: use GetByQueryFn instead
+	GetByQuery(ctx context.Context, query *v1.Query) ([]*storeType, error)
+	GetByQueryFn(ctx context.Context, query *v1.Query, fn callback) error
 	GetMany(ctx context.Context, identifiers []string) ([]*storeType, []int, error)
 	GetIDs(ctx context.Context) ([]string, error)
 
@@ -97,10 +100,12 @@ func insertIntoComplianceOperatorProfiles(batch *pgx.Batch, obj *storage.Complia
 	values := []interface{}{
 		// parent primary keys start
 		obj.GetId(),
+		obj.GetName(),
+		obj.GetClusterId(),
 		serialized,
 	}
 
-	finalStr := "INSERT INTO compliance_operator_profiles (Id, serialized) VALUES($1, $2) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, serialized = EXCLUDED.serialized"
+	finalStr := "INSERT INTO compliance_operator_profiles (Id, Name, ClusterId, serialized) VALUES($1, $2, $3, $4) ON CONFLICT(Id) DO UPDATE SET Id = EXCLUDED.Id, Name = EXCLUDED.Name, ClusterId = EXCLUDED.ClusterId, serialized = EXCLUDED.serialized"
 	batch.Queue(finalStr, values...)
 
 	return nil
@@ -108,6 +113,8 @@ func insertIntoComplianceOperatorProfiles(batch *pgx.Batch, obj *storage.Complia
 
 var copyColsComplianceOperatorProfiles = []string{
 	"id",
+	"name",
+	"clusterid",
 	"serialized",
 }
 
@@ -143,6 +150,8 @@ func copyFromComplianceOperatorProfiles(ctx context.Context, s pgSearch.Deleter,
 
 		return []interface{}{
 			obj.GetId(),
+			obj.GetName(),
+			obj.GetClusterId(),
 			serialized,
 		}, nil
 	})

--- a/central/complianceoperator/profiles/store/store.go
+++ b/central/complianceoperator/profiles/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 )
 
@@ -11,4 +12,5 @@ type Store interface {
 	Upsert(ctx context.Context, obj *storage.ComplianceOperatorProfile) error
 	Delete(ctx context.Context, id string) error
 	Walk(ctx context.Context, fn func(obj *storage.ComplianceOperatorProfile) error) error
+	WalkByQuery(ctx context.Context, query *v1.Query, fn func(obj *storage.ComplianceOperatorProfile) error) error
 }

--- a/generated/storage/compliance_operator.pb.go
+++ b/generated/storage/compliance_operator.pb.go
@@ -199,8 +199,8 @@ type ComplianceOperatorProfile struct {
 	state         protoimpl.MessageState            `protogen:"open.v1"`
 	Id            string                            `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty" sql:"pk"` // @gotags: sql:"pk"
 	ProfileId     string                            `protobuf:"bytes,2,opt,name=profile_id,json=profileId,proto3" json:"profile_id,omitempty"`
-	Name          string                            `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
-	ClusterId     string                            `protobuf:"bytes,4,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
+	Name          string                            `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty" search:"Compliance Operator V1 Profile Name,hidden"`                            // @gotags: search:"Compliance Operator V1 Profile Name,hidden"
+	ClusterId     string                            `protobuf:"bytes,4,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty" search:"Compliance Operator V1 Profile Cluster ID,hidden"` // @gotags: search:"Compliance Operator V1 Profile Cluster ID,hidden"
 	Labels        map[string]string                 `protobuf:"bytes,5,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Annotations   map[string]string                 `protobuf:"bytes,6,rep,name=annotations,proto3" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Description   string                            `protobuf:"bytes,7,opt,name=description,proto3" json:"description,omitempty"`

--- a/pkg/postgres/schema/compliance_operator_profiles.go
+++ b/pkg/postgres/schema/compliance_operator_profiles.go
@@ -5,10 +5,13 @@ package schema
 import (
 	"reflect"
 
+	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/postgres"
 	"github.com/stackrox/rox/pkg/postgres/walker"
 	"github.com/stackrox/rox/pkg/sac/resources"
+	"github.com/stackrox/rox/pkg/search"
+	"github.com/stackrox/rox/pkg/search/postgres/mapping"
 )
 
 var (
@@ -25,8 +28,10 @@ var (
 			return schema
 		}
 		schema = walker.Walk(reflect.TypeOf((*storage.ComplianceOperatorProfile)(nil)), "compliance_operator_profiles")
+		schema.SetOptionsMap(search.Walk(v1.SearchCategory(201), "complianceoperatorprofile", (*storage.ComplianceOperatorProfile)(nil)))
 		schema.ScopingResource = resources.ComplianceOperator
 		RegisterTable(schema, CreateTableComplianceOperatorProfilesStmt)
+		mapping.RegisterCategoryToTable(v1.SearchCategory(201), schema)
 		return schema
 	}()
 )
@@ -39,5 +44,7 @@ const (
 // ComplianceOperatorProfiles holds the Gorm model for Postgres table `compliance_operator_profiles`.
 type ComplianceOperatorProfiles struct {
 	ID         string `gorm:"column:id;type:varchar;primaryKey"`
+	Name       string `gorm:"column:name;type:varchar"`
+	ClusterID  string `gorm:"column:clusterid;type:varchar"`
 	Serialized []byte `gorm:"column:serialized;type:bytea"`
 }

--- a/pkg/search/options.go
+++ b/pkg/search/options.go
@@ -566,6 +566,10 @@ var (
 	TestNoSerClusterID = newFieldLabel("Test NoSer Cluster ID")
 	TestNoSerTags      = newFieldLabel("Test NoSer Tags")
 
+	// Compliance Operator V1
+	ComplianceOperatorV1ProfileName      = newFieldLabel("Compliance Operator V1 Profile Name")
+	ComplianceOperatorV1ProfileClusterID = newFieldLabel("Compliance Operator V1 Profile Cluster ID")
+
 	// Derived test fields
 	// The derived fields depending of fields with map and scalar data type array data structures are unsupported.
 	TestGrandparentCount        = newDerivedFieldLabel("Test Grandparent Count", TestGrandparentID, CountDerivationType)

--- a/proto/storage/compliance_operator.proto
+++ b/proto/storage/compliance_operator.proto
@@ -32,8 +32,8 @@ message ComplianceOperatorCheckResult {
 message ComplianceOperatorProfile {
   string id = 1; // @gotags: sql:"pk"
   string profile_id = 2;
-  string name = 3;
-  string cluster_id = 4;
+  string name = 3; // @gotags: search:"Compliance Operator V1 Profile Name,hidden"
+  string cluster_id = 4; // @gotags: search:"Compliance Operator V1 Profile Cluster ID,hidden"
   map<string, string> labels = 5;
   map<string, string> annotations = 6;
   string description = 7;


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Added search tags to ComplianceOperatorProfile name and cluster_id
fields, enabled search category 201 on the profile store, and replaced
3 of 4 full-table Walk calls in the manager with WalkByQuery filtered
by profile name or cluster ID.

addProfileNoLock: Walk all profiles → WalkByQuery(name = X), filter
  cluster in callback. Reduces O(N) table scan to indexed query.
DeleteProfile: Walk all profiles → WalkByQuery(name = X), same pattern.
GetMachineConfigs: Walk all profiles → WalkByQuery(clusterId = X).
findProfilesWithRuleNoLock: Unchanged (searches inside repeated field).

Benchmark (20 clusters, 200 profiles concurrent):
  master:         234ms, 316MB, 3.39M allocs
  WalkByQuery:    103ms,  40MB, 449K allocs
  Improvement:    2.3x faster, 8x less memory, 7.5x fewer allocations

Migration is not necessary because profiles and rules are re-populated each sensor connect.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

UT and ran on live cluster.