### PR TITLE
ROX-34958: add OOTB disabled policies for init containers

### DIFF
--- a/pkg/defaults/policies/files/init_container_cvss_7.json
+++ b/pkg/defaults/policies/files/init_container_cvss_7.json
@@ -1,0 +1,47 @@
+{
+  "id":  "0fedb887-4178-43de-a386-191b84044cf8",
+  "name":  "Init Container: Fixable CVSS >= 7",
+  "description":  "Alert on deployments with init container images containing fixable vulnerabilities with a CVSS score of 7 or higher",
+  "rationale":  "Init containers with known fixable vulnerabilities can be exploited during pod startup to compromise the pod before main containers begin running.",
+  "remediation":  "Update the init container image to a version that addresses the identified vulnerabilities.",
+  "disabled":  true,
+  "categories":  [
+    "Vulnerability Management"
+  ],
+  "lifecycleStages":  [
+    "BUILD",
+    "DEPLOY"
+  ],
+  "severity":  "MEDIUM_SEVERITY",
+  "policyVersion":  "1.1",
+  "policySections":  [
+    {
+      "policyGroups":  [
+        {
+          "fieldName":  "Fixed By",
+          "values":  [
+            {
+              "value":  ".*"
+            }
+          ]
+        },
+        {
+          "fieldName":  "CVSS",
+          "values":  [
+            {
+              "value":  ">= 7.000000"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "criteriaLocked":  true,
+  "mitreVectorsLocked":  true,
+  "isDefault":  true,
+  "evaluationFilter":  {
+    "skipContainerTypes":  [
+      "REGULAR"
+    ]
+  }
+}

--- a/pkg/defaults/policies/files/init_container_latest_tag.json
+++ b/pkg/defaults/policies/files/init_container_latest_tag.json
@@ -1,0 +1,40 @@
+{
+  "id":  "25628531-a28c-448c-b4e9-04ee9b165fa5",
+  "name":  "Init Container: Latest tag",
+  "description":  "Alert on deployments with init containers using image tag 'latest'",
+  "rationale":  "Init containers using the 'latest' tag can introduce unpredictable behavior during pod initialization. Pinning init container images to specific versions ensures reproducible and auditable startup sequences.",
+  "remediation":  "Use a specific image tag or digest for init container images instead of 'latest'.",
+  "disabled":  true,
+  "categories":  [
+    "DevOps Best Practices",
+    "Supply Chain Security"
+  ],
+  "lifecycleStages":  [
+    "BUILD",
+    "DEPLOY"
+  ],
+  "severity":  "LOW_SEVERITY",
+  "policyVersion":  "1.1",
+  "policySections":  [
+    {
+      "policyGroups":  [
+        {
+          "fieldName":  "Image Tag",
+          "values":  [
+            {
+              "value":  "latest"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "criteriaLocked":  true,
+  "mitreVectorsLocked":  true,
+  "isDefault":  true,
+  "evaluationFilter":  {
+    "skipContainerTypes":  [
+      "REGULAR"
+    ]
+  }
+}

--- a/pkg/defaults/policies/files/init_container_privileged.json
+++ b/pkg/defaults/policies/files/init_container_privileged.json
@@ -1,0 +1,38 @@
+{
+  "id":  "a778bd1e-c81b-4d7f-8d13-147a9bedcaf2",
+  "name":  "Init Container: Privileged",
+  "description":  "Alert on deployments with init containers running in privileged mode",
+  "rationale":  "A privileged init container has full access to host devices and can compromise the node before main containers start. Since init containers run with elevated trust during pod setup, a compromised privileged init container can weaken the security posture of the entire pod.",
+  "remediation":  "Verify that privileged mode is required for the init container and cannot be replaced with specific capabilities.",
+  "disabled":  true,
+  "categories":  [
+    "Privileges"
+  ],
+  "lifecycleStages":  [
+    "DEPLOY"
+  ],
+  "severity":  "MEDIUM_SEVERITY",
+  "policyVersion":  "1.1",
+  "policySections":  [
+    {
+      "policyGroups":  [
+        {
+          "fieldName":  "Privileged Container",
+          "values":  [
+            {
+              "value":  "true"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "criteriaLocked":  true,
+  "mitreVectorsLocked":  true,
+  "isDefault":  true,
+  "evaluationFilter":  {
+    "skipContainerTypes":  [
+      "REGULAR"
+    ]
+  }
+}

--- a/pkg/defaults/policies/files/init_container_writable_root_fs.json
+++ b/pkg/defaults/policies/files/init_container_writable_root_fs.json
@@ -1,0 +1,38 @@
+{
+  "id":  "43392eff-8ff9-484e-a666-515724897e20",
+  "name":  "Init Container: Writable Root Filesystem",
+  "description":  "Alert on deployments with init containers that do not have a read-only root filesystem",
+  "rationale":  "Init containers with writable root filesystems can be exploited to persist malicious changes that affect main containers. A read-only root filesystem limits the attack surface during pod initialization.",
+  "remediation":  "Set readOnlyRootFilesystem to true in the init container's security context. Use volume mounts for any directories that require write access.",
+  "disabled":  true,
+  "categories":  [
+    "Privileges"
+  ],
+  "lifecycleStages":  [
+    "DEPLOY"
+  ],
+  "severity":  "LOW_SEVERITY",
+  "policyVersion":  "1.1",
+  "policySections":  [
+    {
+      "policyGroups":  [
+        {
+          "fieldName":  "Read-Only Root Filesystem",
+          "values":  [
+            {
+              "value":  "false"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "criteriaLocked":  true,
+  "mitreVectorsLocked":  true,
+  "isDefault":  true,
+  "evaluationFilter":  {
+    "skipContainerTypes":  [
+      "REGULAR"
+    ]
+  }
+}

--- a/pkg/defaults/policies/policies.go
+++ b/pkg/defaults/policies/policies.go
@@ -24,7 +24,12 @@ var (
 	policiesFS embed.FS
 
 	// featureFlagFileGuard is a map indexed by file name that ignores files if the feature flag is not enabled.
-	featureFlagFileGuard = map[string]features.FeatureFlag{}
+	featureFlagFileGuard = map[string]features.FeatureFlag{
+		"init_container_latest_tag.json":       features.InitContainerSupport,
+		"init_container_cvss_7.json":           features.InitContainerSupport,
+		"init_container_privileged.json":       features.InitContainerSupport,
+		"init_container_writable_root_fs.json": features.InitContainerSupport,
+	}
 )
 
 // DefaultPolicies returns a slice of the default policies.

--- a/pkg/defaults/policies/policies_test.go
+++ b/pkg/defaults/policies/policies_test.go
@@ -20,7 +20,12 @@ func Test_DefaultPolicies_FilterByFeatureFlag(t *testing.T) {
 
 	// This is required here to be able to check if the policy is present in the final list of default policies
 	// since the feature flag filtering is done by filename other than policy name.
-	fileToPolicyName := map[string]string{}
+	fileToPolicyName := map[string]string{
+		"init_container_latest_tag.json":       "Init Container: Latest tag",
+		"init_container_cvss_7.json":           "Init Container: Fixable CVSS >= 7",
+		"init_container_privileged.json":       "Init Container: Privileged",
+		"init_container_writable_root_fs.json": "Init Container: Writable Root Filesystem",
+	}
 
 	for filename, ff := range featureFlagFileGuard {
 		t.Setenv(ff.EnvVar(), "false")


### PR DESCRIPTION
## Description

Adds 4 disabled-by-default OOTB policies targeting init containers (AC5):

**Build + Deploy (2):**
- **Init Container: Latest tag** — alerts on init containers using image tag `latest`
- **Init Container: Fixable CVSS >= 7** — alerts on init container images with fixable high-severity CVEs

**Deploy (2):**
- **Init Container: Privileged** — alerts on init containers running in privileged mode
- **Init Container: Writable Root Filesystem** — alerts on init containers without read-only root FS

All policies use `evaluationFilter: { skipContainerTypes: ["REGULAR"] }` so they only evaluate init containers. Gated behind `ROX_INIT_CONTAINER_SUPPORT` feature flag via `featureFlagFileGuard`.

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: gated behind `ROX_INIT_CONTAINER_SUPPORT` feature flag
- [x] CI results are inspected

### Automated testing

- [x] modified existing tests

### How I validated my change

Deployed build `4.12.x-193-gdae5ef8468` to a GKE cluster with `ROX_INIT_CONTAINER_SUPPORT` enabled. Verified all 4 OOTB init container policies are present and disabled by default via the Central API:

```
Init Container: Fixable CVSS >= 7       — disabled: true
Init Container: Latest tag              — disabled: true
Init Container: Privileged              — disabled: true
Init Container: Writable Root Filesystem — disabled: true
```

**Result:** All 4 policies present and disabled by default as expected.
