### PR TITLE
ROX-35080: Add configurable key bundle file path

### DIFF
--- a/central/signatureintegration/datastore/key_bundle.go
+++ b/central/signatureintegration/datastore/key_bundle.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/pem"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -54,9 +52,9 @@ func (kb *keyBundle) toDefaultSignatureIntegration() *storage.SignatureIntegrati
 	}
 }
 
-// redHatKeyBundlePath is the well-known path where the key bundle file is stored.
-// The file downloader writes the bundle here; the file watcher reads it.
-var redHatKeyBundlePath = filepath.Join(os.TempDir(), "redhat-signing-keys", "bundle.json")
+func redHatKeyBundlePath() string {
+	return env.RedHatSigningKeyBundleFilePath.Setting()
+}
 
 func keyBundleHandler(siStore store.SignatureIntegrationStore) filewatcher.Handler {
 	return func(data []byte) error {
@@ -96,7 +94,7 @@ func startKeyBundleWatcher(siStore store.SignatureIntegrationStore) {
 		return
 	}
 
-	w := filewatcher.New(redHatKeyBundlePath, interval, keyBundleHandler(siStore),
+	w := filewatcher.New(redHatKeyBundlePath(), interval, keyBundleHandler(siStore),
 		filewatcher.WithOnError(func(_ error) {
 			watcherFileErrorTotal.Inc()
 		}),

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -64,6 +64,11 @@ func seedRedHatDefaultSignatureIntegration(siStore store.SignatureIntegrationSto
 }
 
 func startKeyBundleUpdater() {
+	if env.OfflineModeEnv.BooleanSetting() {
+		log.Info("In offline mode: Red Hat signing key bundle will not be updated automatically")
+		return
+	}
+
 	rawURL := env.RedHatSigningKeyBundleURL.Setting()
 	if rawURL == "" {
 		log.Info("ROX_REDHAT_SIGNING_KEY_BUNDLE_URL not set, key bundle updater will not start")

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -65,7 +65,7 @@ func seedRedHatDefaultSignatureIntegration(siStore store.SignatureIntegrationSto
 
 func startKeyBundleUpdater() {
 	if env.OfflineModeEnv.BooleanSetting() {
-		log.Info("In offline mode: Red Hat signing key bundle will not be updated automatically")
+		log.Info("Offline mode detected: The Red Hat signing key bundle will not be downloaded automatically. Manual updates are possible by mounting the bundle to the file location specified by ROX_REDHAT_SIGNING_KEY_BUNDLE_FILE_PATH")
 		return
 	}
 

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -65,7 +65,7 @@ func seedRedHatDefaultSignatureIntegration(siStore store.SignatureIntegrationSto
 
 func startKeyBundleUpdater() {
 	if env.OfflineModeEnv.BooleanSetting() {
-		log.Info("Offline mode detected: The Red Hat signing key bundle will not be downloaded automatically. Manual updates are possible by mounting the bundle to the file location specified by ROX_REDHAT_SIGNING_KEY_BUNDLE_FILE_PATH")
+		log.Infof("Offline mode detected: The Red Hat signing key bundle will not be downloaded automatically. Manual updates are possible by mounting the bundle to %q", redHatKeyBundlePath)
 		return
 	}
 

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -65,7 +65,9 @@ func seedRedHatDefaultSignatureIntegration(siStore store.SignatureIntegrationSto
 
 func startKeyBundleUpdater() {
 	if env.OfflineModeEnv.BooleanSetting() {
-		log.Infof("Offline mode detected: The Red Hat signing key bundle will not be downloaded automatically. Manual updates are possible by mounting the bundle to %q", redHatKeyBundlePath)
+		log.Infof("Offline mode detected: The Red Hat signing key bundle will not be downloaded automatically. "+
+			"Manual updates are possible by mounting the bundle to %q (configurable via %s)",
+			redHatKeyBundlePath(), env.RedHatSigningKeyBundleFilePath.EnvVar())
 		return
 	}
 
@@ -78,7 +80,7 @@ func startKeyBundleUpdater() {
 
 	interval := env.RedHatSigningKeyUpdateInterval.DurationSetting()
 
-	u := filedownloader.New(bundleURL, redHatKeyBundlePath, interval,
+	u := filedownloader.New(bundleURL, redHatKeyBundlePath(), interval,
 		filedownloader.WithOnComplete(func(err error, duration time.Duration) {
 			updaterDownloadDuration.Observe(duration.Seconds())
 			if err != nil {

--- a/central/signatureintegration/datastore/singleton_test.go
+++ b/central/signatureintegration/datastore/singleton_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	storeMocks "github.com/stackrox/rox/central/signatureintegration/store/mocks"
+	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/signatures"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
 
@@ -27,4 +29,45 @@ func TestSeedSubsequentStartup(t *testing.T) {
 	mockStore.EXPECT().Get(gomock.Any(), id).Return(signatures.DefaultRedHatSignatureIntegration, true, nil).Times(1)
 
 	seedRedHatDefaultSignatureIntegration(mockStore)
+}
+
+func TestStartKeyBundleUpdaterOfflineMode(t *testing.T) {
+	t.Setenv(env.OfflineModeEnv.EnvVar(), "true")
+	t.Setenv(env.RedHatSigningKeyBundleURL.EnvVar(), "https://example.com/keys.json")
+
+	old := bundleUpdater
+	defer func() { bundleUpdater = old }()
+	bundleUpdater = nil
+
+	startKeyBundleUpdater()
+	assert.Nil(t, bundleUpdater, "updater should not start in offline mode")
+}
+
+func TestStartKeyBundleUpdaterOnlineWithURL(t *testing.T) {
+	t.Setenv(env.OfflineModeEnv.EnvVar(), "false")
+	t.Setenv(env.RedHatSigningKeyBundleURL.EnvVar(), "https://example.com/keys.json")
+
+	old := bundleUpdater
+	defer func() {
+		if bundleUpdater != nil {
+			bundleUpdater.Stop()
+		}
+		bundleUpdater = old
+	}()
+	bundleUpdater = nil
+
+	startKeyBundleUpdater()
+	assert.NotNil(t, bundleUpdater, "updater should start in online mode with URL configured")
+}
+
+func TestStartKeyBundleUpdaterOnlineWithoutURL(t *testing.T) {
+	t.Setenv(env.OfflineModeEnv.EnvVar(), "false")
+	t.Setenv(env.RedHatSigningKeyBundleURL.EnvVar(), "")
+
+	old := bundleUpdater
+	defer func() { bundleUpdater = old }()
+	bundleUpdater = nil
+
+	startKeyBundleUpdater()
+	assert.Nil(t, bundleUpdater, "updater should not start without URL")
 }

--- a/image/rhel/Dockerfile
+++ b/image/rhel/Dockerfile
@@ -76,6 +76,7 @@ RUN \
     mkdir -p /var/lib/stackrox && chown -R 4000:4000 /var/lib/stackrox && \
     mkdir -p /var/log/stackrox && chown -R 4000:4000 /var/log/stackrox && \
     mkdir -p /var/cache/stackrox && chown -R 4000:4000 /var/cache/stackrox && \
+    mkdir -p /run/stackrox.io/redhat-signing-keys && chown -R 4000:4000 /run/stackrox.io/redhat-signing-keys && \
     chown -R 4000:4000 /tmp
 
 COPY --from=stackrox_data /stackrox-data /stackrox/static-data

--- a/pkg/env/signature.go
+++ b/pkg/env/signature.go
@@ -10,6 +10,12 @@ var (
 	// If empty, the key bundle updater does not start.
 	RedHatSigningKeyBundleURL = RegisterSetting("ROX_REDHAT_SIGNING_KEY_BUNDLE_URL", AllowEmpty())
 
+	// RedHatSigningKeyBundleFilePath is the local file path where the key bundle is stored.
+	// The updater writes downloaded bundles here; the watcher polls it for changes.
+	// In offline mode, users can mount a bundle at this path for manual key updates.
+	RedHatSigningKeyBundleFilePath = RegisterSetting("ROX_REDHAT_SIGNING_KEY_BUNDLE_FILE_PATH",
+		WithDefault("/run/stackrox.io/redhat-signing-keys/bundle.json"))
+
 	// RedHatSigningKeyUpdateInterval controls how often the updater re-downloads the bundle.
 	RedHatSigningKeyUpdateInterval = registerDurationSetting("ROX_REDHAT_SIGNING_KEY_UPDATE_INTERVAL", 4*time.Hour)
 


### PR DESCRIPTION
## Description

Add `ROX_REDHAT_SIGNING_KEY_BUNDLE_FILE_PATH` env var to make the Red Hat signing key bundle file path configurable and discoverable. The default path follows the existing `/run/stackrox.io/` convention used by declarative configuration.

Changes:
- New env var in `pkg/env/signature.go` with default `/run/stackrox.io/redhat-signing-keys/bundle.json`
- Replace hardcoded `/tmp/redhat-signing-keys/bundle.json` path in `key_bundle.go` with the env var
- Update offline mode log message to show the path and env var name
- Create the directory at build time in the Dockerfile

This enables offline-mode users to mount key bundles at a well-known, discoverable, and configurable location.

Depends on #21142.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

- Unit tests pass (`go test ./central/signatureintegration/datastore/`)
- Existing tests exercise the env var via `t.Setenv`
- Compilation verified
- In-cluster testing blocked by network degradation; will validate once network recovers