### PR TITLE
ROX-34866: Add RHEL 8 VM to scanning e2e test matrix

### DIFF
--- a/scripts/ci/jobs/ocp_vm_scanning_e2e_tests.py
+++ b/scripts/ci/jobs/ocp_vm_scanning_e2e_tests.py
@@ -27,6 +27,7 @@ os.environ["ROX_SCANNER_V4"] = "true"
 # Avoid default rate limiting of VM index reports set to 1 report per minute per VM.
 os.environ["ROX_VM_RELAY_MAX_REPORTS_PER_MINUTE"] = "10"
 os.environ["VM_IMAGES"] = ",".join([
+    "quay.io/rhacs-eng/vm-images:rhel8-dnf-primed-latest",
     "quay.io/rhacs-eng/vm-images:rhel9-dnf-primed-latest",
     "quay.io/rhacs-eng/vm-images:rhel10-dnf-primed-latest",
 ])


### PR DESCRIPTION
## Description

Add the new `rhel8-dnf-primed-latest` container-disk image to the VM scanning e2e test matrix. The image is published by [stackrox/vm-images#5](https://github.com/stackrox/vm-images/pull/5). The e2e suite now exercises RHEL 8, 9, and 10.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- CI: the `ocp-vm-scanning-e2e-tests` job will exercise the new RHEL 8 image alongside the existing RHEL 9 and 10 images:
    - First run: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/21246/pull-ci-stackrox-stackrox-master-ocp-4-21-vm-scanning-e2e-tests/2067518181076897792
    - Next run (after rebase, including the VM metrics-based tests from #20129 ): https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/21246/pull-ci-stackrox-stackrox-master-ocp-4-21-vm-scanning-e2e-tests/2067885122530578432 

