### PR TITLE
test(collector): drop privileged: true for reduced capabilities

### DIFF
--- a/image/templates/helm/stackrox-secured-cluster/templates/collector-pod-security.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector-pod-security.yaml
@@ -46,10 +46,15 @@ metadata:
   annotations:
     {{- include "srox.annotations" (list . "podsecuritypolicy" "stackrox-collector") | nindent 4 }}
 spec:
-  privileged: true
-  allowPrivilegeEscalation: true
+  privileged: false
+  allowPrivilegeEscalation: false
   allowedCapabilities:
-    - '*'
+    - BPF
+    - PERFMON
+    - SYS_PTRACE
+    - SYS_RESOURCE
+  requiredDropCapabilities:
+    - ALL
   volumes:
     - '*'
   allowedHostPaths:
@@ -57,7 +62,7 @@ spec:
       readOnly: true
   hostNetwork: false
   hostIPC: false
-  hostPID: true
+  hostPID: false
   runAsUser:
     rule: 'RunAsAny'
   seLinux:

--- a/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
+++ b/image/templates/helm/stackrox-secured-cluster/templates/collector.yaml.htpl
@@ -72,11 +72,17 @@ spec:
         resources:
           {{- ._rox.collector._resources | nindent 10 }}
         securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
-            - NET_RAW
-          privileged: true
-          readOnlyRootFilesystem: true
+            - ALL
+            add:
+            - BPF
+            - PERFMON
+            - SYS_PTRACE
+            - SYS_RESOURCE
         volumeMounts:
         - mountPath: /host/proc
           name: proc-ro
@@ -133,11 +139,17 @@ spec:
         resources:
           {{- ._rox.collector._famResources | nindent 10 }}
         securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
-            - NET_RAW
-          privileged: true
-          readOnlyRootFilesystem: true
+            - ALL
+            add:
+            - BPF
+            - PERFMON
+            - SYS_PTRACE
+            - SYS_RESOURCE
         volumeMounts:
         - mountPath: /sys
           name: sys-ro
@@ -212,6 +224,7 @@ spec:
           {{- ._rox.collector._complianceResources | nindent 10 }}
         securityContext:
           runAsUser: 0
+          allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           {{ if not ._rox.collector.disableSELinuxOptions }}
           seLinuxOptions:


### PR DESCRIPTION
## Description

### Test finer grain privilege setting on collector and fact containers leveraging newer Linux caps

Replace the blanket `privileged: true` security context on the collector and fact containers with a minimal Linux capability set required for CORE_BPF collection on kernel >= 5.8 (RHEL 9 / OCP 4.12+):

- `CAP_BPF` — load eBPF programs and maps
- `CAP_PERFMON` — attach programs to tracepoints/kprobes
- `CAP_SYS_PTRACE` — read restricted `/proc/<pid>/` entries via the `/host/proc` hostPath mount
- `CAP_SYS_RESOURCE` — raise `RLIMIT_MEMLOCK` for BPF maps

Also adds `allowPrivilegeEscalation: false` to the collector, fact, and compliance containers, and tightens the legacy PSP to match (removing `hostPID: true` and `allowedCapabilities: ['*']`).

**Scope:** collector and fact containers only. node-inventory stays `privileged: true` (separate workstream). The OpenShift SCC annotation is intentionally left pointing at the built-in `privileged` SCC while this is validated on live clusters — the SCC replacement is a follow-up.

**Kernel requirement:** RHEL 8 is out of scope. `CAP_BPF` and `CAP_PERFMON` are available on all supported platforms (kernel >= 5.8).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

This is a proof-of-concept for validation. Testing approach:

- Deploy to a RHEL 9 / OCP 4.14+ cluster with the modified chart
- Verify BPF programs load successfully at collector startup
- Run collection validation E2E tests to confirm syscall events are generated
- Validate the fact/FAM container starts cleanly under the new security context