### PR TITLE
ROX-34975: update v2 bundle ref to 4.9.8-rc.2

### DIFF
--- a/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
+++ b/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
@@ -6,4 +6,4 @@
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 dev heads/master
 v1 4.5.2
-v2 heads/2bcc59d86d479a560c8675e75b166aaa0cf3babc
+v2 tags/4.9.8-rc.2


### PR DESCRIPTION
## Description

Updates the v2 vulnerability bundle stream ref in `VULNERABILITY_BUNDLE_VERSION` from `heads/2bcc59d...` to `tags/4.9.8-rc.2`. The `4.9.8-rc.2` tag includes the claircore bump from [stackrox#21108](https://github.com/stackrox/stackrox/pull/21108), which picks up the ECOSYSTEM skip fix ([quay/claircore#1913](https://github.com/quay/claircore/pull/1913)).

This unblocks the v2 bundle stream in the vulnerability updater workflow.

Incident doc: [ROX-34975](https://redhat.atlassian.net/browse/ROX-34975)

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [ ] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [ ] CI results are inspected

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Config-only change — updates a git ref in the vulnerability bundle version file. Validation will be done by re-running the vulnerability updater workflow after merge.

[ROX-34975]: https://redhat.atlassian.net/browse/ROX-34975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ