### PR TITLE
fix(test): use tagged image for AC init container test

### DIFF
--- a/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
+++ b/qa-tests-backend/src/test/groovy/AdmissionControllerTest.groovy
@@ -401,7 +401,7 @@ class AdmissionControllerTest extends BaseSpecification {
                 .setImagePrefetcherAffinity()
                 .setImage(BUSYBOX_TAGGED_IMAGE)
                 .addLabel("app", "test")
-                .addInitContainer("init-0", BUSYBOX_LATEST_TAG_IMAGE)
+                .addInitContainer("init-0", BUSYBOX_TAGGED_IMAGE)
                 .addInitContainer("init-1", BUSYBOX_TAGGED_IMAGE)
 
         def created = orchestrator.createDeploymentNoWait(deployment)


### PR DESCRIPTION
## Description

ROX-34953 (#21094) removed the `filterInitContainers()` function from `pkg/booleanpolicy/augmentedobjs/construct.go`, so init containers are now evaluated against policies in the detection pipeline. The Go e2e tests were updated in the same commit, but the Groovy QA test "Verify AC allows deployment with init containers" was missed.

The test creates a deployment with `init-0` using `BUSYBOX_LATEST_TAG_IMAGE` (`:latest`), which now correctly triggers the "Latest tag" enforcement policy and denies the deployment. Changed `init-0` to use `BUSYBOX_TAGGED_IMAGE` so the test validates AC handling of init containers without triggering a policy violation.

Found via [periodic CI failure](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-stackrox-stackrox-master-ocp-4.22-lpMainline-lp-ocp-compat-cr--acs--tests-aws/2066898852429959168).

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] modified existing tests

### How I validated my change

Ran `/test gke-qa-e2e-tests` and `/test ocp-next-candidate-qa-e2e-tests` — both passed.