### PR TITLE
chore(ci): Tweak time and use buffered channel for stream stop test

### DIFF
--- a/sensor/common/sensor/buffered_stream_test.go
+++ b/sensor/common/sensor/buffered_stream_test.go
@@ -137,7 +137,7 @@ func (s *bufferedStreamSuite) Test_Stop() {
 	s.Require().NotNil(onStop)
 
 	// This is triggered when the inner stream Send function is called
-	messageReadSignal := make(chan struct{})
+	messageReadSignal := make(chan struct{}, 1)
 	defer close(messageReadSignal)
 
 	// Most of the time, this should be called once
@@ -165,10 +165,10 @@ func (s *bufferedStreamSuite) Test_Stop() {
 			// Since stopC and errC are active, the select will choose one randomly.
 			// We shouldn't fail the test if the channel is not closed immediately.
 			return ok == false
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(100 * time.Millisecond):
 			return false
 		}
-	}, 500*time.Millisecond, 10*time.Millisecond, "timeout waiting for the stream to stop")
+	}, 2*time.Second, 50*time.Millisecond, "timeout waiting for the stream to stop")
 
 	s.Assert().NoError(onStop())
 }


### PR DESCRIPTION
## Description

We had a failure: https://github.com/stackrox/stackrox/actions/runs/27792774492

Problem looks like that inner loop in `run` blocks on `case errC <- s.stream.Send(msg)` - because of `messageReadSignal <- struct{}{}`.

With change on buffered channel - `messageReadSignal <- struct{}{}` should not block anymore.

Beside that times are also tweaked so that `Eventually` allows a few iteration of inner select timeouts.

## User-facing documentation

- [x] [CHANGELOG.md](https://github.com/stackrox/stackrox/blob/master/CHANGELOG.md) is updated **OR** update is not needed
- [x] [documentation PR](https://spaces.redhat.com/display/StackRox/Submitting+a+User+Documentation+Pull+Request) is created and is linked above **OR** is not needed

## Testing and quality

- [x] the change is production ready: the change is [GA](https://github.com/stackrox/stackrox/blob/master/PR_GA.md), or otherwise the functionality is gated by a [feature flag](https://github.com/stackrox/stackrox/blob/master/pkg/features/README.md)
- [x] CI results are [inspected](https://docs.google.com/document/d/1d5ga073jkv4CO1kAJqp8MPGpC6E1bwyrCGZ7S5wKg3w/edit?tab=t.0#heading=h.w4ercgtcg0xp)

### Automated testing

<!--
If no tests have been contributed, please explain why unless it's obvious,
e.g., the PR is a one-line comment change.
-->

- [x] modified existing tests

### How I validated my change

Based issue was possible to reproduce with:
```
<-errC
time.Sleep(50*time.Millisecond)
```
before `stopSignal.Signal()` - that would make `select` in `run()` to process first message and call blocking `Send` on second one.

- [x] tested locally
- [x] tested in VM with multiple runs

