### PR TITLE
refactor(central): decouple compliance persistence from watcher

### DIFF
--- a/central/complianceoperator/v2/pipelines/complianceoperatorresultsv2/pipeline.go
+++ b/central/complianceoperator/v2/pipelines/complianceoperatorresultsv2/pipeline.go
@@ -84,11 +84,14 @@ func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 			return errox.NotFound.Newf("cluster with id %q does not exist", clusterID)
 		}
 		result := internaltov2storage.ComplianceOperatorCheckResult(checkResult, clusterID, clusterName)
+		if err := s.v2Datastore.UpsertResult(ctx, result); err != nil {
+			return err
+		}
 		if err := s.reportMgr.HandleResult(ctx, result); err != nil {
 			log.Errorf("unable to handle the check result in the report manager: %v", err)
 			return err
 		}
-		return s.v2Datastore.UpsertResult(ctx, result)
+		return nil
 	}
 }
 

--- a/central/complianceoperator/v2/pipelines/complianceoperatorresultsv2/pipeline_test.go
+++ b/central/complianceoperator/v2/pipelines/complianceoperatorresultsv2/pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pkg/errors"
 	clusterMocks "github.com/stackrox/rox/central/cluster/datastore/mocks"
 	v2ResultMocks "github.com/stackrox/rox/central/complianceoperator/v2/checkresults/datastore/mocks"
 	reportMgrMocks "github.com/stackrox/rox/central/complianceoperator/v2/report/manager/mocks"
@@ -65,42 +66,42 @@ func (suite *PipelineTestSuite) TearDownTest() {
 func (suite *PipelineTestSuite) TestRunCreate() {
 	ctx := context.Background()
 
-	suite.clusterDS.EXPECT().GetClusterName(ctx, fixtureconsts.Cluster1).Return("cluster1", true, nil).Times(1)
-	suite.v2ResultDS.EXPECT().UpsertResult(ctx, getTestRec(fixtureconsts.Cluster1)).Return(nil).Times(1)
-	suite.reportMgr.EXPECT().HandleResult(gomock.Any(), gomock.Any()).Times(1)
+	gomock.InOrder(
+		suite.clusterDS.EXPECT().GetClusterName(ctx, fixtureconsts.Cluster1).Return("cluster1", true, nil).Times(1),
+		suite.v2ResultDS.EXPECT().UpsertResult(ctx, getTestRec(fixtureconsts.Cluster1)).Return(nil).Times(1),
+		suite.reportMgr.EXPECT().HandleResult(gomock.Any(), gomock.Any()).Return(nil).Times(1),
+	)
 	pipeline := NewPipeline(suite.v2ResultDS, suite.clusterDS, suite.reportMgr)
 
-	msg := &central.MsgFromSensor{
-		Msg: &central.MsgFromSensor_Event{
-			Event: &central.SensorEvent{
-				Id:     id,
-				Action: central.ResourceAction_CREATE_RESOURCE,
-				Resource: &central.SensorEvent_ComplianceOperatorResultV2{
-					ComplianceOperatorResultV2: &central.ComplianceOperatorCheckResultV2{
-						Id:           id,
-						CheckId:      checkID,
-						CheckName:    mockCheckRuleName,
-						ClusterId:    fixtureconsts.Cluster1,
-						Status:       central.ComplianceOperatorCheckResultV2_FAIL,
-						Severity:     central.ComplianceOperatorRuleSeverity_HIGH_RULE_SEVERITY,
-						Description:  "this is a test",
-						Instructions: "this is a test",
-						Labels:       nil,
-						Annotations:  nil,
-						CreatedTime:  createdTime,
-						ScanName:     mockScanName,
-						SuiteName:    mockSuiteName,
-						Rationale:    "test rationale",
-						ValuesUsed:   []string{"var1", "var2"},
-						Warnings:     []string{"warning1", "warning2"},
-					},
-				},
-			},
-		},
-	}
-
-	err := pipeline.Run(ctx, fixtureconsts.Cluster1, msg, nil)
+	err := pipeline.Run(ctx, fixtureconsts.Cluster1, getCreateMsg(), nil)
 	suite.NoError(err)
+}
+
+func (suite *PipelineTestSuite) TestRunCreate_HandleResultError() {
+	ctx := context.Background()
+
+	gomock.InOrder(
+		suite.clusterDS.EXPECT().GetClusterName(ctx, fixtureconsts.Cluster1).Return("cluster1", true, nil).Times(1),
+		suite.v2ResultDS.EXPECT().UpsertResult(ctx, getTestRec(fixtureconsts.Cluster1)).Return(nil).Times(1),
+		suite.reportMgr.EXPECT().HandleResult(gomock.Any(), gomock.Any()).Return(errors.New("watcher error")).Times(1),
+	)
+	pipeline := NewPipeline(suite.v2ResultDS, suite.clusterDS, suite.reportMgr)
+
+	err := pipeline.Run(ctx, fixtureconsts.Cluster1, getCreateMsg(), nil)
+	suite.Error(err)
+	suite.Contains(err.Error(), "watcher error")
+}
+
+func (suite *PipelineTestSuite) TestRunCreate_UpsertError() {
+	ctx := context.Background()
+
+	suite.clusterDS.EXPECT().GetClusterName(ctx, fixtureconsts.Cluster1).Return("cluster1", true, nil).Times(1)
+	suite.v2ResultDS.EXPECT().UpsertResult(ctx, getTestRec(fixtureconsts.Cluster1)).Return(errors.New("db error")).Times(1)
+	pipeline := NewPipeline(suite.v2ResultDS, suite.clusterDS, suite.reportMgr)
+
+	err := pipeline.Run(ctx, fixtureconsts.Cluster1, getCreateMsg(), nil)
+	suite.Error(err)
+	suite.Contains(err.Error(), "db error")
 }
 
 func (suite *PipelineTestSuite) TestRunDelete() {
@@ -140,6 +141,37 @@ func (suite *PipelineTestSuite) TestRunDelete() {
 
 	err := pipeline.Run(ctx, fixtureconsts.Cluster1, msg, nil)
 	suite.NoError(err)
+}
+
+func getCreateMsg() *central.MsgFromSensor {
+	return &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     id,
+				Action: central.ResourceAction_CREATE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorResultV2{
+					ComplianceOperatorResultV2: &central.ComplianceOperatorCheckResultV2{
+						Id:           id,
+						CheckId:      checkID,
+						CheckName:    mockCheckRuleName,
+						ClusterId:    fixtureconsts.Cluster1,
+						Status:       central.ComplianceOperatorCheckResultV2_FAIL,
+						Severity:     central.ComplianceOperatorRuleSeverity_HIGH_RULE_SEVERITY,
+						Description:  "this is a test",
+						Instructions: "this is a test",
+						Labels:       nil,
+						Annotations:  nil,
+						CreatedTime:  createdTime,
+						ScanName:     mockScanName,
+						SuiteName:    mockSuiteName,
+						Rationale:    "test rationale",
+						ValuesUsed:   []string{"var1", "var2"},
+						Warnings:     []string{"warning1", "warning2"},
+					},
+				},
+			},
+		},
+	}
 }
 
 func getTestRec(clusterID string) *storage.ComplianceOperatorCheckResultV2 {

--- a/central/complianceoperator/v2/pipelines/complianceoperatorscansv2/pipeline.go
+++ b/central/complianceoperator/v2/pipelines/complianceoperatorscansv2/pipeline.go
@@ -91,11 +91,14 @@ func (s *pipelineImpl) Run(ctx context.Context, clusterID string, msg *central.M
 		return s.v2Datastore.DeleteScan(ctx, event.GetId())
 	default:
 		scan := internaltov2storage.ComplianceOperatorScanObject(complianceScanObject, clusterID)
+		if err := s.v2Datastore.UpsertScan(ctx, scan); err != nil {
+			return err
+		}
 		if err := s.reportMgr.HandleScan(ctx, scan); err != nil {
 			log.Errorf("unable to handle the scan in the report manager: %v", err)
 			return err
 		}
-		return s.v2Datastore.UpsertScan(ctx, scan)
+		return nil
 	}
 }
 

--- a/central/complianceoperator/v2/pipelines/complianceoperatorscansv2/pipeline_test.go
+++ b/central/complianceoperator/v2/pipelines/complianceoperatorscansv2/pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pkg/errors"
 	reportMgrMocks "github.com/stackrox/rox/central/complianceoperator/v2/report/manager/mocks"
 	v2ScanMocks "github.com/stackrox/rox/central/complianceoperator/v2/scans/datastore/mocks"
 	"github.com/stackrox/rox/central/convert/testutils"
@@ -51,8 +52,10 @@ func (s *PipelineTestSuite) TearDownTest() {
 func (s *PipelineTestSuite) TestRunCreate() {
 	ctx := context.Background()
 
-	s.v2ScanDS.EXPECT().UpsertScan(ctx, testutils.GetScanV2Storage(s.T())).Return(nil).Times(1)
-	s.reportMgr.EXPECT().HandleScan(gomock.Any(), gomock.Any()).Times(1)
+	gomock.InOrder(
+		s.v2ScanDS.EXPECT().UpsertScan(ctx, testutils.GetScanV2Storage(s.T())).Return(nil).Times(1),
+		s.reportMgr.EXPECT().HandleScan(gomock.Any(), gomock.Any()).Return(nil).Times(1),
+	)
 
 	msg := &central.MsgFromSensor{
 		Msg: &central.MsgFromSensor_Event{
@@ -68,6 +71,53 @@ func (s *PipelineTestSuite) TestRunCreate() {
 
 	err := s.pipeline.Run(ctx, fixtureconsts.Cluster1, msg, nil)
 	s.NoError(err)
+}
+
+func (s *PipelineTestSuite) TestRunCreate_HandleScanError() {
+	ctx := context.Background()
+
+	gomock.InOrder(
+		s.v2ScanDS.EXPECT().UpsertScan(ctx, testutils.GetScanV2Storage(s.T())).Return(nil).Times(1),
+		s.reportMgr.EXPECT().HandleScan(gomock.Any(), gomock.Any()).Return(errors.New("watcher error")).Times(1),
+	)
+
+	msg := &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     testutils.ScanUID,
+				Action: central.ResourceAction_CREATE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorScanV2{
+					ComplianceOperatorScanV2: testutils.GetScanV2SensorMsg(s.T()),
+				},
+			},
+		},
+	}
+
+	err := s.pipeline.Run(ctx, fixtureconsts.Cluster1, msg, nil)
+	s.Error(err)
+	s.Contains(err.Error(), "watcher error")
+}
+
+func (s *PipelineTestSuite) TestRunCreate_UpsertError() {
+	ctx := context.Background()
+
+	s.v2ScanDS.EXPECT().UpsertScan(ctx, testutils.GetScanV2Storage(s.T())).Return(errors.New("db error")).Times(1)
+
+	msg := &central.MsgFromSensor{
+		Msg: &central.MsgFromSensor_Event{
+			Event: &central.SensorEvent{
+				Id:     testutils.ScanUID,
+				Action: central.ResourceAction_CREATE_RESOURCE,
+				Resource: &central.SensorEvent_ComplianceOperatorScanV2{
+					ComplianceOperatorScanV2: testutils.GetScanV2SensorMsg(s.T()),
+				},
+			},
+		},
+	}
+
+	err := s.pipeline.Run(ctx, fixtureconsts.Cluster1, msg, nil)
+	s.Error(err)
+	s.Contains(err.Error(), "db error")
 }
 
 func (s *PipelineTestSuite) TestRunDelete() {


### PR DESCRIPTION
## Description

### Problem

The compliance scan and result pipelines call `HandleScan`/`HandleResult` (report manager watcher notification) **before** `UpsertScan`/`UpsertResult` (database persistence). If the watcher returns any error, the pipeline short-circuits and the data is never persisted.

The watcher exists for report generation tracking, not data validation. But errors like "scan not handled by any known scan configuration", "the watcher is stopped", and `ErrScanAlreadyHandled` are not transient DB errors, so the worker queue permanently drops the message. Valid compliance data from secured clusters is lost.

### What this PR does

Swaps the order in both pipelines: persist first, then notify the watcher. Watcher error semantics are preserved (still propagated to the caller, still logged). The only behavioral difference is that data is in the database before the watcher is consulted.

A natural follow-up is making watcher errors non-fatal (log instead of return), so the worker queue no longer drops the message either. This PR is intentionally scoped to the order swap only.

### Why the order swap is safe

- Neither `HandleScan` nor `HandleResult` mutate the scan/result objects — they read fields and send pointers into watcher channels.
- `HandleScan` does not depend on the scan being in the scan datastore — it queries `scanConfigDataStore` and `snapshotDataStore`.
- `HandleResult` depends on the **scan** (not the result) being in the scan datastore, which is unaffected by the result pipeline's order change.
- `UpsertScan`/`UpsertResult` are idempotent (`INSERT ... ON CONFLICT DO UPDATE`).
- The REMOVE_RESOURCE case already follows the persist-first pattern: `HandleScanRemove` errors are logged but not returned, then `DeleteScan` always runs. This PR makes CREATE/UPDATE consistent with REMOVE.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- All pipeline unit tests pass (scan and result pipelines)
- Report manager unit tests pass (no regressions)
- New tests verify ordering with `gomock.InOrder` (UpsertScan/UpsertResult before HandleScan/HandleResult)
- New tests verify error scenarios: watcher error after successful persistence, and upsert error short-circuiting before watcher notification

### Cluster verification

Deployed the patched central to an OCP 4.22 cluster (ga-ocp4-cron) with sensor on a second cluster (ga-ocp4-cron-2) running Compliance Operator v1.9.0.

After triggering CIS compliance scans, **240 check results were persisted to the database** despite the watcher returning `"this scan is not handled by any known scan configuration"` errors for all events. Central logs confirm the new behavior:

```
pipeline.go:91: Error: unable to handle the check result in the report manager: this scan is not handled by any known scan configuration
worker_queue.go:96: Error: Unretryable error found while handling sensor message *central.SensorEvent_ComplianceOperatorResultV2 permanently
```

Before this change, those 240 results would NOT have been persisted — the watcher error would have short-circuited before `UpsertResult` was called. Now `UpsertResult` runs first (data persisted), then `HandleResult` fails (logged, error propagated to worker queue).