### PR TITLE
ci: Replace cron schedule with nightly tag push trigger for e2e tests

### DIFF
--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -2,9 +2,9 @@ name: e2e-db-backup-restore-test
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 5 * * *"
   push:
+    tags:
+    - '*-nightly-*'
     branches:
     - master
   pull_request:

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -2,9 +2,9 @@ name: e2e-nongroovy-tests
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 5 * * *"
   push:
+    tags:
+    - '*-nightly-*'
     branches:
     - master
   pull_request:


### PR DESCRIPTION
Replace cron schedules with nightly tag push triggers for the nongroovy and db-backup-restore GHA e2e workflows.

See https://github.com/openshift/release/pull/80477#discussion_r3405152065