### PR TITLE
chore(ci): skip non-UI GHA jobs on UI-only PRs

### DIFF
--- a/.github/workflows/check-crd-compatibility.yaml
+++ b/.github/workflows/check-crd-compatibility.yaml
@@ -17,7 +17,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   check-crd-compatibility:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      !needs.detect-changes.outputs.ui_only
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -31,12 +31,19 @@ on:
           Newline-separated list of changed filenames, or empty
           string on push/failure (falsy, so jobs default to run).
         value: ${{ jobs.detect.outputs.files }}
+      ui_only:
+        description: >
+          'true' when every changed file is under ui/, empty
+          otherwise. Use to skip non-UI jobs on UI-only PRs:
+          if: !needs.X.outputs.files || !needs.X.outputs.ui_only
+        value: ${{ jobs.detect.outputs.ui_only }}
 
 jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.list.outputs.files }}
+      ui_only: ${{ steps.list.outputs.ui_only }}
     steps:
       - name: List changed files
         id: list
@@ -92,4 +99,9 @@ jobs:
               printf '^%s$\n' "${files[@]}"
               echo "EOF"
             } >> "${GITHUB_OUTPUT}"
+
+            if ! echo "${anchored}" | grep -qv '^\^ui/'; then
+              echo "All changed files are under ui/" >&2
+              echo "ui_only=true" >> "${GITHUB_OUTPUT}"
+            fi
           fi

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -18,9 +18,14 @@ defaults:
     shell: bash
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   wait-for-images:
+    needs: detect-changes
     if: >-
-      github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+      (github.event_name == 'push' || !github.event.pull_request.head.repo.fork) &&
+      (!needs.detect-changes.outputs.files || !needs.detect-changes.outputs.ui_only)
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -18,9 +18,14 @@ defaults:
     shell: bash
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   wait-for-images:
+    needs: detect-changes
     if: >-
-      github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+      (github.event_name == 'push' || !github.event.pull_request.head.repo.fork) &&
+      (!needs.detect-changes.outputs.files || !needs.detect-changes.outputs.ui_only)
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -14,7 +14,14 @@ on:
     - synchronize
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   db-integration-tests:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      !needs.detect-changes.outputs.ui_only
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:scanner-test-0.5.11@sha256:cea78f2b3a5a38c9ccda678712daaed90b7c372d6b5df963feb758b32dccebe1 # ratchet:quay.io/stackrox-io/apollo-ci:scanner-test-0.5.11

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -23,6 +23,10 @@ jobs:
     uses: ./.github/workflows/detect-changes.yml
 
   check-generated-files:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      !needs.detect-changes.outputs.ui_only
     env:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
@@ -153,6 +157,10 @@ jobs:
         run: make style-slim
 
   golangci-lint:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      !needs.detect-changes.outputs.ui_only
     timeout-minutes: 240
     runs-on: ubuntu-latest
     steps:
@@ -198,6 +206,10 @@ jobs:
       run: make golangci-lint-cache-status
 
   check-dependent-images-exist:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      !needs.detect-changes.outputs.ui_only
     # This job ensures that COLLECTOR_VERSION, FACT_VERSION or SCANNER_VERSION files cannot be updated to a version
     # for which the image was not successfully built on Konflux (suffix "-fast"). It also verifies that GHA-built image
     # is there (no suffix) so that the failure also happens in this job.

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -34,6 +34,10 @@ jobs:
         ^.github/actions/job-preamble/
 
   go:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      !needs.detect-changes.outputs.ui_only
     strategy:
       fail-fast: false
       matrix:
@@ -106,6 +110,10 @@ jobs:
         directory: 'junit-reports'
 
   go-postgres:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      !needs.detect-changes.outputs.ui_only
     strategy:
       fail-fast: false
       matrix:
@@ -194,6 +202,10 @@ jobs:
   # they compile and execute without errors. A single postgres version is
   # sufficient since go-postgres already tests against multiple versions.
   go-bench:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      !needs.detect-changes.outputs.ui_only
     runs-on: ubuntu-latest
     env:
       BUILD_TAG: 0.0.0
@@ -356,6 +368,10 @@ jobs:
         directory: 'ui/apps/platform/cypress/test-results/reports'
 
   local-roxctl-tests:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      !needs.detect-changes.outputs.ui_only
     runs-on: ubuntu-latest
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
@@ -400,6 +416,10 @@ jobs:
         directory: 'roxctl-test-output'
 
   shell-unit-tests:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      !needs.detect-changes.outputs.ui_only
     runs-on: ubuntu-latest
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
@@ -436,6 +456,10 @@ jobs:
         directory: 'shell-test-output'
 
   openshift-ci-unit-tests:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      !needs.detect-changes.outputs.ui_only
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
@@ -454,6 +478,10 @@ jobs:
         run: make -C .openshift-ci test
 
   sensor-integration-tests:
+    needs: detect-changes
+    if: >-
+      !needs.detect-changes.outputs.files ||
+      !needs.detect-changes.outputs.ui_only
     env:
       KUBECONFIG: "/tmp/kubeconfig"
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Added a `ui_only` output to the `detect-changes` reusable workflow that is set when all changed files are under `ui/`. Used this to gate 14 non-UI jobs across 6 workflow files so they are skipped on UI-only PRs. Push/schedule/tag events are unaffected — `detect-changes` returns empty output for non-PR events so all jobs still run.

Jobs skipped on UI-only PRs:
- unit-tests.yaml: go, go-postgres, go-bench, local-roxctl-tests, shell-unit-tests, openshift-ci-unit-tests, sensor-integration-tests
- style.yaml: check-generated-files, golangci-lint, check-dependent-images-exist  
- check-crd-compatibility.yaml: check-crd-compatibility
- scanner-db-integration-tests.yaml: db-integration-tests
- e2e-nongroovy-tests.yaml: wait-for-images + gke-nongroovy-e2e-tests
- e2e-db-backup-restore-test.yaml: wait-for-images + gke-db-backup-restore-test

## User-facing documentation

- [x] CHANGELOG.md is updated **OR** update is not needed
- [x] documentation PR is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is GA, or otherwise the functionality is gated by a feature flag
- [x] CI results are inspected

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Changes are CI config only. Verified YAML syntax. The `ui_only` detection uses `grep -qv '^\^ui/'` against the anchored file list — if any file does NOT start with `^ui/`, `ui_only` stays unset and all jobs run normally.