### PR TITLE
ROX-34160: mapper getimage merge names

### DIFF
--- a/central/imagev2/datastore/mapper/datastore/datastore_impl.go
+++ b/central/imagev2/datastore/mapper/datastore/datastore_impl.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	imageDatastore "github.com/stackrox/rox/central/image/datastore"
 	imageV2Datastore "github.com/stackrox/rox/central/imagev2/datastore"
 	v1 "github.com/stackrox/rox/generated/api/v1"
@@ -117,7 +118,7 @@ func (ds *datastoreImpl) GetImage(ctx context.Context, sha string) (*storage.Ima
 	}
 	allNames, err := ds.imageV2DataStore.GetImageNames(ctx, sha)
 	if err != nil {
-		return imageUtils.ConvertToV1(images[0]), true, nil
+		return nil, false, errors.Wrap(err, "getting image names")
 	}
 	return imageUtils.ConvertToV1(images[0], allNames...), true, nil
 }

--- a/central/imagev2/datastore/mapper/datastore/datastore_impl.go
+++ b/central/imagev2/datastore/mapper/datastore/datastore_impl.go
@@ -115,7 +115,11 @@ func (ds *datastoreImpl) GetImage(ctx context.Context, sha string) (*storage.Ima
 	if len(images) == 0 {
 		return nil, false, nil
 	}
-	return imageUtils.ConvertToV1(images[0]), true, nil
+	allNames, err := ds.imageV2DataStore.GetImageNames(ctx, sha)
+	if err != nil {
+		return imageUtils.ConvertToV1(images[0]), true, nil
+	}
+	return imageUtils.ConvertToV1(images[0], allNames...), true, nil
 }
 
 func (ds *datastoreImpl) GetImageMetadata(ctx context.Context, id string) (*storage.Image, bool, error) {

--- a/central/imagev2/datastore/mapper/datastore/datastore_impl_test.go
+++ b/central/imagev2/datastore/mapper/datastore/datastore_impl_test.go
@@ -1,0 +1,59 @@
+//go:build sql_integration
+
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackrox/rox/generated/storage"
+	"github.com/stackrox/rox/pkg/features"
+	"github.com/stackrox/rox/pkg/postgres/pgtest"
+	"github.com/stackrox/rox/pkg/sac"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetImage_MergesAllNamesWhenMultipleV2ImagesShareDigest(t *testing.T) {
+	if !features.FlattenImageData.Enabled() {
+		t.Setenv("ROX_FLATTEN_IMAGE_DATA", "true")
+	}
+	ctx := sac.WithAllAccess(context.Background())
+	testDB := pgtest.ForT(t)
+	ds := GetTestPostgresDataStore(t, testDB.DB).(*datastoreImpl)
+
+	digest := "sha256:abcdef1234567890"
+
+	imageA := &storage.Image{
+		Id: digest,
+		Name: &storage.ImageName{
+			Registry: "quay.io",
+			Remote:   "repo-a/image",
+			Tag:      "latest",
+			FullName: "quay.io/repo-a/image:latest",
+		},
+	}
+	imageB := &storage.Image{
+		Id: digest,
+		Name: &storage.ImageName{
+			Registry: "quay.io",
+			Remote:   "repo-b/image",
+			Tag:      "v1",
+			FullName: "quay.io/repo-b/image:v1",
+		},
+	}
+
+	require.NoError(t, ds.UpsertImage(ctx, imageA))
+	require.NoError(t, ds.UpsertImage(ctx, imageB))
+
+	result, found, err := ds.GetImage(ctx, digest)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	var fullNames []string
+	for _, n := range result.GetNames() {
+		fullNames = append(fullNames, n.GetFullName())
+	}
+	assert.Contains(t, fullNames, imageA.GetName().GetFullName())
+	assert.Contains(t, fullNames, imageB.GetName().GetFullName())
+}


### PR DESCRIPTION
  ## Description

  The V2 mapper's `GetImage(sha)` returns `images[0]` arbitrarily when multiple V2 images share a digest. The returned V1 image contains only  one name, so signature verification policy evaluation fails — `VerifiedImageReferences` is matched by exact string against  `containerImageFullName`, and the missing name causes the violation to persist.

  Root cause of flaky `ImageSignatureVerificationTest` on the `SAME_DIGEST | SAME_DIGEST_WITH_SIGNATURE | false` case.

  **Fix:** Call `GetImageNames` for the digest and pass all names to `ConvertToV1`, matching the existing pattern in `internalScanRespFromImageV2` (`central/image/service/service_impl.go:268`).

  **Alternative considered:** Merging all V2 records into a single V1 image inline — rejected because `GetImageNames` already exists for this purpose and is used elsewhere.

  ## User-facing documentation

  - [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
  - [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked  above **OR** is not needed

  ## Testing and quality

  - [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the
  functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
  - [ ] CI results are
  [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

  ### Automated testing

  - [x] added unit tests
  - [ ] added e2e tests
  - [ ] added regression tests
  - [ ] added compatibility tests
  - [x] modified existing tests

  ### How I validated my change

  - Postgres integration test (`sql_integration` tag) upserts two V2 images with the same digest but different names, calls `GetImage(sha)`,
  asserts both names are present. Confirmed failing before fix, passing after.
  - E2E test changes (dedup + timeout) are defensive hardening — full validation requires CI run of `ImageSignatureVerificationTest`.