### PR TITLE
chore: add creation date label to GCP IAM policy bindings

### DIFF
--- a/qa-tests-backend/scripts/workload-identities/workload-identities.sh
+++ b/qa-tests-backend/scripts/workload-identities/workload-identities.sh
@@ -31,6 +31,7 @@ setup_gcp_variables() {
     service_account="${GCP_SERVICE_ACCOUNT_EMAIL_STACKROX_CI_WORKLOAD_IDENTITY}"
     project="${GCP_PROJECT_NUMBER_WORKLOAD_IDENTITY}"
     subject_central="system:serviceaccount:stackrox:central"
+    iam_principal="principal://iam.googleapis.com/projects/${project}/locations/global/workloadIdentityPools/${cluster}/subject/${subject_central}"
 }
 
 setup_gcp_workload_identities() {
@@ -39,11 +40,15 @@ setup_gcp_workload_identities() {
     setup_gcp
     setup_gcp_variables
 
+    local creation_label="created_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
     # Connect the stackrox ci service account to the workload identity of Central.
+    # The condition acts as a creation timestamp label for later pruning of stale bindings.
     retry 5 true \
         gcloud iam service-accounts add-iam-policy-binding "${service_account}" \
-        --member="principal://iam.googleapis.com/projects/${project}/locations/global/workloadIdentityPools/${cluster}/subject/${subject_central}" \
-        --role=roles/iam.workloadIdentityUser
+        --member="${iam_principal}" \
+        --role=roles/iam.workloadIdentityUser \
+        --condition="title=${creation_label},expression=true"
 
     # Apply STS configuration.
     local -r sts_config=$(PROJECT=${project} CLUSTER=${cluster} SERVICE_ACCOUNT=${service_account} envsubst < \
@@ -58,8 +63,15 @@ cleanup_gcp_workload_identities() {
     setup_gcp
     setup_gcp_variables
 
+    # We need to query the condition title because `remove-iam-policy-binding` requires an exact match including condition.
+    local condition_title
+    condition_title=$(gcloud iam service-accounts get-iam-policy "${service_account}" --format=json | \
+        jq -r --arg iam_principal "${iam_principal}" \
+        '.bindings[] | select(.role=="roles/iam.workloadIdentityUser") | select(.members[]? == $iam_principal) | .condition.title')
+
     retry 5 true \
         gcloud iam service-accounts remove-iam-policy-binding "${service_account}" \
-        --member="principal://iam.googleapis.com/projects/${project}/locations/global/workloadIdentityPools/${cluster}/subject/${subject_central}" \
-        --role=roles/iam.workloadIdentityUser
+        --member="${iam_principal}" \
+        --role=roles/iam.workloadIdentityUser \
+        --condition="title=${condition_title},expression=true"
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Add an IAM condition with a creation timestamp (title=created_at=<UTC>) to workload identity policy bindings. This enables pruning stale bindings that were not cleaned up by CI. The condition uses `expression=true` (always-true CEL) so it does not alter authorization.

Update cleanup to query the condition title before removal, since remove-iam-policy-binding requires an exact condition match.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Let the qa tests run and confirmed that the iam policies are tagged via the condition.

```
{
  "condition": {
    "expression": "true",
    "title": "created_at=2026-06-12T13:44:30Z"
  },
  "members": [
    "principal://iam.googleapis.com/projects/280228816191/locations/global/workloadIdentityPools/rox-ci-71269632/subject/system:serviceaccount:stackrox:central"
  ],
  "role": "roles/iam.workloadIdentityUser"
}
```