### PR TITLE
ROX-35009: Improve wait for informer start

### DIFF
--- a/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
@@ -6,11 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 const (
@@ -121,12 +124,30 @@ func TestCredentialManager(t *testing.T) {
 			var changeCount atomic.Int32
 
 			k8sClient := fake.NewClientset()
+
+			watchRegistered := make(chan struct{})
+			var watchOnce sync.Once
+			k8sClient.PrependWatchReactor("secrets", func(action k8stesting.Action) (bool, watch.Interface, error) {
+				w, err := k8sClient.Tracker().Watch(action.GetResource(), action.GetNamespace())
+				watchOnce.Do(func() { close(watchRegistered) })
+				return true, w, err
+			})
+
 			manager := newCredentialsManagerImpl(k8sClient, namespace, secretName, func() {
 				changeCount.Add(1)
 			})
 			manager.Start()
 			defer manager.Stop()
+
+			// Wait HasSynced first.
 			require.Eventually(t, manager.informer.HasSynced, 30*time.Second, 100*time.Millisecond)
+
+			// Wait that watch is executed and events will be properly received.
+			select {
+			case <-watchRegistered:
+			case <-time.After(10 * time.Second):
+				require.FailNow(t, "timed out waiting for watch to be registered")
+			}
 
 			require.NoError(t, c.setupFn(k8sClient))
 


### PR DESCRIPTION
## Description

After a bit deeper investigation, I found the following.

Problem happens that Go routine that starts informers marks HasSynced as a true before watchers are registered.
Because of that, creating delete events are never received. Because there are no watchers that are listening on these events. It's an issue in the library.

Possible solutions:
1. (**retries failure**) `EventuallyWithT` in outer loop (as we had before) - would work if we would create `changeCount` inside each `EventuallyWithT`. An example of failure with outer `EventuallyWithT`: https://github.com/stackrox/stackrox/actions/runs/24486067310 
2. (**reduced probability**) Pre-create secret - This option delays marking of HasSynced as true. But it does not eliminate the issue.
3. (**eliminates the problem**) WatchReactor - With this solution, we are ensuring that Watcher is actually created before we create and delete a secret. We are sure that listeners on events are there.

**Details about the problem**

To narrow down to easy to understand part: https://github.com/kubernetes/client-go/blob/394ed525a635cb5f2850b9cbf9f056b3ac87a4ff/tools/cache/reflector.go#L500-L508

```
Test thread                                | Informer Start thread
                                           |
- call manager.Start =>
                                             - call list() -> list makes HasSynced = true
                                             <= (switch happens)
- HasSynced (is now true)
- Create / Delete secret
^^ no watchers (nothing is informed)
(switch happens) =>
                                             - call watchWithResync()
                                             ^^ from this point we will get OnAdd/OnDelete events
```

With solution 3. we are ensuring that `Create / Delete secret` will not be executed before `watchWithResync()` creates watcher.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] reproducing failure locally by setting sleep before `watchWithResync` (reproduce)
- [x] tested solution 2. locally with setting sleep before `watchWithResync` (it was failing)
- [x] tested solution 3. locally with setting sleep before `watchWithResync` (it works)
- [x] tested under load in VM 500 times (0 failures)
