### PR TITLE
ROX-34855: Filter empty scope

### DIFF
--- a/central/detection/lifecycle/singleton.go
+++ b/central/detection/lifecycle/singleton.go
@@ -45,7 +45,7 @@ func initialize() {
 	log.Infof("Injecting %d policies into detectors.", len(policies))
 	for _, policy := range policies {
 		err = manager.UpsertPolicy(policy)
-		utils.Should(errors.Wrap(err, "could not inject policy"))
+		log.Error(errors.Wrap(err, "could not inject policy"))
 	}
 	log.Info("Done injecting policies.")
 

--- a/central/detection/lifecycle/singleton.go
+++ b/central/detection/lifecycle/singleton.go
@@ -45,7 +45,7 @@ func initialize() {
 	log.Infof("Injecting %d policies into detectors.", len(policies))
 	for _, policy := range policies {
 		err = manager.UpsertPolicy(policy)
-		log.Error(errors.Wrap(err, "could not inject policy"))
+		utils.Should(errors.Wrap(err, "could not inject policy"))
 	}
 	log.Info("Done injecting policies.")
 

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -234,6 +234,11 @@ func (s *serviceImpl) CountReportConfigurations(ctx context.Context, request *ap
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 	filteredQ := common.WithoutV1ReportConfigs(parsedQuery)
+	// This filter removes report configs with empty collection.
+	// This scenario can happen after downgrade from a future release(4.11 and above) with more resource scope to 4.10.
+	filteredQ = search.ConjunctionQuery(
+		filteredQ,
+		search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery())
 
 	numReportConfigs, err := s.reportConfigStore.Count(ctx, filteredQ)
 	if err != nil {

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -185,7 +185,7 @@ func (s *serviceImpl) ListReportConfigurations(ctx context.Context, query *apiV2
 	// This scenario can happen after downgrade from a future release(4.11 and above) with more resource scope to 4.10.
 	filteredQ = search.ConjunctionQuery(
 		filteredQ,
-		search.NewQueryBuilder().AddExactMatches(search.CollectionID, "").ProtoQuery())
+		search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery())
 
 	// Fill in pagination.
 	paginated.FillPaginationV2(filteredQ, query.GetPagination(), maxPaginationLimit)

--- a/central/reports/service/v2/service_impl.go
+++ b/central/reports/service/v2/service_impl.go
@@ -181,6 +181,11 @@ func (s *serviceImpl) ListReportConfigurations(ctx context.Context, query *apiV2
 		return nil, errors.Wrap(errox.InvalidArgs, err.Error())
 	}
 	filteredQ := common.WithoutV1ReportConfigs(parsedQuery)
+	// This filter removes report configs with empty collection.
+	// This scenario can happen after downgrade from a future release(4.11 and above) with more resource scope to 4.10.
+	filteredQ = search.ConjunctionQuery(
+		filteredQ,
+		search.NewQueryBuilder().AddExactMatches(search.CollectionID, "").ProtoQuery())
 
 	// Fill in pagination.
 	paginated.FillPaginationV2(filteredQ, query.GetPagination(), maxPaginationLimit)

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -35,8 +35,7 @@ import (
 )
 
 var (
-	withoutV1ConfigsQuery = search.NewQueryBuilder().AddExactMatches(search.EmbeddedCollectionID, "").ProtoQuery()
-	withoutEmptyScope     = search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery()
+	withoutEmptyScope = search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery()
 )
 
 type upsertTestCase struct {
@@ -366,17 +365,19 @@ func (s *ReportServiceTestSuite) TestCountReportConfigurations() {
 			desc:  "Empty query",
 			query: &apiV2.RawQuery{Query: ""},
 			expectedQ: search.ConjunctionQuery(
-				search.NewQueryBuilder().ProtoQuery(),
-				withoutV1ConfigsQuery,
-				withoutEmptyScope),
+				common.WithoutV1ReportConfigs(search.EmptyQuery()), // or parsed query variant
+				withoutEmptyScope,
+			),
 		},
 		{
 			desc:  "Query with search field",
 			query: &apiV2.RawQuery{Query: "Report Name:name"},
 			expectedQ: search.ConjunctionQuery(
-				search.NewQueryBuilder().AddStrings(search.ReportName, "name").ProtoQuery(),
-				withoutV1ConfigsQuery,
-				withoutEmptyScope),
+				common.WithoutV1ReportConfigs(
+					search.NewQueryBuilder().AddStrings(search.ReportName, "name").ProtoQuery(),
+				),
+				withoutEmptyScope,
+			),
 		},
 	}
 

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -36,6 +36,7 @@ import (
 
 var (
 	withoutV1ConfigsQuery = search.NewQueryBuilder().AddExactMatches(search.EmbeddedCollectionID, "").ProtoQuery()
+	withoutEmptyScope     = search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery()
 )
 
 type upsertTestCase struct {
@@ -240,12 +241,12 @@ func (s *ReportServiceTestSuite) TestListReportConfigurations() {
 		expectedQ *v1.Query
 	}{
 		{
-			desc:  "Empty query",
+			desc:  "Query with empty query",
 			query: &apiV2.RawQuery{Query: ""},
 			expectedQ: func() *v1.Query {
 				query := search.ConjunctionQuery(
 					common.WithoutV1ReportConfigs(search.EmptyQuery()),
-					search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery())
+					withoutEmptyScope)
 				query.Pagination = &v1.QueryPagination{Limit: maxPaginationLimit}
 				return query
 			}(),
@@ -256,7 +257,7 @@ func (s *ReportServiceTestSuite) TestListReportConfigurations() {
 			expectedQ: func() *v1.Query {
 				query := search.ConjunctionQuery(
 					common.WithoutV1ReportConfigs(search.NewQueryBuilder().AddStrings(search.ReportName, "name").ProtoQuery()),
-					search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery())
+					withoutEmptyScope)
 				query.Pagination = &v1.QueryPagination{Limit: maxPaginationLimit}
 				return query
 			}(),
@@ -270,7 +271,7 @@ func (s *ReportServiceTestSuite) TestListReportConfigurations() {
 			expectedQ: func() *v1.Query {
 				query := search.ConjunctionQuery(
 					common.WithoutV1ReportConfigs(search.EmptyQuery()),
-					search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery())
+					withoutEmptyScope)
 				query.Pagination = &v1.QueryPagination{Limit: 25}
 				return query
 			}(),

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -367,14 +367,16 @@ func (s *ReportServiceTestSuite) TestCountReportConfigurations() {
 			query: &apiV2.RawQuery{Query: ""},
 			expectedQ: search.ConjunctionQuery(
 				search.NewQueryBuilder().ProtoQuery(),
-				withoutV1ConfigsQuery),
+				withoutV1ConfigsQuery,
+				withoutEmptyScope),
 		},
 		{
 			desc:  "Query with search field",
 			query: &apiV2.RawQuery{Query: "Report Name:name"},
 			expectedQ: search.ConjunctionQuery(
 				search.NewQueryBuilder().AddStrings(search.ReportName, "name").ProtoQuery(),
-				withoutV1ConfigsQuery),
+				withoutV1ConfigsQuery,
+				withoutEmptyScope),
 		},
 	}
 

--- a/central/reports/service/v2/service_impl_test.go
+++ b/central/reports/service/v2/service_impl_test.go
@@ -244,8 +244,8 @@ func (s *ReportServiceTestSuite) TestListReportConfigurations() {
 			query: &apiV2.RawQuery{Query: ""},
 			expectedQ: func() *v1.Query {
 				query := search.ConjunctionQuery(
-					search.EmptyQuery(),
-					withoutV1ConfigsQuery)
+					common.WithoutV1ReportConfigs(search.EmptyQuery()),
+					search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery())
 				query.Pagination = &v1.QueryPagination{Limit: maxPaginationLimit}
 				return query
 			}(),
@@ -255,8 +255,8 @@ func (s *ReportServiceTestSuite) TestListReportConfigurations() {
 			query: &apiV2.RawQuery{Query: "Report Name:name"},
 			expectedQ: func() *v1.Query {
 				query := search.ConjunctionQuery(
-					search.NewQueryBuilder().AddStrings(search.ReportName, "name").ProtoQuery(),
-					withoutV1ConfigsQuery)
+					common.WithoutV1ReportConfigs(search.NewQueryBuilder().AddStrings(search.ReportName, "name").ProtoQuery()),
+					search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery())
 				query.Pagination = &v1.QueryPagination{Limit: maxPaginationLimit}
 				return query
 			}(),
@@ -269,8 +269,8 @@ func (s *ReportServiceTestSuite) TestListReportConfigurations() {
 			},
 			expectedQ: func() *v1.Query {
 				query := search.ConjunctionQuery(
-					search.EmptyQuery(),
-					withoutV1ConfigsQuery)
+					common.WithoutV1ReportConfigs(search.EmptyQuery()),
+					search.NewQueryBuilder().AddStrings(search.CollectionID, search.NegateQueryString(search.ExactMatchString(""))).ProtoQuery())
 				query.Pagination = &v1.QueryPagination{Limit: 25}
 				return query
 			}(),


### PR DESCRIPTION
This PR filters out resource scope with empty collection ID from List Report Config API in 4.10. This is done in case someone downgrades from a future release with new scoping methods(like entity scope in 4.11) to a 4.10.x version which can cause UI crash because of new scoping method. ResourceScope will unmarshal as empty scope( as seen in testing) after downgrade and no new jobs will be scheduled in this case given the scheduler validation in 4.10
change me!

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Tested this change manually by deploying 4.11 RC ACS . creating two report config - one with entity scope and other with collection. Downgraded to 4.10.3-4-gb10ca40c7d and verified that collection config shows up in UI and user can download reports. Entity scope config does not show up in UI
