### PR TITLE
chore: Reset MintMaker's `minimumReleaseAge`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,6 +17,8 @@
     // This tells Renovate to combine all updates in one PR so that we have fewer PRs to deal with.
     "group:all",
   ],
+  // Don't apply dependency cooldown because via MintMaker we take only Red Hat dependencies.
+  "minimumReleaseAge":  null,
   // The number of PRs that can be open against the repo.
   "prConcurrentLimit": 20,
   // `null` means the branch limit should be the same as PR limit.


### PR DESCRIPTION
## Description

Context: https://redhat-internal.slack.com/archives/C05TS9N0S7L/p1781600885636809

This change is most likely no-op because `minimumReleaseAge` should have no effect on Dockerfiles when images come from quay.io, should have no effect on Tekton tasks for the same reason, and likely has no effect on lockfiles.
But. I'm not actually sure. Let's just have it than experience delays in opening PRs (and that will be hard to diagnose).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No change.

### How I validated my change

Just ran the validator locally.
