### PR TITLE
ROX-34993: Add relative days to time filters

### DIFF
--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionDate.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionDate.cy.jsx
@@ -38,8 +38,11 @@ function setup() {
 }
 
 function selectCondition(condition) {
+    const escapedCondition = condition.replace(/[()]/g, '\\$&');
     cy.get(selectors.conditionSelectToggle).click();
-    cy.get(`${selectors.conditionSelectItems} button:contains("${condition}")`).click();
+    cy.get(`${selectors.conditionSelectItems} button`)
+        .contains(new RegExp(`^${escapedCondition}$`, 'i'))
+        .click();
 }
 
 describe(Cypress.spec.relative, () => {

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionDate.cy.jsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionDate.cy.jsx
@@ -16,6 +16,11 @@ const selectors = {
     startDateInput: 'input[aria-label="Filter by start date"]',
     endDateInput: 'input[aria-label="Filter by end date"]',
     applyButton: 'button[aria-label="Apply condition and date input to search"]',
+    relativeDaysInput: 'input[aria-label="Number of days"]',
+    relativeApplyButton: 'button[aria-label="Apply relative date filter"]',
+    relativeMinDaysInput: 'input[aria-label="Minimum days ago"]',
+    relativeMaxDaysInput: 'input[aria-label="Maximum days ago"]',
+    relativeRangeApplyButton: 'button[aria-label="Apply relative date range filter"]',
 };
 
 const endBeforeStartErrorText = 'The end date must be on or after the start date';
@@ -38,16 +43,18 @@ function selectCondition(condition) {
 }
 
 describe(Cypress.spec.relative, () => {
-    it('should include Between in the condition selector after Before/On/After', () => {
+    it('should list all conditions in the expected order', () => {
         setup();
 
         cy.get(selectors.conditionSelectToggle).click();
 
-        cy.get(selectors.conditionSelectItems).should('have.length', 4);
+        cy.get(selectors.conditionSelectItems).should('have.length', 6);
         cy.get(selectors.conditionSelectItems).eq(0).should('have.text', 'Before');
         cy.get(selectors.conditionSelectItems).eq(1).should('have.text', 'On');
         cy.get(selectors.conditionSelectItems).eq(2).should('have.text', 'After');
-        cy.get(selectors.conditionSelectItems).eq(3).should('have.text', 'Between');
+        cy.get(selectors.conditionSelectItems).eq(3).should('have.text', 'More than (days ago)');
+        cy.get(selectors.conditionSelectItems).eq(4).should('have.text', 'Between');
+        cy.get(selectors.conditionSelectItems).eq(5).should('have.text', 'Between (days ago)');
     });
 
     it('should keep single-date apply behavior for the After condition', () => {
@@ -210,6 +217,81 @@ describe(Cypress.spec.relative, () => {
         cy.get(selectors.endDateInput).clear();
 
         cy.get(selectors.applyButton).click();
+
+        cy.get('@onSearch').should('not.have.been.called');
+    });
+
+    it('should apply the "More than (days ago)" condition as >Nd format and clear the input', () => {
+        setup();
+
+        selectCondition('More than (days ago)');
+
+        cy.get(selectors.relativeDaysInput).clear();
+        cy.get(selectors.relativeDaysInput).type('365');
+        cy.get(selectors.relativeApplyButton).click();
+
+        cy.get('@onSearch').should('have.been.calledWithExactly', [
+            {
+                action: 'APPEND',
+                category: 'CVE Created Time',
+                value: '>365d',
+            },
+        ]);
+        cy.get(selectors.relativeDaysInput).should('have.value', '');
+    });
+
+    it('should apply the "Between (days ago)" condition as Nd-Md format and clear the inputs', () => {
+        setup();
+
+        selectCondition('Between (days ago)');
+
+        cy.get(selectors.relativeMinDaysInput).clear();
+        cy.get(selectors.relativeMinDaysInput).type('30');
+        cy.get(selectors.relativeMaxDaysInput).clear();
+        cy.get(selectors.relativeMaxDaysInput).type('90');
+        cy.get(selectors.relativeRangeApplyButton).click();
+
+        cy.get('@onSearch').should('have.been.calledWithExactly', [
+            {
+                action: 'APPEND',
+                category: 'CVE Created Time',
+                value: '30d-90d',
+            },
+        ]);
+        cy.get(selectors.relativeMinDaysInput).should('have.value', '');
+        cy.get(selectors.relativeMaxDaysInput).should('have.value', '');
+    });
+
+    it('should not emit "More than (days ago)" when the input is empty', () => {
+        setup();
+
+        selectCondition('More than (days ago)');
+
+        cy.get(selectors.relativeApplyButton).click();
+
+        cy.get('@onSearch').should('not.have.been.called');
+    });
+
+    it('should not emit "Between (days ago)" when inputs are empty', () => {
+        setup();
+
+        selectCondition('Between (days ago)');
+
+        cy.get(selectors.relativeRangeApplyButton).click();
+
+        cy.get('@onSearch').should('not.have.been.called');
+    });
+
+    it('should not emit "Between (days ago)" when min exceeds max', () => {
+        setup();
+
+        selectCondition('Between (days ago)');
+
+        cy.get(selectors.relativeMinDaysInput).clear();
+        cy.get(selectors.relativeMinDaysInput).type('90');
+        cy.get(selectors.relativeMaxDaysInput).clear();
+        cy.get(selectors.relativeMaxDaysInput).type('30');
+        cy.get(selectors.relativeRangeApplyButton).click();
 
         cy.get('@onSearch').should('not.have.been.called');
     });

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionDate.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterConditionDate.tsx
@@ -1,16 +1,29 @@
 import { useState } from 'react';
 import { SelectOption, ToolbarItem } from '@patternfly/react-core';
 
-import { dateConditionMap, dateConditions, dateRangeCondition } from '../utils/utils';
+import {
+    dateConditionMap,
+    dateConditions,
+    dateRangeCondition,
+    dateRelativeOlderThanCondition,
+    dateRelativeRangeCondition,
+} from '../utils/utils';
 import type { GenericSearchFilterAttribute, OnSearchCallback } from '../types';
 
 import SearchFilterDateRange from './SearchFilterDateRange';
+import SearchFilterDateRelativeOlderThan from './SearchFilterDateRelativeOlderThan';
+import SearchFilterDateRelativeRange from './SearchFilterDateRelativeRange';
 import SearchFilterDateSingle from './SearchFilterDateSingle';
 import SimpleSelect from './SimpleSelect';
 
-type DateCondition = (typeof dateConditions)[number] | typeof dateRangeCondition;
+const conditions = [
+    ...dateConditions,
+    dateRelativeOlderThanCondition,
+    dateRangeCondition,
+    dateRelativeRangeCondition,
+] as const;
 
-const conditions: DateCondition[] = [...dateConditions, dateRangeCondition];
+type DateCondition = (typeof conditions)[number];
 
 export type SearchFilterConditionDateProps = {
     attribute: GenericSearchFilterAttribute;
@@ -18,6 +31,54 @@ export type SearchFilterConditionDateProps = {
     onSearch: OnSearchCallback;
     // does not depend on searchFilter
 };
+
+function DateConditionInput({
+    condition,
+    category,
+    isDisabled,
+    onSearch,
+}: {
+    condition: DateCondition;
+    category: string;
+    isDisabled: boolean;
+    onSearch: OnSearchCallback;
+}) {
+    switch (condition) {
+        case dateRelativeOlderThanCondition:
+            return (
+                <SearchFilterDateRelativeOlderThan
+                    category={category}
+                    isDisabled={isDisabled}
+                    onSearch={onSearch}
+                />
+            );
+        case dateRangeCondition:
+            return (
+                <SearchFilterDateRange
+                    category={category}
+                    isDisabled={isDisabled}
+                    onSearch={onSearch}
+                />
+            );
+        case dateRelativeRangeCondition:
+            return (
+                <SearchFilterDateRelativeRange
+                    category={category}
+                    isDisabled={isDisabled}
+                    onSearch={onSearch}
+                />
+            );
+        default:
+            return (
+                <SearchFilterDateSingle
+                    conditionPrefix={dateConditionMap[condition]}
+                    category={category}
+                    isDisabled={isDisabled}
+                    onSearch={onSearch}
+                />
+            );
+    }
+}
 
 function SearchFilterConditionDate({
     attribute,
@@ -49,20 +110,12 @@ function SearchFilterConditionDate({
                     })}
                 </SimpleSelect>
             </ToolbarItem>
-            {conditionExternal === dateRangeCondition ? (
-                <SearchFilterDateRange
-                    category={category}
-                    isDisabled={isDisabled}
-                    onSearch={onSearch}
-                />
-            ) : (
-                <SearchFilterDateSingle
-                    conditionPrefix={dateConditionMap[conditionExternal]}
-                    category={category}
-                    isDisabled={isDisabled}
-                    onSearch={onSearch}
-                />
-            )}
+            <DateConditionInput
+                condition={conditionExternal}
+                category={category}
+                isDisabled={isDisabled}
+                onSearch={onSearch}
+            />
         </>
     );
 }

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterDateRelativeOlderThan.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterDateRelativeOlderThan.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { Button, TextInput, ToolbarItem } from '@patternfly/react-core';
+import { ArrowRightIcon } from '@patternfly/react-icons';
+
+import { serializeRelativeOlderThan } from '../utils/utils';
+import type { OnSearchCallback } from '../types';
+
+export type SearchFilterDateRelativeOlderThanProps = {
+    category: string;
+    isDisabled?: boolean;
+    onSearch: OnSearchCallback;
+};
+
+function SearchFilterDateRelativeOlderThan({
+    category,
+    isDisabled = false,
+    onSearch,
+}: SearchFilterDateRelativeOlderThanProps) {
+    const [days, setDays] = useState('');
+
+    function onApply() {
+        const value = serializeRelativeOlderThan(Number(days));
+        if (days === '' || value === null) {
+            return;
+        }
+        onSearch([{ action: 'APPEND', category, value }]);
+        setDays('');
+    }
+
+    return (
+        <>
+            <ToolbarItem style={{ flexBasis: '6rem' }}>
+                <TextInput
+                    aria-label="Number of days"
+                    isDisabled={isDisabled}
+                    value={days}
+                    type="number"
+                    min={0}
+                    onChange={(_event, value) => setDays(value)}
+                    placeholder="days"
+                />
+            </ToolbarItem>
+            <ToolbarItem>
+                <Button
+                    icon={<ArrowRightIcon />}
+                    variant="control"
+                    aria-label="Apply relative date filter"
+                    onClick={onApply}
+                />
+            </ToolbarItem>
+        </>
+    );
+}
+
+export default SearchFilterDateRelativeOlderThan;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterDateRelativeRange.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/components/SearchFilterDateRelativeRange.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import { Button, TextInput, ToolbarItem } from '@patternfly/react-core';
+import { ArrowRightIcon } from '@patternfly/react-icons';
+
+import { serializeRelativeDateRange } from '../utils/utils';
+import type { OnSearchCallback } from '../types';
+
+export type SearchFilterDateRelativeRangeProps = {
+    category: string;
+    isDisabled?: boolean;
+    onSearch: OnSearchCallback;
+};
+
+function SearchFilterDateRelativeRange({
+    category,
+    isDisabled = false,
+    onSearch,
+}: SearchFilterDateRelativeRangeProps) {
+    const [minDays, setMinDays] = useState('');
+    const [maxDays, setMaxDays] = useState('');
+
+    function onApply() {
+        const value = serializeRelativeDateRange(Number(minDays), Number(maxDays));
+        if (minDays === '' || maxDays === '' || value === null) {
+            return;
+        }
+        onSearch([{ action: 'APPEND', category, value }]);
+        setMinDays('');
+        setMaxDays('');
+    }
+
+    return (
+        <>
+            <ToolbarItem style={{ flexBasis: '6rem' }}>
+                <TextInput
+                    aria-label="Minimum days ago"
+                    isDisabled={isDisabled}
+                    value={minDays}
+                    type="number"
+                    min={0}
+                    onChange={(_event, value) => setMinDays(value)}
+                    placeholder="days"
+                />
+            </ToolbarItem>
+            <ToolbarItem alignSelf="center">to</ToolbarItem>
+            <ToolbarItem style={{ flexBasis: '6rem' }}>
+                <TextInput
+                    aria-label="Maximum days ago"
+                    isDisabled={isDisabled}
+                    value={maxDays}
+                    type="number"
+                    min={0}
+                    onChange={(_event, value) => setMaxDays(value)}
+                    placeholder="days"
+                />
+            </ToolbarItem>
+            <ToolbarItem>
+                <Button
+                    icon={<ArrowRightIcon />}
+                    variant="control"
+                    aria-label="Apply relative date range filter"
+                    onClick={onApply}
+                />
+            </ToolbarItem>
+        </>
+    );
+}
+
+export default SearchFilterDateRelativeRange;

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.test.ts
@@ -1,4 +1,9 @@
-import { convertFromInternalToExternalDatePicker, serializeAbsoluteDateRange } from './utils';
+import {
+    convertFromInternalToExternalDatePicker,
+    serializeAbsoluteDateRange,
+    serializeRelativeDateRange,
+    serializeRelativeOlderThan,
+} from './utils';
 
 describe('utils', () => {
     describe('convertFromInternalToExternalDatePicker', () => {
@@ -108,6 +113,52 @@ describe('utils', () => {
             expect(convertFromInternalToExternalDatePicker(serialized as string)).toEqual(
                 'Between Jan 01, 2025 and Mar 31, 2025'
             );
+        });
+    });
+
+    describe('serializeRelativeOlderThan', () => {
+        it('serializes a positive integer', () => {
+            expect(serializeRelativeOlderThan(365)).toEqual('>365d');
+        });
+
+        it('serializes zero', () => {
+            expect(serializeRelativeOlderThan(0)).toEqual('>0d');
+        });
+
+        it('returns null for a negative number', () => {
+            expect(serializeRelativeOlderThan(-1)).toBeNull();
+        });
+
+        it('returns null for a non-integer', () => {
+            expect(serializeRelativeOlderThan(1.5)).toBeNull();
+        });
+    });
+
+    describe('serializeRelativeDateRange', () => {
+        it('serializes a valid range', () => {
+            expect(serializeRelativeDateRange(30, 90)).toEqual('30d-90d');
+        });
+
+        it('serializes equal min and max', () => {
+            expect(serializeRelativeDateRange(7, 7)).toEqual('7d-7d');
+        });
+
+        it('serializes zero values', () => {
+            expect(serializeRelativeDateRange(0, 30)).toEqual('0d-30d');
+        });
+
+        it('returns null when min exceeds max', () => {
+            expect(serializeRelativeDateRange(90, 30)).toBeNull();
+        });
+
+        it('returns null for a negative number', () => {
+            expect(serializeRelativeDateRange(-1, 30)).toBeNull();
+            expect(serializeRelativeDateRange(0, -1)).toBeNull();
+        });
+
+        it('returns null for a non-integer', () => {
+            expect(serializeRelativeDateRange(1.5, 30)).toBeNull();
+            expect(serializeRelativeDateRange(0, 2.5)).toBeNull();
         });
     });
 });

--- a/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
+++ b/ui/apps/platform/src/Components/CompoundSearchFilter/utils/utils.tsx
@@ -35,13 +35,28 @@ export const dateConditions = Object.keys(
     dateConditionMap
 ) as unknown as (keyof typeof dateConditionMap)[];
 
-// Range condition for the date-picker input. Unlike Before/On/After it is not a
-// prefix on a single date; it serializes to the backend time-range format tr/<startMs>-<endMs>.
+export const dateRelativeOlderThanCondition = 'More than (days ago)' as const;
 export const dateRangeCondition = 'Between' as const;
+export const dateRelativeRangeCondition = 'Between (days ago)' as const;
 
 const absoluteDateRangeRegex = /^tr\/(\d+)-(\d+)$/;
 const relativeDateRangeRegex = /^(\d+)d-(\d+)d$/;
 const relativeDateOlderThanRegex = /^>(\d+)d$/;
+
+function isNonNegativeInteger(n: number): boolean {
+    return Number.isInteger(n) && n >= 0;
+}
+
+export function serializeRelativeOlderThan(days: number): string | null {
+    return isNonNegativeInteger(days) ? `>${days}d` : null;
+}
+
+export function serializeRelativeDateRange(minDays: number, maxDays: number): string | null {
+    if (!isNonNegativeInteger(minDays) || !isNonNegativeInteger(maxDays) || minDays > maxDays) {
+        return null;
+    }
+    return `${minDays}d-${maxDays}d`;
+}
 
 /**
  * Serializes an absolute date range into the backend time-range query format.


### PR DESCRIPTION
## Description

Adds another option to compound search filter date/time fields that allows users to specify a relative date for the query. This is particularly helpful in bookmarks like "show me CVEs in images create >30 days ago".

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
<img width="1606" height="911" alt="image" src="https://github.com/user-attachments/assets/437cb6d3-368c-4309-8f97-3bc46f486a46" />
<img width="1606" height="1102" alt="image" src="https://github.com/user-attachments/assets/eba04a72-7460-4a8e-89b2-22062fd29f55" />
<img width="1606" height="1102" alt="image" src="https://github.com/user-attachments/assets/cc855b66-c4b4-4dd2-8b17-f301f0562a45" />

