### PR TITLE
fix(ui): stabilize empty array ref in `IntegrationsTable`

### DIFF
--- a/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
+++ b/ui/apps/platform/src/Containers/Integrations/IntegrationsListPage/IntegrationsTable.tsx
@@ -18,6 +18,8 @@ import { getIsAPIToken } from '../utils/integrationUtils';
 import type { Integration, IntegrationSource, IntegrationType } from '../utils/integrationUtils';
 import tableColumnDescriptor from '../utils/tableColumnDescriptor';
 
+const emptyIntegrations: Integration[] = [];
+
 function getNewButtonText(type) {
     if (type === 'apitoken') {
         return 'Generate token';
@@ -51,7 +53,7 @@ function IntegrationsTable({
     const { hasReadWriteAccess } = usePermissions();
     const hasWritePermission = hasReadWriteAccess('Integration');
     const { getPathToCreate, getPathToEdit, getPathToViewDetails } = usePageState();
-    const integrations = tableState?.type === 'COMPLETE' ? tableState.data : [];
+    const integrations = tableState?.type === 'COMPLETE' ? tableState.data : emptyIntegrations;
     const {
         selected,
         allRowsSelected,


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

A new empty array was created on every render when the table was not in COMPLETE state. This caused `useTableSelection`'s `useEffect` to fire in a loop (new ref → `setSelected` → re-render → new ref), producing thousands of PatternFly `Th` warnings and 100% CPU usage on any empty integration list page. Hoist to a module-level constant for stable identity.

Partially generated by AI.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Manual test.