### PR TITLE
ci: remove scan-images-with-roxctl from build pipeline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,8 +86,7 @@ jobs:
             "build_and_push_operator": { "name":[], "arch":[] },
             "push_operator_multiarch_manifests": { "name":[] },
             "build_and_push_scanner": { "name":[], "goos":[], "arch":[], "registry":[] },
-            "push_scanner_manifests": { "name":[], "registry":[] },
-            "scan_images_with_roxctl": { "name":[], "image":[], "exclude":[] }
+            "push_scanner_manifests": { "name":[], "registry":[] }
           }'
 
           # The base matrix
@@ -112,11 +111,6 @@ jobs:
 
           matrix="$(jq '.push_scanner_manifests.name += ["default"]' <<< "$matrix")"
           matrix="$(jq '.push_scanner_manifests.registry += ["quay.io/stackrox-io", "quay.io/rhacs-eng"]' <<< "$matrix")"
-
-          matrix="$(jq '.scan_images_with_roxctl.name += ["RHACS_BRANDING", "STACKROX_BRANDING"]' <<< "$matrix")"
-          matrix="$(jq '.scan_images_with_roxctl.image += ["central-db", "collector", "fact", "main", "roxctl", "scanner", "scanner-db", "scanner-db-slim", "scanner-slim", "stackrox-operator", "scanner-v4", "scanner-v4-db"]' <<< "$matrix")"
-          # TODO(ROX-27191): remove the exclusion once there's a community operator.
-          matrix="$(jq '.scan_images_with_roxctl.exclude += [{ "name": "STACKROX_BRANDING", "image": "stackrox-operator" }]' <<< "$matrix")"
 
           if ! is_in_PR_context || pr_has_label ci-build-all-arch; then
             matrix="$(jq '.pre_build_go_binaries.arch += ["ppc64le", "s390x"]' <<< "$matrix")"
@@ -1284,72 +1278,6 @@ jobs:
         gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
         directory: 'junit-reports'
 
-  scan-images-with-roxctl:
-    if: github.event_name == 'push' ||
-      contains(github.event.pull_request.labels.*.name, 'scan-images-with-roxctl')
-    needs:
-      - build-and-push-db
-      - build-and-push-main
-      - build-and-push-operator
-      - build-and-push-scanner
-      - define-job-matrix
-      - push-main-manifests
-      - push-matching-collector-scanner
-      - push-scanner-manifests
-    name: Check images for vulnerabilities
-    runs-on: ubuntu-latest
-    permissions:
-      # Needed for stackrox/central-login to create the JWT token.
-      id-token: write
-      security-events: write
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.define-job-matrix.outputs.matrix).scan_images_with_roxctl }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
-        with:
-          ref: ${{ inputs.commit || github.event.pull_request.head.sha }}
-
-      - uses: ./.github/actions/job-preamble
-        with:
-          gcp-account: ${{ secrets.GCP_SERVICE_ACCOUNT_STACKROX_CI }}
-
-      - name: Central login
-        uses: stackrox/central-login@a090772359782ced9df63d091123154ce297ac6a # ratchet:stackrox/central-login@v1
-        with:
-          endpoint: ${{ vars.ACS_DOGFOODING_CENTRAL_URL }}
-
-      - name: Install roxctl
-        uses: stackrox/roxctl-installer-action@47fb4f5b275066b8322369e6e33fa010915b0d13 # ratchet:stackrox/roxctl-installer-action@v1
-        with:
-          central-endpoint: ${{ vars.ACS_DOGFOODING_CENTRAL_URL }}
-          central-token: ${{ env.ROX_API_TOKEN }}
-
-      - name: Scan images for vulnerabilities
-        env:
-          BUILD_TAG: ${{ needs.define-job-matrix.outputs.build-tag }}
-          SHORTCOMMIT: ${{ needs.define-job-matrix.outputs.short-commit }}
-          GOTAGS: ${{ needs.define-job-matrix.outputs.gotags }}
-        run: |
-          release_tag="$(make --quiet --no-print-directory tag)"
-          if [[ "${{ matrix.image }}" =~ "operator" ]]; then
-            release_tag="$(make -C operator --quiet --no-print-directory tag)"
-          fi
-
-          registry="$(./scripts/ci/lib.sh registry_from_branding "${{ matrix.name }}")"
-
-          roxctl image scan --retries=10 --retry-delay=15 --force --severity=CRITICAL,IMPORTANT --output=sarif \
-            --image="${registry}/${{ matrix.image }}:${release_tag}" \
-            | tee results.sarif
-
-      # TODO: re-enable roxctl scan results upload once quota issue has been resolved
-      # - name: Upload roxctl scan results to GitHub Security tab
-      #   uses: github/codeql-action/upload-sarif@v3
-      #   with:
-      #     category: ${{ matrix.image }}
-      #     sarif_file: results.sarif
-
   slack-on-build-failure:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1374,7 +1302,6 @@ jobs:
       - pre-build-ui
       - push-matching-collector-scanner
       - scan-go-binaries
-      - scan-images-with-roxctl
     permissions:
       actions: read
     steps:


### PR DESCRIPTION
## Description

Build-time image vulnerability scanning duplicates existing coverage:
- .github/workflows/scan-image-vulnerabilities.yaml handles release scans
- Prodsec/Konflux provides additional scanning

The job also created noisy Jira issues via junit2jira (#20748). The SARIF upload to GitHub Security tab was already disabled (#13395).

Originally added in:
- #2243
- #4268

Generated with the help of AI.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI
