### PR TITLE
ROX-33402: UI changes to  fix reporting rbac

### DIFF
--- a/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/VulnerabilityReporting.helpers.js
+++ b/ui/apps/platform/cypress/integration/vulnerabilities/VulnerabilityReporting/VulnerabilityReporting.helpers.js
@@ -56,7 +56,7 @@ export const vulnerabilityReportsViewBasedPath = `${vulnerabilityReportsBasePath
  */
 export function visitVulnerabilityReports(staticResponseMap) {
     const interceptions = visit(
-        vulnerabilityReportsBasePath,
+        vulnerabilityReportsConfigurationPath,
         routeMatcherMapForVulnerabilityReports,
         staticResponseMap
     );

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -52,9 +52,7 @@ import {
     vulnerabilitiesUserWorkloadsPath,
     vulnerabilitiesVirtualMachineCvesPath,
     vulnerabilitiesWorkloadCvesPath,
-    vulnerabilityConfigurationReportsPath,
     vulnerabilityReportsPath,
-    vulnerabilityViewBasedReportsPath,
 } from 'routePaths';
 import type { RouteKey } from 'routePaths';
 
@@ -298,18 +296,6 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
             () => import('Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage')
         ),
         path: vulnerabilityReportsPath,
-    },
-    'vulnerabilities/reports/configuration': {
-        component: asyncComponent(
-            () => import('Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage')
-        ),
-        path: vulnerabilityConfigurationReportsPath,
-    },
-    'vulnerabilities/reports/view-based': {
-        component: asyncComponent(
-            () => import('Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage')
-        ),
-        path: vulnerabilityViewBasedReportsPath,
     },
     'vulnerability-management': {
         component: asyncComponent(() => import('Containers/VulnMgmt/WorkflowLayout')),

--- a/ui/apps/platform/src/Containers/MainPage/Body.tsx
+++ b/ui/apps/platform/src/Containers/MainPage/Body.tsx
@@ -52,7 +52,9 @@ import {
     vulnerabilitiesUserWorkloadsPath,
     vulnerabilitiesVirtualMachineCvesPath,
     vulnerabilitiesWorkloadCvesPath,
+    vulnerabilityConfigurationReportsPath,
     vulnerabilityReportsPath,
+    vulnerabilityViewBasedReportsPath,
 } from 'routePaths';
 import type { RouteKey } from 'routePaths';
 
@@ -296,6 +298,18 @@ const routeComponentMap: Record<RouteKey, RouteComponent> = {
             () => import('Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage')
         ),
         path: vulnerabilityReportsPath,
+    },
+    'vulnerabilities/reports/configuration': {
+        component: asyncComponent(
+            () => import('Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage')
+        ),
+        path: vulnerabilityConfigurationReportsPath,
+    },
+    'vulnerabilities/reports/view-based': {
+        component: asyncComponent(
+            () => import('Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage')
+        ),
+        path: vulnerabilityViewBasedReportsPath,
     },
     'vulnerability-management': {
         component: asyncComponent(() => import('Containers/VulnMgmt/WorkflowLayout')),

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReportingPage.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Route, Routes } from 'react-router-dom-v5-compat';
 
+import PageNotFound from 'Components/PageNotFound'; // NofFoundPage from Body.tsx file would be even better
 import type { ReportPageAction } from 'Components/Reports/reports.types';
 import usePageAction from 'hooks/usePageAction';
 import usePermissions from 'hooks/usePermissions';
@@ -7,8 +8,6 @@ import usePermissions from 'hooks/usePermissions';
 import ImageVulnerabilityReportWizardPage from '../ImageVulnerabilityReports/Wizard/ImageVulnerabilityReportWizardPage';
 
 import ViewVulnReportPage from './ViewVulnReport/ViewVulnReportPage';
-import ConfigReportsTab from './VulnReports/ConfigReportsTab';
-import ViewBasedReportsTab from './VulnReports/ViewBasedReportsTab';
 import VulnReportingLayout from './VulnReports/VulnReportingLayout';
 
 import './VulnReportingPage.css';
@@ -17,38 +16,50 @@ function VulnReportingPage() {
     const { pageAction } = usePageAction<ReportPageAction>();
 
     const { hasReadWriteAccess, hasReadAccess } = usePermissions();
+    const isReportConfigurationEnabled = hasReadAccess('WorkflowAdministration');
     const hasWriteAccessForReport =
-        hasReadWriteAccess('WorkflowAdministration') &&
-        hasReadAccess('Image') && // for vulnerabilities
-        hasReadAccess('Integration'); // for notifiers
+        hasReadWriteAccess('WorkflowAdministration') && hasReadAccess('Integration'); // for notifiers
 
     // TODO: Modify routing for edge cases - https://github.com/stackrox/stackrox/pull/14873#discussion_r2042672432
     return (
         <Routes>
             <Route
+                path="/"
                 element={
-                    (pageAction === 'create' || pageAction === 'createFromFilters') &&
-                    hasWriteAccessForReport ? (
-                        <ImageVulnerabilityReportWizardPage pageAction={pageAction} />
-                    ) : (
-                        <VulnReportingLayout />
-                    )
-                }
-            >
-                <Route index element={<Navigate to="configuration" replace />} />
-                <Route path="configuration" element={<ConfigReportsTab />} />
-                <Route path="view-based" element={<ViewBasedReportsTab />} />
-            </Route>
-            <Route
-                path="/configuration/:reportId"
-                element={
-                    (pageAction === 'clone' || pageAction === 'edit') && hasWriteAccessForReport ? (
-                        <ImageVulnerabilityReportWizardPage pageAction={pageAction} />
-                    ) : (
-                        <ViewVulnReportPage />
-                    )
+                    <Navigate
+                        to={isReportConfigurationEnabled ? 'configuration' : 'view-based'}
+                        replace
+                    />
                 }
             />
+            {isReportConfigurationEnabled && (
+                <Route
+                    path="/configuration"
+                    element={
+                        (pageAction === 'create' || pageAction === 'createFromFilters') &&
+                        hasWriteAccessForReport ? (
+                            <ImageVulnerabilityReportWizardPage pageAction={pageAction} />
+                        ) : (
+                            <VulnReportingLayout />
+                        )
+                    }
+                />
+            )}
+            {isReportConfigurationEnabled && (
+                <Route
+                    path="/configuration/:reportId"
+                    element={
+                        (pageAction === 'clone' || pageAction === 'edit') &&
+                        hasWriteAccessForReport ? (
+                            <ImageVulnerabilityReportWizardPage pageAction={pageAction} />
+                        ) : (
+                            <ViewVulnReportPage />
+                        )
+                    }
+                />
+            )}
+            <Route path="/view-based" element={<VulnReportingLayout />} />
+            <Route path="*" element={<PageNotFound />} />
         </Routes>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
@@ -1,22 +1,41 @@
-import { PageSection, Tab, Tabs, Title } from '@patternfly/react-core';
-import { Outlet, useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import type { ReactElement } from 'react';
+import { PageSection, Tab, TabContent, Tabs, Title } from '@patternfly/react-core';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import PageTitle from 'Components/PageTitle';
+import usePermissions from 'hooks/usePermissions';
+import type { ResourceName } from 'types/roleResources';
 import {
     vulnerabilityConfigurationReportsPath,
     vulnerabilityViewBasedReportsPath,
 } from 'routePaths';
 
-const tabs = [
+import ConfigReportsTab from './ConfigReportsTab';
+import ViewBasedReportsTab from './ViewBasedReportsTab';
+
+type TabType = {
+    id: string;
+    title: string;
+    path: string;
+    resourceAccessRequirements: ResourceName[];
+    tabContentElement: ReactElement;
+};
+
+// Assume resourceAccessRequirements for the route: ['Deployment', 'Image]
+const tabs: TabType[] = [
     {
         id: 'report-configuration',
         title: 'Report configurations',
         path: vulnerabilityConfigurationReportsPath,
+        resourceAccessRequirements: ['WorkflowAdministration'],
+        tabContentElement: <ConfigReportsTab />,
     },
     {
         id: 'view-based-reports',
         title: 'View-based reports',
         path: vulnerabilityViewBasedReportsPath,
+        resourceAccessRequirements: [],
+        tabContentElement: <ViewBasedReportsTab />,
     },
 ];
 
@@ -24,10 +43,16 @@ function VulnReportingLayout() {
     const location = useLocation();
     const navigate = useNavigate();
 
-    const activeTabIndex = tabs.findIndex((tab) => location.pathname.startsWith(tab.path));
+    const { hasReadAccess } = usePermissions();
+    const tabsEnabled = tabs.filter((tab) =>
+        tab.resourceAccessRequirements.every((resourceName) => hasReadAccess(resourceName))
+    );
+
+    const tabIndexFound = tabsEnabled.findIndex((tab) => location.pathname.startsWith(tab.path));
+    const activeTabIndex = tabIndexFound >= 0 ? tabIndexFound : 0;
 
     const onTabSelect = (_event, tabIndex) => {
-        navigate(tabs[tabIndex].path);
+        navigate(tabsEnabled[tabIndex].path);
     };
 
     return (
@@ -44,17 +69,19 @@ function VulnReportingLayout() {
                     mountOnEnter
                     unmountOnExit
                 >
-                    {tabs.map((tab, index) => (
+                    {tabsEnabled.map((tab, index) => (
                         <Tab
                             key={tab.id}
                             eventKey={index}
                             title={tab.title}
-                            tabContentId={`${tab.id}-tab-content`}
+                            tabContentId={tab.id}
                         />
                     ))}
                 </Tabs>
             </PageSection>
-            <Outlet />
+            <TabContent id={tabsEnabled[activeTabIndex].id}>
+                {tabsEnabled[activeTabIndex].tabContentElement}
+            </TabContent>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
@@ -1,10 +1,8 @@
-import type { ReactElement } from 'react';
 import { PageSection, Tab, TabContent, Tabs, Title } from '@patternfly/react-core';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import PageTitle from 'Components/PageTitle';
 import usePermissions from 'hooks/usePermissions';
-import type { ResourceName } from 'types/roleResources';
 import {
     vulnerabilityConfigurationReportsPath,
     vulnerabilityViewBasedReportsPath,
@@ -13,46 +11,37 @@ import {
 import ConfigReportsTab from './ConfigReportsTab';
 import ViewBasedReportsTab from './ViewBasedReportsTab';
 
-type TabType = {
-    id: string;
-    title: string;
-    path: string;
-    resourceAccessRequirements: ResourceName[];
-    tabContentElement: ReactElement;
-};
-
-// Assume resourceAccessRequirements for the route: ['Deployment', 'Image]
-const tabs: TabType[] = [
-    {
-        id: 'report-configuration',
-        title: 'Report configurations',
-        path: vulnerabilityConfigurationReportsPath,
-        resourceAccessRequirements: ['WorkflowAdministration'],
-        tabContentElement: <ConfigReportsTab />,
-    },
-    {
-        id: 'view-based-reports',
-        title: 'View-based reports',
-        path: vulnerabilityViewBasedReportsPath,
-        resourceAccessRequirements: [],
-        tabContentElement: <ViewBasedReportsTab />,
-    },
-];
-
 function VulnReportingLayout() {
     const location = useLocation();
     const navigate = useNavigate();
 
     const { hasReadAccess } = usePermissions();
-    const tabsEnabled = tabs.filter((tab) =>
-        tab.resourceAccessRequirements.every((resourceName) => hasReadAccess(resourceName))
-    );
+    const isReportConfigurationEnabled = hasReadAccess('WorkflowAdministration');
 
-    const tabIndexFound = tabsEnabled.findIndex((tab) => location.pathname.startsWith(tab.path));
+    const tabs = [
+        ...(isReportConfigurationEnabled
+            ? [
+                  {
+                      id: 'report-configuration',
+                      title: 'Report configurations',
+                      path: vulnerabilityConfigurationReportsPath,
+                      content: <ConfigReportsTab />,
+                  },
+              ]
+            : []),
+        {
+            id: 'view-based-reports',
+            title: 'View-based reports',
+            path: vulnerabilityViewBasedReportsPath,
+            content: <ViewBasedReportsTab />,
+        },
+    ];
+
+    const tabIndexFound = tabs.findIndex((tab) => location.pathname.startsWith(tab.path));
     const activeTabIndex = tabIndexFound >= 0 ? tabIndexFound : 0;
 
     const onTabSelect = (_event, tabIndex) => {
-        navigate(tabsEnabled[tabIndex].path);
+        navigate(tabs[tabIndex].path);
     };
 
     return (
@@ -69,7 +58,7 @@ function VulnReportingLayout() {
                     mountOnEnter
                     unmountOnExit
                 >
-                    {tabsEnabled.map((tab, index) => (
+                    {tabs.map((tab, index) => (
                         <Tab
                             key={tab.id}
                             eventKey={index}
@@ -79,9 +68,7 @@ function VulnReportingLayout() {
                     ))}
                 </Tabs>
             </PageSection>
-            <TabContent id={tabsEnabled[activeTabIndex].id}>
-                {tabsEnabled[activeTabIndex].tabContentElement}
-            </TabContent>
+            <TabContent id={tabs[activeTabIndex].id}>{tabs[activeTabIndex].content}</TabContent>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
@@ -1,10 +1,8 @@
-import type { ReactElement } from 'react';
-import { PageSection, Tab, TabContent, Tabs, Title } from '@patternfly/react-core';
+import { PageSection, Tab, Tabs, Title } from '@patternfly/react-core';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import PageTitle from 'Components/PageTitle';
 import usePermissions from 'hooks/usePermissions';
-import type { ResourceName } from 'types/roleResources';
 import {
     vulnerabilityConfigurationReportsPath,
     vulnerabilityViewBasedReportsPath,
@@ -13,46 +11,37 @@ import {
 import ConfigReportsTab from './ConfigReportsTab';
 import ViewBasedReportsTab from './ViewBasedReportsTab';
 
-type TabType = {
-    id: string;
-    title: string;
-    path: string;
-    resourceAccessRequirements: ResourceName[];
-    tabContentElement: ReactElement;
-};
-
-// Assume resourceAccessRequirements for the route: ['Deployment', 'Image]
-const tabs: TabType[] = [
-    {
-        id: 'report-configuration',
-        title: 'Report configurations',
-        path: vulnerabilityConfigurationReportsPath,
-        resourceAccessRequirements: ['WorkflowAdministration'],
-        tabContentElement: <ConfigReportsTab />,
-    },
-    {
-        id: 'view-based-reports',
-        title: 'View-based reports',
-        path: vulnerabilityViewBasedReportsPath,
-        resourceAccessRequirements: [],
-        tabContentElement: <ViewBasedReportsTab />,
-    },
-];
-
 function VulnReportingLayout() {
     const location = useLocation();
     const navigate = useNavigate();
 
     const { hasReadAccess } = usePermissions();
-    const tabsEnabled = tabs.filter((tab) =>
-        tab.resourceAccessRequirements.every((resourceName) => hasReadAccess(resourceName))
-    );
+    const isReportConfigurationEnabled = hasReadAccess('WorkflowAdministration');
 
-    const tabIndexFound = tabsEnabled.findIndex((tab) => location.pathname.startsWith(tab.path));
+    const tabs = [
+        ...(isReportConfigurationEnabled
+            ? [
+                  {
+                      id: 'report-configuration',
+                      title: 'Report configurations',
+                      path: vulnerabilityConfigurationReportsPath,
+                      content: <ConfigReportsTab />,
+                  },
+              ]
+            : []),
+        {
+            id: 'view-based-reports',
+            title: 'View-based reports',
+            path: vulnerabilityViewBasedReportsPath,
+            content: <ViewBasedReportsTab />,
+        },
+    ];
+
+    const tabIndexFound = tabs.findIndex((tab) => location.pathname.startsWith(tab.path));
     const activeTabIndex = tabIndexFound >= 0 ? tabIndexFound : 0;
 
     const onTabSelect = (_event, tabIndex) => {
-        navigate(tabsEnabled[tabIndex].path);
+        navigate(tabs[tabIndex].path);
     };
 
     return (
@@ -69,19 +58,17 @@ function VulnReportingLayout() {
                     mountOnEnter
                     unmountOnExit
                 >
-                    {tabsEnabled.map((tab, index) => (
+                    {tabs.map((tab, index) => (
                         <Tab
                             key={tab.id}
                             eventKey={index}
                             title={tab.title}
-                            tabContentId={tab.id}
+                            tabContentId={`${tab.id}-tab-content`}
                         />
                     ))}
                 </Tabs>
             </PageSection>
-            <TabContent id={tabsEnabled[activeTabIndex].id}>
-                {tabsEnabled[activeTabIndex].tabContentElement}
-            </TabContent>
+            {tabs[activeTabIndex].content}
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/VulnerablityReporting/VulnReports/VulnReportingLayout.tsx
@@ -1,8 +1,10 @@
-import { PageSection, Tab, Tabs, Title } from '@patternfly/react-core';
+import type { ReactElement } from 'react';
+import { PageSection, Tab, TabContent, Tabs, Title } from '@patternfly/react-core';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import PageTitle from 'Components/PageTitle';
 import usePermissions from 'hooks/usePermissions';
+import type { ResourceName } from 'types/roleResources';
 import {
     vulnerabilityConfigurationReportsPath,
     vulnerabilityViewBasedReportsPath,
@@ -11,37 +13,46 @@ import {
 import ConfigReportsTab from './ConfigReportsTab';
 import ViewBasedReportsTab from './ViewBasedReportsTab';
 
+type TabType = {
+    id: string;
+    title: string;
+    path: string;
+    resourceAccessRequirements: ResourceName[];
+    tabContentElement: ReactElement;
+};
+
+// Assume resourceAccessRequirements for the route: ['Deployment', 'Image]
+const tabs: TabType[] = [
+    {
+        id: 'report-configuration',
+        title: 'Report configurations',
+        path: vulnerabilityConfigurationReportsPath,
+        resourceAccessRequirements: ['WorkflowAdministration'],
+        tabContentElement: <ConfigReportsTab />,
+    },
+    {
+        id: 'view-based-reports',
+        title: 'View-based reports',
+        path: vulnerabilityViewBasedReportsPath,
+        resourceAccessRequirements: [],
+        tabContentElement: <ViewBasedReportsTab />,
+    },
+];
+
 function VulnReportingLayout() {
     const location = useLocation();
     const navigate = useNavigate();
 
     const { hasReadAccess } = usePermissions();
-    const isReportConfigurationEnabled = hasReadAccess('WorkflowAdministration');
+    const tabsEnabled = tabs.filter((tab) =>
+        tab.resourceAccessRequirements.every((resourceName) => hasReadAccess(resourceName))
+    );
 
-    const tabs = [
-        ...(isReportConfigurationEnabled
-            ? [
-                  {
-                      id: 'report-configuration',
-                      title: 'Report configurations',
-                      path: vulnerabilityConfigurationReportsPath,
-                      content: <ConfigReportsTab />,
-                  },
-              ]
-            : []),
-        {
-            id: 'view-based-reports',
-            title: 'View-based reports',
-            path: vulnerabilityViewBasedReportsPath,
-            content: <ViewBasedReportsTab />,
-        },
-    ];
-
-    const tabIndexFound = tabs.findIndex((tab) => location.pathname.startsWith(tab.path));
+    const tabIndexFound = tabsEnabled.findIndex((tab) => location.pathname.startsWith(tab.path));
     const activeTabIndex = tabIndexFound >= 0 ? tabIndexFound : 0;
 
     const onTabSelect = (_event, tabIndex) => {
-        navigate(tabs[tabIndex].path);
+        navigate(tabsEnabled[tabIndex].path);
     };
 
     return (
@@ -58,17 +69,19 @@ function VulnReportingLayout() {
                     mountOnEnter
                     unmountOnExit
                 >
-                    {tabs.map((tab, index) => (
+                    {tabsEnabled.map((tab, index) => (
                         <Tab
                             key={tab.id}
                             eventKey={index}
                             title={tab.title}
-                            tabContentId={`${tab.id}-tab-content`}
+                            tabContentId={tab.id}
                         />
                     ))}
                 </Tabs>
             </PageSection>
-            {tabs[activeTabIndex].content}
+            <TabContent id={tabsEnabled[activeTabIndex].id}>
+                {tabsEnabled[activeTabIndex].tabContentElement}
+            </TabContent>
         </>
     );
 }

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -76,9 +76,9 @@ function DeploymentPage({ showVulnerabilityStateTabs, vulnerabilityState }: Depl
 
     // Report-specific functionality
     const { hasReadAccess } = usePermissions();
-    const hasWorkflowAdminAccess = hasReadAccess('WorkflowAdministration');
     const isViewBasedReportsEnabled =
-        hasWorkflowAdminAccess &&
+        hasReadAccess('Image') &&
+        hasReadAccess('Deployment') &&
         (viewContext === 'User workloads' ||
             viewContext === 'Platform' ||
             viewContext === 'All vulnerable images' ||

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -77,6 +77,8 @@ function DeploymentPage({ showVulnerabilityStateTabs, vulnerabilityState }: Depl
     // Report-specific functionality
     const { hasReadAccess } = usePermissions();
     const isViewBasedReportsEnabled =
+        hasReadAccess('Image') &&
+        hasReadAccess('Deployment') &&
         (viewContext === 'User workloads' ||
             viewContext === 'Platform' ||
             viewContext === 'All vulnerable images' ||

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -20,7 +20,6 @@ import TableErrorComponent from 'Components/PatternFly/TableErrorComponent';
 import useURLStringUnion from 'hooks/useURLStringUnion';
 import useURLPagination from 'hooks/useURLPagination';
 import useURLSearch from 'hooks/useURLSearch';
-import usePermissions from 'hooks/usePermissions';
 import type { VulnerabilityState } from 'types/cve.proto';
 import { wrapInQuotes } from 'utils/searchUtils';
 
@@ -75,12 +74,11 @@ function DeploymentPage({ showVulnerabilityStateTabs, vulnerabilityState }: Depl
     const deploymentNotFound = metadataRequest.data && !metadataRequest.data.deployment;
 
     // Report-specific functionality
-    const { hasReadAccess } = usePermissions();
     const isViewBasedReportsEnabled =
-        (viewContext === 'User workloads' ||
-            viewContext === 'Platform' ||
-            viewContext === 'All vulnerable images' ||
-            viewContext === 'Inactive images');
+        viewContext === 'User workloads' ||
+        viewContext === 'Platform' ||
+        viewContext === 'All vulnerable images' ||
+        viewContext === 'Inactive images';
     const [isCreateViewBasedReportModalOpen, setIsCreateViewBasedReportModalOpen] = useState(false);
 
     // Create a scoped search filter that includes the deployment ID filter plus any applied search filters.

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Deployment/DeploymentPage.tsx
@@ -77,8 +77,6 @@ function DeploymentPage({ showVulnerabilityStateTabs, vulnerabilityState }: Depl
     // Report-specific functionality
     const { hasReadAccess } = usePermissions();
     const isViewBasedReportsEnabled =
-        hasReadAccess('Image') &&
-        hasReadAccess('Deployment') &&
         (viewContext === 'User workloads' ||
             viewContext === 'Platform' ||
             viewContext === 'All vulnerable images' ||

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -157,13 +157,13 @@ function ImagePage({
 
     const { hasReadAccess, hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForImage = hasReadWriteAccess('Image'); // SBOM Generation mutates image scan state.
-    const hasWorkflowAdminAccess = hasReadAccess('WorkflowAdministration');
     const isScannerV4Enabled = useIsScannerV4Enabled();
     const [sbomTargetImage, setSbomTargetImage] = useState<GenerateSbomImageParams>();
 
     // Report-specific functionality
     const isViewBasedReportsEnabled =
-        hasWorkflowAdminAccess &&
+        hasReadAccess('Image') &&
+        hasReadAccess('Deployment') &&
         (viewContext === 'User workloads' ||
             viewContext === 'Platform' ||
             viewContext === 'All vulnerable images' ||

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -162,6 +162,8 @@ function ImagePage({
 
     // Report-specific functionality
     const isViewBasedReportsEnabled =
+        hasReadAccess('Image') &&
+        hasReadAccess('Deployment') &&
         (viewContext === 'User workloads' ||
             viewContext === 'Platform' ||
             viewContext === 'All vulnerable images' ||

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -155,17 +155,17 @@ function ImagePage({
     const { searchFilter, setSearchFilter } = useURLSearch();
     const querySearchFilter = parseQuerySearchFilter(searchFilter);
 
-    const { hasReadAccess, hasReadWriteAccess } = usePermissions();
+    const { hasReadWriteAccess } = usePermissions();
     const hasWriteAccessForImage = hasReadWriteAccess('Image'); // SBOM Generation mutates image scan state.
     const isScannerV4Enabled = useIsScannerV4Enabled();
     const [sbomTargetImage, setSbomTargetImage] = useState<GenerateSbomImageParams>();
 
     // Report-specific functionality
     const isViewBasedReportsEnabled =
-        (viewContext === 'User workloads' ||
-            viewContext === 'Platform' ||
-            viewContext === 'All vulnerable images' ||
-            viewContext === 'Inactive images');
+        viewContext === 'User workloads' ||
+        viewContext === 'Platform' ||
+        viewContext === 'All vulnerable images' ||
+        viewContext === 'Inactive images';
     const [isCreateViewBasedReportModalOpen, setIsCreateViewBasedReportModalOpen] = useState(false);
 
     // Create a scoped search filter that includes the image SHA filter plus any applied search filters.

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Image/ImagePage.tsx
@@ -162,8 +162,6 @@ function ImagePage({
 
     // Report-specific functionality
     const isViewBasedReportsEnabled =
-        hasReadAccess('Image') &&
-        hasReadAccess('Deployment') &&
         (viewContext === 'User workloads' ||
             viewContext === 'Platform' ||
             viewContext === 'All vulnerable images' ||

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -129,7 +129,6 @@ function WorkloadCvesOverviewPage() {
     const hasWriteAccessForWatchedImage = hasReadWriteAccess('WatchedImage');
     const hasReadAccessForNamespaces = hasReadAccess('Namespace');
     const hasWriteAccessForImage = hasReadWriteAccess('Image'); // SBOM Generation mutates image scan state.
-    const hasWorkflowAdminAccess = hasReadAccess('WorkflowAdministration');
 
     const { analyticsTrack } = useAnalytics();
 
@@ -297,7 +296,8 @@ function WorkloadCvesOverviewPage() {
     const [isCreateViewBasedReportModalOpen, setIsCreateViewBasedReportModalOpen] = useState(false);
 
     const isViewBasedReportsEnabled =
-        hasWorkflowAdminAccess &&
+        hasReadAccess('Image') &&
+        hasReadAccess('Deployment') &&
         (viewContext === 'User workloads' ||
             viewContext === 'Platform' ||
             viewContext === 'All vulnerable images' ||

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -296,6 +296,8 @@ function WorkloadCvesOverviewPage() {
     const [isCreateViewBasedReportModalOpen, setIsCreateViewBasedReportModalOpen] = useState(false);
 
     const isViewBasedReportsEnabled =
+        hasReadAccess('Image') &&
+        hasReadAccess('Deployment') &&
         (viewContext === 'User workloads' ||
             viewContext === 'Platform' ||
             viewContext === 'All vulnerable images' ||

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -296,10 +296,10 @@ function WorkloadCvesOverviewPage() {
     const [isCreateViewBasedReportModalOpen, setIsCreateViewBasedReportModalOpen] = useState(false);
 
     const isViewBasedReportsEnabled =
-        (viewContext === 'User workloads' ||
-            viewContext === 'Platform' ||
-            viewContext === 'All vulnerable images' ||
-            viewContext === 'Inactive images');
+        viewContext === 'User workloads' ||
+        viewContext === 'Platform' ||
+        viewContext === 'All vulnerable images' ||
+        viewContext === 'Inactive images';
 
     const hasRequestExceptionsAbility = useHasRequestExceptionsAbility();
     const showDeferralUI = hasRequestExceptionsAbility && currentVulnerabilityState === 'OBSERVED';

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -296,8 +296,6 @@ function WorkloadCvesOverviewPage() {
     const [isCreateViewBasedReportModalOpen, setIsCreateViewBasedReportModalOpen] = useState(false);
 
     const isViewBasedReportsEnabled =
-        hasReadAccess('Image') &&
-        hasReadAccess('Deployment') &&
         (viewContext === 'User workloads' ||
             viewContext === 'Platform' ||
             viewContext === 'All vulnerable images' ||

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -194,6 +194,8 @@ export type RouteKey =
     | 'vulnerabilities/exception-management'
     | 'vulnerabilities/node-cves'
     | 'vulnerabilities/reports'
+    | 'vulnerabilities/reports/configuration'
+    | 'vulnerabilities/reports/view-based'
     | 'vulnerabilities/user-workloads'
     | 'vulnerabilities/platform'
     | 'vulnerabilities/all-images'
@@ -370,7 +372,17 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         resourceAccessRequirements: everyResource(['Cluster']),
     },
     'vulnerabilities/reports': {
-        resourceAccessRequirements: everyResource(['WorkflowAdministration']),
+        resourceAccessRequirements: everyResource(['Deployment', 'Image']),
+    },
+    'vulnerabilities/reports/configuration': {
+        resourceAccessRequirements: everyResource([
+            'Deployment',
+            'Image',
+            'WorkflowAdministration',
+        ]),
+    },
+    'vulnerabilities/reports/view-based': {
+        resourceAccessRequirements: everyResource(['Deployment', 'Image']),
     },
     'vulnerabilities/user-workloads': {
         resourceAccessRequirements: everyResource(['Deployment', 'Image']),

--- a/ui/apps/platform/src/routePaths.ts
+++ b/ui/apps/platform/src/routePaths.ts
@@ -194,8 +194,6 @@ export type RouteKey =
     | 'vulnerabilities/exception-management'
     | 'vulnerabilities/node-cves'
     | 'vulnerabilities/reports'
-    | 'vulnerabilities/reports/configuration'
-    | 'vulnerabilities/reports/view-based'
     | 'vulnerabilities/user-workloads'
     | 'vulnerabilities/platform'
     | 'vulnerabilities/all-images'
@@ -372,16 +370,6 @@ const routeRequirementsMap: Record<RouteKey, RouteRequirements> = {
         resourceAccessRequirements: everyResource(['Cluster']),
     },
     'vulnerabilities/reports': {
-        resourceAccessRequirements: everyResource(['Deployment', 'Image']),
-    },
-    'vulnerabilities/reports/configuration': {
-        resourceAccessRequirements: everyResource([
-            'Deployment',
-            'Image',
-            'WorkflowAdministration',
-        ]),
-    },
-    'vulnerabilities/reports/view-based': {
         resourceAccessRequirements: everyResource(['Deployment', 'Image']),
     },
     'vulnerabilities/user-workloads': {


### PR DESCRIPTION
This PR adds UI changes required to fix reporting permissions. Now reporting will require follow permissions 
Reports side navigation will be visible for user who has view (image)+view(deployment) permissions
on report page, report  config  tab will be visible for user who has view (image)+view(deployment)+modify(workflow admin)
on report page view based report tab will be visible for user who has view (image)+view(deployment)
Results page create config report will be visible to user who has view (image)+view(deployment)+modify(workflow admin)
Results page down csv report will be visible to user who has view (image)+view(deployment

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Tested the change manually by deploying  ACS cluster with the UI+backend changes, creating against user with required permission and another user without required permissions and logging in UI with both users 