### PR TITLE
ROX-34991: Add Image Created Time date-picker filter attribute

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/image.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/attributes/image.ts
@@ -37,4 +37,11 @@ export const Registry: CompoundSearchFilterAttribute = {
     inputType: 'autocomplete',
 };
 
-export const imageAttributes = [Label, Name, OperatingSystem, Registry, Tag];
+export const CreatedTime: CompoundSearchFilterAttribute = {
+    displayName: 'Created time',
+    filterChipLabel: 'Image created time',
+    searchTerm: 'Image Created Time',
+    inputType: 'date-picker',
+};
+
+export const imageAttributes = [CreatedTime, Label, Name, OperatingSystem, Registry, Tag];

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/CompoundSearchFilter.cy.jsx
@@ -217,13 +217,14 @@ describe(Cypress.spec.relative, () => {
 
         cy.get(selectors.attributeSelectToggle).click();
 
-        cy.get(selectors.attributeSelectItems).should('have.length', 5);
+        cy.get(selectors.attributeSelectItems).should('have.length', 6);
         // Attributes are in alphabetical order by displayName property.
-        cy.get(selectors.attributeSelectItems).eq(0).should('have.text', 'Label');
-        cy.get(selectors.attributeSelectItems).eq(1).should('have.text', 'Name');
-        cy.get(selectors.attributeSelectItems).eq(2).should('have.text', 'Operating system');
-        cy.get(selectors.attributeSelectItems).eq(3).should('have.text', 'Registry');
-        cy.get(selectors.attributeSelectItems).eq(4).should('have.text', 'Tag');
+        cy.get(selectors.attributeSelectItems).eq(0).should('have.text', 'Created time');
+        cy.get(selectors.attributeSelectItems).eq(1).should('have.text', 'Label');
+        cy.get(selectors.attributeSelectItems).eq(2).should('have.text', 'Name');
+        cy.get(selectors.attributeSelectItems).eq(3).should('have.text', 'Operating system');
+        cy.get(selectors.attributeSelectItems).eq(4).should('have.text', 'Registry');
+        cy.get(selectors.attributeSelectItems).eq(5).should('have.text', 'Tag');
     });
 
     it('should display Deployment attributes in the attribute selector', () => {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -236,12 +236,7 @@ export const searchFilterConfigForImageVulnerabilityReport = [
             ({ searchTerm }) => searchTerm !== 'CVE Created Time'
         ),
     },
-    {
-        ...imageSearchFilterConfig,
-        attributes: imageSearchFilterConfig.attributes.filter(
-            ({ searchTerm }) => searchTerm !== 'Image Created Time'
-        ),
-    },
+    imageSearchFilterConfig,
     imageComponentSearchFilterConfig,
 ];
 

--- a/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/searchFilterConfig.ts
@@ -236,7 +236,12 @@ export const searchFilterConfigForImageVulnerabilityReport = [
             ({ searchTerm }) => searchTerm !== 'CVE Created Time'
         ),
     },
-    imageSearchFilterConfig,
+    {
+        ...imageSearchFilterConfig,
+        attributes: imageSearchFilterConfig.attributes.filter(
+            ({ searchTerm }) => searchTerm !== 'Image Created Time'
+        ),
+    },
     imageComponentSearchFilterConfig,
 ];
 


### PR DESCRIPTION
## Description

**Jira:** [ROX-34991](https://issues.redhat.com/browse/ROX-34991)

This is the top slice of the date range filtering stack, sitting on top of #21051. Images already have a creation timestamp that's searchable on the backend (the "Image Created Time" search term), but the UI never exposed it. I added a "Created time" date-picker attribute to the image entity in the compound search filter, so you can now filter images by creation date on the vulnerability views. Combined with the "Between" condition from ROX-34990, this also gives you date range filtering on it.

- Added a `CreatedTime` date-picker attribute to `imageAttributes` using the "Image Created Time" search term
- Left the attribute available in `searchFilterConfigForImageVulnerabilityReport`: unlike "CVE Created Time" (which is excluded because it means first-discovered-in-system and would mislead report readers), image created time comes from image metadata and means the same thing everywhere, so it's a valid report filter
- Updated the CompoundSearchFilter component test for the new entry in the image attribute selector

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Ran the `CompoundSearchFilter.cy.jsx` component test, which asserts the new "Created time" entry in the image attribute selector
- To see it in the UI: go to Vulnerability Management, pick the Image entity in the filter toolbar, select "Created time", and pick a date. You should see an "Image created time" chip applied and the results filtered.

### UI

#### Screenshots

<img width="1394" height="158" alt="Screenshot 2026-06-11 at 11 55 09 AM" src="https://github.com/user-attachments/assets/dd3c8082-fd34-45aa-b8ef-8798a438f7af" />

#### Screen recordings

https://github.com/user-attachments/assets/437cc921-56a9-481c-8aa5-33fdd6abea34



[ROX-34991]: https://redhat.atlassian.net/browse/ROX-34991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
