### PR TITLE
ROX-35095: Add no-data-testid to pluginLimited with ignores

### DIFF
--- a/tools/allowed-large-files
+++ b/tools/allowed-large-files
@@ -81,8 +81,7 @@ tests/e2e/run-scanner-v4-install.bats
 tests/performance/load/package-lock.json
 tests/performance/scale/config/metrics-acs.yml
 tests/performance/scale/config/metrics-full.yml
+ui/apps/platform/eslint.config.js
 ui/apps/platform/package-lock.json
 ui/apps/platform/src/Containers/Integrations/IntegrationForm/Forms/SignatureIntegrationForm.tsx
 ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
-ui/apps/platform/src/fonts/Open_Sans_Regular.json
-ui/apps/platform/src/images/globalSearchEmptyState.svg

--- a/ui/apps/platform/eslint-plugins/pluginLimited.js
+++ b/ui/apps/platform/eslint-plugins/pluginLimited.js
@@ -332,6 +332,29 @@ const rules = {
             };
         },
     },
+    'no-data-testid': {
+        // Replace data-testid prop in integration tests with semantic selector.
+        meta: {
+            type: 'problem',
+            docs: {
+                description: 'Replace data-testid prop in integration tests with semantic selector',
+            },
+            schema: [],
+        },
+        create(context) {
+            return {
+                JSXAttribute(node) {
+                    if (node.name?.name === 'data-testid') {
+                        context.report({
+                            node,
+                            message:
+                                'Replace data-testid prop in integration tests with semantic selector',
+                        });
+                    }
+                },
+            };
+        },
+    },
     'no-feather-icons': {
         // Forbid feather icons outside legacy folders.
         // See ignores array in eslint.config.js file.

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -936,6 +936,50 @@ module.exports = [
         },
     },
     {
+        files: ['cypress/**/*.{js,ts}', 'src/**/*.{js,jsx,ts,tsx}'],
+        // /*
+        ignores: [
+            'cypress/constants/**',
+            'cypress/integration/clusters/**', // delete obsolete tests
+            'cypress/integration/compliance/**', // deprecated
+            'cypress/integration/configmanagement/**', // deprecated/modernized
+            'cypress/integration/integrations/**', // replace
+            'cypress/integration/networkGraph/**', // replace
+            'cypress/integration/risk/**', // deprecated/modernized
+            'cypress/integration/systemConfig/**', // replace
+            'cypress/integration/vulnmanagement/**', // deprecated
+            'cypress/selectors/**',
+            'src/Components/**', // replace non-deprecated
+            'src/Containers/AccessControl/**', // replace
+            'src/Containers/Clusters/**', // delete obsolete tests
+            'src/Containers/Compliance/**', // deprecated
+            'src/Containers/ConfigManagement/**', // deprecated/modernized
+            'src/Containers/Integrations/**', // replace
+            'src/Containers/Login/**', // replace
+            'src/Containers/MainPage/**', // replace
+            'src/Containers/NetworkGraph/**', // replace
+            'src/Containers/Policies/**', // replace
+            'src/Containers/PolicyCategories/**', // replace
+            'src/Containers/Risk/**', // replace
+            'src/Containers/SystemConfig/**', // replace
+            'src/Containers/SystemHealth/**', // replace
+            'src/Containers/User/**', // replace
+            'src/Containers/VulnMgmt/**', // deprecated
+            'src/css/trumps.css', // delete or replace
+        ],
+        // */
+
+        // languageOptions from previous configuration object
+
+        // Key of plugin is namespace of its rules.
+        plugins: {
+            limited: pluginLimited,
+        },
+        rules: {
+            'limited/no-data-testid': 'error',
+        },
+    },
+    {
         files: ['src/**/*.{js,jsx,ts,tsx}'],
         ignores: [
             'src/Components/CheckboxTable.jsx', // deprecated

--- a/ui/apps/platform/eslint.config.js
+++ b/ui/apps/platform/eslint.config.js
@@ -937,7 +937,6 @@ module.exports = [
     },
     {
         files: ['cypress/**/*.{js,ts}', 'src/**/*.{js,jsx,ts,tsx}'],
-        // /*
         ignores: [
             'cypress/constants/**',
             'cypress/integration/clusters/**', // delete obsolete tests
@@ -967,7 +966,6 @@ module.exports = [
             'src/Containers/VulnMgmt/**', // deprecated
             'src/css/trumps.css', // delete or replace
         ],
-        // */
 
         // languageOptions from previous configuration object
 


### PR DESCRIPTION
## Description

Return/Revenge of help AI to help us.

### Problem

This came up recently. Better for linter to report an error than for reviewer to request a change.

### Analysis

Find in Files `data-testid` has 271 results in 131 files in src folder

| files | folder | analysis |
| ---: | :--- | :--- |
| 66 | src/Components |  |
| 1 | src/Containers/AccessControl |  |
| 7 | src/Containers/Clusters |  |
| 3 | src/Containers/Compliance | deprecated |
| 1 | src/Containers/ConfigManagement | deprecated/modernized |
| 3 | src/Containers/Integrations |  |
| 1 | src/Containers/Login |  |
| 3 | src/Containers/MainPage |  |
| 6 | src/Containers/NetworkGraph |  |
| 18 | src/Containers/Policies |  |
| 2 | src/Containers/PolicyCategories |  |
| 2 | src/Containers/Risk | modernized |
| 6 | src/Containers/SystemConfig |  |
| 4 | src/Containers/SystemHealth |  |
| 2 | src/Containers/User |  |
| 5 | src/Containers/VulnMgmt | deprecated |
| 1 | src/css |  |

Find in Files `data-testid` has 296 results in 54 files in cypress folder

| files | subfolder | analysis |
| ---: | :--- | :--- |
| 8 | cypress/constants |  |
| 5 | cypress/integration/clusters |  |
| 4 | cypress/integration/compliance | deprecated |
| 7 | cypress/integration/configmanagement | deprecated/modernized |
| 1 | cypress/integration/integrations |  |
| 4 | cypress/integration/networkGraph |  |
| 5 | cypress/integration/risk | modernized |
| 1 | cypress/integration/systemConfig |  |
| 12 | cypress/integration/vulnmanagement | deprecated |
| 7 | cypress/selectors |  |

### Solution

Use typescript-eslint playground to see that `name.name` and `value.value` are relevant properties of `JSXAttribute` node.

https://typescript-eslint.io/play/#ts=5.9.3&showAST=es&fileType=.tsx

1. Edit pluginLimited.js file to add `no-data-testid` rule.

2. Edit eslint.config.js file to add `ignores` array.

### Residue

1. Triage src/Containers and cypress/integrations subfolders for return on investment:

    * small number of `data-testid` props in accessible PatternFly components
    * small number of test selectors to rewrite

2. Other side of coin: Delete outdated integration tests (for example, `skip` tests for classic clusters).

## User-facing documentation

- [x] CHANGELOG.md update is not needed
- [x] documentation PR is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added lint rule
- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

1. `npm run tsc` in ui/apps/platform folder.
2. `npm run lint:fast-dev` in ui/apps/platform folder.

    See presence of errors without `ignores` and absence of errors with `ignores` array.
