### PR TITLE
feat(ci): add Codecov Components aligned with CODEOWNERS teams

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,63 @@ codecov:
   notify:
     after_n_builds: 2
     wait_for_ci: false
+
+comment:
+  layout: "header, diff, components"
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+  individual_components:
+    - component_id: core-workflows
+      name: Core Workflows
+      paths:
+        - central/policy/**
+        - central/reports/**
+        - central/reportconfiguration/**
+        - central/vulnmgmt/**
+        - pkg/detection/**
+        - pkg/booleanpolicy/**
+        - pkg/defaults/policies/**
+        - pkg/search/**
+        - pkg/postgres/**
+        - migrator/**
+    - component_id: sensor-ecosystem
+      name: Sensor Ecosystem
+      paths:
+        - sensor/**
+        - roxctl/**
+        - .*/administration/.*
+        - .*/auth/.*
+        - .*/cloudsources/.*
+        - .*/declarativeconfig/.*
+        - pkg/sac/**
+        - pkg/signatures/**
+        - pkg/features/**
+    - component_id: scanner
+      name: Scanner
+      paths:
+        - scanner/**
+        - pkg/scanners/**
+        - pkg/scannerv4/**
+        - pkg/scans/**
+        - pkg/registries/**
+        - pkg/registrymirror/**
+        - pkg/images/enricher/**
+        - pkg/nodes/**
+        - central/scannerdefinitions/**
+        - central/image/service/**
+        - central/imageintegration/service/**
+    - component_id: install
+      name: Install & Operator
+      paths:
+        - operator/**
+        - image/templates/**
+        - pkg/helm/**
+        - pkg/crs/**
+    - component_id: shared-libs
+      name: Shared Libraries
+      paths:
+        - pkg/**


### PR DESCRIPTION
## Description

Components break down coverage by team ownership without requiring upload-time changes. Paths mirror .github/CODEOWNERS boundaries: core-workflows, sensor-ecosystem, scanner, install, plus catch-all shared-libs component.

Each component gets a project-level status check on PRs via
default_rules. PR comments now include component coverage breakdown.

Partially generated by AI.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
## User-facing documentation

- [ ] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [ ] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [ ] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [ ] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [ ] added unit tests
- [ ] added e2e tests
- [ ] added regression tests
- [ ] added compatibility tests
- [ ] modified existing tests

### How I validated my change
- https://app.codecov.io/gh/stackrox/stackrox/pull/21297/components

<img width="1059" height="476" alt="image" src="https://github.com/user-attachments/assets/b6997262-253e-4e7a-9e09-c699a84650ba" />
