### PR TITLE
revert: ROX-34855: Filter empty scope

### DIFF
--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -181,11 +181,6 @@ func (s *serviceImpl) ListReportConfigurations(ctx context.Context, query *apiV2
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 	filteredQ := common.WithoutV1ReportConfigs(parsedQuery)
-	// This filter removes report configs with empty collection.
-	// This scenario can happen after downgrade from a future release(4.11 and above) with more resource scope to 4.10.
-	filteredQ = search.ConjunctionQuery(
-		filteredQ,
-		search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery())
 
 	// Fill in pagination.
 	paginated.FillPaginationV2(filteredQ, query.GetPagination(), maxPaginationLimit)


### PR DESCRIPTION
## Description

Reverts #20856 (ROX-34855: Filter empty scope) on the `release-4.10` branch.

The original change breaks unit tests consistently, as reported by David. Reverting to unblock the 4.10.4 patch release.

This PR was partially generated by AI (Claude Code).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Unit tests in `central/reports/service/v2/` pass after the revert:
```
ok  github.com/stackrox/rox/central/reports/service/v2  2.814s
```