### PR TITLE
ROX-35008: Add Quadlet mode to the VM action

### DIFF
--- a/.github/workflows/add-vms-to-cluster.yml
+++ b/.github/workflows/add-vms-to-cluster.yml
@@ -21,6 +21,19 @@ on:
         options:
           - rhel9
           - rhel10
+      agent-type:
+        description: "Agent install method"
+        required: false
+        default: "native"
+        type: choice
+        options:
+          - native
+          - quadlet
+      image-tag:
+        description: "ACS image tag for roxagent (auto-detected from Central if empty)"
+        required: false
+        default: ""
+        type: string
       ssh-public-key:
         description: "Optional SSH public key for human access to VMs"
         required: false
@@ -45,6 +58,8 @@ jobs:
           cluster-name: ${{ inputs.cluster-name }}
           num-vms: ${{ inputs.num-vms }}
           vm-os: ${{ inputs.vm-os }}
+          agent-type: ${{ inputs.agent-type }}
+          image-tag: ${{ inputs.image-tag }}
           ssh-public-key: ${{ inputs.ssh-public-key }}
           infra-token: ${{ secrets.INFRA_TOKEN }}
           quay-username: ${{ secrets.QUAY_RHACS_ENG_RO_USERNAME }}

--- a/scripts/ci/add-vms/action.yml
+++ b/scripts/ci/add-vms/action.yml
@@ -13,6 +13,14 @@ inputs:
     description: "VM OS: rhel9 or rhel10"
     required: false
     default: "rhel9"
+  agent-type:
+    description: "Agent install method: quadlet or native"
+    required: false
+    default: "native"
+  image-tag:
+    description: "ACS image tag for roxagent container (auto-detected from Central if omitted)"
+    required: false
+    default: ""
   ssh-public-key:
     description: "Optional SSH public key to add for human access to all target VMs"
     required: false
@@ -139,8 +147,13 @@ runs:
         ARGS=(
             --num-vms "${{ inputs.num-vms }}"
             --os "${{ inputs.vm-os }}"
+            --agent "${{ inputs.agent-type }}"
             --artifacts-dir "$ARTIFACTS_DIR"
         )
+
+        if [[ -n "${{ inputs.image-tag }}" ]]; then
+            ARGS+=(--image-tag "${{ inputs.image-tag }}")
+        fi
 
         if [[ -n "${USER_SSH_KEY_PATH:-}" ]]; then
             ARGS+=(--ssh-key "$USER_SSH_KEY_PATH")

--- a/scripts/ci/add-vms/add-vms.sh
+++ b/scripts/ci/add-vms/add-vms.sh
@@ -8,6 +8,8 @@
 #   --cluster NAME       Infra cluster name (calls infractl for kubeconfig)
 #   --num-vms N          Number of VMs (default: 1)
 #   --os OS              VM OS: rhel9|rhel10 (default: rhel9)
+#   --agent TYPE         Agent type: quadlet|native (default: native)
+#   --image-tag TAG      ACS image tag (auto-detected if omitted)
 #   --ssh-key PATH       Path to user SSH public key to add to target VMs
 #   --namespace NS       Target namespace (default: openshift-cnv)
 #   --vm-prefix PREFIX   VM name prefix (default: same as OS)
@@ -27,6 +29,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLUSTER_NAME=""
 NUM_VMS=1
 VM_OS="rhel9"
+AGENT_TYPE="native"
+IMAGE_TAG=""
 USER_SSH_KEY_PATH=""
 NAMESPACE="openshift-cnv"
 VM_PREFIX=""
@@ -48,6 +52,8 @@ parse_args() {
             --cluster)      CLUSTER_NAME="$2"; shift 2 ;;
             --num-vms)      NUM_VMS="$2"; shift 2 ;;
             --os)           VM_OS="$2"; shift 2 ;;
+            --agent)        AGENT_TYPE="$2"; shift 2 ;;
+            --image-tag)    IMAGE_TAG="$2"; shift 2 ;;
             --ssh-key)      USER_SSH_KEY_PATH="$2"; shift 2 ;;
             --namespace)    NAMESPACE="$2"; shift 2 ;;
             --vm-prefix)    VM_PREFIX="$2"; shift 2 ;;
@@ -65,6 +71,7 @@ parse_args() {
         die "--num-vms must be a positive integer"
     fi
     [[ "$VM_OS" =~ ^rhel(9|10)$ ]] || die "--os must be rhel9 or rhel10"
+    [[ "$AGENT_TYPE" =~ ^(quadlet|native)$ ]] || die "--agent must be quadlet or native"
 }
 
 # Sets KUBECONFIG: either fetches it from infractl for the given cluster
@@ -104,7 +111,7 @@ print_summary() {
     echo "Namespace:    $NAMESPACE"
     echo "VM OS:        $VM_OS"
     echo "VM prefix:    $VM_PREFIX"
-    echo "Agent type:   native"
+    echo "Agent type:   $AGENT_TYPE"
     echo "Num VMs:      $NUM_VMS"
     echo ""
 
@@ -223,6 +230,7 @@ write_github_summary() {
 
 cleanup() {
     rm -f "${AUTOMATION_SSH_PRIVKEY:-}" "${AUTOMATION_SSH_PUBKEY:-}"
+    rm -rf "${RENDERED_QUADLET_DIR:-}"
 }
 trap cleanup EXIT
 
@@ -240,11 +248,12 @@ main() {
     echo "  VM OS:       $VM_OS"
     echo "  VM prefix:   $VM_PREFIX"
     echo "  Num VMs:     $NUM_VMS"
-    echo "  Agent type:  native"
+    echo "  Agent type:  $AGENT_TYPE"
+    [[ -n "$IMAGE_TAG" ]] && echo "  Image tag:   $IMAGE_TAG"
     echo ""
 
     # Export variables for sourced scripts
-    export NAMESPACE VM_OS VM_PREFIX NUM_VMS ARTIFACTS_DIR
+    export NAMESPACE VM_OS VM_PREFIX NUM_VMS IMAGE_TAG ARTIFACTS_DIR
     export CONTAINER_IMAGE="quay.io/rhacs-eng/vm-images:${VM_OS}-dnf-primed-latest"
 
     # Step 1: Install virt operator (skippable when action handles this separately)
@@ -271,9 +280,18 @@ main() {
         die "No accessible VMs — cannot install agent. All VMs failed SSH readiness."
     else
         export AUTOMATION_SSH_PRIVKEY
-        # shellcheck source=install-agent-native.sh
-        source "$SCRIPT_DIR/install-agent-native.sh"
-        install_agent_native "${accessible_vms[@]}"
+        case "$AGENT_TYPE" in
+            quadlet)
+                # shellcheck source=install-agent-quadlet.sh
+                source "$SCRIPT_DIR/install-agent-quadlet.sh"
+                install_agent_quadlet "${accessible_vms[@]}"
+                ;;
+            native)
+                # shellcheck source=install-agent-native.sh
+                source "$SCRIPT_DIR/install-agent-native.sh"
+                install_agent_native "${accessible_vms[@]}"
+                ;;
+        esac
     fi
 
     # Step 4: Summary

--- a/scripts/ci/add-vms/install-agent-quadlet.bats
+++ b/scripts/ci/add-vms/install-agent-quadlet.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1091
+
+load "../../test_helpers.bats"
+
+function setup() {
+    source "${BATS_TEST_DIRNAME}/install-agent-quadlet.sh"
+
+    NAMESPACE="openshift-cnv"
+    SSH_USER="cloud-user"
+    IMAGE_TAG="4.12.x-123-gdeadbeef"
+    AUTOMATION_SSH_PRIVKEY="${BATS_TEST_TMPDIR}/id_ed25519"
+    touch "${AUTOMATION_SSH_PRIVKEY}"
+
+    VIRTCTL_INSTALL_COMPLETE="true"
+    VIRTCTL_INSTALLED_IMAGE="Image=quay.io/stackrox-io/main:${IMAGE_TAG}"
+
+    virtctl() {
+        local cmd=""
+        while (($#)); do
+            case "$1" in
+                --command)
+                    cmd="$2"
+                    shift 2
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+
+        if [[ "$cmd" == *"systemctl is-enabled roxagent.timer"* ]]; then
+            [[ "${VIRTCTL_INSTALL_COMPLETE}" == "true" ]]
+            return
+        fi
+
+        if [[ "$cmd" == *"grep -h '^Image='"* ]]; then
+            printf '%s\n' "${VIRTCTL_INSTALLED_IMAGE}"
+            return
+        fi
+
+        echo "unexpected virtctl command: ${cmd}" >&2
+        return 1
+    }
+}
+
+@test "installed_image_tag_matches rejects partial installs even when image matches" {
+    VIRTCTL_INSTALL_COMPLETE="false"
+
+    run installed_image_tag_matches "rhel10-1"
+
+    assert_failure
+}
+
+@test "installed_image_tag_matches rejects mismatched image tags" {
+    VIRTCTL_INSTALLED_IMAGE="Image=quay.io/stackrox-io/main:wrong-tag"
+
+    run installed_image_tag_matches "rhel10-1"
+
+    assert_failure
+}
+
+@test "installed_image_tag_matches accepts complete installs with matching image tags" {
+    run installed_image_tag_matches "rhel10-1"
+
+    assert_success
+}

--- a/scripts/ci/add-vms/install-agent-quadlet.sh
+++ b/scripts/ci/add-vms/install-agent-quadlet.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Install roxagent on VMs using the Quadlet (container) method.
+#
+# Detects or accepts the ACS image tag, renders the correct Image= line
+# in every image-bearing Quadlet file, and calls quadlet/install.sh
+# for each target VM.
+#
+# Idempotent: reads the installed Image= tag on each VM and skips
+# if it matches the desired tag.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QUADLET_DIR="${SCRIPT_DIR}/quadlet"
+
+# Globals (set by caller or defaulted)
+NAMESPACE="${NAMESPACE:-openshift-cnv}"
+SSH_USER="${SSH_USER:-cloud-user}"
+IMAGE_TAG="${IMAGE_TAG:-}"
+AUTOMATION_SSH_PRIVKEY="${AUTOMATION_SSH_PRIVKEY:-}"
+
+# Image-bearing Quadlet files whose Image= line must be rendered.
+# TODO: When the reactive agent lands, add "roxagent-reactive.container" here
+# and update installed_image_tag_matches() to check each file individually.
+IMAGE_BEARING_FILES=("roxagent.container")
+
+# Set by render_quadlet_image_tag; points to temp copy with rendered Image= lines
+RENDERED_QUADLET_DIR=""
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+virtctl_ssh() {
+    local vm_name="$1"
+    local remote_cmd="$2"
+
+    virtctl ssh \
+        --namespace "$NAMESPACE" \
+        --identity-file "$AUTOMATION_SSH_PRIVKEY" \
+        --local-ssh-opts="-o StrictHostKeyChecking=no" \
+        --local-ssh-opts="-o UserKnownHostsFile=/dev/null" \
+        --local-ssh-opts="-o BatchMode=yes" \
+        --local-ssh-opts="-o ConnectTimeout=10" \
+        --command "$remote_cmd" \
+        "${SSH_USER}@vmi/${vm_name}"
+}
+
+cleanup_rendered_quadlet_dir() {
+    rm -rf "${RENDERED_QUADLET_DIR:-}"
+}
+
+detect_image_tag() {
+    if [[ -n "$IMAGE_TAG" ]]; then
+        echo "Using provided image tag: $IMAGE_TAG"
+        return 0
+    fi
+
+    echo "Auto-detecting image tag from Central deployment..."
+    local central_image
+    central_image="$(kubectl get deploy/central -n stackrox \
+        -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+
+    if [[ -z "$central_image" ]]; then
+        die "Cannot auto-detect image tag: Central deployment not found in stackrox namespace. Provide --image-tag explicitly."
+    fi
+
+    # Extract tag from image reference (quay.io/stackrox-io/main:TAG or similar)
+    IMAGE_TAG="${central_image##*:}"
+    if [[ -z "$IMAGE_TAG" || "$IMAGE_TAG" == "$central_image" ]]; then
+        die "Cannot parse tag from Central image: $central_image"
+    fi
+    echo "Detected image tag: $IMAGE_TAG"
+}
+
+render_quadlet_image_tag() {
+    local full_image="quay.io/stackrox-io/main:${IMAGE_TAG}"
+    echo "Rendering Image=${full_image} in Quadlet files..."
+
+    # Work on a temp copy to avoid dirtying the git working tree
+    RENDERED_QUADLET_DIR="$(mktemp -d)"
+    cp -a "${QUADLET_DIR}/." "${RENDERED_QUADLET_DIR}/"
+
+    for f in "${IMAGE_BEARING_FILES[@]}"; do
+        local file="${RENDERED_QUADLET_DIR}/${f}"
+        if [[ ! -f "$file" ]]; then
+            echo "  WARNING: ${f} not found in ${QUADLET_DIR} — skipping."
+            continue
+        fi
+        sed -i.bak "s|^Image=.*|Image=${full_image}|" "$file"
+        rm -f "${file}.bak"
+        echo "  Rendered: $f"
+    done
+}
+
+quadlet_install_is_complete() {
+    local vm_name="$1"
+    local check_cmd="
+        test -f /etc/containers/systemd/roxagent.container &&
+        test -f /etc/systemd/system/roxagent.timer &&
+        test -f /etc/systemd/system/roxagent-prep.service &&
+        test -f /etc/tmpfiles.d/roxagent.conf &&
+        systemctl is-enabled roxagent.timer >/dev/null
+    "
+
+    virtctl_ssh "$vm_name" "$check_cmd" >/dev/null 2>/dev/null
+}
+
+installed_image_tag_matches() {
+    local vm_name="$1"
+    local desired_image="quay.io/stackrox-io/main:${IMAGE_TAG}"
+
+    if ! quadlet_install_is_complete "$vm_name"; then
+        return 1
+    fi
+
+    local installed_image
+    installed_image="$(virtctl_ssh "$vm_name" \
+        "grep -h '^Image=' /etc/containers/systemd/roxagent*.container 2>/dev/null || true" \
+        2>/dev/null | tr -d '[:space:]')"
+
+    local desired_line="Image=${desired_image}"
+    desired_line="$(echo "$desired_line" | tr -d '[:space:]')"
+
+    [[ "$installed_image" == "$desired_line" ]]
+}
+
+install_on_vm() {
+    local vm_name="$1"
+    echo "--- Installing roxagent (Quadlet) on $vm_name ---"
+
+    if installed_image_tag_matches "$vm_name"; then
+        echo "  Image tag already matches on $vm_name — skipping."
+        return 0
+    fi
+
+    QUADLET_FILES_DIR="$RENDERED_QUADLET_DIR" \
+        "${RENDERED_QUADLET_DIR}/install.sh" --virtctl \
+        -n "$NAMESPACE" \
+        --identity-file "$AUTOMATION_SSH_PRIVKEY" \
+        "${SSH_USER}@vmi/${vm_name}"
+
+    echo "  Installed on $vm_name."
+}
+
+install_agent_quadlet() {
+    local vm_names=("$@")
+
+    detect_image_tag
+    render_quadlet_image_tag
+
+    for vm in "${vm_names[@]}"; do
+        install_on_vm "$vm"
+    done
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [[ $# -eq 0 ]]; then
+        echo "Usage: $0 <vm-name> [vm-name...]" >&2
+        exit 1
+    fi
+    trap cleanup_rendered_quadlet_dir EXIT
+    install_agent_quadlet "$@"
+fi

--- a/scripts/ci/add-vms/quadlet/README.md
+++ b/scripts/ci/add-vms/quadlet/README.md
@@ -1,0 +1,192 @@
+# Quadlet Deployment for roxagent
+
+Deploy roxagent as a periodic systemd service on RHEL VMs using Podman Quadlet.
+
+## Overview
+
+This deployment uses [Podman Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) to run roxagent from a container image as a systemd service. The agent runs hourly, scans installed packages, and reports them to StackRox via vsock.
+
+### Components
+
+| File | Description |
+|------|-------------|
+| `roxagent.container` | Quadlet container unit that runs roxagent |
+| `roxagent.timer` | Systemd timer that triggers hourly scans |
+| `roxagent-prep.service` | Prepares RPM database for scanning |
+| `roxagent-tmpfiles.conf` | Recreates `/run/lock/roxagent` on boot |
+| `install.sh` | Installation script for local or remote deployment |
+
+## Prerequisites
+
+* RHEL 8, 9, or 10 VM running on KubeVirt with vsock enabled
+* Podman installed (`dnf install -y podman`)
+* StackRox deployed with VM scanning enabled (`ROX_VIRTUAL_MACHINES=true`)
+* Network access to pull the StackRox main image
+
+## Installation
+
+### 1. Configure the Image Tag
+
+Edit `roxagent.container` and set the correct image tag:
+
+```ini
+Image=quay.io/stackrox-io/main:4.10.0
+```
+
+Use the same version as your StackRox Central deployment.
+
+### 2. Install the Units
+
+**Local installation:**
+
+```bash
+./install.sh
+```
+
+**Remote installation via SSH:**
+
+```bash
+./install.sh user@hostname
+./install.sh user@hostname 2222  # Custom SSH port
+```
+
+### 3. Verify Installation
+
+```bash
+# Check timer status
+sudo systemctl list-timers roxagent.timer
+
+# Run immediately
+sudo systemctl start roxagent.service
+
+# View logs
+sudo journalctl -u roxagent.service -f
+```
+
+## How It Works
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ RHEL VM                                                     │
+│  ┌─────────────────┐                                        │
+│  │ roxagent.timer  │ ──(hourly)──▶ roxagent.service         │
+│  └─────────────────┘                      │                 │
+│                                           ▼                 │
+│  ┌─────────────────┐         ┌────────────────────────┐     │
+│  │ roxagent-prep   │ ──────▶ │ roxagent container     │     │
+│  │ (copy RPM db)   │         │ - scans /host/var/lib/ │     │
+│  └─────────────────┘         │ - sends via vsock      │     │
+│                              └───────────┬────────────┘     │
+└──────────────────────────────────────────┼──────────────────┘
+                                           │ vsock
+┌──────────────────────────────────────────┼─────────────────┐
+│ Kubernetes Host                          ▼                 │
+│  ┌────────────────────────────────────────────┐            │
+│  │ collector pod (compliance container)       │            │
+│  │ - receives vsock connections               │            │
+│  │ - forwards to Sensor                       │            │
+│  └─────────────────────┬──────────────────────┘            │
+│                        │ gRPC                              │
+│                        ▼                                   │
+│  ┌────────────────────────────────────────────┐            │
+│  │ Sensor ──▶ Central                         │            │
+│  └────────────────────────────────────────────┘            │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Why Copy the RPM Database?
+
+The `roxagent-prep.service` copies `/var/lib/rpm` to `/tmp/roxagent-rpm` before each scan. This is required because:
+
+1. **SQLite WAL Mode**: RHEL 9 and 10 use SQLite for the RPM database. SQLite's Write-Ahead Logging (WAL) requires write access even for read-only queries. RHEL 8 uses BerkeleyDB, which also benefits from copying.
+
+2. **Safety**: Copying protects the host's RPM database from any potential issues during scanning.
+
+3. **Consistency**: The copy provides a point-in-time snapshot, avoiding conflicts if packages are installed during the scan.
+
+## Configuration
+
+### Scan Interval
+
+Edit `roxagent.timer` to change the scan frequency:
+
+```ini
+[Timer]
+OnBootSec=5min      # First scan after boot
+OnUnitActiveSec=1h  # Subsequent scans (change to 30m, 2h, etc.)
+```
+
+### Container Options
+
+Edit `roxagent.container` to customize:
+
+```ini
+# Add verbose output
+Exec=--verbose --host-path /host
+
+# Change vsock port (must match StackRox config)
+Exec=--host-path /host --port 2048
+```
+
+## Troubleshooting
+
+### No packages found
+
+Check if the RPM database copy succeeded:
+
+```bash
+ls -la /tmp/roxagent-rpm/
+sudo journalctl -u roxagent-prep.service
+```
+
+### vsock connection failed
+
+Verify vsock is enabled in the VM:
+
+```bash
+ls -la /dev/vsock
+lsmod | grep vsock
+```
+
+### Container fails to start
+
+Check Quadlet generation:
+
+```bash
+/usr/libexec/podman/quadlet --dryrun
+sudo journalctl -u roxagent.service
+```
+
+### VM not appearing in Central
+
+1. Verify `ROX_VIRTUAL_MACHINES=true` is set on Central and Sensor
+2. Check compliance container logs in the collector pod
+3. Verify Sensor can reach Central
+
+### Agent reports lock warning
+
+If logs show `could not acquire lock at /run/lock/roxagent/roxagent.lock`, verify the lock directory exists and is writable:
+
+```bash
+ls -la /run/lock/roxagent/
+sudo mkdir -p /run/lock/roxagent
+```
+
+The install script creates this directory immediately and installs a `tmpfiles.d`
+rule so it is recreated automatically on boot. The prep service also runs
+`mkdir -p /run/lock/roxagent` before every scan as an extra safeguard. If the
+directory was removed manually while the system is running, re-run `install.sh`
+or create it manually.
+
+## Uninstallation
+
+```bash
+sudo systemctl disable --now roxagent.timer
+sudo rm /etc/containers/systemd/roxagent.container
+sudo rm /etc/systemd/system/roxagent.timer
+sudo rm /etc/systemd/system/roxagent-prep.service
+sudo rm /etc/tmpfiles.d/roxagent.conf
+sudo systemctl daemon-reload
+```

--- a/scripts/ci/add-vms/quadlet/install.sh
+++ b/scripts/ci/add-vms/quadlet/install.sh
@@ -1,0 +1,275 @@
+#!/bin/bash
+# Install roxagent Quadlet units on a RHEL VM
+#
+# Usage:
+#   ./install.sh                                                      # Install locally
+#   ./install.sh --virtctl -n openshift-cnv cloud-user@vmi/rhel10-1   # Via virtctl
+#   ./install.sh --ssh user@host                                      # SSH (port 22)
+#   ./install.sh --ssh user@host 2222                                 # SSH with custom port
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Directory containing the Quadlet unit files (roxagent.container, .timer, etc.)
+# to install. Defaults to the script's own directory; override for testing.
+QUADLET_FILES_DIR="${QUADLET_FILES_DIR:-${SCRIPT_DIR}}"
+
+# Host paths that may not exist on all RHEL versions (e.g. DNF paths on
+# yum-only RHEL 8). Volume= lines referencing these are stripped when the
+# source path is absent.
+OPTIONAL_HOST_PATHS=(
+    /etc/yum.repos.d
+    /etc/yum/repos.d
+    /etc/distro.repos.d
+    /etc/redhat-release
+    /etc/system-release-cpe
+    /var/cache/dnf
+    /var/lib/dnf
+)
+
+STAGED_INSTALL_FILES=(
+    install.sh
+    roxagent.container
+    roxagent.timer
+    roxagent-prep.service
+    roxagent-tmpfiles.conf
+)
+
+TRANSPORT_KIND=""
+SSH_HOST=""
+SSH_PORT=""
+VIRTCTL_TARGET=""
+VIRTCTL_FLAGS=()
+
+main() {
+    if [ $# -eq 0 ]; then
+        setup_transport_local
+        install_local
+    elif [ "$1" = "--stage-dir" ]; then
+        if [ $# -ne 2 ]; then
+            echo "usage: $0 --stage-dir <dir>" >&2
+            exit 1
+        fi
+        install_from_stage_dir "$2"
+        return
+    elif [ "$1" = "--ssh" ]; then
+        shift
+        if [ $# -lt 1 ]; then
+            usage
+            exit 1
+        fi
+        setup_transport_ssh "$1" "${2:-22}"
+        install_remote
+    elif [ "$1" = "--virtctl" ]; then
+        shift
+        setup_transport_virtctl "$@"
+        install_remote
+    else
+        usage
+        exit 1
+    fi
+
+    echo ""
+    echo "Done! The roxagent will run periodically."
+    echo ""
+    echo "To run immediately:  sudo systemctl start roxagent.service"
+    echo "To view logs:        sudo journalctl -u roxagent.service -f"
+    echo "To check timer:      sudo systemctl list-timers roxagent.timer"
+}
+
+usage() {
+    cat >&2 <<EOF
+Usage:
+  $0                                           # Install locally
+  $0 --virtctl [virtctl-flags...] <user@vmi/name> # Remote install via virtctl
+  $0 --ssh <user@host> [port]                  # Remote install via SSH
+
+Examples:
+  $0 --virtctl -n openshift-cnv cloud-user@vmi/rhel10-1
+  $0 --ssh root@192.168.1.10
+  $0 --ssh root@192.168.1.10 2222
+EOF
+}
+
+remote_copy() {
+    case "${TRANSPORT_KIND}" in
+        ssh)
+            scp -P "${SSH_PORT}" "$1" "${SSH_HOST}:$2"
+            ;;
+        virtctl)
+            virtctl scp "${VIRTCTL_FLAGS[@]}" "$1" "${VIRTCTL_TARGET}:$2"
+            ;;
+        *)
+            echo "remote_copy called without a remote transport" >&2
+            return 1
+            ;;
+    esac
+}
+
+remote_exec() {
+    case "${TRANSPORT_KIND}" in
+        ssh)
+            ssh -p "${SSH_PORT}" "${SSH_HOST}" bash -s
+            ;;
+        virtctl)
+            virtctl ssh "${VIRTCTL_FLAGS[@]}" "${VIRTCTL_TARGET}" --command 'bash -s'
+            ;;
+        *)
+            echo "remote_exec called without a remote transport" >&2
+            return 1
+            ;;
+    esac
+}
+
+setup_transport_local() {
+    TRANSPORT_KIND="local"
+}
+
+setup_transport_ssh() {
+    TRANSPORT_KIND="ssh"
+    SSH_HOST="$1"
+    SSH_PORT="${2:-22}"
+}
+
+setup_transport_virtctl() {
+    if [ $# -eq 0 ]; then
+        echo "error: virtctl mode requires at least a target (e.g. cloud-user@vmi/rhel10-1)" >&2
+        echo "" >&2
+        usage
+        exit 1
+    fi
+
+    # Expects virtctl mode arguments after the explicit "--virtctl" selector, e.g.:
+    #   -n openshift-cnv cloud-user@vmi/rhel10-1
+    # The last positional arg is the target; everything else are flags.
+    TRANSPORT_KIND="virtctl"
+    VIRTCTL_TARGET="${*: -1}"
+
+    local argc=$#
+    if (( argc > 1 )); then
+        # Collect all arguments except the last one (the target) as flags.
+        VIRTCTL_FLAGS=("${@:1:argc-1}")
+    else
+        VIRTCTL_FLAGS=()
+    fi
+}
+
+# --- Install logic (shared) --------------------------------------------------
+
+create_remote_stage_dir() {
+    local output
+    output="$(
+        remote_exec <<'SCRIPT'
+set -euo pipefail
+stage_dir="$(mktemp -d "${TMPDIR:-/var/tmp}/roxagent-install.XXXXXX")"
+printf '__STAGE_DIR__=%s\n' "${stage_dir}"
+SCRIPT
+    )"
+
+    local stage_dir
+    stage_dir="$(printf '%s\n' "${output}" | sed -n 's/^__STAGE_DIR__=//p' | tail -n 1)"
+    if [ -z "${stage_dir}" ]; then
+        echo "failed to determine remote stage dir" >&2
+        return 1
+    fi
+    printf '%s\n' "${stage_dir}"
+}
+
+copy_remote_stage_files() {
+    local remote_stage_dir="$1"
+    local file
+    for file in "${STAGED_INSTALL_FILES[@]}"; do
+        remote_copy "${QUADLET_FILES_DIR}/${file}" "${remote_stage_dir}/${file}"
+    done
+}
+
+validate_stage_dir() {
+    local stage_dir="$1"
+    local file
+    for file in "${STAGED_INSTALL_FILES[@]}"; do
+        [ "${file}" = "install.sh" ] && continue
+        if [ ! -f "${stage_dir}/${file}" ]; then
+            echo "missing staged file: ${stage_dir}/${file}" >&2
+            return 1
+        fi
+    done
+}
+
+install_from_stage_dir() {
+    local stage_dir="$1"
+    validate_stage_dir "${stage_dir}"
+
+    echo "Installing Quadlet units from ${stage_dir}..."
+
+    # Quadlet container file (strip mounts for paths missing on this host)
+    sudo mkdir -p /etc/containers/systemd/
+    filter_container_file "${stage_dir}/roxagent.container" \
+        | sudo tee /etc/containers/systemd/roxagent.container >/dev/null
+    # restorecon resets SELinux labels so systemd/podman can read the new files.
+    sudo restorecon -Rv /etc/containers/systemd/ 2>/dev/null || true
+
+    # Timer and prep service go in standard systemd directory
+    sudo cp "${stage_dir}/roxagent.timer" /etc/systemd/system/
+    sudo cp "${stage_dir}/roxagent-prep.service" /etc/systemd/system/
+    sudo restorecon -Rv /etc/systemd/system/roxagent.timer /etc/systemd/system/roxagent-prep.service 2>/dev/null || true
+
+    # Recreate the lock directory on every boot since /run is tmpfs.
+    sudo mkdir -p /etc/tmpfiles.d/
+    sudo cp "${stage_dir}/roxagent-tmpfiles.conf" /etc/tmpfiles.d/roxagent.conf
+    sudo restorecon -Rv /etc/tmpfiles.d/roxagent.conf 2>/dev/null || true
+    # systemd-tmpfiles --create applies the rule now (creates /run/lock/roxagent immediately).
+    sudo systemd-tmpfiles --create /etc/tmpfiles.d/roxagent.conf
+
+    echo "Reloading systemd..."
+    sudo systemctl daemon-reload
+
+    echo "Enabling and starting timer..."
+    sudo systemctl enable --now roxagent.timer
+
+    echo "Status:"
+    sudo systemctl list-timers roxagent.timer
+}
+
+install_local() {
+    install_from_stage_dir "${QUADLET_FILES_DIR}"
+}
+
+install_remote() {
+    local remote_stage_dir
+
+    echo "Preparing stage directory on target..."
+    remote_stage_dir="$(create_remote_stage_dir)"
+
+    echo "Copying files to target..."
+    copy_remote_stage_files "${remote_stage_dir}"
+
+    echo "Running install on target..."
+    remote_exec <<SCRIPT
+set -euo pipefail
+cleanup() {
+    rm -rf "${remote_stage_dir}"
+}
+trap cleanup EXIT
+bash "${remote_stage_dir}/install.sh" --stage-dir "${remote_stage_dir}"
+SCRIPT
+}
+
+# Produce a filtered roxagent.container on stdout, removing Volume= lines
+# whose host source path does not exist on this machine.
+filter_container_file() {
+    local file="$1"
+    local pattern=""
+    for p in "${OPTIONAL_HOST_PATHS[@]}"; do
+        if [ ! -e "${p}" ]; then
+            echo "Stripping mount for missing path: ${p}" >&2
+            pattern="${pattern:+${pattern}|}Volume=${p}[:/]"
+        fi
+    done
+    if [ -z "${pattern}" ]; then
+        cat "${file}"
+    else
+        grep -Ev "${pattern}" "${file}"
+    fi
+}
+
+main "$@"

--- a/scripts/ci/add-vms/quadlet/roxagent-prep.service
+++ b/scripts/ci/add-vms/quadlet/roxagent-prep.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Prepare RPM database for StackRox VM Agent
+# Copy the RPM database to a writable location because SQLite WAL mode
+# requires write access even for read-only queries
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/bin/mkdir -p /run/lock/roxagent
+ExecStart=/bin/rm -rf /tmp/roxagent-rpm
+ExecStart=/bin/cp -a /var/lib/rpm /tmp/roxagent-rpm
+ExecStart=/bin/chmod -R 755 /tmp/roxagent-rpm

--- a/scripts/ci/add-vms/quadlet/roxagent-tmpfiles.conf
+++ b/scripts/ci/add-vms/quadlet/roxagent-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /run/lock/roxagent 0755 root root -

--- a/scripts/ci/add-vms/quadlet/roxagent.container
+++ b/scripts/ci/add-vms/quadlet/roxagent.container
@@ -1,0 +1,42 @@
+[Unit]
+Description=StackRox VM Agent Container
+# Copy RPM database before starting (SQLite WAL requires writable access)
+Requires=roxagent-prep.service
+After=roxagent-prep.service
+
+[Container]
+# Replace with your StackRox main image tag
+Image=quay.io/stackrox-io/main:4.11.x-798-g8a5ad6ed58
+# Pull when SHA is different (Default is "always")
+Pull=newer
+Exec=--host-path /host
+Network=host
+
+# Privileged for vsock access
+# Use PodmanArgs for entrypoint (RHEL 8 Quadlet doesn't support Entrypoint key)
+# Run as root since image defaults to non-root user
+SecurityLabelDisable=true
+PodmanArgs=--privileged --user root --entrypoint /stackrox/bin/roxagent --device /dev/vsock
+
+# Mount copied RPM database (writable for SQLite WAL) and host config files (read-only)
+Volume=/tmp/roxagent-rpm:/host/var/lib/rpm:rw
+Volume=/etc/yum.repos.d:/host/etc/yum.repos.d:ro
+Volume=/etc/os-release:/host/etc/os-release:ro
+Volume=/etc/redhat-release:/host/etc/redhat-release:ro
+Volume=/etc/system-release-cpe:/host/etc/system-release-cpe:ro
+# Additional repo directories (may not exist on all RHEL versions)
+Volume=/etc/yum/repos.d:/host/etc/yum/repos.d:ro
+Volume=/etc/distro.repos.d:/host/etc/distro.repos.d:ro
+# DNF cache and state for repo-to-package mapping
+Volume=/var/cache/dnf:/host/var/cache/dnf:ro
+Volume=/var/lib/dnf:/host/var/lib/dnf:ro
+# Single-instance lock shared between host and container roxagent runs
+Volume=/run/lock/roxagent:/run/lock/roxagent:rw
+
+[Service]
+Type=oneshot
+# First start can take longer on slow VMs
+TimeoutStartSec=600
+
+[Install]
+WantedBy=

--- a/scripts/ci/add-vms/quadlet/roxagent.timer
+++ b/scripts/ci/add-vms/quadlet/roxagent.timer
@@ -1,0 +1,21 @@
+[Unit]
+Description=Run StackRox VM Agent periodically
+
+[Timer]
+OnBootSec=5min
+
+# Shortening this interval results in more frequent scans and therefore more load,
+# which, assuming the throughput continues to be limited by scanning capacity,
+# reduces the number of VMs that Stackrox can handle.
+#
+# As of February 2026, the measured capacity of a default Stackrox deployment is:
+#   - 4500 VMs if the report interval is 4 hours
+#   - 1100 VMs if the report interval is 1 hour
+#
+# See the documentation for more details.
+OnUnitActiveSec=3h40m
+RandomizedDelaySec=40min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Description

This stacked PR adds the Quadlet-based roxagent installation path on top of the native-only VM action base.

It re-enables `quadlet` as a selectable action input, adds the Quadlet installer and assets, and keeps the Quadlet-specific logic in a dedicated follow-up PR so the base VM action stays easier to review.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [x] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- [ ] By running it
