### PR TITLE
chore(ui): Skip non-UI GHA jobs on UI-only PRs

### DIFF
--- a/.github/workflows/check-crd-compatibility.yaml
+++ b/.github/workflows/check-crd-compatibility.yaml
@@ -11,6 +11,8 @@ on:
     - opened
     - reopened
     - synchronize
+    paths-ignore:
+    - 'ui/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -31,12 +31,18 @@ on:
           Newline-separated list of changed filenames, or empty
           string on push/failure (falsy, so jobs default to run).
         value: ${{ jobs.detect.outputs.files }}
+      ui_only:
+        description: >
+          'true' when every changed file is under ui/, empty
+          otherwise. Skip non-UI jobs with: if: !needs.X.outputs.ui_only
+        value: ${{ jobs.detect.outputs.ui_only }}
 
 jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.list.outputs.files }}
+      ui_only: ${{ steps.list.outputs.ui_only }}
     steps:
       - name: List changed files
         id: list
@@ -92,4 +98,9 @@ jobs:
               printf '^%s$\n' "${files[@]}"
               echo "EOF"
             } >> "${GITHUB_OUTPUT}"
+
+            if ! echo "${anchored}" | grep -qv '^\^ui/'; then
+              echo "All changed files are under ui/" >&2
+              echo "ui_only=true" >> "${GITHUB_OUTPUT}"
+            fi
           fi

--- a/.github/workflows/e2e-db-backup-restore-test.yaml
+++ b/.github/workflows/e2e-db-backup-restore-test.yaml
@@ -12,6 +12,8 @@ on:
     - opened
     - reopened
     - synchronize
+    paths-ignore:
+    - 'ui/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/e2e-nongroovy-tests.yaml
+++ b/.github/workflows/e2e-nongroovy-tests.yaml
@@ -12,6 +12,8 @@ on:
     - opened
     - reopened
     - synchronize
+    paths-ignore:
+    - 'ui/**'
 
 defaults:
   run:

--- a/.github/workflows/scanner-db-integration-tests.yaml
+++ b/.github/workflows/scanner-db-integration-tests.yaml
@@ -12,6 +12,8 @@ on:
     - opened
     - reopened
     - synchronize
+    paths-ignore:
+    - 'ui/**'
 
 jobs:
   db-integration-tests:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -23,6 +23,8 @@ jobs:
     uses: ./.github/workflows/detect-changes.yml
 
   check-generated-files:
+    needs: detect-changes
+    if: ${{ !needs.detect-changes.outputs.ui_only }}
     env:
       ARTIFACT_DIR: junit-reports/
     runs-on: ubuntu-latest
@@ -154,6 +156,8 @@ jobs:
         run: make style-slim
 
   golangci-lint:
+    needs: detect-changes
+    if: ${{ !needs.detect-changes.outputs.ui_only }}
     timeout-minutes: 240
     runs-on: ubuntu-latest
     steps:
@@ -199,6 +203,8 @@ jobs:
       run: make golangci-lint-cache-status
 
   check-dependent-images-exist:
+    needs: detect-changes
+    if: ${{ !needs.detect-changes.outputs.ui_only }}
     # This job ensures that COLLECTOR_VERSION, FACT_VERSION or SCANNER_VERSION files cannot be updated to a version
     # for which the image was not successfully built on Konflux (suffix "-fast"). It also verifies that GHA-built image
     # is there (no suffix) so that the failure also happens in this job.

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -34,6 +34,8 @@ jobs:
         ^.github/actions/job-preamble/
 
   go:
+    needs: detect-changes
+    if: ${{ !needs.detect-changes.outputs.ui_only }}
     strategy:
       fail-fast: false
       matrix:
@@ -106,6 +108,8 @@ jobs:
         directory: 'junit-reports'
 
   go-postgres:
+    needs: detect-changes
+    if: ${{ !needs.detect-changes.outputs.ui_only }}
     strategy:
       fail-fast: false
       matrix:
@@ -194,6 +198,8 @@ jobs:
   # they compile and execute without errors. A single postgres version is
   # sufficient since go-postgres already tests against multiple versions.
   go-bench:
+    needs: detect-changes
+    if: ${{ !needs.detect-changes.outputs.ui_only }}
     runs-on: ubuntu-latest
     env:
       BUILD_TAG: 0.0.0
@@ -356,6 +362,8 @@ jobs:
         directory: 'ui/apps/platform/cypress/test-results/reports'
 
   local-roxctl-tests:
+    needs: detect-changes
+    if: ${{ !needs.detect-changes.outputs.ui_only }}
     runs-on: ubuntu-latest
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
@@ -400,6 +408,8 @@ jobs:
         directory: 'roxctl-test-output'
 
   shell-unit-tests:
+    needs: detect-changes
+    if: ${{ !needs.detect-changes.outputs.ui_only }}
     runs-on: ubuntu-latest
     outputs:
       new-jiras: ${{ steps.junit2jira.outputs.new-jiras }}
@@ -436,6 +446,8 @@ jobs:
         directory: 'shell-test-output'
 
   openshift-ci-unit-tests:
+    needs: detect-changes
+    if: ${{ !needs.detect-changes.outputs.ui_only }}
     runs-on: ubuntu-latest
     container:
       image: quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11@sha256:df3459cf038e73775314b3a5d36d14dda41e6df438a0273c9efa8d23e0f2358a # ratchet:quay.io/stackrox-io/apollo-ci:stackrox-test-0.5.11
@@ -454,6 +466,8 @@ jobs:
         run: make -C .openshift-ci test
 
   sensor-integration-tests:
+    needs: detect-changes
+    if: ${{ !needs.detect-changes.outputs.ui_only }}
     env:
       KUBECONFIG: "/tmp/kubeconfig"
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Skips GHA jobs that are unaffected by ui-only changes on PRs that only include changed files under `ui/`.

Two approaches:
1. `paths-ignore` when the approach is to skip the entire workflow
2. modified `detect-changes` when we only want to skip a part of the workflow (style checks, unit tests)

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Tested in branch PR that only has a change under `ui/` https://github.com/stackrox/stackrox/pull/21399
<img width="353" height="619" alt="image" src="https://github.com/user-attachments/assets/89143ae5-4b50-46ed-85f8-9f98ce124012" />
<img width="353" height="619" alt="image" src="https://github.com/user-attachments/assets/ed62fd15-27f0-4e8b-959e-ced6938da82a" />

Check https://github.com/stackrox/stackrox/pull/21399/checks and see that jobs skipped with `paths-ignore` do not show up as reported checks at all.

