### PR TITLE
ROX-32873: Collect metrics when process indicators are not persisted

### DIFF
--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -247,12 +247,13 @@ func (m *managerImpl) flushIndicatorQueue() {
 
 	defer centralMetrics.SetFunctionSegmentDuration(time.Now(), "FlushingIndicatorQueue")
 
-	// Map copiedQueue to slice
 	indicatorSlice := make([]*storage.ProcessIndicator, 0, len(copiedQueue))
 	for _, indicator := range copiedQueue {
 		if m.deletedDeploymentsCache.Contains(indicator.GetDeploymentId()) {
 			continue
 		}
+
+		metrics.RecordProcessIndicatorReceived(indicator)
 
 		match, err := m.clusterDataStore.MatchProcessIndicator(lifecycleMgrCtx, indicator)
 

--- a/central/detection/lifecycle/metrics/metrics.go
+++ b/central/detection/lifecycle/metrics/metrics.go
@@ -11,11 +11,11 @@ func init() {
 	prometheus.MustRegister(
 		processFilterCounter,
 		processIndicatorsNotPersisted,
-		processUpsertedArgsSizeHistogram,
-		processUpsertedArgsSizeTotal,
-		processUpsertedCount,
-		processUpsertedLineageSizeHistogram,
-		processUpsertedLineageSizeTotal,
+		processReceivedArgsSizeHistogram,
+		processReceivedArgsSizeTotal,
+		processReceivedCount,
+		processReceivedLineageSizeHistogram,
+		processReceivedLineageSizeTotal,
 	)
 }
 
@@ -34,41 +34,41 @@ var (
 		Help:      "Number of process indicators filtered out and not persisted",
 	})
 
-	processUpsertedArgsSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+	processReceivedArgsSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: pkgMetrics.PrometheusNamespace,
 		Subsystem: pkgMetrics.CentralSubsystem.String(),
-		Name:      "process_upserted_args_size",
-		Help:      "Distribution of process argument sizes in bytes for upserted indicators",
+		Name:      "process_received_args_size",
+		Help:      "Distribution of process argument sizes in bytes for received indicators",
 		Buckets:   []float64{0, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
 	})
 
-	processUpsertedArgsSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	processReceivedArgsSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: pkgMetrics.PrometheusNamespace,
 		Subsystem: pkgMetrics.CentralSubsystem.String(),
-		Name:      "process_upserted_args_size_total",
-		Help:      "Total upserted process argument sizes in bytes by cluster and namespace",
+		Name:      "process_received_args_size_total",
+		Help:      "Total received process argument sizes in bytes by cluster and namespace",
 	}, []string{"cluster", "namespace"})
 
-	processUpsertedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+	processReceivedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: pkgMetrics.PrometheusNamespace,
 		Subsystem: pkgMetrics.CentralSubsystem.String(),
-		Name:      "process_upserted_count",
-		Help:      "Number of process indicators upserted by cluster and namespace",
+		Name:      "process_received_count",
+		Help:      "Number of process indicators received by cluster and namespace",
 	}, []string{"cluster", "namespace"})
 
-	processUpsertedLineageSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+	processReceivedLineageSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: pkgMetrics.PrometheusNamespace,
 		Subsystem: pkgMetrics.CentralSubsystem.String(),
-		Name:      "process_upserted_lineage_size",
-		Help:      "Distribution of process lineage sizes in bytes for upserted indicators",
+		Name:      "process_received_lineage_size",
+		Help:      "Distribution of process lineage sizes in bytes for received indicators",
 		Buckets:   []float64{0, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
 	})
 
-	processUpsertedLineageSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	processReceivedLineageSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: pkgMetrics.PrometheusNamespace,
 		Subsystem: pkgMetrics.CentralSubsystem.String(),
-		Name:      "process_upserted_lineage_size_total",
-		Help:      "Total upserted process lineage sizes in bytes by cluster and namespace",
+		Name:      "process_received_lineage_size_total",
+		Help:      "Total received process lineage sizes in bytes by cluster and namespace",
 	}, []string{"cluster", "namespace"})
 )
 
@@ -117,9 +117,9 @@ func RecordProcessIndicatorReceived(indicator *storage.ProcessIndicator) {
 	clusterID := indicator.GetClusterId()
 	namespace := indicator.GetNamespace()
 
-	processUpsertedArgsSizeHistogram.Observe(float64(argsSizeBytes))
-	processUpsertedArgsSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(argsSizeBytes))
-	processUpsertedCount.WithLabelValues(clusterID, namespace).Inc()
-	processUpsertedLineageSizeHistogram.Observe(float64(lineageSizeBytes))
-	processUpsertedLineageSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(lineageSizeBytes))
+	processReceivedArgsSizeHistogram.Observe(float64(argsSizeBytes))
+	processReceivedArgsSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(argsSizeBytes))
+	processReceivedCount.WithLabelValues(clusterID, namespace).Inc()
+	processReceivedLineageSizeHistogram.Observe(float64(lineageSizeBytes))
+	processReceivedLineageSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(lineageSizeBytes))
 }

--- a/central/detection/lifecycle/metrics/metrics.go
+++ b/central/detection/lifecycle/metrics/metrics.go
@@ -2,30 +2,74 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stackrox/rox/pkg/metrics"
+	pkgMetrics "github.com/stackrox/rox/pkg/metrics"
+
+	"github.com/stackrox/rox/generated/storage"
 )
 
 func init() {
 	prometheus.MustRegister(
 		processFilterCounter,
 		processIndicatorsNotPersisted,
+		processUpsertedArgsSizeHistogram,
+		processUpsertedArgsSizeTotal,
+		processUpsertedCount,
+		processUpsertedLineageSizeHistogram,
+		processUpsertedLineageSizeTotal,
 	)
 }
 
 var (
 	processFilterCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.CentralSubsystem.String(),
+		Namespace: pkgMetrics.PrometheusNamespace,
+		Subsystem: pkgMetrics.CentralSubsystem.String(),
 		Name:      "process_filter",
 		Help:      "Process filter hits and misses",
 	}, []string{"Type"})
 
 	processIndicatorsNotPersisted = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.CentralSubsystem.String(),
+		Namespace: pkgMetrics.PrometheusNamespace,
+		Subsystem: pkgMetrics.CentralSubsystem.String(),
 		Name:      "process_indicators_not_persisted",
 		Help:      "Number of process indicators filtered out and not persisted",
 	})
+
+	processUpsertedArgsSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: pkgMetrics.PrometheusNamespace,
+		Subsystem: pkgMetrics.CentralSubsystem.String(),
+		Name:      "process_upserted_args_size",
+		Help:      "Distribution of process argument sizes in bytes for upserted indicators",
+		Buckets:   []float64{0, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
+	})
+
+	processUpsertedArgsSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: pkgMetrics.PrometheusNamespace,
+		Subsystem: pkgMetrics.CentralSubsystem.String(),
+		Name:      "process_upserted_args_size_total",
+		Help:      "Total upserted process argument sizes in bytes by cluster and namespace",
+	}, []string{"cluster", "namespace"})
+
+	processUpsertedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: pkgMetrics.PrometheusNamespace,
+		Subsystem: pkgMetrics.CentralSubsystem.String(),
+		Name:      "process_upserted_count",
+		Help:      "Number of process indicators upserted by cluster and namespace",
+	}, []string{"cluster", "namespace"})
+
+	processUpsertedLineageSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: pkgMetrics.PrometheusNamespace,
+		Subsystem: pkgMetrics.CentralSubsystem.String(),
+		Name:      "process_upserted_lineage_size",
+		Help:      "Distribution of process lineage sizes in bytes for upserted indicators",
+		Buckets:   []float64{0, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
+	})
+
+	processUpsertedLineageSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: pkgMetrics.PrometheusNamespace,
+		Subsystem: pkgMetrics.CentralSubsystem.String(),
+		Name:      "process_upserted_lineage_size_total",
+		Help:      "Total upserted process lineage sizes in bytes by cluster and namespace",
+	}, []string{"cluster", "namespace"})
 )
 
 // ProcessFilterCounterInc increments a counter for determining how effective the process filter is
@@ -36,4 +80,46 @@ func ProcessFilterCounterInc(typ string) {
 // ProcessIndicatorsNotPersistedInc increments the counter for process indicators filtered out and not persisted.
 func ProcessIndicatorsNotPersistedInc() {
 	processIndicatorsNotPersisted.Inc()
+}
+
+func getProcessArgsSizeBytes(indicator *storage.ProcessIndicator) int {
+	if indicator == nil || indicator.GetSignal() == nil {
+		return 0
+	}
+	return len(indicator.GetSignal().GetArgs())
+}
+
+func getProcessLineageSizeBytes(indicator *storage.ProcessIndicator) int {
+	if indicator == nil || indicator.GetSignal() == nil {
+		return 0
+	}
+
+	lineageInfo := indicator.GetSignal().GetLineageInfo()
+	if len(lineageInfo) == 0 {
+		return 0
+	}
+
+	totalBytes := 0
+	for _, info := range lineageInfo {
+		if info != nil {
+			totalBytes += len(info.GetParentExecFilePath())
+		}
+	}
+
+	return totalBytes
+}
+
+// RecordProcessIndicatorReceived records metrics for a single process indicator
+// received by Central, regardless of whether it is persisted.
+func RecordProcessIndicatorReceived(indicator *storage.ProcessIndicator) {
+	argsSizeBytes := getProcessArgsSizeBytes(indicator)
+	lineageSizeBytes := getProcessLineageSizeBytes(indicator)
+	clusterID := indicator.GetClusterId()
+	namespace := indicator.GetNamespace()
+
+	processUpsertedArgsSizeHistogram.Observe(float64(argsSizeBytes))
+	processUpsertedArgsSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(argsSizeBytes))
+	processUpsertedCount.WithLabelValues(clusterID, namespace).Inc()
+	processUpsertedLineageSizeHistogram.Observe(float64(lineageSizeBytes))
+	processUpsertedLineageSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(lineageSizeBytes))
 }

--- a/central/processindicator/datastore/datastore_impl.go
+++ b/central/processindicator/datastore/datastore_impl.go
@@ -102,7 +102,6 @@ func (ds *datastoreImpl) AddProcessIndicators(ctx context.Context, indicators ..
 				return err
 			}
 		} else {
-			recordProcessIndicatorsBatchAdded(identifierBatch)
 			log.Debugf("successfully added a batch of %d process indicators", len(identifierBatch))
 		}
 	}

--- a/central/processindicator/datastore/metrics.go
+++ b/central/processindicator/datastore/metrics.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/metrics"
 )
 
@@ -35,28 +34,6 @@ var (
 		Help:      "Number of times we miss the cache, and have to evaluate, when trying to prune processes",
 	})
 
-	processUpsertedArgsSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "process_upserted_args_size",
-		Help:      "Distribution of process argument sizes in bytes for upserted indicators",
-		Buckets:   []float64{0, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
-	})
-
-	processUpsertedArgsSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "process_upserted_args_size_total",
-		Help:      "Total upserted process argument sizes in bytes by cluster and namespace",
-	}, []string{"cluster", "namespace"})
-
-	processUpsertedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "process_upserted_count",
-		Help:      "Number of process indicators upserted by cluster and namespace",
-	}, []string{"cluster", "namespace"})
-
 	processIndicatorsRemoved = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metrics.PrometheusNamespace,
 		Subsystem: metrics.CentralSubsystem.String(),
@@ -70,21 +47,6 @@ var (
 		Name:      "process_indicators_removed_total",
 		Help:      "Total number of process indicators removed from the database across all reasons",
 	})
-
-	processUpsertedLineageSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "process_upserted_lineage_size",
-		Help:      "Distribution of process lineage sizes in bytes for upserted indicators",
-		Buckets:   []float64{0, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
-	})
-
-	processUpsertedLineageSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "process_upserted_lineage_size_total",
-		Help:      "Total upserted process lineage sizes in bytes by cluster and namespace",
-	}, []string{"cluster", "namespace"})
 )
 
 func recordProcessIndicatorsRemoved(num int, reason string) {
@@ -100,59 +62,11 @@ func incrementProcessPruningCacheMissesMetric() {
 	processPruningCacheMisses.Inc()
 }
 
-func getProcessArgsSizeBytes(indicator *storage.ProcessIndicator) int {
-	if indicator == nil || indicator.GetSignal() == nil {
-		return 0
-	}
-	return len(indicator.GetSignal().GetArgs())
-}
-
-func getProcessLineageSizeBytes(indicator *storage.ProcessIndicator) int {
-	if indicator == nil || indicator.GetSignal() == nil {
-		return 0
-	}
-
-	lineageInfo := indicator.GetSignal().GetLineageInfo()
-	if len(lineageInfo) == 0 {
-		return 0
-	}
-
-	totalBytes := 0
-	for _, info := range lineageInfo {
-		if info != nil {
-			totalBytes += len(info.GetParentExecFilePath())
-		}
-	}
-
-	return totalBytes
-}
-
-// recordProcessIndicatorsBatchAdded records metrics for a batch of process indicators successfully written to DB.
-func recordProcessIndicatorsBatchAdded(indicators []*storage.ProcessIndicator) {
-	for _, indicator := range indicators {
-		argsSizeBytes := getProcessArgsSizeBytes(indicator)
-		lineageSizeBytes := getProcessLineageSizeBytes(indicator)
-		clusterID := indicator.GetClusterId()
-		namespace := indicator.GetNamespace()
-
-		processUpsertedArgsSizeHistogram.Observe(float64(argsSizeBytes))
-		processUpsertedArgsSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(argsSizeBytes))
-		processUpsertedCount.WithLabelValues(clusterID, namespace).Inc()
-		processUpsertedLineageSizeHistogram.Observe(float64(lineageSizeBytes))
-		processUpsertedLineageSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(lineageSizeBytes))
-	}
-}
-
 func init() {
 	prometheus.MustRegister(
 		processPruningCacheHits,
 		processPruningCacheMisses,
-		processUpsertedArgsSizeHistogram,
-		processUpsertedArgsSizeTotal,
-		processUpsertedCount,
 		processIndicatorsRemoved,
 		processIndicatorsRemovedTotal,
-		processUpsertedLineageSizeHistogram,
-		processUpsertedLineageSizeTotal,
 	)
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Previously when process indicator persistence was disabled metrics regarding process indicators were not collected. This PR changes that. Previously the metrics were collected in the process indicator datastore and the process indicators were filtered out in the detection lifecycle manager, just before calling the process indicator datastore. Thus, metrics were only collected for persisted process indicators. This PR fixes that by moving the collection of the new process indicator metrics from the process indicator datastore to the detection lifecycle manager.

An alternative can be found https://github.com/stackrox/stackrox/pull/21154. In that case there are separate metrics for persisted and unpersisted process indicators. My recommendation is to merge the alternative in favor of this PR.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)
There was one CI failure, but it was the result of an infra error.

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Helm charts were created

```bash
#!/usr/bin/env bash
set -eou pipefail

cd ../../

tag="$(make tag)"

cd -

#repo=${1:-stackrox-io}
repo=${1:-jvirtane}

docker run --rm -v "$(pwd):/usr/src/stackrox" quay.io/$repo/roxctl:"$tag" helm output central-services --image-defaults opensource --output-dir /usr/src/stackrox/stackrox-central-services-chart-"$tag"

docker run --rm -v "$(pwd):/usr/src/stackrox" quay.io/$repo/roxctl:"$tag" helm output secured-cluster-services --image-defaults opensource --output-dir /usr/src/stackrox/stackrox-secured-cluster-chart-"$tag"
```

An openshift-4 cluster was created and the following script was run

```bash
#!/usr/bin/env bash
set -eou pipefail

ARTIFACT_DIR=$1
central1=$2
secured1=$3

./start-central.sh $ARTIFACT_DIR $central1
sleep 60
./get-bundle.sh $ARTIFACT_DIR
sleep 10
./start-secured-cluster.sh $ARTIFACT_DIR $secured1
```

```bash
set -eoux pipefail

echo "Starting central and scanner related pods"

artifacts_dir=$1
helm_charts=$2

export KUBECONFIG="$artifacts_dir"/kubeconfig
admin_password=*******

settings=(
    --namespace stackrox stackrox-central-services --create-namespace "$helm_charts"
    --set central.exposure.route.enabled=true
    --set central.adminPassword.value="$admin_password"
    --set central.persistence.none=true
)

helm install "${settings[@]}"
```

```bash
#!/usr/bin/env bash
set -eou pipefail

artifacts_dir=$1

echo "Grabing bundle"

export KUBECONFIG="$artifacts_dir/kubeconfig"
central_password=asdf
#central_password="$(cat "$artifacts_dir"/kubeadmin-password)"

rm -f perf-bundle.yml

url="$(kubectl -n stackrox get routes central -o json | jq -r '.spec.host')"
#url="$(oc -n stackrox get routes central -o json | jq -r '.spec.host')"
roxctl -e https://"$url":443 \
    -p "$central_password" --insecure-skip-tls-verify \
    central init-bundles generate perf-test \
    --output perf-bundle.yml
```

```bash
#!/usr/bin/env bash
set -eoux pipefail

artifacts_dir=$1
helm_charts=$2

echo "Starting secure cluster services"

export KUBECONFIG=$artifacts_dir/kubeconfig

settings=(
    --namespace stackrox stackrox-secured-cluster-services "$helm_charts" 
    --values perf-bundle.yml
    --set clusterName=perf-test
    --set processIndicators.noPersistence=true
)

echo "${settings[@]}"

helm install "${settings[@]}"
```

The database was checked and their were no process indicators

```
central_active=# select count(*) from process_indicators ;
 count 
-------
     0
(1 row)
```

```
# HELP rox_central_process_received_args_size Distribution of process argument sizes in bytes for received indicators
# TYPE rox_central_process_received_args_size histogram
rox_central_process_received_args_size_bucket{le="0"} 56
rox_central_process_received_args_size_bucket{le="8"} 121
rox_central_process_received_args_size_bucket{le="16"} 195
rox_central_process_received_args_size_bucket{le="32"} 409
rox_central_process_received_args_size_bucket{le="64"} 1161
rox_central_process_received_args_size_bucket{le="128"} 1598
rox_central_process_received_args_size_bucket{le="256"} 1775
rox_central_process_received_args_size_bucket{le="512"} 1850
rox_central_process_received_args_size_bucket{le="1024"} 1952
rox_central_process_received_args_size_bucket{le="2048"} 1974
rox_central_process_received_args_size_bucket{le="4096"} 1988
rox_central_process_received_args_size_bucket{le="8192"} 1988
rox_central_process_received_args_size_bucket{le="16384"} 1988
rox_central_process_received_args_size_bucket{le="32768"} 1988
rox_central_process_received_args_size_bucket{le="65536"} 1988
rox_central_process_received_args_size_bucket{le="+Inf"} 1988
rox_central_process_received_args_size_sum 279783
rox_central_process_received_args_size_count 1988
# HELP rox_central_process_received_args_size_total Total received process argument sizes in bytes by cluster and namespace
# TYPE rox_central_process_received_args_size_total counter
rox_central_process_received_args_size_total{cluster="a0c64307-eb6a-40bb-9391-b996767c5326",namespace="openshift-apiserver"} 546
rox_central_process_received_args_size_total{cluster="a0c64307-eb6a-40bb-9391-b996767c5326",namespace="openshift-apiserver-operator"} 116
rox_central_process_received_args_size_total{cluster="a0c64307-eb6a-40bb-9391-b996767c5326",namespace="openshift-authentication"} 876
rox_central_process_received_args_size_total{cluster="a0c64307-eb6a-40bb-9391-b996767c5326",namespace="openshift-authentication-operator"} 180
rox_central_process_received_args_size_total{cluster="a0c64307-eb6a-40bb-9391-b996767c5326",namespace="openshift-catalogd"} 649
rox_central_process_received_args_size_total{cluster="a0c64307-eb6a-40bb-9391-b996767c5326",namespace="openshift-cloud-controller-manager"} 1688
rox_central_process_received_args_size_total{cluster="a0c64307-eb6a-40bb-9391-b996767c5326",namespace="openshift-cloud-controller-manager-operator"} 568
rox_central_process_received_args_size_total{cluster="a0c64307-eb6a-40bb-9391-b996767c5326",namespace="openshift-cloud-credential-operator"} 8
rox_central_process_received_args_size_total{cluster="a0c64307-eb6a-40bb-9391-b996767c5326",namespace="openshift-cloud-network-config-controller"} 150
rox_central_process_received_args_size_total{cluster="a0c64307-eb6a-40bb-9391-b996767c5326",namespace="openshift-cluster-csi-drivers"} 9536
```