### PR TITLE
fix(ci): lower codecov after_n_builds from 4 to 2

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,5 +5,5 @@ coverage:
         threshold: 1%
 codecov:
   notify:
-    after_n_builds: 4
+    after_n_builds: 2
     wait_for_ci: false


### PR DESCRIPTION
## Description

On PRs, only 2 jobs upload coverage (`go` and `go-postgres` with `GOTAGS=""` — the `GOTAGS=release` matrix variant is excluded). With `after_n_builds: 4`, Codecov never sends PR status checks because it waits for 2 more uploads that won't arrive.

History:
- PR #9049 reduced from 5 to 4 coverage uploads and updated `after_n_builds` accordingly
- PR #13884 removed UI coverage uploads, reducing to 2 on PRs — but `after_n_builds` was not updated

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change

Config-only change to `codecov.yml`. Verified by inspecting unit-tests.yaml matrix: on PRs, `GOTAGS=release` is excluded in both `go` and `go-postgres` jobs, resulting in exactly 2 coverage uploads.