### PR TITLE
ROX-35178: disable v1 vulnerability bundle stream

### DIFF
--- a/.github/workflows/scanner-versioned-definitions-update.yaml
+++ b/.github/workflows/scanner-versioned-definitions-update.yaml
@@ -253,11 +253,6 @@ jobs:
         unzip -l "$path"
         echo "STACKROX_NVD_ZIP_PATH=$path" >> "$GITHUB_ENV"
 
-    - name: Run Updater (single bundle)
-      if: ${{ env.SCANNER_BUNDLE_VERSION == 'v1' }}
-      run: |
-        scanner/bin/updater export --manual-url "${{ needs.prepare-environment.outputs.manual_url }}" "definitions/${SCANNER_BUNDLE_VERSION}"
-
     - name: Run updater (multi bundle)
       run: |
         tag=$(make -s --no-print-directory tag)
@@ -454,38 +449,6 @@ jobs:
       run: |
         echo "Copy upstream dev (dev) to downstream dev (1.0.0)"
         gsutil cp -r gs://definitions.stackrox.io/v4/vulnerability-bundles/dev/* gs://definitions.stackrox.io/v4/vulnerability-bundles/1.0.0/
-
-    - name: Copy v1 to pre-versioned bundles
-      # Run on schedule or when dispatched to build "GA" (only possible if RC was not requested).
-      if: github.event.inputs.rc_ref == ''
-      run: |
-        # Only execute if v1 files were created by the build job.
-        if ! [ -d "definitions_files/v1" ]; then
-           echo "error: no definition files for v1 were created: skipping..."
-           exit 0
-        fi
-        # Using v1 bundle for released versions listed in RELEASE_VERSION.
-        single=gs://definitions.stackrox.io/v4/vulnerability-bundles/v1/vulns.json.zst
-        multi=gs://definitions.stackrox.io/v4/vulnerability-bundles/v1/vulnerabilities.zip
-        # Parse all supported pre-4.6 releases and copy the versioned bundle v1 to ensure
-        # these releases get updates.
-        grep -E "^4\.(4|5)\.[0-9]+$" scanner/updater/version/RELEASE_VERSION | while read -r release; do
-          case "$release" in
-          4.4.*)
-            gsutil cp "$single" "gs://definitions.stackrox.io/v4/vulnerability-bundles/$release/"
-            ;;
-          4.5.*)
-            gsutil cp "$single" "gs://definitions.stackrox.io/v4/vulnerability-bundles/$release/"
-            gsutil cp "$multi" "gs://definitions.stackrox.io/v4/vulnerability-bundles/$release/"
-            ;;
-          *)
-            echo "Should not happen!"
-            echo "Error: unexpected release version: $release"
-            echo "Ignoring..."
-            ;;
-          esac
-          echo "Copied v1 into $release"
-        done
 
   send-notification:
     needs:

--- a/.github/workflows/scripts/scanner-get-released-tags.sh
+++ b/.github/workflows/scripts/scanner-get-released-tags.sh
@@ -112,9 +112,9 @@ while read -r line; do
     fi
 
     case "$version" in
-        dev|v1)
-            # These vulnerability bundle versions are special, and we cannot
-            # validate them by fetching the vulnerability version.
+        dev)
+            # This vulnerability bundle version is special, and we cannot
+            # validate it by fetching the vulnerability version.
             ;;
         *)
             actual_version=$(fetch_version "$resolved_tag")

--- a/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
+++ b/scanner/updater/version/VULNERABILITY_BUNDLE_VERSION
@@ -5,5 +5,4 @@
 # Each vulnerability bundle version serves the Scanner V4 requesting it, which is, by default, based on the version specified in scanner/VULNERABILITY_VERSION in the related Scanner V4 tag.
 # This process ensures that each version's vulnerability data is accurately captured and maintained in accordance with its respective version.
 dev heads/master
-v1 4.5.2
 v2 tags/4.9.8-rc.2


### PR DESCRIPTION
## Description

Disable the v1 vulnerability bundle stream. ACS 4.5 is out of support (SUPPORTEX-26484 confirms no remaining exceptions), so the v1 updater no longer needs to run. Existing v1 bundles in GCS remain available for offline bundle generation for 4.4.x/4.5.x releases.

Removes dead code that was only reachable when v1 was in the build matrix: the single-bundle export step, the v1-to-release GCS copy step, and the v1 branch in the version validation case statement.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

No tests added. The changes are configuration and workflow-only, so there are no unit-testable paths. The workflow itself gates PR runs behind the `pr-update-scanner-vulns` label, which triggers a full build-and-upload cycle and does not ensure a test path for a removal change.

### How I validated my change

No explicit path for manual validation. The next scheduled run after merge (every 4 hours) will confirm the workflow produces dev and v2 bundles without errors.

All v1 references in the workflow and scripts fall into two categories: conditionals that are only reachable when v1 is in the VULNERABILITY_BUNDLE_VERSION matrix (removed in this PR), and offline bundle scripts that read existing v1 bundles from GCS by release version (4.4.x/4.5.x), independent of the build matrix (untouched).