### PR TITLE
fix(tests): add last-scanned-timestamp to mock compliance data

### DIFF
--- a/tests/complianceoperator/resources/ccr/ocp4-moderate-secrets-consider-external-storage.yaml
+++ b/tests/complianceoperator/resources/ccr/ocp4-moderate-secrets-consider-external-storage.yaml
@@ -13,6 +13,7 @@ instructions: |-
 kind: ComplianceCheckResult
 metadata:
   annotations:
+    compliance.openshift.io/last-scanned-timestamp: "2021-11-08T17:36:41Z"
     compliance.openshift.io/rule: secrets-consider-external-storage
   creationTimestamp: "2021-06-22T18:27:15Z"
   generation: 1

--- a/tests/complianceoperator/resources/ccr/ocp4-moderate-secrets-no-environment-variables.yaml
+++ b/tests/complianceoperator/resources/ccr/ocp4-moderate-secrets-no-environment-variables.yaml
@@ -13,6 +13,7 @@ instructions: |-
 kind: ComplianceCheckResult
 metadata:
   annotations:
+    compliance.openshift.io/last-scanned-timestamp: "2021-11-08T17:36:41Z"
     compliance.openshift.io/rule: secrets-no-environment-variables
   creationTimestamp: "2021-06-22T18:27:09Z"
   generation: 1

--- a/tests/complianceoperator/resources/ccr/rhcos4-moderate-master-accounts-no-uid-except-zero.yaml
+++ b/tests/complianceoperator/resources/ccr/rhcos4-moderate-master-accounts-no-uid-except-zero.yaml
@@ -21,6 +21,7 @@ instructions: |-
 kind: ComplianceCheckResult
 metadata:
   annotations:
+    compliance.openshift.io/last-scanned-timestamp: "2021-06-22T18:20:00Z"
     compliance.openshift.io/rule: accounts-no-uid-except-zero
   creationTimestamp: "2021-06-22T18:22:06Z"
   generation: 1

--- a/tests/complianceoperator/resources/ccr/rhcos4-moderate-master-audit-rules-dac-modification-chmod.yaml
+++ b/tests/complianceoperator/resources/ccr/rhcos4-moderate-master-audit-rules-dac-modification-chmod.yaml
@@ -14,6 +14,7 @@ instructions: |-
 kind: ComplianceCheckResult
 metadata:
   annotations:
+    compliance.openshift.io/last-scanned-timestamp: "2021-06-22T18:20:00Z"
     compliance.openshift.io/rule: audit-rules-dac-modification-chmod
   creationTimestamp: "2021-06-22T18:22:09Z"
   generation: 1

--- a/tests/complianceoperator/resources/ccr/rhcos4-moderate-master-audit-rules-dac-modification-chown.yaml
+++ b/tests/complianceoperator/resources/ccr/rhcos4-moderate-master-audit-rules-dac-modification-chown.yaml
@@ -14,6 +14,7 @@ instructions: |-
 kind: ComplianceCheckResult
 metadata:
   annotations:
+    compliance.openshift.io/last-scanned-timestamp: "2021-06-22T18:20:00Z"
     compliance.openshift.io/rule: audit-rules-dac-modification-chown
   creationTimestamp: "2021-06-22T18:22:23Z"
   generation: 1

--- a/tests/complianceoperator/resources/ccr/rhcos4-moderate-worker-accounts-no-uid-except-zero.yaml
+++ b/tests/complianceoperator/resources/ccr/rhcos4-moderate-worker-accounts-no-uid-except-zero.yaml
@@ -21,6 +21,7 @@ instructions: |-
 kind: ComplianceCheckResult
 metadata:
   annotations:
+    compliance.openshift.io/last-scanned-timestamp: "2021-06-22T18:20:00Z"
     compliance.openshift.io/rule: accounts-no-uid-except-zero
   creationTimestamp: "2021-06-22T18:22:15Z"
   generation: 1

--- a/tests/complianceoperator/resources/ccr/rhcos4-moderate-worker-audit-rules-dac-modification-chmod.yaml
+++ b/tests/complianceoperator/resources/ccr/rhcos4-moderate-worker-audit-rules-dac-modification-chmod.yaml
@@ -14,6 +14,7 @@ instructions: |-
 kind: ComplianceCheckResult
 metadata:
   annotations:
+    compliance.openshift.io/last-scanned-timestamp: "2021-06-22T18:20:00Z"
     compliance.openshift.io/rule: audit-rules-dac-modification-chmod
   creationTimestamp: "2021-06-22T18:22:00Z"
   generation: 1

--- a/tests/complianceoperator/resources/ccr/rhcos4-moderate-worker-audit-rules-dac-modification-chown.yaml
+++ b/tests/complianceoperator/resources/ccr/rhcos4-moderate-worker-audit-rules-dac-modification-chown.yaml
@@ -14,6 +14,7 @@ instructions: |-
 kind: ComplianceCheckResult
 metadata:
   annotations:
+    compliance.openshift.io/last-scanned-timestamp: "2021-06-22T18:20:00Z"
     compliance.openshift.io/rule: audit-rules-dac-modification-chown
   creationTimestamp: "2021-06-22T18:22:03Z"
   generation: 1


### PR DESCRIPTION
## Description

The mock `ComplianceCheckResult` CRs in `tests/complianceoperator/resources/ccr/`
predate CO v1.6.0 and were missing the `compliance.openshift.io/last-scanned-timestamp`
annotation. Since ACS requires CO >= v1.6.0 (which always sets this annotation),
the mocks were not representative of real-world data.

On every sensor (re)connection, all 8 mock CRs were sent to Central's v2 pipeline,
which rejected them as unretryable errors because the annotation was missing. This
produced 48 spurious error log lines per CI run across 3 connection cycles — confirmed
via Central pod logs from [this CI run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/20128/pull-ci-stackrox-stackrox-master-ocp-4-12-nongroovy-e2e-tests/2065187930074255360).

The annotation value is set per scan group, matching what CO does in production
(all results from the same scan share the scan's `StartTimestamp`).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Confirmed via Central pod logs from CI that the 48 error lines all correspond to
  the 8 mock CCR files, triggered 3 times by sensor (re)connections.
- Verified all 8 YAML files now include the annotation with RFC 3339 timestamps
  grouped by scan name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)