### PR TITLE
ROX-20453: move VulnMgmtSACTest from Begin to BAT phase

### DIFF
--- a/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
+++ b/qa-tests-backend/src/test/groovy/VulnMgmtSACTest.groovy
@@ -16,7 +16,7 @@ import spock.lang.Tag
 import spock.lang.Unroll
 
 @Retry(count = 3)
-@Tag("Begin")
+@Tag("BAT")
 @Tag("PZ")
 class VulnMgmtSACTest extends BaseSpecification {
     static final private String NONE = "None"


### PR DESCRIPTION
## Description

The test fails with "no image scanners are integrated" because Scanner hasn't registered with Central yet when Begin tests run. Moving to BAT gives Scanner time to become ready.

## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

CI
