### PR TITLE
feat(central): add KnownLabels to TrackerBase

### DIFF
--- a/central/metrics/custom/runner.go
+++ b/central/metrics/custom/runner.go
@@ -30,12 +30,7 @@ import (
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 )
 
-type trackerRunner []struct {
-	tracker.Tracker
-	// getGroupConfig returns the storage configuration associated to the
-	// tracker.
-	getGroupConfig func(*storage.PrometheusMetrics) *storage.PrometheusMetrics_Group
-}
+type trackerRunner []tracker.Registration
 
 // RunnerConfiguration is a composition of tracker configurations.
 // Returned by ValidateConfiguration() and accepted by Reconfigure(). This split
@@ -123,7 +118,7 @@ func (tr trackerRunner) ValidateConfiguration(cfg *storage.PrometheusMetrics) (R
 	}
 	var runnerConfig RunnerConfiguration
 	for _, tracker := range tr {
-		trackerConfig, err := tracker.NewConfiguration(tracker.getGroupConfig(cfg))
+		trackerConfig, err := tracker.NewConfiguration(tracker.GetGroupConfig(cfg))
 		if err != nil {
 			return nil, err
 		}

--- a/central/metrics/custom/tracker/tracker_base.go
+++ b/central/metrics/custom/tracker/tracker_base.go
@@ -40,13 +40,18 @@ type Getter[F Finding] func(F) string
 // specific label only when provided with a finding.
 type LazyLabelGetters[F Finding] map[Label]Getter[F]
 
-// GetLabels returns a slice of labels from the list of lazy getters.
+// GetLabels returns a slice of label names from the list of lazy getters.
 func (ll LazyLabelGetters[F]) GetLabels() []string {
 	result := make([]string, 0, len(ll))
-	for _, label := range slices.Sorted(maps.Keys(ll)) {
+	for _, label := range ll.Labels() {
 		result = append(result, string(label))
 	}
 	return result
+}
+
+// Labels returns a sorted slice of labels from the list of lazy getters.
+func (ll LazyLabelGetters[F]) Labels() []Label {
+	return slices.Sorted(maps.Keys(ll))
 }
 
 type Tracker interface {
@@ -57,6 +62,13 @@ type Tracker interface {
 	NewConfiguration(*storage.PrometheusMetrics_Group) (*Configuration, error)
 	// Reconfigure the tracker with the provided tracker configuration.
 	Reconfigure(*Configuration)
+}
+
+type Registration = struct {
+	Tracker
+	// GetGroupConfig returns the storage configuration associated to the
+	// tracker.
+	GetGroupConfig func(*storage.PrometheusMetrics) *storage.PrometheusMetrics_Group
 }
 
 // FindingErrorSequence is a sequence of pairs of findings and errors.
@@ -120,6 +132,11 @@ type TrackerBase[F Finding] struct {
 	cleanupWG sync.WaitGroup // for sync in testing.
 
 	registryFactory func(userID string) (metrics.CustomRegistry, error) // for mocking in tests.
+
+	// KnownLabels returns the list of labels accepted by this tracker for the
+	// given descriptors. Default implementation returns the getters map keys.
+	// Override to support dynamic labels (e.g., driven by the configuration).
+	KnownLabels func(map[string]*storage.PrometheusMetrics_Group_Labels) []Label
 }
 
 // MakeTrackerBase initializes a scoped tracker without any period or metrics
@@ -155,6 +172,9 @@ func makeTrackerBase[F Finding](metricPrefix, description string, scoped bool,
 		generator:       generator,
 		scoped:          scoped,
 		registryFactory: registryFactory,
+		KnownLabels: func(map[string]*storage.PrometheusMetrics_Group_Labels) []Label {
+			return getters.Labels()
+		},
 	}
 }
 
@@ -165,7 +185,8 @@ func (tracker *TrackerBase[F]) NewConfiguration(cfg *storage.PrometheusMetrics_G
 		current = &Configuration{}
 	}
 
-	md, incFilters, excFilters, err := tracker.translateStorageConfiguration(cfg.GetDescriptors())
+	descriptors := cfg.GetDescriptors()
+	md, incFilters, excFilters, err := translateStorageConfiguration(descriptors, tracker.metricPrefix, tracker.KnownLabels(descriptors))
 	if err != nil {
 		return nil, err
 	}

--- a/central/metrics/custom/tracker/tracker_base.go
+++ b/central/metrics/custom/tracker/tracker_base.go
@@ -64,6 +64,7 @@ type Tracker interface {
 	Reconfigure(*Configuration)
 }
 
+// Registration is a helper structure for the runner to use this tracker.
 type Registration = struct {
 	Tracker
 	// GetGroupConfig returns the storage configuration associated to the

--- a/central/metrics/custom/tracker/validator.go
+++ b/central/metrics/custom/tracker/validator.go
@@ -28,15 +28,15 @@ func validateMetricName(name string) error {
 	return nil
 }
 
-// validateLabels checks if the labels exist in the labelOrder map and returns
+// validateLabels checks if the labels exist in the known labels and returns
 // a sorted label list.
-func (tracker *TrackerBase[F]) validateLabels(labels []string, metricName string) ([]Label, error) {
+func validateLabels(labels []string, metricName string, knownLabels []Label) ([]Label, error) {
 	if len(labels) == 0 {
 		return nil, errInvalidConfiguration.CausedByf("no labels specified for metric %q", metricName)
 	}
 	metricLabels := make([]Label, 0, len(labels))
 	for _, label := range labels {
-		validated, err := tracker.validateLabel(label, metricName)
+		validated, err := validateLabel(label, metricName, knownLabels)
 		if err != nil {
 			return nil, err
 		}
@@ -46,22 +46,22 @@ func (tracker *TrackerBase[F]) validateLabels(labels []string, metricName string
 	return metricLabels, nil
 }
 
-func (tracker *TrackerBase[F]) validateLabel(label string, metricName string) (Label, error) {
-	if _, ok := tracker.getters[Label(label)]; !ok {
-		return "", errInvalidConfiguration.CausedByf("label %q for metric %q is not in the list of known labels %v", label,
-			metricName, tracker.getters.GetLabels())
+func validateLabel(label string, metricName string, knownLabels []Label) (Label, error) {
+	if slices.Contains(knownLabels, Label(label)) {
+		return Label(label), nil
 	}
-	return Label(label), nil
+	return "", errInvalidConfiguration.CausedByf("label %q for metric %q is not in the list of known labels %v", label,
+		metricName, knownLabels)
 }
 
 // parseFilters parses a map of label names to regex patterns, validating each label and pattern.
-func (tracker *TrackerBase[F]) parseFilters(filters map[string]string, metricName, filterType string) (map[Label]*regexp.Regexp, error) {
+func parseFilters(filters map[string]string, metricName, filterType string, knownLabels []Label) (map[Label]*regexp.Regexp, error) {
 	if len(filters) == 0 {
 		return nil, nil
 	}
 	patterns := make(map[Label]*regexp.Regexp, len(filters))
 	for label, pattern := range filters {
-		validated, err := tracker.validateLabel(label, metricName)
+		validated, err := validateLabel(label, metricName, knownLabels)
 		if err != nil {
 			return nil, err
 		}
@@ -83,26 +83,25 @@ func (tracker *TrackerBase[F]) parseFilters(filters map[string]string, metricNam
 
 // translateStorageConfiguration converts the storage object to the usable map,
 // validating the values.
-func (tracker *TrackerBase[F]) translateStorageConfiguration(config map[string]*storage.PrometheusMetrics_Group_Labels) (MetricDescriptors, LabelFilters, LabelFilters, error) {
+func translateStorageConfiguration(config map[string]*storage.PrometheusMetrics_Group_Labels, metricPrefix string, knownLabels []Label) (MetricDescriptors, LabelFilters, LabelFilters, error) {
 	result := make(MetricDescriptors, len(config))
-	metricPrefix := tracker.metricPrefix
 	if metricPrefix != "" {
 		metricPrefix += "_"
 	}
 	includeFilters := make(LabelFilters)
 	excludeFilters := make(LabelFilters)
-	for metricName, labels := range config {
-		metricName = metricPrefix + metricName
+	for descriptorKey, labels := range config {
+		metricName := metricPrefix + descriptorKey
 		if err := validateMetricName(metricName); err != nil {
 			return nil, nil, nil, errInvalidConfiguration.CausedByf(
 				"invalid metric name %q: %v", metricName, err)
 		}
-		metricLabels, err := tracker.validateLabels(labels.GetLabels(), metricName)
+		metricLabels, err := validateLabels(labels.GetLabels(), metricName, knownLabels)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 
-		incPatterns, err := tracker.parseFilters(labels.GetIncludeFilters(), metricName, "include_filter")
+		incPatterns, err := parseFilters(labels.GetIncludeFilters(), metricName, "include_filter", knownLabels)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -110,7 +109,7 @@ func (tracker *TrackerBase[F]) translateStorageConfiguration(config map[string]*
 			includeFilters[MetricName(metricName)] = incPatterns
 		}
 
-		excPatterns, err := tracker.parseFilters(labels.GetExcludeFilters(), metricName, "exclude_filter")
+		excPatterns, err := parseFilters(labels.GetExcludeFilters(), metricName, "exclude_filter", knownLabels)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/central/metrics/custom/tracker/validator_test.go
+++ b/central/metrics/custom/tracker/validator_test.go
@@ -11,8 +11,7 @@ func TestTranslateConfiguration(t *testing.T) {
 	config := makeTestMetricLabels(t)
 	testFilters := makeTestLabelFilters(t)
 
-	tracker := MakeTrackerBase("test", "desc", testLabelGetters, nil)
-	md, incFilters, excFilters, err := tracker.translateStorageConfiguration(config)
+	md, incFilters, excFilters, err := translateStorageConfiguration(config, "test", testLabelGetters.Labels())
 	assert.NoError(t, err)
 	assert.Equal(t, makeTestMetricDescriptors(t), md)
 	assert.Empty(t, excFilters)
@@ -56,37 +55,38 @@ func Test_validateMetricName(t *testing.T) {
 }
 
 func Test_noLabels(t *testing.T) {
-	tracker := MakeTrackerBase("test", "desc", testLabelGetters, nil)
+	knownLabels := testLabelGetters.Labels()
 
 	for _, labels := range []*storage.PrometheusMetrics_Group_Labels{{Labels: []string{}}, {}, nil} {
 		config := map[string]*storage.PrometheusMetrics_Group_Labels{
 			"metric": labels,
 		}
-		md, _, _, err := tracker.translateStorageConfiguration(config)
+		md, _, _, err := translateStorageConfiguration(config, "test", knownLabels)
 		assert.Equal(t, `invalid configuration: no labels specified for metric "test_metric"`, err.Error())
 		assert.Empty(t, md)
 	}
 
-	md, _, _, err := tracker.translateStorageConfiguration(nil)
+	md, _, _, err := translateStorageConfiguration(nil, "test", knownLabels)
 	assert.NoError(t, err)
 	assert.Empty(t, md)
 }
 
 func Test_parseErrors(t *testing.T) {
+	knownLabels := testLabelGetters.Labels()
+
 	config := map[string]*storage.PrometheusMetrics_Group_Labels{
 		"metric1": {
 			Labels: []string{"unknown"},
 		},
 	}
-	tracker := MakeTrackerBase("test", "desc", testLabelGetters, nil)
 
-	md, _, _, err := tracker.translateStorageConfiguration(config)
+	md, _, _, err := translateStorageConfiguration(config, "test", knownLabels)
 	assert.Equal(t, `invalid configuration: label "unknown" for metric "test_metric1" is not in the list of known labels [CVE CVSS Cluster IsFixable Namespace Severity test]`, err.Error())
 	assert.Empty(t, md)
 
 	delete(config, "metric1")
 	config["met rick"] = nil
-	md, _, _, err = tracker.translateStorageConfiguration(config)
+	md, _, _, err = translateStorageConfiguration(config, "test", knownLabels)
 	assert.Equal(t, `invalid configuration: invalid metric name "test_met rick": doesn't match "^[a-zA-Z_:][a-zA-Z0-9_:]*$"`, err.Error())
 	assert.Empty(t, md)
 
@@ -98,9 +98,8 @@ func Test_parseErrors(t *testing.T) {
 			},
 		},
 	}
-	tracker = MakeTrackerBase("test", "desc", testLabelGetters, nil)
 
-	md, _, _, err = tracker.translateStorageConfiguration(config)
+	md, _, _, err = translateStorageConfiguration(config, "test", knownLabels)
 	assert.Equal(t, `invalid configuration: label "filter_unknown_label" for metric "test_metric1" is not in the list of known labels [CVE CVSS Cluster IsFixable Namespace Severity test]`, err.Error())
 	assert.Empty(t, md)
 
@@ -112,9 +111,8 @@ func Test_parseErrors(t *testing.T) {
 			},
 		},
 	}
-	tracker = MakeTrackerBase("test", "desc", testLabelGetters, nil)
 
-	md, _, _, err = tracker.translateStorageConfiguration(config)
+	md, _, _, err = translateStorageConfiguration(config, "test", knownLabels)
 	assert.Equal(t, "invalid configuration: bad include_filter expression for metric \"test_metric1\" label \"Namespace\": error parsing regexp: invalid character class range: `1-$`", err.Error())
 	assert.Empty(t, md)
 


### PR DESCRIPTION
## Description

`TrackerBase` hardcodes the accepted label set from the getter map keys. This prevents trackers from accepting labels that are only known at configuration time (e.g., driven by remote config). The `KnownLabels` function decouples label discovery from the static getter map.

- Add a configurable `KnownLabels` function field to `TrackerBase`.
- Extract `validateLabels`, `parseFilters`, and `translateStorageConfiguration` from receiver methods to standalone functions that accept a `[]Label` parameter.
- Add `Labels()` method to `LazyLabelGetters` and a `Registration` type alias for the tracker+config pair.
- Default `KnownLabels` returns the getter map keys, preserving existing behavior.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- `go build` and `go test` pass for all affected packages.
- Existing validator tests adapted to the new standalone function signatures.

<!-- GHIT dependencies begin -->
Current dependencies on/for this PR:

* [master](../tree/master)
  * **PR #21131** 👈
    * **PR #21132**
      * **PR #21133**
        * **PR #21134**
          * **PR #21360**
            * **PR #21361**
              * **PR #18080**
<!-- GHIT dependencies end -->