### PR TITLE
ROX-35007: enable modernize/slicessort,mapsloop

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -172,13 +172,11 @@ linters:
     modernize:
       disable:
         - any
-        - mapsloop
         - minmax
         - newexpr
         - rangeint
         - reflecttypefor
         - slicescontains
-        - slicessort
   exclusions:
     generated: lax
     rules:

--- a/central/cluster/datastore/datastore_impl.go
+++ b/central/cluster/datastore/datastore_impl.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 	"fmt"
+	"maps"
 	"regexp"
 	"slices"
 	"strings"
@@ -595,9 +596,7 @@ func (ds *datastoreImpl) UpdateAuditLogFileStates(ctx context.Context, id string
 	if cluster.GetAuditLogState() == nil {
 		cluster.AuditLogState = make(map[string]*storage.AuditLogFileState)
 	}
-	for node, state := range states {
-		cluster.AuditLogState[node] = state
-	}
+	maps.Copy(cluster.GetAuditLogState(), states)
 
 	return ds.clusterStorage.Upsert(ctx, cluster)
 }

--- a/central/compliance/standards/types.go
+++ b/central/compliance/standards/types.go
@@ -1,6 +1,7 @@
 package standards
 
 import (
+	"slices"
 	"sort"
 
 	"github.com/stackrox/rox/central/compliance/framework"
@@ -71,9 +72,7 @@ func (s *Standard) protoScopes() []v1.ComplianceStandardMetadata_Scope {
 			scopes = append(scopes, v1.ComplianceStandardMetadata_NODE)
 		}
 	}
-	sort.Slice(scopes, func(i, j int) bool {
-		return scopes[i] < scopes[j]
-	})
+	slices.Sort(scopes)
 	return scopes
 }
 
@@ -260,9 +259,7 @@ func newStandard(standardMD metadata.Standard, checkRegistry framework.CheckRegi
 	for s := range scopeMap {
 		scopes = append(scopes, s)
 	}
-	sort.Slice(scopes, func(i, j int) bool {
-		return scopes[i] < scopes[j]
-	})
+	slices.Sort(scopes)
 	s.scopes = scopes
 
 	return s

--- a/central/cve/fetcher/orchestrator.go
+++ b/central/cve/fetcher/orchestrator.go
@@ -3,6 +3,7 @@ package fetcher
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/pkg/errors"
 	clusterDataStore "github.com/stackrox/rox/central/cluster/datastore"
@@ -76,9 +77,7 @@ func (m *orchestratorCVEManager) Scan(version string, cveType utils.CVEType) ([]
 	scanners := make(map[string]types.OrchestratorScanner)
 
 	concurrency.WithLock(&m.mutex, func() {
-		for k, v := range m.scanners {
-			scanners[k] = v
-		}
+		maps.Copy(scanners, m.scanners)
 	})
 
 	if len(scanners) == 0 {

--- a/central/graphql/generator/schema2.go
+++ b/central/graphql/generator/schema2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"text/template"
@@ -101,9 +102,7 @@ func (t *typeEntry) InputFields() []string {
 }
 
 func (t *typeEntry) ExtraFields() []string {
-	sort.Slice(t.extraResolvers, func(i, j int) bool {
-		return t.extraResolvers[i] < t.extraResolvers[j]
-	})
+	slices.Sort(t.extraResolvers)
 	return t.extraResolvers
 }
 

--- a/central/scrape/scrape_impl.go
+++ b/central/scrape/scrape_impl.go
@@ -3,6 +3,7 @@ package scrape
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -57,9 +58,7 @@ func (s *scrapeImpl) GetResults() map[string]*compliance.ComplianceReturn {
 	defer s.lock.RUnlock()
 
 	ret := make(map[string]*compliance.ComplianceReturn, len(s.results))
-	for id, cr := range s.results {
-		ret[id] = cr
-	}
+	maps.Copy(ret, s.results)
 	return ret
 }
 

--- a/central/sensor/service/connection/connection_test.go
+++ b/central/sensor/service/connection/connection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"maps"
 	"slices"
 	"testing"
 	"time"
@@ -329,9 +330,7 @@ func (s *testSuite) TestSendDeduperStateIfSensorReconciliation() {
 				}
 				deduperStateSent := make(map[string]uint64)
 				for _, state := range deduperStates {
-					for k, v := range state.GetResourceHashes() {
-						deduperStateSent[k] = v
-					}
+					maps.Copy(deduperStateSent, state.GetResourceHashes())
 					s.Equal(tc.expectNumberOfDeduperStates, int(state.GetTotal()))
 					s.True(currentSet.Contains(int(state.GetCurrent())))
 					currentSet.Remove(int(state.GetCurrent()))

--- a/central/splunk/violations_query_test.go
+++ b/central/splunk/violations_query_test.go
@@ -5,7 +5,7 @@ package splunk
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -137,9 +137,7 @@ func (s *violationsTestSuite) TestQueryAlertsAreSortedByAlertID() {
 		a.Id = uuid.NewV4().String()
 		sortedIDs = append(sortedIDs, a.GetId())
 	}
-	sort.Slice(sortedIDs, func(i, j int) bool {
-		return sortedIDs[i] < sortedIDs[j]
-	})
+	slices.Sort(sortedIDs)
 
 	var resultIDs []string
 	s.withAlerts(alerts, func(alertsDS datastore.DataStore) {

--- a/central/testutils/export.go
+++ b/central/testutils/export.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math/rand"
 	"os"
 	"slices"
@@ -348,9 +349,7 @@ func (h *ExportServicePostgresTestHelper) InjectDataAndRunBenchmark(
 				b.Error(err)
 			}
 			imageIDs = append(imageIDs, addedImageIDs...)
-			for imageID, imageName := range addedImageNamesByID {
-				imageNamesByIDs[imageID] = imageName
-			}
+			maps.Copy(imageNamesByIDs, addedImageNamesByID)
 		}
 		log.Info("Injecting ", delta, " deployments")
 		deployments, err := h.InjectDeployments(b, delta, imageIDs, imageNamesByIDs)

--- a/operator/internal/central/extensions/reconcile_defaulting_test.go
+++ b/operator/internal/central/extensions/reconcile_defaulting_test.go
@@ -2,6 +2,7 @@ package extensions
 
 import (
 	"context"
+	"maps"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -126,9 +127,7 @@ func TestReconcileScannerV4FeatureDefaultsExtension(t *testing.T) {
 				Spec:   c.Spec,
 				Status: *c.Status.DeepCopy(),
 			}
-			for key, val := range c.Annotations {
-				central.Annotations[key] = val
-			}
+			maps.Copy(central.Annotations, c.Annotations)
 
 			ctx := context.Background()
 			sch := runtime.NewScheme()

--- a/operator/internal/central/extensions/reconcile_pvc_test.go
+++ b/operator/internal/central/extensions/reconcile_pvc_test.go
@@ -3,6 +3,7 @@ package extensions
 import (
 	"context"
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -525,9 +526,7 @@ func executeAndVerify(t *testing.T, testCase pvcReconciliationTestCase, r reconc
 	}
 
 	pvcsToVerify := make(map[string]pvcVerifyFunc)
-	for name, pvf := range testCase.ExpectedPVCs {
-		pvcsToVerify[name] = pvf
-	}
+	maps.Copy(pvcsToVerify, testCase.ExpectedPVCs)
 
 	pvcList := &corev1.PersistentVolumeClaimList{}
 	err = r.client.List(context.TODO(), pvcList)

--- a/operator/internal/central/extensions/reconcile_tls_test.go
+++ b/operator/internal/central/extensions/reconcile_tls_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -757,9 +758,7 @@ func TestGenerateCentralTLSData_Rotation(t *testing.T) {
 			}
 
 			oldFileMapCopy := make(types.SecretDataMap, len(oldFileMap))
-			for k, v := range oldFileMap {
-				oldFileMapCopy[k] = v
-			}
+			maps.Copy(oldFileMapCopy, oldFileMap)
 
 			newFileMap, err := r.generateCentralTLSData(oldFileMap)
 			require.NoError(t, err)

--- a/operator/internal/common/labels/labels.go
+++ b/operator/internal/common/labels/labels.go
@@ -2,6 +2,7 @@ package labels
 
 import (
 	"bytes"
+	"maps"
 
 	"github.com/pkg/errors"
 	commonLabels "github.com/stackrox/rox/pkg/labels"
@@ -31,9 +32,7 @@ func TLSSecretLabels() map[string]string {
 // DefaultLabels defines the default labels the operator should set on resources it creates.
 func DefaultLabels() map[string]string {
 	labels := make(map[string]string, len(defaultLabels))
-	for k, v := range defaultLabels {
-		labels[k] = v
-	}
+	maps.Copy(labels, defaultLabels)
 
 	return labels
 }
@@ -43,9 +42,7 @@ func MergeLabels(current, newLabels map[string]string) (map[string]string, bool)
 	updated := false
 	mergedLabels := map[string]string{}
 
-	for k, v := range current {
-		mergedLabels[k] = v
-	}
+	maps.Copy(mergedLabels, current)
 	for k, v := range newLabels {
 		if x, exists := mergedLabels[k]; !exists || x != v {
 			updated = true
@@ -61,9 +58,7 @@ func MergeLabels(current, newLabels map[string]string) (map[string]string, bool)
 func WithDefaults(labels map[string]string) (map[string]string, bool) {
 	updated := false
 	newLabels := map[string]string{}
-	for k, v := range labels {
-		newLabels[k] = v
-	}
+	maps.Copy(newLabels, labels)
 
 	for k, v := range defaultLabels {
 		value, hasKey := newLabels[k]
@@ -115,9 +110,7 @@ func (lpr labelPostRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer
 			labels = map[string]string{}
 		}
 
-		for k, v := range lpr.labels {
-			labels[k] = v
-		}
+		maps.Copy(labels, lpr.labels)
 
 		objMeta.SetLabels(labels)
 

--- a/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
+++ b/operator/internal/securedcluster/extensions/reconcile_defaulting_test.go
@@ -3,6 +3,7 @@ package extensions
 import (
 	"context"
 	"errors"
+	"maps"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -248,9 +249,7 @@ func TestReconcileAdmissionControllerDef(t *testing.T) {
 				Spec:   *c.Spec.DeepCopy(),
 				Status: *c.Status.DeepCopy(),
 			}
-			for key, val := range c.Annotations {
-				baseSecuredCluster.Annotations[key] = val
-			}
+			maps.Copy(baseSecuredCluster.Annotations, c.Annotations)
 
 			ctx := context.Background()
 			sch := runtime.NewScheme()
@@ -385,9 +384,7 @@ func TestReconcileScannerV4FeatureDefaultsExtension(t *testing.T) {
 				Spec:   *c.Spec.DeepCopy(),
 				Status: *c.Status.DeepCopy(),
 			}
-			for key, val := range c.Annotations {
-				baseSecuredCluster.Annotations[key] = val
-			}
+			maps.Copy(baseSecuredCluster.Annotations, c.Annotations)
 
 			ctx := context.Background()
 			sch := runtime.NewScheme()

--- a/operator/internal/values/testing/utils.go
+++ b/operator/internal/values/testing/utils.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"maps"
 	"regexp"
 	"testing"
 
@@ -76,9 +77,7 @@ func NewSchedulingExpectations(paths []ComponentPath, expectation SchedulingExpe
 // WithOverride returns a copy of the expectations with the specified component's values overridden.
 func (e SchedulingExpectations) WithOverride(name string, expectation SchedulingExpectation) SchedulingExpectations {
 	result := make(SchedulingExpectations, len(e))
-	for k, v := range e {
-		result[k] = v
-	}
+	maps.Copy(result, e)
 	result[name] = expectation
 	return result
 }

--- a/pkg/auth/authproviders/oidc/map_claims_test.go
+++ b/pkg/auth/authproviders/oidc/map_claims_test.go
@@ -1,6 +1,7 @@
 package oidc
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -15,9 +16,7 @@ type mockClaimExtractor struct {
 func (e *mockClaimExtractor) Claims(input interface{}) error {
 	switch u := input.(type) {
 	case *map[string]interface{}:
-		for k, v := range e.claims {
-			(*u)[k] = v
-		}
+		maps.Copy((*u), e.claims)
 		return nil
 	default:
 		return errors.Errorf("unsupported type %T", input)

--- a/pkg/auth/authproviders/registry_httphandler_test.go
+++ b/pkg/auth/authproviders/registry_httphandler_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -761,12 +762,8 @@ func (*tstAuthProviderBackendFactory) RedactConfig(config map[string]string) map
 
 func (*tstAuthProviderBackendFactory) MergeConfig(newCfg, oldCfg map[string]string) map[string]string {
 	mergedCfg := make(map[string]string, len(newCfg))
-	for k, v := range oldCfg {
-		mergedCfg[k] = v
-	}
-	for k, v := range newCfg {
-		mergedCfg[k] = v
-	}
+	maps.Copy(mergedCfg, oldCfg)
+	maps.Copy(mergedCfg, newCfg)
 	return mergedCfg
 }
 

--- a/pkg/booleanpolicy/evaluator/pathutil/filter_linked.go
+++ b/pkg/booleanpolicy/evaluator/pathutil/filter_linked.go
@@ -1,6 +1,8 @@
 package pathutil
 
 import (
+	"maps"
+
 	"github.com/pkg/errors"
 	"github.com/stackrox/rox/pkg/utils"
 )
@@ -82,9 +84,7 @@ func (t *tree) merge(other *tree) {
 }
 
 func (t *tree) gatherValuesIgnoringArrays(currentPath *map[string][]string) {
-	for fieldName, values := range t.values {
-		(*currentPath)[fieldName] = values
-	}
+	maps.Copy((*currentPath), t.values)
 	for key, child := range t.children {
 		if key.Index() >= 0 {
 			continue
@@ -117,9 +117,7 @@ func (t *tree) populateAllPaths(allPaths *[]map[string][]string, currentPath *ma
 			pathToPass = currentPath
 		} else {
 			newMap := make(map[string][]string, len(*currentPath))
-			for k, v := range *currentPath {
-				newMap[k] = v
-			}
+			maps.Copy(newMap, *currentPath)
 			pathToPass = &newMap
 		}
 		child.populateAllPaths(allPaths, pathToPass)

--- a/pkg/compliance/data/flatten.go
+++ b/pkg/compliance/data/flatten.go
@@ -1,15 +1,17 @@
 package data
 
-import "github.com/stackrox/rox/generated/internalapi/compliance"
+import (
+	"maps"
+
+	"github.com/stackrox/rox/generated/internalapi/compliance"
+)
 
 // FlattenFileMap takes a map of file paths to File objects and returns a map with all recursively nested Files in a single top level map of path to File.
 func FlattenFileMap(toFlatten map[string]*compliance.File) map[string]*compliance.File {
 	totalNodeFiles := make(map[string]*compliance.File)
 	for path, file := range toFlatten {
 		expanded := expandFile(file)
-		for k, v := range expanded {
-			totalNodeFiles[k] = v
-		}
+		maps.Copy(totalNodeFiles, expanded)
 		totalNodeFiles[path] = file
 	}
 	return totalNodeFiles
@@ -19,9 +21,7 @@ func expandFile(parent *compliance.File) map[string]*compliance.File {
 	expanded := make(map[string]*compliance.File)
 	for _, child := range parent.GetChildren() {
 		childExpanded := expandFile(child)
-		for k, v := range childExpanded {
-			expanded[k] = v
-		}
+		maps.Copy(expanded, childExpanded)
 	}
 	expanded[parent.GetPath()] = parent
 	return expanded

--- a/pkg/grpc/metrics/grpc_metrics_impl.go
+++ b/pkg/grpc/metrics/grpc_metrics_impl.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"maps"
 	"runtime/debug"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -118,9 +119,7 @@ func (g *grpcMetricsImpl) GetMetrics() (map[string]map[codes.Code]int64, map[str
 	externalPanics := make(map[string]map[string]int64, len(g.allMetrics))
 	for path, perPathMetric := range g.allMetrics {
 		externalCodeMap := make(map[codes.Code]int64, len(perPathMetric.normalInvocationStats))
-		for responseCode, count := range perPathMetric.normalInvocationStats {
-			externalCodeMap[responseCode] = count
-		}
+		maps.Copy(externalCodeMap, perPathMetric.normalInvocationStats)
 		if len(externalCodeMap) > 0 {
 			externalMetrics[path] = externalCodeMap
 		}

--- a/pkg/grpc/metrics/http_metrics_impl.go
+++ b/pkg/grpc/metrics/http_metrics_impl.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"maps"
 	"net/http"
 	"sync/atomic"
 
@@ -88,9 +89,7 @@ func (h *httpMetricsImpl) GetMetrics() (map[string]map[int]int64, map[string]map
 		// Prevent the response code map from being updated while we copy it
 		concurrency.WithLock(&ppm.normalInvocationStatsMutex, func() {
 			externalCodeMap := make(map[int]int64, len(ppm.normalInvocationStats))
-			for responseCode, count := range ppm.normalInvocationStats {
-				externalCodeMap[responseCode] = count
-			}
+			maps.Copy(externalCodeMap, ppm.normalInvocationStats)
 			if len(externalCodeMap) > 0 {
 				externalMetrics[path] = externalCodeMap
 			}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -32,7 +32,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -146,9 +146,7 @@ var (
 		for severity := range validLevels {
 			severities = append(severities, severity)
 		}
-		sort.Slice(severities, func(i, j int) bool {
-			return severities[i] < severities[j]
-		})
+		slices.Sort(severities)
 		return severities
 	}()
 

--- a/pkg/maputil/maputil.go
+++ b/pkg/maputil/maputil.go
@@ -1,6 +1,8 @@
 package maputil
 
 import (
+	"maps"
+
 	"github.com/stackrox/rox/pkg/concurrency"
 	"github.com/stackrox/rox/pkg/sync"
 )
@@ -8,9 +10,7 @@ import (
 // ShallowClone creates a shallow clone of the given map.
 func ShallowClone[K comparable, V any](inputMap map[K]V) map[K]V {
 	cloned := make(map[K]V, len(inputMap))
-	for k, v := range inputMap {
-		cloned[k] = v
-	}
+	maps.Copy(cloned, inputMap)
 	return cloned
 }
 
@@ -76,9 +76,7 @@ func (m *FastRMap[K, V]) DeleteMany(keys ...K) {
 // If there are key collisions, the passed-in map's elements take precedence.
 func (m *FastRMap[K, V]) SetMany(elements map[K]V) {
 	m.cloneAndMutate(func(clonedMap map[K]V) {
-		for k, v := range elements {
-			clonedMap[k] = v
-		}
+		maps.Copy(clonedMap, elements)
 	})
 }
 

--- a/pkg/registries/docker/metadata_v1.go
+++ b/pkg/registries/docker/metadata_v1.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"encoding/json"
 	"io"
+	"maps"
 	"strings"
 	"time"
 
@@ -76,9 +77,7 @@ func (r *Registry) populateV1DataFromManifest(manifest *schema1.SignedManifest, 
 		}
 		layers = append(layers, layer)
 		// Last label takes precedence and there seems to be a separate image object per layer
-		for labelKey, labelValue := range v1Image.Config.Labels {
-			labels[labelKey] = labelValue
-		}
+		maps.Copy(labels, v1Image.Config.Labels)
 	}
 	// Orient the layers to be oldest to newest
 	fsLayers := make([]string, 0, len(manifest.FSLayers))

--- a/pkg/renderer/render_new.go
+++ b/pkg/renderer/render_new.go
@@ -1,6 +1,7 @@
 package renderer
 
 import (
+	"maps"
 	"path"
 	"strings"
 
@@ -225,9 +226,7 @@ func renderAuxiliaryFiles(c Config, mode mode) ([]*zip.File, error) {
 
 	if mode == renderAll {
 		commonScriptFileMap := make(FileNameMap)
-		for k, v := range commonScriptMap {
-			commonScriptFileMap[k] = v
-		}
+		maps.Copy(commonScriptFileMap, commonScriptMap)
 		if c.K8sConfig.DeploymentFormat == v1.DeploymentFormat_KUBECTL {
 			commonScriptFileMap["common/setup-central.sh"] = "scripts/setup.sh"
 		} else {

--- a/pkg/sac/effectiveaccessscope/compacted.go
+++ b/pkg/sac/effectiveaccessscope/compacted.go
@@ -3,7 +3,7 @@ package effectiveaccessscope
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -38,9 +38,7 @@ func (c ScopeTreeCompacted) String() string {
 	}
 
 	// Ensure order consistency across invocations.
-	sort.Slice(clusterStrs, func(i, j int) bool {
-		return clusterStrs[i] < clusterStrs[j]
-	})
+	slices.Sort(clusterStrs)
 
 	return strings.Join(clusterStrs, ", ")
 }

--- a/pkg/sac/effectiveaccessscope/effective_access_scope.go
+++ b/pkg/sac/effectiveaccessscope/effective_access_scope.go
@@ -1,7 +1,8 @@
 package effectiveaccessscope
 
 import (
-	"sort"
+	"maps"
+	"slices"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
@@ -169,9 +170,7 @@ func (root *ScopeTree) Compactify() ScopeTreeCompacted {
 			}
 		}
 		// Ensure order consistency across invocations.
-		sort.Slice(namespaces, func(i, j int) bool {
-			return namespaces[i] < namespaces[j]
-		})
+		slices.Sort(namespaces)
 		compacted[clusterName] = namespaces
 	}
 
@@ -343,9 +342,7 @@ func (root *ScopeTree) Merge(tree *ScopeTree) {
 	if len(tree.clusterIDToName) > 0 && root.clusterIDToName == nil {
 		root.clusterIDToName = make(map[string]string)
 	}
-	for clusterID, clusterName := range tree.clusterIDToName {
-		root.clusterIDToName[clusterID] = clusterName
-	}
+	maps.Copy(root.clusterIDToName, tree.clusterIDToName)
 	for key, cluster := range tree.Clusters {
 		rootCluster := root.Clusters[key]
 		if rootCluster == nil || cluster.State == Included {
@@ -439,9 +436,7 @@ func getNamespaceFQSN(cluster string, namespace string) string {
 
 func augmentLabels(labels map[string]string, key string, value string) map[string]string {
 	result := make(map[string]string)
-	for k, v := range labels {
-		result[k] = v
-	}
+	maps.Copy(result, labels)
 	result[key] = value
 
 	return result

--- a/pkg/sac/effectiveaccessscope/node_attributes.go
+++ b/pkg/sac/effectiveaccessscope/node_attributes.go
@@ -1,6 +1,8 @@
 package effectiveaccessscope
 
 import (
+	"maps"
+
 	v1 "github.com/stackrox/rox/generated/api/v1"
 )
 
@@ -13,9 +15,7 @@ type treeNodeAttributes struct {
 
 func (t *treeNodeAttributes) copy() *treeNodeAttributes {
 	labels := make(map[string]string, len(t.Labels))
-	for k, v := range t.Labels {
-		labels[k] = v
-	}
+	maps.Copy(labels, t.Labels)
 	return &treeNodeAttributes{
 		ID:     t.ID,
 		Name:   t.Name,

--- a/pkg/search/general_query_parser.go
+++ b/pkg/search/general_query_parser.go
@@ -2,7 +2,7 @@ package search
 
 import (
 	"errors"
-	"sort"
+	"slices"
 
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/pkg/errox"
@@ -42,9 +42,7 @@ func ParseFieldMap(query string) (map[FieldLabel][]string, error) {
 
 // SortFieldLabels takes a list of field labels and returns a sorted list of field labels
 func SortFieldLabels(fieldLabels []FieldLabel) []FieldLabel {
-	sort.Slice(fieldLabels, func(i, j int) bool {
-		return fieldLabels[i] < fieldLabels[j]
-	})
+	slices.Sort(fieldLabels)
 	return fieldLabels
 }
 

--- a/roxctl/helm/derivelocalvalues/local.go
+++ b/roxctl/helm/derivelocalvalues/local.go
@@ -2,6 +2,7 @@ package derivelocalvalues
 
 import (
 	"context"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -87,9 +88,7 @@ func newLocalK8sObjectDescriptionFromPath(inputPath string) (*localK8sObjectDesc
 			if cache[kind] == nil {
 				cache[kind] = make(map[string]unstructured.Unstructured)
 			}
-			for name, u := range resources {
-				cache[kind][name] = u
-			}
+			maps.Copy(cache[kind], resources)
 		}
 	}
 

--- a/sensor/admission-control/manager/image_coalescing_caching_bench_test.go
+++ b/sensor/admission-control/manager/image_coalescing_caching_bench_test.go
@@ -5,8 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math/rand/v2"
-	"sort"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -90,9 +91,7 @@ func (c *coalescingBenchImageClient) CallsByImage() map[string]int64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	result := make(map[string]int64, len(c.callsByImage))
-	for k, v := range c.callsByImage {
-		result[k] = v
-	}
+	maps.Copy(result, c.callsByImage)
 	return result
 }
 
@@ -316,7 +315,7 @@ func percentile(durations []time.Duration, p float64) time.Duration {
 	}
 	sorted := make([]time.Duration, len(durations))
 	copy(sorted, durations)
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	slices.Sort(sorted)
 	idx := int(float64(len(sorted)-1) * p)
 	return sorted[idx]
 }

--- a/sensor/common/admissioncontroller/settings_manager_impl.go
+++ b/sensor/common/admissioncontroller/settings_manager_impl.go
@@ -2,6 +2,7 @@ package admissioncontroller
 
 import (
 	"compress/gzip"
+	"maps"
 	"time"
 
 	"github.com/pkg/errors"
@@ -197,9 +198,7 @@ func copyMap(m map[string]string) map[string]string {
 		return nil
 	}
 	result := make(map[string]string, len(m))
-	for k, v := range m {
-		result[k] = v
-	}
+	maps.Copy(result, m)
 	return result
 }
 

--- a/sensor/common/compliance/auditlog_manager_impl.go
+++ b/sensor/common/compliance/auditlog_manager_impl.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"maps"
 	"time"
 
 	"github.com/stackrox/rox/generated/internalapi/central"
@@ -162,9 +163,8 @@ func (a *auditLogCollectionManagerImpl) getLatestFileStates() map[string]*storag
 
 	// Clone the map before returning because it may get changed before the caller has a chance to use it.
 	nodeStates := make(map[string]*storage.AuditLogFileState, len(a.fileStates))
-	for k, v := range a.fileStates {
-		nodeStates[k] = v // no need to clone this because when the map is updated a new storage.AuditLogFileState is always created (see updateFileState)
-	}
+	// no need to clone this because when the map is updated a new storage.AuditLogFileState is always created (see updateFileState)
+	maps.Copy(nodeStates, a.fileStates)
 	return nodeStates
 }
 

--- a/sensor/common/compliance/node_inventory_handler_impl.go
+++ b/sensor/common/compliance/node_inventory_handler_impl.go
@@ -2,6 +2,7 @@ package compliance
 
 import (
 	"context"
+	"maps"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -507,20 +508,12 @@ func attachRPMtoRHCOS(version, arch string, rpm *v4.IndexReport) *v4.IndexReport
 	}
 	strID := strconv.Itoa(idCandidate)
 	oci := buildRHCOSIndexReport(strID, version, arch)
-	for pkgID, pkg := range rpm.GetContents().GetPackages() {
-		oci.Contents.Packages[pkgID] = pkg
-	}
+	maps.Copy(oci.GetContents().GetPackages(), rpm.GetContents().GetPackages())
 	oci.Contents.PackagesDEPRECATED = append(oci.Contents.PackagesDEPRECATED, rpm.GetContents().GetPackagesDEPRECATED()...)
-	for repoID, repo := range rpm.GetContents().GetRepositories() {
-		oci.Contents.Repositories[repoID] = repo
-	}
+	maps.Copy(oci.GetContents().GetRepositories(), rpm.GetContents().GetRepositories())
 	oci.Contents.RepositoriesDEPRECATED = append(oci.Contents.RepositoriesDEPRECATED, rpm.GetContents().GetRepositoriesDEPRECATED()...)
-	for envId, list := range rpm.GetContents().GetEnvironments() {
-		oci.Contents.Environments[envId] = list
-	}
-	for envId, list := range rpm.GetContents().GetEnvironmentsDEPRECATED() {
-		oci.Contents.EnvironmentsDEPRECATED[envId] = list
-	}
+	maps.Copy(oci.GetContents().GetEnvironments(), rpm.GetContents().GetEnvironments())
+	maps.Copy(oci.GetContents().GetEnvironmentsDEPRECATED(), rpm.GetContents().GetEnvironmentsDEPRECATED())
 	oci.Contents.Distributions = rpm.GetContents().GetDistributions()
 	oci.Contents.DistributionsDEPRECATED = rpm.GetContents().GetDistributionsDEPRECATED()
 	return oci

--- a/sensor/common/sensor/central_communication_impl.go
+++ b/sensor/common/sensor/central_communication_impl.go
@@ -2,6 +2,7 @@ package sensor
 
 import (
 	"context"
+	"maps"
 	"strconv"
 	"time"
 
@@ -335,9 +336,7 @@ func (s *centralCommunicationImpl) initialDeduperSync(stream central.SensorServi
 		}
 
 		log.Infof("Received %d hashes (size=%d), current chunk: %d, total: %d", len(msg.GetDeduperState().GetResourceHashes()), msg.SizeVT(), msg.GetDeduperState().GetCurrent(), msg.GetDeduperState().GetTotal())
-		for k, v := range msg.GetDeduperState().GetResourceHashes() {
-			deduperState[k] = v
-		}
+		maps.Copy(deduperState, msg.GetDeduperState().GetResourceHashes())
 
 		if msg.GetDeduperState().GetCurrent() == msg.GetDeduperState().GetTotal() {
 			break

--- a/sensor/kubernetes/complianceoperator/updater_test.go
+++ b/sensor/kubernetes/complianceoperator/updater_test.go
@@ -3,6 +3,7 @@ package complianceoperator
 import (
 	"context"
 	"fmt"
+	"maps"
 	"testing"
 	"time"
 
@@ -240,9 +241,7 @@ func (s *UpdaterTestSuite) TestCheckRequiredComplianceCRDsExist() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			modifiedDetectedKinds := make(map[string]bool)
-			for kind, value := range detectedKinds {
-				modifiedDetectedKinds[kind] = value
-			}
+			maps.Copy(modifiedDetectedKinds, detectedKinds)
 
 			tc.modifyDetectedKinds(modifiedDetectedKinds)
 

--- a/sensor/kubernetes/listener/namespace_patcher.go
+++ b/sensor/kubernetes/listener/namespace_patcher.go
@@ -2,6 +2,7 @@ package listener
 
 import (
 	"context"
+	"maps"
 
 	"github.com/pkg/errors"
 
@@ -74,9 +75,7 @@ func (h *namespacePatchHandler) patchNamespaceLabels(ns *v1.Namespace, desiredLa
 	if patchedNS.Labels == nil {
 		patchedNS.Labels = desiredLabels
 	} else {
-		for k, v := range desiredLabels {
-			patchedNS.Labels[k] = v
-		}
+		maps.Copy(patchedNS.Labels, desiredLabels)
 	}
 
 	if patchedNS.Annotations == nil {

--- a/sensor/kubernetes/listener/resources/networkpolicy_store.go
+++ b/sensor/kubernetes/listener/resources/networkpolicy_store.go
@@ -1,6 +1,8 @@
 package resources
 
 import (
+	"maps"
+
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/labels"
 	"github.com/stackrox/rox/pkg/sync"
@@ -112,9 +114,7 @@ func (n *networkPolicyStoreImpl) All() map[string]*storage.NetworkPolicy {
 	// copying map to ensure that the store contents will not be mutated from outside
 	result := make(map[string]*storage.NetworkPolicy)
 	for _, m := range n.data {
-		for k, v := range m {
-			result[k] = v
-		}
+		maps.Copy(result, m)
 	}
 	return result
 }

--- a/sensor/upgrader/runner/metadata_transfer.go
+++ b/sensor/upgrader/runner/metadata_transfer.go
@@ -1,6 +1,8 @@
 package runner
 
 import (
+	"maps"
+
 	"github.com/stackrox/rox/pkg/k8sutil/k8sobjects"
 	"github.com/stackrox/rox/sensor/upgrader/common"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -14,9 +16,7 @@ func transferMetadataMap(oldMap, newMap map[string]string) map[string]string {
 		}
 		result[k] = v
 	}
-	for k, v := range newMap {
-		result[k] = v
-	}
+	maps.Copy(result, newMap)
 	return result
 }
 

--- a/tools/policyutil/command/upgrade.go
+++ b/tools/policyutil/command/upgrade.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 
@@ -364,9 +365,7 @@ func ensureReadOnlySettings(policy *storage.Policy) {
 func ensureMitreVectorSorted(policy *storage.Policy) {
 	for _, vector := range policy.GetMitreAttackVectors() {
 		techniques := vector.GetTechniques()
-		sort.Slice(techniques, func(i, j int) bool {
-			return techniques[i] < techniques[j]
-		})
+		slices.Sort(techniques)
 	}
 
 	vectors := policy.GetMitreAttackVectors()


### PR DESCRIPTION
## Description

Enable `modernize/slicessort` and `modernize/mapsloop` golangci-lint rules and apply the resulting fixes across the codebase.

`sort.Slice(x, func(i, j int) bool { return x[i] < x[j] })` → `slices.Sort(x)` and `for k, v := range src { dst[k] = v }` → `maps.Copy(dst, src)`. Both replacements are semantically identical to the original code. No behavioral changes.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI
