### PR TITLE
fix: invert Stop() guard in compliance report manager

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -179,7 +179,7 @@ func (m *managerImpl) Start() {
 
 func (m *managerImpl) Stop() {
 	m.metricsTicker.Stop()
-	if m.isStarted.Load() {
+	if !m.isStarted.Load() {
 		log.Error("Compliance report manager not started")
 		return
 	}

--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -361,6 +361,7 @@ func (m *ManagerTestSuite) TestHandleReadyScanDeleteOldResultsGate() {
 			suiteStore := suiteDS.NewMockDataStore(ctrl)
 			bindingsStore := bindingsDS.NewMockDataStore(ctrl)
 			generator := reportGen.NewMockComplianceReportGenerator(ctrl)
+			generator.EXPECT().Stop().Times(1)
 
 			manager := New(scanConfigDS, scanDS, profileDS, snapshotDS, integrationDS, suiteStore, bindingsStore, checkResultDS, generator)
 			manager.Start()


### PR DESCRIPTION
## Description

The compliance report manager's `Stop()` method has an inverted guard condition that prevents it from ever executing cleanup. The check `if m.isStarted.Load()` returns early when the manager IS started — the opposite of what's intended. This means watchers, the report generator, and the stopper are never cleaned up on shutdown.

The fix negates the condition to `if !m.isStarted.Load()`, so `Stop()` returns early only when the manager was never started.

Found during review of #21005, which adds `defer manager.Stop()` calls that are no-ops without this fix.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- `go test -race -count=10 -timeout=120s ./central/complianceoperator/v2/report/manager/` — full suite, 0 failures across 10 runs
- Before the fix, `Stop()` logged `"Compliance report manager not started"` and returned early after every `Start()` call. After the fix, it correctly runs the full cleanup path (stopping watchers, report generator, stopper).
- Added `generator.EXPECT().Stop().Times(1)` to `TestHandleReadyScanDeleteOldResultsGate` since `Stop()` now actually calls `m.reportGen.Stop()`.

### Cluster verification

Deployed patched Central to OCP 4.22 cluster (`ga-ocp4-cron`) and ran e2e tests.