### PR TITLE
ROX-35032: Deprecate PodSecurityPolicy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ Changes should still be described appropriately in JIRA/doc input pages, for inc
 - Plaintext (non-TLS) Central endpoints, configured via the `ROX_PLAINTEXT_ENDPOINTS` environment
   variable, are deprecated and will be removed in a future release. Modern load balancers and
   ingress controllers support TLS passthrough, making plaintext endpoints unnecessary.
+- ROX-35032: PodSecurityPolicy support is deprecated. The `--enable-pod-security-policies` roxctl
+  flag and the `system.enablePodSecurityPolicies` Helm value now emit deprecation warnings.
+  PSPs were removed from Kubernetes in v1.25 and will be removed from ACS in a future release.
 
 ### Technical Changes
 

--- a/image/templates/helm/shared/internal/scanner-config-shape.yaml
+++ b/image/templates/helm/shared/internal/scanner-config-shape.yaml
@@ -41,4 +41,4 @@ scanner:
     generate: null # bool
   exposeMonitoring: null # bool
 system:
-  enablePodSecurityPolicies: null # bool
+  enablePodSecurityPolicies: null # bool # DEPRECATED: PodSecurityPolicy support is deprecated and will be removed in a future release.

--- a/image/templates/helm/shared/templates/_psp.tpl
+++ b/image/templates/helm/shared/templates/_psp.tpl
@@ -1,5 +1,10 @@
 {{/*
     srox.autoSensePodSecurityPolicies $
+
+    DEPRECATED: PodSecurityPolicy support is deprecated and will be removed in a
+    future release. Kubernetes removed PodSecurityPolicy in v1.25. If you are
+    running on Kubernetes >= 1.25, PSPs are already inactive. Consider migrating
+    to Pod Security Admission or other policy engines.
   */}}
 
 {{ define "srox.autoSensePodSecurityPolicies" }}
@@ -11,9 +16,12 @@
   {{ $_ := set $system "enablePodSecurityPolicies" (has "policy/v1beta1" $._rox._apiServer.apiResources) }}
   {{ if $system.enablePodSecurityPolicies }}
     {{ include "srox.note" (list $ (printf "PodSecurityPolicies are enabled, since your environment supports them according to API server properties.")) }}
+    {{ include "srox.warn" (list $ "PodSecurityPolicy support is deprecated and will be removed in a future release. Kubernetes removed PodSecurityPolicy in v1.25. Consider disabling PSPs by setting system.enablePodSecurityPolicies=false.") }}
   {{ else }}
     {{ include "srox.note" (list $ (printf "PodSecurityPolicies are disabled, since your environment does not support them according to API server properties.")) }}
   {{ end }}
+{{ else if $system.enablePodSecurityPolicies }}
+  {{ include "srox.warn" (list $ "PodSecurityPolicy support is deprecated and will be removed in a future release. Kubernetes removed PodSecurityPolicy in v1.25. Please plan to set system.enablePodSecurityPolicies=false and migrate to Pod Security Admission or another policy engine.") }}
 {{ end }}
 
 {{ end }}

--- a/image/templates/helm/stackrox-central/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-central/internal/config-shape.yaml
@@ -204,4 +204,4 @@ globalPrefix: null # string
 network:
   enableNetworkPolicies: null # bool
 system:
-  enablePodSecurityPolicies: null # bool
+  enablePodSecurityPolicies: null # bool # DEPRECATED: PodSecurityPolicy support is deprecated and will be removed in a future release.

--- a/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
+++ b/image/templates/helm/stackrox-secured-cluster/internal/config-shape.yaml
@@ -209,7 +209,7 @@ meta:
 network:
   enableNetworkPolicies: null # bool
 system:
-  enablePodSecurityPolicies: null # bool
+  enablePodSecurityPolicies: null # bool # DEPRECATED: PodSecurityPolicy support is deprecated and will be removed in a future release.
 crs:
   file: null # string
 consolePlugin:

--- a/roxctl/central/generate/generate.go
+++ b/roxctl/central/generate/generate.go
@@ -378,7 +378,8 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	if !buildinfo.ReleaseBuild {
 		flags.AddHelmChartDebugSetting(c)
 	}
-	c.PersistentFlags().BoolVar(&centralGenerateCmd.rendererConfig.EnablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes).")
+	c.PersistentFlags().BoolVar(&centralGenerateCmd.rendererConfig.EnablePodSecurityPolicies, "enable-pod-security-policies", false, "Deprecated: Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes).")
+	utils.Must(c.PersistentFlags().MarkDeprecated("enable-pod-security-policies", "PodSecurityPolicy support is deprecated and will be removed in a future release."))
 
 	c.AddCommand(centralGenerateCmd.interactive())
 	c.AddCommand(k8s(cliEnvironment))

--- a/roxctl/scanner/generate/generate.go
+++ b/roxctl/scanner/generate/generate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/apiparams"
+	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/roxctl/common"
 	"github.com/stackrox/rox/roxctl/common/environment"
 	"github.com/stackrox/rox/roxctl/common/flags"
@@ -94,7 +95,8 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 	c.Flags().StringVar(&scannerGenerateCmd.apiParams.ScannerV4DBImage, flags.FlagNameScannerV4DBImage, "", "Scanner V4 DB image to use (leave blank to use server default).")
 	c.Flags().StringVar(&scannerGenerateCmd.apiParams.IstioVersion, istioSupportArg, "",
 		"Istio version when deploying into an Istio-enabled cluster (has no effect; ACS now automatically prevents Istio sidecar injection).")
-	c.PersistentFlags().BoolVar(&scannerGenerateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes).")
+	c.PersistentFlags().BoolVar(&scannerGenerateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", false, "Deprecated: Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes).")
+	utils.Must(c.PersistentFlags().MarkDeprecated("enable-pod-security-policies", "PodSecurityPolicy support is deprecated and will be removed in a future release."))
 
 	flags.AddTimeout(c)
 	flags.AddRetryTimeout(c)

--- a/roxctl/sensor/generate/generate.go
+++ b/roxctl/sensor/generate/generate.go
@@ -196,7 +196,8 @@ func Command(cliEnvironment environment.Environment) *cobra.Command {
 		"Istio version when deploying into an Istio-enabled cluster (has no effect; ACS now automatically prevents Istio sidecar injection).")
 
 	c.PersistentFlags().BoolVar(&generateCmd.cluster.GetTolerationsConfig().Disabled, "disable-tolerations", false, "Disable tolerations for tainted nodes.")
-	c.PersistentFlags().BoolVar(&generateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", false, "Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes).")
+	c.PersistentFlags().BoolVar(&generateCmd.enablePodSecurityPolicies, "enable-pod-security-policies", false, "Deprecated: Create PodSecurityPolicy resources (for pre-v1.25 Kubernetes).")
+	utils.Must(c.PersistentFlags().MarkDeprecated("enable-pod-security-policies", "PodSecurityPolicy support is deprecated and will be removed in a future release."))
 
 	// Note: If you need to change the default values for any of the flags below this comment, please change the defaults in the defaultCluster function above
 	c.PersistentFlags().BoolVar(&ignoredBoolFlag, "admission-controller-listen-on-creates", true, "Whether or not to configure the admission controller webhook to listen on deployment creates.")


### PR DESCRIPTION
## Description

Deprecate PodSecurityPolicy support across roxctl CLI and Helm charts.
Kubernetes removed PSPs in v1.25; this deprecation signals removal
from ACS in a future release.

- Mark `--enable-pod-security-policies` as deprecated in `roxctl central generate`,
  `roxctl sensor generate`, and `roxctl scanner generate` using cobra's `MarkDeprecated`
- Add deprecation warnings in Helm `_psp.tpl` when PSPs are auto-detected or explicitly enabled
- Add deprecation comments to `enablePodSecurityPolicies` in config-shape.yaml files
- Update CHANGELOG.md for 4.11

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- `go build ./roxctl/...` — compiles cleanly
- `go test ./roxctl/central/generate/... ./roxctl/sensor/generate/... ./roxctl/scanner/generate/...` — all pass
- `go test ./pkg/helm/charts/tests/centralservices/... ./pkg/helm/charts/tests/securedclusterservices/...` — all pass
- `go test ./roxctl/maincommand/` — command tree golden files unchanged
- `bats tests/roxctl/bats-tests/local/deployment-bundles-psps.bats` — all 6 tests pass
- `make roxvet` — passes