### PR TITLE
ROX-34992: Retarget Aging Images widget to VM 2.0 Images view

### DIFF
--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImages.cy.jsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImages.cy.jsx
@@ -99,9 +99,18 @@ describe(Cypress.spec.relative, () => {
 
         cy.findByText(`${result0 + result1 + result2 + result3} Aging images`);
 
+        cy.findByRole('link', { name: 'View all' })
+            .should('have.attr', 'href')
+            .and('include', '/main/vulnerabilities/all-images')
+            .and('include', 'entityTab=Image');
+
         // Check default links
         cy.findByText(`${range0}-${range1} days`).click();
+        cy.url({ decode: true }).should('include', '/main/vulnerabilities/all-images');
+        cy.url({ decode: true }).should('include', 'entityTab=Image');
         cy.url({ decode: true }).should('include', 's[Image Created Time]=30d-90d');
+        cy.url({ decode: true }).should('include', 'sortOption[field]=Image Created Time');
+        cy.url({ decode: true }).should('include', 'sortOption[direction]=asc');
 
         cy.findByText(`${range1}-${range2} days`).click();
         cy.url({ decode: true }).should('include', 's[Image Created Time]=90d-180d');

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImages.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImages.tsx
@@ -18,10 +18,12 @@ import useURLSearch from 'hooks/useURLSearch';
 import useWidgetConfig from 'hooks/useWidgetConfig';
 import { getRequestQueryStringForSearchFilter } from 'utils/searchUtils';
 import type { SearchFilter } from 'types/search';
-import { vulnManagementImagesPath } from 'routePaths';
-import { getQueryString } from 'utils/queryStringUtils';
 import WidgetCard from 'Components/PatternFly/WidgetCard';
-import AgingImagesChart, { getTimeFilterOption, timeRangeTupleIndices } from './AgingImagesChart';
+import AgingImagesChart, {
+    getAgingImagesListLink,
+    getTimeFilterOption,
+    timeRangeTupleIndices,
+} from './AgingImagesChart';
 import type { TimeRangeCounts, TimeRangeTuple, TimeRangeTupleIndex } from './AgingImagesChart';
 import isResourceScoped from '../utils';
 import NoDataEmptyState from './NoDataEmptyState';
@@ -147,14 +149,6 @@ function isNumberInRange(timeRanges: TimeRangeTuple, index: TimeRangeTupleIndex)
 
 const fieldIdPrefix = 'aging-images';
 
-function getViewAllLink(searchFilter: SearchFilter) {
-    const queryString = getQueryString({
-        s: searchFilter,
-        sort: [{ id: 'Image Created Time', desc: 'false' }],
-    });
-    return `${vulnManagementImagesPath}${queryString}`;
-}
-
 function AgingImages() {
     const { searchFilter } = useURLSearch();
     const { pathname } = useLocation();
@@ -214,7 +208,7 @@ function AgingImages() {
                         alignItems={{ default: 'alignItemsCenter' }}
                     >
                         <FlexItem>
-                            <Link to={getViewAllLink(searchFilter)}>View all</Link>
+                            <Link to={getAgingImagesListLink(searchFilter)}>View all</Link>
                         </FlexItem>
                         <FlexItem>
                             {isOptionsChanged && (

--- a/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImagesChart.tsx
+++ b/ui/apps/platform/src/Containers/Dashboard/Widgets/AgingImagesChart.tsx
@@ -13,7 +13,7 @@ import {
 } from 'utils/chartUtils';
 import { LinkableChartLabel } from 'Components/PatternFly/Charts/LinkableChartLabel';
 import type { SearchFilter } from 'types/search';
-import { vulnManagementImagesPath } from 'routePaths';
+import { vulnerabilitiesAllImagesPath } from 'routePaths';
 import { getQueryString } from 'utils/queryStringUtils';
 import isResourceScoped from '../utils';
 
@@ -42,16 +42,28 @@ export function getTimeFilterOption(ageRange: number, nextAgeRange?: number) {
     return typeof nextAgeRange === 'number' ? `${ageRange}d-${nextAgeRange}d` : `>${ageRange}d`;
 }
 
-function linkForAgingImages(searchFilter: SearchFilter, ageRange: number, nextAgeRange?: number) {
-    const timeFilter = getTimeFilterOption(ageRange, nextAgeRange);
+/**
+ * Builds a link to the VM 2.0 images list view, sorted by image age (oldest first).
+ */
+export function getAgingImagesListLink(searchFilter: SearchFilter) {
     const queryString = getQueryString({
-        s: {
-            ...searchFilter,
-            'Image Created Time': timeFilter,
-        },
-        sort: [{ id: 'Image Created Time', desc: 'false' }],
+        s: searchFilter,
+        sortOption: { field: 'Image Created Time', direction: 'asc' },
+        entityTab: 'Image',
     });
-    return `${vulnManagementImagesPath}${queryString}`;
+    return `${vulnerabilitiesAllImagesPath}${queryString}`;
+}
+
+function linkForAgingImages(
+    searchFilter: SearchFilter,
+    ageRange: number,
+    nextAgeRange: number | undefined
+) {
+    const timeFilter = getTimeFilterOption(ageRange, nextAgeRange);
+    return getAgingImagesListLink({
+        ...searchFilter,
+        'Image Created Time': timeFilter,
+    });
 }
 
 function yAxisTitle(searchFilter: SearchFilter) {

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Overview/WorkloadCvesOverviewPage.tsx
@@ -216,10 +216,7 @@ function WorkloadCvesOverviewPage() {
         );
     }
 
-    function onEntityTabChange(entityTab: WorkloadEntityTab) {
-        pagination.setPage(1);
-        sort.setSortOption(getDefaultSortOption(entityTab, searchFilter));
-
+    function trackEntityTabViewed(entityTab: WorkloadEntityTab) {
         analyticsTrack({
             event: WORKLOAD_CVE_ENTITY_CONTEXT_VIEWED,
             properties: {
@@ -227,6 +224,12 @@ function WorkloadCvesOverviewPage() {
                 page: 'Overview',
             },
         });
+    }
+
+    function onEntityTabChange(entityTab: WorkloadEntityTab) {
+        pagination.setPage(1);
+        sort.setSortOption(getDefaultSortOption(entityTab, searchFilter));
+        trackEntityTabViewed(entityTab);
     }
 
     function onVulnerabilityStateChange(vulnerabilityState: VulnerabilityState) {
@@ -246,13 +249,17 @@ function WorkloadCvesOverviewPage() {
         setSearchFilter(localStorageValue.preferences.defaultFilters);
     }
 
-    // Track the current entity tab when the page is initially visited.
+    // Track the current entity tab when the page is initially visited. Only emit the
+    // analytics event here -- do NOT reset sort or pagination on mount, otherwise a
+    // deep link that carries a sortOption or page (e.g. the Aging Images dashboard
+    // widget linking with `Image Created Time` sort) would have it overwritten by the
+    // entity default before the table renders.
     /* eslint-disable react-hooks/exhaustive-deps */
     useEffect(() => {
-        onEntityTabChange(activeEntityTabKey);
+        trackEntityTabViewed(activeEntityTabKey);
     }, []);
     // activeEntityTabKey
-    // onEntityTabChange
+    // trackEntityTabViewed
     /* eslint-enable react-hooks/exhaustive-deps */
 
     // When the page is initially visited and no local filters are applied, apply the default filters.

--- a/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
+++ b/ui/apps/platform/src/Containers/Vulnerabilities/WorkloadCves/Tables/ImageOverviewTable.tsx
@@ -268,13 +268,13 @@ function ImageOverviewTable({
                     </Th>
                     <Th
                         className={getVisibilityClass('age')}
-                        sort={getSortParams('Image created time')}
+                        sort={getSortParams('Image Created Time')}
                     >
                         Age
                     </Th>
                     <Th
                         className={getVisibilityClass('scanTime')}
-                        sort={getSortParams('Image scan time')}
+                        sort={getSortParams('Image Scan Time')}
                     >
                         Scan time
                     </Th>


### PR DESCRIPTION
## Description

**Jira:** [ROX-34992](https://issues.redhat.com/browse/ROX-34992)

The dashboard Aging Images widget linked to the deprecated VM 1.0 images list. Now that the VM 2.0 Images view has an Image Created Time filter attribute (#21097), the relative-range values the widget emits (`30d-90d`, `>365d`) render there as editable, removable filter chips, so the widget can target the VM 2.0 view instead.

- Retarget the time-bucket links and the "View all" link from `vulnManagementImagesPath` to `vulnerabilitiesAllImagesPath` with `entityTab=Image`
- Collapse the two link builders into a shared `getAgingImagesListLink` helper, since the "View all" and bucket links differ only by the injected time filter
- Make the widget link's `sortOption` (Image Created Time, oldest-first) actually take effect on the landed Images view (see "Sorting fixes" below)

### Sorting fixes

While validating the retarget I noticed the widget's requested sort wasn't taking effect on the Images view it landed on. I dug in and found two separate defects, both fixed here.

The first one is the real culprit. `WorkloadCvesOverviewPage` was calling `onEntityTabChange` from a mount `useEffect`, and that handler resets sort and pagination to the entity default. So on a deep link like the widget's, it overwrote the URL's `sortOption` before the table ever rendered. I split out a `trackEntityTabViewed` helper so the mount effect only fires the analytics event; sort and pagination no longer get reset on mount, which means a URL-provided sort survives. Genuine entity-tab switches still reset the way they did before (that handler is unchanged).

The second one is smaller but worth fixing while I was in here. `ImageOverviewTable` passed `'Image created time'` / `'Image scan time'` to `getSortParams`, but the sort fields declared for the Image tab are Title Case (`Image Created Time` / `Image Scan Time`), and `useURLSort` matches case-sensitively. The query itself sorted fine, but no column header showed up as sorted. I canonicalized the two column names so they line up.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- `AgingImages.cy.jsx` component spec updated to assert the VM 2.0 destination (`/main/vulnerabilities/all-images`, `entityTab=Image`, `sortOption` fields) on both the bucket links and "View all"; 4/4 passing
- `npm run tsc` and `npm run lint:fast-dev` clean on the touched files
- Sorting fixes validated in the running UI: from the Aging Images widget, the landed Images view is now sorted by Image Created Time (oldest-first) with the Age column showing the sort indicator
- To validate in the UI: open the ACS dashboard, find the Aging Images widget, click any time bucket (e.g. "30-90 days"); it should land on the VM 2.0 Images view with an "Image created time" chip ("Between 30 and 90 days ago"), results filtered to that window, and the table sorted oldest-first with the Age column marked as sorted. "View all" should land on the same view unfiltered, sorted oldest-first.

### UI

#### Screen recordings

https://github.com/user-attachments/assets/56629ef8-6859-4d27-9155-fd3620142818


[ROX-34992]: https://redhat.atlassian.net/browse/ROX-34992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

