### PR TITLE
fix(tests): fail CI when Gradle produces no test results

### DIFF
--- a/qa-tests-backend/scripts/run-compatibility.sh
+++ b/qa-tests-backend/scripts/run-compatibility.sh
@@ -83,6 +83,11 @@ _compatibility_test() {
 
     make -C qa-tests-backend compatibility-test || touch FAIL
 
+    if ! find qa-tests-backend/build/test-results -name '*.xml' -print -quit 2>/dev/null | grep -q .; then
+        info "ERROR: No test results (JUnit XML) produced. Gradle may have skipped tests (NO-SOURCE)."
+        touch FAIL
+    fi
+
     update_junit_prefix_with_central_and_sensor_version "${short_central_tag}" "${short_sensor_tag}" "${ROOT}/qa-tests-backend/build/test-results/testCOMPATIBILITY"
 
     store_qa_test_results "compatibility-test-central-v${short_central_tag}-sensor-v${short_sensor_tag}"

--- a/qa-tests-backend/scripts/run-custom-pz.sh
+++ b/qa-tests-backend/scripts/run-custom-pz.sh
@@ -97,6 +97,11 @@ test_custom() {
 
     make -C qa-tests-backend "${test_target}" || touch FAIL
 
+    if ! find qa-tests-backend/build/test-results -name '*.xml' -print -quit 2>/dev/null | grep -q .; then
+        info "ERROR: No test results (JUnit XML) produced. Gradle may have skipped tests (NO-SOURCE)."
+        touch FAIL
+    fi
+
     store_qa_test_results "pz-tests"
     [[ ! -f FAIL ]] || die "PZ tests failed"
 }

--- a/qa-tests-backend/scripts/run-part-1.sh
+++ b/qa-tests-backend/scripts/run-part-1.sh
@@ -180,6 +180,11 @@ test_part_1() {
 
     make -C qa-tests-backend "${test_target}" || touch FAIL
 
+    if ! find qa-tests-backend/build/test-results -name '*.xml' -print -quit 2>/dev/null | grep -q .; then
+        info "ERROR: No test results (JUnit XML) produced. Gradle may have skipped tests (NO-SOURCE)."
+        touch FAIL
+    fi
+
     cleanup_workload_identities
     store_qa_test_results "part-1-tests"
     [[ ! -f FAIL ]] || die "Part 1 tests failed"

--- a/qa-tests-backend/scripts/run-part-2.sh
+++ b/qa-tests-backend/scripts/run-part-2.sh
@@ -25,6 +25,11 @@ run_tests_part_2() {
 
     make -C qa-tests-backend sensor-bounce-test || touch FAIL
 
+    if ! find qa-tests-backend/build/test-results -name '*.xml' -print -quit 2>/dev/null | grep -q .; then
+        info "ERROR: No test results (JUnit XML) produced. Gradle may have skipped tests (NO-SOURCE)."
+        touch FAIL
+    fi
+
     store_qa_test_results "part-2-tests"
     [[ ! -f FAIL ]] || die "Part 2 tests failed"
 }


### PR DESCRIPTION
## Description

Gradle 9 silently skips test tasks (`NO-SOURCE`) and exits 0 when `testClassesDirs` isn't wired to registered `Test` tasks. This went undetected for 16 consecutive master commits after the Gradle 9 upgrade (#20295) because the job reported `SUCCESS` despite running zero Groovy tests.

The root cause was fixed in #20429 (`testClassesDirs`/`classpath` wiring), but there was no defense-in-depth to catch a recurrence. This PR adds a post-`make` guard in all four CI test runner scripts that checks for JUnit XML output after the Gradle invocation. If no XML files exist, the job fails with a clear error instead of silently passing.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] modified existing tests

### How I validated my change

Verified locally with Gradle 9.5.1:

1. **With `testClassesDirs` fix in place**: `./gradlew testDeploymentCheck` runs tests, produces `build/test-results/testDeploymentCheck/TEST-DeploymentCheck.xml`. Guard passes.
2. **With `testClassesDirs` fix removed**: `./gradlew testDeploymentCheck` reports `NO-SOURCE`, exits 0, produces no XML. Guard correctly fails with: `ERROR: No test results (JUnit XML) produced. Gradle may have skipped tests (NO-SOURCE).`

Also verified against 30 Prow CI runs on master that the duration/result pattern matches exactly: all 16 pre-fix runs showed `NO-SOURCE` (43-84 min, `SUCCESS`), all 9 post-fix runs executed tests (135-152 min).