### PR TITLE
feat(CI): retest gha support

### DIFF
--- a/.github/workflows/e2e-byodb-test.yaml
+++ b/.github/workflows/e2e-byodb-test.yaml
@@ -17,6 +17,13 @@ defaults:
     shell: bash
 
 jobs:
+  fail-for-retest-verification:
+    # TODO: Remove this job — temporary failure to verify auto-retest GHA support
+    runs-on: ubuntu-latest
+    steps:
+    - name: Deliberate failure
+      run: exit 1
+
   wait-for-images:
     if: >-
       !github.event.pull_request.head.repo.fork && (

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -18,6 +18,13 @@ defaults:
     shell: bash
 
 jobs:
+  fail-for-retest-verification:
+    # TODO: Remove this job — temporary failure to verify auto-retest GHA support
+    runs-on: ubuntu-latest
+    steps:
+    - name: Deliberate failure
+      run: exit 1
+
   wait-for-images:
     if: >-
       github.event_name == 'push' || !github.event.pull_request.head.repo.fork

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -18,6 +18,13 @@ defaults:
     shell: bash
 
 jobs:
+  fail-for-retest-verification:
+    # TODO: Remove this job — temporary failure to verify auto-retest GHA support
+    runs-on: ubuntu-latest
+    steps:
+    - name: Deliberate failure
+      run: exit 1
+
   wait-for-images:
     if: >-
       github.event_name == 'push' || !github.event.pull_request.head.repo.fork

--- a/tools/retest/github.go
+++ b/tools/retest/github.go
@@ -85,6 +85,42 @@ func checksForCommit(ctx context.Context, client *github.Client, lastCommit stri
 	return result, nil
 }
 
+type failedWorkflowRun struct {
+	ID   int64
+	Name string
+}
+
+func failedGHAWorkflowRuns(ctx context.Context, client *github.Client, headSHA string) ([]failedWorkflowRun, error) {
+	runs, _, err := client.Actions.ListRepositoryWorkflowRuns(ctx, s, s, &github.ListWorkflowRunsOptions{
+		HeadSHA: headSHA,
+		Event:   "pull_request",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var failed []failedWorkflowRun
+	for _, run := range runs.WorkflowRuns {
+		if run.GetStatus() == "completed" && run.GetConclusion() == "failure" {
+			failed = append(failed, failedWorkflowRun{
+				ID:   run.GetID(),
+				Name: run.GetName(),
+			})
+		}
+	}
+	return failed, nil
+}
+
+func rerunFailedWorkflows(ctx context.Context, client *github.Client, prNumber int, runs []failedWorkflowRun) {
+	for _, run := range runs {
+		log.Printf("#%d rerunning failed GHA workflow %q (run %d)", prNumber, run.Name, run.ID)
+		_, err := client.Actions.RerunFailedJobsByID(ctx, s, s, run.ID)
+		if err != nil {
+			log.Printf("#%d could not rerun workflow %q: %v", prNumber, run.Name, err)
+		}
+	}
+}
+
 type Status struct {
 	Context   string    `json:"context"`
 	State     string    `json:"state"`

--- a/tools/retest/main.go
+++ b/tools/retest/main.go
@@ -16,7 +16,10 @@ import (
 
 // allowedCheckFailures defines a set of PR checks that should not prevent the retest job starting
 var allowedCheckFailures = map[string]struct{}{
-	"codecov/patch": {},
+	"codecov/patch":              {},
+	"e2e-byodb-test":             {},
+	"e2e-nongroovy-tests":        {},
+	"e2e-db-backup-restore-test": {},
 }
 
 const s = "stackrox"
@@ -95,13 +98,30 @@ issues:
 		log.Printf("#%d jobs to retest: %s", prNumber, strings.Join(jobsToRetest, ", "))
 		newComments := commentsToCreate(statuses, jobsToRetest, shouldRetestFailedStatuses(statuses, userComments))
 		createComment(ctx, client, prNumber, strings.Join(newComments, "\n"))
+
+		failedRuns, err := failedGHAWorkflowRuns(ctx, client, prDetails.GetHead().GetSHA())
+		if err != nil {
+			log.Printf("#%d could not get GHA workflow runs: %v", prNumber, err)
+			continue
+		}
+		runsToRerun := ghaRunsToRerun(failedRuns, userComments)
+		if len(runsToRerun) > 0 {
+			rerunFailedWorkflows(ctx, client, prNumber, runsToRerun)
+			var rerunComments []string
+			for _, run := range runsToRerun {
+				rerunComments = append(rerunComments,
+					fmt.Sprintf(":arrows_counterclockwise: Rerunning failed GitHub Actions workflow: %s (run %d)", run.Name, run.ID))
+			}
+			createComment(ctx, client, prNumber, strings.Join(rerunComments, "\n"))
+		}
 	}
 	return nil
 }
 
 var (
-	restestNTimes = regexp.MustCompile(`/retest-times\s+(\d+)\s+(.*)`)
-	testJob       = regexp.MustCompile(`/test\s+(.*)`)
+	restestNTimes   = regexp.MustCompile(`/retest-times\s+(\d+)\s+(.*)`)
+	testJob         = regexp.MustCompile(`/test\s+(.*)`)
+	ghaRerunComment = regexp.MustCompile(`:arrows_counterclockwise: Rerunning failed GitHub Actions workflow: .+ \(run (\d+)\)`)
 )
 
 func commentsToCreate(statuses map[string]string, jobsToRetest []string, shouldRetest bool) []string {
@@ -172,7 +192,34 @@ func jobsToRetestFromComments(userComments, allComments []string) ([]string, err
 	return missingTests, nil
 }
 
-const retestComment = "/retest"
+const (
+	retestComment = "/retest"
+	maxGHARetries = 3
+)
+
+func ghaRunsToRerun(failedRuns []failedWorkflowRun, botComments []string) []failedWorkflowRun {
+	rerunCounts := map[int64]int{}
+	for _, c := range botComments {
+		match := ghaRerunComment.FindStringSubmatch(c)
+		if len(match) == 2 {
+			runID, err := strconv.ParseInt(match[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			rerunCounts[runID]++
+		}
+	}
+
+	var result []failedWorkflowRun
+	for _, run := range failedRuns {
+		if rerunCounts[run.ID] >= maxGHARetries {
+			log.Printf("GHA workflow %q (run %d) already rerun %d times, skipping", run.Name, run.ID, rerunCounts[run.ID])
+			continue
+		}
+		result = append(result, run)
+	}
+	return result
+}
 
 func shouldRetestFailedStatuses(statuses map[string]string, comments []string) bool {
 	retested := 0

--- a/tools/retest/main_integration_test.go
+++ b/tools/retest/main_integration_test.go
@@ -164,6 +164,9 @@ func TestIntegration(t *testing.T) {
 			assert.NoError(t, err)
 		case "/repos/stackrox/stackrox/pulls/404":
 			http.NotFound(w, r)
+		case `/repos/stackrox/stackrox/actions/runs?event=pull_request&head_sha=6dcb09b5b57875f334f61aebed695e2e4193db5e`:
+			_, err := w.Write([]byte(`{"total_count": 0, "workflow_runs": []}`))
+			assert.NoError(t, err)
 		case `/repos/stackrox/stackrox/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e/check-runs?filter=latest&status=completed`:
 			_, err := w.Write([]byte(`{
  "total_count": 2,
@@ -206,6 +209,67 @@ func TestIntegration(t *testing.T) {
 	err = run(context.Background(), client)
 	assert.NoError(t, err)
 
+}
+
+func TestIntegrationGHARerun(t *testing.T) {
+	rerunCalled := false
+	var server *httptest.Server
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("%s %s", r.Method, r.RequestURI)
+		if r.Method == http.MethodPost {
+			switch r.RequestURI {
+			case "/repos/stackrox/stackrox/actions/runs/12345/rerun-failed-jobs":
+				rerunCalled = true
+				w.WriteHeader(http.StatusCreated)
+			case "/repos/stackrox/stackrox/issues/10/comments":
+				b, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+				assert.JSONEq(t, `{"body":":arrows_counterclockwise: Rerunning failed GitHub Actions workflow: build (run 12345)"}`, string(b))
+				_, err = w.Write([]byte(`{"html_url": "some url"}`))
+				assert.NoError(t, err)
+			default:
+				assert.Failf(t, "unexpected POST", r.RequestURI)
+			}
+			return
+		}
+		switch r.RequestURI {
+		case `/search/issues?q=repo%3Astackrox%2Fstackrox+label%3Aauto-retest+state%3Aopen+type%3Apr`:
+			_, err := w.Write([]byte(`{"total_count": 1, "items": [{"number": 10, "html_url": "https://github.com/stackrox/stackrox/pull/10"}]}`))
+			assert.NoError(t, err)
+		case "/user":
+			_, err := w.Write([]byte(`{"login": "bot", "html_url": "https://github.com/bot"}`))
+			assert.NoError(t, err)
+		case "/repos/stackrox/stackrox/pulls/10":
+			_, err := w.Write([]byte(`{"number": 10, "head": {"sha": "abc123"}, "statuses_url": "` + server.URL + `/repos/stackrox/stackrox/statuses/abc123"}`))
+			assert.NoError(t, err)
+		case "/repos/stackrox/stackrox/issues/10/comments?direction=asc&sort=created":
+			_, err := w.Write([]byte(`[]`))
+			assert.NoError(t, err)
+		case `/repos/stackrox/stackrox/commits/abc123/check-runs?filter=latest&status=completed`:
+			_, err := w.Write([]byte(`{"total_count": 0, "check_runs": []}`))
+			assert.NoError(t, err)
+		case `/repos/stackrox/stackrox/statuses/abc123`:
+			_, err := w.Write([]byte(`[]`))
+			assert.NoError(t, err)
+		case `/repos/stackrox/stackrox/actions/runs?event=pull_request&head_sha=abc123`:
+			_, err := w.Write([]byte(`{"total_count": 1, "workflow_runs": [{"id": 12345, "name": "build", "status": "completed", "conclusion": "failure"}]}`))
+			assert.NoError(t, err)
+		default:
+			assert.Failf(t, "unexpected GET", r.RequestURI)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+	server = httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	client := github.NewClient(server.Client())
+	baseURL, err := url.Parse(server.URL + "/")
+	assert.NoError(t, err)
+	client.BaseURL = baseURL
+
+	err = run(context.Background(), client)
+	assert.NoError(t, err)
+	assert.True(t, rerunCalled, "RerunFailedJobsByID should have been called")
 }
 
 //go:embed testdata/statuses.json

--- a/tools/retest/main_test.go
+++ b/tools/retest/main_test.go
@@ -377,6 +377,82 @@ func Test_commentsToCreate(t *testing.T) {
 	}
 }
 
+func Test_ghaRunsToRerun(t *testing.T) {
+	tests := map[string]struct {
+		failedRuns  []failedWorkflowRun
+		botComments []string
+		want        []failedWorkflowRun
+	}{
+		"nil": {
+			want: nil,
+		},
+		"no prior reruns": {
+			failedRuns: []failedWorkflowRun{
+				{ID: 100, Name: "build"},
+			},
+			want: []failedWorkflowRun{
+				{ID: 100, Name: "build"},
+			},
+		},
+		"one prior rerun, still under limit": {
+			failedRuns: []failedWorkflowRun{
+				{ID: 100, Name: "build"},
+			},
+			botComments: []string{
+				":arrows_counterclockwise: Rerunning failed GitHub Actions workflow: build (run 100)",
+			},
+			want: []failedWorkflowRun{
+				{ID: 100, Name: "build"},
+			},
+		},
+		"at max retries": {
+			failedRuns: []failedWorkflowRun{
+				{ID: 100, Name: "build"},
+			},
+			botComments: []string{
+				":arrows_counterclockwise: Rerunning failed GitHub Actions workflow: build (run 100)",
+				":arrows_counterclockwise: Rerunning failed GitHub Actions workflow: build (run 100)",
+				":arrows_counterclockwise: Rerunning failed GitHub Actions workflow: build (run 100)",
+			},
+			want: nil,
+		},
+		"mixed runs, one exhausted": {
+			failedRuns: []failedWorkflowRun{
+				{ID: 100, Name: "build"},
+				{ID: 200, Name: "unit-tests"},
+			},
+			botComments: []string{
+				":arrows_counterclockwise: Rerunning failed GitHub Actions workflow: build (run 100)",
+				":arrows_counterclockwise: Rerunning failed GitHub Actions workflow: build (run 100)",
+				":arrows_counterclockwise: Rerunning failed GitHub Actions workflow: build (run 100)",
+				":arrows_counterclockwise: Rerunning failed GitHub Actions workflow: unit-tests (run 200)",
+			},
+			want: []failedWorkflowRun{
+				{ID: 200, Name: "unit-tests"},
+			},
+		},
+		"unrelated comments ignored": {
+			failedRuns: []failedWorkflowRun{
+				{ID: 100, Name: "build"},
+			},
+			botComments: []string{
+				"/retest",
+				"/test some-prow-job",
+				"some random comment",
+			},
+			want: []failedWorkflowRun{
+				{ID: 100, Name: "build"},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := ghaRunsToRerun(tt.failedRuns, tt.botComments)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func Test_splitMultilineComment(t *testing.T) {
 	tests := []struct {
 		comment string


### PR DESCRIPTION
## Description

The auto-retester only supported Prow jobs via /retest comments.
As CI migrates to GitHub Actions, failed GHA workflows need direct
API-based reruns via RerunFailedJobsByID since comment triggers
don't work for GHA.

Also adds e2e test workflows to allowedCheckFailures so their
failures don't block retesting of other jobs.
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

<!--
Use this space to explain **how you validated** that **your change functions
exactly how you expect it**. Feel free to attach JSON snippets, curl commands,
screenshots, etc. Apply a simple benchmark: would the information you provided
convince any reviewer or any external reader that you did enough to validate
your change.

It is acceptable to assume trust and keep this section light, e.g. as a
bullet-point list.

It is acceptable to skip testing in cases when CI is sufficient, or it's a
markdown or code comment change only. It is also acceptable to skip testing for
changes that are too taxing to test before merging. In such case you are
responsible for the change after it gets merged which includes reverting,
fixing, etc. Make sure you validate the change ASAP after it gets merged or
explain in PR when the validation will be performed. Explain here why you
skipped testing in case you did so.

Have you created automated tests for your change? Explain here which validation
activities you did manually and why so.
-->

change me!
