### PR TITLE
ROX-35080: create key bundle directory for offline signing key updates

### DIFF
--- a/central/signatureintegration/datastore/key_bundle.go
+++ b/central/signatureintegration/datastore/key_bundle.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/signatures"
 )
 
-var redHatKeyBundlePath = filepath.Join(os.TempDir(), "redhat-signing-keys", "bundle.json")
+var redHatKeyBundlePath = signatures.RedHatKeyBundlePath
 
 // ensureKeyBundleDirectory creates the directory where the watcher and
 // downloader expect to find bundle.json.

--- a/central/signatureintegration/datastore/key_bundle.go
+++ b/central/signatureintegration/datastore/key_bundle.go
@@ -15,6 +15,25 @@ import (
 
 var redHatKeyBundlePath = filepath.Join(os.TempDir(), "redhat-signing-keys", "bundle.json")
 
+// ensureKeyBundleDirectory creates the directory where the watcher and
+// downloader expect to find bundle.json.
+func ensureKeyBundleDirectory() {
+	dir := filepath.Dir(redHatKeyBundlePath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		log.Warnf("Failed to create key bundle directory %q: %v", dir, err)
+	}
+}
+
+// writeExampleBundle writes bundle.example.json so offline-mode customers can
+// see the expected format without consulting docs.
+func writeExampleBundle() {
+	dir := filepath.Dir(redHatKeyBundlePath)
+	examplePath := filepath.Join(dir, "bundle.example.json")
+	if err := os.WriteFile(examplePath, signatures.DefaultBundleJSON(), 0600); err != nil {
+		log.Warnf("Failed to write example bundle to %q: %v", examplePath, err)
+	}
+}
+
 func keyBundleHandler(siStore store.SignatureIntegrationStore) filewatcher.Handler {
 	return func(data []byte) error {
 		bundle, err := signatures.ParseKeyBundle(data)

--- a/central/signatureintegration/datastore/key_bundle.go
+++ b/central/signatureintegration/datastore/key_bundle.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stackrox/rox/pkg/signatures"
 )
 
-var redHatKeyBundlePath = signatures.RedHatKeyBundlePath
+var redHatKeyBundlePath = signatures.RedHatKeyBundlePath()
 
 // ensureKeyBundleDirectory creates the directory where the watcher and
 // downloader expect to find bundle.json.

--- a/central/signatureintegration/datastore/singleton.go
+++ b/central/signatureintegration/datastore/singleton.go
@@ -99,6 +99,8 @@ func Singleton() DataStore {
 	once.Do(func() {
 		storage := pgStore.New(globaldb.GetPostgres())
 		seedRedHatDefaultSignatureIntegration(storage) // must run before watcher; bundle file takes precedence on first tick
+		ensureKeyBundleDirectory()
+		writeExampleBundle()
 		instance = New(storage, policyDataStore.Singleton())
 		startKeyBundleWatcher(storage)
 		startKeyBundleUpdater()

--- a/central/signatureintegration/datastore/singleton_test.go
+++ b/central/signatureintegration/datastore/singleton_test.go
@@ -1,12 +1,15 @@
 package datastore
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	storeMocks "github.com/stackrox/rox/central/signatureintegration/store/mocks"
 	"github.com/stackrox/rox/pkg/env"
 	"github.com/stackrox/rox/pkg/signatures"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -29,6 +32,34 @@ func TestSeedSubsequentStartup(t *testing.T) {
 	mockStore.EXPECT().Get(gomock.Any(), id).Return(signatures.DefaultRedHatSignatureIntegration, true, nil).Times(1)
 
 	seedRedHatDefaultSignatureIntegration(mockStore)
+}
+
+func TestEnsureKeyBundleDirectory(t *testing.T) {
+	dir := t.TempDir()
+	old := redHatKeyBundlePath
+	redHatKeyBundlePath = filepath.Join(dir, "subdir", "bundle.json")
+	t.Cleanup(func() { redHatKeyBundlePath = old })
+
+	ensureKeyBundleDirectory()
+
+	_, err := os.Stat(filepath.Join(dir, "subdir"))
+	require.NoError(t, err, "directory should be created")
+}
+
+func TestWriteExampleBundle(t *testing.T) {
+	dir := t.TempDir()
+	old := redHatKeyBundlePath
+	redHatKeyBundlePath = filepath.Join(dir, "bundle.json")
+	t.Cleanup(func() { redHatKeyBundlePath = old })
+
+	writeExampleBundle()
+
+	data, err := os.ReadFile(filepath.Join(dir, "bundle.example.json"))
+	require.NoError(t, err, "example bundle should be written")
+
+	bundle, err := signatures.ParseKeyBundle(data)
+	require.NoError(t, err, "example bundle must be valid")
+	assert.NotEmpty(t, bundle.Keys, "example bundle must contain keys")
 }
 
 func TestStartKeyBundleUpdaterOfflineMode(t *testing.T) {

--- a/pkg/signatures/types.go
+++ b/pkg/signatures/types.go
@@ -2,10 +2,16 @@ package signatures
 
 import (
 	_ "embed"
+	"os"
+	"path/filepath"
 	"slices"
 
 	"github.com/stackrox/rox/generated/storage"
 )
+
+// RedHatKeyBundlePath is the default filesystem path for the Red Hat signing
+// key bundle file. The watcher and downloader both use this path.
+var RedHatKeyBundlePath = filepath.Join(os.TempDir(), "redhat-signing-keys", "bundle.json")
 
 const (
 	// SignatureIntegrationIDPrefix should be prepended to every human-hostile ID of a

--- a/pkg/signatures/types.go
+++ b/pkg/signatures/types.go
@@ -2,6 +2,7 @@ package signatures
 
 import (
 	_ "embed"
+	"slices"
 
 	"github.com/stackrox/rox/generated/storage"
 )
@@ -25,6 +26,9 @@ const (
 
 //go:embed "bundle.json"
 var defaultBundleJSON []byte
+
+// DefaultBundleJSON returns a copy of the raw embedded bundle JSON.
+func DefaultBundleJSON() []byte { return slices.Clone(defaultBundleJSON) }
 
 var DefaultRedHatSignatureIntegration = mustParseEmbeddedBundle()
 

--- a/pkg/signatures/types.go
+++ b/pkg/signatures/types.go
@@ -9,9 +9,11 @@ import (
 	"github.com/stackrox/rox/generated/storage"
 )
 
-// RedHatKeyBundlePath is the default filesystem path for the Red Hat signing
-// key bundle file. The watcher and downloader both use this path.
-var RedHatKeyBundlePath = filepath.Join(os.TempDir(), "redhat-signing-keys", "bundle.json")
+var redHatKeyBundlePath = filepath.Join(os.TempDir(), "redhat-signing-keys", "bundle.json")
+
+// RedHatKeyBundlePath returns the default filesystem path for the Red Hat
+// signing key bundle file.
+func RedHatKeyBundlePath() string { return redHatKeyBundlePath }
 
 const (
 	// SignatureIntegrationIDPrefix should be prepended to every human-hostile ID of a


### PR DESCRIPTION
## Description

Second of two stacked PRs for ROX-35080 (automatic Red Hat signing key rotation).

**Why:** Offline-mode customers need a straightforward way to provide updated signing key bundles without rebuilding the image. By creating `/tmp/redhat-signing-keys/` at startup and placing a `bundle.example.json` there, the directory is ready to receive a customer-provided `bundle.json` — either via a volume mount or a manual copy. The example file shows the expected format so customers don't have to guess the schema.

**How it works:**
- On startup, `ensureKeyBundleDirectory()` creates `/tmp/redhat-signing-keys/` and writes `bundle.example.json` from the embedded default bundle.
- The **watcher** polls `bundle.json` in that directory. It starts absent (gracefully skipped) and gets picked up as soon as a customer places one there or the downloader creates it.
- The **downloader** (online mode) writes updated bundles to the same path.
- The **seed** continues to use the embedded `DefaultRedHatSignatureIntegration` from PR #21269 — no file I/O needed, no risk of overwriting customer-provided bundles.
- The path lives under `/tmp` because Central runs with `readOnlyRootFilesystem: true` and `/tmp` is backed by an emptyDir volume (same pattern as the scanner vuln updater).

**What changes:**
- Export `RedHatKeyBundlePath` from `pkg/signatures` so watcher, downloader, and log messages share a single path constant
- Add `DefaultBundleJSON()` accessor for the embedded bundle data
- Add `ensureKeyBundleDirectory()` — creates the directory and writes `bundle.example.json`
- Call it from `Singleton()` at startup
- Remove the local `redHatKeyBundlePath` var (replaced by the exported one)

**Stack:** #21269 (replace key embed with bundle embed) → This PR

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [x] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [x] modified existing tests

### How I validated my change

- All unit tests pass for affected packages
- Deployed in-cluster (ga-ocp4-cron) and verified:
  - `/tmp/redhat-signing-keys/` created at startup with correct ownership (4000:4000)
  - `bundle.example.json` present with the embedded default bundle content
  - No `bundle.json` present — clean slate for customers to mount their own
  - Watcher polls `bundle.json`, gracefully skips while absent
  - E2E `TestDefaultIntegrationExists` — PASS
  - E2E `TestWatcherPicksUpBundleFile` — PASS (writes test bundle, watcher picks it up within 10s)