### PR TITLE
ROX-29892: fix TestSendNetworkFlows flake

### DIFF
--- a/sensor/common/networkflow/manager/manager_sending_test.go
+++ b/sensor/common/networkflow/manager/manager_sending_test.go
@@ -31,6 +31,10 @@ const (
 	// tickerSendTimeout is the maximum duration to wait for ticker send to enrichment goroutine.
 	// Short timeout provides fast failure detection if enrichment goroutine becomes unresponsive.
 	tickerSendTimeout = 50 * time.Millisecond
+
+	// sendCycleTimeout is the maximum duration to wait for a full enrich+send cycle to complete.
+	// Covers enrichment processing, entity lookups, channel writes, and goroutine scheduling.
+	sendCycleTimeout = enrichmentTimeout + sendToCentralTimeout
 )
 
 func TestSendNetworkFlows(t *testing.T) {
@@ -215,7 +219,8 @@ func (b *sendNetflowsSuite) TestUpdatesGetBufferedWhenUnread() {
 		b.thenTickerTicks()
 	}
 
-	// Wait for all 4 send cycles to complete before reading
+	// Wait for all 4 send cycles to complete before reading.
+	// thenTickerTicks guarantees that send() completed, but call to waitForSendCycles documents the intent.
 	b.waitForSendCycles(startingSendCycles + 4)
 
 	// should be able to read four buffered updates in sequence
@@ -247,7 +252,14 @@ func (b *sendNetflowsSuite) TestCallsDetectionEvenOnFullBuffer() {
 	b.assertNoMoreUpdatesToCentral()
 }
 
+// thenTickerTicks fires one enrichment cycle and blocks until both enrichment
+// AND send() complete. Two-phase synchronization:
+//  1. enrichmentDoneSignal — confirms enrichment finished (entity lookups done)
+//  2. sendCyclesCompleted — confirms send() wrote to the channel
+//
+// Lack of waiting for the sendCyclesCompleted caused flakiness in the test (ROX-29892).
 func (b *sendNetflowsSuite) thenTickerTicks() {
+	expected := b.m.sendCyclesCompleted.Load() + 1
 	b.m.enrichmentDoneSignal.Reset()
 	select {
 	case b.fakeTicker <- time.Now():
@@ -255,6 +267,7 @@ func (b *sendNetflowsSuite) thenTickerTicks() {
 		b.T().Fatal("ticker send blocked - enrichment goroutine not responsive")
 	}
 	b.waitForEnrichmentDone()
+	b.waitForSendCycles(expected)
 }
 
 func (b *sendNetflowsSuite) waitForEnrichmentDone() {
@@ -271,7 +284,7 @@ func (b *sendNetflowsSuite) waitForEnrichmentDone() {
 
 func (b *sendNetflowsSuite) waitForSendCycles(expectedCycles uint64) {
 	start := time.Now()
-	deadline := time.Now().Add(sendToCentralTimeout)
+	deadline := time.Now().Add(sendCycleTimeout)
 
 	for {
 		currentCycles := b.m.sendCyclesCompleted.Load()
@@ -327,6 +340,7 @@ func mustNotRead[T any](t *testing.T, ch chan T) {
 }
 
 func mustReadTimeout[T any](t *testing.T, ch chan T, timeout time.Duration) T {
+	t.Helper()
 	var result T
 	select {
 	case v, more := <-ch:


### PR DESCRIPTION
## Description

`thenTickerTicks()` waited only for `enrichmentDoneSignal`, which fires before `send()` writes to the `sensorUpdates` channel. Under CI load with the race detector, the test would try to read from the channel before the message arrived, causing intermittent failures:
- "blocked on reading from channel" (TestCloseOldConnectionFailedLookup, TestCloseEndpoint)
- "blocked on sending to channel" (TestCallsDetectionEvenOnFullBuffer)

Fix: add `waitForSendCycles()` to `thenTickerTicks()` so it blocks until `sendCyclesCompleted` increments (at the end of `send()`), guaranteeing the message is in the channel when assertions run. Two-phase sync: enrichmentDoneSignal confirms enrichment finished, then sendCyclesCompleted confirms the channel write.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Ran `go test -race ./sensor/common/networkflow/manager/... -run TestSendNetworkFlows -count=20` locally — all pass, no data races.
- CI
