### PR TITLE
ROX-32873: Separate metrics for persisted and not persisted processes

### DIFF
--- a/central/detection/lifecycle/manager_impl.go
+++ b/central/detection/lifecycle/manager_impl.go
@@ -268,7 +268,7 @@ func (m *managerImpl) flushIndicatorQueue() {
 
 			indicatorSlice = append(indicatorSlice, indicator)
 		} else {
-			metrics.ProcessIndicatorsNotPersistedInc()
+			processIndicatorDatastore.RecordProcessIndicatorNotPersisted(indicator)
 		}
 	}
 

--- a/central/detection/lifecycle/metrics/metrics.go
+++ b/central/detection/lifecycle/metrics/metrics.go
@@ -8,7 +8,6 @@ import (
 func init() {
 	prometheus.MustRegister(
 		processFilterCounter,
-		processIndicatorsNotPersisted,
 	)
 }
 
@@ -19,21 +18,9 @@ var (
 		Name:      "process_filter",
 		Help:      "Process filter hits and misses",
 	}, []string{"Type"})
-
-	processIndicatorsNotPersisted = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: metrics.PrometheusNamespace,
-		Subsystem: metrics.CentralSubsystem.String(),
-		Name:      "process_indicators_not_persisted",
-		Help:      "Number of process indicators filtered out and not persisted",
-	})
 )
 
 // ProcessFilterCounterInc increments a counter for determining how effective the process filter is
 func ProcessFilterCounterInc(typ string) {
 	processFilterCounter.With(prometheus.Labels{"Type": typ}).Inc()
-}
-
-// ProcessIndicatorsNotPersistedInc increments the counter for process indicators filtered out and not persisted.
-func ProcessIndicatorsNotPersistedInc() {
-	processIndicatorsNotPersisted.Inc()
 }

--- a/central/processindicator/datastore/metrics.go
+++ b/central/processindicator/datastore/metrics.go
@@ -85,6 +85,50 @@ var (
 		Name:      "process_upserted_lineage_size_total",
 		Help:      "Total upserted process lineage sizes in bytes by cluster and namespace",
 	}, []string{"cluster", "namespace"})
+
+	processNotPersistedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "process_indicators_not_persisted",
+		Help:      "Number of process indicators filtered out and not persisted",
+	})
+
+	processNotPersistedArgsSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "process_not_persisted_args_size",
+		Help:      "Distribution of process argument sizes in bytes for indicators not persisted",
+		Buckets:   []float64{0, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
+	})
+
+	processNotPersistedArgsSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "process_not_persisted_args_size_total",
+		Help:      "Total not-persisted process argument sizes in bytes by cluster and namespace",
+	}, []string{"cluster", "namespace"})
+
+	processNotPersistedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "process_not_persisted_count",
+		Help:      "Number of process indicators not persisted by cluster and namespace",
+	}, []string{"cluster", "namespace"})
+
+	processNotPersistedLineageSizeHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "process_not_persisted_lineage_size",
+		Help:      "Distribution of process lineage sizes in bytes for indicators not persisted",
+		Buckets:   []float64{0, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536},
+	})
+
+	processNotPersistedLineageSizeTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "process_not_persisted_lineage_size_total",
+		Help:      "Total not-persisted process lineage sizes in bytes by cluster and namespace",
+	}, []string{"cluster", "namespace"})
 )
 
 func recordProcessIndicatorsRemoved(num int, reason string) {
@@ -143,6 +187,21 @@ func recordProcessIndicatorsBatchAdded(indicators []*storage.ProcessIndicator) {
 	}
 }
 
+// RecordProcessIndicatorNotPersisted records metrics for a process indicator that was filtered out and not persisted.
+func RecordProcessIndicatorNotPersisted(indicator *storage.ProcessIndicator) {
+	argsSizeBytes := getProcessArgsSizeBytes(indicator)
+	lineageSizeBytes := getProcessLineageSizeBytes(indicator)
+	clusterID := indicator.GetClusterId()
+	namespace := indicator.GetNamespace()
+
+	processNotPersistedTotal.Inc()
+	processNotPersistedArgsSizeHistogram.Observe(float64(argsSizeBytes))
+	processNotPersistedArgsSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(argsSizeBytes))
+	processNotPersistedCount.WithLabelValues(clusterID, namespace).Inc()
+	processNotPersistedLineageSizeHistogram.Observe(float64(lineageSizeBytes))
+	processNotPersistedLineageSizeTotal.WithLabelValues(clusterID, namespace).Add(float64(lineageSizeBytes))
+}
+
 func init() {
 	prometheus.MustRegister(
 		processPruningCacheHits,
@@ -154,5 +213,11 @@ func init() {
 		processIndicatorsRemovedTotal,
 		processUpsertedLineageSizeHistogram,
 		processUpsertedLineageSizeTotal,
+		processNotPersistedTotal,
+		processNotPersistedArgsSizeHistogram,
+		processNotPersistedArgsSizeTotal,
+		processNotPersistedCount,
+		processNotPersistedLineageSizeHistogram,
+		processNotPersistedLineageSizeTotal,
 	)
 }


### PR DESCRIPTION
## Description

<!--
A detailed explanation of the changes in your PR. Feel free to remove this
section if the title of your PR is sufficiently descriptive. To learn more
about contributing to this project, check "*.md" files under:
    https://github.com/stackrox/stackrox/tree/master/.github
-->

Previously when process indicator persistence was disabled metrics regarding process indicators were not collected. This PR changes that. Previously the metrics were collected in the process indicator datastore and the process indicators were filtered out in the detection lifecycle manager, just before calling the process indicator datastore. Thus, metrics were only collected for persisted process indicators. This PR makes it so that the same metrics are collected for process indicators that are not persisted. The metrics with "upserted" are kept and metrics with "not_persisted" are kept.

An alternative where the metrics for process indicators are treated the same weather they are persisted or not can be found at https://github.com/stackrox/stackrox/pull/21072. In that case the word "upserted" is changed to "received" in the names of the metrics.

My recommendation is to merge this PR in favor of the alternative as it useful to have separate metrics for persisted and unpersisted process indicators.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

Helm charts were created

```bash
#!/usr/bin/env bash
set -eou pipefail

cd ../../

tag="$(make tag)"

cd -

#repo=${1:-stackrox-io}
repo=${1:-jvirtane}

docker run --rm -v "$(pwd):/usr/src/stackrox" quay.io/$repo/roxctl:"$tag" helm output central-services --image-defaults opensource --output-dir /usr/src/stackrox/stackrox-central-services-chart-"$tag"

docker run --rm -v "$(pwd):/usr/src/stackrox" quay.io/$repo/roxctl:"$tag" helm output secured-cluster-services --image-defaults opensource --output-dir /usr/src/stackrox/stackrox-secured-cluster-chart-"$tag"
```

An openshift-4 cluster was created and the following script was run

```bash
#!/usr/bin/env bash
set -eou pipefail

ARTIFACT_DIR=$1
central1=$2
secured1=$3

./start-central.sh $ARTIFACT_DIR $central1
sleep 60
./get-bundle.sh $ARTIFACT_DIR
sleep 10
./start-secured-cluster.sh $ARTIFACT_DIR $secured1
```

```bash
set -eoux pipefail

echo "Starting central and scanner related pods"

artifacts_dir=$1
helm_charts=$2

export KUBECONFIG="$artifacts_dir"/kubeconfig
admin_password=*******

settings=(
    --namespace stackrox stackrox-central-services --create-namespace "$helm_charts"
    --set central.exposure.route.enabled=true
    --set central.adminPassword.value="$admin_password"
    --set central.persistence.none=true
)

helm install "${settings[@]}"
```

```bash
#!/usr/bin/env bash
set -eou pipefail

artifacts_dir=$1

echo "Grabing bundle"

export KUBECONFIG="$artifacts_dir/kubeconfig"
central_password=asdf
#central_password="$(cat "$artifacts_dir"/kubeadmin-password)"

rm -f perf-bundle.yml

url="$(kubectl -n stackrox get routes central -o json | jq -r '.spec.host')"
#url="$(oc -n stackrox get routes central -o json | jq -r '.spec.host')"
roxctl -e https://"$url":443 \
    -p "$central_password" --insecure-skip-tls-verify \
    central init-bundles generate perf-test \
    --output perf-bundle.yml
```

```bash
#!/usr/bin/env bash
set -eoux pipefail

artifacts_dir=$1
helm_charts=$2

echo "Starting secure cluster services"

export KUBECONFIG=$artifacts_dir/kubeconfig

settings=(
    --namespace stackrox stackrox-secured-cluster-services "$helm_charts" 
    --values perf-bundle.yml
    --set clusterName=perf-test
    --set processIndicators.noPersistence=true
)

echo "${settings[@]}"

helm install "${settings[@]}"
```

The database was checked and their were no process indicators

```
central_active=# select count(*) from process_indicators ;
 count 
-------
     0
(1 row)
```

```
rox_central_process_filter{Type="Added"} 1746
# HELP rox_central_process_indicators_not_persisted Number of process indicators filtered out and not persisted
# TYPE rox_central_process_indicators_not_persisted counter
rox_central_process_indicators_not_persisted 1592
# HELP rox_central_process_indicators_removed_total Total number of process indicators removed from the database across all reasons
# TYPE rox_central_process_indicators_removed_total counter
rox_central_process_indicators_removed_total 0
# HELP rox_central_process_not_persisted_args_size Distribution of process argument sizes in bytes for indicators not persisted
# TYPE rox_central_process_not_persisted_args_size histogram
rox_central_process_not_persisted_args_size_bucket{le="0"} 44
rox_central_process_not_persisted_args_size_bucket{le="8"} 84
rox_central_process_not_persisted_args_size_bucket{le="16"} 157
rox_central_process_not_persisted_args_size_bucket{le="32"} 300
rox_central_process_not_persisted_args_size_bucket{le="64"} 850
rox_central_process_not_persisted_args_size_bucket{le="128"} 1204
rox_central_process_not_persisted_args_size_bucket{le="256"} 1379
rox_central_process_not_persisted_args_size_bucket{le="512"} 1454
rox_central_process_not_persisted_args_size_bucket{le="1024"} 1556
rox_central_process_not_persisted_args_size_bucket{le="2048"} 1578
rox_central_process_not_persisted_args_size_bucket{le="4096"} 1592
rox_central_process_not_persisted_args_size_bucket{le="8192"} 1592
rox_central_process_not_persisted_args_size_bucket{le="16384"} 1592
rox_central_process_not_persisted_args_size_bucket{le="32768"} 1592
rox_central_process_not_persisted_args_size_bucket{le="65536"} 1592
rox_central_process_not_persisted_args_size_bucket{le="+Inf"} 1592
rox_central_process_not_persisted_args_size_sum 261417
rox_central_process_not_persisted_args_size_count 1592
# HELP rox_central_process_not_persisted_args_size_total Total not-persisted process argument sizes in bytes by cluster and namespace
# TYPE rox_central_process_not_persisted_args_size_total counter
rox_central_process_not_persisted_args_size_total{cluster="fe062b57-90fd-4b8b-86b1-cd5d9eb7b15c",namespace="openshift-apiserver"} 546
rox_central_process_not_persisted_args_size_total{cluster="fe062b57-90fd-4b8b-86b1-cd5d9eb7b15c",namespace="openshift-apiserver-operator"} 116
rox_central_process_not_persisted_args_size_total{cluster="fe062b57-90fd-4b8b-86b1-cd5d9eb7b15c",namespace="openshift-authentication"} 876
rox_central_process_not_persisted_args_size_total{cluster="fe062b57-90fd-4b8b-86b1-cd5d9eb7b15c",namespace="openshift-authentication-operator"} 180
rox_central_process_not_persisted_args_size_total{cluster="fe062b57-90fd-4b8b-86b1-cd5d9eb7b15c",namespace="openshift-catalogd"} 649
rox_central_process_not_persisted_args_size_total{cluster="fe062b57-90fd-4b8b-86b1-cd5d9eb7b15c",namespace="openshift-cloud-controller-manager"} 1688
```

```
# HELP rox_central_process_upserted_args_size Distribution of process argument sizes in bytes for upserted indicators
# TYPE rox_central_process_upserted_args_size histogram
rox_central_process_upserted_args_size_bucket{le="0"} 0
rox_central_process_upserted_args_size_bucket{le="8"} 0
rox_central_process_upserted_args_size_bucket{le="16"} 0
rox_central_process_upserted_args_size_bucket{le="32"} 0
rox_central_process_upserted_args_size_bucket{le="64"} 0
rox_central_process_upserted_args_size_bucket{le="128"} 0
rox_central_process_upserted_args_size_bucket{le="256"} 0
rox_central_process_upserted_args_size_bucket{le="512"} 0
rox_central_process_upserted_args_size_bucket{le="1024"} 0
rox_central_process_upserted_args_size_bucket{le="2048"} 0
rox_central_process_upserted_args_size_bucket{le="4096"} 0
rox_central_process_upserted_args_size_bucket{le="8192"} 0
rox_central_process_upserted_args_size_bucket{le="16384"} 0
rox_central_process_upserted_args_size_bucket{le="32768"} 0
rox_central_process_upserted_args_size_bucket{le="65536"} 0
rox_central_process_upserted_args_size_bucket{le="+Inf"} 0
rox_central_process_upserted_args_size_sum 0
rox_central_process_upserted_args_size_count 0
# HELP rox_central_process_upserted_lineage_size Distribution of process lineage sizes in bytes for upserted indicators
# TYPE rox_central_process_upserted_lineage_size histogram
rox_central_process_upserted_lineage_size_bucket{le="0"} 0
rox_central_process_upserted_lineage_size_bucket{le="8"} 0
rox_central_process_upserted_lineage_size_bucket{le="16"} 0
rox_central_process_upserted_lineage_size_bucket{le="32"} 0
rox_central_process_upserted_lineage_size_bucket{le="64"} 0
rox_central_process_upserted_lineage_size_bucket{le="128"} 0
rox_central_process_upserted_lineage_size_bucket{le="256"} 0
rox_central_process_upserted_lineage_size_bucket{le="512"} 0
```

This test was repeated with

```
    --set processIndicators.noPersistence=false
    --set processIndicators.excludeNamespaceFilter="^stackrox$"
```

The metrics were checked

```
# HELP rox_central_process_indicators_not_persisted Number of process indicators filtered out and not persisted
# TYPE rox_central_process_indicators_not_persisted counter
rox_central_process_indicators_not_persisted 66
# HELP rox_central_process_indicators_removed_total Total number of process indicators removed from the database across all reasons
# TYPE rox_central_process_indicators_removed_total counter
rox_central_process_indicators_removed_total 0
# HELP rox_central_process_not_persisted_args_size Distribution of process argument sizes in bytes for indicators not persisted
# TYPE rox_central_process_not_persisted_args_size histogram
rox_central_process_not_persisted_args_size_bucket{le="0"} 19
rox_central_process_not_persisted_args_size_bucket{le="8"} 26
rox_central_process_not_persisted_args_size_bucket{le="16"} 30
rox_central_process_not_persisted_args_size_bucket{le="32"} 46
rox_central_process_not_persisted_args_size_bucket{le="64"} 58
rox_central_process_not_persisted_args_size_bucket{le="128"} 66
rox_central_process_not_persisted_args_size_bucket{le="256"} 66
rox_central_process_not_persisted_args_size_bucket{le="512"} 66
rox_central_process_not_persisted_args_size_bucket{le="1024"} 66
rox_central_process_not_persisted_args_size_bucket{le="2048"} 66
rox_central_process_not_persisted_args_size_bucket{le="4096"} 66
rox_central_process_not_persisted_args_size_bucket{le="8192"} 66
rox_central_process_not_persisted_args_size_bucket{le="16384"} 66
rox_central_process_not_persisted_args_size_bucket{le="32768"} 66
rox_central_process_not_persisted_args_size_bucket{le="65536"} 66
rox_central_process_not_persisted_args_size_bucket{le="+Inf"} 66
rox_central_process_not_persisted_args_size_sum 1952
rox_central_process_not_persisted_args_size_count 66
# HELP rox_central_process_not_persisted_args_size_total Total not-persisted process argument sizes in bytes by cluster and namespace
# TYPE rox_central_process_not_persisted_args_size_total counter
rox_central_process_not_persisted_args_size_total{cluster="c90ed1cb-199a-4626-bca6-43efb947028e",namespace="stackrox"} 1952
# HELP rox_central_process_not_persisted_count Number of process indicators not persisted by cluster and namespace
# TYPE rox_central_process_not_persisted_count counter
rox_central_process_not_persisted_count{cluster="c90ed1cb-199a-4626-bca6-43efb947028e",namespace="stackrox"} 66
```

```
# HELP rox_central_process_upserted_args_size Distribution of process argument sizes in bytes for upserted indicators
# TYPE rox_central_process_upserted_args_size histogram
rox_central_process_upserted_args_size_bucket{le="0"} 25
rox_central_process_upserted_args_size_bucket{le="8"} 36
rox_central_process_upserted_args_size_bucket{le="16"} 62
rox_central_process_upserted_args_size_bucket{le="32"} 120
rox_central_process_upserted_args_size_bucket{le="64"} 337
rox_central_process_upserted_args_size_bucket{le="128"} 462
rox_central_process_upserted_args_size_bucket{le="256"} 581
rox_central_process_upserted_args_size_bucket{le="512"} 656
rox_central_process_upserted_args_size_bucket{le="1024"} 758
rox_central_process_upserted_args_size_bucket{le="2048"} 780
rox_central_process_upserted_args_size_bucket{le="4096"} 794
rox_central_process_upserted_args_size_bucket{le="8192"} 794
rox_central_process_upserted_args_size_bucket{le="16384"} 794
rox_central_process_upserted_args_size_bucket{le="32768"} 794
rox_central_process_upserted_args_size_bucket{le="65536"} 794
rox_central_process_upserted_args_size_bucket{le="+Inf"} 794
rox_central_process_upserted_args_size_sum 214830
rox_central_process_upserted_args_size_count 794
# HELP rox_central_process_upserted_args_size_total Total upserted process argument sizes in bytes by cluster and namespace
# TYPE rox_central_process_upserted_args_size_total counter
rox_central_process_upserted_args_size_total{cluster="c90ed1cb-199a-4626-bca6-43efb947028e",namespace="openshift-apiserver"} 546
rox_central_process_upserted_args_size_total{cluster="c90ed1cb-199a-4626-bca6-43efb947028e",namespace="openshift-apiserver-operator"} 116
rox_central_process_upserted_args_size_total{cluster="c90ed1cb-199a-4626-bca6-43efb947028e",namespace="openshift-authentication"} 876
rox_central_process_upserted_args_size_total{cluster="c90ed1cb-199a-4626-bca6-43efb947028e",namespace="openshift-authentication-operator"} 180
rox_central_process_upserted_args_size_total{cluster="c90ed1cb-199a-4626-bca6-43efb947028e",namespace="openshift-catalogd"} 649
rox_central_process_upserted_args_size_total{cluster="c90ed1cb-199a-4626-bca6-43efb947028e",namespace="openshift-cloud-controller-manager"} 1688
rox_central_process_upserted_args_size_total{cluster="c90ed1cb-199a-4626-bca6-43efb947028e",namespace="openshift-cloud-controller-manager-operator"} 568
```

The central db was checked

```
central_active=# select count(*) from process_indicators ;
 count 
-------
   899
(1 row)

central_active=# select count(*) from process_indicators where namespace = 'stackrox' ;
 count 
-------
     0
(1 row)
```