### PR TITLE
ROX-32857: Wait for sync event after reconnection in compliance tests

### DIFF
--- a/sensor/tests/complianceoperator/sync_test.go
+++ b/sensor/tests/complianceoperator/sync_test.go
@@ -166,6 +166,7 @@ func restartAndWaitForHello(t *testing.T, tc *helper.TestContext, centralCaps []
 	tc.RestartFakeCentralConnection(centralCaps...)
 	t.Log("Wait for Hello message")
 	tc.WaitForHello(t, helloMessageTimeout)
+	tc.WaitForSyncEvent(t, 10*time.Second)
 }
 
 func createSyncScanConfigsMessage(scanConfigs ...*central.ApplyComplianceScanConfigRequest) *central.MsgToSensor {


### PR DESCRIPTION
## Description

`restartAndWaitForHello` only waited for the `Hello` handshake :handshake:  but not for reconciliation to complete, causing a race where subsequent messages could arrive before Sensor finished syncing. Every other reconnection test (connection_test, alert_test, crd_test) already waits for `WaitForSyncEvent` after `WaitForHello`.

Partially generated by AI.
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI