### PR TITLE
feat: replace Client interceptors with GetRequestHandler

### DIFF
--- a/central/main.go
+++ b/central/main.go
@@ -213,6 +213,7 @@ import (
 	"github.com/stackrox/rox/pkg/grpc/authz/or"
 	"github.com/stackrox/rox/pkg/grpc/authz/perrpc"
 	"github.com/stackrox/rox/pkg/grpc/authz/user"
+	"github.com/stackrox/rox/pkg/grpc/common/requestinterceptor"
 	"github.com/stackrox/rox/pkg/grpc/errors"
 	"github.com/stackrox/rox/pkg/grpc/ratelimit"
 	"github.com/stackrox/rox/pkg/grpc/routes"
@@ -645,10 +646,15 @@ func startGRPCServer() {
 		centralSAC.GetEnricher().GetPreAuthContextEnricher(authzTraceSink),
 	)
 
-	// Telemetry client has to add interceptors before starting the server.
+	// Single request interceptor computes RequestParams once and fans out to
+	// all registered handlers (telemetry, metrics, etc.).
+	ri := requestinterceptor.NewRequestInterceptor()
+	config.HTTPInterceptors = append(config.HTTPInterceptors, ri.HTTPInterceptor())
+	config.UnaryInterceptors = append(config.UnaryInterceptors, ri.UnaryServerInterceptor())
+	config.StreamInterceptors = append(config.StreamInterceptors, ri.StreamServerInterceptor())
+
 	c := phonehomeClient.Singleton()
-	config.HTTPInterceptors = append(config.HTTPInterceptors, c.GetHTTPInterceptor())
-	config.UnaryInterceptors = append(config.UnaryInterceptors, c.GetGRPCInterceptor())
+	ri.Add("telemetry", c.GetRequestHandler())
 
 	server := pkgGRPC.NewAPI(config)
 	server.Register(servicesToRegister()...)

--- a/central/main.go
+++ b/central/main.go
@@ -654,7 +654,7 @@ func startGRPCServer() {
 	config.StreamInterceptors = append(config.StreamInterceptors, ri.StreamServerInterceptor())
 
 	c := phonehomeClient.Singleton()
-	ri.Add("telemetry", c.GetRequestHandler())
+	c.SetInterceptor(ri)
 
 	server := pkgGRPC.NewAPI(config)
 	server.Register(servicesToRegister()...)

--- a/central/telemetry/centralclient/client.go
+++ b/central/telemetry/centralclient/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/clientprofile"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/grpc/client/authn/basic"
+	"github.com/stackrox/rox/pkg/grpc/common/requestinterceptor"
 	"github.com/stackrox/rox/pkg/images/defaults"
 	"github.com/stackrox/rox/pkg/logging"
 	"github.com/stackrox/rox/pkg/sac"
@@ -37,12 +38,21 @@ var (
 	log           = logging.LoggerForModule()
 )
 
+const handlerName = "telemetry"
+
 // CentralClient adds Central specific features to the generic phonehome client.
 type CentralClient struct {
 	*phonehome.Client
 
+	interceptor       *requestinterceptor.RequestInterceptor
 	campaignMux       sync.RWMutex
 	telemetryCampaign clientprofile.RuleSet
+}
+
+// SetInterceptor stores the RequestInterceptor for dynamic handler
+// registration based on the telemetry enabled state.
+func (c *CentralClient) SetInterceptor(ri *requestinterceptor.RequestInterceptor) {
+	c.interceptor = ri
 }
 
 // noopClient returns a disabled client.
@@ -194,6 +204,9 @@ func (c *CentralClient) Disable() {
 		c.Gatherer().Stop()
 	}
 	c.Client.WithdrawConsent()
+	if c.interceptor != nil {
+		c.interceptor.Remove(handlerName)
+	}
 }
 
 // Enable telemetry collection: grant consent and confirm the initial client
@@ -203,6 +216,9 @@ func (c *CentralClient) Enable() {
 		return
 	}
 	c.Client.GrantConsent()
+	if c.interceptor != nil {
+		c.interceptor.Add(handlerName, c.GetRequestHandler())
+	}
 
 	c.Gatherer().Start(
 		// Wrap WithNoDuplicates() with dynamic timestamp: don't capture the

--- a/pkg/grpc/common/requestinterceptor/interceptor.go
+++ b/pkg/grpc/common/requestinterceptor/interceptor.go
@@ -68,7 +68,7 @@ func (ri *RequestInterceptor) UnaryServerInterceptor() grpc.UnaryServerIntercept
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		resp, err := handler(ctx, req)
 		if ri.hasHandlers() {
-			rp := GetGRPCRequestDetails(ctx, err, info.FullMethod, req)
+			rp := getGRPCRequestDetails(ctx, err, info.FullMethod, req)
 			ri.dispatch(rp)
 		}
 		return resp, err
@@ -80,7 +80,7 @@ func (ri *RequestInterceptor) StreamServerInterceptor() grpc.StreamServerInterce
 	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		err := handler(srv, ss)
 		if ri.hasHandlers() {
-			rp := GetGRPCRequestDetails(ss.Context(), err, info.FullMethod, nil)
+			rp := getGRPCRequestDetails(ss.Context(), err, info.FullMethod, nil)
 			ri.dispatch(rp)
 		}
 		return err
@@ -98,20 +98,20 @@ func (ri *RequestInterceptor) HTTPInterceptor() httputil.HTTPInterceptor {
 				if sptr := wrappedWriter.GetStatusCode(); sptr != nil {
 					status = *sptr
 				}
-				rp := GetHTTPRequestDetails(r.Context(), r, status)
+				rp := getHTTPRequestDetails(r.Context(), r, status)
 				ri.dispatch(rp)
 			}
 		})
 	}
 }
 
-// GetGRPCRequestDetails constructs a RequestParams for a gRPC invocation.
+// getGRPCRequestDetails constructs a RequestParams for a gRPC invocation.
 // For grpc-gateway requests it uses the HTTP method, path, status code, and
 // headers, merging User-Agent values from both gRPC metadata and the HTTP
 // request. For pure gRPC calls it uses the full method name as both Method
 // and Path, derives the code from erroxGRPC.RoxErrorToGRPCCode, and builds
 // Headers from gRPC metadata.
-func GetGRPCRequestDetails(ctx context.Context, err error, grpcFullMethod string, req any) *RequestParams {
+func getGRPCRequestDetails(ctx context.Context, err error, grpcFullMethod string, req any) *RequestParams {
 	id, iderr := authn.IdentityFromContext(ctx)
 	if iderr != nil && grpcFullMethod != v1.PingService_Ping_FullMethodName {
 		log.Debugf("Cannot identify user from context for method call %q: %v", grpcFullMethod, iderr)
@@ -152,9 +152,8 @@ func GetGRPCRequestDetails(ctx context.Context, err error, grpcFullMethod string
 	}
 }
 
-// GetHTTPRequestDetails extracts the authenticated user (if any) from ctx and constructs
-// a RequestParams describing the given HTTP request and response status.
-func GetHTTPRequestDetails(ctx context.Context, r *http.Request, status int) *RequestParams {
+// getHTTPRequestDetails constructs a RequestParams for an HTTP request.
+func getHTTPRequestDetails(ctx context.Context, r *http.Request, status int) *RequestParams {
 	id, iderr := authn.IdentityFromContext(ctx)
 	if iderr != nil {
 		log.Debug("Cannot identify user from context: ", iderr)

--- a/pkg/grpc/common/requestinterceptor/request_details_test.go
+++ b/pkg/grpc/common/requestinterceptor/request_details_test.go
@@ -48,7 +48,7 @@ func (s *requestDetailsTestSuite) TestGrpcRequestInfo() {
 	ctx, err := rih.UpdateContextForGRPC(metadata.NewIncomingContext(ctx, md))
 	s.NoError(err)
 
-	rp := GetGRPCRequestDetails(ctx, err, testRP.Path, "request")
+	rp := getGRPCRequestDetails(ctx, err, testRP.Path, "request")
 	s.Equal(testRP.Path, rp.Path)
 	s.Equal(testRP.Code, rp.Code)
 	s.Nil(rp.UserID)
@@ -74,7 +74,7 @@ func (s *requestDetailsTestSuite) TestGrpcWithHTTPRequestInfo() {
 	ctx, err := rih.UpdateContextForGRPC(metadata.NewIncomingContext(ctx, md))
 	s.NoError(err)
 
-	rp := GetGRPCRequestDetails(ctx, err, "ignored grpc method", "request")
+	rp := getGRPCRequestDetails(ctx, err, "ignored grpc method", "request")
 	s.Equal(http.StatusOK, rp.Code)
 	// Original HTTP User-Agent + gRPC transport agent merged under one key.
 	s.Equal([]string{"user", "gateway"}, rp.Headers.Values(userAgentHeaderKey))
@@ -124,7 +124,7 @@ func (s *requestDetailsTestSuite) TestGrpcWithHTTPRequestInfo_UserAgentVariants(
 			ctx, err := rih.UpdateContextForGRPC(metadata.NewIncomingContext(ctx, md))
 			s.NoError(err)
 
-			rp := GetGRPCRequestDetails(ctx, err, "ignored", "request")
+			rp := getGRPCRequestDetails(ctx, err, "ignored", "request")
 			s.Equal(tc.expected, rp.Headers.Values(userAgentHeaderKey))
 		})
 	}
@@ -141,21 +141,21 @@ type testBodyI interface {
 func (s *requestDetailsTestSuite) TestHttpWithBody() {
 	body := "{ \"n\": 42 }"
 	req, _ := http.NewRequest(http.MethodPost, "/http/body", bytes.NewReader([]byte(body)))
-	rp := GetHTTPRequestDetails(context.Background(), req, 0)
+	rp := getHTTPRequestDetails(context.Background(), req, 0)
 
 	rb := GetGRPCRequestBody(testBodyI.getTestBody, rp)
 	s.Nil(rb, "body is not captured for HTTP requests")
 }
 
 func (s *requestDetailsTestSuite) TestGrpcWithBody() {
-	rp := GetGRPCRequestDetails(context.Background(), nil, "/grpc/body", &testBody{N: 42})
+	rp := getGRPCRequestDetails(context.Background(), nil, "/grpc/body", &testBody{N: 42})
 
 	rb := GetGRPCRequestBody(testBodyI.getTestBody, rp)
 	if s.NotNil(rb) {
 		s.Equal(42, rb.N)
 	}
 
-	rp = GetGRPCRequestDetails(context.Background(), nil, "/grpc/body", nil)
+	rp = getGRPCRequestDetails(context.Background(), nil, "/grpc/body", nil)
 
 	rb = GetGRPCRequestBody(testBodyI.getTestBody, rp)
 	s.Nil(rb)
@@ -175,7 +175,7 @@ func (s *requestDetailsTestSuite) TestHttpRequestInfo() {
 	req.Header.Add(userAgentHeaderKey, testRP.Headers.Get(userAgentHeaderKey))
 
 	ctx := authn.ContextWithIdentity(context.Background(), testRP.UserID, nil)
-	rp := GetHTTPRequestDetails(ctx, req, 200)
+	rp := getHTTPRequestDetails(ctx, req, 200)
 	s.Equal(testRP.Path, rp.Path)
 	s.Equal(testRP.Code, rp.Code)
 	s.Equal(mockID, rp.UserID)

--- a/pkg/telemetry/phonehome/client.go
+++ b/pkg/telemetry/phonehome/client.go
@@ -3,19 +3,15 @@ package phonehome
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/stackrox/rox/pkg/errox"
 	"github.com/stackrox/rox/pkg/eventual"
 	"github.com/stackrox/rox/pkg/grpc/authn"
-	"github.com/stackrox/rox/pkg/grpc/common/requestinterceptor"
-	"github.com/stackrox/rox/pkg/httputil"
 	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/segment"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
 	"github.com/stackrox/rox/pkg/version"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -303,29 +299,11 @@ func (c *Client) Telemeter() telemeter.Telemeter {
 	return c.telemeter
 }
 
-// GetGRPCInterceptor returns an API interceptor function for GRPC requests.
-func (c *Client) GetGRPCInterceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		resp, err := handler(ctx, req)
-		rp := requestinterceptor.GetGRPCRequestDetails(ctx, err, info.FullMethod, req)
+// GetRequestHandler returns a handler that tracks telemetry events
+// asynchronously. Register it with a RequestInterceptor.
+func (c *Client) GetRequestHandler() func(*RequestParams) {
+	return func(rp *RequestParams) {
 		go c.track(rp)
-		return resp, err
-	}
-}
-
-// GetHTTPInterceptor returns an API interceptor function for HTTP requests.
-func (c *Client) GetHTTPInterceptor() httputil.HTTPInterceptor {
-	return func(handler http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			statusTrackingWriter := httputil.NewStatusTrackingWriter(w)
-			handler.ServeHTTP(statusTrackingWriter, r)
-			status := 0
-			if sptr := statusTrackingWriter.GetStatusCode(); sptr != nil {
-				status = *sptr
-			}
-			rp := requestinterceptor.GetHTTPRequestDetails(r.Context(), r, status)
-			go c.track(rp)
-		})
 	}
 }
 

--- a/pkg/telemetry/phonehome/examples_test.go
+++ b/pkg/telemetry/phonehome/examples_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/stackrox/rox/pkg/grpc/common/requestinterceptor"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/segment/mock"
 	"github.com/stackrox/rox/pkg/telemetry/phonehome/telemeter"
@@ -152,10 +153,13 @@ func ExampleClient_AddInterceptorFuncs() {
 		})
 	c.GrantConsent()
 
+	ri := requestinterceptor.NewRequestInterceptor()
+	ri.Add("telemetry", c.GetRequestHandler())
+
 	myServiceHandler := http.NotFoundHandler()
 
 	mux := http.NewServeMux()
-	mux.Handle("/", c.GetHTTPInterceptor()(myServiceHandler))
+	mux.Handle("/", ri.HTTPInterceptor()(myServiceHandler))
 	mux.ServeHTTP(
 		httptest.NewRecorder(),
 		httptest.NewRequest(http.MethodGet, "/service", bytes.NewReader([]byte{})),


### PR DESCRIPTION
## Description

With the `RequestInterceptor` registry in place, the telemetry client no longer needs to own the interceptor lifecycle. Replacing the two protocol-specific interceptors with a single `GetRequestHandler()` turns the client into just another consumer of the registry. This also adds stream interceptor support that was previously missing.

- Replace `Client.GetGRPCInterceptor()` and `Client.GetHTTPInterceptor()` with `GetRequestHandler()`.
- Wire `RequestInterceptor` in `central/main.go` with unary, stream, and HTTP interceptors.
- Unexport `getGRPCRequestDetails` / `getHTTPRequestDetails` — now package-internal to `requestinterceptor`.
- Remove unused imports from `phonehome/client.go`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- `go build` and `go test` pass for `requestinterceptor`, `phonehome`, and `central`.
- Example test (`ExampleClient_AddInterceptorFuncs`) updated to use the new wiring pattern.
- Merge of all 4 stacked branches verified to be functionally equivalent to the original combined change.

<!-- GHIT dependencies begin -->
Current dependencies on/for this PR:

* [master](../tree/master)
  * **PR #21131**
    * **PR #21132**
      * **PR #21133**
        * **PR #21134** 👈
          * **PR #21360**
            * **PR #21361**
              * **PR #18080**
<!-- GHIT dependencies end -->