### PR TITLE
ROX-35083: Disable key bundle updater in offline mode

### DIFF
--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -64,6 +64,11 @@ func seedRedHatDefaultSignatureIntegration(siStore store.SignatureIntegrationSto
 }
 
 func startKeyBundleUpdater() {
+	if env.OfflineModeEnv.BooleanSetting() {
+		log.Info("In offline mode: Red Hat signing key bundle will not be updated automatically")
+		return
+	}
+
 	rawURL := env.RedHatSigningKeyBundleURL.Setting()
 	if rawURL == "" {
 		log.Info("ROX_REDHAT_SIGNING_KEY_BUNDLE_URL not set, key bundle updater will not start")

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -65,7 +65,7 @@ func seedRedHatDefaultSignatureIntegration(siStore store.SignatureIntegrationSto
 
 func startKeyBundleUpdater() {
 	if env.OfflineModeEnv.BooleanSetting() {
-		log.Info("In offline mode: Red Hat signing key bundle will not be updated automatically")
+		log.Info("Offline mode detected: The Red Hat signing key bundle will not be downloaded automatically. Manual updates are possible by mounting the bundle to the file location specified by ROX_REDHAT_SIGNING_KEY_BUNDLE_FILE_PATH")
 		return
 	}
 

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -65,7 +65,7 @@ func seedRedHatDefaultSignatureIntegration(siStore store.SignatureIntegrationSto
 
 func startKeyBundleUpdater() {
 	if env.OfflineModeEnv.BooleanSetting() {
-		log.Info("Offline mode detected: The Red Hat signing key bundle will not be downloaded automatically. Manual updates are possible by mounting the bundle to the file location specified by ROX_REDHAT_SIGNING_KEY_BUNDLE_FILE_PATH")
+		log.Infof("Offline mode detected: The Red Hat signing key bundle will not be downloaded automatically. Manual updates are possible by mounting the bundle to %q", redHatKeyBundlePath)
 		return
 	}
 

--- a/central/signatureintegration/datastore/singleton_test.go
+++ b/central/signatureintegration/datastore/singleton_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	storeMocks "github.com/stackrox/rox/central/signatureintegration/store/mocks"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/signatures"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
 
@@ -27,4 +29,45 @@ func TestSeedSubsequentStartup(t *testing.T) {
 	mockStore.EXPECT().Get(gomock.Any(), id).Return(signatures.DefaultRedHatSignatureIntegration, true, nil).Times(1)
 
 	seedRedHatDefaultSignatureIntegration(mockStore)
+}
+
+func TestStartKeyBundleUpdaterOfflineMode(t *testing.T) {
+	t.Setenv(env.OfflineModeEnv.EnvVar(), "true")
+	t.Setenv(env.RedHatSigningKeyBundleURL.EnvVar(), "https://example.com/keys.json")
+
+	old := bundleUpdater
+	defer func() { bundleUpdater = old }()
+	bundleUpdater = nil
+
+	startKeyBundleUpdater()
+	assert.Nil(t, bundleUpdater, "updater should not start in offline mode")
+}
+
+func TestStartKeyBundleUpdaterOnlineWithURL(t *testing.T) {
+	t.Setenv(env.OfflineModeEnv.EnvVar(), "false")
+	t.Setenv(env.RedHatSigningKeyBundleURL.EnvVar(), "https://example.com/keys.json")
+
+	old := bundleUpdater
+	defer func() {
+		if bundleUpdater != nil {
+			bundleUpdater.Stop()
+		}
+		bundleUpdater = old
+	}()
+	bundleUpdater = nil
+
+	startKeyBundleUpdater()
+	assert.NotNil(t, bundleUpdater, "updater should start in online mode with URL configured")
+}
+
+func TestStartKeyBundleUpdaterOnlineWithoutURL(t *testing.T) {
+	t.Setenv(env.OfflineModeEnv.EnvVar(), "false")
+	t.Setenv(env.RedHatSigningKeyBundleURL.EnvVar(), "")
+
+	old := bundleUpdater
+	defer func() { bundleUpdater = old }()
+	bundleUpdater = nil
+
+	startKeyBundleUpdater()
+	assert.Nil(t, bundleUpdater, "updater should not start without URL")
 }


### PR DESCRIPTION
## Description

The Red Hat signing key bundle updater (`startKeyBundleUpdater`) did not check `ROX_OFFLINE_MODE`. In air-gapped deployments where `ROX_REDHAT_SIGNING_KEY_BUNDLE_URL` has a default value, the updater would attempt outbound HTTP requests and log warnings every 4 hours.

This adds an offline mode guard at the top of `startKeyBundleUpdater()`, following the same pattern used by the scanner definitions handler (`central/scannerdefinitions/handler/handler.go`). When `ROX_OFFLINE_MODE=true`, the HTTP downloader does not start. The file watcher is unaffected — disconnected customers can still place key bundles manually.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Three unit tests covering the matrix:
- `TestStartKeyBundleUpdaterOfflineMode`: offline + URL set → updater nil
- `TestStartKeyBundleUpdaterOnlineWithURL`: online + URL set → updater starts
- `TestStartKeyBundleUpdaterOnlineWithoutURL`: online + no URL → updater nil (existing behavior)

All 18 tests in the package pass:
```
ok  github.com/stackrox/rox/central/signatureintegration/datastore  1.115s
```