### PR TITLE
ci: add benchmark comparison job for PR regression detection

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -236,6 +236,71 @@ jobs:
     # Do not create junit report for bench tests:
     # https://github.com/jstemmer/go-junit-report/issues/174
 
+  go-bench-compare:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      pull-requests: write
+    env:
+      BUILD_TAG: 0.0.0
+      SHORTCOMMIT: "0000000"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Cache Go dependencies
+      uses: ./.github/actions/cache-go-dependencies
+
+    - name: Install benchstat
+      run: go install golang.org/x/perf/cmd/benchstat@latest
+
+    - name: Compare benchmarks
+      run: |
+        scripts/bench-compare.sh \
+          "origin/${{ github.base_ref }}" \
+          HEAD \
+          --count 6 \
+          --keep \
+          --output bench-results
+
+    - name: Comment on PR
+      if: always()
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        if [ ! -s bench-results/comparison.txt ]; then
+          echo "No benchmark comparison to post."
+          exit 0
+        fi
+
+        marker='<!-- bench-compare -->'
+        {
+          echo "${marker}"
+          echo "## Benchmark Comparison"
+          echo ""
+          echo '```'
+          cat bench-results/comparison.txt
+          echo '```'
+        } > bench-results/comment.md
+
+        # Update existing comment or create a new one
+        existing=$(gh api \
+          "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+          --jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
+          | head -1)
+
+        if [ -n "$existing" ]; then
+          gh api \
+            --method PATCH \
+            "repos/${{ github.repository }}/issues/comments/${existing}" \
+            -F body=@bench-results/comment.md
+        else
+          gh pr comment "${{ github.event.pull_request.number }}" -F bench-results/comment.md
+        fi
+
   ui:
     needs: detect-changes
     if: >-

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -263,8 +263,6 @@ jobs:
           "origin/${{ github.base_ref }}" \
           HEAD \
           --count 10 \
-          --benchtime 100ms \
-          --timeout 5m \
           --keep \
           --output bench-results
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -263,7 +263,6 @@ jobs:
           "origin/${{ github.base_ref }}" \
           HEAD \
           --count 10 \
-          --benchtime 3x \
           --keep \
           --output bench-results
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -263,6 +263,7 @@ jobs:
           "origin/${{ github.base_ref }}" \
           HEAD \
           --count 10 \
+          --benchtime 1s \
           --keep \
           --output bench-results
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -263,7 +263,7 @@ jobs:
           "origin/${{ github.base_ref }}" \
           HEAD \
           --count 10 \
-          --benchtime 1s \
+          --benchtime 100ms \
           --keep \
           --output bench-results
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -264,6 +264,7 @@ jobs:
           HEAD \
           --count 10 \
           --benchtime 100ms \
+          --timeout 5m \
           --keep \
           --output bench-results
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -262,7 +262,8 @@ jobs:
         scripts/bench-compare.sh \
           "origin/${{ github.base_ref }}" \
           HEAD \
-          --count 6 \
+          --count 10 \
+          --benchtime 3x \
           --keep \
           --output bench-results
 

--- a/pkg/concurrency/value_stream.go
+++ b/pkg/concurrency/value_stream.go
@@ -1,6 +1,7 @@
 package concurrency
 
 import (
+	"sync"
 	"sync/atomic"
 )
 
@@ -47,6 +48,7 @@ import (
 //	}
 type ValueStream[T any] struct {
 	curr atomic.Pointer[valueStreamStrictIter[T]] // always holds a *valueStreamStrictIter[T]
+	mu   sync.Mutex
 }
 
 // NewValueStream initializes a value stream with an initial value.
@@ -164,6 +166,9 @@ func (i *valueStreamSkipIter[T]) Next(ctx ErrorWaitable) (ValueStreamIter[T], er
 // Push pushes a value onto the stream. It returns both the current value, as well as the iterator pointing to the just
 // inserted value.
 func (s *ValueStream[T]) Push(val T) (T, ValueStreamIter[T]) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	newIter := &valueStreamStrictIter[T]{
 		valueStreamIterBase: valueStreamIterBase[T]{
 			currVal: val,

--- a/pkg/concurrency/value_stream_bench_test.go
+++ b/pkg/concurrency/value_stream_bench_test.go
@@ -9,9 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const benchStreamSize = 10000
-
 func BenchmarkValueStreamWrite(b *testing.B) {
+
 	vs := NewValueStream(0)
 
 	for b.Loop() {
@@ -20,15 +19,8 @@ func BenchmarkValueStreamWrite(b *testing.B) {
 }
 
 func BenchmarkBufChanWrite(b *testing.B) {
-	c := make(chan struct{}, benchStreamSize)
-	b.Cleanup(func() { close(c) })
 
-	go func() {
-		ok := true
-		for ok {
-			_, ok = <-c
-		}
-	}()
+	c := make(chan struct{}, b.N)
 
 	for b.Loop() {
 		c <- struct{}{}
@@ -36,9 +28,13 @@ func BenchmarkBufChanWrite(b *testing.B) {
 }
 
 func BenchmarkBuf1ChanWrite(b *testing.B) {
-	c := make(chan struct{}, 1)
-	b.Cleanup(func() { close(c) })
 
+	c := make(chan struct{}, 1)
+	b.Cleanup(func() {
+		close(c)
+	})
+
+	// Read from channel in a tight loop
 	go func() {
 		ok := true
 		for ok {
@@ -52,9 +48,13 @@ func BenchmarkBuf1ChanWrite(b *testing.B) {
 }
 
 func BenchmarkUnbufChanWrite(b *testing.B) {
-	c := make(chan struct{})
-	b.Cleanup(func() { close(c) })
 
+	c := make(chan struct{})
+	b.Cleanup(func() {
+		close(c)
+	})
+
+	// Read from channel in a tight loop
 	go func() {
 		ok := true
 		for ok {
@@ -68,6 +68,7 @@ func BenchmarkUnbufChanWrite(b *testing.B) {
 }
 
 func BenchmarkSliceAppend(b *testing.B) {
+
 	var slice []struct{}
 
 	for b.Loop() {
@@ -76,6 +77,7 @@ func BenchmarkSliceAppend(b *testing.B) {
 }
 
 func BenchmarkSliceAppendWithMutex(b *testing.B) {
+
 	var slice []struct{}
 	var mutex sync.Mutex
 
@@ -87,53 +89,36 @@ func BenchmarkSliceAppendWithMutex(b *testing.B) {
 }
 
 func BenchmarkValueStreamRead(b *testing.B) {
+
 	vs := NewValueStream(0)
 	it := vs.Iterator(true)
 
-	for i := 0; i < benchStreamSize; i++ {
+	for i := 0; i < b.N; i++ {
 		vs.Push(i)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(b.N)*time.Millisecond)
 	defer cancel()
 
 	var err error
-	i := 0
 	for b.Loop() && err == nil {
 		it, err = it.Next(ctx)
-		i++
-		if i >= benchStreamSize {
-			it = vs.Iterator(true)
-			for j := 0; j < benchStreamSize; j++ {
-				vs.Push(j)
-			}
-			i = 0
-		}
 	}
 	require.NoError(b, err)
 }
 
 func BenchmarkValueStreamReadAsync(b *testing.B) {
+
 	vs := NewValueStream(0)
 	it := vs.Iterator(true)
 
-	done := make(chan struct{})
-	b.Cleanup(func() { close(done) })
-
-	go func() {
-		i := 0
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				vs.Push(i)
-				i++
-			}
+	go func(n int) {
+		for i := 0; i < n; i++ {
+			vs.Push(i)
 		}
-	}()
+	}(b.N)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(b.N)*time.Millisecond)
 	defer cancel()
 
 	var err error
@@ -144,24 +129,13 @@ func BenchmarkValueStreamReadAsync(b *testing.B) {
 }
 
 func BenchmarkBufChanRead(b *testing.B) {
-	c := make(chan int, benchStreamSize)
 
-	done := make(chan struct{})
-	b.Cleanup(func() { close(done) })
+	c := make(chan int, b.N)
+	for i := 0; i < b.N; i++ {
+		c <- i
+	}
 
-	go func() {
-		i := 0
-		for {
-			select {
-			case <-done:
-				return
-			case c <- i:
-				i++
-			}
-		}
-	}()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(b.N)*time.Millisecond)
 	defer cancel()
 
 	var err error
@@ -176,24 +150,17 @@ func BenchmarkBufChanRead(b *testing.B) {
 }
 
 func BenchmarkBuf1ChanRead(b *testing.B) {
+
 	c := make(chan int, 1)
 
-	done := make(chan struct{})
-	b.Cleanup(func() { close(done) })
-
-	go func() {
-		i := 0
-		for {
-			select {
-			case <-done:
-				return
-			case c <- i:
-				i++
-			}
+	// Write to channel in a tight loop
+	go func(n int) {
+		for i := 0; i < n; i++ {
+			c <- i
 		}
-	}()
+	}(b.N)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(b.N)*time.Millisecond)
 	defer cancel()
 
 	var err error
@@ -204,28 +171,20 @@ func BenchmarkBuf1ChanRead(b *testing.B) {
 			err = ctx.Err()
 		}
 	}
-	require.NoError(b, err)
 }
 
 func BenchmarkUnbufChanRead(b *testing.B) {
+
 	c := make(chan int)
 
-	done := make(chan struct{})
-	b.Cleanup(func() { close(done) })
-
-	go func() {
-		i := 0
-		for {
-			select {
-			case <-done:
-				return
-			case c <- i:
-				i++
-			}
+	// Write to channel in a tight loop
+	go func(n int) {
+		for i := 0; i < n; i++ {
+			c <- i
 		}
-	}()
+	}(b.N)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(b.N)*time.Millisecond)
 	defer cancel()
 
 	var err error
@@ -236,33 +195,33 @@ func BenchmarkUnbufChanRead(b *testing.B) {
 			err = ctx.Err()
 		}
 	}
-	require.NoError(b, err)
 }
 
 func BenchmarkSliceRead(b *testing.B) {
-	for b.Loop() {
-		b.StopTimer()
-		slice := make([]int, benchStreamSize)
-		b.StartTimer()
 
-		for len(slice) > 0 {
-			slice = slice[1:]
-		}
+	slice := make([]int, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		slice = append(slice, i)
 	}
+
+	for b.Loop() {
+		slice = slice[1:]
+	}
+	require.Empty(b, slice)
 }
 
 func BenchmarkSliceReadWithMutex(b *testing.B) {
+
+	slice := make([]int, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		slice = append(slice, i)
+	}
 	var mutex sync.Mutex
 
 	for b.Loop() {
-		b.StopTimer()
-		slice := make([]int, benchStreamSize)
-		b.StartTimer()
-
-		for len(slice) > 0 {
-			WithLock(&mutex, func() {
-				slice = slice[1:]
-			})
-		}
+		WithLock(&mutex, func() {
+			slice = slice[1:]
+		})
 	}
+	require.Empty(b, slice)
 }

--- a/pkg/concurrency/value_stream_bench_test.go
+++ b/pkg/concurrency/value_stream_bench_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func BenchmarkValueStreamWrite(b *testing.B) {
+const benchStreamSize = 10000
 
+func BenchmarkValueStreamWrite(b *testing.B) {
 	vs := NewValueStream(0)
 
 	for b.Loop() {
@@ -19,8 +20,15 @@ func BenchmarkValueStreamWrite(b *testing.B) {
 }
 
 func BenchmarkBufChanWrite(b *testing.B) {
+	c := make(chan struct{}, benchStreamSize)
+	b.Cleanup(func() { close(c) })
 
-	c := make(chan struct{}, b.N)
+	go func() {
+		ok := true
+		for ok {
+			_, ok = <-c
+		}
+	}()
 
 	for b.Loop() {
 		c <- struct{}{}
@@ -28,13 +36,9 @@ func BenchmarkBufChanWrite(b *testing.B) {
 }
 
 func BenchmarkBuf1ChanWrite(b *testing.B) {
-
 	c := make(chan struct{}, 1)
-	b.Cleanup(func() {
-		close(c)
-	})
+	b.Cleanup(func() { close(c) })
 
-	// Read from channel in a tight loop
 	go func() {
 		ok := true
 		for ok {
@@ -48,13 +52,9 @@ func BenchmarkBuf1ChanWrite(b *testing.B) {
 }
 
 func BenchmarkUnbufChanWrite(b *testing.B) {
-
 	c := make(chan struct{})
-	b.Cleanup(func() {
-		close(c)
-	})
+	b.Cleanup(func() { close(c) })
 
-	// Read from channel in a tight loop
 	go func() {
 		ok := true
 		for ok {
@@ -68,7 +68,6 @@ func BenchmarkUnbufChanWrite(b *testing.B) {
 }
 
 func BenchmarkSliceAppend(b *testing.B) {
-
 	var slice []struct{}
 
 	for b.Loop() {
@@ -77,7 +76,6 @@ func BenchmarkSliceAppend(b *testing.B) {
 }
 
 func BenchmarkSliceAppendWithMutex(b *testing.B) {
-
 	var slice []struct{}
 	var mutex sync.Mutex
 
@@ -89,36 +87,53 @@ func BenchmarkSliceAppendWithMutex(b *testing.B) {
 }
 
 func BenchmarkValueStreamRead(b *testing.B) {
-
 	vs := NewValueStream(0)
 	it := vs.Iterator(true)
 
-	for i := 0; i < b.N; i++ {
+	for i := 0; i < benchStreamSize; i++ {
 		vs.Push(i)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(b.N)*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	var err error
+	i := 0
 	for b.Loop() && err == nil {
 		it, err = it.Next(ctx)
+		i++
+		if i >= benchStreamSize {
+			it = vs.Iterator(true)
+			for j := 0; j < benchStreamSize; j++ {
+				vs.Push(j)
+			}
+			i = 0
+		}
 	}
 	require.NoError(b, err)
 }
 
 func BenchmarkValueStreamReadAsync(b *testing.B) {
-
 	vs := NewValueStream(0)
 	it := vs.Iterator(true)
 
-	go func(n int) {
-		for i := 0; i < n; i++ {
-			vs.Push(i)
-		}
-	}(b.N)
+	done := make(chan struct{})
+	b.Cleanup(func() { close(done) })
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(b.N)*time.Millisecond)
+	go func() {
+		i := 0
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				vs.Push(i)
+				i++
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	var err error
@@ -129,13 +144,24 @@ func BenchmarkValueStreamReadAsync(b *testing.B) {
 }
 
 func BenchmarkBufChanRead(b *testing.B) {
+	c := make(chan int, benchStreamSize)
 
-	c := make(chan int, b.N)
-	for i := 0; i < b.N; i++ {
-		c <- i
-	}
+	done := make(chan struct{})
+	b.Cleanup(func() { close(done) })
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(b.N)*time.Millisecond)
+	go func() {
+		i := 0
+		for {
+			select {
+			case <-done:
+				return
+			case c <- i:
+				i++
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	var err error
@@ -150,17 +176,24 @@ func BenchmarkBufChanRead(b *testing.B) {
 }
 
 func BenchmarkBuf1ChanRead(b *testing.B) {
-
 	c := make(chan int, 1)
 
-	// Write to channel in a tight loop
-	go func(n int) {
-		for i := 0; i < n; i++ {
-			c <- i
-		}
-	}(b.N)
+	done := make(chan struct{})
+	b.Cleanup(func() { close(done) })
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(b.N)*time.Millisecond)
+	go func() {
+		i := 0
+		for {
+			select {
+			case <-done:
+				return
+			case c <- i:
+				i++
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	var err error
@@ -171,20 +204,28 @@ func BenchmarkBuf1ChanRead(b *testing.B) {
 			err = ctx.Err()
 		}
 	}
+	require.NoError(b, err)
 }
 
 func BenchmarkUnbufChanRead(b *testing.B) {
-
 	c := make(chan int)
 
-	// Write to channel in a tight loop
-	go func(n int) {
-		for i := 0; i < n; i++ {
-			c <- i
-		}
-	}(b.N)
+	done := make(chan struct{})
+	b.Cleanup(func() { close(done) })
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(b.N)*time.Millisecond)
+	go func() {
+		i := 0
+		for {
+			select {
+			case <-done:
+				return
+			case c <- i:
+				i++
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	var err error
@@ -195,33 +236,33 @@ func BenchmarkUnbufChanRead(b *testing.B) {
 			err = ctx.Err()
 		}
 	}
+	require.NoError(b, err)
 }
 
 func BenchmarkSliceRead(b *testing.B) {
-
-	slice := make([]int, 0, b.N)
-	for i := 0; i < b.N; i++ {
-		slice = append(slice, i)
-	}
-
 	for b.Loop() {
-		slice = slice[1:]
+		b.StopTimer()
+		slice := make([]int, benchStreamSize)
+		b.StartTimer()
+
+		for len(slice) > 0 {
+			slice = slice[1:]
+		}
 	}
-	require.Empty(b, slice)
 }
 
 func BenchmarkSliceReadWithMutex(b *testing.B) {
-
-	slice := make([]int, 0, b.N)
-	for i := 0; i < b.N; i++ {
-		slice = append(slice, i)
-	}
 	var mutex sync.Mutex
 
 	for b.Loop() {
-		WithLock(&mutex, func() {
-			slice = slice[1:]
-		})
+		b.StopTimer()
+		slice := make([]int, benchStreamSize)
+		b.StartTimer()
+
+		for len(slice) > 0 {
+			WithLock(&mutex, func() {
+				slice = slice[1:]
+			})
+		}
 	}
-	require.Empty(b, slice)
 }

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -250,6 +250,7 @@ run_benchmarks() {
         export MUTEX_WATCHDOG_TIMEOUT_SECS=30
 
         # shellcheck disable=SC2086
+        timeout "$TIMEOUT" \
         go test \
             $parallel_flag \
             -tags "$go_tags" \
@@ -261,7 +262,7 @@ run_benchmarks() {
             -count "$BENCHCOUNT" \
             "${valid_pkgs[@]}" \
             2>&1 | tee "${output_file}.raw"
-    ) || warn "[$label] Some benchmarks failed. Results may be partial."
+    ) || warn "[$label] Some benchmarks failed or timed out. Results may be partial."
 
     # Filter to benchstat-parseable lines only (Benchmark lines + header lines)
     grep -E '^(Benchmark|goos:|goarch:|pkg:|cpu:|PASS|ok )' "${output_file}.raw" > "$output_file" || true

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -187,11 +187,11 @@ done
 # ── Setup results directory ──────────────────────────────────────
 
 if [[ -n "$OUTPUT_DIR" ]]; then
-    RESULTS_DIR="$OUTPUT_DIR"
+    mkdir -p "$OUTPUT_DIR"
+    RESULTS_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 else
     RESULTS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bench-compare-XXXXXX")"
 fi
-mkdir -p "$RESULTS_DIR"
 
 BASE_RESULTS="$RESULTS_DIR/base.txt"
 HEAD_RESULTS="$RESULTS_DIR/head.txt"

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -260,8 +260,11 @@ run_benchmarks() {
             -timeout "$TIMEOUT" \
             -count "$BENCHCOUNT" \
             "${valid_pkgs[@]}" \
-            2>&1 | tee "$output_file"
+            2>&1 | tee "${output_file}.raw"
     ) || warn "[$label] Some benchmarks failed. Results may be partial."
+
+    # Filter to benchstat-parseable lines only (Benchmark lines + header lines)
+    grep -E '^(Benchmark|goos:|goarch:|pkg:|cpu:|PASS|ok )' "${output_file}.raw" > "$output_file" || true
 }
 
 # ── Run benchmarks on base ref ───────────────────────────────────

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -297,7 +297,7 @@ if [[ ! -s "$BASE_RESULTS" ]] || [[ ! -s "$HEAD_RESULTS" ]]; then
     die "One or both benchmark result files are empty. Cannot compare."
 fi
 
-benchstat "$BASE_RESULTS" "$HEAD_RESULTS" | tee "$COMPARISON"
+benchstat base="$BASE_RESULTS" head="$HEAD_RESULTS" | tee "$COMPARISON"
 
 echo ""
 if "$KEEP_RESULTS"; then

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+UNIT_TEST_IGNORE="stackrox/rox/sensor/tests|stackrox/rox/operator/tests|stackrox/rox/central/reports/config/store/postgres|stackrox/rox/central/complianceoperator/v2/scanconfigurations/store/postgres|stackrox/rox/central/auth/store/postgres|stackrox/rox/scanner/e2etests"
+
+# Defaults
+BASE_REF="origin/master"
+HEAD_REF="HEAD"
+BENCHCOUNT=6
+BENCHTIME="1x"
+TIMEOUT="20m"
+INCLUDE_DB=false
+BENCH_FILTER="."
+USER_PACKAGES=""
+OUTPUT_DIR=""
+KEEP_RESULTS=false
+
+WORKTREE_DIR=""
+WORKTREE_HEAD_DIR=""
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [BASE_REF] [HEAD_REF] [flags]
+
+Compare Go benchmark results between two git refs.
+Detects changed packages, runs benchmarks on both refs, and compares with benchstat.
+
+Arguments:
+  BASE_REF              Ref to compare against (default: origin/master)
+  HEAD_REF              Ref being evaluated (default: HEAD, i.e. current working tree)
+
+Flags:
+  --count N             Number of benchmark iterations (default: 6)
+  --benchtime T         Go -benchtime flag (default: 1x)
+  --timeout T           Per-test timeout (default: 20m)
+  --db                  Include sql_integration benchmarks (requires Postgres)
+  --packages P,...      Override auto-detection with comma-separated package list
+  --bench REGEXP        Filter benchmark names (default: . meaning all)
+  --output DIR          Directory for result files (default: temp dir)
+  --keep                Preserve worktree and results after exit
+  -h, --help            Show this help
+
+Examples:
+  $(basename "$0")                                    # current branch vs origin/master
+  $(basename "$0") origin/release-4.8                  # current branch vs release-4.8
+  $(basename "$0") origin/master my-branch             # explicit refs
+  $(basename "$0") --db                                # include DB benchmarks
+  $(basename "$0") --count 10 --benchtime 2x           # more iterations
+  $(basename "$0") --packages github.com/stackrox/rox/pkg/queue
+  $(basename "$0") --keep --output ./bench-results/    # keep results for later
+EOF
+}
+
+# ── Argument parsing ──────────────────────────────────────────────
+
+_positional=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --count)     BENCHCOUNT="$2"; shift 2 ;;
+        --benchtime) BENCHTIME="$2"; shift 2 ;;
+        --timeout)   TIMEOUT="$2"; shift 2 ;;
+        --db)        INCLUDE_DB=true; shift ;;
+        --no-db)     INCLUDE_DB=false; shift ;;
+        --packages)  USER_PACKAGES="$2"; shift 2 ;;
+        --bench)     BENCH_FILTER="$2"; shift 2 ;;
+        --output)    OUTPUT_DIR="$2"; shift 2 ;;
+        --keep)      KEEP_RESULTS=true; shift ;;
+        -h|--help)   usage; exit 0 ;;
+        -*)          die "Unknown flag: $1. Use --help for usage." ;;
+        *)
+            case "$_positional" in
+                0) BASE_REF="$1" ;;
+                1) HEAD_REF="$1" ;;
+                *) die "Unexpected argument: $1" ;;
+            esac
+            _positional=$((_positional + 1))
+            shift
+            ;;
+    esac
+done
+
+# ── Safety checks ────────────────────────────────────────────────
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1 \
+    || die "Invalid base ref: $BASE_REF"
+git rev-parse --verify "${HEAD_REF}^{commit}" >/dev/null 2>&1 \
+    || die "Invalid head ref: $HEAD_REF"
+
+if ! command -v benchstat &>/dev/null; then
+    info "Installing benchstat..."
+    go install golang.org/x/perf/cmd/benchstat@latest
+fi
+
+if "$INCLUDE_DB"; then
+    pg_host="${POSTGRES_HOST:-localhost}"
+    pg_port="${POSTGRES_PORT:-5432}"
+    if command -v pg_isready &>/dev/null; then
+        pg_isready -h "$pg_host" -p "$pg_port" -q 2>/dev/null \
+            || die "Postgres is not reachable at ${pg_host}:${pg_port}. Start Postgres or drop --db."
+    else
+        (echo >/dev/tcp/"$pg_host"/"$pg_port") 2>/dev/null \
+            || die "Postgres is not reachable at ${pg_host}:${pg_port}. Start Postgres or drop --db."
+    fi
+fi
+
+# ── Resolve refs for display ─────────────────────────────────────
+
+BASE_SHA="$(git rev-parse --short "$BASE_REF")"
+HEAD_SHA="$(git rev-parse --short "$HEAD_REF")"
+info "Comparing $BASE_REF ($BASE_SHA) vs $HEAD_REF ($HEAD_SHA)"
+
+# ── Detect changed packages ─────────────────────────────────────
+
+go_tags="test"
+if "$INCLUDE_DB"; then go_tags="test,sql_integration"; fi
+
+if [[ -n "$USER_PACKAGES" ]]; then
+    IFS=',' read -ra BENCH_PKGS <<< "$USER_PACKAGES"
+    info "Using user-specified packages: ${BENCH_PKGS[*]}"
+else
+    changed_dirs="$(
+        git diff --name-only "${BASE_REF}...${HEAD_REF}" -- '*.go' \
+        | xargs -n1 dirname 2>/dev/null \
+        | sort -u
+    )" || true
+
+    if [[ -z "$changed_dirs" ]]; then
+        info "No Go files changed between $BASE_REF and $HEAD_REF."
+        exit 0
+    fi
+
+    changed_pkgs="$(
+        echo "$changed_dirs" \
+        | sed 's@^@./@' \
+        | xargs go list -tags "$go_tags" -e 2>/dev/null \
+        | grep -Ev "$UNIT_TEST_IGNORE"
+    )" || true
+
+    if [[ -z "$changed_pkgs" ]]; then
+        info "No valid Go packages in the changed files."
+        exit 0
+    fi
+
+    # Find which changed packages actually have benchmarks
+    BENCH_PKGS_PURE=()
+    BENCH_PKGS_DB=()
+
+    while IFS= read -r pkg; do
+        pkg_dir="$(go list -tags "$go_tags" -f '{{.Dir}}' "$pkg" 2>/dev/null)" || continue
+        if ! grep -qrl 'testing\.B' "$pkg_dir" --include='*_test.go' 2>/dev/null; then
+            continue
+        fi
+        if grep -ql '//go:build.*sql_integration' "$pkg_dir"/*_test.go 2>/dev/null; then
+            BENCH_PKGS_DB+=("$pkg")
+        else
+            BENCH_PKGS_PURE+=("$pkg")
+        fi
+    done <<< "$changed_pkgs"
+
+    BENCH_PKGS=("${BENCH_PKGS_PURE[@]+"${BENCH_PKGS_PURE[@]}"}")
+    if "$INCLUDE_DB"; then
+        BENCH_PKGS+=("${BENCH_PKGS_DB[@]+"${BENCH_PKGS_DB[@]}"}")
+    fi
+
+    if [[ ${#BENCH_PKGS[@]} -eq 0 ]]; then
+        info "No benchmarks found in changed packages."
+        if [[ ${#BENCH_PKGS_DB[@]} -gt 0 ]]; then
+            info "${#BENCH_PKGS_DB[@]} package(s) have sql_integration benchmarks. Re-run with --db to include them."
+        fi
+        exit 0
+    fi
+fi
+
+info "Found benchmarks in ${#BENCH_PKGS[@]} package(s):"
+for pkg in "${BENCH_PKGS[@]}"; do
+    info "  $pkg"
+done
+
+# ── Setup results directory ──────────────────────────────────────
+
+if [[ -n "$OUTPUT_DIR" ]]; then
+    RESULTS_DIR="$OUTPUT_DIR"
+else
+    RESULTS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bench-compare-XXXXXX")"
+fi
+mkdir -p "$RESULTS_DIR"
+
+BASE_RESULTS="$RESULTS_DIR/base.txt"
+HEAD_RESULTS="$RESULTS_DIR/head.txt"
+COMPARISON="$RESULTS_DIR/comparison.txt"
+
+# ── Cleanup trap ─────────────────────────────────────────────────
+
+cleanup() {
+    local exit_code=$?
+    if [[ -n "$WORKTREE_DIR" ]]; then
+        git worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true
+    fi
+    if [[ -n "$WORKTREE_HEAD_DIR" ]]; then
+        git worktree remove --force "$WORKTREE_HEAD_DIR" 2>/dev/null || true
+    fi
+    if ! "$KEEP_RESULTS" && [[ -z "$OUTPUT_DIR" ]]; then
+        rm -rf "$RESULTS_DIR"
+    fi
+    exit "$exit_code"
+}
+trap cleanup EXIT
+
+# ── Benchmark runner ─────────────────────────────────────────────
+
+run_benchmarks() {
+    local work_dir="$1"
+    local output_file="$2"
+    local label="$3"
+
+    # Filter packages that exist in this ref
+    local valid_pkgs=()
+    for pkg in "${BENCH_PKGS[@]}"; do
+        if (cd "$work_dir" && go list -tags "$go_tags" -e "$pkg" >/dev/null 2>&1); then
+            valid_pkgs+=("$pkg")
+        else
+            warn "[$label] Package $pkg does not exist in this ref, skipping."
+        fi
+    done
+
+    if [[ ${#valid_pkgs[@]} -eq 0 ]]; then
+        warn "[$label] No valid benchmark packages found."
+        touch "$output_file"
+        return
+    fi
+
+    local parallel_flag=""
+    if "$INCLUDE_DB"; then parallel_flag="-p 1"; fi
+
+    info "[$label] Running ${#valid_pkgs[@]} package(s) with -count=$BENCHCOUNT -benchtime=$BENCHTIME..."
+
+    (
+        cd "$work_dir"
+        export CGO_ENABLED=1
+        export GOEXPERIMENT=cgocheck2
+        export MUTEX_WATCHDOG_TIMEOUT_SECS=30
+
+        # shellcheck disable=SC2086
+        go test \
+            $parallel_flag \
+            -tags "$go_tags" \
+            -run='^$' \
+            -bench="$BENCH_FILTER" \
+            -benchtime="$BENCHTIME" \
+            -benchmem \
+            -timeout "$TIMEOUT" \
+            -count "$BENCHCOUNT" \
+            "${valid_pkgs[@]}" \
+            2>&1 | tee "$output_file"
+    ) || warn "[$label] Some benchmarks failed. Results may be partial."
+}
+
+# ── Run benchmarks on base ref ───────────────────────────────────
+
+WORKTREE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bench-base-XXXXXX")"
+info "Creating worktree for $BASE_REF at $WORKTREE_DIR..."
+git worktree add --detach "$WORKTREE_DIR" "$BASE_REF" 2>/dev/null
+
+run_benchmarks "$WORKTREE_DIR" "$BASE_RESULTS" "base"
+
+# ── Run benchmarks on head ref ───────────────────────────────────
+
+if [[ "$HEAD_REF" == "HEAD" ]]; then
+    run_benchmarks "$REPO_ROOT" "$HEAD_RESULTS" "head"
+else
+    WORKTREE_HEAD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bench-head-XXXXXX")"
+    info "Creating worktree for $HEAD_REF at $WORKTREE_HEAD_DIR..."
+    git worktree add --detach "$WORKTREE_HEAD_DIR" "$HEAD_REF" 2>/dev/null
+    run_benchmarks "$WORKTREE_HEAD_DIR" "$HEAD_RESULTS" "head"
+fi
+
+# ── Compare with benchstat ───────────────────────────────────────
+
+echo ""
+echo "============================================"
+echo "  Benchmark Comparison"
+echo "  base: $BASE_REF ($BASE_SHA)"
+echo "  head: $HEAD_REF ($HEAD_SHA)"
+echo "============================================"
+echo ""
+
+if [[ ! -s "$BASE_RESULTS" ]] || [[ ! -s "$HEAD_RESULTS" ]]; then
+    die "One or both benchmark result files are empty. Cannot compare."
+fi
+
+benchstat "$BASE_RESULTS" "$HEAD_RESULTS" | tee "$COMPARISON"
+
+echo ""
+if "$KEEP_RESULTS"; then
+    info "Results preserved:"
+    info "  Base:       $BASE_RESULTS"
+    info "  Head:       $HEAD_RESULTS"
+    info "  Comparison: $COMPARISON"
+fi

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -94,6 +94,7 @@ git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1 \
 git rev-parse --verify "${HEAD_REF}^{commit}" >/dev/null 2>&1 \
     || die "Invalid head ref: $HEAD_REF"
 
+export PATH="$(go env GOPATH)/bin:$PATH"
 if ! command -v benchstat &>/dev/null; then
     info "Installing benchstat..."
     go install golang.org/x/perf/cmd/benchstat@latest


### PR DESCRIPTION
## Description

Adds a CI job that automatically compares Go benchmark results between a PR and its base branch. When a PR touches packages that contain benchmarks, the job runs them on both refs using git worktrees, compares with `benchstat`, and posts results as a PR comment.

- `scripts/bench-compare.sh` — local script that detects changed packages, runs benchmarks on both refs, compares with benchstat
- `go-bench-compare` job in `unit-tests.yaml` — CI wrapper that calls the script and posts results

The job is non-blocking (`continue-on-error: true`) and only runs on PRs.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Tested the script locally by introducing an artificial regression (adding a mutex to `ValueStream.Push`) and running `scripts/bench-compare.sh`. The script correctly detected the regression with `benchstat` showing `+78.82% (p=0.008)` on `BenchmarkValueStreamWrite`.