### PR TITLE
refactor: use set.StringSet for duplicate detection in parseKeyBundle

### DIFF
--- a/pkg/signatures/key_bundle.go
+++ b/pkg/signatures/key_bundle.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackrox/rox/generated/storage"
 	"github.com/stackrox/rox/pkg/errox"
+	"github.com/stackrox/rox/pkg/set"
 )
 
 var (
@@ -39,7 +40,7 @@ func ParseKeyBundle(data []byte) (*KeyBundle, error) {
 	if len(bundle.Keys) == 0 {
 		return nil, ErrKeyBundleEmpty
 	}
-	seenNames := make(map[string]struct{}, len(bundle.Keys))
+	seenNames := set.NewStringSet()
 	for i := range bundle.Keys {
 		entry := &bundle.Keys[i]
 		entry.Name = strings.TrimSpace(entry.Name)
@@ -49,10 +50,9 @@ func ParseKeyBundle(data []byte) (*KeyBundle, error) {
 		if strings.ContainsAny(entry.Name, "/\\") {
 			return nil, ErrKeyNamePathSeparator.CausedByf("key name %q", entry.Name)
 		}
-		if _, exists := seenNames[entry.Name]; exists {
+		if !seenNames.Add(entry.Name) {
 			return nil, ErrKeyNameDuplicate.CausedByf("%q", entry.Name)
 		}
-		seenNames[entry.Name] = struct{}{}
 		keyBlock, rest := pem.Decode([]byte(strings.TrimSpace(entry.PEM)))
 		if !IsValidPublicKeyPEMBlock(keyBlock, rest) {
 			return nil, ErrKeyInvalidPEM.CausedByf("key %q", entry.Name)


### PR DESCRIPTION
## Summary
- Replace manual `map[string]struct{}` with the project's `set.StringSet` type for duplicate key name detection in `ParseKeyBundle`
- Uses `set.Add()` return value (false if already present) to simplify the duplicate check

Stacked on [PR #21269](https://github.com/stackrox/stackrox/pull/21269). Addresses the nit from [review comment](https://github.com/stackrox/stackrox/pull/21269#discussion_r3442733386) — the suggestion was on code that existed on master before the move, so it's extracted into its own PR.

## Test plan
- [x] Existing `TestParseKeyBundle` tests cover duplicate detection behavior — no behavioral change, only a type-level refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)