### PR TITLE
ROX-35009: Add watch to secret informer tests

### DIFF
--- a/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
+++ b/pkg/cloudproviders/gcp/auth/cred_manager_impl_test.go
@@ -139,7 +139,10 @@ func TestCredentialManager(t *testing.T) {
 			manager.Start()
 			defer manager.Stop()
 
-			// Wait HasSynced first.
+			// There is a problem with fake informer. It happens that Go routine that starts informers,
+			// marks HasSynced as a true before watchers are registered. Because of that,
+			// events are never received. There are no watchers that are listening to these events
+			// after HasSynced is true. That's why we need to wait for HasSynced and Watch event.
 			require.Eventually(t, manager.informer.HasSynced, 30*time.Second, 100*time.Millisecond)
 
 			// Wait that watch is executed and events will be properly received.

--- a/pkg/secretinformer/informer_test.go
+++ b/pkg/secretinformer/informer_test.go
@@ -6,11 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stackrox/rox/pkg/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 const (
@@ -22,15 +25,14 @@ const (
 
 func TestSecretInformer(t *testing.T) {
 	cases := map[string]struct {
-		preCreateSecret     bool
-		setupFn             func(t *testing.T, k8sClient *fake.Clientset)
+		setupFn             func(k8sClient *fake.Clientset) error
 		expectedOnAddCnt    int
 		expectedOnUpdateCnt int
 		expectedOnDeleteCnt int
 		expectedData        string
 	}{
 		"secret added": {
-			setupFn: func(t *testing.T, k8sClient *fake.Clientset) {
+			setupFn: func(k8sClient *fake.Clientset) error {
 				_, err := k8sClient.CoreV1().Secrets(namespace).Create(
 					context.Background(),
 					&v1.Secret{
@@ -41,13 +43,13 @@ func TestSecretInformer(t *testing.T) {
 					},
 					metav1.CreateOptions{},
 				)
-				require.NoError(t, err)
+				return err
 			},
 			expectedOnAddCnt: 1,
 			expectedData:     secretData,
 		},
 		"secret updated": {
-			setupFn: func(t *testing.T, k8sClient *fake.Clientset) {
+			setupFn: func(k8sClient *fake.Clientset) error {
 				_, err := k8sClient.CoreV1().Secrets(namespace).Create(
 					context.Background(),
 					&v1.Secret{
@@ -58,7 +60,9 @@ func TestSecretInformer(t *testing.T) {
 					},
 					metav1.CreateOptions{},
 				)
-				require.NoError(t, err)
+				if err != nil {
+					return err
+				}
 				_, err = k8sClient.CoreV1().Secrets(namespace).Update(
 					context.Background(),
 					&v1.Secret{
@@ -69,35 +73,14 @@ func TestSecretInformer(t *testing.T) {
 					},
 					metav1.UpdateOptions{},
 				)
-				require.NoError(t, err)
+				return err
 			},
 			expectedOnAddCnt:    1,
 			expectedOnUpdateCnt: 1,
 			expectedData:        secretData,
 		},
 		"secret deleted": {
-			preCreateSecret: true,
-			setupFn: func(t *testing.T, k8sClient *fake.Clientset) {
-				err := k8sClient.CoreV1().Secrets(namespace).Delete(
-					context.Background(), secretName, metav1.DeleteOptions{},
-				)
-				require.NoError(t, err)
-			},
-			expectedOnAddCnt:    1,
-			expectedOnDeleteCnt: 1,
-			expectedData:        secretData,
-		},
-		"no secret": {
-			setupFn: func(_ *testing.T, _ *fake.Clientset) {},
-		},
-	}
-
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			var onAddCnt, onUpdateCnt, onDeleteCnt atomic.Int32
-
-			k8sClient := fake.NewClientset()
-			if c.preCreateSecret {
+			setupFn: func(k8sClient *fake.Clientset) error {
 				_, err := k8sClient.CoreV1().Secrets(namespace).Create(
 					context.Background(),
 					&v1.Secret{
@@ -108,8 +91,38 @@ func TestSecretInformer(t *testing.T) {
 					},
 					metav1.CreateOptions{},
 				)
-				require.NoError(t, err)
-			}
+				if err != nil {
+					return err
+				}
+				err = k8sClient.CoreV1().Secrets(namespace).Delete(
+					context.Background(), secretName, metav1.DeleteOptions{},
+				)
+				return err
+			},
+			expectedOnAddCnt:    1,
+			expectedOnDeleteCnt: 1,
+			expectedData:        secretData,
+		},
+		"no secret": {
+			setupFn: func(k8sClient *fake.Clientset) error {
+				return nil
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			var onAddCnt, onUpdateCnt, onDeleteCnt atomic.Int32
+
+			k8sClient := fake.NewClientset()
+
+			watchRegistered := make(chan struct{})
+			var watchOnce sync.Once
+			k8sClient.PrependWatchReactor("secrets", func(action k8stesting.Action) (bool, watch.Interface, error) {
+				w, err := k8sClient.Tracker().Watch(action.GetResource(), action.GetNamespace())
+				watchOnce.Do(func() { close(watchRegistered) })
+				return true, w, err
+			})
 
 			informer := NewSecretInformer(
 				namespace,
@@ -130,22 +143,27 @@ func TestSecretInformer(t *testing.T) {
 			err := informer.Start()
 			require.NoError(t, err)
 			defer informer.Stop()
+
+			// There is a problem with fake informer. It happens that Go routine that starts informers,
+			// marks HasSynced as a true before watchers are registered. Because of that,
+			// events are never received. There are no watchers that are listening to these events
+			// after HasSynced is true. That's why we need to wait for HasSynced and Watch event.
 			require.Eventually(t, informer.HasSynced, 30*time.Second, 100*time.Millisecond)
 
-			if c.preCreateSecret {
-				require.Eventually(t, func() bool {
-					return onAddCnt.Load() > 0
-				}, 30*time.Second, 50*time.Millisecond,
-					"add callback not invoked for pre-created secret")
+			// Wait that watch is executed and events will be properly received.
+			select {
+			case <-watchRegistered:
+			case <-time.After(10 * time.Second):
+				require.FailNow(t, "timed out waiting for watch to be registered")
 			}
 
-			c.setupFn(t, k8sClient)
+			require.NoError(t, c.setupFn(k8sClient))
 
 			assert.Eventually(t, func() bool {
 				return onAddCnt.Load() == int32(c.expectedOnAddCnt) &&
 					onUpdateCnt.Load() == int32(c.expectedOnUpdateCnt) &&
 					onDeleteCnt.Load() == int32(c.expectedOnDeleteCnt)
-			}, 30*time.Second, 50*time.Millisecond,
+			}, 10*time.Second, 50*time.Millisecond,
 				"callbacks not invoked as expected (add: %d/%d, update: %d/%d, delete: %d/%d)",
 				onAddCnt.Load(), c.expectedOnAddCnt, onUpdateCnt.Load(), c.expectedOnUpdateCnt,
 				onDeleteCnt.Load(), c.expectedOnDeleteCnt)


### PR DESCRIPTION
## Description

This is 2nd round of improvements, similar to what was done in: https://github.com/stackrox/stackrox/pull/21095

I have reverted changes added with: https://github.com/stackrox/stackrox/pull/21013 - because they are just complicating setup and do not solve the issue.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

- [x] run previous tests with similar steps to reproduce used for https://github.com/stackrox/stackrox/pull/21095 (tests were failing)
- [x] after fix run tests with same steps to reproduce - tests were successful
- [x] run tests without reproduce steps before pushing changes
