### PR TITLE
fix(central): prevent cross-cluster compliance data deletion on sensor reconnect

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_impl.go
+++ b/central/complianceoperator/v2/report/manager/manager_impl.go
@@ -428,15 +428,15 @@ func (m *managerImpl) HandleScanRemove(scanID string) error {
 	return nil
 }
 
+// getWatcher returns an existing ScanWatcher or creates a new one. A new
+// watcher is only created when numChecks == 0, which means the scan's
+// check-count annotation is not yet set (i.e., the scan is starting, not
+// finished). This prevents creating watchers for completed scans whose events
+// are replayed during sensor reconnections.
 func (m *managerImpl) getWatcher(sensorCtx context.Context, id string, numChecks int) watcher.ScanWatcher {
 	var scanWatcher watcher.ScanWatcher
 	concurrency.WithLock(&m.watchingScansLock, func() {
 		var found bool
-		// The check for `numChecks == 0` is here to prevent starting a watcher twice per scan.
-		// It may happen that additional status updates (e.g., state) from CO arrive
-		// after the watcher is removed from the watchingScans (i.e., we have all the checks).
-		// Not checking that would cause a new watcher to be created here and in some circumstances
-		// (when no e-mail is provided for notification), the watcher would time-out and delete the data from DB.
 		if scanWatcher, found = m.watchingScans[id]; !found && numChecks == 0 {
 			scanWatcher = watcher.NewScanWatcher(m.automaticReportingCtx, sensorCtx, id, m.readyQueue)
 			m.watchingScans[id] = scanWatcher
@@ -447,7 +447,12 @@ func (m *managerImpl) getWatcher(sensorCtx context.Context, id string, numChecks
 	return scanWatcher
 }
 
-// HandleResult starts a new ScanWatcher if needed and pushes the checkResult to it
+// HandleResult pushes the checkResult to an existing ScanWatcher. Unlike
+// HandleScan, this method never creates a new watcher. Watchers are only
+// created by HandleScan which carries the check-count annotation needed to
+// determine completion. This prevents phantom watcher creation from replayed
+// check results during sensor reconnections, which previously triggered a
+// cascade leading to cross-cluster data deletion.
 func (m *managerImpl) HandleResult(sensorCtx context.Context, result *storage.ComplianceOperatorCheckResultV2) error {
 	if !features.ComplianceReporting.Enabled() || !features.ScanScheduleReportJobs.Enabled() {
 		return nil
@@ -468,12 +473,20 @@ func (m *managerImpl) HandleResult(sensorCtx context.Context, result *storage.Co
 		}
 		return err
 	}
-	w := m.getWatcher(sensorCtx, id, 0)
+	w := m.getExistingWatcher(id)
 	if w != nil {
 		return w.PushCheckResult(result)
 	}
-	log.Debugf("Received check result update after removing the watcher %+v", result)
+	log.Debugf("Received check result update but no watcher exists for %s", id)
 	return nil
+}
+
+// getExistingWatcher returns an existing ScanWatcher for the given id, or nil
+// if none exists. It never creates a new watcher.
+func (m *managerImpl) getExistingWatcher(id string) watcher.ScanWatcher {
+	return concurrency.WithLock1(&m.watchingScansLock, func() watcher.ScanWatcher {
+		return m.watchingScans[id]
+	})
 }
 
 // handleReadyScan pulls scans that are ready to be reported

--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -506,81 +506,108 @@ func (m *ManagerTestSuite) TestHandleScanRemove() {
 	})
 }
 
-func (m *ManagerTestSuite) TestHandleResult() {
+func (m *ManagerTestSuite) TestHandleResultDoesNotCreateWatcher() {
 	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
-	managerImplementation, ok := manager.(*managerImpl)
-	require.True(m.T(), ok)
+	impl := manager.(*managerImpl)
+
 	timeNow := time.Now()
-	pastTime := timeNow.Add(-10 * time.Second)
-	futureTime := timeNow.Add(10 * time.Second)
-	timeNowProto, err := protocompat.ConvertTimeToTimestampOrError(timeNow)
-	require.NoError(m.T(), err)
-	nowRFCFormat := timeNow.Format(time.RFC3339Nano)
-	pastRFCFormat := pastTime.Format(time.RFC3339Nano)
-	futureRFCFormat := futureTime.Format(time.RFC3339Nano)
-	result := &storage.ComplianceOperatorCheckResultV2{
-		Annotations: map[string]string{
-			"compliance.openshift.io/last-scanned-timestamp": pastRFCFormat,
-		},
-	}
+	nowRFC := timeNow.Format(time.RFC3339Nano)
 	scan := &storage.ComplianceOperatorScanV2{
 		ClusterId: "cluster-id",
 		Id:        "scan-id",
 	}
-	m.scanDataStore.EXPECT().SearchScans(gomock.Any(), gomock.Any()).Times(2).
-		Return([]*storage.ComplianceOperatorScanV2{scan}, nil)
-	m.scanConfigDataStore.EXPECT().GetScanConfigurations(gomock.Any(), gomock.Any()).AnyTimes().
-		Return(
-			[]*storage.ComplianceOperatorScanConfigurationV2{
-				{
-					Id: "scan-config-id",
-				},
-			}, nil,
-		)
-	m.snapshotDataStore.EXPECT().SearchSnapshots(gomock.Any(), gomock.Any()).AnyTimes().
-		Return([]*storage.ComplianceOperatorReportSnapshotV2{}, nil)
-	id, err := watcher.GetWatcherIDFromCheckResult(context.Background(), result, m.scanDataStore, m.snapshotDataStore, m.scanConfigDataStore)
-	require.NoError(m.T(), err)
-	err = manager.HandleResult(context.Background(), result.CloneVT())
-	assert.NoError(m.T(), err)
-	concurrency.WithLock(&managerImplementation.watchingScansLock, func() {
-		w, ok := managerImplementation.watchingScans[id]
-		assert.True(m.T(), ok)
-		assert.NotNil(m.T(), w)
-		delete(managerImplementation.watchingScans, id)
-	})
+	result := &storage.ComplianceOperatorCheckResultV2{
+		Annotations: map[string]string{
+			watcher.LastScannedAnnotationKey: nowRFC,
+		},
+	}
 
-	scan.LastStartedTime = timeNowProto
 	m.scanDataStore.EXPECT().SearchScans(gomock.Any(), gomock.Any()).AnyTimes().
 		Return([]*storage.ComplianceOperatorScanV2{scan}, nil)
+	m.scanConfigDataStore.EXPECT().GetScanConfigurations(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorScanConfigurationV2{{Id: "sc-id"}}, nil)
+	m.snapshotDataStore.EXPECT().SearchSnapshots(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorReportSnapshotV2{}, nil)
 
-	err = manager.HandleResult(context.Background(), result.CloneVT())
-	assert.Error(m.T(), err)
-	concurrency.WithLock(&managerImplementation.watchingScansLock, func() {
-		assert.Len(m.T(), managerImplementation.watchingScans, 0)
+	// HandleResult with no existing watcher should NOT create one.
+	err := manager.HandleResult(context.Background(), result.CloneVT())
+	m.Require().NoError(err)
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		m.Assert().Empty(impl.watchingScans, "HandleResult must not create a watcher")
+	})
+}
+
+func (m *ManagerTestSuite) TestHandleResultPushesToExistingWatcher() {
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+	impl := manager.(*managerImpl)
+
+	timestamp := protocompat.TimestampNow()
+	timestampRFC := timestamp.AsTime().Format(time.RFC3339Nano)
+	scan := &storage.ComplianceOperatorScanV2{
+		ClusterId:       "cluster-id",
+		Id:              "scan-id",
+		LastStartedTime: timestamp,
+	}
+	result := &storage.ComplianceOperatorCheckResultV2{
+		Annotations: map[string]string{
+			watcher.LastScannedAnnotationKey: timestampRFC,
+		},
+	}
+
+	m.scanDataStore.EXPECT().SearchScans(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorScanV2{scan}, nil)
+	m.scanConfigDataStore.EXPECT().GetScanConfigurations(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorScanConfigurationV2{{Id: "sc-id"}}, nil)
+	m.snapshotDataStore.EXPECT().SearchSnapshots(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorReportSnapshotV2{}, nil)
+
+	// Create a watcher via HandleScan first.
+	err := manager.HandleScan(context.Background(), scan)
+	m.Require().NoError(err)
+
+	id, err := watcher.GetWatcherIDFromScan(context.Background(), scan, m.snapshotDataStore, m.scanConfigDataStore, nil)
+	m.Require().NoError(err)
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		m.Require().Contains(impl.watchingScans, id, "HandleScan should have created the watcher")
 	})
 
-	result.Annotations["compliance.openshift.io/last-scanned-timestamp"] = nowRFCFormat
+	// HandleResult should push to the existing watcher without error.
 	err = manager.HandleResult(context.Background(), result.CloneVT())
-	assert.NoError(m.T(), err)
-	id, err = watcher.GetWatcherIDFromCheckResult(context.Background(), result, m.scanDataStore, m.snapshotDataStore, m.scanConfigDataStore)
-	require.NoError(m.T(), err)
-	concurrency.WithLock(&managerImplementation.watchingScansLock, func() {
-		w, ok := managerImplementation.watchingScans[id]
-		assert.True(m.T(), ok)
-		assert.NotNil(m.T(), w)
-		delete(managerImplementation.watchingScans, id)
-	})
-	result.Annotations["compliance.openshift.io/last-scanned-timestamp"] = futureRFCFormat
+	m.Assert().NoError(err)
+}
+
+func (m *ManagerTestSuite) TestHandleResultRejectsOldCheckResult() {
+	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
+	impl := manager.(*managerImpl)
+
+	timeNow := time.Now()
+	pastRFC := timeNow.Add(-10 * time.Second).Format(time.RFC3339Nano)
+	timeNowProto, err := protocompat.ConvertTimeToTimestampOrError(timeNow)
+	m.Require().NoError(err)
+
+	scan := &storage.ComplianceOperatorScanV2{
+		ClusterId:       "cluster-id",
+		Id:              "scan-id",
+		LastStartedTime: timeNowProto,
+	}
+	result := &storage.ComplianceOperatorCheckResultV2{
+		Annotations: map[string]string{
+			watcher.LastScannedAnnotationKey: pastRFC,
+		},
+	}
+
+	m.scanDataStore.EXPECT().SearchScans(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorScanV2{scan}, nil)
+	m.scanConfigDataStore.EXPECT().GetScanConfigurations(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorScanConfigurationV2{{Id: "sc-id"}}, nil)
+	m.snapshotDataStore.EXPECT().SearchSnapshots(gomock.Any(), gomock.Any()).AnyTimes().
+		Return([]*storage.ComplianceOperatorReportSnapshotV2{}, nil)
+
+	// Check result older than the scan should be rejected.
 	err = manager.HandleResult(context.Background(), result.CloneVT())
-	assert.NoError(m.T(), err)
-	id, err = watcher.GetWatcherIDFromCheckResult(context.Background(), result, m.scanDataStore, m.snapshotDataStore, m.scanConfigDataStore)
-	require.NoError(m.T(), err)
-	concurrency.WithLock(&managerImplementation.watchingScansLock, func() {
-		w, ok := managerImplementation.watchingScans[id]
-		assert.True(m.T(), ok)
-		assert.NotNil(m.T(), w)
-		delete(managerImplementation.watchingScans, id)
+	m.Assert().Error(err)
+	concurrency.WithLock(&impl.watchingScansLock, func() {
+		m.Assert().Empty(impl.watchingScans, "no watcher should be created for old result")
 	})
 }
 


### PR DESCRIPTION
## Description

Fixes intermittent cluster disappearance from the Compliance > Coverage dashboard (ROX-34779).

**Root cause:** When a sensor reconnects and replays K8s ComplianceScan/CheckResult objects, `HandleResult` (which passes `numChecks=0` to `getWatcher`) creates phantom watchers from stale check results. These feed into a ScanConfigWatcher that only receives data from the single reconnecting cluster. When the ScanConfigWatcher times out, `DeleteOldResultsFromMissingScans` computes the full expected scan set (all clusters in the config), determines that other clusters are "missing," and deletes their check results with `includeCurrent=true`. This wipes compliance data for those clusters from the DB, making them vanish from the dashboard. The cycle repeats every 1-2 hours as different sensors reconnect.

**Fix:** `HandleResult` no longer creates watchers — it only pushes results to existing ones via a new `getExistingWatcher` lookup method. Watchers are only created by `HandleScan`, which carries the check-count annotation. The existing `numChecks > 0` guard in `getWatcher` correctly blocks watcher creation for completed scans (whose check-count annotation is always set), so replayed scan events from sensor reconnections don't create watchers either. This breaks the cascade at the entry point: no phantom watcher → no ScanConfigWatcher from stale events → no cross-cluster deletion.

Check result data continues to be persisted to the DB via `UpsertResult` regardless of watcher state — the watcher only tracks result IDs for report generation, not for persistence.

**Alternative considered:** TTL-based `completedScans` cache (PR #20972): covers only a 5-minute window, insufficient for sensor reconnections hours apart; also removes the permanent `numChecks > 0` guard from `HandleScan`, making it less protected than before.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [x] modified existing tests

### How I validated my change

- Replaced `TestHandleResult` with three targeted tests:
  - `TestHandleResultDoesNotCreateWatcher` — verifies no watcher is created when HandleResult is called without a pre-existing watcher
  - `TestHandleResultPushesToExistingWatcher` — verifies results push to watchers created by HandleScan
  - `TestHandleResultRejectsOldCheckResult` — verifies old check results are still rejected
- All existing tests in `manager_test.go` and `scanconfigwatcher_test.go` pass unchanged