### PR TITLE
ROX-35011: Fix orchestrator version access crash

### DIFF
--- a/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityCluster.jsx
+++ b/ui/apps/platform/src/Containers/ConfigManagement/Entity/ConfigManagementEntityCluster.jsx
@@ -163,7 +163,7 @@ const ConfigManagementEntityCluster = ({
                     status: { orchestratorMetadata = null },
                 } = entity;
 
-                const { version = 'N/A' } = orchestratorMetadata;
+                const { version = 'N/A' } = orchestratorMetadata ?? {};
 
                 const metadataKeyValuePairs = [
                     {

--- a/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtClusterOverview.jsx
+++ b/ui/apps/platform/src/Containers/VulnMgmt/Entity/Cluster/VulnMgmtClusterOverview.jsx
@@ -46,7 +46,7 @@ const VulnMgmtClusterOverview = ({ data, entityContext }) => {
     }
 
     const { orchestratorMetadata = null } = status;
-    const { buildDate = '', version = 'N/A' } = orchestratorMetadata;
+    const { buildDate = '', version = 'N/A' } = orchestratorMetadata ?? {};
 
     function yesNoMaybe(value) {
         if (!value && value !== false) {


### PR DESCRIPTION
## Description

When `cluster.status.orchestratorMetadata` is `null`, pages using this API without a safety check on `version` will crash outright. Although the case of why this happened in a single CI run is unclear, the impact and API contract suggests a clear UI improvement.

Would be prevented in TypeScript files, but alas.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Mock GraphQL response.

Before change, matches exact CI error and happens on the exact same pages affected by this change:
<img width="1530" height="843" alt="image" src="https://github.com/user-attachments/assets/0aa5564e-fb18-42d6-b1d9-3ad68d1e9d1c" />


After change:
<img width="1530" height="843" alt="image" src="https://github.com/user-attachments/assets/7518229e-ed08-4b4f-9d08-dcdaba96a2b5" />

