### PR TITLE
ROX-34975: bump claircore to e018c5a585a0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.4
-	github.com/quay/claircore v1.5.44
+	github.com/quay/claircore v1.5.45-0.20260612075416-e018c5a585a0
 	github.com/quay/claircore/toolkit v1.2.5-0.20250120211107-bea8a6c197b2
 	github.com/quay/zlog v1.1.9
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319

--- a/go.sum
+++ b/go.sum
@@ -1288,8 +1288,8 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
-github.com/quay/claircore v1.5.44 h1:brG93+ZvX4IZJtFLBTB/p8mTtKSvX7knzgfTkBoME0Y=
-github.com/quay/claircore v1.5.44/go.mod h1:iOpZqd2tErng1hTypZy0pBWP8xFT3Iwj1Rr/iiWL4Sg=
+github.com/quay/claircore v1.5.45-0.20260612075416-e018c5a585a0 h1:lk5C3HlSyDrwhG+C6AMkWi3bxvfVkzkNom84saV23BE=
+github.com/quay/claircore v1.5.45-0.20260612075416-e018c5a585a0/go.mod h1:iOpZqd2tErng1hTypZy0pBWP8xFT3Iwj1Rr/iiWL4Sg=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=
 github.com/quay/claircore/toolkit v1.2.5-0.20250120211107-bea8a6c197b2 h1:v4MBdtms7OhJgipiFSYNgfQ0nr7O+VPVESYwpS2Wb4M=
 github.com/quay/claircore/toolkit v1.2.5-0.20250120211107-bea8a6c197b2/go.mod h1:7CB7Q7tUGC0GwprVcq354sLRPRzmKJiLMgqJ1BzIwYc=


### PR DESCRIPTION
## Description

Bumps claircore from `v1.5.44` to `v1.5.45-0.20260612075416-e018c5a585a0` on the `release-4.9` branch to unblock the v2 vulnerability bundle stream.

This picks up [quay/claircore#1913](https://github.com/quay/claircore/pull/1913), the backport of [quay/claircore#1908](https://github.com/quay/claircore/pull/1908) to `stable-1.5.44`. The fix replaces a hard error on ECOSYSTEM range types for Go/npm with a warning-and-skip, preventing a single malformed advisory from blocking the entire vulnerability bundle pipeline.

Incident doc: [ROX-34975](https://redhat.atlassian.net/browse/ROX-34975)

Generated with the assistance of AI.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [ ] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Dependency bump only — no stackrox code changes. The fix is tested upstream in quay/claircore#1913. Validation will be done by re-running the vulnerability updater workflow after merge.

[ROX-34975]: https://redhat.atlassian.net/browse/ROX-34975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ