### PR TITLE
ROX-34955: reject evaluation filter with container type on build-only…

### DIFF
--- a/central/policy/service/validator.go
+++ b/central/policy/service/validator.go
@@ -96,6 +96,7 @@ func (s *policyValidator) internalValidate(policy *storage.Policy, additionalVal
 	errorList.AddError(s.validateCapabilities(policy))
 	errorList.AddError(s.validateEventSource(policy))
 	errorList.AddError(s.validateEnforcement(policy))
+	errorList.AddError(s.validateEvaluationFilter(policy))
 
 	for _, validator := range additionalValidators {
 		errorList.AddError(validator(policy))
@@ -503,4 +504,14 @@ func (s *policyValidator) eventSourceError() error {
 	}
 
 	return fmt.Errorf("event source must be %s for runtime policies", strings.Join(eventSources, " or "))
+}
+
+func (s *policyValidator) validateEvaluationFilter(policy *storage.Policy) error {
+	if len(policy.GetEvaluationFilter().GetSkipContainerTypes()) == 0 {
+		return nil
+	}
+	if policies.AppliesAtBuildTime(policy) && !policies.AppliesAtDeployTime(policy) && !policies.AppliesAtRunTime(policy) {
+		return errors.New("container type filters in the evaluation filter are not applicable to build-only policies")
+	}
+	return nil
 }

--- a/central/policy/service/validator_test.go
+++ b/central/policy/service/validator_test.go
@@ -1374,3 +1374,55 @@ func (s *PolicyValidatorTestSuite) TestValidateScope() {
 		})
 	}
 }
+
+func (s *PolicyValidatorTestSuite) TestValidateEvaluationFilter() {
+	tests := map[string]struct {
+		lifecycleStages    []storage.LifecycleStage
+		skipContainerTypes []storage.ContainerType
+		expectError        bool
+	}{
+		"build-only with skip init is rejected": {
+			lifecycleStages:    []storage.LifecycleStage{storage.LifecycleStage_BUILD},
+			skipContainerTypes: []storage.ContainerType{storage.ContainerType_INIT},
+			expectError:        true,
+		},
+		"deploy with skip init is allowed": {
+			lifecycleStages:    []storage.LifecycleStage{storage.LifecycleStage_DEPLOY},
+			skipContainerTypes: []storage.ContainerType{storage.ContainerType_INIT},
+		},
+		"build + deploy with skip init is allowed": {
+			lifecycleStages:    []storage.LifecycleStage{storage.LifecycleStage_BUILD, storage.LifecycleStage_DEPLOY},
+			skipContainerTypes: []storage.ContainerType{storage.ContainerType_INIT},
+		},
+		"runtime with skip init is allowed": {
+			lifecycleStages:    []storage.LifecycleStage{storage.LifecycleStage_RUNTIME},
+			skipContainerTypes: []storage.ContainerType{storage.ContainerType_INIT},
+		},
+		"build-only with no filter is allowed": {
+			lifecycleStages: []storage.LifecycleStage{storage.LifecycleStage_BUILD},
+		},
+		"no lifecycle stages with skip init is allowed": {
+			skipContainerTypes: []storage.ContainerType{storage.ContainerType_INIT},
+		},
+	}
+
+	for name, tc := range tests {
+		s.Run(name, func() {
+			policy := &storage.Policy{
+				LifecycleStages: tc.lifecycleStages,
+			}
+			if tc.skipContainerTypes != nil {
+				policy.EvaluationFilter = &storage.EvaluationFilter{
+					SkipContainerTypes: tc.skipContainerTypes,
+				}
+			}
+
+			err := s.validator.validateEvaluationFilter(policy)
+			if tc.expectError {
+				s.Error(err)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds validation to reject policies with container type evaluation filters when only the BUILD lifecycle stage is selected. Container type filtering is not applicable to build-time evaluation since build policies evaluate images, not container specs.

Stacked on #21096 .

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: gated behind `ROX_EVALUATION_FILTER` feature flag
- [x] CI results are inspected

### Automated testing

- [x] added unit tests

### How I validated my change

Deployed build `4.12.x-172-gacb65d1ea2` to a GKE cluster with `ROX_INIT_CONTAINER_SUPPORT` and `ROX_EVALUATION_FILTER` feature flags enabled. Tested policy creation via the API:

**Test 1: Build-only policy with `skipContainerTypes: ["INIT"]` is rejected**
- Attempted to create a BUILD-only policy with an evaluation filter containing `skipContainerTypes: ["INIT"]`
- API returned error: `container type filters in the evaluation filter are not applicable to build-only policies`

**Test 2: Deploy policy with `skipContainerTypes: ["INIT"]` is accepted**
- Created a DEPLOY policy with the same evaluation filter
- Policy created successfully

**Test 3: Build-only policy without evaluation filter is accepted (no regression)**
- Created a BUILD-only policy with no evaluation filter
- Policy created successfully

**Result:** 3/3 passed

