### PR TITLE
ROX-34626: Migrate detector serializer to PubSub

### DIFF
--- a/sensor/common/detector/detector.go
+++ b/sensor/common/detector/detector.go
@@ -130,7 +130,7 @@ func New(clusterID clusterIDPeekWaiter, enforcer enforcer.Enforcer, admCtrlSetti
 
 		output:                    make(chan *message.ExpiringMessage),
 		auditEventsChan:           auditLogEvents,
-		deploymentAlertOutputChan: make(chan outputResult),
+		deploymentAlertOutputChan: make(chan *detectorEvents.DeployAlertOutputEvent),
 		deploymentProcessingMap:   make(map[string]int64),
 
 		enricher:            newEnricher(clusterID, cache, serviceAccountStore, registryStore, localScan, pubSubDispatcher),
@@ -169,7 +169,7 @@ type detectorImpl struct {
 
 	output                    chan *message.ExpiringMessage
 	auditEventsChan           chan *sensor.AuditEvents
-	deploymentAlertOutputChan chan outputResult
+	deploymentAlertOutputChan chan *detectorEvents.DeployAlertOutputEvent
 
 	deploymentProcessingMap  map[string]int64
 	deploymentProcessingLock sync.RWMutex
@@ -268,11 +268,18 @@ func (d *detectorImpl) Start() error {
 		); err != nil {
 			return errors.Wrap(err, "failed to register detector scan result consumer")
 		}
+		if err := d.pubSubDispatcher.RegisterConsumerToLane(
+			pubsub.DetectorDeployAlertOutputConsumer,
+			pubsub.DetectorDeployAlertOutputTopic,
+			pubsub.DetectorDeployAlertOutputLane,
+			d.handleDeployAlertOutputEvent,
+		); err != nil {
+			return errors.Wrap(err, "failed to register detector deploy alert output consumer")
+		}
 	}
 
-	go d.serializeDeployTimeOutput()
-
 	if !d.pubSubEnabled() {
+		go d.serializeDeployTimeOutput()
 		go d.runDetector()
 		go d.processDeployment()
 		go d.runAuditLogEventDetector()
@@ -287,13 +294,6 @@ func (d *detectorImpl) Start() error {
 	return nil
 }
 
-type outputResult struct {
-	results   *central.AlertResults
-	timestamp int64
-	action    central.ResourceAction
-	context   context.Context
-}
-
 // serializeDeployTimeOutput serializes all messages that are going to be output. This allows us to guarantee the ordering
 // of the messages. e.g. an alert update is not sent once the alert removal msg has been sent and alerts generated
 // from an older version of a deployment
@@ -304,50 +304,87 @@ func (d *detectorImpl) serializeDeployTimeOutput() {
 		case <-d.serializerStopper.Flow().StopRequested():
 			return
 		case result := <-d.deploymentAlertOutputChan:
-			alertResults := result.results
-
-			switch result.action {
-			case central.ResourceAction_REMOVE_RESOURCE:
-				// Remove the deployment from being processed
-				concurrency.WithLock(&d.deploymentProcessingLock, func() {
-					delete(d.deploymentProcessingMap, alertResults.GetDeploymentId())
-				})
-			case central.ResourceAction_CREATE_RESOURCE:
-				// Regardless if an UPDATE was processed before the create, we should try to enforce on the CREATE
-				d.enforcer.ProcessAlertResults(result.action, storage.LifecycleStage_DEPLOY, alertResults)
-				fallthrough
-			case central.ResourceAction_UPDATE_RESOURCE, central.ResourceAction_SYNC_RESOURCE:
-				isMostRecentUpdate := concurrency.WithRLock1(&d.deploymentProcessingLock, func() bool {
-					value, exists := d.deploymentProcessingMap[alertResults.GetDeploymentId()]
-					if !exists {
-						// CREATE and UPDATE actions write a 0 timestamp into the map to signify that it is being processed
-						// whereas a REMOVE deletes the deployment ID entry. Once we have processed a REMOVE, we cannot send
-						// more deploytime alerts that are active as those alerts will not be cleaned up
-						// instead, mark the states of all alerts as RESOLVED
-						for _, alert := range alertResults.GetAlerts() {
-							alert.State = storage.ViolationState_RESOLVED
-						}
-						return true
-					}
-					isMostRecentUpdate := result.timestamp >= value
-					if isMostRecentUpdate {
-						d.deploymentProcessingMap[alertResults.GetDeploymentId()] = result.timestamp
-					}
-					return isMostRecentUpdate
-				})
-				// If the deployment is not being marked as being processed, then it was already removed and don't push to the channel
-				// If the timestamp of the deployment is older than one that has already been processed then also ignore
-				if !isMostRecentUpdate {
-					continue
-				}
+			if !d.serializeDeployAlertOutput(result) {
+				continue
 			}
 			select {
 			case <-d.serializerStopper.Flow().StopRequested():
 				return
-			case d.output <- createAlertResultsMsg(result.context, result.action, alertResults):
+			case d.output <- createAlertResultsMsg(result.Context, result.Action, result.Results):
 			}
 		}
 	}
+}
+
+func (d *detectorImpl) sendDeployAlertOutput(result *detectorEvents.DeployAlertOutputEvent) {
+	if d.pubSubEnabled() {
+		if err := d.pubSubDispatcher.Publish(result); err != nil {
+			log.Errorf("Failed to publish deploy alert output event: %v", err)
+		}
+		return
+	}
+	select {
+	case <-d.alertStopSig.Done():
+	case d.deploymentAlertOutputChan <- result:
+	}
+}
+
+// serializeDeployAlertOutput processes the deploy alert result through the
+// serializer logic (timestamp tracking, dedup, enforcer). Returns true if the
+// result should be sent to output, false if it was filtered out.
+func (d *detectorImpl) serializeDeployAlertOutput(result *detectorEvents.DeployAlertOutputEvent) bool {
+	alertResults := result.Results
+
+	switch result.Action {
+	case central.ResourceAction_REMOVE_RESOURCE:
+		// Remove the deployment from being processed
+		concurrency.WithLock(&d.deploymentProcessingLock, func() {
+			delete(d.deploymentProcessingMap, alertResults.GetDeploymentId())
+		})
+	case central.ResourceAction_CREATE_RESOURCE:
+		// Regardless if an UPDATE was processed before the create, we should try to enforce on the CREATE
+		d.enforcer.ProcessAlertResults(result.Action, storage.LifecycleStage_DEPLOY, alertResults)
+		fallthrough
+	case central.ResourceAction_UPDATE_RESOURCE, central.ResourceAction_SYNC_RESOURCE:
+		isMostRecentUpdate := concurrency.WithRLock1(&d.deploymentProcessingLock, func() bool {
+			value, exists := d.deploymentProcessingMap[alertResults.GetDeploymentId()]
+			if !exists {
+				// CREATE and UPDATE actions write a 0 timestamp into the map to signify that it is being processed
+				// whereas a REMOVE deletes the deployment ID entry. Once we have processed a REMOVE, we cannot send
+				// more deploytime alerts that are active as those alerts will not be cleaned up
+				// instead, mark the states of all alerts as RESOLVED
+				for _, alert := range alertResults.GetAlerts() {
+					alert.State = storage.ViolationState_RESOLVED
+				}
+				return true
+			}
+			isMostRecentUpdate := result.Timestamp >= value
+			if isMostRecentUpdate {
+				d.deploymentProcessingMap[alertResults.GetDeploymentId()] = result.Timestamp
+			}
+			return isMostRecentUpdate
+		})
+		// If the deployment is not being marked as being processed, then it was already removed and don't push to the channel
+		// If the timestamp of the deployment is older than one that has already been processed then also ignore
+		if !isMostRecentUpdate {
+			return false
+		}
+	}
+	return true
+}
+
+func (d *detectorImpl) handleDeployAlertOutputEvent(event pubsub.Event) error {
+	e, ok := event.(*detectorEvents.DeployAlertOutputEvent)
+	if !ok {
+		return errors.Errorf("unexpected event type: %T", event)
+	}
+	if d.serializeDeployAlertOutput(e) {
+		select {
+		case d.output <- createAlertResultsMsg(e.Context, e.Action, e.Results):
+		case <-d.alertStopSig.Done():
+		}
+	}
+	return nil
 }
 
 func (d *detectorImpl) Stop() {
@@ -363,8 +400,8 @@ func (d *detectorImpl) Stop() {
 	if !d.pubSubEnabled() {
 		_ = d.detectorStopper.Client().Stopped().Wait()
 		_ = d.auditStopper.Client().Stopped().Wait()
+		_ = d.serializerStopper.Client().Stopped().Wait()
 	}
-	_ = d.serializerStopper.Client().Stopped().Wait()
 }
 
 func (d *detectorImpl) Notify(e common.SensorComponentEvent) {
@@ -510,19 +547,15 @@ func (d *detectorImpl) detectDeploymentFromScanResult(ctx context.Context, deplo
 		return alerts[i].GetPolicy().GetId() < alerts[j].GetPolicy().GetId()
 	})
 
-	select {
-	case <-d.detectorStopper.Flow().StopRequested():
-	case <-d.serializerStopper.Flow().StopRequested():
-	case d.deploymentAlertOutputChan <- outputResult{
-		results: &central.AlertResults{
+	d.sendDeployAlertOutput(&detectorEvents.DeployAlertOutputEvent{
+		Results: &central.AlertResults{
 			DeploymentId: deployment.GetId(),
 			Alerts:       alerts,
 		},
-		timestamp: deployment.GetStateTimestamp(),
-		action:    action,
-		context:   ctx,
-	}:
-	}
+		Timestamp: deployment.GetStateTimestamp(),
+		Action:    action,
+		Context:   ctx,
+	})
 }
 
 func (d *detectorImpl) runDetector() {
@@ -686,18 +719,14 @@ func (d *detectorImpl) processDeploymentNoLock(ctx context.Context, deployment *
 		d.baselineEval.RemoveDeployment(deployment.GetId())
 		d.deduper.removeDeployment(deployment.GetId())
 
+		// Push an empty AlertResults object to mark deploytime alerts as stale.
+		// This allows us to not worry about synchronizing alert msgs with deployment msgs.
 		go func() {
-			// Push an empty AlertResults object to the channel which will mark deploytime alerts as stale
-			// This allows us to not worry about synchronizing alert msgs with deployment msgs
-			select {
-			case <-d.alertStopSig.Done():
-				return
-			case d.deploymentAlertOutputChan <- outputResult{
-				context: ctx,
-				results: &central.AlertResults{DeploymentId: deployment.GetId()},
-				action:  action,
-			}:
-			}
+			d.sendDeployAlertOutput(&detectorEvents.DeployAlertOutputEvent{
+				Context: ctx,
+				Results: &central.AlertResults{DeploymentId: deployment.GetId()},
+				Action:  action,
+			})
 		}()
 	case central.ResourceAction_CREATE_RESOURCE:
 		d.deduper.addDeployment(deployment)

--- a/sensor/common/detector/detector_helpers_test.go
+++ b/sensor/common/detector/detector_helpers_test.go
@@ -68,7 +68,7 @@ func createTestDetectorWithBufferSize(tb testing.TB, pubSubEnabled bool, bufferS
 		unifiedDetector:           &fakeUnifiedDetector{},
 		output:                    make(chan *message.ExpiringMessage, 1000),
 		auditEventsChan:           make(chan *sensor.AuditEvents),
-		deploymentAlertOutputChan: make(chan outputResult),
+		deploymentAlertOutputChan: make(chan *detectorEvents.DeployAlertOutputEvent),
 		deploymentProcessingMap:   make(map[string]int64),
 		enricher:                  newEnricher(&fakeClusterIDPeekWaiter{}, nil, serviceAccountStore, nil, nil, nil),
 		deploymentStore:           deploymentStore,
@@ -123,6 +123,7 @@ func createTestDetectorWithBufferSize(tb testing.TB, pubSubEnabled bool, bufferS
 					),
 				),
 				lane.NewBlockingLane(pubsub.DetectorScanResultLane),
+				lane.NewBlockingLane(pubsub.DetectorDeployAlertOutputLane),
 			},
 		))
 		require.NoError(tb, err)

--- a/sensor/common/detector/detector_serializer_test.go
+++ b/sensor/common/detector/detector_serializer_test.go
@@ -1,0 +1,233 @@
+package detector
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/sensor/common"
+	detectorEvents "github.com/stackrox/rox/sensor/common/detector/events"
+	"github.com/stackrox/rox/sensor/common/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSerializerOlderUpdateIsIgnored(t *testing.T) {
+	for _, pubSubEnabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("pubsub=%t", pubSubEnabled), func(t *testing.T) {
+			t.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
+
+			synctest.Test(t, func(t *testing.T) {
+				d, _, nps, _ := createTestDetector(t, pubSubEnabled)
+				d.unifiedDetector = &fakeUnifiedDetector{
+					alerts: []*storage.Alert{{Id: "a1", Policy: &storage.Policy{Id: "p1"}}},
+				}
+				nps.EXPECT().Find("default", gomock.Any()).Return(nil).AnyTimes()
+
+				require.NoError(t, d.Start())
+				defer d.Stop()
+
+				d.Notify(common.SensorComponentEventCentralReachable)
+
+				// CREATE with timestamp 100
+				depNew := &storage.Deployment{
+					Id: "dep-1", Name: "test", Namespace: "default",
+					StateTimestamp: 100,
+				}
+				d.ProcessDeployment(context.Background(), depNew, central.ResourceAction_CREATE_RESOURCE)
+				synctest.Wait()
+				<-d.output
+
+				// UPDATE with older timestamp 50 — should be ignored by serializer
+				d.deduper.removeDeployment("dep-1")
+				depOld := &storage.Deployment{
+					Id: "dep-1", Name: "test", Namespace: "default",
+					StateTimestamp: 50,
+				}
+				d.ProcessDeployment(context.Background(), depOld, central.ResourceAction_UPDATE_RESOURCE)
+				synctest.Wait()
+
+				select {
+				case msg := <-d.output:
+					t.Fatalf("expected no output for older update but got: %v", msg)
+				default:
+				}
+			})
+		})
+	}
+}
+
+func TestSerializerCreateEnforces(t *testing.T) {
+	for _, pubSubEnabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("pubsub=%t", pubSubEnabled), func(t *testing.T) {
+			t.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
+
+			synctest.Test(t, func(t *testing.T) {
+				d, _, nps, _ := createTestDetector(t, pubSubEnabled)
+				enforcerFake := &recordingEnforcer{}
+				d.enforcer = enforcerFake
+				d.unifiedDetector = &fakeUnifiedDetector{
+					alerts: []*storage.Alert{{Id: "a1", Policy: &storage.Policy{Id: "p1"}}},
+				}
+				nps.EXPECT().Find("default", gomock.Any()).Return(nil).AnyTimes()
+
+				require.NoError(t, d.Start())
+				defer d.Stop()
+
+				d.Notify(common.SensorComponentEventCentralReachable)
+
+				dep := &storage.Deployment{Id: "dep-1", Name: "test", Namespace: "default"}
+				d.ProcessDeployment(context.Background(), dep, central.ResourceAction_CREATE_RESOURCE)
+				synctest.Wait()
+				<-d.output
+
+				assert.True(t, enforcerFake.called.Load(), "enforcer should be called on CREATE")
+			})
+		})
+	}
+}
+
+func TestSerializerRemoveDeletesFromProcessingMap(t *testing.T) {
+	for _, pubSubEnabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("pubsub=%t", pubSubEnabled), func(t *testing.T) {
+			t.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
+
+			synctest.Test(t, func(t *testing.T) {
+				d, _, nps, _ := createTestDetector(t, pubSubEnabled)
+				nps.EXPECT().Find("default", gomock.Any()).Return(nil).AnyTimes()
+
+				require.NoError(t, d.Start())
+				defer d.Stop()
+
+				d.Notify(common.SensorComponentEventCentralReachable)
+
+				dep := &storage.Deployment{Id: "dep-1", Name: "test", Namespace: "default"}
+
+				// CREATE to add to processing map
+				d.ProcessDeployment(context.Background(), dep, central.ResourceAction_CREATE_RESOURCE)
+				synctest.Wait()
+				<-d.output
+
+				_, exists := d.deploymentProcessingMap["dep-1"]
+				assert.True(t, exists, "deployment should be in processing map after CREATE")
+
+				// REMOVE should delete from processing map and send empty alerts
+				d.ProcessDeployment(context.Background(), dep, central.ResourceAction_REMOVE_RESOURCE)
+				synctest.Wait()
+
+				select {
+				case msg := <-d.output:
+					alertResults := msg.GetEvent().GetAlertResults()
+					assert.Equal(t, "dep-1", alertResults.GetDeploymentId())
+					assert.Empty(t, alertResults.GetAlerts(), "REMOVE should send empty alerts")
+				default:
+					t.Fatal("expected output for REMOVE")
+				}
+
+				_, exists = d.deploymentProcessingMap["dep-1"]
+				assert.False(t, exists, "deployment should be removed from processing map after REMOVE")
+			})
+		})
+	}
+}
+
+// TestSerializerUpdateAfterRemoveMarksAlertsResolved verifies that when the
+// serializer receives an UPDATE for a deployment not in the processing map,
+// all alerts are marked RESOLVED. This simulates a race where a late UPDATE
+// (still in the enricher/blockingScan goroutine) reaches the serializer after
+// a faster REMOVE has already cleared the deployment from the processing map.
+//
+// We send directly to the serializer instead of going through ProcessDeployment
+// because ProcessDeployment calls markDeploymentForProcessing which re-adds
+// the deployment to the map, making it impossible to reproduce the race with
+// synctest's deterministic scheduling. An empty processing map is equivalent
+// to the post-REMOVE state, so no CREATE/REMOVE setup is needed.
+func TestSerializerUpdateAfterRemoveMarksAlertsResolved(t *testing.T) {
+	for _, pubSubEnabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("pubsub=%t", pubSubEnabled), func(t *testing.T) {
+			t.Setenv(features.SensorInternalPubSub.EnvVar(), fmt.Sprintf("%t", pubSubEnabled))
+
+			synctest.Test(t, func(t *testing.T) {
+				d, _, _, _ := createTestDetector(t, pubSubEnabled)
+
+				require.NoError(t, d.Start())
+				defer d.Stop()
+
+				d.sendDeployAlertOutput(&detectorEvents.DeployAlertOutputEvent{
+					Context: context.Background(),
+					Action:  central.ResourceAction_UPDATE_RESOURCE,
+					Results: &central.AlertResults{
+						DeploymentId: "dep-1",
+						Alerts: []*storage.Alert{
+							{Id: "a1", Policy: &storage.Policy{Id: "p1"}},
+						},
+					},
+				})
+				synctest.Wait()
+
+				select {
+				case msg := <-d.output:
+					alertResults := msg.GetEvent().GetAlertResults()
+					require.NotEmpty(t, alertResults.GetAlerts())
+					for _, alert := range alertResults.GetAlerts() {
+						assert.Equal(t, storage.ViolationState_RESOLVED, alert.GetState(),
+							"alerts for UPDATE after REMOVE should be marked RESOLVED")
+					}
+				default:
+					t.Fatal("expected output for UPDATE after REMOVE")
+				}
+			})
+		})
+	}
+}
+
+func TestSerializerPubSubStopUnblocksOutputSend(t *testing.T) {
+	t.Setenv(features.SensorInternalPubSub.EnvVar(), "true")
+
+	synctest.Test(t, func(t *testing.T) {
+		d, _, nps, _ := createTestDetector(t, true)
+		d.output = make(chan *message.ExpiringMessage)
+		d.unifiedDetector = &fakeUnifiedDetector{
+			alerts: []*storage.Alert{{Id: "a1", Policy: &storage.Policy{Id: "p1"}}},
+		}
+		nps.EXPECT().Find("default", gomock.Any()).Return(nil).AnyTimes()
+
+		require.NoError(t, d.Start())
+
+		d.Notify(common.SensorComponentEventCentralReachable)
+
+		dep := &storage.Deployment{Id: "dep-1", Name: "test", Namespace: "default"}
+		d.ProcessDeployment(context.Background(), dep, central.ResourceAction_CREATE_RESOURCE)
+		synctest.Wait()
+
+		// Don't read from d.output — the consumer callback is blocked on the send.
+		// Stop should complete because the send is guarded by alertStopSig.
+		done := make(chan struct{})
+		go func() {
+			d.Stop()
+			close(done)
+		}()
+		synctest.Wait()
+
+		select {
+		case <-done:
+		default:
+			t.Fatal("Stop() did not complete: handleDeployAlertOutputEvent is blocked on d.output without a stop guard")
+		}
+	})
+}
+
+type recordingEnforcer struct {
+	fakeEnforcer
+	called atomic.Bool
+}
+
+func (r *recordingEnforcer) ProcessAlertResults(_ central.ResourceAction, _ storage.LifecycleStage, _ *central.AlertResults) {
+	r.called.Store(true)
+}

--- a/sensor/common/detector/events/deploy_alert_output.go
+++ b/sensor/common/detector/events/deploy_alert_output.go
@@ -1,0 +1,24 @@
+package events
+
+import (
+	"context"
+
+	"github.com/stackrox/rox/generated/internalapi/central"
+	"github.com/stackrox/rox/sensor/common/pubsub"
+)
+
+// DeployAlertOutputEvent carries deploy-time alert results to the serializer.
+type DeployAlertOutputEvent struct {
+	Results   *central.AlertResults
+	Timestamp int64
+	Action    central.ResourceAction
+	Context   context.Context
+}
+
+func (e *DeployAlertOutputEvent) Topic() pubsub.Topic {
+	return pubsub.DetectorDeployAlertOutputTopic
+}
+
+func (e *DeployAlertOutputEvent) Lane() pubsub.LaneID {
+	return pubsub.DetectorDeployAlertOutputLane
+}

--- a/sensor/common/pubsub/consumerid.go
+++ b/sensor/common/pubsub/consumerid.go
@@ -15,6 +15,7 @@ const (
 	DetectorAuditLogConsumer
 	DetectorDeploymentConsumer
 	DetectorScanResultConsumer
+	DetectorDeployAlertOutputConsumer
 )
 
 var (
@@ -31,6 +32,7 @@ var (
 		DetectorAuditLogConsumer:            "DetectorAuditLog",
 		DetectorDeploymentConsumer:          "DetectorDeployment",
 		DetectorScanResultConsumer:          "DetectorScanResult",
+		DetectorDeployAlertOutputConsumer:   "DetectorDeployAlertOutput",
 	}
 )
 

--- a/sensor/common/pubsub/laneid.go
+++ b/sensor/common/pubsub/laneid.go
@@ -14,6 +14,7 @@ const (
 	DetectorAuditLogLane
 	DetectorDeploymentLane
 	DetectorScanResultLane
+	DetectorDeployAlertOutputLane
 )
 
 var (
@@ -29,6 +30,7 @@ var (
 		DetectorAuditLogLane:           "DetectorAuditLog",
 		DetectorDeploymentLane:         "DetectorDeployment",
 		DetectorScanResultLane:         "DetectorScanResult",
+		DetectorDeployAlertOutputLane:  "DetectorDeployAlertOutput",
 	}
 )
 

--- a/sensor/common/pubsub/topic.go
+++ b/sensor/common/pubsub/topic.go
@@ -14,6 +14,7 @@ const (
 	DetectorAuditLogTopic
 	DetectorDeploymentTopic
 	DetectorScanResultTopic
+	DetectorDeployAlertOutputTopic
 )
 
 var (
@@ -29,6 +30,7 @@ var (
 		DetectorAuditLogTopic:           "DetectorAuditLog",
 		DetectorDeploymentTopic:         "DetectorDeployment",
 		DetectorScanResultTopic:         "DetectorScanResult",
+		DetectorDeployAlertOutputTopic:  "DetectorDeployAlertOutput",
 	}
 )
 

--- a/sensor/kubernetes/sensor/pubsub.go
+++ b/sensor/kubernetes/sensor/pubsub.go
@@ -45,6 +45,7 @@ func buildPubSubDispatcher() (common.PubSubDispatcher, error) {
 			lane.NewBlockingLane(pubsub.DetectorAuditLogLane),
 			buildConcurrentLane(pubsub.DetectorDeploymentLane, env.DetectorDeploymentBufferSize),
 			lane.NewBlockingLane(pubsub.DetectorScanResultLane),
+			lane.NewBlockingLane(pubsub.DetectorDeployAlertOutputLane),
 		},
 	))
 	if err != nil {


### PR DESCRIPTION
## Description

Migrate the detector serializer (deploymentAlertOutputChan) to the internal PubSub system, gated by ROX_SENSOR_PUBSUB. Builds on the enricher pipeline migration.

- Add DeployAlertOutputEvent, topic, lane, and consumer constants
- Register a BlockingLane for ordering guarantees
- Both producers (detectDeploymentFromScanResult and REMOVE in processDeploymentNoLock) publish via sendDeployAlertOutput which routes to PubSub or the legacy channel
- Consumer callback handleDeployAlertOutputEvent calls serializeDeployAlertOutput with the same ordering/enforcement logic as the legacy serializer
- Refactor shared serialization logic into serializeDeployAlertOutput (returns bool), used by both legacy and PubSub paths

## User-facing documentation

- [x] CHANGELOG.md is updated OR update is not needed

## Testing and quality

- [x] the change is production ready: gated by ROX_SENSOR_PUBSUB feature flag
- [ ] CI results are inspected

### Automated testing

- [x] added unit tests
- [x] modified existing tests

### How I validated my change

- All existing detector tests pass with both PubSub enabled and disabled
- New serializer tests cover: older update ignored, CREATE enforces, REMOVE deletes from processing map and sends empty alerts, UPDATE after REMOVE marks alerts RESOLVED, Stop() unblocks PubSub output send
- Deployment benchmark shows ~31us absolute overhead (three PubSub hops)