### PR TITLE
ROX-35008: Add GH action to add VMs to existing OCP clusters

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@ pkg/search/**/*                     @stackrox/core-workflows
 */discoveredclusters/**/          @stackrox/sensor-ecosystem
 */signatureintegration/**/*       @stackrox/sensor-ecosystem
 compliance/virtualmachines/**/*   @stackrox/sensor-ecosystem
+scripts/ci/add-vms/**/*           @stackrox/sensor-ecosystem @vikin91
 pkg/features/**/*                 @stackrox/sensor-ecosystem
 pkg/images/defaults/**/*          @stackrox/sensor-ecosystem
 pkg/sac/**/*                      @stackrox/sensor-ecosystem

--- a/.github/workflows/add-vms-to-cluster.yml
+++ b/.github/workflows/add-vms-to-cluster.yml
@@ -1,5 +1,5 @@
 name: "Add VMs to Cluster"
-run-name: "Add VMs to ${{ inputs.cluster-name }}"
+run-name: "Add ${{ inputs.num-vms }} ${{ inputs.vm-os }} VMs to ${{ inputs.cluster-name }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/add-vms-to-cluster.yml
+++ b/.github/workflows/add-vms-to-cluster.yml
@@ -11,8 +11,8 @@ on:
       num-vms:
         description: "Number of VMs to deploy"
         required: false
-        default: "1"
-        type: string
+        default: 1
+        type: number
       vm-os:
         description: "VM OS"
         required: false

--- a/.github/workflows/add-vms-to-cluster.yml
+++ b/.github/workflows/add-vms-to-cluster.yml
@@ -1,4 +1,5 @@
 name: "Add VMs to Cluster"
+run-name: "Add VMs to ${{ inputs.cluster-name }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/add-vms-to-cluster.yml
+++ b/.github/workflows/add-vms-to-cluster.yml
@@ -1,0 +1,50 @@
+name: "Add VMs to Cluster"
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster-name:
+        description: "Infra cluster name (from `infractl list`)"
+        required: true
+        type: string
+      num-vms:
+        description: "Number of VMs to deploy"
+        required: false
+        default: "1"
+        type: string
+      vm-os:
+        description: "VM OS"
+        required: false
+        default: "rhel9"
+        type: choice
+        options:
+          - rhel9
+          - rhel10
+      ssh-public-key:
+        description: "Optional SSH public key for human access to VMs"
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  add-vms:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      INFRA_TOKEN: ${{ secrets.INFRA_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Add VMs to cluster
+        uses: ./scripts/ci/add-vms
+        with:
+          cluster-name: ${{ inputs.cluster-name }}
+          num-vms: ${{ inputs.num-vms }}
+          vm-os: ${{ inputs.vm-os }}
+          ssh-public-key: ${{ inputs.ssh-public-key }}
+          infra-token: ${{ secrets.INFRA_TOKEN }}
+          quay-username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}
+          quay-password: ${{ secrets.QUAY_RHACS_ENG_RO_PASSWORD }}

--- a/scripts/ci/add-vms/action.yml
+++ b/scripts/ci/add-vms/action.yml
@@ -1,0 +1,147 @@
+name: "Add VMs to ACS Cluster"
+description: "Install OpenShift Virtualization, deploy VMs, and install roxagent on an Infra-managed cluster"
+
+inputs:
+  cluster-name:
+    description: "Infra cluster name (from `infractl list`)"
+    required: true
+  num-vms:
+    description: "Number of VMs to deploy"
+    required: false
+    default: "1"
+  vm-os:
+    description: "VM OS: rhel9 or rhel10"
+    required: false
+    default: "rhel9"
+  ssh-public-key:
+    description: "Optional SSH public key to add for human access to all target VMs"
+    required: false
+    default: ""
+  infra-token:
+    description: "Infra API token"
+    required: true
+  quay-username:
+    description: "Quay.io username for pulling VM images"
+    required: true
+  quay-password:
+    description: "Quay.io password for pulling VM images"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install infractl
+      uses: stackrox/actions/infra/install-infractl@9238e423c3ae1ac4eb0f254cbb98da9daae24d86 # ratchet:stackrox/actions/infra/install-infractl@v1
+
+    - name: Fetch cluster artifacts
+      shell: bash
+      env:
+        INFRA_TOKEN: ${{ inputs.infra-token }}
+      run: |
+        infractl artifacts "${{ inputs.cluster-name }}" --download-dir "${{ github.workspace }}/artifacts" >/dev/null
+        echo "KUBECONFIG=${{ github.workspace }}/artifacts/kubeconfig" >> "$GITHUB_ENV"
+        echo "ARTIFACTS_DIR=${{ github.workspace }}/artifacts" >> "$GITHUB_ENV"
+
+    - name: Verify cluster access
+      shell: bash
+      run: |
+        kubectl cluster-info
+        kubectl get nodes
+
+    - name: Install sshpass
+      shell: bash
+      run: |
+        if ! command -v sshpass &>/dev/null; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq sshpass
+        fi
+
+    - name: Install virt operator (before virtctl)
+      shell: bash
+      run: |
+        "${{ github.workspace }}/scripts/ci/add-vms/install-virt-operator.sh"
+
+    - name: Install virtctl from cluster
+      shell: bash
+      run: |
+        fetch_cluster_ingress_ca() {
+            local ca_bundle
+            ca_bundle="$(mktemp)"
+            if kubectl get configmap -n openshift-config-managed default-ingress-cert \
+                    -o jsonpath='{.data.ca-bundle\.crt}' > "$ca_bundle" 2>/dev/null \
+               && [[ -s "$ca_bundle" ]]; then
+                echo "Using ingress CA from default-ingress-cert configmap" >&2
+            elif kubectl get secret -n openshift-ingress-operator router-ca \
+                    -o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d > "$ca_bundle" \
+                 && [[ -s "$ca_bundle" ]]; then
+                echo "Using ingress CA from router-ca secret" >&2
+            else
+                rm -f "$ca_bundle"
+                return 1
+            fi
+            printf '%s\n' "$ca_bundle"
+        }
+
+        download_and_install_virtctl() {
+            local download_url
+            download_url="$(kubectl get consoleclidownload virtctl-clidownloads-kubevirt-hyperconverged \
+                -o jsonpath='{.spec.links[?(@.text=="Download virtctl for Linux for x86_64")].href}' 2>/dev/null || true)"
+
+            if [[ -z "$download_url" ]]; then
+                echo "ERROR: ConsoleCLIDownload not available after virt operator install."
+                return 1
+            fi
+
+            echo "Downloading virtctl from $download_url..."
+            curl -fsSL "$@" "$download_url" | tar xz -C /usr/local/bin virtctl
+
+            if [[ ! -f /usr/local/bin/virtctl ]]; then
+                echo "ERROR: Downloaded archive does not contain virtctl."
+                return 1
+            fi
+
+            chmod +x /usr/local/bin/virtctl
+            echo "virtctl installed."
+        }
+
+        ca_bundle=""
+        cleanup() {
+            rm -f "${ca_bundle:-}"
+        }
+        trap cleanup EXIT
+
+        if ca_bundle="$(fetch_cluster_ingress_ca)" && download_and_install_virtctl --cacert "$ca_bundle"; then
+            :
+        else
+            echo "WARNING: Verified virtctl download failed; falling back to insecure curl -k in CI." >&2
+            # SECURITY RISK ACCEPTANCE:
+            # - TLS verification is intentionally disabled in this fallback path.
+            # - This is only used in CI after the verified download path fails.
+            # - The download URL still comes from the cluster-managed ConsoleCLIDownload resource.
+            download_and_install_virtctl -k
+        fi
+
+    - name: Prepare user SSH key
+      if: inputs.ssh-public-key != ''
+      shell: bash
+      run: |
+        echo "${{ inputs.ssh-public-key }}" > "${{ runner.temp }}/user-ssh-key.pub"
+        echo "USER_SSH_KEY_PATH=${{ runner.temp }}/user-ssh-key.pub" >> "$GITHUB_ENV"
+
+    - name: Run add-vms (virt operator already installed)
+      shell: bash
+      env:
+        QUAY_RHACS_ENG_RO_USERNAME: ${{ inputs.quay-username }}
+        QUAY_RHACS_ENG_RO_PASSWORD: ${{ inputs.quay-password }}
+        SKIP_VIRT_OPERATOR: "true"
+      run: |
+        ARGS=(
+            --num-vms "${{ inputs.num-vms }}"
+            --os "${{ inputs.vm-os }}"
+            --artifacts-dir "$ARTIFACTS_DIR"
+        )
+
+        if [[ -n "${USER_SSH_KEY_PATH:-}" ]]; then
+            ARGS+=(--ssh-key "$USER_SSH_KEY_PATH")
+        fi
+
+        "${{ github.workspace }}/scripts/ci/add-vms/add-vms.sh" "${ARGS[@]}"

--- a/scripts/ci/add-vms/action.yml
+++ b/scripts/ci/add-vms/action.yml
@@ -38,9 +38,9 @@ runs:
       env:
         INFRA_TOKEN: ${{ inputs.infra-token }}
       run: |
-        infractl artifacts "${{ inputs.cluster-name }}" --download-dir "${{ github.workspace }}/artifacts" >/dev/null
-        echo "KUBECONFIG=${{ github.workspace }}/artifacts/kubeconfig" >> "$GITHUB_ENV"
-        echo "ARTIFACTS_DIR=${{ github.workspace }}/artifacts" >> "$GITHUB_ENV"
+        infractl artifacts "${{ inputs.cluster-name }}" --download-dir "${{ runner.temp }}/artifacts" >/dev/null
+        echo "KUBECONFIG=${{ runner.temp }}/artifacts/kubeconfig" >> "$GITHUB_ENV"
+        echo "ARTIFACTS_DIR=${{ runner.temp }}/artifacts" >> "$GITHUB_ENV"
 
     - name: Verify cluster access
       shell: bash
@@ -92,7 +92,7 @@ runs:
             fi
 
             echo "Downloading virtctl from $download_url..."
-            curl -fsSL "$@" "$download_url" | tar xz -C /usr/local/bin virtctl
+            curl -fsSL --retry 5 --retry-delay 5 "$@" "$download_url" | tar xz -C /usr/local/bin virtctl
 
             if [[ ! -f /usr/local/bin/virtctl ]]; then
                 echo "ERROR: Downloaded archive does not contain virtctl."
@@ -123,8 +123,10 @@ runs:
     - name: Prepare user SSH key
       if: inputs.ssh-public-key != ''
       shell: bash
+      env:
+        SSH_PUBLIC_KEY: ${{ inputs.ssh-public-key }}
       run: |
-        echo "${{ inputs.ssh-public-key }}" > "${{ runner.temp }}/user-ssh-key.pub"
+        printf '%s\n' "$SSH_PUBLIC_KEY" > "${{ runner.temp }}/user-ssh-key.pub"
         echo "USER_SSH_KEY_PATH=${{ runner.temp }}/user-ssh-key.pub" >> "$GITHUB_ENV"
 
     - name: Run add-vms (virt operator already installed)

--- a/scripts/ci/add-vms/add-vms.bats
+++ b/scripts/ci/add-vms/add-vms.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1091
+
+load "../../test_helpers.bats"
+
+@test "write_github_summary writes the VM access and service summary" {
+    summary_file="${BATS_TEST_TMPDIR}/summary.md"
+
+    run env GITHUB_STEP_SUMMARY="$summary_file" bash -c '
+        source "$1"
+        NAMESPACE="openshift-cnv"
+        VM_OS="rhel10"
+        VM_PREFIX="rhel10"
+        NUM_VMS=2
+        MANAGED_VMS=("rhel10-1")
+        ADOPTED_VMS=("rhel10-2")
+        SKIPPED_VMS=("rhel10-3")
+        NATIVE_AGENT_READY_VMS=("rhel10-1" "rhel10-2")
+        NATIVE_AGENT_FAILED_VMS=("rhel10-3")
+        write_github_summary
+    ' _ "${BATS_TEST_DIRNAME}/add-vms.sh"
+
+    assert_success
+
+    run cat "$summary_file"
+    assert_output --partial "## Add VMs to Cluster"
+    assert_output --partial "### Native agent service verification"
+    assert_output --partial "Successfully started on:"
+    assert_output --partial "rhel10-1"
+    assert_output --partial "rhel10-2"
+    assert_output --partial "Needs attention:"
+    assert_output --partial "### SSH access"
+    assert_output --partial "add-vms-id_ed25519"
+    assert_output --partial "virtctl ssh -n openshift-cnv --identity-file ./add-vms-id_ed25519 cloud-user@vmi/rhel10-1"
+}

--- a/scripts/ci/add-vms/add-vms.sh
+++ b/scripts/ci/add-vms/add-vms.sh
@@ -59,6 +59,8 @@ parse_args() {
 
     VM_PREFIX="${VM_PREFIX:-${VM_OS}}"
 
+    # The workflow uses type: number, but gh CLI and the API still accept
+    # arbitrary strings, so we validate here as well.
     if ! [[ "$NUM_VMS" =~ ^[0-9]+$ ]] || (( NUM_VMS < 1 )); then
         die "--num-vms must be a positive integer"
     fi

--- a/scripts/ci/add-vms/add-vms.sh
+++ b/scripts/ci/add-vms/add-vms.sh
@@ -36,6 +36,7 @@ NATIVE_AGENT_FAILED_VMS=()
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+# Prints the usage block from the file header comments and exits.
 usage() {
     sed -n '2,/^$/s/^# //p' "${BASH_SOURCE[0]}" >&2
     exit 1
@@ -64,6 +65,9 @@ parse_args() {
     [[ "$VM_OS" =~ ^rhel(9|10)$ ]] || die "--os must be rhel9 or rhel10"
 }
 
+# Sets KUBECONFIG: either fetches it from infractl for the given cluster
+# name, or expects it to be pre-set in the environment.
+# Validates that kubectl can reach the cluster before returning.
 resolve_kubeconfig() {
     if [[ -n "$CLUSTER_NAME" ]]; then
         command -v infractl &>/dev/null || die "infractl required when --cluster is used"
@@ -137,6 +141,8 @@ print_summary() {
     write_github_summary
 }
 
+# Appends a markdown heading + bullet list to GITHUB_STEP_SUMMARY.
+# No-op when the list is empty. Args: heading, items...
 append_summary_list() {
     local heading="$1"
     shift
@@ -155,6 +161,9 @@ append_summary_list() {
     } >> "$GITHUB_STEP_SUMMARY"
 }
 
+# Writes the GitHub Actions job summary (markdown) with run configuration,
+# VM categories, agent health, and SSH access instructions.
+# No-op when GITHUB_STEP_SUMMARY is unset (i.e. local runs).
 write_github_summary() {
     if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
         return 0

--- a/scripts/ci/add-vms/add-vms.sh
+++ b/scripts/ci/add-vms/add-vms.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Main orchestrator for adding VMs to an ACS cluster and installing roxagent.
+#
+# Usage:
+#   add-vms.sh [options]
+#
+# Options:
+#   --cluster NAME       Infra cluster name (calls infractl for kubeconfig)
+#   --num-vms N          Number of VMs (default: 1)
+#   --os OS              VM OS: rhel9|rhel10 (default: rhel9)
+#   --ssh-key PATH       Path to user SSH public key to add to target VMs
+#   --namespace NS       Target namespace (default: openshift-cnv)
+#   --vm-prefix PREFIX   VM name prefix (default: same as OS)
+#   --artifacts-dir DIR  Path to infractl artifacts directory
+#
+# Environment:
+#   KUBECONFIG                   If set and --cluster not given, uses this directly
+#   STACKROX_REPO                Required for native agent build (default: repo root)
+#   QUAY_RHACS_ENG_RO_USERNAME   Required; used to create VM image pull secret
+#   QUAY_RHACS_ENG_RO_PASSWORD   Required; used to create VM image pull secret
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Defaults
+CLUSTER_NAME=""
+NUM_VMS=1
+VM_OS="rhel9"
+USER_SSH_KEY_PATH=""
+NAMESPACE="openshift-cnv"
+VM_PREFIX=""
+ARTIFACTS_DIR=""
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+usage() {
+    sed -n '2,/^$/s/^# //p' "${BASH_SOURCE[0]}" >&2
+    exit 1
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --cluster)      CLUSTER_NAME="$2"; shift 2 ;;
+            --num-vms)      NUM_VMS="$2"; shift 2 ;;
+            --os)           VM_OS="$2"; shift 2 ;;
+            --ssh-key)      USER_SSH_KEY_PATH="$2"; shift 2 ;;
+            --namespace)    NAMESPACE="$2"; shift 2 ;;
+            --vm-prefix)    VM_PREFIX="$2"; shift 2 ;;
+            --artifacts-dir) ARTIFACTS_DIR="$2"; shift 2 ;;
+            --help|-h)      usage ;;
+            *)              die "Unknown option: $1" ;;
+        esac
+    done
+
+    VM_PREFIX="${VM_PREFIX:-${VM_OS}}"
+
+    if ! [[ "$NUM_VMS" =~ ^[0-9]+$ ]] || (( NUM_VMS < 1 )); then
+        die "--num-vms must be a positive integer"
+    fi
+    [[ "$VM_OS" =~ ^rhel(9|10)$ ]] || die "--os must be rhel9 or rhel10"
+}
+
+resolve_kubeconfig() {
+    if [[ -n "$CLUSTER_NAME" ]]; then
+        command -v infractl &>/dev/null || die "infractl required when --cluster is used"
+        echo "Fetching artifacts for cluster '$CLUSTER_NAME'..."
+        ARTIFACTS_DIR="${ARTIFACTS_DIR:-$(mktemp -d)}"
+        infractl artifacts "$CLUSTER_NAME" --download-dir "$ARTIFACTS_DIR" >/dev/null
+        export KUBECONFIG="${ARTIFACTS_DIR}/kubeconfig"
+        echo "KUBECONFIG set to $KUBECONFIG"
+    fi
+
+    [[ -n "${KUBECONFIG:-}" ]] || die "KUBECONFIG not set. Use --cluster or set KUBECONFIG."
+    kubectl cluster-info &>/dev/null || die "Cannot connect to cluster via KUBECONFIG=$KUBECONFIG"
+}
+
+resolve_user_ssh_key() {
+    if [[ -n "$USER_SSH_KEY_PATH" ]]; then
+        [[ -f "$USER_SSH_KEY_PATH" ]] || die "SSH public key file not found: $USER_SSH_KEY_PATH"
+        USER_SSH_PUBLIC_KEY="$(cat "$USER_SSH_KEY_PATH")"
+        export USER_SSH_PUBLIC_KEY
+        echo "User SSH key loaded from $USER_SSH_KEY_PATH"
+    elif [[ -n "${USER_SSH_PUBLIC_KEY:-}" ]]; then
+        echo "User SSH key loaded from environment."
+    fi
+}
+
+print_summary() {
+    echo ""
+    echo "==========================================="
+    echo "  Add VMs to Cluster — Summary"
+    echo "==========================================="
+    echo ""
+    echo "Namespace:    $NAMESPACE"
+    echo "VM OS:        $VM_OS"
+    echo "VM prefix:    $VM_PREFIX"
+    echo "Agent type:   native"
+    echo "Num VMs:      $NUM_VMS"
+    echo ""
+
+    if [[ ${#MANAGED_VMS[@]} -gt 0 ]]; then
+        echo "Managed VMs (automation key access):"
+        for vm in "${MANAGED_VMS[@]}"; do echo "  - $vm"; done
+    fi
+    if [[ ${#ADOPTED_VMS[@]} -gt 0 ]]; then
+        echo "Adopted VMs (password fallback, key now injected):"
+        for vm in "${ADOPTED_VMS[@]}"; do echo "  - $vm"; done
+    fi
+    if [[ ${#SKIPPED_VMS[@]} -gt 0 ]]; then
+        echo "Skipped VMs (inaccessible):"
+        for vm in "${SKIPPED_VMS[@]}"; do echo "  - $vm"; done
+        echo ""
+        echo "To grant access to skipped VMs, add the automation public key"
+        echo "to ~/.ssh/authorized_keys on each VM."
+    fi
+
+    echo ""
+    echo "--- SSH Access ---"
+    echo ""
+    echo "Fetch automation private key:"
+    echo "  kubectl get secret ${AUTOMATION_SSH_SECRET:-acs-vm-automation-ssh} -n $NAMESPACE \\"
+    echo "    -o jsonpath='{.data.id_ed25519}' | base64 -d > ./add-vms-id_ed25519"
+    echo "  chmod 600 ./add-vms-id_ed25519"
+    echo ""
+    echo "SSH into a VM:"
+    echo "  virtctl ssh -n $NAMESPACE --identity-file ./add-vms-id_ed25519 ${SSH_USER:-cloud-user}@vmi/${VM_PREFIX}-1"
+    echo ""
+    echo "Check VM status:"
+    echo "  kubectl get vm,vmi -n $NAMESPACE"
+    echo ""
+    echo "==========================================="
+}
+
+cleanup() {
+    rm -f "${AUTOMATION_SSH_PRIVKEY:-}" "${AUTOMATION_SSH_PUBKEY:-}"
+}
+trap cleanup EXIT
+
+main() {
+    echo "=== Add VMs to ACS Cluster ==="
+    echo ""
+
+    parse_args "$@"
+    resolve_kubeconfig
+    resolve_user_ssh_key
+
+    echo ""
+    echo "Configuration:"
+    echo "  Namespace:   $NAMESPACE"
+    echo "  VM OS:       $VM_OS"
+    echo "  VM prefix:   $VM_PREFIX"
+    echo "  Num VMs:     $NUM_VMS"
+    echo "  Agent type:  native"
+    echo ""
+
+    # Export variables for sourced scripts
+    export NAMESPACE VM_OS VM_PREFIX NUM_VMS ARTIFACTS_DIR
+    export CONTAINER_IMAGE="quay.io/rhacs-eng/vm-images:${VM_OS}-dnf-primed-latest"
+
+    # Step 1: Install virt operator (skippable when action handles this separately)
+    if [[ "${SKIP_VIRT_OPERATOR:-false}" != "true" ]]; then
+        # shellcheck source=install-virt-operator.sh
+        source "$SCRIPT_DIR/install-virt-operator.sh"
+        install_virt_operator
+        echo ""
+    else
+        echo "Skipping virt operator install (handled externally)."
+    fi
+
+    # Step 2: Deploy VMs
+    # shellcheck source=deploy-vms.sh
+    source "$SCRIPT_DIR/deploy-vms.sh"
+    deploy_vms
+    echo ""
+
+    # Step 3: Install agent
+    local accessible_vms=()
+    accessible_vms+=("${MANAGED_VMS[@]}" "${ADOPTED_VMS[@]}")
+
+    if [[ ${#accessible_vms[@]} -eq 0 ]]; then
+        die "No accessible VMs — cannot install agent. All VMs failed SSH readiness."
+    else
+        export AUTOMATION_SSH_PRIVKEY
+        # shellcheck source=install-agent-native.sh
+        source "$SCRIPT_DIR/install-agent-native.sh"
+        install_agent_native "${accessible_vms[@]}"
+    fi
+
+    # Step 4: Summary
+    print_summary
+}
+
+main "$@"

--- a/scripts/ci/add-vms/add-vms.sh
+++ b/scripts/ci/add-vms/add-vms.sh
@@ -31,6 +31,8 @@ USER_SSH_KEY_PATH=""
 NAMESPACE="openshift-cnv"
 VM_PREFIX=""
 ARTIFACTS_DIR=""
+NATIVE_AGENT_READY_VMS=()
+NATIVE_AGENT_FAILED_VMS=()
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
@@ -131,6 +133,81 @@ print_summary() {
     echo "  kubectl get vm,vmi -n $NAMESPACE"
     echo ""
     echo "==========================================="
+
+    write_github_summary
+}
+
+append_summary_list() {
+    local heading="$1"
+    shift
+
+    if [[ $# -eq 0 ]]; then
+        return 0
+    fi
+
+    {
+        echo "$heading"
+        local item
+        for item in "$@"; do
+            echo "- \`$item\`"
+        done
+        echo ""
+    } >> "$GITHUB_STEP_SUMMARY"
+}
+
+write_github_summary() {
+    if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        return 0
+    fi
+
+    {
+        echo "## Add VMs to Cluster"
+        echo ""
+        echo "- Namespace: \`$NAMESPACE\`"
+        echo "- VM OS: \`$VM_OS\`"
+        echo "- VM prefix: \`$VM_PREFIX\`"
+        echo "- Agent type: \`native\`"
+        echo "- Requested VMs: \`$NUM_VMS\`"
+        echo ""
+    } >> "$GITHUB_STEP_SUMMARY"
+
+    append_summary_list "### Managed VMs (automation key access)" "${MANAGED_VMS[@]}"
+    append_summary_list "### Adopted VMs (password fallback, key now injected)" "${ADOPTED_VMS[@]}"
+    append_summary_list "### Skipped VMs (inaccessible)" "${SKIPPED_VMS[@]}"
+
+    {
+        echo "### Native agent service verification"
+        echo ""
+    } >> "$GITHUB_STEP_SUMMARY"
+    append_summary_list "Successfully started on:" "${NATIVE_AGENT_READY_VMS[@]}"
+    append_summary_list "Needs attention:" "${NATIVE_AGENT_FAILED_VMS[@]}"
+
+    {
+        echo "### SSH access"
+        echo ""
+        echo "Download the automation private key:"
+        echo ""
+        echo '```bash'
+        echo "kubectl get secret ${AUTOMATION_SSH_SECRET:-acs-vm-automation-ssh} -n $NAMESPACE \\"
+        echo "  -o jsonpath='{.data.id_ed25519}' | base64 -d > ./add-vms-id_ed25519"
+        echo "chmod 600 ./add-vms-id_ed25519"
+        echo '```'
+        echo ""
+        echo "SSH into a VM:"
+        echo ""
+        echo '```bash'
+        echo "virtctl ssh -n $NAMESPACE --identity-file ./add-vms-id_ed25519 ${SSH_USER:-cloud-user}@vmi/${VM_PREFIX}-1"
+        echo '```'
+        echo ""
+        echo "Check VM status:"
+        echo ""
+        echo '```bash'
+        echo "kubectl get vm,vmi -n $NAMESPACE"
+        echo '```'
+        echo ""
+    } >> "$GITHUB_STEP_SUMMARY"
+
+    echo "::notice title=VM action summary::See the job summary for VM access, key download, and native service verification."
 }
 
 cleanup() {
@@ -192,4 +269,6 @@ main() {
     print_summary
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/ci/add-vms/deploy-vms.sh
+++ b/scripts/ci/add-vms/deploy-vms.sh
@@ -217,6 +217,11 @@ deploy_all_vms() {
 # Polls until the KubeVirt VirtualMachineInstance reports condition=Ready.
 # Timeout: ~10 min (20 retries * 30s). Returns 1 on timeout.
 #
+# Not using a single kubectl wait: the VMI resource may not exist yet when
+# this is called, and we need periodic dump_vmi_status diagnostics (VMI
+# phase, conditions, launcher pod events) to identify scheduling or image
+# pull failures in CI.
+#
 # Each iteration uses a short fixed kubectl wait timeout (30s) instead of
 # a dynamic one, so we get regular progress updates and can print
 # diagnostics between attempts. The previous dynamic timeout

--- a/scripts/ci/add-vms/deploy-vms.sh
+++ b/scripts/ci/add-vms/deploy-vms.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# Deploy RHEL VMs on a KubeVirt/OpenShift Virtualization cluster.
+# Manages automation SSH keypair, creates VMs, waits for SSH readiness,
+# and adopts pre-existing VMs via password fallback.
+#
+# Designed to be sourced by add-vms.sh or run standalone.
+
+set -euo pipefail
+
+# Globals (set by caller or defaulted)
+NAMESPACE="${NAMESPACE:-openshift-cnv}"
+SSH_USER="${SSH_USER:-cloud-user}"
+VM_OS="${VM_OS:-rhel9}"
+VM_PREFIX="${VM_PREFIX:-${VM_OS}}"
+NUM_VMS="${NUM_VMS:-1}"
+CONTAINER_IMAGE="${CONTAINER_IMAGE:-quay.io/rhacs-eng/vm-images:${VM_OS}-dnf-primed-latest}"
+AUTOMATION_SSH_SECRET="${AUTOMATION_SSH_SECRET:-acs-vm-automation-ssh}"
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-}"
+USER_SSH_PUBLIC_KEY="${USER_SSH_PUBLIC_KEY:-}"
+IMAGE_PULL_SECRET_NAME="${IMAGE_PULL_SECRET_NAME:-acs-vm-pull-secret}"
+
+# Populated during execution
+AUTOMATION_SSH_PRIVKEY=""
+AUTOMATION_SSH_PUBKEY=""
+
+# Arrays tracking VM state
+declare -a MANAGED_VMS=()
+declare -a ADOPTED_VMS=()
+declare -a SKIPPED_VMS=()
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# --- SSH keypair management ---
+
+ensure_automation_ssh_key() {
+    echo "=== Ensuring automation SSH keypair ==="
+
+    if kubectl get secret "$AUTOMATION_SSH_SECRET" -n "$NAMESPACE" &>/dev/null; then
+        echo "Loading existing automation SSH key from secret '$AUTOMATION_SSH_SECRET'..."
+        AUTOMATION_SSH_PRIVKEY="$(mktemp)"
+        kubectl get secret "$AUTOMATION_SSH_SECRET" -n "$NAMESPACE" \
+            -o jsonpath='{.data.id_ed25519}' | base64 -d > "$AUTOMATION_SSH_PRIVKEY"
+        chmod 600 "$AUTOMATION_SSH_PRIVKEY"
+        AUTOMATION_SSH_PUBKEY="$(mktemp)"
+        kubectl get secret "$AUTOMATION_SSH_SECRET" -n "$NAMESPACE" \
+            -o jsonpath='{.data.id_ed25519\.pub}' | base64 -d > "$AUTOMATION_SSH_PUBKEY"
+        echo "Loaded automation SSH key."
+    else
+        echo "Generating new automation SSH keypair..."
+        AUTOMATION_SSH_PRIVKEY="$(mktemp)"
+        rm -f "$AUTOMATION_SSH_PRIVKEY"
+        AUTOMATION_SSH_PUBKEY="${AUTOMATION_SSH_PRIVKEY}.pub"
+        ssh-keygen -t ed25519 -f "$AUTOMATION_SSH_PRIVKEY" -N "" -C "acs-vm-automation" -q
+        echo "Storing automation SSH key in secret '$AUTOMATION_SSH_SECRET'..."
+        kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+        kubectl create secret generic "$AUTOMATION_SSH_SECRET" -n "$NAMESPACE" \
+            --from-file=id_ed25519="$AUTOMATION_SSH_PRIVKEY" \
+            --from-file=id_ed25519.pub="$AUTOMATION_SSH_PUBKEY"
+        echo "Automation SSH key created and stored."
+    fi
+}
+
+# --- Image pull secret ---
+
+ensure_image_pull_secret() {
+    echo "=== Ensuring image pull secret ==="
+
+    if [[ -z "${QUAY_RHACS_ENG_RO_USERNAME:-}" || -z "${QUAY_RHACS_ENG_RO_PASSWORD:-}" ]]; then
+        die "QUAY_RHACS_ENG_RO_USERNAME and QUAY_RHACS_ENG_RO_PASSWORD must be set to create VM image pull secret"
+    fi
+
+    echo "Creating image pull secret '$IMAGE_PULL_SECRET_NAME' in namespace '$NAMESPACE'..."
+    kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+    kubectl create secret docker-registry "$IMAGE_PULL_SECRET_NAME" \
+        -n "$NAMESPACE" \
+        --docker-server=quay.io \
+        --docker-username="$QUAY_RHACS_ENG_RO_USERNAME" \
+        --docker-password="$QUAY_RHACS_ENG_RO_PASSWORD" \
+        --dry-run=client -o yaml | kubectl apply -f -
+    echo "Image pull secret created/updated."
+}
+
+# --- VM creation ---
+
+vm_exists() {
+    kubectl get vm "$1" -n "$NAMESPACE" &>/dev/null
+}
+
+get_vm_status() {
+    kubectl get vm "$1" -n "$NAMESPACE" -o jsonpath='{.status.printableStatus}' 2>/dev/null || echo "Unknown"
+}
+
+build_vm_manifest() {
+    local vm_name="$1"
+    local ssh_keys_yaml=""
+
+    # Always include automation public key
+    local auto_pub
+    auto_pub="$(cat "$AUTOMATION_SSH_PUBKEY")"
+    ssh_keys_yaml="              - ${auto_pub}"
+
+    # Optionally include user public key
+    if [[ -n "$USER_SSH_PUBLIC_KEY" ]]; then
+        ssh_keys_yaml="${ssh_keys_yaml}
+              - ${USER_SSH_PUBLIC_KEY}"
+    fi
+
+    cat <<EOF
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: ${vm_name}
+  namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: add-vms-automation
+spec:
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        kubevirt.io/size: small
+        kubevirt.io/domain: ${vm_name}
+    spec:
+      domain:
+        cpu:
+          cores: 2
+          sockets: 1
+          threads: 1
+        devices:
+          autoattachVSOCK: true
+          disks:
+            - name: containerdisk
+              bootOrder: 1
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              bootOrder: 2
+              disk:
+                bus: virtio
+          interfaces:
+          - name: default
+            masquerade: {}
+        memory:
+          guest: 4Gi
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: "2"
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: ${CONTAINER_IMAGE}
+            imagePullSecret: ${IMAGE_PULL_SECRET_NAME}
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              user: ${SSH_USER}
+              ssh_pwauth: false
+              ssh_authorized_keys:
+${ssh_keys_yaml}
+EOF
+}
+
+create_vm() {
+    local vm_name="$1" vm_index="$2"
+    echo "[${vm_index}/${NUM_VMS}] VM: $vm_name"
+
+    if vm_exists "$vm_name"; then
+        local status
+        status="$(get_vm_status "$vm_name")"
+        echo "  Already exists (status: $status)"
+        if [[ "$status" == "Running" ]]; then
+            echo "  Skipping creation."
+            return 0
+        elif [[ "$status" == "Stopped" ]]; then
+            echo "  Starting stopped VM..."
+            kubectl patch vm "$vm_name" -n "$NAMESPACE" --type merge \
+                -p '{"spec":{"runStrategy":"Always"}}' &>/dev/null
+            return 0
+        fi
+        return 0
+    fi
+
+    if build_vm_manifest "$vm_name" | kubectl apply -f - &>/dev/null; then
+        echo "  Created."
+    else
+        echo "  FAILED to create."
+        return 1
+    fi
+}
+
+deploy_all_vms() {
+    echo "=== Deploying VMs ==="
+
+    for i in $(seq 1 "$NUM_VMS"); do
+        if ! create_vm "${VM_PREFIX}-${i}" "$i"; then
+            SKIPPED_VMS+=("${VM_PREFIX}-${i}")
+        fi
+    done
+}
+
+# --- Wait for VMI + SSH ---
+
+wait_for_vmi_ready() {
+    local vm_name="$1" max_retries=30 i=0
+    echo "  Waiting for VMI $vm_name to be ready..."
+    while (( i < max_retries )); do
+        if kubectl get "vmi/$vm_name" -n "$NAMESPACE" &>/dev/null; then
+            if kubectl wait --for=condition=Ready "vmi/$vm_name" -n "$NAMESPACE" \
+                    --timeout="$(( (max_retries - i) * 10 ))s" &>/dev/null; then
+                echo "  VMI $vm_name is ready."
+                return 0
+            fi
+        fi
+        i=$((i + 1))
+        (( i % 5 == 0 )) && echo "    Still waiting for VMI... (${i}/${max_retries})"
+        sleep 10
+    done
+    echo "  VMI $vm_name did not become ready in time."
+    return 1
+}
+
+ssh_probe_with_key() {
+    local vm_name="$1"
+    virtctl ssh \
+        --namespace "$NAMESPACE" \
+        --identity-file "$AUTOMATION_SSH_PRIVKEY" \
+        --local-ssh-opts="-o StrictHostKeyChecking=no" \
+        --local-ssh-opts="-o UserKnownHostsFile=/dev/null" \
+        --local-ssh-opts="-o BatchMode=yes" \
+        --local-ssh-opts="-o ConnectTimeout=10" \
+        --command "echo SSH_PROBE_OK" \
+        "${SSH_USER}@vmi/${vm_name}" 2>/dev/null | grep -q "SSH_PROBE_OK"
+}
+
+parse_vm_password() {
+    if [[ -z "$ARTIFACTS_DIR" ]]; then
+        return 1
+    fi
+    local vm_access_file="${ARTIFACTS_DIR}/vm-access.md"
+    if [[ ! -f "$vm_access_file" ]]; then
+        return 1
+    fi
+    grep -oP '(?<=Password:\s).*' "$vm_access_file" 2>/dev/null | head -1
+}
+
+adopt_vm_with_password() {
+    local vm_name="$1"
+    local password
+    password="$(parse_vm_password)" || return 1
+    if [[ -z "$password" ]]; then
+        return 1
+    fi
+
+    echo "  Attempting password-based adoption for $vm_name..."
+    if ! command -v sshpass &>/dev/null; then
+        echo "  WARNING: sshpass not installed — cannot adopt pre-existing VM."
+        return 1
+    fi
+
+    local auto_pub
+    auto_pub="$(cat "$AUTOMATION_SSH_PUBKEY")"
+
+    # Use sshpass to inject automation public key (base64-encode to avoid shell injection)
+    local auto_pub_b64
+    auto_pub_b64="$(echo "$auto_pub" | base64 -w0)"
+    if sshpass -p "$password" virtctl ssh \
+        --namespace "$NAMESPACE" \
+        --local-ssh-opts="-o StrictHostKeyChecking=no" \
+        --local-ssh-opts="-o UserKnownHostsFile=/dev/null" \
+        --local-ssh-opts="-o ConnectTimeout=10" \
+        --local-ssh-opts="-o PubkeyAuthentication=no" \
+        --command "mkdir -p ~/.ssh && chmod 700 ~/.ssh && echo ${auto_pub_b64} | base64 -d >> ~/.ssh/authorized_keys && sort -u -o ~/.ssh/authorized_keys ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys && echo ADOPT_OK" \
+        "${SSH_USER}@vmi/${vm_name}" 2>/dev/null | grep -q "ADOPT_OK"; then
+        echo "  Adopted $vm_name — automation key injected."
+        return 0
+    fi
+    return 1
+}
+
+ensure_user_key_on_vm() {
+    local vm_name="$1"
+    if [[ -z "$USER_SSH_PUBLIC_KEY" ]]; then
+        return 0
+    fi
+    echo "  Ensuring user SSH key on $vm_name..."
+    local user_key_b64
+    user_key_b64="$(echo "$USER_SSH_PUBLIC_KEY" | base64 -w0)"
+    virtctl ssh \
+        --namespace "$NAMESPACE" \
+        --identity-file "$AUTOMATION_SSH_PRIVKEY" \
+        --local-ssh-opts="-o StrictHostKeyChecking=no" \
+        --local-ssh-opts="-o UserKnownHostsFile=/dev/null" \
+        --local-ssh-opts="-o ConnectTimeout=10" \
+        --command "mkdir -p ~/.ssh && chmod 700 ~/.ssh && echo ${user_key_b64} | base64 -d >> ~/.ssh/authorized_keys && sort -u -o ~/.ssh/authorized_keys ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys" \
+        "${SSH_USER}@vmi/${vm_name}" 2>/dev/null || true
+}
+
+wait_for_ssh_and_adopt() {
+    local vm_name="$1"
+    local max_retries=90 i=0
+
+    echo "  Waiting for SSH on $vm_name..."
+    while (( i < max_retries )); do
+        if ssh_probe_with_key "$vm_name"; then
+            echo "  SSH ready (automation key) on $vm_name."
+            MANAGED_VMS+=("$vm_name")
+            ensure_user_key_on_vm "$vm_name"
+            return 0
+        fi
+        i=$((i + 1))
+
+        # Periodically try password-based adoption for pre-existing VMs
+        if (( i % 10 == 0 )); then
+            if adopt_vm_with_password "$vm_name"; then
+                ADOPTED_VMS+=("$vm_name")
+                ensure_user_key_on_vm "$vm_name"
+                return 0
+            fi
+        fi
+
+        (( i % 5 == 0 )) && echo "    Still waiting for SSH... (${i}/${max_retries})"
+        sleep 10
+    done
+
+    # Final password attempt
+    if adopt_vm_with_password "$vm_name"; then
+        ADOPTED_VMS+=("$vm_name")
+        ensure_user_key_on_vm "$vm_name"
+        return 0
+    fi
+
+    echo "  WARNING: Cannot access $vm_name — skipping."
+    echo "  To grant access manually, add this public key to ~/.ssh/authorized_keys on the VM:"
+    echo "    $(cat "$AUTOMATION_SSH_PUBKEY")"
+    SKIPPED_VMS+=("$vm_name")
+    return 1
+}
+
+vm_is_skipped() {
+    local name="$1"
+    local vm
+    for vm in "${SKIPPED_VMS[@]+"${SKIPPED_VMS[@]}"}"; do
+        [[ "$vm" == "$name" ]] && return 0
+    done
+    return 1
+}
+
+wait_for_all_vms() {
+    echo "=== Waiting for VMs ==="
+    for i in $(seq 1 "$NUM_VMS"); do
+        local vm_name="${VM_PREFIX}-${i}"
+        if vm_is_skipped "$vm_name"; then
+            echo "  Skipping $vm_name (creation failed)."
+            continue
+        fi
+        if ! wait_for_vmi_ready "$vm_name"; then
+            SKIPPED_VMS+=("$vm_name")
+            continue
+        fi
+        wait_for_ssh_and_adopt "$vm_name" || SKIPPED_VMS+=("$vm_name")
+    done
+}
+
+# --- Entrypoint when run standalone ---
+
+deploy_vms() {
+    ensure_automation_ssh_key
+    ensure_image_pull_secret
+    deploy_all_vms
+    wait_for_all_vms
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    deploy_vms
+fi

--- a/scripts/ci/add-vms/deploy-vms.sh
+++ b/scripts/ci/add-vms/deploy-vms.sh
@@ -32,6 +32,10 @@ die() { echo "ERROR: $*" >&2; exit 1; }
 
 # --- SSH keypair management ---
 
+# Loads or creates the automation SSH keypair used for all VM access.
+# If the k8s secret already exists, downloads the key from it.
+# Otherwise generates a new ed25519 pair and stores it in the secret.
+# Sets globals: AUTOMATION_SSH_PRIVKEY, AUTOMATION_SSH_PUBKEY (temp file paths).
 ensure_automation_ssh_key() {
     echo "=== Ensuring automation SSH keypair ==="
 
@@ -90,6 +94,9 @@ get_vm_status() {
     kubectl get vm "$1" -n "$NAMESPACE" -o jsonpath='{.status.printableStatus}' 2>/dev/null || echo "Unknown"
 }
 
+# Prints a KubeVirt VirtualMachine YAML manifest to stdout.
+# Embeds the automation (and optional user) SSH public keys via cloud-init
+# so the VM is SSH-accessible immediately after boot.
 build_vm_manifest() {
     local vm_name="$1"
     local ssh_keys_yaml=""
@@ -165,6 +172,8 @@ ${ssh_keys_yaml}
 EOF
 }
 
+# Creates or restarts a single VM. Idempotent: skips if running, restarts
+# if stopped, creates if absent. Returns 1 only on creation failure.
 create_vm() {
     local vm_name="$1" vm_index="$2"
     echo "[${vm_index}/${NUM_VMS}] VM: $vm_name"
@@ -205,6 +214,8 @@ deploy_all_vms() {
 
 # --- Wait for VMI + SSH ---
 
+# Polls until the KubeVirt VirtualMachineInstance reports condition=Ready.
+# Timeout: ~5 min (30 retries * 10s). Returns 1 on timeout.
 wait_for_vmi_ready() {
     local vm_name="$1" max_retries=30 i=0
     echo "  Waiting for VMI $vm_name to be ready..."
@@ -224,6 +235,8 @@ wait_for_vmi_ready() {
     return 1
 }
 
+# Single non-interactive SSH attempt using the automation key.
+# Returns 0 if the VM is reachable, 1 otherwise.
 ssh_probe_with_key() {
     local vm_name="$1"
     virtctl ssh \
@@ -237,6 +250,10 @@ ssh_probe_with_key() {
         "${SSH_USER}@vmi/${vm_name}" 2>/dev/null | grep -q "SSH_PROBE_OK"
 }
 
+# Extracts the VM password from the infractl artifacts directory.
+# Pre-existing infra clusters ship a vm-access.md with a password that
+# we can use as a fallback when the automation key is not yet injected.
+# Prints the password to stdout; returns 1 if unavailable.
 parse_vm_password() {
     if [[ -z "$ARTIFACTS_DIR" ]]; then
         return 1
@@ -248,6 +265,10 @@ parse_vm_password() {
     grep -oP '(?<=Password:\s).*' "$vm_access_file" 2>/dev/null | head -1
 }
 
+# "Adopts" a pre-existing VM by logging in with its password (via sshpass)
+# and injecting the automation SSH public key into authorized_keys.
+# After this succeeds, all further access uses key-based auth.
+# The public key is base64-encoded in transit to avoid shell injection.
 adopt_vm_with_password() {
     local vm_name="$1"
     local password
@@ -282,6 +303,9 @@ adopt_vm_with_password() {
     return 1
 }
 
+# Appends the caller's personal SSH public key (if provided) to the VM's
+# authorized_keys. This is a convenience for developer SSH access and is
+# separate from the automation key used by CI.
 ensure_user_key_on_vm() {
     local vm_name="$1"
     if [[ -z "$USER_SSH_PUBLIC_KEY" ]]; then
@@ -300,6 +324,12 @@ ensure_user_key_on_vm() {
         "${SSH_USER}@vmi/${vm_name}" 2>/dev/null || true
 }
 
+# Retry loop (~15 min) that waits for SSH access on a VM.
+# Tries key-based auth first; every 10 attempts falls back to password
+# adoption for pre-existing VMs. Classifies the VM into one of:
+#   MANAGED_VMS  — automation key worked (newly created VM)
+#   ADOPTED_VMS  — password fallback succeeded, key now injected
+#   SKIPPED_VMS  — all attempts failed, VM is inaccessible
 wait_for_ssh_and_adopt() {
     local vm_name="$1"
     local max_retries=90 i=0

--- a/scripts/ci/add-vms/deploy-vms.sh
+++ b/scripts/ci/add-vms/deploy-vms.sh
@@ -215,24 +215,58 @@ deploy_all_vms() {
 # --- Wait for VMI + SSH ---
 
 # Polls until the KubeVirt VirtualMachineInstance reports condition=Ready.
-# Timeout: ~5 min (30 retries * 10s). Returns 1 on timeout.
+# Timeout: ~10 min (20 retries * 30s). Returns 1 on timeout.
+#
+# Each iteration uses a short fixed kubectl wait timeout (30s) instead of
+# a dynamic one, so we get regular progress updates and can print
+# diagnostics between attempts. The previous dynamic timeout
+# ((max-i)*10s) caused individual kubectl wait calls to block for
+# minutes, hiding the actual VM state from the CI log.
 wait_for_vmi_ready() {
-    local vm_name="$1" max_retries=30 i=0
+    local vm_name="$1" max_retries=20 i=0
     echo "  Waiting for VMI $vm_name to be ready..."
     while (( i < max_retries )); do
         if kubectl get "vmi/$vm_name" -n "$NAMESPACE" &>/dev/null; then
             if kubectl wait --for=condition=Ready "vmi/$vm_name" -n "$NAMESPACE" \
-                    --timeout="$(( (max_retries - i) * 10 ))s" &>/dev/null; then
+                    --timeout=30s &>/dev/null; then
                 echo "  VMI $vm_name is ready."
                 return 0
             fi
         fi
         i=$((i + 1))
-        (( i % 5 == 0 )) && echo "    Still waiting for VMI... (${i}/${max_retries})"
-        sleep 10
+        if (( i % 3 == 0 )); then
+            echo "    Still waiting for VMI... (${i}/${max_retries})"
+            dump_vmi_status "$vm_name"
+        fi
     done
     echo "  VMI $vm_name did not become ready in time."
+    dump_vmi_status "$vm_name"
     return 1
+}
+
+# Prints a short diagnostic for a VMI that isn't ready yet.
+# Shows the VMI status/conditions and recent pod events to help
+# identify scheduling failures, image pull errors, etc.
+dump_vmi_status() {
+    local vm_name="$1"
+    echo "    --- VMI diagnostic for $vm_name ---"
+    kubectl get "vmi/$vm_name" -n "$NAMESPACE" \
+        -o jsonpath='    Status: {.status.phase}{"\n"}' 2>/dev/null || true
+    kubectl get "vmi/$vm_name" -n "$NAMESPACE" \
+        -o jsonpath='    Conditions: {.status.conditions[*].type}={.status.conditions[*].status}{"\n"}' 2>/dev/null || true
+    # Show recent events for the launcher pod — surfaces image pull
+    # errors, scheduling failures, and other infrastructure issues.
+    local pod
+    pod="$(kubectl get pods -n "$NAMESPACE" -l "kubevirt.io/domain=${vm_name}" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    if [[ -n "$pod" ]]; then
+        echo "    Pod: $pod"
+        kubectl get events -n "$NAMESPACE" --field-selector "involvedObject.name=$pod" \
+            --sort-by='.lastTimestamp' 2>/dev/null | tail -5 | sed 's/^/    /' || true
+    else
+        echo "    No launcher pod found yet."
+    fi
+    echo "    ---"
 }
 
 # Single non-interactive SSH attempt using the automation key.

--- a/scripts/ci/add-vms/install-agent-native-summary.bats
+++ b/scripts/ci/add-vms/install-agent-native-summary.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1091
+
+load "../../test_helpers.bats"
+
+function setup() {
+    source "${BATS_TEST_DIRNAME}/install-agent-native.sh"
+
+    NAMESPACE="openshift-cnv"
+    SSH_USER="cloud-user"
+    AUTOMATION_SSH_PRIVKEY="${BATS_TEST_TMPDIR}/id_ed25519"
+    touch "${AUTOMATION_SSH_PRIVKEY}"
+}
+
+@test "native_agent_service_verified tracks successful starts" {
+    virtctl() {
+        local cmd=""
+        while (($#)); do
+            case "$1" in
+                --command)
+                    cmd="$2"
+                    shift 2
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+
+        if [[ "$cmd" == *"systemctl show roxagent.service"* ]]; then
+            printf 'success\nenabled\nactive\n'
+            return 0
+        fi
+
+        return 1
+    }
+
+    run native_agent_service_verified "rhel10-1"
+
+    assert_success
+}
+
+@test "native_agent_service_verified rejects unhealthy service state" {
+    virtctl() {
+        local cmd=""
+        while (($#)); do
+            case "$1" in
+                --command)
+                    cmd="$2"
+                    shift 2
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+
+        if [[ "$cmd" == *"systemctl show roxagent.service"* ]]; then
+            printf 'failed\nenabled\ninactive\n'
+            return 0
+        fi
+
+        return 1
+    }
+
+    run native_agent_service_verified "rhel10-1"
+
+    assert_failure
+}

--- a/scripts/ci/add-vms/install-agent-native-summary.bats
+++ b/scripts/ci/add-vms/install-agent-native-summary.bats
@@ -12,28 +12,35 @@ function setup() {
     touch "${AUTOMATION_SSH_PRIVKEY}"
 }
 
-@test "native_agent_service_verified tracks successful starts" {
+# mock_virtctl_service_status stubs virtctl to return the given
+# service_result, timer_enabled, and timer_active values when the
+# command contains "systemctl show roxagent.service".
+mock_virtctl_service_status() {
+    local service_result="$1" timer_enabled="$2" timer_active="$3"
+    # Export so the subshell created by `run` can see them.
+    export _MOCK_SERVICE_RESULT="$service_result"
+    export _MOCK_TIMER_ENABLED="$timer_enabled"
+    export _MOCK_TIMER_ACTIVE="$timer_active"
+
     virtctl() {
         local cmd=""
         while (($#)); do
             case "$1" in
-                --command)
-                    cmd="$2"
-                    shift 2
-                    ;;
-                *)
-                    shift
-                    ;;
+                --command) cmd="$2"; shift 2 ;;
+                *)         shift ;;
             esac
         done
 
         if [[ "$cmd" == *"systemctl show roxagent.service"* ]]; then
-            printf 'success\nenabled\nactive\n'
+            printf '%s\n%s\n%s\n' "$_MOCK_SERVICE_RESULT" "$_MOCK_TIMER_ENABLED" "$_MOCK_TIMER_ACTIVE"
             return 0
         fi
-
         return 1
     }
+}
+
+@test "native_agent_service_verified tracks successful starts" {
+    mock_virtctl_service_status "success" "enabled" "active"
 
     run native_agent_service_verified "rhel10-1"
 
@@ -41,27 +48,7 @@ function setup() {
 }
 
 @test "native_agent_service_verified rejects unhealthy service state" {
-    virtctl() {
-        local cmd=""
-        while (($#)); do
-            case "$1" in
-                --command)
-                    cmd="$2"
-                    shift 2
-                    ;;
-                *)
-                    shift
-                    ;;
-            esac
-        done
-
-        if [[ "$cmd" == *"systemctl show roxagent.service"* ]]; then
-            printf 'failed\nenabled\ninactive\n'
-            return 0
-        fi
-
-        return 1
-    }
+    mock_virtctl_service_status "failed" "enabled" "inactive"
 
     run native_agent_service_verified "rhel10-1"
 

--- a/scripts/ci/add-vms/install-agent-native.bats
+++ b/scripts/ci/add-vms/install-agent-native.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1091
+
+load "../../test_helpers.bats"
+
+function setup() {
+    source "${BATS_TEST_DIRNAME}/install-agent-native.sh"
+}
+
+@test "create_native_prep_service_file prepares the curated roxroot tree" {
+    run create_native_prep_service_file
+
+    assert_success
+    assert_output --partial "ExecStartPre=/bin/rm -rf /tmp/roxroot"
+    assert_output --partial "ExecStartPre=/bin/mkdir -p /tmp/roxroot/etc/pki"
+    assert_output --partial "ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/lib /tmp/roxroot/var/lib/dnf"
+    assert_output --partial "ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/cache /tmp/roxroot/var/cache/dnf"
+    assert_output --partial "ExecStartPre=/bin/mkdir -p /run/lock/roxagent"
+    assert_output --partial "ExecStart=/bin/rm -rf /tmp/roxagent-rpm"
+    assert_output --partial "ExecStart=/bin/cp -a /var/lib/rpm /tmp/roxagent-rpm"
+}
+
+@test "create_native_service_file mounts only the required scan inputs into roxroot" {
+    run create_native_service_file \
+        /etc/os-release \
+        /etc/pki/entitlement \
+        /var/cache/dnf
+
+    assert_success
+    assert_output --partial "Requires=roxagent-prep.service"
+    assert_output --partial "After=network.target roxagent-prep.service"
+    assert_output --partial "BindPaths=/tmp/roxagent-rpm:/tmp/roxroot/var/lib/rpm"
+    assert_output --partial "BindReadOnlyPaths=/etc/os-release:/tmp/roxroot/etc/os-release"
+    assert_output --partial "BindReadOnlyPaths=/etc/pki/entitlement:/tmp/roxroot/etc/pki/entitlement"
+    assert_output --partial "BindReadOnlyPaths=/var/cache/dnf:/tmp/roxroot/var/cache/dnf"
+    assert_output --partial "ExecStart=/usr/local/bin/roxagent --host-path /tmp/roxroot"
+}

--- a/scripts/ci/add-vms/install-agent-native.bats
+++ b/scripts/ci/add-vms/install-agent-native.bats
@@ -7,8 +7,8 @@ function setup() {
     source "${BATS_TEST_DIRNAME}/install-agent-native.sh"
 }
 
-@test "create_native_prep_service_file prepares the curated roxroot tree" {
-    run create_native_prep_service_file
+@test "roxagent-prep.service prepares the curated roxroot tree" {
+    run cat "$SYSTEMD_DIR/roxagent-prep.service"
 
     assert_success
     assert_output --partial "ExecStartPre=/bin/rm -rf /tmp/roxroot"

--- a/scripts/ci/add-vms/install-agent-native.bats
+++ b/scripts/ci/add-vms/install-agent-native.bats
@@ -12,9 +12,9 @@ function setup() {
 
     assert_success
     assert_output --partial "ExecStartPre=/bin/rm -rf /tmp/roxroot"
-    assert_output --partial "ExecStartPre=/bin/mkdir -p /tmp/roxroot/etc/pki"
-    assert_output --partial "ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/lib /tmp/roxroot/var/lib/dnf"
-    assert_output --partial "ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/cache /tmp/roxroot/var/cache/dnf"
+    assert_output --partial "ExecStartPre=/bin/mkdir -p /tmp/roxroot/etc/pki/entitlement"
+    assert_output --partial "ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/lib/dnf"
+    assert_output --partial "ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/cache/dnf"
     assert_output --partial "ExecStartPre=/bin/mkdir -p /run/lock/roxagent"
     assert_output --partial "ExecStart=/bin/rm -rf /tmp/roxagent-rpm"
     assert_output --partial "ExecStart=/bin/cp -a /var/lib/rpm /tmp/roxagent-rpm"

--- a/scripts/ci/add-vms/install-agent-native.sh
+++ b/scripts/ci/add-vms/install-agent-native.sh
@@ -32,6 +32,16 @@ NATIVE_MOUNT_CANDIDATES=(
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+build_ssh_opts() {
+    _ssh_opts=(
+        --namespace "$NAMESPACE"
+        --identity-file "$AUTOMATION_SSH_PRIVKEY"
+        --local-ssh-opts="-o StrictHostKeyChecking=no"
+        --local-ssh-opts="-o UserKnownHostsFile=/dev/null"
+        --local-ssh-opts="-o ConnectTimeout=10"
+    )
+}
+
 build_agent() {
     echo "=== Building roxagent binary ===" >&2
 
@@ -114,16 +124,10 @@ EOF
 
 native_agent_service_verified() {
     local vm_name="$1"
-    local ssh_opts=(
-        --namespace "$NAMESPACE"
-        --identity-file "$AUTOMATION_SSH_PRIVKEY"
-        --local-ssh-opts="-o StrictHostKeyChecking=no"
-        --local-ssh-opts="-o UserKnownHostsFile=/dev/null"
-        --local-ssh-opts="-o ConnectTimeout=10"
-    )
+    build_ssh_opts
 
     local status_output
-    status_output="$(virtctl ssh "${ssh_opts[@]}" \
+    status_output="$(virtctl ssh "${_ssh_opts[@]}" \
         --command "service_result=\"\$(systemctl show roxagent.service -p Result --value 2>/dev/null || true)\";
 timer_enabled=\"\$(systemctl is-enabled roxagent.timer 2>/dev/null || true)\";
 timer_active=\"\$(systemctl is-active roxagent.timer 2>/dev/null || true)\";
@@ -142,13 +146,7 @@ install_on_vm() {
 
     echo "--- Installing roxagent (native) on $vm_name ---"
 
-    local ssh_opts=(
-        --namespace "$NAMESPACE"
-        --identity-file "$AUTOMATION_SSH_PRIVKEY"
-        --local-ssh-opts="-o StrictHostKeyChecking=no"
-        --local-ssh-opts="-o UserKnownHostsFile=/dev/null"
-        --local-ssh-opts="-o ConnectTimeout=10"
-    )
+    build_ssh_opts
 
     echo "  Probing host inputs for curated roxroot mount set..."
     local probe_cmd mount_path
@@ -162,13 +160,13 @@ install_on_vm() {
     while IFS= read -r mount_path; do
         [[ -n "$mount_path" ]] && available_mounts+=("$mount_path")
     done < <(
-        virtctl ssh "${ssh_opts[@]}" \
+        virtctl ssh "${_ssh_opts[@]}" \
             --command "$probe_cmd" \
             "${SSH_USER}@vmi/${vm_name}" 2>/dev/null || true
     )
 
     echo "  Copying binary..."
-    virtctl scp "${ssh_opts[@]}" \
+    virtctl scp "${_ssh_opts[@]}" \
         "$binary_path" \
         "${SSH_USER}@vmi/${vm_name}:/tmp/roxagent"
 
@@ -181,18 +179,18 @@ install_on_vm() {
     create_native_service_file "${available_mounts[@]}" > "$service_file"
     create_native_timer_file > "$timer_file"
 
-    virtctl scp "${ssh_opts[@]}" \
+    virtctl scp "${_ssh_opts[@]}" \
         "$prep_service_file" \
         "${SSH_USER}@vmi/${vm_name}:/tmp/roxagent-prep.service"
-    virtctl scp "${ssh_opts[@]}" \
+    virtctl scp "${_ssh_opts[@]}" \
         "$service_file" \
         "${SSH_USER}@vmi/${vm_name}:/tmp/roxagent.service"
-    virtctl scp "${ssh_opts[@]}" \
+    virtctl scp "${_ssh_opts[@]}" \
         "$timer_file" \
         "${SSH_USER}@vmi/${vm_name}:/tmp/roxagent.timer"
     rm -f "$prep_service_file" "$service_file" "$timer_file"
 
-    virtctl ssh "${ssh_opts[@]}" \
+    virtctl ssh "${_ssh_opts[@]}" \
         --command 'set -e
 sudo install -m 0755 /tmp/roxagent /usr/local/bin/roxagent
 sudo restorecon -v /usr/local/bin/roxagent 2>/dev/null || true
@@ -209,7 +207,7 @@ echo "NATIVE_INSTALL_OK"' \
     echo "  Installed on $vm_name."
     echo "  Verifying agent status on $vm_name..."
     local verify_output
-    verify_output="$(virtctl ssh "${ssh_opts[@]}" \
+    verify_output="$(virtctl ssh "${_ssh_opts[@]}" \
         --command 'sudo systemctl start roxagent.service; echo "---"; sudo systemctl status roxagent.timer --no-pager; echo "---"; sudo journalctl -u roxagent.service --no-pager -n 20' \
         "${SSH_USER}@vmi/${vm_name}" 2>&1 || true)"
     printf '%s\n' "$verify_output"

--- a/scripts/ci/add-vms/install-agent-native.sh
+++ b/scripts/ci/add-vms/install-agent-native.sh
@@ -32,6 +32,8 @@ NATIVE_MOUNT_CANDIDATES=(
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+# Populates the _ssh_opts array with common virtctl ssh/scp flags.
+# Callers use: build_ssh_opts; virtctl ssh "${_ssh_opts[@]}" ...
 build_ssh_opts() {
     _ssh_opts=(
         --namespace "$NAMESPACE"
@@ -42,6 +44,8 @@ build_ssh_opts() {
     )
 }
 
+# Cross-compiles the roxagent binary for linux/amd64.
+# Prints the path to the built binary on stdout.
 build_agent() {
     echo "=== Building roxagent binary ===" >&2
 
@@ -58,6 +62,9 @@ build_agent() {
     echo "$output"
 }
 
+# Prints a systemd unit (to stdout) that prepares the sandbox directory
+# tree roxagent needs: /tmp/roxroot/{etc,var} and a writable RPM DB copy.
+# Runs as a oneshot dependency before the main roxagent service.
 create_native_prep_service_file() {
     cat <<'EOF'
 [Unit]
@@ -80,6 +87,10 @@ ExecStart=/bin/chmod -R 755 /tmp/roxagent-rpm
 EOF
 }
 
+# Prints a systemd unit (to stdout) for the main roxagent service.
+# Args: host paths that exist on the VM (from NATIVE_MOUNT_CANDIDATES).
+# Each path is bind-mounted read-only into the /tmp/roxroot sandbox so
+# roxagent can inspect host OS metadata without full root access.
 create_native_service_file() {
     local mount_path
 
@@ -122,6 +133,9 @@ WantedBy=timers.target
 EOF
 }
 
+# Checks whether roxagent is healthy on $1 (vm_name) by SSHing in and
+# querying systemd. Returns 0 only if the last service run succeeded,
+# the timer is enabled, and the timer is active.
 native_agent_service_verified() {
     local vm_name="$1"
     build_ssh_opts
@@ -141,6 +155,10 @@ printf \"%s\\n%s\\n%s\\n\" \"\$service_result\" \"\$timer_enabled\" \"\$timer_ac
         "${status_lines[2]:-}" == "active" ]]
 }
 
+# Deploys roxagent onto a single VM ($1) using the pre-built binary ($2).
+# Steps: probe which host paths exist -> scp binary + systemd units ->
+# install and enable via SSH -> run once and verify health.
+# Appends the VM name to NATIVE_AGENT_READY_VMS or NATIVE_AGENT_FAILED_VMS.
 install_on_vm() {
     local vm_name="$1" binary_path="$2"
 
@@ -219,6 +237,7 @@ echo "NATIVE_INSTALL_OK"' \
     fi
 }
 
+# Top-level entry point: builds the agent once, installs on each VM.
 install_agent_native() {
     local vm_names=("$@")
 

--- a/scripts/ci/add-vms/install-agent-native.sh
+++ b/scripts/ci/add-vms/install-agent-native.sh
@@ -62,31 +62,6 @@ build_agent() {
     echo "$output"
 }
 
-# Prints a systemd unit (to stdout) that prepares the sandbox directory
-# tree roxagent needs: /tmp/roxroot/{etc,var} and a writable RPM DB copy.
-# Runs as a oneshot dependency before the main roxagent service.
-create_native_prep_service_file() {
-    cat <<'EOF'
-[Unit]
-Description=Prepare native StackRox VM Agent inputs
-
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStartPre=/bin/rm -rf /tmp/roxroot
-ExecStartPre=/bin/mkdir -p /tmp/roxroot/etc/pki /tmp/roxroot/etc/pki/entitlement
-ExecStartPre=/bin/mkdir -p /tmp/roxroot/etc/yum.repos.d /tmp/roxroot/etc/yum/repos.d /tmp/roxroot/etc/distro.repos.d
-ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/lib /tmp/roxroot/var/lib/dnf
-ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/cache /tmp/roxroot/var/cache/dnf
-ExecStartPre=/bin/mkdir -p /run/lock/roxagent
-ExecStartPre=/bin/touch /tmp/roxroot/etc/os-release /tmp/roxroot/etc/redhat-release /tmp/roxroot/etc/system-release-cpe
-
-ExecStart=/bin/rm -rf /tmp/roxagent-rpm
-ExecStart=/bin/cp -a /var/lib/rpm /tmp/roxagent-rpm
-ExecStart=/bin/chmod -R 755 /tmp/roxagent-rpm
-EOF
-}
-
 # Prints a systemd unit (to stdout) for the main roxagent service.
 # Args: host paths that exist on the VM (from NATIVE_MOUNT_CANDIDATES).
 # Each path is bind-mounted read-only into the /tmp/roxroot sandbox so
@@ -117,21 +92,7 @@ StandardError=journal
 EOF
 }
 
-create_native_timer_file() {
-    cat <<'EOF'
-[Unit]
-Description=Run StackRox VM Agent periodically
-
-[Timer]
-OnBootSec=5min
-OnUnitActiveSec=3h40m
-RandomizedDelaySec=40min
-Persistent=true
-
-[Install]
-WantedBy=timers.target
-EOF
-}
+SYSTEMD_DIR="$SCRIPT_DIR/systemd"
 
 # Checks whether roxagent is healthy on $1 (vm_name) by SSHing in and
 # querying systemd. Returns 0 only if the last service run succeeded,
@@ -191,11 +152,9 @@ install_on_vm() {
     echo "  Installing systemd units..."
     local service_file prep_service_file timer_file
     service_file="$(mktemp)"
-    prep_service_file="$(mktemp)"
-    timer_file="$(mktemp)"
-    create_native_prep_service_file > "$prep_service_file"
     create_native_service_file "${available_mounts[@]}" > "$service_file"
-    create_native_timer_file > "$timer_file"
+    prep_service_file="$SYSTEMD_DIR/roxagent-prep.service"
+    timer_file="$SYSTEMD_DIR/roxagent.timer"
 
     virtctl scp "${_ssh_opts[@]}" \
         "$prep_service_file" \
@@ -206,7 +165,7 @@ install_on_vm() {
     virtctl scp "${_ssh_opts[@]}" \
         "$timer_file" \
         "${SSH_USER}@vmi/${vm_name}:/tmp/roxagent.timer"
-    rm -f "$prep_service_file" "$service_file" "$timer_file"
+    rm -f "$service_file"
 
     virtctl ssh "${_ssh_opts[@]}" \
         --command 'set -e

--- a/scripts/ci/add-vms/install-agent-native.sh
+++ b/scripts/ci/add-vms/install-agent-native.sh
@@ -15,6 +15,8 @@ ROXAGENT_SRC="${STACKROX_REPO}/compliance/virtualmachines/roxagent"
 NAMESPACE="${NAMESPACE:-openshift-cnv}"
 SSH_USER="${SSH_USER:-cloud-user}"
 AUTOMATION_SSH_PRIVKEY="${AUTOMATION_SSH_PRIVKEY:-}"
+NATIVE_AGENT_READY_VMS=()
+NATIVE_AGENT_FAILED_VMS=()
 
 NATIVE_MOUNT_CANDIDATES=(
     /etc/os-release
@@ -110,6 +112,31 @@ WantedBy=timers.target
 EOF
 }
 
+native_agent_service_verified() {
+    local vm_name="$1"
+    local ssh_opts=(
+        --namespace "$NAMESPACE"
+        --identity-file "$AUTOMATION_SSH_PRIVKEY"
+        --local-ssh-opts="-o StrictHostKeyChecking=no"
+        --local-ssh-opts="-o UserKnownHostsFile=/dev/null"
+        --local-ssh-opts="-o ConnectTimeout=10"
+    )
+
+    local status_output
+    status_output="$(virtctl ssh "${ssh_opts[@]}" \
+        --command "service_result=\"\$(systemctl show roxagent.service -p Result --value 2>/dev/null || true)\";
+timer_enabled=\"\$(systemctl is-enabled roxagent.timer 2>/dev/null || true)\";
+timer_active=\"\$(systemctl is-active roxagent.timer 2>/dev/null || true)\";
+printf \"%s\\n%s\\n%s\\n\" \"\$service_result\" \"\$timer_enabled\" \"\$timer_active\"" \
+        "${SSH_USER}@vmi/${vm_name}" 2>/dev/null || true)"
+
+    mapfile -t status_lines <<< "$status_output"
+
+    [[ "${status_lines[0]:-}" == "success" &&
+        "${status_lines[1]:-}" == "enabled" &&
+        "${status_lines[2]:-}" == "active" ]]
+}
+
 install_on_vm() {
     local vm_name="$1" binary_path="$2"
 
@@ -181,9 +208,17 @@ echo "NATIVE_INSTALL_OK"' \
 
     echo "  Installed on $vm_name."
     echo "  Verifying agent status on $vm_name..."
-    virtctl ssh "${ssh_opts[@]}" \
+    local verify_output
+    verify_output="$(virtctl ssh "${ssh_opts[@]}" \
         --command 'sudo systemctl start roxagent.service; echo "---"; sudo systemctl status roxagent.timer --no-pager; echo "---"; sudo journalctl -u roxagent.service --no-pager -n 20' \
-        "${SSH_USER}@vmi/${vm_name}" || true
+        "${SSH_USER}@vmi/${vm_name}" 2>&1 || true)"
+    printf '%s\n' "$verify_output"
+
+    if native_agent_service_verified "$vm_name"; then
+        NATIVE_AGENT_READY_VMS+=("$vm_name")
+    else
+        NATIVE_AGENT_FAILED_VMS+=("$vm_name")
+    fi
 }
 
 install_agent_native() {

--- a/scripts/ci/add-vms/install-agent-native.sh
+++ b/scripts/ci/add-vms/install-agent-native.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Install roxagent on VMs using the native binary method.
+#
+# Builds the roxagent binary from source and deploys via virtctl scp.
+# Always overwrites (binary has no version info; binary is small).
+#
+# Requires: Go toolchain, STACKROX_REPO (defaults to repo root).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STACKROX_REPO="${STACKROX_REPO:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+ROXAGENT_SRC="${STACKROX_REPO}/compliance/virtualmachines/roxagent"
+
+NAMESPACE="${NAMESPACE:-openshift-cnv}"
+SSH_USER="${SSH_USER:-cloud-user}"
+AUTOMATION_SSH_PRIVKEY="${AUTOMATION_SSH_PRIVKEY:-}"
+
+NATIVE_MOUNT_CANDIDATES=(
+    /etc/os-release
+    /etc/redhat-release
+    /etc/system-release-cpe
+    /etc/pki/entitlement
+    /etc/yum.repos.d
+    /etc/yum/repos.d
+    /etc/distro.repos.d
+    /var/cache/dnf
+    /var/lib/dnf
+)
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+build_agent() {
+    echo "=== Building roxagent binary ===" >&2
+
+    if [[ ! -d "$ROXAGENT_SRC" ]]; then
+        die "roxagent source not found at $ROXAGENT_SRC — set STACKROX_REPO"
+    fi
+
+    command -v go &>/dev/null || die "Go toolchain required for native agent build"
+
+    local output="/tmp/roxagent-amd64"
+    echo "Building from ${ROXAGENT_SRC}..." >&2
+    GOOS=linux GOARCH=amd64 go build -o "$output" "$ROXAGENT_SRC"
+    echo "Built: $output" >&2
+    echo "$output"
+}
+
+create_native_prep_service_file() {
+    cat <<'EOF'
+[Unit]
+Description=Prepare native StackRox VM Agent inputs
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/bin/rm -rf /tmp/roxroot
+ExecStartPre=/bin/mkdir -p /tmp/roxroot/etc/pki /tmp/roxroot/etc/pki/entitlement
+ExecStartPre=/bin/mkdir -p /tmp/roxroot/etc/yum.repos.d /tmp/roxroot/etc/yum/repos.d /tmp/roxroot/etc/distro.repos.d
+ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/lib /tmp/roxroot/var/lib/dnf
+ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/cache /tmp/roxroot/var/cache/dnf
+ExecStartPre=/bin/mkdir -p /run/lock/roxagent
+ExecStartPre=/bin/touch /tmp/roxroot/etc/os-release /tmp/roxroot/etc/redhat-release /tmp/roxroot/etc/system-release-cpe
+
+ExecStart=/bin/rm -rf /tmp/roxagent-rpm
+ExecStart=/bin/cp -a /var/lib/rpm /tmp/roxagent-rpm
+ExecStart=/bin/chmod -R 755 /tmp/roxagent-rpm
+EOF
+}
+
+create_native_service_file() {
+    local mount_path
+
+    cat <<'EOF'
+[Unit]
+Description=StackRox VM Agent (native)
+After=network.target roxagent-prep.service
+Requires=roxagent-prep.service
+
+[Service]
+Type=oneshot
+User=root
+BindPaths=/tmp/roxagent-rpm:/tmp/roxroot/var/lib/rpm
+EOF
+
+    for mount_path in "$@"; do
+        printf 'BindReadOnlyPaths=%s:/tmp/roxroot%s\n' "$mount_path" "$mount_path"
+    done
+
+    cat <<'EOF'
+ExecStart=/usr/local/bin/roxagent --host-path /tmp/roxroot
+StandardOutput=journal
+StandardError=journal
+EOF
+}
+
+create_native_timer_file() {
+    cat <<'EOF'
+[Unit]
+Description=Run StackRox VM Agent periodically
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=3h40m
+RandomizedDelaySec=40min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+}
+
+install_on_vm() {
+    local vm_name="$1" binary_path="$2"
+
+    echo "--- Installing roxagent (native) on $vm_name ---"
+
+    local ssh_opts=(
+        --namespace "$NAMESPACE"
+        --identity-file "$AUTOMATION_SSH_PRIVKEY"
+        --local-ssh-opts="-o StrictHostKeyChecking=no"
+        --local-ssh-opts="-o UserKnownHostsFile=/dev/null"
+        --local-ssh-opts="-o ConnectTimeout=10"
+    )
+
+    echo "  Probing host inputs for curated roxroot mount set..."
+    local probe_cmd mount_path
+    probe_cmd="for path in"
+    for mount_path in "${NATIVE_MOUNT_CANDIDATES[@]}"; do
+        probe_cmd+=" ${mount_path}"
+    done
+    probe_cmd+="; do [ -e \"\$path\" ] && printf \"%s\\n\" \"\$path\"; done"
+
+    local -a available_mounts=()
+    while IFS= read -r mount_path; do
+        [[ -n "$mount_path" ]] && available_mounts+=("$mount_path")
+    done < <(
+        virtctl ssh "${ssh_opts[@]}" \
+            --command "$probe_cmd" \
+            "${SSH_USER}@vmi/${vm_name}" 2>/dev/null || true
+    )
+
+    echo "  Copying binary..."
+    virtctl scp "${ssh_opts[@]}" \
+        "$binary_path" \
+        "${SSH_USER}@vmi/${vm_name}:/tmp/roxagent"
+
+    echo "  Installing systemd units..."
+    local service_file prep_service_file timer_file
+    service_file="$(mktemp)"
+    prep_service_file="$(mktemp)"
+    timer_file="$(mktemp)"
+    create_native_prep_service_file > "$prep_service_file"
+    create_native_service_file "${available_mounts[@]}" > "$service_file"
+    create_native_timer_file > "$timer_file"
+
+    virtctl scp "${ssh_opts[@]}" \
+        "$prep_service_file" \
+        "${SSH_USER}@vmi/${vm_name}:/tmp/roxagent-prep.service"
+    virtctl scp "${ssh_opts[@]}" \
+        "$service_file" \
+        "${SSH_USER}@vmi/${vm_name}:/tmp/roxagent.service"
+    virtctl scp "${ssh_opts[@]}" \
+        "$timer_file" \
+        "${SSH_USER}@vmi/${vm_name}:/tmp/roxagent.timer"
+    rm -f "$prep_service_file" "$service_file" "$timer_file"
+
+    virtctl ssh "${ssh_opts[@]}" \
+        --command 'set -e
+sudo install -m 0755 /tmp/roxagent /usr/local/bin/roxagent
+sudo restorecon -v /usr/local/bin/roxagent 2>/dev/null || true
+rm -f /tmp/roxagent
+sudo cp /tmp/roxagent-prep.service /etc/systemd/system/roxagent-prep.service
+sudo cp /tmp/roxagent.service /etc/systemd/system/roxagent.service
+sudo cp /tmp/roxagent.timer /etc/systemd/system/roxagent.timer
+sudo restorecon -Rv /etc/systemd/system/roxagent-prep.service /etc/systemd/system/roxagent.service /etc/systemd/system/roxagent.timer 2>/dev/null || true
+sudo systemctl daemon-reload
+sudo systemctl enable --now roxagent.timer
+echo "NATIVE_INSTALL_OK"' \
+        "${SSH_USER}@vmi/${vm_name}"
+
+    echo "  Installed on $vm_name."
+    echo "  Verifying agent status on $vm_name..."
+    virtctl ssh "${ssh_opts[@]}" \
+        --command 'sudo systemctl start roxagent.service; echo "---"; sudo systemctl status roxagent.timer --no-pager; echo "---"; sudo journalctl -u roxagent.service --no-pager -n 20' \
+        "${SSH_USER}@vmi/${vm_name}" || true
+}
+
+install_agent_native() {
+    local vm_names=("$@")
+
+    local binary_path
+    binary_path="$(build_agent)"
+
+    for vm in "${vm_names[@]}"; do
+        install_on_vm "$vm" "$binary_path"
+    done
+
+    rm -f "$binary_path"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [[ $# -eq 0 ]]; then
+        echo "Usage: $0 <vm-name> [vm-name...]" >&2
+        exit 1
+    fi
+    install_agent_native "$@"
+fi

--- a/scripts/ci/add-vms/install-virt-operator.sh
+++ b/scripts/ci/add-vms/install-virt-operator.sh
@@ -4,6 +4,7 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OLM_NAMESPACE="openshift-cnv"
 HCO_NAME="kubevirt-hyperconverged"
 SUBSCRIPTION_NAME="kubevirt-hyperconverged"
@@ -43,33 +44,7 @@ install_virt_operator() {
     fi
 
     echo "Installing namespace, OperatorGroup, and Subscription..."
-    kubectl apply -f - <<'EOF'
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-cnv
----
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: openshift-cnv
-  namespace: openshift-cnv
-spec:
-  targetNamespaces:
-  - openshift-cnv
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: kubevirt-hyperconverged
-  namespace: openshift-cnv
-spec:
-  channel: stable
-  name: kubevirt-hyperconverged
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
-  installPlanApproval: Automatic
-EOF
+    kubectl apply -f "$SCRIPT_DIR/manifests/cnv-subscription.yaml"
 
     # Wait for installedCSV (up to 5 min)
     echo "Waiting for Subscription to report installedCSV..."

--- a/scripts/ci/add-vms/install-virt-operator.sh
+++ b/scripts/ci/add-vms/install-virt-operator.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Install OpenShift Virtualization (HyperConverged) operator.
+# Idempotent: skips if HCO is already healthy.
+
+set -euo pipefail
+
+OLM_NAMESPACE="openshift-cnv"
+HCO_NAME="kubevirt-hyperconverged"
+SUBSCRIPTION_NAME="kubevirt-hyperconverged"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+hco_condition() {
+    local cond="$1"
+    kubectl -n "$OLM_NAMESPACE" get hyperconverged "$HCO_NAME" \
+        -o jsonpath="{.status.conditions[?(@.type==\"${cond}\")].status}" 2>/dev/null || echo "Unknown"
+}
+
+hco_is_healthy() {
+    local avail prog degr
+    avail="$(hco_condition Available)"
+    prog="$(hco_condition Progressing)"
+    degr="$(hco_condition Degraded)"
+    [[ "$avail" == "True" && "$prog" == "False" && "$degr" == "False" ]]
+}
+
+wait_for_virt_handler_rollout() {
+    echo "Waiting for virt-handler rollout..."
+    kubectl rollout status ds/virt-handler -n "$OLM_NAMESPACE" --timeout=600s \
+        || die "virt-handler did not roll out successfully"
+}
+
+install_virt_operator() {
+    echo "=== OpenShift Virtualization Installer ==="
+
+    command -v kubectl &>/dev/null || die "kubectl is not installed"
+    kubectl cluster-info &>/dev/null || die "Cannot connect to Kubernetes cluster"
+
+    # Idempotent: skip if already healthy
+    if kubectl get hyperconverged "$HCO_NAME" -n "$OLM_NAMESPACE" &>/dev/null && hco_is_healthy; then
+        echo "OpenShift Virtualization is already installed and healthy — skipping."
+        return 0
+    fi
+
+    echo "Installing namespace, OperatorGroup, and Subscription..."
+    kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cnv
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-cnv
+  namespace: openshift-cnv
+spec:
+  targetNamespaces:
+  - openshift-cnv
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+  channel: stable
+  name: kubevirt-hyperconverged
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+EOF
+
+    # Wait for installedCSV (up to 5 min)
+    echo "Waiting for Subscription to report installedCSV..."
+    local elapsed=0
+    until kubectl -n "$OLM_NAMESPACE" get sub "$SUBSCRIPTION_NAME" \
+            -o jsonpath='{.status.installedCSV}' 2>/dev/null | grep -q .; do
+        sleep 5; elapsed=$((elapsed + 5))
+        if (( elapsed >= 300 )); then
+            die "Timeout waiting for installedCSV after ${elapsed}s"
+        fi
+        (( elapsed % 30 == 0 )) && echo "  Still waiting... (${elapsed}s)"
+    done
+
+    local csv
+    csv="$(kubectl -n "$OLM_NAMESPACE" get sub "$SUBSCRIPTION_NAME" -o jsonpath='{.status.installedCSV}')"
+    echo "InstalledCSV: $csv"
+
+    # Wait for CSV to reach Succeeded (up to 15 min)
+    echo "Waiting for CSV to reach Succeeded..."
+    elapsed=0
+    while true; do
+        local phase
+        phase="$(kubectl -n "$OLM_NAMESPACE" get csv "$csv" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+        if [[ "$phase" == "Succeeded" ]]; then
+            echo "CSV is Succeeded"
+            break
+        fi
+        sleep 5; elapsed=$((elapsed + 5))
+        if (( elapsed >= 900 )); then
+            die "CSV did not reach Succeeded after ${elapsed}s (current: ${phase:-Unknown})"
+        fi
+        (( elapsed % 60 == 0 )) && echo "  CSV phase: ${phase:-Unknown} (${elapsed}s)"
+    done
+
+    # Create HyperConverged CR (without VSOCK initially — added separately if needed)
+    echo "Creating HyperConverged CR..."
+    kubectl apply -f - <<EOF
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: ${HCO_NAME}
+  namespace: ${OLM_NAMESPACE}
+spec: {}
+EOF
+
+    # Wait for HCO healthy (up to 30 min)
+    echo "Waiting for HyperConverged to become healthy..."
+    elapsed=0
+    while true; do
+        if hco_is_healthy; then
+            echo "HyperConverged is healthy"
+            break
+        fi
+        sleep 10; elapsed=$((elapsed + 10))
+        if (( elapsed >= 1800 )); then
+            die "Timeout waiting for HCO to become healthy after ${elapsed}s"
+        fi
+        if (( elapsed % 60 == 0 )); then
+            echo "  Status: Available=$(hco_condition Available), Progressing=$(hco_condition Progressing), Degraded=$(hco_condition Degraded) (${elapsed}s)"
+        fi
+    done
+
+    # Enable VSOCK feature gate if not already present (check KubeVirt CR, patch via HCO annotation)
+    local kv_gates
+    kv_gates="$(kubectl get kubevirt -n "$OLM_NAMESPACE" \
+        -o jsonpath='{.items[0].spec.configuration.developerConfiguration.featureGates}' 2>/dev/null || true)"
+    if [[ "$kv_gates" != *"VSOCK"* ]]; then
+        echo "Annotating HyperConverged CR to add VSOCK feature gate..."
+        local vsock_patch='[{"op":"add","path":"/spec/configuration/developerConfiguration/featureGates/-","value":"VSOCK"}]'
+        kubectl annotate hyperconverged "$HCO_NAME" -n "$OLM_NAMESPACE" --overwrite \
+            "kubevirt.kubevirt.io/jsonpatch=${vsock_patch}"
+
+        echo "Waiting for VSOCK to appear in KubeVirt CR feature gates..."
+        local vsock_elapsed=0
+        while (( vsock_elapsed < 300 )); do
+            kv_gates="$(kubectl get kubevirt -n "$OLM_NAMESPACE" \
+                -o jsonpath='{.items[0].spec.configuration.developerConfiguration.featureGates}' 2>/dev/null || true)"
+            if [[ "$kv_gates" == *"VSOCK"* ]]; then
+                echo "VSOCK feature gate is active."
+                break
+            fi
+            sleep 5; vsock_elapsed=$((vsock_elapsed + 5))
+            (( vsock_elapsed % 30 == 0 )) && echo "  Still waiting for VSOCK... (${vsock_elapsed}s)"
+        done
+        if [[ "$kv_gates" != *"VSOCK"* ]]; then
+            die "KubeVirt CR still missing VSOCK after ${vsock_elapsed}s"
+        fi
+    else
+        echo "VSOCK feature gate already enabled."
+    fi
+    wait_for_virt_handler_rollout
+
+    # Patch subscription with KVM_EMULATION
+    local current_kvm
+    current_kvm="$(kubectl get subscription "$SUBSCRIPTION_NAME" -n "$OLM_NAMESPACE" \
+        -o jsonpath='{.spec.config.env[?(@.name=="KVM_EMULATION")].value}' 2>/dev/null || echo "")"
+    if [[ "$current_kvm" != "true" ]]; then
+        echo "Patching subscription with KVM_EMULATION=true..."
+        # Ensure spec.config.env exists, then add the entry without clobbering other env vars
+        kubectl get subscription "$SUBSCRIPTION_NAME" -n "$OLM_NAMESPACE" -o json \
+            | jq '.spec.config.env = ((.spec.config.env // []) | map(select(.name != "KVM_EMULATION")) + [{"name":"KVM_EMULATION","value":"true"}])
+                 | .spec.config.selector = {"matchLabels":{"name":"hyperconverged-cluster-operator"}}' \
+            | kubectl apply -f -
+    else
+        echo "KVM_EMULATION already set."
+    fi
+
+    echo "=== OpenShift Virtualization installed successfully ==="
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    install_virt_operator
+fi

--- a/scripts/ci/add-vms/install-virt-operator.sh
+++ b/scripts/ci/add-vms/install-virt-operator.sh
@@ -48,15 +48,10 @@ install_virt_operator() {
 
     # Wait for installedCSV (up to 5 min)
     echo "Waiting for Subscription to report installedCSV..."
-    local elapsed=0
-    until kubectl -n "$OLM_NAMESPACE" get sub "$SUBSCRIPTION_NAME" \
-            -o jsonpath='{.status.installedCSV}' 2>/dev/null | grep -q .; do
-        sleep 5; elapsed=$((elapsed + 5))
-        if (( elapsed >= 300 )); then
-            die "Timeout waiting for installedCSV after ${elapsed}s"
-        fi
-        (( elapsed % 30 == 0 )) && echo "  Still waiting... (${elapsed}s)"
-    done
+    if ! kubectl wait -n "$OLM_NAMESPACE" "sub/$SUBSCRIPTION_NAME" \
+            --for=jsonpath='{.status.installedCSV}' --timeout=300s 2>/dev/null; then
+        die "Timeout waiting for installedCSV after 300s"
+    fi
 
     local csv
     csv="$(kubectl -n "$OLM_NAMESPACE" get sub "$SUBSCRIPTION_NAME" -o jsonpath='{.status.installedCSV}')"
@@ -64,20 +59,13 @@ install_virt_operator() {
 
     # Wait for CSV to reach Succeeded (up to 15 min)
     echo "Waiting for CSV to reach Succeeded..."
-    elapsed=0
-    while true; do
+    if ! kubectl wait -n "$OLM_NAMESPACE" "csv/$csv" \
+            --for=jsonpath='{.status.phase}'=Succeeded --timeout=900s 2>/dev/null; then
         local phase
         phase="$(kubectl -n "$OLM_NAMESPACE" get csv "$csv" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
-        if [[ "$phase" == "Succeeded" ]]; then
-            echo "CSV is Succeeded"
-            break
-        fi
-        sleep 5; elapsed=$((elapsed + 5))
-        if (( elapsed >= 900 )); then
-            die "CSV did not reach Succeeded after ${elapsed}s (current: ${phase:-Unknown})"
-        fi
-        (( elapsed % 60 == 0 )) && echo "  CSV phase: ${phase:-Unknown} (${elapsed}s)"
-    done
+        die "CSV did not reach Succeeded after 900s (current: ${phase:-Unknown})"
+    fi
+    echo "CSV is Succeeded"
 
     # Create HyperConverged CR (without VSOCK initially — added separately if needed)
     echo "Creating HyperConverged CR..."
@@ -91,8 +79,11 @@ spec: {}
 EOF
 
     # Wait for HCO healthy (up to 30 min)
+    # Not using kubectl wait: health requires three conditions simultaneously
+    # (Available=True, Progressing=False, Degraded=False) and we print all
+    # three every 60s to diagnose stalls during the long bootstrap window.
     echo "Waiting for HyperConverged to become healthy..."
-    elapsed=0
+    local elapsed=0
     while true; do
         if hco_is_healthy; then
             echo "HyperConverged is healthy"
@@ -117,6 +108,8 @@ EOF
         kubectl annotate hyperconverged "$HCO_NAME" -n "$OLM_NAMESPACE" --overwrite \
             "kubevirt.kubevirt.io/jsonpatch=${vsock_patch}"
 
+        # Not using kubectl wait: the condition is substring containment within
+        # an array field, which kubectl wait --for=jsonpath cannot express.
         echo "Waiting for VSOCK to appear in KubeVirt CR feature gates..."
         local vsock_elapsed=0
         while (( vsock_elapsed < 300 )); do

--- a/scripts/ci/add-vms/manifests/cnv-subscription.yaml
+++ b/scripts/ci/add-vms/manifests/cnv-subscription.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cnv
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-cnv
+  namespace: openshift-cnv
+spec:
+  targetNamespaces:
+  - openshift-cnv
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+  channel: stable
+  name: kubevirt-hyperconverged
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/scripts/ci/add-vms/systemd/roxagent-prep.service
+++ b/scripts/ci/add-vms/systemd/roxagent-prep.service
@@ -5,10 +5,10 @@ Description=Prepare native StackRox VM Agent inputs
 Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=/bin/rm -rf /tmp/roxroot
-ExecStartPre=/bin/mkdir -p /tmp/roxroot/etc/pki /tmp/roxroot/etc/pki/entitlement
+ExecStartPre=/bin/mkdir -p /tmp/roxroot/etc/pki/entitlement
 ExecStartPre=/bin/mkdir -p /tmp/roxroot/etc/yum.repos.d /tmp/roxroot/etc/yum/repos.d /tmp/roxroot/etc/distro.repos.d
-ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/lib /tmp/roxroot/var/lib/dnf
-ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/cache /tmp/roxroot/var/cache/dnf
+ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/lib/dnf
+ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/cache/dnf
 ExecStartPre=/bin/mkdir -p /run/lock/roxagent
 ExecStartPre=/bin/touch /tmp/roxroot/etc/os-release /tmp/roxroot/etc/redhat-release /tmp/roxroot/etc/system-release-cpe
 

--- a/scripts/ci/add-vms/systemd/roxagent-prep.service
+++ b/scripts/ci/add-vms/systemd/roxagent-prep.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Prepare native StackRox VM Agent inputs
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/bin/rm -rf /tmp/roxroot
+ExecStartPre=/bin/mkdir -p /tmp/roxroot/etc/pki /tmp/roxroot/etc/pki/entitlement
+ExecStartPre=/bin/mkdir -p /tmp/roxroot/etc/yum.repos.d /tmp/roxroot/etc/yum/repos.d /tmp/roxroot/etc/distro.repos.d
+ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/lib /tmp/roxroot/var/lib/dnf
+ExecStartPre=/bin/mkdir -p /tmp/roxroot/var/cache /tmp/roxroot/var/cache/dnf
+ExecStartPre=/bin/mkdir -p /run/lock/roxagent
+ExecStartPre=/bin/touch /tmp/roxroot/etc/os-release /tmp/roxroot/etc/redhat-release /tmp/roxroot/etc/system-release-cpe
+
+ExecStart=/bin/rm -rf /tmp/roxagent-rpm
+ExecStart=/bin/cp -a /var/lib/rpm /tmp/roxagent-rpm
+ExecStart=/bin/chmod -R 755 /tmp/roxagent-rpm

--- a/scripts/ci/add-vms/systemd/roxagent.timer
+++ b/scripts/ci/add-vms/systemd/roxagent.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run StackRox VM Agent periodically
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=3h40m
+RandomizedDelaySec=40min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow and supporting shell scripts to provision RHEL VMs on an existing OCP cluster and install the native roxagent on them.

This PR is now the native-only base of the stack:
- installs OpenShift Virtualization when needed and waits for required rollout
- deploys or adopts RHEL VMs and configures automation SSH access
- installs roxagent natively and mounts a curated `/tmp/roxroot` view for scanning
- exposes a `workflow_dispatch` action for running the flow from GitHub Actions

⚠️ Some parts of the shell scripts are duplicated from `compliance/virtualmachines/roxagent/quadlet/install.sh` to make the action self-contained (in case we would like to move it outside of the repo some day). 

### Follow-ups

- Quadlet support #21089 
- Do not compile `roxagent` on the fly

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

#### Running the action:

Adding new VM to an existing cluster with another VM (cluster has KVM and virt operator installed already)

```
gh workflow run add-vms-to-cluster.yml \
    --ref piotr/ROX-35008-action-add-VMs \
    -f cluster-name=pr-06-08-vm \
    -f num-vms=1 \
    -f vm-os=rhel10
```
Logs: https://github.com/stackrox/stackrox/actions/runs/27331925416


Adding to a totally fresh cluster (no ACS):
```
➜ gh workflow run add-vms-to-cluster.yml \
    --ref piotr/ROX-35008-action-add-VMs \
    -f cluster-name=pr-06-11-action1 \
    -f num-vms=1 \
    -f vm-os=rhel10 
```

Logs: https://github.com/stackrox/stackrox/actions/runs/27337049006 (action was ✅  but roxagent had a tiny failure - wrong binary was uploaded)
Logs for rerun (to overwrite the roxagent): https://github.com/stackrox/stackrox/actions/runs/27338863169/job/80770148617#logs

Creating 3 VMs (one already existing, 2 new VMs): https://github.com/stackrox/stackrox/actions/runs/27417112604 (only 2 VMs fit onto the cluster, 3rd could not have been scheduled).

Tested situation in which there are not enough resources for all requested VMs:

```
=== Waiting for VMs ===
  Waiting for VMI rhel10-1 to be ready...
    Still waiting for VMI... (3/20)
    --- VMI diagnostic for rhel10-1 ---
    Status: Scheduling
    Conditions: Ready PodScheduled=False False
    Pod: virt-launcher-rhel10-1-5nn4t
    LAST SEEN   TYPE      REASON             OBJECT                             MESSAGE
    23m         Warning   FailedScheduling   pod/virt-launcher-rhel10-1-5nn4t   0/6 nodes are available: 3 Insufficient devices.kubevirt.io/kvm, 3 node(s) had untolerated taint(s). no new claims to deallocate, preemption: 0/6 nodes are available: 6 Preemption is not helpful for scheduling.
```
https://github.com/stackrox/stackrox/actions/runs/27555917336/job/81454768087

#### Manually by running the bash scripts:
    
1. Creating a new VM on existing cluster
2. Taking over an existing VM (created before manually) and updating roxagent

```
QUAY_RHACS_ENG_RO_USERNAME=user QUAY_RHACS_ENG_RO_PASSWORD=xxx \
    scripts/ci/add-vms/add-vms.sh \
        --num-vms 1 \
        --os rhel10 \
        --ssh-key ~/.ssh/id_ed25519.pub
```
