### PR TITLE
fix(konflux): remove quotes from Dockerfile LABEL values

### DIFF
--- a/image/postgres/konflux.Dockerfile
+++ b/image/postgres/konflux.Dockerfile
@@ -8,15 +8,15 @@ RUN if [[ "$BUILD_TAG" == "" ]]; then >&2 echo "error: required BUILD_TAG arg is
 
 LABEL com.redhat.component=rhacs-central-db-container
 LABEL com.redhat.license_terms=https://www.redhat.com/agreements
-LABEL description=Central Database Image for Red Hat Advanced Cluster Security for Kubernetes
-LABEL io.k8s.description=Central Database Image for Red Hat Advanced Cluster Security for Kubernetes
+LABEL description="Central Database Image for Red Hat Advanced Cluster Security for Kubernetes"
+LABEL io.k8s.description="Central Database Image for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL io.k8s.display-name=central-db
 LABEL io.openshift.tags=rhacs,central-db,stackrox
-LABEL maintainer=Red Hat, Inc.
+LABEL maintainer="Red Hat, Inc."
 LABEL name=advanced-cluster-security/rhacs-central-db-rhel9
 # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
 LABEL source-location=https://github.com/stackrox/stackrox
-LABEL summary=Central DB for Red Hat Advanced Cluster Security for Kubernetes
+LABEL summary="Central DB for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL url=https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c
 # We must set version label to prevent inheriting value set in the base stage.
 LABEL version=${BUILD_TAG}

--- a/image/postgres/konflux.Dockerfile
+++ b/image/postgres/konflux.Dockerfile
@@ -6,24 +6,23 @@ USER root
 ARG BUILD_TAG
 RUN if [[ "$BUILD_TAG" == "" ]]; then >&2 echo "error: required BUILD_TAG arg is unset"; exit 6; fi
 
-LABEL \
-    com.redhat.component="rhacs-central-db-container" \
-    com.redhat.license_terms="https://www.redhat.com/agreements" \
-    description="Central Database Image for Red Hat Advanced Cluster Security for Kubernetes" \
-    io.k8s.description="Central Database Image for Red Hat Advanced Cluster Security for Kubernetes" \
-    io.k8s.display-name="central-db" \
-    io.openshift.tags="rhacs,central-db,stackrox" \
-    maintainer="Red Hat, Inc." \
-    name="advanced-cluster-security/rhacs-central-db-rhel9" \
-    # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
-    source-location="https://github.com/stackrox/stackrox" \
-    summary="Central DB for Red Hat Advanced Cluster Security for Kubernetes" \
-    url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
-    # We must set version label to prevent inheriting value set in the base stage.
-    version="${BUILD_TAG}" \
-    # Release label is required by EC although has no practical semantics.
-    # We also set it to not inherit one from a base stage in case it's RHEL or UBI.
-    release="1"
+LABEL com.redhat.component=rhacs-central-db-container
+LABEL com.redhat.license_terms=https://www.redhat.com/agreements
+LABEL description=Central Database Image for Red Hat Advanced Cluster Security for Kubernetes
+LABEL io.k8s.description=Central Database Image for Red Hat Advanced Cluster Security for Kubernetes
+LABEL io.k8s.display-name=central-db
+LABEL io.openshift.tags=rhacs,central-db,stackrox
+LABEL maintainer=Red Hat, Inc.
+LABEL name=advanced-cluster-security/rhacs-central-db-rhel9
+# Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
+LABEL source-location=https://github.com/stackrox/stackrox
+LABEL summary=Central DB for Red Hat Advanced Cluster Security for Kubernetes
+LABEL url=https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c
+# We must set version label to prevent inheriting value set in the base stage.
+LABEL version=${BUILD_TAG}
+# Release label is required by EC although has no practical semantics.
+# We also set it to not inherit one from a base stage in case it's RHEL or UBI.
+LABEL release=1
 
 RUN localedef -f UTF-8 -i en_US en_US.UTF-8 && \
     mkdir -p /var/lib/postgresql && \

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -111,26 +111,25 @@ RUN GOARCH=$(uname -m) ; \
 
 ARG BUILD_TAG
 
-LABEL \
-    com.redhat.component="rhacs-main-container" \
-    com.redhat.license_terms="https://www.redhat.com/agreements" \
-    description="Main Image for Red Hat Advanced Cluster Security for Kubernetes" \
-    distribution-scope="public" \
-    io.k8s.description="Main Image for Red Hat Advanced Cluster Security for Kubernetes" \
-    io.k8s.display-name="main" \
-    io.openshift.tags="rhacs,main,stackrox" \
-    maintainer="Red Hat, Inc." \
-    name="advanced-cluster-security/rhacs-main-rhel9" \
-    # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
-    source-location="https://github.com/stackrox/stackrox" \
-    summary="Main Image for Red Hat Advanced Cluster Security for Kubernetes" \
-    url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
-    vendor="Red Hat, Inc." \
-    # We must set version label to prevent inheriting value set in the base stage.
-    version="${BUILD_TAG}" \
-    # Release label is required by EC although has no practical semantics.
-    # We also set it to not inherit one from a base stage in case it's RHEL or UBI.
-    release="1"
+LABEL com.redhat.component=rhacs-main-container
+LABEL com.redhat.license_terms=https://www.redhat.com/agreements
+LABEL description=Main Image for Red Hat Advanced Cluster Security for Kubernetes
+LABEL distribution-scope=public
+LABEL io.k8s.description=Main Image for Red Hat Advanced Cluster Security for Kubernetes
+LABEL io.k8s.display-name=main
+LABEL io.openshift.tags=rhacs,main,stackrox
+LABEL maintainer=Red Hat, Inc.
+LABEL name=advanced-cluster-security/rhacs-main-rhel9
+# Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
+LABEL source-location=https://github.com/stackrox/stackrox
+LABEL summary=Main Image for Red Hat Advanced Cluster Security for Kubernetes
+LABEL url=https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c
+LABEL vendor=Red Hat, Inc.
+# We must set version label to prevent inheriting value set in the base stage.
+LABEL version=${BUILD_TAG}
+# Release label is required by EC although has no practical semantics.
+# We also set it to not inherit one from a base stage in case it's RHEL or UBI.
+LABEL release=1
 
 EXPOSE 8443
 

--- a/image/rhel/konflux.Dockerfile
+++ b/image/rhel/konflux.Dockerfile
@@ -113,18 +113,18 @@ ARG BUILD_TAG
 
 LABEL com.redhat.component=rhacs-main-container
 LABEL com.redhat.license_terms=https://www.redhat.com/agreements
-LABEL description=Main Image for Red Hat Advanced Cluster Security for Kubernetes
+LABEL description="Main Image for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL distribution-scope=public
-LABEL io.k8s.description=Main Image for Red Hat Advanced Cluster Security for Kubernetes
+LABEL io.k8s.description="Main Image for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL io.k8s.display-name=main
 LABEL io.openshift.tags=rhacs,main,stackrox
-LABEL maintainer=Red Hat, Inc.
+LABEL maintainer="Red Hat, Inc."
 LABEL name=advanced-cluster-security/rhacs-main-rhel9
 # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
 LABEL source-location=https://github.com/stackrox/stackrox
-LABEL summary=Main Image for Red Hat Advanced Cluster Security for Kubernetes
+LABEL summary="Main Image for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL url=https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c
-LABEL vendor=Red Hat, Inc.
+LABEL vendor="Red Hat, Inc."
 # We must set version label to prevent inheriting value set in the base stage.
 LABEL version=${BUILD_TAG}
 # Release label is required by EC although has no practical semantics.

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -60,15 +60,15 @@ ARG BUILD_TAG
 
 LABEL com.redhat.component=rhacs-roxctl-container
 LABEL com.redhat.license_terms=https://www.redhat.com/agreements
-LABEL description=The CLI for Red Hat Advanced Cluster Security for Kubernetes
-LABEL io.k8s.description=The CLI for Red Hat Advanced Cluster Security for Kubernetes
+LABEL description="The CLI for Red Hat Advanced Cluster Security for Kubernetes"
+LABEL io.k8s.description="The CLI for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL io.k8s.display-name=roxctl
 LABEL io.openshift.tags=rhacs,roxctl,stackrox
-LABEL maintainer=Red Hat, Inc.
+LABEL maintainer="Red Hat, Inc."
 LABEL name=advanced-cluster-security/rhacs-roxctl-rhel9
 # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
 LABEL source-location=https://github.com/stackrox/stackrox
-LABEL summary=The CLI for Red Hat Advanced Cluster Security for Kubernetes
+LABEL summary="The CLI for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL url=https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c
 # We must set version label to prevent inheriting value set in the base stage.
 LABEL version=${BUILD_TAG}

--- a/image/roxctl/konflux.Dockerfile
+++ b/image/roxctl/konflux.Dockerfile
@@ -58,24 +58,23 @@ COPY --from=package_installer /out/ /
 
 ARG BUILD_TAG
 
-LABEL \
-    com.redhat.component="rhacs-roxctl-container" \
-    com.redhat.license_terms="https://www.redhat.com/agreements" \
-    description="The CLI for Red Hat Advanced Cluster Security for Kubernetes" \
-    io.k8s.description="The CLI for Red Hat Advanced Cluster Security for Kubernetes" \
-    io.k8s.display-name="roxctl" \
-    io.openshift.tags="rhacs,roxctl,stackrox" \
-    maintainer="Red Hat, Inc." \
-    name="advanced-cluster-security/rhacs-roxctl-rhel9" \
-    # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
-    source-location="https://github.com/stackrox/stackrox" \
-    summary="The CLI for Red Hat Advanced Cluster Security for Kubernetes" \
-    url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
-    # We must set version label to prevent inheriting value set in the base stage.
-    version="${BUILD_TAG}" \
-    # Release label is required by EC although has no practical semantics.
-    # We also set it to not inherit one from a base stage in case it's RHEL or UBI.
-    release="1"
+LABEL com.redhat.component=rhacs-roxctl-container
+LABEL com.redhat.license_terms=https://www.redhat.com/agreements
+LABEL description=The CLI for Red Hat Advanced Cluster Security for Kubernetes
+LABEL io.k8s.description=The CLI for Red Hat Advanced Cluster Security for Kubernetes
+LABEL io.k8s.display-name=roxctl
+LABEL io.openshift.tags=rhacs,roxctl,stackrox
+LABEL maintainer=Red Hat, Inc.
+LABEL name=advanced-cluster-security/rhacs-roxctl-rhel9
+# Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
+LABEL source-location=https://github.com/stackrox/stackrox
+LABEL summary=The CLI for Red Hat Advanced Cluster Security for Kubernetes
+LABEL url=https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c
+# We must set version label to prevent inheriting value set in the base stage.
+LABEL version=${BUILD_TAG}
+# Release label is required by EC although has no practical semantics.
+# We also set it to not inherit one from a base stage in case it's RHEL or UBI.
+LABEL release=1
 
 ENV ROX_ROXCTL_IN_MAIN_IMAGE="true"
 

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -47,24 +47,24 @@ FROM ubi-micro-base
 
 ARG BUILD_TAG
 
-LABEL \
-    com.redhat.component="rhacs-operator-container" \
-    com.redhat.license_terms="https://www.redhat.com/agreements" \
-    description="Operator for Red Hat Advanced Cluster Security for Kubernetes" \
-    io.k8s.description="Operator for Red Hat Advanced Cluster Security for Kubernetes" \
-    io.k8s.display-name="operator" \
-    io.openshift.tags="rhacs,operator,stackrox" \
-    maintainer="Red Hat, Inc." \
-    name="advanced-cluster-security/rhacs-rhel9-operator" \
-    # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
-    source-location="https://github.com/stackrox/stackrox" \
-    summary="Operator for Red Hat Advanced Cluster Security for Kubernetes" \
-    url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
-    # We must set version label to prevent inheriting value set in the base stage.
-    version="${BUILD_TAG}" \
-    # Release label is required by EC although has no practical semantics.
-    # We also set it to not inherit one from a base stage in case it's RHEL or UBI.
-    release="1"
+LABEL com.redhat.component=rhacs-operator-container
+LABEL com.redhat.license_terms=https://www.redhat.com/agreements
+LABEL description=Operator for Red Hat Advanced Cluster Security for Kubernetes
+LABEL io.k8s.description=Operator for Red Hat Advanced Cluster Security for Kubernetes
+LABEL io.k8s.display-name=operator
+LABEL io.openshift.tags=rhacs,operator,stackrox
+LABEL maintainer=Red Hat, Inc.
+LABEL name=advanced-cluster-security/rhacs-rhel9-operator
+# Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
+LABEL source-location=https://github.com/stackrox/stackrox
+LABEL summary=Operator for Red Hat Advanced Cluster Security for Kubernetes
+LABEL url=https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c
+LABEL vendor=Red Hat, Inc.
+# We must set version label to prevent inheriting value set in the base stage.
+LABEL version=${BUILD_TAG}
+# Release label is required by EC although has no practical semantics.
+# We also set it to not inherit one from a base stage in case it's RHEL or UBI.
+LABEL release=1
 
 COPY --from=package_installer /out/ /
 

--- a/operator/konflux.Dockerfile
+++ b/operator/konflux.Dockerfile
@@ -49,17 +49,17 @@ ARG BUILD_TAG
 
 LABEL com.redhat.component=rhacs-operator-container
 LABEL com.redhat.license_terms=https://www.redhat.com/agreements
-LABEL description=Operator for Red Hat Advanced Cluster Security for Kubernetes
-LABEL io.k8s.description=Operator for Red Hat Advanced Cluster Security for Kubernetes
+LABEL description="Operator for Red Hat Advanced Cluster Security for Kubernetes"
+LABEL io.k8s.description="Operator for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL io.k8s.display-name=operator
 LABEL io.openshift.tags=rhacs,operator,stackrox
-LABEL maintainer=Red Hat, Inc.
+LABEL maintainer="Red Hat, Inc."
 LABEL name=advanced-cluster-security/rhacs-rhel9-operator
 # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
 LABEL source-location=https://github.com/stackrox/stackrox
-LABEL summary=Operator for Red Hat Advanced Cluster Security for Kubernetes
+LABEL summary="Operator for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL url=https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c
-LABEL vendor=Red Hat, Inc.
+LABEL vendor="Red Hat, Inc."
 # We must set version label to prevent inheriting value set in the base stage.
 LABEL version=${BUILD_TAG}
 # Release label is required by EC although has no practical semantics.

--- a/scanner/image/db/konflux.Dockerfile
+++ b/scanner/image/db/konflux.Dockerfile
@@ -3,24 +3,23 @@ FROM registry.redhat.io/rhel9/postgresql-15:latest@sha256:ba85fa939583ef38cbd53c
 ARG BUILD_TAG
 RUN if [[ "$BUILD_TAG" == "" ]]; then >&2 echo "error: required BUILD_TAG arg is unset"; exit 6; fi
 
-LABEL \
-    com.redhat.component="rhacs-scanner-v4-db-container" \
-    com.redhat.license_terms="https://www.redhat.com/agreements" \
-    description="Scanner v4 Database Image for Red Hat Advanced Cluster Security for Kubernetes" \
-    io.k8s.description="Scanner v4 Database Image for Red Hat Advanced Cluster Security for Kubernetes" \
-    io.k8s.display-name="scanner-v4-db" \
-    io.openshift.tags="rhacs,scanner-v4-db,stackrox" \
-    maintainer="Red Hat, Inc." \
-    name="advanced-cluster-security/rhacs-scanner-v4-db-rhel9" \
-    # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
-    source-location="https://github.com/stackrox/stackrox" \
-    summary="Scanner v4 DB for Red Hat Advanced Cluster Security for Kubernetes" \
-    url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
-    # We must set version label to prevent inheriting value set in the base stage.
-    version="${BUILD_TAG}" \
-    # Release label is required by EC although has no practical semantics.
-    # We also set it to not inherit one from a base stage in case it's RHEL or UBI.
-    release="1"
+LABEL com.redhat.component=rhacs-scanner-v4-db-container
+LABEL com.redhat.license_terms=https://www.redhat.com/agreements
+LABEL description=Scanner v4 Database Image for Red Hat Advanced Cluster Security for Kubernetes
+LABEL io.k8s.description=Scanner v4 Database Image for Red Hat Advanced Cluster Security for Kubernetes
+LABEL io.k8s.display-name=scanner-v4-db
+LABEL io.openshift.tags=rhacs,scanner-v4-db,stackrox
+LABEL maintainer=Red Hat, Inc.
+LABEL name=advanced-cluster-security/rhacs-scanner-v4-db-rhel9
+# Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
+LABEL source-location=https://github.com/stackrox/stackrox
+LABEL summary=Scanner v4 DB for Red Hat Advanced Cluster Security for Kubernetes
+LABEL url=https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c
+# We must set version label to prevent inheriting value set in the base stage.
+LABEL version=${BUILD_TAG}
+# Release label is required by EC although has no practical semantics.
+# We also set it to not inherit one from a base stage in case it's RHEL or UBI.
+LABEL release=1
 
 USER root
 

--- a/scanner/image/db/konflux.Dockerfile
+++ b/scanner/image/db/konflux.Dockerfile
@@ -5,15 +5,15 @@ RUN if [[ "$BUILD_TAG" == "" ]]; then >&2 echo "error: required BUILD_TAG arg is
 
 LABEL com.redhat.component=rhacs-scanner-v4-db-container
 LABEL com.redhat.license_terms=https://www.redhat.com/agreements
-LABEL description=Scanner v4 Database Image for Red Hat Advanced Cluster Security for Kubernetes
-LABEL io.k8s.description=Scanner v4 Database Image for Red Hat Advanced Cluster Security for Kubernetes
+LABEL description="Scanner v4 Database Image for Red Hat Advanced Cluster Security for Kubernetes"
+LABEL io.k8s.description="Scanner v4 Database Image for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL io.k8s.display-name=scanner-v4-db
 LABEL io.openshift.tags=rhacs,scanner-v4-db,stackrox
-LABEL maintainer=Red Hat, Inc.
+LABEL maintainer="Red Hat, Inc."
 LABEL name=advanced-cluster-security/rhacs-scanner-v4-db-rhel9
 # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
 LABEL source-location=https://github.com/stackrox/stackrox
-LABEL summary=Scanner v4 DB for Red Hat Advanced Cluster Security for Kubernetes
+LABEL summary="Scanner v4 DB for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL url=https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c
 # We must set version label to prevent inheriting value set in the base stage.
 LABEL version=${BUILD_TAG}

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -40,24 +40,23 @@ FROM ubi-micro-base
 
 ARG BUILD_TAG
 
-LABEL \
-    com.redhat.component="rhacs-scanner-v4-container" \
-    com.redhat.license_terms="https://www.redhat.com/agreements" \
-    description="This image supports image scanning v4 for Red Hat Advanced Cluster Security for Kubernetes" \
-    io.k8s.description="This image supports image scanning v4 for Red Hat Advanced Cluster Security for Kubernetes" \
-    io.k8s.display-name="scanner-v4" \
-    io.openshift.tags="rhacs,scanner-v4,stackrox" \
-    maintainer="Red Hat, Inc." \
-    name="advanced-cluster-security/rhacs-scanner-v4-rhel9" \
-    # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
-    source-location="https://github.com/stackrox/stackrox" \
-    summary="The image scanner v4 for Red Hat Advanced Cluster Security for Kubernetes" \
-    url="https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c" \
-    # We must set version label to prevent inheriting value set in the base stage.
-    version="${BUILD_TAG}" \
-    # Release label is required by EC although has no practical semantics.
-    # We also set it to not inherit one from a base stage in case it's RHEL or UBI.
-    release="1"
+LABEL com.redhat.component=rhacs-scanner-v4-container
+LABEL com.redhat.license_terms=https://www.redhat.com/agreements
+LABEL description=This image supports image scanning v4 for Red Hat Advanced Cluster Security for Kubernetes
+LABEL io.k8s.description=This image supports image scanning v4 for Red Hat Advanced Cluster Security for Kubernetes
+LABEL io.k8s.display-name=scanner-v4
+LABEL io.openshift.tags=rhacs,scanner-v4,stackrox
+LABEL maintainer=Red Hat, Inc.
+LABEL name=advanced-cluster-security/rhacs-scanner-v4-rhel9
+# Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
+LABEL source-location=https://github.com/stackrox/stackrox
+LABEL summary=The image scanner v4 for Red Hat Advanced Cluster Security for Kubernetes
+LABEL url=https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c
+# We must set version label to prevent inheriting value set in the base stage.
+LABEL version=${BUILD_TAG}
+# Release label is required by EC although has no practical semantics.
+# We also set it to not inherit one from a base stage in case it's RHEL or UBI.
+LABEL release=1
 
 COPY --from=package_installer /out/ /
 

--- a/scanner/image/scanner/konflux.Dockerfile
+++ b/scanner/image/scanner/konflux.Dockerfile
@@ -42,15 +42,15 @@ ARG BUILD_TAG
 
 LABEL com.redhat.component=rhacs-scanner-v4-container
 LABEL com.redhat.license_terms=https://www.redhat.com/agreements
-LABEL description=This image supports image scanning v4 for Red Hat Advanced Cluster Security for Kubernetes
-LABEL io.k8s.description=This image supports image scanning v4 for Red Hat Advanced Cluster Security for Kubernetes
+LABEL description="This image supports image scanning v4 for Red Hat Advanced Cluster Security for Kubernetes"
+LABEL io.k8s.description="This image supports image scanning v4 for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL io.k8s.display-name=scanner-v4
 LABEL io.openshift.tags=rhacs,scanner-v4,stackrox
-LABEL maintainer=Red Hat, Inc.
+LABEL maintainer="Red Hat, Inc."
 LABEL name=advanced-cluster-security/rhacs-scanner-v4-rhel9
 # Custom Snapshot creation in `operator-bundle-pipeline` depends on source-location label to be set correctly.
 LABEL source-location=https://github.com/stackrox/stackrox
-LABEL summary=The image scanner v4 for Red Hat Advanced Cluster Security for Kubernetes
+LABEL summary="The image scanner v4 for Red Hat Advanced Cluster Security for Kubernetes"
 LABEL url=https://catalog.redhat.com/software/container-stacks/detail/60eefc88ee05ae7c5b8f041c
 # We must set version label to prevent inheriting value set in the base stage.
 LABEL version=${BUILD_TAG}


### PR DESCRIPTION
## Description

The `labels.json` generator in the Brew build pipeline (buildah 1.43.1) started preserving Dockerfile syntax quotes as literal characters in `/root/buildinfo/labels.json`. This breaks scanner vuln matching for container-first CVEs because fields like `com.redhat.component`, `name`, and `version` end up with extra `"` wrapping the values.

Verified affected: both 4.10.4 and 4.11.0 images (buildah 1.42.2 → 1.43.1 upgrade). Verified clean: 4.10.3 (buildah 1.42.2). OCI config labels are correct in all versions — only the `labels.json` file inside the image is affected.

Workaround: split the multi-line `LABEL \` block into individual `LABEL key=value` statements and remove quotes where the value contains no spaces. Values with spaces (description, maintainer, summary, vendor) still require quotes due to the Konflux Dockerfile parser (`konflux-build-cli`) which splits on whitespace. Those quoted values will still have extra quotes in `labels.json`, but they are not used for scanner matching.

The upstream fix for the Konflux parser is tracked in https://github.com/konflux-ci/build-definitions/pull/3599. Once that lands, all quotes can be removed.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No test changes — this is a Dockerfile label syntax change only.

### How I validated my change

Compared `/root/buildinfo/labels.json` extracted from published images:

- **4.10.3** (buildah 1.42.2): labels are clean
- **4.10.4** (buildah 1.43.1): labels have extra quotes — confirms this is a build infra regression, not a source change
- **4.11.0** (buildah 1.43.1): same extra quotes

Validation that the fix works requires a Konflux build of this branch — checking the resulting `labels.json` in the built image.