### PR TITLE
ROX-34953: wire up detection pipeline

### DIFF
--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -220,7 +220,7 @@ func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image
 	return obj, err
 }
 
-// constructDeployment is the internal implementation that also returns the filtered deployment,
+// constructDeployment is the internal implementation that also returns the deployment,
 // allowing callers like ConstructDeploymentWithProcess to use it for index lookups.
 func constructDeployment(deployment *storage.Deployment, images []*storage.Image, applied *NetworkPoliciesApplied) (*pathutil.AugmentedObj, *storage.Deployment, error) {
 	obj := pathutil.NewAugmentedObj(deployment)

--- a/pkg/booleanpolicy/augmentedobjs/construct.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/booleanpolicy/evaluator/pathutil"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/utils"
 )
 
@@ -224,7 +223,6 @@ func ConstructDeployment(deployment *storage.Deployment, images []*storage.Image
 // constructDeployment is the internal implementation that also returns the filtered deployment,
 // allowing callers like ConstructDeploymentWithProcess to use it for index lookups.
 func constructDeployment(deployment *storage.Deployment, images []*storage.Image, applied *NetworkPoliciesApplied) (*pathutil.AugmentedObj, *storage.Deployment, error) {
-	deployment, images = filterInitContainers(deployment, images)
 	obj := pathutil.NewAugmentedObj(deployment)
 	if len(images) != len(deployment.GetContainers()) {
 		return nil, nil, errors.Errorf("deployment %s/%s had %d containers, but got %d images",
@@ -271,39 +269,6 @@ func constructDeployment(deployment *storage.Deployment, images []*storage.Image
 	}
 
 	return obj, deployment, nil
-}
-
-// filterInitContainers returns a filtered deployment and image slice with init containers removed.
-// TODO(ROX-33067): Make this filter conditional on policy evaluation settings.
-func filterInitContainers(deployment *storage.Deployment, images []*storage.Image) (*storage.Deployment, []*storage.Image) {
-	if !features.InitContainerSupport.Enabled() {
-		return deployment, images
-	}
-
-	hasInit := false
-	for _, c := range deployment.GetContainers() {
-		if c.GetType() == storage.ContainerType_INIT {
-			hasInit = true
-			break
-		}
-	}
-	if !hasInit {
-		return deployment, images
-	}
-
-	filtered := deployment.CloneVT()
-	filtered.Containers = nil
-	var filteredImages []*storage.Image
-	for i, c := range deployment.GetContainers() {
-		if c.GetType() == storage.ContainerType_INIT {
-			continue
-		}
-		filtered.Containers = append(filtered.Containers, c)
-		if i < len(images) {
-			filteredImages = append(filteredImages, images[i])
-		}
-	}
-	return filtered, filteredImages
 }
 
 // ConstructImage constructs the augmented image object.

--- a/pkg/booleanpolicy/augmentedobjs/construct_test.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct_test.go
@@ -5,84 +5,10 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/features"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestFilterInitContainers(t *testing.T) {
-	initContainer := &storage.Container{
-		Name: "init",
-		Type: storage.ContainerType_INIT,
-	}
-	regularContainer := &storage.Container{
-		Name: "main",
-		Type: storage.ContainerType_REGULAR,
-	}
-	initImage := &storage.Image{
-		Id: "init-image",
-	}
-	regularImage := &storage.Image{
-		Id: "main-image",
-	}
-
-	cases := map[string]struct {
-		flagEnabled        bool
-		containers         []*storage.Container
-		images             []*storage.Image
-		expectedContainers []*storage.Container
-		expectedImages     []*storage.Image
-	}{
-		"flag enabled, init containers filtered out": {
-			flagEnabled:        true,
-			containers:         []*storage.Container{initContainer, regularContainer},
-			images:             []*storage.Image{initImage, regularImage},
-			expectedContainers: []*storage.Container{regularContainer},
-			expectedImages:     []*storage.Image{regularImage},
-		},
-		"flag enabled, no init containers is a no-op": {
-			flagEnabled:        true,
-			containers:         []*storage.Container{regularContainer},
-			images:             []*storage.Image{regularImage},
-			expectedContainers: []*storage.Container{regularContainer},
-			expectedImages:     []*storage.Image{regularImage},
-		},
-		"flag disabled, init containers passed through": {
-			flagEnabled:        false,
-			containers:         []*storage.Container{initContainer, regularContainer},
-			images:             []*storage.Image{initImage, regularImage},
-			expectedContainers: []*storage.Container{initContainer, regularContainer},
-			expectedImages:     []*storage.Image{initImage, regularImage},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			if tc.flagEnabled {
-				t.Setenv(features.InitContainerSupport.EnvVar(), "true")
-			} else {
-				t.Setenv(features.InitContainerSupport.EnvVar(), "false")
-			}
-
-			deployment := &storage.Deployment{
-				Containers: tc.containers,
-			}
-
-			filtered, filteredImages := filterInitContainers(deployment, tc.images)
-
-			require.Len(t, filtered.GetContainers(), len(tc.expectedContainers))
-			for i, c := range filtered.GetContainers() {
-				assert.Equal(t, tc.expectedContainers[i].GetName(), c.GetName())
-				assert.Equal(t, tc.expectedContainers[i].GetType(), c.GetType())
-			}
-			require.Len(t, filteredImages, len(tc.expectedImages))
-			for i, img := range filteredImages {
-				assert.Equal(t, tc.expectedImages[i].GetId(), img.GetId())
-			}
-		})
-	}
-}
-
-func TestConstructDeploymentFiltersInitContainers(t *testing.T) {
+func TestConstructDeploymentIncludesInitContainers(t *testing.T) {
 	t.Setenv(features.InitContainerSupport.EnvVar(), "true")
 
 	deployment := &storage.Deployment{
@@ -103,14 +29,13 @@ func TestConstructDeploymentFiltersInitContainers(t *testing.T) {
 	require.NotNil(t, obj)
 }
 
-func TestConstructDeploymentWithProcessFiltersInitContainers(t *testing.T) {
+func TestConstructDeploymentWithProcessIncludesInitContainers(t *testing.T) {
 	cases := map[string]struct {
 		containers       []*storage.Container
 		images           []*storage.Image
 		processContainer string
-		expectError      bool
 	}{
-		"single init + single regular, process on regular": {
+		"process on regular container with init present": {
 			containers: []*storage.Container{
 				{Name: "init", Type: storage.ContainerType_INIT},
 				{Name: "main", Type: storage.ContainerType_REGULAR},
@@ -118,25 +43,15 @@ func TestConstructDeploymentWithProcessFiltersInitContainers(t *testing.T) {
 			images:           []*storage.Image{{Id: "init-img"}, {Id: "main-img"}},
 			processContainer: "main",
 		},
-		"init between two regular containers, process on second regular": {
+		"process on init container": {
 			containers: []*storage.Container{
-				{Name: "app", Type: storage.ContainerType_REGULAR},
-				{Name: "init-setup", Type: storage.ContainerType_INIT},
-				{Name: "sidecar", Type: storage.ContainerType_REGULAR},
+				{Name: "init", Type: storage.ContainerType_INIT},
+				{Name: "main", Type: storage.ContainerType_REGULAR},
 			},
-			images:           []*storage.Image{{Id: "app-img"}, {Id: "init-img"}, {Id: "sidecar-img"}},
-			processContainer: "sidecar",
+			images:           []*storage.Image{{Id: "init-img"}, {Id: "main-img"}},
+			processContainer: "init",
 		},
-		"init between two regular containers, process on first regular": {
-			containers: []*storage.Container{
-				{Name: "app", Type: storage.ContainerType_REGULAR},
-				{Name: "init-setup", Type: storage.ContainerType_INIT},
-				{Name: "sidecar", Type: storage.ContainerType_REGULAR},
-			},
-			images:           []*storage.Image{{Id: "app-img"}, {Id: "init-img"}, {Id: "sidecar-img"}},
-			processContainer: "app",
-		},
-		"multiple init containers before multiple regular containers": {
+		"multiple init and regular containers": {
 			containers: []*storage.Container{
 				{Name: "init-db", Type: storage.ContainerType_INIT},
 				{Name: "init-config", Type: storage.ContainerType_INIT},
@@ -147,32 +62,13 @@ func TestConstructDeploymentWithProcessFiltersInitContainers(t *testing.T) {
 			images:           []*storage.Image{{Id: "init-db-img"}, {Id: "init-config-img"}, {Id: "api-img"}, {Id: "worker-img"}, {Id: "sidecar-img"}},
 			processContainer: "sidecar",
 		},
-		"multiple init containers + single regular, process on regular": {
-			containers: []*storage.Container{
-				{Name: "init-db", Type: storage.ContainerType_INIT},
-				{Name: "init-config", Type: storage.ContainerType_INIT},
-				{Name: "main", Type: storage.ContainerType_REGULAR},
-			},
-			images:           []*storage.Image{{Id: "init-db-img"}, {Id: "init-config-img"}, {Id: "main-img"}},
-			processContainer: "main",
-		},
-		"process on filtered init container returns error": {
-			containers: []*storage.Container{
-				{Name: "init", Type: storage.ContainerType_INIT},
-				{Name: "main", Type: storage.ContainerType_REGULAR},
-			},
-			images:           []*storage.Image{{Id: "init-img"}, {Id: "main-img"}},
-			processContainer: "init",
-			expectError:      true,
-		},
-		"no init containers, multiple regular, process on last": {
+		"no init containers": {
 			containers: []*storage.Container{
 				{Name: "app", Type: storage.ContainerType_REGULAR},
 				{Name: "sidecar", Type: storage.ContainerType_REGULAR},
-				{Name: "proxy", Type: storage.ContainerType_REGULAR},
 			},
-			images:           []*storage.Image{{Id: "app-img"}, {Id: "sidecar-img"}, {Id: "proxy-img"}},
-			processContainer: "proxy",
+			images:           []*storage.Image{{Id: "app-img"}, {Id: "sidecar-img"}},
+			processContainer: "sidecar",
 		},
 	}
 
@@ -193,55 +89,8 @@ func TestConstructDeploymentWithProcessFiltersInitContainers(t *testing.T) {
 			}
 
 			obj, err := ConstructDeploymentWithProcess(deployment, tc.images, &NetworkPoliciesApplied{}, process, false)
-			if tc.expectError {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "not found")
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, obj)
-			}
+			require.NoError(t, err)
+			require.NotNil(t, obj)
 		})
 	}
-}
-
-func TestConstructDeploymentWithProcessFlagOff(t *testing.T) {
-	t.Setenv(features.InitContainerSupport.EnvVar(), "false")
-
-	deployment := &storage.Deployment{
-		Id:        "deploy-1",
-		Name:      "test-deploy",
-		Namespace: "default",
-		ClusterId: "cluster-1",
-		Containers: []*storage.Container{
-			{Name: "init-db", Type: storage.ContainerType_INIT},
-			{Name: "init-config", Type: storage.ContainerType_INIT},
-			{Name: "api", Type: storage.ContainerType_REGULAR},
-			{Name: "sidecar", Type: storage.ContainerType_REGULAR},
-		},
-	}
-	images := []*storage.Image{
-		{Id: "init-db-img"},
-		{Id: "init-config-img"},
-		{Id: "api-img"},
-		{Id: "sidecar-img"},
-	}
-
-	// With flag off, init containers are NOT filtered. Process on a regular container
-	// should still resolve correctly against the full unfiltered list.
-	process := &storage.ProcessIndicator{
-		ContainerName: "sidecar",
-		Signal:        &storage.ProcessSignal{ExecFilePath: "/bin/sh"},
-	}
-	obj, err := ConstructDeploymentWithProcess(deployment, images, &NetworkPoliciesApplied{}, process, false)
-	require.NoError(t, err)
-	require.NotNil(t, obj)
-
-	// Process on an init container should also resolve when flag is off (no filtering).
-	processOnInit := &storage.ProcessIndicator{
-		ContainerName: "init-db",
-		Signal:        &storage.ProcessSignal{ExecFilePath: "/bin/sh"},
-	}
-	obj, err = ConstructDeploymentWithProcess(deployment, images, &NetworkPoliciesApplied{}, processOnInit, false)
-	require.NoError(t, err)
-	require.NotNil(t, obj)
 }

--- a/pkg/booleanpolicy/augmentedobjs/construct_test.go
+++ b/pkg/booleanpolicy/augmentedobjs/construct_test.go
@@ -4,13 +4,10 @@ import (
 	"testing"
 
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConstructDeploymentIncludesInitContainers(t *testing.T) {
-	t.Setenv(features.InitContainerSupport.EnvVar(), "true")
-
 	deployment := &storage.Deployment{
 		Name:      "test-deploy",
 		Namespace: "default",
@@ -74,8 +71,6 @@ func TestConstructDeploymentWithProcessIncludesInitContainers(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Setenv(features.InitContainerSupport.EnvVar(), "true")
-
 			deployment := &storage.Deployment{
 				Id:         "deploy-1",
 				Name:       "test-deploy",

--- a/tests/init_container_test.go
+++ b/tests/init_container_test.go
@@ -344,44 +344,44 @@ func (s *InitContainerSuite) TestMultipleInitContainers() {
 	t.Logf("Multiple init containers verified: %d init, %d regular", initCount, regularCount)
 }
 
-func (s *InitContainerSuite) TestPolicyFilteringInitNotViolated() {
+func (s *InitContainerSuite) TestPolicyEvaluatesInitContainers() {
 	t := s.T()
 	ns := fmt.Sprintf("init-test-policy-%d", rand.IntN(10000))
 	createNamespaceWithLabels(t, ns, nil)
 	defer deleteNamespace(t, ns)
 
 	createdPolicy := s.createPolicyWithCleanup(s.newLatestTagPolicy(
-		fmt.Sprintf("Test - Init Not Violated %d", rand.IntN(10000)), ns,
+		fmt.Sprintf("Test - Init Violated %d", rand.IntN(10000)), ns,
 	))
 
-	// Init container uses :latest (should be filtered), regular uses tagged image (no violation)
-	deployName := fmt.Sprintf("init-policy-no-alert-%d", rand.IntN(10000))
+	// Init container uses :latest, regular uses tagged image — init container should trigger violation
+	deployName := fmt.Sprintf("init-policy-alert-%d", rand.IntN(10000))
 	s.createDeploymentWithInitContainers(deployName, ns, []string{busyboxLatest}, nginxTagged)
 	defer teardownDeploymentWithoutCheck(t, deployName, ns)
 
 	s.waitForDeploymentWithContainers(deployName, 2)
 
-	s.waitForViolationAlert(deployName, createdPolicy.GetName(), 0)
-	t.Logf("Verified: init container with :latest tag did not trigger policy violation")
+	s.waitForViolationAlert(deployName, createdPolicy.GetName(), 1)
+	t.Logf("Verified: init container with :latest tag triggered policy violation")
 }
 
-func (s *InitContainerSuite) TestPolicyFilteringRegularStillViolated() {
+func (s *InitContainerSuite) TestPolicyEvaluatesBothContainerTypes() {
 	t := s.T()
 	ns := fmt.Sprintf("init-test-policy-reg-%d", rand.IntN(10000))
 	createNamespaceWithLabels(t, ns, nil)
 	defer deleteNamespace(t, ns)
 
 	createdPolicy := s.createPolicyWithCleanup(s.newLatestTagPolicy(
-		fmt.Sprintf("Test - Regular Still Violated %d", rand.IntN(10000)), ns,
+		fmt.Sprintf("Test - Both Violated %d", rand.IntN(10000)), ns,
 	))
 
-	// Both use :latest — regular should trigger violation, init should be filtered
-	deployName := fmt.Sprintf("init-policy-alert-%d", rand.IntN(10000))
+	// Both use :latest — both should trigger violations
+	deployName := fmt.Sprintf("init-policy-both-%d", rand.IntN(10000))
 	s.createDeploymentWithInitContainers(deployName, ns, []string{busyboxLatest}, nginxLatest)
 	defer teardownDeploymentWithoutCheck(t, deployName, ns)
 
 	s.waitForDeploymentWithContainers(deployName, 2)
 
 	s.waitForViolationAlert(deployName, createdPolicy.GetName(), 1)
-	t.Logf("Verified: regular container with :latest tag triggered policy violation")
+	t.Logf("Verified: both init and regular containers with :latest tag triggered policy violation")
 }


### PR DESCRIPTION
## Description

Removes the global `filterInitContainers()` function from `pkg/booleanpolicy/augmentedobjs/construct.go`. Init containers now flow through to policy evaluation for all policies by default. Per-policy filtering is handled by the `CompiledPolicy.filters` infrastructure (from PR #20760) using the container type filter implemented in #21062.

Stacked on #21062.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: gated behind `ROX_INIT_CONTAINER_SUPPORT` and `ROX_EVALUATION_FILTER` feature flags
- [x] CI results are inspected

### Automated testing

- [x] modified existing tests

### How I validated my change

Deployed build `4.12.x-146-gef2860a456` to a GKE cluster with both `ROX_INIT_CONTAINER_SUPPORT` and `ROX_EVALUATION_FILTER` feature flags enabled on Central and Sensor. Ran 4 test cases:

**Test Case 1: Default "Latest tag" policy fires on init container**
- Deployed a workload with an init container using `busybox:latest` and a main container using a pinned tag (`nginx-1.21.1`)
- The "Latest tag" policy generated a violation: `Container 'init-with-latest' has image with tag 'latest'`
- Previously this would not have fired because init containers were filtered before policy evaluation

**Test Case 2: "Privileged Container" policy fires on privileged init container**
- Deployed a workload with a privileged init container and a non-privileged main container
- The "Privileged Container" policy generated a violation: `Container 'init-privileged' is privileged`

**Test Case 3: Policy with `skipContainerTypes: ["INIT"]` skips init containers**
- Created a custom "Latest tag" policy via API with `evaluationFilter: { skipContainerTypes: ["INIT"] }`
- Deployed a workload where both init and main containers use `:latest`
- The policy only generated a violation for the main container: `Container 'main-latest' has image with tag 'latest'`
- The init container was correctly filtered out by the evaluation filter

**Test Case 4: Policy without evaluation filter fires on both container types**
- Created a custom "Latest tag" policy via API with no evaluation filter
- Deployed a workload where both init and main containers use `:latest`
- The policy generated violations for both containers:
  - `Container 'init-latest-all' has image with tag 'latest'`
  - `Container 'main-latest-all' has image with tag 'latest'`

**Result:** 4/4 passed

