### PR TITLE
ROX-35030: Fix entity scope E2E test flake

### DIFF
--- a/tests/report_entity_scope_test.go
+++ b/tests/report_entity_scope_test.go
@@ -40,6 +40,31 @@ func (s *ReportEntityScopeSuite) SetupSuite() {
 	s.ctx, s.cancel = context.WithTimeout(context.Background(), 10*time.Minute)
 	conn := centralgrpc.GRPCConnectionToCentral(s.T())
 	s.service = apiV2.NewReportServiceClient(conn)
+	s.waitForCentralReady()
+}
+
+func (s *ReportEntityScopeSuite) waitForCentralReady() {
+	s.T().Log("Waiting for Central to be ready...")
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	timer := time.NewTimer(2 * time.Minute)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+			_, err := s.service.CountReportConfigurations(ctx, &apiV2.RawQuery{})
+			cancel()
+			if err == nil {
+				s.T().Log("Central is ready")
+				return
+			}
+			s.T().Logf("Central not ready yet: %v", err)
+		case <-timer.C:
+			s.Require().Fail("Timed out waiting for Central to become ready")
+			return
+		}
+	}
 }
 
 func (s *ReportEntityScopeSuite) TearDownSuite() {

--- a/tests/report_entity_scope_test.go
+++ b/tests/report_entity_scope_test.go
@@ -45,26 +45,12 @@ func (s *ReportEntityScopeSuite) SetupSuite() {
 
 func (s *ReportEntityScopeSuite) waitForCentralReady() {
 	s.T().Log("Waiting for Central to be ready...")
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-	timer := time.NewTimer(2 * time.Minute)
-	defer timer.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
-			_, err := s.service.CountReportConfigurations(ctx, &apiV2.RawQuery{})
-			cancel()
-			if err == nil {
-				s.T().Log("Central is ready")
-				return
-			}
-			s.T().Logf("Central not ready yet: %v", err)
-		case <-timer.C:
-			s.Require().Fail("Timed out waiting for Central to become ready")
-			return
-		}
-	}
+	s.Require().Eventually(func() bool {
+		ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+		defer cancel()
+		_, err := s.service.CountReportConfigurations(ctx, &apiV2.RawQuery{})
+		return err == nil
+	}, 2*time.Minute, 2*time.Second, "Central did not become ready")
 }
 
 func (s *ReportEntityScopeSuite) TearDownSuite() {


### PR DESCRIPTION
## Description

The `TestReportEntityScope` suite's `SetupSuite` creates a lazy gRPC connection to Central but doesn't verify Central is actually reachable. When the first test method (`TestCreateReportConfigWithEntityScope`) runs, its `PostReportConfiguration` call fails because Central isn't ready yet. The retry interceptor's 5 retries (~12s with exponential backoff) aren't enough to cover Central's startup time in CI.

Added a `waitForCentralReady()` readiness poll in `SetupSuite()` that makes a lightweight `CountReportConfigurations` call every 2 seconds (up to 2 minutes) until Central accepts connections, before any test methods run.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- Code compiles cleanly with `go vet -tags test_e2e ./tests/`
- The fix adds a readiness poll before test methods run, matching the pattern used by other E2E tests that wait for infrastructure readiness
- The CI failure in ROX-35030 shows Central becoming available after the retry window; this fix extends the wait to 2 minutes with 2s polling