### PR TITLE
ci: stabilize TMPDIR for Go test cache

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -22,6 +22,7 @@ env:
   # prevent per-commit cache misses.
   BUILD_TAG: 0.0.0
   SHORTCOMMIT: "0000000"
+  TMPDIR: /tmp
 
 jobs:
   detect-changes:


### PR DESCRIPTION
## Description

Set `TMPDIR=/tmp` in the unit-tests workflow env block.

Go's test cache ([`computeTestInputsID`](https://go.dev/src/cmd/go/internal/test/test.go)) hashes every environment variable that the test binary reads via `os.Getenv()`. These reads are recorded in the test binary's internal log (via [`testing/internal/testdeps`](https://go.dev/src/testing/internal/testdeps/deps.go)) and replayed by `computeTestInputsID` on subsequent runs to verify that inputs haven't changed.

Approximately half of our test packages call `os.TempDir()` (directly or through imported libraries), which reads `TMPDIR`. On GHA, each job gets a unique `TMPDIR` — so `testInputsID` differs between the master push (cache save) and PR run (cache restore), causing Phase 2 cache misses for every affected package.

| Config | Cache hits |
|--------|-----------|
| Master baseline (no fix) | **571/762 (75%)** |
| With `TMPDIR=/tmp` (from master cache) | **693/762 (91%)** |
| With `TMPDIR=/tmp` (own cache, stable) | **712/762 (93%)** |

`GODEBUG=gocachehash=1` on CI (PR #21276) captured 128,527 `testInputs` hash lines across 762 packages. 817 of those reference `TMPDIR`.

## Testing and quality

- [x] CI results are inspected

### Automated testing

No test changes. This fixes the CI test caching infrastructure.

### How I validated my change

- `GODEBUG=gocachehash=1` on CI captured hash inputs confirming TMPDIR in `testInputsID` (PR #21276, run 27789436790)
- 10-branch parallel A/B experiment (PRs #21199-#21215) isolated variables
- PR #21277 (experiment version) cherry-picked 11 master commits demonstrating 93% cache hits across real code changes vs 75% baseline
- Local reproduction confirmed TMPDIR is not hashed when stable