### PR TITLE
ROX-34939: hold GC lock during bundle import

### DIFF
--- a/scanner/matcher/updater/vuln/updater.go
+++ b/scanner/matcher/updater/vuln/updater.go
@@ -470,9 +470,18 @@ func (u *Updater) updateBundle(ctx context.Context, zipF *zip.File, zipTime time
 		return nil
 	}
 
+	// Acquire the GC lock to prevent concurrent garbage collection from
+	// deleting vuln rows while we insert uo_vuln references to them.
+	gcCtx, gcDone := u.locker.TryLock(lCtx, gcName)
+	defer gcDone()
+	if err := gcCtx.Err(); err != nil {
+		slog.InfoContext(ctx, "skipping: GC is running", "reason", err)
+		return nil
+	}
+
 	// Ensure there is an update timestamp for this bundle, and check if it's newer
 	// than this update.
-	lastTime, err := u.metadataStore.GetOrSetLastVulnerabilityUpdate(lCtx, zipF.Name, prevTime)
+	lastTime, err := u.metadataStore.GetOrSetLastVulnerabilityUpdate(gcCtx, zipF.Name, prevTime)
 	if err != nil {
 		return fmt.Errorf("querying last update: %w", err)
 	}
@@ -495,11 +504,11 @@ func (u *Updater) updateBundle(ctx context.Context, zipF *zip.File, zipTime time
 	}
 	defer dec.Close()
 
-	if err := u.importFunc(lCtx, dec); err != nil {
+	if err := u.importFunc(gcCtx, dec); err != nil {
 		return fmt.Errorf("importing vulnerabilities: %w", err)
 	}
 
-	err = u.metadataStore.SetLastVulnerabilityUpdate(lCtx, zipF.Name, zipTime)
+	err = u.metadataStore.SetLastVulnerabilityUpdate(gcCtx, zipF.Name, zipTime)
 	if err != nil {
 		return fmt.Errorf("updating timestamp (import was successful): %w", err)
 	}

--- a/scanner/matcher/updater/vuln/updater_test.go
+++ b/scanner/matcher/updater/vuln/updater_test.go
@@ -370,6 +370,68 @@ func TestIsBundleAllowed(t *testing.T) {
 	}
 }
 
+func TestUpdateBundleSkipsWhenGCLockHeld(t *testing.T) {
+	srv, now := testHTTPServer(t, func(r *http.Request) io.ReadSeeker {
+		var buf bytes.Buffer
+		zipWriter := zip.NewWriter(&buf)
+		w, err := zipWriter.Create("bundles/test.json.zst")
+		require.NoError(t, err)
+		_, err = w.Write([]byte("fake"))
+		require.NoError(t, err)
+		require.NoError(t, zipWriter.Close())
+		return bytes.NewReader(buf.Bytes())
+	})
+
+	locker := &testLocker{
+		locker: updates.NewLocalLockSource(),
+	}
+	store := mocks.NewMockMatcherStore(gomock.NewController(t))
+	metadataStore := mocks.NewMockMatcherMetadataStore(gomock.NewController(t))
+	u := &Updater{
+		locker:        locker,
+		store:         store,
+		metadataStore: metadataStore,
+		client:        srv.Client(),
+		urls:          []string{srv.URL},
+		root:          t.TempDir(),
+		skipGC:        true,
+		importFunc:    func(_ context.Context, _ io.Reader) error { return nil },
+		retryDelay:    1 * time.Second,
+		retryMax:      1,
+		distManager:   newDistManager(store),
+	}
+
+	// Hold the GC lock before updating.
+	gcCtx, gcDone := locker.Lock(context.Background(), gcName)
+	require.NoError(t, gcCtx.Err())
+	defer gcDone()
+
+	// The update should fetch the zip but skip every bundle because the
+	// GC lock is held. No store calls (UpdateVulnerabilitiesIter, etc.)
+	// should be made for the bundle.
+	gomock.InOrder(
+		// runMultiBundleUpdate: get previous update time
+		metadataStore.EXPECT().
+			GetLastVulnerabilityUpdate(gomock.Any()).
+			Return(now.Add(-time.Minute), nil),
+		// runMultiBundleUpdate: clean deleted updaters
+		metadataStore.EXPECT().
+			GCVulnerabilityUpdates(gomock.Any(), gomock.Any(), now).
+			Return(nil),
+		// distManager.update
+		store.EXPECT().
+			Distributions(gomock.Any()).
+			Return(nil, nil),
+		// Initialized check
+		metadataStore.EXPECT().
+			GetLastVulnerabilityUpdate(gomock.Any()).
+			Return(now, nil),
+	)
+
+	err := u.Update(test.Logging(t))
+	assert.NoError(t, err)
+}
+
 func TestIsRetryableDialError(t *testing.T) {
 	testCases := map[string]struct {
 		err  error


### PR DESCRIPTION
## Description

`updateBundle` and `runGCFullPeriodic` run concurrently on separate goroutines with different locks (bundle name vs `"garbage-collection"`). When GC overlaps with a long-running bundle import, it can delete a `vuln` row between the `INSERT vuln ON CONFLICT DO NOTHING` no-op and the `INSERT uo_vuln` FK check, causing `SQLSTATE 23503`. Once triggered, the error repeats every update cycle and the affected bundle stops updating.

`updateBundle` now acquires the GC lock before importing. If GC is already running, the update skips and retries next cycle. This makes GC and bundle imports mutually exclusive without changing claircore.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Reproduced the race against a local restore of the production `scanner-v4-db`
  dump using a SQL script with `dblink` to simulate the concurrent GC goroutine.
- Without the fix: GC acquires the lock (no contention), deletes the vuln row,
  updater's `INSERT uo_vuln` fails with `SQLSTATE 23503`.
- With the fix: updater holds the GC lock, GC's `TryLock` fails, vuln row stays
  intact, `INSERT uo_vuln` succeeds.
- Added `TestUpdateBundleSkipsWhenGCLockHeld` to verify that when the GC lock is
  already held, `updateBundle` skips the import without calling store methods.

For the LLM enthusiasts, here's a replication of the problem and fix within SQL, which is how I did a lot of the initial discovery and troubleshoting:
<details>
<summary>repro-race-combined.sql</summary>

```sql
SET client_min_messages TO notice;

-- =============================================================
-- GC/update race: reproduction and fix validation
-- =============================================================
--
-- This script reproduces the FK violation that blocks rhel-vex
-- vulnerability updates, then shows that acquiring the GC lock
-- before starting the batch prevents the race.
--
-- It runs the same sequence twice: once without the fix (GC
-- deletes the vuln, updater fails) and once with it (GC is
-- blocked, updater succeeds). The only difference between the
-- two runs is whether the updater acquires the GC lock in step 1.
--
-- Prerequisites:
--   - Restore the scanner-v4 database dump into a local PostgreSQL.
--   - CREATE EXTENSION IF NOT EXISTS dblink;
--
-- How to run:
--   cat repro-race-combined.sql | psql -h localhost -U postgres -f-
--
-- Expected output:
--   === Without fix ===
--   UPDATER: INSERT vuln ON CONFLICT DO NOTHING -- no-op
--   GC: TryLock = t -- acquired, proceeding with cleanup
--   GC: deleted uo_vuln refs -- DELETE 1
--   GC: deleted vuln row -- DELETE 1
--   UPDATER: INSERT uo_vuln -- FAILED (vuln deleted by GC)
--   CLEANUP: done
--
--   === With fix ===
--   UPDATER: acquired GC lock
--   UPDATER: INSERT vuln ON CONFLICT DO NOTHING -- no-op
--   GC: TryLock = f -- lock held by updater, skipping
--   UPDATER: INSERT uo_vuln -- succeeded (no race)
--   UPDATER: released GC lock
--   CLEANUP: done

-- Helper: runs a single test with use_fix = true or false.
-- The body is identical either way; only step 1 and step 5 change.
CREATE OR REPLACE FUNCTION _repro_race(use_fix boolean) RETURNS void
LANGUAGE plpgsql AS $fn$
DECLARE
    v_id bigint := 336108331;
    v_hash bytea := '\x1245ee253781d56be90903b6edf220d5';
    uo_new bigint := 11358;
    gc_conn text := 'gc_session';
    gc_result text;
    gc_lock_key bigint := 99999;
    got_lock boolean;
BEGIN
    PERFORM dblink_connect(gc_conn, 'dbname=postgres host=localhost user=postgres');

    -- ---------------------------------------------------------------
    -- Step 1. UPDATER: begin update
    --
    -- THE FIX: acquire the GC lock here so GC cannot run concurrently.
    -- Without the fix, this step is empty and GC is free to overlap.
    --
    -- In the code, this maps to adding a TryLock on gcName in
    -- updateBundle() (scanner/matcher/updater/vuln/updater.go).
    -- ---------------------------------------------------------------
    IF use_fix THEN
        PERFORM pg_advisory_lock(gc_lock_key);
        RAISE NOTICE 'UPDATER: acquired GC lock';
    END IF;

    -- ---------------------------------------------------------------
    -- Step 2. UPDATER: INSERT vuln ON CONFLICT DO NOTHING
    --
    -- First statement in each (insert, assoc) pair that claircore
    -- batches in updateVulnerabilities. The vuln already exists
    -- from a prior update, so the INSERT is a no-op.
    -- ---------------------------------------------------------------
    INSERT INTO vuln (hash_kind, hash, updater, name)
    VALUES ('md5', v_hash, 'rhel-vex', 'CVE-2023-26159')
    ON CONFLICT (hash_kind, hash) DO NOTHING;
    RAISE NOTICE 'UPDATER: INSERT vuln ON CONFLICT DO NOTHING -- no-op';

    -- ---------------------------------------------------------------
    -- Step 3. GC: try to acquire the lock, then delete the vuln
    --
    -- In production this runs on a separate goroutine (gc.go):
    --   Phase 1: DeleteUpdateOperations CASCADE-deletes uo_vuln rows
    --   Phase 2: vulnCleanup deletes orphaned vuln rows
    --
    -- dblink runs on a separate connection and auto-commits, so
    -- deletes are immediately visible to new READ COMMITTED snapshots
    -- on the updater's connection.
    --
    -- Without the fix, TryLock succeeds (no contention) and GC
    -- proceeds to delete the vuln row. With the fix, TryLock fails
    -- (updater holds the lock) and GC skips this cycle.
    -- ---------------------------------------------------------------
    SELECT res INTO got_lock FROM dblink(gc_conn,
        'SELECT pg_try_advisory_lock(' || gc_lock_key || ')') AS t(res boolean);
    RAISE NOTICE 'GC: TryLock = % -- %', got_lock,
        CASE WHEN got_lock THEN 'acquired, proceeding with cleanup'
             ELSE 'lock held by updater, skipping' END;

    IF got_lock THEN
        gc_result := dblink_exec(gc_conn,
            'DELETE FROM uo_vuln WHERE vuln = ' || v_id);
        RAISE NOTICE 'GC: deleted uo_vuln refs -- %', gc_result;

        gc_result := dblink_exec(gc_conn,
            'DELETE FROM vuln WHERE id = ' || v_id);
        RAISE NOTICE 'GC: deleted vuln row -- %', gc_result;

        SELECT res INTO got_lock FROM dblink(gc_conn,
            'SELECT pg_advisory_unlock(' || gc_lock_key || ')') AS t(res boolean);
    END IF;

    -- ---------------------------------------------------------------
    -- Step 4. UPDATER: INSERT uo_vuln (the "assoc" statement)
    --
    -- Second statement in each batch pair. The subselect looks up
    -- the vuln by hash to get its ID.
    --
    -- Without the fix: GC deleted the vuln in step 3. The subselect
    -- returns NULL -> NOT NULL violation. (In production's pgx batch
    -- pipeline, the subselect and FK trigger get separate snapshots,
    -- producing SQLSTATE 23503 instead of 23502. Same root cause.)
    --
    -- With the fix: GC was blocked, vuln still exists, insert succeeds.
    -- ---------------------------------------------------------------
    BEGIN
        INSERT INTO uo_vuln (uo, vuln) VALUES (
            uo_new,
            (SELECT id FROM vuln WHERE hash_kind = 'md5' AND hash = v_hash)
        ) ON CONFLICT DO NOTHING;
        RAISE NOTICE 'UPDATER: INSERT uo_vuln -- succeeded (no race)';
    EXCEPTION
        WHEN foreign_key_violation THEN
            RAISE NOTICE 'UPDATER: INSERT uo_vuln -- FAILED (23503 FK violation)';
        WHEN not_null_violation THEN
            RAISE NOTICE 'UPDATER: INSERT uo_vuln -- FAILED (vuln deleted by GC)';
    END;

    -- ---------------------------------------------------------------
    -- Step 5. UPDATER: end update
    --
    -- With the fix, release the GC lock so GC can run on its next cycle.
    -- ---------------------------------------------------------------
    IF use_fix THEN
        PERFORM pg_advisory_unlock(gc_lock_key);
        RAISE NOTICE 'UPDATER: released GC lock';
    END IF;

    -- ---------------------------------------------------------------
    -- Cleanup: restore the rows so the script is idempotent.
    -- ---------------------------------------------------------------
    gc_result := dblink_exec(gc_conn,
        'INSERT INTO vuln (id, hash_kind, hash, updater, name) VALUES ('
        || v_id || ', ''md5'', ''\x1245ee253781d56be90903b6edf220d5'', ''rhel-vex'', ''CVE-2023-26159'')
         ON CONFLICT DO NOTHING');
    gc_result := dblink_exec(gc_conn,
        'INSERT INTO uo_vuln (uo, vuln) VALUES (7861, ' || v_id || ') ON CONFLICT DO NOTHING');
    DELETE FROM uo_vuln WHERE uo = uo_new AND vuln = v_id;
    RAISE NOTICE 'CLEANUP: done';

    PERFORM dblink_disconnect(gc_conn);
END;
$fn$;

-- Run without fix, then with fix.
DO $$ BEGIN RAISE NOTICE ''; RAISE NOTICE '=== Without fix ==='; END $$;
SELECT _repro_race(false);
DO $$ BEGIN RAISE NOTICE ''; RAISE NOTICE '=== With fix ==='; END $$;
SELECT _repro_race(true);

-- Clean up the helper function.
DROP FUNCTION _repro_race(boolean);
```

</details>