### PR TITLE
ci: Run nongroovy and db-backup-restore GHA tests on all PRs

### DIFF
--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -18,8 +18,7 @@ defaults:
 jobs:
   wait-for-images:
     if: >-
-      !github.event.pull_request.head.repo.fork ||
-      github.event_name != 'pull_request'
+      !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -9,7 +9,6 @@ on:
     types:
     - opened
     - reopened
-    - labeled
     - synchronize
 
 defaults:
@@ -19,10 +18,8 @@ defaults:
 jobs:
   wait-for-images:
     if: >-
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-db-backup-restore-test')
-      )
+      !github.event.pull_request.head.repo.fork ||
+      github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   wait-for-images:
     if: >-
-      !github.event.pull_request.head.repo.fork
+      github.event_name == 'push' || !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -2,6 +2,8 @@ name: e2e-db-backup-restore-test
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "30 5 * * *"
   push:
     branches:
     - master

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -9,7 +9,6 @@ on:
     types:
     - opened
     - reopened
-    - labeled
     - synchronize
 
 defaults:
@@ -19,10 +18,8 @@ defaults:
 jobs:
   wait-for-images:
     if: >-
-      !github.event.pull_request.head.repo.fork && (
-        github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'e2e-nongroovy-tests')
-      )
+      !github.event.pull_request.head.repo.fork ||
+      github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -2,6 +2,8 @@ name: e2e-nongroovy-tests
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"
   push:
     branches:
     - master

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -18,8 +18,7 @@ defaults:
 jobs:
   wait-for-images:
     if: >-
-      !github.event.pull_request.head.repo.fork ||
-      github.event_name != 'pull_request'
+      !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   wait-for-images:
     if: >-
-      !github.event.pull_request.head.repo.fork
+      github.event_name == 'push' || !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo


### PR DESCRIPTION
## Description

Removes the label gates from the nongroovy and db-backup-restore GHA e2e workflows so they run on all PRs instead of requiring opt-in labels (`e2e-nongroovy-tests`, `e2e-db-backup-restore-test`).

Both workflows have been running green on master for weeks ([nongroovy](https://github.com/stackrox/stackrox/actions/workflows/e2e-nongroovy-tests.yaml?query=event%3Apush), [db-backup-restore](https://github.com/stackrox/stackrox/actions/workflows/e2e-db-backup-restore-test.yaml?query=event%3Apush)). Discussed and agreed upon in #proj-acs-ci-improvement.

Prow PR jobs will be disabled separately via openshift/release. Prow nightly jobs remain unchanged for OCP interoperability testing.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Both workflows have been running on master pushes for weeks with consistent pass rates. This PR simply removes the label requirement so they also run on PRs.
