### PR TITLE
ROX-30838: Fix missing reportGen.Stop() mock expectation

### DIFF
--- a/central/complianceoperator/v2/report/manager/manager_test.go
+++ b/central/complianceoperator/v2/report/manager/manager_test.go
@@ -398,11 +398,14 @@ func (m *ManagerTestSuite) TestHandleReadyScanDeleteOldResultsGate() {
 			suiteStore := suiteDS.NewMockDataStore(ctrl)
 			bindingsStore := bindingsDS.NewMockDataStore(ctrl)
 			generator := reportGen.NewMockComplianceReportGenerator(ctrl)
-			generator.EXPECT().Stop().Times(1)
+			generator.EXPECT().Stop().AnyTimes()
 
 			manager := New(scanConfigDS, scanDS, profileDS, snapshotDS, integrationDS, suiteStore, bindingsStore, checkResultDS, generator)
 			manager.Start()
-			defer manager.Stop()
+			m.T().Cleanup(func() {
+				manager.Stop()
+				ctrl.Finish()
+			})
 			managerImp := manager.(*managerImpl)
 
 			result := &watcher.ScanWatcherResults{
@@ -426,8 +429,6 @@ func (m *ManagerTestSuite) TestHandleReadyScanDeleteOldResultsGate() {
 			case <-time.After(2 * time.Second):
 				m.FailNow("timeout waiting for handleReadyScan to process the result")
 			}
-
-			ctrl.Finish()
 		})
 	}
 }
@@ -472,6 +473,7 @@ func (m *ManagerTestSuite) TestHandleScan() {
 }
 
 func (m *ManagerTestSuite) TestHandleScanRemove() {
+	m.reportGen.EXPECT().Stop().AnyTimes()
 	manager := New(m.scanConfigDataStore, m.scanDataStore, m.profileDataStore, m.snapshotDataStore, m.complianceIntegrationDataStore, m.suiteDataStore, m.bindingsDataStore, m.checkResultDataStore, m.reportGen)
 	managerImplementation, ok := manager.(*managerImpl)
 	require.True(m.T(), ok)


### PR DESCRIPTION
## Description

Fixes test failures introduced by the `defer manager.Stop()` addition in #21005.

`manager.Stop()` calls `reportGen.Stop()`, but neither `TestHandleReadyScanDeleteOldResultsGate` nor `TestHandleScanRemove` had mock expectations for it.

**`TestHandleReadyScanDeleteOldResultsGate`:** Had `generator.EXPECT().Stop().Times(1)` but `defer manager.Stop()` ran after `ctrl.Finish()` (LIFO order). Fixed by removing the defer, calling `manager.Stop()` explicitly before `ctrl.Finish()`, and using `AnyTimes()`.

**`TestHandleScanRemove`:** Uses suite-level `m.reportGen` with `defer manager.Stop()` which runs after `TearDownTest` → `m.mockCtrl.Finish()`. Fixed by adding `m.reportGen.EXPECT().Stop().AnyTimes()`.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- `go test -race -count=1 ./central/complianceoperator/v2/report/manager/` — all tests pass