### PR TITLE
ROX-33929: Increase query timeout for PLOP load tests

### DIFF
--- a/central/processlisteningonport/datastore/datastore_impl_test.go
+++ b/central/processlisteningonport/datastore/datastore_impl_test.go
@@ -2738,8 +2738,14 @@ func (suite *PLOPDataStoreTestSuite) TestRemovePLOPsWithoutPodUID() {
 func (suite *PLOPDataStoreTestSuite) addTooMany(plops []*storage.ProcessListeningOnPortFromSensor) {
 	batchSize := 30000
 
+	// Use an explicit context timeout so that ContextWithTimeoutIfNotExists
+	// in the Postgres pool layer sees an existing deadline and skips the
+	// 60-second default per-query timeout, which is too short in some cases.
+	ctx, cancel := context.WithTimeout(suite.hasWriteCtx, 5*time.Minute)
+	defer cancel()
+
 	for plopBatch := range slices.Chunk(plops, batchSize) {
-		err := suite.datastore.AddProcessListeningOnPort(suite.hasWriteCtx, fixtureconsts.Cluster1, plopBatch...)
+		err := suite.datastore.AddProcessListeningOnPort(ctx, fixtureconsts.Cluster1, plopBatch...)
 		suite.NoError(err)
 	}
 }


### PR DESCRIPTION
## Description

Based on failure analysis it looks that 60sec query timeout is not sufficient in some cases where PLOP tests are executed. Mostly for 125k PLOPs test. We can often see `context deadline exceeded` - assumption is that it comes from default timeout used in `pkg/postgres/pool_impl.go` - by `ContextWithTimeoutIfNotExists`.

Fix proposal is to define timeout in test and not rely on default set by `ContextWithTimeoutIfNotExists`. That should bump timeout from 1min to 5min and queries will have more time to finish.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- [x] let CI pipeline run the test
- [x] run tests locally

