### PR TITLE
fix(central): don't drop check results on report manager errors

### DIFF
--- a/central/complianceoperator/v2/pipelines/complianceoperatorresultsv2/pipeline.go
+++ b/central/complianceoperator/v2/pipelines/complianceoperatorresultsv2/pipeline.go
@@ -86,7 +86,6 @@ func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 		result := internaltov2storage.ComplianceOperatorCheckResult(checkResult, clusterID, clusterName)
 		if err := s.reportMgr.HandleResult(ctx, result); err != nil {
 			log.Errorf("unable to handle the check result in the report manager: %v", err)
-			return err
 		}
 		return s.v2Datastore.UpsertResult(ctx, result)
 	}

--- a/central/complianceoperator/v2/pipelines/complianceoperatorresultsv2/pipeline_test.go
+++ b/central/complianceoperator/v2/pipelines/complianceoperatorresultsv2/pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pkg/errors"
 	clusterMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	v2ResultMocks "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore/mocks"
 	reportMgrMocks "github.com/stackrox/rox/central/complianceoperator/v2/report/manager/mocks"
@@ -132,6 +133,43 @@ func (suite *PipelineTestSuite) TestRunDelete() {
 						Rationale:    "test rationale",
 						ValuesUsed:   []string{"var1", "var2"},
 						Warnings:     []string{"warning1", "warning2"},
+					},
+				},
+			},
+		},
+	}
+
+	err := pipeline.Run(ctx, fixtureconsts.Cluster1, msg, nil)
+	suite.NoError(err)
+}
+
+func (suite *PipelineTestSuite) TestRunCreateUpsertsPersistsWhenReportManagerFails() {
+	ctx := context.Background()
+
+	suite.clusterDS.EXPECT().GetClusterName(ctx, fixtureconsts.Cluster1).Return("cluster1", true, nil).Times(1)
+	suite.reportMgr.EXPECT().HandleResult(gomock.Any(), gomock.Any()).Return(errors.New("annotation not found")).Times(1)
+	suite.v2ResultDS.EXPECT().UpsertResult(ctx, gomock.Any()).Return(nil).Times(1)
+	pipeline := NewPipeline(suite.v2ResultDS, suite.clusterDS, suite.reportMgr)
+
+	msg := &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     id,
+				Action: central.ResourceAction_CREATE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorResultV2{
+					ComplianceOperatorResultV2: &central.ComplianceOperatorCheckResultV2{
+						Id:           id,
+						CheckId:      checkID,
+						CheckName:    mockCheckRuleName,
+						ClusterId:    fixtureconsts.Cluster1,
+						Status:       central.ComplianceOperatorCheckResultV2_FAIL,
+						Severity:     central.ComplianceOperatorRuleSeverity_HIGH_RULE_SEVERITY,
+						Description:  "this is a test",
+						Instructions: "this is a test",
+						Annotations:  nil,
+						CreatedTime:  createdTime,
+						ScanName:     mockScanName,
+						SuiteName:    mockSuiteName,
 					},
 				},
 			},


### PR DESCRIPTION
## Description

The v2 compliance check result pipeline coupled two independent operations:
feeding the scan watcher (report manager) and persisting the check result
to the datastore. When `HandleResult` failed — e.g., because the
`compliance.openshift.io/last-scanned-timestamp` annotation was missing —
the error caused an early return that skipped `UpsertResult`, permanently
dropping the check result from the v2 datastore.

**Root cause:** `HandleResult` returns a non-transient, non-context-cancelled
error, so `worker_queue.go` classifies it as unretryable and discards the
message. The result never reaches the database and the scan watcher never
receives it. If enough results are dropped, the watcher times out, and the
compliance dashboard shows incomplete or stale data.

**Fix:** Log the report manager error but don't gate the upsert on it.
The scan watcher and the datastore serve different purposes (report
generation vs dashboard queries) and should not block each other.

**Considered alternative:** Make `GetWatcherIDFromCheckResult` tolerate
a missing annotation (e.g., fall back to the scan's `LastStartedTime`).
That would also fix the watcher side, but the coupling in the pipeline
is the more fundamental issue — any future `HandleResult` failure mode
would re-create the same data loss. The watcher-side improvement is
left for a follow-up.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Added `TestRunCreateUpsertsPersistsWhenReportManagerFails` which verifies
  that `UpsertResult` is still called even when `HandleResult` returns an error.
- Existing tests continue to pass, confirming no regression for the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)