### PR TITLE
ROX-35055: Increase wait time for tailored profile to be ready

### DIFF
--- a/tests/compliance_operator_v2_test.go
+++ b/tests/compliance_operator_v2_test.go
@@ -304,7 +304,7 @@ func createTailoredProfile(ctx context.Context, t *testing.T, client ctrlClient.
 		require.Equalf(c, complianceoperatorv1.TailoredProfileStateReady, current.Status.State,
 			"TailoredProfile %s not READY (state: %q, error: %q)",
 			name, current.Status.State, current.Status.ErrorMessage)
-	}, 10*time.Second, 1*time.Second)
+	}, 1*time.Minute, 2*time.Second)
 }
 
 // waitUntilTPInCentralDB waits for a tailored profile to appear in Central's


### PR DESCRIPTION
## Description

Bump wait time for tailored profile to be ready.  As we can see from logs, tailored profile is created. It's there in the cluster, but status is not ready.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] I didn't validate my change, only based on investigation
