### PR TITLE
ROX-34626: Migrate detector enricher pipeline to PubSub

### DIFF
--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -496,7 +496,7 @@ func (d *detectorImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return d.output
 }
 
-func (d *detectorImpl) detectDeploymentFromScanResult(deployment *storage.Deployment, images []*storage.Image, netpolApplied *augmentedobjs.NetworkPoliciesApplied, action central.ResourceAction, ctx context.Context) {
+func (d *detectorImpl) detectDeploymentFromScanResult(ctx context.Context, deployment *storage.Deployment, images []*storage.Image, netpolApplied *augmentedobjs.NetworkPoliciesApplied, action central.ResourceAction) {
 	detectorMetrics.RemoveBlockingScanCall()
 	alerts := d.unifiedDetector.DetectDeployment(booleanpolicy.EnhancedDeployment{
 		Deployment:             deployment,
@@ -533,7 +533,7 @@ func (d *detectorImpl) runDetector() {
 		case <-d.detectorStopper.Flow().StopRequested():
 			return
 		case scanOutput := <-d.enricher.outputChan():
-			d.detectDeploymentFromScanResult(scanOutput.Deployment, scanOutput.Images, scanOutput.NetworkPoliciesApplied, scanOutput.Action, scanOutput.Context)
+			d.detectDeploymentFromScanResult(scanOutput.Context, scanOutput.Deployment, scanOutput.Images, scanOutput.NetworkPoliciesApplied, scanOutput.Action)
 		}
 	}
 }
@@ -543,7 +543,7 @@ func (d *detectorImpl) handleScanResultEvent(event pubsub.Event) error {
 	if !ok {
 		return errors.Errorf("unexpected event type: %T", event)
 	}
-	d.detectDeploymentFromScanResult(scanResult.Deployment, scanResult.Images, scanResult.NetworkPoliciesApplied, scanResult.Action, scanResult.Context)
+	d.detectDeploymentFromScanResult(scanResult.Context, scanResult.Deployment, scanResult.Images, scanResult.NetworkPoliciesApplied, scanResult.Action)
 	return nil
 }
 

--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -133,7 +133,7 @@ func New(clusterID clusterIDPeekWaiter, enforcer enforcer.Enforcer, admCtrlSetti
 		deploymentAlertOutputChan: make(chan outputResult),
 		deploymentProcessingMap:   make(map[string]int64),
 
-		enricher:            newEnricher(clusterID, cache, serviceAccountStore, registryStore, localScan),
+		enricher:            newEnricher(clusterID, cache, serviceAccountStore, registryStore, localScan, pubSubDispatcher),
 		serviceAccountStore: serviceAccountStore,
 		deploymentStore:     deploymentStore,
 		nodeStore:           nodeStore,
@@ -260,12 +260,20 @@ func (d *detectorImpl) Start() error {
 		); err != nil {
 			return errors.Wrap(err, "failed to register detector deployment consumer")
 		}
+		if err := d.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.DetectorScanResultConsumer,
+			pubsub.DetectorScanResultTopic,
+			pubsub.DetectorScanResultLane,
+			d.handleScanResultEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register detector scan result consumer")
+		}
 	}
 
-	go d.runDetector()
 	go d.serializeDeployTimeOutput()
 
 	if !d.pubSubEnabled() {
+		go d.runDetector()
 		go d.processDeployment()
 		go d.runAuditLogEventDetector()
 		go d.processIndicator()
@@ -352,8 +360,8 @@ func (d *detectorImpl) Stop() {
 	d.alertStopSig.Signal()
 	d.enricher.stop()
 
-	_ = d.detectorStopper.Client().Stopped().Wait()
 	if !d.pubSubEnabled() {
+		_ = d.detectorStopper.Client().Stopped().Wait()
 		_ = d.auditStopper.Client().Stopped().Wait()
 	}
 	_ = d.serializerStopper.Client().Stopped().Wait()
@@ -488,6 +496,35 @@ func (d *detectorImpl) ResponsesC() <-chan *message.ExpiringMessage {
 	return d.output
 }
 
+func (d *detectorImpl) detectDeploymentFromScanResult(deployment *storage.Deployment, images []*storage.Image, netpolApplied *augmentedobjs.NetworkPoliciesApplied, action central.ResourceAction, ctx context.Context) {
+	detectorMetrics.RemoveBlockingScanCall()
+	alerts := d.unifiedDetector.DetectDeployment(booleanpolicy.EnhancedDeployment{
+		Deployment:             deployment,
+		Images:                 images,
+		NetworkPoliciesApplied: netpolApplied,
+	})
+
+	metrics.IncrementDetectorDeploymentProcessed()
+
+	sort.Slice(alerts, func(i, j int) bool {
+		return alerts[i].GetPolicy().GetId() < alerts[j].GetPolicy().GetId()
+	})
+
+	select {
+	case <-d.detectorStopper.Flow().StopRequested():
+	case <-d.serializerStopper.Flow().StopRequested():
+	case d.deploymentAlertOutputChan <- outputResult{
+		results: &central.AlertResults{
+			DeploymentId: deployment.GetId(),
+			Alerts:       alerts,
+		},
+		timestamp: deployment.GetStateTimestamp(),
+		action:    action,
+		context:   ctx,
+	}:
+	}
+}
+
 func (d *detectorImpl) runDetector() {
 	defer d.detectorStopper.Flow().ReportStopped()
 
@@ -496,36 +533,18 @@ func (d *detectorImpl) runDetector() {
 		case <-d.detectorStopper.Flow().StopRequested():
 			return
 		case scanOutput := <-d.enricher.outputChan():
-			detectorMetrics.RemoveBlockingScanCall()
-			alerts := d.unifiedDetector.DetectDeployment(booleanpolicy.EnhancedDeployment{
-				Deployment:             scanOutput.deployment,
-				Images:                 scanOutput.images,
-				NetworkPoliciesApplied: scanOutput.networkPoliciesApplied,
-			})
-
-			metrics.IncrementDetectorDeploymentProcessed()
-
-			sort.Slice(alerts, func(i, j int) bool {
-				return alerts[i].GetPolicy().GetId() < alerts[j].GetPolicy().GetId()
-			})
-
-			select {
-			case <-d.detectorStopper.Flow().StopRequested():
-				return
-			case <-d.serializerStopper.Flow().StopRequested():
-				return
-			case d.deploymentAlertOutputChan <- outputResult{
-				results: &central.AlertResults{
-					DeploymentId: scanOutput.deployment.GetId(),
-					Alerts:       alerts,
-				},
-				timestamp: scanOutput.deployment.GetStateTimestamp(),
-				action:    scanOutput.action,
-				context:   scanOutput.context,
-			}:
-			}
+			d.detectDeploymentFromScanResult(scanOutput.Deployment, scanOutput.Images, scanOutput.NetworkPoliciesApplied, scanOutput.Action, scanOutput.Context)
 		}
 	}
+}
+
+func (d *detectorImpl) handleScanResultEvent(event pubsub.Event) error {
+	scanResult, ok := event.(*detectorEvents.ScanResultEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	d.detectDeploymentFromScanResult(scanResult.Deployment, scanResult.Images, scanResult.NetworkPoliciesApplied, scanResult.Action, scanResult.Context)
+	return nil
 }
 
 func (d *detectorImpl) detectAndAlertForAuditLog(auditEvents *sensor.AuditEvents) {

--- a/sensor/common/detector/detector_helpers_test.go
+++ b/sensor/common/detector/detector_helpers_test.go
@@ -70,7 +70,7 @@ func createTestDetectorWithBufferSize(tb testing.TB, pubSubEnabled bool, bufferS
 		auditEventsChan:           make(chan *sensor.AuditEvents),
 		deploymentAlertOutputChan: make(chan outputResult),
 		deploymentProcessingMap:   make(map[string]int64),
-		enricher:                  newEnricher(&fakeClusterIDPeekWaiter{}, nil, serviceAccountStore, nil, nil),
+		enricher:                  newEnricher(&fakeClusterIDPeekWaiter{}, nil, serviceAccountStore, nil, nil, nil),
 		deploymentStore:           deploymentStore,
 		nodeStore:                 nodeStore,
 		networkPolicyStore:        networkPolicyStore,
@@ -122,11 +122,13 @@ func createTestDetectorWithBufferSize(tb testing.TB, pubSubEnabled bool, bufferS
 						),
 					),
 				),
+				lane.NewBlockingLane(pubsub.DetectorScanResultLane),
 			},
 		))
 		require.NoError(tb, err)
 		tb.Cleanup(dispatcher.Stop)
 		d.pubSubDispatcher = dispatcher
+		d.enricher.pubSubDispatcher = dispatcher
 	}
 
 	return d, deploymentStore, networkPolicyStore, nodeStore

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -21,8 +21,10 @@ import (
 	"github.com/stackrox/rox/pkg/protoutils"
 	"github.com/stackrox/rox/pkg/utils"
 	"github.com/stackrox/rox/sensor/common/centralcaps"
+	detectorEvents "github.com/stackrox/rox/sensor/common/detector/events"
 	"github.com/stackrox/rox/sensor/common/detector/metrics"
 	"github.com/stackrox/rox/sensor/common/image/cache"
+	"github.com/stackrox/rox/sensor/common/pubsub"
 	"github.com/stackrox/rox/sensor/common/registry"
 	"github.com/stackrox/rox/sensor/common/scan"
 	"github.com/stackrox/rox/sensor/common/store"
@@ -34,22 +36,18 @@ var (
 	scanTimeout = env.ScanTimeout.DurationSetting()
 )
 
-type scanResult struct {
-	context                context.Context
-	action                 central.ResourceAction
-	deployment             *storage.Deployment
-	images                 []*storage.Image
-	networkPoliciesApplied *augmentedobjs.NetworkPoliciesApplied
-}
-
 type imageChanResult struct {
 	image        *storage.Image
 	containerIdx int
 }
 
+type scanResultPublisher interface {
+	Publish(pubsub.Event) error
+}
+
 type enricher struct {
 	imageSvc       v1.ImageServiceClient
-	scanResultChan chan scanResult
+	scanResultChan chan *detectorEvents.ScanResultEvent
 
 	serviceAccountStore store.ServiceAccountStore
 	localScan           *scan.LocalScan
@@ -57,6 +55,7 @@ type enricher struct {
 	stopSig             concurrency.Signal
 	regStore            *registry.Store
 	clusterID           clusterIDPeekWaiter
+	pubSubDispatcher    scanResultPublisher
 }
 
 type clusterIDPeekWaiter interface {
@@ -260,15 +259,16 @@ func (c *cacheValue) updateImageNoLock(image *storage.Image) {
 	c.image.Names = protoutils.SliceUnique(append(c.image.GetNames(), existingNames...))
 }
 
-func newEnricher(clusterID clusterIDPeekWaiter, cache cache.Image, serviceAccountStore store.ServiceAccountStore, registryStore *registry.Store, localScan *scan.LocalScan) *enricher {
+func newEnricher(clusterID clusterIDPeekWaiter, cache cache.Image, serviceAccountStore store.ServiceAccountStore, registryStore *registry.Store, localScan *scan.LocalScan, pubSubDispatcher scanResultPublisher) *enricher {
 	return &enricher{
-		scanResultChan:      make(chan scanResult),
+		scanResultChan:      make(chan *detectorEvents.ScanResultEvent),
 		serviceAccountStore: serviceAccountStore,
 		imageCache:          cache,
 		stopSig:             concurrency.NewSignal(),
 		localScan:           localScan,
 		regStore:            registryStore,
 		clusterID:           clusterID,
+		pubSubDispatcher:    pubSubDispatcher,
 	}
 }
 
@@ -410,22 +410,37 @@ func (e *enricher) getPullSecrets(deployment *storage.Deployment) []string {
 }
 
 func (e *enricher) blockingScan(ctx context.Context, deployment *storage.Deployment, netpolApplied *augmentedobjs.NetworkPoliciesApplied, action central.ResourceAction) {
+	// We pass the expiring message context to getImages here.
+	// This will allow us to cancel the scanWithRetries call if sensor disconnects.
+	images := e.getImages(ctx, deployment)
+
+	if e.pubSubDispatcher != nil {
+		if err := e.pubSubDispatcher.Publish(&detectorEvents.ScanResultEvent{
+			Context:                ctx,
+			Action:                 action,
+			Deployment:             deployment,
+			Images:                 images,
+			NetworkPoliciesApplied: netpolApplied,
+		}); err != nil {
+			log.Errorf("Failed to publish scan result event: %v", err)
+		}
+		return
+	}
+
 	select {
 	case <-e.stopSig.Done():
 		return
-	case e.scanResultChan <- scanResult{
-		context:    ctx,
-		action:     action,
-		deployment: deployment,
-		// We pass the expiring message context to getImages here.
-		// This will allow us to cancel the scanWithRetries call if sensor disconnects.
-		images:                 e.getImages(ctx, deployment),
-		networkPoliciesApplied: netpolApplied,
+	case e.scanResultChan <- &detectorEvents.ScanResultEvent{
+		Context:                ctx,
+		Action:                 action,
+		Deployment:             deployment,
+		Images:                 images,
+		NetworkPoliciesApplied: netpolApplied,
 	}:
 	}
 }
 
-func (e *enricher) outputChan() <-chan scanResult {
+func (e *enricher) outputChan() <-chan *detectorEvents.ScanResultEvent {
 	return e.scanResultChan
 }
 

--- a/sensor/common/detector/enricher.go
+++ b/sensor/common/detector/enricher.go
@@ -414,7 +414,7 @@ func (e *enricher) blockingScan(ctx context.Context, deployment *storage.Deploym
 	// This will allow us to cancel the scanWithRetries call if sensor disconnects.
 	images := e.getImages(ctx, deployment)
 
-	if e.pubSubDispatcher != nil {
+	if features.SensorInternalPubSub.Enabled() && e.pubSubDispatcher != nil {
 		if err := e.pubSubDispatcher.Publish(&detectorEvents.ScanResultEvent{
 			Context:                ctx,
 			Action:                 action,

--- a/sensor/common/detector/enricher_test.go
+++ b/sensor/common/detector/enricher_test.go
@@ -53,7 +53,7 @@ func (s *enricherSuite) SetupTest() {
 		&fakeClusterIDPeekWaiter{},
 		s.mockCache,
 		s.mockServiceAccountStore,
-		s.mockRegistryStore, nil)
+		s.mockRegistryStore, nil, nil)
 }
 
 func (s *enricherSuite) TearDownTest() {

--- a/sensor/common/detector/events/scan_result.go
+++ b/sensor/common/detector/events/scan_result.go
@@ -1,0 +1,27 @@
+package events
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/booleanpolicy/augmentedobjs"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+)
+
+// ScanResultEvent holds an enriched scan result for deploy-time detection.
+type ScanResultEvent struct {
+	Context                context.Context
+	Action                 central.ResourceAction
+	Deployment             *storage.Deployment
+	Images                 []*storage.Image
+	NetworkPoliciesApplied *augmentedobjs.NetworkPoliciesApplied
+}
+
+func (e *ScanResultEvent) Topic() pubsub.Topic {
+	return pubsub.DetectorScanResultTopic
+}
+
+func (e *ScanResultEvent) Lane() pubsub.LaneID {
+	return pubsub.DetectorScanResultLane
+}

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -14,6 +14,7 @@ const (
 	DetectorFileAccessConsumer
 	DetectorAuditLogConsumer
 	DetectorDeploymentConsumer
+	DetectorScanResultConsumer
 )
 
 var (
@@ -29,6 +30,7 @@ var (
 		DetectorFileAccessConsumer:          "DetectorFileAccess",
 		DetectorAuditLogConsumer:            "DetectorAuditLog",
 		DetectorDeploymentConsumer:          "DetectorDeployment",
+		DetectorScanResultConsumer:          "DetectorScanResult",
 	}
 )
 

--- a/sensor/common/pubsub/laneid.go
+++ b/sensor/common/pubsub/laneid.go
@@ -13,6 +13,7 @@ const (
 	DetectorFileAccessLane
 	DetectorAuditLogLane
 	DetectorDeploymentLane
+	DetectorScanResultLane
 )
 
 var (
@@ -27,6 +28,7 @@ var (
 		DetectorFileAccessLane:         "DetectorFileAccess",
 		DetectorAuditLogLane:           "DetectorAuditLog",
 		DetectorDeploymentLane:         "DetectorDeployment",
+		DetectorScanResultLane:         "DetectorScanResult",
 	}
 )
 

--- a/sensor/common/pubsub/topic.go
+++ b/sensor/common/pubsub/topic.go
@@ -13,6 +13,7 @@ const (
 	DetectorFileAccessTopic
 	DetectorAuditLogTopic
 	DetectorDeploymentTopic
+	DetectorScanResultTopic
 )
 
 var (
@@ -27,6 +28,7 @@ var (
 		DetectorFileAccessTopic:         "DetectorFileAccess",
 		DetectorAuditLogTopic:           "DetectorAuditLog",
 		DetectorDeploymentTopic:         "DetectorDeployment",
+		DetectorScanResultTopic:         "DetectorScanResult",
 	}
 )
 

--- a/sensor/kubernetes/sensor/pubsub.go
+++ b/sensor/kubernetes/sensor/pubsub.go
@@ -44,6 +44,7 @@ func buildPubSubDispatcher() (common.PubSubDispatcher, error) {
 			buildConcurrentLane(pubsub.DetectorFileAccessLane, env.DetectorFileAccessBufferSize),
 			lane.NewBlockingLane(pubsub.DetectorAuditLogLane),
 			buildConcurrentLane(pubsub.DetectorDeploymentLane, env.DetectorDeploymentBufferSize),
+			lane.NewBlockingLane(pubsub.DetectorScanResultLane),
 		},
 	))
 	if err != nil {


### PR DESCRIPTION
## Description

Migrate the detector enricher (scanResultChan) pipeline to the internal PubSub system, gated by ROX_SENSOR_PUBSUB. Builds on the deployment pipeline migration.

- Add DetectorScanResultTopic, DetectorScanResultLane, DetectorScanResultConsumer to PubSub constants
- Add ScanResultEvent in detector/events/ implementing pubsub.Event
- Register a BlockingLane (order guaranteed, no drops, matches the current unbuffered channel)
- In PubSub mode, enricher.blockingScan publishes to PubSub instead of writing to scanResultChan
- Refactor shared detection logic into detectDeploymentFromScanResult used by both runDetector (legacy) and handleScanResultEvent (PubSub)
- Stop() skips waiting on detectorStopper in PubSub mode since runDetector does not run

## User-facing documentation

- [x] CHANGELOG.md is updated OR update is not needed

## Testing and quality

- [x] the change is production ready: gated by ROX_SENSOR_PUBSUB feature flag
- [ ] CI results are inspected

### Automated testing

- [x] modified existing tests

### How I validated my change

- All existing detector tests pass with both PubSub enabled and disabled
- Deployment benchmark shows ~16us absolute overhead (two PubSub hops)