### PR TITLE
ROX-26851: fix flaky compliance-operator install in CI

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -806,12 +806,12 @@ deploy_optional_e2e_components() {
 install_the_compliance_operator() {
     csv=$(oc get csv -n openshift-compliance -o json | jq ".items[] | select(.metadata.name | test(\"compliance-operator\")).metadata.name")
     if [[ $csv == "" ]]; then
-        # Install from subscription, but point to the upstream images available
-        # in https://github.com/complianceascode/compliance-operator/pkgs/container/compliance-operator.
-        # Similar process as documented in https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-installation.html
+        # Install from the upstream catalog source to avoid flaky failures caused
+        # by the redhat-operators catalog refreshing mid-install (ROX-26851).
         info "Installing the compliance operator"
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/namespace.yaml"
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/catalog-source.yaml"
+        wait_for_catalogsource_ready openshift-marketplace compliance-operator 300
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/operator-group.yaml"
         oc create -f "${ROOT}/tests/e2e/yaml/compliance-operator/subscription.yaml"
         wait_for_object_to_appear openshift-compliance deploy/compliance-operator 900
@@ -1973,6 +1973,33 @@ wait_for_object_to_appear() {
         info "Waiting for $namespace $object to appear"
         sleep "$waitInterval"
     done
+
+    return 0
+}
+
+wait_for_catalogsource_ready() {
+    if [[ "$#" -lt 2 ]]; then
+        die "missing args. usage: wait_for_catalogsource_ready <namespace> <name> [<delay>]"
+    fi
+
+    local namespace="$1"
+    local name="$2"
+    local delay="${3:-300}"
+    local waitInterval=10
+    local tries=$(( delay / waitInterval ))
+    local count=0
+
+    info "Waiting for CatalogSource $namespace/$name to be READY"
+    until [[ "$(oc get catalogsource "$name" -n "$namespace" -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null)" == "READY" ]]; do
+        count=$((count + 1))
+        if [[ $count -ge "$tries" ]]; then
+            info "CatalogSource $namespace/$name did not become READY after $count tries"
+            oc get catalogsource "$name" -n "$namespace" -o yaml || true
+            return 1
+        fi
+        sleep "$waitInterval"
+    done
+    info "CatalogSource $namespace/$name is READY"
 
     return 0
 }

--- a/tests/e2e/yaml/compliance-operator/catalog-source.yaml
+++ b/tests/e2e/yaml/compliance-operator/catalog-source.yaml
@@ -7,4 +7,4 @@ spec:
   displayName: Compliance Operator Upstream
   publisher: github.com/complianceascode/compliance-operator
   sourceType: grpc
-  image: ghcr.io/complianceascode/compliance-operator-catalog:latest
+  image: ghcr.io/complianceascode/compliance-operator-catalog@sha256:b5ad7b09f3fa12d99821b7768d6af54eba02e9328feb71c5aee7624401d5a3e8

--- a/tests/e2e/yaml/compliance-operator/subscription.yaml
+++ b/tests/e2e/yaml/compliance-operator/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: compliance-operator-sub
   namespace: openshift-compliance
 spec:
-  channel: stable
+  channel: alpha
   name: compliance-operator
-  source: redhat-operators
+  source: compliance-operator
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Description

The compliance-operator e2e install fails intermittently because the OLM subscription references `redhat-operators`, whose catalog pod periodically refreshes its index image. If the subscription is created during a refresh window, OLM gets a gRPC `DeadlineExceeded` and keeps retrying until the test's 900-second timeout is exceeded.

A dedicated upstream CatalogSource (`compliance-operator`) was already being created in every CI run but left unused — the subscription was switched to `redhat-operators` in Feb 2024 as a temporary workaround for an upstream crash (PR #10042). That crash is long fixed, but the workaround was never reverted.

This PR:
- Reverts the subscription source to `compliance-operator` (the dedicated upstream catalog) and channel to `alpha` (the only channel upstream publishes).
- Adds `wait_for_catalogsource_ready` to ensure the catalog pod is up and serving gRPC before the subscription is created.
- Pins the catalog image by digest instead of floating with `:latest`, so upstream changes don't introduce unrelated test failures.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

CI-only change (e2e test infrastructure). Validation will happen via the compliance-e2e-tests CI job on this PR and post-merge.