### PR TITLE
fix(tests): Exclude VM scanning tests from general e2e test target

### DIFF
--- a/tests/vm_scanning_cluster_preflight_checks_test.go
+++ b/tests/vm_scanning_cluster_preflight_checks_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_cluster_preflight_test.go
+++ b/tests/vm_scanning_cluster_preflight_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_e2e_utils_test.go
+++ b/tests/vm_scanning_e2e_utils_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_suite_test.go
+++ b/tests/vm_scanning_suite_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_utils_config_test.go
+++ b/tests/vm_scanning_utils_config_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 

--- a/tests/vm_scanning_utils_test.go
+++ b/tests/vm_scanning_utils_test.go
@@ -1,4 +1,4 @@
-//go:build test_e2e || test_e2e_vm
+//go:build test_e2e_vm
 
 package tests
 


### PR DESCRIPTION
## Description

Backport for #20746

(cherry picked from commit 9b92accd2782a9fa4f35c86f2ba297aa20997d88)