### PR TITLE
feat: add RequestInterceptor fan-out registry

### DIFF
--- a/pkg/grpc/common/requestinterceptor/interceptor.go
+++ b/pkg/grpc/common/requestinterceptor/interceptor.go
@@ -3,18 +3,107 @@ package requestinterceptor
 import (
 	"context"
 	"net/http"
+	"sync/atomic"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	erroxGRPC "github.com/stackrox/rox/pkg/errox/grpc"
 	"github.com/stackrox/rox/pkg/grpc/authn"
 	grpcError "github.com/stackrox/rox/pkg/grpc/errors"
 	"github.com/stackrox/rox/pkg/grpc/requestinfo"
+	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/logging"
+	"github.com/stackrox/rox/pkg/sync"
+	"google.golang.org/grpc"
 )
 
 const userAgentHeaderKey = "User-Agent"
 
 var log = logging.LoggerForModule()
+
+// RequestHandler is called with the computed RequestParams for every API
+// request. Handlers are registered with the RequestInterceptor.
+type RequestHandler func(*RequestParams)
+
+// RequestInterceptor computes RequestParams once per API request and fans
+// out to all registered handlers. If no handlers are registered, the
+// interceptor is a no-op and does not compute RequestParams.
+type RequestInterceptor struct {
+	handlers sync.Map
+	count    atomic.Int32
+}
+
+// NewRequestInterceptor creates a new interceptor registry.
+func NewRequestInterceptor() *RequestInterceptor {
+	return &RequestInterceptor{}
+}
+
+// Add registers a named handler. Replaces any existing handler with the
+// same name.
+func (ri *RequestInterceptor) Add(name string, h RequestHandler) {
+	if _, loaded := ri.handlers.Swap(name, h); !loaded {
+		ri.count.Add(1)
+	}
+}
+
+// Remove unregisters a handler by name.
+func (ri *RequestInterceptor) Remove(name string) {
+	if _, loaded := ri.handlers.LoadAndDelete(name); loaded {
+		ri.count.Add(-1)
+	}
+}
+
+func (ri *RequestInterceptor) dispatch(rp *RequestParams) {
+	ri.handlers.Range(func(_, v any) bool {
+		v.(RequestHandler)(rp)
+		return true
+	})
+}
+
+func (ri *RequestInterceptor) hasHandlers() bool {
+	return ri.count.Load() > 0
+}
+
+// UnaryServerInterceptor returns a gRPC unary server interceptor.
+func (ri *RequestInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		resp, err := handler(ctx, req)
+		if ri.hasHandlers() {
+			rp := GetGRPCRequestDetails(ctx, err, info.FullMethod, req)
+			ri.dispatch(rp)
+		}
+		return resp, err
+	}
+}
+
+// StreamServerInterceptor returns a gRPC stream server interceptor.
+func (ri *RequestInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		err := handler(srv, ss)
+		if ri.hasHandlers() {
+			rp := GetGRPCRequestDetails(ss.Context(), err, info.FullMethod, nil)
+			ri.dispatch(rp)
+		}
+		return err
+	}
+}
+
+// HTTPInterceptor returns an HTTP middleware interceptor.
+func (ri *RequestInterceptor) HTTPInterceptor() httputil.HTTPInterceptor {
+	return func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			wrappedWriter := httputil.NewStatusTrackingWriter(w)
+			handler.ServeHTTP(wrappedWriter, r)
+			if ri.hasHandlers() {
+				status := http.StatusOK
+				if sptr := wrappedWriter.GetStatusCode(); sptr != nil {
+					status = *sptr
+				}
+				rp := GetHTTPRequestDetails(r.Context(), r, status)
+				ri.dispatch(rp)
+			}
+		})
+	}
+}
 
 // GetGRPCRequestDetails constructs a RequestParams for a gRPC invocation.
 // For grpc-gateway requests it uses the HTTP method, path, status code, and

--- a/pkg/grpc/common/requestinterceptor/interceptor_test.go
+++ b/pkg/grpc/common/requestinterceptor/interceptor_test.go
@@ -1,0 +1,136 @@
+package requestinterceptor
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stackrox/rox/pkg/grpc/requestinfo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+func TestRequestInterceptor_noHandlers(t *testing.T) {
+	ri := NewRequestInterceptor()
+
+	interceptor := ri.UnaryServerInterceptor()
+	resp, err := interceptor(context.Background(), "req",
+		&grpc.UnaryServerInfo{FullMethod: "/test"},
+		func(ctx context.Context, req any) (any, error) {
+			return "ok", nil
+		})
+	assert.Equal(t, "ok", resp)
+	assert.NoError(t, err)
+}
+
+func TestRequestInterceptor_dispatchesOnce(t *testing.T) {
+	ri := NewRequestInterceptor()
+
+	var count1, count2 atomic.Int32
+	var captured1, captured2 *RequestParams
+
+	ri.Add("handler1", func(rp *RequestParams) {
+		count1.Add(1)
+		captured1 = rp
+	})
+	ri.Add("handler2", func(rp *RequestParams) {
+		count2.Add(1)
+		captured2 = rp
+	})
+
+	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &net.UnixAddr{Net: "pipe"}})
+	req, _ := http.NewRequest(http.MethodGet, "/test/path", nil)
+	rih := requestinfo.NewRequestInfoHandler()
+	md := rih.AnnotateMD(ctx, req)
+	ctx, riErr := rih.UpdateContextForGRPC(metadata.NewIncomingContext(ctx, md))
+	require.NoError(t, riErr)
+
+	interceptor := ri.UnaryServerInterceptor()
+	_, err := interceptor(ctx, "req",
+		&grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+		func(ctx context.Context, req any) (any, error) {
+			return "ok", nil
+		})
+	assert.NoError(t, err)
+
+	assert.Equal(t, int32(1), count1.Load())
+	assert.Equal(t, int32(1), count2.Load())
+
+	assert.Same(t, captured1, captured2)
+	assert.Equal(t, "/test/path", captured1.Path)
+}
+
+func TestRequestInterceptor_remove(t *testing.T) {
+	ri := NewRequestInterceptor()
+
+	var called atomic.Bool
+	ri.Add("temp", func(rp *RequestParams) {
+		called.Store(true)
+	})
+	ri.Remove("temp")
+
+	assert.False(t, ri.hasHandlers())
+}
+
+type fakeStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (f fakeStream) Context() context.Context { return f.ctx }
+
+func TestRequestInterceptor_Stream(t *testing.T) {
+	ri := NewRequestInterceptor()
+
+	var captured *RequestParams
+	ri.Add("test", func(rp *RequestParams) {
+		captured = rp
+	})
+
+	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: &net.UnixAddr{Net: "pipe"}})
+	req, _ := http.NewRequest(http.MethodGet, "/stream/path", nil)
+	rih := requestinfo.NewRequestInfoHandler()
+	md := rih.AnnotateMD(ctx, req)
+	ctx, riErr := rih.UpdateContextForGRPC(metadata.NewIncomingContext(ctx, md))
+	require.NoError(t, riErr)
+
+	interceptor := ri.StreamServerInterceptor()
+	err := interceptor(nil, fakeStream{ctx: ctx},
+		&grpc.StreamServerInfo{FullMethod: "/test.Service/StreamMethod"},
+		func(srv any, ss grpc.ServerStream) error {
+			return nil
+		})
+	assert.NoError(t, err)
+
+	require.NotNil(t, captured)
+	assert.Equal(t, "/stream/path", captured.Path)
+	assert.Nil(t, captured.GRPCReq)
+}
+
+func TestRequestInterceptor_HTTP(t *testing.T) {
+	ri := NewRequestInterceptor()
+
+	var captured *RequestParams
+	ri.Add("test", func(rp *RequestParams) {
+		captured = rp
+	})
+
+	handler := ri.HTTPInterceptor()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/resource", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.NotNil(t, captured)
+	assert.Equal(t, "/api/resource", captured.Path)
+	assert.Equal(t, http.MethodPost, captured.Method)
+	assert.Equal(t, http.StatusCreated, captured.Code)
+}


### PR DESCRIPTION
## Description

The telemetry client currently owns the gRPC/HTTP interceptors and computes `RequestParams` inside them. Every new consumer of request data would need its own interceptor, duplicating the parameter extraction and requiring changes to the server wiring in `central/main.go`. The registry computes `RequestParams` once and fans out to all registered handlers, so consumers can be added or removed at runtime without touching the interceptor chain.

- Named handlers via `Add(name, handler)` / `Remove(name)`.
- `UnaryServerInterceptor()`, `StreamServerInterceptor()`, and `HTTPInterceptor()` methods.
- `sync.Map` + `atomic.Int32` for lock-free handler tracking.
- No-op when no handlers are registered (skips `RequestParams` computation entirely).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- New unit tests cover: no-handler pass-through, multi-handler dispatch, handler removal, stream interceptor, and HTTP interceptor.
- `go build` and `go test` pass.

<!-- GHIT dependencies begin -->
Current dependencies on/for this PR:

* [master](../tree/master)
  * **PR #21131**
    * **PR #21132**
      * **PR #21133** 👈
        * **PR #21134**
          * **PR #21360**
            * **PR #21361**
              * **PR #18080**
<!-- GHIT dependencies end -->