### PR TITLE
feat: Add cache audit metrics for cached stores

### DIFF
--- a/pkg/search/postgres/cache_metrics.go
+++ b/pkg/search/postgres/cache_metrics.go
@@ -1,0 +1,46 @@
+package postgres
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stackrox/rox/pkg/metrics"
+)
+
+func init() {
+	prometheus.MustRegister(
+		cacheEntries,
+		cachePopulationDuration,
+		cacheBypassTotal,
+		cacheMissTotal,
+	)
+}
+
+var (
+	cacheEntries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "cache_entries",
+		Help:      "Number of entries in each cached store",
+	}, []string{"Type"})
+
+	cachePopulationDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "cache_population_duration_seconds",
+		Help:      "Time taken to populate each cached store at startup",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"Type"})
+
+	cacheBypassTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "cache_bypass_total",
+		Help:      "Number of queries that bypassed the cache and hit the database directly",
+	}, []string{"Type", "Operation"})
+
+	cacheMissTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "cache_miss_total",
+		Help:      "Number of cache lookups where the ID was not found",
+	}, []string{"Type", "Operation"})
+)

--- a/pkg/search/postgres/cache_metrics.go
+++ b/pkg/search/postgres/cache_metrics.go
@@ -10,6 +10,7 @@ func init() {
 		cacheEntries,
 		cachePopulationDuration,
 		cacheBypassTotal,
+		cacheHitTotal,
 		cacheMissTotal,
 	)
 }
@@ -35,6 +36,13 @@ var (
 		Subsystem: metrics.CentralSubsystem.String(),
 		Name:      "cache_bypass_total",
 		Help:      "Number of queries that bypassed the cache and hit the database directly",
+	}, []string{"Type", "Operation"})
+
+	cacheHitTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metrics.PrometheusNamespace,
+		Subsystem: metrics.CentralSubsystem.String(),
+		Name:      "cache_hit_total",
+		Help:      "Number of cache lookups where the ID was found",
 	}, []string{"Type", "Operation"})
 
 	cacheMissTotal = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/pkg/search/postgres/store_cache.go
+++ b/pkg/search/postgres/store_cache.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	v1 "github.com/stackrox/rox/generated/api/v1"
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/auth/permissions"
@@ -138,6 +139,7 @@ func (c *cachedStore[T, PT]) Upsert(ctx context.Context, obj PT) error {
 	c.cacheLock.Lock()
 	defer c.cacheLock.Unlock()
 	c.addToCacheNoLock(obj)
+	c.setCacheEntriesGauge()
 	return nil
 }
 
@@ -153,6 +155,7 @@ func (c *cachedStore[T, PT]) UpsertMany(ctx context.Context, objs []PT) error {
 	for _, obj := range objs {
 		c.addToCacheNoLock(obj)
 	}
+	c.setCacheEntriesGauge()
 	return nil
 }
 
@@ -184,6 +187,7 @@ func (c *cachedStore[T, PT]) Delete(ctx context.Context, id string) error {
 	c.cacheLock.Lock()
 	defer c.cacheLock.Unlock()
 	delete(c.cache, id)
+	c.setCacheEntriesGauge()
 	return nil
 }
 
@@ -219,6 +223,7 @@ func (c *cachedStore[T, PT]) DeleteMany(ctx context.Context, identifiers []strin
 	for _, id := range filteredIDs {
 		delete(c.cache, id)
 	}
+	c.setCacheEntriesGauge()
 	return nil
 }
 
@@ -241,6 +246,7 @@ func (c *cachedStore[T, PT]) Exists(ctx context.Context, id string) (bool, error
 	defer c.cacheLock.RUnlock()
 	obj, found := c.cache[id]
 	if !found {
+		cacheMissTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "Exists"}).Inc()
 		return false, nil
 	}
 	return c.isReadAllowed(ctx, obj), nil
@@ -251,6 +257,7 @@ func (c *cachedStore[T, PT]) Count(ctx context.Context, q *v1.Query) (int, error
 	if checkScopeQueries(ctx, q) {
 		return c.countFromCache(ctx)
 	}
+	cacheBypassTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "Count"}).Inc()
 	return c.underlyingStore.Count(ctx, q)
 }
 
@@ -281,6 +288,7 @@ func (c *cachedStore[T, PT]) Get(ctx context.Context, id string) (PT, bool, erro
 	defer c.cacheLock.RUnlock()
 	obj, found := c.cache[id]
 	if !found {
+		cacheMissTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "Get"}).Inc()
 		return nil, false, nil
 	}
 	if !c.isReadAllowed(ctx, obj) {
@@ -302,6 +310,7 @@ func (c *cachedStore[T, PT]) GetMany(ctx context.Context, identifiers []string) 
 	for idx, id := range identifiers {
 		obj, found := c.cache[id]
 		if !found {
+			cacheMissTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "GetMany"}).Inc()
 			misses = append(misses, idx)
 			continue
 		}
@@ -320,6 +329,7 @@ func (c *cachedStore[T, PT]) WalkByQuery(ctx context.Context, query *v1.Query, f
 	if checkScopeQueries(ctx, query) {
 		return c.Walk(ctx, fn)
 	}
+	cacheBypassTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "WalkByQuery"}).Inc()
 	return c.underlyingStore.WalkByQuery(ctx, query, fn)
 }
 
@@ -347,6 +357,7 @@ func (c *cachedStore[T, PT]) GetByQueryFn(ctx context.Context, query *v1.Query, 
 	if checkScopeQueries(ctx, query) {
 		return c.Walk(ctx, fn)
 	}
+	cacheBypassTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "GetByQueryFn"}).Inc()
 	return c.underlyingStore.GetByQueryFn(ctx, query, fn)
 }
 
@@ -364,6 +375,7 @@ func (c *cachedStore[T, PT]) GetByQuery(ctx context.Context, query *v1.Query) ([
 		}
 		return result, err
 	}
+	cacheBypassTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "GetByQuery"}).Inc()
 	return c.underlyingStore.GetByQuery(ctx, query)
 }
 
@@ -390,6 +402,7 @@ func (c *cachedStore[T, PT]) deleteByQueryWithIDs(ctx context.Context, query *v1
 	for _, id := range identifiersToRemove {
 		delete(c.cache, id)
 	}
+	c.setCacheEntriesGauge()
 	return identifiersToRemove, nil
 }
 
@@ -414,6 +427,7 @@ func (c *cachedStore[T, PT]) GetIDsByQuery(ctx context.Context, query *v1.Query)
 	if checkScopeQueries(ctx, query) {
 		return c.GetIDs(ctx)
 	}
+	cacheBypassTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "GetIDsByQuery"}).Inc()
 	return c.underlyingStore.GetIDsByQuery(ctx, query)
 }
 
@@ -479,13 +493,21 @@ func (c *cachedStore[T, PT]) isActionAllowed(ctx context.Context, action storage
 }
 
 func (c *cachedStore[T, PT]) populateCache() error {
+	timer := prometheus.NewTimer(cachePopulationDuration.WithLabelValues(c.schema.TypeName))
+	defer timer.ObserveDuration()
 	c.cacheLock.Lock()
 	defer c.cacheLock.Unlock()
 	c.cache = make(map[string]PT)
-	return c.underlyingStore.Walk(sac.WithAllAccess(context.Background()), func(obj PT) error {
+	err := c.underlyingStore.Walk(sac.WithAllAccess(context.Background()), func(obj PT) error {
 		c.addToCacheNoLock(obj)
 		return nil
 	})
+	c.setCacheEntriesGauge()
+	return err
+}
+
+func (c *cachedStore[T, PT]) setCacheEntriesGauge() {
+	cacheEntries.WithLabelValues(c.schema.TypeName).Set(float64(len(c.cache)))
 }
 
 func (c *cachedStore[T, PT]) addToCacheNoLock(obj PT) {

--- a/pkg/search/postgres/store_cache.go
+++ b/pkg/search/postgres/store_cache.go
@@ -249,6 +249,7 @@ func (c *cachedStore[T, PT]) Exists(ctx context.Context, id string) (bool, error
 		cacheMissTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "Exists"}).Inc()
 		return false, nil
 	}
+	cacheHitTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "Exists"}).Inc()
 	return c.isReadAllowed(ctx, obj), nil
 }
 
@@ -294,6 +295,7 @@ func (c *cachedStore[T, PT]) Get(ctx context.Context, id string) (PT, bool, erro
 	if !c.isReadAllowed(ctx, obj) {
 		return nil, false, nil
 	}
+	cacheHitTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "Get"}).Inc()
 	return obj.CloneVT(), true, nil
 }
 
@@ -307,10 +309,11 @@ func (c *cachedStore[T, PT]) GetMany(ctx context.Context, identifiers []string) 
 	defer c.cacheLock.RUnlock()
 	results := make([]PT, 0, len(identifiers))
 	misses := make([]int, 0)
+	var notFound int
 	for idx, id := range identifiers {
 		obj, found := c.cache[id]
 		if !found {
-			cacheMissTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "GetMany"}).Inc()
+			notFound++
 			misses = append(misses, idx)
 			continue
 		}
@@ -320,6 +323,10 @@ func (c *cachedStore[T, PT]) GetMany(ctx context.Context, identifiers []string) 
 		}
 		results = append(results, obj.CloneVT())
 	}
+	if notFound > 0 {
+		cacheMissTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "GetMany"}).Add(float64(notFound))
+	}
+	cacheHitTotal.With(prometheus.Labels{"Type": c.schema.TypeName, "Operation": "GetMany"}).Add(float64(len(results)))
 	return results, misses, nil
 }
 


### PR DESCRIPTION
## Description

Adds four Prometheus metrics to the cached store implementation (`pkg/search/postgres/store_cache.go`) to provide empirical observability into Central's in-memory caches. This work supports the HA strategy discovery effort ([ROX-34526](https://redhat.atlassian.net/browse/ROX-34526)), where the team needs data to decide which caches to keep, remove, or synchronize across Central replicas.

The new metrics, defined in `pkg/search/postgres/cache_metrics.go`, are:

- **`rox_central_cache_entries`** (gauge) -- current number of entries per cached store, updated on every mutation and after initial population.
- **`rox_central_cache_population_duration_seconds`** (histogram) -- time to populate each cache at startup, useful for understanding startup cost.
- **`rox_central_cache_bypass_total`** (counter) -- queries that fell through to the database because they contained scoped queries the cache cannot serve (`Count`, `GetByQuery`, `WalkByQuery`, `GetByQueryFn`, `GetIDsByQuery`).
- **`rox_central_cache_miss_total`** (counter) -- ID-based lookups where the requested key was not in the cache (`Get`, `GetMany`, `Exists`).

All metrics are labeled by `Type` (the store's schema type name) and, where applicable, `Operation`, so they can be sliced per resource kind and per code path. No behavioral changes are introduced; the cache continues to function identically.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

No user-facing documentation needed. These are internal Prometheus metrics for engineering observability, not exposed to customers.

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

- Deployed instrumented build to a GKE cluster with the `default` scale workload (2,500 synthetic deployments, 1,000 nodes, 5 pods per deployment)
- Verified all 4 metrics emit correctly via `curl localhost:9090/metrics | grep rox_central_cache`
- Confirmed metrics are labeled correctly by `Type` (Deployment, Pod, Cluster, etc.) and `Operation`
- Existing cached store unit tests pass without modification


[ROX-34526]: https://redhat.atlassian.net/browse/ROX-34526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ