### PR TITLE
ROX-34954: enable init container scanning in admission controller

### DIFF
--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -390,30 +390,35 @@ class AdmissionControllerTest extends BaseSpecification {
         "namespace removal"| "backend"    | null
     }
 
+    @Unroll
     @Tag("BAT")
     @IgnoreIf({ System.getenv("ROX_INIT_CONTAINER_SUPPORT") != "true" })
-    def "Verify AC allows deployment with init containers"() {
+    def "Verify AC enforcement on init containers: #desc"() {
         when:
         "Create a deployment with init containers"
         def deployment = new Deployment()
-                .setName("init-ac-test")
+                .setName("init-ac-${desc.replaceAll(' ', '-')}")
                 .setNamespace(TEST_NAMESPACE)
                 .setImagePrefetcherAffinity()
                 .setImage(BUSYBOX_TAGGED_IMAGE)
                 .addLabel("app", "test")
-                .addInitContainer("init-0", BUSYBOX_LATEST_TAG_IMAGE)
-                .addInitContainer("init-1", BUSYBOX_TAGGED_IMAGE)
+                .addInitContainer("init-0", initImage)
 
         def created = orchestrator.createDeploymentNoWait(deployment)
 
         then:
-        "Admission controller allows the deployment"
-        assert created
+        "Verify admission controller allows or blocks based on init container image"
+        assert created == allowed
 
         cleanup:
         if (created) {
             deleteDeploymentWithCaution(deployment)
         }
+
+        where:
+        initImage                | allowed | desc
+        BUSYBOX_TAGGED_IMAGE     | true    | "allowed with tagged init container"
+        BUSYBOX_LATEST_TAG_IMAGE | false   | "blocked with latest tag init container"
     }
 
 }

--- a/sensor/admission-control/manager/images.go
+++ b/sensor/admission-control/manager/images.go
@@ -9,7 +9,6 @@ import (
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/types"
 	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/protoconv/resources"
@@ -222,14 +221,8 @@ func (m *manager) getAvailableImagesAndKickOffScans(ctx context.Context, shouldF
 	fetchCount := 0
 
 	scanInline := s.GetClusterConfig().GetAdmissionControllerConfig().GetScanInline()
-	initContainerSupportEnabled := features.InitContainerSupport.Enabled()
 
 	for idx, container := range deployment.GetContainers() {
-		// Init container images are filtered from policy evaluation (ROX-34026), skip scanning them.
-		if initContainerSupportEnabled && container.GetType() == storage.ContainerType_INIT {
-			images[idx] = types.ToImage(container.GetImage())
-			continue
-		}
 		image := container.GetImage()
 		if image.GetId() != "" || scanInline {
 			cachedImage := m.getCachedImage(image, s, true)

--- a/sensor/admission-control/manager/images_test.go
+++ b/sensor/admission-control/manager/images_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stackrox/rox/generated/internalapi/sensor"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/coalescer"
-	"github.com/stackrox/rox/pkg/features"
 	"github.com/stackrox/rox/pkg/images/utils"
 	"github.com/stackrox/rox/pkg/sizeboundedcache"
 	"github.com/stretchr/testify/require"
@@ -402,22 +401,17 @@ func (s *ImageCacheTestSuite) TestClearImageCacheGen() {
 
 func (s *ImageCacheTestSuite) TestGetAvailableImagesInitContainerHandling() {
 	cases := map[string]struct {
-		flagEnabled    bool
 		containers     []*storage.Container
 		expectedImages []string
-		skippedIndexes []int // indexes where init containers should get placeholder (no scan)
 	}{
-		"flag on, single init + single regular": {
-			flagEnabled: true,
+		"single init + single regular": {
 			containers: []*storage.Container{
 				{Name: "init", Type: storage.ContainerType_INIT, Image: &storage.ContainerImage{Id: "sha256:init123", Name: &storage.ImageName{FullName: "docker.io/library/busybox:1.36"}}},
 				{Name: "main", Type: storage.ContainerType_REGULAR, Image: &storage.ContainerImage{Id: "sha256:main456", Name: &storage.ImageName{FullName: "docker.io/library/nginx:1.25"}}},
 			},
 			expectedImages: []string{"docker.io/library/busybox:1.36", "docker.io/library/nginx:1.25"},
-			skippedIndexes: []int{0},
 		},
-		"flag on, multiple init + multiple regular": {
-			flagEnabled: true,
+		"multiple init + multiple regular": {
 			containers: []*storage.Container{
 				{Name: "init-db", Type: storage.ContainerType_INIT, Image: &storage.ContainerImage{Id: "sha256:initdb123", Name: &storage.ImageName{FullName: "docker.io/library/busybox:1.36"}}},
 				{Name: "init-config", Type: storage.ContainerType_INIT, Image: &storage.ContainerImage{Id: "sha256:initcfg456", Name: &storage.ImageName{FullName: "docker.io/library/alpine:3.18"}}},
@@ -425,27 +419,11 @@ func (s *ImageCacheTestSuite) TestGetAvailableImagesInitContainerHandling() {
 				{Name: "sidecar", Type: storage.ContainerType_REGULAR, Image: &storage.ContainerImage{Id: "sha256:side012", Name: &storage.ImageName{FullName: "docker.io/library/redis:7.2"}}},
 			},
 			expectedImages: []string{"docker.io/library/busybox:1.36", "docker.io/library/alpine:3.18", "docker.io/library/nginx:1.25", "docker.io/library/redis:7.2"},
-			skippedIndexes: []int{0, 1},
-		},
-		"flag off, init containers not skipped": {
-			flagEnabled: false,
-			containers: []*storage.Container{
-				{Name: "init", Type: storage.ContainerType_INIT, Image: &storage.ContainerImage{Id: "sha256:init123", Name: &storage.ImageName{FullName: "docker.io/library/busybox:1.36"}}},
-				{Name: "main", Type: storage.ContainerType_REGULAR, Image: &storage.ContainerImage{Id: "sha256:main456", Name: &storage.ImageName{FullName: "docker.io/library/nginx:1.25"}}},
-			},
-			expectedImages: []string{"docker.io/library/busybox:1.36", "docker.io/library/nginx:1.25"},
-			skippedIndexes: nil,
 		},
 	}
 
 	for name, tc := range cases {
 		s.Run(name, func() {
-			if tc.flagEnabled {
-				s.T().Setenv(features.InitContainerSupport.EnvVar(), "true")
-			} else {
-				s.T().Setenv(features.InitContainerSupport.EnvVar(), "false")
-			}
-
 			st := createTestState(false)
 			st.ClusterConfig = &storage.DynamicClusterConfig{
 				AdmissionControllerConfig: &storage.AdmissionControllerConfig{
@@ -467,16 +445,6 @@ func (s *ImageCacheTestSuite) TestGetAvailableImagesInitContainerHandling() {
 			s.Require().Len(images, len(tc.expectedImages))
 			for i, expected := range tc.expectedImages {
 				s.Equal(expected, images[i].GetName().GetFullName())
-			}
-
-			skipped := make(map[int]bool)
-			for _, idx := range tc.skippedIndexes {
-				skipped[idx] = true
-			}
-			for i := range images {
-				if skipped[i] {
-					s.Empty(images[i].GetScan(), "init container at index %d should have no scan", i)
-				}
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Removes the init container scan skip in the admission controller. Previously, init container images were given placeholder stubs instead of being scanned. Now that policies evaluate init containers, they need real scans for policy enforcement at deploy time.

Stacked on #21094

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: gated behind `ROX_INIT_CONTAINER_SUPPORT` feature flag
- [x] CI results are inspected

### Automated testing

- [x] modified existing tests

### How I validated my change

Deployed build `4.12.x-161-gf146277460` to a GKE cluster with `ROX_INIT_CONTAINER_SUPPORT` and `ROX_EVALUATION_FILTER` feature flags enabled on Central, Sensor, and the admission controller. Created enforced policies (using `SCALE_TO_ZERO_ENFORCEMENT`) scoped to a test namespace and ran 4 test cases:

**Test Case 1: Admission controller blocks deployment with violating init container**
- Created an enforced "Latest tag" policy scoped to the test namespace
- Deployed a workload with an init container using `busybox:latest` and a main container using a pinned tag
- The admission controller rejected the deployment: `Container 'init' has image with tag 'latest'`

**Test Case 2: Admission controller allows deployment when no containers violate**
- Deployed a workload where both init and main containers use tagged images
- The admission controller allowed the deployment

**Test Case 3: Admission controller allows violating init container when policy skips INIT**
- Created an enforced policy with `evaluationFilter: { skipContainerTypes: ["INIT"] }`
- Deployed a workload with an init container using `busybox:latest` and a main container using a pinned tag
- The admission controller allowed the deployment because the policy skips init containers

**Test Case 4: Admission controller blocks when main container violates but init is clean**
- Created an enforced policy with no evaluation filter
- Deployed a workload with a tagged init container and a `busybox:latest` main container
- The admission controller rejected the deployment: `Container 'main' has image with tag 'latest'`

**Result:** 4/4 passed
