### PR TITLE
ROX-35080: Seed key bundle file on startup

### DIFF
--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -2,6 +2,11 @@ package datastore
 
 import (
 	"context"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -63,6 +68,52 @@ func seedRedHatDefaultSignatureIntegration(siStore store.SignatureIntegrationSto
 	utils.Should(errors.Wrap(err, "seeding default Red Hat signature integration"))
 }
 
+// seedKeyBundleFile writes the embedded key data to the bundle file path if the
+// file does not already exist. This gives the watcher something to poll from the
+// start and provides offline-mode users with a template they can inspect and replace.
+func seedKeyBundleFile() {
+	bundlePath := redHatKeyBundlePath()
+	if _, err := os.Stat(bundlePath); err == nil {
+		log.Debugf("Key bundle file %q already exists, skipping seed", bundlePath)
+		return
+	} else if !errors.Is(err, os.ErrNotExist) {
+		log.Warnf("Cannot stat key bundle path %q (read-only mount?): %v, skipping seed", bundlePath, err)
+		return
+	}
+
+	si := signatures.DefaultRedHatSignatureIntegration
+	bundle := keyBundle{
+		Keys: make([]keyBundleEntry, 0, len(si.GetCosign().GetPublicKeys())),
+	}
+	for _, key := range si.GetCosign().GetPublicKeys() {
+		pemStr := key.GetPublicKeyPemEnc()
+		if block, _ := pem.Decode([]byte(strings.TrimSpace(pemStr))); block != nil {
+			pemStr = string(pem.EncodeToMemory(block))
+		}
+		bundle.Keys = append(bundle.Keys, keyBundleEntry{
+			Name: key.GetName(),
+			PEM:  pemStr,
+		})
+	}
+
+	data, err := json.MarshalIndent(bundle, "", "  ")
+	if err != nil {
+		log.Errorf("Failed to marshal embedded key bundle: %v", err)
+		return
+	}
+	data = append(data, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(bundlePath), 0700); err != nil {
+		log.Errorf("Failed to create key bundle directory: %v", err)
+		return
+	}
+	if err := os.WriteFile(bundlePath, data, 0600); err != nil {
+		log.Errorf("Failed to write key bundle file %q: %v", bundlePath, err)
+		return
+	}
+	log.Infof("Seeded key bundle file %q with %d embedded key(s)", bundlePath, len(bundle.Keys))
+}
+
 func startKeyBundleUpdater() {
 	if env.OfflineModeEnv.BooleanSetting() {
 		log.Infof("Offline mode detected: The Red Hat signing key bundle will not be downloaded automatically. "+
@@ -101,6 +152,7 @@ func Singleton() DataStore {
 	once.Do(func() {
 		storage := pgStore.New(globaldb.GetPostgres())
 		seedRedHatDefaultSignatureIntegration(storage) // must run before watcher; bundle file takes precedence on first tick
+		seedKeyBundleFile()
 		instance = New(storage, policyDataStore.Singleton())
 		startKeyBundleWatcher(storage)
 		startKeyBundleUpdater()

--- a/central/signatureintegration/datastore/singleton_test.go
+++ b/central/signatureintegration/datastore/singleton_test.go
@@ -1,12 +1,16 @@
 package datastore
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	storeMocks "github.com/stackrox/rox/central/signatureintegration/store/mocks"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/signatures"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -58,6 +62,48 @@ func TestStartKeyBundleUpdaterOnlineWithURL(t *testing.T) {
 
 	startKeyBundleUpdater()
 	assert.NotNil(t, bundleUpdater, "updater should start in online mode with URL configured")
+}
+
+func TestSeedKeyBundleFileCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "subdir", "bundle.json")
+	t.Setenv(env.RedHatSigningKeyBundleFilePath.EnvVar(), bundlePath)
+
+	seedKeyBundleFile()
+
+	data, err := os.ReadFile(bundlePath)
+	require.NoError(t, err)
+
+	var bundle keyBundle
+	require.NoError(t, json.Unmarshal(data, &bundle))
+	assert.NotEmpty(t, bundle.Keys, "seeded bundle should contain at least one key")
+
+	expectedKeys := signatures.DefaultRedHatSignatureIntegration.GetCosign().GetPublicKeys()
+	require.Len(t, bundle.Keys, len(expectedKeys))
+	for i, expected := range expectedKeys {
+		assert.Equal(t, expected.GetName(), bundle.Keys[i].Name)
+	}
+
+	// Verify the seeded file passes the watcher's parseKeyBundle validation,
+	// ensuring the PEM is normalized and the format is correct end-to-end.
+	parsed, err := parseKeyBundle(data)
+	require.NoError(t, err, "seeded bundle must be valid per parseKeyBundle")
+	assert.Len(t, parsed.Keys, len(expectedKeys))
+}
+
+func TestSeedKeyBundleFileSkipsExisting(t *testing.T) {
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, "bundle.json")
+	t.Setenv(env.RedHatSigningKeyBundleFilePath.EnvVar(), bundlePath)
+
+	existing := []byte(`{"keys": [{"name": "custom", "pem": "custom-data"}]}`)
+	require.NoError(t, os.WriteFile(bundlePath, existing, 0600))
+
+	seedKeyBundleFile()
+
+	data, err := os.ReadFile(bundlePath)
+	require.NoError(t, err)
+	assert.Equal(t, existing, data, "existing file should not be overwritten")
 }
 
 func TestStartKeyBundleUpdaterOnlineWithoutURL(t *testing.T) {


### PR DESCRIPTION
## Description

On Central startup, write the embedded Red Hat signing key data to the bundle file path if the file does not already exist. This gives the watcher a file to poll from the start and provides offline-mode users with a template they can inspect and replace.

Key design decisions:
- PEM data is normalized (decoded and re-encoded) before writing so the seeded file is byte-identical to what `parseKeyBundle` produces, preventing a spurious DB upsert on the watcher's first tick
- Non-`ErrNotExist` stat errors (e.g. read-only mounts) are handled explicitly with a clear diagnostic message
- Existing files are never overwritten (e.g. manually-mounted bundles)
- Parent directories are created with `MkdirAll` if they don't exist
- Trailing newline appended for POSIX compliance

Depends on #21194.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests

### How I validated my change

- `TestSeedKeyBundleFileCreatesFile`: verifies file creation with subdirectory, content matches embedded keys, and round-trips through `parseKeyBundle` validation
- `TestSeedKeyBundleFileSkipsExisting`: verifies existing files are not overwritten
- All existing tests continue to pass
- In-cluster testing blocked by network degradation; will validate once network recovers